### PR TITLE
Planner: add TypedDicts for steps/plans and tighten normalization types

### DIFF
--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -18,8 +18,11 @@ def test_normalize_step_fills_defaults_and_preserves():
         "eta_hours": 2.5,
         "dependencies": ["a", 2],
     }
-    normalized = planner_core._normalize_step(step, default_eta_hours=10, 
-default_risk=0.5)
+    normalized = planner_core._normalize_step(
+        step,
+        default_eta_hours=10,
+        default_risk=0.5,
+    )
 
     # 既存値は尊重される
     assert normalized["eta_hours"] == 2.5
@@ -48,6 +51,19 @@ def test_normalize_steps_list_filters_invalid():
         assert "eta_hours" in s
         assert "risk" in s
         assert "dependencies" in s
+
+
+def test_normalize_step_handles_non_list_dependencies():
+    step = {"id": "s1", "dependencies": "not-a-list"}
+    normalized = planner_core._normalize_step(
+        step,
+        default_eta_hours="2",
+        default_risk="0.2",
+    )
+
+    assert normalized["eta_hours"] == 2.0
+    assert normalized["risk"] == pytest.approx(0.2)
+    assert normalized["dependencies"] == []
 
 
 # -------------------------------
@@ -366,4 +382,3 @@ def test_generate_plan_includes_expected_steps():
     assert "reflect" in ids
     # 「調べ」が含まれるクエリなので research ステップも含まれる
     assert "research" in ids
-


### PR DESCRIPTION
### Motivation
- Planner の step 定義が緩く型チェックや IDE 補完の恩恵を受けにくいため、`TypedDict` を用いて型を明示し可読性と静的検査性を向上させる目的で修正しました。 
- `dependencies` 等の入力が不正な場合の挙動をテストでカバーして回帰を防止するため、追加のユニットテストを用意しました。 
- セキュリティ注意: 今回は型注釈とテスト追加のみで実行時の振る舞いを大きく変えるものではありませんが、型は実行時検証を保証しないため外部入力の扱いには引き続き注意してください。

### Description
- `StepDict` と `PlanDict` の `TypedDict` を `veritas_os/core/planner.py` に追加し、`_normalize_step` / `_normalize_steps_list` / `_simple_qa_plan` の引数・戻り値注釈をそれぞれ `StepDict` / `List[StepDict]` / `PlanDict` に更新しました。 
- 内部実装のロジックは変更せず、`eta_hours` / `risk` / `dependencies` 補完処理は従来通り維持しています。 
- テスト `veritas_os/tests/test_planner.py` に `test_normalize_step_handles_non_list_dependencies` を追加し、既存テストの呼び出し整形を PEP8 準拠に修正しました。 
- 依存インポートに `TypedDict` を追加し、ファイル内のインポート順序を整理しました（動作影響なし）。

### Testing
- 追加された単体テスト群は `veritas_os/tests/test_planner.py` にあり、ローカルで `pytest veritas_os/tests/test_planner.py` を実行しようとしましたが、実行環境で `pyenv` が指定する Python `3.12.7` が未インストールかつ `pytest` が見つからないためテストは実行できませんでした。 
- 自動テストは現状未実行のため、CI 上で `pytest` を走らせることを推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989704e51088326bd09a2a8fa233294)