### PR TITLE
Align docs with current /workspace environment and venv workflow

### DIFF
--- a/docs/notes/AGI_BENCH_INTEGRATION_GUIDE.md
+++ b/docs/notes/AGI_BENCH_INTEGRATION_GUIDE.md
@@ -4,6 +4,27 @@
 
 VERITAS OSのAGIベンチマークシステムと自己改善ループを完全に統合し、「ベンチ実行 → 結果分析 → タスク生成 → 実装 → 検証」のサイクルを実現します。
 
+## 現行環境仕様（前提）
+
+本ドキュメントのコマンドは、リポジトリ直下（例: `/workspace/veritas_os`）で
+Python 3.11 の仮想環境を有効化した前提で記載します。
+
+```bash
+cd /workspace/veritas_os
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+必要に応じて、以下の環境変数を設定してください。
+
+```bash
+export OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
+export VERITAS_API_KEY="your-secret-api-key"
+export LLM_PROVIDER="openai"
+export LLM_MODEL="gpt-4.1-mini"
+```
+
 ---
 
 ## システム構成
@@ -176,7 +197,7 @@ python scripts/bench_summary.py
 **出力例**:
 ```
 === VERITAS Bench Summary ===
-対象ディレクトリ: /path/to/logs/benchmarks
+対象ディレクトリ: /workspace/veritas_os/scripts/logs/benchmarks
 集計日時: 2025-01-30 14:40:00
 
 [agi_veritas_self_hosting] VERITAS self-hosting AGI research OS design
@@ -515,7 +536,7 @@ for bench_id, ts in sorted(times.items()):
 
 ```bash
 # cron設定例（毎週月曜 9:00）
-0 9 * * 1 cd /path/to/veritas_os && python scripts/run_benchmarks_improved.py --all
+0 9 * * 1 cd /workspace/veritas_os && python scripts/run_benchmarks_improved.py --all
 ```
 
 ### 2. Gitとの統合

