### PR TITLE
Harden search_memory CLI input handling and add tests

### DIFF
--- a/veritas_os/tests/test_search_memory_script.py
+++ b/veritas_os/tests/test_search_memory_script.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "search_memory.py"
+
+spec = importlib.util.spec_from_file_location("search_memory", MODULE_PATH)
+search_memory = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+spec.loader.exec_module(search_memory)
+
+
+def test_positive_int_accepts_positive_values() -> None:
+    assert search_memory._positive_int("3") == 3
+
+
+def test_positive_int_rejects_zero_or_negative_values() -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        search_memory._positive_int("0")
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        search_memory._positive_int("-1")
+
+
+def test_flatten_hits_accepts_dict_and_list_payloads() -> None:
+    dict_payload = {
+        "doc": [{"text": "hello"}],
+        "note": [{"text": "world", "kind": "custom"}],
+    }
+    flat_dict = search_memory._flatten_hits(dict_payload)
+    assert flat_dict[0]["kind"] == "doc"
+    assert flat_dict[1]["kind"] == "custom"
+
+    list_payload = [{"text": "a"}, {"text": "b"}]
+    flat_list = search_memory._flatten_hits(list_payload)
+    assert len(flat_list) == 2
+
+
+def test_extract_preview_text_truncates_and_normalizes_newlines() -> None:
+    hit = {"text": "line1\nline2" + "x" * 250}
+    preview = search_memory._extract_preview_text(hit)
+
+    assert "\n" not in preview
+    assert preview.endswith("...")
+    assert len(preview) == 200


### PR DESCRIPTION
### Motivation
- Improve robustness of the MemoryOS CLI by validating user input and avoiding silent failures when parsing values.
- Centralize preview formatting to ensure consistent newline normalization and truncation behavior.
- Add tests and docstrings for the new behavior to meet project quality standards.
- Security: the script prints hit contents to stdout, which can leak sensitive memory data to logs, so this risk should be considered in deployment.

### Description
- Added ` _positive_int` and wired it into the parser to enforce `--top-k` being an integer >= 1 in `veritas_os/scripts/search_memory.py`.
- Introduced `_extract_preview_text` to normalize newlines and truncate previews to 200 characters, and replaced inline preview logic with a call to it.
- Narrowed exception handling when formatting `score` from a broad `except Exception` to `except (TypeError, ValueError)` to avoid hiding unexpected errors.
- Added `veritas_os/tests/test_search_memory_script.py` covering ` _positive_int`, `_flatten_hits`, and `_extract_preview_text`, and included docstrings for new helpers.

### Testing
- Ran `pytest -q veritas_os/tests/test_search_memory_script.py` and all tests passed (`4 passed`).
- Ran `ruff check veritas_os/scripts/search_memory.py veritas_os/tests/test_search_memory_script.py --output-format concise` and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf875718c8326b49ca89156612a01)