### PR TITLE
Harden mask format handling in PII sanitizer

### DIFF
--- a/veritas_os/core/sanitize.py
+++ b/veritas_os/core/sanitize.py
@@ -568,11 +568,11 @@ class PIIDetector:
         }
         return token_map.get(pii_type, "PII")
 
-    def _build_mask_text(self, mask_format: str, token: str) -> str:
+    def _build_mask_text(self, mask_format: object, token: str) -> str:
         """Build mask text safely even when format strings are malformed.
 
         Args:
-            mask_format: User-provided format string.
+            mask_format: User-provided format template.
             token: Localized PII token.
 
         Returns:
@@ -585,8 +585,8 @@ class PIIDetector:
             default format keeps masking available and avoids accidental 500s.
         """
         try:
-            return mask_format.format(token=token)
-        except (KeyError, ValueError):
+            return str(mask_format).format(token=token)
+        except (AttributeError, IndexError, KeyError, ValueError):
             _logger.warning("Invalid mask_format; falling back to default")
             return f"〔{token}〕"
 

--- a/veritas_os/tests/test_sanitize.py
+++ b/veritas_os/tests/test_sanitize.py
@@ -100,3 +100,23 @@ def test_detector_mask_uses_fallback_on_broken_braces(caplog):
 
     assert masked == "連絡先は 〔メール〕 です"
     assert "Invalid mask_format; falling back to default" in caplog.text
+
+
+def test_detector_mask_accepts_non_string_mask_format():
+    detector = sanitize.PIIDetector()
+    text = "連絡先は test.user@example.com です"
+
+    masked = detector.mask(text, mask_format=123)  # type: ignore[arg-type]
+
+    assert masked == "連絡先は 123 です"
+
+
+def test_detector_mask_uses_fallback_on_positional_format(caplog):
+    detector = sanitize.PIIDetector()
+    text = "連絡先は test.user@example.com です"
+
+    with caplog.at_level("WARNING"):
+        masked = detector.mask(text, mask_format="{}")
+
+    assert masked == "連絡先は 〔メール〕 です"
+    assert "Invalid mask_format; falling back to default" in caplog.text


### PR DESCRIPTION
### Motivation
- Prevent user-supplied `mask_format` values from causing runtime exceptions that could break PII masking and surface as 500s. 
- Accept non-string `mask_format` inputs and handle malformed format templates (including positional-style templates) more gracefully. 

### Description
- Change `_build_mask_text` signature to accept `mask_format: object` and coerce with `str(mask_format).format(token=token)` before formatting. 
- Broadened the fallback exception handling to catch `AttributeError` and `IndexError` in addition to `KeyError` and `ValueError`. 
- Updated the method docstring to reflect the template/coercion behavior. 
- Added unit tests `test_detector_mask_accepts_non_string_mask_format` and `test_detector_mask_uses_fallback_on_positional_format` to cover regression cases. 

### Testing
- Ran `pytest -q veritas_os/tests/test_sanitize.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918d1ec1f483268099306ca9234bda)