### PR TITLE
Add CI slow-test isolation and --durations reporting; Makefile test-split helper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
       OPENAI_API_KEY: "DUMMY_FOR_CI"
       VERITAS_API_KEY: "DUMMY_FOR_CI"
       COVERAGE_FAIL_UNDER: "85"
+      PYTEST_MARKEXPR: "not slow"
 
     steps:
       - name: Checkout
@@ -109,6 +110,8 @@ jobs:
             --cov-report=xml:coverage.xml \
             --cov-report=html:coverage-html \
             --cov-fail-under=${COVERAGE_FAIL_UNDER} \
+            -m "${PYTEST_MARKEXPR}" \
+            --durations=20 \
             --junitxml=test-reports/pytest.xml \
             --tb=short
 
@@ -133,6 +136,46 @@ jobs:
       - name: Fail job if tests failed
         if: steps.pytest.outcome == 'failure'
         run: exit 1
+
+
+  test-slow:
+    name: test-slow (py3.12)
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      PIP_NO_PYTHON_VERSION_WARNING: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r veritas_os/requirements.txt
+          python -m pip install pytest
+
+      - name: Run slow tests (if any)
+        run: |
+          set -euxo pipefail
+          status=0
+          pytest -q veritas_os/tests -m slow --durations=20 --tb=short || status=$?
+          if [ "$status" -eq 5 ]; then
+            echo "No slow tests were selected."
+            exit 0
+          fi
+          exit "$status"
 
   # ============================================================
   # Frontend: typecheck + lint + unit tests + a11y

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON_FALLBACK ?= 3.12
 UV ?= uv
 TEST_ARGS ?=
 
-.PHONY: test test-cov
+.PHONY: test test-cov test-split
 
 test:
 	@command -v $(UV) >/dev/null 2>&1 || { echo "Error: uv is required. Install from https://docs.astral.sh/uv/."; exit 1; }
@@ -34,3 +34,14 @@ test-cov:
 	fi; \
 	echo "[veritas] Falling back to Python $(PYTHON_FALLBACK) (local or managed)"; \
 	UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_FALLBACK) --with pytest --with pytest-cov pytest --cov=veritas_os $(TEST_ARGS)
+
+
+test-split:
+	@command -v $(UV) >/dev/null 2>&1 || { echo "Error: uv is required. Install from https://docs.astral.sh/uv/."; exit 1; }
+	@set -e; \
+	for expr in "not (api or server or dashboard or governance or schemas or openapi or constants or telos or evolver)" \
+	            "api or server or dashboard or governance or schemas or openapi or constants or telos or evolver" \
+	            "memory or embedder or index_cosine"; do \
+		echo "[veritas] Running split tests: -k $$expr"; \
+		UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_FALLBACK) --with pytest pytest -q veritas_os/tests -k "$$expr" --durations=20; \
+	done

--- a/veritas_os/tests/conftest.py
+++ b/veritas_os/tests/conftest.py
@@ -35,3 +35,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "asyncio: mark test as asynchronous and execute via asyncio.run",
     )
+    config.addinivalue_line(
+        "markers",
+        "slow: mark test as slow or external-I/O dependent",
+    )


### PR DESCRIPTION
### Motivation
- Long pytest runs were causing CI timeouts and poor visibility into slow tests, so default test runs should exclude slow/external-I/O tests and always report top slowest tests. 
- Provide an explicit CI lane for `@pytest.mark.slow` to allow gradual migration of I/O-dependent tests off the main matrix. 
- Add a local helper to split tests into groups for faster bottleneck diagnosis. 
- Security note: no application runtime secrets or privileged operations were added, but `make test-split` and CI install steps rely on network/PyPI so flaky network or supply-chain issues remain a risk and should be monitored.

### Description
- CI: introduce `PYTEST_MARKEXPR: "not slow"` and run `pytest` with `-m "${PYTEST_MARKEXPR}"` by default to skip `slow` tests, and add `--durations=20` to report the slowest tests every run (file: `.github/workflows/main.yml`).
- CI: add a new `test-slow` job (py3.12) that runs `pytest -m slow --durations=20` and treats the `no tests selected` case as success to avoid failing CI during staged migration (file: `.github/workflows/main.yml`).
- Local dev: add `make test-split` target to run grouped `pytest -q -k "..." --durations=20` splits (API vs non-API vs memory-related groups) to help identify bottleneck file groups quickly (file: `Makefile`).
- Tests: register a `slow` marker in `veritas_os/tests/conftest.py` so `@pytest.mark.slow` can be used without warnings (file: `veritas_os/tests/conftest.py`).

### Testing
- `python - <<'PY' ... yaml.safe_load('.github/workflows/main.yml') ... PY` — YAML parsing of modified workflow succeeded (pass).
- `ruff check veritas_os/tests/conftest.py` — linter passed for the modified `conftest.py` (pass).
- `pytest --version` — verified environment uses pytest 9.0.2 (informational).
- `timeout 60 pytest -q veritas_os/tests --tb=short` — reproduced the reported timeout (`EXIT:124`), confirming the original problem remains until slow tests are separated (reproduced).
- `timeout 20 make test-split` — attempted but failed while creating the virtualenv due to network/PyPI tunnel/connect error during dependency install (network failure; not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dce8ed7108326bd3e06ead31e001b)