### PR TITLE
Harden web search retry env parsing

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -1,5 +1,6 @@
 # tests/test_web_search_extra.py
 """Additional tests for web_search module to improve coverage."""
+
 from __future__ import annotations
 
 import importlib
@@ -35,6 +36,24 @@ class TestNormalizeStr:
         assert "BadStr" in result  # repr fallback
 
 
+class TestSafeIntHelpers:
+    """Tests for integer environment helper functions."""
+
+    def test_safe_int_with_min_uses_floor(self, monkeypatch):
+        monkeypatch.setenv("VERITAS_WEBSEARCH_MAX_RETRIES", "0")
+        assert (
+            web_search_mod._safe_int_with_min("VERITAS_WEBSEARCH_MAX_RETRIES", 3, 1)
+            == 1
+        )
+
+    def test_safe_int_with_min_falls_back_on_invalid_value(self, monkeypatch):
+        monkeypatch.setenv("VERITAS_WEBSEARCH_MAX_RETRIES", "invalid")
+        assert (
+            web_search_mod._safe_int_with_min("VERITAS_WEBSEARCH_MAX_RETRIES", 3, 1)
+            == 3
+        )
+
+
 class TestShouldEnforceVeritasAnchor:
     """Tests for _should_enforce_veritas_anchor function."""
 
@@ -43,19 +62,41 @@ class TestShouldEnforceVeritasAnchor:
         assert web_search_mod._should_enforce_veritas_anchor(None) is False
 
     def test_bureau_veritas_excluded(self):
-        assert web_search_mod._should_enforce_veritas_anchor("bureau veritas certification") is False
-        assert web_search_mod._should_enforce_veritas_anchor("bureauveritas.com") is False
+        assert (
+            web_search_mod._should_enforce_veritas_anchor(
+                "bureau veritas certification"
+            )
+            is False
+        )
+        assert (
+            web_search_mod._should_enforce_veritas_anchor("bureauveritas.com") is False
+        )
 
     def test_veritas_os_triggers(self):
-        assert web_search_mod._should_enforce_veritas_anchor("veritas os documentation") is True
-        assert web_search_mod._should_enforce_veritas_anchor("trustlog verification") is True
+        assert (
+            web_search_mod._should_enforce_veritas_anchor("veritas os documentation")
+            is True
+        )
+        assert (
+            web_search_mod._should_enforce_veritas_anchor("trustlog verification")
+            is True
+        )
         assert web_search_mod._should_enforce_veritas_anchor("fuji gate safety") is True
-        assert web_search_mod._should_enforce_veritas_anchor("valuecore alignment") is True
-        assert web_search_mod._should_enforce_veritas_anchor("veritas_os package") is True
-        assert web_search_mod._should_enforce_veritas_anchor("veritas-os github") is True
+        assert (
+            web_search_mod._should_enforce_veritas_anchor("valuecore alignment") is True
+        )
+        assert (
+            web_search_mod._should_enforce_veritas_anchor("veritas_os package") is True
+        )
+        assert (
+            web_search_mod._should_enforce_veritas_anchor("veritas-os github") is True
+        )
 
     def test_normal_query_not_triggered(self):
-        assert web_search_mod._should_enforce_veritas_anchor("python web framework") is False
+        assert (
+            web_search_mod._should_enforce_veritas_anchor("python web framework")
+            is False
+        )
 
 
 class TestApplyAnchorAndBlacklist:
@@ -64,7 +105,9 @@ class TestApplyAnchorAndBlacklist:
     def test_applies_anchor_when_needed(self):
         result = web_search_mod._apply_anchor_and_blacklist("veritas query")
         assert result["anchor_applied"] is True
-        assert "VERITAS OS" in result["final_query"] or "TrustLog" in result["final_query"]
+        assert (
+            "VERITAS OS" in result["final_query"] or "TrustLog" in result["final_query"]
+        )
 
     def test_no_anchor_when_already_present(self):
         query = "veritas os trustlog fuji"
@@ -83,54 +126,65 @@ class TestIsBlockedResult:
     """Tests for _is_blocked_result function."""
 
     def test_blocks_blacklisted_keyword_in_title(self):
-        assert web_search_mod._is_blocked_result(
-            "Bureau Veritas certification",
-            "some snippet",
-            "https://example.com"
-        ) is True
+        assert (
+            web_search_mod._is_blocked_result(
+                "Bureau Veritas certification", "some snippet", "https://example.com"
+            )
+            is True
+        )
 
     def test_blocks_blacklisted_site_in_url(self):
