### PR TITLE
Make deduplication fallback deterministic in merge_trust_logs

### DIFF
--- a/veritas_os/scripts/merge_trust_logs.py
+++ b/veritas_os/scripts/merge_trust_logs.py
@@ -84,6 +84,11 @@ def _normalize_for_hash(entry: Dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, ensure_ascii=False)
 
 
+def _stable_entry_fingerprint(entry: Dict[str, Any]) -> str:
+    """Return a deterministic fingerprint for entries without request_id."""
+    return _sha256(_normalize_for_hash(entry))
+
+
 def load_any_json(path: Path) -> List[Dict[str, Any]]:
     """
     JSON / JSONL / JSON with items[] をいい感じに読み込む。
@@ -215,7 +220,11 @@ def merge_trust_logs(
                         uniq[rid] = item
             else:
                 # request_id が無いエントリは created_at/timestamp をキーとして扱う
-                ts_key = item.get("created_at") or item.get("timestamp") or str(hash(str(item)))
+                ts_key = (
+                    item.get("created_at")
+                    or item.get("timestamp")
+                    or _stable_entry_fingerprint(item)
+                )
                 existing = uniq.get(ts_key)
                 if not existing:
                     uniq[ts_key] = item
@@ -293,4 +302,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/veritas_os/tests/test_merge_trust_logs.py
+++ b/veritas_os/tests/test_merge_trust_logs.py
@@ -1,0 +1,35 @@
+"""Tests for merge_trust_logs utility behaviors."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from veritas_os.scripts import merge_trust_logs
+
+
+def _read_jsonl(path: Path) -> list[dict[str, object]]:
+    """Read JSONL file into a list of dictionaries."""
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_merge_without_request_id_is_stable_across_runs(tmp_path: Path) -> None:
+    """Entries without request_id use a stable fingerprint and deterministic merge output."""
+    src = tmp_path / "trust_log.jsonl"
+    out1 = tmp_path / "merged_1.jsonl"
+    out2 = tmp_path / "merged_2.jsonl"
+
+    entry = {"event": "audit", "created_at": "", "payload": {"x": 1}}
+    src.write_text(
+        "\n".join([json.dumps(entry), json.dumps(entry)]) + "\n",
+        encoding="utf-8",
+    )
+
+    merge_trust_logs.merge_trust_logs([src], out1, recompute_hash=False)
+    merge_trust_logs.merge_trust_logs([src], out2, recompute_hash=False)
+
+    merged1 = _read_jsonl(out1)
+    merged2 = _read_jsonl(out2)
+
+    assert merged1 == [entry]
+    assert merged2 == [entry]


### PR DESCRIPTION
### Motivation

- Replace a non-deterministic fallback key (`hash(str(item))`) used when `request_id` and timestamps are missing to avoid Python hash-seed variability causing unstable merge results. 
- Add a regression test and docstring for the change to ensure deterministic behavior and to satisfy test/doc requirements for significant changes.

### Description

- Add `_stable_entry_fingerprint(entry: Dict[str, Any]) -> str` which returns a deterministic SHA-256 of the canonical JSON payload. 
- Use `_stable_entry_fingerprint` as the final fallback for `ts_key` instead of `str(hash(str(item)))` in `merge_trust_logs` to ensure stable deduplication keys. 
- Add `veritas_os/tests/test_merge_trust_logs.py` which verifies that merging entries without `request_id` produces identical output across repeated runs when `recompute_hash=False`.

### Testing

- Ran `pytest -q veritas_os/tests/test_merge_trust_logs.py veritas_os/tests/test_trust_log.py` and all tests passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69917ed4e47c83269ece3a1aeb3593d4)