### PR TITLE
Harden health_check URL validation and add unit tests

### DIFF
--- a/veritas_os/scripts/health_check.py
+++ b/veritas_os/scripts/health_check.py
@@ -53,6 +53,14 @@ WITHIN = timedelta(days=1)   # 「最近」の基準（24h 以内）
 
 
 # ===== セキュリティ: URL バリデーション =====
+def _is_valid_ipv4(hostname: str) -> bool:
+    """IPv4 アドレス形式とオクテット範囲を検証する。"""
+    if not re.match(r"^\d{1,3}(?:\.\d{1,3}){3}$", hostname):
+        return False
+    octets = hostname.split(".")
+    return all(0 <= int(octet) <= 255 for octet in octets)
+
+
 def _validate_url(url: str) -> Optional[str]:
     """
     ★ セキュリティ修正: URL を検証し、安全な場合のみ返す。
@@ -74,40 +82,49 @@ def _validate_url(url: str) -> Optional[str]:
         if char in url:
             return None
 
-    try:
-        parsed = urlparse(url)
+    parsed = urlparse(url)
 
-        # スキームの検証（http/https のみ）
-        if parsed.scheme not in ("http", "https"):
-            return None
-
-        # ホスト名の検証
-        hostname = parsed.hostname
-        if not hostname:
-            return None
-
-        # ホスト名は英数字、ハイフン、ドットのみ（IDN は punycode に変換済み前提）
-        if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$", hostname):
-            # IPv4 アドレスの場合は別途チェック
-            if not re.match(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", hostname):
-                return None
-
-        # ポートの検証
-        port = parsed.port
-        if port is not None:
-            if not (1 <= port <= 65535):
-                return None
-
-        # パスに危険な文字がないか再確認
-        path = parsed.path or ""
-        for char in dangerous_chars:
-            if char in path:
-                return None
-
-        return url
-
-    except Exception:
+    # スキームの検証（http/https のみ）
+    if parsed.scheme not in ("http", "https"):
         return None
+
+    # 認証情報付き URL を禁止（資格情報漏えい防止）
+    if parsed.username or parsed.password:
+        return None
+
+    # クエリ/フラグメントは不要なため禁止（予期しない挙動を防止）
+    if parsed.query or parsed.fragment:
+        return None
+
+    # ホスト名の検証
+    hostname = parsed.hostname
+    if not hostname:
+        return None
+
+    # IPv4 風（数字とドットのみ）の場合はオクテット範囲を厳密検証
+    if re.match(r"^[0-9.]+$", hostname):
+        if not _is_valid_ipv4(hostname):
+            return None
+    # ホスト名は英数字、ハイフン、ドットのみ（IDN は punycode に変換済み前提）
+    elif not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$", hostname):
+        return None
+
+    # ポートの検証
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+
+    if port is not None and not (1 <= port <= 65535):
+        return None
+
+    # パスに危険な文字がないか再確認
+    path = parsed.path or ""
+    for char in dangerous_chars:
+        if char in path:
+            return None
+
+    return url
 
 
 API_BASE = os.getenv("VERITAS_API_BASE", "http://127.0.0.1:8000")

--- a/veritas_os/tests/test_health_check_script.py
+++ b/veritas_os/tests/test_health_check_script.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "health_check.py"
+
+
+spec = importlib.util.spec_from_file_location("health_check", MODULE_PATH)
+health_check = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+spec.loader.exec_module(health_check)
+
+
+def test_is_valid_ipv4_accepts_valid_octets() -> None:
+    assert health_check._is_valid_ipv4("127.0.0.1") is True
+    assert health_check._is_valid_ipv4("255.255.255.255") is True
+
+
+def test_is_valid_ipv4_rejects_out_of_range_octets() -> None:
+    assert health_check._is_valid_ipv4("256.0.0.1") is False
+    assert health_check._is_valid_ipv4("999.1.1.1") is False
+
+
+def test_validate_url_rejects_credentials_query_and_fragment() -> None:
+    assert health_check._validate_url("http://user:pass@example.com") is None
+    assert health_check._validate_url("http://example.com/?debug=true") is None
+    assert health_check._validate_url("http://example.com/#fragment") is None
+
+
+def test_validate_url_rejects_invalid_ip_and_port() -> None:
+    assert health_check._validate_url("http://999.1.1.1:8000") is None
+    assert health_check._validate_url("http://127.0.0.1:70000") is None
+
+
+def test_validate_url_accepts_safe_http_url() -> None:
+    safe_url = "https://127.0.0.1:8000/health"
+    assert health_check._validate_url(safe_url) == safe_url


### PR DESCRIPTION
### Motivation
- Strengthen URL validation used by the `health_check.py` script to reduce attack surface from malformed `VERITAS_API_BASE` values and prevent credential leakage or SSRF-like misuse. 
- Ensure IPv4 addresses are validated strictly (octets 0–255) so obviously invalid IPs like `999.1.1.1` are rejected. 
- Security note: the script still falls back to invoking `curl` when `requests` is not available, so `requests` should be present in runtime environments to minimize reliance on shell tooling.

### Description
- Added `_is_valid_ipv4(hostname: str) -> bool` with a docstring to validate IPv4 format and octet ranges.
- Hardened `_validate_url(url: str) -> Optional[str]` to reject embedded credentials, query and fragment components, enforce `http`/`https` schemes, validate hostnames (or strict IPv4), handle port parse errors (`ValueError`), and re-check for dangerous characters in the path.
- Added focused unit tests in `veritas_os/tests/test_health_check_script.py` covering valid/invalid IPv4s, credential-bearing URLs, query/fragment rejection, invalid ports, and a safe URL acceptance case.
- Kept existing behavior: when `requests` is unavailable the script still falls back to a `curl` subprocess (no new network execution paths introduced).

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_health_check_script.py veritas_os/tests/test_code_review_fixes.py veritas_os/tests/test_code_review_fixes_v2.py` and all tests passed (29 passed).
- Ran `python -m ruff check veritas_os/scripts/health_check.py veritas_os/tests/test_health_check_script.py` and static checks passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff9a216488326957460ee52eb5d78)