### PR TITLE
Harden CosineIndex load validation for non-finite vectors

### DIFF
--- a/veritas_os/memory/index_cosine.py
+++ b/veritas_os/memory/index_cosine.py
@@ -176,6 +176,15 @@ class CosineIndex:
             )
             self.vecs = np.zeros((0, self.dim), dtype=np.float32)
             self.ids = []
+            return
+
+        if not np.isfinite(self.vecs).all():
+            logger.warning(
+                "[CosineIndex] Loaded vecs include non-finite values (NaN/Inf), resetting index: %s",
+                self.path,
+            )
+            self.vecs = np.zeros((0, self.dim), dtype=np.float32)
+            self.ids = []
 
     def save(self) -> None:
         if self.path is None:

--- a/veritas_os/tests/test_index_cosine.py
+++ b/veritas_os/tests/test_index_cosine.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import numpy as np
+
+from veritas_os.memory.index_cosine import CosineIndex
+
+
+def test_cosine_index_load_resets_non_finite_vectors(tmp_path: Path) -> None:
+    """Loaded index with NaN vectors should be reset for safe search behavior."""
+    idx_path = tmp_path / "index.npz"
+    np.savez(
+        idx_path,
+        vecs=np.array([[1.0, np.nan], [2.0, 3.0]], dtype=np.float32),
+        ids=np.array(["a", "b"], dtype=str),
+    )
+
+    idx = CosineIndex(dim=2, path=idx_path)
+
+    assert idx.size == 0
+    assert idx.vecs.shape == (0, 2)
+    assert idx.ids == []
+
+
+def test_cosine_index_load_keeps_finite_vectors(tmp_path: Path) -> None:
+    """Loaded index with finite vectors should remain available for retrieval."""
+    idx_path = tmp_path / "index.npz"
+    np.savez(
+        idx_path,
+        vecs=np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32),
+        ids=np.array(["x", "y"], dtype=str),
+    )
+
+    idx = CosineIndex(dim=2, path=idx_path)
+
+    assert idx.size == 2
+    results = idx.search(np.array([1.0, 0.0], dtype=np.float32), k=1)
+    assert results[0][0][0] == "x"


### PR DESCRIPTION
### Motivation
- Persisted vector indexes that include `NaN`/`Inf` can silently break cosine similarity computations and destabilize search results. 
- The index already resets on clear inconsistencies (shape/dimension/count); non-finite values should be treated the same for safety and determinism. 

### Description
- Added a post-load finite-value check in `CosineIndex._validate_loaded_index_or_reset` that logs a warning and resets the index when `vecs` contains non-finite values. 
- Maintained existing early-return behavior for other inconsistencies (`ndim`, dimension mismatch, ids/vec count mismatch). 
- Added `veritas_os/tests/test_index_cosine.py` with two tests that verify resetting on non-finite vectors and preserving valid finite indexes. 

### Testing
- Ran `pytest -q veritas_os/tests/test_index_cosine.py` and both tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69917b7889cc832687b99760a0eb67a1)