### PR TITLE
Clarify proprietary license posture and add security guidance to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml)
 
 **Version**: 2.0.0  
-**Release Date**: 2025-12-01  
+**Planned Release**: 2025-12-01  
 **Author**: Takeshi Fujishita
 
 VERITAS OS wraps an LLM (e.g. OpenAI GPT-4.1-mini) with a **deterministic, safety-gated, hash-chained decision pipeline**.
@@ -186,7 +186,18 @@ pytest
 pytest --cov=veritas_os
 ```
 
-> Note: Coverage/CI badges will be added via GitHub Actions (recommended for external trust).
+> Note: Coverage badges are planned; CI is available via GitHub Actions.
+
+---
+
+## Security Notes (Important)
+
+- **API keys**: Avoid exporting secrets directly in shell history where possible. Prefer
+  `.env` files (git-ignored) or secret managers and inject them at runtime. Rotate keys
+  regularly and limit scope/permissions.
+- **TrustLog data**: TrustLog is append-only JSONL. If your payloads can contain PII or
+  sensitive data, ensure you have access controls, retention policies, and (if needed)
+  encryption at rest.
 
 ---
 
@@ -200,8 +211,10 @@ pytest --cov=veritas_os
 
 ## License
 
-**All Rights Reserved.**
-See [`LICENSE`](LICENSE).
+**All Rights Reserved (Proprietary).**
+This repository is **not** open-source. Usage, modification, and distribution
+are restricted unless explicitly permitted in a subdirectory-specific LICENSE
+file. See [`LICENSE`](LICENSE) for full terms.
 
 For academic use, please cite the Zenodo DOI.
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml)
 
 **Version**: 2.0.0  
-**Release Date**: 2025-12-01  
+**Planned Release**: 2025-12-01  
 **Author**: Takeshi Fujishita
 
 VERITAS OS は、LLM（例：OpenAI GPT-4.1-mini）を  
@@ -188,8 +188,18 @@ pytest
 pytest --cov=veritas_os
 ```
 
-> 推奨：GitHub Actions（CI）で pytest + coverage を自動化し、
-> 外部から再現できる “信頼の証拠” を固定します。
+> 補足：CI は GitHub Actions で利用可能です。Coverage バッジは追加予定です。
+
+---
+
+## セキュリティ注意（重要）
+
+- **APIキー**: 可能な限りシェル履歴に残る `export` を避け、`.env`（gitignore）
+  や Secret Manager を使って実行時に注入してください。定期的なローテーションと
+  最小権限の付与を推奨します。
+- **TrustLogのデータ**: TrustLog は JSONL の追記ログです。ペイロードに個人情報
+  や機密情報が含まれる可能性がある場合、アクセス制御、保持期間、必要に応じて
+  保存時暗号化を実施してください。
 
 ---
 
@@ -203,7 +213,9 @@ pytest --cov=veritas_os
 
 ## ライセンス
 
-**All Rights Reserved.**
+**All Rights Reserved（プロプライエタリ）**。本リポジトリは
+オープンソースではありません。使用・改変・配布は、サブディレクトリに
+明示された LICENSE がある場合を除き制限されています。
 詳細は [`LICENSE`](LICENSE) を参照してください。
 
 学術用途では Zenodo DOI を引用してください。
@@ -228,5 +240,3 @@ pytest --cov=veritas_os
 
 * Issues: [https://github.com/veritasfuji-japan/veritas_os/issues](https://github.com/veritasfuji-japan/veritas_os/issues)
 * Email: [veritas.fuji@gmail.com](mailto:veritas.fuji@gmail.com)
-
-


### PR DESCRIPTION
### Motivation

- Make the repository's commercial/closed operation posture explicit by clarifying the license language and reducing ambiguity about permitted use. 
- Improve operational security guidance for commercial deployments by surfacing best practices for secret handling and TrustLog retention/encryption. 
- Ensure parity between English and Japanese documentation so maintainers and operators receive the same guidance.

### Description

- Update `README.md` to rename `Release Date` to `Planned Release` and adjust CI/coverage wording to indicate CI is available via GitHub Actions and coverage badges are planned. 
- Add a new `Security Notes (Important)` section in `README.md` that advises on safe handling of API keys and TrustLog data, including use of `.env`/secret managers, key rotation, least-privilege, access controls, retention policies, and encryption at rest. 
- Apply the same changes to `README_JP.md`, including the `Planned Release` wording, CI/coverage clarification, and the `セキュリティ注意（重要）` guidance in Japanese. 
- Clarify license text in both `README.md` and `README_JP.md` to `All Rights Reserved (Proprietary)` and state that usage/modification/distribution are restricted except where a subdirectory-specific `LICENSE` explicitly permits it.

### Testing

- No automated tests were run because this is a documentation-only change. 
- Changes were limited to `README.md`, `README_JP.md`, and reference to `LICENSE`, and therefore no code linting or unit tests were applicable. 
- Manual verification: the updated sections are present in both files and mirror each other in English and Japanese.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc9870498832698d2d16366febc27)