### PR TITLE
Harden CosineIndex loading against pickle-backed .npz files

### DIFF
--- a/veritas_os/memory/index_cosine.py
+++ b/veritas_os/memory/index_cosine.py
@@ -1,10 +1,18 @@
 # veritas/memory/index_cosine.py
-import numpy as np
+import os
 import threading
+
+import numpy as np
 from pathlib import Path
 from typing import List, Tuple, Iterable, Optional, Any
 
 from veritas_os.core.atomic_io import atomic_write_npz
+
+
+def _allow_legacy_pickle_npz() -> bool:
+    """Allow loading legacy npz files that require pickle (unsafe)."""
+    value = os.getenv("VERITAS_MEMORY_ALLOW_LEGACY_NPZ", "").strip().lower()
+    return value in {"1", "true", "yes", "y", "on"}
 
 
 class CosineIndex:
@@ -33,13 +41,26 @@ class CosineIndex:
     def _load(self):
         with self._lock:
             try:
-                data = np.load(self.path, allow_pickle=True)
+                data = np.load(self.path, allow_pickle=False)
                 self.vecs = data["vecs"].astype(np.float32)
-                self.ids = list(data["ids"].tolist())
+                self.ids = [str(i) for i in data["ids"].tolist()]
+                return
             except Exception:
-                # 壊れていたら諦めて空からスタート
-                self.vecs = np.zeros((0, self.dim), dtype=np.float32)
-                self.ids = []
+                pass
+
+            if _allow_legacy_pickle_npz():
+                try:
+                    data = np.load(self.path, allow_pickle=True)
+                    self.vecs = data["vecs"].astype(np.float32)
+                    self.ids = [str(i) for i in data["ids"].tolist()]
+                    self.save()
+                    return
+                except Exception:
+                    pass
+
+            # 壊れていたら諦めて空からスタート
+            self.vecs = np.zeros((0, self.dim), dtype=np.float32)
+            self.ids = []
 
     def save(self):
         if self.path is None:
@@ -49,7 +70,7 @@ class CosineIndex:
                 atomic_write_npz(
                     self.path,
                     vecs=self.vecs,
-                    ids=np.array(self.ids, dtype=object)
+                    ids=np.array(self.ids, dtype=str),
                 )
             except Exception as e:
                 print("[CosineIndex] save failed:", e)


### PR DESCRIPTION
### Motivation
- The existing `CosineIndex` used `np.load(..., allow_pickle=True)` which risks remote code execution if a malicious `.npz` is present, so loading must default to a safe format.
- Provide a clear opt-in path for loading legacy, pickle-backed `.npz` files to allow migration while minimizing exposure via an environment flag `VERITAS_MEMORY_ALLOW_LEGACY_NPZ`.
- Normalize saved IDs to plain strings to avoid future pickle payloads in saved metadata.

### Description
- Change: default to `np.load(..., allow_pickle=False)` when loading persistence in `CosineIndex._load` and return early on success to use only safe formats.
- Add: helper `_allow_legacy_pickle_npz()` which checks `VERITAS_MEMORY_ALLOW_LEGACY_NPZ` to allow explicit, opt-in legacy loading.
- Add: opt-in legacy branch that retries `np.load(..., allow_pickle=True)` only when the env flag is set, then migrates the file by calling `save()` after successful load.
- Save behavior: convert `ids` to `dtype=str` when writing (`atomic_write_npz(..., ids=np.array(self.ids, dtype=str))`) and coerce loaded ids to `str` to avoid object-dtype/pickle-backed values.
- Tests: add two unit tests in `veritas_os/tests/test_memory_index_cosine.py` to assert that legacy `.npz` files are ignored by default and that they are loaded/migrated when `VERITAS_MEMORY_ALLOW_LEGACY_NPZ=1`.

### Testing
- Added tests: `test_cosine_index_legacy_npz_requires_opt_in` and `test_cosine_index_legacy_npz_migrates_on_opt_in` which validate opt-in behavior and migration.
- Attempted to run `pytest -q veritas_os/tests/test_memory_index_cosine.py` but the run failed due to the environment lacking the pinned Python/pytest setup (`pyenv` reported missing `3.12.7` / `pytest` not found), so tests were not executed successfully (exit 127).
- No other automated test runs completed in this environment; the new tests are included and expected to pass when run in a correctly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980093437408326905a6b5f3b0befe8)