### PR TITLE
Harden web search URL sanitization to HTTPS only

### DIFF
--- a/veritas_os/tests/test_web_search.py
+++ b/veritas_os/tests/test_web_search.py
@@ -157,9 +157,18 @@ def test_normalize_result_item_truncates_long_fields(_bypass_ssrf) -> None:
 # -----------------------------
 
 
-def test_sanitize_websearch_url_rejects_unsafe_scheme() -> None:
-    """危険なスキームの URL は空文字へ正規化する。"""
+def test_sanitize_websearch_url_rejects_non_https_scheme() -> None:
+    """HTTPS 以外のスキーム URL は空文字へ正規化する。"""
     assert web_search_mod._sanitize_websearch_url("file:///etc/passwd") == ""
+    assert web_search_mod._sanitize_websearch_url("http://example.com/search") == ""
+
+
+def test_sanitize_websearch_url_accepts_https_scheme() -> None:
+    """HTTPS スキーム URL はそのまま利用する。"""
+    assert (
+        web_search_mod._sanitize_websearch_url("https://example.com/search")
+        == "https://example.com/search"
+    )
 
 
 def test_resolve_websearch_credentials_ignores_unsafe_runtime_url(monkeypatch) -> None:

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -58,7 +58,7 @@ WEBSEARCH_KEY: str = os.getenv("VERITAS_WEBSEARCH_KEY", "").strip()
 
 
 def _sanitize_websearch_url(url: str) -> str:
-    """Validate env-derived web search URL and drop unsafe schemes.
+    """Validate env-derived web search URL and enforce HTTPS-only endpoints.
 
     Security note:
         Runtime env overrides are useful for incident response, but they must
@@ -70,11 +70,11 @@ def _sanitize_websearch_url(url: str) -> str:
         return ""
 
     parsed = urlparse(candidate)
-    if parsed.scheme in ("http", "https"):
+    if parsed.scheme == "https":
         return candidate
 
     logging.getLogger(__name__).warning(
-        "VERITAS_WEBSEARCH_URL has unsafe scheme %r; URL will be ignored",
+        "VERITAS_WEBSEARCH_URL must use https (got scheme=%r); URL will be ignored",
         parsed.scheme,
     )
     return ""


### PR DESCRIPTION
### Motivation
- Prevent accidental use of non-HTTPS WEBSEARCH endpoints which can leak API keys or allow untrusted schemes (e.g. `file://`) to be used via runtime env overrides.

### Description
- Restrict `_sanitize_websearch_url` to accept only `https` schemes and log a clearer warning for non-HTTPS schemes.
- Ensure runtime credential resolution uses the strengthened sanitizer so env overrides are also validated via `_sanitize_websearch_url`.
- Add tests that assert non-HTTPS schemes (`file://`, `http://`) are rejected and HTTPS is accepted, and update existing tests accordingly.
- Minor wording improvement in the sanitizer docstring and warning message to clarify the HTTPS requirement.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and all tests passed (`80 passed`).
- Ran `ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search.py` and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cfd2f83288326be2040c9b6f9b4b4)