### PR TITLE
Add HSTS response header to API security middleware

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -532,6 +532,12 @@ async def add_security_headers(request: Request, call_next):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    # Security hardening: browsers only honor HSTS over HTTPS.
+    # Sending this header proactively helps production deployments enforce
+    # transport security and reduces protocol-downgrade attack surface.
+    response.headers["Strict-Transport-Security"] = (
+        "max-age=31536000; includeSubDomains"
+    )
     response.headers["Cache-Control"] = "no-store"
     return response
 
@@ -1768,6 +1774,5 @@ def trust_feedback(body: dict):
         # Log the detailed error server-side, but do not expose it to the client.
         logger.error("[Trust] feedback failed: %s", e)
         return {"status": "error", "detail": "internal error in trust_feedback"}
-
 
 

--- a/veritas_os/tests/test_server_coverage.py
+++ b/veritas_os/tests/test_server_coverage.py
@@ -174,6 +174,10 @@ def test_security_headers_present():
     assert resp.headers.get("X-Content-Type-Options") == "nosniff"
     assert resp.headers.get("X-Frame-Options") == "DENY"
     assert resp.headers.get("X-XSS-Protection") == "1; mode=block"
+    assert (
+        resp.headers.get("Strict-Transport-Security")
+        == "max-age=31536000; includeSubDomains"
+    )
     assert resp.headers.get("Cache-Control") == "no-store"
 
 


### PR DESCRIPTION
### Motivation
- Code-review notes flagged missing HTTP hardening headers (including HSTS) as a medium-priority security improvement, so the API should instruct browsers to enforce HTTPS.
- Keep the change small and within the API layer responsibilities without touching Planner/Kernel/Fuji/MemoryOS boundaries.
- Existing higher-risk items such as legacy `pickle` deserialization remain deferred and must be tracked separately as a security warning.

### Description
- Add `Strict-Transport-Security: max-age=31536000; includeSubDomains` to the `add_security_headers` middleware in `veritas_os/api/server.py`.
- Extend `veritas_os/tests/test_server_coverage.py::test_security_headers_present` to assert the HSTS header and value.
- Changes are narrowly scoped to the API middleware and its test and follow PEP8/compact patching conventions.

### Testing
- Ran `pytest -q veritas_os/tests/test_server_coverage.py::test_security_headers_present`, which passed (1 passed).
- Ran `pytest -q veritas_os/tests/test_server_coverage.py`, which passed (66 passed, 3 warnings).
- No other automated tests were modified and the added test ensures the header is checked in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927d19b5208326a9766cce621d0c98)