### PR TITLE
Harden legacy pickle migration with sunset enforcement

### DIFF
--- a/veritas_os/tests/test_memory_coverage.py
+++ b/veritas_os/tests/test_memory_coverage.py
@@ -36,6 +36,25 @@ class TestAllowLegacyPickleMigration:
         monkeypatch.setenv("VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION", "no")
         assert memory._allow_legacy_pickle_migration() is False
 
+    def test_sunset_passed_forces_false(self, monkeypatch):
+        monkeypatch.setenv("VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION", "1")
+        monkeypatch.setenv("VERITAS_MEMORY_PICKLE_MIGRATION_SUNSET", "2000-01-01")
+        assert memory._allow_legacy_pickle_migration() is False
+
+
+class TestLegacyPickleMigrationSunset:
+    def test_past_sunset(self, monkeypatch):
+        monkeypatch.setenv("VERITAS_MEMORY_PICKLE_MIGRATION_SUNSET", "2000-01-01")
+        assert memory._legacy_pickle_migration_sunset_passed() is True
+
+    def test_future_sunset(self, monkeypatch):
+        monkeypatch.setenv("VERITAS_MEMORY_PICKLE_MIGRATION_SUNSET", "2999-12-31")
+        assert memory._legacy_pickle_migration_sunset_passed() is False
+
+    def test_invalid_sunset_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("VERITAS_MEMORY_PICKLE_MIGRATION_SUNSET", "invalid-date")
+        assert memory._legacy_pickle_migration_sunset_passed() is True
+
 
 class TestShouldDeletePickleAfterMigration:
     def test_default_delete(self, monkeypatch):


### PR DESCRIPTION
### Motivation
- Review documents flagged residual security risk from allowing legacy `pickle` deserialization, so the migration window must be time-bounded and fail-closed when expired.  
- Skills used: none (no AGENTS skill was required for this code-only change).  
- Security warning: this reduces exposure but `pickle` support still exists in code and must be fully removed in a planned deprecation to eliminate remaining risk.

### Description
- Updated `veritas_os/core/memory.py` so `_allow_legacy_pickle_migration()` now returns `False` unless `VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION` is explicitly enabled and the configured sunset has not passed.  
- Added `_legacy_pickle_migration_sunset_passed()` which reads `VERITAS_MEMORY_PICKLE_MIGRATION_SUNSET` (`YYYY-MM-DD`) with a secure default and fail-closed behavior on malformed values, and added logging for enabled/disabled states.  
- Added tests in `veritas_os/tests/test_memory_coverage.py` verifying forced-disable after sunset, past/future-sunset behavior, and invalid-sunset handling.  
- Change scope is limited to MemoryOS (`veritas_os/core/memory.py`) and its tests only.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_coverage.py` and the suite passed with `70 passed`.  
- Ran `ruff check veritas_os/core/memory.py veritas_os/tests/test_memory_coverage.py` and linting passed (`All checks passed`).  
- All automated tests and linters invoked for this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699273fcf354832695f62e945ec7a2d9)