### PR TITLE
Introduce two-tier licensing framework (Proprietary Core + MIT interface)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to VERITAS
+
+Thank you for your interest in contributing.
+
+## Repository license model
+
+This repository uses a two-tier licensing strategy:
+
+- Tier1 (Core): proprietary (top-level `LICENSE`)
+- Tier2 (Interface assets): open-licensed in selected directories
+
+Please review `README.md` license matrix before contributing.
+
+## Contribution policy by scope
+
+### 1) Core (proprietary)
+
+Directories and files covered only by the top-level proprietary license are not
+open for general external contributions.
+
+- Default policy: maintainers-only changes.
+- Exceptional external contributions may be accepted only after explicit
+  maintainer invitation and signed CLA.
+
+### 2) Interface assets (open-licensed)
+
+Contributions are welcome for interface-oriented directories (for example:
+`spec/`, `sdk/`, `cli/`, `policies/examples/`) under the applicable
+subdirectory license.
+
+Contributors must use either:
+- DCO sign-off (required for normal external PRs), and
+- CLA when requested by maintainers for substantial legal/IP reasons.
+
+## DCO (Developer Certificate of Origin)
+
+By contributing, you certify that you have the right to submit your work under
+the repository's applicable license terms.
+
+Add this line to each commit message:
+
+`Signed-off-by: Your Name <you@example.com>`
+
+Use Git's `-s` flag:
+
+```bash
+git commit -s -m "Your commit message"
+```
+
+## CLA policy
+
+Maintainers may request a Contributor License Agreement (CLA), especially for:
+- Core-adjacent work
+- major feature contributions
+- legal/commercially sensitive changes
+
+If a CLA is required, maintainers will provide instructions in the PR.
+
+## Security reporting
+
+Please do not open public issues for sensitive vulnerabilities.
+Follow `SECURITY.md` for responsible disclosure.

--- a/LICENSE
+++ b/LICENSE
@@ -1,132 +1,105 @@
-PROPRIETARY LICENSE NOTICE FOR VERITAS OS REPOSITORY
-====================================================
+VERITAS Core Proprietary License (EULA)
+Version 1.0 - Effective 2026-02-22
 
-Copyright (c) 2025 Takeshi Fujishita. All Rights Reserved.
+Copyright (c) 2025 Takeshi Fujishita and VERITAS contributors.
+All rights reserved.
 
-This repository contains multiple software components, documentation, and
-related assets. Unless otherwise explicitly stated in a subdirectory-specific
-LICENSE file, all contents of this repository are provided on an
-“ALL RIGHTS RESERVED” basis.
+IMPORTANT: This repository is a multi-license repository. The default license
+for all files is this proprietary EULA unless another directory-specific
+LICENSE file explicitly applies.
 
-By accessing, cloning, or downloading this repository, you acknowledge and
-agree to the following terms.
+1. Definitions
 
+"Core" means proprietary VERITAS software and assets, including but not limited
+to decision logic, Planner, Kernel, FUJI Gate, TrustLog, core pipelines,
+internal policy engines, and any source files not covered by an explicit open
+license in this repository.
 
-1. SCOPE
---------
+"Evaluation Use" means non-production internal testing for technical
+assessment, security review, or compatibility review.
 
-1.1. Core Code
+"Commercial Use" means any direct or indirect revenue-generating or
+production/business use, including SaaS, internal production systems, or
+customer-facing operations.
 
-Unless a different license is clearly indicated in a specific directory
-or file, all source code under (including but not limited to):
+"Managed Service" means hosting, operating, or providing all or a substantial
+portion of Core functionality as a service for third parties.
 
-    - veritas_os/
-    - scripts/
-    - tools/          (unless otherwise noted)
-    - config/         (unless otherwise noted)
-    - tests/          (unless otherwise noted)
+2. License Grant
 
-is proprietary software and is NOT licensed for public use, copying,
-modification, distribution, or sublicensing without the prior written
-permission of the copyright holder.
+Subject to your compliance with this EULA, Licensor grants you a limited,
+non-exclusive, non-transferable, revocable license to:
+(a) access and use Core for Evaluation Use; and
+(b) make reasonable internal copies strictly for Evaluation Use.
 
-Such code is provided for review, evaluation, and archival purposes only,
-unless a separate written agreement grants you additional rights.
+No right is granted for Commercial Use except under a separate written
+commercial agreement with Licensor.
 
+3. Restrictions
 
-1.2. Open-Source / Publicly Licensed Components
+You must not, and must not permit others to:
 
