### PR TITLE
Potential fix for code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -1127,13 +1127,15 @@ async def memory_search(payload: dict):
 def memory_get(body: dict):
     store = get_memory_store()
     if store is None:
-        return {"ok": False, "error": f"memory store unavailable: {_memory_store_state.err}", "value": None}
+        # Do not expose internal error details to clients
+        return {"ok": False, "error": "memory store unavailable", "value": None}
 
     try:
         value = _store_get(store, body["user_id"], body["key"])
         return {"ok": True, "value": value}
-    except Exception as e:
-        return {"ok": False, "error": str(e), "value": None}
+    except Exception:
+        # Return a generic error instead of leaking exception messages
+        return {"ok": False, "error": "memory get failed", "value": None}
 
 
 # ==============================


### PR DESCRIPTION
Potential fix for [https://github.com/veritasfuji-japan/veritas_os/security/code-scanning/13](https://github.com/veritasfuji-japan/veritas_os/security/code-scanning/13)

In general, to fix information exposure via exceptions in HTTP APIs, avoid including raw exception messages or stack traces in responses. Instead, return generic, user‑friendly error messages, and log the detailed error information on the server where developers can access it without exposing it to clients.

For this specific case, the best fix without changing functionality is:

- Keep the internal tracking of `_memory_store_state.err` for diagnostics and logging.
- Stop interpolating `_memory_store_state.err` into the `error` field of the `/v1/memory/get` response when the memory store is unavailable.
- Replace it with a generic message such as `"memory store unavailable"`.
- Similarly, in the exception handler inside `memory_get`, avoid returning `str(e)` to the client; instead, return a generic error message like `"memory get failed"` (or similar), while leaving actual logging behavior unchanged (the provided snippet doesn’t show logging here, so we won’t add extra logging to avoid assumptions).

Concretely:

- In `memory_get`, change the `if store is None` branch to return a generic error string that does not embed `_memory_store_state.err`.
- In the `except Exception as e:` block of `memory_get`, change the response to a generic error that does not expose `str(e)`.

No new imports or helper functions are strictly required for this change; we are only modifying the response payloads.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
