### PR TITLE
Align CI coverage threshold with README coverage messaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,7 @@ jobs:
       PIP_NO_PYTHON_VERSION_WARNING: "1"
       OPENAI_API_KEY: "DUMMY_FOR_CI"
       VERITAS_API_KEY: "DUMMY_FOR_CI"
+      COVERAGE_FAIL_UNDER: "85"
 
     steps:
       - name: Checkout
@@ -116,7 +117,7 @@ jobs:
             --cov-report=term-missing \
             --cov-report=xml:coverage.xml \
             --cov-report=html:coverage-html \
-            --cov-fail-under=40 \
+            --cov-fail-under=${COVERAGE_FAIL_UNDER} \
             --junitxml=test-reports/pytest.xml \
             --tb=short
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-red.svg)](LICENSE)
 [![CI](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml)
 [![Docker Publish](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml)
-[![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen.svg)](docs/COVERAGE_REPORT.md)
+[![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen.svg)](docs/COVERAGE_REPORT.md) <!-- Snapshot value from docs/COVERAGE_REPORT.md; CI gate is configured in .github/workflows/main.yml -->
 [![GHCR](https://img.shields.io/badge/GHCR-ghcr.io%2Fveritasfuji--japan%2Fveritas__os-2496ED?logo=docker&logoColor=white)](https://ghcr.io/veritasfuji-japan/veritas_os)
 [![README JP](https://img.shields.io/badge/README-日本語-0f766e.svg)](README_JP.md)
 
@@ -269,6 +269,8 @@ make test PYTHON_VERSION=3.11
 
 * GitHub Actions runs **pytest + coverage** on a Python 3.11/3.12 matrix.
 * Coverage artifacts are stored as **XML/HTML** outputs.
+* CI enforces a minimum coverage gate (`--cov-fail-under`) currently set to **85%**.
+* The coverage badge is currently a documentation snapshot value from `docs/COVERAGE_REPORT.md` (planned: automatic update from CI artifacts).
 * The CI job fails if tests fail, acting as a quality gate.
 
 ## Security Notes (Important)

--- a/README_JP.md
+++ b/README_JP.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-red.svg)](LICENSE)
 [![CI](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml)
 [![Docker Publish](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml)
-[![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen.svg)](docs/COVERAGE_REPORT.md)
+[![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen.svg)](docs/COVERAGE_REPORT.md) <!-- Snapshot value from docs/COVERAGE_REPORT.md; CI gate is configured in .github/workflows/main.yml -->
 [![GHCR](https://img.shields.io/badge/GHCR-ghcr.io%2Fveritasfuji--japan%2Fveritas__os-2496ED?logo=docker&logoColor=white)](https://ghcr.io/veritasfuji-japan/veritas_os)
 [![README EN](https://img.shields.io/badge/README-English-1d4ed8.svg)](README.md)
 
@@ -347,6 +347,8 @@ Dockerfile の `CMD` を環境に合わせて更新してください。
 ## 近いロードマップ（短期）
 
 * CI（GitHub Actions）：pytest + coverage + レポート生成
+* CI ではカバレッジ下限（`--cov-fail-under`）を **85%** に設定しています。
+* Coverage バッジ値は現在 `docs/COVERAGE_REPORT.md` 由来のスナップショットです（将来的に CI artifact からの自動更新を想定）。
 * セキュリティ強化：入力検証、ログ/秘密情報の衛生
 * Policy-as-Code：**規程 → ValueCore/FUJIルール → テスト自動生成**（コンパイラ層）
 


### PR DESCRIPTION
### Motivation

- The README shows a `92%` coverage badge while CI previously used `--cov-fail-under=40`, which creates a visible mismatch and weakens external trust. 
- The change aims to reduce that gap by making the CI gate explicit/configurable and documenting the badge as a snapshot until automation is implemented.

### Description

- Introduced a configurable coverage gate via environment variable `COVERAGE_FAIL_UNDER` (set to `85`) in `/.github/workflows/main.yml` and switched the pytest invocation to `--cov-fail-under=${COVERAGE_FAIL_UNDER}`. 
- Updated `README.md` to annotate the coverage badge and to state that the CI minimum coverage gate is `85%` and that the badge is a documentation snapshot (planned: automated update from CI artifacts). 
- Applied the same explanatory annotations to `README_JP.md` to keep English/Japanese docs consistent. 
- Only CI configuration and documentation were changed; no runtime code paths were modified.

### Testing

- Ran `pytest -q veritas_os/tests/test_config_coverage.py --tb=short`, which passed (`31 passed`).
- Attempted a full coverage run with `pytest --cov=... --cov-fail-under=85`, but installation of `pytest-cov` failed in this environment due to network/proxy restrictions, so the `--cov-*` verification could not be executed here. 
- A non-coverage full test run in this environment showed a failing async test due to missing async plugin support (`pytest-asyncio`), however the workflow installs `pytest-asyncio` and `pytest-cov` during CI, so the matrix CI should perform the full validation when run in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ec66b541883268ffa1ee1eb294af7)