### PR TITLE
GitHub URL sanitizer: reject non-default and invalid HTTPS ports

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -232,6 +232,14 @@ def test_sanitize_html_url_rejects_embedded_credentials():
     assert github_adapter._sanitize_html_url("https://user:secret@github.com/owner/repo") == ""
 
 
+def test_sanitize_html_url_rejects_non_default_https_port():
+    assert github_adapter._sanitize_html_url("https://github.com:444/owner/repo") == ""
+
+
+def test_sanitize_html_url_rejects_invalid_port():
+    assert github_adapter._sanitize_html_url("https://github.com:abc/owner/repo") == ""
+
+
 def test_sanitize_html_url_allows_github_hosts():
     assert (
         github_adapter._sanitize_html_url("https://github.com/owner/repo")


### PR DESCRIPTION
### Motivation
- Accepting explicit non-default ports (e.g. `https://github.com:444/...`) or invalid port tokens (e.g. `:abc`) can create ambiguous or spoofable link destinations, so the sanitizer must be stricter to reduce link-related attack surface. 
- This is a targeted security hardening for the GitHub URL sanitizer used when rendering external repository links.

### Description
- Tightened `github_adapter._sanitize_html_url` to reject explicit non-default HTTPS ports and to reject URLs where port parsing raises `ValueError` (invalid port tokens). 
- Documented the new policy in the sanitizer docstring (`Security policy` section) for maintainability. 
- Added two regression tests to `veritas_os/tests/test_github_adapter.py` to assert that non-default HTTPS ports and invalid ports are dropped.

### Testing
- Ran `pytest -q veritas_os/tests/test_github_adapter.py` and observed `22 passed` (all tests in that file passed). 
- Related test subsets executed earlier in the review also passed: `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` reported `76 passed`, and `pytest -q veritas_os/tests/test_code_review_fixes.py veritas_os/tests/test_code_review_fixes_v2.py` reported `25 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699539f67d088326859a706b05662c05)