### PR TITLE
Add JA/EN language toggle and i18n provider to frontend shell

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { ThemeStyles, applyThemeClass } from "@veritas/design-system";
 import { MissionLayout } from "../components/mission-layout";
+import { I18nProvider } from "../components/i18n";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -19,7 +20,9 @@ export default function RootLayout({
         <ThemeStyles />
       </head>
       <body>
-        <MissionLayout>{children}</MissionLayout>
+        <I18nProvider>
+          <MissionLayout>{children}</MissionLayout>
+        </I18nProvider>
       </body>
     </html>
   );

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import CommandDashboardPage from "./page";
+import { I18nProvider } from "../components/i18n";
 
 describe("CommandDashboardPage", () => {
   it("renders dashboard skeleton content", () => {
-    render(<CommandDashboardPage />);
+    render(
+      <I18nProvider>
+        <CommandDashboardPage />
+      </I18nProvider>
+    );
 
     expect(screen.getByText("Command Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Uptime Lattice")).toBeInTheDocument();

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,13 +1,18 @@
+"use client";
+
 import { MissionPage } from "../components/mission-page";
 import { LiveEventStream } from "../components/live-event-stream";
+import { useI18n } from "../components/i18n";
 
 export default function CommandDashboardPage(): JSX.Element {
+  const { t } = useI18n();
+
   return (
     <div className="space-y-6">
       <LiveEventStream />
       <MissionPage
         title="Command Dashboard"
-        subtitle="ミッション全体の健全性を俯瞰監視し、異常シグナルを即時に検出します。"
+        subtitle={t("page.dashboard.subtitle")}
         chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
       />
     </div>

--- a/frontend/app/risk/page.tsx
+++ b/frontend/app/risk/page.tsx
@@ -1,10 +1,15 @@
+"use client";
+
 import { MissionPage } from "../../components/mission-page";
+import { useI18n } from "../../components/i18n";
 
 export default function RiskIntelligencePage(): JSX.Element {
+  const { t } = useI18n();
+
   return (
     <MissionPage
       title="Risk Intelligence"
-      subtitle="先行指標とシナリオ推論により、未来リスクの予兆を可視化します。"
+      subtitle={t("page.risk.subtitle")}
       chips={["Predictive Radar", "Threat Horizon", "Impact Forecast"]}
     />
   );

--- a/frontend/components/i18n.tsx
+++ b/frontend/components/i18n.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+export type Locale = "ja" | "en";
+
+type TranslationValue = string;
+
+const TRANSLATIONS: Record<Locale, Record<string, TranslationValue>> = {
+  ja: {
+    "layout.skipToMain": "メインコンテンツへスキップ",
+    "layout.sidebar": "サイドバー",
+    "layout.brandSubtitle": "可読性を優先した運用ビュー",
+    "layout.language": "言語",
+    "layout.environment": "環境",
+    "layout.connection": "接続",
+    "layout.latestEvent": "最新イベント",
+    "layout.envValue": "本番対応サンドボックス",
+    "layout.connectionValue": "ニューラルメッシュ安定 · 99.982%",
+    "layout.eventValue": "ポリシー同期 #4821 完了",
+    "nav.dashboard.short": "監視",
+    "nav.dashboard.desc": "全体ヘルスとアラート",
+    "nav.console.short": "実行",
+    "nav.console.desc": "意思決定フロー",
+    "nav.governance.short": "統制",
+    "nav.governance.desc": "ポリシー運用",
+    "nav.audit.short": "監査",
+    "nav.audit.desc": "証跡と追跡",
+    "nav.risk.short": "予測",
+    "nav.risk.desc": "先行リスク検知",
+    "mission.widget": "ウィジェット {index}: 運用プレビュー",
+    "page.dashboard.subtitle": "ミッション全体の健全性を俯瞰監視し、異常シグナルを即時に検出します。",
+    "page.governance.subtitle": "規範ポリシーの適用状況を可視化し、逸脱を最小遅延で是正します。",
+    "page.audit.subtitle": "追跡可能な証跡を集約し、すべての意思決定を検証可能に維持します。",
+    "page.risk.subtitle": "先行指標とシナリオ推論により、未来リスクの予兆を可視化します。",
+    "stream.title": "ライブイベントストリーム",
+    "stream.apiBase": "API Base URL",
+    "stream.apiKey": "APIキー",
+    "stream.status": "状態",
+    "stream.invalidUrl": "有効な API Base URL を入力してください。",
+    "stream.securityWarning": "セキュリティ注意: EventSource の互換性のため API キーはクエリ文字列で送信されます。共有ログで本番シークレットを使わないでください。",
+    "stream.clear": "イベントをクリア",
+    "stream.waiting": "イベント待機中...",
+    "stream.connected": "🟢 接続中",
+    "stream.reconnecting": "🟡 再接続中",
+    "stream.invalid": "🔴 URL不正"
+  },
+  en: {
+    "layout.skipToMain": "Skip to main content",
+    "layout.sidebar": "Sidebar",
+    "layout.brandSubtitle": "Operational view focused on readability",
+    "layout.language": "Language",
+    "layout.environment": "Environment",
+    "layout.connection": "Connection",
+    "layout.latestEvent": "Latest Event",
+    "layout.envValue": "Production-ready Sandbox",
+    "layout.connectionValue": "Neural Mesh Stable · 99.982%",
+    "layout.eventValue": "Policy Sync #4821 Completed",
+    "nav.dashboard.short": "Watch",
+    "nav.dashboard.desc": "Global health and alerts",
+    "nav.console.short": "Exec",
+    "nav.console.desc": "Decision pipeline",
+    "nav.governance.short": "Control",
+    "nav.governance.desc": "Policy operations",
+    "nav.audit.short": "Audit",
+    "nav.audit.desc": "Evidence and traceability",
+    "nav.risk.short": "Forecast",
+    "nav.risk.desc": "Early risk detection",
+    "mission.widget": "Widget {index}: operational preview",
+    "page.dashboard.subtitle": "Monitor mission-wide health and detect anomaly signals immediately.",
+    "page.governance.subtitle": "Visualize policy enforcement posture and remediate drift with minimal delay.",
+    "page.audit.subtitle": "Aggregate verifiable evidence and keep every decision traceable.",
+    "page.risk.subtitle": "Use leading indicators and scenario reasoning to detect emerging future risks.",
+    "stream.title": "Live Event Stream",
+    "stream.apiBase": "API Base URL",
+    "stream.apiKey": "API Key",
+    "stream.status": "Status",
+    "stream.invalidUrl": "Please enter a valid API Base URL.",
+    "stream.securityWarning": "Security note: API key is sent in the query string for EventSource compatibility. Avoid using production secrets in shared logs.",
+    "stream.clear": "Clear events",
+    "stream.waiting": "Waiting for events...",
+    "stream.connected": "🟢 connected",
+    "stream.reconnecting": "🟡 reconnecting",
+    "stream.invalid": "🔴 invalid url"
+  }
+};
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string, vars?: Record<string, string | number>) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+interface I18nProviderProps {
+  children: React.ReactNode;
+}
+
+export function I18nProvider({ children }: I18nProviderProps): JSX.Element {
+  const [locale, setLocale] = useState<Locale>("ja");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("veritas_locale");
+    if (stored === "ja" || stored === "en") {
+      setLocale(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem("veritas_locale", locale);
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      locale,
+      setLocale,
+      t: (key, vars = {}) => {
+        const table = TRANSLATIONS[locale];
+        const raw = table[key] ?? TRANSLATIONS.en[key] ?? key;
+
+        return Object.entries(vars).reduce(
+          (nextText, [name, replacement]) => nextText.replace(`{${name}}`, String(replacement)),
+          raw
+        );
+      }
+    }),
+    [locale]
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n(): I18nContextValue {
+  const value = useContext(I18nContext);
+  if (!value) {
+    throw new Error("useI18n must be used within I18nProvider");
+  }
+  return value;
+}
+

--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -2,6 +2,15 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LiveEventStream } from "./live-event-stream";
+import { I18nProvider } from "./i18n";
+
+function renderWithI18n(): void {
+  render(
+    <I18nProvider>
+      <LiveEventStream />
+    </I18nProvider>
+  );
+}
 
 class MockEventSource {
   static instances: MockEventSource[] = [];
@@ -30,9 +39,9 @@ describe("LiveEventStream", () => {
   it("renders and prepends incoming SSE events", async () => {
     vi.stubGlobal("EventSource", MockEventSource);
 
-    render(<LiveEventStream />);
+    renderWithI18n();
 
-    expect(screen.getByText("Live Event Stream")).toBeInTheDocument();
+    expect(screen.getByText("ライブイベントストリーム")).toBeInTheDocument();
     expect(MockEventSource.instances.length).toBe(1);
 
     const source = MockEventSource.instances[0];
@@ -54,27 +63,27 @@ describe("LiveEventStream", () => {
   it("shows validation error and avoids connecting when API base URL is invalid", () => {
     vi.stubGlobal("EventSource", MockEventSource);
 
-    render(<LiveEventStream />);
+    renderWithI18n();
 
     fireEvent.change(screen.getByLabelText("API Base URL"), { target: { value: "not a url" } });
 
     expect(screen.getByText("有効な API Base URL を入力してください。")).toBeInTheDocument();
-    expect(screen.getByText("🔴 invalid url")).toBeInTheDocument();
+    expect(screen.getByText("🔴 URL不正")).toBeInTheDocument();
     expect(MockEventSource.instances.length).toBe(1);
   });
 
   it("shows a security warning when API key is configured", () => {
     vi.stubGlobal("EventSource", MockEventSource);
 
-    render(<LiveEventStream />);
+    renderWithI18n();
 
-    const apiKeyInput = screen.getByLabelText("API Key");
+    const apiKeyInput = screen.getByLabelText("APIキー");
     fireEvent.change(apiKeyInput, { target: { value: "secret-token" } });
 
     expect(apiKeyInput).toHaveAttribute("type", "password");
     expect(
       screen.getByText(
-        "Security note: API key is sent in the query string for EventSource compatibility. Avoid using production secrets in shared logs.",
+        "セキュリティ注意: EventSource の互換性のため API キーはクエリ文字列で送信されます。共有ログで本番シークレットを使わないでください。",
       ),
     ).toBeInTheDocument();
   });
@@ -82,7 +91,7 @@ describe("LiveEventStream", () => {
   it("clears rendered events when clear button is pressed", async () => {
     vi.stubGlobal("EventSource", MockEventSource);
 
-    render(<LiveEventStream />);
+    renderWithI18n();
 
     const source = MockEventSource.instances[0];
     await act(async () => {
@@ -96,7 +105,7 @@ describe("LiveEventStream", () => {
       } as MessageEvent<string>);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Clear events" }));
+    fireEvent.click(screen.getByRole("button", { name: "イベントをクリア" }));
 
     expect(screen.getByText("イベント待機中...")).toBeInTheDocument();
   });

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -2,6 +2,7 @@
 
 import { Card } from "@veritas/design-system";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useI18n } from "./i18n";
 
 const DEFAULT_API_BASE = process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL ?? "http://localhost:8000";
 const ENV_API_KEY = process.env.NEXT_PUBLIC_VERITAS_API_KEY ?? "";
@@ -36,6 +37,7 @@ function buildEventUrl(apiBase: string, apiKey: string): string | null {
 }
 
 export function LiveEventStream(): JSX.Element {
+  const { t } = useI18n();
   const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
   const [apiKey, setApiKey] = useState(ENV_API_KEY);
   const [events, setEvents] = useState<StreamEvent[]>([]);
@@ -45,10 +47,10 @@ export function LiveEventStream(): JSX.Element {
   const streamUrl = useMemo(() => buildEventUrl(apiBase, apiKey), [apiBase, apiKey]);
   const hasInvalidApiBase = apiBase.trim().length > 0 && streamUrl === null;
   const streamStatus = hasInvalidApiBase
-    ? "🔴 invalid url"
+    ? t("stream.invalid")
     : connected
-      ? "🟢 connected"
-      : "🟡 reconnecting";
+      ? t("stream.connected")
+      : t("stream.reconnecting");
 
   useEffect(() => {
     if (!streamUrl) {
@@ -101,10 +103,10 @@ export function LiveEventStream(): JSX.Element {
   }, [streamUrl]);
 
   return (
-    <Card title="Live Event Stream" className="border-primary/40 bg-surface/80">
+    <Card title={t("stream.title")} className="border-primary/40 bg-surface/80">
       <div className="mb-3 grid gap-3 md:grid-cols-2">
         <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          API Base URL
+          {t("stream.apiBase")}
           <input
             value={apiBase}
             onChange={(event) => setApiBase(event.target.value)}
@@ -112,7 +114,7 @@ export function LiveEventStream(): JSX.Element {
           />
         </label>
         <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          API Key
+          {t("stream.apiKey")}
           <input
             value={apiKey}
             onChange={(event) => setApiKey(event.target.value)}
@@ -125,14 +127,14 @@ export function LiveEventStream(): JSX.Element {
       </div>
 
       <p className="mb-2 text-xs text-muted-foreground">
-        Status: <span aria-live="polite">{streamStatus}</span>
+        {t("stream.status")}: <span aria-live="polite">{streamStatus}</span>
       </p>
       {hasInvalidApiBase ? (
-        <p className="mb-2 text-xs text-destructive">有効な API Base URL を入力してください。</p>
+        <p className="mb-2 text-xs text-destructive">{t("stream.invalidUrl")}</p>
       ) : null}
       {apiKey.trim().length > 0 ? (
         <p className="mb-2 text-xs text-amber-600">
-          Security note: API key is sent in the query string for EventSource compatibility. Avoid using production secrets in shared logs.
+          {t("stream.securityWarning")}
         </p>
       ) : null}
 
@@ -142,13 +144,13 @@ export function LiveEventStream(): JSX.Element {
           onClick={() => setEvents([])}
           className="rounded-md border border-border/80 bg-background px-3 py-1 text-xs text-foreground hover:border-primary/70"
         >
-          Clear events
+          {t("stream.clear")}
         </button>
       </div>
 
       <div className="max-h-72 space-y-2 overflow-auto pr-1">
         {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground">イベント待機中...</p>
+          <p className="text-sm text-muted-foreground">{t("stream.waiting")}</p>
         ) : (
           events.map((event) => (
             <article key={`${event.id}-${event.ts}`} className="rounded-md border border-border/60 bg-background/60 p-2">

--- a/frontend/components/mission-layout.test.tsx
+++ b/frontend/components/mission-layout.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MissionLayout } from "./mission-layout";
+import { I18nProvider } from "./i18n";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/governance"
@@ -8,9 +9,11 @@ vi.mock("next/navigation", () => ({
 describe("MissionLayout", () => {
   it("shows all navigation links and highlights active route", () => {
     render(
-      <MissionLayout>
-        <div>child</div>
-      </MissionLayout>
+      <I18nProvider>
+        <MissionLayout>
+          <div>child</div>
+        </MissionLayout>
+      </I18nProvider>
     );
 
     expect(screen.getByRole("link", { name: /command dashboard/i })).toBeInTheDocument();
@@ -19,8 +22,22 @@ describe("MissionLayout", () => {
       "href",
       "/governance"
     );
-    expect(screen.getByText("Environment")).toBeInTheDocument();
-    expect(screen.getByText("Latest Event")).toBeInTheDocument();
+    expect(screen.getByText("環境")).toBeInTheDocument();
+    expect(screen.getByText("最新イベント")).toBeInTheDocument();
     expect(screen.getByText("可読性を優先した運用ビュー")).toBeInTheDocument();
+  });
+
+  it("switches language to english", () => {
+    render(
+      <I18nProvider>
+        <MissionLayout>
+          <div>child</div>
+        </MissionLayout>
+      </I18nProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "en" }));
+    expect(screen.getByText("Operational view focused on readability")).toBeInTheDocument();
+    expect(screen.getByText("Global health and alerts")).toBeInTheDocument();
   });
 });

--- a/frontend/components/mission-layout.tsx
+++ b/frontend/components/mission-layout.tsx
@@ -3,31 +3,14 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Card } from "@veritas/design-system";
+import { useI18n } from "./i18n";
 
 const NAV_ITEMS = [
-  { href: "/", label: "Command Dashboard", short: "監視", desc: "全体ヘルスとアラート" },
-  { href: "/console", label: "Decision Console", short: "実行", desc: "意思決定フロー" },
-  { href: "/governance", label: "Governance Control", short: "統制", desc: "ポリシー運用" },
-  { href: "/audit", label: "TrustLog Explorer", short: "監査", desc: "証跡と追跡" },
-  { href: "/risk", label: "Risk Intelligence", short: "予測", desc: "先行リスク検知" }
-];
-
-const HEADER_METRICS = [
-  {
-    title: "Environment",
-    value: "Production-ready Sandbox",
-    tone: "text-emerald-600"
-  },
-  {
-    title: "Connection",
-    value: "Neural Mesh Stable · 99.982%",
-    tone: "text-sky-600"
-  },
-  {
-    title: "Latest Event",
-    value: "Policy Sync #4821 Completed",
-    tone: "text-violet-600"
-  }
+  { href: "/", label: "Command Dashboard", shortKey: "nav.dashboard.short", descKey: "nav.dashboard.desc" },
+  { href: "/console", label: "Decision Console", shortKey: "nav.console.short", descKey: "nav.console.desc" },
+  { href: "/governance", label: "Governance Control", shortKey: "nav.governance.short", descKey: "nav.governance.desc" },
+  { href: "/audit", label: "TrustLog Explorer", shortKey: "nav.audit.short", descKey: "nav.audit.desc" },
+  { href: "/risk", label: "Risk Intelligence", shortKey: "nav.risk.short", descKey: "nav.risk.desc" }
 ];
 
 interface MissionLayoutProps {
@@ -36,23 +19,48 @@ interface MissionLayoutProps {
 
 export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
   const pathname = usePathname();
+  const { locale, setLocale, t } = useI18n();
+
+  const headerMetrics = [
+    { title: t("layout.environment"), value: t("layout.envValue"), tone: "text-emerald-600" },
+    { title: t("layout.connection"), value: t("layout.connectionValue"), tone: "text-sky-600" },
+    { title: t("layout.latestEvent"), value: t("layout.eventValue"), tone: "text-violet-600" }
+  ];
 
   return (
     <>
       <aside
-        aria-label="サイドバー"
+        aria-label={t("layout.sidebar")}
         className="border-b border-border/70 bg-surface/95 p-6 backdrop-blur-xl lg:row-span-full lg:border-b-0 lg:border-r"
       >
         <a
           href="#main-content"
           className="sr-only z-[var(--ds-z-overlay)] rounded-md bg-primary px-3 py-2 text-primary-foreground focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[hsl(var(--ds-color-focus-ring))]"
         >
-          メインコンテンツへスキップ
+          {t("layout.skipToMain")}
         </a>
         <div className="mb-8 rounded-xl border border-border/60 bg-background/70 p-4 shadow-sm">
           <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground">Mission Control IA</p>
           <h1 className="mt-2 text-2xl font-semibold tracking-tight">統治OS</h1>
-          <p className="mt-2 text-sm text-muted-foreground">可読性を優先した運用ビュー</p>
+          <p className="mt-2 text-sm text-muted-foreground">{t("layout.brandSubtitle")}</p>
+        </div>
+        <div className="mb-4 flex items-center justify-between rounded-xl border border-border/60 bg-background/70 p-3 text-xs">
+          <span className="font-medium text-muted-foreground">{t("layout.language")}</span>
+          <div className="flex rounded-md border border-border/70 bg-background">
+            {(["ja", "en"] as const).map((nextLocale) => (
+              <button
+                key={nextLocale}
+                type="button"
+                onClick={() => setLocale(nextLocale)}
+                className={[
+                  "px-2 py-1 uppercase",
+                  locale === nextLocale ? "bg-primary/20 text-foreground" : "text-muted-foreground"
+                ].join(" ")}
+              >
+                {nextLocale}
+              </button>
+            ))}
+          </div>
         </div>
         <nav aria-label="Main navigation" className="space-y-2">
           {NAV_ITEMS.map((item) => {
@@ -73,10 +81,10 @@ export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
                 <div className="mb-1 flex items-center justify-between gap-3">
                   <p className="text-sm font-semibold text-foreground">{item.label}</p>
                   <span className="rounded-full border border-border/80 bg-surface px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                    {item.short}
+                    {t(item.shortKey)}
                   </span>
                 </div>
-                <p className="text-xs text-muted-foreground">{item.desc}</p>
+                <p className="text-xs text-muted-foreground">{t(item.descKey)}</p>
               </Link>
             );
           })}
@@ -85,7 +93,7 @@ export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
 
       <header className="min-w-0 border-b border-border/70 bg-surface/80 px-6 py-4 backdrop-blur-xl">
         <div className="grid gap-3 md:grid-cols-3">
-          {HEADER_METRICS.map((metric) => (
+          {headerMetrics.map((metric) => (
             <Card key={metric.title} title={metric.title} className="border-border/70 bg-background/75 p-4 shadow-sm">
               <p className={["text-xs uppercase tracking-wide", metric.tone].join(" ")}>{metric.value}</p>
             </Card>

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Card } from "@veritas/design-system";
+import { useI18n } from "./i18n";
 
 interface MissionPageProps {
   title: string;
@@ -7,6 +10,8 @@ interface MissionPageProps {
 }
 
 export function MissionPage({ title, subtitle, chips }: MissionPageProps): JSX.Element {
+  const { t } = useI18n();
+
   return (
     <div className="space-y-6">
       <Card title={title} className="border-border/70 bg-surface/85 p-1 shadow-sm">
@@ -19,7 +24,7 @@ export function MissionPage({ title, subtitle, chips }: MissionPageProps): JSX.E
             <div className="space-y-3">
               <div className="h-1.5 w-24 rounded-full bg-primary/65" />
               <div className="h-16 rounded-lg border border-dashed border-primary/40 bg-primary/5" />
-              <p className="text-xs text-muted-foreground">Widget {index + 1}: operational preview</p>
+              <p className="text-xs text-muted-foreground">{t("mission.widget", { index: index + 1 })}</p>
             </div>
           </Card>
         ))}


### PR DESCRIPTION
### Motivation
- Provide a simple, central client-side i18n layer so the frontend shell and shared components can switch between Japanese and English. 
- Persist operator locale in the browser and update `<html lang>` so accessibility and tests can rely on the selected locale. 
- Localize user-facing labels and status messages in the app shell and LiveEventStream while keeping existing runtime behavior unchanged.

### Description
- Added a client-side `I18nProvider` and `useI18n()` hook with JA/EN dictionaries and `localStorage` persistence at `frontend/components/i18n.tsx`. 
- Wrapped the application root with `I18nProvider` in `frontend/app/layout.tsx` and added a `ja`/`en` toggle UI in the sidebar (`frontend/components/mission-layout.tsx`). 
- Replaced hard-coded strings with translation keys in `MissionLayout`, `MissionPage`, `LiveEventStream`, `app/page.tsx`, and `app/risk/page.tsx`, and preserved the SSE API-key security warning (now localized). 
- Updated component tests to render inside `I18nProvider`, added an English switch assertion, and adjusted test expectations to localized strings (`frontend/components/*.(test|tsx)` updates). 

### Testing
- Ran unit tests with `cd frontend && pnpm test` and all frontend tests passed (`30` tests passed). 
- Ran linter `cd frontend && pnpm lint` with no ESLint issues. 
- Started the dev server and exercised the UI toggle via a Playwright script to capture a screenshot after switching to English, confirming runtime behavior and locale persistence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba7f8444483269455dbfe84e0c763)