### PR TITLE
Add docker-compose stack for frontend/backend with safe env defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Frontend (browser) -> backend API base URL.
+# For docker compose, the default uses backend service DNS.
+NEXT_PUBLIC_API_BASE_URL=http://backend:8000
+
+# Backend CORS allow-list (comma separated).
+# Keep this strict; only local development origins are included by default.
+VERITAS_CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# Backend authentication secret (set a strong random value in real environments).
+VERITAS_API_SECRET=change-me

--- a/README_UI.md
+++ b/README_UI.md
@@ -32,3 +32,17 @@ pnpm -r typecheck
 # workspace 全体のテスト
 pnpm -r test
 ```
+
+
+## Docker Compose で一括起動
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+- frontend: `http://localhost:3000`
+- backend: `http://localhost:8000`
+- compose では frontend が `NEXT_PUBLIC_API_BASE_URL=http://backend:8000` を使用します。
+
+> 秘密情報は `docker-compose.yml` に直書きせず、`.env` 側で上書きしてください。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: veritas-backend
+    ports:
+      - "8000:8000"
+    environment:
+      VERITAS_CORS_ALLOW_ORIGINS: ${VERITAS_CORS_ALLOW_ORIGINS:-http://localhost:3000,http://127.0.0.1:3000}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  frontend:
+    image: node:20-bookworm
+    container_name: veritas-frontend
+    working_dir: /app
+    command: >-
+      sh -c "corepack enable && pnpm install --frozen-lockfile &&
+      pnpm --filter frontend dev --hostname 0.0.0.0 --port 3000"
+    ports:
+      - "3000:3000"
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://backend:8000}
+    volumes:
+      - ./:/app
+    depends_on:
+      backend:
+        condition: service_healthy

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1,10 +1,39 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import Home from "./page";
 
 describe("Home", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "http://backend:8000";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+  });
+
   it("renders layer0 card", () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ service: "backend", status: "ok" })
+    } as Response);
+
     render(<Home />);
     expect(screen.getByText("Layer0 Design System Ready")).toBeInTheDocument();
     expect(screen.getByLabelText("デザインシステム動作確認")).toBeInTheDocument();
+  });
+
+  it("shows backend health status", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ service: "backend", status: "ok" })
+    } as Response);
+
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("backend connection: backend: ok")
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,13 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Button, Card } from "@veritas/design-system";
 import type { HealthResponse } from "@veritas/types";
+
+type BackendHealthState = {
+  ok: boolean;
+  message: string;
+};
 
 const sampleHealth: HealthResponse = {
   status: "ok",
@@ -7,7 +15,67 @@ const sampleHealth: HealthResponse = {
   timestamp: new Date().toISOString()
 };
 
+/**
+ * Fetch backend health from the configured public API base URL.
+ *
+ * The URL must be provided by NEXT_PUBLIC_API_BASE_URL so that
+ * compose and local development can target different backends safely.
+ */
+async function checkBackendHealth(): Promise<BackendHealthState> {
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  if (!apiBaseUrl) {
+    return {
+      ok: false,
+      message: "NEXT_PUBLIC_API_BASE_URL is not configured"
+    };
+  }
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/health`);
+    if (!response.ok) {
+      return {
+        ok: false,
+        message: `backend health request failed (${response.status})`
+      };
+    }
+
+    const data = (await response.json()) as HealthResponse;
+    return {
+      ok: true,
+      message: `${data.service ?? "backend"}: ${data.status}`
+    };
+  } catch {
+    return {
+      ok: false,
+      message: "backend unreachable"
+    };
+  }
+}
+
 export default function Home(): JSX.Element {
+  const [backendHealth, setBackendHealth] = useState<BackendHealthState>({
+    ok: false,
+    message: "checking backend..."
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    const run = async (): Promise<void> => {
+      const nextState = await checkBackendHealth();
+      if (active) {
+        setBackendHealth(nextState);
+      }
+    };
+
+    void run();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   return (
     <div className="flex flex-col gap-4">
       <Card title="Layer0 Design System Ready">
@@ -17,6 +85,9 @@ export default function Home(): JSX.Element {
         <pre className="font-audit mt-4 rounded-md bg-muted p-3 text-xs">
           {JSON.stringify(sampleHealth, null, 2)}
         </pre>
+        <p aria-live="polite" className="mt-4 text-sm">
+          backend connection: {backendHealth.message}
+        </p>
         <Button aria-label="デザインシステム動作確認" className="mt-4">
           Accessible action
         </Button>


### PR DESCRIPTION
### Motivation
- Provide a single-command developer startup (`docker compose up`) that brings up both `backend` (port `8000`) and `frontend` (port `3000`) while preserving the existing backend startup (`python -m uvicorn veritas_os.api.server:app --reload --port 8000`).
- Ensure the frontend targets the internal backend DNS via `NEXT_PUBLIC_API_BASE_URL` so compose networking works reliably (`http://backend:8000` by default). 
- Avoid embedding secrets in the compose file by adding a `.env.example` and using environment variables (with conservative CORS defaults) to reduce accidental exposure. 

### Description
- Added root `docker-compose.yml` that defines `backend` (built from the existing `Dockerfile`, exposes `8000`, and includes a healthcheck) and `frontend` (uses `node:20-bookworm`, runs `pnpm --filter frontend dev` on `0.0.0.0:3000`, mounts the repo, and depends on `backend` health). 
- Introduced `.env.example` with `NEXT_PUBLIC_API_BASE_URL`, `VERITAS_CORS_ALLOW_ORIGINS`, and a placeholder `VERITAS_API_SECRET` to keep secrets out of the compose file. 
- Updated `frontend/app/page.tsx` to perform a `/health` request against `NEXT_PUBLIC_API_BASE_URL` and display backend reachability status in the UI. 
- Extended `frontend/app/page.test.tsx` to mock `fetch` and `NEXT_PUBLIC_API_BASE_URL`, adding a test that verifies the backend health message is rendered; updated `README_UI.md` with `docker compose` usage instructions. 

### Testing
- Attempted `pnpm --filter frontend test` (Vitest) but the run failed due to `corepack/pnpm` package download being blocked by the environment proxy (network `403`), so tests could not complete. (failed)
- Ran a headless Playwright check to access `http://localhost:3000` but it failed with `ERR_EMPTY_RESPONSE` because the services were not started in this environment, so in-situ browser validation could not complete. (failed)
- Attempted to validate compose with `docker compose config` but the `docker` binary is not available in this environment, so stack-level configuration could not be exercised here. (validation skipped)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9c855e08832699ae0cf865d89539)