### PR TITLE
Harden GitHub adapter retry config and disable redirects

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -71,11 +71,12 @@ def test_github_search_repos_success(monkeypatch):
         def json(self):
             return self._payload
 
-    def fake_get(url, headers=None, params=None, timeout=None):
+    def fake_get(url, headers=None, params=None, timeout=None, **kwargs):
         # URL・パラメータがそれなりに渡っているかだけ軽く確認
         assert "api.github.com/search/repositories" in url
         assert params["q"] == "veritas_os"
         assert params["per_page"] == 3
+        assert kwargs.get("allow_redirects") is False
         assert "Authorization" in headers
         assert "dummy-token" in headers["Authorization"]
         payload = {
@@ -197,3 +198,8 @@ def test_normalize_repo_item_uses_safe_defaults():
     assert result["html_url"] == ""
     assert result["description"] == ""
     assert result["stars"] == 7
+
+
+def test_safe_float_non_finite_returns_default(monkeypatch):
+    monkeypatch.setenv("VERITAS_GITHUB_RETRY_DELAY", "nan")
+    assert github_adapter._safe_float("VERITAS_GITHUB_RETRY_DELAY", 1.5) == 1.5


### PR DESCRIPTION
### Motivation
- Prevent invalid environment values (e.g. `nan`/`inf`) from corrupting retry timing and causing unpredictable behavior in GitHub API calls. 
- Ensure retry loop cannot be disabled by misconfiguration by enforcing `GITHUB_MAX_RETRIES >= 1`. 
- Reduce redirect-based abuse surface by disabling HTTP redirects when calling the GitHub API. 
- Note: `VERITAS_GITHUB_TOKEN` is still read from environment variables so secret-management and logging should be treated carefully in production. 

### Description
- Added `math` import and hardened `_safe_float` so non-finite floats fall back to the provided default and added a docstring to explain behavior. 
- Clamped `GITHUB_MAX_RETRIES` with `max(..., 1)` to enforce a minimum of one retry attempt. 
- Passed `allow_redirects=False` to `requests.get` inside `_get_with_retry` to prevent redirect chaining. 
- Updated tests: widened the mock `fake_get` signature to accept `**kwargs` and assert `allow_redirects` is `False`, and added `test_safe_float_non_finite_returns_default` to cover `nan` handling. 

### Testing
- Ran `pytest -q veritas_os/tests/test_github_adapter.py` and all tests passed (`9 passed`). 
- Ran `ruff check veritas_os/tools/github_adapter.py veritas_os/tests/test_github_adapter.py` and static checks passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699166ab6110832693dd3bcf5ca198e0)