### PR TITLE
Harden web_search endpoint validation to HTTPS-only

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -440,6 +440,14 @@ class TestWebSearchSsrfGuard:
             is False
         )
 
+    def test_http_scheme_is_blocked(self):
+        assert (
+            web_search_mod._is_allowed_websearch_url(
+                "http://api.allowed.example/search"
+            )
+            is False
+        )
+
     def test_allowlist_blocks_non_listed_host(self, monkeypatch):
         monkeypatch.setattr(
             web_search_mod,

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -306,9 +306,13 @@ def _is_private_or_local_host(hostname: str) -> bool:
 
 
 def _is_allowed_websearch_url(url: str) -> bool:
-    """WEBSEARCH endpoint のスキーム・ホスト安全性を検証する。"""
+    """WEBSEARCH endpoint のスキーム・ホスト安全性を検証する。
+
+    Security note:
+        API key を平文送信しないため、HTTPS のみ許可する。
+    """
     parsed = urlparse((url or "").strip())
-    if parsed.scheme not in ("http", "https"):
+    if parsed.scheme != "https":
         return False
 
     # URL 埋め込み資格情報の利用を禁止し、誤設定や漏えいリスクを低減する。


### PR DESCRIPTION
### Motivation
- Prevent leakage of the `X-API-KEY` by disallowing plaintext `http` endpoints for `VERITAS_WEBSEARCH_URL` and enforce encrypted transport for outbound web search requests.
- Keep the change limited to the web search adapter (no cross-cutting responsibility changes beyond `veritas_os/tools/web_search.py`).
- Security warning: existing deployments using `http://...` for `VERITAS_WEBSEARCH_URL` will have web search disabled and must migrate to `https://...` to restore functionality.

### Description
- Require `https` only in `_is_allowed_websearch_url` and add a security-focused docstring explaining the rationale. 
- Add `test_http_scheme_is_blocked` in `veritas_os/tests/test_web_search_extra.py` to assert `http://...` endpoints are rejected.
- Preserve existing SSRF and credential-embedding protections (host allowlist, private-host checks, embedded-credentials rejection) while tightening the allowed scheme.

### Testing
- Ran `ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search_extra.py`, which passed with no issues. 
- Ran `pytest -q veritas_os/tests/test_web_search_extra.py`, which completed successfully with `46 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a02fb9d0832698e8b3a756c6b4cf)