### PR TITLE
feat(ui): implement Layer0 design system tokens, themes, and accessible AppShell

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,22 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
-  --primary: 222.2 47.4% 11.2%;
-  --primary-foreground: 210 40% 98%;
-  --muted: 210 40% 96.1%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --border: 214.3 31.8% 91.4%;
-  --radius: 0.5rem;
-}
-
 * {
-  border-color: hsl(var(--border));
+  border-color: hsl(var(--ds-color-border));
 }
 
 body {
-  background: hsl(var(--background));
-  color: hsl(var(--foreground));
+  background: hsl(var(--ds-color-background));
+  color: hsl(var(--ds-color-foreground));
+  font-family: var(--ds-font-sans);
+}
+
+code,
+pre,
+.font-audit {
+  font-family: var(--ds-font-mono);
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
+import { AppShell, ThemeStyles, applyThemeClass } from "@veritas/design-system";
 import "./globals.css";
-import { applyThemeClass } from "@veritas/design-system";
 
 export const metadata: Metadata = {
   title: "Veritas UI",
@@ -11,10 +11,18 @@ export default function RootLayout({
   children
 }: Readonly<{
   children: React.ReactNode;
-}>) {
+}>): JSX.Element {
   return (
-    <html lang="ja">
-      <body className={applyThemeClass("light")}>{children}</body>
+    <html className={applyThemeClass("light")} lang="ja">
+      <body>
+        <ThemeStyles />
+        <AppShell
+          description="共通レイアウトとアクセシブルなデザイントークンを適用しています。"
+          title="Veritas UI Workspace"
+        >
+          {children}
+        </AppShell>
+      </body>
     </html>
   );
 }

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -2,8 +2,9 @@ import { render, screen } from "@testing-library/react";
 import Home from "./page";
 
 describe("Home", () => {
-  it("renders workspace card", () => {
+  it("renders layer0 card", () => {
     render(<Home />);
-    expect(screen.getByText("Veritas UI Workspace")).toBeInTheDocument();
+    expect(screen.getByText("Layer0 Design System Ready")).toBeInTheDocument();
+    expect(screen.getByLabelText("デザインシステム動作確認")).toBeInTheDocument();
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,16 +7,20 @@ const sampleHealth: HealthResponse = {
   timestamp: new Date().toISOString()
 };
 
-export default function Home() {
+export default function Home(): JSX.Element {
   return (
-    <main className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center gap-4 p-6">
-      <Card title="Veritas UI Workspace">
-        <p className="text-sm text-muted-foreground">
-          frontend は packages/types と packages/design-system を参照できています。
+    <div className="flex flex-col gap-4">
+      <Card title="Layer0 Design System Ready">
+        <p className="text-muted-foreground">
+          frontend は packages/design-system のトークン・テーマ・アクセシビリティ基盤を利用しています。
         </p>
-        <pre className="mt-4 rounded-md bg-muted p-3 text-xs">{JSON.stringify(sampleHealth, null, 2)}</pre>
-        <Button className="mt-4">shadcn/ui style button</Button>
+        <pre className="font-audit mt-4 rounded-md bg-muted p-3 text-xs">
+          {JSON.stringify(sampleHealth, null, 2)}
+        </pre>
+        <Button aria-label="デザインシステム動作確認" className="mt-4">
+          Accessible action
+        </Button>
       </Card>
-    </main>
+    </div>
   );
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -6,25 +6,46 @@ const config: Config = {
     "./components/**/*.{ts,tsx}",
     "../packages/design-system/src/**/*.{ts,tsx}"
   ],
+  darkMode: "class",
   theme: {
     extend: {
       colors: {
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        background: "hsl(var(--ds-color-background))",
+        foreground: "hsl(var(--ds-color-foreground))",
+        surface: {
+          DEFAULT: "hsl(var(--ds-color-surface))",
+          foreground: "hsl(var(--ds-color-surface-foreground))"
+        },
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))"
+          DEFAULT: "hsl(var(--ds-color-primary))",
+          foreground: "hsl(var(--ds-color-primary-foreground))"
         },
         muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))"
+          DEFAULT: "hsl(var(--ds-color-muted))",
+          foreground: "hsl(var(--ds-color-muted-foreground))"
         },
-        border: "hsl(var(--border))"
+        border: "hsl(var(--ds-color-border))"
+      },
+      fontFamily: {
+        sans: ["var(--ds-font-sans)"],
+        mono: ["var(--ds-font-mono)"]
       },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)"
+        sm: "var(--ds-radius-sm)",
+        md: "var(--ds-radius-md)",
+        lg: "var(--ds-radius-lg)"
+      },
+      boxShadow: {
+        sm: "var(--ds-shadow-sm)",
+        md: "var(--ds-shadow-md)",
+        lg: "var(--ds-shadow-lg)"
+      },
+      zIndex: {
+        base: "var(--ds-z-base)",
+        nav: "var(--ds-z-nav)",
+        overlay: "var(--ds-z-overlay)",
+        toast: "var(--ds-z-toast)",
+        modal: "var(--ds-z-modal)"
       }
     }
   },

--- a/packages/design-system/src/app-shell.tsx
+++ b/packages/design-system/src/app-shell.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { cn } from "./utils";
+
+interface AppShellProps {
+  children: ReactNode;
+  title: string;
+  description?: string;
+  className?: string;
+}
+
+/**
+ * Shared full-screen app layout with keyboard-first navigation and landmarks.
+ */
+export function AppShell({
+  children,
+  title,
+  description,
+  className
+}: AppShellProps): JSX.Element {
+  return (
+    <div className={cn("min-h-screen bg-background text-foreground", className)}>
+      <a
+        href="#main-content"
+        className="sr-only z-[var(--ds-z-overlay)] rounded-md bg-primary px-3 py-2 text-primary-foreground focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[hsl(var(--ds-color-focus-ring))]"
+      >
+        メインコンテンツへスキップ
+      </a>
+      <header className="border-b border-border bg-surface/90 px-6 py-4 backdrop-blur" role="banner">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        {description ? <p className="mt-1 text-sm text-muted-foreground">{description}</p> : null}
+      </header>
+      <main id="main-content" className="mx-auto w-full max-w-5xl px-6 py-8" role="main" tabIndex={-1}>
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/packages/design-system/src/button.tsx
+++ b/packages/design-system/src/button.tsx
@@ -3,12 +3,13 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "./utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[hsl(var(--ds-color-focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:opacity-90",
-        outline: "border border-border bg-background hover:bg-muted"
+        outline: "border border-border bg-background hover:bg-muted",
+        ghost: "bg-transparent hover:bg-muted"
       }
     },
     defaultVariants: {
@@ -22,8 +23,8 @@ export interface ButtonProps
     VariantProps<typeof buttonVariants> {}
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, ...props }, ref) => (
-    <button className={cn(buttonVariants({ variant }), className)} ref={ref} {...props} />
+  ({ className, type = "button", variant, ...props }, ref) => (
+    <button className={cn(buttonVariants({ variant }), className)} ref={ref} type={type} {...props} />
   )
 );
 

