### PR TITLE
Stabilize security gates: block prod Node vulns, add SBOM nightly, sync Python deps & pre-commit

### DIFF
--- a/.github/workflows/sbom-nightly.yml
+++ b/.github/workflows/sbom-nightly.yml
@@ -1,0 +1,84 @@
+name: Nightly SBOM
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    name: Generate and compare SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install SBOM tooling (Python)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cyclonedx-bom
+
+      - name: Generate Python SBOM (CycloneDX)
+        run: cyclonedx-py requirements veritas_os/requirements.txt --output-file security/sbom/python.cdx.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '9.15.3'
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Node SBOM (CycloneDX)
+        run: pnpm dlx @cyclonedx/cyclonedx-npm --output-file security/sbom/node.cdx.json --spec-version 1.5
+
+      - name: Generate SBOM hashes
+        run: |
+          sha256sum security/sbom/python.cdx.json > security/sbom/python.cdx.sha256
+          sha256sum security/sbom/node.cdx.json > security/sbom/node.cdx.sha256
+
+      - name: Compare with baseline hashes
+        run: |
+          set -euo pipefail
+          status=0
+
+          if [ -f security/sbom/baseline/python.cdx.sha256 ]; then
+            diff -u security/sbom/baseline/python.cdx.sha256 security/sbom/python.cdx.sha256 || status=1
+          else
+            echo "::warning::Missing baseline hash: security/sbom/baseline/python.cdx.sha256"
+          fi
+
+          if [ -f security/sbom/baseline/node.cdx.sha256 ]; then
+            diff -u security/sbom/baseline/node.cdx.sha256 security/sbom/node.cdx.sha256 || status=1
+          else
+            echo "::warning::Missing baseline hash: security/sbom/baseline/node.cdx.sha256"
+          fi
+
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::SBOM hash drift detected. Review dependency changes."
+          fi
+
+      - name: Upload SBOM artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-nightly
+          path: |
+            security/sbom/*.cdx.json
+            security/sbom/*.cdx.sha256
+          if-no-files-found: error

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -1,0 +1,74 @@
+name: Security Gates
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audit:
+    name: Dependency audit (Python + Node)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pip-audit
+
+      - name: Python dependency audit (pip-audit)
+        run: pip-audit -r veritas_os/requirements.txt
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '9.15.3'
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Node dependency audit (production, blocking)
+        run: pnpm audit --prod --audit-level=high
+
+      - name: Node dependency audit (full dependency tree, report-only)
+        run: |
+          set -euo pipefail
+          pnpm audit --audit-level=high || {
+            echo '::warning::Non-production dependency vulnerabilities detected by pnpm audit. Review and remediate in frontend toolchain updates.'
+          }
+
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ARGS: --no-banner --redact --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks
+        args:
+          - --no-banner
+          - --redact

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,3 +47,40 @@ If declined, we will explain why (e.g., not a security issue, out of scope, or c
 - DoS from extremely large inputs without a practical exploit path
 - Issues requiring compromised credentials or malicious admins
 - Reports lacking reproducible details
+
+
+## Automated Security Gates
+
+The repository enforces automated gates to reduce the risk of introducing known vulnerabilities, secret leaks, and unsafe dependency drift.
+
+### CI required checks
+- **Dependency audit (Python):** `pip-audit -r veritas_os/requirements.txt`
+- **Dependency audit (Node, blocking):** `pnpm audit --prod --audit-level=high`
+- **Dependency audit (Node, report):** `pnpm audit --audit-level=high` (non-blocking warning for dev/tooling chains)
+- **Secret scan:** `gitleaks` on every `push` and `pull_request`
+
+These checks are configured as GitHub Actions workflows and should be treated as required status checks for merges into `main`.
+
+### Developer local checks (pre-commit)
+Install and enable local hooks:
+
+```bash
+python -m pip install pre-commit
+pre-commit install
+```
+
+The repository uses pre-commit to run `gitleaks` before commits so secrets are blocked as early as possible.
+
+### Nightly SBOM generation and drift monitoring
+A nightly workflow generates CycloneDX SBOM files for Python and Node dependencies and compares their SHA256 hashes against baseline hashes stored under `security/sbom/baseline/`.
+
+- Generated files:
+  - `security/sbom/python.cdx.json`
+  - `security/sbom/node.cdx.json`
+- Drift indicators:
+  - `security/sbom/python.cdx.sha256`
+  - `security/sbom/node.cdx.sha256`
+
+If hash drift is detected, the workflow emits warnings and uploads artifacts for review.
+
+> **Security warning:** Without these automated gates, known vulnerable packages and accidental secret exposures can bypass manual review and reach production.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "fastapi==0.115.0",
+  "fastapi==0.119.0",
   "uvicorn==0.30.3",
   "pydantic==2.8.2",
   "python-dotenv==1.0.1",
@@ -35,8 +35,10 @@ dependencies = [
   "jinja2==3.1.6",
   "numpy==1.26.4",
   "pandas==2.2.3",
-  "pdfplumber==0.11.4",
+  "pdfplumber==0.11.8",
   "trio==0.26.2",
+  "starlette==0.47.2",
+  "pdfminer.six==20251230",
   "psutil==6.0.0",
 ]
 

--- a/security/sbom/README.md
+++ b/security/sbom/README.md
@@ -1,0 +1,16 @@
+# SBOM Baseline
+
+This directory stores baseline SHA256 hashes used by the nightly SBOM drift monitor.
+
+## Expected baseline files
+- `baseline/python.cdx.sha256`
+- `baseline/node.cdx.sha256`
+
+Generate and refresh baseline hashes with:
+
+```bash
+sha256sum security/sbom/python.cdx.json > security/sbom/baseline/python.cdx.sha256
+sha256sum security/sbom/node.cdx.json > security/sbom/baseline/node.cdx.sha256
+```
+
+> Update baselines only after verifying dependency changes are intentional.

--- a/veritas_os/requirements.txt
+++ b/veritas_os/requirements.txt
@@ -6,7 +6,7 @@
 # to upgrade specific packages after testing.
 
 # --- API / Server ---
-fastapi==0.115.0
+fastapi==0.119.0
 uvicorn==0.30.3
 pydantic==2.8.2
 python-dotenv==1.0.1
@@ -28,8 +28,10 @@ matplotlib==3.9.2
 jinja2==3.1.6
 numpy==1.26.4
 pandas==2.2.3
-pdfplumber==0.11.4
+pdfplumber==0.11.8
 trio==0.26.2
+starlette==0.47.2
+pdfminer.six==20251230
 
 # --- System Tools (optional but stable) ---
 psutil==6.0.0


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by dev-tooling transitive vulnerabilities while still blocking production runtime risks by distinguishing `pnpm audit` behavior for `--prod` vs full-tree audits. 
- Ensure dependency metadata and runtime pins are consistent so `pip-audit` and packaging reflect the same resolved versions. 
- Add automated SBOM generation and baseline comparison to detect dependency drift and make secret scans part of developer workflows.

### Description
- Adjusted Node audit steps to enforce a blocking production audit with `pnpm audit --prod --audit-level=high` and added a report-only full-tree `pnpm audit --audit-level=high` that emits warnings (file: `.github/workflows/security-gates.yml`).
- Added a nightly SBOM workflow that generates CycloneDX SBOMs for Python and Node, produces SHA256 hashes, compares them to baselines, and uploads artifacts (file: `.github/workflows/sbom-nightly.yml`).
- Synchronized Python packaging and runtime pins by bumping `fastapi` and `pdfplumber` and adding explicit `starlette` and `pdfminer.six` pins in `pyproject.toml` and `veritas_os/requirements.txt` (files: `pyproject.toml`, `veritas_os/requirements.txt`).
- Added `pre-commit` configuration to run `gitleaks` locally and a `security/sbom/README.md` that documents baseline creation (files: `.pre-commit-config.yaml`, `security/sbom/README.md`).
- Updated `SECURITY.md` to document the two-tier Node audit policy and the nightly SBOM drift monitoring (file: `SECURITY.md`).

### Testing
- Ran `git diff --check` which succeeded with no whitespace/content issues. 
- Verified repository status with `git status --short` showing only intended changes and committed the gate adjustment. 
- Attempted local `pnpm` lockfile update and `pnpm install --lockfile-only` but registry access failed with HTTP 403 in this environment so `pnpm audit` could not be re-run locally. 
- Local `pip install` validation of updated `veritas_os/requirements.txt` was previously blocked by outbound proxy and could not complete, so dependency-audit validation must be executed in CI.

Security warning: pinned dependency updates and gate adjustments are a risk-based change—they can introduce runtime incompatibilities and do not remove the obligation to remediate dev-tooling vulnerabilities; run full CI (`pip-audit`, `pnpm audit`, `gitleaks`, SBOM generation) before promoting these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd92d61a08326990bf563c6cdfd21)