### PR TITLE
docs: add repository code review report (2026-02-12)

### DIFF
--- a/CODE_REVIEW_2026_02_12_AGENT.md
+++ b/CODE_REVIEW_2026_02_12_AGENT.md
@@ -1,0 +1,44 @@
+# CODE REVIEW 2026-02-12 (Agent)
+
+## Scope
+- Repository-wide lightweight review (`veritas_os`, `frontend`, `packages`) excluding vendored `node_modules`.
+- Static grep-based security scan + Python lint + Python test run.
+
+## Commands executed
+1. `rg --files | head -n 200`
+2. `rg -n "(eval\(|exec\(|subprocess\.|pickle\.loads|yaml\.load\(|os\.system\(|requests\.(get|post)\(|http://)" veritas_os frontend packages --glob '!**/node_modules/**'`
+3. `python -m pytest -q -x`
+4. `ruff check veritas_os`
+
+## Summary of findings
+
+### 1) Test environment inconsistency (High)
+- `python -m pytest -q -x` failed with:
+  - `async def functions are not natively supported`
+  - `PytestUnknownMarkWarning: Unknown pytest.mark.asyncio`
+- Impact:
+  - Full CI confidence is reduced because async integration tests are not runnable in the default test environment.
+  - Regressions in async paths may be missed.
+- Recommendation:
+  - Add and pin `pytest-asyncio` (or unify on `pytest-anyio`) in test dependencies.
+  - Add explicit pytest marker configuration in `pyproject.toml`.
+
+### 2) Transport security defaults are HTTP in multiple entry points (Medium)
+- Several runtime defaults rely on `http://localhost` / `http://127.0.0.1`.
+- Impact:
+  - Local-only defaults are acceptable for development, but become risky if copied into shared/staging deployments.
+- Recommendation:
+  - Document stronger production defaults (`https://` + explicit host allowlist).
+  - Add startup warnings when non-loopback HTTP endpoints are configured.
+
+### 3) Outbound request surfaces present; retry/error hygiene is mostly good (Info)
+- `veritas_os/tools/web_search.py` and `veritas_os/tools/github_adapter.py` have retry and bounded backoff logic.
+- Good points:
+  - Timeout usage and retry bounds are present.
+  - Error message sanitization exists in `github_adapter`.
+- Recommendation:
+  - Consider optional egress/domain allowlist enforcement for stricter production hardening.
+
+## Overall assessment
+- Codebase health appears generally solid from lint and broad test execution progress.
+- Most urgent actionable issue is async test plugin/config alignment.

--- a/CODE_REVIEW_2026_02_12_AGENT.md
+++ b/CODE_REVIEW_2026_02_12_AGENT.md
@@ -1,44 +1,44 @@
-# CODE REVIEW 2026-02-12 (Agent)
+# コードレビュー 2026-02-12（Agent）
 
-## Scope
-- Repository-wide lightweight review (`veritas_os`, `frontend`, `packages`) excluding vendored `node_modules`.
-- Static grep-based security scan + Python lint + Python test run.
+## 対象範囲
+- `veritas_os` / `frontend` / `packages` を対象にしたリポジトリ全体のライトレビュー（ベンダリング済み `node_modules` は除外）。
+- 静的な grep ベースのセキュリティスキャン + Python lint + Python テスト実行。
 
-## Commands executed
+## 実行コマンド
 1. `rg --files | head -n 200`
 2. `rg -n "(eval\(|exec\(|subprocess\.|pickle\.loads|yaml\.load\(|os\.system\(|requests\.(get|post)\(|http://)" veritas_os frontend packages --glob '!**/node_modules/**'`
 3. `python -m pytest -q -x`
 4. `ruff check veritas_os`
 
-## Summary of findings
+## 指摘事項サマリ
 
-### 1) Test environment inconsistency (High)
-- `python -m pytest -q -x` failed with:
+### 1) テスト環境の不整合（High）
+- `python -m pytest -q -x` は以下で失敗:
   - `async def functions are not natively supported`
   - `PytestUnknownMarkWarning: Unknown pytest.mark.asyncio`
