### PR TITLE
H1: Make llm_client environment parsing fail-safe

### DIFF
--- a/veritas_os/core/llm_client.py
+++ b/veritas_os/core/llm_client.py
@@ -57,17 +57,33 @@ class LLMError(Exception):
 # 設定値（環境変数）
 # =========================
 
+
+def _safe_int(key: str, default: int) -> int:
+    """環境変数を int として安全に取得する。"""
+    try:
+        return int(os.getenv(key, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(key: str, default: float) -> float:
+    """環境変数を float として安全に取得する。"""
+    try:
+        return float(os.getenv(key, str(default)))
+    except (TypeError, ValueError):
+        return default
+
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", LLMProvider.OPENAI.value)
 # ★ 現在のデフォルトは gpt-4.1-mini を想定（env で上書き可）
 LLM_MODEL = os.environ.get("LLM_MODEL", "gpt-4.1-mini")
 
-LLM_TIMEOUT = float(os.environ.get("LLM_TIMEOUT", "60"))
-LLM_CONNECT_TIMEOUT = float(os.environ.get("LLM_CONNECT_TIMEOUT", "10"))
-LLM_MAX_RETRIES = int(os.environ.get("LLM_MAX_RETRIES", "3"))
-LLM_RETRY_DELAY = float(os.environ.get("LLM_RETRY_DELAY", "2"))
+LLM_TIMEOUT = _safe_float("LLM_TIMEOUT", 60.0)
+LLM_CONNECT_TIMEOUT = _safe_float("LLM_CONNECT_TIMEOUT", 10.0)
+LLM_MAX_RETRIES = _safe_int("LLM_MAX_RETRIES", 3)
+LLM_RETRY_DELAY = _safe_float("LLM_RETRY_DELAY", 2.0)
 
 # Maximum response body size to parse (16 MB) — prevents memory exhaustion
-LLM_MAX_RESPONSE_BYTES = int(os.environ.get("LLM_MAX_RESPONSE_BYTES", str(16 * 1024 * 1024)))
+LLM_MAX_RESPONSE_BYTES = _safe_int("LLM_MAX_RESPONSE_BYTES", 16 * 1024 * 1024)
 
 
 # =========================
@@ -559,4 +575,3 @@ __all__ = [
     "chat_gemini",
     "chat_local",
 ]
-


### PR DESCRIPTION
### Motivation
- Prevent import-time crashes in `llm_client` when numeric environment variables contain invalid values by adopting a fail-safe parsing pattern used elsewhere (e.g. `web_search`).
- Avoid process startup/import failures caused by `int()`/`float()` raising on bad env input while preserving default behavior for valid inputs.
- Note: silently falling back to defaults reduces crash risk but can hide configuration mistakes, so operators may want logging/monitoring for malformed env values.

### Description
- Added `_safe_int` and `_safe_float` helpers to `veritas_os/core/llm_client.py` to parse environment values with safe fallbacks.
- Replaced direct `int()`/`float()` casts for `LLM_TIMEOUT`, `LLM_CONNECT_TIMEOUT`, `LLM_MAX_RETRIES`, `LLM_RETRY_DELAY`, and `LLM_MAX_RESPONSE_BYTES` with the new safe helpers.
- Added unit tests to `veritas_os/tests/test_llm_client.py` that assert ` _safe_int`/`_safe_float` return defaults for invalid inputs and that reloading the module with invalid env values yields the configured defaults.
- Maintained prior behavior for correct inputs and confined changes to `llm_client` and its tests.

### Testing
- Successfully compiled the modified files with `python3.12 -m compileall veritas_os/core/llm_client.py veritas_os/tests/test_llm_client.py`.
- Added automated tests but could not run them with `pytest` because `pytest` is not installed in this environment, so unit tests were not executed here.
- Attempted a dynamic module reload sanity check, but execution failed in this environment due to the missing runtime dependency `requests`, so runtime import/reload assertions could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca511f50483269a7eccad5c29c94a)