### PR TITLE
Add security guidance and missing env vars to English and Japanese READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ pip install -r requirements.txt
 ```bash
 export OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
 export VERITAS_API_KEY="your-secret-api-key"
+export VERITAS_API_SECRET="your-long-random-secret"
 export LLM_PROVIDER="openai"
 export LLM_MODEL="gpt-4.1-mini"
+export VERITAS_MAX_REQUEST_BODY_SIZE="10485760"
 ```
 
 ### 3) Start server
@@ -143,6 +145,18 @@ Example payload:
   }
 }
 ```
+
+---
+
+## Security Notes (Important)
+
+- **Never use placeholder or short secrets**: `VERITAS_API_SECRET` should be a long,
+  random value (32+ chars recommended). Placeholder or short secrets can effectively
+  disable or weaken HMAC protection.
+- **CORS safety**: avoid wildcard origins (`*`) when `allow_credentials` is enabled.
+  Configure explicit trusted origins only.
+- **Legacy pickle migration is risky**: if you enable legacy pickle migration for
+  MemoryOS, treat it as a short-lived migration path and disable it afterward.
 
 ---
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -121,10 +121,12 @@ pip install -r requirements.txt
 ```bash
 export OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
 export VERITAS_API_KEY="your-secret-api-key"
+export VERITAS_API_SECRET="your-long-random-secret"
 export LLM_PROVIDER="openai"
 export LLM_MODEL="gpt-4.1-mini"
 export VERITAS_ENCRYPTED_LOG_ROOT="/path/to/encrypted/logs"
 export VERITAS_REQUIRE_ENCRYPTED_LOG_DIR="1"
+export VERITAS_MAX_REQUEST_BODY_SIZE="10485760"
 ```
 
 ### 3) サーバ起動
@@ -152,6 +154,18 @@ python -m uvicorn veritas_os.api.server:app --reload --port 8000
   }
 }
 ```
+
+---
+
+## セキュリティ注意（重要）
+
+- **プレースホルダや短すぎるシークレットは禁止**:
+  `VERITAS_API_SECRET` は長いランダム値（推奨32文字以上）を設定してください。
+  プレースホルダや短い値はHMAC保護を無効化・弱体化する恐れがあります。
+- **CORSの安全性**: `allow_credentials` を有効にした状態で
+  ワイルドカード（`*`）を使わず、信頼できるオリジンのみを許可してください。
+- **Legacy pickle移行は危険**:
+  MemoryOSで旧pickle移行を有効にする場合は、移行完了後に必ず無効化してください。
 
 ---
 


### PR DESCRIPTION
### Motivation

- Make critical operational and security guidance more visible by documenting the HMAC secret, request-size limit, and CORS/pickle risks in the Quickstart docs.  
- Ensure both `README.md` and `README_JP.md` present matching environment variable examples for consistent developer onboarding.

### Description

- Add `VERITAS_API_SECRET` and `VERITAS_MAX_REQUEST_BODY_SIZE` environment variable examples to the Quickstart sections in `README.md` and `README_JP.md`.  
- Insert a new "Security Notes (Important)" / "セキュリティ注意（重要）" section in both README files that warns about short/placeholder secrets, CORS with credentials, and risky legacy pickle migration for MemoryOS.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881dacbfec83268b86337c9328b36c)