### PR TITLE
Fix memory_train dataset ingestion and add regression test

### DIFF
--- a/veritas_os/tests/test_memory_train_script.py
+++ b/veritas_os/tests/test_memory_train_script.py
@@ -1,0 +1,71 @@
+"""Tests for scripts/memory_train.py dataset loading behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "memory_train.py"
+
+
+def load_module():
+    """Load memory_train.py as a module for script-level tests."""
+    spec = importlib.util.spec_from_file_location("memory_train", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class MemoryTrainScriptTests(unittest.TestCase):
+    """Behavioral tests for memory_train dataset ingestion."""
+
+    def test_load_decision_data_parses_json_and_jsonl(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            json_path = tmp_path / "records.json"
+            json_path.write_text(
+                json.dumps(
+                    [
+                        {"input": "Allow this", "decision": "allow"},
+                        {"prompt": "Modify this", "label": "modify"},
+                        {"text": "Bad label", "label": "unknown"},
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            jsonl_path = tmp_path / "records.jsonl"
+            jsonl_path.write_text(
+                "\n".join(
+                    [
+                        json.dumps({"query": "Deny this", "output": "deny"}),
+                        json.dumps({"query": "Skip", "output": "other"}),
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            module.DATA_DIRS = [tmp_path]
+
+            loaded = module.load_decision_data()
+
+        self.assertEqual(
+            loaded,
+            [
+                ("Allow this", "allow"),
+                ("Modify this", "modify"),
+                ("Deny this", "deny"),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- `memory_train.py` referenced a missing `load_decision_data()` which prevented running the script and blocked local model training workflows.  
- The script contained non-PEP8 import formatting which was cleaned up to match repository style.  
- Data-loading from local datasets needs explicit error handling and a security note, since syntactically valid but malicious training records could still poison models.

### Description
- Implemented `load_decision_data()` in `veritas_os/scripts/memory_train.py` to scan `DATA_DIRS` for `*.json` and `*.jsonl` files, parse list or line-delimited payloads, and normalize schema fields (`input|prompt|text|query` for text and `decision|label|output` for label) while returning only `allow|modify|deny` pairs.  
- Added a docstring for the loader and handled `OSError`/`json.JSONDecodeError` to safely skip invalid files without executing arbitrary code.  
- Reordered and simplified imports in `memory_train.py` to be PEP8-compliant.  
- Added a focused regression test `veritas_os/tests/test_memory_train_script.py` that uses `tempfile.TemporaryDirectory()` to verify JSON and JSONL ingestion and label filtering.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_memory_train_script.py` and the test passed (`1 passed`).  
- Ran `python -m pytest -q veritas_os/tests/test_memory_model.py` to validate dependent functionality and it passed (`10 passed`).  
- Ran `ruff check veritas_os/scripts/memory_train.py veritas_os/tests/test_memory_train_script.py` and lint checks passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ef581a8b88326b75b69f8907763b9)