### PR TITLE
Harden URL parsing in alert_doctor validators

### DIFF
--- a/veritas_os/scripts/alert_doctor.py
+++ b/veritas_os/scripts/alert_doctor.py
@@ -60,7 +60,12 @@ def _validate_webhook_url(webhook_url: str) -> bool:
     if parsed.scheme != "https":
         return False
 
-    if parsed.port is not None:
+    try:
+        parsed_port = parsed.port
+    except ValueError:
+        return False
+
+    if parsed_port is not None:
         return False
 
     if parsed.username or parsed.password:
@@ -110,6 +115,11 @@ def _validate_health_url(url: str) -> bool:
         return False
 
     if parsed.username or parsed.password:
+        return False
+
+    try:
+        parsed.port
+    except ValueError:
         return False
 
     hostname: Optional[str] = parsed.hostname

--- a/veritas_os/tests/test_alert_doctor.py
+++ b/veritas_os/tests/test_alert_doctor.py
@@ -36,6 +36,14 @@ def test_validate_webhook_url_rejects_ports_userinfo_and_extra_parts():
     )
 
 
+
+
+def test_validate_webhook_url_rejects_malformed_port():
+    """Webhook URL with malformed port should be rejected safely."""
+    assert not alert_doctor._validate_webhook_url(
+        "https://hooks.slack.com:abc/services/a/b/c"
+    )
+
 def test_post_slack_rejects_invalid_webhook_without_network(monkeypatch):
     """post_slack should fail fast when webhook URL is invalid."""
     monkeypatch.setattr(alert_doctor, "WEBHOOK", "http://hooks.slack.com/services/a/b/c")
@@ -91,6 +99,12 @@ def test_validate_health_url_accepts_only_localhosts():
     assert not alert_doctor._validate_health_url("http://example.com/health")
     assert not alert_doctor._validate_health_url("http://user@127.0.0.1/health")
 
+
+
+
+def test_validate_health_url_rejects_malformed_port():
+    """Health URL with malformed port should be rejected safely."""
+    assert not alert_doctor._validate_health_url("http://127.0.0.1:abc/health")
 
 def test_http_get_blocks_non_local_url_without_network(monkeypatch):
     """http_get should reject non-local targets before urlopen is called."""


### PR DESCRIPTION
### Motivation
- Prevent malformed user-supplied URLs (e.g. `:abc` ports) from causing `ValueError` when accessing `parsed.port`, which could destabilize alert and health-check logic.
- Ensure validators fail-closed for security-sensitive workflows (Slack webhook posting and local health probes).

### Description
- Guard access to `parsed.port` with a `try/except ValueError` in `_validate_webhook_url` and `_validate_health_url`, returning `False` on error.
- Keep existing checks for scheme, userinfo, hostname, query/fragment, and allowed hosts unchanged.
- Add two regression tests `test_validate_webhook_url_rejects_malformed_port` and `test_validate_health_url_rejects_malformed_port` to assert malformed ports are rejected.

### Testing
- Ran `pytest -q veritas_os/tests/test_alert_doctor.py` and all tests passed (`11 passed in 0.22s`).
- Ran `ruff check veritas_os/scripts/alert_doctor.py veritas_os/tests/test_alert_doctor.py` and static checks passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699189b27ac48326a3b449e7a189ceab)