### PR TITLE
Harden web search SSRF checks with hostname canonicalization

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -192,6 +192,19 @@ class TestIsBlockedResult:
             is False
         )
 
+    def test_extract_hostname_trailing_dot_is_normalized(self):
+        assert (
+            web_search_mod._extract_hostname("https://example.com./path")
+            == "example.com"
+        )
+
+
+class TestHostCanonicalization:
+    """Tests for hostname normalization helper."""
+
+    def test_canonicalize_hostname_strips_trailing_dot(self):
+        assert web_search_mod._canonicalize_hostname("Example.COM.") == "example.com"
+
 
 class TestWebSearchHostSafety:
     """Tests for host-level SSRF safety validation."""


### PR DESCRIPTION
### Motivation
- Prevent allowlist/SSRF bypasses caused by trailing-dot FQDNs (e.g. `example.com.`) being treated as distinct from `example.com`.
- Centralize hostname normalization to avoid inconsistent checks across `_extract_hostname`, allowlist matching, and private-host detection.
- Add regression tests to ensure trailing-dot and case/whitespace variants are canonicalized.

### Description
- Add `_canonicalize_hostname(hostname: str)` to normalize hostnames by trimming whitespace, lowercasing, and stripping a trailing dot.
- Normalize entries from `VERITAS_WEBSEARCH_HOST_ALLOWLIST` by removing trailing dots when building `WEBSEARCH_HOST_ALLOWLIST`.
- Ensure `_extract_hostname()` strips trailing dots and reuse `_canonicalize_hostname()` in `_is_obviously_private_or_local_host()`, `_is_private_or_local_host()`, and `_is_allowed_websearch_url()` for consistent policy checks.
- Add two unit tests in `veritas_os/tests/test_web_search_extra.py` to verify trailing-dot normalization and canonicalization behavior.

### Testing
- Ran `ruff` on `veritas_os/tools/web_search.py` and `veritas_os/tests/test_web_search_extra.py` and it passed.
- Ran `pytest` for `veritas_os/tests/test_web_search.py` and `veritas_os/tests/test_web_search_extra.py` and all tests passed (tests covering web search host safety and new regressions passed).
- Also ran `pytest` for `veritas_os/tests/test_memory_index_cosine.py` as part of earlier validation and it passed (one warning about legacy pickle opt-in was emitted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e814388c8326837f9211970d0e60)