### PR TITLE
chore: fix Python lint violations in utility scripts

### DIFF
--- a/veritas_os/scripts/analyze_logs.py
+++ b/veritas_os/scripts/analyze_logs.py
@@ -5,7 +5,11 @@
 VERITAS Log Analyzer (Doctor Dashboard + CSV + Graph)
 """
 
-import json, re, sys, csv, argparse
+import argparse
+import csv
+import json
+import re
+import sys
 from pathlib import Path
 from datetime import datetime
 from collections import Counter, defaultdict
@@ -276,5 +280,4 @@ def main(argv=None):
 
 if __name__ == "__main__":
     main()
-
 

--- a/veritas_os/scripts/bench.py
+++ b/veritas_os/scripts/bench.py
@@ -53,7 +53,7 @@ def run_bench(yaml_name: str) -> None:
     print(f"- id   : {bench_id}")
     print(f"- name : {name}")
     print(f"- POST : {url}")
-    print(f"- using API_KEY from env VERITAS_API_KEY")
+    print("- using API_KEY from env VERITAS_API_KEY")
 
     resp = requests.post(url, headers=headers, json=req_payload, timeout=120)
     print(f"- HTTP : {resp.status_code}")

--- a/veritas_os/scripts/bench_summary.py
+++ b/veritas_os/scripts/bench_summary.py
@@ -171,7 +171,7 @@ def main() -> None:
         if decision_status_set:
             print(f"  decision_status : {dict(collections.Counter(decision_status_set))}")
         else:
-            print(f"  decision_status : N/A")
+            print("  decision_status : N/A")
 
         print(
             f"  平均 elapsed    : {avg_elapsed:.3f} sec"

--- a/veritas_os/scripts/doctor.py
+++ b/veritas_os/scripts/doctor.py
@@ -311,10 +311,14 @@ def analyze_logs():
     # ファイル群を走査
     for path in files:
         name = os.path.basename(path)
-        if   name.startswith("decide_"):  cat = "decide"
-        elif name.startswith("health_"):  cat = "health"
-        elif "status" in name:            cat = "status"
-        else:                             cat = "other"
+        if name.startswith("decide_"):
+            cat = "decide"
+        elif name.startswith("health_"):
+            cat = "health"
+        elif "status" in name:
+            cat = "status"
+        else:
+            cat = "other"
 
         try:
             items = _read_json_or_jsonl(path)
@@ -404,7 +408,7 @@ def analyze_logs():
         if trustlog_stats['last_hash']:
             print(f"   🔑 最終ハッシュ: {trustlog_stats['last_hash']}")
     else:
-        print(f"   ❌ ハッシュチェーン検証: FAILED")
+        print("   ❌ ハッシュチェーン検証: FAILED")
         if trustlog_stats['chain_breaks'] > 0:
             print(f"   ⚠️ チェーン破損: {trustlog_stats['chain_breaks']} 箇所")
             if trustlog_stats['first_break']:

--- a/veritas_os/scripts/memory_sync.py
+++ b/veritas_os/scripts/memory_sync.py
@@ -4,7 +4,9 @@
 # ===========================
 # VERITAS MemoryOS Sync
 # ===========================
-import json, os, time
+import json
+import os
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 

--- a/veritas_os/scripts/merge_trust_logs.py
+++ b/veritas_os/scripts/merge_trust_logs.py
@@ -247,7 +247,7 @@ def merge_trust_logs(
             f.write(json.dumps(item, ensure_ascii=False) + "\n")
 
     print(f"\n✅ Merged {len(items)} unique logs → {out_path}")
-    print(f"   Output format: JSONL (one JSON per line)")
+    print("   Output format: JSONL (one JSON per line)")
     if recompute_hash:
         print("   Note: sha256 / sha256_prev chain has been recomputed.")
 


### PR DESCRIPTION
### Motivation
- Clean up Ruff/PEP8 lint violations in several operational scripts to improve readability and maintainability.
- Remove misleading `f`-string prefixes and split combined imports to follow PEP 8 style.
- Increase readability in `doctor.py` by expanding condensed inline `if/elif/else` assignments into multi-line statements.
- As part of review, verify `subprocess.Popen` usage in diagnostics remains guarded to avoid introducing security risk.

### Description
- Split multi-import statements into one-per-line in `veritas_os/scripts/analyze_logs.py` and `veritas_os/scripts/memory_sync.py`.
- Removed unnecessary `f` prefixes where no interpolation occurs in `veritas_os/scripts/bench.py`, `veritas_os/scripts/bench_summary.py`, and `veritas_os/scripts/merge_trust_logs.py`.
- Refactored the single-line `if/elif/else` categorization in `veritas_os/scripts/doctor.py` into expanded, readable blocks and removed an unnecessary `f`-string there as well.
- These edits are stylistic/formatting only and intentionally avoid behavioral changes.

### Testing
- Ran `ruff check` on the modified scripts and it passed without errors.
- Ran `pytest -q veritas_os/tests/test_doctor_coverage.py veritas_os/tests/test_memory_train_script.py veritas_os/tests/test_code_review_fixes.py` which completed successfully (`47 passed`).
- Additional `pytest -q veritas_os/tests/test_code_review_fixes.py veritas_os/tests/test_code_review_fixes_v2.py` run also succeeded (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ffccdf07c8326b1d38894bfe0ad96)