### PR TITLE
Fix PIIDetector None-handling consistency for mask/detect APIs

### DIFF
--- a/veritas_os/core/sanitize.py
+++ b/veritas_os/core/sanitize.py
@@ -406,7 +406,7 @@ class PIIDetector:
     def _validate_my_number(self, match: str, context: str) -> bool:
         return _is_valid_my_number(match)
 
-    def detect(self, text: str) -> List[PIIMatch]:
+    def detect(self, text: str | None) -> List[PIIMatch]:
         """
         テキストからPIIを検出
 
@@ -461,7 +461,7 @@ class PIIDetector:
         results.sort(key=lambda x: x.start)
         return results
 
-    def mask(self, text: str, mask_format: str = "〔{token}〕") -> str:
+    def mask(self, text: str | None, mask_format: str = "〔{token}〕") -> str:
         """
         テキスト内のPIIをマスク
 
@@ -472,8 +472,11 @@ class PIIDetector:
         Returns:
             マスク済みテキスト
         """
-        if not text:
-            return text
+        if text is None:
+            return ""
+
+        if text == "":
+            return ""
 
         detections = self.detect(text)
         if not detections:
@@ -520,7 +523,7 @@ class PIIDetector:
 _default_detector = PIIDetector(validate_checksums=True)
 
 
-def detect_pii(text: str) -> List[Dict[str, Any]]:
+def detect_pii(text: str | None) -> List[Dict[str, Any]]:
     """
     テキストからPIIを検出
 

--- a/veritas_os/tests/test_sanitize_pii.py
+++ b/veritas_os/tests/test_sanitize_pii.py
@@ -381,7 +381,7 @@ class TestPIIDetector:
     def test_mask_empty_text(self):
         detector = PIIDetector()
         assert detector.mask("") == ""
-        assert detector.mask(None) is None
+        assert detector.mask(None) == ""
 
     def test_no_overlap_detection(self):
         """Overlapping patterns should not produce duplicate detections."""


### PR DESCRIPTION
### Motivation
- Normalize and simplify API behavior so `PIIDetector.detect()`/`PIIDetector.mask()` and the compatibility wrappers consistently handle `None` vs empty-string inputs, avoiding surprising return-type differences while preserving existing DoS/length protections.
- Security note: this change does not widen attack surface, but PII masking must still be used carefully (avoid logging raw input before masking).

### Description
- Change `PIIDetector.detect()` signature to accept `str | None` and normalize input via `_prepare_input_text()` so `None` is treated as empty input.
- Change `PIIDetector.mask()` signature to accept `str | None` and return `""` for `None` (and preserve empty-string passthrough), aligning behavior with `mask_pii()`.
- Change `detect_pii()` wrapper signature to accept `str | None` for API consistency and update the test assertion in `veritas_os/tests/test_sanitize_pii.py` to expect `""` from `detector.mask(None)`.

### Testing
- Ran the relevant test suite with `python -m pytest -q veritas_os/tests/test_sanitize.py veritas_os/tests/test_sanitize_pii.py` and all tests passed (`62 passed`).
- Ran static checks with `ruff check veritas_os/core/sanitize.py veritas_os/tests/test_sanitize_pii.py` and the linter reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699024d7a8f08326a6458effd1739cfe)