### PR TITLE
Harden web search requests against environment proxy injection

### DIFF
--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -280,7 +280,11 @@ def _post_with_retry(
     Security note:
         Redirects are disabled so that a trusted WEBSEARCH endpoint cannot
         bounce requests to internal/private addresses (SSRF via redirect).
+        Environment-derived HTTP(S) proxy settings are explicitly disabled
+        to prevent accidental API-key forwarding via runtime proxy injection.
     """
+    request_proxies = {"http": None, "https": None}
+
     for attempt in range(1, WEBSEARCH_MAX_RETRIES + 1):
         try:
             response = requests.post(
@@ -289,6 +293,7 @@ def _post_with_retry(
                 json=payload,
                 timeout=timeout,
                 allow_redirects=False,
+                proxies=request_proxies,
             )
             status_code = getattr(response, "status_code", None)
             if status_code is not None and _should_retry_status(status_code):


### PR DESCRIPTION
### Motivation
- Prevent accidental API-key forwarding via environment-configured HTTP(S) proxies that `requests` honors by default. 
- Add a conservative, explicit safeguard for the outbound web-search call path without altering retry semantics. 

### Description
- In `veritas_os/tools/web_search.py`, the `_post_with_retry` function now sets `request_proxies = {"http": None, "https": None}` and passes it to `requests.post` as `proxies=request_proxies` to disable env-derived proxies. 
- The `_post_with_retry` docstring was updated to document the proxy-disable rationale and its security intent. 
- Added a regression test `test_disables_env_proxy_usage` in `veritas_os/tests/test_web_search_extra.py` that verifies `_post_with_retry` calls `requests.post` with `proxies={"http": None, "https": None}`. 

### Testing
- Ran the targeted test class with `pytest -q veritas_os/tests/test_web_search_extra.py::TestPostWithRetry` and it passed (`..`).
- Ran the web search test suite with `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and all tests passed (`95 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc832f7f88326a48bfe0539acb10b)