### PR TITLE
Harden Chainlit formatter numeric coercion

### DIFF
--- a/chainlit_app.py
+++ b/chainlit_app.py
@@ -41,6 +41,14 @@ def _safe_int(value: Any) -> Optional[int]:
     return int(as_float)
 
 
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    """Return a finite float for formatting, or a default value."""
+    parsed = _safe_float(value)
+    if parsed is None:
+        return default
+    return parsed
+
+
 # --------- VERITAS API 呼び出しヘルパー ---------
 
 async def call_veritas_decide(query: str) -> Dict[str, Any]:
@@ -76,8 +84,8 @@ def format_main_answer(res: Dict[str, Any]) -> str:
     desc = chosen.get("description") or ""
 
     decision_status = gate.get("decision_status") or res.get("decision_status")
-    risk = gate.get("risk", 0.0)
-    telos = res.get("telos_score", 0.0)
+    risk = _coerce_float(gate.get("risk"), default=0.0)
+    telos = _coerce_float(res.get("telos_score"), default=0.0)
 
     # Planner ステップ（上位5件）
     steps = (planner.get("steps") or [])[:5]

--- a/veritas_os/tests/test_chainlit_app_formatters.py
+++ b/veritas_os/tests/test_chainlit_app_formatters.py
@@ -85,3 +85,18 @@ def test_format_main_answer_handles_string_ema() -> None:
     )
 
     assert "total=1.500 / ema=2.250" in result
+
+
+def test_format_main_answer_handles_non_numeric_gate_values() -> None:
+    """Formatter should default invalid risk/telos values to 0.000."""
+    result = module.format_main_answer(
+        {
+            "chosen": {"title": "A"},
+            "gate": {"decision_status": "allow", "risk": "high"},
+            "telos_score": "unknown",
+            "values": {"total": 1.0},
+        }
+    )
+
+    assert "FUJIリスク: **0.000**" in result
+    assert "Telosスコア: **0.000**" in result


### PR DESCRIPTION
### Motivation
- Prevent formatting failures when upstream `gate.risk` or `telos_score` contain non-numeric or non-finite values by normalizing them before `:.3f` formatting.
- Keep changes limited to the presentation layer (formatters) without touching Planner/Kernel/Fuji/MemoryOS responsibilities.
- Security note: the app currently logs the raw `query` on API errors which can expose sensitive input; consider masking or redacting user-provided data in logs.

### Description
- Added a small helper `def _coerce_float(value: Any, default: float = 0.0) -> float` in `chainlit_app.py` to return a finite float or a default when conversion fails.
- Updated `format_main_answer` to use `_coerce_float` for `gate.get("risk")` and `res.get("telos_score")` to ensure safe `:.3f` formatting.
- Added regression test `test_format_main_answer_handles_non_numeric_gate_values` in `veritas_os/tests/test_chainlit_app_formatters.py` to assert non-numeric `risk`/`telos_score` render as `0.000`.

### Testing
- Ran `pytest -q veritas_os/tests/test_chainlit_app_formatters.py` and observed all tests pass: `4 passed in 0.29s`.
- Ran `ruff check chainlit_app.py veritas_os/tests/test_chainlit_app_formatters.py` and it passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69993f93f8888326903e1ba2c88bf44d)