### PR TITLE
Treat VERITAS_WEBSEARCH_HOST_ALLOWLIST env as explicit override (allow empty)

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -619,3 +619,20 @@ class TestWebSearchSsrfGuard:
 
         assert resp["ok"] is False
         assert resp["error"] == "WEBSEARCH_API unavailable"
+
+
+class TestWebSearchAllowlistResolution:
+    """Tests for runtime host allowlist resolution behavior."""
+
+    def test_empty_env_allowlist_overrides_module_default(self, monkeypatch):
+        monkeypatch.setattr(
+            web_search_mod,
+            "WEBSEARCH_HOST_ALLOWLIST",
+            {"api.allowed.example"},
+            raising=False,
+        )
+        monkeypatch.setenv("VERITAS_WEBSEARCH_HOST_ALLOWLIST", "")
+
+        result = web_search_mod._resolve_websearch_host_allowlist()
+
+        assert result == set()

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -135,8 +135,8 @@ def _resolve_websearch_host_allowlist() -> set[str]:
         This resolver mirrors credential resolution so operators can update the
         allowlist without restarting the process.
     """
-    env_allowlist_raw = os.getenv("VERITAS_WEBSEARCH_HOST_ALLOWLIST", "")
-    if env_allowlist_raw.strip():
+    env_allowlist_raw = os.getenv("VERITAS_WEBSEARCH_HOST_ALLOWLIST")
+    if env_allowlist_raw is not None:
         return {
             host.strip().lower().rstrip(".")
             for host in env_allowlist_raw.split(",")


### PR DESCRIPTION
### Motivation
- Make runtime host allowlist behavior deterministic by treating the `VERITAS_WEBSEARCH_HOST_ALLOWLIST` environment variable as an explicit override when present, including when set to an empty string. 
- This enables operators to intentionally clear a baked-in/module-level allowlist during incident response without changing code or restarting processes. 
- Security note: this change does not relax SSRF protections; it only makes override semantics explicit, but operators should be warned that clearing the allowlist may affect endpoint restrictions.

### Description
- Change `_resolve_websearch_host_allowlist()` to call `os.getenv("VERITAS_WEBSEARCH_HOST_ALLOWLIST")` without a default and branch on `is not None`, so an explicitly-set empty env value returns an empty set after normalization. 
- Added `TestWebSearchAllowlistResolution::test_empty_env_allowlist_overrides_module_default` to `veritas_os/tests/test_web_search_extra.py` to cover the empty-env override behavior. 
- Modified `veritas_os/tools/web_search.py` and `veritas_os/tests/test_web_search_extra.py` accordingly to preserve normalization and existing host-safety checks.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search_extra.py veritas_os/tests/test_code_review_fixes_v2.py` and the suite passed. 
- Result: `71 passed` for the invoked tests. 
- No test failures observed and the change is limited to the web search allowlist resolution and its test coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c75e564cc8326b545cfa2fffc1ee2)