### PR TITLE
planner: robustly parse multiple fenced JSON blocks

### DIFF
--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -477,9 +477,19 @@ def _safe_parse(raw: Any) -> Dict[str, Any]:
     if not s:
         return {"steps": []}
 
-    m = _FENCE_RE.search(s)
-    if m:
-        s = m.group(1).strip()
+    fence_matches = list(_FENCE_RE.finditer(s))
+    if fence_matches:
+        fallback_parsed: Optional[Dict[str, Any]] = None
+        for fence_match in fence_matches:
+            fenced = fence_match.group(1).strip()
+            parsed = _safe_json_extract_core(fenced)
+            if parsed.get("steps"):
+                return parsed
+            if fallback_parsed is None:
+                fallback_parsed = parsed
+
+        if fallback_parsed is not None:
+            return fallback_parsed
 
     return _safe_json_extract_core(s)
 

--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -167,6 +167,25 @@ def test_safe_json_extract_code_block():
     assert obj["steps"][0]["id"] == "s1"
 
 
+def test_safe_parse_selects_valid_json_from_multiple_fenced_blocks():
+    raw = """
+    before
+    ```json
+    {"steps": [}
+    ```
+    between
+    ```json
+    {"steps": [{"id": "s2"}]}
+    ```
+    after
+    """
+
+    obj = planner_core._safe_parse(raw)
+
+    assert isinstance(obj, dict)
+    assert [s["id"] for s in obj["steps"]] == ["s2"]
+
+
 def test_safe_json_extract_recovers_from_broken_but_embedded_steps():
     # 全体としては壊れているが、"steps" 配列内のオブジェクトは valid JSON
     raw = 'prefix "steps": [{"id": "ok1"}, {"id": "ok2"} BROKEN'


### PR DESCRIPTION
### Motivation
- LLM responses can contain multiple fenced JSON blocks where earlier fences may be malformed and later fences valid, and the previous logic parsed only the first fence and could miss a valid plan.
- Improve resilience of planner JSON extraction while preserving existing DoS/anti-ReDoS protections and behavior when no fences are present.

### Description
- Update `_safe_parse` in `veritas_os/core/planner.py` to iterate all fenced code blocks (` ```json ... ````), parse each with `_safe_json_extract_core`, and return the first parsed result that contains non-empty `steps` while keeping a fallback parsed result for best-effort recovery.
- Preserve the original fallback behavior by still parsing the full input when no fenced blocks are present.
- Add regression test `test_safe_parse_selects_valid_json_from_multiple_fenced_blocks` in `veritas_os/tests/test_planner.py` to ensure a later valid fenced block is selected when an earlier block is malformed.
- Changes are limited to planner parsing logic and a unit test; no changes to Kernel / Fuji / MemoryOS responsibilities.

### Testing
- Ran planner tests with `pytest -q veritas_os/tests/test_planner.py` and they passed (`41 passed`).
- Ran sanitize-related tests with `pytest -q veritas_os/tests/test_sanitize.py veritas_os/tests/test_sanitize_pii.py` and they passed (`72 passed`).
- All added/affected tests passed in CI-local runs, and existing DoS limits and decoder probe bounds remain unchanged to mitigate risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699197b07338832696ee7af8a57d2c9e)