### PR TITLE
planner: improve simple-QA detection for short multilingual questions

### DIFF
--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -164,10 +164,37 @@ def _is_simple_qa(query: str, context: Dict[str, Any] | None = None) -> bool:
         return False
 
     is_short = len(q) <= 40
+    question_prefixes = (
+        "what",
+        "why",
+        "when",
+        "where",
+        "who",
+        "which",
+        "how",
+        "can ",
+        "could ",
+        "should ",
+        "is ",
+        "are ",
+        "do ",
+        "does ",
+        "did ",
+    )
+    question_endings = (
+        "か",
+        "かね",
+        "かな",
+        "でしょうか",
+        "教えて",
+        "を教えて",
+        "知りたい",
+    )
     looks_question = (
         ("?" in q)
         or ("？" in q)
-        or q.endswith(("か", "かね", "かな", "でしょうか"))
+        or q_lower.startswith(question_prefixes)
+        or q.endswith(question_endings)
     )
     has_plan_words = any(
         k in q for k in ["どう進め", "進め方", "計画", "プラン", "ロードマップ", "タスク"]
@@ -1231,5 +1258,4 @@ def generate_plan(
     )
 
     return steps
-
 

--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -77,6 +77,8 @@ def test_normalize_step_handles_non_list_dependencies():
         ("どう進めたらいいですか？", {}, False),  # 「どう進め」が含まれると simple_qa にならない
         ("VERITAS の弱点を教えて", {}, False),  # AGI / VERITAS 系は除外
         ("VERITAS の弱点を教えて", {"simple_qa": True}, True),  # 明示フラグ優先
+        ("what is this", {}, True),  # 英語の疑問文（?なし）
+        ("料金を教えて", {}, True),  # 日本語の短い質問（?なし）
     ],
 )
 def test_is_simple_qa_variants(query, ctx, expected):


### PR DESCRIPTION
### Motivation
- Short, multilingual user queries without an explicit question mark were frequently misclassified and not taken down the `simple_qa` fast path, reducing responsiveness for trivial Q&A; this change tightens the heuristic to better capture those cases.
- Keep the change scoped to Planner responsibilities without touching Kernel, Fuji, or MemoryOS logic to avoid crossing component boundaries.

### Description
- Extended `_is_simple_qa` to detect English question prefixes (e.g., `what`, `how`, `is`, `do`) and additional Japanese question endings (e.g., `教えて`, `を教えて`, `知りたい`) and incorporated them into the existing short-question heuristic. 
- Added two regression test cases (`"what is this"` and `"料金を教えて"`) to `veritas_os/tests/test_planner.py` to validate multilingual detection. 
- Change is limited to `veritas_os/core/planner.py` and tests in `veritas_os/tests/test_planner.py`, and follows the PEP8 requirement for code changes. 
- This is a heuristic hardening only and does not alter security policy or Fuji responsibilities. 

### Testing
- Ran `pytest -q veritas_os/tests/test_planner.py veritas_os/tests/test_planner_coverage.py` and the run completed successfully with `119 passed` and `3 warnings`.
- Unit tests added for the new variants passed as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb4c9cd4c832680238f792c0acdff)