### PR TITLE
Harden GitHub adapter response payload validation

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -283,3 +283,25 @@ def test_github_search_repos_rejects_non_dict_payload(monkeypatch):
     assert res["ok"] is False
     assert res["results"] == []
     assert res["error"] == "GitHub API error: invalid response payload"
+
+
+def test_github_search_repos_rejects_non_list_items(monkeypatch):
+    """Dict payload with non-list items is rejected safely."""
+    monkeypatch.setenv("VERITAS_GITHUB_TOKEN", "dummy-token")
+
+    class DummyResp:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"items": {"full_name": "owner/repo"}}
+
+    monkeypatch.setattr(github_adapter.requests, "get", lambda *args, **kwargs: DummyResp())
+
+    res = github_adapter.github_search_repos("veritas_os")
+
+    assert res["ok"] is False
+    assert res["results"] == []
+    assert res["error"] == "GitHub API error: invalid response payload"

--- a/veritas_os/tools/github_adapter.py
+++ b/veritas_os/tools/github_adapter.py
@@ -347,6 +347,17 @@ def github_search_repos(query: str, max_results: int = 5) -> dict:
         }
 
     items = data.get("items", []) or []
+    if not isinstance(items, list):
+        logger.warning(
+            "GitHub API error: unexpected items payload type=%s",
+            type(items).__name__,
+        )
+        return {
+            "ok": False,
+            "results": [],
+            "error": "GitHub API error: invalid response payload",
+        }
+
     results = [_normalize_repo_item(it) for it in items if isinstance(it, dict)]
 
     return {


### PR DESCRIPTION
### Motivation
- Prevent silent failures and reduce risk from malformed GitHub API responses by validating that `data["items"]` is a `list` before iterating, and return a safe error when the payload shape is unexpected.

### Description
- Added a runtime type guard in `github_search_repos` to check `items = data.get("items", [])` and return `{"ok": False, "results": [], "error": "GitHub API error: invalid response payload"}` with a warning if `items` is not a `list`.
- Logged a warning when the `items` payload type is unexpected to aid observability and debugging.
- Added a regression test `test_github_search_repos_rejects_non_list_items` in `veritas_os/tests/test_github_adapter.py` to assert the adapter safely rejects dict/non-list `items` payloads.
- Changes are limited to `veritas_os/tools/github_adapter.py` and its tests only.

### Testing
- Ran `ruff check veritas_os/tools/github_adapter.py veritas_os/tests/test_github_adapter.py --output-format concise` and it passed.
- Ran `pytest -q veritas_os/tests/test_github_adapter.py` which completed successfully with `20 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69926a730c1483268a9066e31d7937a9)