### PR TITLE
Suppress dashboard password logging

### DIFF
--- a/veritas_os/api/dashboard_server.py
+++ b/veritas_os/api/dashboard_server.py
@@ -44,9 +44,8 @@ _env_password = os.getenv("DASHBOARD_PASSWORD", "")
 if not _env_password:
     _env_password = secrets.token_urlsafe(24)
     logger.warning(
-        "DASHBOARD_PASSWORD not set. Generated random password: %s  "
+        "DASHBOARD_PASSWORD not set. Generated a random password. "
         "Set DASHBOARD_PASSWORD env var for persistent access.",
-        _env_password,
     )
 DASHBOARD_PASSWORD = _env_password
 
@@ -404,4 +403,3 @@ if __name__ == "__main__":
     print("=" * 60)
 
     uvicorn.run(app, host=os.getenv("DASHBOARD_HOST", "127.0.0.1"), port=8000)
-


### PR DESCRIPTION
### Motivation
- Prevent accidental credential leakage by removing the auto-generated dashboard password from warning logs when `DASHBOARD_PASSWORD` is not set.

### Description
- Replace the `logger.warning` message in `veritas_os/api/dashboard_server.py` so it no longer interpolates or prints the generated password (keeps the advice to set `DASHBOARD_PASSWORD` for persistent access).

### Testing
- No automated tests were run for this trivial change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69896c4b9e8883269d6f9a1579b25bc8)