### PR TITLE
Potential fix for code scanning alert no. 17: Information exposure through an exception

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -1207,8 +1207,9 @@ def trust_feedback(body: dict):
         return {"status": "error", "detail": "value_core.append_trust_log not found"}
 
     except Exception as e:
+        # Log the detailed error server-side, but do not expose it to the client.
         print("[Trust] feedback failed:", e)
-        return {"status": "error", "detail": str(e)}
+        return {"status": "error", "detail": "internal error in trust_feedback"}
 
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/veritasfuji-japan/veritas_os/security/code-scanning/17](https://github.com/veritasfuji-japan/veritas_os/security/code-scanning/17)

In general, to fix this type of issue you should avoid returning raw exception objects or messages to the client. Instead, log the full error server-side (optionally including the stack trace) and return a generic, non-sensitive error message in the API response. This preserves debuggability for developers while limiting what an attacker can learn from error responses.

For this specific case in `veritas_os/api/server.py`, the best fix without changing existing functionality is:
- Keep or slightly improve the server-side logging in the `except` block, so the exception is still visible to operators.
- Replace the client-facing `"detail": str(e)` with a generic message that does not include `e` at all, e.g. `"detail": "internal error in trust_feedback"` or `"detail": "internal server error"`.
- Optionally, keep the `"status": "error"` field so callers can still detect failures exactly as before; only the content of `"detail"` becomes generic.

Concretely, update lines 1209–1211 so that:
- The `print` continues to log the original exception (you may slightly adjust the message if desired), but
- The returned dict is changed to not reference `e` at all.

No new imports are strictly required, since we can continue using `print` for logging, consistent with the existing code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
