### PR TITLE
PII redaction before TrustLog and Memory persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ pytest --cov=veritas_os
 
 ---
 
+## Operational Security Notes
+
+- **Force PII masking before persisting TrustLog/Memory**. Apply `redact()` (PII masking) prior to storage to reduce leakage risk.
+- **Encryption at rest (optional)**: TrustLog/Memory are stored in plaintext; consider encryption or KMS integration based on requirements.
+- **CORS and API key must be set**. Configure `VERITAS_CORS_ALLOW_ORIGINS` and `VERITAS_API_KEY` to avoid unsafe defaults.
+
+---
+
 ## Roadmap (Near-Term)
 
 * CI (GitHub Actions): pytest + coverage + artifact reports

--- a/README_JP.md
+++ b/README_JP.md
@@ -193,6 +193,14 @@ pytest --cov=veritas_os
 
 ---
 
+## 運用・セキュリティ上の注意
+
+- **TrustLog / Memory の保存前に PII マスクを強制することを推奨**します。保存前に `redact()`（PIIマスク）を通すことで、ログ/記憶に機微情報が残るリスクを低減できます。
+- **暗号化 at rest（オプション）**: TrustLog / Memory は平文保存のため、要件に応じて暗号化やKMS連携を検討してください。
+- **CORS と API Key の未設定は危険**です。`VERITAS_CORS_ALLOW_ORIGINS` と `VERITAS_API_KEY` を必ず設定してください。
+
+---
+
 ## 近いロードマップ（短期）
 
 * CI（GitHub Actions）：pytest + coverage + レポート生成
@@ -228,5 +236,4 @@ pytest --cov=veritas_os
 
 * Issues: [https://github.com/veritasfuji-japan/veritas_os/issues](https://github.com/veritasfuji-japan/veritas_os/issues)
 * Email: [veritas.fuji@gmail.com](mailto:veritas.fuji@gmail.com)
-
 

--- a/veritas_os/tests/test_pipeline_redaction.py
+++ b/veritas_os/tests/test_pipeline_redaction.py
@@ -1,0 +1,15 @@
+from veritas_os.core import pipeline
+
+
+def test_redact_payload_masks_pii():
+    payload = {
+        "query": "Reach me at test@example.com or 090-1234-5678.",
+        "count": 1,
+        "nested": [{"note": "Alt: test@example.com"}],
+    }
+
+    redacted = pipeline.redact_payload(payload)
+
+    assert "test@example.com" not in redacted["query"]
+    assert "090-1234-5678" not in redacted["query"]
+    assert "test@example.com" not in redacted["nested"][0]["note"]


### PR DESCRIPTION
### Motivation

- Reduce risk of sensitive data leakage by ensuring PII is masked before audit logs or MemoryOS persistence.  
- Provide a safe default that uses existing sanitizer if available and a conservative regex fallback when not.  
- Surface operational guidance about plaintext storage, CORS and API key defaults to help operators avoid accidental exposure.

### Description

- Add optional import of `mask_pii` from `veritas_os.core.sanitize` and a fallback regex-based masker via `_redact_text` used for PII masking.  
- Add recursive `redact_payload` helper that masks strings inside nested `dict`/`list`/`tuple` structures.  
- Apply `redact_payload` to `audit_entry` before `append_trust_log` and to decision/episode payloads before `_memory_put` in `veritas_os/core/pipeline.py`.  
- Add unit test `veritas_os/tests/test_pipeline_redaction.py` covering nested payload redaction and document operational security notes in `README.md` and `README_JP.md` (PII masking recommendation, encryption at rest, and CORS/API key warning).

### Testing

- Added `veritas_os/tests/test_pipeline_redaction.py` which asserts that email and phone-like strings are removed from nested payloads.  
- Attempted to run `pytest veritas_os/tests/test_pipeline_redaction.py` but the run failed due to the environment missing the configured Python (`pyenv` 3.12.7) and `pytest` (`pyenv: version `3.12.7' is not installed` / `pytest: command not found`).  
- All changes were committed; the test exists but could not be executed in CI/local environment because of the runtime mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc5e7af4883269b0efa2a506b4c24)