### PR TITLE
fix(frontend-e2e): disambiguate FUJI locator in smoke test

### DIFF
--- a/frontend/app/console/page.test.tsx
+++ b/frontend/app/console/page.test.tsx
@@ -193,4 +193,57 @@ describe("DecisionConsolePage", () => {
       expect(screen.getAllByText("17.0%").length).toBeGreaterThan(1);
     });
   });
+
+  it("renders FUJI Gate status and expandable steps", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        error: null,
+        request_id: "req-004",
+        version: "1.0",
+        decision_status: "modify",
+        rejection_reason: "needs redaction",
+        chosen: { id: "a4" },
+        alternatives: [{ id: "a4" }],
+        options: [{ id: "a4" }],
+        fuji: { decision_status: "modify" },
+        gate: { decision_status: "modify", risk: 0.65 },
+        evidence: [{ source: "doc", snippet: "s", confidence: 0.9 }],
+        critique: [{ issue: "x" }],
+        debate: [{ stance: "pro" }],
+        telos_score: 0.7,
+        values: { utility: 0.7 },
+        plan: [
+          { title: "Mask PII", objective: "Remove personal identifiers" },
+        ],
+        planner: null,
+        persona: {},
+        memory_citations: [],
+        memory_used_count: 0,
+        trust_log: null,
+        extras: {},
+      }),
+    } as Response);
+
+    render(<DecisionConsolePage />);
+
+    fireEvent.change(screen.getByPlaceholderText("API key"), {
+      target: { value: "test-key" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("メッセージを入力"), {
+      target: { value: "step expansion" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "送信" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("FUJI Gate Status")).toBeInTheDocument();
+      expect(screen.getByText("MODIFY")).toBeInTheDocument();
+      expect(screen.getByText("Step Expansion")).toBeInTheDocument();
+      expect(screen.getByText("Mask PII · Planner generated step", { exact: false })).toBeInTheDocument();
+    });
+  });
+
 });

--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -369,23 +369,25 @@ function buildPipelineStepViews(result: DecideResponse): PipelineStepView[] {
   const gateStatus = typeof gate.decision_status === "string" ? gate.decision_status : "unknown";
   const plan = Array.isArray(result.plan) ? result.plan : [];
 
-  const planSteps = plan
-    .map((step) => {
-      const asMap = (step ?? {}) as Record<string, unknown>;
-      const title = typeof asMap.title === "string" ? asMap.title : null;
-      const objective = typeof asMap.objective === "string" ? asMap.objective : null;
-      if (!title && !objective) {
-        return null;
-      }
-      const label = title ?? objective ?? "Untitled step";
-      return {
-        name: label,
-        summary: "Planner generated step",
-        status: "complete" as const,
-        detail: renderValue(asMap),
-      };
-    })
-    .filter((step): step is PipelineStepView => step !== null);
+  const planSteps = plan.reduce<PipelineStepView[]>((acc, step) => {
+    const asMap = (step ?? {}) as Record<string, unknown>;
+    const title = typeof asMap.title === "string" ? asMap.title : null;
+    const objective = typeof asMap.objective === "string" ? asMap.objective : null;
+
+    if (!title && !objective) {
+      return acc;
+    }
+
+    const label = title ?? objective ?? "Untitled step";
+    acc.push({
+      name: label,
+      summary: "Planner generated step",
+      status: "complete",
+      detail: renderValue(asMap),
+    });
+
+    return acc;
+  }, []);
 
   if (planSteps.length > 0) {
     return planSteps;

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -13,7 +13,8 @@ test.describe("Smoke: 3-minute demo flow", () => {
     await expect(page.getByRole("heading", { name: "Decision Console" })).toBeVisible();
     await expect(page.getByText("Pipeline Visualizer")).toBeVisible();
     await expect(page.getByText("Evidence")).toBeVisible();
-    await expect(page.getByText("FUJI")).toBeVisible();
+    // Scope to <li> so strict mode won't match the separate "FUJI Gate Status" heading
+    await expect(page.locator("li", { hasText: "FUJI" })).toBeVisible();
     // Scope to <li> to avoid matching sidebar's "TrustLog Explorer"
     await expect(page.locator("li", { hasText: "TrustLog" })).toBeVisible();
 


### PR DESCRIPTION
### Motivation
- Fix a Playwright strict-mode ambiguity where `getByText("FUJI")` matched multiple visible elements after adding the new FUJI Gate Status UI, causing flaky E2E failures.

### Description
- Narrowed the FUJI assertion in the smoke test to the pipeline list item by changing the locator to `page.locator("li", { hasText: "FUJI" })` in `frontend/e2e/smoke.spec.ts` so it no longer collides with the new `FUJI Gate Status` heading.

### Testing
- Ran unit tests with `pnpm --filter frontend test -- --run app/console/page.test.tsx` and they passed.
- Ran linter with `pnpm --filter frontend lint` and it reported no warnings or errors.
- Attempted E2E with `pnpm --filter frontend e2e -- e2e/smoke.spec.ts --project=chromium` which failed in this environment because Playwright browser binaries were not installed; install them with `pnpm exec playwright install` to run E2E locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c23c4fdc483269a2fa5afae9a85d5)