### PR TITLE
Add self-healing loop with guardrails and TrustLog audit

### DIFF
--- a/docs/self_healing_loop.md
+++ b/docs/self_healing_loop.md
@@ -1,0 +1,72 @@
+# Self-Healing Loop (自己修復ループ)
+
+## 目的
+FUJI Safety Gate が `REJECTED` を返した場合に、FujiFeedback（action / hint）を再入力として使い、
+人間が介入しなくても思考を修正して再実行する仕組みを提供します。
+同時に、安全性と監査性を最優先し、無限ループや価値観の勝手な変更を防ぐためのガードレールを実装しています。
+
+## Self-Healing の安全装置（ガードレール）
+- **最大試行回数**: `VERITAS_MAX_HEALING_ATTEMPTS`（デフォルト 3）
+- **予算上限**: `VERITAS_HEALING_MAX_SECONDS`（デフォルト 20秒）と `VERITAS_HEALING_MAX_STEPS`（デフォルト 6）
+- **同一エラー連続停止**: `VERITAS_HEALING_MAX_SAME_ERROR`（デフォルト 2）
+- **差分なし停止**: 再入力が前回と実質同一（attempt を除外した構造比較）なら停止
+- **安全系 (F-4xxx) は原則自己修復しない**: F-4001 / F-4003 を含む安全系は即 HUMAN_REVIEW
+
+## HealingPolicy（F-code → action）
+| F-code | アクション | 方針 |
+|---|---|---|
+| F-1002 Insufficient Evidence | REQUEST_EVIDENCE | 不足根拠の収集・明示 |
+| F-1005 Inconsistent Data | RE-CRITIQUE | 矛盾点の整理と根拠の再評価 |
+| F-2101 Critique Unresolved | RE-DEBATE | Critique指摘を最優先で再議論 |
+| F-2203 Logic Leap | RE-DEBATE | 推論の飛躍を分解・補完 |
+| F-3001 ValueCore Mismatch | HUMAN_REVIEW | 価値観再解釈は人間レビュー |
+| F-3008 Ethical Boundary | HUMAN_REVIEW | 倫理境界越えは即停止 |
+| F-4xxx Safety/Security | HUMAN_REVIEW | 自己修復禁止（即停止） |
+
+## 停止条件と HUMAN_REVIEW 遷移
+以下のいずれかに該当すると Self-Healing を停止し、HUMAN_REVIEW に移行します。
+- 最大試行回数超過
+- 予算上限超過（時間 / ステップ）
+- 同一エラー連続発生
+- 差分なし停止（前回と実質同一の入力）
+- F-3xxx / F-4xxx 等のポリシーで HUMAN_REVIEW 指定
+
+## TrustLog への記録内容
+各 attempt ごとに以下のメタデータを TrustLog に追加します。
+- `healing_enabled`
+- `healing_attempt`
+- `prev_error_code`
+- `chosen_action`
+- `budget_remaining`
+- `diff_summary`
+- `linked_trust_log_id`
+- `stop_reason`（停止時）
+
+## Self-Healing 入力フォーマット
+Self-Healing 再入力は次のフォーマットに統一しています。
+
+```json
+{
+  "original_task": "オリジナルのタスク文",
+  "last_output": {
+    "chosen": {"id": "step_1", "title": "..." },
+    "plan": {"steps": [...]}
+  },
+  "rejection": {
+    "status": "REJECTED",
+    "gate": "FUJI_SAFETY_GATE_v2",
+    "error": { "code": "F-2101", "message": "...", "detail": "...", "layer": "...", "severity": "HIGH", "blocking": true },
+    "feedback": { "action": "RE-DEBATE", "hint": "..." },
+    "trust_log_id": "TL-20250101-0001"
+  },
+  "attempt": 1,
+  "policy_decision": "policy_map:F-2101->RE-DEBATE"
+}
+```
+
+## 例: F-2101 での再実行
+1. FUJI Gate が `REJECTED`（F-2101）を返す  
+2. HealingPolicy が `RE-DEBATE` を選択  
+3. 上記テンプレートに `attempt=1` を含めた再入力を作成  
+4. 再実行し、ガードレールに抵触しない限り最大3回まで再試行
+