-Certain parts of this repository (for example, documentation,
-research papers, or example scripts) MAY be released under open-source
-licenses such as the Apache License, Version 2.0.
+(a) use Core for Commercial Use without a separate written agreement;
+(b) offer Core, or substantially similar functionality, as a Managed Service;
+(c) circumvent, disable, or bypass license keys, metering, access controls,
+    usage limitations, or other technical protection mechanisms;
+(d) remove, alter, or obscure copyright, attribution, trademark, patent,
+    or proprietary notices;
+(e) redistribute, sublicense, sell, lease, or transfer Core;
+(f) reverse engineer, decompile, or disassemble Core except where mandatory
+    law expressly prohibits such restriction;
+(g) create or distribute derivative works of Core except as expressly
+    authorized in writing by Licensor;
+(h) use Core to build, train, validate, or benchmark a competing product or
+    service that reproduces Core decision logic.
 
-These components are explicitly marked by a LICENSE file placed inside
-the corresponding subdirectory, for example:
+4. Ownership
 
-    - docs/LICENSE
-    - examples/LICENSE
-    - other-subdir/LICENSE
+Core is licensed, not sold. Licensor and its licensors retain all right,
+title, and interest in and to Core, including all intellectual property rights.
 
-If a subdirectory contains its own LICENSE file, the terms in that file
-govern ONLY the contents of that subdirectory, and do NOT automatically
-apply to the entire repository.
+5. Open Components in this Repository
 
+Certain directories are provided under separate open licenses (for example MIT)
+that apply only to those directories. Those licenses do not apply to Core.
+See README.md and directory LICENSE files for scope.
 
-2. RIGHTS RESERVED
-------------------
+6. Compliance and Audit Cooperation
 
-2.1. Default Rule
+Upon reasonable written request, you will provide information sufficient to
+confirm compliance with this EULA for material uses of Core.
 
-Except where a different license is explicitly provided in a
-subdirectory-specific LICENSE file, the following applies:
+7. Term and Termination
 
-    - You may NOT copy, modify, merge, publish, distribute, sublicense,
-      or sell copies of the proprietary parts of this software.
-    - You may NOT use the proprietary code to create derivative works
-      without explicit written permission.
-    - You may NOT remove or alter any copyright, trademark, or other
-      proprietary notices.
+This EULA continues until terminated. It terminates automatically if you
+breach any term. Upon termination, you must stop all use and destroy copies of
+Core in your control, except where retention is required by law.
 
-Any use beyond what is permitted by applicable law (such as fair use or
-mandatory statutory rights) requires prior written consent from the
-copyright holder.
+8. Disclaimer of Warranties
 
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, CORE IS PROVIDED "AS IS" AND "AS
+AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
 
-2.2. No Implied License
+9. Limitation of Liability
 
-The presence of publicly viewable source code in this repository does NOT
-imply any grant of license or rights. No license is granted by estoppel,
-implication, or otherwise, except as expressly set forth in:
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, LICENSOR WILL NOT BE LIABLE FOR ANY
+INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES,
+OR ANY LOSS OF PROFITS, REVENUE, DATA, GOODWILL, OR BUSINESS INTERRUPTION,
+ARISING FROM OR RELATED TO CORE OR THIS EULA. LICENSOR'S AGGREGATE LIABILITY
+WILL NOT EXCEED USD 100.
 
-    - this top-level LICENSE, and
-    - any subdirectory-specific LICENSE files.
+10. Governing Law
 
+This EULA is governed by applicable law designated by Licensor's principal
+place of business, excluding conflict of law principles.
 
-3. OPEN-SOURCE LICENSE REFERENCES
----------------------------------
+11. Commercial Licensing Contact
 
-Where Apache License Version 2.0 or another open-source license is used,
-the full license text is provided in the relevant subdirectory LICENSE file
-(e.g., `docs/LICENSE`, `veritas_os/templates/LICENSE`, `examples/LICENSE`).
+For commercial licensing, OEM, or partnership inquiries:
+licensing@veritasfuji.example (placeholder)
 
-For the avoidance of doubt:
+12. Entire Agreement
 
