### PR TITLE
Harden GitHub URL sanitization for repository links

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -235,3 +235,13 @@ def test_sanitize_html_url_allows_github_hosts():
 
 def test_sanitize_html_url_rejects_insecure_http_scheme():
     assert github_adapter._sanitize_html_url("http://github.com/owner/repo") == ""
+
+
+def test_sanitize_html_url_rejects_query_and_fragment():
+    assert github_adapter._sanitize_html_url("https://github.com/owner/repo?tab=readme") == ""
+    assert github_adapter._sanitize_html_url("https://github.com/owner/repo#readme") == ""
+
+
+def test_sanitize_html_url_rejects_non_repo_paths():
+    assert github_adapter._sanitize_html_url("https://github.com/owner") == ""
+    assert github_adapter._sanitize_html_url("https://github.com/settings/profile") == ""


### PR DESCRIPTION
### Motivation
- 外部に表示する GitHub リポジトリ URL の混入やリンク注入リスクを低減するため、許可する URL を厳格化する必要があった。
- クエリ文字列やフラグメント、非リポジトリパスなどが入ると曖昧な遷移先やトラッキング付き URL が表示されてしまうため防止する。
- 既存のレンダリング経路で誤った外部リンクが出力されるリスクを抑えることが目的。セキュリティ上の注意として、GitHub の予約パスや仕様変更に伴い denylist の見直しが必要である。

### Description
- `veritas_os/tools/github_adapter.py` に以下を追加してサニタイズを強化した: 正規表現によるリポジトリパス検査（`/owner/repo` のみ許可）、クエリ文字列とフラグメントの拒否、及び予約済みルート（`settings` 等）の拒否ロジックを導入し docstring を更新した。
- HTML URL 正規化はこれらの条件に合致しない場合に空文字列を返すよう変更した（安全でないスキーム、埋め込み認証情報、不正ホストは従来通り拒否）。
- `veritas_os/tests/test_github_adapter.py` にクエリ/フラグメント拒否と非リポジトリパス拒否を検証するユニットテストを追加した。
- 変更ファイル: `veritas_os/tools/github_adapter.py`, `veritas_os/tests/test_github_adapter.py`。

### Testing
- `pytest -q veritas_os/tests/test_github_adapter.py` を実行し、16 tests が全て合格した（`16 passed`）。
- `ruff check veritas_os/tools/github_adapter.py veritas_os/tests/test_github_adapter.py` を実行し、スタイルチェックは合格した（`All checks passed!`）。
- セキュリティ注記: 予約パスリストは将来的に GitHub 側の変更で更新が必要となるため、定期的なレビューを推奨する。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b1efc9ac83268f2a0239bc455852)