### PR TITLE
frontend: validate API responses at runtime and fix SSE test act warning

### DIFF
--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -44,4 +44,30 @@ describe("TrustLogExplorerPage", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(screen.getByText(/表示件数: 2/)).toBeInTheDocument();
   });
+
+  it("shows validation error when trust logs response shape is invalid", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [{ request_id: 10 }],
+        cursor: "0",
+        next_cursor: null,
+        limit: 50,
+        has_more: false,
+      }),
+    } as Response);
+
+    render(<TrustLogExplorerPage />);
+
+    fireEvent.change(screen.getByLabelText("X-API-Key"), {
+      target: { value: "test-key" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("レスポンス形式エラー: trust logs の形式が不正です。")).toBeInTheDocument();
+    });
+  });
+
 });

--- a/frontend/app/governance/page.test.tsx
+++ b/frontend/app/governance/page.test.tsx
@@ -204,4 +204,24 @@ describe("GovernanceControlPage", () => {
     fireEvent.click(screen.getByText("リセット"));
     expect(screen.getByText("変更はありません。")).toBeInTheDocument();
   });
+
+  it("shows validation error when policy response shape is invalid", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, policy: { updated_by: 123 } }),
+    } as Response);
+
+    render(<GovernanceControlPage />);
+
+    fireEvent.change(screen.getByLabelText("X-API-Key"), {
+      target: { value: "test-key" },
+    });
+    fireEvent.click(screen.getByText("ポリシーを読み込む"));
+
+    await waitFor(() => {
+      expect(screen.getByText("レスポンス形式エラー: policy の形式が不正です。")).toBeInTheDocument();
+    });
+  });
+
 });

