### PR TITLE
test: remove obsolete noqa suppression in world_v2 tests

### DIFF
--- a/veritas_os/tests/test_world_v2.py
+++ b/veritas_os/tests/test_world_v2.py
@@ -12,7 +12,7 @@ def setup_tmp_world(tmp_path, monkeypatch):
     """
     monkeypatch.setenv("VERITAS_DATA_DIR", str(tmp_path))
 
-    import veritas_os.core.world as world_module  # noqa: WPS433 (local import OK for reload)
+    import veritas_os.core.world as world_module
     importlib.reload(world_module)
     return world_module
 


### PR DESCRIPTION
### Motivation
- Remove an invalid `# noqa: WPS433` suppression from a local import to eliminate Ruff lint noise and keep test code clean.

### Description
- Deleted the `# noqa: WPS433 (local import OK for reload)` comment on the `import veritas_os.core.world as world_module` line in `veritas_os/tests/test_world_v2.py` with no behavioral changes.

### Testing
- Ran `ruff check veritas_os/tests/test_world_v2.py` and `pytest -q veritas_os/tests/test_world_v2.py`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d63c8b0a883269d605dec808dfcf8)