### PR TITLE
planner: tighten simple QA heuristic for English planning prompts

### DIFF
--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -233,6 +233,19 @@ def _is_simple_qa(query: str, context: Dict[str, Any] | None = None) -> bool:
     )
     has_plan_words = any(
         k in q for k in ["どう進め", "進め方", "計画", "プラン", "ロードマップ", "タスク"]
+    ) or any(
+        k in q_lower
+        for k in [
+            "roadmap",
+            "plan",
+            "strategy",
+            "next step",
+            "next steps",
+            "implementation",
+            "implement",
+            "task",
+            "tasks",
+        ]
     )
 
     if is_short and looks_question and not has_plan_words:

--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -109,6 +109,8 @@ def test_normalize_step_uses_defaults_for_invalid_existing_values():
         ("VERITAS の弱点を教えて", {"simple_qa": True}, True),  # 明示フラグ優先
         ("what is this", {}, True),  # 英語の疑問文（?なし）
         ("料金を教えて", {}, True),  # 日本語の短い質問（?なし）
+        ("How should we implement this?", {}, False),  # 計画系キーワードを含む英語
+        ("What's the roadmap for rollout?", {}, False),  # roadmap は simple_qa から除外
     ],
 )
 def test_is_simple_qa_variants(query, ctx, expected):


### PR DESCRIPTION
### Motivation
- Review feedback indicated short multilingual queries could be misclassified as simple Q&A when they actually express planning/implementation intent, causing intent drift in Planner.
- The change aims to reduce false-positive simple-QA classification for short English prompts containing planning/action keywords while keeping existing Japanese heuristics.

### Description
- Extend `veritas_os/core/planner.py::_is_simple_qa` to treat common English planning/action terms (e.g. `roadmap`, `plan`, `strategy`, `next step(s)`, `implementation`, `implement`, `task(s)`) as non-simple-QA intent. 
- Add regression tests in `veritas_os/tests/test_planner.py` asserting English planning-style queries are not classified as simple QA. 
- Changes are limited to the Planner heuristic and tests, preserved PEP8 style, and do not cross Planner/Kernel/Fuji/MemoryOS responsibilities.

### Testing
- Ran `pytest -q veritas_os/tests/test_planner.py::test_is_simple_qa_variants veritas_os/tests/test_planner_coverage.py::test_is_simple_qa_plan_words` and the test run succeeded with all relevant tests passing (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927b42d7ec832687083c305cb9182f)