### PR TITLE
feat(frontend): add chat-style input panel to decision console

### DIFF
--- a/frontend/app/console/page.test.tsx
+++ b/frontend/app/console/page.test.tsx
@@ -18,11 +18,11 @@ describe("DecisionConsolePage", () => {
   it("shows 401 message when api key is missing", async () => {
     render(<DecisionConsolePage />);
 
-    fireEvent.change(screen.getByPlaceholderText("意思決定したい問いを入力"), {
+    fireEvent.change(screen.getByPlaceholderText("メッセージを入力"), {
       target: { value: "Test" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "実行" }));
+    fireEvent.click(screen.getByRole("button", { name: "送信" }));
 
     expect(await screen.findByText(/401: APIキー不足/)).toBeInTheDocument();
   });
@@ -63,15 +63,18 @@ describe("DecisionConsolePage", () => {
     fireEvent.change(screen.getByPlaceholderText("API key"), {
       target: { value: "test-key" },
     });
-    fireEvent.change(screen.getByPlaceholderText("意思決定したい問いを入力"), {
+    fireEvent.change(screen.getByPlaceholderText("メッセージを入力"), {
       target: { value: "A/B test" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "実行" }));
+    fireEvent.click(screen.getByRole("button", { name: "送信" }));
 
     await waitFor(() => {
       expect(screen.getByText("decision_status / chosen")).toBeInTheDocument();
       expect(screen.getByText("memory_citations / memory_used_count")).toBeInTheDocument();
+      expect(screen.getByRole("list", { name: "chat messages" })).toBeInTheDocument();
+      expect(screen.getByText("user")).toBeInTheDocument();
+      expect(screen.getByText("assistant")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Improve the `/console` developer UI by presenting requests and responses in a chat-like conversation to make decision outcomes and error states easier to inspect.
- Provide a compact, human-readable assistant summary from `DecideResponse` to quickly surface key decision fields.
- Preserve existing `/v1/decide` behavior while making responses and errors visible in the UI for debugging and exploration.

### Description
- Added a `ChatMessage` interface and `chatMessages` state to track user and assistant messages in the console UI. 
- Implemented `toAssistantMessage(payload: DecideResponse)` helper that formats `DecideResponse` into a concise assistant reply and added a small docstring for it. 
- Appended assistant-side messages for success and all error paths (`401`, `503`, other HTTP errors, schema mismatch, network errors) and push user messages when sending requests. 
- Updated the UI: renamed the input label from `query` to `message`, changed the submit button from `実行` to `送信`, and added a chat history panel rendered above the request form. 
- Updated tests in `frontend/app/console/page.test.tsx` to match new placeholders/button text and to assert chat history rendering.

### Testing
- Ran unit tests: `cd frontend && pnpm vitest run app/console/page.test.tsx`, which completed with all tests passing. 
- Performed an automated smoke run: started the Next dev server and verified the `/console` page loaded successfully. 
- Executed an automated Playwright script that filled the chat textarea, clicked `送信`, and captured a screenshot, which completed and produced `artifacts/console-chat.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699badf26db08326aad1dbaa59c4c585)