### PR TITLE
Harden cosine search k validation and deterministic tie ordering

### DIFF
--- a/veritas_os/memory/index_cosine.py
+++ b/veritas_os/memory/index_cosine.py
@@ -291,6 +291,8 @@ class CosineIndex:
         戻り値: [[(id, score), ...], ...]  （クエリごとに1リスト）
         スレッドセーフ: 検索中は一貫したスナップショットを使用
         """
+        if not isinstance(k, int) or isinstance(k, bool):
+            raise ValueError(f"CosineIndex.search: k must be an int, got {type(k).__name__}")
         if k < 1:
             raise ValueError(f"CosineIndex.search: k must be >= 1, got {k}")
 
@@ -317,6 +319,6 @@ class CosineIndex:
         out: List[List[Tuple[str, float]]] = []
         for row in sims:
             kk = min(k, len(ids_snapshot))
-            idx = np.argsort(-row)[:kk]
+            idx = np.argsort(-row, kind="stable")[:kk]
             out.append([(ids_snapshot[i], float(row[i])) for i in idx])
         return out

--- a/veritas_os/tests/test_memory_index_cosine.py
+++ b/veritas_os/tests/test_memory_index_cosine.py
@@ -366,6 +366,28 @@ def test_search_invalid_k_raises():
     assert "k must be >= 1" in str(exc.value)
 
 
+@pytest.mark.parametrize("invalid_k", [1.2, "2", None, True])
+def test_search_non_integer_k_raises(invalid_k):
+    """k が int 以外（および bool）の場合は ValueError。"""
+    idx = CosineIndex(dim=2)
+    idx.add(np.array([[1.0, 0.0]], dtype=np.float32), ids=["x"])
+
+    with pytest.raises(ValueError) as exc:
+        idx.search(np.array([1.0, 0.0], dtype=np.float32), k=invalid_k)  # type: ignore[arg-type]
+
+    assert "k must be an int" in str(exc.value)
+
+
+def test_search_tie_scores_keep_insertion_order():
+    """同点スコアでは挿入順序を維持して結果を返す。"""
+    idx = CosineIndex(dim=2)
+    idx.add(np.array([[1.0, 0.0], [1.0, 0.0]], dtype=np.float32), ids=["first", "second"])
+
+    res = idx.search(np.array([1.0, 0.0], dtype=np.float32), k=2)
+
+    assert [item_id for item_id, _ in res[0]] == ["first", "second"]
+
+
 # ---------------------------------------------------------
 # 永続化: save / _load のラウンドトリップ
 # ---------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent callers from accidentally passing non-integer or boolean `k` values to `CosineIndex.search`, which can hide bugs via implicit coercion.
- Ensure deterministic ranking when multiple items have identical similarity scores by preserving insertion order for ties.
- Maintain existing security posture without widening trust boundaries, leaving legacy pickle opt-in behavior unchanged.

### Description
- Add strict validation in `CosineIndex.search` to raise `ValueError` when `k` is not an `int` or is a `bool`.
- Use `np.argsort(..., kind="stable")` in `search` to ensure stable ordering for tie scores so insertion order is preserved.
- Add tests `test_search_non_integer_k_raises` and `test_search_tie_scores_keep_insertion_order` in `veritas_os/tests/test_memory_index_cosine.py` to cover the new behavior.
- Kept code PEP8-compliant and ensured changes pass static checks.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_memory_index_cosine.py` which completed with `33 passed, 1 warning`.
- Ran `python -m ruff check veritas_os/memory/index_cosine.py veritas_os/tests/test_memory_index_cosine.py` which passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b355bf4c083268a50df9cf068ba5a)