### PR TITLE
memory: Make engine interfaces abstract ABCs (Embedder/VectorIndex/MemoryStore)

### DIFF
--- a/veritas_os/memory/engine.py
+++ b/veritas_os/memory/engine.py
@@ -1,19 +1,51 @@
-# veritas/memory/engine.py
-from typing import List, Dict, Any, Optional, Tuple
+"""Memory engine interfaces.
+
+This module defines abstract contracts used by MemoryOS components.
+Implementations are intentionally separate so planners/kernels can swap
+embedding/index/store backends without changing call sites.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple
+
 import numpy as np
 
-class Embedder:
+
+class Embedder(ABC):
+    """Text-to-vector encoder contract."""
+
+    @abstractmethod
     def embed(self, texts: List[str]) -> np.ndarray:
-        """(N, D) 返却。失敗時はTF-IDFやhashベース代替にフォールバック"""
-        raise NotImplementedError
+        """Return an ``(N, D)`` embedding matrix for ``texts``."""
 
-class VectorIndex:
-    def add(self, vecs: np.ndarray, ids: List[str]): ...
-    def search(self, vecs: np.ndarray, topk: int) -> List[List[Tuple[str, float]]]: ...
-    def save(self): ...
-    def load(self): ...
 
-class MemoryStore:
-    def put(self, kind: str, item: Dict[str, Any]) -> str: ...
+class VectorIndex(ABC):
+    """Vector retrieval backend contract."""
+
+    @abstractmethod
+    def add(self, vecs: np.ndarray, ids: List[str]) -> None:
+        """Store vectors and their IDs in the index."""
+
+    @abstractmethod
+    def search(self, vecs: np.ndarray, topk: int) -> List[List[Tuple[str, float]]]:
+        """Return top-k scored IDs for each query vector."""
+
+    @abstractmethod
+    def save(self) -> None:
+        """Persist index state."""
+
+    @abstractmethod
+    def load(self) -> None:
+        """Load previously persisted index state."""
+
+
+class MemoryStore(ABC):
+    """Long-term memory persistence/search contract."""
+
+    @abstractmethod
+    def put(self, kind: str, item: Dict[str, Any]) -> str:
+        """Persist an item and return its assigned identifier."""
+
+    @abstractmethod
     def search(self, query: str, k: int = 8, kinds: Optional[List[str]] = None) -> Dict[str, List[Dict]]:
-        """kinds∈{episodic,semantic,skills}"""
+        """Search items. ``kinds`` is typically episodic/semantic/skills."""

--- a/veritas_os/tests/test_memory_engine.py
+++ b/veritas_os/tests/test_memory_engine.py
@@ -4,7 +4,7 @@ memory/engine.py インターフェイス層のテスト。
 
 目的:
 - Embedder / VectorIndex / MemoryStore が import できること
-- Embedder のデフォルト実装が NotImplementedError を投げること
+- Embedder が抽象基底クラスとして直接インスタンス化不可であること
 - VectorIndex / MemoryStore を継承したダミー実装が
   型的・インターフェイス的に問題なく動くこと
   （＝将来の実装差し替えに耐えられるプロトコルになっていること）
@@ -37,13 +37,10 @@ def test_engine_interfaces_exist():
 # ---------------------------------------------------------
 
 
-def test_embedder_default_raises_not_implemented():
-    """
-    Embedder は抽象インターフェイスとして NotImplementedError を投げる。
-    """
-    emb = mem_engine.Embedder()
-    with pytest.raises(NotImplementedError):
-        emb.embed(["hello", "world"])
+def test_embedder_is_abstract_and_cannot_be_instantiated():
+    """Embedder は抽象基底クラスとして直接インスタンス化できない。"""
+    with pytest.raises(TypeError):
+        mem_engine.Embedder()
 
 
 class DummyEmbedder(mem_engine.Embedder):


### PR DESCRIPTION
### Motivation
- Clarify and enforce MemoryOS interface contracts by preventing accidental instantiation of incomplete base implementations. 
- Make extension points explicit so planners/kernels can swap embedding/index/store backends safely without changing call sites. 
- Keep changes scoped to MemoryOS responsibilities and reduce misuse risk by failing fast on incomplete implementations.

### Description
- Converted `veritas_os/memory/engine.py` to define `Embedder`, `VectorIndex`, and `MemoryStore` as `abc.ABC` classes and added `@abstractmethod` declarations and concise docstrings for each method. 
- Replaced informal placeholder method definitions with explicit abstract method signatures: `Embedder.embed`, `VectorIndex.add/search/save/load`, and `MemoryStore.put/search`. 
- Updated `veritas_os/tests/test_memory_engine.py` to assert that `Embedder` cannot be directly instantiated (expect `TypeError`) and adjusted module docstring accordingly. 
- Kept change surface minimal: this is a contract-level refactor with no new external I/O or serialization behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_engine.py`, which executed the test module and returned `5 passed` (success). 
- Ran `ruff check veritas_os/memory/engine.py veritas_os/tests/test_memory_engine.py`, which completed with `All checks passed!` (PEP8/static checks OK). 
- No other automated tests were modified; all validation executed against the local repository succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3ec88d188326a713fa4ccdf184c1)