### PR TITLE
docs: add CI quality gate details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,13 @@ pytest
 pytest --cov=veritas_os
 ```
 
-> Note: Coverage badges are planned; CI is available via GitHub Actions.
+### CI / Quality Gate
+
+* GitHub Actions runs **pytest + coverage** on a Python 3.11/3.12 matrix.
+* Coverage artifacts are stored as **XML/HTML** outputs (badges are not yet in place).
+* The CI job fails if tests fail, acting as a quality gate.
+
+> Note: Coverage badges are planned.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Add explicit CI/quality gate information to `README.md` so contributors understand the repository runs `pytest` with coverage and that CI enforces test success.

### Description
- Update `README.md` by adding a "CI / Quality Gate" section that documents GitHub Actions running `pytest + coverage` on a Python 3.11/3.12 matrix, storing coverage artifacts as XML/HTML, and failing the job when tests fail.

### Testing
- No automated tests were run because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e115c9e888326a633e4cfa6936a65)