### PR TITLE
Harden GitHub adapter html_url sanitization to require HTTPS

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -231,3 +231,7 @@ def test_sanitize_html_url_allows_github_hosts():
         github_adapter._sanitize_html_url("https://github.com/owner/repo")
         == "https://github.com/owner/repo"
     )
+
+
+def test_sanitize_html_url_rejects_insecure_http_scheme():
+    assert github_adapter._sanitize_html_url("http://github.com/owner/repo") == ""

--- a/veritas_os/tools/github_adapter.py
+++ b/veritas_os/tools/github_adapter.py
@@ -103,8 +103,9 @@ def _normalize_repo_item(item: dict) -> dict:
 def _sanitize_html_url(raw_url: object) -> str:
     """Return a safe GitHub repository URL or an empty string.
 
-    Only absolute HTTP(S) URLs are accepted to reduce the risk of unsafe
-    schemes (e.g. ``javascript:``) or malformed link injection.
+    Only absolute HTTPS URLs are accepted to reduce the risk of unsafe
+    schemes (e.g. ``javascript:``), downgraded transport, or malformed link
+    injection.
 
     Security policy:
         - Only GitHub hosts are allowed because this field is rendered as an
@@ -117,7 +118,7 @@ def _sanitize_html_url(raw_url: object) -> str:
         return ""
 
     parsed = urlsplit(url)
-    if parsed.scheme not in {"http", "https"}:
+    if parsed.scheme != "https":
         logger.warning("Dropped GitHub html_url with unsafe scheme: %r", parsed.scheme)
         return ""
     if not parsed.netloc:


### PR DESCRIPTION
### Motivation
- Prevent insecure transport downgrade and reduce XSS/credential leakage risk by rejecting non-HTTPS GitHub links at the sanitizer boundary.

### Description
- Restrict `github_adapter._sanitize_html_url` to accept only `https://` URLs, update the function docstring to document the HTTPS-only policy, and add a regression test that ensures `http://github.com/...` is rejected (files modified: `veritas_os/tools/github_adapter.py`, `veritas_os/tests/test_github_adapter.py`).

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_github_adapter.py` which passed (`14 passed`), and ran `ruff check veritas_os/tools/github_adapter.py veritas_os/tests/test_github_adapter.py` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a3f560e88326b18f3608d9eae421)