### PR TITLE
api: add schema coercion observability and warnings

### DIFF
--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -323,6 +323,7 @@ class DecideRequest(BaseModel):
 
     @model_validator(mode="after")
     def _unify_options(self) -> "DecideRequest":
+        """Unify compatibility fields and record coercion observability events."""
         events: List[str] = []
 
         if "raw" in self.context:
@@ -571,6 +572,7 @@ class DecideResponse(BaseModel):
 
     @model_validator(mode="after")
     def _unify_and_sanitize(self) -> "DecideResponse":
+        """Normalize response payload and expose coercion metadata for audits."""
         events: List[str] = []
 
         # alternatives があって options が空ならミラー（互換）


### PR DESCRIPTION
### Motivation
- Implement Phase 1 of the schema review by adding observability for coercion and extra-key acceptance at the API boundary without breaking existing compatibility.
- Provide audit signals when `trust_log` promotion fails so downstream monitoring/QA can detect structural issues early.
- Keep responsibility boundaries intact and avoid changing rejection/strict behavior in this iteration.

### Description
- Added `coercion_events` (excluded from serialization) to `DecideRequest` and `DecideResponse` to record normalization/coercion occurrences such as `coercion.options_to_alternatives` and `coercion.alternatives_to_options`.
- Emit `warning` logs when `extra="allow"` causes extra keys to be accepted and record those events as `coercion.request_extra_keys_allowed` / `coercion.response_extra_keys_allowed`.
- When `DecideResponse` cannot promote a dict to `TrustLog`, log a warning, record `coercion.trust_log_promotion_failed`, preserve the raw mapping, and surface coercion events in `meta.x_coerced_fields` for easier auditing.
- Added tests in `veritas_os/tests/test_schemas_extra_v2.py` to validate request/response coercion events, extra-key observability, and `trust_log` promotion failure behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_schemas_extra_v2.py`, result: `37 passed`.
- Ran `pytest -q veritas_os/tests/test_schemas_extra.py`, result: `25 passed`.
- All added tests validating coercion event tracking and metadata succeeded.

Security note: this change only adds observability and logs while keeping `extra="allow"` behavior; the risk surface from accepting unknown keys remains and should be migrated later via the planned `warn -> soft fail -> forbid` progression and by enforcing HTTP body size limits at the gateway.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5f6e22408326b349c0e91631d0fe)