### PR TITLE
Harden web search result normalization and add focused tests

### DIFF
--- a/veritas_os/tests/test_web_search.py
+++ b/veritas_os/tests/test_web_search.py
@@ -64,6 +64,32 @@ def test_sanitize_max_results_clamps_values() -> None:
     assert web_search_mod._sanitize_max_results("abc") == 5
 
 
+def test_normalize_result_item_rejects_unsafe_scheme() -> None:
+    """危険なスキームは正規化段階で除外する。"""
+    item = {
+        "title": "bad",
+        "link": "javascript:alert(1)",
+        "snippet": "x",
+    }
+    assert web_search_mod._normalize_result_item(item) is None
+
+
+def test_normalize_result_item_truncates_long_fields() -> None:
+    """検索結果の各フィールドは上限長で切り詰める。"""
+    item = {
+        "title": "t" * 700,
+        "link": "https://example.com/" + ("p" * 3000),
+        "snippet": "s" * 3000,
+    }
+
+    normalized = web_search_mod._normalize_result_item(item)
+
+    assert normalized is not None
+    assert len(normalized["title"]) == 512
+    assert len(normalized["url"]) == 2048
+    assert len(normalized["snippet"]) == 2048
+
+
 # -----------------------------
 # web_search 本体のテスト
 # -----------------------------


### PR DESCRIPTION
### Motivation
- Improve safety and maintainability of `web_search` result handling by centralizing per-item normalization and enforcing size limits for untrusted API payloads.
- Reduce risks from malicious or oversized external search results (non-`http/https` schemes and very large fields) that can cause resource exhaustion, log contamination, or surface unexpected inputs.
- Keep changes confined to `veritas_os/tools/web_search.py` and its tests so Planner/Kernel/Fuji/MemoryOS responsibilities are not crossed.
- Note: this is a defensive mitigation and further SSRF/network hardening may still be required for full protection.

### Description
- Added `_normalize_result_item(item)` to validate the result `url` (allow only `http`/`https`) and to truncate `title`, `url`, and `snippet` to bounded lengths to limit memory/log exposure.
- Replaced inline per-item normalization in `web_search` with the new helper for consistent enforcement and reduced branching.
- Added two unit tests in `veritas_os/tests/test_web_search.py`: `test_normalize_result_item_rejects_unsafe_scheme` and `test_normalize_result_item_truncates_long_fields` to cover unsafe-scheme rejection and truncation behavior.
- Preserved existing SSRF guard for `WEBSEARCH_URL` and did not change cross-cutting subsystem boundaries.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py` and received `14 passed` (all tests in that file passed).
- Ran linting with `python -m ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search.py` and it passed with no issues.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699068927a4483268e69e8d172d91782)