### PR TITLE
Segmented scanning for oversized PII inputs in sanitize.PIIDetector

### DIFF
--- a/veritas_os/tests/test_sanitize.py
+++ b/veritas_os/tests/test_sanitize.py
@@ -64,6 +64,17 @@ def test_detector_prepare_input_text_handles_none_and_truncates(caplog):
     with caplog.at_level("WARNING"):
         prepared = detector._prepare_input_text(oversized)
 
-    assert len(prepared) == sanitize._MAX_PII_INPUT_LENGTH
-    assert "PII input truncated" in caplog.text
+    assert prepared == oversized
+    assert "PII input truncated" not in caplog.text
 
+
+def test_detect_pii_scans_large_text_without_truncating(caplog):
+    huge_prefix = "x" * sanitize._MAX_PII_INPUT_LENGTH
+    email = "very.large.user@example.com"
+    text = f"{huge_prefix}\n{email}"
+
+    with caplog.at_level("WARNING"):
+        matches = sanitize.detect_pii(text)
+
+    assert any(match["type"] == "email" and match["value"] == email for match in matches)
+    assert "PII input segmented for scanning" in caplog.text


### PR DESCRIPTION
### Motivation
- Prevent silent truncation of very large inputs which could cause PII after the cutoff to be missed by the scanner.
- Keep regex work bounded to avoid DoS/reDoS while still scanning the entire input.
- Provide a maintainable helper for per-segment detection so existing overlap/confidence logic is reused.
- Warn that segment overlap sizing affects detection of patterns crossing chunk boundaries and may need tuning.

### Description
- Stop truncating input in `PIIDetector._prepare_input_text` so the full string is preserved for scanning and update its docstring accordingly.
- Add `PIIDetector._detect_in_segment` to perform pattern iteration, overlap filtering, validator checks, and return matches with absolute offsets.
- Update `PIIDetector.detect` to perform segmented scanning when input length exceeds `_MAX_PII_INPUT_LENGTH`, using an overlap window and de-duplicating spans to avoid duplicate matches across chunks.
- Adjust masking flow to consume the new detection behavior and add docstrings for the new helper.
- Update tests in `veritas_os/tests/test_sanitize.py` to reflect non-truncating behavior and to verify segmented scanning and logging for very large inputs.

### Testing
- Ran `pytest -q veritas_os/tests/test_sanitize.py veritas_os/tests/test_alert_doctor.py` and all tests passed (`14 passed`).
- Added `test_detect_pii_scans_large_text_without_truncating` which asserts detection of PII placed after a very large prefix and checks for the segmentation warning log, and it succeeded.
- Existing sanitize tests were preserved and continue to pass with the new behavior.
- Note: segmentation behavior is logged (`PII input segmented for scanning`) and verified by the tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908e8f2a248326b05ac175ad88376d)