### PR TITLE
Refactor intent option generation to table-driven templates

### DIFF
--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -160,6 +160,29 @@ INTENT_PATTERNS = {
     "plan": re.compile(r"(計画|進め|やるべき|todo|最小ステップ|スケジュール|plan)", re.I),
 }
 
+INTENT_OPTION_TEMPLATES = {
+    "weather": [
+        "天気アプリ/サイトで明日の予報を確認する",
+        "降水確率が高い時間にリマインドを設定する",
+        "傘・レインウェア・防水靴を準備する",
+    ],
+    "health": [
+        "今日は休息し回復を最優先にする",
+        "15分の軽い散歩で血流を上げる",
+        "短時間サウナ＋十分な水分補給を行う",
+    ],
+    "learn": [
+        "一次情報（公式/論文）を調べる",
+        "要点を3行に要約する",
+        "学んだことを1つだけ行動に落とす",
+    ],
+    "plan": [
+        "最小ステップで前進する",
+        "情報収集を優先する",
+        "今日は休息し回復に充てる",
+    ],
+}
+
 
 def _detect_intent(q: str) -> str:
     q = (q or "").strip().lower()
@@ -170,29 +193,8 @@ def _detect_intent(q: str) -> str:
 
 
 def _gen_options_by_intent(intent: str) -> List[OptionDict]:
-    if intent == "weather":
-        return [
-            _mk_option("天気アプリ/サイトで明日の予報を確認する"),
-            _mk_option("降水確率が高い時間にリマインドを設定する"),
-            _mk_option("傘・レインウェア・防水靴を準備する"),
-        ]
-    if intent == "health":
-        return [
-            _mk_option("今日は休息し回復を最優先にする"),
-            _mk_option("15分の軽い散歩で血流を上げる"),
-            _mk_option("短時間サウナ＋十分な水分補給を行う"),
-        ]
-    if intent == "learn":
-        return [
-            _mk_option("一次情報（公式/論文）を調べる"),
-            _mk_option("要点を3行に要約する"),
-            _mk_option("学んだことを1つだけ行動に落とす"),
-        ]
-    return [
-        _mk_option("最小ステップで前進する"),
-        _mk_option("情報収集を優先する"),
-        _mk_option("今日は休息し回復に充てる"),
-    ]
+    templates = INTENT_OPTION_TEMPLATES.get(intent, INTENT_OPTION_TEMPLATES["plan"])
+    return [_mk_option(title) for title in templates]
 
 
 # ============================================================
@@ -1122,7 +1124,6 @@ async def decide(
         "decision_status": decision_status,
         "rejection_reason": rejection_reason,
     }
-
 
 
 


### PR DESCRIPTION
### Motivation
- Reduce branching and improve maintainability by centralizing intent option titles into a table-driven structure instead of scattered `if` blocks.
- Make future addition of intent-specific options simpler and avoid function bloat in `_gen_options_by_intent`.
- Preserve existing behavior and fallback semantics so unknown intents still resolve to `plan` by default.
- Security reminder: option text may be persisted or logged, so continue existing PII/masking practices.

### Description
- Added `INTENT_OPTION_TEMPLATES` mapping that defines option title templates for `weather`, `health`, `learn`, and `plan` intents.
- Replaced the multi-branch implementation of `_gen_options_by_intent` with a template lookup and a list comprehension that calls `_mk_option` for each title.
- Kept `INTENT_PATTERNS` and `_detect_intent` unchanged and preserved the default `plan` fallback.
- Maintained PEP8 formatting for the modified code.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2848b94c8326af7fae70ad9bd11e)