--- a/veritas_os/core/self_healing.py
+++ b/veritas_os/core/self_healing.py
@@ -1,0 +1,287 @@
+# veritas_os/core/self_healing.py
+# -*- coding: utf-8 -*-
+"""
+Self-Healing loop utilities for VERITAS OS.
+
+This module defines the policy, guardrails, and helper utilities for
+re-running a rejected task using FUJI feedback in a safe, auditable way.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import os
+import time
+from typing import Any, Dict, Optional
+
+from .fuji_codes import FujiAction
+
+MAX_HEALING_ATTEMPTS = int(os.getenv("VERITAS_MAX_HEALING_ATTEMPTS", "3"))
+MAX_HEALING_STEPS = int(os.getenv("VERITAS_HEALING_MAX_STEPS", "6"))
+MAX_HEALING_SECONDS = float(os.getenv("VERITAS_HEALING_MAX_SECONDS", "20"))
+MAX_CONSECUTIVE_SAME_ERROR = int(
+    os.getenv("VERITAS_HEALING_MAX_SAME_ERROR", "2")
+)
+
+
+@dataclass(frozen=True)
+class HealingBudget:
+    """Budget guardrails for self-healing attempts."""
+
+    max_attempts: int = MAX_HEALING_ATTEMPTS
+    max_steps: int = MAX_HEALING_STEPS
+    max_seconds: float = MAX_HEALING_SECONDS
+
+
+@dataclass
+class HealingState:
+    """Mutable state for self-healing attempts."""
+
+    attempt: int = 0
+    steps_used: int = 0
+    start_time: float = field(default_factory=time.monotonic)
+    last_error_code: Optional[str] = None
+    same_error_count: int = 0
+    last_input_signature: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class HealingDecision:
+    """Policy decision for self-healing action."""
+
+    action: FujiAction
+    allow: bool
+    reason: str
+    stop_reason: Optional[str] = None
+
+
+def is_healing_enabled(context: Dict[str, Any]) -> bool:
+    """Return whether self-healing is enabled for the current context."""
+    if context.get("self_healing_enabled") is False:
+        return False
+    env_flag = os.getenv("VERITAS_SELF_HEALING_ENABLED", "1")
+    return env_flag.strip().lower() not in ("0", "false", "no", "off")
+
+
+def is_safety_code(error_code: str) -> bool:
+    """Return True if the FUJI error code is safety/security related."""
+    return str(error_code).startswith("F-4")
+
+
+def _coerce_action(action_value: Any) -> Optional[FujiAction]:
+    try:
+        return FujiAction(str(action_value))
+    except Exception:
+        return None
+
+
+def decide_healing_action(
+    error_code: str,
+    feedback_action: Optional[str] = None,
+) -> HealingDecision:
+    """
+    Decide the healing action for a FUJI error code.
+
+    Safety errors (F-4xxx) are not self-healed by default.
+    """
+    code = str(error_code or "")
+
+    if is_safety_code(code) or code in {"F-4001", "F-4003"}:
+        return HealingDecision(
+            action=FujiAction.HUMAN_REVIEW,
+            allow=False,
+            reason="safety_or_security_code_requires_human_review",
+            stop_reason="safety_code_blocked",
+        )
+
+    if code == "F-3008":
+        return HealingDecision(
+            action=FujiAction.HUMAN_REVIEW,
+            allow=False,
+            reason="ethical_boundary_requires_human_review",
+            stop_reason="ethical_boundary",
+        )
+
+    if code == "F-3001":
+        return HealingDecision(
+            action=FujiAction.HUMAN_REVIEW,
+            allow=False,
+            reason="value_core_mismatch_requires_human_review",
+            stop_reason="value_core_mismatch",
+        )
+
+    mapping = {
+        "F-1002": FujiAction.REQUEST_EVIDENCE,
+        "F-1005": FujiAction.RE_CRITIQUE,
+        "F-2101": FujiAction.RE_DEBATE,
+        "F-2203": FujiAction.RE_DEBATE,
+    }
+    action = mapping.get(code) or _coerce_action(feedback_action)
+    if action is None:
+        action = FujiAction.HUMAN_REVIEW
+        return HealingDecision(
+            action=action,
+            allow=False,
+            reason="unknown_code_requires_human_review",
+            stop_reason="unknown_code",
+        )
+
+    if action == FujiAction.HUMAN_REVIEW:
+        return HealingDecision(
+            action=action,
+            allow=False,
+            reason="feedback_requires_human_review",
+            stop_reason="feedback_human_review",
+        )
+
+    return HealingDecision(
+        action=action,
+        allow=True,
+        reason=f"policy_map:{code}->{action.value}",
+    )
+
+
+def build_healing_input(
+    *,
+    original_task: str,
+    last_output: Dict[str, Any],
+    rejection: Dict[str, Any],
+    attempt: int,
+    policy_decision: str,
+) -> Dict[str, Any]:
+    """Build the standardized self-healing input payload."""
+    feedback = rejection.get("feedback") if isinstance(rejection, dict) else {}
+    error = rejection.get("error") if isinstance(rejection, dict) else {}
+    return {
+        "original_task": original_task,
+        "last_output": last_output,
+        "rejection": {
+            "status": rejection.get("status"),
+            "gate": rejection.get("gate"),
+            "error": error,
+            "feedback": feedback,
+            "trust_log_id": rejection.get("trust_log_id"),
+        },
+        "attempt": int(attempt),
+        "policy_decision": policy_decision,
+    }
+
+
+def healing_input_signature(healing_input: Dict[str, Any]) -> str:
+    """
+    Build a deterministic signature for diff detection.
+
+    The attempt number is ignored to detect no-op retries.
+    """
+    payload = dict(healing_input)
+    payload.pop("attempt", None)
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def diff_summary(
+    prev_input: Optional[Dict[str, Any]],
+    next_input: Dict[str, Any],
+) -> str:
+    """Summarize changes between two healing inputs."""
+    if not prev_input:
+        return "initial_healing_input"
+
+    changed_fields = []
+    for key in ("original_task", "last_output", "rejection", "policy_decision"):
+        if prev_input.get(key) != next_input.get(key):
+            changed_fields.append(key)
+
+    if not changed_fields:
+        return "no_meaningful_change"
+
+    return "changed_fields:" + ",".join(changed_fields)
+
+
+def budget_remaining(state: HealingState, budget: HealingBudget) -> Dict[str, Any]:
+    """Return remaining budget snapshot for logging."""
+    elapsed = time.monotonic() - state.start_time
+    return {
+        "attempts_remaining": max(0, budget.max_attempts - state.attempt),
+        "steps_remaining": max(0, budget.max_steps - state.steps_used),
+        "seconds_remaining": max(0.0, budget.max_seconds - elapsed),
+    }
+
+
+def check_guardrails(
+    *,
+    state: HealingState,
+    budget: HealingBudget,
+    error_code: str,
+    input_signature: str,
+) -> Optional[str]:
+    """Return a stop reason if any guardrail is violated."""
+    attempt_no = state.attempt + 1
+    elapsed = time.monotonic() - state.start_time
+
+    if attempt_no > budget.max_attempts:
+        return "max_attempts_exceeded"
+    if state.steps_used >= budget.max_steps:
+        return "budget_steps_exceeded"
+    if elapsed >= budget.max_seconds:
+        return "budget_time_exceeded"
+
+    next_same_error = state.same_error_count
+    if error_code and error_code == state.last_error_code:
+        next_same_error += 1
+    else:
+        next_same_error = 1
+    if next_same_error >= MAX_CONSECUTIVE_SAME_ERROR:
+        return "same_error_consecutive_limit"
+
+    if state.last_input_signature and input_signature == state.last_input_signature:
+        return "no_meaningful_change"
+
+    return None
+
+
+def advance_state(
+    *,
+    state: HealingState,
+    error_code: str,
+    input_signature: str,
+) -> None:
+    """Update healing state after scheduling an attempt."""
+    state.attempt += 1
+    state.steps_used += 1
+    if error_code and error_code == state.last_error_code:
+        state.same_error_count += 1
+    else:
+        state.same_error_count = 1
+    state.last_error_code = error_code
+    state.last_input_signature = input_signature
+
+
+def build_healing_trust_log_entry(
+    *,
+    request_id: str,
+    healing_enabled: bool,
+    attempt: int,
+    prev_error_code: Optional[str],
+    chosen_action: str,
+    budget_snapshot: Dict[str, Any],
+    diff_summary_text: str,
+    linked_trust_log_id: Optional[str],
+    stop_reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a TrustLog entry for healing attempts."""
+    entry: Dict[str, Any] = {
+        "request_id": request_id,
+        "kind": "self_healing",
+        "healing_enabled": healing_enabled,
+        "healing_attempt": int(attempt),
+        "prev_error_code": prev_error_code,
+        "chosen_action": chosen_action,
+        "budget_remaining": budget_snapshot,
+        "diff_summary": diff_summary_text,
+        "linked_trust_log_id": linked_trust_log_id,
+    }
+    if stop_reason:
+        entry["stop_reason"] = stop_reason
+    return entry
+

