### PR TITLE
Harden URL credential PII detection for mixed-case schemes

### DIFF
--- a/veritas_os/core/sanitize.py
+++ b/veritas_os/core/sanitize.py
@@ -160,7 +160,8 @@ RE_IPV6 = re.compile(
 #   既存実装は ``user:password`` のみを検出しており、アクセストークン等を
 #   user 部分に埋め込んだ URL を見逃す可能性があったため包括的に検出する。
 RE_URL_CREDENTIAL = re.compile(
-    r'(?:https?|ftp)://[^@\s/]+@[^\s/]+'
+    r'(?:https?|ftp)://[^@\s/]+@[^\s/]+',
+    re.IGNORECASE,
 )
 
 # --- 銀行口座番号（日本）---

--- a/veritas_os/tests/test_sanitize_pii.py
+++ b/veritas_os/tests/test_sanitize_pii.py
@@ -373,6 +373,13 @@ class TestURLCredentialDetection:
         creds = [r for r in result if r["type"] == "url_credential"]
         assert len(creds) == 1
 
+    def test_uppercase_scheme_detected(self):
+        """Credential URLs should be detected regardless of scheme casing."""
+        text = "URL: HTTPS://user:pass@example.com/path"
+        result = detect_pii(text)
+        creds = [r for r in result if r["type"] == "url_credential"]
+        assert len(creds) == 1
+
     def test_credential_masking(self):
         text = "ftp://user:pass@ftp.example.com"
         masked = mask_pii(text)


### PR DESCRIPTION
### Motivation
- Credential-bearing URLs with uppercase or mixed-case schemes could bypass PII detection, leaving secrets (passwords/tokens) exposed; make the URL credential regex case-insensitive to close this privacy/security gap.  

### Description
- Compile `RE_URL_CREDENTIAL` with `re.IGNORECASE` in `veritas_os/core/sanitize.py` and add `test_uppercase_scheme_detected` to `veritas_os/tests/test_sanitize_pii.py` to cover uppercase-scheme credential URLs.  

### Testing
- Ran linting with `ruff check veritas_os/core/sanitize.py veritas_os/tests/test_sanitize_pii.py --output-format concise` and it passed.  
- Ran `python -m pytest -q veritas_os/tests/test_sanitize_pii.py` and the suite passed (`69 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953b90eb588326860df2fd7d7614a4)