### PR TITLE
Harden Slack webhook URL validation in alert_doctor

### DIFF
--- a/veritas_os/tests/test_alert_doctor.py
+++ b/veritas_os/tests/test_alert_doctor.py
@@ -18,6 +18,23 @@ def test_validate_webhook_url_rejects_insecure_or_untrusted_hosts():
     assert not alert_doctor._validate_webhook_url("")
 
 
+
+
+def test_validate_webhook_url_rejects_ports_userinfo_and_extra_parts():
+    """Webhook URL with unsafe URL parts should be rejected."""
+    assert not alert_doctor._validate_webhook_url(
+        "https://hooks.slack.com:443/services/a/b/c"
+    )
+    assert not alert_doctor._validate_webhook_url(
+        "https://user@hooks.slack.com/services/a/b/c"
+    )
+    assert not alert_doctor._validate_webhook_url(
+        "https://hooks.slack.com/services/a/b/c?debug=true"
+    )
+    assert not alert_doctor._validate_webhook_url(
+        "https://hooks.slack.com/not-services/a/b/c"
+    )
+
 def test_post_slack_rejects_invalid_webhook_without_network(monkeypatch):
     """post_slack should fail fast when webhook URL is invalid."""
     monkeypatch.setattr(alert_doctor, "WEBHOOK", "http://hooks.slack.com/services/a/b/c")


### PR DESCRIPTION
### Motivation
- Reduce SSRF/misrouting and accidental deliveries by enforcing stricter Slack webhook URL shape and host checks for the alert delivery script.
- Make security constraints explicit in the code via docstring to clarify allowed webhook formats.
- Note that `subprocess` usage still exists elsewhere in the script and should remain restricted; this change focuses only on input validation.

### Description
- Expanded `alert_doctor._validate_webhook_url` docstring and added strict checks to require `https`, disallow explicit `port`, `username`/`password` (userinfo), query strings, and fragments, and require the path to start with `/services/`.
- Enforced allowed hostnames to the canonical Slack webhook domains (`hooks.slack.com`, `hooks.slack-gov.com`) as part of the validation flow.
- Added `test_validate_webhook_url_rejects_ports_userinfo_and_extra_parts` in `veritas_os/tests/test_alert_doctor.py` to cover the rejected URL forms.

### Testing
- Ran `pytest -q veritas_os/tests/test_alert_doctor.py veritas_os/tests/test_code_review_fixes_v2.py` which completed successfully with `21 passed in 0.94s`.
- Earlier `pytest -q veritas_os/tests/test_code_review_fixes_v2.py` also passed with `16 passed` when run standalone.
- The changes were committed and a PR description was generated for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eeda251c4832681ab2b6ab634fce2)