--- a/docs/notes/BENCHMARK_MIGRATION_GUIDE.md
+++ b/docs/notes/BENCHMARK_MIGRATION_GUIDE.md
@@ -292,7 +292,7 @@ python scripts/run_benchmarks_enhanced.py agi_mvp_plan.yaml
 {
   "bench_id": "agi_mvp_plan",
   "name": "AGI MVP demo planning",
-  "yaml_path": "/path/to/benchmarks/agi_mvp_plan.yaml",
+  "yaml_path": "/workspace/veritas_os/benchmarks/agi_mvp_plan.yaml",
   "request": { ... },
   "status_code": 200,
   "elapsed_sec": 15.234,
@@ -311,6 +311,8 @@ python scripts/run_benchmarks_enhanced.py agi_mvp_plan.yaml
 
 ```bash
 # 依存関係を確認
+cd /workspace/veritas_os
+source .venv/bin/activate
 pip install requests pyyaml
 
 # Pythonバージョン確認（3.8+必要）

--- a/docs/notes/CRITIQUE_INTEGRATION_GUIDE.md
+++ b/docs/notes/CRITIQUE_INTEGRATION_GUIDE.md
@@ -71,6 +71,9 @@ def analyze(
 ### ステップ1: バックアップ（1分）
 
 ```bash
+# リポジトリ直下で実行
+cd /workspace/veritas_os
+
 # 現在のファイルをバックアップ
 cp veritas_os/core/critique.py veritas_os/core/critique.py.backup
 
@@ -82,8 +85,11 @@ cp veritas_os/core/critique.py \
 ### ステップ2: 改善版を配置（1分）
 
 ```bash
+# 改善版のパスは環境に合わせて調整
+IMPROVED_CRITIQUE="/workspace/veritas_os/outputs/critique.py"
+
 # 改善版をコピー
-cp /mnt/user-data/outputs/critique.py veritas_os/core/critique.py
+cp "${IMPROVED_CRITIQUE}" veritas_os/core/critique.py
 
 # パーミッション確認
 chmod 644 veritas_os/core/critique.py
@@ -93,7 +99,7 @@ chmod 644 veritas_os/core/critique.py
 
 ```bash
 # 基本動作テスト
-cd veritas_os
+cd /workspace/veritas_os
 python -m core.critique
 
 # 期待される出力:
@@ -111,7 +117,7 @@ python -m core.critique
 ```python
 # test_critique_integration.py
 import sys
-sys.path.insert(0, '/path/to/veritas_os')
+sys.path.insert(0, '/workspace/veritas_os')
 
 from core.critique import analyze, summarize_critiques, filter_by_severity
 
@@ -515,7 +521,7 @@ ImportError: cannot import name 'analyze' from 'veritas_os.core.critique'
 echo $PYTHONPATH
 
 # 正しいディレクトリから実行
-cd /path/to/veritas_os/parent
+cd /workspace
 python -c "from veritas_os.core.critique import analyze; print('OK')"
 ```
 

--- a/docs/notes/DEBATE_IMPROVEMENT_REPORT.md
+++ b/docs/notes/DEBATE_IMPROVEMENT_REPORT.md
@@ -335,7 +335,8 @@ warnings = {
 
 ### 1. ファイル置き換え
 ```bash
-cp debate_improved.py /path/to/veritas_os/core/debate.py
+cd /workspace/veritas_os
+cp debate_improved.py veritas_os/core/debate.py
 ```
 
 ### 2. 依存関係の確認

--- a/docs/notes/DEPLOYMENT_COMPLETE.md
+++ b/docs/notes/DEPLOYMENT_COMPLETE.md
@@ -29,11 +29,17 @@
 
 #### 依存関係
 ```bash
-pip install "numpy==1.26.4" --force-reinstall
+cd /workspace/veritas_os
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install "numpy==1.26.4"
 pip install sentence-transformers
 ```
 
 **重要**: NumPy 2.x は非互換。1.26.4を使用すること。
+**警告**: グローバル環境での `pip install` や `--force-reinstall` は依存破壊の
+リスクがあります。必ず仮想環境（`.venv`）内で実行してください。
 
 ---
 
@@ -41,7 +47,8 @@ pip install sentence-transformers
 
 #### 配置手順
 ```bash
-cp debate_improved.py /path/to/veritas_os/core/debate.py
+cd /workspace/veritas_os
+cp debate_improved.py veritas_os/core/debate.py
 ```
 
 #### 改善内容
@@ -55,8 +62,9 @@ cp debate_improved.py /path/to/veritas_os/core/debate.py
 
 #### 配置手順
 ```bash
-cp run_benchmarks_enhanced.py /path/to/veritas_os/scripts/
-cp self_heal_tasks.py /path/to/veritas_os/scripts/
+cd /workspace/veritas_os
+cp run_benchmarks_enhanced.py veritas_os/scripts/
+cp self_heal_tasks.py veritas_os/scripts/
 chmod +x scripts/run_benchmarks_enhanced.py
 chmod +x scripts/self_heal_tasks.py
 ```
@@ -87,7 +95,7 @@ python scripts/bench_summary.py
 
 ### 問題3: `Numpy is not available`
 **原因**: NumPy 2.x と PyTorch の非互換性  
-**解決**: `pip install "numpy==1.26.4" --force-reinstall`
+**解決**: `source .venv/bin/activate && pip install "numpy==1.26.4"`
 
 ### 問題4: モジュールロード時の循環インポート
 **原因**: `core/__init__.py` が全モジュールをインポート  
@@ -112,6 +120,7 @@ python scripts/bench_summary.py
 1. **ベクトル検索の利用開始**
    ```bash
    # 既存メモリからインデックス構築
+   cd /workspace/veritas_os
    python -c "from core import memory; memory.rebuild_vector_index()"
    
    # 検索テスト
@@ -120,11 +129,13 @@ python scripts/bench_summary.py
 
 2. **DebateOS配置**（推奨）
    ```bash
+   cd /workspace/veritas_os
    cp debate_improved.py core/debate.py
    ```
 
 3. **ベンチマーク実行**
    ```bash
+   cd /workspace/veritas_os
    cp run_benchmarks_enhanced.py scripts/
    python scripts/run_benchmarks_enhanced.py --all
    ```
@@ -135,6 +146,7 @@ python scripts/bench_summary.py
 # weekly_veritas_maintenance.sh
 
 # ベンチマーク実行
+cd /workspace/veritas_os
 python scripts/run_benchmarks_enhanced.py --all --output-plan
 
 # タスク生成

--- a/docs/notes/MEMORY_IMPROVEMENT_REPORT.md
+++ b/docs/notes/MEMORY_IMPROVEMENT_REPORT.md
@@ -249,13 +249,18 @@ def rebuild_vector_index():
 #### 1. 依存関係のインストール
 
 ```bash
-pip install sentence-transformers --break-system-packages
+cd /workspace/veritas_os
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install sentence-transformers
 ```
 
 #### 2. ファイル置き換え
 
 ```bash
-cp memory_improved.py /path/to/veritas_os/core/memory.py
+cd /workspace/veritas_os
+cp memory_improved.py veritas_os/core/memory.py
 ```
 
 #### 3. インデックスの構築
@@ -466,8 +471,13 @@ Score: 0.701 | ReasonOS と PlannerOS の統合方針
 
 **解決策**:
 ```bash
-pip install sentence-transformers --break-system-packages
+cd /workspace/veritas_os
+source .venv/bin/activate
+pip install sentence-transformers
 ```
+
+**警告**: グローバル環境での `pip install --break-system-packages` は依存破壊の
+リスクがあります。必ず仮想環境（`.venv`）内で実行してください。
 
 ---
 

--- a/docs/notes/VERITAS_IMPROVEMENT_SUMMARY.md
+++ b/docs/notes/VERITAS_IMPROVEMENT_SUMMARY.md
@@ -78,7 +78,8 @@ VERITAS OSの実用性向上のため、3つの主要コンポーネントを改
 
 ```bash
 # 1. ファイル配置
-cp debate_improved.py /path/to/veritas_os/core/debate.py
+cd /workspace/veritas_os
+cp debate_improved.py veritas_os/core/debate.py
 
 # 2. 動作確認
 python -c "from veritas_os.core import debate; print('OK')"
@@ -88,10 +89,14 @@ python -c "from veritas_os.core import debate; print('OK')"
 
 ```bash
 # 1. 依存関係インストール
-pip install sentence-transformers --break-system-packages
+cd /workspace/veritas_os
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install sentence-transformers
 
 # 2. ファイル配置
-cp memory_improved.py /path/to/veritas_os/core/memory.py
+cp memory_improved.py veritas_os/core/memory.py
 
 # 3. インデックス構築
 python -c "from veritas_os.core import memory; memory.rebuild_vector_index()"
@@ -104,17 +109,20 @@ python test_memory_vector.py
 
 ```bash
 # 1. ファイル配置
-cp run_benchmarks_improved.py /path/to/veritas_os/scripts/
-cp self_heal_tasks.py /path/to/veritas_os/scripts/
-chmod +x /path/to/veritas_os/scripts/*.py
+cd /workspace/veritas_os
+cp run_benchmarks_improved.py veritas_os/scripts/
+cp self_heal_tasks.py veritas_os/scripts/
+chmod +x veritas_os/scripts/*.py
 
 # 2. ベンチマーク実行
-cd /path/to/veritas_os
 python scripts/run_benchmarks_improved.py agi_mvp_plan.yaml
 
 # 3. タスク生成
 python scripts/self_heal_tasks.py --bench latest
 ```
+
+**警告**: グローバル環境での `pip install --break-system-packages` は依存破壊の
+リスクがあります。必ず仮想環境（`.venv`）内で実行してください。
 
 ---
 
@@ -286,7 +294,9 @@ ModuleNotFoundError: No module named 'sentence_transformers'
 
 **解決**:
 ```bash
-pip install sentence-transformers --break-system-packages
+cd /workspace/veritas_os
+source .venv/bin/activate
+pip install sentence-transformers
 ```
 
 #### 2. ベンチマークがタイムアウト

--- a/docs/notes/WORLD_MIGRATION_GUIDE.md
+++ b/docs/notes/WORLD_MIGRATION_GUIDE.md
@@ -106,17 +106,20 @@ simulate_decision(option, context, world_state)
 
 ```bash
 # 既存ファイルをバックアップ
+cd /workspace/veritas_os
 cp veritas_os/core/world.py veritas_os/core/world.py.backup
 cp veritas_os/core/world_model.py veritas_os/core/world_model.py.backup
 
 # データファイルもバックアップ
-cp ~/veritas/world_state.json ~/veritas/world_state.json.backup
+DATA_DIR="${VERITAS_DATA_DIR:-$HOME/veritas}"
+cp "${DATA_DIR}/world_state.json" "${DATA_DIR}/world_state.json.backup"
 ```
 
 ### Step 2: 統合版を配置
 
 ```bash
 # 統合版をworld.pyとして配置
+cd /workspace/veritas_os
 cp world.py veritas_os/core/world.py
 
 # world_model.pyは削除（または.oldにリネーム）
@@ -141,6 +144,7 @@ from veritas_os.core.world import update_from_decision
 
 ```bash
 # 基本動作テスト
+cd /workspace/veritas_os
 python -c "
 from veritas_os.core import world
 
@@ -547,7 +551,7 @@ cp ~/veritas/world_state.json ~/veritas/world_state.json.backup
 
 ### 最終ファイル
 
-**[world.py](computer:///mnt/user-data/outputs/world.py)** - 統合版（950行）
+**/workspace/veritas_os/veritas_os/core/world.py** - 統合版（950行）
 
 ---
 


### PR DESCRIPTION
### Motivation
- Update deployment and integration guides to reflect the actual repository layout (`/workspace/veritas_os`) and a reproducible Python 3.11 venv workflow. 
- Replace legacy path placeholders and ad-hoc install instructions that risk confusion or dependency breakage. 
- Surface a clear security warning about performing `pip install` in the global environment and make backups/data-paths environment-aware.

### Description
- Updated multiple documentation files to use repo-root commands and venv flow, including `docs/notes/AGI_BENCH_INTEGRATION_GUIDE.md`, `BENCHMARK_MIGRATION_GUIDE.md`, `CRITIQUE_INTEGRATION_GUIDE.md`, `DEBATE_IMPROVEMENT_REPORT.md`, `DEPLOYMENT_COMPLETE.md`, `MEMORY_IMPROVEMENT_REPORT.md`, `VERITAS_IMPROVEMENT_SUMMARY.md`, and `WORLD_MIGRATION_GUIDE.md`. 
- Added a "現行環境仕様（前提）" section and `python3.11 -m venv .venv` / `source .venv/bin/activate` + `pip install -r requirements.txt` steps to relevant guides and examples. 
- Replaced `/path/to`, `/mnt/user-data` and other placeholders with `/workspace/veritas_os` or environment-aware variables such as `DATA_DIR="${VERITAS_DATA_DIR:-$HOME/veritas}"`, adjusted cron and logs paths, and fixed example YAML/log paths. 
- Changed risky install lines to recommend activating the virtualenv before installing (e.g. `source .venv/bin/activate && pip install "numpy==1.26.4"`) and added explicit warnings about dependency-destroying global `pip` operations.

### Testing
- Automated tests: none executed because this PR contains documentation-only changes; no runtime code was modified. 
- Recommendation: run documentation linting / link-check or the project CI to validate docs rendering and example command correctness after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e0ae77cb08326abefd06b5eb555c2)