### PR TITLE
Improve live event stream UX and secret handling in frontend

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -38,7 +38,12 @@ describe("LiveEventStream", () => {
     const source = MockEventSource.instances[0];
     await act(async () => {
       source.onmessage?.({
-        data: JSON.stringify({ id: 1, type: "decide.completed", ts: "2026-01-01T00:00:00Z", payload: { ok: true } }),
+        data: JSON.stringify({
+          id: 1,
+          type: "decide.completed",
+          ts: "2026-01-01T00:00:00Z",
+          payload: { ok: true },
+        }),
       } as MessageEvent<string>);
     });
 
@@ -54,6 +59,7 @@ describe("LiveEventStream", () => {
     fireEvent.change(screen.getByLabelText("API Base URL"), { target: { value: "not a url" } });
 
     expect(screen.getByText("有効な API Base URL を入力してください。")).toBeInTheDocument();
+    expect(screen.getByText("🔴 invalid url")).toBeInTheDocument();
     expect(MockEventSource.instances.length).toBe(1);
   });
 
@@ -62,12 +68,36 @@ describe("LiveEventStream", () => {
 
     render(<LiveEventStream />);
 
-    fireEvent.change(screen.getByLabelText("API Key"), { target: { value: "secret-token" } });
+    const apiKeyInput = screen.getByLabelText("API Key");
+    fireEvent.change(apiKeyInput, { target: { value: "secret-token" } });
 
+    expect(apiKeyInput).toHaveAttribute("type", "password");
     expect(
       screen.getByText(
         "Security note: API key is sent in the query string for EventSource compatibility. Avoid using production secrets in shared logs.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("clears rendered events when clear button is pressed", async () => {
+    vi.stubGlobal("EventSource", MockEventSource);
+
+    render(<LiveEventStream />);
+
+    const source = MockEventSource.instances[0];
+    await act(async () => {
+      source.onmessage?.({
+        data: JSON.stringify({
+          id: 1,
+          type: "decide.completed",
+          ts: "2026-01-01T00:00:00Z",
+          payload: { ok: true },
+        }),
+      } as MessageEvent<string>);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear events" }));
+
+    expect(screen.getByText("イベント待機中...")).toBeInTheDocument();
   });
 });

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -44,6 +44,11 @@ export function LiveEventStream(): JSX.Element {
 
   const streamUrl = useMemo(() => buildEventUrl(apiBase, apiKey), [apiBase, apiKey]);
   const hasInvalidApiBase = apiBase.trim().length > 0 && streamUrl === null;
+  const streamStatus = hasInvalidApiBase
+    ? "🔴 invalid url"
+    : connected
+      ? "🟢 connected"
+      : "🟡 reconnecting";
 
   useEffect(() => {
     if (!streamUrl) {
@@ -58,6 +63,10 @@ export function LiveEventStream(): JSX.Element {
       if (!mounted) {
         return;
       }
+      if (reconnectRef.current) {
+        clearTimeout(reconnectRef.current);
+      }
+
       source = new EventSource(streamUrl);
 
       source.onopen = () => {
@@ -108,13 +117,15 @@ export function LiveEventStream(): JSX.Element {
             value={apiKey}
             onChange={(event) => setApiKey(event.target.value)}
             placeholder="X-API-Key"
+            type="password"
+            autoComplete="off"
             className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
           />
         </label>
       </div>
 
       <p className="mb-2 text-xs text-muted-foreground">
-        Status: {connected ? "🟢 connected" : "🟡 reconnecting"}
+        Status: <span aria-live="polite">{streamStatus}</span>
       </p>
       {hasInvalidApiBase ? (
         <p className="mb-2 text-xs text-destructive">有効な API Base URL を入力してください。</p>
@@ -124,6 +135,16 @@ export function LiveEventStream(): JSX.Element {
           Security note: API key is sent in the query string for EventSource compatibility. Avoid using production secrets in shared logs.
         </p>
       ) : null}
+
+      <div className="mb-3">
+        <button
+          type="button"
+          onClick={() => setEvents([])}
+          className="rounded-md border border-border/80 bg-background px-3 py-1 text-xs text-foreground hover:border-primary/70"
+        >
+          Clear events
+        </button>
+      </div>
 
       <div className="max-h-72 space-y-2 overflow-auto pr-1">
         {events.length === 0 ? (


### PR DESCRIPTION
### Motivation
- Make the live SSE UI clearer and more operator-friendly by surfacing explicit connection states and controls. 
- Reduce accidental secret exposure in the UI while preserving existing EventSource behavior that requires query-string API keys. 
- Prevent reconnect-timer buildup which can cause noisy reconnect loops and memory churn. 

### Description
- Add explicit `streamStatus` that distinguishes `invalid url`, `connected`, and `reconnecting`, and expose it with `aria-live` for accessibility. 
- Mask the API key input by setting `type="password"` and `autoComplete="off"` to reduce shoulder-surfing risk. 
- Clear any outstanding reconnect timer before opening a new `EventSource` to avoid duplicate timers. 
- Add a `Clear events` button that empties the rendered event list, and extend `vitest` unit tests to cover invalid-URL status, masked API input, and event clearing behavior. 
- All changes are limited to the frontend live event stream component and its tests (`frontend/components/live-event-stream.tsx` and `frontend/components/live-event-stream.test.tsx`). 

### Testing
- Ran unit tests with `pnpm --filter frontend test -- components/live-event-stream.test.tsx` and all 4 tests passed. 
- Executed an automated Playwright script against the local dev server to exercise the UI and capture a screenshot (used for validation, succeeded). 
- Dev server was started (`pnpm --filter frontend dev`) to verify runtime behavior and UI interactions (startup and page render succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9fbf49488326885046902aa530ac)