### PR TITLE
planner: 例外ハンドリングを細分化してフォールバック例外を明示化

### DIFF
--- a/veritas_os/tests/test_planner_coverage.py
+++ b/veritas_os/tests/test_planner_coverage.py
@@ -403,7 +403,7 @@ def test_try_get_memory_snippet_query_fallback(monkeypatch):
 
 def test_try_get_memory_snippet_search_exception(monkeypatch):
     mock_mem = MagicMock()
-    mock_mem.search.side_effect = RuntimeError("fail")
+    mock_mem.search.side_effect = ValueError("fail")
     monkeypatch.setattr(planner_core, "mem", mock_mem)
     assert planner_core._try_get_memory_snippet("test", {}) is None
 
@@ -504,10 +504,10 @@ def test_plan_for_veritas_agi_llm_empty_steps(monkeypatch):
 def test_plan_for_veritas_agi_llm_exception(monkeypatch):
     monkeypatch.setattr(planner_core.world_model, "snapshot", lambda key: {"progress": 0.1})
     monkeypatch.setattr(planner_core, "mem", MagicMock(spec=[]))
-    monkeypatch.setattr(planner_core.llm_client, "chat", lambda **kw: (_ for _ in ()).throw(RuntimeError("fail")))
+    monkeypatch.setattr(planner_core.llm_client, "chat", lambda **kw: (_ for _ in ()).throw(ValueError("fail")))
 
     def _chat_fail(**kw):
-        raise RuntimeError("LLM down")
+        raise ValueError("LLM down")
     monkeypatch.setattr(planner_core.llm_client, "chat", _chat_fail)
 
     result = planner_core.plan_for_veritas_agi(
@@ -554,7 +554,7 @@ def test_plan_for_veritas_agi_disallow_step1_all_step1(monkeypatch):
 
 def test_plan_for_veritas_agi_world_snapshot_fail(monkeypatch):
     def _snap_fail(key):
-        raise RuntimeError("snap fail")
+        raise ValueError("snap fail")
     monkeypatch.setattr(planner_core.world_model, "snapshot", _snap_fail)
     monkeypatch.setattr(planner_core, "mem", MagicMock(spec=[]))
     monkeypatch.setattr(planner_core.llm_client, "chat", lambda **kw: {
@@ -625,7 +625,7 @@ def test_generate_code_tasks_code_planner_path(monkeypatch):
 
 def test_generate_code_tasks_code_planner_fails(monkeypatch):
     def _fail(**kw):
-        raise RuntimeError("code planner fail")
+        raise ValueError("code planner fail")
     monkeypatch.setattr(planner_core.code_planner, "generate_code_change_plan", _fail)
     monkeypatch.setattr(planner_core.world_model, "get_state", lambda: None)
     result = planner_core.generate_code_tasks(bench={})


### PR DESCRIPTION
### Motivation
- CODEX改善レビューのP0提案（広すぎる `except Exception` を縮小して観測性を高める）に従い、Planner の重要経路で例外握りつぶしを減らすための変更です。 
- 想定される入力/属性/I/O不整合はフォールバック許容として扱い、それ以外の例外は表面化させて障害検知を容易にします。 

### Description
- 追加された定数 `_FALLBACK_SAFE_ERRORS` と `_MEMORY_LOOKUP_ERRORS` により、フォールバックで許容する例外クラスを中央管理しました（`veritas_os/core/planner.py`）。
- `_simple_qa_plan`、`_try_get_memory_snippet`、`plan_for_veritas_agi` の world snapshot / memory lookup / LLM経路、`generate_code_tasks` の code_planner / world_state 読み出しでの `except Exception` を具体的な例外タプルへ置換しました（該当箇所を限定的に捕捉）。
- テストの期待挙動に合わせて `veritas_os/tests/test_planner_coverage.py` の故意に失敗を発生させるケースを `RuntimeError` から `ValueError` に変更し、狙いどおりのフォールバック経路を確保しました。
- 変更ファイル: `veritas_os/core/planner.py`, `veritas_os/tests/test_planner_coverage.py`。

### Testing
- 実行した自動テスト: `pytest -q veritas_os/tests/test_planner_coverage.py`, 結果: all tests passed (`86 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd06493208326a29594e760c38831)