### PR TITLE
Harden critique min_evidence parsing and add regression tests

### DIFF
--- a/veritas_os/core/critique.py
+++ b/veritas_os/core/critique.py
@@ -103,6 +103,14 @@ def _as_float(x: Any, default: float = 0.0) -> float:
         return float(default)
 
 
+def _as_non_negative_int(x: Any, default: int) -> int:
+    """Convert to int and clamp negatives to 0; return default on parse errors."""
+    try:
+        return max(int(x), 0)
+    except (TypeError, ValueError):
+        return max(int(default), 0)
+
+
 def _crit(
     issue: str,
     severity: Severity,
@@ -168,7 +176,7 @@ def analyze(
     critiques: List[Dict[str, Any]] = []
 
     # ==== 閾値（context から取得 / デフォルト付き） ====
-    min_evidence: int = int(ctx.get("min_evidence", 2))
+    min_evidence: int = _as_non_negative_int(ctx.get("min_evidence", 2), 2)
     risk_threshold: float = _as_float(ctx.get("risk_threshold", 0.7), 0.7)
     complexity_threshold: float = _as_float(ctx.get("complexity_threshold", 5.0), 5.0)
     value_threshold: float = _as_float(ctx.get("value_threshold", 0.3), 0.3)
@@ -583,5 +591,4 @@ if __name__ == "__main__":
     summary = summarize_critiques(result1)
     print(summary)
     print("\n=== Self-Test Finished ===")
-
 

--- a/veritas_os/tests/test_critique_extra.py
+++ b/veritas_os/tests/test_critique_extra.py
@@ -179,6 +179,29 @@ class TestAnalyzeDict:
         assert result["ok"] is True
 
 
+class TestAnalyzeValidation:
+    """Validation and edge-case tests for analyze/analyze_dict."""
+
+    def test_min_evidence_invalid_string_is_safe(self):
+        """Invalid min_evidence values should not raise parsing errors."""
+        result = crit_mod.analyze(
+            option={"title": "t"},
+            evidence=[],
+            context={"min_evidence": "not-a-number"},
+        )
+        assert isinstance(result, list)
+
+    def test_min_evidence_negative_is_clamped(self):
+        """Negative min_evidence should be clamped to zero."""
+        result = crit_mod.analyze(
+            option={"title": "t"},
+            evidence=[],
+            context={"min_evidence": -5},
+        )
+        issues = {item.get("issue") for item in result}
+        assert "根拠不足" not in issues
+
+
 class TestNormSeverity:
     """Tests for _norm_severity helper."""
 


### PR DESCRIPTION
### Motivation
- Prevent `analyze()` from raising on malformed `context["min_evidence"]` values and avoid surprising behavior for negative thresholds.  
- Improve input validation and robustness of the critique module while keeping responsibilities and interfaces unchanged.

### Description
- Added a helper ` _as_non_negative_int(x, default)` in `veritas_os/core/critique.py` to safely parse `min_evidence`, clamp negative values to `0`, and fall back to the provided default on parse errors.  
- Replaced direct `int(ctx.get("min_evidence", 2))` usage with ` _as_non_negative_int(ctx.get("min_evidence", 2), 2)` in `analyze()` so invalid or negative inputs are handled deterministically.  
- Added regression tests in `veritas_os/tests/test_critique_extra.py` that assert non-numeric `min_evidence` does not raise and that negative `min_evidence` is clamped (no "根拠不足" issue when min is negative).

### Testing
- Ran `pytest -q veritas_os/tests/test_critique_extra.py`; result: `23 passed`.  
- Ran `ruff check veritas_os/core/critique.py veritas_os/tests/test_critique_extra.py`; result: `All checks passed`.  
- Also ran targeted sanity tests `pytest -q veritas_os/tests/test_sanitize.py veritas_os/tests/test_tools.py`; result: `16 passed`.

Security: This change improves robustness against malformed inputs and introduces no new security risks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2ec52b78832696e594acec6c8974)