### PR TITLE
Harden web_search against empty sanitized queries

### DIFF
--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -680,6 +680,23 @@ def web_search(query: str, max_results: int = 5) -> Dict[str, Any]:
     # ★ クエリインジェクション対策: 制御文字を除去
     raw_query = _RE_CONTROL_CHARS.sub("", raw_query)
 
+    if not raw_query:
+        return {
+            "ok": False,
+            "results": [],
+            "error": "WEBSEARCH_API invalid query: empty",
+            "meta": _build_meta(
+                raw_count=0,
+                agi_filter_applied=False,
+                agi_result_count=None,
+                boosted_query=None,
+                final_query="",
+                anchor_applied=False,
+                blacklist_applied=False,
+                blocked_count=0,
+            ),
+        }
+
     unavailable_response = {
         "ok": False,
         "results": [],


### PR DESCRIPTION
### Motivation
- Control-character-only or otherwise-empty queries could be sanitized to an empty string and still proceed to external API calls, wasting retries and potentially leaking noise to external services.
- Improve robustness by validating the sanitized query early and fail-fast when it becomes empty.
- Security: this reduces unnecessary network egress and helps avoid calling external search endpoints with invalid input, but operators must still ensure `VERITAS_WEBSEARCH_URL`/`KEY` are managed and the SSRF guards remain properly configured.

### Description
- Add an early-return validation in `web_search` to detect an empty sanitized query and return a structured error `{"error": "WEBSEARCH_API invalid query: empty"}` while preserving the response schema and `meta` fields.
- Add regression test `test_web_search_rejects_empty_query_after_sanitization` to assert that empty-sanitized queries do not call `requests.post` and produce the expected error response.
- Changes are limited to `veritas_os/tools/web_search.py` and `veritas_os/tests/test_web_search.py` and do not affect Planner / Kernel / Fuji / MemoryOS responsibilities.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_web_search.py -q` and it passed (100%).
- Ran `python -m pytest -q veritas_os/tests/test_code_review_fixes_v2.py -q` and it passed (100%).
- No other automated tests were modified; the new test verifies no outbound HTTP call is performed for control-character-only input.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d867be6e0832681f06e70dd270cb8)