### PR TITLE
Make memory_train dataset loading deterministic

### DIFF
--- a/veritas_os/tests/test_memory_train_script.py
+++ b/veritas_os/tests/test_memory_train_script.py
@@ -66,6 +66,32 @@ class MemoryTrainScriptTests(unittest.TestCase):
             ],
         )
 
+    def test_load_decision_data_uses_deterministic_file_order(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            (tmp_path / "z_records.json").write_text(
+                json.dumps([{"input": "Z first by create", "decision": "allow"}]),
+                encoding="utf-8",
+            )
+
+            (tmp_path / "a_records.json").write_text(
+                json.dumps([{"input": "A second by create", "decision": "deny"}]),
+                encoding="utf-8",
+            )
+
+            module.DATA_DIRS = [tmp_path]
+            loaded = module.load_decision_data()
+
+        self.assertEqual(
+            loaded,
+            [
+                ("A second by create", "deny"),
+                ("Z first by create", "allow"),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- `memory_train.py` がファイル発見でファイルシステムの順序に依存しており学習データの読み込み順が不安定だったため、読み込み順を決定的にして学習再現性を高める目的で変更しました。 
- 外部から投入される JSON/JSONL を直接読み込む設計のため、運用次第でデータ汚染（training data poisoning）が発生するリスクがあり、その点は運用注意として残します。 

### Description
- モジュールインポート時の副作用ログ出力 (`print(...)`) を削除しました。 
- `glob.glob` を使ったファイル検出を廃止して、ソート済みの `Path` を逐次返すヘルパー関数 `_iter_dataset_files(data_dir, patterns)` を追加し、`load_decision_data()` でこれを利用するように置き換えました。 
- ファイル名ソートに基づく決定的な走査順を導入し、同一ディレクトリ内のファイル読み込み順を安定化しました。 
- `veritas_os/tests/test_memory_train_script.py` に `test_load_decision_data_uses_deterministic_file_order` を追加して、作成順と無関係にアルファベット順で処理されることを検証するユニットテストを追加しました。 

### Testing
- 実行した自動テストは `python -m unittest veritas_os/tests/test_memory_train_script.py` で、2 件のテストが実行され `OK` となり成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f076c02a88326a7a3aeb6ad777486)