### PR TITLE
Enforce HMAC startup validation and require signed requests on protected APIs

### DIFF
--- a/veritas_os/tests/test_api_decide.py
+++ b/veritas_os/tests/test_api_decide.py
@@ -1,4 +1,9 @@
 # tests/test_api_decide.py
+import hmac
+import json
+import secrets
+import time
+
 from fastapi.testclient import TestClient
 
 from veritas_os.api.server import app
@@ -7,6 +12,7 @@ from veritas_os.api.server import app
 def test_decide_minimal(monkeypatch):
     # APIキーを設定
     monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+    monkeypatch.setenv("VERITAS_API_SECRET", "test-secret")
     client = TestClient(app)
 
     payload = {
@@ -16,10 +22,27 @@ def test_decide_minimal(monkeypatch):
         }
     }
 
+    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    ts = str(int(time.time()))
+    nonce = secrets.token_hex(8)
+    secret = b"test-secret"
+    signature_payload = f"{ts}\n{nonce}\n{body}"
+    signature = hmac.new(
+        secret,
+        signature_payload.encode("utf-8"),
+        "sha256",
+    ).hexdigest()
+
     res = client.post(
         "/v1/decide",
-        headers={"X-API-Key": "test-key"},
-        json=payload,
+        headers={
+            "X-API-Key": "test-key",
+            "X-Timestamp": ts,
+            "X-Nonce": nonce,
+            "X-Signature": signature,
+            "Content-Type": "application/json",
+        },
+        content=body,
     )
 
     assert res.status_code == 200
@@ -31,4 +54,3 @@ def test_decide_minimal(monkeypatch):
     assert "fuji" in data
     assert "gate" in data
     assert "trust_log" in data
-


### PR DESCRIPTION
### Motivation
- Harden API authentication by making an HMAC secret required at startup and by enforcing request HMAC verification on production-facing endpoints to reduce accidental misconfiguration and unsigned access. 
- Make the server obtain the API secret at call time (rather than long-lived module-only storage) to reduce long-term memory exposure of secrets. 
- Require HMAC verification in the runtime routes used for decisioning and memory operations so that these sensitive APIs must be called with a valid signature. 
- Security note: nonce replay protection is implemented in-process; this is weaker for multi-instance deployments and a shared/central nonce store is recommended to avoid replay risk.

### Description
- Added `_require_hmac_secret()` with a docstring that raises `RuntimeError` if `VERITAS_API_SECRET` is missing or set to the placeholder, and registered a startup handler `enforce_hmac_secret()` to validate the secret before accepting requests. 
- Changed `_get_api_secret()` to prefer per-call environment lookup when `API_SECRET` is not explicitly set so tests can still monkeypatch `API_SECRET` while production uses `VERITAS_API_SECRET`. 
- Marked `/v1/decide`, `/v1/fuji/validate`, `/v1/memory/put`, `/v1/memory/search`, and `/v1/memory/get` as dependent on `verify_signature` in addition to the existing `require_api_key` and rate-limit checks. 
- Added and updated unit tests to exercise the new startup checks and signed-request flows by setting `VERITAS_API_SECRET` in fixtures, generating HMAC headers via `_signed_body_and_headers`, and asserting behaviors for missing/placeholder secrets and signed endpoints; also added two explicit tests `test_require_hmac_secret_missing` and `test_require_hmac_secret_placeholder`.

### Testing
- Updated many API tests: `veritas_os/tests/test_api_server_extra.py`, `veritas_os/tests/test_api_extra.py`, and `veritas_os/tests/test_api_decide.py` to send HMAC-signed requests and to include new startup validation tests. 
- Attempted to run `pytest veritas_os/tests/test_api_decide.py veritas_os/tests/test_api_extra.py veritas_os/tests/test_api_server_extra.py`, but the run failed due to the environment not providing the requested Python version / pytest (`pyenv: version 3.12.7 not installed / pytest: command not found`). 
- No automated test failures in-repo were observed during patching, but full test execution could not be completed due to the CI/local environment mismatch noted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802feca6948326b259300677a6178f)