### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import os
 import re
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -226,7 +227,14 @@ def _is_blocked_result(title: str, snippet: str, url: str) -> bool:
         if RE_BUREAUVERITAS.search(host_guess) or "bureauveritas" in host_guess:
             return True
 
-    if "veritas.com" in u:
+    # veritas.com domain block（ホスト名を優先的にチェック）
+    parsed = urlparse(u)
+    host = (parsed.hostname or "").lower().replace("www.", "")
+    if host:
+        if host == "veritas.com" or host.endswith(".veritas.com"):
+            return True
+    elif "veritas.com" in u:
+        # ホストが取得できない不正URLなどは従来どおりサブストリングで弾く
         return True
 
     return False


### PR DESCRIPTION
Potential fix for [https://github.com/veritasfuji-japan/veritas_os/security/code-scanning/1](https://github.com/veritasfuji-japan/veritas_os/security/code-scanning/1)

In general, to fix incomplete URL substring sanitization you should parse the URL, extract the hostname, and then perform host‑based checks (possibly allowing arbitrary subdomains) instead of searching for substrings in the raw URL string. This avoids both false positives (e.g. `http://example.com/path/veritas.com`) and false negatives (e.g. tricks with credentials or ports) and makes the intent “block/allow certain domains” explicit.

For this specific case, the minimal and safe fix is:

- Parse `url` with `urllib.parse.urlparse` and extract `hostname`.
- If a hostname is present, use it (lowercased, with `www.` stripped) to decide whether to block `veritas.com`, for example by checking `host == "veritas.com"` or `host.endswith(".veritas.com")`.
- Fall back to the existing substring logic only when parsing yields no hostname (e.g. malformed URLs), so we don’t silently let through clearly bad results.
- Keep the rest of `_is_blocked_result` unchanged.

Concretely:

- Add `from urllib.parse import urlparse` alongside the existing imports at the top of `veritas_os/tools/web_search.py`.
- Replace the current `if "veritas.com" in u:` block with a small section that:
  - uses `urlparse(u)` to get a `ParseResult`,
  - normalizes the hostname (remove `www.`),
  - blocks if the normalized host is exactly `veritas.com` or any subdomain (`.veritas.com`),
  - and, if there is no hostname, falls back to the original substring `"veritas.com" in u` behavior.

This preserves existing functionality (blocking veritas.com‑related results) while aligning with the recommendation to base checks on the host instead of arbitrary substrings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
