### PR TITLE
Hide /v1/decide error details in client responses

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -182,6 +182,9 @@ def _errstr(e: Exception) -> str:
     return f"{type(e).__name__}: {e}"
 
 
+DECIDE_GENERIC_ERROR = "service_unavailable"
+
+
 def _log_decide_failure(message: str, err: Optional[Exception | str]) -> None:
     """Log internal decide pipeline errors without exposing details to clients."""
     if err is None:
@@ -892,8 +895,8 @@ async def decide(req: DecideRequest, request: Request):
             status_code=503,
             content={
                 "ok": False,
-                "error": "decision_pipeline unavailable",
-                "detail": "decision_pipeline unavailable",
+                "error": DECIDE_GENERIC_ERROR,
+                "detail": DECIDE_GENERIC_ERROR,
                 "trust_log": None,  # ★互換
             },
         )
@@ -906,8 +909,8 @@ async def decide(req: DecideRequest, request: Request):
             status_code=503,
             content={
                 "ok": False,
-                "error": "decision_pipeline execution failed",
-                "detail": "decision_pipeline execution failed",
+                "error": DECIDE_GENERIC_ERROR,
+                "detail": DECIDE_GENERIC_ERROR,
                 "trust_log": None,  # ★互換
             },
         )
@@ -1237,7 +1240,6 @@ def trust_feedback(body: dict):
         # Log the detailed error server-side, but do not expose it to the client.
         print("[Trust] feedback failed:", e)
         return {"status": "error", "detail": "internal error in trust_feedback"}
-
 
 
 

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -480,8 +480,8 @@ def test_decide_pipeline_unavailable_hides_detail(monkeypatch):
 
     assert r.status_code == 503
     data = r.json()
-    assert data["error"] == "decision_pipeline unavailable"
-    assert data["detail"] == "decision_pipeline unavailable"
+    assert data["error"] == server.DECIDE_GENERIC_ERROR
+    assert data["detail"] == server.DECIDE_GENERIC_ERROR
     assert "boom" not in data["detail"]
 
 
@@ -505,8 +505,8 @@ def test_decide_pipeline_execution_failure_hides_detail(monkeypatch):
 
     assert r.status_code == 503
     data = r.json()
-    assert data["error"] == "decision_pipeline execution failed"
-    assert data["detail"] == "decision_pipeline execution failed"
+    assert data["error"] == server.DECIDE_GENERIC_ERROR
+    assert data["detail"] == server.DECIDE_GENERIC_ERROR
     assert "boom" not in data["detail"]
 
 
@@ -988,4 +988,3 @@ def test_decide_basic_requires_api_key():
     body = {"query": "hello", "user_id": "userX"}
     r = client.post("/v1/decide/basic", json=body)
     assert r.status_code in (401, 403, 404, 422)
-


### PR DESCRIPTION
### Motivation
- Prevent internal `/v1/decide` pipeline errors from leaking implementation details to clients by returning a generic error string while preserving full details in server logs. 
- Improve security posture by reducing information exposure from error responses, with the trade-off that clients get less diagnostic detail.

### Description
- Add `DECIDE_GENERIC_ERROR` constant and use it for client-facing `error`/`detail` fields when the decision pipeline is unavailable or its execution fails. 
- Keep detailed error text logged server-side via the existing `_log_decide_failure` function so operators can still investigate. 
- Update unit tests in `veritas_os/tests/test_api_server_extra.py` to assert the response uses `server.DECIDE_GENERIC_ERROR` for both pipeline-unavailable and execution-failure cases.

### Testing
- Updated tests `test_decide_pipeline_unavailable_hides_detail` and `test_decide_pipeline_execution_failure_hides_detail` to expect the generalized error payload. 
- Attempted to run the two tests with `pytest -q veritas_os/tests/test_api_server_extra.py::test_decide_pipeline_unavailable_hides_detail veritas_os/tests/test_api_server_extra.py::test_decide_pipeline_execution_failure_hides_detail` but execution failed due to the environment reporting `pyenv`/`pytest` not available, so automated tests could not be executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f723882b88326b2375e165b4a7284)