### PR TITLE
Canonicalize alternatives over legacy options and add coercion/deprecation observability

### DIFF
--- a/veritas_os/tests/test_schemas_extra_v2.py
+++ b/veritas_os/tests/test_schemas_extra_v2.py
@@ -351,3 +351,26 @@ class TestSchemaCoercionObservability:
         )
         assert "coercion.trust_log_promotion_failed" in resp.coercion_events
         assert "coercion.trust_log_promotion_failed" in resp.meta.get("x_coerced_fields", [])
+
+    def test_request_conflicting_options_are_overridden_by_alternatives(self):
+        req = schemas.DecideRequest(
+            query="test",
+            alternatives=[{"id": "a", "title": "A"}],
+            options=[{"id": "b", "title": "B"}],
+        )
+        assert "deprecation.options_field_used" in req.coercion_events
+        assert "coercion.options_overridden_by_alternatives" in req.coercion_events
+        assert req.options[0].id == "a"
+
+    def test_response_conflicting_options_are_overridden_by_alternatives(self):
+        resp = schemas.DecideResponse(
+            request_id="r1",
+            alternatives=[{"id": "a", "title": "A"}],
+            options=[{"id": "b", "title": "B"}],
+        )
+        assert "coercion.response_options_overridden_by_alternatives" in resp.coercion_events
+        assert resp.options[0].id == "a"
+        assert "coercion.response_options_overridden_by_alternatives" in resp.meta.get(
+            "x_coerced_fields",
+            [],
+        )


### PR DESCRIPTION
### Motivation
- Improve schema contract consistency by making `alternatives` the canonical field while preserving backward compatibility with legacy `options` and surfacing conflicts for migration.
- Provide better observability for silent coercions so clients and operators can detect when the server normalizes or overrides incoming payload shapes.
- Keep changes limited to the API schema boundary and avoid touching Planner / Kernel / Fuji / MemoryOS responsibilities.

### Description
- `DecideRequest._unify_options` now records a `deprecation.options_field_used` event and emits a warning when legacy `options` is present, and it normalizes `options` to `alternatives` when both are present but conflicting by adding `coercion.options_overridden_by_alternatives` and a warning; docstring updated to clarify canonical intent.
- `DecideResponse._unify_and_sanitize` performs the same conflict detection/normalization for responses and emits `coercion.response_options_overridden_by_alternatives` with a warning when `alternatives` and `options` differ.
- Added tests to `veritas_os/tests/test_schemas_extra_v2.py` that assert deprecation/coercion events and normalization behavior for both requests and responses, and expanded validator docstrings to explain migration intent.
- No change to `extra="allow"` policy or HTTP body-size protections; this PR focuses on auditability and canonicalization only.

### Testing
- Ran `pytest -q veritas_os/tests/test_schemas_extra_v2.py` and all tests passed (`39 passed`).
- New tests verify that `deprecation.options_field_used`, `coercion.options_overridden_by_alternatives`, and `coercion.response_options_overridden_by_alternatives` are emitted and that `options` are normalized to `alternatives` when conflicts occur.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c65a9c3f4832699c1dc847a2777a2)