### PR TITLE
fix: スレッドセーフ強化とセキュリティ改善

### DIFF
--- a/veritas_os/core/self_healing.py
+++ b/veritas_os/core/self_healing.py
@@ -20,7 +20,8 @@ from .fuji_codes import FujiAction
 
 logger = logging.getLogger(__name__)
 
-def _safe_int(env_key: str, default: int) -> int:
+def _env_int(env_key: str, default: int) -> int:
+    """環境変数を int として安全に取得する（キー名を引数として受け取る版）。"""
     val = os.getenv(env_key)
     if val is None:
         return default
@@ -30,7 +31,8 @@ def _safe_int(env_key: str, default: int) -> int:
         return default
 
 
-def _safe_float(env_key: str, default: float) -> float:
+def _env_float(env_key: str, default: float) -> float:
+    """環境変数を float として安全に取得する（キー名を引数として受け取る版）。"""
     val = os.getenv(env_key)
     if val is None:
         return default
@@ -40,10 +42,10 @@ def _safe_float(env_key: str, default: float) -> float:
         return default
 
 
-MAX_HEALING_ATTEMPTS = _safe_int("VERITAS_MAX_HEALING_ATTEMPTS", 3)
-MAX_HEALING_STEPS = _safe_int("VERITAS_HEALING_MAX_STEPS", 6)
-MAX_HEALING_SECONDS = _safe_float("VERITAS_HEALING_MAX_SECONDS", 20.0)
-MAX_CONSECUTIVE_SAME_ERROR = _safe_int("VERITAS_HEALING_MAX_SAME_ERROR", 2)
+MAX_HEALING_ATTEMPTS = _env_int("VERITAS_MAX_HEALING_ATTEMPTS", 3)
+MAX_HEALING_STEPS = _env_int("VERITAS_HEALING_MAX_STEPS", 6)
+MAX_HEALING_SECONDS = _env_float("VERITAS_HEALING_MAX_SECONDS", 20.0)
+MAX_CONSECUTIVE_SAME_ERROR = _env_int("VERITAS_HEALING_MAX_SAME_ERROR", 2)
 
 
 @dataclass(frozen=True)

--- a/veritas_os/tests/test_self_healing_coverage.py
+++ b/veritas_os/tests/test_self_healing_coverage.py
@@ -155,15 +155,15 @@ def test_advance_state_different_error_resets_count() -> None:
     assert state.last_error_code == "F-2101"
 
 
-# ── _safe_int / _safe_float env parsing with invalid values ───────────
+# ── _env_int / _env_float env parsing with invalid values ───────────
 
 def test_safe_int_invalid_value() -> None:
     with mock.patch.dict(os.environ, {"VERITAS_TEST_INT": "notanint"}):
-        result = self_healing._safe_int("VERITAS_TEST_INT", 42)
+        result = self_healing._env_int("VERITAS_TEST_INT", 42)
         assert result == 42
 
 
 def test_safe_float_invalid_value() -> None:
     with mock.patch.dict(os.environ, {"VERITAS_TEST_FLOAT": "notafloat"}):
-        result = self_healing._safe_float("VERITAS_TEST_FLOAT", 3.14)
+        result = self_healing._env_float("VERITAS_TEST_FLOAT", 3.14)
         assert result == 3.14


### PR DESCRIPTION
- sanitize.py: _iter_patterns_by_priority のスレッドセーフ化
  hasattr による非アトミックな遅延初期化を double-checked locking パターンに改善。
  _sort_lock (threading.Lock) を __init__ で初期化し、複数スレッドによる
  同時ソートを防止する。

- server.py: lazy import ヘルパーのスレッドセーフ化
  _LazyState に lock フィールドと __post_init__ を追加し、
  get_cfg / get_decision_pipeline / get_fuji_core / get_value_core /
  get_memory_store の各関数を double-checked locking で保護。
  並行リクエスト時の重複インポート競合を解消する。

- server.py: ノンス長の上限チェック追加 (_NONCE_MAX_LENGTH = 256)
  超長いノンス文字列を _nonce_store に登録する前に拒否し、
  メモリ枯渇型 DoS への耐性を向上させる。

- self_healing.py: モジュール内ヘルパー関数を _env_int / _env_float に改名
  utils.py の _safe_float(value, default) と引数シグネチャが異なる関数を
  _env_int(env_key, default) / _env_float(env_key, default) と明確に命名し直し、
  混同リスクを排除する。

- test_self_healing_coverage.py: テストを新しい関数名に対応させる

https://claude.ai/code/session_017g6LcRD47PBwMffzVhBbBL