### PR TITLE
Validate API credentials at startup; set `VERITAS_API_SECRET` in tests and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
       PIP_NO_PYTHON_VERSION_WARNING: "1"
       OPENAI_API_KEY: "DUMMY_FOR_CI"
       VERITAS_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_API_SECRET: "DUMMY_FOR_CI"
 
     steps:
       - name: Checkout

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -397,6 +397,27 @@ def _get_expected_api_key() -> str:
     return (API_KEY_DEFAULT or "").strip()
 
 
+def _validate_api_credentials_on_startup() -> None:
+    """Validate required API credentials on startup.
+
+    Raises:
+        RuntimeError: When API key or secret is missing/placeholder.
+    """
+    expected_key = _get_expected_api_key()
+    if not expected_key:
+        raise RuntimeError("VERITAS_API_KEY is required at startup.")
+
+    api_secret = _get_api_secret()
+    if not api_secret:
+        raise RuntimeError("VERITAS_API_SECRET is required at startup.")
+
+
+@app.on_event("startup")
+def _startup_validate_api_credentials() -> None:
+    """FastAPI startup hook for mandatory API credential validation."""
+    _validate_api_credentials_on_startup()
+
+
 def require_api_key(x_api_key: Optional[str] = Security(api_key_scheme)):
     """
     テスト契約:
@@ -1240,7 +1261,6 @@ def trust_feedback(body: dict):
         # Log the detailed error server-side, but do not expose it to the client.
         print("[Trust] feedback failed:", e)
         return {"status": "error", "detail": "internal error in trust_feedback"}
-
 
 
 

--- a/veritas_os/tests/test_api_decide.py
+++ b/veritas_os/tests/test_api_decide.py
@@ -7,6 +7,7 @@ from veritas_os.api.server import app
 def test_decide_minimal(monkeypatch):
     # APIキーを設定
     monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+    monkeypatch.setenv("VERITAS_API_SECRET", "test-api-secret")
     client = TestClient(app)
 
     payload = {
@@ -31,4 +32,3 @@ def test_decide_minimal(monkeypatch):
     assert "fuji" in data
     assert "gate" in data
     assert "trust_log" in data
-

--- a/veritas_os/tests/test_api_extra.py
+++ b/veritas_os/tests/test_api_extra.py
@@ -26,6 +26,7 @@ def client(monkeypatch):
     毎回APIキーを環境変数にセットし、TestClientを返します。
     """
     monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+    monkeypatch.setenv("VERITAS_API_SECRET", "test-api-secret")
     return TestClient(server.app)
 
 
@@ -472,4 +473,3 @@ class TestPerformance:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-


### PR DESCRIPTION
### Motivation
- Ensure the FastAPI app fails fast on missing credentials by validating both `VERITAS_API_KEY` and `VERITAS_API_SECRET` at startup so misconfiguration surfaces early in tests/CI.
- Stabilize tests that create a `TestClient` by making tests set `VERITAS_API_SECRET` before client construction to satisfy the new startup requirement.
- Add a CI environment variable `VERITAS_API_SECRET` to avoid GitHub Actions matrix runs failing due to startup validation; note this is a dummy value and must be replaced with a secure secret in production/real CI.

### Description
- Add `_validate_api_credentials_on_startup()` with a docstring and register it as a FastAPI startup hook via `@app.on_event("startup")` in `veritas_os/api/server.py`, and it raises `RuntimeError` when key/secret are missing.
- Update CI (`.github/workflows/main.yml`) to set `VERITAS_API_SECRET: "DUMMY_FOR_CI"` in the test job environment.
- Update tests to set the API secret before creating `TestClient`: added `monkeypatch.setenv("VERITAS_API_SECRET", ...)` in `veritas_os/tests/test_api_decide.py` and `veritas_os/tests/test_api_extra.py` fixtures, and refactored `veritas_os/tests/test_api_server_extra.py` to provide a `client` fixture that sets both `VERITAS_API_KEY` and `VERITAS_API_SECRET` before instantiating `TestClient`.
- Add unit tests for the startup validator: `test_validate_api_credentials_on_startup_missing_key`, `test_validate_api_credentials_on_startup_missing_secret`, and `test_validate_api_credentials_on_startup_ok` in `veritas_os/tests/test_api_server_extra.py`.

### Testing
- No automated tests were executed locally because the environment's Python version did not match the project's test matrix; pytest was not run here (local runs fail due to Python version mismatch).
- The CI workflow will run `pytest` across the matrix (`python-version: 3.11, 3.12`) with `VERITAS_API_SECRET` provided and should surface any remaining failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7a5559188326b4abc0cbe0360c98)