### PR TITLE
Harden web_search parsing for malformed organic payloads

### DIFF
--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -695,8 +695,20 @@ def web_search(query: str, max_results: int = 5) -> Dict[str, Any]:
             }
 
         organic = data.get("organic") or []
+        if not isinstance(organic, list):
+            logger.warning(
+                "WEBSEARCH_API returned non-list organic payload type=%s",
+                type(organic).__name__,
+            )
+            organic = []
         raw_items: List[Dict[str, Any]] = []
         for item in organic:
+            if not isinstance(item, dict):
+                logger.warning(
+                    "WEBSEARCH_API dropped non-dict organic item type=%s",
+                    type(item).__name__,
+                )
+                continue
             normalized = _normalize_result_item(item)
             if normalized is None:
                 continue


### PR DESCRIPTION
### Motivation
- External web search providers may return unexpected JSON shapes which previously could cause runtime errors when iterating and normalizing `organic` results. 
- The change aims to make the adapter resilient to malformed upstream payloads while preserving the public response contract and not expanding responsibilities beyond the Web Search adapter.

### Description
- Add defensive checks in `veritas_os/tools/web_search.py` to treat a non-list `organic` field as empty and emit a warning log. 
- Skip and warn on non-dictionary entries inside the `organic` list before calling normalization, ensuring only dict items are processed. 
- Add regression tests in `veritas_os/tests/test_web_search_extra.py` covering the cases where `organic` is not a list and where `organic` contains non-dict items. 
- Changes are limited to the Web Search adapter and its tests and do not alter other subsystems.

### Testing
- Ran unit tests with `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py`, and all tests passed (`70 passed`).
- Ran linter checks with `ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search_extra.py`, and all checks passed.

Security note: this improves robustness against malformed or adversarial upstream payloads and reduces exception/DoS risk from unexpected shapes, but does not eliminate other external-input risks (large responses, malicious content, or supply-chain issues) so existing URL/host restrictions and logging/monitoring should be maintained.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f41085b48326b645f0ad8d83be52)