### PR TITLE
Harden self-heal timeout bounds in alert_doctor

### DIFF
--- a/veritas_os/scripts/alert_doctor.py
+++ b/veritas_os/scripts/alert_doctor.py
@@ -41,10 +41,15 @@ API_BASE = os.getenv("VERITAS_API_BASE", "http://127.0.0.1:8000")
 HEALTH_URL = f"{API_BASE}/health"
 MAX_HEAL_OUTPUT_CHARS = 400
 DEFAULT_HEAL_TIMEOUT_SEC = 60
+MAX_HEAL_TIMEOUT_SEC = 300
 
 
 def _resolve_heal_timeout_seconds() -> int:
-    """Return a safe timeout (seconds) for the self-heal subprocess."""
+    """Return a bounded timeout (seconds) for the self-heal subprocess.
+
+    The timeout is constrained to avoid accidental long-lived subprocesses
+    caused by malformed or extreme environment values.
+    """
     raw = os.getenv("VERITAS_HEAL_TIMEOUT_SEC", str(DEFAULT_HEAL_TIMEOUT_SEC))
     try:
         timeout_sec = int(raw)
@@ -52,6 +57,8 @@ def _resolve_heal_timeout_seconds() -> int:
         return DEFAULT_HEAL_TIMEOUT_SEC
     if timeout_sec <= 0:
         return DEFAULT_HEAL_TIMEOUT_SEC
+    if timeout_sec > MAX_HEAL_TIMEOUT_SEC:
+        return MAX_HEAL_TIMEOUT_SEC
     return timeout_sec
 
 

--- a/veritas_os/tests/test_alert_doctor.py
+++ b/veritas_os/tests/test_alert_doctor.py
@@ -175,6 +175,15 @@ def test_resolve_heal_timeout_seconds_fallbacks(monkeypatch):
         == alert_doctor.DEFAULT_HEAL_TIMEOUT_SEC
     )
 
+
+def test_resolve_heal_timeout_seconds_caps_large_value(monkeypatch):
+    """Large timeout env values should be capped to a safe upper bound."""
+    monkeypatch.setenv("VERITAS_HEAL_TIMEOUT_SEC", "9999")
+    assert (
+        alert_doctor._resolve_heal_timeout_seconds()
+        == alert_doctor.MAX_HEAL_TIMEOUT_SEC
+    )
+
     monkeypatch.setenv("VERITAS_HEAL_TIMEOUT_SEC", "0")
     assert (
         alert_doctor._resolve_heal_timeout_seconds()


### PR DESCRIPTION
### Motivation
- Prevent misconfigured or maliciously large `VERITAS_HEAL_TIMEOUT_SEC` values from causing long-lived self-heal subprocesses and reducing operational/DoS risk.
- Provide an explicit upper bound and clarify behavior in the function docstring so the intent is clear to maintainers and auditors.
- Note: the environment variable remains an external control point and should be managed securely to avoid residual risk.

### Description
- Add `MAX_HEAL_TIMEOUT_SEC = 300` and cap returned timeout values in `_resolve_heal_timeout_seconds()` to this upper bound.
- Expand `_resolve_heal_timeout_seconds()` docstring to state the bounded behavior and security rationale.
- Add `test_resolve_heal_timeout_seconds_caps_large_value` to `veritas_os/tests/test_alert_doctor.py` to verify oversized env values are clipped to `MAX_HEAL_TIMEOUT_SEC`.

### Testing
- Ran `pytest -q veritas_os/tests/test_alert_doctor.py` and observed `15 passed` for the updated test file.
- Ran `ruff check veritas_os/scripts/alert_doctor.py veritas_os/tests/test_alert_doctor.py` and all lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6af276e48326b448245beb97de93)