### PR TITLE
Harden GitHub adapter response payload validation

### DIFF
--- a/veritas_os/tools/github_adapter.py
+++ b/veritas_os/tools/github_adapter.py
@@ -335,6 +335,17 @@ def github_search_repos(query: str, max_results: int = 5) -> dict:
             "error": "GitHub API error: request failed",
         }
 
+    if not isinstance(data, dict):
+        logger.warning(
+            "GitHub API error: unexpected JSON payload type=%s",
+            type(data).__name__,
+        )
+        return {
+            "ok": False,
+            "results": [],
+            "error": "GitHub API error: invalid response payload",
+        }
+
     items = data.get("items", []) or []
     results = [_normalize_repo_item(it) for it in items if isinstance(it, dict)]
 


### PR DESCRIPTION
### Motivation
- GitHub API responses can be malformed or have an unexpected JSON shape (e.g. a list instead of a dict), which previously could raise internal exceptions and leak stack details to callers. 
- The change aims to improve runtime resilience and keep error responses sanitized when external services return unexpected payloads.

### Description
- Added a defensive check in `github_search_repos` to verify the parsed JSON is a `dict` and return a sanitized error (`"GitHub API error: invalid response payload"`) when it is not. 
- Emits a warning via `logger.warning` with the unexpected payload type instead of propagating an exception. 
- Added `test_github_search_repos_rejects_non_dict_payload` to `veritas_os/tests/test_github_adapter.py` which mocks a list payload from `.json()` and verifies the function fails safely. 
- Changes are limited to `veritas_os/tools/github_adapter.py` and its tests, and do not affect other subsystems.

### Testing
- Ran `pytest -q veritas_os/tests/test_github_adapter.py veritas_os/tests/test_dashboard_server.py` and all tests passed (`43 passed in 1.43s`).
- Ran `ruff check veritas_os --output-format concise` and linting passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d5ba97e48326add986ef803a59fb)