### PR TITLE
Clarify license scope, fix README repository URLs, and add pyproject.toml

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -87,12 +87,15 @@ implication, or otherwise, except as expressly set forth in:
 
 Where Apache License Version 2.0 or another open-source license is used,
 the full license text is provided in the relevant subdirectory LICENSE file
-(e.g., `docs/LICENSE`, `examples/LICENSE`).
+(e.g., `docs/LICENSE`, `veritas_os/templates/LICENSE`, `examples/LICENSE`).
 
 For the avoidance of doubt:
 
     - The existence of an Apache-2.0 LICENSE in `docs/` means that the
       documentation in `docs/` is licensed under Apache-2.0.
+    - The existence of an Apache-2.0 LICENSE in `veritas_os/templates/`
+      means that template assets in `veritas_os/templates/` are licensed
+      under Apache-2.0.
     - It does NOT mean that `veritas_os/` or other core code is licensed
       under Apache-2.0, unless explicitly and clearly stated.
 
@@ -127,4 +130,3 @@ please contact:
 If you are unsure whether a specific file or directory is open-source
 or proprietary, please assume it is proprietary and contact the author.
 ------------------------------------------------------------
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "veritas-os"
+version = "2.0.0"
+description = "Auditable Decision OS for LLM Agents"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { file = "LICENSE" }
+authors = [
+  { name = "Takeshi Fujishita", email = "veritas.fuji@gmail.com" },
+]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "License :: Other/Proprietary License",
+  "Operating System :: OS Independent",
+]
+dependencies = [
+  "fastapi==0.115.0",
+  "uvicorn==0.30.3",
+  "pydantic==2.8.2",
+  "python-dotenv==1.0.1",
+  "orjson==3.11.5",
+  "PyYAML==6.0.1",
+  "joblib==1.4.2",
+  "scikit-learn==1.5.2",
+  "sentence-transformers==3.0.1",
+  "openai==1.51.0",
+  "requests==2.32.4",
+  "anthropic==0.34.2",
+  "matplotlib==3.9.2",
+  "jinja2==3.1.6",
+  "numpy==1.26.4",
+  "pandas==2.2.3",
+  "pdfplumber==0.11.4",
+  "trio==0.26.2",
+  "psutil==6.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/veritasfuji-japan/veritas_os"
+Repository = "https://github.com/veritasfuji-japan/veritas_os"
+Issues = "https://github.com/veritasfuji-japan/veritas_os/issues"
+
+[tool.setuptools.packages.find]
+include = ["veritas_os*"]
+
+[tool.setuptools.package-data]
+veritas_os = [
+  "benchmarks/*.yaml",
+  "policies/*.yaml",
+  "prompts/*.txt",
+  "sample_data/memory/*.jsonl",
+  "templates/**/*.txt",
+]

--- a/veritas_os/README.md
+++ b/veritas_os/README.md
@@ -144,7 +144,7 @@ The OS decides **both** the multi-step plan and the immediate next action.
 ### 3.1 Root Layout
 
 ```text
-veritas_clean_test2/
+veritas_os/
 ├── chainlit_app.py
 ├── chainlit.md
 ├── data/
@@ -651,8 +651,8 @@ Endpoints:
 
 ```bash
 # 1. Clone
-git clone https://github.com/veritasfuji-japan/veritas_clean_test2.git
-cd veritas_clean_test2
+git clone https://github.com/veritasfuji-japan/veritas_os.git
+cd veritas_os
 
 # 2. Virtualenv
 python3.11 -m venv .venv
@@ -819,7 +819,7 @@ For academic use, please cite the DOI:
   title  = {VERITAS OS: Proto-AGI Decision OS},
   year   = {2025},
   doi    = {10.5281/zenodo.17688094},
-  url    = {https://github.com/veritasfuji-japan/veritas_clean_test2}
+  url    = {https://github.com/veritasfuji-japan/veritas_os}
 }
 ```
 
@@ -863,7 +863,7 @@ This project is influenced by:
 
 ### Contact
 
-* GitHub Issues: [https://github.com/veritasfuji-japan/veritas_clean_test2/issues](https://github.com/veritasfuji-japan/veritas_clean_test2/issues)
+* GitHub Issues: [https://github.com/veritasfuji-japan/veritas_os/issues](https://github.com/veritasfuji-japan/veritas_os/issues)
 * Email: `veritas.fuji@gmail.com`
 
 ---

--- a/veritas_os/README_JP.md
+++ b/veritas_os/README_JP.md
@@ -160,7 +160,7 @@ OS は、
 ### 3.1 ルート構成
 
 ```text
-veritas_clean_test2/
+veritas_os/
 ├── chainlit_app.py
 ├── chainlit.md
 ├── data/
@@ -686,8 +686,8 @@ python veritas_os/scripts/dashboard_server.py
 
 ```bash
 # 1. Clone
-git clone https://github.com/veritasfuji-japan/veritas_clean_test2.git
-cd veritas_clean_test2
+git clone https://github.com/veritasfuji-japan/veritas_os.git
+cd veritas_os
 
 # 2. Virtualenv
 python3.11 -m venv .venv
@@ -860,7 +860,7 @@ All Rights Reserved.
   title  = {VERITAS OS: Proto-AGI Decision OS},
   year   = {2025},
   doi    = {10.5281/zenodo.17688094},
-  url    = {https://github.com/veritasfuji-japan/veritas_clean_test2}
+  url    = {https://github.com/veritasfuji-japan/veritas_os}
 }
 ```
 
@@ -906,7 +906,7 @@ git push origin feature/AmazingFeature
 
 ### 連絡先
 
-* GitHub Issues: [https://github.com/veritasfuji-japan/veritas_clean_test2/issues](https://github.com/veritasfuji-japan/veritas_clean_test2/issues)
+* GitHub Issues: [https://github.com/veritasfuji-japan/veritas_os/issues](https://github.com/veritasfuji-japan/veritas_os/issues)
 * Email: `veritas.fuji@gmail.com`
 
 ---


### PR DESCRIPTION
### Motivation

- Clarify mixed-license documentation so subtree Apache-2.0 notices are explicit and avoid ambiguity about which assets are permissively licensed. 
- Replace stale `veritas_clean_test2` repository references in localized READMEs so clone instructions, bibtex URL, Issues link, and directory examples point to the correct `veritas_os` repository. 
- Add a `pyproject.toml` to provide PEP 621 metadata and a canonical packaging entry for the project. 

### Description

- Updated the top-level `LICENSE` to explicitly list `veritas_os/templates/LICENSE` as a subtree that may carry Apache-2.0, keeping the default core code as proprietary. 
- Rewrote occurrences of `veritas_clean_test2` to `veritas_os` across `veritas_os/README.md` and `veritas_os/README_JP.md` including `git clone` URL, `cd` target, BibTeX `url`, GitHub Issues link, and the root directory example. 
- Added `pyproject.toml` containing PEP 621 project metadata, pinned runtime dependencies (aligned with `veritas_os/requirements.txt`), and `setuptools` package discovery and package-data configuration. 
- Scope is limited to documentation and packaging metadata; no changes were made to Planner/Kernel/FUJI/MemoryOS runtime logic. 

### Testing

- Parsed the new `pyproject.toml` using Python `tomllib` with `tomllib.load()` and the parse succeeded. 
- Searched for stale `veritas_clean_test2` references using ripgrep (`rg`) and confirmed replacements in `veritas_os/README.md` and `veritas_os/README_JP.md`. 
- Verified the updated license-reference lines in `LICENSE` via text inspection. 
- Confirmed repository state updated and changes committed (local status checks); all automated checks executed succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca0376e888326a07f350a5e8792ad)