### PR TITLE
Harden health_check by disabling HTTP redirect following

### DIFF
--- a/veritas_os/scripts/health_check.py
+++ b/veritas_os/scripts/health_check.py
@@ -202,7 +202,8 @@ def check_server() -> Dict[str, Any]:
     # requests ライブラリを優先使用（セキュリティ向上）
     if HAS_REQUESTS:
         try:
-            resp = requests.get(url, timeout=3)
+            # Redirect 追従を無効化し、検証済み URL 以外への遷移を防止する。
+            resp = requests.get(url, timeout=3, allow_redirects=False)
             body = resp.text
             ok = resp.ok and ('"ok":true' in body.replace(" ", "").lower())
             return {


### PR DESCRIPTION
### Motivation
- Prevent health-checks from following HTTP redirects so a previously validated URL cannot be bypassed by a redirect (reduces SSRF-like redirect abuse). 
- Keep health verification pinned to the validated endpoint by making `check_server()` deterministic with respect to the target URL. 
- Note that if `requests` is not available the code falls back to invoking `curl` as a subprocess, which remains an operational security consideration and should be monitored.

### Description
- Add `allow_redirects=False` to the `requests.get` call in `check_server()` to disable automatic redirect following. 
- Add a regression test `test_check_server_disables_redirect_following` in `veritas_os/tests/test_health_check_script.py` that monkeypatches `requests.get` and asserts `allow_redirects` is `False`. 
- Preserve existing URL validation and the `curl` fallback behavior. 
- Add an inline comment documenting the security rationale for disabling redirects.

### Testing
- Ran `pytest -q veritas_os/tests/test_health_check_script.py` and the suite passed with `9 passed`.
- No additional automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999354d14c8832688a8cf61b9f7b93c)