### PR TITLE
test: remove stale pytest asyncio config option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,6 @@ Homepage = "https://github.com/veritasfuji-japan/veritas_os"
 Repository = "https://github.com/veritasfuji-japan/veritas_os"
 Issues = "https://github.com/veritasfuji-japan/veritas_os/issues"
 
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-
 [tool.setuptools.packages.find]
 include = ["veritas_os*"]
 


### PR DESCRIPTION
### Motivation
- Remove the obsolete `pytest` config `asyncio_mode = "auto"` from `pyproject.toml` to stop the recurring `PytestConfigWarning: Unknown config option: asyncio_mode` since async tests are executed by the local `conftest.py` hook.

### Description
- Delete the `[tool.pytest.ini_options] asyncio_mode = "auto"` setting from `pyproject.toml` so configuration matches the repository's in-tree async test runner (`veritas_os/tests/conftest.py`).

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_async_support.py veritas_os/tests/test_fuji_policy_guardrails.py` which completed with `3 passed` and no warnings about `asyncio_mode`.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fdb976208326a1efc7eac9ffdcbf)