### PR TITLE
Harden websearch URL sanitization to reject credentialed/malformed HTTPS URLs

### DIFF
--- a/veritas_os/tests/test_web_search.py
+++ b/veritas_os/tests/test_web_search.py
@@ -262,6 +262,16 @@ def test_sanitize_websearch_url_accepts_https_scheme() -> None:
     )
 
 
+def test_sanitize_websearch_url_rejects_embedded_credentials() -> None:
+    """HTTPS でも userinfo を含む URL は拒否する。"""
+    assert web_search_mod._sanitize_websearch_url("https://user:pass@example.com/search") == ""
+
+
+def test_sanitize_websearch_url_rejects_missing_hostname() -> None:
+    """HTTPS でも hostname が無い URL は拒否する。"""
+    assert web_search_mod._sanitize_websearch_url("https:///search") == ""
+
+
 def test_resolve_websearch_credentials_ignores_unsafe_runtime_url(monkeypatch) -> None:
     """実行時 URL が危険なスキームならモジュール既定値へフォールバックする。"""
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Avoid accidental credential leakage and malformed endpoint misconfiguration by tightening validation of `VERITAS_WEBSEARCH_URL` inputs. 
- Prevent SSRF/ambiguous-request risks from non-HTTPS, userinfo-embedded, or hostname-less URLs before they propagate to runtime request logic. 
- Provide clearer operator visibility via explicit warning logs when unsafe values are ignored. 
- Note: existing deployments that used `https://user:pass@...` as `VERITAS_WEBSEARCH_URL` will be rejected and must move credentials to the API key/header.

### Description
- Strengthened `_sanitize_websearch_url` to explicitly reject non-`https` schemes, URLs containing embedded credentials (`username`/`password`), and URLs without a hostname, and added per-case warning logs. 
- Kept downstream guard `_is_allowed_websearch_url` behavior but moved early rejection to sanitization to harden configuration handling. 
- Initialize `WEBSEARCH_URL` using the updated sanitizer so module-level defaults are validated at import time. 
- Added two focused unit tests `test_sanitize_websearch_url_rejects_embedded_credentials` and `test_sanitize_websearch_url_rejects_missing_hostname` to cover the new rejection cases.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and all tests passed (`93 passed in 0.92s`).
- Ran `ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search.py` and lint checks passed.
- Note: an ad-hoc external HTTP fetch attempted in the rollout failed due to the environment proxy (403) and is unrelated to the unit tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d8cfa1390832688c382103af6e443)