### PR TITLE
feat(ui): scaffold pnpm monorepo with Next.js frontend and shared packages

### DIFF
--- a/README_UI.md
+++ b/README_UI.md
@@ -1,0 +1,34 @@
+# UI Monorepo Quickstart
+
+## frontend だけをローカル起動
+
+```bash
+pnpm install
+pnpm --filter frontend dev
+```
+
+> `http://localhost:3000` で起動します。
+
+## backend 接続用の環境変数
+
+`frontend/.env.local` を作成し、API ベース URL を設定してください。
+
+```env
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+```
+
+## 最低限の開発コマンド
+
+```bash
+# frontend 開発サーバー
+pnpm --filter frontend dev
+
+# frontend lint
+pnpm --filter frontend lint
+
+# workspace 全体の型チェック
+pnpm -r typecheck
+
+# workspace 全体のテスト
+pnpm -r test
+```

--- a/docs/ui/architecture.md
+++ b/docs/ui/architecture.md
@@ -1,0 +1,19 @@
+# UI Architecture Notes
+
+## 目的
+
+- frontend を App Router ベースで独立起動可能にする。
+- API 型を `packages/types` に集約し、唯一の真実にする。
+- テーマ・トークン・共通 UI を `packages/design-system` に集約する。
+
+## パッケージ責務
+
+- `frontend/`: 画面実装とユーザー操作。
+- `packages/types/`: API contract の型。
+- `packages/design-system/`: UI トークン、テーマ、共通コンポーネント。
+
+## 運用メモ
+
+- 新しい API レスポンス型は `packages/types/src/index.ts` に追加。
+- 共通 UI は `packages/design-system/src` へ追加し、frontend 側で直接複製しない。
+- frontend では `@veritas/types` と `@veritas/design-system` を import して利用する。

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,23 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --border: 214.3 31.8% 91.4%;
+  --radius: 0.5rem;
+}
+
+* {
+  border-color: hsl(var(--border));
+}
+
+body {
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { applyThemeClass } from "@veritas/design-system";
+
+export const metadata: Metadata = {
+  title: "Veritas UI",
+  description: "Veritas monorepo frontend scaffold"
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="ja">
+      <body className={applyThemeClass("light")}>{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from "@testing-library/react";
+import Home from "./page";
+
+describe("Home", () => {
+  it("renders workspace card", () => {
+    render(<Home />);
+    expect(screen.getByText("Veritas UI Workspace")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,22 @@
+import { Button, Card } from "@veritas/design-system";
+import type { HealthResponse } from "@veritas/types";
+
+const sampleHealth: HealthResponse = {
+  status: "ok",
+  service: "frontend",
+  timestamp: new Date().toISOString()
+};
+
+export default function Home() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center gap-4 p-6">
+      <Card title="Veritas UI Workspace">
+        <p className="text-sm text-muted-foreground">
+          frontend は packages/types と packages/design-system を参照できています。
+        </p>
+        <pre className="mt-4 rounded-md bg-muted p-3 text-xs">{JSON.stringify(sampleHealth, null, 2)}</pre>
+        <Button className="mt-4">shadcn/ui style button</Button>
+      </Card>
+    </main>
+  );
+}

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ["@veritas/design-system", "@veritas/types"]
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@veritas/design-system": "workspace:*",
+    "@veritas/types": "workspace:*",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.469.0",
+    "next": "14.2.24",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "tailwind-merge": "^2.6.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.1.0",
+    "@types/node": "^22.10.2",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.24",
+    "jsdom": "^25.0.1",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,34 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "../packages/design-system/src/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        border: "hsl(var(--border))"
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@veritas/design-system": ["../packages/design-system/src/index.ts"],
+      "@veritas/types": ["../packages/types/src/index.ts"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["**/*.test.ts", "**/*.test.tsx"]
+  }
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "veritas-os-monorepo",
+  "private": true,
+  "packageManager": "pnpm@9.15.3",
+  "scripts": {
+    "ui:dev": "pnpm --filter frontend dev",
+    "ui:build": "pnpm --filter frontend build",
+    "ui:lint": "pnpm --filter frontend lint",
+    "ui:typecheck": "pnpm -r typecheck",
+    "ui:test": "pnpm -r test"
+  }
+}

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@veritas/design-system",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.6.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/design-system/src/button.tsx
+++ b/packages/design-system/src/button.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "./utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:opacity-90",
+        outline: "border border-border bg-background hover:bg-muted"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, ...props }, ref) => (
+    <button className={cn(buttonVariants({ variant }), className)} ref={ref} {...props} />
+  )
+);
+
+Button.displayName = "Button";

--- a/packages/design-system/src/card.tsx
+++ b/packages/design-system/src/card.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+export function Card({
+  title,
+  className,
+  children
+}: {
+  title: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={cn("w-full rounded-lg border bg-background p-6 shadow-sm", className)}>
+      <h1 className="text-xl font-semibold">{title}</h1>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./button";
+export * from "./card";
+export * from "./theme";

--- a/packages/design-system/src/theme.test.ts
+++ b/packages/design-system/src/theme.test.ts
@@ -1,0 +1,9 @@
+import { applyThemeClass, tokens } from "./theme";
+
+describe("theme", () => {
+  it("provides tokens and theme classes", () => {
+    expect(tokens.radius.base).toBe("0.5rem");
+    expect(applyThemeClass("light")).toBe("");
+    expect(applyThemeClass("dark")).toBe("dark");
+  });
+});

--- a/packages/design-system/src/theme.ts
+++ b/packages/design-system/src/theme.ts
@@ -1,0 +1,16 @@
+export const tokens = {
+  color: {
+    background: "hsl(var(--background))",
+    foreground: "hsl(var(--foreground))",
+    primary: "hsl(var(--primary))"
+  },
+  radius: {
+    base: "0.5rem"
+  }
+} as const;
+
+export type ThemeMode = "light" | "dark";
+
+export function applyThemeClass(mode: ThemeMode): string {
+  return mode === "dark" ? "dark" : "";
+}

--- a/packages/design-system/src/utils.ts
+++ b/packages/design-system/src/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@veritas/types",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/types/src/index.test.ts
+++ b/packages/types/src/index.test.ts
@@ -1,0 +1,13 @@
+import type { HealthResponse } from "./index";
+
+describe("types", () => {
+  it("accepts a valid health response shape", () => {
+    const response: HealthResponse = {
+      status: "ok",
+      service: "api",
+      timestamp: "2026-01-01T00:00:00.000Z"
+    };
+
+    expect(response.status).toBe("ok");
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,10 @@
+export interface HealthResponse {
+  status: "ok" | "degraded" | "error";
+  service: string;
+  timestamp: string;
+}
+
+export interface ApiError {
+  code: string;
+  message: string;
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - frontend
+  - packages/*


### PR DESCRIPTION
### Motivation
- Create a minimal UI monorepo scaffold so `frontend` can run standalone while sharing types and UI primitives as single sources of truth under `packages/*`.
- Provide a Next.js 14 (App Router) + TypeScript + Tailwind + shadcn/ui compatible starter and shared packages for theme/tokens and API types.
- Keep `veritas_os/` unchanged and add documentation and quickstart for local frontend development via `README_UI.md` and `docs/ui/`.
- Security note: adding many runtime/dev dependencies increases supply-chain risk, so generating a lockfile and running dependency scans is recommended before CI deployment.

### Description
- Added a root `pnpm-workspace.yaml` and root `package.json` with UI-focused scripts such as `ui:dev` and `ui:typecheck` to enable `pnpm` workspace linking of packages.
- Scaffolded `frontend/` with Next.js configuration (`next.config.mjs`, `tsconfig.json`, `tailwind.config.ts`, `postcss.config.mjs`, `components.json`) and a sample page that imports `@veritas/types` and `@veritas/design-system` to prove workspace resolution.
- Added `packages/types/` implementing API contracts (`HealthResponse`, `ApiError`) and a minimal `vitest` test to document the shape.
- Added `packages/design-system/` with tokens (`tokens`), `applyThemeClass`, and shared components (`Button`, `Card`) plus utils and a small unit test, and exported them from `src/index.ts`.
- Added docs and quickstart: `README_UI.md` (how to start `frontend` locally, env hint, dev commands) and `docs/ui/architecture.md` (package responsibilities and operational notes).

### Testing
- Attempted to run `pnpm install`, but environment/proxy restrictions prevented fetching `pnpm`/dependencies so workspace installation did not complete (network error when contacting `registry.npmjs.org`).
- Unit tests (`vitest`) were added to `frontend`, `packages/types`, and `packages/design-system` for local verification, but they were not executed due to the failed dependency installation.
- A Playwright attempt to capture `http://127.0.0.1:3000` failed with `ERR_EMPTY_RESPONSE` because the frontend dev server could not be started without installed dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8ca7bd408326a74bb38d54179dfc)