### PR TITLE
Harden GitHub token handling for safer Authorization headers

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -175,6 +175,12 @@ def test_github_search_repos_retries_on_timeout(monkeypatch):
     assert res["results"][0]["full_name"] == "veritasfuji-japan/veritas_os"
 
 
+def test_get_github_token_rejects_control_chars(monkeypatch):
+    """Tokens with control characters are rejected for header safety."""
+    monkeypatch.setenv("VERITAS_GITHUB_TOKEN", "token\nvalue")
+    assert github_adapter._get_github_token() == ""
+
+
 def test_get_github_token_reads_latest_env(monkeypatch):
     """Environment token updates are reflected without module reload."""
     monkeypatch.setenv("VERITAS_GITHUB_TOKEN", "token-a")

--- a/veritas_os/tools/github_adapter.py
+++ b/veritas_os/tools/github_adapter.py
@@ -81,8 +81,18 @@ def _get_github_token() -> str:
 
     The token is resolved at call time so that emergency token rotations can
     take effect without restarting the running process.
+
+    Security:
+        Tokens containing control characters are rejected. This prevents
+        malformed ``Authorization`` headers and reduces header-injection risk
+        from accidentally tainted environment values.
     """
-    return os.getenv("VERITAS_GITHUB_TOKEN", "").strip()
+    raw_token = os.getenv("VERITAS_GITHUB_TOKEN", "")
+    token = raw_token.strip()
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in token):
+        logger.warning("VERITAS_GITHUB_TOKEN contains control characters")
+        return ""
+    return token
 
 
 def _get_retry_settings() -> tuple[int, float, float, float]:


### PR DESCRIPTION
### Motivation
- Prevent malformed `Authorization` headers and header-injection risks by rejecting GitHub tokens that contain ASCII control characters (including newlines) coming from environment variables.
- Document the security rationale in the `_get_github_token` docstring to make the intent explicit.
- This is a targeted safety hardening that does not change broader component responsibilities but reduces an operational/secret-handling risk.

### Description
- Validate `VERITAS_GITHUB_TOKEN` at call time in `veritas_os.tools.github_adapter._get_github_token()` and return `""` if control characters are present, emitting a warning instead of returning a tainted token.
- Extend the `_get_github_token` docstring with the security rationale for rejecting control characters.
- Add a regression test `test_get_github_token_rejects_control_chars` to `veritas_os/tests/test_github_adapter.py` to assert that tokens containing newlines are rejected.

### Testing
- Ran `pytest -q veritas_os/tests/test_github_adapter.py` and the test suite for the dashboard integration with `pytest -q veritas_os/tests/test_github_adapter.py veritas_os/tests/test_dashboard_server.py`, and all tests passed.
- The added regression test verifies the new behavior for `VERITAS_GITHUB_TOKEN` containing control characters and passed under the CI-like local test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c0aebd5883268928a3acb2e036d0)