### PR TITLE
Block invalid URLs and use hostname-based blacklist checks

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -103,6 +103,13 @@ class TestIsBlockedResult:
             "https://www.veritas.com/product"
         ) is True
 
+    def test_blocks_veritas_com_without_scheme(self):
+        assert web_search_mod._is_blocked_result(
+            "Veritas Storage",
+            "backup solutions",
+            "veritas.com/product"
+        ) is True
+
     def test_allows_clean_result(self):
         assert web_search_mod._is_blocked_result(
             "Python Tutorial",
@@ -116,6 +123,20 @@ class TestIsBlockedResult:
             "ISO Certification",
             "Quality management",
             "https://www.bureauveritas.co.jp/services"
+        ) is True
+
+    def test_allows_veritas_substring_in_path(self):
+        assert web_search_mod._is_blocked_result(
+            "Example",
+            "Some snippet",
+            "https://example.com/path/veritas.com/info"
+        ) is False
+
+    def test_blocks_invalid_url_without_hostname(self):
+        assert web_search_mod._is_blocked_result(
+            "Example",
+            "Some snippet",
+            "http:///path/only"
         ) is True
 
 

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -102,6 +102,19 @@ def _normalize_str(x: Any, *, limit: int = 4000) -> str:
     return s
 
 
+def _extract_hostname(url: str) -> str:
+    """URLからホスト名を抽出する（スキームなしURLも対応）。"""
+    if not url:
+        return ""
+    candidate = url.strip()
+    parsed = urlparse(candidate)
+    host = parsed.hostname
+    if not host and "://" not in candidate:
+        parsed = urlparse(f"http://{candidate}")
+        host = parsed.hostname
+    return (host or "").lower()
+
+
 def _is_agi_query(q: str) -> bool:
     """クエリが AGI 関連っぽいかどうかをざっくり判定"""
     q = q or ""
@@ -210,32 +223,31 @@ def _is_blocked_result(title: str, snippet: str, url: str) -> bool:
     t = (title or "").lower()
     s = (snippet or "").lower()
     u = (url or "").lower()
+    host = _extract_hostname(u).replace("www.", "")
+
+    if u and not host:
+        return True
 
     for kw in BLACKLIST_KEYWORDS:
         kwl = kw.lower()
-        if kwl in t or kwl in s or kwl in u:
+        if kwl in t or kwl in s:
             return True
 
     for site in BLACKLIST_SITES:
-        if site.lower() in u:
-            return True
+        site_host = _extract_hostname(site).replace("www.", "")
+        if host and site_host:
+            if host == site_host or host.endswith(f".{site_host}"):
+                return True
 
     # bureauveritas.* wildcard block（ドメイン抽出が雑でも防ぐ）
-    if "bureauveritas." in u:
-        host_guess = u.split("/")[2] if "://" in u and len(u.split("/")) > 2 else u
-        host_guess = host_guess.split(":")[0].replace("www.", "")
-        if RE_BUREAUVERITAS.search(host_guess) or "bureauveritas" in host_guess:
+    if host:
+        if RE_BUREAUVERITAS.search(host) or "bureauveritas" in host:
             return True
 
     # veritas.com domain block（ホスト名を優先的にチェック）
-    parsed = urlparse(u)
-    host = (parsed.hostname or "").lower().replace("www.", "")
     if host:
         if host == "veritas.com" or host.endswith(".veritas.com"):
             return True
-    elif "veritas.com" in u:
-        # ホストが取得できない不正URLなどは従来どおりサブストリングで弾く
-        return True
 
     return False
 
@@ -433,8 +445,6 @@ def web_search(query: str, max_results: int = 5) -> Dict[str, Any]:
                 "blocked_count": 0,
             },
         }
-
-
 
 
 


### PR DESCRIPTION
### Motivation
- Prevent false positives/negatives from naive substring matching by extracting and checking hostnames when applying site/domain blacklist rules.  
- Treat scheme-less URLs like `veritas.com/...` correctly by supporting hostname extraction for inputs without a scheme.  
- Fail closed for malformed URLs by blocking results when a provided URL has content but no extractable hostname to avoid accidental whitelist bypass.  
- Security: this change may remove malformed-but-legitimate results, so calling code should normalize/validate user inputs where appropriate.

### Description
- Add `_extract_hostname(url: str) -> str` helper that extracts hostnames and supports scheme-less inputs by prepending `http://` when needed.  
- Update `_is_blocked_result` to use hostname-based checks: keywords are matched only against title/snippet, site blacklist entries are matched using extracted hostnames, and `veritas.com` / `bureauveritas.*` patterns are checked against the hostname.  
- Treat inputs that contain a non-empty `url` but yield no hostname from `_extract_hostname` as blocked.  
- Add unit tests in `veritas_os/tests/test_web_search_extra.py` to cover scheme-less blocking (`veritas.com/...`), allow `veritas.com` substrings in the path, and block invalid URLs without a hostname.

### Testing
- Added unit tests in `veritas_os/tests/test_web_search_extra.py` covering the new behaviors and they were committed successfully.  
- Ran `PYENV_VERSION=3.12.12 python -m pytest -q veritas_os/tests/test_web_search_extra.py`, but test collection failed with `ModuleNotFoundError: No module named 'requests'` so the test suite did not complete.  
- No further automated test failures were observed in this change set beyond the missing dependency during test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697df652ca0483268e013dedf6eb7854)