### PR TITLE
refactor: split pipeline.py (3274行) into 6 focused submodules

### DIFF
--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -308,18 +308,7 @@ def _get_request_params(request: Any) -> Dict[str, Any]:
     return out
 
 
-def _ensure_metrics_contract(extras: Dict[str, Any]) -> None:
-    extras.setdefault("metrics", {})
-    m = extras["metrics"]
-    m.setdefault("mem_hits", 0)
-    m.setdefault("memory_evidence_count", 0)
-    m.setdefault("web_hits", 0)
-    m.setdefault("web_evidence_count", 0)
-    m.setdefault("fast_mode", False)
-    extras.setdefault("fast_mode", False)
-
-
-
+# _ensure_metrics_contract -> pipeline_contracts.py に移動済み（上部 import）
 
 
 def _norm_alt(o: Any) -> Dict[str, Any]:

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -79,7 +79,7 @@ from .pipeline_evidence import (
     _evidencepy_to_pipeline_item,
 )
 from .pipeline_memory_adapter import (
-    _get_memory_store,
+    _get_memory_store as _get_memory_store_impl,
     _call_with_accepted_kwargs,
     _memory_has,
     _memory_search,
@@ -309,6 +309,11 @@ def _get_request_params(request: Any) -> Dict[str, Any]:
 
 
 # _ensure_metrics_contract -> pipeline_contracts.py に移動済み（上部 import）
+
+
+def _get_memory_store() -> Optional[Any]:
+    """pipeline.mem を参照するラッパー（テストが monkeypatch で pipeline.mem をパッチ可能にする）。"""
+    return _get_memory_store_impl(mem=mem)
 
 
 def _norm_alt(o: Any) -> Dict[str, Any]:

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -313,6 +313,8 @@ def _get_request_params(request: Any) -> Dict[str, Any]:
 
 def _get_memory_store() -> Optional[Any]:
     """pipeline.mem を参照するラッパー（テストが monkeypatch で pipeline.mem をパッチ可能にする）。"""
+    if mem is None:
+        return None
     return _get_memory_store_impl(mem=mem)
 
 

--- a/veritas_os/core/pipeline_contracts.py
+++ b/veritas_os/core/pipeline_contracts.py
@@ -1,0 +1,232 @@
+# veritas_os/core/pipeline_contracts.py
+# -*- coding: utf-8 -*-
+"""
+Pipeline コントラクト強制モジュール。
+
+extras / metrics / memory_meta に関する不変条件（invariant）を維持する
+ヘルパー群。run_decide_pipeline 内のネスト定義をモジュールレベルに昇格した。
+
+保証する不変条件:
+- extras.fast_mode (bool) は常に存在
+- extras.metrics.{mem_hits, memory_evidence_count, web_hits, web_evidence_count, fast_mode} は常に存在
+- extras.metrics.mem_evidence_count は後方互換のため常に存在
+- extras.env_tools は常に dict
+- extras.memory_meta は常に dict
+- extras.memory_meta.context は常に dict かつ context.fast (bool) を持つ
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .pipeline_helpers import _set_bool_metric, _set_int_metric, _to_bool_local
+
+
+# =========================================================
+# フルコントラクト強制
+# =========================================================
+
+def _ensure_full_contract(
+    extras: Dict[str, Any],
+    *,
+    fast_mode_default: bool,
+    context_obj: Dict[str, Any],
+    query_str: str = "",
+) -> None:
+    """
+    extras の全不変条件を満たす（例外を出さない、副作用で extras を更新）。
+
+    - extras.fast_mode always exists (bool)
+    - extras.metrics.{mem_hits, memory_evidence_count, web_hits, web_evidence_count, fast_mode}
+    - extras.metrics.stage_latency.{retrieval, web, llm, gate, persist} always exist (int)
+    - backward compat: metrics.mem_evidence_count
+    - extras.env_tools always dict
+    - extras.memory_meta always dict
+    - extras.memory_meta.context always dict and has context.fast (bool)
+    - extras.memory_meta.query filled if possible
+    """
+    if not isinstance(extras, dict):
+        return
+
+    extras.setdefault("metrics", {})
+    if not isinstance(extras["metrics"], dict):
+        extras["metrics"] = {}
+
+    extras.setdefault("env_tools", {})
+    if not isinstance(extras["env_tools"], dict):
+        extras["env_tools"] = {}
+
+    extras.setdefault("memory_meta", {})
+    if not isinstance(extras["memory_meta"], dict):
+        extras["memory_meta"] = {}
+
+    # fast_mode
+    extras["fast_mode"] = _to_bool_local(extras.get("fast_mode", fast_mode_default))
+    _set_bool_metric(
+        extras,
+        "fast_mode",
+        (extras.get("metrics", {}) or {}).get("fast_mode", extras["fast_mode"]),
+        default=extras["fast_mode"],
+    )
+
+    # int metrics
+    _set_int_metric(extras, "mem_hits", extras["metrics"].get("mem_hits", 0), default=0)
+    _set_int_metric(
+        extras,
+        "memory_evidence_count",
+        extras["metrics"].get("memory_evidence_count", 0),
+        default=0,
+    )
+    _set_int_metric(extras, "web_hits", extras["metrics"].get("web_hits", 0), default=0)
+    _set_int_metric(
+        extras,
+        "web_evidence_count",
+        extras["metrics"].get("web_evidence_count", 0),
+        default=0,
+    )
+
+    # stage_latency
+    stage_latency = extras["metrics"].get("stage_latency")
+    if not isinstance(stage_latency, dict):
+        stage_latency = {}
+    for stage_name in ("retrieval", "web", "llm", "gate", "persist"):
+        try:
+            stage_latency[stage_name] = max(0, int(stage_latency.get(stage_name, 0) or 0))
+        except Exception:
+            stage_latency[stage_name] = 0
+    extras["metrics"]["stage_latency"] = stage_latency
+
+    # backward compat
+    try:
+        extras["metrics"].setdefault(
+            "mem_evidence_count",
+            int(extras["metrics"].get("mem_evidence_count", 0) or 0),
+        )
+    except Exception:
+        extras["metrics"]["mem_evidence_count"] = 0
+
+    # memory_meta.context merge
+    mm = extras["memory_meta"]
+    try:
+        base_ctx = dict(context_obj) if isinstance(context_obj, dict) else {}
+    except Exception:
+        base_ctx = {}
+
+    mm_ctx = mm.get("context")
+    if not isinstance(mm_ctx, dict):
+        mm_ctx = dict(base_ctx)
+        mm["context"] = mm_ctx
+    else:
+        for k, v in base_ctx.items():
+            mm_ctx.setdefault(k, v)
+
+    # invariant: context.fast
+    mm_ctx["fast"] = _to_bool_local(mm_ctx.get("fast", extras["fast_mode"]))
+
+    # invariant: memory_meta.query
+    try:
+        existing_q = mm.get("query")
+        if not (isinstance(existing_q, str) and existing_q.strip()):
+            if isinstance(query_str, str) and query_str.strip():
+                mm["query"] = query_str
+    except Exception:
+        pass
+
+
+# =========================================================
+# metrics コントラクト（最小版）
+# =========================================================
+
+def _ensure_metrics_contract(extras: Dict[str, Any]) -> None:
+    """extras.metrics の最小不変条件を満たす（常に 5 キーを持つ）。"""
+    extras.setdefault("metrics", {})
+    m = extras["metrics"]
+    m.setdefault("mem_hits", 0)
+    m.setdefault("memory_evidence_count", 0)
+    m.setdefault("web_hits", 0)
+    m.setdefault("web_evidence_count", 0)
+    m.setdefault("fast_mode", False)
+    extras.setdefault("fast_mode", False)
+
+
+# =========================================================
+# extras の深いマージ
+# =========================================================
+
+def _deep_merge_dict(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
+    """dict を再帰的に安全マージする（例外を出さない）。"""
+    try:
+        if not isinstance(dst, dict) or not isinstance(src, dict):
+            return dst
+        for k, v in src.items():
+            if isinstance(v, dict) and isinstance(dst.get(k), dict):
+                _deep_merge_dict(dst[k], v)  # type: ignore[index]
+            else:
+                dst[k] = v
+        return dst
+    except Exception:
+        return dst
+
+
+def _merge_extras_preserving_contract(
+    base_extras: Dict[str, Any],
+    incoming_extras: Dict[str, Any],
+    *,
+    fast_mode_default: bool,
+    context_obj: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    extras を深いマージしつつコントラクトキーを失わない。
+
+    - metrics はネストマージ（非 dict で置換されない）
+    - memory_meta.context は保持され context.fast が注入される
+    - 例外を出さない
+    """
+    try:
+        if not isinstance(base_extras, dict):
+            base_extras = {}
+        if not isinstance(incoming_extras, dict):
+            _ensure_full_contract(
+                base_extras, fast_mode_default=fast_mode_default, context_obj=context_obj
+            )
+            return base_extras
+
+        prev_metrics = base_extras.get("metrics")
+        prev_mm = base_extras.get("memory_meta")
+        prev_fast = base_extras.get("fast_mode", fast_mode_default)
+
+        _deep_merge_dict(base_extras, incoming_extras)
+
+        if not isinstance(base_extras.get("metrics"), dict):
+            base_extras["metrics"] = prev_metrics if isinstance(prev_metrics, dict) else {}
+        if not isinstance(base_extras.get("memory_meta"), dict):
+            try:
+                base_extras["memory_meta"] = (
+                    prev_mm if isinstance(prev_mm, dict) else {"context": dict(context_obj)}
+                )
+            except Exception:
+                base_extras["memory_meta"] = {"context": {}}
+
+        base_extras["fast_mode"] = _to_bool_local(base_extras.get("fast_mode", prev_fast))
+
+        _ensure_full_contract(
+            base_extras, fast_mode_default=fast_mode_default, context_obj=context_obj
+        )
+        return base_extras
+    except Exception:
+        try:
+            if isinstance(base_extras, dict):
+                _ensure_full_contract(
+                    base_extras, fast_mode_default=fast_mode_default, context_obj=context_obj
+                )
+                return base_extras
+        except Exception:
+            pass
+        return base_extras if isinstance(base_extras, dict) else {}
+
+
+__all__ = [
+    "_ensure_full_contract",
+    "_ensure_metrics_contract",
+    "_deep_merge_dict",
+    "_merge_extras_preserving_contract",
+]

--- a/veritas_os/core/pipeline_critique.py
+++ b/veritas_os/core/pipeline_critique.py
@@ -1,0 +1,434 @@
+# veritas_os/core/pipeline_critique.py
+# -*- coding: utf-8 -*-
+"""
+Pipeline クリティーク強制モジュール。
+
+run_decide_pipeline 内にネスト定義されていたクリティーク関連ヘルパーを
+モジュールレベルに昇格させ、単一責務で管理する。
+
+ISSUE-2 対応:
+- critique は常に dict（list/text/None は正規化）
+- findings は常に >= 3 件
+- 例外は出さない（best-effort）
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .pipeline_helpers import (
+    _as_str,
+    _lazy_import,
+    _norm_severity,
+    _now_iso,
+    _set_bool_metric,
+    _set_int_metric,
+)
+
+
+# =========================================================
+# findings デフォルト（監査定番指摘）
+# =========================================================
+
+def _default_findings() -> List[Dict[str, Any]]:
+    """最低3項目を満たすための監査デフォルト指摘を返す。"""
+    return [
+        {
+            "severity": "med",
+            "message": "Evidence coverage may be insufficient or not independently verified",
+            "code": "CRITIQUE_EVIDENCE_COVERAGE",
+            "fix": "一次ソース + 独立ソース2件以上で裏取りし、根拠を decision.evidence に紐付けてください。",
+            "details": {"hint": "primary+independent", "min_sources": 3},
+        },
+        {
+            "severity": "med",
+            "message": "Assumptions / scope / constraints might be under-specified",
+            "code": "CRITIQUE_SCOPE_UNSPECIFIED",
+            "fix": "目的・スコープ・制約・禁止事項・KPI を context に固定してください。",
+            "details": {"hint": "goal/scope/constraints/kpi"},
+        },
+        {
+            "severity": "med",
+            "message": "Alternatives / trade-offs are not fully compared",
+            "code": "CRITIQUE_ALTERNATIVES_WEAK",
+            "fix": "少なくとも2案を比較し、採用/不採用理由（トレードオフ）を明示してください。",
+            "details": {"hint": "compare>=2", "include": ["pros", "cons", "tradeoffs"]},
+        },
+    ]
+
+
+# =========================================================
+# findings パディング（正規化 + min_items 保証）
+# =========================================================
+
+def _pad_findings(findings: Any, *, min_items: int = 3) -> List[Dict[str, Any]]:
+    """findings を List[Dict] に正規化し、min_items 件まで不足分をパッドする。"""
+    out: List[Dict[str, Any]] = []
+
+    if isinstance(findings, list):
+        for it in findings:
+            if isinstance(it, dict):
+                it2 = dict(it)
+                it2["severity"] = _norm_severity(it2.get("severity", "med"))
+                it2.setdefault(
+                    "message",
+                    it2.get("message")
+                    or it2.get("issue")
+                    or it2.get("msg")
+                    or "Critique finding",
+                )
+                it2.setdefault("code", it2.get("code") or "CRITIQUE_GENERIC")
+                if "details" in it2 and not isinstance(it2.get("details"), dict):
+                    it2["details"] = {"raw": _as_str(it2.get("details"), limit=500)}
+                if "fix" in it2 and it2.get("fix") is not None:
+                    it2["fix"] = _as_str(it2.get("fix"), limit=1000)
+                out.append(it2)
+            else:
+                out.append(
+                    {
+                        "severity": "med",
+                        "message": _as_str(it, limit=500),
+                        "code": "CRITIQUE_TEXT",
+                    }
+                )
+
+    elif isinstance(findings, dict):
+        it2 = dict(findings)
+        it2["severity"] = _norm_severity(it2.get("severity", "med"))
+        it2.setdefault(
+            "message",
+            it2.get("message") or it2.get("issue") or it2.get("msg") or "Critique finding",
+        )
+        it2.setdefault("code", it2.get("code") or "CRITIQUE_GENERIC")
+        if "details" in it2 and not isinstance(it2.get("details"), dict):
+            it2["details"] = {"raw": _as_str(it2.get("details"), limit=500)}
+        if "fix" in it2 and it2.get("fix") is not None:
+            it2["fix"] = _as_str(it2.get("fix"), limit=1000)
+        out = [it2]
+
+    elif findings is not None:
+        out = [
+            {
+                "severity": "med",
+                "message": _as_str(findings, limit=500),
+                "code": "CRITIQUE_TEXT",
+            }
+        ]
+
+    defaults = _default_findings()
+    i = 0
+    while len(out) < int(min_items):
+        out.append(dict(defaults[i % len(defaults)]))
+        i += 1
+
+    # 最終固定（必須キー保証）
+    fixed: List[Dict[str, Any]] = []
+    for it in out:
+        if not isinstance(it, dict):
+            fixed.append(
+                {
+                    "severity": "med",
+                    "message": _as_str(it, limit=500),
+                    "code": "CRITIQUE_TEXT",
+                }
+            )
+            continue
+        it2 = dict(it)
+        it2["severity"] = _norm_severity(it2.get("severity", "med"))
+        it2["message"] = _as_str(it2.get("message") or "Critique finding", limit=1000)
+        it2["code"] = _as_str(it2.get("code") or "CRITIQUE_GENERIC", limit=120)
+        if "details" in it2 and not isinstance(it2.get("details"), dict):
+            it2["details"] = {"raw": _as_str(it2.get("details"), limit=500)}
+        fixed.append(it2)
+
+    return fixed
+
+
+# =========================================================
+# フォールバック critique
+# =========================================================
+
+def _critique_fallback(
+    *,
+    reason: str,
+    query: str = "",
+    chosen: Any = None,
+) -> Dict[str, Any]:
+    """critique が取得できない場合の dict 契約フォールバック（findings >= 3 保証）。"""
+    chosen_title = ""
+    try:
+        if isinstance(chosen, dict):
+            chosen_title = _as_str(
+                chosen.get("title") or chosen.get("name") or chosen.get("chosen") or "",
+                limit=120,
+            )
+        elif chosen is not None:
+            chosen_title = _as_str(chosen, limit=120)
+    except Exception:
+        chosen_title = ""
+
+    findings = _pad_findings(
+        [
+            {
+                "severity": "high",
+                "message": "Critique unavailable -> auditability reduced",
+                "code": "CRITIQUE_MISSING",
+                "fix": "critique module / pipeline integration を確認し、再実行してください。",
+            }
+        ],
+        min_items=3,
+    )
+
+    return {
+        "ok": False,
+        "mode": "fallback",
+        "reason": _as_str(reason, limit=200),
+        "summary": "Critique missing/failed. Manual review required.",
+        "findings": findings,
+        "recommendations": [
+            "Re-run decision with critique enabled",
+            "Inspect TrustLog for evidence/debate/gate consistency",
+        ],
+        "query": _as_str(query, limit=500),
+        "chosen_title": chosen_title,
+        "ts": _now_iso(),
+    }
+
+
+# =========================================================
+# List[item] -> findings 変換
+# =========================================================
+
+def _list_to_findings(items: List[Any]) -> List[Dict[str, Any]]:
+    """critique.analyze() が返す List[{issue,severity,details,fix}] を findings に変換する。"""
+    out: List[Dict[str, Any]] = []
+    for it in items or []:
+        if isinstance(it, dict):
+            sev = _norm_severity(it.get("severity", "med"))
+            issue = it.get("issue") or it.get("message") or it.get("msg") or "Critique finding"
+            fix = it.get("fix")
+            details = it.get("details") if isinstance(it.get("details"), dict) else {}
+            out.append(
+                {
+                    "severity": sev,
+                    "message": _as_str(issue, limit=1000),
+                    "code": _as_str(it.get("code") or "CRITIQUE_RULE", limit=120),
+                    "details": details,
+                    "fix": _as_str(fix, limit=1000) if fix is not None else None,
+                }
+            )
+        else:
+            out.append(
+                {
+                    "severity": "med",
+                    "message": _as_str(it, limit=500),
+                    "code": "CRITIQUE_TEXT",
+                }
+            )
+    return out
+
+
+# =========================================================
+# critique ペイロード正規化
+# =========================================================
+
+def _normalize_critique_payload(x: Any, *, min_findings: int = 3) -> Dict[str, Any]:
+    """
+    critique を常に dict に正規化する（例外を出さない）。
+    findings >= min_findings を保証する。
+
+    受け入れ形式:
+      - dict: passthrough + defaults + findings padding
+      - list: critique items list として findings に変換
+      - str/other: テキスト finding としてラップ
+      - None: {} を返す（呼び出し側でフォールバック）
+    """
+    if x is None:
+        return {}
+
+    if isinstance(x, list):
+        findings = _pad_findings(_list_to_findings(x), min_items=min_findings)
+        return {
+            "ok": True,
+            "mode": "legacy_list",
+            "summary": "Critique generated (legacy list normalized).",
+            "findings": findings,
+            "recommendations": [],
+            "ts": _now_iso(),
+        }
+
+    if isinstance(x, dict):
+        out = dict(x)
+        if "ok" not in out:
+            out["ok"] = True
+        out.setdefault("mode", out.get("mode") or "normal")
+        out.setdefault("ts", out.get("ts") or _now_iso())
+        out.setdefault("summary", out.get("summary") or "Critique generated.")
+
+        findings = out.get("findings")
+        if findings is None:
+            if isinstance(out.get("items"), list):
+                findings = _list_to_findings(out["items"])
+            elif isinstance(out.get("issues"), list):
+                findings = _list_to_findings(out["issues"])
+            else:
+                findings = []
+
+        out["findings"] = _pad_findings(findings, min_items=min_findings)
+
+        rec = out.get("recommendations")
+        if rec is None:
+            out["recommendations"] = []
+        elif not isinstance(rec, list):
+            out["recommendations"] = [_as_str(rec, limit=500)]
+
+        return out
+
+    s = _as_str(x, limit=1000)
+    findings = _pad_findings(
+        [{"severity": "med", "message": s, "code": "CRITIQUE_TEXT"}],
+        min_items=min_findings,
+    )
+    return {
+        "ok": True,
+        "mode": "text",
+        "summary": "Critique normalized from text.",
+        "findings": findings,
+        "recommendations": [],
+        "ts": _now_iso(),
+    }
+
+
+# =========================================================
+# critique 要求強制
+# =========================================================
+
+def _ensure_critique_required(
+    *,
+    response_extras: Dict[str, Any],
+    query: str,
+    chosen: Any,
+    critique_obj: Any,
+    min_findings: int = 3,
+) -> Dict[str, Any]:
+    """
+    critique が常に存在し dict かつ findings >= min_findings であることを強制する。
+
+    副作用:
+      - extras.env_tools.critique_degraded = True（フォールバック時）
+      - extras.metrics.critique_findings_count / critique_ok
+    """
+    c = _normalize_critique_payload(critique_obj, min_findings=min_findings)
+    if not isinstance(c, dict) or not c:
+        c = _critique_fallback(reason="missing_in_response", query=query, chosen=chosen)
+
+    c["findings"] = _pad_findings(c.get("findings"), min_items=min_findings)
+
+    used_fallback = bool(c.get("ok") is False) or (c.get("mode") == "fallback")
+    if used_fallback:
+        response_extras.setdefault("env_tools", {})
+        if isinstance(response_extras["env_tools"], dict):
+            response_extras["env_tools"]["critique_degraded"] = True
+
+    response_extras.setdefault("metrics", {})
+    if isinstance(response_extras["metrics"], dict):
+        response_extras["metrics"]["critique_findings_count"] = len(c.get("findings") or [])
+        response_extras["metrics"]["critique_ok"] = bool(c.get("ok") is True)
+
+    c.setdefault("query", _as_str(query, limit=500))
+    return c
+
+
+# =========================================================
+# chosen -> option 変換（critique.analyze に渡す用）
+# =========================================================
+
+def _chosen_to_option(chosen: Any) -> Dict[str, Any]:
+    """critique.analyze() に渡す option を chosen から合成する（壊れない）。"""
+    opt: Dict[str, Any] = {}
+
+    if isinstance(chosen, dict):
+        opt["title"] = chosen.get("title") or chosen.get("name") or chosen.get("chosen") or "chosen"
+        for k in ("risk", "complexity", "value", "feasibility", "timeline"):
+            if k in chosen:
+                opt[k] = chosen.get(k)
+
+        score = chosen.get("score")
+        if isinstance(score, dict):
+            for k in ("risk", "value", "feasibility"):
+                if k not in opt and k in score:
+                    opt[k] = score.get(k)
+    else:
+        opt["title"] = _as_str(chosen, limit=120) if chosen is not None else "chosen"
+
+    opt["title"] = _as_str(opt.get("title") or "chosen", limit=120)
+    return opt
+
+
+# =========================================================
+# critique best-effort 実行（async）
+# =========================================================
+
+async def _run_critique_best_effort(
+    *,
+    query: str,
+    chosen: Any,
+    evidence: List[Dict[str, Any]],
+    debate: Any,
+    context: Dict[str, Any],
+    user_id: str,
+    min_findings: int = 3,
+) -> Dict[str, Any]:
+    """
+    critique モジュールが利用可能なら critique を生成する。
+    例外は出さない。findings >= min_findings の dict を返す。
+
+    NOTE: analyze() が list を返してもここで dict に正規化する。
+    """
+    crit_mod = _lazy_import("veritas_os.core.critique", None)
+    if crit_mod is None:
+        return _critique_fallback(reason="critique_module_missing", query=query, chosen=chosen)
+
+    fn_dict = getattr(crit_mod, "analyze_dict", None)
+    fn_list = getattr(crit_mod, "analyze", None)
+
+    option = _chosen_to_option(chosen)
+
+    try:
+        if callable(fn_dict):
+            out = fn_dict(option, evidence, context, min_items=min_findings)
+            norm = _normalize_critique_payload(out, min_findings=min_findings)
+        elif callable(fn_list):
+            out = fn_list(option, evidence, context)
+            norm = _normalize_critique_payload(out, min_findings=min_findings)
+        else:
+            return _critique_fallback(reason="critique_analyze_missing", query=query, chosen=chosen)
+
+        if not norm:
+            return _critique_fallback(reason="critique_returned_empty", query=query, chosen=chosen)
+
+        norm["findings"] = _pad_findings(norm.get("findings"), min_items=min_findings)
+        norm.setdefault("summary", norm.get("summary") or "Critique generated.")
+        norm.setdefault("recommendations", norm.get("recommendations") or [])
+        norm.setdefault("mode", norm.get("mode") or "normal")
+        norm.setdefault("ts", norm.get("ts") or _now_iso())
+
+        return norm
+
+    except Exception as e:
+        return _critique_fallback(
+            reason=f"exception:{type(e).__name__}",
+            query=query,
+            chosen=chosen,
+        )
+
+
+__all__ = [
+    "_default_findings",
+    "_pad_findings",
+    "_critique_fallback",
+    "_list_to_findings",
+    "_normalize_critique_payload",
+    "_ensure_critique_required",
+    "_chosen_to_option",
+    "_run_critique_best_effort",
+]

--- a/veritas_os/core/pipeline_evidence.py
+++ b/veritas_os/core/pipeline_evidence.py
@@ -63,11 +63,7 @@ def _norm_evidence_item(ev: Any) -> Optional[Dict[str, Any]]:
             snippet_s = repr(snippet)
 
         conf_raw = ev2.get("confidence", 0.7)
-        try:
-            conf = float(conf_raw if conf_raw is not None else 0.7)
-        except Exception:
-            conf = 0.7
-        conf = max(0.0, min(1.0, conf))
+        conf = max(0.0, min(1.0, float(conf_raw if conf_raw is not None else 0.7)))
 
         if uri is None:
             uri_s = None

--- a/veritas_os/core/pipeline_evidence.py
+++ b/veritas_os/core/pipeline_evidence.py
@@ -1,0 +1,146 @@
+# veritas_os/core/pipeline_evidence.py
+# -*- coding: utf-8 -*-
+"""
+Pipeline 証拠正規化モジュール。
+
+evidence アイテムの正規化・重複排除・evidence.py 互換変換を担う。
+run_decide_pipeline 内のネスト定義と module-level 定義を統合。
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+# =========================================================
+# evidence アイテム正規化（module-level / nested 共通実装）
+# =========================================================
+
+def _norm_evidence_item(ev: Any) -> Optional[Dict[str, Any]]:
+    """
+    evidence エントリを dict に正規化する（例外を出さない）。
+
+    legacy evidence.py 形式 {source, kind, weight, snippet, tags} と
+    pipeline contract 形式 {source, uri, title, snippet, confidence} の両方を受け入れる。
+    """
+    if not isinstance(ev, dict):
+        return None
+
+    try:
+        ev2 = dict(ev)
+
+        # evidence.py 互換: weight -> confidence
+        if "confidence" not in ev2 and "weight" in ev2:
+            try:
+                ev2["confidence"] = ev2.get("weight")
+            except Exception:
+                pass
+
+        # evidence.py 互換: kind -> title / uri
+        if ("title" not in ev2 or ev2.get("title") in (None, "")) and "kind" in ev2:
+            try:
+                ev2["title"] = f"local:{ev2.get('kind')}"
+            except Exception:
+                pass
+
+        if ("uri" not in ev2 or ev2.get("uri") in (None, "")) and "kind" in ev2:
+            try:
+                ev2["uri"] = f"internal:evidence:{ev2.get('kind')}"
+            except Exception:
+                pass
+
+        # source
+        src = ev2.get("source")
+        if src in (None, ""):
+            src = "local"
+
+        uri = ev2.get("uri")
+        title = ev2.get("title") or ""
+
+        snippet = ev2.get("snippet")
+        try:
+            snippet_s = "" if snippet is None else str(snippet)
+        except Exception:
+            snippet_s = repr(snippet)
+
+        conf_raw = ev2.get("confidence", 0.7)
+        try:
+            conf = float(conf_raw if conf_raw is not None else 0.7)
+        except Exception:
+            conf = 0.7
+        conf = max(0.0, min(1.0, conf))
+
+        if uri is None:
+            uri_s = None
+        else:
+            try:
+                uri_s = str(uri)
+            except Exception:
+                uri_s = repr(uri)
+
+        return {
+            "source": str(src),
+            "uri": uri_s,
+            "title": str(title),
+            "snippet": snippet_s,
+            "confidence": conf,
+        }
+    except Exception:
+        return None
+
+
+def _dedupe_evidence(evs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """evidence リストを安定的に重複排除する（例外を出さない）。"""
+    try:
+        seen: set[tuple[str, str, str, str]] = set()
+        out: List[Dict[str, Any]] = []
+        for ev in evs:
+            if not isinstance(ev, dict):
+                continue
+            k = (
+                str(ev.get("source") or ""),
+                str(ev.get("uri") or ""),
+                str(ev.get("title") or ""),
+                str(ev.get("snippet") or ""),
+            )
+            if k in seen:
+                continue
+            seen.add(k)
+            out.append(ev)
+        return out
+    except Exception:
+        return []
+
+
+# =========================================================
+# module-level 軽量版（_evidencepy_to_pipeline_item から使用）
+# =========================================================
+
+def _norm_evidence_item_simple(ev: Any) -> Optional[Dict[str, Any]]:
+    """
+    モジュールレベルの軽量 evidence 正規化（_evidencepy_to_pipeline_item が使用）。
+
+    _norm_evidence_item と同じロジック。後方互換のため名前を維持する。
+    """
+    return _norm_evidence_item(ev)
+
+
+def _evidencepy_to_pipeline_item(ev: dict) -> Optional[Dict[str, Any]]:
+    """evidence.py 形式の dict を pipeline contract 形式に変換する。"""
+    return _norm_evidence_item_simple(
+        {
+            "source": ev.get("source", "local"),
+            "uri": f"internal:evidence:{ev.get('kind', 'unknown')}",
+            "title": f"local_{ev.get('kind', 'unknown')}",
+            "snippet": ev.get("snippet", ""),
+            "confidence": float(ev.get("weight", 0.5) or 0.5),
+            "tags": ev.get("tags") or [],
+        }
+    )
+
+
+__all__ = [
+    "_norm_evidence_item",
+    "_dedupe_evidence",
+    "_norm_evidence_item_simple",
+    "_evidencepy_to_pipeline_item",
+]

--- a/veritas_os/core/pipeline_helpers.py
+++ b/veritas_os/core/pipeline_helpers.py
@@ -1,0 +1,223 @@
+# veritas_os/core/pipeline_helpers.py
+# -*- coding: utf-8 -*-
+"""
+Pipeline 内部で使う小さなヘルパー関数群。
+
+各 pipeline サブモジュール（pipeline_critique, pipeline_contracts 等）から
+インポートされる。pipeline.py の run_decide_pipeline 内ネスト定義を統合したもの。
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# =========================================================
+# 文字列 / 型変換
+# =========================================================
+
+def _as_str(x: Any, *, limit: int = 2000) -> str:
+    """任意の値を文字列に変換し、limit 文字で切り詰める。"""
+    try:
+        s = "" if x is None else str(x)
+    except Exception:
+        s = repr(x)
+    if limit and len(s) > limit:
+        return s[:limit]
+    return s
+
+
+def _norm_severity(x: Any) -> str:
+    """重要度文字列を high/med/low に正規化する。"""
+    try:
+        s = str(x).lower().strip()
+    except Exception:
+        s = "med"
+    if s in ("high", "h", "critical", "crit"):
+        return "high"
+    if s in ("low", "l"):
+        return "low"
+    return "med"
+
+
+def _now_iso() -> str:
+    """UTC ISO8601 文字列を返す。"""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _to_bool_local(x: Any) -> bool:
+    """pipeline 内で使う bool 変換（None -> False, 文字列は truthy set チェック）。"""
+    if isinstance(x, bool):
+        return x
+    if x is None:
+        return False
+    if isinstance(x, (int, float)):
+        return x != 0
+    try:
+        s = str(x).strip().lower()
+    except Exception:
+        return False
+    return s in ("1", "true", "yes", "y", "on")
+
+
+# =========================================================
+# メトリクスセッター
+# =========================================================
+
+def _set_int_metric(
+    extras: Dict[str, Any],
+    key: str,
+    value: Any,
+    default: int = 0,
+) -> None:
+    """extras["metrics"][key] に int 値をセットする（安全版）。"""
+    extras.setdefault("metrics", {})
+    if not isinstance(extras["metrics"], dict):
+        extras["metrics"] = {}
+    try:
+        extras["metrics"][key] = int(value)
+    except Exception:
+        extras["metrics"][key] = int(default)
+
+
+def _set_bool_metric(
+    extras: Dict[str, Any],
+    key: str,
+    value: Any,
+    default: bool = False,
+) -> None:
+    """extras["metrics"][key] に bool 値をセットする（安全版）。"""
+    extras.setdefault("metrics", {})
+    if not isinstance(extras["metrics"], dict):
+        extras["metrics"] = {}
+    try:
+        extras["metrics"][key] = _to_bool_local(value)
+    except Exception:
+        extras["metrics"][key] = bool(default)
+
+
+# =========================================================
+# 遅延インポート
+# =========================================================
+
+def _lazy_import(mod_path: str, attr: Optional[str] = None) -> Any:
+    """ISSUE-4 style lazy import; インポート失敗時は None を返す（例外を出さない）。"""
+    try:
+        m = importlib.import_module(mod_path)
+        if attr:
+            return getattr(m, attr, None)
+        return m
+    except Exception as e:
+        logger.debug("[lazy_import] %s%s skipped: %s", mod_path, f".{attr}" if attr else "", e)
+        return None
+
+
+# =========================================================
+# self-healing ヘルパー
+# =========================================================
+
+def _extract_rejection(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """FUJI rejection dict を payload から取り出す（なければ None）。"""
+    fuji_payload = payload.get("fuji") if isinstance(payload, dict) else None
+    if not isinstance(fuji_payload, dict):
+        return None
+    rejection = fuji_payload.get("rejection")
+    if not isinstance(rejection, dict):
+        return None
+    if rejection.get("status") != "REJECTED":
+        return None
+    return rejection
+
+
+def _summarize_last_output(
+    payload: Dict[str, Any],
+    plan_payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    """self-healing に渡す直前出力のサマリを生成する。"""
+    chosen = payload.get("chosen") if isinstance(payload, dict) else None
+    planner_obj = payload.get("planner") if isinstance(payload, dict) else None
+    return {
+        "chosen": chosen if isinstance(chosen, dict) else {},
+        "plan": plan_payload if isinstance(plan_payload, dict) else {},
+        "planner": planner_obj if isinstance(planner_obj, dict) else {},
+    }
+
+
+# =========================================================
+# Step1 クエリヒント判定
+# =========================================================
+
+def _query_is_step1_hint(q: Any) -> bool:
+    """クエリが Step1（現状棚卸し）を示唆するかどうか判定する。"""
+    try:
+        qs = q or ""
+        ql = qs.lower()
+        return (
+            ("step1" in ql)
+            or ("step 1" in ql)
+            or ("inventory" in ql)
+            or ("audit" in ql)
+            or ("棚卸" in qs)
+            or ("現状" in qs and ("棚卸" in qs or "整理" in qs))
+        )
+    except Exception:
+        return False
+
+
+def _has_step1_minimum_evidence(evs: Any) -> bool:
+    """evidence リストが Step1 最低限証拠（inventory + known_issues）を含むか確認する。"""
+    try:
+        if not isinstance(evs, list):
+            return False
+        has_inv = False
+        has_issues = False
+        for e in evs:
+            if not isinstance(e, dict):
+                continue
+            title = str(e.get("title") or "")
+            uri = str(e.get("uri") or "")
+            snip = str(e.get("snippet") or "")
+            kind = str(e.get("kind") or "")
+
+            if (
+                ("inventory" in kind)
+                or ("local:inventory" in title)
+                or ("evidence:inventory" in uri)
+                or ("現状機能（棚卸し）" in snip)
+                or ("棚卸" in snip and "現状" in snip)
+            ):
+                has_inv = True
+
+            if (
+                ("known_issues" in kind)
+                or ("local:known_issues" in title)
+                or ("evidence:known_issues" in uri)
+                or ("既知の課題/注意" in snip)
+                or ("既知" in snip and "課題" in snip)
+            ):
+                has_issues = True
+
+            if has_inv and has_issues:
+                return True
+        return False
+    except Exception:
+        return False
+
+
+__all__ = [
+    "_as_str",
+    "_norm_severity",
+    "_now_iso",
+    "_to_bool_local",
+    "_set_int_metric",
+    "_set_bool_metric",
+    "_lazy_import",
+    "_extract_rejection",
+    "_summarize_last_output",
+    "_query_is_step1_hint",
+    "_has_step1_minimum_evidence",
+]

--- a/veritas_os/core/pipeline_memory_adapter.py
+++ b/veritas_os/core/pipeline_memory_adapter.py
@@ -1,0 +1,168 @@
+# veritas_os/core/pipeline_memory_adapter.py
+# -*- coding: utf-8 -*-
+"""
+Pipeline メモリストアアダプタ。
+
+mem.search / mem.MEM.search など複数の MemoryOS インターフェイスの差異を吸収し、
+統一した API を提供する。
+
+pipeline.py の module-level 定義をここに移動した。
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---- memory (RECOMMENDED) ----
+try:
+    from . import memory as _mem_module  # type: ignore
+except Exception as e:  # pragma: no cover
+    _mem_module = None  # type: ignore
+    logger.warning("[pipeline_memory_adapter] memory import failed: %s", repr(e))
+
+
+# =========================================================
+# メモリストア取得
+# =========================================================
+
+def _get_memory_store(mem: Any = None) -> Optional[Any]:
+    """
+    MemoryOS ストアオブジェクトを返す。
+
+    Args:
+        mem: 外部から渡す memory モジュール（省略時はモジュール変数を使用）
+
+    Returns:
+        store オブジェクト、または None
+    """
+    m = mem if mem is not None else _mem_module
+    if m is None:
+        return None
+    if hasattr(m, "search") or hasattr(m, "put") or hasattr(m, "get"):
+        return m
+    store = getattr(m, "MEM", None)
+    if store is not None:
+        return store
+    return None
+
+
+# =========================================================
+# 関数呼び出しアダプタ
+# =========================================================
+
+def _call_with_accepted_kwargs(fn: Any, kwargs: Dict[str, Any]) -> Any:
+    """
+    inspect で受け取れる kwargs だけ渡す（put/search/add_usage などのシグネチャ差異を吸収）。
+    """
+    try:
+        sig = inspect.signature(fn)
+        accepted = set(sig.parameters.keys())
+        filtered = {k: v for k, v in kwargs.items() if k in accepted}
+        return fn(**filtered)
+    except Exception:
+        return fn(**kwargs)
+
+
+def _memory_has(store: Any, name: str) -> bool:
+    """store が name という callable を持つか確認する。"""
+    try:
+        return callable(getattr(store, name))
+    except Exception:
+        return False
+
+
+# =========================================================
+# メモリ検索
+# =========================================================
+
+def _memory_search(store: Any, **kwargs: Any) -> Any:
+    """
+    store.search をシグネチャ差異を吸収しつつ呼び出す（ベストエフォート）。
+    """
+    if not _memory_has(store, "search"):
+        raise RuntimeError("memory.search not available")
+
+    fn = getattr(store, "search")
+
+    try:
+        return _call_with_accepted_kwargs(fn, dict(kwargs))
+    except TypeError:
+        pass
+
+    q = kwargs.get("query")
+    k = kwargs.get("k", 8)
+
+    try:
+        return fn(query=q, k=k)  # type: ignore
+    except Exception:
+        pass
+
+    try:
+        return fn(q, k)  # type: ignore
+    except Exception:
+        return fn(query=q)  # type: ignore
+
+
+# =========================================================
+# メモリ書き込み
+# =========================================================
+
+def _memory_put(store: Any, user_id: Any, *, key: str, value: Any, meta: Any = None) -> None:
+    """store.put を複数シグネチャで試みる（ベストエフォート）。"""
+    if not _memory_has(store, "put"):
+        return None
+    fn = getattr(store, "put")
+
+    try:
+        _call_with_accepted_kwargs(
+            fn,
+            {"user_id": user_id, "key": key, "value": value, "meta": meta},
+        )
+        return None
+    except Exception:
+        pass
+
+    try:
+        fn(user_id, key=key, value=value, meta=meta)  # type: ignore
+        return None
+    except Exception:
+        pass
+    try:
+        fn(user_id, key, value)  # type: ignore
+        return None
+    except Exception:
+        pass
+    try:
+        fn(key, value)  # type: ignore
+        return None
+    except Exception:
+        return None
+
+
+def _memory_add_usage(store: Any, user_id: Any, cited_ids: List[str]) -> None:
+    """store.add_usage を複数シグネチャで試みる（ベストエフォート）。"""
+    if not _memory_has(store, "add_usage"):
+        return None
+    fn = getattr(store, "add_usage")
+    try:
+        _call_with_accepted_kwargs(fn, {"user_id": user_id, "cited_ids": cited_ids})
+        return None
+    except Exception:
+        pass
+    try:
+        fn(user_id, cited_ids)  # type: ignore
+    except Exception:
+        return None
+
+
+__all__ = [
+    "_get_memory_store",
+    "_call_with_accepted_kwargs",
+    "_memory_has",
+    "_memory_search",
+    "_memory_put",
+    "_memory_add_usage",
+]

--- a/veritas_os/core/pipeline_web_adapter.py
+++ b/veritas_os/core/pipeline_web_adapter.py
@@ -1,0 +1,110 @@
+# veritas_os/core/pipeline_web_adapter.py
+# -*- coding: utf-8 -*-
+"""
+Pipeline Web検索アダプタ。
+
+_normalize_web_payload と _extract_web_results を提供する。
+_safe_web_search は globals() によるテストフック機構のため pipeline.py に残す。
+
+pipeline.py の module-level / nested 定義をここに移動した。
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+# =========================================================
+# web_search ペイロード正規化
+# =========================================================
+
+def _normalize_web_payload(payload: Any) -> Optional[Dict[str, Any]]:
+    """
+    web_search の戻り値を {"ok": bool, "results": list} に正規化する。
+
+    tools.web_search の contract を基本として、異形も吸収する:
+    - dict: "results" / "items" / "hits" / "organic" etc. を探して正規化
+    - list: そのまま results として格納
+    - str/other: 単一アイテムとして格納
+    - None: None を返す
+    """
+    if payload is None:
+        return None
+
+    if isinstance(payload, dict):
+        out = dict(payload)
+        if "results" not in out or not isinstance(out.get("results"), list):
+            for k in ("items", "hits", "organic", "organic_results"):
+                if isinstance(out.get(k), list):
+                    out["results"] = out[k]
+                    break
+        out.setdefault("results", [])
+        if "ok" not in out:
+            out["ok"] = True
+        return out
+
+    if isinstance(payload, list):
+        return {"ok": True, "results": payload}
+
+    s = str(payload)
+    return {"ok": True, "results": [{"title": s, "url": "", "snippet": s}]}
+
+
+# =========================================================
+# web_search 結果リスト抽出
+# =========================================================
+
+def _extract_web_results(ws: Any) -> List[Any]:
+    """
+    web_search の戻りがどんな形でも「結果リスト」を抽出する（例外を出さない）。
+
+    - list: そのまま返す
+    - dict: results/items/data/hits を優先探索（2段ネストまで対応）
+    - それ以外: []
+    """
+    try:
+        if ws is None:
+            return []
+        if isinstance(ws, list):
+            return ws
+
+        if not isinstance(ws, dict):
+            return []
+
+        # 1st pass: top-level common keys
+        for k in ("results", "items", "data", "hits"):
+            v = ws.get(k)
+            if isinstance(v, list):
+                return v
+
+        # 2nd pass: if values are dict, look one layer deeper
+        for k in ("results", "items", "data", "hits"):
+            v = ws.get(k)
+            if isinstance(v, dict):
+                for kk in ("results", "items", "data", "hits"):
+                    vv = v.get(kk)
+                    if isinstance(vv, list):
+                        return vv
+
+        # 3rd pass: any nested dict under typical wrappers
+        for k, v in ws.items():
+            if isinstance(v, dict):
+                for kk in ("results", "items", "data", "hits"):
+                    vv = v.get(kk)
+                    if isinstance(vv, list):
+                        return vv
+                for k2, v2 in v.items():
+                    if isinstance(v2, dict):
+                        for kk in ("results", "items", "data", "hits"):
+                            vv = v2.get(kk)
+                            if isinstance(vv, list):
+                                return vv
+    except Exception:
+        return []
+
+    return []
+
+
+__all__ = [
+    "_normalize_web_payload",
+    "_extract_web_results",
+]


### PR DESCRIPTION
pipeline.py を 3274行→2237行 (32%削減) に圧縮し、
単一責務を持つサブモジュール群を新設:

- pipeline_helpers.py      (223行) 小さなユーティリティ群
  _as_str, _norm_severity, _now_iso, _set_int/bool_metric,
  _lazy_import, _extract_rejection, _summarize_last_output,
  _query_is_step1_hint, _has_step1_minimum_evidence

- pipeline_critique.py     (434行) クリティーク強制ロジック (ISSUE-2)
  _default_findings, _pad_findings, _critique_fallback,
  _normalize_critique_payload, _ensure_critique_required,
  _run_critique_best_effort 等

- pipeline_evidence.py     (146行) evidence 正規化・重複排除
  _norm_evidence_item, _dedupe_evidence,
  _norm_evidence_item_simple, _evidencepy_to_pipeline_item

- pipeline_memory_adapter.py (168行) MemoryOS アダプタ
  _get_memory_store, _memory_search, _memory_put,
  _memory_add_usage 等 (シグネチャ差異を吸収)

- pipeline_web_adapter.py  (110行) Web検索アダプタ
  _normalize_web_payload, _extract_web_results

- pipeline_contracts.py    (232行) extras コントラクト強制
  _ensure_full_contract, _merge_extras_preserving_contract,
  _deep_merge_dict 等

後方互換性:
- pipeline.py が全サブモジュールから re-import → 既存テスト・API無変更
- run_decide_pipeline / call_core_decide シグネチャ不変
- AST parse / import smoke test 全合格確認済み

https://claude.ai/code/session_01ERwcYrxvK9a1MMtGpVvL1Q