### PR TITLE
PIIサニタイザの電話正規表現の境界強化

### DIFF
--- a/veritas_os/core/sanitize.py
+++ b/veritas_os/core/sanitize.py
@@ -66,7 +66,7 @@ RE_EMAIL = re.compile(
 # 偽陽性を減らすため、より厳密なパターンを使用
 # --- 日本の携帯: 070/080/090-XXXX-XXXX
 RE_PHONE_JP_MOBILE = re.compile(
-    r'0[789]0[-\s]?\d{4}[-\s]?\d{4}'
+    r'(?<!\d)0[789]0[-\s]?\d{4}[-\s]?\d{4}(?!\d)'
 )
 # 日本の固定電話: 0X-XXXX-XXXX または 0XX-XXX-XXXX
 RE_PHONE_JP_LANDLINE = re.compile(
@@ -74,7 +74,7 @@ RE_PHONE_JP_LANDLINE = re.compile(
 )
 # 国際電話: +XX-XXX... 形式
 RE_PHONE_INTL = re.compile(
-    r'\+\d{1,3}[-\s]?\d{1,4}[-\s]?\d{1,4}[-\s]?\d{1,4}(?:[-\s]?\d{1,4})?'
+    r'(?<!\d)\+\d{1,3}[-\s]?\d{1,4}[-\s]?\d{1,4}[-\s]?\d{1,4}(?:[-\s]?\d{1,4})?(?!\d)'
 )
 # フリーダイヤル: 0120-XXX-XXX, 0800-XXX-XXXX
 RE_PHONE_FREE = re.compile(

--- a/veritas_os/tests/test_sanitize_pii.py
+++ b/veritas_os/tests/test_sanitize_pii.py
@@ -33,6 +33,15 @@ def test_detector_prioritizes_high_confidence_on_overlap() -> None:
     assert matches[0].type == "high"
 
 
+def test_phone_patterns_do_not_match_embedded_digits() -> None:
+    """Domestic phone regexes should not match when surrounded by digits."""
+    text = "顧客ID1090123456789は連絡先ではない"
+    result = detect_pii(text)
+
+    phones = [r for r in result if r["type"] == "phone_mobile"]
+    assert phones == []
+
+
 class TestEmailDetection:
     """Tests for email address detection."""
 


### PR DESCRIPTION
### Motivation
- 電話番号パターンが長い識別子や連続した数字列に部分一致して誤検出（過剰マスキング）する問題を防ぐための改善。 

### Description
- `veritas_os/core/sanitize.py` の携帯番号パターン `RE_PHONE_JP_MOBILE` に前後が数字でないことを要求する負の先読み/後読みを追加して境界を厳密化した（`(?<!\d)...(?!\d)` を追加）。
- 同様に国際番号パターン `RE_PHONE_INTL` にも同様の境界強化を適用した。 
- `veritas_os/tests/test_sanitize_pii.py` に回帰テストを追加し、識別子内に埋め込まれた数字列が国内携帯番号として検出されないことを確認するテストを追加した。 

### Testing
- `pytest -q veritas_os/tests/test_sanitize_pii.py` を実行し全テストが通過（`60 passed`）。
- `ruff check veritas_os/core/sanitize.py veritas_os/tests/test_sanitize_pii.py` を実行し静的チェックは問題なし（All checks passed）。

Security note: 誤検出を減らすことで過剰マスキングのリスクは低減されるが、国際番号や特殊な文脈では依然として誤検出／見逃しが起こり得るため、高リスク用途では文脈ベースの追加検証（国番号ホワイトリストや周辺テキストキーワードの活用）を検討してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990551965688326a6e9a4c7e228daab)