### PR TITLE
Improve get_last_hash() to handle oversized JSONL tail entries

### DIFF
--- a/veritas_os/tests/test_trust_log.py
+++ b/veritas_os/tests/test_trust_log.py
@@ -180,6 +180,13 @@ def test_get_last_hash_invalid_json_returns_none(temp_log_env):
     assert trust_log.get_last_hash() is None
 
 
+def test_get_last_hash_handles_very_large_last_line(temp_log_env):
+    payload = {"sha256": "large123", "blob": "x" * 70000}
+    temp_log_env["jsonl"].write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    assert trust_log.get_last_hash() == "large123"
+
+
 # ============================
 #  append_trust_log のチェーン検証
 # ============================


### PR DESCRIPTION
### Motivation
- Address a bug where `get_last_hash()` could return `None` when the final JSONL entry exceeded the previous read window (causing the tail chunk to be an incomplete JSON record). 
- Keep memory usage bounded while ensuring the final record is parsed correctly for large entries. 
- No new external attack surface or write permissions are introduced by this change. 

### Description
- Update `veritas_os/logging/trust_log.py::get_last_hash()` to iteratively expand the read window backward (in 64KB steps) and attempt to parse the final JSONL line until success or start-of-file is reached. 
- Add robust UTF-8 decoding with `errors="replace"` and fallback handling for `JSONDecodeError` to avoid false negatives on large or partially-read multibyte sequences. 
- Preserve existing thread-safety by holding the `_trust_log_lock` while reading the tail. 
- Add a regression test `test_get_last_hash_handles_very_large_last_line` in `veritas_os/tests/test_trust_log.py` that writes a >64KB final JSONL line and asserts correct `sha256` extraction. 

### Testing
- Ran `pytest -q veritas_os/tests/test_trust_log.py` and all tests passed: `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908b82a7dc8326bd688dab2ea9aebd)