### PR TITLE
Harden Slack notifier: add timeout, sanitize error logs, and add tests

### DIFF
--- a/veritas_os/scripts/notify_slack.py
+++ b/veritas_os/scripts/notify_slack.py
@@ -1,20 +1,58 @@
 #!/usr/bin/env python3
-import os, sys, requests, datetime
+"""Send a Slack notification message via incoming webhook.
 
-WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
-if not WEBHOOK_URL:
-    print("[ERROR] Missing SLACK_WEBHOOK_URL in environment.")
-    sys.exit(1)
+Security considerations:
+- HTTP request timeout is always set to prevent indefinite hangs.
+- Error logging never prints response body to avoid accidental data exposure.
+"""
 
-msg = sys.argv[1] if len(sys.argv) > 1 else "VERITAS notification"
-timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+import datetime
+import os
+import sys
 
-payload = {
-    "text": f"🧠 *VERITAS通知*\n>{msg}\n🕒 {timestamp}"
-}
+import requests
 
-res = requests.post(WEBHOOK_URL, json=payload)
-if res.status_code == 200:
-    print("[Slack] 通知送信成功")
-else:
-    print(f"[Slack] エラー: {res.status_code} - {res.text}")
+DEFAULT_TIMEOUT_SEC = 10
+
+
+def build_payload(message: str) -> dict[str, str]:
+    """Build the Slack webhook payload for a user-facing notification."""
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return {"text": f"🧠 *VERITAS通知*\n>{message}\n🕒 {timestamp}"}
+
+
+def send_slack_notification(webhook_url: str, message: str) -> int:
+    """Send a Slack notification and return a process-compatible exit code."""
+    payload = build_payload(message)
+
+    try:
+        response = requests.post(
+            webhook_url,
+            json=payload,
+            timeout=DEFAULT_TIMEOUT_SEC,
+        )
+    except requests.RequestException as exc:
+        print(f"[Slack] 通知送信失敗: network_error={exc.__class__.__name__}")
+        return 1
+
+    if response.status_code == 200:
+        print("[Slack] 通知送信成功")
+        return 0
+
+    print(f"[Slack] エラー: status_code={response.status_code}")
+    return 1
+
+
+def main() -> int:
+    """CLI entrypoint for Slack notification dispatch."""
+    webhook_url = os.getenv("SLACK_WEBHOOK_URL")
+    if not webhook_url:
+        print("[ERROR] Missing SLACK_WEBHOOK_URL in environment.")
+        return 1
+
+    message = sys.argv[1] if len(sys.argv) > 1 else "VERITAS notification"
+    return send_slack_notification(webhook_url, message)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/veritas_os/tests/test_notify_slack.py
+++ b/veritas_os/tests/test_notify_slack.py
@@ -1,0 +1,91 @@
+"""Tests for scripts/notify_slack.py security-sensitive behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "notify_slack.py"
+
+
+def load_module():
+    """Load notify_slack.py as an importable module for tests."""
+    fake_requests = types.SimpleNamespace(
+        post=lambda **_: None,
+        RequestException=Exception,
+    )
+    sys.modules.setdefault("requests", fake_requests)
+
+    spec = importlib.util.spec_from_file_location("notify_slack", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class _DummyResponse:
+    """Test double for requests.Response-like behavior."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+class NotifySlackTests(unittest.TestCase):
+    """Behavioral tests for Slack notification script hardening."""
+
+    def test_send_slack_uses_timeout(self):
+        """requests.post should always include a finite timeout value."""
+        module = load_module()
+        observed = {}
+
+        def fake_post(url, json, timeout):
+            observed["url"] = url
+            observed["json"] = json
+            observed["timeout"] = timeout
+            return _DummyResponse(200)
+
+        with mock.patch.object(module.requests, "post", side_effect=fake_post):
+            exit_code = module.send_slack_notification(
+                "https://hooks.slack.com/services/a/b/c",
+                "hello",
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(observed["url"], "https://hooks.slack.com/services/a/b/c")
+        self.assertEqual(observed["timeout"], module.DEFAULT_TIMEOUT_SEC)
+        self.assertIn("hello", observed["json"]["text"])
+
+    def test_send_slack_error_log_does_not_include_response_text(self):
+        """Error logging must avoid printing server response body."""
+        module = load_module()
+
+        with mock.patch.object(module.requests, "post", return_value=_DummyResponse(500)):
+            with mock.patch("builtins.print") as mock_print:
+                exit_code = module.send_slack_notification(
+                    "https://hooks.slack.com/services/a/b/c",
+                    "hello",
+                )
+
+        self.assertEqual(exit_code, 1)
+        logged = "\n".join(" ".join(map(str, call.args)) for call in mock_print.call_args_list)
+        self.assertIn("status_code=500", logged)
+        self.assertNotIn("response", logged.lower())
+
+    def test_main_returns_error_when_webhook_env_missing(self):
+        """CLI should fail with non-zero status when webhook URL is absent."""
+        module = load_module()
+
+        with mock.patch.object(module.os, "getenv", return_value=None):
+            with mock.patch.object(module.sys, "argv", ["notify_slack.py", "hi"]):
+                exit_code = module.main()
+
+        self.assertEqual(exit_code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent indefinite hangs in the Slack notifier by ensuring outbound requests always use a finite timeout. 
- Reduce risk of accidental information exposure by avoiding printing raw response bodies on error. 
- Improve readability and maintainability by splitting bundled imports, adding docstrings and a `main()` entrypoint. 
- Note: this change does not add webhook URL scheme/host validation and such validation is recommended to further reduce misconfiguration risk.

### Description
- Rewrote `veritas_os/scripts/notify_slack.py` to be PEP8-friendly and split imports, added module and function docstrings, and introduced `build_payload`, `send_slack_notification`, and `main` functions. 
- Added explicit request timeout via `DEFAULT_TIMEOUT_SEC = 10` and passed `timeout` to `requests.post` to avoid indefinite blocking. 
- Sanitized error logging to print only `status_code` or the exception class name instead of the raw response body (no `res.text` exposure). 
- Added unit tests at `veritas_os/tests/test_notify_slack.py` that assert `requests.post` is called with a timeout, that error logs do not contain response text, and that CLI `main()` returns non-zero when webhook env is missing.

### Testing
- Ran `python3 -m unittest -q veritas_os/tests/test_notify_slack.py` and all tests passed (3 tests, OK). 
- Attempted `python3 -m pytest -q veritas_os/tests/test_notify_slack.py` but `pytest` is not installed in the environment so that run failed. 
- Attempted `python -m pytest` was blocked by system `pyenv` configuration (missing target version) so that run also failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5a8bb3f88326ad927d773e514f01)