### PR TITLE
frontend: send live event API key via header instead of URL query

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -1,58 +1,54 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LiveEventStream } from "./live-event-stream";
 
-class MockEventSource {
-  static instances: MockEventSource[] = [];
-
-  url: string;
-  onopen: (() => void) | null = null;
-  onmessage: ((event: MessageEvent<string>) => void) | null = null;
-  onerror: (() => void) | null = null;
-
-  constructor(url: string) {
-    this.url = url;
-    MockEventSource.instances.push(this);
-  }
-
-  close(): void {
-    // no-op
-  }
+function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
 }
 
 describe("LiveEventStream", () => {
   afterEach(() => {
-    MockEventSource.instances = [];
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
   it("renders and prepends incoming SSE events", async () => {
-    vi.stubGlobal("EventSource", MockEventSource);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: createReadableStream([
+          "data: {\"id\": 1, \"type\": \"decide.completed\", \"ts\": \"2026-01-01T00:00:00Z\", \"payload\": {\"ok\": true}}\n\n",
+        ]),
+      }),
+    );
 
     render(<LiveEventStream />);
 
     expect(screen.getByText("Live Event Stream")).toBeInTheDocument();
-    expect(MockEventSource.instances.length).toBe(1);
-
-    const source = MockEventSource.instances[0];
-    await act(async () => {
-      source.onmessage?.({
-        data: JSON.stringify({
-          id: 1,
-          type: "decide.completed",
-          ts: "2026-01-01T00:00:00Z",
-          payload: { ok: true },
-        }),
-      } as MessageEvent<string>);
-    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
     expect(await screen.findByText("decide.completed")).toBeInTheDocument();
     expect(screen.getByText(/"ok": true/)).toBeInTheDocument();
   });
 
-  it("shows validation error and avoids connecting when API base URL is invalid", () => {
-    vi.stubGlobal("EventSource", MockEventSource);
+  it("shows validation error and avoids connecting when API base URL is invalid", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: createReadableStream([]),
+      }),
+    );
 
     render(<LiveEventStream />);
 
@@ -60,40 +56,48 @@ describe("LiveEventStream", () => {
 
     expect(screen.getByText("有効な API Base URL を入力してください。")).toBeInTheDocument();
     expect(screen.getByText("🔴 invalid url")).toBeInTheDocument();
-    expect(MockEventSource.instances.length).toBe(1);
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("shows a security warning when API key is configured", () => {
-    vi.stubGlobal("EventSource", MockEventSource);
+  it("sends API key in the X-API-Key header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: createReadableStream([]),
+    });
+    vi.stubGlobal("fetch", fetchMock);
 
     render(<LiveEventStream />);
 
     const apiKeyInput = screen.getByLabelText("API Key");
     fireEvent.change(apiKeyInput, { target: { value: "secret-token" } });
 
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
     expect(apiKeyInput).toHaveAttribute("type", "password");
-    expect(
-      screen.getByText(
-        "Security note: API key is sent in the query string for EventSource compatibility. Avoid using production secrets in shared logs.",
-      ),
-    ).toBeInTheDocument();
+    expect(lastCall[1]?.headers).toEqual({ "X-API-Key": "secret-token" });
+    expect(screen.getByText("Security note: API key is sent in the X-API-Key header.")).toBeInTheDocument();
   });
 
   it("clears rendered events when clear button is pressed", async () => {
-    vi.stubGlobal("EventSource", MockEventSource);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: createReadableStream([
+          "data: {\"id\": 1, \"type\": \"decide.completed\", \"ts\": \"2026-01-01T00:00:00Z\", \"payload\": {\"ok\": true}}\n\n",
+        ]),
+      }),
+    );
 
     render(<LiveEventStream />);
 
-    const source = MockEventSource.instances[0];
     await act(async () => {
-      source.onmessage?.({
-        data: JSON.stringify({
-          id: 1,
-          type: "decide.completed",
-          ts: "2026-01-01T00:00:00Z",
-          payload: { ok: true },
-        }),
-      } as MessageEvent<string>);
+      await Promise.resolve();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Clear events" }));


### PR DESCRIPTION
### Motivation
- Prevent leaking the SSE `api_key` via URL query strings which expose credentials to browser history, proxies, and referer logs. 
- Move to a header-based transport to align with safer auth practices and enable easier server-side deprecation of query auth. 

### Description
- Replace `EventSource` URL-query auth with `fetch` + `ReadableStream` and send the API key in an `X-API-Key` header instead of the query string. 
- Remove `api_key` construction from `buildEventUrl` so the URL is purely the `/v1/events` endpoint. 
- Add `processSseChunk` helper to parse chunked SSE `data:` frames from the stream and ignore heartbeats/comments before JSON parsing. 
- Update UI security note to reflect header-based auth and update unit tests to mock `fetch` streaming and validate header delivery. 

### Testing
- Ran the targeted unit tests with `pnpm --filter frontend test -- components/live-event-stream.test.tsx` and the suite `components/live-event-stream.test.tsx` passed (4 tests). 
- Ran TypeScript typecheck with `pnpm --filter frontend typecheck` which succeeded. 
- Note: an initial incorrect test invocation (`pnpm --filter frontend test -- frontend/components/live-event-stream.test.tsx`) exited with no files found, then the correct invocation above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a038b33bb48326a6ba67e47513b4c1)