### PR TITLE
Harden planner fenced JSON parsing against excessive block scans

### DIFF
--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -268,6 +268,17 @@ def test_safe_json_extract_step_object_attempt_limit(caplog):
     assert any("extraction attempt limit reached" in rec.message for rec in caplog.records)
 
 
+def test_safe_parse_limits_fenced_block_scan_attempts(caplog):
+    block = "```json\n{\"steps\": [}\n```"
+    raw = "\n".join([block] * (planner_core._MAX_FENCED_BLOCK_SCAN_ATTEMPTS + 10))
+
+    with caplog.at_level("WARNING"):
+        obj = planner_core._safe_parse(raw)
+
+    assert obj["steps"] == []
+    assert any("fenced JSON scan limit reached" in rec.message for rec in caplog.records)
+
+
 # -------------------------------
 # _fallback_plan / _infer_veritas_stage / _fallback_plan_for_stage
 # -------------------------------


### PR DESCRIPTION
### Motivation
- `_safe_parse` could materialize an unbounded list of fenced code-block matches from LLM output, which opens a CPU/memory DoS vector when adversarially large or repeated fenced blocks are present.  
- Add a bounded, streaming approach to scanning fenced JSON blocks to reduce resource amplification while preserving existing rescue/fallback semantics.

### Description
- Add `_MAX_FENCED_BLOCK_SCAN_ATTEMPTS` and switch fenced-block handling in `_safe_parse` to iterate `for fence_match in _FENCE_RE.finditer(s)` with an attempts cap instead of `list(_FENCE_RE.finditer(...))`.  
- Emit a warning log when the fenced-block scan limit is reached and stop further fenced-block processing, preserving earlier fallback parsing.  
- Add `test_safe_parse_limits_fenced_block_scan_attempts` in `veritas_os/tests/test_planner.py` to validate the cap and warning behavior.  
- Keep changes scoped to Planner parsing logic and ensure PEP8/ruff compliance in modified files.

### Testing
- Ran the new focused tests `pytest -q veritas_os/tests/test_planner.py::test_safe_parse_limits_fenced_block_scan_attempts` and `pytest -q veritas_os/tests/test_planner.py::test_safe_parse_selects_valid_json_from_multiple_fenced_blocks`, which passed.  
- Ran `pytest -q veritas_os/tests/test_planner.py veritas_os/tests/test_planner_coverage.py` and observed `134 passed` across those suites.  
- Ran `ruff check` on the modified files and it passed with no findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7169fb44832696525f5bddafc49a)