### PR TITLE
Add ValueCore (Value EMA) drift monitoring API and Governance UI card

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -32,7 +32,7 @@ from fastapi.security.api_key import APIKeyHeader
 
 # ---- API層（ここは基本 "安定" 前提）----
 from veritas_os.api.schemas import DecideRequest, DecideResponse, FujiDecision
-from veritas_os.api.governance import get_policy, update_policy
+from veritas_os.api.governance import get_policy, get_value_drift, update_policy
 from veritas_os.api.constants import (
     DECISION_ALLOW,
     DECISION_REJECTED,
@@ -1828,6 +1828,20 @@ def trust_feedback(body: dict):
 # ==============================
 # Governance Policy API
 # ==============================
+
+@app.get("/v1/governance/value-drift", dependencies=[Depends(require_api_key)])
+def governance_value_drift(telos_baseline: float = Query(default=0.5, ge=0.0, le=1.0)):
+    """Return ValueCore drift metrics against a Telos baseline."""
+    try:
+        result = get_value_drift(telos_baseline=telos_baseline)
+        return {"ok": True, "value_drift": result}
+    except Exception as e:
+        logger.error("governance_value_drift failed: %s", e)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": "Failed to load value drift metrics"},
+        )
+
 
 @app.get("/v1/governance/policy", dependencies=[Depends(require_api_key)])
 def governance_get():


### PR DESCRIPTION
### Motivation
- Provide observability for ValueCore (Value EMA) drift versus an organization Telos baseline so operators can detect policy drift (unexpected radicalization or complacency). 
- Expose a compact, protected API and a small UI surface to surface baseline, latest EMA, percent drift and recent EMA history for governance workflows.

### Description
- Implemented ValueCore drift computation in `veritas_os/api/governance.py` including history loading/normalization from known value_stats locations, clamping of EMA/baseline, percent-drift calculation and a `get_value_drift()` helper that returns `baseline`, `latest_ema`, `drift_percent`, `history` and `status` (`ok`/`no_data`).
- Added `GET /v1/governance/value-drift` endpoint in `veritas_os/api/server.py` protected by the existing API key dependency and returning the helper payload or a 500 JSONResponse on error.
- Extended governance frontend `frontend/app/governance/page.tsx` to fetch the value-drift API after loading the policy and render a new "Policy Drift (ValueCore監視)" Card showing baseline, latest EMA, drift% and a recent history list.
- Added unit tests and small docstrings: backend tests in `veritas_os/tests/test_governance_api.py` for helper behavior (with/without history) and endpoint success/error paths, and frontend tests in `frontend/app/governance/page.test.tsx` for fetch/render behavior (including the new card); meaningful function docstrings were added for clarity.

### Testing
- Ran backend unit tests: `pytest -q veritas_os/tests/test_governance_api.py` — all tests passed (25 passed).
- Ran frontend unit tests: `pnpm -s vitest run app/governance/page.test.tsx` (from `frontend/`) — all governance page tests passed (10 passed).
- Manually exercised dev server and captured a UI screenshot using a Playwright script against Next dev server to validate rendering; navigation and card rendering succeeded.

Security notes: the new endpoint is gated by the existing API key requirement and server-side clamps are applied to baseline/EMA to limit malformed-input impact; however the returned history includes timestamps (operational metadata) so consider access restrictions to management roles only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb930b7c88326b3a64c33975c45a3)