### PR TITLE
Harden Slack webhook validation in alert_doctor

### DIFF
--- a/veritas_os/tests/test_alert_doctor.py
+++ b/veritas_os/tests/test_alert_doctor.py
@@ -1,0 +1,55 @@
+"""Tests for veritas_os/scripts/alert_doctor.py."""
+
+from veritas_os.scripts import alert_doctor
+
+
+def test_validate_webhook_url_accepts_valid_slack_hosts():
+    """Valid Slack webhook domains with HTTPS should be accepted."""
+    assert alert_doctor._validate_webhook_url("https://hooks.slack.com/services/a/b/c")
+    assert alert_doctor._validate_webhook_url(
+        "https://hooks.slack-gov.com/services/a/b/c"
+    )
+
+
+def test_validate_webhook_url_rejects_insecure_or_untrusted_hosts():
+    """Non-HTTPS or non-Slack hosts should be rejected."""
+    assert not alert_doctor._validate_webhook_url("http://hooks.slack.com/services/a/b/c")
+    assert not alert_doctor._validate_webhook_url("https://example.com/services/a/b/c")
+    assert not alert_doctor._validate_webhook_url("")
+
+
+def test_post_slack_rejects_invalid_webhook_without_network(monkeypatch):
+    """post_slack should fail fast when webhook URL is invalid."""
+    monkeypatch.setattr(alert_doctor, "WEBHOOK", "http://hooks.slack.com/services/a/b/c")
+
+    def _unexpected_call(*_args, **_kwargs):
+        raise AssertionError("Network call must not happen for invalid webhook")
+
+    monkeypatch.setattr(alert_doctor.urllib.request, "urlopen", _unexpected_call)
+    assert alert_doctor.post_slack("hello") is False
+
+
+def test_post_slack_succeeds_with_valid_webhook(monkeypatch):
+    """post_slack should return True when Slack returns HTTP 200."""
+    monkeypatch.setattr(
+        alert_doctor,
+        "WEBHOOK",
+        "https://hooks.slack.com/services/a/b/c",
+    )
+
+    class _DummyResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def _urlopen(*_args, **_kwargs):
+        return _DummyResponse()
+
+    monkeypatch.setattr(alert_doctor.urllib.request, "urlopen", _urlopen)
+    monkeypatch.setattr(alert_doctor.time, "sleep", lambda *_args, **_kwargs: None)
+
+    assert alert_doctor.post_slack("hello", max_retry=1) is True


### PR DESCRIPTION
### Motivation
- Prevent arbitrary or insecure Slack webhook destinations (SSRF / exfiltration) by validating webhook URLs before sending alerts.
- Improve code readability and PEP8 compliance by splitting imports and adding type hints where appropriate.
- Add automated tests and docstring for the new security behaviour so regressions are detectable.

### Description
- Added `_validate_webhook_url(webhook_url: str) -> bool` which enforces `https` and restricts hosts to `hooks.slack.com` and `hooks.slack-gov.com`.
- Updated `post_slack()` to fail-fast with a security warning when the configured `WEBHOOK` is invalid, avoiding network calls for untrusted URLs.
- Refactored imports for clarity, added small type hints (`timeout: int`, `Optional[str]`), and annotated the Python 3.8 fallback branch with `# pragma: no cover`.
- Added unit tests `veritas_os/tests/test_alert_doctor.py` covering valid/invalid webhook validation, no-network short-circuit behavior, and a mocked successful 200 response.

### Testing
- Compiled `veritas_os/scripts/alert_doctor.py` and `veritas_os/tests/test_alert_doctor.py` with `python3 -m compileall` and compilation succeeded.
- Attempted to run `python3 -m pytest veritas_os/tests/test_alert_doctor.py` but `pytest` is not installed in this environment so tests were not executed.
- New tests were added and committed as part of this change and should pass once `pytest` is available in CI.

Security note: this change restricts webhook destinations but `SLACK_WEBHOOK_URL` is still environment-managed, so operational secret management (access control, rotation, audit) remains important.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d48256d508326a2c3dda53ffb7817)