-        assert web_search_mod._is_blocked_result(
-            "Some title",
-            "some snippet",
-            "https://bureauveritas.com/page"
-        ) is True
+        assert (
+            web_search_mod._is_blocked_result(
+                "Some title", "some snippet", "https://bureauveritas.com/page"
+            )
+            is True
+        )
 
     def test_blocks_veritas_com(self):
-        assert web_search_mod._is_blocked_result(
-            "Veritas Storage",
-            "backup solutions",
-            "https://www.veritas.com/product"
-        ) is True
+        assert (
+            web_search_mod._is_blocked_result(
+                "Veritas Storage", "backup solutions", "https://www.veritas.com/product"
+            )
+            is True
+        )
 
     def test_blocks_veritas_com_without_scheme(self):
-        assert web_search_mod._is_blocked_result(
-            "Veritas Storage",
-            "backup solutions",
-            "veritas.com/product"
-        ) is True
+        assert (
+            web_search_mod._is_blocked_result(
+                "Veritas Storage", "backup solutions", "veritas.com/product"
+            )
+            is True
+        )
 
     def test_allows_clean_result(self):
-        assert web_search_mod._is_blocked_result(
-            "Python Tutorial",
-            "Learn Python programming",
-            "https://python.org/tutorial"
-        ) is False
+        assert (
+            web_search_mod._is_blocked_result(
+                "Python Tutorial",
+                "Learn Python programming",
+                "https://python.org/tutorial",
+            )
+            is False
+        )
 
     def test_blocks_bureauveritas_wildcard(self):
         # Test bureauveritas.* wildcard blocking
-        assert web_search_mod._is_blocked_result(
-            "ISO Certification",
-            "Quality management",
-            "https://www.bureauveritas.co.jp/services"
-        ) is True
+        assert (
+            web_search_mod._is_blocked_result(
+                "ISO Certification",
+                "Quality management",
+                "https://www.bureauveritas.co.jp/services",
+            )
+            is True
+        )
 
     def test_allows_veritas_substring_in_path(self):
-        assert web_search_mod._is_blocked_result(
-            "Example",
-            "Some snippet",
-            "https://example.com/path/veritas.com/info"
-        ) is False
+        assert (
+            web_search_mod._is_blocked_result(
+                "Example", "Some snippet", "https://example.com/path/veritas.com/info"
+            )
+            is False
+        )
 
 
 class TestWebSearchHostSafety:
@@ -154,6 +208,7 @@ class TestWebSearchHostSafety:
 
 class DummyResponse:
     """Mock response for requests.post."""
+
     def __init__(self, data: Dict[str, Any], status_code: int = 200):
         self._data = data
         self.status_code = status_code
@@ -187,7 +242,10 @@ class TestWebSearchVeritasContext:
         resp = web_search_mod.web_search("veritas os documentation", max_results=3)
 
         assert resp["ok"] is True
-        assert resp["meta"]["anchor_applied"] is True or resp["meta"]["blacklist_applied"] is True
+        assert (
+            resp["meta"]["anchor_applied"] is True
+            or resp["meta"]["blacklist_applied"] is True
+        )
 
     def test_veritas_query_blocks_bureauveritas_results(self, monkeypatch):
         """VERITAS context should filter out Bureau Veritas results."""
@@ -290,7 +348,10 @@ class TestIsAgiQueryExtended:
     """Extended tests for _is_agi_query."""
 
     def test_artificial_general_intelligence_full(self):
-        assert web_search_mod._is_agi_query("artificial general intelligence safety") is True
+        assert (
+            web_search_mod._is_agi_query("artificial general intelligence safety")
+            is True
+        )
 
     def test_case_insensitive_agi(self):
         assert web_search_mod._is_agi_query("AGI") is True
@@ -302,32 +363,40 @@ class TestLooksAgiResultExtended:
     """Extended tests for _looks_agi_result."""
 
     def test_openai_site(self):
-        assert web_search_mod._looks_agi_result(
-            "GPT-5 Research",
-            "AI capabilities",
-            "https://openai.com/research"
-        ) is True
+        assert (
+            web_search_mod._looks_agi_result(
+                "GPT-5 Research", "AI capabilities", "https://openai.com/research"
+            )
+            is True
+        )
 
     def test_deepmind_site(self):
