### PR TITLE
Harden tool log sanitization and usage-log limit behavior

### DIFF
--- a/veritas_os/core/tools.py
+++ b/veritas_os/core/tools.py
@@ -402,7 +402,8 @@ def _sanitize_value(value: Any) -> Any:
     if isinstance(value, list):
         return [_sanitize_value(item) for item in value]
     if isinstance(value, tuple):
-        return tuple(_sanitize_value(item) for item in value)
+        # Keep the payload JSON-serializable for telemetry/log export.
+        return [_sanitize_value(item) for item in value]
     if isinstance(value, str) and len(value) > 200:
         return value[:200] + "..."
     return value
@@ -428,8 +429,11 @@ def get_tool_usage_log(limit: int = 100) -> List[Dict[str, Any]]:
     Args:
         limit: 取得する最大件数
     """
+    normalized_limit = max(0, int(limit))
+    if normalized_limit == 0:
+        return []
     with _tool_usage_log_lock:
-        return _tool_usage_log[-limit:][::-1]
+        return _tool_usage_log[-normalized_limit:][::-1]
 
 
 def clear_tool_usage_log() -> None:


### PR DESCRIPTION
### Motivation
- Prevent non-JSON-serializable payloads from entering tool usage logs and make `get_tool_usage_log` robust to invalid `limit` values.
- Add small regression tests to cover tuple sanitization and negative/zero `limit` behavior so future changes don't regress these invariants.

### Description
- Convert `tuple` values to `list` in `_sanitize_value` so sanitized arguments remain JSON-serializable when logged (changed in `veritas_os/core/tools.py`).
- Normalize the `limit` parameter in `get_tool_usage_log` using `normalized_limit = max(0, int(limit))` and return `[]` for `0` to avoid unexpected slice semantics (changed in `veritas_os/core/tools.py`).
- Add tests `test_sanitize_args_converts_tuple_to_list_for_json_safety` and `test_get_tool_usage_log_returns_empty_for_negative_limit` to `veritas_os/tests/test_core_tools.py` to validate the new behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_core_tools.py veritas_os/tests/test_tools_env.py` and all tests passed (`24 passed`).
- Ran subset verification `pytest -q veritas_os/tests/test_code_review_fixes_v2.py veritas_os/tests/test_code_review_fixes.py` earlier and those passed (`25 passed`).

Security note: The change preserves credential redaction but normalizes `tuple` -> `list` types in logs; if any downstream consumer depends on `tuple` identity, update that integration because the log payloads are now JSON-friendly lists instead of tuples.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b08693188326833e993ce93447f0)