### PR TITLE
memory_train: implement load_decision_data and add regression tests

### DIFF
--- a/veritas_os/scripts/memory_train.py
+++ b/veritas_os/scripts/memory_train.py
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
-import os, json, glob, random
-from pathlib import Path
+import glob
+import json
+import os
+import random
 from collections import Counter
+from pathlib import Path
+from typing import Iterable
 
 import joblib
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -13,24 +17,109 @@ from sklearn.linear_model import LogisticRegression
 
 print("[memory_train] running file:", __file__)
 
-# ▼ ここを修正：VERITAS_DIR を「このリポジトリ」にする
-#   .../veritas_clean_test2/veritas_os/scripts/memory_train.py
-#   という位置にある前提で、1つ上が repo root
-REPO_ROOT   = Path(__file__).resolve().parents[1]   # .../veritas_os
+REPO_ROOT = Path(__file__).resolve().parents[1]
 VERITAS_DIR = REPO_ROOT
 
-# データセット置き場（リポジトリ内）
 DATASET_DIR = VERITAS_DIR / "datasets"
 DATASET_DIR.mkdir(parents=True, exist_ok=True)
 
 DATA_DIRS = [
     DATASET_DIR,
-    VERITAS_DIR / "scripts" / "logs",   # 必要なら使う
+    VERITAS_DIR / "scripts" / "logs",
 ]
 
-# ▼ モデルの保存先もリポジトリ内 core/models に統一
 MODEL_PATH = VERITAS_DIR / "core" / "models"
 MODEL_PATH.mkdir(parents=True, exist_ok=True)
+
+VALID_LABELS = {"allow", "modify", "deny"}
+TEXT_KEYS = ("text", "prompt", "input", "query", "message")
+LABEL_KEYS = ("label", "decision", "verdict", "action")
+
+
+def _extract_record(item: dict) -> tuple[str, str] | None:
+    """Extract training text and label from a single JSON object.
+
+    Args:
+        item: One JSON object loaded from dataset files.
+
+    Returns:
+        A ``(text, label)`` tuple when required fields are found and the label is
+        valid, otherwise ``None``.
+    """
+    label = next((str(item[k]).strip().lower() for k in LABEL_KEYS if k in item), None)
+    if label not in VALID_LABELS:
+        return None
+
+    text = next((str(item[k]).strip() for k in TEXT_KEYS if k in item), "")
+    if not text:
+        return None
+
+    return text, label
+
+
+def _load_jsonl(path: Path) -> Iterable[tuple[str, str]]:
+    """Load records from a JSON Lines dataset file.
+
+    Invalid lines are skipped to keep the script resilient against partial logs.
+    """
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                print(f"[WARN] skip invalid JSONL: {path}:{line_no}")
+                continue
+
+            if isinstance(item, dict):
+                record = _extract_record(item)
+                if record:
+                    yield record
+
+
+def load_decision_data() -> list[tuple[str, str]]:
+    """Load decision-training data from repository dataset directories.
+
+    Supported formats are ``.json`` and ``.jsonl``. The function only accepts
+    labels in ``allow/modify/deny`` and skips malformed entries.
+    """
+    patterns = ["*.json", "*.jsonl"]
+    files: list[Path] = []
+
+    for base in DATA_DIRS:
+        if not base.exists():
+            continue
+        for pattern in patterns:
+            matched = [Path(p) for p in glob.glob(os.path.join(base, pattern))]
+            files.extend(matched)
+
+    records: list[tuple[str, str]] = []
+    for path in sorted(set(files)):
+        if path.suffix == ".jsonl":
+            records.extend(_load_jsonl(path))
+            continue
+
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            print(f"[WARN] skip invalid JSON: {path}")
+            continue
+
+        if isinstance(payload, dict):
+            payload = [payload]
+        if not isinstance(payload, list):
+            continue
+
+        for item in payload:
+            if isinstance(item, dict):
+                record = _extract_record(item)
+                if record:
+                    records.append(record)
+
+    print(f"[memory_train] loaded {len(records)} records from {len(files)} files")
+    return records
 
 
 def train_memory_model(data):
@@ -60,7 +149,7 @@ def train_memory_model(data):
         by_label[y].append((x, y))
 
     balanced = []
-    for lbl, items in by_label.items():
+    for items in by_label.values():
         if not items:
             continue
         need = max(0, min_ok - len(items))
@@ -74,8 +163,8 @@ def train_memory_model(data):
 
     print("Class counts (after rebalance):", Counter(y for _, y in balanced))
 
-    X_texts, y = zip(*balanced)
-    X_texts = [str(t) for t in X_texts]
+    x_texts, y = zip(*balanced)
+    x_texts = [str(t) for t in x_texts]
 
     classes = np.array(["allow", "modify", "deny"])
     weights = compute_class_weight(class_weight="balanced", classes=classes, y=list(y))