-        assert web_search_mod._looks_agi_result(
-            "Gemini",
-            "AI research",
-            "https://deepmind.com/research"
-        ) is True
+        assert (
+            web_search_mod._looks_agi_result(
+                "Gemini", "AI research", "https://deepmind.com/research"
+            )
+            is True
+        )
 
     def test_keyword_agi_in_snippet(self):
-        assert web_search_mod._looks_agi_result(
-            "Book Review",
-            "Discussion about AGI and AI risk",
-            "https://blog.example.com"
-        ) is True
+        assert (
+            web_search_mod._looks_agi_result(
+                "Book Review",
+                "Discussion about AGI and AI risk",
+                "https://blog.example.com",
+            )
+            is True
+        )
 
     def test_keyword_artificial_general_intelligence(self):
-        assert web_search_mod._looks_agi_result(
-            "Research Paper",
-            "artificial general intelligence capabilities",
-            "https://research.example.com"
-        ) is True
+        assert (
+            web_search_mod._looks_agi_result(
+                "Research Paper",
+                "artificial general intelligence capabilities",
+                "https://research.example.com",
+            )
+            is True
+        )
 
 
 class TestWebSearchSsrfGuard:
@@ -340,7 +409,6 @@ class TestWebSearchSsrfGuard:
 
     def test_public_ip_host_is_allowed(self):
         assert web_search_mod._is_private_or_local_host("8.8.8.8") is False
-
 
     def test_embedded_credentials_are_blocked(self):
         assert (

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -75,6 +75,12 @@ def _safe_int(key: str, default: int) -> int:
         return default
 
 
+def _safe_int_with_min(key: str, default: int, minimum: int) -> int:
+    """環境変数を整数として読み取り、下限値を適用して返す。"""
+    value = _safe_int(key, default)
+    return max(value, minimum)
+
+
 def _safe_float(key: str, default: float) -> float:
     try:
         return float(os.getenv(key, str(default)))
@@ -82,11 +88,13 @@ def _safe_float(key: str, default: float) -> float:
         return default
 
 
-WEBSEARCH_MAX_RETRIES = _safe_int("VERITAS_WEBSEARCH_MAX_RETRIES", 3)
-WEBSEARCH_RETRY_DELAY = _safe_float("VERITAS_WEBSEARCH_RETRY_DELAY", 1.0)
-WEBSEARCH_RETRY_MAX_DELAY = _safe_float(
-    "VERITAS_WEBSEARCH_RETRY_MAX_DELAY", 8.0
+WEBSEARCH_MAX_RETRIES = _safe_int_with_min(
+    "VERITAS_WEBSEARCH_MAX_RETRIES",
+    3,
+    1,
 )
+WEBSEARCH_RETRY_DELAY = _safe_float("VERITAS_WEBSEARCH_RETRY_DELAY", 1.0)
+WEBSEARCH_RETRY_MAX_DELAY = _safe_float("VERITAS_WEBSEARCH_RETRY_MAX_DELAY", 8.0)
 WEBSEARCH_RETRY_JITTER = _safe_float("VERITAS_WEBSEARCH_RETRY_JITTER", 0.1)
 WEBSEARCH_HOST_ALLOWLIST = {
     host.strip().lower()


### PR DESCRIPTION
### Motivation
- Prevent misconfiguration where `VERITAS_WEBSEARCH_MAX_RETRIES=0` (or negative) disables retries and causes unexpected behavior when calling external websearch endpoints. 
- Ensure helper functions and their behavior are documented and covered by tests while keeping changes narrowly scoped to the web search adapter.

### Description
- Add `_safe_int_with_min(key: str, default: int, minimum: int)` with a docstring to read integer env vars and enforce a floor. 
- Use `_safe_int_with_min` for `WEBSEARCH_MAX_RETRIES` so the retry loop will run at least once even if env is set to `0` or a negative value. 
- Add unit tests in `veritas_os/tests/test_web_search_extra.py` validating the new helper for both zero and invalid string values. 
- Run `ruff format` to apply PEP8 formatting to the touched files.

### Testing
- Ran `ruff format veritas_os/tools/web_search.py veritas_os/tests/test_web_search_extra.py` which completed successfully. 
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and all tests passed (`52 passed`). 
- No automated tests failed; change is limited to retry env parsing logic for the web search adapter and covered by added tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990673d2e9083268b8bd3a5f6d9be69)