### PR TITLE
Harden VERITAS_DEBUG_MODE parsing for whitespace-padded values

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -1001,7 +1001,9 @@ async def on_validation_error(request: Request, exc: RequestValidationError):
 
 def _is_debug_mode() -> bool:
     """VERITAS_DEBUG_MODE が有効かどうかを判定する。"""
-    return os.getenv("VERITAS_DEBUG_MODE", "").lower() in ("1", "true", "yes")
+    debug_flag = os.getenv("VERITAS_DEBUG_MODE", "")
+    normalized_flag = debug_flag.strip().lower()
+    return normalized_flag in ("1", "true", "yes")
 
 
 @app.get("/")
@@ -1722,7 +1724,6 @@ def trust_feedback(body: dict):
         # Log the detailed error server-side, but do not expose it to the client.
         logger.error("[Trust] feedback failed: %s", e)
         return {"status": "error", "detail": "internal error in trust_feedback"}
-
 
 
 

--- a/veritas_os/tests/test_server_coverage.py
+++ b/veritas_os/tests/test_server_coverage.py
@@ -423,6 +423,11 @@ def test_is_debug_mode_on(monkeypatch):
     assert server._is_debug_mode() is True
 
 
+def test_is_debug_mode_with_spaces(monkeypatch):
+    monkeypatch.setenv("VERITAS_DEBUG_MODE", "  TRUE  ")
+    assert server._is_debug_mode() is True
+
+
 # ----------------------------------------------------------------
 # 42. _is_placeholder_secret
 # ----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Environment variables may include accidental leading/trailing whitespace from deployment tooling, which can cause truthy values like `"TRUE"` to be misread as false.
- Improve operational robustness of the API server's debug-mode detection without changing external behavior beyond normalization.

### Description
- Normalize the `VERITAS_DEBUG_MODE` environment value using `debug_flag.strip().lower()` before checking membership in `("1", "true", "yes")` inside `server._is_debug_mode()`.
- Add regression test `test_is_debug_mode_with_spaces` in `veritas_os/tests/test_server_coverage.py` to verify that whitespace-padded truthy values are accepted.
- No other functional changes or surface API alterations; the only behavioral change is more permissive recognition of truthy env values.
- This change is limited to API server input normalization and does not cross the Planner / Kernel / Fuji / MemoryOS responsibility boundaries.

### Testing
- Ran `pytest -q veritas_os/tests/test_server_coverage.py -k debug_mode` and observed `3 passed, 61 deselected` for the debug-mode related tests.
- Ran `ruff check veritas_os/api/server.py veritas_os/tests/test_server_coverage.py` and observed `All checks passed!`.
- No failing tests were introduced by these changes.

Security
- Warning: enabling `VERITAS_DEBUG_MODE` will allow inclusion of `raw_body` in 422 responses (with PII masking and truncation applied), so avoid enabling this flag in production unless necessary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69907bb149708326ae446500a4c14581)