--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LiveEventStream } from "./live-event-stream";
@@ -36,9 +36,11 @@ describe("LiveEventStream", () => {
     expect(MockEventSource.instances.length).toBe(1);
 
     const source = MockEventSource.instances[0];
-    source.onmessage?.({
-      data: JSON.stringify({ id: 1, type: "decide.completed", ts: "2026-01-01T00:00:00Z", payload: { ok: true } }),
-    } as MessageEvent<string>);
+    await act(async () => {
+      source.onmessage?.({
+        data: JSON.stringify({ id: 1, type: "decide.completed", ts: "2026-01-01T00:00:00Z", payload: { ok: true } }),
+      } as MessageEvent<string>);
+    });
 
     expect(await screen.findByText("decide.completed")).toBeInTheDocument();
     expect(screen.getByText(/"ok": true/)).toBeInTheDocument();

--- a/frontend/lib/api-validators.test.ts
+++ b/frontend/lib/api-validators.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isGovernancePolicyResponse,
+  isRequestLogResponse,
+  isTrustLogsResponse,
+} from "./api-validators";
+
+const validGovernanceResponse = {
+  ok: true,
+  policy: {
+    version: "governance_v1",
+    fuji_rules: {
+      pii_check: true,
+      self_harm_block: true,
+      illicit_block: true,
+      violence_review: true,
+      minors_review: true,
+      keyword_hard_block: true,
+      keyword_soft_flag: true,
+      llm_safety_head: true,
+    },
+    risk_thresholds: {
+      allow_upper: 0.4,
+      warn_upper: 0.65,
+      human_review_upper: 0.85,
+      deny_upper: 1.0,
+    },
+    auto_stop: {
+      enabled: true,
+      max_risk_score: 0.85,
+      max_consecutive_rejects: 5,
+      max_requests_per_minute: 60,
+    },
+    log_retention: {
+      retention_days: 90,
+      audit_level: "full",
+      include_fields: ["status", "risk"],
+      redact_before_log: true,
+      max_log_size: 10000,
+    },
+    updated_at: "2026-02-12T00:00:00Z",
+    updated_by: "system",
+  },
+};
+
+describe("api validators", () => {
+  it("accepts valid governance policy response", () => {
+    expect(isGovernancePolicyResponse(validGovernanceResponse)).toBe(true);
+  });
+
+  it("rejects malformed governance policy response", () => {
+    expect(
+      isGovernancePolicyResponse({
+        ok: true,
+        policy: {
+          ...validGovernanceResponse.policy,
+          updated_by: 123,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts valid trust logs response", () => {
+    expect(
+      isTrustLogsResponse({
+        items: [{ request_id: "req-1", stage: "fuji", created_at: "2026-02-12T00:00:00Z" }],
+        cursor: "0",
+        next_cursor: "1",
+        limit: 50,
+        has_more: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed trust logs response", () => {
+    expect(
+      isTrustLogsResponse({
+        items: [{ request_id: 10 }],
+        cursor: "0",
+        next_cursor: "1",
+        limit: 50,
+        has_more: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts valid request log response", () => {
+    expect(
+      isRequestLogResponse({
+        request_id: "req-1",
+        items: [{ request_id: "req-1", stage: "planner" }],
+        count: 1,
+        chain_ok: true,
+        verification_result: "ok",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed request log response", () => {
+    expect(
+      isRequestLogResponse({
+        request_id: "req-1",
+        items: [],
+        count: "1",
+        chain_ok: true,
+        verification_result: "ok",
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/lib/api-validators.ts
+++ b/frontend/lib/api-validators.ts
@@ -1,0 +1,223 @@
+interface FujiRules {
+  pii_check: boolean;
+  self_harm_block: boolean;
+  illicit_block: boolean;
+  violence_review: boolean;
+  minors_review: boolean;
+  keyword_hard_block: boolean;
+  keyword_soft_flag: boolean;
+  llm_safety_head: boolean;
+}
+
+interface RiskThresholds {
+  allow_upper: number;
+  warn_upper: number;
+  human_review_upper: number;
+  deny_upper: number;
+}
+
+interface AutoStop {
+  enabled: boolean;
+  max_risk_score: number;
+  max_consecutive_rejects: number;
+  max_requests_per_minute: number;
+}
+
+interface LogRetention {
+  retention_days: number;
+  audit_level: string;
+  include_fields: string[];
+  redact_before_log: boolean;
+  max_log_size: number;
+}
+
+export interface GovernancePolicy {
+  version: string;
+  fuji_rules: FujiRules;
+  risk_thresholds: RiskThresholds;
+  auto_stop: AutoStop;
+  log_retention: LogRetention;
+  updated_at: string;
+  updated_by: string;
+}
+
+export interface GovernancePolicyResponse {
+  ok: boolean;
+  policy: GovernancePolicy;
+}
+
+export interface TrustLogItem {
+  request_id?: string;
+  created_at?: string;
+  stage?: string;
+  sha256?: string;
+  sha256_prev?: string;
+  [key: string]: unknown;
+}
+
+export interface TrustLogsResponse {
+  items: TrustLogItem[];
+  cursor: string;
+  next_cursor: string | null;
+  limit: number;
+  has_more: boolean;
+}
+
+export interface RequestLogResponse {
+  request_id: string;
+  items: TrustLogItem[];
+  count: number;
+  chain_ok: boolean;
+  verification_result: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function hasBooleanField(obj: Record<string, unknown>, key: string): boolean {
+  return typeof obj[key] === "boolean";
+}
+
+function hasNumberField(obj: Record<string, unknown>, key: string): boolean {
+  return typeof obj[key] === "number" && Number.isFinite(obj[key]);
+}
+
+function hasStringField(obj: Record<string, unknown>, key: string): boolean {
+  return typeof obj[key] === "string";
+}
+
+function isFujiRules(value: unknown): value is FujiRules {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return [
+    "pii_check",
+    "self_harm_block",
+    "illicit_block",
+    "violence_review",
+    "minors_review",
+    "keyword_hard_block",
+    "keyword_soft_flag",
+    "llm_safety_head",
+  ].every((key) => hasBooleanField(value, key));
+}
+
+function isRiskThresholds(value: unknown): value is RiskThresholds {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return ["allow_upper", "warn_upper", "human_review_upper", "deny_upper"].every((key) => hasNumberField(value, key));
+}
+
+function isAutoStop(value: unknown): value is AutoStop {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    hasBooleanField(value, "enabled")
+    && hasNumberField(value, "max_risk_score")
+    && hasNumberField(value, "max_consecutive_rejects")
+    && hasNumberField(value, "max_requests_per_minute")
+  );
+}
+
+function isLogRetention(value: unknown): value is LogRetention {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    hasNumberField(value, "retention_days")
+    && hasStringField(value, "audit_level")
+    && Array.isArray(value.include_fields)
+    && value.include_fields.every((field) => typeof field === "string")
+    && hasBooleanField(value, "redact_before_log")
+    && hasNumberField(value, "max_log_size")
+  );
+}
+
+export function isGovernancePolicy(value: unknown): value is GovernancePolicy {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    hasStringField(value, "version")
+    && isFujiRules(value.fuji_rules)
+    && isRiskThresholds(value.risk_thresholds)
+    && isAutoStop(value.auto_stop)
+    && isLogRetention(value.log_retention)
+    && hasStringField(value, "updated_at")
+    && hasStringField(value, "updated_by")
+  );
+}
+
+export function isGovernancePolicyResponse(value: unknown): value is GovernancePolicyResponse {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return typeof value.ok === "boolean" && isGovernancePolicy(value.policy);
+}
+
+export function isTrustLogItem(value: unknown): value is TrustLogItem {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.request_id !== undefined && typeof value.request_id !== "string") {
+    return false;
+  }
+
+  if (value.created_at !== undefined && typeof value.created_at !== "string") {
+    return false;
+  }
+
+  if (value.stage !== undefined && typeof value.stage !== "string") {
+    return false;
+  }
+
+  if (value.sha256 !== undefined && typeof value.sha256 !== "string") {
+    return false;
+  }
+
+  if (value.sha256_prev !== undefined && typeof value.sha256_prev !== "string") {
+    return false;
+  }
+
+  return true;
+}
+
+export function isTrustLogsResponse(value: unknown): value is TrustLogsResponse {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    Array.isArray(value.items)
+    && value.items.every((item) => isTrustLogItem(item))
+    && hasStringField(value, "cursor")
+    && (value.next_cursor === null || typeof value.next_cursor === "string")
+    && hasNumberField(value, "limit")
+    && hasBooleanField(value, "has_more")
+  );
+}
+
+export function isRequestLogResponse(value: unknown): value is RequestLogResponse {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    hasStringField(value, "request_id")
+    && Array.isArray(value.items)
+    && value.items.every((item) => isTrustLogItem(item))
+    && hasNumberField(value, "count")
+    && hasBooleanField(value, "chain_ok")
+    && hasStringField(value, "verification_result")
+  );
+}


### PR DESCRIPTION
### Motivation
- Prevent UI breakage and improve security posture by adding runtime validation for backend responses that were previously cast into TypeScript types without checks. 
- Address test stability warnings from the review by wrapping SSE event emissions in `act(...)` to avoid future flakiness. 
- Remove an ESLint hooks disable and make the governance auto-load behavior explicit and safe for env-key usage. 
- Keep the high-risk SSE API-key-in-query issue visible as an outstanding operational/security risk. 

### Description
- Added a runtime validator module `frontend/lib/api-validators.ts` implementing type guards such as `isGovernancePolicyResponse`, `isTrustLogsResponse`, and `isRequestLogResponse` to validate shapes returned by the server. 
- Updated `frontend/app/governance/page.tsx` to treat `res.json()` as `unknown`, validate with `isGovernancePolicyResponse` before using the payload, and show a safe error message on mismatch; also refactored the auto-load effect to remove `eslint-disable` and use a `useRef` + `shouldAutoLoad` guard for a one-time env-key auto-load. 
- Updated `frontend/app/audit/page.tsx` to validate `/v1/trust/logs` and `/v1/trust/{request_id}` responses using the new validators and surface an explicit error when the response shape is invalid. 
- Fixed `frontend/components/live-event-stream.test.tsx` by wrapping SSE `onmessage` dispatch in `await act(async () => { ... })` to eliminate the `act(...)` warning. 
- Added tests: `frontend/lib/api-validators.test.ts` (unit tests for validators) and additional malformed-response test cases in `frontend/app/governance/page.test.tsx` and `frontend/app/audit/page.test.tsx` to assert safe error paths. 
- All changes are limited to frontend runtime validation, test stabilization, and small UX/error-path behavior; no cross-cutting responsibilities were changed. 

### Testing
- Ran targeted test suite: `pnpm --filter frontend test -- app/governance/page.test.tsx app/governance/a11y.test.tsx app/audit/page.test.tsx components/live-event-stream.test.tsx lib/api-validators.test.ts`, and all test files passed (5 files, 23 tests passed). 
- Ran typecheck: `pnpm --filter frontend typecheck` and it completed successfully with no TypeScript errors. 
- Notes: tests exercise the new validators and malformed-response handling and succeeded; SSE test stability warning was resolved by the `act(...)` change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9c69818083269daf391c4fad44e7)