### PR TITLE
Remove unused exception variable in web_search retry helper

### DIFF
--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -242,7 +242,6 @@ def _post_with_retry(
         Redirects are disabled so that a trusted WEBSEARCH endpoint cannot
         bounce requests to internal/private addresses (SSRF via redirect).
     """
-    last_exc: Optional[Exception] = None
     for attempt in range(1, WEBSEARCH_MAX_RETRIES + 1):
         try:
             response = requests.post(
@@ -267,7 +266,6 @@ def _post_with_retry(
             response.raise_for_status()
             return response
         except requests.exceptions.RequestException as exc:
-            last_exc = exc
             if attempt < WEBSEARCH_MAX_RETRIES:
                 delay = _compute_backoff(attempt)
                 logger.warning(


### PR DESCRIPTION
### Motivation
- Fix a Ruff `F841` unused-variable finding by removing the unused `last_exc` from the `_post_with_retry` retry helper in `veritas_os/tools/web_search.py`, while keeping retry behavior unchanged; note that `web_search` touches external APIs so further security-focused reviews are recommended. 

### Description
- Deleted the unused `last_exc: Optional[Exception] = None` assignment and the subsequent unused assignment inside the `except requests.exceptions.RequestException as exc:` block in `_post_with_retry` in `veritas_os/tools/web_search.py` without changing control flow or retry semantics. 

### Testing
- Ran `python -m ruff check veritas_os/tools/web_search.py --select F --output-format=concise` which passed for the modified file. 
- Ran `pytest -q veritas_os/tests/test_web_search.py` resulting in `23 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b288cbec0832689ec81aede9da736)