### PR TITLE
Reject bool for CosineIndex dim and add regression test

### DIFF
--- a/veritas_os/memory/index_cosine.py
+++ b/veritas_os/memory/index_cosine.py
@@ -126,7 +126,7 @@ class CosineIndex:
         Raises:
             ValueError: If ``dim`` is not a positive integer.
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(dim, int) or isinstance(dim, bool) or dim < 1:
             raise ValueError(f"CosineIndex.__init__: dim must be a positive int, got {dim!r}")
 
         self.dim = dim

--- a/veritas_os/tests/test_index_cosine.py
+++ b/veritas_os/tests/test_index_cosine.py
@@ -35,3 +35,11 @@ def test_cosine_index_load_keeps_finite_vectors(tmp_path: Path) -> None:
     assert idx.size == 2
     results = idx.search(np.array([1.0, 0.0], dtype=np.float32), k=1)
     assert results[0][0][0] == "x"
+
+
+def test_cosine_index_rejects_bool_dimension() -> None:
+    """`bool` is not a valid dimension even though it subclasses `int`."""
+    import pytest
+
+    with pytest.raises(ValueError, match="dim must be a positive int"):
+        CosineIndex(dim=True)


### PR DESCRIPTION
### Motivation
- Prevent accidental acceptance of `bool` values as a vector dimensionality because `bool` subclasses `int` in Python and `True` could previously be interpreted as `1`, hiding caller bugs and causing confusing runtime behavior.

### Description
- Tighten validation in `CosineIndex.__init__` to explicitly reject `bool` by changing the check to `if not isinstance(dim, int) or isinstance(dim, bool) or dim < 1:` in `veritas_os/memory/index_cosine.py`.
- Add a regression test `test_cosine_index_rejects_bool_dimension` in `veritas_os/tests/test_index_cosine.py` that asserts `CosineIndex(dim=True)` raises `ValueError`.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_index_cosine.py` which completed successfully with `3 passed`.
- Ran the broader memory tests with `python -m pytest -q veritas_os/tests/test_memory_engine.py veritas_os/tests/test_memory_core.py veritas_os/tests/test_memory_extra.py` which completed successfully with `48 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d34fe95488326b5227e17bf10f701)