### PR TITLE
ci: disambiguate custom CodeQL workflow name

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: CodeQL (custom)
 
 on:
   push:


### PR DESCRIPTION
### Motivation
- PR チェック画面で同名の `CodeQL` チェックが複数表示されるとどの実行がリポジトリ定義由来か分かりづらく、必要な判定ミスなど運用リスクがあるためワークフロー名を一意化しました。

### Description
- `.github/workflows/codeql.yml` の `name` を `CodeQL` から `CodeQL (custom)` に変更し、ワークフローのステップ・トリガー・権限・ジョブ内容には変更を加えていません。

### Testing
- リポジトリ内の該当ワークフローファイル確認と差分検査のために `rg`, `sed`, `git diff`, `git status` を実行して内容と差分を検証し、すべて成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1f63d6f48326a30a522361078165)