### PR TITLE
feat(frontend): add real-time 24h risk heatmap with clustering alerts

### DIFF
--- a/frontend/app/risk/page.test.tsx
+++ b/frontend/app/risk/page.test.tsx
@@ -1,0 +1,38 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import RiskIntelligencePage from "./page";
+
+describe("RiskIntelligencePage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the real-time scatter heatmap", () => {
+    render(<RiskIntelligencePage />);
+
+    expect(screen.getByText("Risk Intelligence")).toBeInTheDocument();
+    expect(screen.getByText("Real-time Risk Heatmap")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", {
+        name: "Scatter plot of request uncertainty and risk from the last 24 hours",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Normal")).toBeInTheDocument();
+  });
+
+  it("raises cluster alert when high risk points continue to stream", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+    render(<RiskIntelligencePage />);
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(screen.getByText("Cluster Alert")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/risk/page.tsx
+++ b/frontend/app/risk/page.tsx
@@ -1,11 +1,184 @@
-import { MissionPage } from "../../components/mission-page";
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useEffect, useMemo, useState } from "react";
+
+interface RiskPoint {
+  id: string;
+  uncertainty: number;
+  risk: number;
+  timestamp: number;
+}
+
+const STREAM_WINDOW_MS = 24 * 60 * 60 * 1000;
+const ALERT_CLUSTER_THRESHOLD = 0.82;
+const STREAM_TICK_MS = 2_000;
+const MAX_POINTS = 480;
+
+/**
+ * Generates initial synthetic request telemetry distributed over the past 24h.
+ */
+function createInitialPoints(now: number): RiskPoint[] {
+  return Array.from({ length: 160 }, (_, index) => {
+    const wave = (Math.sin(index * 0.42) + 1) / 2;
+    const uncertainty = Math.min(1, Math.max(0.03, wave * 0.88 + (index % 5) * 0.02));
+    const risk = Math.min(1, Math.max(0.04, ((Math.cos(index * 0.31) + 1) / 2) * 0.9));
+
+    return {
+      id: `seed-${index}`,
+      uncertainty,
+      risk,
+      timestamp: now - (index / 160) * STREAM_WINDOW_MS,
+    };
+  });
+}
+
+/**
+ * Creates one new near-real-time point while preserving occasional high-risk events.
+ */
+function createStreamPoint(now: number): RiskPoint {
+  const id = `${now}-${Math.random().toString(36).slice(2, 8)}`;
+  const uncertainty = Math.random();
+  const baseRisk = uncertainty * 0.65 + Math.random() * 0.35;
+  const spike = Math.random() > 0.93 ? 0.15 : 0;
+
+  return {
+    id,
+    uncertainty,
+    risk: Math.min(1, baseRisk + spike),
+    timestamp: now,
+  };
+}
+
+function toChartCoordinate(value: number): number {
+  return Math.round(value * 100);
+}
 
 export default function RiskIntelligencePage(): JSX.Element {
+  const [points, setPoints] = useState<RiskPoint[]>(() => createInitialPoints(Date.now()));
+  const [now, setNow] = useState<number>(Date.now());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      const tick = Date.now();
+      setNow(tick);
+      setPoints((previous) => {
+        const next = [...previous, createStreamPoint(tick)]
+          .filter((point) => tick - point.timestamp <= STREAM_WINDOW_MS)
+          .slice(-MAX_POINTS);
+        return next;
+      });
+    }, STREAM_TICK_MS);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const clusterStats = useMemo(() => {
+    const highRiskPoints = points.filter(
+      (point) => point.uncertainty >= ALERT_CLUSTER_THRESHOLD && point.risk >= ALERT_CLUSTER_THRESHOLD,
+    );
+    const ratio = points.length === 0 ? 0 : highRiskPoints.length / points.length;
+    return {
+      ratio,
+      count: highRiskPoints.length,
+      alert: highRiskPoints.length >= 15 || ratio >= 0.08,
+    };
+  }, [points]);
+
   return (
-    <MissionPage
-      title="Risk Intelligence"
-      subtitle="先行指標とシナリオ推論により、未来リスクの予兆を可視化します。"
-      chips={["Predictive Radar", "Threat Horizon", "Impact Forecast"]}
-    />
+    <div className="space-y-6">
+      <Card title="Risk Intelligence" className="border-border/70 bg-surface/85 p-1 shadow-sm">
+        <p className="max-w-4xl text-sm leading-relaxed text-muted-foreground">
+          過去24時間の全リクエストを不確実性（横軸）と潜在的リスク（縦軸）でリアルタイム可視化します。
+          危険なクラスタリングを検知するとアラートを表示し、予防的な統治判断を支援します。
+        </p>
+      </Card>
+
+      <Card
+        title="Real-time Risk Heatmap"
+        className="border-border/70 bg-background/80 shadow-sm"
+      >
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+            <div className="flex items-center gap-2">
+              <span
+                className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${
+                  clusterStats.alert
+                    ? "bg-destructive/15 text-destructive"
+                    : "bg-primary/15 text-primary"
+                }`}
+              >
+                {clusterStats.alert ? "Cluster Alert" : "Normal"}
+              </span>
+              <span className="text-muted-foreground">
+                High-Risk Cluster: {clusterStats.count} / {points.length} (
+                {(clusterStats.ratio * 100).toFixed(1)}%)
+              </span>
+            </div>
+            <span className="text-xs text-muted-foreground" aria-live="polite">
+              Last update: {new Date(now).toLocaleTimeString("ja-JP", { hour12: false })}
+            </span>
+          </div>
+
+          <div className="rounded-xl border border-border/70 bg-surface/40 p-4">
+            <div className="relative mx-auto h-[360px] w-full max-w-5xl">
+              <svg
+                viewBox="0 0 100 100"
+                className="h-full w-full"
+                role="img"
+                aria-label="Scatter plot of request uncertainty and risk from the last 24 hours"
+              >
+                <defs>
+                  <linearGradient id="riskGradient" x1="0" y1="100" x2="100" y2="0">
+                    <stop offset="0%" stopColor="hsl(var(--primary) / 0.18)" />
+                    <stop offset="55%" stopColor="hsl(var(--warning) / 0.2)" />
+                    <stop offset="100%" stopColor="hsl(var(--destructive) / 0.28)" />
+                  </linearGradient>
+                </defs>
+
+                <rect x="0" y="0" width="100" height="100" fill="url(#riskGradient)" rx="2" />
+
+                {[20, 40, 60, 80].map((line) => (
+                  <g key={line}>
+                    <line x1={line} y1={0} x2={line} y2={100} stroke="hsl(var(--border) / 0.6)" strokeWidth="0.3" />
+                    <line x1={0} y1={line} x2={100} y2={line} stroke="hsl(var(--border) / 0.6)" strokeWidth="0.3" />
+                  </g>
+                ))}
+
+                <line x1="82" y1="0" x2="82" y2="100" stroke="hsl(var(--destructive) / 0.6)" strokeDasharray="1 1" strokeWidth="0.4" />
+                <line x1="0" y1="18" x2="100" y2="18" stroke="hsl(var(--destructive) / 0.6)" strokeDasharray="1 1" strokeWidth="0.4" />
+
+                {points.map((point) => {
+                  const x = toChartCoordinate(point.uncertainty);
+                  const y = 100 - toChartCoordinate(point.risk);
+                  const critical = point.uncertainty >= ALERT_CLUSTER_THRESHOLD
+                    && point.risk >= ALERT_CLUSTER_THRESHOLD;
+
+                  return (
+                    <circle
+                      key={point.id}
+                      cx={x}
+                      cy={y}
+                      r={critical ? 1.2 : 0.8}
+                      fill={critical ? "hsl(var(--destructive))" : "hsl(var(--primary) / 0.82)"}
+                      opacity={critical ? 0.95 : 0.72}
+                    />
+                  );
+                })}
+              </svg>
+
+              <span className="absolute -bottom-7 left-1/2 -translate-x-1/2 text-xs text-muted-foreground">
+                Uncertainty →
+              </span>
+              <span className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-8 -rotate-90 text-xs text-muted-foreground">
+                Risk →
+              </span>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
   );
 }


### PR DESCRIPTION
### Motivation
- 現行の「Risk Intelligence」プレースホルダーを、管理者が過去24時間のリクエストにおける“不確実性（Uncertainty）×潜在リスク（Risk）”を一目で把握できるリアルタイム散布ヒートマップに置き換え、異常なクラスタリング検出で予防的統治を支援します。
- 合成ストリームで挙動を可視化することで、将来の実データ連携・アラート閾値調整のための実装基盤を提供します。

### Description
- `frontend/app/risk/page.tsx` をクライアントコンポーネントに置換し、過去24時間ウィンドウで2秒間隔の擬似ストリームを生成して散布図をリアルタイム更新する実装を追加しました。
- 高リスク判定用の定数とロジック（`ALERT_CLUSTER_THRESHOLD`, ウィンドウサイズ, `MAX_POINTS` など）と、クラスタ検出ロジックに基づくアラート表示（Normal / Cluster Alert）を導入しました。
- 描画は SVG ベースの散布図で行い、重要なヘルパー関数に説明コメント（docstring 相当）を追加しました。
- `frontend/app/risk/page.test.tsx` を新規追加し、レンダリングのアクセシビリティと高リスク継続ストリーム時のアラート遷移を `vitest` で検証するテストを実装しました.

### Testing
- 実行したテストは `pnpm --filter frontend test -- app/risk/page.test.tsx` で、`app/risk/page.test.tsx` の 2 テストが共に成功しました (passed).
- 型チェックは `pnpm --filter frontend typecheck` を実行して問題ないことを確認しました (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb166b9288326932063e6530688f3)