### PR TITLE
docs: README_JP — clarify kernel vs pipeline ValueCore/TrustLog behavior

### DIFF
--- a/README_JP.md
+++ b/README_JP.md
@@ -70,6 +70,12 @@ VERITAS は **ガバナンス（統制）** を中心に置きます。
 Options → Evidence → Critique → Debate → Planner → ValueCore → FUJI → TrustLog
 ````
 
+> **注意（kernel 経由 vs pipeline 経由）**  
+> `kernel.py` 経由の `/v1/decide` では `telos_score` は `telos_weights` から簡易算出され、  
+> `pipeline.py` の **ValueCore 評価**（`value_core.evaluate`）や **TrustLog への監査書き込み** は
+> **実行されません**。ValueCore/TrustLog を含む完全な評価・監査が必要な場合は
+> **pipeline 経由**の実行を前提にしてください。
+
 同梱サブシステム：
 
 * **MemoryOS** — エピソード/セマンティック記憶、検索


### PR DESCRIPTION
### Motivation
- 明確化のため、`/v1/decide` の実行経路（`kernel.py` 経由 vs `pipeline.py` 経由）で `telos_score` の算出・ValueCore 評価・TrustLog 書き込みの挙動が異なる点を README に追記しました。 

### Description
- `README_JP.md` に、`kernel.py` 経由では `telos_weights` から簡易的に `telos_score` が算出され、`pipeline.py` の `value_core.evaluate` 呼び出しや TrustLog への監査書き込みは行われない旨の注意文を追加（ドキュメントのみ、コード変更なし）。

### Testing
- ドキュメントのみの変更のため自動化テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fff4ddc24832680d3984859e0a5ee)