### PR TITLE
Harden Chainlit formatter handling for malformed numeric API fields

### DIFF
--- a/veritas_os/tests/test_chainlit_app_formatters.py
+++ b/veritas_os/tests/test_chainlit_app_formatters.py
@@ -1,0 +1,87 @@
+"""Regression tests for robust formatting in ``chainlit_app``."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _load_chainlit_app_module():
+    """Load ``chainlit_app`` with a lightweight chainlit stub for tests."""
+    chainlit_stub = types.ModuleType("chainlit")
+
+    def _identity_decorator(_func=None):
+        def decorator(func):
+            return func
+
+        if _func is None:
+            return decorator
+        return decorator(_func)
+
+    class _Message:
+        def __init__(self, content: str):
+            self.content = content
+
+        async def send(self):
+            return None
+
+        async def update(self):
+            return None
+
+    chainlit_stub.on_chat_start = _identity_decorator
+    chainlit_stub.on_message = _identity_decorator
+    chainlit_stub.Message = _Message
+
+    sys.modules.setdefault("chainlit", chainlit_stub)
+    return importlib.import_module("chainlit_app")
+
+
+module = _load_chainlit_app_module()
+
+
+def test_format_metrics_ignores_non_numeric_values() -> None:
+    """Formatter should skip non-numeric metrics instead of raising an error."""
+    result = module.format_metrics(
+        {
+            "extras": {
+                "metrics": {
+                    "latency_ms": "oops",
+                    "mem_evidence_count": "NaN",
+                    "avg_world_utility": "bad",
+                }
+            }
+        }
+    )
+
+    assert "メトリクス情報はまだありません" in result
+
+
+def test_format_memory_and_evidence_handles_bad_confidence() -> None:
+    """Formatter should tolerate non-float confidence fields in evidence payloads."""
+    result = module.format_memory_and_evidence(
+        {
+            "evidence": [
+                {
+                    "source": "memory_store",
+                    "snippet": "important memory",
+                    "confidence": "unknown",
+                }
+            ]
+        }
+    )
+
+    assert "conf=0.00" in result
+
+
+def test_format_main_answer_handles_string_ema() -> None:
+    """Formatter should render EMA when it is delivered as a numeric string."""
+    result = module.format_main_answer(
+        {
+            "chosen": {"title": "A"},
+            "gate": {"decision_status": "allow", "risk": 0.1},
+            "values": {"total": "1.5", "ema": "2.25"},
+        }
+    )
+
+    assert "total=1.500 / ema=2.250" in result


### PR DESCRIPTION
### Motivation
- Prevent Chainlit UI rendering from crashing when API payloads contain non-numeric, `NaN`, or `Inf` values by making numeric parsing tolerant.
- Improve robustness of presentation-layer formatters without changing core responsibilities of Planner/Kernel/Fuji/MemoryOS.
- Security note: the change reduces crash risk but the app still renders external API strings, so continue to apply length limits and sanitization for displayed text to avoid information leakage or UI injection issues.

### Description
- Add `_safe_float` and `_safe_int` helpers in `chainlit_app.py` with docstrings to safely parse numeric-like values and treat invalid/NaN/Inf as `None`.
- Update `format_main_answer` to use safe conversions for `values.total` and `values.ema` and avoid exceptions on string inputs.
- Update `format_metrics` to coerce metrics via the safe helpers and skip malformed entries so formatters return a graceful message when no valid metrics exist.
- Update `format_memory_and_evidence` to tolerate non-numeric `memory_used_count` and malformed `evidence.confidence`, and add tests in `veritas_os/tests/test_chainlit_app_formatters.py` covering these cases.

### Testing
- Ran `pytest -q veritas_os/tests/test_chainlit_app_formatters.py` which passed (`3 passed`).
- Ran `pytest -q veritas_os/tests/test_api_constants.py veritas_os/tests/test_chainlit_app_formatters.py` which passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb963125c83269ff7d7286e0bb153)