### PR TITLE
Harden web search endpoint validation and simplify unavailable response handling

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -322,6 +322,15 @@ class TestWebSearchSsrfGuard:
     def test_public_ip_host_is_allowed(self):
         assert web_search_mod._is_private_or_local_host("8.8.8.8") is False
 
+
+    def test_embedded_credentials_are_blocked(self):
+        assert (
+            web_search_mod._is_allowed_websearch_url(
+                "https://user:pass@api.allowed.example/search"
+            )
+            is False
+        )
+
     def test_allowlist_blocks_non_listed_host(self, monkeypatch):
         monkeypatch.setattr(
             web_search_mod,


### PR DESCRIPTION
### Motivation
- Prevent credential leakage and misconfiguration by rejecting endpoint URLs that embed credentials (e.g. `https://user:pass@host/...`).
- Reduce duplicated return payload code paths for the unavailable-websearch case to improve maintainability while preserving behavior.
- Limit scope to the Web Search tool to avoid crossing Planner / Kernel / Fuji / MemoryOS responsibilities.

### Description
- Added a guard in `_is_allowed_websearch_url` to reject URLs that contain embedded `username` or `password` components. 
- Consolidated duplicate unavailable responses into a single `unavailable_response` object and reused it for both missing configuration and SSRF-guard rejection paths in `web_search`.
- Added a unit test `test_embedded_credentials_are_blocked` in `veritas_os/tests/test_web_search_extra.py` to verify that embedded-credentials endpoints are blocked.
- Changes were made only in `veritas_os/tools/web_search.py` and `veritas_os/tests/test_web_search_extra.py` and kept within the tool's responsibility boundary.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and all tests passed (`46 passed`).
- Ran `python -m ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search_extra.py` and lint checks passed (`All checks passed`).
- No additional automated test failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ffec2915c8326bbc8a6c0140bf4bb)