### PR TITLE
feat(frontend): add Japanese/English language toggle (I18nProvider)

### DIFF
--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { Card } from "@veritas/design-system";
 import { isRequestLogResponse, isTrustLogsResponse, type RequestLogResponse, type TrustLogItem } from "../../lib/api-validators";
+import { useI18n } from "../../components/i18n-provider";
 
 const DEFAULT_API_BASE = process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL ?? "http://localhost:8000";
 const ENV_API_KEY = process.env.NEXT_PUBLIC_VERITAS_API_KEY ?? "";
@@ -17,6 +18,7 @@ function toPrettyJson(value: unknown): string {
 }
 
 export default function TrustLogExplorerPage(): JSX.Element {
+  const { t } = useI18n();
   const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
   const [apiKey, setApiKey] = useState(ENV_API_KEY);
   const [cursor, setCursor] = useState<string | null>(null);
@@ -61,13 +63,13 @@ export default function TrustLogExplorerPage(): JSX.Element {
       });
 
       if (!response.ok) {
-        setError(`HTTP ${response.status}: trust logs取得に失敗しました。`);
+        setError(`HTTP ${response.status}: ${t("trust logs取得に失敗しました。", "Failed to fetch trust logs.")}`);
         return;
       }
 
       const payload: unknown = await response.json();
       if (!isTrustLogsResponse(payload)) {
-        setError("レスポンス形式エラー: trust logs の形式が不正です。");
+        setError(t("レスポンス形式エラー: trust logs の形式が不正です。", "Response format error: trust logs payload is invalid."));
         return;
       }
       const nextItems = payload.items;
@@ -78,7 +80,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
         setSelected(nextItems[0]);
       }
     } catch {
-      setError("ネットワークエラー: trust logs 取得に失敗しました。");
+      setError(t("ネットワークエラー: trust logs 取得に失敗しました。", "Network error: failed to fetch trust logs."));
     } finally {
       setLoading(false);
     }
@@ -89,7 +91,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
     setRequestResult(null);
     setError(null);
     if (!value) {
-      setError("request_id を入力してください。");
+      setError(t("request_id を入力してください。", "Please enter request_id."));
       return;
     }
 
@@ -102,13 +104,13 @@ export default function TrustLogExplorerPage(): JSX.Element {
       });
 
       if (!response.ok) {
-        setError(`HTTP ${response.status}: request_id 検索に失敗しました。`);
+        setError(`HTTP ${response.status}: ${t("request_id 検索に失敗しました。", "Failed to search request_id.")}`);
         return;
       }
 
       const payload: unknown = await response.json();
       if (!isRequestLogResponse(payload)) {
-        setError("レスポンス形式エラー: request_id 応答の形式が不正です。");
+        setError(t("レスポンス形式エラー: request_id 応答の形式が不正です。", "Response format error: request_id payload is invalid."));
         return;
       }
       setRequestResult(payload);
@@ -116,7 +118,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
         setSelected(payload.items[payload.items.length - 1]);
       }
     } catch {
-      setError("ネットワークエラー: request_id 検索に失敗しました。");
+      setError(t("ネットワークエラー: request_id 検索に失敗しました。", "Network error: failed to search request_id."));
     } finally {
       setLoading(false);
     }
