### PR TITLE
docs: replace placeholder license contact, update THIRD_PARTY_NOTICES, remove draft review

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -97,7 +97,7 @@ place of business, excluding conflict of law principles.
 11. Commercial Licensing Contact
 
 For commercial licensing, OEM, or partnership inquiries:
-licensing@veritasfuji.example (placeholder)
+veritas.fuji@gmail.com
 
 12. Entire Agreement
 

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,21 +1,75 @@
-THIRD-PARTY NOTICES (Initial Template)
+THIRD-PARTY NOTICES
 
-This file is an initial notice template for third-party software
-licenses used by VERITAS components.
+Last updated: 2026-02-22
 
-Important:
-- Dependency-specific notices may be generated and expanded in future releases.
-- Package manager lockfiles and dependency metadata should be consulted for
-  authoritative dependency listings.
+This file documents third-party license obligations for distributed VERITAS
+artifacts. It is based on dependency manifests currently committed in this
+repository. Downstream redistributors remain responsible for validating the
+final dependency set in built artifacts.
 
-Potential sources of third-party license obligations in this repository include:
-- Python dependencies listed in requirements and lock/manifests
-- JavaScript/TypeScript dependencies in package.json and pnpm lockfiles
-- Container base images and OS packages referenced by Dockerfile
+Security / compliance warning:
+- If this notice file is stale relative to lockfiles or build outputs,
+  redistribution may violate attribution or notice requirements.
+- Treat updates to dependency manifests as a trigger to review this file.
 
-Maintainers should update this file before each release with:
-- dependency name
-- version
-- license
-- copyright notice
-- source URL (if required)
+1) Python dependencies (runtime + tooling)
+Source manifest: `veritas_os/requirements.txt`
+
+Representative dependencies declared in the manifest include:
+- fastapi
+- uvicorn
+- pydantic
+- requests
+- numpy
+- scipy
+- faiss-cpu
+- sentence-transformers
+- opencv-python
+- pytest
+- pytest-cov
+
+Note:
+- Exact transitive dependency versions and licenses depend on resolver output.
+- Before release, generate a full dependency report from the locked environment
+  and append package name, version, license, copyright, and source URL.
+
+2) JavaScript / TypeScript dependencies
+Source manifests:
+- `package.json` (workspace root)
+- `frontend/package.json`
+- `packages/design-system/package.json`
+- `packages/types/package.json`
+
+Representative dependencies declared in manifests include:
+- next
+- react
+- react-dom
+- tailwindcss
+- class-variance-authority
+- clsx
+- tailwind-merge
+- @playwright/test
+- vitest
+- @testing-library/react
+- typescript
+
+Note:
+- Exact resolved versions and transitive dependency licenses are determined by
+  `pnpm-lock.yaml` at build time.
+- Before release, produce a lockfile-based notice report and include license
+  texts where required.
+
+3) Container and OS package obligations
+Potential additional obligations may arise from:
+- `Dockerfile` base image license terms
+- Installed OS packages in container layers
+
+Before release:
+- Record base image digest and license terms.
+- Export package list from image layers and merge applicable notices.
+
+4) Maintainer checklist (release gate)
+- [ ] Regenerate dependency inventory from lockfiles / pinned environments.
+- [ ] Verify each dependency license compatibility with distribution model.
+- [ ] Include required attribution texts in distributed artifacts.
+- [ ] Re-check trademark usage against `TRADEMARKS`.


### PR DESCRIPTION
### Motivation
- Remove unsafe placeholder contact in the root license and provide a real maintainer contact to ensure commercial inquiries and audits can proceed.
- Replace the initial-template `THIRD_PARTY_NOTICES` with a practical, release-oriented notice to reduce compliance risk during redistribution.
- Remove the draft review file to avoid shipping internal review artifacts in the repository as requested.
- Surface an explicit security/compliance warning about stale notice files to prevent accidental redistribution violations.

### Description
- Replaced the placeholder commercial contact in `LICENSE` with `veritas.fuji@gmail.com` to provide a concrete contact point for licensing/OEM inquiries. 
- Rewrote `THIRD_PARTY_NOTICES` from the template into an actionable document that cites manifest sources, lists representative Python/JS dependencies, documents container/OS obligations, and adds a maintainer release checklist. 
- Deleted `docs/review/LICENSE_REVIEW_2026_02_22_JP.md` so the draft review is not included in the pushed repository. 
- Added an explicit security/compliance warning to `THIRD_PARTY_NOTICES` urging regeneration of dependency inventories and lockfile-based validation before release.

### Testing
- Ran `rg -n "placeholder|Initial Template|licensing@veritasfuji.example" LICENSE THIRD_PARTY_NOTICES README.md README_JP.md docs/review` and confirmed no remaining placeholder entries; command succeeded. 
- Ran `git status --short` to verify the working-tree changes and file removal are present; command succeeded. 
- Inspected `LICENSE` excerpt with `nl -ba LICENSE | sed -n '90,120p'` to confirm the new contact appears in the EULA; inspection succeeded. 
- Inspected `THIRD_PARTY_NOTICES` with `nl -ba THIRD_PARTY_NOTICES | sed -n '1,220p'` to confirm the new content, checklist, and security warning; inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aec9d25148326af906fd52ee52c21)