### PR TITLE
Harden doctor subprocess executable validation

### DIFF
--- a/veritas_os/tests/test_kernel_extra_v2.py
+++ b/veritas_os/tests/test_kernel_extra_v2.py
@@ -28,6 +28,37 @@ import pytest
 from veritas_os.core import kernel
 
 
+
+
+# =========================================================
+# _is_safe_python_executable
+# =========================================================
+
+class TestIsSafePythonExecutable:
+    def test_returns_false_for_none(self):
+        assert kernel._is_safe_python_executable(None) is False
+
+    def test_returns_false_for_relative_path(self):
+        assert kernel._is_safe_python_executable("python3") is False
+
+    def test_returns_false_for_non_executable_file(self, tmp_path):
+        file_path = tmp_path / "python3"
+        file_path.write_text("#!/bin/false\n")
+        file_path.chmod(0o600)
+        assert kernel._is_safe_python_executable(str(file_path)) is False
+
+    def test_returns_false_for_unexpected_executable_name(self, tmp_path):
+        file_path = tmp_path / "bash"
+        file_path.write_text("#!/bin/false\n")
+        file_path.chmod(0o700)
+        assert kernel._is_safe_python_executable(str(file_path)) is False
+
+    def test_returns_true_for_python_like_executable(self, tmp_path):
+        file_path = tmp_path / "python3.12"
+        file_path.write_text("#!/bin/true\n")
+        file_path.chmod(0o700)
+        assert kernel._is_safe_python_executable(str(file_path)) is True
+
 # =========================================================
 # _open_doctor_log_fd
 # =========================================================


### PR DESCRIPTION
### Motivation
- Prevent potential command-hijacking or unintended binary launches when the kernel auto-starts the `doctor` subprocess by validating the Python interpreter path more strictly.
- Centralize and clarify the `sys.executable` validation logic so the launch decision is auditable and easier to test.

### Description
- Add `_is_safe_python_executable(executable_path: str | None) -> bool` which requires an absolute path, existing regular file, executable permission, and a python/pypy-like binary name.
- Replace the inline `sys.executable` checks in `kernel.decide` with a call to `_is_safe_python_executable` to enforce the new validation before spawning the `doctor` subprocess.
- Add unit tests for `_is_safe_python_executable` in `veritas_os/tests/test_kernel_extra_v2.py` covering `None`, relative path, non-executable file, unexpected binary name, and a python-like executable.
- Keep responsibility localized to Kernel code and do not change external module interfaces or behaviors beyond the pre-launch safety checks.

### Testing
- Ran `ruff check veritas_os/core/kernel.py veritas_os/tests/test_kernel_extra_v2.py --output-format concise` and it passed with no offenses.
- Ran `pytest -q veritas_os/tests/test_kernel_extra_v2.py` and the new/modified tests passed (all tests completed successfully).
- Ran a regression subset `pytest -q veritas_os/tests/test_fuji_policy_guardrails.py veritas_os/tests/test_planner.py veritas_os/tests/test_kernel_core.py` and those tests passed as before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999af12726c8326bf4297ffd88ef380)