### PR TITLE
Harden CosineIndex path validation against symlinked parent dirs

### DIFF
--- a/veritas_os/tests/test_memory_index_cosine.py
+++ b/veritas_os/tests/test_memory_index_cosine.py
@@ -114,6 +114,25 @@ def test_cosine_index_refuses_non_regular_file_path(tmp_path):
     assert idx.ids == []
 
 
+def test_cosine_index_refuses_path_under_symlink_directory(tmp_path):
+    """親ディレクトリがシンボリックリンクなら読み込みを拒否する。"""
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    link_dir = tmp_path / "linked_dir"
+    link_dir.symlink_to(real_dir, target_is_directory=True)
+
+    p = link_dir / "index.npz"
+    vecs = np.array([[1.0, 0.0]], dtype=np.float32)
+    ids = np.array(["a"], dtype=str)
+    np.savez(p, vecs=vecs, ids=ids)
+
+    idx = CosineIndex(dim=2, path=p)
+
+    assert idx.size == 0
+    assert idx.vecs.shape == (0, 2)
+    assert idx.ids == []
+
+
 def test_cosine_index_legacy_npz_requires_opt_in(tmp_path, monkeypatch):
     """レガシーnpz(allow_pickleが必要)はopt-inしないと無視される。"""
     p = tmp_path / "legacy_index.npz"


### PR DESCRIPTION
### Motivation
- Prevent load-time symlink redirection attacks by ensuring index files under symlinked parent directories are refused even when the final file is not itself a symlink.
- Tighten MemoryOS index-loading security while keeping legacy migration opt-in behavior intact.
- Keep changes local to the Memory index layer without crossing Planner / Kernel / Fuji / MemoryOS responsibility boundaries.

### Description
- Expanded the `_is_safe_index_path` docstring to document the parent-directory symlink threat model and added checks to reject paths whose parent directories are symlinks.
- Added warning logs for detection of symlinked parent directories and for failures when inspecting parent paths.
- Kept existing checks that refuse symlink files and non-regular files, and preserved the legacy-`npz` opt-in migration flow (`VERITAS_MEMORY_ALLOW_LEGACY_NPZ`).
- Added a regression test `test_cosine_index_refuses_path_under_symlink_directory` in `veritas_os/tests/test_memory_index_cosine.py` to assert indices under symlinked directories are refused and the index falls back to empty.

### Testing
- Ran `ruff check veritas_os/memory/index_cosine.py veritas_os/tests/test_memory_index_cosine.py` and it passed.
- Ran `pytest -q veritas_os/tests/test_memory_index_cosine.py` and all tests passed (`34 passed, 1 warning`).
- Note: an external web check attempted during the rollout failed due to environment proxy (`403 Forbidden`) but is unrelated to the code changes.

Security warning: `VERITAS_MEMORY_ALLOW_LEGACY_NPZ=1` remains an opt-in that enables pickle-based loading and therefore carries arbitrary code execution risk; disable it immediately after any one-time migration and follow the existing migration guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6e4d7690832690504969feaa7829)