### PR TITLE
Harden web search timeout configuration bounds

### DIFF
--- a/veritas_os/tests/test_web_search.py
+++ b/veritas_os/tests/test_web_search.py
@@ -89,6 +89,13 @@ def test_sanitize_max_results_clamps_values() -> None:
     assert web_search_mod._sanitize_max_results("abc") == 5
 
 
+def test_sanitize_timeout_seconds_clamps_values() -> None:
+    assert web_search_mod._sanitize_timeout_seconds(0) == 1
+    assert web_search_mod._sanitize_timeout_seconds(120) == 60
+    assert web_search_mod._sanitize_timeout_seconds("7") == 7
+    assert web_search_mod._sanitize_timeout_seconds("abc") == 15
+
+
 def test_normalize_result_item_rejects_unsafe_scheme() -> None:
     """危険なスキームは正規化段階で除外する。"""
     item = {


### PR DESCRIPTION
### Motivation
- Prevent misconfiguration of the web-search adapter from causing hangs or resource exhaustion by making the outbound HTTP timeout configurable and clamped to a safe range.

### Description
- Added environment-backed `VERITAS_WEBSEARCH_TIMEOUT` and module constant `WEBSEARCH_TIMEOUT_SECONDS` to allow runtime override with a secure default of `15` seconds in `veritas_os/tools/web_search.py`.
- Implemented `_sanitize_timeout_seconds()` to clamp timeout values into a safe range (`1–60` seconds) and used the sanitized value for the outbound request instead of the previous hardcoded literal.
- Added a unit test `test_sanitize_timeout_seconds_clamps_values()` in `veritas_os/tests/test_web_search.py` to validate boundary and invalid-value behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and all web-search related tests passed (`78 passed`).
- Ran `python -m ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search.py` and lint checks passed.
- The new unit test `test_sanitize_timeout_seconds_clamps_values()` succeeded as part of the above test run.

Security note: this is a defensive hardening change and preserves existing SSRF and host-allowlist protections; operators should still enforce strict `VERITAS_WEBSEARCH_URL` and allowlist configuration to avoid accidental exposure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c0fe9b4b483268b601ed129bc22f0)