### PR TITLE
Harden GitHub adapter against bidi control spoofing

### DIFF
--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -14,6 +14,10 @@ def test_prepare_query_basic_and_truncate():
     assert q_ctrl == "a b"
     assert truncated_ctrl is False
 
+    q_bidi, truncated_bidi = github_adapter._prepare_query("safe\u202Etext")
+    assert q_bidi == "safe text"
+    assert truncated_bidi is False
+
     # None でも落ちない
     q2, truncated2 = github_adapter._prepare_query(None)
     assert q2 == ""
@@ -231,6 +235,20 @@ def test_normalize_repo_item_sanitizes_control_chars_and_whitespace():
 
     assert result["full_name"] == "owner/ repo"
     assert result["description"] == "line1 line2"
+
+
+def test_normalize_repo_item_sanitizes_bidi_controls():
+    result = github_adapter._normalize_repo_item(
+        {
+            "full_name": "ow\u202Ener/repo",
+            "html_url": "https://github.com/owner/repo",
+            "description": "desc\u2066spoof\u2069",
+            "stargazers_count": 1,
+        }
+    )
+
+    assert result["full_name"] == "ow ner/repo"
+    assert result["description"] == "desc spoof"
 
 
 def test_sanitize_text_field_limits_length():


### PR DESCRIPTION
### Motivation
- Reduce visual-spoofing risk by stripping Unicode bidirectional control characters from user-provided GitHub query and metadata fields to avoid UI/log display manipulation.
- This change complements existing ASCII-control sanitization and aims to harden the adapter against a class of security issues while preserving current behavior.
- Note: external inputs rendered in UI/logs should still be continuously monitored since other injection/spoof vectors may remain.

### Description
- Add `_RE_BIDI_CONTROL_CHARS` (matching `U+202A..U+202E` and `U+2066..U+2069`) and remove matches in `_prepare_query` to sanitize incoming queries.
- Remove bidi controls in `_sanitize_text_field` so normalized repo fields (`full_name`, `description`) are safe for logs/UI, and expand the docstring to document the policy.
- Add unit tests verifying bidi control removal in `_prepare_query` and `_normalize_repo_item` (`test_prepare_query_basic_and_truncate` addition and `test_normalize_repo_item_sanitizes_bidi_controls`).
- Changes are limited to `veritas_os/tools/github_adapter.py` and its tests and adhere to the existing module responsibilities.

### Testing
- Ran `pytest -q veritas_os/tests/test_github_adapter.py` and the test file passed: `25 passed in 1.82s`.
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5224e5808326a4261a521f63671b)