### PR TITLE
Harden API security headers with CSP and Permissions-Policy

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -528,10 +528,24 @@ async def limit_body_size(request: Request, call_next):
 # クリックジャッキング、MIMEスニッフィング、XSS攻撃を防止
 @app.middleware("http")
 async def add_security_headers(request: Request, call_next):
+    """Apply baseline response security headers for API endpoints.
+
+    Notes:
+        - A strict Content Security Policy (CSP) is attached even for JSON API
+          responses to reduce the risk of accidental HTML rendering and inline
+          script execution in browser-based tooling.
+        - ``Permissions-Policy`` disables powerful browser features by default
+          because this API does not require them.
+    """
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers["Content-Security-Policy"] = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+    response.headers["Permissions-Policy"] = (
+        "accelerometer=(), camera=(), geolocation=(), gyroscope=(), "
+        "magnetometer=(), microphone=(), payment=(), usb=()"
+    )
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     # Security hardening: browsers only honor HSTS over HTTPS.
     # Sending this header proactively helps production deployments enforce

--- a/veritas_os/tests/test_server_coverage.py
+++ b/veritas_os/tests/test_server_coverage.py
@@ -175,6 +175,15 @@ def test_security_headers_present():
     assert resp.headers.get("X-Frame-Options") == "DENY"
     assert resp.headers.get("X-XSS-Protection") == "1; mode=block"
     assert (
+        resp.headers.get("Content-Security-Policy")
+        == "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+    )
+    assert (
+        resp.headers.get("Permissions-Policy")
+        == "accelerometer=(), camera=(), geolocation=(), gyroscope=(), "
+        "magnetometer=(), microphone=(), payment=(), usb=()"
+    )
+    assert (
         resp.headers.get("Strict-Transport-Security")
         == "max-age=31536000; includeSubDomains"
     )


### PR DESCRIPTION
### Motivation
- Reduce browser-side attack surface for API responses by applying a stricter baseline of HTTP security headers in the API middleware.
- Make the purpose and scope of the middleware explicit by adding a docstring so future maintainers understand the trade-offs.
- Warn that a strict CSP (`default-src 'none'`) can constrain any future endpoints that intentionally serve HTML, so per-endpoint header policies may be required.

### Description
- Added a docstring to `add_security_headers` in `veritas_os/api/server.py` describing the CSP and Permissions-Policy intent and scope.
- Added `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; base-uri 'none'` to responses to prevent accidental HTML rendering and framing.
- Added a restrictive `Permissions-Policy` header disabling unused powerful browser features (accelerometer, camera, geolocation, gyroscope, magnetometer, microphone, payment, usb).
- Extended `veritas_os/tests/test_server_coverage.py` to assert the presence and exact values of the new headers; changes follow the existing API boundary and adhere to PEP8 formatting.

### Testing
- Ran `pytest -q veritas_os/tests/test_server_coverage.py` and observed `66 passed` with 3 warnings, confirming the new middleware and tests pass.
- Additionally ran `pytest -q veritas_os/tests/test_critique.py veritas_os/tests/test_critique_extra.py` earlier which returned `28 passed` to validate unrelated test stability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999abd94b348326984b318e68ce35e5)