@@ -83,21 +172,18 @@ def train_memory_model(data):
     print("[DEBUG] computed class_weight:", class_weight)
 
     vec = TfidfVectorizer(max_features=4000, ngram_range=(1, 2))
-    X = vec.fit_transform(X_texts)
+    x_data = vec.fit_transform(x_texts)
 
     clf = LogisticRegression(
         max_iter=400,
         class_weight=class_weight,
         n_jobs=None,
     )
-    clf.fit(X, y)
+    clf.fit(x_data, y)
 
     joblib.dump((vec, clf), MODEL_PATH / "memory_model.pkl")
     print(f"✅ model saved → {MODEL_PATH}/memory_model.pkl")
 
-
-# （load_decision_data 以下はそのままでOK）
-# ...
 
 if __name__ == "__main__":
     data = load_decision_data()

--- a/veritas_os/tests/test_memory_train_script.py
+++ b/veritas_os/tests/test_memory_train_script.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from veritas_os.scripts import memory_train
 
@@ -58,3 +59,16 @@ def test_load_decision_data_skips_malformed_json(monkeypatch, tmp_path: Path) ->
     records = memory_train.load_decision_data()
 
     assert records == []
+
+
+def test_load_training_dependencies_raises_runtime_error_on_missing_package() -> None:
+    with patch(
+        "veritas_os.scripts.memory_train.import_module",
+        side_effect=ModuleNotFoundError("No module named 'numpy'"),
+    ):
+        try:
+            memory_train._load_training_dependencies()
+        except RuntimeError as exc:
+            assert "Missing package" in str(exc)
+        else:
+            raise AssertionError("RuntimeError was not raised")

--- a/veritas_os/tests/test_memory_train_script.py
+++ b/veritas_os/tests/test_memory_train_script.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from veritas_os.scripts import memory_train
+
+
+def test_load_decision_data_supports_json_and_jsonl(monkeypatch, tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "datasets"
+    logs_dir = tmp_path / "logs"
+    dataset_dir.mkdir()
+    logs_dir.mkdir()
+
+    json_path = dataset_dir / "records.json"
+    json_path.write_text(
+        json.dumps(
+            [
+                {"text": "safe query", "label": "allow"},
+                {"prompt": "needs update", "decision": "modify"},
+                {"text": "ignored", "label": "unknown"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    jsonl_path = logs_dir / "events.jsonl"
+    jsonl_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"query": "blocked request", "verdict": "deny"}),
+                "not-json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(memory_train, "DATA_DIRS", [dataset_dir, logs_dir])
+    records = memory_train.load_decision_data()
+
+    assert sorted(records) == sorted(
+        [
+            ("safe query", "allow"),
+            ("needs update", "modify"),
+            ("blocked request", "deny"),
+        ]
+    )
+
+
+def test_load_decision_data_skips_malformed_json(monkeypatch, tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "datasets"
+    dataset_dir.mkdir()
+
+    bad_json = dataset_dir / "broken.json"
+    bad_json.write_text("{invalid", encoding="utf-8")
+
+    monkeypatch.setattr(memory_train, "DATA_DIRS", [dataset_dir])
+    records = memory_train.load_decision_data()
+
+    assert records == []


### PR DESCRIPTION
### Motivation
- `memory_train.py` referenced `load_decision_data()` but it was not defined, causing runtime failures when running the script; the change restores that responsibility in the script layer. 
- The loader needed to support both `.json` and `.jsonl` dataset formats robustly and skip malformed entries to avoid crashes during training runs. 
- Small style and clarity fixes were applied (PEP8 import formatting, variable naming, removal of dead comments) and docstrings were added to clarify expected inputs and failure behavior. 
- Security note: loading training data directly from files can enable model poisoning if untrusted data is present, so operational controls over dataset sources remain necessary.

### Description
- Implemented `_extract_record`, `_load_jsonl`, and `load_decision_data` in `veritas_os/scripts/memory_train.py` to load and normalize training records from `DATA_DIRS` supporting `*.json` and `*.jsonl`, and to accept only `allow/modify/deny` labels. 
- Added `VALID_LABELS`, `TEXT_KEYS`, and `LABEL_KEYS` constants and docstrings to make parsing rules explicit and maintainable. 
- Made minor refactors for readability and PEP8 compliance (reordered imports, removed repository-specific comments, normalized local variable names used by the trainer). 
- Added regression tests at `veritas_os/tests/test_memory_train_script.py` covering mixed JSON/JSONL loading and skipping of malformed JSON files.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_train_script.py`, which passed (`2 passed`). 
- Ran `ruff check veritas_os/scripts/memory_train.py veritas_os/tests/test_memory_train_script.py`, which reported no remaining issues for those files. 
- Ran broader unit test groups including `veritas_os/tests/test_memory_model.py` and `veritas_os/tests/test_memory_core.py`, which passed (`26 passed`), and a selected core suite including planner/kernel/fuji/memory tests which also passed (`88 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ebf25aeac8326b25cc12203596bae)