### PR TITLE
Improve web search error classification logging

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -318,6 +318,28 @@ class TestWebSearchEdgeCases:
         assert resp["ok"] is True
         assert resp["results"] == []
 
+
+class TestClassifyWebsearchError:
+    """Tests for _classify_websearch_error helper."""
+
+    def test_timeout_error(self):
+        err = web_search_mod.requests.exceptions.Timeout("boom")
+        assert web_search_mod._classify_websearch_error(err) == "timeout"
+
+    def test_http_4xx_error(self):
+        response = type("Response", (), {"status_code": 404})()
+        err = web_search_mod.requests.exceptions.HTTPError(response=response)
+        assert web_search_mod._classify_websearch_error(err) == "http_4xx"
+
+    def test_http_5xx_error(self):
+        response = type("Response", (), {"status_code": 503})()
+        err = web_search_mod.requests.exceptions.HTTPError(response=response)
+        assert web_search_mod._classify_websearch_error(err) == "http_5xx"
+
+    def test_parse_error(self):
+        err = ValueError("invalid json")
+        assert web_search_mod._classify_websearch_error(err) == "response_parse"
+
     def test_result_with_missing_fields(self, monkeypatch):
         """Handle results with missing title/snippet/link."""
         monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Improve observability and auditability of external Web search failures by classifying error types (timeout / 4xx / 5xx / parse / other). 
- Avoid leaking internal exception details to clients while surfacing useful categories in logs for operators. 
- Follow earlier code-review guidance to categorize external I/O failures and keep the public API response generic for security.

### Description
- Added `_classify_websearch_error(error: Exception) -> str` to `veritas_os/tools/web_search.py` to normalize failure categories such as `timeout`, `http_4xx`, `http_5xx`, `request_exception`, `response_parse`, and `unexpected`.
- Wrapped `resp.json()` in a `try/except ValueError` branch and log a categorized parse failure while returning the existing generic error payload to callers.
- Enhanced the generic exception logging to include the normalized error category and exception type without exposing internals in the API response.
- Added unit tests for the new classifier in `veritas_os/tests/test_web_search_extra.py` covering timeout, HTTP 4xx, HTTP 5xx, and parse errors.

### Testing
- Ran `ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search_extra.py --output-format concise` and it passed.
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and all tests passed (`58 passed`).
- All changes are limited to `veritas_os/tools/web_search.py` and its tests and do not cross Planner/Kernel/Fuji/MemoryOS responsibilities.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699074152d848326bc35b503fc91b16a)