### PR TITLE
Harden web search timeout parsing with bounded env handling

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -72,6 +72,33 @@ class TestSafeIntHelpers:
             == 3
         )
 
+    def test_safe_int_with_bounds_applies_lower_bound(self, monkeypatch):
+        monkeypatch.setenv("VERITAS_WEBSEARCH_TIMEOUT", "0")
+        assert web_search_mod._safe_int_with_bounds(
+            "VERITAS_WEBSEARCH_TIMEOUT",
+            15,
+            1,
+            300,
+        ) == 1
+
+    def test_safe_int_with_bounds_applies_upper_bound(self, monkeypatch):
+        monkeypatch.setenv("VERITAS_WEBSEARCH_TIMEOUT", "9999")
+        assert web_search_mod._safe_int_with_bounds(
+            "VERITAS_WEBSEARCH_TIMEOUT",
+            15,
+            1,
+            300,
+        ) == 300
+
+    def test_safe_int_with_bounds_raises_on_invalid_range(self):
+        with pytest.raises(ValueError):
+            web_search_mod._safe_int_with_bounds(
+                "VERITAS_WEBSEARCH_TIMEOUT",
+                15,
+                10,
+                9,
+            )
+
 
 class TestShouldEnforceVeritasAnchor:
     """Tests for _should_enforce_veritas_anchor function."""

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -116,6 +116,19 @@ def _safe_int_with_min(key: str, default: int, minimum: int) -> int:
     return max(value, minimum)
 
 
+def _safe_int_with_bounds(
+    key: str,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    """環境変数を整数として読み取り、指定レンジに収めて返す。"""
+    if minimum > maximum:
+        raise ValueError("minimum must be less than or equal to maximum")
+    value = _safe_int(key, default)
+    return min(max(value, minimum), maximum)
+
+
 def _safe_float(key: str, default: float) -> float:
     """環境変数を有限な浮動小数として取得し、異常値は default に戻す。"""
     try:
@@ -153,7 +166,12 @@ WEBSEARCH_MAX_RETRIES = _safe_int_with_min(
 WEBSEARCH_RETRY_DELAY = _safe_float("VERITAS_WEBSEARCH_RETRY_DELAY", 1.0)
 WEBSEARCH_RETRY_MAX_DELAY = _safe_float("VERITAS_WEBSEARCH_RETRY_MAX_DELAY", 8.0)
 WEBSEARCH_RETRY_JITTER = _safe_float("VERITAS_WEBSEARCH_RETRY_JITTER", 0.1)
-WEBSEARCH_TIMEOUT_SECONDS = _safe_int("VERITAS_WEBSEARCH_TIMEOUT", 15)
+WEBSEARCH_TIMEOUT_SECONDS = _safe_int_with_bounds(
+    "VERITAS_WEBSEARCH_TIMEOUT",
+    15,
+    1,
+    300,
+)
 WEBSEARCH_HOST_ALLOWLIST = {
     host.strip().lower().rstrip(".")
     for host in os.getenv("VERITAS_WEBSEARCH_HOST_ALLOWLIST", "").split(",")


### PR DESCRIPTION
### Motivation
- Outbound web request timeouts are security- and reliability-sensitive so misconfigured env values (zero/negative or excessively large) must be clamped to safe limits to avoid denial-of-service or unavailable behavior. 
- Provide a clear failure mode when callers specify an invalid bounds range so configuration mistakes are detected early. 
- This change both hardens runtime behavior and reduces an operational risk surface for the websearch adapter.

### Description
- Add a new helper ` _safe_int_with_bounds(key, default, minimum, maximum)` in `veritas_os/tools/web_search.py` that parses an integer env var, clamps it into the inclusive `[minimum, maximum]` range, and raises `ValueError` when `minimum > maximum` with an explanatory docstring. 
- Replace `WEBSEARCH_TIMEOUT_SECONDS` parsing to use ` _safe_int_with_bounds("VERITAS_WEBSEARCH_TIMEOUT", 15, 1, 300)` so timeout values are constrained to `1..300` seconds. 
- Add regression tests in `veritas_os/tests/test_web_search_extra.py` covering lower-bound clamp, upper-bound clamp, and invalid-range `ValueError` behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search_extra.py`, and all tests passed (`57 passed`).
- Ran `ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search_extra.py`, and lint checks passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d239ad1708326a2bb25cd4322e97e)