### PR TITLE
Normalize tool names in call_tool

### DIFF
--- a/veritas_os/tests/test_core_tools.py
+++ b/veritas_os/tests/test_core_tools.py
@@ -124,6 +124,24 @@ def test_call_tool_web_search_branch_uses_query_and_max_results(clean_tools_stat
     assert captured["max_results"] == 3
 
 
+def test_call_tool_normalizes_kind_for_registry_lookup(clean_tools_state):
+    captured: Dict[str, Any] = {}
+
+    def dummy_web_search(query: str, max_results: int = 5):
+        captured["query"] = query
+        captured["max_results"] = max_results
+        return {"ok": True, "results": [query], "error": None}
+
+    tools.ALLOWED_TOOLS.add("web_search")
+    tools.TOOL_REGISTRY["web_search"] = dummy_web_search
+
+    resp = tools.call_tool(" Web_Search ", query="veritas", max_results=1)
+    assert resp["ok"] is True
+    assert resp["results"] == ["veritas"]
+    assert captured["query"] == "veritas"
+    assert captured["max_results"] == 1
+
+
 # =========================
 # ツール管理 API
 # =========================
@@ -218,4 +236,3 @@ def test_get_tool_stats_counts_success_and_status(clean_tools_state):
     # success_rate が 0〜1 の範囲で、1/2 付近
     assert 0.0 <= stats["success_rate"] <= 1.0
     assert math.isclose(stats["success_rate"], 0.5, rel_tol=1e-6)
-


### PR DESCRIPTION
### Motivation
- Prevent incorrect denials or missing implementations when `call_tool` is called with different casing or surrounding whitespace by normalizing the tool name before checks and lookups.
- Make logging and registry lookup consistent by using the normalized name everywhere inside `call_tool` while preserving the public API surface.
- Note security consideration: `_sanitize_args` only performs shallow key matching and truncation so nested or non-exact secret keys can still leak sensitive data and should be handled at a higher layer.

### Description
- Normalize the incoming `kind` to `normalized_kind = str(kind).strip().lower()` and use it for permission checks, `TOOL_REGISTRY` lookup, logging, branching, and error messages inside `call_tool` in `veritas_os/core/tools.py`.
- Adjust the `web_search` / `github_search` / `llm_safety` branch checks and all `_log_tool_usage` calls to use `normalized_kind` and improve the success log call to use formatted logger arguments.
- Add a unit test `test_call_tool_normalizes_kind_for_registry_lookup` to `veritas_os/tests/test_core_tools.py` which verifies case- and whitespace-insensitive tool name handling.
- Changes affect only internal behavior; public interfaces, logs schema, and exposed constants remain unchanged and no more than two files were modified.

### Testing
- Added unit test `test_call_tool_normalizes_kind_for_registry_lookup` in `veritas_os/tests/test_core_tools.py` (not executed due to environment issue).
- Attempted to run `pytest /workspace/veritas_os/veritas_os/tests/test_core_tools.py` but execution failed because the environment uses `pyenv` with missing version `3.12.7` and `pytest` was not found, so automated tests could not be executed here.
- Manual static checks: updated code keeps existing function signatures and preserves logging/meta shapes, and the new test exercises the normalization behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc37f474c832699761d2bf1fb3b4d)