### PR TITLE
Harden optional imports behind explicit capability flags

### DIFF
--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -248,7 +248,7 @@ class CapabilityConfig:
     )
     enable_memory_sentence_transformers: bool = field(
         default_factory=lambda: _parse_bool(
-            "VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS", True
+            "VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS", False
         )
     )
     emit_manifest_on_import: bool = field(

--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -246,6 +246,11 @@ class CapabilityConfig:
     enable_memory_joblib_model: bool = field(
         default_factory=lambda: _parse_bool("VERITAS_CAP_MEMORY_JOBLIB_MODEL", True)
     )
+    enable_memory_sentence_transformers: bool = field(
+        default_factory=lambda: _parse_bool(
+            "VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS", True
+        )
+    )
     emit_manifest_on_import: bool = field(
         default_factory=lambda: _parse_bool("VERITAS_CAP_EMIT_MANIFEST", True)
     )


### PR DESCRIPTION
### Motivation
- Avoid implicit feature gating based on import success and make optional integrations explicitly controlled by capability flags for reproducible runtime behavior.
- Surface configuration mismatches early by treating a missing dependency as an error when its capability flag is enabled rather than silently degrading.
- Improve security posture by reducing environment-dependent silent fallbacks that can hide missing critical dependencies.

### Description
- Added a new capability flag `enable_memory_sentence_transformers` (`VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS`) to `veritas_os/core/config.py` to gate Memory embedding behavior explicitly.
- Updated `veritas_os/core/fuji.py` so that when `VERITAS_CAP_FUJI_YAML_POLICY=1` PyYAML must be importable and a `RuntimeError` is raised if it is not; also simplified the emitted manifest to reflect the explicit flag.
- Updated `veritas_os/core/memory.py` `VectorMemory._load_model` to consult `VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS` and to raise `RuntimeError` when the flag is enabled but `sentence_transformers` is unavailable; added the flag to the memory capability manifest.
- Extended `veritas_os/tests/test_capability_flags.py` with tests that assert (1) Fuji YAML capability enabled + missing PyYAML raises a `RuntimeError`, and (2) Memory sentence-transformers capability enabled + missing `sentence_transformers` raises a `RuntimeError`.

### Testing
- Executed `pytest -vv veritas_os/tests/test_capability_flags.py -x` and all tests in that file passed (including the new failure-path tests).
- Executed `python -m py_compile veritas_os/core/config.py veritas_os/core/fuji.py veritas_os/core/memory.py veritas_os/tests/test_capability_flags.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe58c53588326bb81677ed8708423)