### PR TITLE
refactor: use importlib.util.find_spec for openai import in llm_safety

### DIFF
--- a/veritas_os/tools/llm_safety.py
+++ b/veritas_os/tools/llm_safety.py
@@ -20,6 +20,7 @@ FUJI Gate から呼ばれる「安全ヘッド」。
 """
 
 from __future__ import annotations
+import importlib.util
 from typing import Any, Dict, List
 import json
 import logging
@@ -30,10 +31,9 @@ import time
 
 logger = logging.getLogger(__name__)
 
-try:
-    # OpenAI クライアント（インポートできなければ使わない）
+if importlib.util.find_spec("openai") is not None:  # pragma: no cover
     from openai import OpenAI  # type: ignore
-except (ImportError, ModuleNotFoundError):  # pragma: no cover
+else:  # pragma: no cover
     OpenAI = None  # type: ignore
 
 


### PR DESCRIPTION
### Motivation
- Replace the `try/except` import guard with an explicit `importlib.util.find_spec` check to comply with the repository guideline of avoiding try/catch around imports.
- Preserve the existing runtime fallback behavior so that `OpenAI` remains `None` when the `openai` package is not installed.
- Security note: the availability of the `openai` package changes execution path (LLM-based safety vs heuristic fallback), so dependency pinning in deployments is recommended to avoid unexpected mode switches.

### Description
- Imported `importlib.util` and removed the `try/except` import pattern in `veritas_os/tools/llm_safety.py`.
- Replaced the guarded import with `if importlib.util.find_spec("openai") is not None: from openai import OpenAI else: OpenAI = None` while keeping behavior unchanged.
- The only file modified is `veritas_os/tools/llm_safety.py` (small, local refactor: 3 insertions, 3 deletions).

### Testing
- Ran `pytest -q veritas_os/tests/test_llm_safety.py`, which succeeded with `12 passed` in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69907e55dbec83268c1dd2c84069a955)