-- Impact:
-  - Full CI confidence is reduced because async integration tests are not runnable in the default test environment.
-  - Regressions in async paths may be missed.
-- Recommendation:
-  - Add and pin `pytest-asyncio` (or unify on `pytest-anyio`) in test dependencies.
-  - Add explicit pytest marker configuration in `pyproject.toml`.
+- 影響:
+  - デフォルト環境で async 統合テストを実行できず、CI の信頼性が低下する。
+  - async 経路の回帰を見逃す可能性がある。
+- 推奨対応:
+  - テスト依存関係に `pytest-asyncio` を追加してバージョン固定（または `pytest-anyio` へ統一）。
+  - `pyproject.toml` に pytest のマーカー設定を明示する。
 
-### 2) Transport security defaults are HTTP in multiple entry points (Medium)
-- Several runtime defaults rely on `http://localhost` / `http://127.0.0.1`.
-- Impact:
-  - Local-only defaults are acceptable for development, but become risky if copied into shared/staging deployments.
-- Recommendation:
-  - Document stronger production defaults (`https://` + explicit host allowlist).
-  - Add startup warnings when non-loopback HTTP endpoints are configured.
+### 2) 通信デフォルトが HTTP である箇所が複数存在（Medium）
+- 実行時デフォルトとして `http://localhost` / `http://127.0.0.1` を利用している箇所が複数ある。
+- 影響:
+  - ローカル開発用途としては妥当だが、共有環境・ステージング・本番へ設定が流用されるとリスクになる。
+- 推奨対応:
+  - 本番向けに `https://` を推奨する設定方針と許可ホスト制御（allowlist）を明文化する。
+  - 非 loopback 宛ての HTTP が設定された場合に起動時警告を出す。
 
-### 3) Outbound request surfaces present; retry/error hygiene is mostly good (Info)
-- `veritas_os/tools/web_search.py` and `veritas_os/tools/github_adapter.py` have retry and bounded backoff logic.
-- Good points:
-  - Timeout usage and retry bounds are present.
-  - Error message sanitization exists in `github_adapter`.
-- Recommendation:
-  - Consider optional egress/domain allowlist enforcement for stricter production hardening.
+### 3) 外部通信面は存在するが、再試行/エラー制御は概ね良好（Info）
+- `veritas_os/tools/web_search.py` と `veritas_os/tools/github_adapter.py` には、再試行と上限付きバックオフの実装がある。
+- 良い点:
+  - タイムアウト指定と再試行上限がある。
+  - `github_adapter` にはエラーメッセージのサニタイズがある。
+- 推奨対応:
+  - 本番ハードニングとして、任意で外向き通信先ドメインの allowlist 強制を検討する。
 
-## Overall assessment
-- Codebase health appears generally solid from lint and broad test execution progress.
-- Most urgent actionable issue is async test plugin/config alignment.
+## 総評
+- lint 結果と広範囲テスト実行の進捗から、コードベース全体の健全性は概ね良好。
+- 最優先の改善点は、async テスト実行基盤（plugin / marker）整合の確保。


### PR DESCRIPTION
### Motivation
- Provide a repository-wide lightweight code review summary documenting scan commands, notable findings, and actionable recommendations (primarily the async pytest plugin/marker misconfiguration). 

### Description
- Add `CODE_REVIEW_2026_02_12_AGENT.md` containing scope, executed commands (`rg`, `python -m pytest`, `ruff`), findings, severities, and recommendations about async test support, HTTP defaults, and outbound request hardening. 

### Testing
- Ran `ruff check veritas_os` which passed, and ran `python -m pytest -q -x` which stopped after `1 failed, 727 passed` due to async test support (`pytest.mark.asyncio` / missing `pytest-asyncio` or equivalent) causing the single failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de80bd8d48326844b654d97655d4d)