### PR TITLE
Fix critical security issues: thread-safety and null checks

### DIFF
--- a/veritas_os/core/fuji.py
+++ b/veritas_os/core/fuji.py
@@ -483,7 +483,7 @@ def _apply_policy(
 # =========================================================
 def fuji_core_decide(
     *,
-    safety_head: SafetyHeadResult,
+    safety_head: SafetyHeadResult | None,
     stakes: float,
     telos_score: float,
     evidence_count: int,
@@ -493,10 +493,21 @@ def fuji_core_decide(
     text: str = "",
     poc_mode: bool = False,
 ) -> Dict[str, Any]:
+    """
+    ★ セキュリティ修正: 入力パラメータのnullチェック強化
+    """
     policy = policy or POLICY
 
-    categories = list(safety_head.categories or [])
-    risk = float(safety_head.risk_score)
+    # ★ safety_head が None の場合のフォールバック
+    if safety_head is None:
+        safety_head = _fallback_safety_head(text or "")
+
+    # ★ 安全なアクセス: categories と risk_score
+    categories = list(safety_head.categories or []) if safety_head.categories else []
+    try:
+        risk = float(safety_head.risk_score) if safety_head.risk_score is not None else 0.05
+    except (TypeError, ValueError):
+        risk = 0.05
     base_reasons: List[str] = []
     guidance = safety_head.rationale or ""
 


### PR DESCRIPTION
Security fixes:
- server.py: Add thread-safe nonce store with threading.Lock
- server.py: Add thread-safe rate limiter with threading.Lock
- server.py: Remove module-level API_SECRET, use _get_api_secret() instead
- kernel.py: Add defensive null checks in _dedupe_alts()
- kernel.py: Add safe async/sync detection for reason_core calls
- kernel.py: Add missing reason_core import with fallback
- fuji.py: Add null check for safety_head parameter

This prevents:
- Race conditions in concurrent request handling
- Memory dump exposure of secrets
- NullPointerException-like errors in dict operations
- Async/await misuse with non-async functions

https://claude.ai/code/session_01Txawq7FT15kSuV2dF6yquo