### PR TITLE
Harden tool dispatch input normalization and bounds

### DIFF
--- a/veritas_os/tools/__init__.py
+++ b/veritas_os/tools/__init__.py
@@ -11,40 +11,88 @@ from typing import Any, Dict
 
 from .web_search import web_search
 from .github_adapter import github_search_repos
-from .llm_safety import run as llm_safety_run   # ★ 追加：LLM 安全ヘッド
+from .llm_safety import run as llm_safety_run
+
+_DEFAULT_MAX_RESULTS = 5
+_DEFAULT_MAX_CATEGORIES = 5
+_MIN_LIMIT = 1
+_MAX_RESULTS_LIMIT = 100
+_MAX_CATEGORIES_LIMIT = 20
+
+
+def _normalize_kind(kind: Any) -> str:
+    """Normalize tool kind safely for dispatch."""
+    return str(kind).strip().lower()
+
+
+def _clamp_int(
+    value: Any,
+    *,
+    default: int,
+    min_value: int,
+    max_value: int,
+) -> int:
+    """Convert ``value`` to int and clamp it to a safe range."""
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(min_value, min(max_value, normalized))
 
 
 def call_tool(kind: str, **kwargs: Any) -> Dict[str, Any]:
     """
     kind でツールを振り分ける共通インターフェイス
     """
+    normalized_kind = _normalize_kind(kind)
+    if not normalized_kind:
+        return {
+            "ok": False,
+            "results": [],
+            "error": "unknown tool: ",
+        }
+
+    max_results = _clamp_int(
+        kwargs.get("max_results", _DEFAULT_MAX_RESULTS),
+        default=_DEFAULT_MAX_RESULTS,
+        min_value=_MIN_LIMIT,
+        max_value=_MAX_RESULTS_LIMIT,
+    )
+
+    max_categories = _clamp_int(
+        kwargs.get("max_categories", _DEFAULT_MAX_CATEGORIES),
+        default=_DEFAULT_MAX_CATEGORIES,
+        min_value=_MIN_LIMIT,
+        max_value=_MAX_CATEGORIES_LIMIT,
+    )
+
     # --- web 検索 ---
-    if kind == "web_search":
+    if normalized_kind == "web_search":
         return web_search(
             query=kwargs.get("query", ""),
-            max_results=kwargs.get("max_results", 5),
+            max_results=max_results,
         )
 
     # --- GitHub 検索 ---
-    if kind == "github_search":
+    if normalized_kind == "github_search":
         return github_search_repos(
             query=kwargs.get("query", ""),
-            max_results=kwargs.get("max_results", 5),
+            max_results=max_results,
         )
 
     # --- LLM ベース安全ヘッド ---
-    if kind == "llm_safety":
+    if normalized_kind == "llm_safety":
         # llm_safety.run(text=..., context=..., alternatives=...)
         return llm_safety_run(
             text=kwargs.get("text", "") or kwargs.get("query", ""),
             context=kwargs.get("context") or {},
             alternatives=kwargs.get("alternatives") or [],
-            max_categories=kwargs.get("max_categories", 5),
+            max_categories=max_categories,
         )
 
     # --- 未知ツール ---
     return {
         "ok": False,
         "results": [],
-        "error": f"unknown tool: {kind}",
+        "error": f"unknown tool: {normalized_kind}",
     }


### PR DESCRIPTION
### Motivation
- Prevent inconsistent dispatch caused by case/whitespace variants of `kind` and reduce risk from oversized or malformed numeric inputs being forwarded to tool implementations.
- Add conservative defaults and limits for `max_results` and `max_categories` to avoid resource-exhausting requests.
- Improve error/message consistency by using normalized `kind` when reporting unknown tools.
- Note: this reduces input-abuse vectors but does not fully mitigate content-level safety (prompt injection); downstream tool sanitization is still recommended.

### Description
- Normalize `kind` values via `_normalize_kind` and use it for dispatch to accept case/whitespace variants reliably, and return normalized unknown-tool errors.
- Add `_clamp_int` helper and constants (`_DEFAULT_MAX_RESULTS`, `_DEFAULT_MAX_CATEGORIES`, `_MIN_LIMIT`, `_MAX_RESULTS_LIMIT`, `_MAX_CATEGORIES_LIMIT`) and apply clamping to `max_results` and `max_categories` before calling tool implementations.
- Preserve previous behavior for other parameters while ensuring numeric args are safely bounded and invalid values fall back to sensible defaults.
- Files changed: `veritas_os/tools/__init__.py` and tests added in `veritas_os/tests/test_tools_env.py` (two regression tests covering kind normalization and clamping).

### Testing
- Ran `ruff check veritas_os/tools/__init__.py veritas_os/tests/test_tools_env.py` and lint checks passed.
- Ran `pytest -q veritas_os/tests/test_tools_env.py` and all tests succeeded (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c4de759b083268f2cf4f5e3350af8)