### PR TITLE
Remove placeholder VERITAS_API_KEY default

### DIFF
--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -185,7 +185,7 @@ class VeritasConfig:
     api_key_str: str = field(
         default_factory=lambda: os.getenv(
             "VERITAS_API_KEY",
-            "YOUR_VERITAS_PUBLIC_API_KEY_HERE",
+            "",
         )
     )
     api_secret: str = field(


### PR DESCRIPTION
### Motivation
- Eliminate a hardcoded placeholder API key to avoid accidental insecure defaults and force explicit `VERITAS_API_KEY` configuration.

### Description
- Change `VeritasConfig.api_key_str` default factory in `veritas_os/core/config.py` to use an empty string instead of `"YOUR_VERITAS_PUBLIC_API_KEY_HERE"`.

### Testing
- No automated tests were run for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e36be01788326bceb6c18064103bd)