### PR TITLE
refactor(planner): centralize normalization policies

### DIFF
--- a/veritas_os/core/planner_normalization.py
+++ b/veritas_os/core/planner_normalization.py
@@ -1,0 +1,125 @@
+"""Normalization helpers for Planner payloads.
+
+This module centralizes value normalization and error policies used in
+``veritas_os.core.planner`` so future schema extensions can reuse the same
+conversion rules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Mapping
+
+FailurePolicy = Literal["use_default", "reject"]
+
+
+@dataclass(frozen=True)
+class NumericNormalizationRule:
+    """Rule set for normalizing numeric planner fields.
+
+    Attributes:
+        default: Fallback value used when conversion fails and policy is
+            ``"use_default"``.
+        minimum: Optional lower clamp bound.
+        maximum: Optional upper clamp bound.
+        on_failure: Conversion failure policy. ``"use_default"`` keeps planner
+            resilient, while ``"reject"`` re-raises conversion errors.
+    """
+
+    default: float
+    minimum: float | None = None
+    maximum: float | None = None
+    on_failure: FailurePolicy = "use_default"
+
+
+NORMALIZATION_POLICY_TABLE: Dict[str, NumericNormalizationRule] = {
+    "eta_hours": NumericNormalizationRule(
+        default=1.0,
+        minimum=0.0,
+        on_failure="use_default",
+    ),
+    "risk": NumericNormalizationRule(
+        default=0.1,
+        minimum=0.0,
+        maximum=1.0,
+        on_failure="use_default",
+    ),
+    "progress": NumericNormalizationRule(
+        default=0.0,
+        minimum=0.0,
+        maximum=1.0,
+        on_failure="use_default",
+    ),
+    "decision_count": NumericNormalizationRule(
+        default=0.0,
+        minimum=0.0,
+        on_failure="use_default",
+    ),
+}
+
+
+def normalize_float(
+    value: Any,
+    *,
+    field_name: str,
+    rule_overrides: Mapping[str, NumericNormalizationRule] | None = None,
+    default_override: Any | None = None,
+) -> float:
+    """Normalize a value into float using planner normalization policies."""
+    rules = rule_overrides or NORMALIZATION_POLICY_TABLE
+    rule = rules[field_name]
+
+    default_candidate = rule.default if default_override is None else default_override
+    fallback = _coerce_default(default_candidate, field_name=field_name, rule=rule)
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        if rule.on_failure == "reject":
+            raise
+        numeric = fallback
+
+    if rule.minimum is not None:
+        numeric = max(rule.minimum, numeric)
+    if rule.maximum is not None:
+        numeric = min(rule.maximum, numeric)
+
+    return numeric
+
+
+def normalize_int(
+    value: Any,
+    *,
+    field_name: str,
+    rule_overrides: Mapping[str, NumericNormalizationRule] | None = None,
+    default_override: Any | None = None,
+) -> int:
+    """Normalize a value into int using planner normalization policies."""
+    normalized = normalize_float(
+        value,
+        field_name=field_name,
+        rule_overrides=rule_overrides,
+        default_override=default_override,
+    )
+    return int(normalized)
+
+
+def _coerce_default(
+    default_value: Any,
+    *,
+    field_name: str,
+    rule: NumericNormalizationRule,
+) -> float:
+    """Coerce and clamp default values according to rule and failure policy."""
+    try:
+        numeric_default = float(default_value)
+    except (TypeError, ValueError):
+        if rule.on_failure == "reject":
+            raise
+        numeric_default = float(rule.default)
+
+    if rule.minimum is not None:
+        numeric_default = max(rule.minimum, numeric_default)
+    if rule.maximum is not None:
+        numeric_default = min(rule.maximum, numeric_default)
+    return numeric_default

--- a/veritas_os/tests/test_planner_normalization.py
+++ b/veritas_os/tests/test_planner_normalization.py
@@ -1,0 +1,41 @@
+"""Tests for planner normalization utility policies."""
+
+import pytest
+
+from veritas_os.core import planner_normalization as norm
+
+
+def test_normalize_float_uses_default_for_invalid_input():
+    value = norm.normalize_float(
+        "invalid",
+        field_name="eta_hours",
+        default_override=2.5,
+    )
+    assert value == pytest.approx(2.5)
+
+
+def test_normalize_float_clamps_by_policy_bounds():
+    risk = norm.normalize_float(2.7, field_name="risk")
+    assert risk == pytest.approx(1.0)
+
+
+def test_normalize_float_reject_policy_raises_conversion_error():
+    reject_rules = {
+        **norm.NORMALIZATION_POLICY_TABLE,
+        "custom": norm.NumericNormalizationRule(
+            default=1.0,
+            on_failure="reject",
+        ),
+    }
+
+    with pytest.raises(ValueError):
+        norm.normalize_float(
+            "bad",
+            field_name="custom",
+            rule_overrides=reject_rules,
+        )
+
+
+def test_normalize_int_uses_common_policy_table():
+    count = norm.normalize_int("5", field_name="decision_count")
+    assert count == 5


### PR DESCRIPTION
### Motivation
- Planner contains repeated numeric normalization logic (eta/risk/progress/etc.) which risks inconsistent behavior when extending schemas. 
- Centralizing conversion and failure policies reduces maintenance burden and makes behavior (default vs reject) explicit. 
- The change keeps responsibility inside the Planner boundary and avoids touching Kernel/FUJI/MemoryOS code. 
- Security note: some `except Exception` catch-all sites remain in `planner.py` and may hide normalization failures, so tightening exception handling is recommended in follow-ups.

### Description
- Added a new module `veritas_os/core/planner_normalization.py` that defines `NumericNormalizationRule`, a `NORMALIZATION_POLICY_TABLE`, and helpers `normalize_float` and `normalize_int` with configurable `use_default`/`reject` policies and clamping. 
- Replaced inline numeric coercion in `veritas_os/core/planner.py` with calls to `normalize_float`/`normalize_int` for step-level `eta_hours`/`risk`, world-stage `progress`, and code-task metadata `progress`/`decision_count`. 
- Added module docstring and created unit tests `veritas_os/tests/test_planner_normalization.py` covering default fallback, clamping, reject-policy behavior, and integer normalization. 
- No external dependencies added and the change is scoped to Planner-related code only.

### Testing
- Ran the focused tests with `pytest -q veritas_os/tests/test_planner.py veritas_os/tests/test_planner_normalization.py` and observed `53 passed, 3 warnings`. 
- New normalization tests exercise `use_default` fallback, bounds clamping, and `reject` policy raising, and they passed. 
- Note: only the targeted planner tests were run as part of this change; full test-suite runs were not performed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fa454c8fc832695a02ae1d1b1b46a)