### PR TITLE
Harden default CORS configuration (disable wildcard origin by default)

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -349,7 +349,7 @@ app = FastAPI(title="VERITAS Public API", version="1.0.3")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=getattr(cfg, "cors_allow_origins", ["*"]) or ["*"],
+    allow_origins=getattr(cfg, "cors_allow_origins", []),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -1126,7 +1126,6 @@ def trust_feedback(body: dict):
     except Exception as e:
         print("[Trust] feedback failed:", e)
         return {"status": "error", "detail": str(e)}
-
 
 
 

--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -6,6 +6,13 @@ from pathlib import Path
 from dataclasses import dataclass, field
 
 
+def _parse_cors_origins(raw_value: str) -> list[str]:
+    """Parse comma-separated CORS origins from an env var into a clean list."""
+    if not raw_value:
+        return []
+    return [value.strip() for value in raw_value.split(",") if value.strip()]
+
+
 @dataclass
 class VeritasConfig:
     # ==== API ====
@@ -50,7 +57,11 @@ class VeritasConfig:
     creator_name: str = "fuji"
     product_name: str = "VERITAS"
 
-    cors_allow_origins: list[str] = field(default_factory=lambda: ["*"])
+    cors_allow_origins: list[str] = field(
+        default_factory=lambda: _parse_cors_origins(
+            os.getenv("VERITAS_CORS_ALLOW_ORIGINS", "")
+        )
+    )
 
     def __post_init__(self):
         # --- API alias ---


### PR DESCRIPTION
### Motivation
- The previous default allowed CORS wildcard (`"*"`) which permits any website to make browser requests and can expose API keys or sensitive behavior if keys leak. 
- Make CORS configuration explicit and safe by requiring operators to set allowed origins via `VERITAS_CORS_ALLOW_ORIGINS`.

### Description
- Add `_parse_cors_origins(raw_value: str) -> list[str]` to parse a comma-separated `VERITAS_CORS_ALLOW_ORIGINS` env var and strip empty values with a docstring.  
- Change `VeritasConfig.cors_allow_origins` to default to the parsed env var value (empty list if unset) instead of `['*']`.  
- Update FastAPI CORS middleware to use `allow_origins=getattr(cfg, "cors_allow_origins", [])` so there is no wildcard fallback in the server layer.
- This makes cross-origin access denied by default until `VERITAS_CORS_ALLOW_ORIGINS` is explicitly configured.

### Testing
- No automated tests were executed during this change (no test run requested).  
- Recommend adding a unit test for `_parse_cors_origins` and a CI check to validate CORS headers behavior in the app startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7ce2bf0c8326b62f1e60be6d726b)