### PR TITLE
Harden health_check URL host allowlist

### DIFF
--- a/veritas_os/tests/test_health_check_script.py
+++ b/veritas_os/tests/test_health_check_script.py
@@ -39,6 +39,18 @@ def test_validate_url_accepts_safe_http_url() -> None:
     assert health_check._validate_url(safe_url) == safe_url
 
 
+def test_validate_url_rejects_public_host_by_default() -> None:
+    assert health_check._validate_url("https://example.com/health") is None
+
+
+def test_validate_url_accepts_public_host_when_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_HEALTH_ALLOW_PUBLIC", "1")
+    assert (
+        health_check._validate_url("https://example.com/health")
+        == "https://example.com/health"
+    )
+
+
 def test_validate_url_rejects_hostname_label_starting_with_hyphen() -> None:
     assert health_check._validate_url("https://-bad.example.com/health") is None
 


### PR DESCRIPTION
### Motivation
- Reduce SSRF/unsafe-target risk when `VERITAS_API_BASE` or health-check URLs are misconfigured or user-controlled by restricting allowed hosts for health checks.
- Make the health check behavior conservative by default while allowing an explicit opt-in for public endpoints when required.

### Description
- Added `ipaddress` import and new helper `_is_allowed_health_host(hostname: str) -> bool` which permits only localhost/loopback/private/link-local addresses by default and honors `VERITAS_HEALTH_ALLOW_PUBLIC=1` to allow public hosts.
- Integrated the host-allowlist check into `_validate_url()` so URL validation now rejects public DNS names/IPs unless explicitly enabled, and DNS names are rejected by default to reduce SSRF blast radius.
- Added unit tests `test_validate_url_rejects_public_host_by_default()` and `test_validate_url_accepts_public_host_when_enabled()` to cover default-deny and opt-in behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_health_check_script.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af453a4e483268d75040dd10a8f46)