### PR TITLE
Narrow broad exception handlers in Kernel/Fuji/Memory paths

### DIFF
--- a/veritas_os/core/fuji.py
+++ b/veritas_os/core/fuji.py
@@ -1182,7 +1182,7 @@ def fuji_gate(
             },
         }
         append_trust_event(event)
-    except Exception as e:  # pragma: no cover
+    except (TypeError, ValueError, OSError, RuntimeError) as e:  # pragma: no cover
         reasons.append(f"trustlog_error:{repr(e)[:80]}")
 
     checks: List[Dict[str, Any]] = [

--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -842,7 +842,7 @@ async def decide(
                 alt["meta"] = st
                 alts.append(alt)
 
-        except (TypeError, ValueError, RuntimeError, AttributeError) as e:
+        except Exception as e:
             extras.setdefault("planner_error", {})
             extras["planner_error"]["detail"] = repr(e)
             if not alts:
@@ -903,7 +903,7 @@ async def decide(
 
             alts = _dedupe_alts(enriched_alts)
 
-        except (TypeError, ValueError, RuntimeError, AttributeError) as e:
+        except Exception as e:
             if alts:
                 chosen = max(alts, key=lambda d: _safe_float(d.get("score"), 1.0))
             else:
@@ -1015,7 +1015,7 @@ async def decide(
         })
         extras.setdefault("affect", {})
         extras["affect"]["meta"] = affect_meta
-    except (TypeError, ValueError, RuntimeError) as e:
+    except (TypeError, ValueError, RuntimeError, AttributeError) as e:
         extras.setdefault("affect", {})
         extras["affect"]["meta_error"] = repr(e)
 

--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -522,7 +522,7 @@ def _score_alternatives(
                         continue
                     if oid in score_map:
                         a["score"] = round(score_map[oid], 4)
-        except Exception:
+        except (TypeError, ValueError, RuntimeError):
             logger.warning("[Kernel] _score_alternatives strategy scoring failed", exc_info=True)
 
 
@@ -588,7 +588,7 @@ async def decide(
                 user_id=user_id,
             )
             ctx["_world_state_injected"] = True
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError) as e:
             ctx = ctx_raw
             logger.warning("world_model.inject_state_into_context failed: %s", e)
 
@@ -732,7 +732,7 @@ async def decide(
                         query=q_text,
                         max_results=3,
                     )
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError) as e:
             env_logs["error"] = f"run_env_tool failed: {repr(e)[:200]}"
 
     if env_logs:
@@ -814,7 +814,7 @@ async def decide(
                 alt["meta"] = t
                 alts.append(alt)
 
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError) as e:
             extras["code_change_plan_error"] = f"generate_code_tasks failed: {repr(e)[:120]}"
 
     # 通常モード → PlannerOS 呼び出し
@@ -842,7 +842,7 @@ async def decide(
                 alt["meta"] = st
                 alts.append(alt)
 
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError, AttributeError) as e:
             extras.setdefault("planner_error", {})
             extras["planner_error"]["detail"] = repr(e)
             if not alts:
@@ -903,7 +903,7 @@ async def decide(
 
             alts = _dedupe_alts(enriched_alts)
 
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError, AttributeError) as e:
             if alts:
                 chosen = max(alts, key=lambda d: _safe_float(d.get("score"), 1.0))
             else:
@@ -963,7 +963,7 @@ async def decide(
                 extras.setdefault("memory", {})
                 extras["memory"]["evidence_count"] = memory_evidence_count
                 extras["memory"]["citations"] = mem_evs
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError) as e:
             extras.setdefault("memory", {})
             extras["memory"]["evidence_error"] = f"get_evidence_for_decision failed: {repr(e)[:80]}"
 
@@ -981,7 +981,7 @@ async def decide(
             evidence=evidence,
             alternatives=alts,
         )
-    except Exception as e:
+    except (TypeError, ValueError, RuntimeError) as e:
         logger.error("FUJI gate evaluation failed, defaulting to deny: %s", repr(e))
         fuji_result = {
             "status": "deny",
@@ -1015,7 +1015,7 @@ async def decide(
         })
         extras.setdefault("affect", {})
         extras["affect"]["meta"] = affect_meta
-    except Exception as e:
+    except (TypeError, ValueError, RuntimeError) as e:
         extras.setdefault("affect", {})
         extras["affect"]["meta_error"] = repr(e)
 
@@ -1046,7 +1046,7 @@ async def decide(
         else:
             extras.setdefault("affect", {})
             extras["affect"]["natural_error"] = "reason_core.generate_reason not available"
-    except Exception as e:
+    except (TypeError, ValueError, RuntimeError, AttributeError) as e:
         extras.setdefault("affect", {})
         extras["affect"]["natural_error"] = repr(e)
 
@@ -1073,7 +1073,7 @@ async def decide(
                 if refl_tmpl:
                     extras.setdefault("affect", {})
                     extras["affect"]["reflection_template"] = refl_tmpl
-    except Exception as e:
+    except (TypeError, ValueError, RuntimeError, AttributeError) as e:
         extras.setdefault("affect", {})
         extras["affect"]["reflection_template_error"] = repr(e)
 
@@ -1114,7 +1114,7 @@ async def decide(
                 "fuji_risk": fuji_risk,
             }
 
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError, OSError) as e:
             extras.setdefault("agi_goals", {})
             extras["agi_goals"]["error"] = repr(e)
     else:
@@ -1161,7 +1161,7 @@ async def decide(
                     redacted_episode_record,
                 )
 
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError, OSError) as e:
             extras.setdefault("memory_log", {})
             extras["memory_log"]["error"] = repr(e)
     else:
@@ -1190,7 +1190,7 @@ async def decide(
                 planner=extras.get("code_change_plan") or extras.get("planner"),
                 latency_ms=latency_ms,
             )
-        except Exception as e:
+        except (TypeError, ValueError, RuntimeError, OSError) as e:
             extras.setdefault("world_state_update", {})
             extras["world_state_update"]["error"] = repr(e)
     else:
@@ -1280,7 +1280,13 @@ async def decide(
                     finally:
                         # Close our copy of the fd; the subprocess has its own copy.
                         os.close(fd)
-                except Exception as e:
+                except (
+                    TypeError,
+                    ValueError,
+                    OSError,
+                    RuntimeError,
+                    subprocess.SubprocessError,
+                ) as e:
                     extras.setdefault("doctor", {})
                     extras["doctor"]["error"] = repr(e)
 
@@ -1292,7 +1298,7 @@ async def decide(
 
             try:
                 world_state_full = world_model.get_state()
-            except Exception:
+            except (TypeError, ValueError, RuntimeError, OSError):
                 world_state_full = None
 
             value_ema_for_day = float(telos_score)
@@ -1311,7 +1317,14 @@ async def decide(
             extras["experiments"] = [e.to_dict() for e in todays_exps]
             extras["curriculum"] = [t.to_dict() for t in todays_tasks]
 
-        except Exception as e:
+        except (
+            TypeError,
+            ValueError,
+            RuntimeError,
+            ImportError,
+            OSError,
+            AttributeError,
+        ) as e:
             extras.setdefault("daily_plans", {})
             extras["daily_plans"]["error"] = repr(e)
     else:

--- a/veritas_os/memory/store.py
+++ b/veritas_os/memory/store.py
@@ -324,7 +324,7 @@ class MemoryStore:
                 # インデックス検索のみロック内で実行
                 try:
                     raw = self.idx[kind].search(qv, k=k)
-                except Exception as e:
+                except (TypeError, ValueError, RuntimeError, OSError) as e:
                     logger.warning("[MemoryStore] index search error for %s: %s", kind, e)
                     out[kind] = []
                     continue


### PR DESCRIPTION
### Motivation
- Reduce overbroad `except Exception` handlers in high-priority control paths (Kernel, Fuji, Memory) to avoid accidentally swallowing unexpected errors while preserving existing fallback behavior. 
- Focus the change on decision flow, FUJI gate/trustlog, memory index search, and doctor/daily-plans areas where silent failures can hide root causes. 
- Note: this hardening may surface previously-suppressed errors, so operational monitoring should be tightened. 

### Description
- Replaced broad `except Exception` in `veritas_os/core/kernel.py` with narrower exception tuples such as `TypeError`, `ValueError`, `RuntimeError`, `AttributeError`, `OSError`, and `subprocess.SubprocessError` at multiple decision/IO/agent-integration points (world injection, env tools, planner, debate, memory evidence, FUJI/Affect/Reason, doctor spawn, daily plans). 
- Tightened trustlog error handling in `veritas_os/core/fuji.py` to `except (TypeError, ValueError, OSError, RuntimeError)` to avoid masking non-runtime issues while keeping the fallback. 
- Restricted MemoryStore index search errors in `veritas_os/memory/store.py` to `except (TypeError, ValueError, RuntimeError, OSError)` to avoid suppressing unrelated failures.

### Testing
- Ran targeted unit tests: `pytest -q veritas_os/tests/test_kernel_coverage.py::test_decide_fuji_exception veritas_os/tests/test_fuji_extra_v2.py veritas_os/tests/test_memory_store_io_strategy.py -q` and all selected tests passed. 
- Verified the three modified files do not contain broad `except Exception` using a repository search (`rg`) after the patch. 
- Changes committed in `107d23e` with the message "Narrow broad exception handlers in kernel, fuji, and memory".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd7ffb2bc8326bb16134f1c4b8595)