### PR TITLE
Harden alert_doctor health URL validation

### DIFF
--- a/veritas_os/scripts/alert_doctor.py
+++ b/veritas_os/scripts/alert_doctor.py
@@ -101,7 +101,8 @@ def _validate_health_url(url: str) -> bool:
 
     The alerting workflow should only probe a local Veritas API endpoint.
     Allowed destinations are loopback hosts over HTTP/HTTPS without
-    embedded credentials.
+    embedded credentials. To avoid broad localhost access, only the
+    ``/health`` endpoint is permitted and query/fragment parts are denied.
     """
     if not url:
         return False
@@ -117,6 +118,9 @@ def _validate_health_url(url: str) -> bool:
     if parsed.username or parsed.password:
         return False
 
+    if parsed.query or parsed.fragment:
+        return False
+
     try:
         parsed.port
     except ValueError:
@@ -124,6 +128,10 @@ def _validate_health_url(url: str) -> bool:
 
     hostname: Optional[str] = parsed.hostname
     if not hostname:
+        return False
+
+    normalized_path = parsed.path or "/"
+    if normalized_path != "/health":
         return False
 
     return hostname.lower() in {"localhost", "127.0.0.1", "::1"}

--- a/veritas_os/tests/test_alert_doctor.py
+++ b/veritas_os/tests/test_alert_doctor.py
@@ -96,6 +96,11 @@ def test_validate_health_url_accepts_only_localhosts():
     """Health URL should allow only loopback destinations."""
     assert alert_doctor._validate_health_url("http://127.0.0.1:8000/health")
     assert alert_doctor._validate_health_url("https://localhost/health")
+    assert not alert_doctor._validate_health_url("http://127.0.0.1:8000/")
+    assert not alert_doctor._validate_health_url("http://127.0.0.1:8000/metrics")
+    assert not alert_doctor._validate_health_url(
+        "http://127.0.0.1:8000/health?verbose=1"
+    )
     assert not alert_doctor._validate_health_url("http://example.com/health")
     assert not alert_doctor._validate_health_url("http://user@127.0.0.1/health")
 


### PR DESCRIPTION
### Motivation
- Reduce SSRF/accidental internal probing by narrowing allowed health-check targets to loopback hosts targeting exactly `/health` and by rejecting query strings and fragments.

### Description
- Tighten `alert_doctor._validate_health_url` so it returns `False` for URLs with query/fragment and requires the normalized path to equal `/health`.
- Update the function docstring to explain the narrower policy and rationale.
- Extend `veritas_os/tests/test_alert_doctor.py` with negative cases for `http://127.0.0.1:8000/`, `http://127.0.0.1:8000/metrics`, and `http://127.0.0.1:8000/health?verbose=1` to prevent regressions.
- Changes are confined to `veritas_os/scripts/alert_doctor.py` and its tests only.

### Testing
- Ran `ruff check veritas_os/scripts/alert_doctor.py veritas_os/tests/test_alert_doctor.py` and it returned `All checks passed!`.
- Ran `pytest -q veritas_os/tests/test_alert_doctor.py` and the test suite passed with `11 passed`.
- No automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c8ee828c8326a21db9acc738b776)