### PR TITLE
Harden SSRF host checks to block all non-global IP destinations

### DIFF
--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -348,14 +348,7 @@ def _is_obviously_private_or_local_host(hostname: str) -> bool:
 
     try:
         ip = ipaddress.ip_address(host)
-        return (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        )
+        return not ip.is_global
     except ValueError:
         pass
 
@@ -396,14 +389,7 @@ def _is_private_or_local_host(hostname: str) -> bool:
             ip = ipaddress.ip_address(ip_text)
         except ValueError:
             continue
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        ):
+        if not ip.is_global:
             return True
     return False
 


### PR DESCRIPTION
### Motivation
- Close an SSRF gap where special-use ranges (notably Carrier-Grade NAT `100.64.0.0/10`) could be treated as allowed by earlier per-attribute checks.  
- Keep the change scoped to the web-search adapter (`veritas_os/tools/web_search.py`) and its tests without touching other subsystem responsibilities.  
- Security warning: the new logic is stricter and will block any non-global IPs, so environments that intentionally rely on non-global destination addresses must review allowlists or endpoint design.  

### Description
- Replace the earlier multi-attribute IP checks with a single `not ip.is_global` classification in `_is_obviously_private_or_local_host` and the DNS-resolution path in `_is_private_or_local_host` inside `veritas_os/tools/web_search.py`.  
- Add two targeted tests in `veritas_os/tests/test_web_search.py`: `test_private_host_check_blocks_carrier_grade_nat_literal` and `test_private_host_check_blocks_carrier_grade_nat_dns_result` to ensure CGNAT and DNS-resolved CGNAT addresses are blocked.  
- Maintain existing conservative behaviors such as LRU-cached successful DNS lookups and conservative blocking on resolution failures.  

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py` and all tests passed (`29 passed`).  
- Ran `ruff` on the modified files with `ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search.py` and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3ad464808326af2409a3462ae4af)