### PR TITLE
planner: handle stray leading closing brace in JSON rescue

### DIFF
--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -554,6 +554,10 @@ def _safe_json_extract_core(raw: str) -> Dict[str, Any]:
                         buf_start = i
                     depth += 1
                 elif ch == "}":
+                    if depth == 0:
+                        # 先頭側の壊れた `}` を無視して復旧可能性を維持する
+                        i += 1
+                        continue
                     depth -= 1
                     if depth == 0 and buf_start is not None:
                         obj_str = text[buf_start : i + 1]
@@ -1258,4 +1262,3 @@ def generate_plan(
     )
 
     return steps
-

--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -138,6 +138,13 @@ def test_safe_json_extract_recovers_from_broken_but_embedded_steps():
     assert ids == ["ok1", "ok2"]
 
 
+def test_safe_json_extract_ignores_leading_unbalanced_closing_brace():
+    raw = '} noise "steps": [{"id": "ok1"}, {"id": "ok2"}] tail'
+    obj = planner_core._safe_json_extract(raw)
+    ids = [s["id"] for s in obj["steps"]]
+    assert ids == ["ok1", "ok2"]
+
+
 # -------------------------------
 # _fallback_plan / _infer_veritas_stage / _fallback_plan_for_stage
 # -------------------------------


### PR DESCRIPTION
### Motivation
- Harden planner JSON recovery so a malformed LLM output that begins with an unbalanced closing brace (`}`) does not prevent extracting valid `steps`; change is limited to planner parsing internals and does not expand responsibilities or add new I/O, however note that parsing arbitrary LLM output remains a place to monitor for adversarial or resource-exhaustion inputs.

### Description
- When extracting objects from a `"steps"` array, ignore leading unbalanced `}` characters by skipping them when `depth == 0`, and add the regression test `test_safe_json_extract_ignores_leading_unbalanced_closing_brace`; the change follows PEP8 and is restricted to planner parsing logic.

### Testing
- Ran `pytest -q veritas_os/tests/test_planner.py` and the suite passed with `34 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb779562c8326be1ed824155293bd)