### PR TITLE
planner: normalize eta/risk values safely

### DIFF
--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -66,6 +66,36 @@ def test_normalize_step_handles_non_list_dependencies():
     assert normalized["dependencies"] == []
 
 
+def test_normalize_step_clamps_eta_and_risk_ranges():
+    step = {
+        "id": "s1",
+        "eta_hours": -3,
+        "risk": 1.7,
+        "dependencies": [],
+    }
+    normalized = planner_core._normalize_step(step)
+
+    assert normalized["eta_hours"] == 0.0
+    assert normalized["risk"] == 1.0
+
+
+def test_normalize_step_uses_defaults_for_invalid_existing_values():
+    step = {
+        "id": "s1",
+        "eta_hours": "invalid",
+        "risk": object(),
+        "dependencies": [],
+    }
+    normalized = planner_core._normalize_step(
+        step,
+        default_eta_hours=2.5,
+        default_risk=0.3,
+    )
+
+    assert normalized["eta_hours"] == pytest.approx(2.5)
+    assert normalized["risk"] == pytest.approx(0.3)
+
+
 # -------------------------------
 # _is_simple_qa / _simple_qa_plan
 # -------------------------------


### PR DESCRIPTION
### Motivation
- Planner のステップ正規化で、外部や LLM 由来の不正な型・範囲の値が downstream に流れるリスクを低減するため、`eta_hours` / `risk` の正規化ロジックを強化しました。 
- 既存の実装は欠損時のみデフォルトを補完していたため、既に存在するが型や範囲が不正な値を許してしまっていました。修正は Planner の責務内に限定しています。 
- 変更は docstring を追加して意図を明確化し、挙動を検証するユニットテストを追加しています。  

### Description
- `veritas_os/core/planner.py` の `_normalize_step` を強化し、既存値も含めて型変換と範囲クランプを行うようにしました。具体的には `eta_hours` を `float` に変換して `>= 0.0` に丸め、`risk` を `float` に変換して `0.0..1.0` にクランプします。無効な既存値はデフォルトにフォールバックします。 
- 同関数の docstring を拡充し、正規化ポリシー（ETA・リスク・dependencies）を明記しました。 
- `veritas_os/tests/test_planner.py` に以下のテストを追加しました: 範囲外値のクランプ検証と、既存の不正な値に対するデフォルトフォールバック検証。 
- 変更は Planner の責務範囲に限定し、Kernel / Fuji / MemoryOS など他コンポーネントへの影響は発生しないようにしています。 

### Testing
- 単体テストとして `python -m pytest veritas_os/tests/test_planner.py veritas_os/tests/test_planner_coverage.py -q` を実行し、`125 passed` で成功しました. 
- コードスタイルチェックとして `python -m ruff check veritas_os/core/planner.py veritas_os/tests/test_planner.py` を実行し、すべて通過しました（PEP8 準拠）。 
- セキュリティ: 今回の変更は入力値の堅牢化により「型/範囲異常が引き起こす実行時障害や予期せぬ振る舞い」のリスクを低減しており、新たなセキュリティリスクは導入していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900e061c808326ae2d35835cabf263)