### PR TITLE
PIIスキャンの重複判定を最適化してDoSリスクを低減

### DIFF
--- a/veritas_os/tests/test_sanitize_pii.py
+++ b/veritas_os/tests/test_sanitize_pii.py
@@ -573,3 +573,17 @@ class TestComplexScenarios:
         text = "これは普通の日本語テキストです。特に個人情報は含まれていません。"
         masked = mask_pii(text)
         assert masked == text
+
+
+def test_detect_in_segment_uses_neighbor_overlap_checks() -> None:
+    """In-segment overlap handling should keep adjacent non-overlapping spans."""
+    detector = PIIDetector(validate_checksums=False)
+    detector._patterns = [
+        ("first", re.compile(r"abc"), "FIRST", None, 0.9),
+        ("second", re.compile(r"def"), "SECOND", None, 0.8),
+        ("overlap", re.compile(r"bcde"), "OVERLAP", None, 0.7),
+    ]
+
+    matches = detector.detect("abcdef")
+
+    assert [m.type for m in matches] == ["first", "second"]


### PR DESCRIPTION
### Motivation
- 大量マッチが発生する入力での重複検出処理が全件線形走査になっており、最悪ケースで二乗時間になってしまう問題を防ぐための最適化です。 
- 既存の「信頼度優先（高信頼度パターンが先に採用される）」挙動は維持しつつ、検出ループの計算量を改善します。 
- セキュリティ警告: 正規表現ベースの検出は依然として大量マッチや複雑パターンによる負荷リスクを完全には排除しないため、今回の変更はそのリスクの一部を緩和する対策であることを明記します.

### Description
- `veritas_os/core/sanitize.py` の `PIIDetector._detect_in_segment` を変更し、既存の `detected_ranges` 全走査をやめて `detected_starts` を `start` 昇順で保持し、`bisect_left` による近傍チェックのみで重複判定する実装に置換しました。 
- 追加のコメントで Security/Performance 意図を明記し、将来の保守性を高めました。 
- 回帰テスト `test_detect_in_segment_uses_neighbor_overlap_checks` を `veritas_os/tests/test_sanitize_pii.py` に追加し、隣接する非重複スパンが保持され、低優先度の重複スパンが除外されることを検証するようにしました。 
- 変更ファイル: `veritas_os/core/sanitize.py`、`veritas_os/tests/test_sanitize_pii.py`。

### Testing
- 実行: `pytest -q veritas_os/tests/test_sanitize_pii.py` — 結果: 全テスト合格（`68 passed`）。
- スタイル/静的チェック: `ruff check veritas_os/core/sanitize.py veritas_os/tests/test_sanitize_pii.py --output-format=concise` — 結果: `All checks passed!`。
- 変更は既存の信頼度順ソートやマスク挙動を変えておらず、追加した回帰テストで期待動作を確認済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ea4c3ec08326add7405c26b9e940)