### PR TITLE
Fix hostname-based URL blacklist checks

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -103,6 +103,13 @@ class TestIsBlockedResult:
             "https://www.veritas.com/product"
         ) is True
 
+    def test_blocks_veritas_com_without_scheme(self):
+        assert web_search_mod._is_blocked_result(
+            "Veritas Storage",
+            "backup solutions",
+            "veritas.com/product"
+        ) is True
+
     def test_allows_clean_result(self):
         assert web_search_mod._is_blocked_result(
             "Python Tutorial",
@@ -117,6 +124,13 @@ class TestIsBlockedResult:
             "Quality management",
             "https://www.bureauveritas.co.jp/services"
         ) is True
+
+    def test_allows_veritas_substring_in_path(self):
+        assert web_search_mod._is_blocked_result(
+            "Example",
+            "Some snippet",
+            "https://example.com/path/veritas.com/info"
+        ) is False
 
 
 class DummyResponse:


### PR DESCRIPTION
### Motivation
- Avoid false positives from substring matching in URLs by basing blacklist decisions on extracted hostnames and handling scheme-less URLs. 
- Ensure `veritas.com` and `bureauveritas.*` are recognized reliably even when URLs lack a scheme. 
- Add targeted tests for the new behaviors and provide a docstring for the new helper. 
- Security: if hostname extraction fails, blacklist checks may be skipped, so inputs should be normalized/validated in calling code.

### Description
- Add `_extract_hostname(url: str) -> str` helper that extracts hostnames and supports scheme-less inputs. 
- Update `_is_blocked_result` to use hostname-based checks and stop relying on raw substring matches in the full URL for domain blocks. 
- Remove URL substring checks for `BLACKLIST_KEYWORDS` and instead match those keywords only against title/snippet. 
- Add unit tests in `veritas_os/tests/test_web_search_extra.py` to cover scheme-less URLs and to ensure substrings inside the path (e.g. `https://example.com/path/veritas.com/...`) do not trigger blocks.

### Testing
- Attempted to run `pytest -q veritas_os/tests/test_web_search_extra.py` but it failed because the configured `pyenv` Python version (`3.12.7`) is not installed and `pytest` is not available in the active environment. 
- New tests were added and committed; they have not been executed successfully in CI/local due to the environment issue described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697df652ca0483268e013dedf6eb7854)