### PR TITLE
Refactor: prioritized improvements from code review

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,8 @@ jobs:
             httpx \
             anyio \
             pytest \
-            pytest-cov
+            pytest-cov \
+            pytest-asyncio
 
       - name: Run tests (with coverage)
         id: pytest

--- a/veritas_os/core/kernel_stages.py
+++ b/veritas_os/core/kernel_stages.py
@@ -1,0 +1,691 @@
+# veritas_os/core/kernel_stages.py
+# -*- coding: utf-8 -*-
+"""
+kernel.decide() から責務を分離したステージモジュール
+
+各ステージは独立してテスト可能で、設定値はconfig.pyから取得します。
+"""
+from __future__ import annotations
+
+import uuid
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+import logging
+
+from .config import scoring_cfg, pipeline_cfg
+from .types import OptionDict, EvidenceDict
+from .utils import _safe_float
+
+log = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Stage 1: Context Preparation
+# =============================================================================
+
+def prepare_context(
+    context: Dict[str, Any],
+    query: str,
+) -> Dict[str, Any]:
+    """
+    コンテキストを準備・正規化する
+
+    Args:
+        context: 入力コンテキスト
+        query: クエリ文字列
+
+    Returns:
+        正規化されたコンテキスト
+    """
+    ctx = dict(context or {})
+    ctx.setdefault("user_id", "cli")
+    ctx.setdefault("request_id", uuid.uuid4().hex)
+    ctx.setdefault("query", query)
+    ctx.setdefault("stakes", 0.5)
+    ctx.setdefault("mode", "")
+
+    # Telos weights
+    tw = ctx.get("telos_weights") or {}
+    w_trans = _safe_float(tw.get("W_Transcendence", 0.6), 0.6)
+    w_strug = _safe_float(tw.get("W_Struggle", 0.4), 0.4)
+    ctx["_computed_telos_score"] = round(0.5 * w_trans + 0.5 * w_strug, 3)
+
+    return ctx
+
+
+# =============================================================================
+# Stage 2: Memory & Evidence Collection
+# =============================================================================
+
+def collect_memory_evidence(
+    user_id: str,
+    query: str,
+    context: Dict[str, Any],
+    fast_mode: bool = False,
+) -> Dict[str, Any]:
+    """
+    MemoryOS からエビデンスを収集する
+
+    Args:
+        user_id: ユーザーID
+        query: 検索クエリ
+        context: コンテキスト
+        fast_mode: 高速モードフラグ
+
+    Returns:
+        {
+            "evidence": List[Dict],
+            "memory_summary": str,
+            "evidence_count": int,
+            "source": str,
+        }
+    """
+    result: Dict[str, Any] = {
+        "evidence": [],
+        "memory_summary": "",
+        "evidence_count": 0,
+        "source": "none",
+    }
+
+    # Pipeline から提供されていればそれを使用
+    pipeline_evidence = context.get("_pipeline_evidence")
+    if pipeline_evidence and isinstance(pipeline_evidence, list):
+        result["evidence"] = pipeline_evidence
+        result["evidence_count"] = len(pipeline_evidence)
+        result["source"] = "pipeline_provided"
+        return result
+
+    if fast_mode:
+        result["source"] = "skipped_fast_mode"
+        return result
+
+    try:
+        from . import memory as mem_core
+        memory_summary = mem_core.summarize_for_planner(
+            user_id=user_id,
+            query=query,
+            limit=pipeline_cfg.memory_search_limit,
+        )
+        result["memory_summary"] = memory_summary
+        result["source"] = "MemoryOS.summarize_for_planner"
+    except Exception as e:
+        log.warning("Memory summarize failed: %s", e)
+        result["source"] = f"error: {repr(e)[:80]}"
+
+    return result
+
+
+# =============================================================================
+# Stage 3: World Model
+# =============================================================================
+
+def run_world_simulation(
+    user_id: str,
+    query: str,
+    context: Dict[str, Any],
+    fast_mode: bool = False,
+) -> Dict[str, Any]:
+    """
+    WorldModel シミュレーションを実行
+
+    Args:
+        user_id: ユーザーID
+        query: クエリ
+        context: コンテキスト
+        fast_mode: 高速モードフラグ
+
+    Returns:
+        {
+            "simulation": Dict | None,
+            "source": str,
+        }
+    """
+    result: Dict[str, Any] = {
+        "simulation": None,
+        "source": "none",
+    }
+
+    if context.get("_world_sim_done"):
+        result["simulation"] = context.get("_world_sim_result")
+        result["source"] = "pipeline_provided"
+        return result
+
+    if fast_mode:
+        result["source"] = "skipped_fast_mode"
+        return result
+
+    try:
+        from . import world as world_model
+        world_sim = world_model.simulate(
+            user_id=user_id,
+            query=query,
+            chosen=None,
+        )
+        result["simulation"] = world_sim
+        result["source"] = "world.simulate()"
+    except Exception as e:
+        log.warning("World simulation failed: %s", e)
+        result["source"] = f"error: {repr(e)[:80]}"
+
+    return result
+
+
+# =============================================================================
+# Stage 4: Environment Tools
+# =============================================================================
+
+def run_environment_tools(
+    query: str,
+    context: Dict[str, Any],
+    fast_mode: bool = False,
+) -> Dict[str, Any]:
+    """
+    環境ツール（Web検索、GitHub検索など）を実行
+
+    Args:
+        query: 検索クエリ
+        context: コンテキスト
+        fast_mode: 高速モードフラグ
+
+    Returns:
+        ツール実行結果の辞書
+    """
+    result: Dict[str, Any] = {}
+
+    # Pipeline から提供されていればそれを使用
+    pipeline_env = context.get("_pipeline_env_tools")
+    if pipeline_env and isinstance(pipeline_env, dict):
+        return pipeline_env
+
+    if fast_mode:
+        return {"skipped": {"reason": "fast_mode"}}
+
+    try:
+        from veritas_os.tools import call_tool
+        ql = query.lower()
+
+        if context.get("use_env_tools"):
+            result["web_search"] = _run_tool_safe(
+                call_tool, "web_search", query=query, max_results=3
+            )
+            result["github_search"] = _run_tool_safe(
+                call_tool, "github_search", query=query, max_results=3
+            )
+        else:
+            if "github" in ql:
+                result["github_search"] = _run_tool_safe(
+                    call_tool, "github_search", query=query, max_results=3
+                )
+            if any(k in ql for k in ["agi", "論文", "paper", "research"]):
+                result["web_search"] = _run_tool_safe(
+                    call_tool, "web_search", query=query, max_results=3
+                )
+    except Exception as e:
+        result["error"] = f"run_env_tool failed: {repr(e)[:200]}"
+
+    return result
+
+
+def _run_tool_safe(call_tool_fn, kind: str, **kwargs) -> Dict[str, Any]:
+    """ツールを安全に実行"""
+    try:
+        result = call_tool_fn(kind, **kwargs)
+        if not isinstance(result, dict):
+            result = {"raw": result}
+        result.setdefault("ok", True)
+        result.setdefault("results", [])
+        return result
+    except Exception as e:
+        return {
+            "ok": False,
+            "results": [],
+            "error": f"env_tool error: {repr(e)[:200]}",
+        }
+
+
+# =============================================================================
+# Stage 5: Alternatives Scoring
+# =============================================================================
+
+def score_alternatives(
+    intent: str,
+    query: str,
+    alternatives: List[Dict[str, Any]],
+    telos_score: float,
+    stakes: float,
+    persona_bias: Dict[str, float] | None,
+    context: Dict[str, Any] | None = None,
+) -> None:
+    """
+    alternatives に対してスコアリングを行う
+
+    設定値はすべて scoring_cfg から取得。
+
+    Args:
+        intent: 検出されたintent
+        query: クエリ文字列
+        alternatives: オプションリスト
+        telos_score: Telosスコア
+        stakes: ステークス値
+        persona_bias: ペルソナバイアス辞書
+        context: コンテキスト
+    """
+    ql = (query or "").lower()
+    bias = persona_bias or {}
+    ctx = context or {}
+
+    # value_core が利用可能かチェック
+    try:
+        from . import value_core
+        vc_compute = getattr(value_core, "compute_value_score", None)
+        OptionScore = getattr(value_core, "OptionScore", None)
+        has_value_core = callable(vc_compute) and OptionScore is not None
+    except Exception:
+        has_value_core = False
+        vc_compute = None
+        OptionScore = None
+
+    # adapt モジュール
+    try:
+        from . import adapt
+    except Exception:
+        adapt = None
+
+    def _kw_hit(title: str, kws: List[str]) -> bool:
+        t = (title or "").lower()
+        return any(k in t for k in kws)
+
+    if not alternatives:
+        return
+
+    for a in alternatives:
+        base = _safe_float(a.get("score"), 1.0)
+        title = a.get("title", "") or ""
+        desc = a.get("description", "") or ""
+
+        # ---- intent ヒューリスティック（設定値使用） ----
+        if intent == "weather" and _kw_hit(title, ["予報", "降水", "傘", "天気"]):
+            base += scoring_cfg.intent_weather_bonus
+        elif intent == "health" and _kw_hit(title, ["休息", "回復", "散歩", "サウナ", "睡眠"]):
+            base += scoring_cfg.intent_health_bonus
+        elif intent == "learn" and _kw_hit(title, ["一次情報", "要約", "行動"]):
+            base += scoring_cfg.intent_learn_bonus
+        elif intent == "plan" and _kw_hit(title, ["最小", "情報収集", "休息", "リファクタ", "テスト"]):
+            base += scoring_cfg.intent_plan_bonus
+
+        # クエリ内容と候補タイトルの組み合わせによる微調整
+        if any(k in ql for k in ["雨", "降水", "umbrella", "forecast"]) and "傘" in title:
+            base += scoring_cfg.query_match_bonus
+
+        # stakes が高い場合は「休息・情報収集寄り」をやや優遇
+        if stakes >= scoring_cfg.high_stakes_threshold and _kw_hit(title, ["休息", "回復", "情報"]):
+            base += scoring_cfg.high_stakes_bonus
+
+        # ---- persona bias ----
+        by_title = bias.get(title.lower(), 0.0)
+        by_fuzzy = 0.0
+        if adapt is not None and hasattr(adapt, "fuzzy_bias_lookup"):
+            by_fuzzy = adapt.fuzzy_bias_lookup(bias, title)
+        by_id = bias.get(f"@id:{a.get('id')}", 0.0)
+        bias_boost = max(by_title, by_fuzzy, by_id)
+        base *= (1.0 + scoring_cfg.persona_bias_multiplier * bias_boost)
+
+        # ---- Telos スコアによる全体スケール ----
+        base *= (scoring_cfg.telos_scale_base + scoring_cfg.telos_scale_factor * max(0.0, min(1.0, telos_score)))
+
+        # ---- value_core があれば ValueScore を乗算 ----
+        if has_value_core and vc_compute is not None and OptionScore is not None:
+            try:
+                persona_weight = float(bias_boost)
+            except Exception:
+                persona_weight = 0.0
+
+            try:
+                opt_score = OptionScore(
+                    id=str(a.get("id") or ""),
+                    title=title,
+                    description=desc,
+                    base_score=base,
+                    telos_score=float(telos_score),
+                    stakes=float(stakes),
+                    persona_bias=persona_weight,
+                    world_projection=a.get("world"),
+                )
+                vscore = float(vc_compute(opt_score))
+                base *= vscore
+            except Exception:
+                pass
+
+        a["score_raw"] = _safe_float(a.get("score"), 1.0)
+        a["score"] = round(base, 4)
+
+
+# =============================================================================
+# Stage 6: Debate
+# =============================================================================
+
+def run_debate_stage(
+    query: str,
+    alternatives: List[Dict[str, Any]],
+    context: Dict[str, Any],
+    fast_mode: bool = False,
+) -> Dict[str, Any]:
+    """
+    DebateOS ステージを実行
+
+    Args:
+        query: クエリ文字列
+        alternatives: オプションリスト
+        context: コンテキスト
+        fast_mode: 高速モードフラグ
+
+    Returns:
+        {
+            "chosen": Dict | None,
+            "debate_logs": List[Dict],
+            "enriched_alternatives": List[Dict],
+            "source": str,
+        }
+    """
+    result: Dict[str, Any] = {
+        "chosen": None,
+        "debate_logs": [],
+        "enriched_alternatives": alternatives,
+        "source": "none",
+    }
+
+    if fast_mode:
+        # 高速モード: 最高スコアを選択
+        if alternatives:
+            result["chosen"] = max(alternatives, key=lambda d: _safe_float(d.get("score"), 1.0))
+        else:
+            result["chosen"] = _mk_option("デフォルト選択")
+        result["debate_logs"].append({
+            "summary": "fast_mode のため DebateOS をスキップ",
+            "risk_delta": 0.0,
+            "suggested_choice_id": result["chosen"].get("id") if result["chosen"] else None,
+            "source": "fast_mode_local",
+        })
+        result["source"] = "fast_mode"
+        return result
+
+    try:
+        from . import debate as debate_core
+
+        user_id = context.get("user_id", "cli")
+        stakes = _safe_float(context.get("stakes", 0.5), 0.5)
+        tw = context.get("telos_weights") or {}
+        mode = context.get("mode", "")
+
+        debate_result = debate_core.run_debate(
+            query=query,
+            options=alternatives,
+            context={
+                "user_id": user_id,
+                "stakes": stakes,
+                "telos_weights": tw,
+                "mode": mode,
+            },
+        )
+
+        result["chosen"] = debate_result.get("chosen")
+        result["enriched_alternatives"] = debate_result.get("options") or alternatives
+        result["source"] = debate_result.get("source", "openai_llm")
+
+        result["debate_logs"].append({
+            "summary": "Multi-Agent DebateOS により候補が評価されました。",
+            "risk_delta": 0.0,
+            "suggested_choice_id": result["chosen"].get("id") if isinstance(result["chosen"], dict) else None,
+            "source": result["source"],
+        })
+
+    except Exception as e:
+        log.warning("DebateOS failed: %s", e)
+        if alternatives:
+            result["chosen"] = max(alternatives, key=lambda d: _safe_float(d.get("score"), 1.0))
+        else:
+            result["chosen"] = _mk_option("フォールバック選択")
+        result["debate_logs"].append({
+            "summary": f"DebateOS フォールバック (例外: {repr(e)[:80]})",
+            "risk_delta": 0.0,
+            "suggested_choice_id": result["chosen"].get("id") if result["chosen"] else None,
+            "source": "fallback",
+        })
+        result["source"] = "fallback"
+
+    return result
+
+
+# =============================================================================
+# Stage 7: FUJI Gate
+# =============================================================================
+
+def run_fuji_gate(
+    query: str,
+    context: Dict[str, Any],
+    evidence: List[Dict[str, Any]],
+    alternatives: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """
+    FUJI Gate 評価を実行
+
+    Args:
+        query: クエリ文字列
+        context: コンテキスト
+        evidence: エビデンスリスト
+        alternatives: オプションリスト
+
+    Returns:
+        FUJI Gate の評価結果
+    """
+    try:
+        from . import fuji as fuji_core
+
+        user_id = context.get("user_id", "cli")
+        stakes = _safe_float(context.get("stakes", 0.5), 0.5)
+        mode = context.get("mode", "")
+        telos_score = context.get("_computed_telos_score", 0.5)
+
+        fuji_result = fuji_core.evaluate(
+            query,
+            context={
+                "user_id": user_id,
+                "stakes": stakes,
+                "mode": mode,
+                "telos_score": telos_score,
+                "fuji_safe_applied": context.get("fuji_safe_applied", False),
+            },
+            evidence=evidence,
+            alternatives=alternatives,
+        )
+        return fuji_result
+
+    except Exception as e:
+        log.error("FUJI Gate failed: %s", e)
+        return {
+            "status": "allow",
+            "decision_status": "allow",
+            "rejection_reason": None,
+            "reasons": [f"fuji_error:{repr(e)[:80]}"],
+            "violations": [],
+            "risk": 0.05,
+            "checks": [],
+            "guidance": None,
+            "modifications": [],
+            "redactions": [],
+            "safe_instructions": [],
+        }
+
+
+# =============================================================================
+# Stage 8: Post-processing & Learning
+# =============================================================================
+
+def update_persona_and_goals(
+    chosen: Dict[str, Any],
+    context: Dict[str, Any],
+    fuji_result: Dict[str, Any],
+    telos_score: float,
+    fast_mode: bool = False,
+) -> Dict[str, Any]:
+    """
+    ペルソナとAGIゴールを更新
+
+    Args:
+        chosen: 選択されたオプション
+        context: コンテキスト
+        fuji_result: FUJI Gate の結果
+        telos_score: Telosスコア
+        fast_mode: 高速モードフラグ
+
+    Returns:
+        更新結果の辞書
+    """
+    result: Dict[str, Any] = {
+        "updated": False,
+        "error": None,
+    }
+
+    if fast_mode or context.get("_agi_goals_adjusted_by_pipeline"):
+        result["skipped"] = True
+        return result
+
+    try:
+        from . import adapt
+        from . import agi_goals
+        from . import world as world_model
+
+        persona2 = adapt.update_persona_bias_from_history(window=pipeline_cfg.persona_update_window)
+
+        b = dict(persona2.get("bias_weights") or {})
+        key = (chosen.get("title") or "").strip().lower() or f"@id:{chosen.get('id')}"
+        if key:
+            b[key] = b.get(key, 0.0) + pipeline_cfg.persona_bias_increment
+
+        s = sum(b.values()) or 1.0
+        b = {kk: vv / s for kk, vv in b.items()}
+        b = adapt.clean_bias_weights(b)
+
+        world_snap: Dict[str, Any] = {}
+        world_sim = context.get("_world_sim_result")
+        if isinstance(world_sim, dict):
+            world_snap = dict(world_sim)
+
+        value_ema = float(telos_score)
+        fuji_risk = float(fuji_result.get("risk", 0.05))
+
+        new_bias = agi_goals.auto_adjust_goals(
+            bias_weights=b,
+            world_snap=world_snap,
+            value_ema=value_ema,
+            fuji_risk=fuji_risk,
+        )
+
+        persona2["bias_weights"] = new_bias
+        adapt.save_persona(persona2)
+
+        result["updated"] = True
+        result["last_auto_adjust"] = {
+            "value_ema": value_ema,
+            "fuji_risk": fuji_risk,
+        }
+
+    except Exception as e:
+        log.warning("Persona/AGI goals update failed: %s", e)
+        result["error"] = repr(e)
+
+    return result
+
+
+def save_episode_to_memory(
+    query: str,
+    chosen: Dict[str, Any],
+    context: Dict[str, Any],
+    intent: str,
+    mode: str,
+    telos_score: float,
+) -> bool:
+    """
+    エピソードをMemoryOSに保存
+
+    Args:
+        query: クエリ文字列
+        chosen: 選択されたオプション
+        context: コンテキスト
+        intent: 検出されたintent
+        mode: モード
+        telos_score: Telosスコア
+
+    Returns:
+        保存成功したかどうか
+    """
+    if context.get("_episode_saved_by_pipeline"):
+        return True
+
+    try:
+        from . import memory as mem_core
+
+        user_id = context.get("user_id", "cli")
+        req_id = context.get("request_id", uuid.uuid4().hex)
+
+        episode_text = (
+            f"[query] {query}\n"
+            f"[chosen] {chosen.get('title')}\n"
+            f"[mode] {mode}\n"
+            f"[intent] {intent}\n"
+            f"[telos_score] {telos_score}"
+        )
+
+        episode_record = {
+            "text": episode_text,
+            "tags": ["episode", "decide", "veritas"],
+            "meta": {
+                "user_id": user_id,
+                "request_id": req_id,
+                "mode": mode,
+                "intent": intent,
+            },
+        }
+
+        try:
+            mem_core.MEM.put("episodic", episode_record)
+        except TypeError:
+            mem_core.MEM.put(
+                user_id,
+                f"decision:{req_id}",
+                episode_record,
+            )
+
+        return True
+
+    except Exception as e:
+        log.warning("Episode save failed: %s", e)
+        return False
+
+
+# =============================================================================
+# Utility functions
+# =============================================================================
+
+def _mk_option(title: str, description: str = "", _id: Optional[str] = None) -> Dict[str, Any]:
+    """オプション辞書を生成する"""
+    return {
+        "id": _id or uuid.uuid4().hex,
+        "title": title,
+        "description": description,
+        "score": 1.0,
+    }
+
+
+__all__ = [
+    "prepare_context",
+    "collect_memory_evidence",
+    "run_world_simulation",
+    "run_environment_tools",
+    "score_alternatives",
+    "run_debate_stage",
+    "run_fuji_gate",
+    "update_persona_and_goals",
+    "save_episode_to_memory",
+]

--- a/veritas_os/tests/test_integration_pipeline.py
+++ b/veritas_os/tests/test_integration_pipeline.py
@@ -1,0 +1,531 @@
+# veritas_os/tests/test_integration_pipeline.py
+# -*- coding: utf-8 -*-
+"""
+統合テスト: 決定パイプライン全体のエンドツーエンドテスト
+
+優先度: 高
+- kernel.decide() の全ステージが正しく連携するか
+- 設定値が正しく適用されるか
+- エラー時のフォールバックが機能するか
+"""
+import pytest
+import uuid
+from unittest.mock import patch, MagicMock
+from typing import Dict, Any, List
+
+
+# =============================================================================
+# Test: Config Module
+# =============================================================================
+
+class TestConfigModule:
+    """設定モジュールのテスト"""
+
+    def test_scoring_config_defaults(self):
+        """ScoringConfig のデフォルト値が正しく設定されているか"""
+        from veritas_os.core.config import ScoringConfig
+
+        cfg = ScoringConfig()
+
+        assert cfg.intent_weather_bonus == 0.4
+        assert cfg.intent_health_bonus == 0.4
+        assert cfg.intent_learn_bonus == 0.35
+        assert cfg.intent_plan_bonus == 0.3
+        assert cfg.query_match_bonus == 0.2
+        assert cfg.high_stakes_threshold == 0.7
+        assert cfg.high_stakes_bonus == 0.2
+        assert cfg.persona_bias_multiplier == 0.3
+        assert cfg.telos_scale_base == 0.9
+        assert cfg.telos_scale_factor == 0.2
+
+    def test_fuji_config_defaults(self):
+        """FujiConfig のデフォルト値が正しく設定されているか"""
+        from veritas_os.core.config import FujiConfig
+
+        cfg = FujiConfig()
+
+        assert cfg.default_min_evidence == 1
+        assert cfg.max_uncertainty == 0.60
+        assert cfg.low_evidence_risk_penalty == 0.10
+        assert cfg.safety_head_error_base_risk == 0.30
+        assert cfg.telos_risk_scale_factor == 0.10
+        assert cfg.pii_safe_risk_cap == 0.40
+        assert cfg.name_like_only_risk_cap == 0.20
+
+    def test_pipeline_config_defaults(self):
+        """PipelineConfig のデフォルト値が正しく設定されているか"""
+        from veritas_os.core.config import PipelineConfig
+
+        cfg = PipelineConfig()
+
+        assert cfg.memory_search_limit == 8
+        assert cfg.evidence_top_k == 5
+        assert cfg.max_plan_steps == 10
+        assert cfg.debate_timeout_seconds == 30
+        assert cfg.persona_update_window == 50
+        assert cfg.persona_bias_increment == 0.05
+
+    def test_config_env_override(self):
+        """環境変数による設定上書きが機能するか"""
+        import os
+        from veritas_os.core.config import _parse_float, _parse_int
+
+        # _parse_float
+        assert _parse_float("NON_EXISTENT_KEY", 1.5) == 1.5
+
+        # _parse_int
+        assert _parse_int("NON_EXISTENT_KEY", 10) == 10
+
+
+# =============================================================================
+# Test: Kernel Stages Module
+# =============================================================================
+
+class TestKernelStages:
+    """kernel_stages モジュールのテスト"""
+
+    def test_prepare_context_defaults(self):
+        """prepare_context がデフォルト値を正しく設定するか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context({}, "test query")
+
+        assert ctx["user_id"] == "cli"
+        assert "request_id" in ctx
+        assert ctx["query"] == "test query"
+        assert ctx["stakes"] == 0.5
+        assert ctx["mode"] == ""
+        assert "_computed_telos_score" in ctx
+
+    def test_prepare_context_preserves_values(self):
+        """prepare_context が既存の値を保持するか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context(
+            {"user_id": "test_user", "stakes": 0.8},
+            "test query"
+        )
+
+        assert ctx["user_id"] == "test_user"
+        assert ctx["stakes"] == 0.8
+
+    def test_score_alternatives_intent_weather(self):
+        """weather intent のスコアリングが正しく動作するか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+        from veritas_os.core.config import scoring_cfg
+
+        alternatives = [
+            {"id": "1", "title": "天気予報を確認", "score": 1.0},
+            {"id": "2", "title": "その他のオプション", "score": 1.0},
+        ]
+
+        score_alternatives(
+            intent="weather",
+            query="今日の天気は？",
+            alternatives=alternatives,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        # 天気関連のオプションがより高いスコアを持つはず
+        weather_opt = next(a for a in alternatives if a["id"] == "1")
+        other_opt = next(a for a in alternatives if a["id"] == "2")
+
+        assert weather_opt["score"] > other_opt["score"]
+
+    def test_score_alternatives_high_stakes(self):
+        """高 stakes 時のスコアリングが正しく動作するか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+        from veritas_os.core.config import scoring_cfg
+
+        alternatives = [
+            {"id": "1", "title": "休息を取る", "score": 1.0},
+            {"id": "2", "title": "継続する", "score": 1.0},
+        ]
+
+        score_alternatives(
+            intent="plan",
+            query="疲れている",
+            alternatives=alternatives,
+            telos_score=0.5,
+            stakes=0.8,  # high stakes
+            persona_bias=None,
+        )
+
+        # 休息オプションがボーナスを得るはず
+        rest_opt = next(a for a in alternatives if a["id"] == "1")
+        continue_opt = next(a for a in alternatives if a["id"] == "2")
+
+        assert rest_opt["score"] > continue_opt["score"]
+
+    def test_score_alternatives_persona_bias(self):
+        """persona bias が正しく適用されるか（@id: 形式を使用）"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        # @id: 形式を使用してfuzzy matchingを避ける
+        alternatives = [
+            {"id": "preferred_abc", "title": "First Choice", "score": 1.0},
+            {"id": "other_xyz", "title": "Second Choice", "score": 1.0},
+        ]
+
+        # 大きなバイアス値を使用して差が出るようにする
+        score_alternatives(
+            intent="plan",
+            query="test",
+            alternatives=alternatives,
+            telos_score=0.5,
+            stakes=0.5,
+            # @id: 形式でIDに直接マッチさせる
+            persona_bias={"@id:preferred_abc": 5.0},
+        )
+
+        preferred = next(a for a in alternatives if a["id"] == "preferred_abc")
+        other = next(a for a in alternatives if a["id"] == "other_xyz")
+
+        assert preferred["score"] > other["score"]
+
+    def test_collect_memory_evidence_fast_mode(self):
+        """fast_mode で memory 収集がスキップされるか"""
+        from veritas_os.core.kernel_stages import collect_memory_evidence
+
+        result = collect_memory_evidence(
+            user_id="test",
+            query="test query",
+            context={},
+            fast_mode=True,
+        )
+
+        assert result["source"] == "skipped_fast_mode"
+        assert result["evidence"] == []
+
+    def test_run_world_simulation_fast_mode(self):
+        """fast_mode で world simulation がスキップされるか"""
+        from veritas_os.core.kernel_stages import run_world_simulation
+
+        result = run_world_simulation(
+            user_id="test",
+            query="test query",
+            context={},
+            fast_mode=True,
+        )
+
+        assert result["source"] == "skipped_fast_mode"
+        assert result["simulation"] is None
+
+    def test_run_debate_stage_fast_mode(self):
+        """fast_mode で debate がスキップされ、最高スコアが選択されるか"""
+        from veritas_os.core.kernel_stages import run_debate_stage
+
+        alternatives = [
+            {"id": "1", "title": "Low score", "score": 0.5},
+            {"id": "2", "title": "High score", "score": 0.9},
+        ]
+
+        result = run_debate_stage(
+            query="test",
+            alternatives=alternatives,
+            context={},
+            fast_mode=True,
+        )
+
+        assert result["source"] == "fast_mode"
+        assert result["chosen"]["id"] == "2"  # highest score
+
+    def test_run_fuji_gate_returns_valid_structure(self):
+        """run_fuji_gate が有効な構造を返すか"""
+        from veritas_os.core.kernel_stages import run_fuji_gate
+
+        result = run_fuji_gate(
+            query="safe query",
+            context={"user_id": "test", "stakes": 0.5},
+            evidence=[],
+            alternatives=[],
+        )
+
+        assert "status" in result
+        assert "risk" in result
+        assert isinstance(result["risk"], (int, float))
+
+
+# =============================================================================
+# Test: End-to-End Pipeline Integration
+# =============================================================================
+
+class TestEndToEndPipeline:
+    """エンドツーエンドのパイプライン統合テスト"""
+
+    @pytest.mark.asyncio
+    async def test_kernel_decide_basic_flow(self):
+        """kernel.decide() の基本フローが動作するか"""
+        from veritas_os.core import kernel
+
+        # LLM呼び出しをモック（正しいパスでパッチ）
+        with patch("veritas_os.core.llm_client.chat") as mock_chat:
+            mock_chat.return_value = {
+                "text": "テスト応答",
+                "content": "テスト応答",
+            }
+
+            # kernel.decide() は async 関数で alternatives 引数が必要
+            result = await kernel.decide(
+                context={
+                    "user_id": "test_user",
+                    "mode": "fast",
+                },
+                query="今日の天気は？",
+                alternatives=[
+                    {"id": "1", "title": "天気予報を確認", "score": 1.0},
+                ],
+            )
+
+            assert result is not None
+            assert "chosen" in result
+            assert "fuji" in result
+
+    @pytest.mark.asyncio
+    async def test_kernel_decide_fast_mode(self):
+        """fast mode で kernel.decide() が高速に完了するか"""
+        from veritas_os.core import kernel
+
+        with patch("veritas_os.core.llm_client.chat") as mock_chat:
+            mock_chat.return_value = {"text": "response"}
+
+            result = await kernel.decide(
+                context={
+                    "user_id": "test",
+                    "mode": "fast",
+                },
+                query="simple question",
+                alternatives=[
+                    {"id": "1", "title": "Answer", "score": 1.0},
+                ],
+            )
+
+            assert result is not None
+            # fast mode ではメモリ/debate がスキップされる
+
+    @pytest.mark.asyncio
+    async def test_kernel_decide_with_evidence(self):
+        """evidence 付きで kernel.decide() が動作するか"""
+        from veritas_os.core import kernel
+
+        with patch("veritas_os.core.llm_client.chat") as mock_chat:
+            mock_chat.return_value = {"text": "response"}
+
+            result = await kernel.decide(
+                context={
+                    "user_id": "test",
+                    "_pipeline_evidence": [
+                        {"source": "test", "text": "evidence text", "score": 0.8}
+                    ],
+                },
+                query="research question",
+                alternatives=[
+                    {"id": "1", "title": "Research Result", "score": 1.0},
+                ],
+            )
+
+            assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_kernel_decide_handles_errors(self):
+        """kernel.decide() がエラーを適切にハンドリングするか"""
+        from veritas_os.core import kernel
+
+        # LLM呼び出しがエラーになるケース
+        with patch("veritas_os.core.llm_client.chat") as mock_chat:
+            mock_chat.side_effect = Exception("LLM error")
+
+            # エラーでもクラッシュせずに結果を返す（fast modeでLLM不要）
+            result = await kernel.decide(
+                context={"user_id": "test", "mode": "fast"},
+                query="test query",
+                alternatives=[
+                    {"id": "1", "title": "Default", "score": 1.0},
+                ],
+            )
+
+            assert result is not None
+
+
+# =============================================================================
+# Test: FUJI Gate Integration
+# =============================================================================
+
+class TestFujiGateIntegration:
+    """FUJI Gate の統合テスト"""
+
+    def test_fuji_evaluate_safe_query(self):
+        """安全なクエリが allow されるか"""
+        from veritas_os.core import fuji
+
+        result = fuji.evaluate(
+            "今日の天気を教えてください",
+            context={"user_id": "test", "stakes": 0.5},
+            evidence=[{"source": "test", "text": "天気情報", "score": 0.8}],
+            alternatives=[],
+        )
+
+        assert result["status"] in ("allow", "allow_with_warning")
+        assert result["risk"] < 0.5
+
+    def test_fuji_evaluate_low_evidence_warning(self):
+        """evidence 不足時に警告が出るか"""
+        from veritas_os.core import fuji
+
+        result = fuji.evaluate(
+            "重要な決定をしてください",
+            context={"user_id": "test", "stakes": 0.8},
+            evidence=[],  # no evidence
+            alternatives=[],
+        )
+
+        # low_evidence の場合、guidance に警告が含まれるはず
+        guidance = result.get("guidance", "")
+        # または reasons に low_evidence が含まれるはず
+        reasons = result.get("reasons", [])
+
+        has_low_evidence_warning = (
+            "エビデンス" in guidance or
+            any("low_evidence" in str(r) for r in reasons)
+        )
+        assert has_low_evidence_warning or result["risk"] > 0.0
+
+    def test_fuji_config_values_applied(self):
+        """FUJI Gate が設定値を正しく使用しているか"""
+        from veritas_os.core import fuji
+        from veritas_os.core.config import fuji_cfg
+
+        # DEFAULT_MIN_EVIDENCE が config から取得されていることを確認
+        assert fuji.DEFAULT_MIN_EVIDENCE == fuji_cfg.default_min_evidence
+        assert fuji.MAX_UNCERTAINTY == fuji_cfg.max_uncertainty
+
+
+# =============================================================================
+# Test: Memory Integration
+# =============================================================================
+
+class TestMemoryIntegration:
+    """Memory システムの統合テスト"""
+
+    def test_memory_search_returns_valid_structure(self):
+        """memory.search() が有効な構造を返すか"""
+        from veritas_os.core import memory
+
+        results = memory.search(
+            query="test query",
+            k=5,
+        )
+
+        assert isinstance(results, list)
+        for item in results:
+            assert isinstance(item, dict)
+
+    def test_memory_summarize_for_planner(self):
+        """memory.summarize_for_planner() が動作するか"""
+        from veritas_os.core import memory
+
+        summary = memory.summarize_for_planner(
+            user_id="test_user",
+            query="test query",
+            limit=5,
+        )
+
+        assert isinstance(summary, str)
+
+
+# =============================================================================
+# Test: Configuration Isolation
+# =============================================================================
+
+class TestConfigurationIsolation:
+    """設定が各モジュール間で正しく共有されているか"""
+
+    def test_scoring_config_shared(self):
+        """scoring_cfg が正しくインポートされるか"""
+        from veritas_os.core.config import scoring_cfg
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        # score_alternatives が scoring_cfg を使用していることを確認
+        # (内部で使用されているため、直接テストは困難だが、エラーなく動作することを確認)
+        alternatives = [{"id": "1", "title": "test", "score": 1.0}]
+        score_alternatives(
+            intent="test",
+            query="test",
+            alternatives=alternatives,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+        assert True  # エラーなく完了
+
+    def test_fuji_config_shared(self):
+        """fuji_cfg が fuji.py で正しく使用されているか"""
+        from veritas_os.core.config import fuji_cfg
+        from veritas_os.core import fuji
+
+        # fuji.py の定数が config から取得されていることを確認
+        assert fuji.DEFAULT_MIN_EVIDENCE == fuji_cfg.default_min_evidence
+
+
+# =============================================================================
+# Test: Error Resilience
+# =============================================================================
+
+class TestErrorResilience:
+    """エラー耐性のテスト"""
+
+    def test_kernel_stages_handle_missing_modules(self):
+        """モジュールが欠けていてもクラッシュしないか"""
+        from veritas_os.core.kernel_stages import (
+            collect_memory_evidence,
+            run_world_simulation,
+        )
+
+        # fast_mode でモジュール呼び出しをスキップ
+        mem_result = collect_memory_evidence("test", "query", {}, fast_mode=True)
+        assert mem_result["source"] == "skipped_fast_mode"
+
+        world_result = run_world_simulation("test", "query", {}, fast_mode=True)
+        assert world_result["source"] == "skipped_fast_mode"
+
+    def test_score_alternatives_handles_empty_list(self):
+        """空のリストでもクラッシュしないか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        # 空のリストを渡してもエラーにならない
+        score_alternatives(
+            intent="test",
+            query="test",
+            alternatives=[],
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+        assert True  # エラーなく完了
+
+    def test_score_alternatives_handles_malformed_data(self):
+        """不正なデータでもクラッシュしないか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        # 不完全なデータ
+        alternatives = [
+            {"id": "1"},  # title, score なし
+            {"title": "test"},  # id, score なし
+            {},  # 空
+        ]
+
+        score_alternatives(
+            intent="test",
+            query="test",
+            alternatives=alternatives,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+        assert True  # エラーなく完了
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/veritas_os/tests/test_kernel_stages.py
+++ b/veritas_os/tests/test_kernel_stages.py
@@ -1,0 +1,610 @@
+# veritas_os/tests/test_kernel_stages.py
+# -*- coding: utf-8 -*-
+"""
+kernel_stages モジュールのユニットテスト
+
+各ステージ関数の詳細なテスト
+"""
+import pytest
+import uuid
+from unittest.mock import patch, MagicMock
+from typing import Dict, Any, List
+
+
+# =============================================================================
+# Test: prepare_context
+# =============================================================================
+
+class TestPrepareContext:
+    """prepare_context 関数のテスト"""
+
+    def test_sets_default_user_id(self):
+        """デフォルトの user_id が設定されるか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context({}, "query")
+        assert ctx["user_id"] == "cli"
+
+    def test_preserves_existing_user_id(self):
+        """既存の user_id が保持されるか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context({"user_id": "custom_user"}, "query")
+        assert ctx["user_id"] == "custom_user"
+
+    def test_generates_request_id(self):
+        """request_id が生成されるか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context({}, "query")
+        assert "request_id" in ctx
+        assert len(ctx["request_id"]) > 0
+
+    def test_sets_query(self):
+        """query が正しく設定されるか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context({}, "my query")
+        assert ctx["query"] == "my query"
+
+    def test_sets_default_stakes(self):
+        """デフォルトの stakes が設定されるか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context({}, "query")
+        assert ctx["stakes"] == 0.5
+
+    def test_computes_telos_score(self):
+        """_computed_telos_score が計算されるか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context({}, "query")
+        assert "_computed_telos_score" in ctx
+        assert isinstance(ctx["_computed_telos_score"], float)
+
+    def test_computes_telos_score_with_custom_weights(self):
+        """カスタム weights で telos_score が計算されるか"""
+        from veritas_os.core.kernel_stages import prepare_context
+
+        ctx = prepare_context({
+            "telos_weights": {
+                "W_Transcendence": 0.8,
+                "W_Struggle": 0.2,
+            }
+        }, "query")
+
+        expected = round(0.5 * 0.8 + 0.5 * 0.2, 3)
+        assert ctx["_computed_telos_score"] == expected
+
+
+# =============================================================================
+# Test: collect_memory_evidence
+# =============================================================================
+
+class TestCollectMemoryEvidence:
+    """collect_memory_evidence 関数のテスト"""
+
+    def test_fast_mode_skips_collection(self):
+        """fast_mode で収集がスキップされるか"""
+        from veritas_os.core.kernel_stages import collect_memory_evidence
+
+        result = collect_memory_evidence(
+            user_id="test",
+            query="query",
+            context={},
+            fast_mode=True,
+        )
+
+        assert result["source"] == "skipped_fast_mode"
+        assert result["evidence"] == []
+        assert result["evidence_count"] == 0
+
+    def test_uses_pipeline_provided_evidence(self):
+        """パイプライン提供のエビデンスが使用されるか"""
+        from veritas_os.core.kernel_stages import collect_memory_evidence
+
+        provided_evidence = [
+            {"source": "test", "text": "evidence 1", "score": 0.9},
+            {"source": "test", "text": "evidence 2", "score": 0.8},
+        ]
+
+        result = collect_memory_evidence(
+            user_id="test",
+            query="query",
+            context={"_pipeline_evidence": provided_evidence},
+            fast_mode=False,
+        )
+
+        assert result["source"] == "pipeline_provided"
+        assert result["evidence"] == provided_evidence
+        assert result["evidence_count"] == 2
+
+
+# =============================================================================
+# Test: run_world_simulation
+# =============================================================================
+
+class TestRunWorldSimulation:
+    """run_world_simulation 関数のテスト"""
+
+    def test_fast_mode_skips_simulation(self):
+        """fast_mode でシミュレーションがスキップされるか"""
+        from veritas_os.core.kernel_stages import run_world_simulation
+
+        result = run_world_simulation(
+            user_id="test",
+            query="query",
+            context={},
+            fast_mode=True,
+        )
+
+        assert result["source"] == "skipped_fast_mode"
+        assert result["simulation"] is None
+
+    def test_uses_pipeline_provided_simulation(self):
+        """パイプライン提供のシミュレーション結果が使用されるか"""
+        from veritas_os.core.kernel_stages import run_world_simulation
+
+        sim_result = {"state": "test_state"}
+
+        result = run_world_simulation(
+            user_id="test",
+            query="query",
+            context={
+                "_world_sim_done": True,
+                "_world_sim_result": sim_result,
+            },
+            fast_mode=False,
+        )
+
+        assert result["source"] == "pipeline_provided"
+        assert result["simulation"] == sim_result
+
+
+# =============================================================================
+# Test: run_environment_tools
+# =============================================================================
+
+class TestRunEnvironmentTools:
+    """run_environment_tools 関数のテスト"""
+
+    def test_fast_mode_skips_tools(self):
+        """fast_mode でツールがスキップされるか"""
+        from veritas_os.core.kernel_stages import run_environment_tools
+
+        result = run_environment_tools(
+            query="query",
+            context={},
+            fast_mode=True,
+        )
+
+        assert "skipped" in result
+        assert result["skipped"]["reason"] == "fast_mode"
+
+    def test_uses_pipeline_provided_tools(self):
+        """パイプライン提供のツール結果が使用されるか"""
+        from veritas_os.core.kernel_stages import run_environment_tools
+
+        provided_tools = {"web_search": {"results": []}}
+
+        result = run_environment_tools(
+            query="query",
+            context={"_pipeline_env_tools": provided_tools},
+            fast_mode=False,
+        )
+
+        assert result == provided_tools
+
+
+# =============================================================================
+# Test: score_alternatives (詳細)
+# =============================================================================
+
+class TestScoreAlternativesDetailed:
+    """score_alternatives 関数の詳細テスト"""
+
+    def test_weather_intent_bonus(self):
+        """weather intent のボーナスが適用されるか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+        from veritas_os.core.config import scoring_cfg
+
+        alts = [
+            {"id": "1", "title": "天気予報を確認", "score": 1.0},
+            {"id": "2", "title": "別のオプション", "score": 1.0},
+        ]
+
+        score_alternatives(
+            intent="weather",
+            query="天気",
+            alternatives=alts,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        weather_score = next(a["score"] for a in alts if a["id"] == "1")
+        other_score = next(a["score"] for a in alts if a["id"] == "2")
+
+        # weather オプションがより高いスコアを持つ
+        assert weather_score > other_score
+
+    def test_health_intent_bonus(self):
+        """health intent のボーナスが適用されるか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        alts = [
+            {"id": "1", "title": "休息を取る", "score": 1.0},
+            {"id": "2", "title": "作業を続ける", "score": 1.0},
+        ]
+
+        score_alternatives(
+            intent="health",
+            query="疲れた",
+            alternatives=alts,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        rest_score = next(a["score"] for a in alts if a["id"] == "1")
+        work_score = next(a["score"] for a in alts if a["id"] == "2")
+
+        assert rest_score > work_score
+
+    def test_learn_intent_bonus(self):
+        """learn intent のボーナスが適用されるか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        alts = [
+            {"id": "1", "title": "一次情報を確認", "score": 1.0},
+            {"id": "2", "title": "推測する", "score": 1.0},
+        ]
+
+        score_alternatives(
+            intent="learn",
+            query="学習",
+            alternatives=alts,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        primary_score = next(a["score"] for a in alts if a["id"] == "1")
+        guess_score = next(a["score"] for a in alts if a["id"] == "2")
+
+        assert primary_score > guess_score
+
+    def test_plan_intent_bonus(self):
+        """plan intent のボーナスが適用されるか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        alts = [
+            {"id": "1", "title": "最小限の変更でテスト", "score": 1.0},
+            {"id": "2", "title": "完全に新規実装", "score": 1.0},
+        ]
+
+        score_alternatives(
+            intent="plan",
+            query="計画",
+            alternatives=alts,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        minimal_score = next(a["score"] for a in alts if a["id"] == "1")
+        large_score = next(a["score"] for a in alts if a["id"] == "2")
+
+        # plan intent では「最小」「テスト」などのキーワードにボーナス
+        assert minimal_score > large_score
+
+    def test_query_match_umbrella_bonus(self):
+        """雨/傘のクエリマッチボーナスが適用されるか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        alts = [
+            {"id": "1", "title": "傘を持っていく", "score": 1.0},
+            {"id": "2", "title": "そのまま出かける", "score": 1.0},
+        ]
+
+        score_alternatives(
+            intent="weather",
+            query="今日は雨が降りそう",
+            alternatives=alts,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        umbrella_score = next(a["score"] for a in alts if a["id"] == "1")
+        no_umbrella_score = next(a["score"] for a in alts if a["id"] == "2")
+
+        assert umbrella_score > no_umbrella_score
+
+    def test_high_stakes_rest_bonus(self):
+        """高 stakes 時の休息ボーナスが適用されるか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+        from veritas_os.core.config import scoring_cfg
+
+        alts = [
+            {"id": "1", "title": "休息を取る", "score": 1.0},
+            {"id": "2", "title": "急いで進める", "score": 1.0},
+        ]
+
+        # High stakes (>= 0.7)
+        score_alternatives(
+            intent="plan",
+            query="重要な判断",
+            alternatives=alts,
+            telos_score=0.5,
+            stakes=0.8,
+            persona_bias=None,
+        )
+
+        rest_score = next(a["score"] for a in alts if a["id"] == "1")
+        rush_score = next(a["score"] for a in alts if a["id"] == "2")
+
+        assert rest_score > rush_score
+
+    def test_persona_bias_boost(self):
+        """persona bias がスコアに反映されるか（@id: 形式を使用）"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        # @id: 形式を使用してfuzzy matchingを避ける
+        alts = [
+            {"id": "preferred_123", "title": "First Choice", "score": 1.0},
+            {"id": "other_456", "title": "Second Choice", "score": 1.0},
+        ]
+
+        score_alternatives(
+            intent="plan",
+            query="test",
+            alternatives=alts,
+            telos_score=0.5,
+            stakes=0.5,
+            # @id: 形式でIDに直接マッチさせる
+            persona_bias={"@id:preferred_123": 5.0},
+        )
+
+        preferred_score = next(a["score"] for a in alts if a["id"] == "preferred_123")
+        other_score = next(a["score"] for a in alts if a["id"] == "other_456")
+
+        # persona_bias_multiplier (0.3) * 5.0 = 1.5 の乗数ブースト
+        assert preferred_score > other_score
+
+    def test_telos_scale_applied(self):
+        """Telos スコアによるスケーリングが適用されるか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        alts_low = [{"id": "1", "title": "test", "score": 1.0}]
+        alts_high = [{"id": "1", "title": "test", "score": 1.0}]
+
+        score_alternatives(
+            intent="plan",
+            query="test",
+            alternatives=alts_low,
+            telos_score=0.0,  # low
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        score_alternatives(
+            intent="plan",
+            query="test",
+            alternatives=alts_high,
+            telos_score=1.0,  # high
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        # 高い telos_score はより高いスコアをもたらす
+        assert alts_high[0]["score"] > alts_low[0]["score"]
+
+    def test_score_raw_preserved(self):
+        """元のスコアが score_raw に保存されるか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        alts = [{"id": "1", "title": "test", "score": 0.75}]
+
+        score_alternatives(
+            intent="plan",
+            query="test",
+            alternatives=alts,
+            telos_score=0.5,
+            stakes=0.5,
+            persona_bias=None,
+        )
+
+        assert "score_raw" in alts[0]
+        assert alts[0]["score_raw"] == 0.75
+
+
+# =============================================================================
+# Test: run_debate_stage
+# =============================================================================
+
+class TestRunDebateStage:
+    """run_debate_stage 関数のテスト"""
+
+    def test_fast_mode_selects_highest_score(self):
+        """fast_mode で最高スコアが選択されるか"""
+        from veritas_os.core.kernel_stages import run_debate_stage
+
+        alts = [
+            {"id": "1", "title": "Low", "score": 0.3},
+            {"id": "2", "title": "High", "score": 0.9},
+            {"id": "3", "title": "Medium", "score": 0.6},
+        ]
+
+        result = run_debate_stage(
+            query="test",
+            alternatives=alts,
+            context={},
+            fast_mode=True,
+        )
+
+        assert result["chosen"]["id"] == "2"
+        assert result["source"] == "fast_mode"
+
+    def test_fast_mode_creates_default_for_empty_alts(self):
+        """fast_mode で空のリストにデフォルトが生成されるか"""
+        from veritas_os.core.kernel_stages import run_debate_stage
+
+        result = run_debate_stage(
+            query="test",
+            alternatives=[],
+            context={},
+            fast_mode=True,
+        )
+
+        assert result["chosen"] is not None
+        assert "title" in result["chosen"]
+
+    def test_debate_logs_generated(self):
+        """debate_logs が生成されるか"""
+        from veritas_os.core.kernel_stages import run_debate_stage
+
+        alts = [{"id": "1", "title": "Test", "score": 1.0}]
+
+        result = run_debate_stage(
+            query="test",
+            alternatives=alts,
+            context={},
+            fast_mode=True,
+        )
+
+        assert len(result["debate_logs"]) > 0
+        assert "summary" in result["debate_logs"][0]
+
+
+# =============================================================================
+# Test: run_fuji_gate
+# =============================================================================
+
+class TestRunFujiGate:
+    """run_fuji_gate 関数のテスト"""
+
+    def test_returns_valid_structure(self):
+        """有効な構造が返されるか"""
+        from veritas_os.core.kernel_stages import run_fuji_gate
+
+        result = run_fuji_gate(
+            query="safe query",
+            context={"user_id": "test", "stakes": 0.5},
+            evidence=[],
+            alternatives=[],
+        )
+
+        assert "status" in result
+        assert "risk" in result
+        assert "violations" in result
+
+    def test_handles_fuji_error(self):
+        """FUJI エラー時にフォールバックが動作するか"""
+        from veritas_os.core.kernel_stages import run_fuji_gate
+
+        # fuji モジュールを直接パッチ
+        with patch("veritas_os.core.fuji.evaluate") as mock_evaluate:
+            mock_evaluate.side_effect = Exception("FUJI error")
+
+            # エラーでもクラッシュせずに結果を返す
+            result = run_fuji_gate(
+                query="test",
+                context={"user_id": "test"},
+                evidence=[],
+                alternatives=[],
+            )
+
+            # エラー時は allow で低リスクを返す
+            assert result["status"] == "allow"
+            assert result["risk"] == 0.05
+
+
+# =============================================================================
+# Test: update_persona_and_goals
+# =============================================================================
+
+class TestUpdatePersonaAndGoals:
+    """update_persona_and_goals 関数のテスト"""
+
+    def test_fast_mode_skips_update(self):
+        """fast_mode で更新がスキップされるか"""
+        from veritas_os.core.kernel_stages import update_persona_and_goals
+
+        result = update_persona_and_goals(
+            chosen={"id": "1", "title": "test"},
+            context={},
+            fuji_result={"risk": 0.1},
+            telos_score=0.5,
+            fast_mode=True,
+        )
+
+        assert result.get("skipped") is True
+
+    def test_pipeline_provided_skips_update(self):
+        """パイプラインで既に処理済みの場合スキップされるか"""
+        from veritas_os.core.kernel_stages import update_persona_and_goals
+
+        result = update_persona_and_goals(
+            chosen={"id": "1", "title": "test"},
+            context={"_agi_goals_adjusted_by_pipeline": True},
+            fuji_result={"risk": 0.1},
+            telos_score=0.5,
+            fast_mode=False,
+        )
+
+        assert result.get("skipped") is True
+
+
+# =============================================================================
+# Test: save_episode_to_memory
+# =============================================================================
+
+class TestSaveEpisodeToMemory:
+    """save_episode_to_memory 関数のテスト"""
+
+    def test_pipeline_provided_returns_true(self):
+        """パイプラインで既に保存済みの場合 True を返すか"""
+        from veritas_os.core.kernel_stages import save_episode_to_memory
+
+        result = save_episode_to_memory(
+            query="test",
+            chosen={"id": "1", "title": "test"},
+            context={"_episode_saved_by_pipeline": True},
+            intent="test",
+            mode="fast",
+            telos_score=0.5,
+        )
+
+        assert result is True
+
+
+# =============================================================================
+# Test: Utility functions
+# =============================================================================
+
+class TestUtilityFunctions:
+    """ユーティリティ関数のテスト"""
+
+    def test_mk_option_generates_valid_structure(self):
+        """_mk_option が有効な構造を生成するか"""
+        from veritas_os.core.kernel_stages import _mk_option
+
+        opt = _mk_option("Test Title", "Test Description")
+
+        assert "id" in opt
+        assert opt["title"] == "Test Title"
+        assert opt["description"] == "Test Description"
+        assert opt["score"] == 1.0
+
+    def test_mk_option_with_custom_id(self):
+        """_mk_option でカスタム ID が使用できるか"""
+        from veritas_os.core.kernel_stages import _mk_option
+
+        opt = _mk_option("Test", _id="custom_id")
+
+        assert opt["id"] == "custom_id"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
1. kernel.decide() refactoring - responsibility separation
   - Created kernel_stages.py with independent stage functions
   - Delegated scoring logic to kernel_stages.score_alternatives()

2. Configuration externalization (magic number removal)
   - Added ScoringConfig, FujiConfig, PipelineConfig to config.py
   - Updated fuji.py to use fuji_cfg settings
   - All thresholds now configurable via environment variables

3. Integration tests added
   - test_kernel_stages.py: 32 unit tests for stage functions
   - test_integration_pipeline.py: 27 integration tests
   - All 59 tests passing

https://claude.ai/code/session_017nPf7YaccdnJN32H1ZUtKw