### PR TITLE
docs: align README_JP pipeline order and critique format

### DIFF
--- a/README_JP.md
+++ b/README_JP.md
@@ -57,7 +57,7 @@ VERITAS は **ガバナンス（統制）** を中心に置きます。
 | `chosen` | 選択したアクション + 根拠、確信度、不確実性、効用、リスク |
 | `alternatives[]` | 他の候補アクション |
 | `evidence[]` | 参照した根拠（MemoryOS / WorldModel / 任意ツールなど） |
-| `critique[]` | 自己批判・弱点・前提の穴 |
+| `critique` | 自己批判・弱点・前提の穴（dict） |
 | `debate[]` | 擬似マルチエージェント討論（賛成/反対/第三者） |
 | `telos_score` | ValueCoreに対する整合スコア |
 | `fuji` | FUJI Gate判定（allow / modify / rejected） |
@@ -67,7 +67,7 @@ VERITAS は **ガバナンス（統制）** を中心に置きます。
 意思決定パイプライン（メンタルモデル）：
 
 ```text
-Options → Evidence → Critique → Debate → Planner → ValueCore → FUJI → TrustLog
+WorldModel → Planner → Memory/Web Evidence → Kernel → Debate → Critique → FUJI → ValueCore → Gate → TrustLog
 ````
 
 同梱サブシステム：


### PR DESCRIPTION
### Motivation
- Update `README_JP.md` so the documented decision pipeline order and the `critique` field description reflect the current implementation and contracts.

### Description
- Edited `README_JP.md` to state that `critique` is returned as a `dict` (not an array) and to update the pipeline sequence to `WorldModel → Planner → Memory/Web Evidence → Kernel → Debate → Critique → FUJI → ValueCore → Gate → TrustLog`.

### Testing
- No automated tests were run because this is a documentation-only change affecting `README_JP.md` (CI/test matrix remains unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f969eb8008326b45ee6b967d12166)