### PR TITLE
feat(audit-ui): add regulatory report generator export panel

### DIFF
--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -115,4 +115,82 @@ describe("TrustLogExplorerPage", () => {
       expect(screen.getByText("TAMPER-PROOF ✅")).toBeInTheDocument();
     }, { timeout: 4000 });
   });
+
+  it("shows period validation error when generating report without dates", async () => {
+    render(<TrustLogExplorerPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "JSON生成" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("期間を指定してください。")).toBeInTheDocument();
+    });
+  });
+
+  it("builds regulatory report summary from selected period", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            request_id: "req-100",
+            stage: "fuji",
+            status: "rejected",
+            created_at: "2026-02-12T10:00:00Z",
+            sha256: "cccccccccccccccccccccccccccccccc",
+            sha256_prev: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          },
+          {
+            request_id: "req-099",
+            stage: "fuji",
+            status: "allow",
+            created_at: "2026-02-11T10:00:00Z",
+            sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            sha256_prev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          },
+        ],
+        cursor: "0",
+        next_cursor: null,
+        limit: 50,
+        has_more: false,
+      }),
+    } as Response);
+
+    const createObjectUrlMock = vi.fn(() => "blob:report");
+    const revokeObjectUrlMock = vi.fn();
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = createObjectUrlMock;
+    URL.revokeObjectURL = revokeObjectUrlMock;
+    const clickMock = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(<TrustLogExplorerPage />);
+
+    fireEvent.change(screen.getByLabelText("X-API-Key"), {
+      target: { value: "test-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/表示件数: 2/)).toBeInTheDocument();
+    });
+
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    fireEvent.change(dateInputs[0], { target: { value: "2026-02-10" } });
+    fireEvent.change(dateInputs[1], { target: { value: "2026-02-12" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "JSON生成" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("entries: 2 / decision_ids: 2")).toBeInTheDocument();
+      expect(screen.getByText("FUJI rejection: 1/2 (50.0%)")).toBeInTheDocument();
+    });
+
+    expect(createObjectUrlMock).toHaveBeenCalledTimes(1);
+    expect(clickMock).toHaveBeenCalledTimes(1);
+    expect(revokeObjectUrlMock).toHaveBeenCalledTimes(1);
+
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    clickMock.mockRestore();
+  });
 });


### PR DESCRIPTION
### Motivation
- Provide auditors and regulators an easy one-click export (PDF/JSON) of decision-pipeline data, FUJI Gate rejection rates, and TrustLog integrity proof for a specified period to reduce reporting effort and enable compliance automation.
- Surface a clear security warning because exported reports may include sensitive audit metadata that must be handled under PII/confidential-data policies.

### Description
- Added a new UI panel `Regulatory Report Generator` in `frontend/app/audit/page.tsx` with date-range inputs and actions to `Generate JSON` (download) and `Generate PDF` (print window).
- Implemented report construction logic: new TypeScript interfaces (`ReportPeriod`, `StageSummary`, `RegulatoryReport`) and helper functions `isWithinPeriod`, `isRejectedEntry`, and `isPassedEntry` that aggregate stage summaries, FUJI gate rejection stats, and TrustLog hash-chain integrity checks.
- Implemented `createRegulatoryReport`, `downloadJsonReport`, and `generatePdfReport` functions, plus UI state (`reportStartDate`, `reportEndDate`, `reportError`, `latestReport`) and localized validation/error messages.
- Added tests in `frontend/app/audit/page.test.tsx` to cover period validation and successful JSON report generation and summary rendering; included a user-facing security warning in the UI.

### Testing
- Ran `pnpm --filter frontend test app/audit/page.test.tsx` and observed all tests passing: 5 tests passed.
- Started the frontend dev server (`pnpm --filter frontend dev ...`) and rendered `/audit` to verify the new panel and generated a screenshot to validate the UI render.
- Unit/UI tests cover: loading trust logs, response-shape validation, hash-chain verification, report period validation, and JSON export flow; all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd6e862348326bef4543bc07ced5a)