### PR TITLE
Cache host-safety DNS checks in web_search and clear cache in tests

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -11,6 +11,12 @@ import pytest
 web_search_mod = importlib.import_module("veritas_os.tools.web_search")
 
 
+@pytest.fixture(autouse=True)
+def clear_host_safety_cache() -> None:
+    """Host safety判定のキャッシュを各テストで初期化する。"""
+    web_search_mod._is_private_or_local_host.cache_clear()
+
+
 class TestNormalizeStr:
     """Tests for _normalize_str helper function."""
 

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -47,6 +47,7 @@ import re
 import time
 import ipaddress
 import socket
+from functools import lru_cache
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -279,8 +280,13 @@ def _is_obviously_private_or_local_host(hostname: str) -> bool:
     return False
 
 
+@lru_cache(maxsize=256)
 def _is_private_or_local_host(hostname: str) -> bool:
-    """ホストが localhost / private / loopback / link-local かを判定する。"""
+    """ホストが localhost / private / loopback / link-local かを判定する。
+
+    DNS 解決は外部 I/O であり繰り返すと遅延や負荷が大きくなるため、
+    直近の判定結果を LRU キャッシュする。
+    """
     host = (hostname or "").strip().lower()
     if _is_obviously_private_or_local_host(host):
         return True


### PR DESCRIPTION
### Motivation
- Reduce repeated DNS resolution overhead in the web search host safety check by caching recent results to improve performance and latency.
- Keep tests deterministic by ensuring the host-safety cache is cleared between tests so monkeypatching DNS behavior behaves as expected.
- Maintain conservative security posture: unresolved or private hosts remain blocked, but caching introduces a potential staleness risk that must be acknowledged.

### Description
- Added `from functools import lru_cache` and decorated `_is_private_or_local_host` with `@lru_cache(maxsize=256)` in `veritas_os/tools/web_search.py` to cache DNS-based host safety results and documented rationale in the function docstring.
- Introduced an `autouse` pytest fixture in `veritas_os/tests/test_web_search_extra.py` that calls `_is_private_or_local_host.cache_clear()` before each test to avoid cross-test cache contamination.
- No other behavior changes to allowlist logic, private-host blocking, or error handling; this change is scoped to the web search tool only and keeps responsibilities unchanged.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` after changes and all tests passed: `61 passed`.
- Existing sanitize tests were previously executed (for unrelated module) and passed: `68 passed` (no changes to sanitize were made).
- Tests include cache-clearing fixture to validate behavior under monkeypatched DNS failures and preserve determinism in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991733b2fd483269bed7e90d7068553)