--- a/veritas_os/tests/test_self_healing_loop.py
+++ b/veritas_os/tests/test_self_healing_loop.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from veritas_os.core import self_healing
+from veritas_os.core.fuji_codes import FujiAction
+
+
+def test_f2101_selects_redebate_and_attempt_increments() -> None:
+    decision = self_healing.decide_healing_action("F-2101")
+    assert decision.allow is True
+    assert decision.action == FujiAction.RE_DEBATE
+
+    state = self_healing.HealingState()
+    signature = self_healing.healing_input_signature(
+        {
+            "original_task": "task",
+            "last_output": {},
+            "rejection": {},
+            "attempt": 1,
+            "policy_decision": decision.reason,
+        }
+    )
+    self_healing.advance_state(
+        state=state,
+        error_code="F-2101",
+        input_signature=signature,
+    )
+    assert state.attempt == 1
+
+
+def test_same_error_consecutive_stops() -> None:
+    state = self_healing.HealingState(
+        attempt=1,
+        steps_used=1,
+        last_error_code="F-1002",
+        same_error_count=1,
+        last_input_signature="sig-1",
+    )
+    budget = self_healing.HealingBudget(max_attempts=5, max_steps=5, max_seconds=60)
+    stop_reason = self_healing.check_guardrails(
+        state=state,
+        budget=budget,
+        error_code="F-1002",
+        input_signature="sig-2",
+    )
+    assert stop_reason == "same_error_consecutive_limit"
+
+
+def test_max_attempts_exceeded_stops() -> None:
+    state = self_healing.HealingState(attempt=2, steps_used=2)
+    budget = self_healing.HealingBudget(max_attempts=2, max_steps=5, max_seconds=60)
+    stop_reason = self_healing.check_guardrails(
+        state=state,
+        budget=budget,
+        error_code="F-1002",
+        input_signature="sig-1",
+    )
+    assert stop_reason == "max_attempts_exceeded"
+
+
+def test_f4003_immediate_human_review() -> None:
+    decision = self_healing.decide_healing_action("F-4003")
+    assert decision.allow is False
+    assert decision.action == FujiAction.HUMAN_REVIEW
+
+
+def test_no_meaningful_change_stop() -> None:
+    state = self_healing.HealingState(
+        attempt=1,
+        steps_used=1,
+        last_input_signature="sig-1",
+        last_error_code="F-1002",
+        same_error_count=1,
+    )
+    budget = self_healing.HealingBudget(max_attempts=5, max_steps=5, max_seconds=60)
+    stop_reason = self_healing.check_guardrails(
+        state=state,
+        budget=budget,
+        error_code="F-1005",
+        input_signature="sig-1",
+    )
+    assert stop_reason == "no_meaningful_change"
+
+
+def test_trust_log_entry_contains_healing_metadata() -> None:
+    entry = self_healing.build_healing_trust_log_entry(
+        request_id="req-123",
+        healing_enabled=True,
+        attempt=1,
+        prev_error_code="F-2101",
+        chosen_action="RE-DEBATE",
+        budget_snapshot={"attempts_remaining": 2},
+        diff_summary_text="initial_healing_input",
+        linked_trust_log_id="TL-1",
+        stop_reason=None,
+    )
+    assert entry["healing_attempt"] == 1
+    assert entry["prev_error_code"] == "F-2101"
+    assert entry["chosen_action"] == "RE-DEBATE"
+