-    - The existence of an Apache-2.0 LICENSE in `docs/` means that the
-      documentation in `docs/` is licensed under Apache-2.0.
-    - The existence of an Apache-2.0 LICENSE in `veritas_os/templates/`
-      means that template assets in `veritas_os/templates/` are licensed
-      under Apache-2.0.
-    - It does NOT mean that `veritas_os/` or other core code is licensed
-      under Apache-2.0, unless explicitly and clearly stated.
-
-
-4. NO WARRANTY
---------------
-
-UNLESS OTHERWISE REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING,
-THE SOFTWARE AND OTHER CONTENTS OF THIS REPOSITORY ARE PROVIDED "AS IS",
-WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-PURPOSE, AND NON-INFRINGEMENT.
-
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE OR RELATED
-CONTENTS.
-
-
-5. CONTACT
-----------
-
-For licensing inquiries, commercial use, or any request to obtain a
-separate license to the proprietary components of this repository,
-please contact:
-
-    Takeshi Fujishita
-    (Contact information to be provided separately.)
-
-------------------------------------------------------------
-If you are unsure whether a specific file or directory is open-source
-or proprietary, please assume it is proprietary and contact the author.
-------------------------------------------------------------
+This EULA and any executed commercial agreement constitute the entire agreement
+for Core licensing in this repository.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+VERITAS Notice File
+
+Copyright (c) 2025 Takeshi Fujishita and VERITAS contributors.
+
+This repository contains proprietary Core components and selected open-licensed
+interface components. License scope is defined by the top-level LICENSE and
+subdirectory LICENSE files.
+
+Primary project repository:
+https://github.com/veritasfuji-japan/veritas_os
+
+Attribution guidance:
+- Keep this NOTICE file in redistributions where required by applicable
+  license terms.
+- Keep copyright and attribution notices intact.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17838349.svg)](https://doi.org/10.5281/zenodo.17838349)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
-[![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-red.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Multi--license%20(Core%20Proprietary%20%2B%20MIT)-purple.svg)](LICENSE)
 [![CI](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml)
 [![Docker Publish](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/publish-ghcr.yml)
 [![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen.svg)](docs/COVERAGE_REPORT.md) <!-- Snapshot value from docs/COVERAGE_REPORT.md; CI gate is configured in .github/workflows/main.yml -->
@@ -321,10 +321,50 @@ make test PYTHON_VERSION=3.11
 
 ## License
 
-**All Rights Reserved (Proprietary).**
-This repository is **not** open-source. Usage, modification, and distribution
-are restricted unless explicitly permitted in a subdirectory-specific LICENSE
-file. See [`LICENSE`](LICENSE) for full terms.
+This repository is a **multi-license repository** with clear directory scope.
+
+> 日本語補助: このリポジトリは「Coreはプロプライエタリ」「Interfaceはオープン」の二層ライセンスです。
+
+### License matrix (scope by directory)
+
+| Scope | License | Commercial use | Redistribution | Notes |
+|---|---|---|---|---|
+| Default (entire repo unless overridden) | VERITAS Core Proprietary EULA (`/LICENSE`) | Contract required | Not permitted without written permission | Includes Core decision logic and pipeline |
+| `spec/` | MIT (`/spec/LICENSE`) | Permitted | Permitted | Open interface artifacts |
+| `sdk/` | MIT (`/sdk/LICENSE`) | Permitted | Permitted | SDK interface layer |
+| `cli/` | MIT (`/cli/LICENSE`) | Permitted | Permitted | CLI interface layer |
+| `policies/examples/` | MIT (`/policies/examples/LICENSE`) | Permitted | Permitted | Policy templates/examples |
+
+### Core abuse-prevention restrictions (high level)
+
+Under the Core Proprietary EULA, you may not:
+
+- provide Core (or substantially similar functionality) as a competing managed service;
+- bypass license keys, metering, or other technical protection controls;
+- remove copyright, attribution, proprietary notice, or trademark markings;
+- redistribute Core or use Core for commercial production use without a commercial agreement.
+
+See [`LICENSE`](LICENSE), [`TRADEMARKS`](TRADEMARKS), and [`NOTICE`](NOTICE).
+
+### Transition note for existing users
+
+This PR formalizes existing intent into a clearer two-tier structure:
+
+- Core remains proprietary by default.
+- Interface assets are explicitly open-licensed by directory.
+- No Core logic (Planner/Kernel/FUJI/TrustLog pipeline internals) is open-sourced by this change.
+
+### Roadmap: phased move from mono-repo licensing (Plan B) to multi-repo split (Plan A)
+
+Phase 1 (this PR):
+- Directory-scoped licensing in this mono-repo (Core proprietary + interface MIT)
+
+Phase 2 (next PRs):
+- `veritas-spec` (OpenAPI/schema)
+- `veritas-sdk-python`, `veritas-sdk-js`
+- `veritas-cli`
+- `veritas-policy-templates`
+- Keep `veritas_os` focused on proprietary Core only
 
 For academic use, please cite the Zenodo DOI.
 

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,21 @@
+THIRD-PARTY NOTICES (Initial Template)
+
+This file is an initial notice template for third-party software
+licenses used by VERITAS components.
+
+Important:
+- Dependency-specific notices may be generated and expanded in future releases.
+- Package manager lockfiles and dependency metadata should be consulted for
+  authoritative dependency listings.
+
+Potential sources of third-party license obligations in this repository include:
+- Python dependencies listed in requirements and lock/manifests
+- JavaScript/TypeScript dependencies in package.json and pnpm lockfiles
+- Container base images and OS packages referenced by Dockerfile
+
+Maintainers should update this file before each release with:
+- dependency name
+- version
+- license
+- copyright notice
+- source URL (if required)

--- a/TRADEMARKS
+++ b/TRADEMARKS
@@ -1,0 +1,16 @@
+VERITAS Trademarks and Brand Usage
+
+"VERITAS", "FUJI", and related logos, marks, and branding elements are
+trademarks or unregistered marks of Takeshi Fujishita and/or affiliated
+rightsholders.
+
+No trademark rights are granted under any software license in this
+repository, including MIT-licensed subdirectories.
+
+You may not use project trademarks in a way that:
+1) implies endorsement, affiliation, sponsorship, or certification;
+2) causes confusion about source, ownership, or official status; or
+3) dilutes, tarnishes, or misrepresents the VERITAS/FUJI brands.
+
+For trademark permissions, contact:
+trademarks@veritasfuji.example (placeholder)

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,23 @@
+SPDX-License-Identifier: MIT
+
+MIT License
+
+Copyright (c) 2025 VERITAS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/BUSL-1.1-template.txt
+++ b/licenses/BUSL-1.1-template.txt
@@ -1,0 +1,17 @@
+# Business Source License 1.1 (BUSL-1.1) - VERITAS Template (Not Active)
+# SPDX reference: BUSL-1.1
+#
+# IMPORTANT:
+# - This file is a planning template only.
+# - BUSL-1.1 is NOT currently adopted for VERITAS Core by this file alone.
+# - Formal adoption requires legal review and explicit maintainer decision.
+
+Parameters to fill if adopted:
+- Licensor: <LEGAL ENTITY OR INDIVIDUAL>
+- Licensed Work: <DESCRIPTION>
+- Additional Use Grant: <OPTIONAL>
+- Change Date: <YYYY-MM-DD>
+- Change License: <e.g., Apache-2.0>
+
+Reference text:
+https://spdx.org/licenses/BUSL-1.1.html

