### PR TITLE
Harden GitHub adapter URL normalization and add regression test

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -200,6 +200,19 @@ def test_normalize_repo_item_uses_safe_defaults():
     assert result["stars"] == 7
 
 
+def test_normalize_repo_item_drops_unsafe_html_url():
+    result = github_adapter._normalize_repo_item(
+        {
+            "full_name": "owner/repo",
+            "html_url": "javascript:alert(1)",
+            "description": "demo",
+            "stargazers_count": 1,
+        }
+    )
+
+    assert result["html_url"] == ""
+
+
 def test_safe_float_non_finite_returns_default(monkeypatch):
     monkeypatch.setenv("VERITAS_GITHUB_RETRY_DELAY", "nan")
     assert github_adapter._safe_float("VERITAS_GITHUB_RETRY_DELAY", 1.5) == 1.5


### PR DESCRIPTION
### Motivation
- Prevent propagation of unsafe or malformed `html_url` values returned by the GitHub API (e.g. `javascript:` schemes) into downstream consumers to reduce link-injection risk.
- Make HTML URL handling secure-by-default while keeping changes limited to the Tools layer and avoiding cross-cutting changes to Planner/Kernel/Fuji/MemoryOS responsibilities.

### Description
- Added `from urllib.parse import urlsplit` and implemented a new `_sanitize_html_url(raw_url: object) -> str` helper with a docstring that accepts only absolute `http`/`https` URLs with a host and returns an empty string for unsafe or hostless values.
- Wired `_sanitize_html_url` into `_normalize_repo_item` so normalized items use the sanitized `html_url` instead of returning raw API values, and log a warning when dropping unsafe URLs.
- Added a regression test `test_normalize_repo_item_drops_unsafe_html_url` to `veritas_os/tests/test_github_adapter.py` verifying that `javascript:` schemes are dropped.

### Testing
- Ran `pytest -q veritas_os/tests/test_github_adapter.py` and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69916f743df88326a2bd0ec325cdd511)