### PR TITLE
Harden llm_safety category normalization and add regression tests

### DIFF
--- a/veritas_os/tests/test_llm_safety.py
+++ b/veritas_os/tests/test_llm_safety.py
@@ -161,6 +161,26 @@ def test_score_risk_prefers_heuristic_override():
     assert "heuristic_risk_override" in scored["notes"]
 
 
+def test_normalize_categories_deduplicates_and_clips():
+    """カテゴリ正規化は重複を除去し、各要素を64文字で制限する。"""
+    overlong = "x" * 120
+    normalized = llm_safety._normalize_categories(
+        [" PII ", "PII", "", "illicit", overlong],
+        max_categories=10,
+    )
+
+    assert normalized[0] == "PII"
+    assert normalized[1] == "illicit"
+    assert len(normalized[2]) == 64
+    assert len(normalized) == 3
+
+
+def test_normalize_categories_respects_non_positive_limit():
+    """上限が 0 以下なら空配列を返す。"""
+    normalized = llm_safety._normalize_categories(["PII", "illicit"], max_categories=0)
+    assert normalized == []
+
+
 # -----------------------------
 # run() の挙動テスト
 # -----------------------------


### PR DESCRIPTION
### Motivation

- LLM-provided `categories` can contain duplicates, empty strings, or extremely long values which bloat audit logs and produce inconsistent outputs. 
- Normalizing and bounding categories improves determinism and reduces risk of log/response DoS from untrusted model output. 
- Keep the safety head’s outputs small and audit-friendly without changing upstream Planner/Kernel responsibilities.

### Description

- Add `_normalize_categories(categories, max_categories)` to `veritas_os/tools/llm_safety.py` to trim, deduplicate, and clip each category to 64 characters and return an empty list when `max_categories <= 0`.
- Use `_normalize_categories` in `_analyze_with_llm()` instead of naive slicing of combined categories to ensure returned lists are safe and bounded.
- Add regression tests in `veritas_os/tests/test_llm_safety.py` verifying deduplication, per-item clipping, and behavior for non-positive `max_categories`.

### Testing

- Ran `pytest -q veritas_os/tests/test_llm_safety.py veritas_os/tests/test_code_review_fixes.py` and all tests passed (`20 passed`).
- Ran `ruff check veritas_os/tools/llm_safety.py veritas_os/tests/test_llm_safety.py` and lint checks passed.
- The changes are localized to `llm_safety` post-processing and unit-tested to prevent regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69906e3026208326a88a5a804eeeb121)