### PR TITLE
Harden allowlisted websearch endpoint validation against private resolution

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -461,11 +461,37 @@ class TestWebSearchSsrfGuard:
             {"api.allowed.example"},
             raising=False,
         )
+        monkeypatch.setattr(
+            web_search_mod,
+            "_is_private_or_local_host",
+            lambda *_: False,
+            raising=False,
+        )
         assert (
             web_search_mod._is_allowed_websearch_url(
                 "https://api.allowed.example/search"
             )
             is True
+        )
+
+    def test_allowlist_rejects_private_resolution(self, monkeypatch):
+        monkeypatch.setattr(
+            web_search_mod,
+            "WEBSEARCH_HOST_ALLOWLIST",
+            {"api.allowed.example"},
+            raising=False,
+        )
+        monkeypatch.setattr(
+            web_search_mod,
+            "_is_private_or_local_host",
+            lambda *_: True,
+            raising=False,
+        )
+        assert (
+            web_search_mod._is_allowed_websearch_url(
+                "https://api.allowed.example/search"
+            )
+            is False
         )
 
     def test_web_search_returns_unavailable_for_blocked_endpoint(self, monkeypatch):

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -319,8 +319,10 @@ def _is_allowed_websearch_url(url: str) -> bool:
     if WEBSEARCH_HOST_ALLOWLIST:
         if host not in WEBSEARCH_HOST_ALLOWLIST:
             return False
-        # Allowlisted hosts still must not be obviously local/private.
-        return not _is_obviously_private_or_local_host(host)
+        # Allowlisted hosts must also resolve to public IPs.
+        # This prevents DNS rebinding/misconfiguration from tunneling
+        # requests into private networks.
+        return not _is_private_or_local_host(host)
 
     if _is_private_or_local_host(host):
         return False


### PR DESCRIPTION
### Motivation
- Close an SSRF/DNS-rebinding gap where a hostname in `WEBSEARCH_HOST_ALLOWLIST` could still resolve to private/local IPs and be used as a tunneling vector. 
- Ensure that allowlisted websearch endpoints are validated not only by hostname but also by their actual resolution being public. 
- Improve overall guardrails for `web_search` endpoint validation while keeping normal non-allowlist behavior unchanged.

### Description
- Update `_is_allowed_websearch_url` to require that allowlisted hosts also pass `_is_private_or_local_host` (i.e. they must not resolve to private/local addresses) by returning `not _is_private_or_local_host(host)` for the allowlist branch. 
- Add and adjust unit tests in `veritas_os/tests/test_web_search_extra.py` to assert that allowlisted hosts are accepted when resolution is public (mocked) and rejected when resolution is private (mocked). 
- Add explanatory comments near the allowlist branch to document the DNS-rebinding/misconfiguration mitigation and keep existing behavior for non-allowlisted hosts.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and iterated until all tests passed; final result: `59 passed`. 
- Ran `ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search_extra.py --output-format concise` and received `All checks passed!`. 
- Static checks and tests succeeded after the changes, and added tests validate the new allowlist resolution behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69907fcb5a6483268ccf79f882f162fd)