--- a/policies/examples/LICENSE
+++ b/policies/examples/LICENSE
@@ -1,0 +1,23 @@
+SPDX-License-Identifier: MIT
+
+MIT License
+
+Copyright (c) 2025 VERITAS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/LICENSE
+++ b/sdk/LICENSE
@@ -1,0 +1,23 @@
+SPDX-License-Identifier: MIT
+
+MIT License
+
+Copyright (c) 2025 VERITAS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/spec/LICENSE
+++ b/spec/LICENSE
@@ -1,0 +1,23 @@
+SPDX-License-Identifier: MIT
+
+MIT License
+
+Copyright (c) 2025 VERITAS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
### Motivation

- Establish a clear two-tier license model so Core decision logic and pipelines remain proprietary while interface artifacts can be reused under a permissive license.  
- Provide an immediate, practical Plan B (mono-repo directory-scoped licensing) to reduce user confusion before a phased Plan A multi-repo split.  
- Prevent accidental leakage or reuse of Core internals by explicitly documenting restrictions (managed-service/anti-circumvention/redistribution/reverse-engineering) in a top-level EULA.  
- Preserve international readability with English legal text and add Japanese helper notes in the README for local stakeholders.

### Description

- Replace the repository root `LICENSE` with `VERITAS Core Proprietary License (EULA)` that includes evaluation grant, commercial-use-by-contract requirement, managed-service prohibition, anti-circumvention, attribution/trademark preservation, reverse-engineering limits, disclaimer/limitation of liability, termination, and commercial contact.  
- Create interface directories and add permissive licenses: `spec/LICENSE` (MIT), `sdk/LICENSE` (MIT), `cli/LICENSE` (MIT), and `policies/examples/LICENSE` (MIT).  
- Add repository legal companion files: `NOTICE`, `TRADEMARKS`, and `THIRD_PARTY_NOTICES` (initial template), plus `CONTRIBUTING.md` that documents contribution rules (Core: maintainers/CLA only; Interface: DCO/CLA as requested).  
- Update `README.md` with a one-page license matrix, Core abuse-prevention summary, transition explanation and a roadmap describing the Phase 1 mono-repo approach and Phase 2 multi-repo split (A→veritas-spec, SDKs, CLI, templates); add `licenses/BUSL-1.1-template.txt` as a non-active planning template.

### Testing

- Verified created and updated files exist and contain the expected headers and sections by inspecting files (`nl`/`sed` checks) and reviewing the diff, and the checks completed successfully.  
- Performed a repository diff to confirm only the intended files changed using `git diff -- LICENSE README.md CONTRIBUTING.md NOTICE TRADEMARKS THIRD_PARTY_NOTICES spec/LICENSE sdk/LICENSE cli/LICENSE policies/examples/LICENSE licenses/BUSL-1.1-template.txt`, which produced the expected changes.  
- Committed the changes and verified the repository state with `git status` and `git log -1`, and the commit completed successfully.  
- Note: This PR does not change runtime code paths or unit tests; CI (pytest + coverage) will run as normal on merge and must pass the project gates (coverage >= configured threshold).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ace06de1c83268436773dd7df11aa)