### PR TITLE
Harden health_check URL validation for percent-encoded control chars

### DIFF
--- a/veritas_os/scripts/health_check.py
+++ b/veritas_os/scripts/health_check.py
@@ -96,6 +96,12 @@ def _validate_url(url: str) -> Optional[str]:
     if url != url.strip() or re.search(r"[\x00-\x1f\x7f\s]", url):
         return None
 
+    # パーセントエンコードされた制御文字を禁止（例: %0a, %0d）
+    # requests / curl がそのまま送信しても、下流ログ解析や中間プロキシで
+    # 予期しない解釈をされるリスクを下げるために拒否する。
+    if re.search(r"%(?:0[0-9a-fA-F]|1[0-9a-fA-F]|7f)", url):
+        return None
+
     # 危険な文字を検出（コマンドインジェクション防止）
     dangerous_chars = [";", "|", "&", "$", "`", "(", ")", "{", "}", "<", ">", "\n", "\r", "\\"]
     for char in dangerous_chars:

--- a/veritas_os/tests/test_health_check_script.py
+++ b/veritas_os/tests/test_health_check_script.py
@@ -58,6 +58,11 @@ def test_validate_url_rejects_whitespace_and_control_chars() -> None:
     assert health_check._validate_url("https://127.0.0.1:8000/hea\nlth") is None
 
 
+def test_validate_url_rejects_percent_encoded_control_chars() -> None:
+    assert health_check._validate_url("https://127.0.0.1:8000/health%0a") is None
+    assert health_check._validate_url("https://127.0.0.1:8000/health%0D") is None
+
+
 def test_check_server_disables_redirect_following(monkeypatch) -> None:
     class DummyResponse:
         ok = True


### PR DESCRIPTION
### Motivation
- Prevent URLs containing percent-encoded control characters (e.g. `%0a`, `%0d`, `%7f`) from being considered safe, reducing risk of downstream log/proxy parsing ambiguity and potential injection vectors.

### Description
- Add a regex check in `veritas_os/scripts/health_check.py` to reject percent-encoded control bytes before any network request is attempted by `_validate_url`.
- Add regression tests in `veritas_os/tests/test_health_check_script.py` (`test_validate_url_rejects_percent_encoded_control_chars`) to ensure encoded control characters are rejected.

### Testing
- Ran `ruff check veritas_os/scripts/health_check.py veritas_os/tests/test_health_check_script.py` and it passed.
- Ran `pytest -q veritas_os/tests/test_health_check_script.py` and all tests passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69993ba722948326acb900fb5e2e9038)