### PR TITLE
planner: limit JSON extraction input size to reduce DoS risk

### DIFF
--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -152,6 +152,17 @@ def test_safe_json_extract_ignores_leading_unbalanced_closing_brace():
     assert ids == ["ok1", "ok2"]
 
 
+def test_safe_json_extract_truncates_oversized_input(caplog):
+    payload = json.dumps({"steps": [{"id": "ok1"}]})
+    raw = ("x" * (planner_core._MAX_JSON_EXTRACT_CHARS + 100)) + payload
+
+    with caplog.at_level("WARNING"):
+        obj = planner_core._safe_json_extract(raw)
+
+    assert obj["steps"] == []
+    assert any("input too large" in rec.message for rec in caplog.records)
+
+
 # -------------------------------
 # _fallback_plan / _infer_veritas_stage / _fallback_plan_for_stage
 # -------------------------------


### PR DESCRIPTION
### Motivation
- Prevent excessive CPU usage / DoS from pathological or very large LLM outputs by capping how much text the planner's JSON-rescue logic will scan, and document the behavior in the function docstring.
- Keep the change narrowly scoped to the Planner JSON extraction path and avoid touching Kernel / Fuji / MemoryOS responsibilities.

### Description
- Add `_MAX_JSON_EXTRACT_CHARS = 200_000` and truncate `raw` input to this length in `_safe_json_extract_core`, emitting a `WARNING` when truncation occurs.
- Update `_safe_json_extract_core` docstring to explain truncation and the DoS mitigation intent.
- Add `test_safe_json_extract_truncates_oversized_input` to `veritas_os/tests/test_planner.py` which verifies the fallback to an empty `steps` and that a warning log is emitted for oversized input.

### Testing
- Ran `pytest -q veritas_os/tests/test_planner.py` and all tests in that file passed (36 passed).
- Ran `ruff check veritas_os/core/planner.py veritas_os/tests/test_planner.py --output-format concise` and linting passed (All checks passed!).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fd8dd46608326892ee125ced7c8f2)