--- a/packages/design-system/src/card.tsx
+++ b/packages/design-system/src/card.tsx
@@ -1,19 +1,24 @@
 import * as React from "react";
 import { cn } from "./utils";
 
-export function Card({
-  title,
-  className,
-  children
-}: {
+interface CardProps {
   title: string;
   className?: string;
   children: React.ReactNode;
-}) {
+}
+
+export function Card({ title, className, children }: CardProps): JSX.Element {
+  const titleId = React.useId();
+
   return (
-    <section className={cn("w-full rounded-lg border bg-background p-6 shadow-sm", className)}>
-      <h1 className="text-xl font-semibold">{title}</h1>
-      <div className="mt-3">{children}</div>
+    <section
+      aria-labelledby={titleId}
+      className={cn("w-full rounded-lg border border-border bg-surface p-6 shadow-sm", className)}
+    >
+      <h2 className="text-xl font-semibold" id={titleId}>
+        {title}
+      </h2>
+      <div className="mt-3 text-sm leading-relaxed">{children}</div>
     </section>
   );
 }

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./app-shell";
 export * from "./button";
 export * from "./card";
 export * from "./theme";
+export * from "./theme-styles";

--- a/packages/design-system/src/theme-styles.tsx
+++ b/packages/design-system/src/theme-styles.tsx
@@ -1,0 +1,9 @@
+import { createThemeCss } from "./theme";
+
+/**
+ * Injects design-system CSS variables so host applications can consume
+ * tokenized light/dark themes without duplicating variable declarations.
+ */
+export function ThemeStyles(): JSX.Element {
+  return <style id="veritas-design-system-theme">{createThemeCss()}</style>;
+}

--- a/packages/design-system/src/theme.test.ts
+++ b/packages/design-system/src/theme.test.ts
@@ -1,8 +1,25 @@
-import { applyThemeClass, tokens } from "./theme";
+import { applyThemeClass, createThemeCss, tokens } from "./theme";
 
 describe("theme", () => {
-  it("provides tokens and theme classes", () => {
-    expect(tokens.radius.base).toBe("0.5rem");
+  it("provides token groups required by layer0", () => {
+    expect(tokens.color.background).toContain("--ds-color-background");
+    expect(tokens.typography.mono).toBe("var(--ds-font-mono)");
+    expect(tokens.spacing[4]).toBe("1rem");
+    expect(tokens.radius.md).toBe("0.5rem");
+    expect(tokens.shadow.md).toContain("rgb");
+    expect(tokens.zIndex.modal).toBe("60");
+  });
+
+  it("creates light and dark css variable maps", () => {
+    const css = createThemeCss();
+
+    expect(css).toContain(":root {");
+    expect(css).toContain(".dark {");
+    expect(css).toContain("--ds-color-focus-ring");
+    expect(css).toContain("--ds-font-mono");
+  });
+
+  it("provides theme classes", () => {
     expect(applyThemeClass("light")).toBe("");
     expect(applyThemeClass("dark")).toBe("dark");
   });

--- a/packages/design-system/src/theme.ts
+++ b/packages/design-system/src/theme.ts
@@ -1,15 +1,132 @@
+/**
+ * Design token and theme definitions for Veritas UI.
+ *
+ * Layer0 responsibilities:
+ * - Tokenized primitives (color / typography / spacing / radius / shadow / z-index)
+ * - Light / dark CSS variable maps
+ * - Accessibility utility variables (focus ring)
+ */
 export const tokens = {
   color: {
-    background: "hsl(var(--background))",
-    foreground: "hsl(var(--foreground))",
-    primary: "hsl(var(--primary))"
+    background: "hsl(var(--ds-color-background))",
+    foreground: "hsl(var(--ds-color-foreground))",
+    surface: "hsl(var(--ds-color-surface))",
+    surfaceForeground: "hsl(var(--ds-color-surface-foreground))",
+    primary: "hsl(var(--ds-color-primary))",
+    primaryForeground: "hsl(var(--ds-color-primary-foreground))",
+    muted: "hsl(var(--ds-color-muted))",
+    mutedForeground: "hsl(var(--ds-color-muted-foreground))",
+    border: "hsl(var(--ds-color-border))",
+    focusRing: "hsl(var(--ds-color-focus-ring))"
+  },
+  typography: {
+    sans: "var(--ds-font-sans)",
+    mono: "var(--ds-font-mono)",
+    size: {
+      xs: "0.75rem",
+      sm: "0.875rem",
+      md: "1rem",
+      lg: "1.125rem",
+      xl: "1.25rem"
+    },
+    lineHeight: {
+      compact: "1.3",
+      normal: "1.5",
+      relaxed: "1.65"
+    }
+  },
+  spacing: {
+    1: "0.25rem",
+    2: "0.5rem",
+    3: "0.75rem",
+    4: "1rem",
+    6: "1.5rem",
+    8: "2rem",
+    12: "3rem"
   },
   radius: {
-    base: "0.5rem"
+    sm: "0.375rem",
+    md: "0.5rem",
+    lg: "0.75rem"
+  },
+  shadow: {
+    sm: "0 1px 2px 0 rgb(0 0 0 / 0.12)",
+    md: "0 4px 10px -2px rgb(0 0 0 / 0.18)",
+    lg: "0 10px 24px -8px rgb(0 0 0 / 0.24)"
+  },
+  zIndex: {
+    base: "1",
+    nav: "20",
+    overlay: "40",
+    toast: "50",
+    modal: "60"
   }
 } as const;
 
 export type ThemeMode = "light" | "dark";
+
+type CssVariableMap = Record<string, string>;
+
+const sharedVariables: CssVariableMap = {
+  "--ds-font-sans": "Inter, 'Noto Sans JP', 'Segoe UI', sans-serif",
+  "--ds-font-mono": "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+  "--ds-spacing-1": tokens.spacing[1],
+  "--ds-spacing-2": tokens.spacing[2],
+  "--ds-spacing-3": tokens.spacing[3],
+  "--ds-spacing-4": tokens.spacing[4],
+  "--ds-spacing-6": tokens.spacing[6],
+  "--ds-spacing-8": tokens.spacing[8],
+  "--ds-spacing-12": tokens.spacing[12],
+  "--ds-radius-sm": tokens.radius.sm,
+  "--ds-radius-md": tokens.radius.md,
+  "--ds-radius-lg": tokens.radius.lg,
+  "--ds-shadow-sm": tokens.shadow.sm,
+  "--ds-shadow-md": tokens.shadow.md,
+  "--ds-shadow-lg": tokens.shadow.lg,
+  "--ds-z-base": tokens.zIndex.base,
+  "--ds-z-nav": tokens.zIndex.nav,
+  "--ds-z-overlay": tokens.zIndex.overlay,
+  "--ds-z-toast": tokens.zIndex.toast,
+  "--ds-z-modal": tokens.zIndex.modal
+};
+
+const lightVariables: CssVariableMap = {
+  "--ds-color-background": "0 0% 100%",
+  "--ds-color-foreground": "224 71% 8%",
+  "--ds-color-surface": "210 33% 98%",
+  "--ds-color-surface-foreground": "224 71% 8%",
+  "--ds-color-primary": "221 83% 53%",
+  "--ds-color-primary-foreground": "210 40% 98%",
+  "--ds-color-muted": "216 33% 94%",
+  "--ds-color-muted-foreground": "218 18% 38%",
+  "--ds-color-border": "214 29% 84%",
+  "--ds-color-focus-ring": "221 83% 53%"
+};
+
+const darkVariables: CssVariableMap = {
+  "--ds-color-background": "222 47% 7%",
+  "--ds-color-foreground": "213 31% 91%",
+  "--ds-color-surface": "223 33% 10%",
+  "--ds-color-surface-foreground": "213 31% 91%",
+  "--ds-color-primary": "217 91% 60%",
+  "--ds-color-primary-foreground": "222 47% 11%",
+  "--ds-color-muted": "218 24% 19%",
+  "--ds-color-muted-foreground": "215 20% 71%",
+  "--ds-color-border": "217 19% 25%",
+  "--ds-color-focus-ring": "217 91% 60%"
+};
+
+function serializeVariables(selector: string, variables: CssVariableMap): string {
+  const lines = Object.entries(variables).map(([key, value]) => `  ${key}: ${value};`);
+  return `${selector} {\n${lines.join("\n")}\n}`;
+}
+
+export function createThemeCss(): string {
+  return [
+    serializeVariables(":root", { ...sharedVariables, ...lightVariables }),
+    serializeVariables(".dark", darkVariables)
+  ].join("\n\n");
+}
 
 export function applyThemeClass(mode: ThemeMode): string {
   return mode === "dark" ? "dark" : "";


### PR DESCRIPTION
### Motivation
- Layer0 として `color / typography / spacing / radius / shadow / z-index` を中核のトークンとして一元化し、ライト/ダークのテーマとアクセシビリティ基盤を提供するために設計システムを実装しました。 
- フロントエンド全体で共通利用できる CSS 変数注入と全画面レイアウトを用意して開発・監査の一貫性を高めます。 
- 監査表示用の mono フォントとキーボード操作・フォーカスリング・ARIA の改善を通じてアクセシビリティ（WCAG 目標）を向上させます。 
- セキュリティ的には主に静的スタイルの変更であり新たな機密処理は導入していませんが、外部フォントや CSS 変数注入はホスト側で未検証の入力を注入しないよう注意が必要です。

### Description
- `packages/design-system/src/theme.ts` に `tokens`、`createThemeCss`、`applyThemeClass` を追加してトークン化とライト/ダークの CSS 変数マップを提供しました。 
- `packages/design-system/src/theme-styles.tsx` で `ThemeStyles` を追加し、アプリ側でトークンを注入できるようにしました。 
- `packages/design-system/src/app-shell.tsx` にアクセシブルな全画面レイアウト `AppShell` を追加し、スキップリンク・ランドマーク・強いフォーカスリングを備えました。 
- `Button` と `Card` を改善して `Button` は `type="button"` と高視認性のフォーカスリングをデフォルトにし、`Card` は `aria-labelledby` と安定した見出し id を使うようにしました。 
- フロントエンド側では `frontend/app/globals.css`、`frontend/tailwind.config.ts`、`frontend/app/layout.tsx`、`frontend/app/page.tsx` を更新して `--ds-...` 変数を消費し、`ThemeStyles` と `AppShell` をルートに適用しました。 
- 主要モジュールに責務を説明するコメント（docstring 相当）を追加し、変更箇所に関する単体テストを追加/更新しました（`packages/design-system/src/theme.test.ts`、`frontend/app/page.test.tsx`）。

### Testing
- 追加したユニットテストは `packages/design-system/src/theme.test.ts` と `frontend/app/page.test.tsx` で作成していますが、ローカル環境でのパッケージ管理ツール取得問題によりフル実行はできませんでした。 
- 実行: `pnpm -r typecheck` を試行しましたが、Corepack が `pnpm` をダウンロードできずネットワーク/プロキシエラーで失敗しました。 
- UI の視覚検証として Playwright でスクリーンショット取得を試みましたが、アプリが起動しておらず `net::ERR_EMPTY_RESPONSE` で失敗しました。 
- テストと型チェックはネットワークが利用可能な CI / 開発環境で再実行することを推奨します（追加の lint/型チェックは未完了）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d981c5e3c8326b280fc26d7e81c18)