### PR TITLE
Harden health_check URL hostname validation

### DIFF
--- a/veritas_os/scripts/health_check.py
+++ b/veritas_os/scripts/health_check.py
@@ -61,6 +61,23 @@ def _is_valid_ipv4(hostname: str) -> bool:
     return all(0 <= int(octet) <= 255 for octet in octets)
 
 
+def _is_valid_hostname(hostname: str) -> bool:
+    """RFC に準拠した安全なホスト名かどうかを検証する。"""
+    if len(hostname) > 253:
+        return False
+
+    labels = hostname.split(".")
+    for label in labels:
+        if not label or len(label) > 63:
+            return False
+        if label.startswith("-") or label.endswith("-"):
+            return False
+        if not re.match(r"^[a-zA-Z0-9-]+$", label):
+            return False
+
+    return True
+
+
 def _validate_url(url: str) -> Optional[str]:
     """
     ★ セキュリティ修正: URL を検証し、安全な場合のみ返す。
@@ -105,8 +122,8 @@ def _validate_url(url: str) -> Optional[str]:
     if re.match(r"^[0-9.]+$", hostname):
         if not _is_valid_ipv4(hostname):
             return None
-    # ホスト名は英数字、ハイフン、ドットのみ（IDN は punycode に変換済み前提）
-    elif not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$", hostname):
+    # ホスト名を RFC 準拠で厳密検証
+    elif not _is_valid_hostname(hostname):
         return None
 
     # ポートの検証

--- a/veritas_os/tests/test_health_check_script.py
+++ b/veritas_os/tests/test_health_check_script.py
@@ -37,3 +37,17 @@ def test_validate_url_rejects_invalid_ip_and_port() -> None:
 def test_validate_url_accepts_safe_http_url() -> None:
     safe_url = "https://127.0.0.1:8000/health"
     assert health_check._validate_url(safe_url) == safe_url
+
+
+def test_validate_url_rejects_hostname_label_starting_with_hyphen() -> None:
+    assert health_check._validate_url("https://-bad.example.com/health") is None
+
+
+def test_validate_url_rejects_hostname_label_ending_with_hyphen() -> None:
+    assert health_check._validate_url("https://bad-.example.com/health") is None
+
+
+def test_validate_url_rejects_hostname_label_too_long() -> None:
+    long_label = "a" * 64
+    url = f"https://{long_label}.example.com/health"
+    assert health_check._validate_url(url) is None


### PR DESCRIPTION
### Motivation
- Strengthen URL validation used by the health check utility to reduce acceptance of malformed hostnames that could weaken input validation in a security-sensitive path. 
- The previous hostname check used a permissive regex that could allow syntactically invalid labels (empty labels, labels >63 chars, or labels starting/ending with `-`).

### Description
- Added a new helper ` _is_valid_hostname(hostname: str) -> bool` with an RFC-style check for total length, per-label length, allowed characters, and forbidding labels that start or end with `-`, and included a brief docstring. 
- Replaced the former permissive hostname regex in `_validate_url()` with a call to `_is_valid_hostname()` and kept strict checks for IPv4-like hosts and port ranges. 
- Added three regression tests in `veritas_os/tests/test_health_check_script.py` that assert invalid hostname-label cases are rejected (leading `-`, trailing `-`, and a 64-character label).

### Testing
- Ran `pytest -q veritas_os/tests/test_health_check_script.py`, which executed the new and existing URL/IPv4 validation tests and all tests passed (`8 passed`).
- The change is localized to `veritas_os/scripts/health_check.py` and its tests and did not produce failing tests in the targeted test file.

Security note: this improves input-validation hardening (reduces SSRF/invalid-host risks) but does not replace network-level controls or allowlisting; consider additional runtime/network protections for fully mitigating SSRF and related risks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990071471cc8326a9dfff5444cb289c)