### PR TITLE
Harden memory tag validation limits

### DIFF
--- a/veritas_os/tests/test_memory_store.py
+++ b/veritas_os/tests/test_memory_store.py
@@ -223,6 +223,24 @@ def test_put_validates_tags_and_meta_types(memory_env):
         ms.put("episodic", {"text": "ok", "tags": [], "meta": "not-dict"})
 
 
+def test_put_validates_tags_constraints(memory_env):
+    """put は tags の件数・要素長・空要素を検証する。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    ms = store.MemoryStore(dim=4)
+
+    too_many_tags = [f"t{i}" for i in range(store.MAX_TAGS_PER_ITEM + 1)]
+    with pytest.raises(ValueError, match="item.tags too many"):
+        ms.put("episodic", {"text": "ok", "tags": too_many_tags, "meta": {}})
+
+    too_long_tag = "x" * (store.MAX_TAG_LENGTH + 1)
+    with pytest.raises(ValueError, match="item.tags element too long"):
+        ms.put("episodic", {"text": "ok", "tags": [too_long_tag], "meta": {}})
+
+    with pytest.raises(ValueError, match="item.tags must not contain empty values"):
+        ms.put("episodic", {"text": "ok", "tags": ["   "], "meta": {}})
+
+
 def test_put_validates_id_shape_and_length(memory_env):
     """put は不正な id 形状と過剰長 id を拒否する。"""
     store, files, index_paths, FakeIndex, FakeEmbedder = memory_env


### PR DESCRIPTION
### Motivation
- Prevent unbounded tags metadata from being used to bloat storage or cause DoS-like behavior by adding explicit input limits for memory items.
- Keep validations within MemoryStore responsibilities and provide clearer error messages for malformed tag payloads.

### Description
- Add `MAX_TAGS_PER_ITEM = 64` and `MAX_TAG_LENGTH = 128` to `veritas_os/memory/store.py` and enforce them in `MemoryStore._normalize_item`.
- Validate that `tags` is a list, reject too many tags, reject empty/whitespace-only tags, and reject tags exceeding the length limit while normalizing tag strings.
- Add `test_put_validates_tags_constraints` to `veritas_os/tests/test_memory_store.py` to cover too-many-tags, too-long-tag, and empty-tag cases.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_memory_store.py` which resulted in `11 passed`.
- Ran `ruff check veritas_os/memory/store.py veritas_os/tests/test_memory_store.py --output-format concise` and all checks passed.
- The changes are limited to memory input validation and reduce risk of storage/DoS abuse without expanding privileges or network surface.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999bd6c2210832695fb6ecac2f5a903)