### PR TITLE
Fix PII overlap handling to enforce confidence-based deduplication

### DIFF
--- a/veritas_os/tests/test_sanitize_pii.py
+++ b/veritas_os/tests/test_sanitize_pii.py
@@ -59,6 +59,20 @@ def test_mask_pii_handles_non_string_bytes_via_detector() -> None:
     assert "〔メール〕" in masked
 
 
+def test_detect_resolves_cross_pattern_overlap_by_confidence() -> None:
+    """Overlap resolution should keep only the highest-confidence match."""
+    detector = PIIDetector(validate_checksums=False)
+    detector._patterns = [
+        ("low", re.compile(r"1234"), "LOW", None, 0.1),
+        ("high", re.compile(r"1234"), "HIGH", None, 0.9),
+    ]
+
+    matches = detector.detect("abc1234xyz")
+
+    assert len(matches) == 1
+    assert matches[0].type == "high"
+
+
 class TestEmailDetection:
     """Tests for email address detection."""
 


### PR DESCRIPTION
### Motivation
- Segmented scanning and multiple overlapping regex patterns could produce duplicate or competing PII matches, leading to nondeterministic masking and unstable downstream behavior.  
- The goal is to enforce a single winner per overlapping span using pattern `confidence` so masking is deterministic.  
- Security note: this improves deduplication but PII detection remains regex-based and can still produce false positives/negatives, so operational auditing and higher-layer safeguards are recommended.

### Description
- Replace the final position-only sort in `PIIDetector.detect` with a global overlap-resolution pass by adding `PIIDetector._resolve_global_overlaps` and returning its result from `detect` (file: `veritas_os/core/sanitize.py`).
- The new `_resolve_global_overlaps` implements confidence-prioritized selection by sorting matches by `(-confidence, start, end)`, selecting non-overlapping candidates, then restoring `start` order for deterministic masking.  
- Add a regression test `test_detect_resolves_cross_pattern_overlap_by_confidence` to `veritas_os/tests/test_sanitize_pii.py` that asserts only the highest-confidence overlapping match is kept.  
- Implementation includes docstring for the new method and adheres to PEP8 formatting.

### Testing
- Ran `ruff check veritas_os/core/sanitize.py veritas_os/tests/test_sanitize_pii.py` and linter checks passed.  
- Ran `pytest -q veritas_os/tests/test_sanitize_pii.py` and all tests passed (`64 passed`).  
- The change is limited to the sanitization layer and was validated with the added regression test for overlap resolution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69919a802ddc83269d70bb53f84591db)