### PR TITLE
docs: clarify log storage paths in Japanese README

### DIFF
--- a/README_JP.md
+++ b/README_JP.md
@@ -185,6 +185,20 @@ h_t = SHA256(h_{t-1} || r_t)
 
 これにより、決定履歴は **改ざん検知可能**な監査証跡として扱えます。
 
+### ログ保存パス（`scripts/logs` vs `~/.veritas`）
+
+- **`scripts/logs`（既定）**: `veritas_os.logging.paths` 経由で保存される TrustLog/ダッシュボード用ログの既定パスです。  
+  `VERITAS_DATA_DIR` または `VERITAS_LOG_ROOT` を設定している場合は、そのパスが優先されます。
+- **`~/.veritas`（既定）**: ValueCore の補助ログ（`~/.veritas/trust_log.jsonl` など）や、
+  Kernel 直呼び時の Doctor ログ（`~/.veritas/logs/doctor.log` など）が保存されます。
+
+**使い分け/注意点**
+- `/v1/decide` を **pipeline 経由**で実行している場合は主に `scripts/logs` に出力されます。
+- **Kernel 直呼び**や ValueCore 単体のユーティリティは `~/.veritas` を参照するため、
+  監査・解析の際は **両方のパスにログが分散し得る**ことに注意してください。
+- ログ保存先を統一したい場合は `VERITAS_DATA_DIR`/`VERITAS_LOG_ROOT` の設定を優先してください。
+  いずれのパスも **機微情報が含まれる可能性**があるため、アクセス権限と保管ポリシーを必ず確認してください。
+
 ---
 
 ## テスト


### PR DESCRIPTION
### Motivation
- 明確化のため、TrustLog や Doctor/ValueCore が書き込むログの保存先が `scripts/logs` と `~/.veritas` に分かれる点を README_JP.md に追記しました。これにより監査時のログ分散や保存先設定の混乱を防ぎます。

### Description
- `README_JP.md` に `scripts/logs` と `~/.veritas` の違い、`VERITAS_DATA_DIR`/`VERITAS_LOG_ROOT` による優先順、`/v1/decide` の pipeline 実行時と Kernel/ValueCore 実行時の出力先の使い分け、及びアクセス権／保管ポリシー確認の注意喚起を追記しました（ドキュメントのみ、コード変更なし）。

### Testing
- ドキュメントのみの変更のため自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698006aa2dd08326ae9a8e75621cf5c6)