### PR TITLE
sanitize: 共通入力前処理を追加し上限を定数化、回帰テストを追加

### DIFF
--- a/veritas_os/core/sanitize.py
+++ b/veritas_os/core/sanitize.py
@@ -39,6 +39,8 @@ _logger = logging.getLogger(__name__)
 
 # Luhnチェック時の入力文字列長上限（DoS対策）
 _MAX_CARD_INPUT_LENGTH = 256
+# PII検査対象の入力長上限（ReDoS/CPU DoS対策）
+_MAX_PII_INPUT_LENGTH = 1_000_000
 
 
 # =============================================================================
@@ -377,6 +379,27 @@ class PIIDetector:
             ("passport_jp", RE_PASSPORT_JP, "パスポート番号", None, 0.70),
         ]
 
+    def _prepare_input_text(self, text: str | None) -> str:
+        """Normalize and safely bound input text for PII scanning.
+
+        Args:
+            text: Raw input text. ``None`` is treated as an empty string.
+
+        Returns:
+            Sanitized string clipped to the configured maximum length.
+        """
+        if text is None:
+            return ""
+
+        if len(text) > _MAX_PII_INPUT_LENGTH:
+            _logger.warning(
+                "PII input truncated from %d to %d chars",
+                len(text),
+                _MAX_PII_INPUT_LENGTH,
+            )
+            return text[:_MAX_PII_INPUT_LENGTH]
+        return text
+
     def _validate_credit_card(self, match: str, context: str) -> bool:
         return _is_valid_credit_card(match)
 
@@ -393,14 +416,9 @@ class PIIDetector:
         Returns:
             検出されたPIIのリスト
         """
+        text = self._prepare_input_text(text)
         if not text:
             return []
-
-        # ★ セキュリティ: 入力長制限（ReDoS / CPU DoS 防止）
-        _MAX_PII_INPUT_LENGTH = 1_000_000  # 1M chars (~1 MB for ASCII)
-        if len(text) > _MAX_PII_INPUT_LENGTH:
-            _logger.warning("PII input truncated from %d to %d chars", len(text), _MAX_PII_INPUT_LENGTH)
-            text = text[:_MAX_PII_INPUT_LENGTH]
 
         results: List[PIIMatch] = []
         detected_ranges: List[tuple] = []  # 重複検出防止用

--- a/veritas_os/tests/test_sanitize.py
+++ b/veritas_os/tests/test_sanitize.py
@@ -55,3 +55,15 @@ def test_mask_pii_does_not_change_non_pii_text():
     assert masked == text
 
 
+def test_detector_prepare_input_text_handles_none_and_truncates(caplog):
+    detector = sanitize.PIIDetector()
+
+    assert detector._prepare_input_text(None) == ""
+
+    oversized = "a" * (sanitize._MAX_PII_INPUT_LENGTH + 10)
+    with caplog.at_level("WARNING"):
+        prepared = detector._prepare_input_text(oversized)
+
+    assert len(prepared) == sanitize._MAX_PII_INPUT_LENGTH
+    assert "PII input truncated" in caplog.text
+


### PR DESCRIPTION
### Motivation
- PII 検出の前処理（`None` 正規化、巨大入力の切り詰め）を検出経路で一貫して扱うために責務を分離しました。 
- ReDoS / CPU DoS リスクを明示的に緩和するため、入力長上限をモジュール定数化しました。 
- 変更点は `sanitize` モジュール内に限定し、他コンポーネントの責務を越えないようにしました。

### Description
- モジュール定数 `_MAX_PII_INPUT_LENGTH = 1_000_000` を追加して PII 検査対象の入力長上限を明示化しました (`veritas_os/core/sanitize.py`).
- `PIIDetector` に `_prepare_input_text(self, text: str | None) -> str` を追加し、`None` の扱いと上限切り詰め・警告ログ出力を一元化しました (`veritas_os/core/sanitize.py`).
- `detect` が直接入力を扱う代わりに `_prepare_input_text` を経由するように変更して前処理の重複を削減しました (`veritas_os/core/sanitize.py`).
- 回帰テスト `test_detector_prepare_input_text_handles_none_and_truncates` を追加し、`None` 処理、切り詰め長さ、警告ログを検証しました (`veritas_os/tests/test_sanitize.py`).
- 付随して既存の動作（マスク/検出）に影響がないことを保つため、後方互換の互換関数はそのまま維持しています.

### Testing
- 実行したテスト: `pytest veritas_os/tests/test_sanitize.py -q` — 成功、`4 passed`。
- 静的チェック: `ruff check veritas_os/core/sanitize.py veritas_os/tests/test_sanitize.py` — 成功、`All checks passed!`。
- 追加の注意: 正規表現ベースの PII 検出は依然として巨大入力や巧妙なペイロードで負荷がかかる可能性があるため、本変更は切り詰めによる緩和を追加したものであり完全な防御ではないことを警告します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990110d332883269304bcf7a6a8290f)