### PR TITLE
Harden CORS origin parsing against wildcard usage

### DIFF
--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -7,6 +7,7 @@ VERITAS OS 設定モジュール
 """
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from dataclasses import dataclass, field
@@ -17,7 +18,13 @@ def _parse_cors_origins(raw_value: str) -> list[str]:
     """Parse comma-separated CORS origins from an env var into a clean list."""
     if not raw_value:
         return []
-    return [value.strip() for value in raw_value.split(",") if value.strip()]
+    values = [value.strip() for value in raw_value.split(",") if value.strip()]
+    if "*" in values:
+        logging.getLogger(__name__).warning(
+            "VERITAS_CORS_ALLOW_ORIGINS contains '*'. "
+            "Credentials are enabled, so '*' is ignored for safety."
+        )
+    return [value for value in values if value != "*"]
 
 
 def _parse_float(env_key: str, default: float) -> float:

--- a/veritas_os/tests/test_config_cors.py
+++ b/veritas_os/tests/test_config_cors.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import logging
+
+from veritas_os.core import config
+
+
+def test_parse_cors_origins_ignores_wildcard(caplog):
+    caplog.set_level(logging.WARNING)
+
+    origins = config._parse_cors_origins("https://example.com, *")
+
+    assert origins == ["https://example.com"]
+    assert "ignored for safety" in caplog.text


### PR DESCRIPTION
### Motivation
- Prevent insecure CORS configuration where `allow_credentials=True` combined with `VERITAS_CORS_ALLOW_ORIGINS='*'` would allow credentials to be sent to any origin.
- Ensure runtime safety by filtering out the wildcard and notifying operators via logs when `*` is supplied.

### Description
- Change `veritas_os/core/config.py` to parse `VERITAS_CORS_ALLOW_ORIGINS` into a list, log a warning if `*` is present, and return a list that excludes `*` to avoid unsafe credentialed CORS behavior.
- Add a unit test `veritas_os/tests/test_config_cors.py` that asserts `*` is ignored and that a warning message is emitted.
- Kept the existing docstring on `_parse_cors_origins` and ensured changes are limited to CORS parsing logic.

### Testing
- Added `veritas_os/tests/test_config_cors.py` which exercises `_parse_cors_origins` to confirm wildcard removal and warning emission.
- Attempted to run `pytest veritas_os/tests/test_config_cors.py` but the run failed due to the local environment missing the configured Python shim and `pytest` (pyenv reported `3.12.7` not installed), so automated test execution did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69845ffaff088326a98fe23d9991e5f1)