### PR TITLE
Harden CosineIndex input validation and safe NPZ loading

### DIFF
--- a/veritas_os/memory/index_cosine.py
+++ b/veritas_os/memory/index_cosine.py
@@ -1,11 +1,11 @@
 # veritas/memory/index_cosine.py
-import logging
 import os
 import threading
+import logging
 
 import numpy as np
 from pathlib import Path
-from typing import List, Tuple, Iterable, Optional, Any
+from typing import Any, Iterable, List, Optional, Tuple
 
 from veritas_os.core.atomic_io import atomic_write_npz
 
@@ -47,6 +47,12 @@ def _allow_legacy_pickle_npz() -> bool:
     return False
 
 
+def _validate_finite_array(name: str, values: np.ndarray) -> None:
+    """Raise ValueError when an input vector contains NaN/Inf values."""
+    if not np.isfinite(values).all():
+        raise ValueError(f"CosineIndex.{name}: vectors must be finite (no NaN/Inf)")
+
+
 class CosineIndex:
     """
     シンプルな Cosine 類似度インデックス + 永続化 (.npz)
@@ -73,9 +79,9 @@ class CosineIndex:
     def _load(self) -> None:
         with self._lock:
             try:
-                data = np.load(self.path, allow_pickle=False)
-                self.vecs = data["vecs"].astype(np.float32)
-                self.ids = [str(i) for i in data["ids"].tolist()]
+                with np.load(self.path, allow_pickle=False) as data:
+                    self.vecs = data["vecs"].astype(np.float32)
+                    self.ids = [str(i) for i in data["ids"].tolist()]
                 return
             except Exception as e:
                 # ★ M-18 修正: エラーをログに記録（破損と不在を区別可能に）
@@ -103,9 +109,9 @@ class CosineIndex:
                         self.path,
                     )
                     try:
-                        data = np.load(self.path, allow_pickle=True)
-                        self.vecs = data["vecs"].astype(np.float32)
-                        self.ids = [str(i) for i in data["ids"].tolist()]
+                        with np.load(self.path, allow_pickle=True) as data:
+                            self.vecs = data["vecs"].astype(np.float32)
+                            self.ids = [str(i) for i in data["ids"].tolist()]
                         # Immediately re-save without pickle to migrate
                         self.save()
                         logger.info(
@@ -143,11 +149,12 @@ class CosineIndex:
         with self._lock:
             return len(self.ids)
 
-    def add(self, vecs: Any, ids: Iterable[str]):
+    def add(self, vecs: Any, ids: Iterable[str]) -> None:
         """ベクトルと id を追加して即保存（スレッドセーフ）"""
         vecs = np.asarray(vecs, dtype=np.float32)
         if vecs.ndim == 1:
             vecs = vecs.reshape(1, -1)
+        _validate_finite_array("add", vecs)
 
         if vecs.shape[1] != self.dim:
             raise ValueError(f"CosineIndex.add: dim mismatch {vecs.shape[1]} != {self.dim}")
@@ -178,6 +185,7 @@ class CosineIndex:
         q = np.asarray(qv, dtype=np.float32)
         if q.ndim == 1:
             q = q.reshape(1, -1)
+        _validate_finite_array("search", q)
         if q.shape[1] != self.dim:
             raise ValueError(f"CosineIndex.search: dim mismatch {q.shape[1]} != {self.dim}")
 

--- a/veritas_os/tests/test_thread_safety.py
+++ b/veritas_os/tests/test_thread_safety.py
@@ -145,6 +145,22 @@ class TestCosineIndexThreadSafety:
         assert results[0][0][1] > 0.99  # Very high similarity
 
 
+def test_rejects_non_finite_vectors(tmp_path: Path):
+    """CosineIndex should reject NaN/Inf vectors to avoid poisoned results."""
+    pytest.importorskip("numpy")
+    import numpy as np
+
+    idx = CosineIndex(dim=2, path=tmp_path / "test.npz")
+
+    with pytest.raises(ValueError, match="finite"):
+        idx.add(np.array([[np.nan, 0.0]], dtype=np.float32), ["bad_nan"])
+
+    idx.add(np.array([[1.0, 0.0]], dtype=np.float32), ["ok"])
+
+    with pytest.raises(ValueError, match="finite"):
+        idx.search(np.array([[np.inf, 0.0]], dtype=np.float32), k=1)
+
+
 class TestMemoryStoreThreadSafety:
     """Tests for MemoryStore thread safety."""
 


### PR DESCRIPTION
### Motivation
- Non-finite vectors (NaN/Inf) can silently poison cosine-similarity computations and destabilize retrieval results, so they must be rejected at API boundaries. 
- `np.load` should be used as a context manager to ensure file handles/resources are released reliably. 
- Preserve existing handling and warning for legacy pickle-based `.npz` files while reducing attack surface from malformed inputs. 

### Description
- Add `_validate_finite_array(name, values)` to raise `ValueError` for any NaN/Inf entries and call it from `CosineIndex.add` and `CosineIndex.search`. 
- Replace `np.load(...)` usage with `with np.load(...) as data:` in both the safe and legacy load paths to ensure proper resource cleanup. 
- Reorder and tighten typing/imports in `veritas_os/memory/index_cosine.py` for PEP8 consistency and readability. 
- Add regression test `test_rejects_non_finite_vectors` to `veritas_os/tests/test_thread_safety.py` to verify `add`/`search` raise on non-finite inputs. 

### Testing
- Ran `pytest -q veritas_os/tests/test_thread_safety.py -q` and all tests in that file passed (`100%`). 
- The new regression test confirms `CosineIndex` rejects NaN/Inf on both `add` and `search` (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69905a3e0d408326817744ae3f9a9dc4)