### PR TITLE
Emit warnings for invalid numeric env vars in config

### DIFF
--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -29,24 +29,30 @@ def _parse_cors_origins(raw_value: str) -> list[str]:
 
 
 def _parse_float(env_key: str, default: float) -> float:
-    """環境変数からfloatを取得"""
+    """環境変数から float を取得し、不正値時は警告して既定値を返す。"""
     val = os.getenv(env_key)
     if val is None:
         return default
     try:
         return float(val)
     except ValueError:
+        logging.getLogger(__name__).warning(
+            "Invalid float for %s; falling back to default.", env_key
+        )
         return default
 
 
 def _parse_int(env_key: str, default: int) -> int:
-    """環境変数からintを取得"""
+    """環境変数から int を取得し、不正値時は警告して既定値を返す。"""
     val = os.getenv(env_key)
     if val is None:
         return default
     try:
         return int(val)
     except ValueError:
+        logging.getLogger(__name__).warning(
+            "Invalid int for %s; falling back to default.", env_key
+        )
         return default
 
 

--- a/veritas_os/tests/test_config_coverage.py
+++ b/veritas_os/tests/test_config_coverage.py
@@ -74,6 +74,14 @@ def test_parse_float_invalid(monkeypatch):
     assert _parse_float("TEST_FLOAT_KEY", 9.9) == 9.9
 
 
+def test_parse_float_invalid_logs_warning(monkeypatch, caplog):
+    monkeypatch.setenv("TEST_FLOAT_KEY", "bad")
+    caplog.set_level(logging.WARNING)
+
+    assert _parse_float("TEST_FLOAT_KEY", 1.0) == 1.0
+    assert "Invalid float for TEST_FLOAT_KEY" in caplog.text
+
+
 def test_parse_float_empty(monkeypatch):
     monkeypatch.setenv("TEST_FLOAT_KEY", "")
     # empty string -> ValueError -> default
@@ -97,6 +105,14 @@ def test_parse_int_valid(monkeypatch):
 def test_parse_int_invalid(monkeypatch):
     monkeypatch.setenv("TEST_INT_KEY", "abc")
     assert _parse_int("TEST_INT_KEY", 99) == 99
+
+
+def test_parse_int_invalid_logs_warning(monkeypatch, caplog):
+    monkeypatch.setenv("TEST_INT_KEY", "bad")
+    caplog.set_level(logging.WARNING)
+
+    assert _parse_int("TEST_INT_KEY", 2) == 2
+    assert "Invalid int for TEST_INT_KEY" in caplog.text
 
 
 def test_parse_int_float_string(monkeypatch):


### PR DESCRIPTION
### Motivation
- Improve observability when environment variables intended to be numeric are invalid so misconfiguration does not silently fall back to defaults; this reduces operational risk.

### Description
- Add warning logs and clearer docstrings to `_parse_float` and `_parse_int` in `veritas_os/core/config.py` so invalid env values emit a `logging.WARNING` before returning the default.
- Add tests `test_parse_float_invalid_logs_warning` and `test_parse_int_invalid_logs_warning` to `veritas_os/tests/test_config_coverage.py` to assert warnings are emitted for bad numeric env inputs.

### Testing
- Ran `pytest -q veritas_os/tests/test_config_coverage.py` which passed: `33 passed`.
- Ran `ruff check veritas_os/core/config.py veritas_os/tests/test_config_coverage.py` which reported `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699078d2914883269fa104adb2562951)