### PR TITLE
memory: decommission runtime pickle migration and pivot training outputs to ONNX

### DIFF
--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -36,6 +36,10 @@ if not IS_WIN and capability_cfg.enable_memory_posix_file_lock:
 else:
     fcntl = None  # type: ignore
 
+# Backward-compatibility shim for tests/consumers that introspect this symbol.
+# Runtime pickle/joblib loading is intentionally decommissioned for security.
+joblib_load = None
+
 if capability_cfg.emit_manifest_on_import:
     emit_capability_manifest(
         component="memory",

--- a/veritas_os/tests/test_memory_coverage.py
+++ b/veritas_os/tests/test_memory_coverage.py
@@ -28,9 +28,13 @@ class TestAllowLegacyPickleMigration:
         assert memory._allow_legacy_pickle_migration() is False
 
     @pytest.mark.parametrize("val", ["1", "true", "yes", "y", "on", "TRUE", " Yes "])
-    def test_truthy_values(self, monkeypatch, val):
+    def test_truthy_values_still_false_after_runtime_decommission(
+        self,
+        monkeypatch,
+        val,
+    ):
         monkeypatch.setenv("VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION", val)
-        assert memory._allow_legacy_pickle_migration() is True
+        assert memory._allow_legacy_pickle_migration() is False
 
     def test_falsy_value(self, monkeypatch):
         monkeypatch.setenv("VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION", "no")

--- a/veritas_os/tests/test_memory_vector.py
+++ b/veritas_os/tests/test_memory_vector.py
@@ -261,12 +261,7 @@ def test_legacy_pickle_migration_disabled_by_default(tmp_path: Path, monkeypatch
 
 
 def test_legacy_pickle_migration_opt_in(tmp_path: Path, monkeypatch):
-    """オプトイン時でも _reconstruct がブロックされるため移行は安全に失敗する。
-
-    numpy 配列を含む pickle は _reconstruct を使用するため、
-    セキュリティ強化により RestrictedUnpickler がこれを拒否する。
-    移行は graceful に失敗し、ドキュメントは空のまま残る。
-    """
+    """オプトイン指定しても runtime での移行は常に拒否される。"""
     import numpy as np
 
     idx_path = tmp_path / "legacy_index.pkl"
@@ -279,10 +274,9 @@ def test_legacy_pickle_migration_opt_in(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION", "1")
 
     vm = _new_vector_memory(index_path=idx_path, dim=4)
-    # _reconstruct blocked → migration gracefully fails
+    # runtime decommissioned: pickle migration is always disabled
     assert len(vm.documents) == 0
     assert not idx_path.with_suffix(".json").exists()
-
 
 
 


### PR DESCRIPTION
### Motivation
- Close a high-risk runtime deserialization attack surface by removing the ability to re-enable legacy pickle migration via environment variables.
- Ensure runtime only consumes safe, auditable artifacts (JSON indexes, ONNX models) and push legacy .pkl → offline/one-shot migration workflows.
- Provide an explicit, auditable training output path that avoids joblib/pickle artifacts.

### Description
- Permanently disable runtime pickle migration by making `_allow_legacy_pickle_migration()` always return `False` and emitting a clear security warning about offline migration requirements.
- Remove runtime migration/read paths for legacy `.pkl` vector indexes and model artifacts, logging explicit security errors when `.pkl` artifacts are detected, and make `VectorMemory` JSON-only for index loading.
- Pivot default artifact names and expectations from `memory_model.pkl`/`vector_index.pkl` to `memory_model.onnx`/`vector_index.json` and surface explicit log messages when legacy pickles remain in `core/models`.
- Update `scripts/memory_train.py` to emit runtime-safe artifacts: always write JSON metadata and attempt an ONNX export of the trained pipeline (best-effort using `skl2onnx`), and add a docstring explaining the security rationale.
- Update unit tests to reflect the new runtime behavior (truthy `VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION` no longer enables runtime migration and legacy `.pkl` indexes are not migrated at runtime).

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_coverage.py` which passed (tests validating the decommissioned migration helpers and RestrictedUnpickler behavior succeeded).
- Ran `python -m pytest -q veritas_os/tests/test_memory_train_script.py` which passed (script-level dataset loading tests and deterministic ordering passed).
- Updated memory-related unit tests to assert the new runtime-decommission semantics and exercised the VectorMemory JSON loading path in tests. All automated tests listed above completed successfully.

Security note: this PR closes the runtime pickle attack surface but does not remove existing `.pkl` files from deployments, so operators must perform offline one-shot migration to JSON/ONNX and delete any leftover pickle artifacts to fully eliminate the risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fac05a0cc8326afc4b9f480d027c6)