### PR TITLE
Ensure tests set API credentials before creating TestClient; add startup-validation tests

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -397,6 +397,27 @@ def _get_expected_api_key() -> str:
     return (API_KEY_DEFAULT or "").strip()
 
 
+def _validate_api_credentials_on_startup() -> None:
+    """Validate required API credentials on startup.
+
+    Raises:
+        RuntimeError: When API key or secret is missing/placeholder.
+    """
+    expected_key = _get_expected_api_key()
+    if not expected_key:
+        raise RuntimeError("VERITAS_API_KEY is required at startup.")
+
+    api_secret = _get_api_secret()
+    if not api_secret:
+        raise RuntimeError("VERITAS_API_SECRET is required at startup.")
+
+
+@app.on_event("startup")
+def _startup_validate_api_credentials() -> None:
+    """FastAPI startup hook for mandatory API credential validation."""
+    _validate_api_credentials_on_startup()
+
+
 def require_api_key(x_api_key: Optional[str] = Security(api_key_scheme)):
     """
     テスト契約:
@@ -1240,7 +1261,6 @@ def trust_feedback(body: dict):
         # Log the detailed error server-side, but do not expose it to the client.
         print("[Trust] feedback failed:", e)
         return {"status": "error", "detail": "internal error in trust_feedback"}
-
 
 
 

--- a/veritas_os/tests/test_api_extra.py
+++ b/veritas_os/tests/test_api_extra.py
@@ -26,6 +26,7 @@ def client(monkeypatch):
     毎回APIキーを環境変数にセットし、TestClientを返します。
     """
     monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+    monkeypatch.setenv("VERITAS_API_SECRET", "test-api-secret")
     return TestClient(server.app)
 
 
@@ -472,4 +473,3 @@ class TestPerformance:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-


### PR DESCRIPTION
### Motivation
- Fix flaky API tests by ensuring `TestClient` is created only after required env vars are set so the FastAPI app startup validation sees the configured credentials. 
- Add unit tests to cover the startup validation behavior for missing API key and missing API secret to detect misconfiguration early. 
- Warn that the application now fails fast on missing `VERITAS_API_SECRET`, so CI/prod must securely provision this secret to avoid startup failures. 

### Description
- Add a `client` fixture that sets `VERITAS_API_KEY` and `VERITAS_API_SECRET` before returning `TestClient(server.app)` and convert tests to use this fixture (`veritas_os/tests/test_api_server_extra.py`).
- Update `veritas_os/tests/test_api_extra.py` to set `VERITAS_API_SECRET` in the shared `client` fixture.
- Add three unit tests in `veritas_os/tests/test_api_server_extra.py`: `test_validate_api_credentials_on_startup_missing_key`, `test_validate_api_credentials_on_startup_missing_secret`, and `test_validate_api_credentials_on_startup_ok` to verify startup credential validation behavior. 
- Keep docstrings for new fixtures/tests and follow PEP8 formatting in the changed files. 

### Testing
- Attempted to run `python3.11 -m pytest veritas_os/tests/test_api_server_extra.py veritas_os/tests/test_api_extra.py`, but the run failed in this environment due to `pyenv`/Python version mismatch (`pyenv: version 3.12.7` active and `python3.11` not found), so the new tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7a5559188326b4abc0cbe0360c98)