### PR TITLE
Refactor web_search meta construction and max_results sanitization

### DIFF
--- a/veritas_os/tests/test_web_search.py
+++ b/veritas_os/tests/test_web_search.py
@@ -57,6 +57,13 @@ def test_looks_agi_result_false_for_unrelated() -> None:
     assert web_search_mod._looks_agi_result(title, snippet, url) is False
 
 
+def test_sanitize_max_results_clamps_values() -> None:
+    assert web_search_mod._sanitize_max_results(0) == 1
+    assert web_search_mod._sanitize_max_results(101) == 100
+    assert web_search_mod._sanitize_max_results("3") == 3
+    assert web_search_mod._sanitize_max_results("abc") == 5
+
+
 # -----------------------------
 # web_search 本体のテスト
 # -----------------------------
@@ -277,4 +284,3 @@ def test_web_search_handles_request_exception(monkeypatch) -> None:
     assert resp["ok"] is False
     assert resp["results"] == []
     assert "WEBSEARCH_API error" in resp["error"]
-


### PR DESCRIPTION
### Motivation
- Reduce duplication and improve maintainability in `veritas_os/tools/web_search.py` by centralizing repeated response metadata assembly. 
- Ensure `max_results` handling is robust and constrained to a safe range to avoid excessive resource usage. 
- Preserve existing SSRF and query-sanitization protections while making the logic easier to test. 

### Description
- Added `_sanitize_max_results(max_results, *, default=5)` to coerce and clamp `max_results` into the `1..100` range and added a short docstring. 
- Introduced `_build_meta(...)` to produce the `meta` dict for `web_search` responses and replaced duplicated inline constructions with calls to this helper. 
- Removed a redundant `resp.raise_for_status()` call after the `_post_with_retry` wrapper returns a validated response. 
- Added `test_sanitize_max_results_clamps_values` to `veritas_os/tests/test_web_search.py` and included docstrings/comments for new helpers to satisfy testability and documentation requirements. 
- Changes are limited to `veritas_os/tools/web_search.py` and its tests and do not alter Planner / Kernel / Fuji / MemoryOS responsibilities. 

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_web_search.py` and all tests in that file passed (`12 passed`). 
- Ran static checks with `python -m ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search.py` and linting passed. 
- No other automated tests were modified and the change is scoped to the web search module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699020e6f3c083269c3eee8d19d93fd9)