### PR TITLE
refactor(core): コードベース全体のレビューと改善

### DIFF
--- a/veritas_os/core/fuji.py
+++ b/veritas_os/core/fuji.py
@@ -227,7 +227,8 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _safe_int(x: Any, default: int) -> int:
+def _safe_nonneg_int(x: Any, default: int) -> int:
+    """安全に非負整数に変換する。負の値はデフォルト値を返す。"""
     try:
         v = int(x)
         return v if v >= 0 else default
@@ -1084,7 +1085,7 @@ def fuji_gate(
     telos_score = _safe_float(ctx.get("telos_score", ctx.get("value_ema", 0.5)), 0.5)
     safe_applied = bool(ctx.get("fuji_safe_applied") or ctx.get("pii_already_masked"))
 
-    min_evidence = _safe_int(
+    min_evidence = _safe_nonneg_int(
         ctx.get("min_evidence")
         or ctx.get("fuji_min_evidence")
         or os.getenv("VERITAS_MIN_EVIDENCE", DEFAULT_MIN_EVIDENCE),

--- a/veritas_os/core/sanitize.py
+++ b/veritas_os/core/sanitize.py
@@ -499,8 +499,13 @@ class PIIDetector:
         Overlap resolution keeps the first accepted match, therefore scanning
         higher-confidence patterns first reduces false positives when multiple
         patterns can match the same substring.
+
+        The result is cached on first call since pattern priority does not
+        change after ``__init__``.
         """
-        return sorted(self._patterns, key=lambda item: item[4], reverse=True)
+        if not hasattr(self, "_sorted_patterns"):
+            self._sorted_patterns = sorted(self._patterns, key=lambda item: item[4], reverse=True)
+        return self._sorted_patterns
 
     def detect(self, text: str | None) -> List[PIIMatch]:
         """

--- a/veritas_os/tests/test_fuji_coverage.py
+++ b/veritas_os/tests/test_fuji_coverage.py
@@ -481,13 +481,13 @@ class TestUtilityFunctions:
         assert "T" in result
 
     def test_safe_int_valid(self):
-        assert fuji._safe_int("5", 0) == 5
+        assert fuji._safe_nonneg_int("5", 0) == 5
 
     def test_safe_int_negative(self):
-        assert fuji._safe_int(-1, 10) == 10
+        assert fuji._safe_nonneg_int(-1, 10) == 10
 
     def test_safe_int_invalid(self):
-        assert fuji._safe_int("abc", 42) == 42
+        assert fuji._safe_nonneg_int("abc", 42) == 42
 
     def test_normalize_text(self):
         assert fuji._normalize_text("  Hello　World  ") == "hello world"

--- a/veritas_os/tests/test_fuji_extra.py
+++ b/veritas_os/tests/test_fuji_extra.py
@@ -30,17 +30,17 @@ class TestSafeInt:
 
     def test_valid_int(self):
         """Valid int should be returned."""
-        assert fuji_mod._safe_int(42, default=0) == 42
-        assert fuji_mod._safe_int("10", default=0) == 10
+        assert fuji_mod._safe_nonneg_int(42, default=0) == 42
+        assert fuji_mod._safe_nonneg_int("10", default=0) == 10
 
     def test_invalid_returns_default(self):
         """Invalid input should return default."""
-        assert fuji_mod._safe_int("not a number", default=5) == 5
-        assert fuji_mod._safe_int(None, default=0) == 0
+        assert fuji_mod._safe_nonneg_int("not a number", default=5) == 5
+        assert fuji_mod._safe_nonneg_int(None, default=0) == 0
 
     def test_negative_returns_default(self):
         """Negative int should return default."""
-        assert fuji_mod._safe_int(-5, default=0) == 0
+        assert fuji_mod._safe_nonneg_int(-5, default=0) == 0
 
 
 class TestToText:

--- a/veritas_os/tests/test_llm_client.py
+++ b/veritas_os/tests/test_llm_client.py
@@ -566,7 +566,7 @@ def test_chat_http_error_raises(monkeypatch):
     with pytest.raises(LLMError) as exc:
         llm_client.chat("SYS", "USER", provider=LLMProvider.OPENAI.value)
 
-    assert "API error" in str(exc.value) and "500" in str(exc.value)
+    assert "500" in str(exc.value)
 
 
 def test_chat_request_exception_retries_and_fails(monkeypatch):
@@ -657,8 +657,8 @@ def test_chat_claude_shortcut(monkeypatch):
 
     res = llm_client.chat_claude("SYS", "USER")
     assert called["provider"] == LLMProvider.ANTHROPIC.value
-    assert called["model"] == "claude-3-5-sonnet-20241022"
-    assert res["model"] == "claude-3-5-sonnet-20241022"
+    assert called["model"] == "claude-opus-4-6"
+    assert res["model"] == "claude-opus-4-6"
 
 
 def test_chat_gemini_shortcut(monkeypatch):
@@ -673,8 +673,8 @@ def test_chat_gemini_shortcut(monkeypatch):
 
     res = llm_client.chat_gemini("SYS", "USER")
     assert called["provider"] == LLMProvider.GOOGLE.value
-    assert called["model"] == "gemini-pro"
-    assert res["model"] == "gemini-pro"
+    assert called["model"] == "gemini-1.5-pro"
+    assert res["model"] == "gemini-1.5-pro"
 
 
 def test_chat_local_shortcut(monkeypatch):
@@ -698,8 +698,8 @@ def test_env_parsing_safe_helpers_return_default_for_invalid_values(monkeypatch)
     monkeypatch.setenv("VERITAS_TEST_SAFE_INT", "invalid-int")
     monkeypatch.setenv("VERITAS_TEST_SAFE_FLOAT", "invalid-float")
 
-    assert llm_client._safe_int("VERITAS_TEST_SAFE_INT", 7) == 7
-    assert llm_client._safe_float("VERITAS_TEST_SAFE_FLOAT", 1.5) == 1.5
+    assert llm_client._env_int("VERITAS_TEST_SAFE_INT", 7) == 7
+    assert llm_client._env_float("VERITAS_TEST_SAFE_FLOAT", 1.5) == 1.5
 
 
 def test_env_parsing_failsafe_on_module_reload(monkeypatch):


### PR DESCRIPTION
## llm_client.py
- `_safe_float`/`_safe_int` を `_env_float`/`_env_int` にリネーム
  - utils.py の同名関数（値変換）と異なり環境変数キーを引数に取るため
  - 名前の混乱・誤用を防止
- 5xxサーバーエラー時にエクスポネンシャルバックオフでリトライ追加
  - 500-599 は一時的なサーバー障害のため再試行が有効
- `chat_claude` のデフォルトモデルを claude-opus-4-6 に更新
- `chat_gemini` のデフォルトモデルを gemini-1.5-pro に更新（gemini-pro は廃止）

## sanitize.py
- `PIIDetector._iter_patterns_by_priority()` の結果をキャッシュ
  - `detect()` 呼び出しのたびにソートしていた無駄な計算を排除
  - パターン優先度は `__init__` 後に変化しないため安全

## fuji.py
- ローカル `_safe_int` を `_safe_nonneg_int` にリネーム
  - 「非負整数専用」であることを関数名で明示
  - utils.py の `_safe_int` との混同を防止

## kernel.py
- `_wait_with_timeout` ネスト関数を `_make_doctor_reaper` ファクトリ関数に変更
  - ネスト関数内の `global` 宣言を排除し可読性を向上
  - 変数キャプチャの意図を明確化

https://claude.ai/code/session_01GWmXVb9h2gdUgEcNnis9Ud