### PR DESCRIPTION
### Motivation
- Provide an automated Self‑Healing loop that reuses FUJI feedback to repair and re-run rejected decisions while preserving safety and auditability.
- Prevent infinite retries, unsafe behavior, and silent value drift by implementing explicit guardrails (attempt limits, budget, same‑error stop, diff detection, and safety‑code blocking).
- Record every healing attempt into TrustLog for forensic/monitoring needs and make the flow testable and deterministic.

### Description
- Add `veritas_os/core/self_healing.py` implementing HealingPolicy, guardrails (`HealingBudget`/`HealingState`), decision mapping (`decide_healing_action`), standardized retry input builder (`build_healing_input`), diff signature, budget helpers, and TrustLog entry builder.
- Integrate the Self‑Healing loop into the decide pipeline (`veritas_os/core/pipeline.py`) to detect FUJI `REJECTED` responses, apply policy, evaluate guardrails, append TrustLog entries for each attempt, and re‑invoke the core decide with a standardized healing input until stopping conditions are met.
- Add deterministic unit tests in `veritas_os/tests/test_self_healing_loop.py` that cover selecting `RE-DEBATE` for `F-2101`, same‑error consecutive stopping, max attempts stopping, `F-4003` immediate human review, no‑meaningful‑change stopping, and TrustLog metadata presence.
- Add developer documentation `docs/self_healing_loop.md` explaining purpose, healing policy (F-code → action), guardrails, TrustLog fields, and example healing input format.
- Security note: Self‑Healing treats FUJI feedback as re‑input; safety/security FUJI codes (F-4xxx) are blocked from auto‑healing and a human‑review path is enforced to reduce risk of prompt injection or sensitive leakage.

### Testing
- Added deterministic unit tests in `veritas_os/tests/test_self_healing_loop.py` that exercise policy selection, state advancement, guardrail detection, and TrustLog entry building; the tests do not call external APIs and use no randomness.
- Attempted to run `pytest -q veritas_os/tests/test_self_healing_loop.py`, but execution failed in this environment due to a local Python version/pyenv mismatch and missing `pytest` (error: pyenv version `3.12.7` not installed / `pytest` not found); tests are expected to pass in CI where Python/pytest are configured.
- Tests are written to be CI‑friendly (deterministic, no external I/O) and should pass under the repository’s supported Python versions once the test environment is aligned.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4961cac88326b55de394bb26a935)