### PR TITLE
Prefer canonical SHA-256 but fall back to legacy values in trust_log tail extraction

### DIFF
--- a/veritas_os/tests/test_trust_log.py
+++ b/veritas_os/tests/test_trust_log.py
@@ -170,15 +170,15 @@ def test_get_last_hash_no_file_returns_none(temp_log_env):
 def test_get_last_hash_reads_last_line_sha256(temp_log_env):
     # 2行分の JSONL を書いて、最後の sha256 を返せるか
     entries = [
-        {"sha256": "aaa111"},
-        {"sha256": "bbb222"},
+        {"sha256": "a" * 64},
+        {"sha256": "b" * 64},
     ]
     with open(temp_log_env["jsonl"], "w", encoding="utf-8") as f:
         for e in entries:
             f.write(json.dumps(e) + "\n")
 
     last = trust_log.get_last_hash()
-    assert last == "bbb222"
+    assert last == "b" * 64
 
 
 def test_get_last_hash_invalid_json_returns_none(temp_log_env):
@@ -187,30 +187,41 @@ def test_get_last_hash_invalid_json_returns_none(temp_log_env):
 
 
 def test_get_last_hash_handles_very_large_last_line(temp_log_env):
-    payload = {"sha256": "large123", "blob": "x" * 70000}
+    payload = {"sha256": "c" * 64, "blob": "x" * 70000}
     temp_log_env["jsonl"].write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
-    assert trust_log.get_last_hash() == "large123"
+    assert trust_log.get_last_hash() == "c" * 64
 
 
 def test_get_last_hash_skips_trailing_partial_json_line(temp_log_env):
-    valid = json.dumps({"sha256": "stable_hash"})
+    valid = json.dumps({"sha256": "d" * 64})
     partial = '{"sha256": "broken"'
     temp_log_env["jsonl"].write_text(f"{valid}\n{partial}", encoding="utf-8")
 
-    assert trust_log.get_last_hash() == "stable_hash"
+    assert trust_log.get_last_hash() == "d" * 64
 
 
 def test_extract_last_sha256_from_lines_ignores_invalid_entries():
+    valid_hash = "a" * 64
     lines = [
         "",
         "not-json",
         json.dumps(["list", "is", "ignored"]),
         json.dumps({"sha256": ""}),
         json.dumps({"sha256": "good_hash"}),
+        json.dumps({"sha256": valid_hash}),
     ]
 
-    assert trust_log._extract_last_sha256_from_lines(lines) == "good_hash"
+    assert trust_log._extract_last_sha256_from_lines(lines) == valid_hash
+
+
+def test_extract_last_sha256_from_lines_falls_back_to_non_hex_sha256():
+    lines = [
+        json.dumps({"sha256": "g" * 64}),
+        json.dumps({"sha256": "123"}),
+    ]
+
+    assert trust_log._extract_last_sha256_from_lines(lines) == "123"
 
 
 # ============================


### PR DESCRIPTION
### Motivation
- A previous hardening change caused CI/test failures by returning `None` when legacy or non-canonical `sha256` values appeared in the log tail, so compatibility must be restored while keeping stronger validation.
- The intent is to prefer canonical 64-character lowercase hex SHA-256 values but accept older non-empty string values for backward compatibility and surface a warning for operators.

### Description
- Added a compiled regex `_SHA256_HEX_RE` and enhanced the docstring for `_extract_last_sha256_from_lines` to document the canonical-preferred, legacy-fallback behavior.
- Updated `_extract_last_sha256_from_lines` to scan backward, return the newest canonical SHA-256 if present, otherwise return the newest non-empty `sha256` string and emit a `logger.warning` when falling back.
- Updated tests in `veritas_os/tests/test_trust_log.py` to assert canonical-priority behavior and the legacy fallback case, and ensured the changes follow PEP8 formatting.

### Testing
- Ran `pytest -q veritas_os/tests/test_trust_log.py veritas_os/tests/test_code_review_fixes_v2.py` and all tests passed (`35 passed`).
- Ran `ruff check veritas_os/logging/trust_log.py veritas_os/tests/test_trust_log.py` and static checks passed.
- Attempted full coverage-enabled test run in CI mode but installing `pytest-cov` failed due to network/proxy restrictions in the environment, so coverage collection could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f29bc61c83269c2448c4abd55059)