### PR TITLE
Improve mixed-language Simple QA detection in Kernel QA

### DIFF
--- a/veritas_os/tests/test_kernel_core.py
+++ b/veritas_os/tests/test_kernel_core.py
@@ -63,6 +63,12 @@ def test_detect_simple_qa_patterns():
     assert kernel._detect_simple_qa(long_q) is None
 
 
+def test_detect_simple_qa_mixed_language_and_spacing():
+    """日英混在・余分スペースでも simple_qa が検出されることを確認。"""
+    assert kernel._detect_simple_qa("What   time is it   today?") == "time"
+    assert kernel._detect_simple_qa("what day is it today??") == "weekday"
+    assert kernel._detect_simple_qa("What is the date today?") == "date"
+
 def test_detect_knowledge_qa_patterns():
     # 「〜とは？」系
     assert kernel._detect_knowledge_qa("東京とは？") is True


### PR DESCRIPTION
### Motivation
- Review documents reported edge cases where short, mixed-language QA queries (e.g. English + Japanese or irregular spacing) were not detected reliably by Kernel QA heuristics.  
- The fix must remain within the Kernel responsibility boundary and avoid changes to Planner / Fuji / MemoryOS.  
- Preserve existing AGI keyword blocking and short-query guard while making the heuristic robust for realistic multilingual queries.

### Description
- Normalize input in `detect_simple_qa` to collapse multiple/全角 spaces and strip trailing punctuation before matching, and use the normalized string for regex checks.  
- Allow a narrowly scoped exception to the strict short-query length guard for mixed-language QA patterns that include `today` plus English phrases like `what time`, `what day`, or `what is the date`.  
- Update matching to use the normalized/lowercased form and add concise inline documentation/comments; changes are limited to `veritas_os/core/kernel_qa.py` and a regression test was added in `veritas_os/tests/test_kernel_core.py` to cover mixed-language/spacing edge cases.

### Testing
- Ran `pytest -q veritas_os/tests/test_kernel_core.py -k "simple_qa"` and the targeted tests passed (`3 passed`).  
- Ran `ruff check veritas_os/core/kernel_qa.py veritas_os/tests/test_kernel_core.py` and static checks passed.  
- The change is limited-scope and unit-tested for the covered edge cases; no other automated test suites were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69926e31cbc88326b44179b38fb0328e)