### PR TITLE
Fix bench summary decision_status frequency aggregation

### DIFF
--- a/veritas_os/tests/test_bench_summary.py
+++ b/veritas_os/tests/test_bench_summary.py
@@ -1,0 +1,21 @@
+"""Tests for scripts/bench_summary.py output helpers."""
+
+from __future__ import annotations
+
+from veritas_os.scripts import bench_summary
+
+
+def test_build_decision_status_counter_preserves_duplicates() -> None:
+    """Repeated statuses should remain counted in benchmark summaries."""
+    rows = [
+        {"decision_status": "pass"},
+        {"decision_status": "pass"},
+        {"decision_status": "review"},
+        {"decision_status": None},
+        {},
+    ]
+
+    result = bench_summary._build_decision_status_counter(rows)
+
+    assert result["pass"] == 2
+    assert result["review"] == 1


### PR DESCRIPTION
### Motivation
- Fix a reporting bug where `decision_status` values were aggregated via a `set`, collapsing duplicates and undercounting repeated statuses.
- Undercounting repeated statuses can hide recurring failures or anomalies in benchmark monitoring, so full frequency information must be preserved.

### Description
- Add `_build_decision_status_counter(rows: List[Dict[str, Any]]) -> collections.Counter` helper with a docstring that explains the previous undercount issue and intended behavior.
- Replace the prior set-based aggregation in `main()` with the new helper and remove the unused `latest_row` variable to simplify the status printing path.
- Add a unit test `veritas_os/tests/test_bench_summary.py` that asserts duplicate `decision_status` values are counted correctly.

### Testing
- Ran `pytest -q veritas_os/tests/test_bench_summary.py` and it passed (`1 passed`).
- Ran `python -m compileall veritas_os/scripts/bench_summary.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991de54f4e083269fb305c0d428b459)