### PR TITLE
Add FUJI standard codes registry and standard REJECTED payload; integrate with FUJI gate

### DIFF
--- a/docs/fuji_error_codes.md
+++ b/docs/fuji_error_codes.md
@@ -1,0 +1,103 @@
+# FUJI Standard Codes (F-1xxx〜F-4xxx)
+
+## コード範囲とレイヤー
+
+FUJI Standard Codes は `F-1xxx` から `F-4xxx` までの範囲で、先頭の数字が思考レイヤーを表します。
+
+| レイヤー | コード範囲 | 意味 |
+| --- | --- | --- |
+| Data & Evidence | F-1xxx | データと証拠の整合性 |
+| Logic & Debate | F-2xxx | 推論・議論の整合性 |
+| Value & Policy | F-3xxx | 価値優先度・ポリシー適合 |
+| Safety & Security | F-4xxx | セキュリティ・安全上のリスク |
+
+## 新しいコードの追加方法
+
+1. `veritas_os/core/fuji_codes.py` の `FUJI_REGISTRY` にエントリを追加します。
+2. コードは正規表現 `^F-[1-4]\d{3}$` に一致する必要があります。
+3. `FujiError` と `FujiFeedback` を必ず定義し、`layer`/`severity`/`blocking`/`feedback.action` を明示します。
+4. 追加後は `validate_fuji_code` とテストを更新し、CIで確認します。
+
+## severity / blocking / action の意味
+
+- **severity**
+  - `LOW`: 軽微、修正推奨
+  - `MEDIUM`: 明確なリスクあり
+  - `HIGH`: 重大なリスク（必ず `blocking=True`）
+- **blocking**
+  - `True`: FUJI Gate が拒否を返すべき状況
+  - `False`: 修正/補完で継続可能
+- **feedback.action**
+  - `RE-DEBATE`: 再討議
+  - `RE-CRITIQUE`: 再批判
+  - `REQUEST_EVIDENCE`: 根拠要求
+  - `REWRITE_PLAN`: 計画の再構成
+  - `HUMAN_REVIEW`: 人間レビュー
+
+## REJECTED 応答例
+
+### F-2101 (Critique Unresolved)
+
+```json
+{
+  "status": "REJECTED",
+  "gate": "FUJI_SAFETY_GATE_v2",
+  "error": {
+    "code": "F-2101",
+    "message": "Critique Unresolved",
+    "detail": "Critiqueで指摘されたリスクがPlanに反映されていません。",
+    "layer": "Logic & Debate",
+    "severity": "HIGH",
+    "blocking": true
+  },
+  "feedback": {
+    "action": "RE-DEBATE",
+    "hint": "指摘されたリスクを反映した上で議論を再実行し、修正案を提示してください。"
+  },
+  "trust_log_id": "TL-20250101-0001"
+}
+```
+
+### F-3001 (ValueCore Mismatch)
+
+```json
+{
+  "status": "REJECTED",
+  "gate": "FUJI_SAFETY_GATE_v2",
+  "error": {
+    "code": "F-3001",
+    "message": "ValueCore Mismatch",
+    "detail": "優先価値より別価値を優先しておりポリシー違反です。",
+    "layer": "Value & Policy",
+    "severity": "HIGH",
+    "blocking": true
+  },
+  "feedback": {
+    "action": "REWRITE_PLAN",
+    "hint": "優先価値（例: 安全性）を最上位に置いた計画へ修正してください。"
+  },
+  "trust_log_id": "TL-20250101-0002"
+}
+```
+
+### F-4003 (Sensitive Info Leak Risk)
+
+```json
+{
+  "status": "REJECTED",
+  "gate": "FUJI_SAFETY_GATE_v2",
+  "error": {
+    "code": "F-4003",
+    "message": "Sensitive Info Leak Risk",
+    "detail": "個人情報/機密情報の漏洩リスクがあります。",
+    "layer": "Safety & Security",
+    "severity": "MEDIUM",
+    "blocking": true
+  },
+  "feedback": {
+    "action": "REWRITE_PLAN",
+    "hint": "個人情報を削除またはマスクし、安全な範囲に修正してください。"
+  },
+  "trust_log_id": "TL-20250101-0003"
+}
+```

