### PR TITLE
Harden PII sanitizer input normalization

### DIFF
--- a/veritas_os/tests/test_sanitize_pii.py
+++ b/veritas_os/tests/test_sanitize_pii.py
@@ -42,6 +42,23 @@ def test_phone_patterns_do_not_match_embedded_digits() -> None:
     assert phones == []
 
 
+def test_detect_pii_accepts_non_string_inputs() -> None:
+    """detect_pii should safely coerce non-string payload values."""
+    byte_result = detect_pii(b"mail: test@example.com")
+    assert any(item["type"] == "email" for item in byte_result)
+
+    int_result = detect_pii(12345)
+    assert int_result == []
+
+
+def test_mask_pii_handles_non_string_bytes_via_detector() -> None:
+    """PIIDetector.mask should decode bytes before masking."""
+    detector = PIIDetector()
+    masked = detector.mask(b"contact: test@example.com")
+    assert "test@example.com" not in masked
+    assert "〔メール〕" in masked
+
+
 class TestEmailDetection:
     """Tests for email address detection."""
 


### PR DESCRIPTION
### Motivation
- Prevent crashes and TypeErrors when the sanitizer receives non-string payloads (e.g. `bytes` or arbitrary objects) so PII redaction remains robust for unexpected API inputs.
- Avoid leaking internals via unhandled exceptions caused by type errors during PII processing.
- Security note: converting arbitrary objects to `str()` reduces crash surface but may expose `__repr__` content for objects that include sensitive internals, so avoid logging or exposing raw converted strings.

### Description
- Implemented `PIIDetector._prepare_input_text` to accept `object | None` and safely coerce `str`, `bytes` (decoded with `utf-8, errors='replace'`) and other objects via `str()` with a docstring noting the security tradeoff. 
- Updated `PIIDetector.mask` to normalize input via `_prepare_input_text` before detection and replacement to eliminate `bytes`+`str` concatenation errors. 
- Broadened public helper signatures to `detect_pii(text: object | None)` and `mask_pii(text: object | None)` to make usage safer when callers pass non-string payloads. 
- Added regression tests in `veritas_os/tests/test_sanitize_pii.py` to cover `bytes` and non-string inputs and verify masking/detection behavior.

### Testing
- Ran linter: `ruff check veritas_os/core/sanitize.py veritas_os/tests/test_sanitize_pii.py` and it passed. 
- Ran focused unit tests: `pytest -q veritas_os/tests/test_sanitize_pii.py` and `pytest -q veritas_os/tests/test_sanitize.py veritas_os/tests/test_api_server_extra.py` and they all passed (new and related tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699099f63b988326ab8cbca42ad8920f)