### PR TITLE
Harden chainlit formatter payload handling

### DIFF
--- a/veritas_os/tests/test_chainlit_app_formatters.py
+++ b/veritas_os/tests/test_chainlit_app_formatters.py
@@ -100,3 +100,35 @@ def test_format_main_answer_handles_non_numeric_gate_values() -> None:
 
     assert "FUJIリスク: **0.000**" in result
     assert "Telosスコア: **0.000**" in result
+
+
+def test_format_web_results_handles_non_dict_tools_payload() -> None:
+    """Formatter should avoid crashes for malformed tool payload types."""
+    result = module.format_web_results(
+        {
+            "extras": {
+                "env_tools": {
+                    "web_search": "broken",
+                }
+            }
+        }
+    )
+
+    assert "検索エラー" in result
+
+
+def test_format_main_answer_ignores_non_dict_plan_steps() -> None:
+    """Formatter should skip invalid step items and keep valid planner steps."""
+    result = module.format_main_answer(
+        {
+            "chosen": {"title": "A"},
+            "gate": {"decision_status": "allow", "risk": 0.1},
+            "values": {"total": 1.0},
+            "planner": {
+                "steps": ["bad-step", {"title": "valid", "detail": "ok"}],
+            },
+        }
+    )
+
+    assert "bad-step" not in result
+    assert "valid" in result


### PR DESCRIPTION
### Motivation
- Formatter functions in `chainlit_app.py` could crash when API responses contained malformed types (e.g. strings instead of dict/list), so presentation should be made more defensive. 
- Fixes are limited to the display/formatting layer and must not change Planner/Kernel/Fuji/MemoryOS decision logic.

### Description
- Add defensive helpers ` _as_dict` and `_as_list` to normalize potentially-malformed payload values before use. 
- Update `format_main_answer`, `format_metrics`, `format_memory_and_evidence`, and `format_web_results` to use the new helpers and to skip non-dict/list items safely. 
- Add regression tests `test_format_web_results_handles_non_dict_tools_payload` and `test_format_main_answer_ignores_non_dict_plan_steps` in `veritas_os/tests/test_chainlit_app_formatters.py` to cover malformed `web_search` payloads and mixed-type planner steps. 
- Keep changes limited to the Chainlit presentation layer and add docstrings for the new helpers.

### Testing
- Ran `pytest -q veritas_os/tests/test_chainlit_app_formatters.py`, all tests passed (`6 passed`).
- Ran `ruff check chainlit_app.py veritas_os/tests/test_chainlit_app_formatters.py`, checks passed.

Security: No new high-severity security issues were introduced because the changes only add defensive type-checking in the UI formatting layer, but continue to validate and avoid rendering untrusted internal error details to end users.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ceaec99a48326a028d483e1e83669)