### PR TITLE
Add cost-benefit uncertainty analytics to decision pipeline

### DIFF
--- a/veritas_os/tests/test_api_pipeline.py
+++ b/veritas_os/tests/test_api_pipeline.py
@@ -506,6 +506,15 @@ async def test_run_decide_pipeline_happy_path(patched_pipeline):
     assert "mem_hits" in metrics
     assert "value_ema" in metrics
     assert "effective_risk" in metrics
+    assert "cost_benefit" in metrics
+
+    cost_benefit = metrics.get("cost_benefit") or {}
+    assert isinstance(cost_benefit, dict)
+    assert "total_token_cost" in cost_benefit
+    assert "total_uncertainty_reduction_pct" in cost_benefit
+    assert len(cost_benefit.get("steps", [])) == 3
+    stages = [step.get("stage") for step in cost_benefit.get("steps", [])]
+    assert stages == ["debate", "critique", "fuji_gate"]
 
     # ★ Memory evidence が evidence に混ざること（仕様として担保）
     assert any(
@@ -1038,7 +1047,6 @@ async def test_run_decide_pipeline_trustlog_and_shadow_exception_swallowed(monke
     assert isinstance(metrics, dict)
     assert "effective_risk" in metrics
     assert "gate" in payload
-
 
 
 


### PR DESCRIPTION
### Motivation
- Make the economic rationale of running heavy pipeline stages visible by quantifying how much each stage (Debate / Critique / FUJI) reduces decision uncertainty and the estimated token cost incurred.
- Provide a stable `extras.metrics.cost_benefit` contract so consumers can always read analytics even when stages are skipped or degraded.
- Security note: the token-cost is a local estimate derived from payload serialization and is not provider billing; do not use it as a precise billing metric and avoid exposing raw payloads externally.

### Description
- Added helper functions in `veritas_os/core/pipeline.py`: `_resolve_uncertainty` (derive uncertainty from `uncertainty`/`confidence`/`score`), `_estimate_tokens` (serialize-and-estimate token count), and `_build_cost_benefit_analytics` (assemble per-stage uncertainty before/after, reductions and aggregate token estimate).
- Extended `response_extras` defaults to include a `metrics.cost_benefit` structure so the analytics shape always exists even before computation.
- Wired analytics computation into `run_decide_pipeline` after Debate/Critique/FUJI processing and populated `extras.metrics.cost_benefit` with per-stage entries (`debate`, `critique`, `fuji_gate`) plus totals.
- Updated tests in `veritas_os/tests/test_api_pipeline.py` to assert presence of `cost_benefit`, required keys (`total_token_cost`, `total_uncertainty_reduction_pct`) and that the `steps` list contains the three expected stages.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_pipeline.py::test_run_decide_pipeline_happy_path` and the test passed (test run reported as passing).
- The added assertions validate the new `extras.metrics.cost_benefit` contract and expected stage ordering; no other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc3fdf4b883268e6ee568af7c9017)