### PR TITLE
Resolve GitHub token at call-time to support live rotation

### DIFF
--- a/veritas_os/tools/github_adapter.py
+++ b/veritas_os/tools/github_adapter.py
@@ -14,9 +14,6 @@ import time
 import requests
 
 
-GITHUB_TOKEN = os.environ.get("VERITAS_GITHUB_TOKEN", "").strip()
-
-
 def _safe_int(key: str, default: int) -> int:
     try:
         return int(os.getenv(key, str(default)))
@@ -43,6 +40,15 @@ MAX_QUERY_LEN = 256
 GITHUB_API_MAX_PER_PAGE = 100
 
 logger = logging.getLogger(__name__)
+
+
+def _get_github_token() -> str:
+    """Return the latest GitHub token from environment variables.
+
+    The token is resolved at call time so that emergency token rotations can
+    take effect without restarting the running process.
+    """
+    return os.getenv("VERITAS_GITHUB_TOKEN", "").strip()
 
 
 def _prepare_query(raw: str, max_len: int = MAX_QUERY_LEN) -> tuple[str, bool]:
@@ -140,7 +146,8 @@ def github_search_repos(query: str, max_results: int = 5) -> dict:
           "meta": { ... }
         }
     """
-    if not GITHUB_TOKEN:
+    token = _get_github_token()
+    if not token:
         return {
             "ok": False,
             "results": [],
@@ -169,7 +176,7 @@ def github_search_repos(query: str, max_results: int = 5) -> dict:
     }
     headers = {
         "Accept": "application/vnd.github+json",
-        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Authorization": f"Bearer {token}",
     }
 
     try:


### PR DESCRIPTION
### Motivation
- Long-running processes previously cached `VERITAS_GITHUB_TOKEN` at import time causing rotated/rotated-out tokens to remain in use; resolving the token at call time allows emergency rotation without process restart.
- Tests relied on module-level token injection which no longer matches runtime behavior, so tests needed to be adapted to exercise environment-driven token resolution.
- This change is scoped to the GitHub adapter and its tests and does not alter Planner / Kernel / Fuji / MemoryOS responsibilities.
- Security note: this reduces operational risk from stale credentials, but operators must still keep environment variables and token rotation practices secure.

### Description
- Introduced `_get_github_token()` which reads and returns `VERITAS_GITHUB_TOKEN` from the environment at call time with a docstring explaining the intent.
- Removed the module-level `GITHUB_TOKEN` constant and changed `github_search_repos()` to call `_get_github_token()` and use the returned `token` in the `Authorization` header.
- Updated tests to set the environment via `monkeypatch.setenv(...)` instead of mutating a module-level variable, and added `test_get_github_token_reads_latest_env` to verify live env updates are observed.
- Kept existing API semantics and error shapes unchanged; code changes are limited to `veritas_os/tools/github_adapter.py` and `veritas_os/tests/test_github_adapter.py` and adhere to PEP8 formatting.

### Testing
- Ran `pytest -q veritas_os/tests/test_github_adapter.py` and observed all tests pass (`7 passed`).
- The modified test suite verifies query preparation, error handling, retry behavior, and that `_get_github_token()` reflects environment changes without module reload.
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991603aa89483269f3119f431a46eed)