### PR TITLE
planner: harden oversized JSON handling in _safe_parse

### DIFF
--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -163,6 +163,17 @@ def test_safe_json_extract_truncates_oversized_input(caplog):
     assert any("input too large" in rec.message for rec in caplog.records)
 
 
+def test_safe_parse_truncates_oversized_input(caplog):
+    payload = json.dumps({"steps": [{"id": "ok1"}]})
+    raw = ("x" * (planner_core._MAX_JSON_EXTRACT_CHARS + 100)) + payload
+
+    with caplog.at_level("WARNING"):
+        obj = planner_core._safe_parse(raw)
+
+    assert obj["steps"] == []
+    assert any("input too large" in rec.message for rec in caplog.records)
+
+
 # -------------------------------
 # _fallback_plan / _infer_veritas_stage / _fallback_plan_for_stage
 # -------------------------------


### PR DESCRIPTION
### Motivation
- LLM出力のサイズが大きい場合に `_safe_parse` 側で正規表現やパース処理が未制限のまま動作しており、CPU/メモリ負荷やパーサDoSリスクが残っていたため早期に入力を制限して防御する目的で変更しました。 
- 挙動互換を保ちつつサイズ制御を共通化して重複を減らすために central helper を導入しました。 
- セキュリティ観点として巨大な外部入力への耐性を高める修正であり、解析コストの増大リスクを低減しますが、上流での入力検証は引き続き推奨されます。 

### Description
- 追加: `veritas_os/core/planner.py` に `_truncate_json_extract_input(raw: str) -> str` ヘルパーを追加し docstring を付与して入力サイズ制限と警告ログ出力を集中化しました。 
- 変更: `_safe_parse` の先頭でフェンス抽出前にこのヘルパーを使うようにして、フリー形式モデル出力に対するサイズ上限制御を適用しました。 
- 変更: `_safe_json_extract_core` 側も同ヘルパーを利用するようにして重複ロジックを削除し、一貫して先頭のみを解析対象にしています。 
- テスト: `veritas_os/tests/test_planner.py` に `_safe_parse` 経路の回帰テスト `test_safe_parse_truncates_oversized_input` を追加して、サイズ超過で切り詰めと警告が出ることを検証しています。 

### Testing
- 実行: `python -m pytest -q veritas_os/tests/test_planner.py` — 結果: `37 passed, 3 warnings`。 
- 実行: `python -m ruff check veritas_os/core/planner.py veritas_os/tests/test_planner.py` — 結果: `All checks passed!`。 
- 追加テスト `test_safe_parse_truncates_oversized_input` により、`_safe_parse` 経路でも巨大入力が切り詰められ警告ログが出ることを自動確認済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff728e5b88326974d214ca254c3bd)