### PR TITLE
docs: add workflow/GHCR badges, TOC, and smoke-test; add Docker section to README_JP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-red.svg)](LICENSE)
 [![CI](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml)
+[![Docker Publish](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml)
+[![GHCR](https://img.shields.io/badge/GHCR-ghcr.io%2Fveritasfuji--japan%2Fveritas__os-2496ED?logo=docker&logoColor=white)](https://ghcr.io/veritasfuji-japan/veritas_os)
+[![README JP](https://img.shields.io/badge/README-日本語-0f766e.svg)](README_JP.md)
 
 **Version**: 2.0.0  
 **Planned Release**: In Development  
@@ -22,6 +25,20 @@ VERITAS OS wraps an LLM (e.g. OpenAI GPT-4.1-mini) with a **deterministic, safet
 - **Zenodo paper (EN)**: https://doi.org/10.5281/zenodo.17838349
 - **Zenodo paper (JP)**: https://doi.org/10.5281/zenodo.17838456
 - **Japanese README**: `README_JP.md` (if present)
+
+## Contents
+
+- [Why VERITAS?](#why-veritas)
+- [What It Does](#what-it-does)
+- [API Overview](#api-overview)
+- [Quickstart](#quickstart)
+- [Security Notes (Important)](#security-notes-important)
+- [Docker (GHCR)](#docker-ghcr)
+- [Architecture (High-Level)](#architecture-high-level)
+- [TrustLog (Hash-Chained Audit Log)](#trustlog-hash-chained-audit-log)
+- [Tests](#tests)
+- [Roadmap (Near-Term)](#roadmap-near-term)
+- [License](#license)
 
 ---
 
@@ -229,6 +246,12 @@ make test-cov
 These targets use `uv` with `PYTHON_VERSION=3.12.7` and automatically download the
 interpreter if it is not already installed.
 
+Fast smoke check:
+
+```bash
+make test TEST_ARGS="-q veritas_os/tests/test_api_constants.py"
+```
+
 Optional overrides:
 
 ```bash
@@ -239,12 +262,8 @@ make test PYTHON_VERSION=3.11
 ### CI / Quality Gate
 
 * GitHub Actions runs **pytest + coverage** on a Python 3.11/3.12 matrix.
-* Coverage artifacts are stored as **XML/HTML** outputs (badges are not yet in place).
+* Coverage artifacts are stored as **XML/HTML** outputs.
 * The CI job fails if tests fail, acting as a quality gate.
-
-> Note: Coverage badges are planned.
-
----
 
 ## Security Notes (Important)
 
@@ -303,8 +322,3 @@ For academic use, please cite the Zenodo DOI.
 
 * Issues: [https://github.com/veritasfuji-japan/veritas_os/issues](https://github.com/veritasfuji-japan/veritas_os/issues)
 * Email: [veritas.fuji@gmail.com](mailto:veritas.fuji@gmail.com)
-
-
-
-
-PR test: 2025-12-13 00:38:09

--- a/README_JP.md
+++ b/README_JP.md
@@ -5,6 +5,9 @@
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-red.svg)](LICENSE)
 [![CI](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml)
+[![Docker Publish](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml)
+[![GHCR](https://img.shields.io/badge/GHCR-ghcr.io%2Fveritasfuji--japan%2Fveritas__os-2496ED?logo=docker&logoColor=white)](https://ghcr.io/veritasfuji-japan/veritas_os)
+[![README EN](https://img.shields.io/badge/README-English-1d4ed8.svg)](README.md)
 
 **Version**: 2.0.0  
 **Planned Release**: 2025-12-01  
@@ -23,6 +26,20 @@ VERITAS OS は、LLM（例：OpenAI GPT-4.1-mini）を
 - **Zenodo論文（英語）**: https://doi.org/10.5281/zenodo.17838349
 - **Zenodo論文（日本語）**: https://doi.org/10.5281/zenodo.17838456
 - **English README**: `README.md`
+
+## 目次
+
+- [なぜVERITASか（何が違う？）](#なぜveritasか何が違う)
+- [できること](#できること)
+- [API一覧（概要）](#api一覧概要)
+- [Quickstart（最短起動）](#quickstart最短起動)
+- [セキュリティ注意（重要）](#セキュリティ注意重要)
+- [Docker（GHCR）](#dockerghcr)
+- [アーキテクチャ（高レベル）](#アーキテクチャ高レベル)
+- [TrustLog（ハッシュチェーン監査ログ）](#trustlogハッシュチェーン監査ログ)
+- [テスト](#テスト)
+- [近いロードマップ（短期）](#近いロードマップ短期)
+- [ライセンス](#ライセンス)
 
 ---
 
@@ -103,6 +120,8 @@ Options → Evidence → Critique → Debate → Planner → ValueCore → FUJI 
 ---
 
 ## Quickstart（最短起動）
+
+> Docker での起動手順は [Docker（GHCR）](#dockerghcr) を参照してください。
 
 ### 1) インストール
 
@@ -249,7 +268,37 @@ make test TEST_ARGS="-q veritas_os/tests/test_time_utils.py"
 make test PYTHON_VERSION=3.11
 ```
 
+スモークチェック（最短）:
+
+```bash
+make test TEST_ARGS="-q veritas_os/tests/test_api_constants.py"
+```
+
 > 補足：CI は GitHub Actions で利用可能です。Coverage バッジは追加予定です。
+
+---
+
+## Docker（GHCR）
+
+最新イメージを取得:
+
+```bash
+docker pull ghcr.io/veritasfuji-japan/veritas_os:latest
+```
+
+API サーバ起動:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e OPENAI_API_KEY="YOUR_OPENAI_API_KEY" \
+  -e VERITAS_API_KEY="your-secret-api-key" \
+  -e LLM_PROVIDER="openai" \
+  -e LLM_MODEL="gpt-4.1-mini" \
+  ghcr.io/veritasfuji-japan/veritas_os:latest
+```
+
+FastAPI エントリポイントが `veritas_os.api.server:app` と異なる場合は、
+Dockerfile の `CMD` を環境に合わせて更新してください。
 
 ---
 


### PR DESCRIPTION
### Motivation
- Improve onboarding and visibility by adding distribution badges, a table-of-contents for navigation, and a short smoke-test; warn about external badge/image requests as a potential operational/security consideration.

### Description
- Updated `README.md` and `README_JP.md` to add Docker publish and GHCR badges, cross-link badges between EN/JP READMEs, a Contents/目次 section for quick navigation, and a fast smoke-test (`make test TEST_ARGS="-q veritas_os/tests/test_api_constants.py"`); added a Docker (GHCR) usage section to `README_JP.md` for parity.

### Testing
- Ran `git diff -- README.md README_JP.md` and verified the expected diffs; success.
- Attempted the fast smoke check with `make test TEST_ARGS='-q veritas_os/tests/test_api_constants.py'`, but test execution failed due to external network access errors when `uv` attempted to download Python and PyPI packages (env blocked outbound fetch); no unit test failures in repository code were observed because tests could not be executed in this environment.
- Changes were committed (`docs: improve EN/JP README and add workflow badges`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb370e1308326ae4efd6c658d96e5)