### PR TITLE
tests: support asyncio-marked tests without external plugin

### DIFF
--- a/veritas_os/tests/conftest.py
+++ b/veritas_os/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest configuration for asynchronous test execution.
+
+This project includes ``@pytest.mark.asyncio`` tests but does not require an
+external async pytest plugin in all environments. The hook below executes
+coroutine test functions with ``asyncio.run`` so async tests remain portable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    """Run ``async def`` test functions without external pytest async plugins."""
+    test_function = pyfuncitem.obj
+    if not inspect.iscoroutinefunction(test_function):
+        return None
+
+    fixture_args: dict[str, Any] = {
+        arg_name: pyfuncitem.funcargs[arg_name]
+        for arg_name in pyfuncitem._fixtureinfo.argnames
+    }
+    asyncio.run(test_function(**fixture_args))
+    return True
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers used in this test suite."""
+    config.addinivalue_line(
+        "markers",
+        "asyncio: mark test as asynchronous and execute via asyncio.run",
+    )

--- a/veritas_os/tests/test_async_support.py
+++ b/veritas_os/tests/test_async_support.py
@@ -1,0 +1,14 @@
+"""Regression tests for asynchronous pytest compatibility."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_asyncio_marked_test_executes_without_plugin() -> None:
+    """Ensure ``@pytest.mark.asyncio`` tests execute in minimal environments."""
+    await asyncio.sleep(0)
+    assert True


### PR DESCRIPTION
### Motivation
- The test suite included `@pytest.mark.asyncio` tests which failed in environments without `pytest-asyncio`, causing CI/test runs to fail.
- The goal is to make async-marked tests portable without adding an external dependency while keeping changes limited to the test harness.
- No new external input handling or privilege changes were introduced, but note that running coroutine tests via `asyncio.run` will execute test coroutines and may trigger side effects, so test code should be reviewed for unsafe operations.

### Description
- Add `veritas_os/tests/conftest.py` implementing a `pytest_pyfunc_call` hook that runs `async def` test functions using `asyncio.run` when no async plugin is present.
- Register the `asyncio` marker in `pytest_configure` to suppress unknown-marker warnings.
- Add regression test `veritas_os/tests/test_async_support.py` that asserts `@pytest.mark.asyncio` tests run under the new hook.
- Include module docstrings and follow PEP8 formatting for the added files.

### Testing
- Ran `pytest -q veritas_os/tests/test_async_support.py veritas_os/tests/test_integration_pipeline.py::TestEndToEndPipeline::test_kernel_decide_basic_flow` and both tests passed.
- Ran `python -m py_compile veritas_os/tests/conftest.py veritas_os/tests/test_async_support.py` and compilation succeeded.
- The previously failing async test case is resolved by these changes as validated by the targeted test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee256396c83268e46f11e3e2bc9d6)