### PR TITLE
Harden tool argument sanitization for set values

### DIFF
--- a/veritas_os/core/tools.py
+++ b/veritas_os/core/tools.py
@@ -405,6 +405,10 @@ def _sanitize_value(value: Any) -> Any:
     if isinstance(value, tuple):
         # Keep the payload JSON-serializable for telemetry/log export.
         return [_sanitize_value(item) for item in value]
+    if isinstance(value, set):
+        # Sort by repr() for deterministic output across mixed value types.
+        sanitized_items = [_sanitize_value(item) for item in value]
+        return sorted(sanitized_items, key=repr)
     if isinstance(value, str) and len(value) > 200:
         return value[:200] + "..."
     return value

--- a/veritas_os/tests/test_core_tools.py
+++ b/veritas_os/tests/test_core_tools.py
@@ -262,6 +262,18 @@ def test_sanitize_args_converts_tuple_to_list_for_json_safety():
     assert sanitized["events"][0]["Authorization"] == "***REDACTED***"
     assert sanitized["events"][1] == "ok"
 
+def test_sanitize_args_converts_set_to_sorted_list_for_json_safety():
+    args = {
+        "scopes": {"write", "read", "admin"},
+        "mixed": {("b", 2), ("a", 1)},
+    }
+
+    sanitized = tools._sanitize_args(args)
+
+    assert sanitized["scopes"] == ["admin", "read", "write"]
+    assert isinstance(sanitized["mixed"], list)
+    assert sanitized["mixed"] == [["a", 1], ["b", 2]]
+
 def test_get_tool_stats_empty_when_no_calls(clean_tools_state):
     stats = tools.get_tool_stats()
     assert stats["total_calls"] == 0


### PR DESCRIPTION
### Motivation
- Tool usage logging must be JSON-serializable and deterministic, but `set` values were left unchanged which can break serialization and produce nondeterministic ordering.
- This change keeps sanitization within the ToolOS responsibility of safe tool-arg handling and reduces operational/security risk from logs containing non-JSON types.

### Description
- Update `veritas_os/core/tools.py` to handle `set` values in `_sanitize_value` by recursively sanitizing elements and returning a deterministically sorted `list` (sorted by `repr`).
- Add a focused regression test `test_sanitize_args_converts_set_to_sorted_list_for_json_safety` in `veritas_os/tests/test_core_tools.py` that verifies `set[str]` and `set[tuple]` convert to stable lists.
- Changes are small, PEP8-compliant, and limited to tool argument sanitization without touching Planner/Kernel/Fuji/MemoryOS responsibilities.

### Testing
- Ran `pytest -q veritas_os/tests/test_core_tools.py` and the suite passed (`20 passed`).
- Additionally, earlier smoke tests including `pytest -q veritas_os/tests/test_api_constants.py veritas_os/tests/test_config_coverage.py veritas_os/tests/test_time_utils.py` were executed and passed (`47 passed`).
- All modified-file tests passed locally and confirm the new sanitization behavior.

Security note: previous behavior could cause JSON serialization failures and nondeterministic log ordering; this patch mitigates that but sorting by `repr()` may have edge cases for mixed/custom types and should be reviewed if logs are exported to sensitive sinks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf274ec2483269252ff4dbcf73fef)