### PR TITLE
docs: add LinkedIn badge to README and README_JP

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen.svg)](docs/COVERAGE_REPORT.md) <!-- Snapshot value from docs/COVERAGE_REPORT.md; CI gate is configured in .github/workflows/main.yml -->
 [![GHCR](https://img.shields.io/badge/GHCR-ghcr.io%2Fveritasfuji--japan%2Fveritas__os-2496ED?logo=docker&logoColor=white)](https://ghcr.io/veritasfuji-japan/veritas_os)
 [![README JP](https://img.shields.io/badge/README-日本語-0f766e.svg)](README_JP.md)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-Takeshi%20Fujishita-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/in/takeshi-fujishita-279709392?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app)
 
 **Version**: 2.0.0-alpha  
 **Release Status**: In Development  

--- a/README_JP.md
+++ b/README_JP.md
@@ -8,6 +8,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen.svg)](docs/COVERAGE_REPORT.md) <!-- docs/COVERAGE_REPORT.md のスナップショット値。CIゲートは .github/workflows/main.yml で管理 -->
 [![GHCR](https://img.shields.io/badge/GHCR-ghcr.io%2Fveritasfuji--japan%2Fveritas__os-2496ED?logo=docker&logoColor=white)](https://ghcr.io/veritasfuji-japan/veritas_os)
 [![README EN](https://img.shields.io/badge/README-English-1d4ed8.svg)](README.md)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-Takeshi%20Fujishita-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/in/takeshi-fujishita-279709392?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app)
 
 **Version**: 2.0.0-alpha  
 **Release Status**: 開発中  


### PR DESCRIPTION
### Motivation
- Add a LinkedIn badge linking to Takeshi Fujishita's profile to the top badge block of both `README.md` and `README_JP.md` for discoverability, and note that the added URL contains `utm_*` tracking query parameters which may have privacy/tracking implications. 

### Description
- Inserted a Shields.io LinkedIn badge line into the badge section at the top of `README.md` and `README_JP.md`; this is a documentation-only change with no runtime impact. 

### Testing
- Verified the badge lines exist using `rg -n "LinkedIn" README.md README_JP.md`, checked repository status with `git status --short`, and committed the changes, and all automated checks ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af9574788832688025c8e91b05465)