### PR TITLE
docs: レビューステータスを単一化し Completeness 文書をアーカイブ化

### DIFF
--- a/docs/notes/CODE_REVIEW_DOCUMENT_MAP.md
+++ b/docs/notes/CODE_REVIEW_DOCUMENT_MAP.md
@@ -1,6 +1,13 @@
+---
+title: コードレビュー文書マップ（整理版）
+doc_type: review_document_index
+latest: true
+updated_at: 2026-02-25
+---
+
 # コードレビュー文書マップ（整理版）
 
-最終更新: 2026-02-16
+最終更新: 2026-02-25
 
 この文書は、リポジトリ内に点在しているコードレビュー関連 Markdown の
 **参照順序**と**用途**を整理するためのインデックスです。
@@ -25,7 +32,7 @@
 ## 2. 参照目的別の読み分け
 
 ### A. 直近の包括レビューを読みたい
-- `docs/review/CODE_REVIEW_2026_02_16_COMPLETENESS_JP.md`（完成度パーセンテージ評価）
+- `docs/review/CODE_REVIEW_2026_02_16_COMPLETENESS_JP.md`（履歴アーカイブ。最新判定は `CODE_REVIEW_STATUS.md` に統合済み）
 - `docs/review/CODE_REVIEW_2026_02_11.md`
 - `docs/review/CODE_REVIEW_2026_02_10.md`
 

--- a/docs/review/CODE_REVIEW_2026_02_16_COMPLETENESS_JP.md
+++ b/docs/review/CODE_REVIEW_2026_02_16_COMPLETENESS_JP.md
@@ -1,4 +1,17 @@
-# CODE REVIEW 2026-02-16（全体完成度評価）
+---
+title: CODE REVIEW 2026-02-16（全体完成度評価）
+doc_type: review_status_archive
+latest: false
+lifecycle: archived
+updated_at: 2026-02-25
+superseded_by: docs/review/CODE_REVIEW_STATUS.md
+---
+
+# CODE REVIEW 2026-02-16（全体完成度評価 / アーカイブ）
+
+> この文書は履歴アーカイブです。最新のステータス判定は
+> `docs/review/CODE_REVIEW_STATUS.md` を参照してください。
+
 
 ## 結論
 - **全体完成度: 68%**

--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -1,7 +1,15 @@
+---
+title: VERITAS OS - Code Review Status Update
+doc_type: review_status
+latest: true
+lifecycle: active
+updated_at: 2026-02-25
+---
+
 # VERITAS OS - Code Review Status Update
 
-**Date**: 2026-02-08 (Updated)
-**Status**: Code review issues addressed and new issues identified
+**Date**: 2026-02-25 (Updated)
+**Status**: Single source of truth for review status (active)
 **PR**: copilot/review-all-code-improvements
 
 ---
@@ -10,6 +18,23 @@
 
 - 文書整理ガイド: `docs/notes/CODE_REVIEW_DOCUMENT_MAP.md`
 - 現行の一次情報: `docs/review/CODE_REVIEW_STATUS.md` + `docs/review/CODE_REVIEW_2026_02_11_RUNTIME_CHECK.md`
+
+---
+
+## Consolidated Status Policy
+
+- この文書を**唯一のステータス一次情報**として運用する。
+- `docs/review/CODE_REVIEW_2026_02_16_COMPLETENESS_JP.md` は履歴アーカイブとして扱う。
+- 最新判定は本書に統合し、重複更新を禁止する。
+
+## Latest Assessment (Integrated)
+
+- **統合時点の全体完成度判定: 68%**
+- 根拠:
+  1. 指摘45件中27件対応（ベースライン60%）。
+  2. `ruff check veritas_os` 通過。
+  3. `test_code_review_fixes*.py` 系統の代表テスト通過（25件）。
+  4. Deferred項目（特に `pickle` 依存）が残るため上限評価を抑制。
 
 ---
 


### PR DESCRIPTION
### Motivation
- レビュー関連文書が重複して最新判断の二重管理リスクを生んでいるため、ステータスの単一運用（Single source of truth）を確立するための整理を行いました。 
- 履歴的な完成度評価は参照用に残す一方で、日次/運用向けのステータスは1つに集約する方針を明確化しました。 
- 未解決の高リスク項目（特に `pickle` デシリアライズ依存）は引き続きセキュリティ上の注意点として明示したままにしています。 

### Description
- `docs/review/CODE_REVIEW_STATUS.md` に front matter（`latest: true`, `updated_at` など）を追加し、`Consolidated Status Policy` と統合済みの `Latest Assessment`（全体完成度: 68%）セクションを挿入しました。 
- `docs/review/CODE_REVIEW_2026_02_16_COMPLETENESS_JP.md` をフロントマター付きのアーカイブ化文書（`latest: false`, `lifecycle: archived`, `superseded_by: docs/review/CODE_REVIEW_STATUS.md`）とし、冒頭で履歴扱いである旨を明示しました。 
- `docs/notes/CODE_REVIEW_DOCUMENT_MAP.md` に front matter を追加して `updated_at` を更新し、`CODE_REVIEW_2026_02_16_COMPLETENESS_JP.md` を「履歴アーカイブ」として扱う旨を反映しました。 

### Testing
- 変更はドキュメントのみのためコード実行テストは不要ですが、差分整合性チェックとして `git diff --check` を実行し空白エラー等がないことを確認しました。 
- ドキュメント更新のみに限定しており、Planner / Kernel / Fuji / MemoryOS の責務境界を越える実装変更は行っていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e75b3a1a48326a010f5aecf8738be)