### PR TITLE
Harden llm_safety category normalization

### DIFF
--- a/veritas_os/tests/test_llm_safety.py
+++ b/veritas_os/tests/test_llm_safety.py
@@ -175,6 +175,16 @@ def test_normalize_categories_deduplicates_and_clips():
     assert len(normalized) == 3
 
 
+
+
+def test_normalize_categories_strips_controls_and_casefold_dedup():
+    """制御文字を除去し、大文字小文字差分の重複を抑止する。"""
+    normalized = llm_safety._normalize_categories(
+        [" PII\x00", "pii", "\n\tillicit\r", "ILLICIT"],
+        max_categories=10,
+    )
+
+    assert normalized == ["PII", "illicit"]
 def test_normalize_categories_respects_non_positive_limit():
     """上限が 0 以下なら空配列を返す。"""
     normalized = llm_safety._normalize_categories(["PII", "illicit"], max_categories=0)


### PR DESCRIPTION
### Motivation
- LLM-returned category labels can contain control characters and case/whitespace variations that pollute audit logs and create duplicate semantic categories, so categories must be sanitized before logging or aggregation.
- This reduces risk of misleading telemetry and makes downstream processing more robust against malformed model outputs.

### Description
- Add a compiled `_RE_CONTROL_CHARS` and strip control characters from each category before further processing.
- Collapse consecutive whitespace to a single space and trim the result to avoid noisy or empty labels.
- Make deduplication case-insensitive by using `casefold()` for the `seen` key while preserving the original trimmed label in the returned list.
- Update the categories normalization docstring and add a regression test `test_normalize_categories_strips_controls_and_casefold_dedup` in `veritas_os/tests/test_llm_safety.py`.

### Testing
- Ran `ruff check veritas_os/tools/llm_safety.py veritas_os/tests/test_llm_safety.py --output-format concise` and it passed.
- Ran `pytest -q veritas_os/tests/test_llm_safety.py` and `13 passed` in ~0.97s.
- Also ran a related test subset `pytest -q veritas_os/tests/test_web_search_extra.py veritas_os/tests/test_tools.py veritas_os/tests/test_tools_env.py` and received `65 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699900e983988326bad4f2147b2c7993)