### PR TITLE
Harden health_check URL validation and optional requests import

### DIFF
--- a/veritas_os/scripts/health_check.py
+++ b/veritas_os/scripts/health_check.py
@@ -14,17 +14,16 @@ import os
 import json
 import subprocess
 import re
+import importlib.util
 from pathlib import Path
 from datetime import datetime, timedelta
 from typing import Dict, Any, List, Optional
 from urllib.parse import urlparse
 
 # requests ライブラリ（セキュリティ向上のため curl subprocess を置換）
-try:
+HAS_REQUESTS = importlib.util.find_spec("requests") is not None
+if HAS_REQUESTS:
     import requests
-    HAS_REQUESTS = True
-except ImportError:
-    HAS_REQUESTS = False
 
 # ===== パス設定 =====
 HERE = Path(__file__).resolve().parent      # .../veritas_os/scripts
@@ -91,6 +90,10 @@ def _validate_url(url: str) -> Optional[str]:
         検証済みの URL（安全な場合）、または None（不正な場合）
     """
     if not url or not isinstance(url, str):
+        return None
+
+    # 前後空白および制御文字混入を禁止（ログ混乱や解析の曖昧化を防止）
+    if url != url.strip() or re.search(r"[\x00-\x1f\x7f\s]", url):
         return None
 
     # 危険な文字を検出（コマンドインジェクション防止）

--- a/veritas_os/tests/test_health_check_script.py
+++ b/veritas_os/tests/test_health_check_script.py
@@ -53,6 +53,11 @@ def test_validate_url_rejects_hostname_label_too_long() -> None:
     assert health_check._validate_url(url) is None
 
 
+def test_validate_url_rejects_whitespace_and_control_chars() -> None:
+    assert health_check._validate_url(" https://127.0.0.1:8000/health") is None
+    assert health_check._validate_url("https://127.0.0.1:8000/hea\nlth") is None
+
+
 def test_check_server_disables_redirect_following(monkeypatch) -> None:
     class DummyResponse:
         ok = True


### PR DESCRIPTION
### Motivation
- Reduce risk from environment-provided endpoints and malformed input by tightening URL validation to reject whitespace and control characters, and make optional `requests` import explicit and deterministic.

### Description
- Use `importlib.util.find_spec("requests")` to set `HAS_REQUESTS` and import `requests` only when present, avoiding broad import-time exception handling.
- Strengthen `_validate_url` to immediately reject URLs with leading/trailing whitespace or embedded control characters and keep existing checks for dangerous characters, schemes, credentials, query/fragment, hostname, and port.
- Add `test_validate_url_rejects_whitespace_and_control_chars` in `veritas_os/tests/test_health_check_script.py` to cover the new validation rules.
- Preserve `check_server` behavior and secure fallback to `curl` only for pre-validated URLs.

### Testing
- Ran `pytest -q veritas_os/tests/test_health_check_script.py` and all tests passed (`10 passed`).
- Ran `ruff check veritas_os/scripts/health_check.py veritas_os/tests/test_health_check_script.py` and all lint checks passed.

Security note: `VERITAS_API_BASE` remains sensitive when injected from the environment; these changes reduce log-forging and malformed-URL risks but operators should still avoid supplying untrusted endpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699938a74138832696927c4a12a2f975)