### PR TITLE
Refactor trust-log verifier into testable helpers and add unit tests

### DIFF
--- a/veritas_os/tests/test_verify_trust_log_script.py
+++ b/veritas_os/tests/test_verify_trust_log_script.py
@@ -1,0 +1,79 @@
+"""Tests for scripts/verify_trust_log.py verification helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "verify_trust_log.py"
+
+
+def load_module():
+    """Load verify_trust_log.py as a module for direct helper testing."""
+    spec = importlib.util.spec_from_file_location("verify_trust_log", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_verify_entries_accepts_valid_chain():
+    """verify_entries should report no errors for a correctly linked chain."""
+    module = load_module()
+
+    entry1 = {"request_id": "r1", "message": "first", "sha256_prev": None}
+    entry1["sha256"] = module.compute_hash(None, entry1)
+
+    entry2 = {"request_id": "r2", "message": "second", "sha256_prev": entry1["sha256"]}
+    entry2["sha256"] = module.compute_hash(entry2["sha256_prev"], entry2)
+
+    total, errors, last_hash = module.verify_entries([entry1, entry2])
+
+    assert total == 2
+    assert errors == []
+    assert last_hash == entry2["sha256"]
+
+
+def test_verify_entries_reports_chain_break_and_hash_mismatch():
+    """verify_entries should capture both chain and hash violations."""
+    module = load_module()
+
+    entry = {
+        "request_id": "broken",
+        "message": "tampered",
+        "sha256_prev": "unexpected-prev",
+        "sha256": "not-a-real-hash",
+    }
+
+    total, errors, _ = module.verify_entries([entry])
+
+    assert total == 1
+    error_types = {err["type"] for err in errors}
+    assert "chain_break" in error_types
+    assert "hash_mismatch" in error_types
+
+
+def test_iter_entries_skips_invalid_json_line(tmp_path):
+    """iter_entries should skip malformed lines and continue parsing."""
+    module = load_module()
+
+    log_path = tmp_path / "trust_log.jsonl"
+    valid_1 = {"request_id": "r1", "value": 1}
+    valid_2 = {"request_id": "r2", "value": 2}
+
+    log_path.write_text(
+        "\n".join(
+            [
+                json.dumps(valid_1, ensure_ascii=False),
+                "{bad-json",
+                json.dumps(valid_2, ensure_ascii=False),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    entries = list(module.iter_entries(log_path))
+
+    assert entries == [valid_1, valid_2]


### PR DESCRIPTION
### Motivation
- Separate IO from verification logic so trust-log verification becomes unit-testable and easier to maintain. 
- Improve resilience when processing JSONL by skipping malformed lines rather than failing the whole run. 
- Note: skipping malformed lines can mask tampering or corruption, so strict deployments may prefer failing on malformed input or applying a warning-threshold policy.

### Description
- Extracted `verify_entries(entries)` which encapsulates chain and hash checks and returns `(total, errors, last_hash)` for pure verification logic. 
- Made `iter_entries(log_path=...)` accept an explicit `Path` and yield parsed JSON lines while warning on malformed lines. 
- Kept `main()` as the CLI entrypoint but simplified it to use the new helpers and updated the success message to `Current chain head hash`. 
- Added `veritas_os/tests/test_verify_trust_log_script.py` with tests covering a valid chain, detection of both chain-break and hash-mismatch, and skipping of malformed JSON lines, and added typing hints and docstrings; formatting issues were fixed with `ruff`.

### Testing
- Ran `ruff check veritas_os/scripts/verify_trust_log.py veritas_os/tests/test_verify_trust_log_script.py --output-format concise` and all checks passed. 
- Ran `pytest -q veritas_os/tests/test_verify_trust_log_script.py` and the new test module reported `3 passed`. 
- No changes were made to credential handling or external authentication in this refactor, so no new attack surface was introduced by these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ffb49868483269a7ddc507ed95bbd)