--- a/veritas_os/core/fuji_codes.py
+++ b/veritas_os/core/fuji_codes.py
@@ -1,0 +1,306 @@
+# veritas_os/core/fuji_codes.py
+# -*- coding: utf-8 -*-
+"""
+FUJI Standard Codes registry and rejection response builders.
+
+This module defines the FUJI error code system (F-1xxx to F-4xxx),
+validates registry consistency, and builds the standard REJECTED JSON
+response payload required by FUJI Safety Gate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+import re
+
+FUJI_CODE_PATTERN = re.compile(r"^F-[1-4]\d{3}$")
+
+
+class FujiLayer(str, Enum):
+    """FUJI error layer mapping."""
+
+    DATA_EVIDENCE = "Data & Evidence"
+    LOGIC_DEBATE = "Logic & Debate"
+    VALUE_POLICY = "Value & Policy"
+    SAFETY_SECURITY = "Safety & Security"
+
+
+class FujiSeverity(str, Enum):
+    """FUJI severity levels."""
+
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+
+
+class FujiAction(str, Enum):
+    """FUJI feedback action codes."""
+
+    RE_DEBATE = "RE-DEBATE"
+    RE_CRITIQUE = "RE-CRITIQUE"
+    REQUEST_EVIDENCE = "REQUEST_EVIDENCE"
+    REWRITE_PLAN = "REWRITE_PLAN"
+    HUMAN_REVIEW = "HUMAN_REVIEW"
+
+
+@dataclass(frozen=True)
+class FujiError:
+    """FUJI error information."""
+
+    code: str
+    message: str
+    detail: str
+    layer: FujiLayer
+    severity: FujiSeverity
+    blocking: bool
+
+
+@dataclass(frozen=True)
+class FujiFeedback:
+    """FUJI feedback instruction."""
+
+    action: FujiAction
+    hint: str
+
+
+@dataclass(frozen=True)
+class FujiGateResponse:
+    """Standard FUJI gate response."""
+
+    status: str
+    gate: str
+    error: Optional[FujiError]
+    feedback: Optional[FujiFeedback]
+    trust_log_id: str
+
+
+@dataclass(frozen=True)
+class FujiRegistryEntry:
+    """Registry entry for FUJI codes."""
+
+    error: FujiError
+    feedback: FujiFeedback
+
+
+_LAYER_BY_PREFIX: Dict[str, FujiLayer] = {
+    "1": FujiLayer.DATA_EVIDENCE,
+    "2": FujiLayer.LOGIC_DEBATE,
+    "3": FujiLayer.VALUE_POLICY,
+    "4": FujiLayer.SAFETY_SECURITY,
+}
+
+
+FUJI_REGISTRY: Dict[str, FujiRegistryEntry] = {
+    "F-1002": FujiRegistryEntry(
+        error=FujiError(
+            code="F-1002",
+            message="Insufficient Evidence",
+            detail="根拠が結論を支えるには不十分です。",
+            layer=FujiLayer.DATA_EVIDENCE,
+            severity=FujiSeverity.MEDIUM,
+            blocking=False,
+        ),
+        feedback=FujiFeedback(
+            action=FujiAction.REQUEST_EVIDENCE,
+            hint="判断に必要な一次情報・根拠を追加し、出典と妥当性を明示してください。",
+        ),
+    ),
+    "F-1005": FujiRegistryEntry(
+        error=FujiError(
+            code="F-1005",
+            message="Inconsistent Data",
+            detail="証拠Aと証拠Bに解消不能な矛盾があります。",
+            layer=FujiLayer.DATA_EVIDENCE,
+            severity=FujiSeverity.HIGH,
+            blocking=True,
+        ),
+        feedback=FujiFeedback(
+            action=FujiAction.RE_CRITIQUE,
+            hint="矛盾する証拠の優先度と原因を再評価し、整合するデータに置き換えてください。",
+        ),
+    ),
+    "F-2101": FujiRegistryEntry(
+        error=FujiError(
+            code="F-2101",
+            message="Critique Unresolved",
+            detail="Critiqueで指摘されたリスクがPlanに反映されていません。",
+            layer=FujiLayer.LOGIC_DEBATE,
+            severity=FujiSeverity.HIGH,
+            blocking=True,
+        ),
+        feedback=FujiFeedback(
+            action=FujiAction.RE_DEBATE,
+            hint="指摘されたリスクを反映した上で議論を再実行し、修正案を提示してください。",
+        ),
+    ),
+    "F-2203": FujiRegistryEntry(
+        error=FujiError(
+            code="F-2203",
+            message="Logic Leap",
+            detail="根拠から結論までの推論に飛躍があります。",
+            layer=FujiLayer.LOGIC_DEBATE,
+            severity=FujiSeverity.MEDIUM,
+            blocking=False,
+        ),
+        feedback=FujiFeedback(
+            action=FujiAction.RE_CRITIQUE,
+            hint="推論の前提と論理の連結を明示し、欠落したステップを補完してください。",
+        ),
+    ),
+    "F-3001": FujiRegistryEntry(
+        error=FujiError(
+            code="F-3001",
+            message="ValueCore Mismatch",
+            detail="優先価値より別価値を優先しておりポリシー違反です。",
+            layer=FujiLayer.VALUE_POLICY,
+            severity=FujiSeverity.HIGH,
+            blocking=True,
+        ),
+        feedback=FujiFeedback(
+            action=FujiAction.REWRITE_PLAN,
+            hint="優先価値（例: 安全性）を最上位に置いた計画へ修正してください。",
+        ),
+    ),
+    "F-3008": FujiRegistryEntry(
+        error=FujiError(
+            code="F-3008",
+            message="Ethical Boundary",
+            detail="行動が倫理/規定の境界線を越えています。",
+            layer=FujiLayer.VALUE_POLICY,
+            severity=FujiSeverity.HIGH,
+            blocking=True,
+        ),
+        feedback=FujiFeedback(
+            action=FujiAction.HUMAN_REVIEW,
+            hint="行動案を停止し、倫理基準に照らした再評価と人間レビューを依頼してください。",
+        ),
+    ),
+    "F-4001": FujiRegistryEntry(
+        error=FujiError(
+            code="F-4001",
+            message="Prompt Injection Suspected",
+            detail="プロンプトインジェクションの疑いがあります。",
+            layer=FujiLayer.SAFETY_SECURITY,
+            severity=FujiSeverity.HIGH,
+            blocking=True,
+        ),
+        feedback=FujiFeedback(
+            action=FujiAction.HUMAN_REVIEW,
+            hint="入力を安全に再評価し、ポリシーを無視する指示を除去してください。",
+        ),
+    ),
+    "F-4003": FujiRegistryEntry(
+        error=FujiError(
+            code="F-4003",
+            message="Sensitive Info Leak Risk",
+            detail="個人情報/機密情報の漏洩リスクがあります。",
+            layer=FujiLayer.SAFETY_SECURITY,
+            severity=FujiSeverity.MEDIUM,
+            blocking=True,
+        ),
+        feedback=FujiFeedback(
+            action=FujiAction.REWRITE_PLAN,
+            hint="個人情報を削除またはマスクし、安全な範囲に修正してください。",
+        ),
+    ),
+}
+
+
+def _enforce_registry_rules(code: str, entry: FujiRegistryEntry) -> None:
+    if not FUJI_CODE_PATTERN.match(code):
+        raise ValueError(f"invalid FUJI code format: {code}")
+
+    prefix = code.split("-", 1)[1][0]
+    expected_layer = _LAYER_BY_PREFIX.get(prefix)
+    if entry.error.layer != expected_layer:
+        raise ValueError(f"layer mismatch for {code}: {entry.error.layer}")
+
+    if entry.error.severity == FujiSeverity.HIGH and not entry.error.blocking:
+        raise ValueError(f"severity HIGH requires blocking=True for {code}")
+
+    if code in {"F-4001", "F-4003"}:
+        if entry.error.severity == FujiSeverity.LOW:
+            raise ValueError(f"{code} must be >= MEDIUM severity")
+        if not entry.error.blocking:
+            raise ValueError(f"{code} must be blocking")
+
+    if code == "F-2101" and entry.feedback.action != FujiAction.RE_DEBATE:
+        raise ValueError("F-2101 feedback.action must be RE-DEBATE")
+
+
+def _validate_registry() -> None:
+    for code, entry in FUJI_REGISTRY.items():
+        _enforce_registry_rules(code, entry)
+
+
+_validate_registry()
+
+
+def validate_fuji_code(code: str) -> None:
+    """
+    Validate that a FUJI code is correctly formatted and registered.
+    """
+    if not FUJI_CODE_PATTERN.match(code):
+        raise ValueError(f"invalid FUJI code format: {code}")
+    if code not in FUJI_REGISTRY:
+        raise ValueError(f"unknown FUJI code: {code}")
+
+
+def build_fuji_rejection(
+    code: str,
+    trust_log_id: str,
+    detail_override: Optional[str] = None,
+    hint_override: Optional[str] = None,
+) -> dict:
+    """
+    Build the standard REJECTED JSON response for FUJI Safety Gate.
+    """
+    validate_fuji_code(code)
+    entry = FUJI_REGISTRY[code]
+
+    detail = detail_override if detail_override is not None else entry.error.detail
+    hint = hint_override if hint_override is not None else entry.feedback.hint
+
+    error_payload = {
+        "code": entry.error.code,
+        "message": entry.error.message,
+        "detail": detail,
+        "layer": entry.error.layer.value,
+        "severity": entry.error.severity.value,
+        "blocking": entry.error.blocking,
+    }
+    feedback_payload = {
+        "action": entry.feedback.action.value,
+        "hint": hint,
+    }
+
+    response = FujiGateResponse(
+        status="REJECTED",
+        gate="FUJI_SAFETY_GATE_v2",
+        error=entry.error,
+        feedback=entry.feedback,
+        trust_log_id=str(trust_log_id),
+    )
+
+    return {
+        "status": response.status,
+        "gate": response.gate,
+        "error": error_payload,
+        "feedback": feedback_payload,
+        "trust_log_id": response.trust_log_id,
+    }
+
+
+__all__ = [
+    "FujiLayer",
+    "FujiSeverity",
+    "FujiAction",
+    "FujiError",
+    "FujiFeedback",
+    "FujiGateResponse",
+    "FUJI_REGISTRY",
+    "validate_fuji_code",
+    "build_fuji_rejection",
+]

--- a/veritas_os/tests/test_fuji_codes.py
+++ b/veritas_os/tests/test_fuji_codes.py
@@ -1,0 +1,58 @@
+# veritas_os/tests/test_fuji_codes.py
+"""Tests for FUJI Standard Codes and rejection responses."""
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.core.fuji_codes import build_fuji_rejection, validate_fuji_code
+
+
+def test_validate_fuji_code_accepts_known():
+    """Registered FUJI codes should pass validation."""
+    validate_fuji_code("F-2101")
+
+
+@pytest.mark.parametrize("code", ["F-999", "F-5000", "X-1002", "F-1999"])
+def test_validate_fuji_code_rejects_invalid(code):
+    """Invalid or unknown FUJI codes should raise."""
+    with pytest.raises(ValueError):
+        validate_fuji_code(code)
+
+
+def test_build_fuji_rejection_structure():
+    """Rejected payload should match the standard JSON structure."""
+    payload = build_fuji_rejection("F-2101", trust_log_id="TL-20250101-0001")
+    assert payload["status"] == "REJECTED"
+    assert payload["gate"] == "FUJI_SAFETY_GATE_v2"
+    assert payload["error"]["code"] == "F-2101"
+    assert payload["error"]["layer"] == "Logic & Debate"
+    assert payload["feedback"]["action"] == "RE-DEBATE"
+    assert payload["trust_log_id"] == "TL-20250101-0001"
+
+
+@pytest.mark.parametrize(
+    ("code", "layer"),
+    [
+        ("F-1002", "Data & Evidence"),
+        ("F-2101", "Logic & Debate"),
+        ("F-3001", "Value & Policy"),
+        ("F-4003", "Safety & Security"),
+    ],
+)
+def test_build_fuji_rejection_layers(code, layer):
+    """Each layer should return the correct layer label."""
+    payload = build_fuji_rejection(code, trust_log_id="TL-20250101-0002")
+    assert payload["error"]["layer"] == layer
+
+
+def test_f_2101_action_is_redebate():
+    """F-2101 must always use RE-DEBATE action."""
+    payload = build_fuji_rejection("F-2101", trust_log_id="TL-20250101-0003")
+    assert payload["feedback"]["action"] == "RE-DEBATE"
+
+
+def test_f_4003_is_blocking_medium_or_higher():
+    """F-4003 should be blocking and at least MEDIUM severity."""
+    payload = build_fuji_rejection("F-4003", trust_log_id="TL-20250101-0004")
+    assert payload["error"]["blocking"] is True
+    assert payload["error"]["severity"] in {"MEDIUM", "HIGH"}


### PR DESCRIPTION
### Motivation
- Provide a machine-readable, audit-friendly FUJI error code system (F-1xxx〜F-4xxx) and a deterministic REJECTED JSON response for the FUJI Safety Gate. 
- Classify errors by thinking layer (Data/Evidence, Logic/Debate, Value/Policy, Safety/Security) and enforce consistency rules (format, severity/blocking, F-2101 action). 
- Integrate standardized rejection output into the existing FUJI flow while preserving existing TrustLog/rejection fields and not breaking current ACCEPTED behavior.

### Description
- Implemented a strongly-typed FUJI registry and builders in `veritas_os/core/fuji_codes.py` using `dataclasses`, `Enum`, and a regex validator; registry includes required codes (`F-1002`, `F-1005`, `F-2101`, `F-2203`, `F-3001`, `F-3008`, `F-4001`, `F-4003`) and enforces consistency rules. 
- Added `build_fuji_rejection(...)` and `validate_fuji_code(...)` that produce the exact standard REJECTED JSON structure and allow optional `detail`/`hint` overrides. 
- Integrated into `veritas_os/core/fuji.py` by adding `_select_fuji_code(...)` and `_resolve_trust_log_id(...)` and emitting a new `rejection` field with the standard JSON when `decision_status == "deny"`, while keeping legacy fields such as `rejection_reason` and TrustLog append behavior unchanged. 
- Added deterministic unit tests `veritas_os/tests/test_fuji_codes.py` and developer documentation `docs/fuji_error_codes.md` with examples (F-2101, F-3001, F-4003) and guidelines for adding new codes.

### Testing
- Added automated unit tests in `veritas_os/tests/test_fuji_codes.py` that cover: valid/invalid code validation, full REJECTED payload structure, per-layer mapping (F-1xxx/F-2xxx/F-3xxx/F-4xxx), and enforcement that `F-2101` uses `RE-DEBATE`. 
- I attempted to run the new tests locally with `pytest -q veritas_os/tests/test_fuji_codes.py`, but the environment aborted the run because the configured Python via `pyenv` is not installed and `pytest` was not available, so no tests were executed locally. 
- CI should execute the new tests deterministically; they do not depend on time or randomness (the `trust_log_id` is injected by callers), but note that if `trust_log_id` is missing the code falls back to `"TL-UNKNOWN"`, which reduces audit traceability and should be avoided in production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e448e76108326bca45f02f94fd34b)