### PR TITLE
ci: stabilize CodeQL checks with language matrix + security upload permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,11 +15,19 @@ on:
 permissions:
   actions: read
   contents: read
+  security-events: write
 
 jobs:
   analyze:
-    name: Analyze (Python)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - javascript-typescript
+          - actions
 
     steps:
       - name: Checkout repository
@@ -28,7 +36,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: python
+          languages: ${{ matrix.language }}
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3
@@ -36,4 +44,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
-          upload: false
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
### Motivation
- Improve CodeQL analysis coverage and enable uploads to GitHub Advanced Security by running multi-language analysis (repository includes Python, frontend, and workflow code) and providing the necessary permission for SARIF uploads.

### Description
- Modify `.github/workflows/codeql.yml` to add `security-events: write`, convert the analyze job to a language matrix (`python`, `javascript-typescript`, `actions`), set `with: languages: ${{ matrix.language }}`, and replace `upload: false` with `category: /language:${{ matrix.language }}` so results are language-scoped and uploadable.

### Testing
- Parsed the workflow with a small Python check using `yaml.safe_load` which confirmed the matrix contains three languages, and ran `pytest -q veritas_os/tests/test_health_check_script.py` which passed (13 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b16dfaaa08326bae76940f272eb2e)