### PR TITLE
refactor: Unify _to_text() function into utils.py

### DIFF
--- a/veritas_os/core/fuji.py
+++ b/veritas_os/core/fuji.py
@@ -44,7 +44,7 @@ from .types import (
     EvidenceDict,
     ISOTimestamp,
 )
-from .utils import _safe_float
+from .utils import _safe_float, _to_text
 
 # ---------------------------------------------------------
 # 依存モジュール（存在しない場合はフォールバック）
@@ -138,17 +138,7 @@ def _safe_int(x: Any, default: int) -> int:
         return default
 
 
-def _to_text(x: Any) -> str:
-    if x is None:
-        return ""
-    if isinstance(x, str):
-        return x
-    if isinstance(x, dict):
-        for k in ("query", "title", "description", "text", "prompt"):
-            v = x.get(k)
-            if isinstance(v, str) and v:
-                return v
-    return str(x)
+# _to_text は utils.py から統合インポート済み
 
 
 def _normalize_text(s: str) -> str:

--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -27,7 +27,7 @@ from .types import (
     DebateViewpoint,
     CritiquePoint,
 )
-from .utils import _safe_float
+from .utils import _safe_float, _to_text
 
 import asyncio
 import inspect
@@ -113,16 +113,7 @@ def _tokens(s: str) -> List[str]:
     return [t for t in s.split() if t]
 
 
-def _to_text(x: Any) -> str:
-    if x is None:
-        return ""
-    if isinstance(x, str):
-        return x
-    if isinstance(x, dict):
-        for k in ("title", "text", "description", "prompt"):
-            if k in x and isinstance(x[k], str):
-                return x[k]
-    return str(x)
+# _to_text は utils.py から統合インポート済み
 
 
 def _mk_option(title: str, description: str = "", _id: Optional[str] = None) -> OptionDict:

--- a/veritas_os/core/utils.py
+++ b/veritas_os/core/utils.py
@@ -171,6 +171,44 @@ def _truncate(text: str, max_len: int = 100, suffix: str = "...") -> str:
     return text[:max_len - len(suffix)] + suffix
 
 
+def _to_text(x: Any) -> str:
+    """
+    任意の値をテキスト文字列に変換する。
+
+    辞書の場合は一般的なテキストフィールド（query, title, description等）を探索し、
+    最初に見つかった非空文字列を返す。
+
+    Args:
+        x: 変換対象の値（None, str, dict, その他）
+
+    Returns:
+        テキスト文字列。Noneの場合は空文字列。
+
+    Examples:
+        >>> _to_text(None)
+        ''
+        >>> _to_text("hello")
+        'hello'
+        >>> _to_text({"title": "Test", "description": "Desc"})
+        'Test'
+        >>> _to_text({"query": "Search term"})
+        'Search term'
+        >>> _to_text(123)
+        '123'
+    """
+    if x is None:
+        return ""
+    if isinstance(x, str):
+        return x
+    if isinstance(x, dict):
+        # 一般的なテキストフィールドを優先順位で探索
+        for k in ("query", "title", "text", "description", "prompt"):
+            v = x.get(k)
+            if isinstance(v, str) and v:
+                return v
+    return str(x)
+
+
 __all__ = [
     # 数値変換
     "_safe_float",
@@ -181,4 +219,5 @@ __all__ = [
     # 辞書・文字列
     "_get_nested",
     "_truncate",
+    "_to_text",
 ]


### PR DESCRIPTION
- Add _to_text() to utils.py with comprehensive docstring
- Import _to_text from utils.py in kernel.py and fuji.py
- Remove duplicate _to_text() definitions from kernel.py and fuji.py
- The unified version supports: query, title, text, description, prompt keys
- Includes empty string check for dict values (from fuji.py version)

This reduces code duplication and ensures consistent behavior across modules.

https://claude.ai/code/session_011V9FFoVqkPqDLQnQRmSjMN