### PR TITLE
Harden GitHub adapter query sanitization and response normalization

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -10,6 +10,10 @@ def test_prepare_query_basic_and_truncate():
     assert q == "foo bar"
     assert truncated is False
 
+    q_ctrl, truncated_ctrl = github_adapter._prepare_query("a\x00\x1fb")
+    assert q_ctrl == "a b"
+    assert truncated_ctrl is False
+
     # None でも落ちない
     q2, truncated2 = github_adapter._prepare_query(None)
     assert q2 == ""
@@ -177,3 +181,19 @@ def test_get_github_token_reads_latest_env(monkeypatch):
 
     monkeypatch.setenv("VERITAS_GITHUB_TOKEN", "token-b")
     assert github_adapter._get_github_token() == "token-b"
+
+
+def test_normalize_repo_item_uses_safe_defaults():
+    result = github_adapter._normalize_repo_item(
+        {
+            "full_name": None,
+            "html_url": None,
+            "description": None,
+            "stargazers_count": "7",
+        }
+    )
+
+    assert result["full_name"] == ""
+    assert result["html_url"] == ""
+    assert result["description"] == ""
+    assert result["stars"] == 7


### PR DESCRIPTION
### Motivation
- Improve robustness by sanitizing untrusted GitHub search queries and normalizing upstream API items to avoid log/response pollution and type errors.
- Prevent malformed or malicious input (e.g. embedded control characters or None fields) from propagating into outputs while keeping request-time token resolution and retry logic intact.
- Security note: these changes reduce injection/log-pollution risks but do not remove API-level risks, so operators should continue token rotation and use least-privilege tokens.

### Description
- Add control-character removal and whitespace collapsing to `_prepare_query` so queries are sanitized before truncation.
- Introduce `_normalize_repo_item` (with a docstring) to coerce `stargazers_count` to `int` and provide safe empty-string defaults for missing fields, and use it when building `results` while filtering non-dict items.
- Preserve existing dynamic token resolution (`_get_github_token`) and retry/backoff behavior without behavioral changes.
- Add tests covering control-character query sanitization and safe normalization defaults.

### Testing
- Ran `pytest -q veritas_os/tests/test_github_adapter.py` which succeeded (8 passed).
- Ran `pytest -q veritas_os/tests/test_tools.py` which succeeded (7 passed).
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` which succeeded (60 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699163046278832689ce1915a0b0b8aa)