### PR TITLE
Harden extra_messages handling in llm client

### DIFF
--- a/veritas_os/core/llm_client.py
+++ b/veritas_os/core/llm_client.py
@@ -178,17 +178,35 @@ def _format_request(
     """
     extra_messages = extra_messages or []
 
+    def _normalize_extra_messages(messages: List[Dict[str, str]]) -> List[Dict[str, str]]:
+        """Validate extra_messages and normalize each entry to string role/content.
+
+        Non-dict entries are ignored to prevent malformed caller input from
+        triggering runtime errors during request construction.
+        """
+        normalized_messages: List[Dict[str, str]] = []
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+
+            role = str(message.get("role") or "user")
+            content = str(message.get("content") or "")
+            normalized_messages.append({"role": role, "content": content})
+        return normalized_messages
+
     # ★ セキュリティ: extra_messages の件数制限（DoS防止）
     _MAX_EXTRA_MESSAGES = 100
     if len(extra_messages) > _MAX_EXTRA_MESSAGES:
         log.warning("extra_messages truncated from %d to %d", len(extra_messages), _MAX_EXTRA_MESSAGES)
         extra_messages = extra_messages[:_MAX_EXTRA_MESSAGES]
 
+    extra_messages = _normalize_extra_messages(extra_messages)
+
     if provider == LLMProvider.ANTHROPIC.value:
         msgs: List[Dict[str, str]] = [{"role": "user", "content": user_prompt}]
         for m in extra_messages:
-            role = m.get("role") or "user"
-            content = m.get("content") or ""
+            role = m["role"]
+            content = m["content"]
             msgs.append({"role": role, "content": content})
 
         return {
@@ -204,8 +222,8 @@ def _format_request(
         # system + user + extra を 1 テキストにまとめる簡易実装
         extra_text = ""
         for m in extra_messages:
-            role = m.get("role") or "user"
-            content = m.get("content") or ""
+            role = m["role"]
+            content = m["content"]
             extra_text += f"\n\n[{role}]\n{content}"
 
         full_text = f"{system_prompt}\n\n{user_prompt}{extra_text}"
@@ -226,8 +244,8 @@ def _format_request(
             {"role": "user", "content": user_prompt},
         ]
         for m in extra_messages:
-            role = m.get("role") or "user"
-            content = m.get("content") or ""
+            role = m["role"]
+            content = m["content"]
             msgs.append({"role": role, "content": content})
 
         return {
@@ -242,8 +260,8 @@ def _format_request(
         {"role": "user", "content": user_prompt},
     ]
     for m in extra_messages:
-        role = m.get("role") or "user"
-        content = m.get("content") or ""
+        role = m["role"]
+        content = m["content"]
         msgs.append({"role": role, "content": content})
 
     return {

--- a/veritas_os/tests/test_llm_client.py
+++ b/veritas_os/tests/test_llm_client.py
@@ -201,6 +201,24 @@ def test_format_request_ollama_with_extra_messages():
     assert msgs[3] == {"role": "user", "content": "implicit"}
 
 
+def test_format_request_ignores_non_dict_extra_messages():
+    payload = _format_request(
+        provider=LLMProvider.OPENAI,
+        system_prompt="SYS",
+        user_prompt="USER",
+        model="gpt-4.1-mini",
+        temperature=0.1,
+        max_tokens=100,
+        extra_messages=["invalid", {"role": "assistant", "content": 123}],
+    )
+
+    assert payload["messages"] == [
+        {"role": "system", "content": "SYS"},
+        {"role": "user", "content": "USER"},
+        {"role": "assistant", "content": "123"},
+    ]
+
+
 # ------------------------------------------------------------
 # _parse_response のテスト
 # ------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when callers pass malformed `extra_messages` (e.g., non-dict entries or non-string content) which could cause `.get()` calls to raise and break LLM request construction.
- Improve robustness of multi-provider request formatting while keeping the existing DoS protection that caps `extra_messages` to 100 items.
- Maintain prompt-supply behavior while reducing crash surface from unexpected input types.
- Security: this change reduces type-related failures but does not eliminate prompt-injection risks, which must be mitigated at the caller/policy layer.

### Description
- Added `_normalize_extra_messages` helper in `veritas_os/core/llm_client.py` that ignores non-dict entries and coerces `role`/`content` to strings with a concise docstring.
- Applied normalization after existing `_MAX_EXTRA_MESSAGES` truncation so the DoS cap is preserved and normalized data is consumed by all provider branches.
- Replaced `m.get(...)` usage with direct key access on normalized entries for Anthropic/Google/Ollama/OpenAI/OpenRouter paths.
- Added `test_format_request_ignores_non_dict_extra_messages` in `veritas_os/tests/test_llm_client.py` to cover non-dict items and non-string content stringification.

### Testing
- Ran `pytest -q veritas_os/tests/test_llm_client.py` and observed `43 passed` in `0.41s`.
- Existing related tests were not regressed by this change and the new regression test validates the hardened behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991798dbb388326bac43d383c309d83)