### PR TITLE
Stop retrying non-retryable HTTP errors in web_search and add regression test

### DIFF
--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -285,6 +285,13 @@ def _post_with_retry(
             response.raise_for_status()
             return response
         except requests.exceptions.RequestException as exc:
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            if (
+                isinstance(exc, requests.exceptions.HTTPError)
+                and status_code is not None
+                and not _should_retry_status(status_code)
+            ):
+                raise
             if attempt < WEBSEARCH_MAX_RETRIES:
                 delay = _compute_backoff(attempt)
                 logger.warning(


### PR DESCRIPTION
### Motivation
- Avoid wasting resources and amplifying failures by not retrying deterministic client errors (e.g. HTTP 4xx other than 429) from the web search backend.
- Align retry behavior with `_should_retry_status` so only 429/5xx and transient network errors are retried.
- Security note: this change reduces accidental amplification on misconfigured endpoints and does not relax SSRF/credential protections, but operators should continue to ensure endpoint/allowlist correctness.

### Description
- Update `_post_with_retry` in `veritas_os.tools.web_search` to inspect `exc.response.status_code` and immediately re-raise `requests.exceptions.HTTPError` when the status code is present and not considered retryable by `_should_retry_status`.
- Preserve existing retry/backoff behavior for retryable statuses (429 and >=500) and for other `requests.exceptions.RequestException` cases.
- Add `TestPostWithRetry::test_does_not_retry_on_non_retryable_http_error` to `veritas_os/tests/test_web_search_extra.py` which asserts a single attempt for a 400 response and that an `HTTPError` is raised.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and all web_search related tests passed (`87 passed in 1.28s`).
- Ran the focused regression test `python -m pytest -q veritas_os/tests/test_web_search_extra.py::TestPostWithRetry::test_does_not_retry_on_non_retryable_http_error` and it passed (`1 passed`).
- The changes are narrowly scoped to `veritas_os/tools/web_search.py` and its tests and did not break existing web search behavior in automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d8276530c8326a3d12b0abbaf2575)