### PR TITLE
Redact TrustLog previews and align FUJI fallback with policy keywords

### DIFF
--- a/veritas_os/tests/test_fuji_policy_guardrails.py
+++ b/veritas_os/tests/test_fuji_policy_guardrails.py
@@ -1,0 +1,67 @@
+# veritas_os/tests/test_fuji_policy_guardrails.py
+from __future__ import annotations
+
+import veritas_os.core.fuji as fuji
+
+
+def test_trust_log_redacts_text_preview(monkeypatch):
+    """
+    TrustLog に書き込む text_preview から PII を赤化することを確認する。
+    """
+    captured: dict[str, dict] = {}
+
+    def fake_append_trust_event(event: dict) -> None:
+        captured["event"] = event
+
+    monkeypatch.setattr(fuji, "append_trust_event", fake_append_trust_event)
+    monkeypatch.setattr(
+        fuji,
+        "call_tool",
+        lambda *args, **kwargs: {
+            "ok": True,
+            "risk_score": 0.1,
+            "categories": [],
+            "rationale": "",
+            "model": "test",
+        },
+    )
+
+    policy = dict(fuji._DEFAULT_POLICY)
+    policy["blocked_keywords"] = {"hard_block": ["forbidden"], "sensitive": []}
+    policy["audit"] = {"redact_before_log": True}
+    policy["pii"] = {
+        "enabled": True,
+        "masked_markers": ["[redacted]"],
+        "redact_kinds": {
+            "phone": True,
+            "email": True,
+            "address_jp": True,
+            "person_name_jp": False,
+        },
+    }
+    monkeypatch.setattr(fuji, "POLICY", policy)
+
+    text = "連絡先は090-1234-5678とtest@example.com、住所は東京都港区1-2-3です。"
+    fuji.fuji_gate(text, context={}, evidence=[], alternatives=[])
+
+    event = captured["event"]
+    assert "090-1234-5678" not in event["text_preview"]
+    assert "test@example.com" not in event["text_preview"]
+    assert "東京都港区1-2-3" not in event["text_preview"]
+    assert "[redacted]" in event["text_preview"]
+
+
+def test_fallback_safety_head_uses_policy_keywords(monkeypatch):
+    """
+    fallback Safety Head が policy の blocked_keywords を参照することを確認。
+    """
+    policy = dict(fuji._DEFAULT_POLICY)
+    policy["blocked_keywords"] = {
+        "hard_block": ["forbiddenword"],
+        "sensitive": ["sensitiveword"],
+    }
+    monkeypatch.setattr(fuji, "POLICY", policy)
+
+    result = fuji._fallback_safety_head("forbiddenword")
+    assert "illicit" in result.categories
+    assert "forbiddenword" in result.rationale


### PR DESCRIPTION
### Motivation
- Ensure TrustLog previews do not expose PII by supporting policy-driven redaction before logging.  
- Make the FUJI fallback safety head consult the active policy for blocked/sensitive keywords instead of relying on hardcoded lists.  
- Security note: redaction is controlled by policy flags (`audit.redact_before_log`, `pii.enabled`), so misconfiguration can leave PII in logs and must be checked in production.

### Description
- Reworked fallback keyword handling by renaming hardcoded sets to `BANNED_KEYWORDS_FALLBACK` / `SENSITIVE_KEYWORDS_FALLBACK` and adding `_policy_blocked_keywords(policy)` to extract policy `blocked_keywords`.  
- Added `_redact_text_for_trust_log(text, policy)` to redact PII (phone/email/address/name) according to policy `audit` and `pii` settings, and integrated it into `fuji_gate` so `text_preview` is redacted before `append_trust_event` is called.  
- Updated `_fallback_safety_head` to consult the active `POLICY` via `_policy_blocked_keywords` when detecting illicit/sensitive hits.  
- Added tests in `veritas_os/tests/test_fuji_policy_guardrails.py` that assert TrustLog preview redaction and that the fallback safety head uses policy keywords; helper functions include concise docstrings.

### Testing
- New unit tests were added at `veritas_os/tests/test_fuji_policy_guardrails.py` which use `monkeypatch` to verify redaction and policy keyword usage.  
- An attempted automated run `pytest veritas_os/tests/test_fuji_policy_guardrails.py` failed in this environment due to the Python toolchain (`pyenv` / `pytest`) not being available (pyenv requested `3.12.7` and `pytest` is not installed), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eaffe296083268a769c9ac018a668)