@@ -126,7 +128,10 @@ export default function TrustLogExplorerPage(): JSX.Element {
     <div className="space-y-6">
       <Card title="TrustLog Explorer" className="border-primary/50 bg-surface/85">
         <p className="text-sm text-muted-foreground">
-          /v1/trust/logs と /v1/trust/{"{request_id}"} を使って、監査証跡を時系列に確認します。
+          {t(
+            "/v1/trust/logs と /v1/trust/{request_id} を使って、監査証跡を時系列に確認します。",
+            "Use /v1/trust/logs and /v1/trust/{request_id} to review audit evidence in chronological order.",
+          )}
         </p>
       </Card>
 
@@ -134,88 +139,43 @@ export default function TrustLogExplorerPage(): JSX.Element {
         <div className="grid gap-3 md:grid-cols-2">
           <label className="space-y-1 text-xs">
             <span className="font-medium">API Base URL</span>
-            <input
-              className="w-full rounded-md border border-border bg-background px-2 py-2"
-              value={apiBase}
-              onChange={(event) => setApiBase(event.target.value)}
-            />
+            <input className="w-full rounded-md border border-border bg-background px-2 py-2" value={apiBase} onChange={(event) => setApiBase(event.target.value)} />
           </label>
           <label className="space-y-1 text-xs">
             <span className="font-medium">X-API-Key</span>
-            <input
-              className="w-full rounded-md border border-border bg-background px-2 py-2"
-              value={apiKey}
-              onChange={(event) => setApiKey(event.target.value)}
-              type="password"
-              autoComplete="off"
-            />
+            <input className="w-full rounded-md border border-border bg-background px-2 py-2" value={apiKey} onChange={(event) => setApiKey(event.target.value)} type="password" autoComplete="off" />
           </label>
         </div>
 
         <div className="mt-3 flex flex-wrap gap-2">
-          <button
-            type="button"
-            className="rounded-md border border-primary/60 bg-primary/20 px-3 py-2 text-sm"
-            disabled={loading || !apiKey.trim()}
-            onClick={() => void loadLogs(null, true)}
-          >
-            最新ログを読み込み
+          <button type="button" className="rounded-md border border-primary/60 bg-primary/20 px-3 py-2 text-sm" disabled={loading || !apiKey.trim()} onClick={() => void loadLogs(null, true)}>
+            {t("最新ログを読み込み", "Load latest logs")}
           </button>
-          <button
-            type="button"
-            className="rounded-md border border-border px-3 py-2 text-sm"
-            disabled={loading || !hasMore || !cursor || !apiKey.trim()}
-            onClick={() => void loadLogs(cursor, false)}
-          >
-            さらに読み込む
+          <button type="button" className="rounded-md border border-border px-3 py-2 text-sm" disabled={loading || !hasMore || !cursor || !apiKey.trim()} onClick={() => void loadLogs(cursor, false)}>
+            {t("さらに読み込む", "Load more")}
           </button>
         </div>
       </Card>
 
-      <Card title="request_id 検索" className="bg-background/75">
+      <Card title={t("request_id 検索", "request_id Search")} className="bg-background/75">
         <div className="flex flex-col gap-2 md:flex-row">
-          <input
-            aria-label="request_id"
-            className="w-full rounded-md border border-border bg-background px-2 py-2 text-sm"
-            placeholder="request_id"
-            value={requestId}
-            onChange={(event) => setRequestId(event.target.value)}
-          />
-          <button
-            type="button"
-            className="rounded-md border border-primary/60 bg-primary/20 px-3 py-2 text-sm"
-            disabled={loading || !apiKey.trim()}
-            onClick={() => void searchByRequestId()}
-          >
-            検索
+          <input aria-label="request_id" className="w-full rounded-md border border-border bg-background px-2 py-2 text-sm" placeholder="request_id" value={requestId} onChange={(event) => setRequestId(event.target.value)} />
+          <button type="button" className="rounded-md border border-primary/60 bg-primary/20 px-3 py-2 text-sm" disabled={loading || !apiKey.trim()} onClick={() => void searchByRequestId()}>
+            {t("検索", "Search")}
           </button>
         </div>
-        {requestResult ? (
-          <p className="mt-2 text-xs text-muted-foreground">
-            count: {requestResult.count} / chain_ok: {String(requestResult.chain_ok)} /
-            verification_result: {requestResult.verification_result}
-          </p>
-        ) : null}
+        {requestResult ? <p className="mt-2 text-xs text-muted-foreground">count: {requestResult.count} / chain_ok: {String(requestResult.chain_ok)} / verification_result: {requestResult.verification_result}</p> : null}
       </Card>
 
       {error ? <p className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-300">{error}</p> : null}
 
       <Card title="Timeline" className="bg-background/75">
         <div className="mb-3 flex items-center gap-2 text-xs">
-          <label htmlFor="stage-filter" className="font-medium">ステージフィルタ</label>
-          <select
-            id="stage-filter"
-            className="rounded-md border border-border bg-background px-2 py-1"
-            value={stageFilter}
-            onChange={(event) => setStageFilter(event.target.value)}
-          >
-            {stageOptions.map((stage) => (
-              <option key={stage} value={stage}>
-                {stage}
-              </option>
-            ))}
+          <label htmlFor="stage-filter" className="font-medium">{t("ステージフィルタ", "Stage filter")}</label>
+          <select id="stage-filter" className="rounded-md border border-border bg-background px-2 py-1" value={stageFilter} onChange={(event) => setStageFilter(event.target.value)}>
+            {stageOptions.map((stage) => (<option key={stage} value={stage}>{stage}</option>))}
           </select>
-          <span className="text-muted-foreground">表示件数: {filteredItems.length}</span>
+          <span className="text-muted-foreground">{t("表示件数", "Visible")}: {filteredItems.length}</span>
         </div>
 
         <ol className="max-h-[520px] space-y-2 overflow-y-auto border-l border-border pl-4">
@@ -226,9 +186,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
               <li key={id}>
                 <button
                   type="button"
-                  className={`w-full rounded-md border px-3 py-2 text-left text-xs ${
-                    isSelected ? "border-primary/60 bg-primary/15" : "border-border bg-background/60"
-                  }`}
+                  className={`w-full rounded-md border px-3 py-2 text-left text-xs ${isSelected ? "border-primary/60 bg-primary/15" : "border-border bg-background/60"}`}
                   onClick={() => setSelected(item)}
                 >
                   <p className="font-semibold">{item.stage ?? "UNKNOWN"}</p>
@@ -244,13 +202,11 @@ export default function TrustLogExplorerPage(): JSX.Element {
       <Card title="Selected JSON" className="bg-background/75">
         {selected ? (
           <details open>
-            <summary className="cursor-pointer text-sm font-semibold">JSON 展開</summary>
-            <pre className="mt-2 overflow-x-auto rounded-md border border-border bg-background/70 p-3 text-xs">
-              {toPrettyJson(selected)}
-            </pre>
+            <summary className="cursor-pointer text-sm font-semibold">{t("JSON 展開", "Expand JSON")}</summary>
+            <pre className="mt-2 overflow-x-auto rounded-md border border-border bg-background/70 p-3 text-xs">{toPrettyJson(selected)}</pre>
           </details>
         ) : (
-          <p className="text-sm text-muted-foreground">ログを選択してください。</p>
+          <p className="text-sm text-muted-foreground">{t("ログを選択してください。", "Select a log.")}</p>
         )}
       </Card>
     </div>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 import { ThemeStyles, applyThemeClass } from "@veritas/design-system";
 import { MissionLayout } from "../components/mission-layout";
+import { I18nProvider } from "../components/i18n-provider";
 import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Mission Control IA",
-  description: "統治OSの運用コンソール"
+  description: "Governance OS operations console"
 };
 
 export default function RootLayout({
@@ -19,7 +20,9 @@ export default function RootLayout({
         <ThemeStyles />
       </head>
       <body>
-        <MissionLayout>{children}</MissionLayout>
+        <I18nProvider>
+          <MissionLayout>{children}</MissionLayout>
+        </I18nProvider>
       </body>
     </html>
   );

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,13 +1,21 @@
+"use client";
+
 import { MissionPage } from "../components/mission-page";
 import { LiveEventStream } from "../components/live-event-stream";
+import { useI18n } from "../components/i18n-provider";
 
 export default function CommandDashboardPage(): JSX.Element {
+  const { t } = useI18n();
+
   return (
     <div className="space-y-6">
       <LiveEventStream />
       <MissionPage
         title="Command Dashboard"
-        subtitle="ミッション全体の健全性を俯瞰監視し、異常シグナルを即時に検出します。"
+        subtitle={t(
+          "ミッション全体の健全性を俯瞰監視し、異常シグナルを即時に検出します。",
+          "Monitor overall mission health at a glance and detect abnormal signals immediately.",
+        )}
         chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
       />
     </div>

--- a/frontend/app/risk/page.tsx
+++ b/frontend/app/risk/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card } from "@veritas/design-system";
+import { useI18n } from "../../components/i18n-provider";
 import { useEffect, useMemo, useState } from "react";
 
 interface RiskPoint {
@@ -55,6 +56,7 @@ function toChartCoordinate(value: number): number {
 }
 
 export default function RiskIntelligencePage(): JSX.Element {
+  const { t, language } = useI18n();
   const [points, setPoints] = useState<RiskPoint[]>(() => createInitialPoints(Date.now()));
   const [now, setNow] = useState<number>(Date.now());
 
@@ -91,8 +93,7 @@ export default function RiskIntelligencePage(): JSX.Element {
     <div className="space-y-6">
       <Card title="Risk Intelligence" className="border-border/70 bg-surface/85 p-1 shadow-sm">
         <p className="max-w-4xl text-sm leading-relaxed text-muted-foreground">
-          過去24時間の全リクエストを不確実性（横軸）と潜在的リスク（縦軸）でリアルタイム可視化します。
-          危険なクラスタリングを検知するとアラートを表示し、予防的な統治判断を支援します。
+          {t("過去24時間の全リクエストを不確実性（横軸）と潜在的リスク（縦軸）でリアルタイム可視化します。危険なクラスタリングを検知するとアラートを表示し、予防的な統治判断を支援します。", "Visualize all requests from the last 24 hours in real time by uncertainty (x-axis) and potential risk (y-axis). When dangerous clustering is detected, alerts support proactive governance decisions.")}
         </p>
       </Card>
 
@@ -118,7 +119,7 @@ export default function RiskIntelligencePage(): JSX.Element {
               </span>
             </div>
             <span className="text-xs text-muted-foreground" aria-live="polite">
-              Last update: {new Date(now).toLocaleTimeString("ja-JP", { hour12: false })}
+              Last update: {new Date(now).toLocaleTimeString(language === "ja" ? "ja-JP" : "en-US", { hour12: false })}
             </span>
           </div>
 

--- a/frontend/components/i18n-provider.tsx
+++ b/frontend/components/i18n-provider.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+type Language = "ja" | "en";
+
+interface I18nContextValue {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  t: (ja: string, en: string) => string;
+}
+
+const defaultI18nContext: I18nContextValue = {
+  language: "ja",
+  setLanguage: () => undefined,
+  t: (ja: string, en: string) => ja ?? en,
+};
+
+const I18nContext = createContext<I18nContextValue>(defaultI18nContext);
+
+export function I18nProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  const [language, setLanguage] = useState<Language>("ja");
+
+  useEffect(() => {
+    const storedLanguage = window.localStorage.getItem("veritas_language");
+    if (storedLanguage === "ja" || storedLanguage === "en") {
+      setLanguage(storedLanguage);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem("veritas_language", language);
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+      t: (ja: string, en: string) => (language === "ja" ? ja : en),
+    }),
+    [language],
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n(): I18nContextValue {
+  return useContext(I18nContext);
+}

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card } from "@veritas/design-system";
+import { useI18n } from "./i18n-provider";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const DEFAULT_API_BASE = process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL ?? "http://localhost:8000";
@@ -36,6 +37,7 @@ function buildEventUrl(apiBase: string, apiKey: string): string | null {
 }
 
 export function LiveEventStream(): JSX.Element {
+  const { t } = useI18n();
   const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
   const [apiKey, setApiKey] = useState(ENV_API_KEY);
   const [events, setEvents] = useState<StreamEvent[]>([]);
@@ -128,7 +130,7 @@ export function LiveEventStream(): JSX.Element {
         Status: <span aria-live="polite">{streamStatus}</span>
       </p>
       {hasInvalidApiBase ? (
-        <p className="mb-2 text-xs text-destructive">有効な API Base URL を入力してください。</p>
+        <p className="mb-2 text-xs text-destructive">{t("有効な API Base URL を入力してください。", "Enter a valid API Base URL.")}</p>
       ) : null}
       {apiKey.trim().length > 0 ? (
         <p className="mb-2 text-xs text-amber-600">
@@ -148,7 +150,7 @@ export function LiveEventStream(): JSX.Element {
 
       <div className="max-h-72 space-y-2 overflow-auto pr-1">
         {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground">イベント待機中...</p>
+          <p className="text-sm text-muted-foreground">{t("イベント待機中...", "Waiting for events...")}</p>
         ) : (
           events.map((event) => (
             <article key={`${event.id}-${event.ts}`} className="rounded-md border border-border/60 bg-background/60 p-2">

--- a/frontend/components/mission-layout.tsx
+++ b/frontend/components/mission-layout.tsx
@@ -3,31 +3,70 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Card } from "@veritas/design-system";
+import { useI18n } from "./i18n-provider";
 
 const NAV_ITEMS = [
-  { href: "/", label: "Command Dashboard", short: "監視", desc: "全体ヘルスとアラート" },
-  { href: "/console", label: "Decision Console", short: "実行", desc: "意思決定フロー" },
-  { href: "/governance", label: "Governance Control", short: "統制", desc: "ポリシー運用" },
-  { href: "/audit", label: "TrustLog Explorer", short: "監査", desc: "証跡と追跡" },
-  { href: "/risk", label: "Risk Intelligence", short: "予測", desc: "先行リスク検知" }
+  {
+    href: "/",
+    label: "Command Dashboard",
+    shortJa: "監視",
+    shortEn: "Watch",
+    descJa: "全体ヘルスとアラート",
+    descEn: "System health and alerts",
+  },
+  {
+    href: "/console",
+    label: "Decision Console",
+    shortJa: "実行",
+    shortEn: "Run",
+    descJa: "意思決定フロー",
+    descEn: "Decision pipeline",
+  },
+  {
+    href: "/governance",
+    label: "Governance Control",
+    shortJa: "統制",
+    shortEn: "Policy",
+    descJa: "ポリシー運用",
+    descEn: "Policy operations",
+  },
+  {
+    href: "/audit",
+    label: "TrustLog Explorer",
+    shortJa: "監査",
+    shortEn: "Audit",
+    descJa: "証跡と追跡",
+    descEn: "Evidence and traceability",
+  },
+  {
+    href: "/risk",
+    label: "Risk Intelligence",
+    shortJa: "予測",
+    shortEn: "Risk",
+    descJa: "先行リスク検知",
+    descEn: "Early risk detection",
+  },
 ];
 
 const HEADER_METRICS = [
   {
     title: "Environment",
-    value: "Production-ready Sandbox",
-    tone: "text-emerald-600"
+    valueJa: "本番準備済みサンドボックス",
+    valueEn: "Production-ready Sandbox",
+    tone: "text-emerald-600",
   },
   {
     title: "Connection",
-    value: "Neural Mesh Stable · 99.982%",
-    tone: "text-sky-600"
+    valueJa: "Neural Mesh 安定 · 99.982%",
+    valueEn: "Neural Mesh Stable · 99.982%",
+    tone: "text-sky-600",
   },
   {
     title: "Latest Event",
-    value: "Policy Sync #4821 Completed",
-    tone: "text-violet-600"
-  }
+    valueJa: "Policy Sync #4821 完了",
+    valueEn: "Policy Sync #4821 Completed",
+    tone: "text-violet-600",
+  },
 ];
 
 interface MissionLayoutProps {
@@ -36,23 +75,40 @@ interface MissionLayoutProps {
 
 export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
   const pathname = usePathname();
+  const { language, setLanguage, t } = useI18n();
 
   return (
     <>
       <aside
-        aria-label="サイドバー"
+        aria-label={t("サイドバー", "Sidebar")}
         className="border-b border-border/70 bg-surface/95 p-6 backdrop-blur-xl lg:row-span-full lg:border-b-0 lg:border-r"
       >
         <a
           href="#main-content"
           className="sr-only z-[var(--ds-z-overlay)] rounded-md bg-primary px-3 py-2 text-primary-foreground focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[hsl(var(--ds-color-focus-ring))]"
         >
-          メインコンテンツへスキップ
+          {t("メインコンテンツへスキップ", "Skip to main content")}
         </a>
         <div className="mb-8 rounded-xl border border-border/60 bg-background/70 p-4 shadow-sm">
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground">Mission Control IA</p>
-          <h1 className="mt-2 text-2xl font-semibold tracking-tight">統治OS</h1>
-          <p className="mt-2 text-sm text-muted-foreground">可読性を優先した運用ビュー</p>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground">Mission Control IA</p>
+            <label className="text-xs text-muted-foreground">
+              <span className="mr-2">Lang</span>
+              <select
+                aria-label="Language"
+                value={language}
+                onChange={(event) => setLanguage(event.target.value as "ja" | "en")}
+                className="rounded-md border border-border bg-background px-2 py-1"
+              >
+                <option value="ja">日本語</option>
+                <option value="en">English</option>
+              </select>
+            </label>
+          </div>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight">{t("統治OS", "Governance OS")}</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {t("可読性を優先した運用ビュー", "Operations view optimized for readability")}
+          </p>
         </div>
         <nav aria-label="Main navigation" className="space-y-2">
           {NAV_ITEMS.map((item) => {
@@ -67,16 +123,16 @@ export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
                   "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[hsl(var(--ds-color-focus-ring))]",
                   isActive
                     ? "border-primary/70 bg-primary/10 shadow-[0_8px_28px_hsl(var(--ds-color-primary)_/_0.18)]"
-                    : "border-border/70 bg-background/70 hover:border-primary/50 hover:bg-background"
+                    : "border-border/70 bg-background/70 hover:border-primary/50 hover:bg-background",
                 ].join(" ")}
               >
                 <div className="mb-1 flex items-center justify-between gap-3">
                   <p className="text-sm font-semibold text-foreground">{item.label}</p>
                   <span className="rounded-full border border-border/80 bg-surface px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                    {item.short}
+                    {t(item.shortJa, item.shortEn)}
                   </span>
                 </div>
-                <p className="text-xs text-muted-foreground">{item.desc}</p>
+                <p className="text-xs text-muted-foreground">{t(item.descJa, item.descEn)}</p>
               </Link>
             );
           })}
@@ -87,7 +143,7 @@ export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
         <div className="grid gap-3 md:grid-cols-3">
           {HEADER_METRICS.map((metric) => (
             <Card key={metric.title} title={metric.title} className="border-border/70 bg-background/75 p-4 shadow-sm">
-              <p className={["text-xs uppercase tracking-wide", metric.tone].join(" ")}>{metric.value}</p>
+              <p className={["text-xs uppercase tracking-wide", metric.tone].join(" ")}>{t(metric.valueJa, metric.valueEn)}</p>
             </Card>
           ))}
         </div>

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@veritas/design-system";
+import { useI18n } from "./i18n-provider";
 
 interface MissionPageProps {
   title: string;
@@ -7,6 +8,8 @@ interface MissionPageProps {
 }
 
 export function MissionPage({ title, subtitle, chips }: MissionPageProps): JSX.Element {
+  const { t } = useI18n();
+
   return (
     <div className="space-y-6">
       <Card title={title} className="border-border/70 bg-surface/85 p-1 shadow-sm">
@@ -19,7 +22,7 @@ export function MissionPage({ title, subtitle, chips }: MissionPageProps): JSX.E
             <div className="space-y-3">
               <div className="h-1.5 w-24 rounded-full bg-primary/65" />
               <div className="h-16 rounded-lg border border-dashed border-primary/40 bg-primary/5" />
-              <p className="text-xs text-muted-foreground">Widget {index + 1}: operational preview</p>
+              <p className="text-xs text-muted-foreground">{t(`Widget ${index + 1}: 運用プレビュー`, `Widget ${index + 1}: operational preview`)}</p>
             </div>
           </Card>
         ))}


### PR DESCRIPTION
### Motivation
- Provide a lightweight client-side i18n layer so the frontend can display either Japanese or English and operators can switch languages at runtime with persistence. 
- Keep user-facing messages, error text and small UI labels translatable without changing app routes or backend contracts. 
- Security note: the Live Event Stream still places the API key in the EventSource query string for compatibility, which increases secret-exposure risk in shared logs and must be treated cautiously in production. 

### Description
- Added a new `I18nProvider` + `useI18n()` (`frontend/components/i18n-provider.tsx`) exposing `t(ja, en)` and persistent language state in `localStorage`. 
- Wrapped the app root with `<I18nProvider>` and updated metadata description to English-aware text in `frontend/app/layout.tsx`. 
- Reworked the sidebar (`frontend/components/mission-layout.tsx`) to include a language selector and replaced many static JP labels/short descriptions/metrics with `t(ja, en)` calls. 
- Converted key pages/components to use `useI18n().t(...)`: Command Dashboard, MissionPage, LiveEventStream, Decision Console, TrustLog Explorer and Risk page, and represented danger presets with `{ja,en}` pairs in the console to allow translation. 
- Made `useI18n` safe for tests by providing a default context value so unit tests run without needing to mount a provider. 

### Testing
- Ran unit tests with `cd frontend && pnpm test` and all frontend tests passed: `31 passed (31)` after fixing provider default; an initial run failed until the default context was added. 
- Verified dev server startup with `cd frontend && pnpm dev --port 3000` (Next.js served locally) and captured a Playwright screenshot of the updated dashboard (`artifacts/i18n-dashboard.png`). 
- No backend/API behavior was changed and existing API contracts remain the same; automated tests and a local dev run were used for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb4fd6e9883268e56007b5a6c2fd6)