### PR TITLE
Gate optional integrations behind explicit capability flags

### DIFF
--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -215,6 +215,58 @@ class PipelineConfig:
 
 
 @dataclass
+class CapabilityConfig:
+    """Optional capability flags shared by core modules.
+
+    Optional integrations are controlled explicitly by feature flags instead of
+    import success/failure so that runtime behavior remains reproducible.
+    """
+
+    enable_kernel_reason: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_KERNEL_REASON", True)
+    )
+    enable_kernel_strategy: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_KERNEL_STRATEGY", True)
+    )
+    enable_kernel_sanitize: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_KERNEL_SANITIZE", True)
+    )
+    enable_fuji_tool_bridge: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_FUJI_TOOL_BRIDGE", True)
+    )
+    enable_fuji_trust_log: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_FUJI_TRUST_LOG", True)
+    )
+    enable_fuji_yaml_policy: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_FUJI_YAML_POLICY", True)
+    )
+    enable_memory_posix_file_lock: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_MEMORY_POSIX_FILE_LOCK", True)
+    )
+    enable_memory_joblib_model: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_MEMORY_JOBLIB_MODEL", True)
+    )
+    emit_manifest_on_import: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_EMIT_MANIFEST", True)
+    )
+
+
+def emit_capability_manifest(component: str, manifest: Dict[str, bool]) -> None:
+    """Emit a structured capability manifest to logs.
+
+    This output helps operators quickly detect disabled features and prevents
+    silent drift caused by environment-dependent optional imports.
+    """
+    disabled = sorted(name for name, enabled in manifest.items() if not enabled)
+    logging.getLogger(__name__).info(
+        "[CapabilityManifest] component=%s manifest=%s disabled=%s",
+        component,
+        manifest,
+        disabled,
+    )
+
+
+@dataclass
 class VeritasConfig:
     # ==== API ====
     api_key_str: str = field(
@@ -355,3 +407,4 @@ cfg = VeritasConfig()
 scoring_cfg = ScoringConfig()
 fuji_cfg = FujiConfig()
 pipeline_cfg = PipelineConfig()
+capability_cfg = CapabilityConfig()

--- a/veritas_os/tests/test_capability_flags.py
+++ b/veritas_os/tests/test_capability_flags.py
@@ -1,0 +1,54 @@
+"""Capability flag behavior for optional integrations.
+
+These tests ensure optional imports are controlled by explicit feature flags
+rather than implicit import success.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _reload_config_and(module_name: str):
+    """Reload config first, then target module to apply env-driven flags."""
+    import veritas_os.core.config as config_mod
+
+    config_mod = importlib.reload(config_mod)
+    target_mod = importlib.import_module(module_name)
+    target_mod = importlib.reload(target_mod)
+    return config_mod, target_mod
+
+
+def test_kernel_capability_flags_disable_optional_layers(monkeypatch):
+    """Kernel optional layers can be disabled by explicit capability flags."""
+    monkeypatch.setenv("VERITAS_CAP_KERNEL_REASON", "0")
+    monkeypatch.setenv("VERITAS_CAP_KERNEL_STRATEGY", "0")
+    monkeypatch.setenv("VERITAS_CAP_KERNEL_SANITIZE", "0")
+
+    _, kernel_mod = _reload_config_and("veritas_os.core.kernel")
+
+    assert kernel_mod.reason_core is None
+    assert kernel_mod.strategy_core is None
+    assert kernel_mod._HAS_SANITIZE is False
+
+
+def test_fuji_tool_bridge_flag_blocks_call_tool(monkeypatch):
+    """Fuji blocks external tool bridge when capability flag is disabled."""
+    monkeypatch.setenv("VERITAS_CAP_FUJI_TOOL_BRIDGE", "0")
+
+    _, fuji_mod = _reload_config_and("veritas_os.core.fuji")
+
+    try:
+        fuji_mod.call_tool("web_search", query="veritas")
+        assert False, "Expected RuntimeError when tool bridge is disabled"
+    except RuntimeError as exc:
+        assert "VERITAS_CAP_FUJI_TOOL_BRIDGE" in str(exc)
+
+
+def test_memory_joblib_flag_disables_loader(monkeypatch):
+    """Memory module disables joblib model loading via capability flag."""
+    monkeypatch.setenv("VERITAS_CAP_MEMORY_JOBLIB_MODEL", "0")
+
+    _, memory_mod = _reload_config_and("veritas_os.core.memory")
+
+    assert memory_mod.joblib_load is None


### PR DESCRIPTION
### Motivation
- Optional `try/except ImportError` imports caused runtime-dependent behavior and reduced reproducibility and clear responsibility boundaries across Kernel/Fuji/Memory. 
- Make optional integrations deterministic and operator-controllable by switching from import-success detection to explicit feature flags. 
- Emit a capability manifest at import time so operators can detect disabled features and avoid silent drift. 
- Surface operational and security decisions (e.g. external tool access, YAML policy use, pickle/joblib usage) as explicit capabilities to harden runtime expectations.

### Description
- Added `CapabilityConfig` and `emit_capability_manifest()` in `veritas_os/core/config.py` and exposed `capability_cfg` as a shared config for core modules. 
- Kernel changes in `veritas_os/core/kernel.py` gate `reason`, `strategy`, and sanitize behavior behind `VERITAS_CAP_*` flags and introduce `ReasonCapability`/`StrategyCapability` `Protocol`s to fix kernel-facing responsibility contracts. 
- Fuji changes in `veritas_os/core/fuji.py` gate the external tool bridge, trust-log appends and YAML policy parsing behind capability flags and make `call_tool`/`append_trust_event` follow those flags, and emit manifest info at import. 
- Memory changes in `veritas_os/core/memory.py` gate POSIX file locking and `joblib` model loading behind capability flags and emit manifest info at import. 
- Added tests in `veritas_os/tests/test_capability_flags.py` that reload modules under env-driven flags to assert the new flag-driven semantics.

### Testing
- Ran static compile checks with `python -m py_compile` for the modified modules and they succeeded. 
- Executed `pytest -q veritas_os/tests/test_capability_flags.py` and the new capability tests passed (3 tests). 
- Ran `pytest` on a representative subset (`veritas_os/tests/test_kernel_coverage.py`, `veritas_os/tests/test_fuji_core.py`, `veritas_os/tests/test_memory_core.py`) and those suites completed successfully. 
- All automated checks performed for this change passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f8da0fa3c832682aea69dafd68237)