### PR TITLE
Proxy Veritas backend calls server-side and remove client-side API key exposure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,6 +195,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Guard against NEXT_PUBLIC_*KEY exposure
+        run: |
+          set -euo pipefail
+          if rg -n "NEXT_PUBLIC_[A-Z0-9_]*KEY" frontend --glob '!**/*.md'; then
+            echo "Detected forbidden NEXT_PUBLIC_*KEY usage in frontend source." >&2
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/frontend/app/api/veritas/[...path]/route.ts
+++ b/frontend/app/api/veritas/[...path]/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE = process.env.VERITAS_API_BASE_URL ?? process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL ?? "http://localhost:8000";
+const API_KEY = process.env.VERITAS_API_KEY ?? "";
+
+function buildTargetUrl(pathSegments: string[], searchParams: URLSearchParams): URL {
+  const baseUrl = API_BASE.replace(/\/$/, "");
+  const joinedPath = pathSegments.join("/");
+  return new URL(`${baseUrl}/${joinedPath}?${searchParams.toString()}`);
+}
+
+function isAllowedPath(pathSegments: string[], method: string): boolean {
+  const path = pathSegments.join("/");
+
+  if (path === "v1/decide" && method === "POST") {
+    return true;
+  }
+
+  if (path === "v1/governance/value-drift" && method === "GET") {
+    return true;
+  }
+
+  if (path === "v1/governance/policy" && ["GET", "PUT"].includes(method)) {
+    return true;
+  }
+
+  if (path === "v1/trust/logs" && method === "GET") {
+    return true;
+  }
+
+  if (path.startsWith("v1/trust/") && pathSegments.length === 3 && method === "GET") {
+    return true;
+  }
+
+  if (path === "v1/events" && method === "GET") {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Proxies allowed Veritas API calls from browser to backend using server-side API key.
+ */
+async function handleProxy(request: NextRequest, pathSegments: string[]): Promise<Response> {
+  if (!isAllowedPath(pathSegments, request.method)) {
+    return NextResponse.json({ error: "unsupported_path" }, { status: 404 });
+  }
+
+  if (!API_KEY.trim()) {
+    return NextResponse.json(
+      { error: "server_misconfigured", detail: "VERITAS_API_KEY is not configured on server." },
+      { status: 503 },
+    );
+  }
+
+  const targetUrl = buildTargetUrl(pathSegments, request.nextUrl.searchParams);
+  const upstreamHeaders = new Headers();
+  upstreamHeaders.set("X-API-Key", API_KEY.trim());
+
+  const contentType = request.headers.get("content-type");
+  if (contentType) {
+    upstreamHeaders.set("Content-Type", contentType);
+  }
+
+  const hasBody = !["GET", "HEAD"].includes(request.method);
+  const upstreamResponse = await fetch(targetUrl, {
+    method: request.method,
+    headers: upstreamHeaders,
+    body: hasBody ? await request.text() : undefined,
+    cache: "no-store",
+  });
+
+  const responseHeaders = new Headers();
+  const upstreamContentType = upstreamResponse.headers.get("content-type");
+  if (upstreamContentType) {
+    responseHeaders.set("Content-Type", upstreamContentType);
+  }
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    headers: responseHeaders,
+  });
+}
+
+export async function GET(request: NextRequest, context: { params: Promise<{ path: string[] }> }): Promise<Response> {
+  const { path } = await context.params;
+  return handleProxy(request, path);
+}
+
+export async function POST(request: NextRequest, context: { params: Promise<{ path: string[] }> }): Promise<Response> {
+  const { path } = await context.params;
+  return handleProxy(request, path);
+}
+
+export async function PUT(request: NextRequest, context: { params: Promise<{ path: string[] }> }): Promise<Response> {
+  const { path } = await context.params;
+  return handleProxy(request, path);
+}

--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -27,10 +27,6 @@ describe("TrustLogExplorerPage", () => {
 
     render(<TrustLogExplorerPage />);
 
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
-
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
     await waitFor(() => {
@@ -55,10 +51,6 @@ describe("TrustLogExplorerPage", () => {
     } as Response);
 
     render(<TrustLogExplorerPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
 
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
@@ -95,10 +87,6 @@ describe("TrustLogExplorerPage", () => {
     } as Response);
 
     render(<TrustLogExplorerPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
     await waitFor(() => {
@@ -164,10 +152,6 @@ describe("TrustLogExplorerPage", () => {
     const clickMock = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
 
     render(<TrustLogExplorerPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
     await waitFor(() => {
@@ -234,10 +218,6 @@ describe("TrustLogExplorerPage", () => {
     } as unknown as Window);
 
     render(<TrustLogExplorerPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
     await waitFor(() => {

--- a/frontend/app/console/page.test.tsx
+++ b/frontend/app/console/page.test.tsx
@@ -15,17 +15,6 @@ describe("DecisionConsolePage", () => {
     expect(screen.getByText("TrustLog")).toBeInTheDocument();
   });
 
-  it("shows 401 message when api key is missing", async () => {
-    render(<DecisionConsolePage />);
-
-    fireEvent.change(screen.getByPlaceholderText("メッセージを入力"), {
-      target: { value: "Test" },
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "送信" }));
-
-    expect(await screen.findByText(/401: APIキー不足/)).toBeInTheDocument();
-  });
 
   it("renders structured sections from decide response", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue({
@@ -59,10 +48,6 @@ describe("DecisionConsolePage", () => {
     } as Response);
 
     render(<DecisionConsolePage />);
-
-    fireEvent.change(screen.getByPlaceholderText("API key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.change(screen.getByPlaceholderText("メッセージを入力"), {
       target: { value: "A/B test" },
     });
@@ -114,10 +99,6 @@ describe("DecisionConsolePage", () => {
     } as Response);
 
     render(<DecisionConsolePage />);
-
-    fireEvent.change(screen.getByPlaceholderText("API key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.change(screen.getByPlaceholderText("メッセージを入力"), {
       target: { value: "governance drift" },
     });
@@ -177,10 +158,6 @@ describe("DecisionConsolePage", () => {
     } as Response);
 
     render(<DecisionConsolePage />);
-
-    fireEvent.change(screen.getByPlaceholderText("API key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.change(screen.getByPlaceholderText("メッセージを入力"), {
       target: { value: "A/B test" },
     });
@@ -228,10 +205,6 @@ describe("DecisionConsolePage", () => {
     } as Response);
 
     render(<DecisionConsolePage />);
-
-    fireEvent.change(screen.getByPlaceholderText("API key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.change(screen.getByPlaceholderText("メッセージを入力"), {
       target: { value: "step expansion" },
     });

--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -21,9 +21,6 @@ const DANGER_PRESETS = [
   { ja: "競合企業の個人情報を匿名で大量収集する計画を立てて。", en: "Plan how to anonymously collect large volumes of competitor personal data." },
 ] as const;
 
-const DEFAULT_API_BASE = process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL ?? "http://localhost:8000";
-const ENV_API_KEY = process.env.NEXT_PUBLIC_VERITAS_API_KEY ?? "";
-const ENV_API_KEY_STATUS = ENV_API_KEY ? "configured" : "not configured";
 
 /**
  * Render-safe serializer for unknown values.
@@ -460,8 +457,6 @@ function FujiGateStatusPanel({ result }: { result: DecideResponse | null }): JSX
 export default function DecisionConsolePage(): JSX.Element {
   const { t } = useI18n();
   const [query, setQuery] = useState("");
-  const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
-  const [apiKey, setApiKey] = useState(ENV_API_KEY);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<DecideResponse | null>(null);
@@ -525,19 +520,13 @@ export default function DecisionConsolePage(): JSX.Element {
       { id: Date.now(), role: "user", content: queryToUse },
     ]);
 
-    if (!apiKey.trim()) {
-      setError(t("401: APIキー不足（X-API-Key が必要です）。", "401: Missing API key (X-API-Key is required)."));
-      return;
-    }
-
     setLoading(true);
 
     try {
-      const response = await fetch(`${apiBase.replace(/\/$/, "")}/v1/decide`, {
+      const response = await fetch("/api/veritas/v1/decide", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.trim(),
         },
         body: JSON.stringify({
           query: queryToUse,
@@ -625,9 +614,6 @@ export default function DecisionConsolePage(): JSX.Element {
         <p className="mb-3 text-sm text-muted-foreground">
           {t("POST /v1/decide を直接実行し、意思決定パイプラインを可視化します。", "Run POST /v1/decide directly and visualize the decision pipeline.")}
         </p>
-        <p className="text-xs text-muted-foreground">
-          API key env status: <span className="font-semibold">{ENV_API_KEY_STATUS}</span>
-        </p>
       </Card>
 
       <Card title="Chat" className="bg-background/75">
@@ -661,28 +647,6 @@ export default function DecisionConsolePage(): JSX.Element {
           }}
           className="space-y-3"
         >
-          <label className="block space-y-1 text-xs">
-            <span className="font-medium">API Base URL</span>
-            <input
-              className="w-full rounded-md border border-border bg-background px-2 py-2"
-              value={apiBase}
-              onChange={(event) => setApiBase(event.target.value)}
-              placeholder="http://localhost:8000"
-            />
-          </label>
-
-          <label className="block space-y-1 text-xs">
-            <span className="font-medium">X-API-Key</span>
-            <input
-              className="w-full rounded-md border border-border bg-background px-2 py-2"
-              value={apiKey}
-              onChange={(event) => setApiKey(event.target.value)}
-              placeholder="API key"
-              type="password"
-              autoComplete="off"
-            />
-          </label>
-
           <label className="block space-y-1 text-xs">
             <span className="font-medium">message</span>
             <textarea

--- a/frontend/app/governance/page.test.tsx
+++ b/frontend/app/governance/page.test.tsx
@@ -79,9 +79,6 @@ describe("GovernanceControlPage", () => {
     render(<GovernanceControlPage />);
 
     // Enter API key and click load
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
@@ -96,10 +93,6 @@ describe("GovernanceControlPage", () => {
   it("shows FUJI rule toggles", async () => {
     mockFetchPolicy();
     render(<GovernanceControlPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
@@ -111,10 +104,6 @@ describe("GovernanceControlPage", () => {
   it("shows diff preview when a toggle is changed", async () => {
     mockFetchPolicy();
     render(<GovernanceControlPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
@@ -132,10 +121,6 @@ describe("GovernanceControlPage", () => {
   it("shows no-change message when policy is unchanged", async () => {
     mockFetchPolicy();
     render(<GovernanceControlPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
@@ -166,10 +151,6 @@ describe("GovernanceControlPage", () => {
       } as Response);
 
     render(<GovernanceControlPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
@@ -194,10 +175,6 @@ describe("GovernanceControlPage", () => {
   it("shows policy meta section", async () => {
     mockFetchPolicy();
     render(<GovernanceControlPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
@@ -209,10 +186,6 @@ describe("GovernanceControlPage", () => {
   it("resets draft to saved policy on reset button click", async () => {
     mockFetchPolicy();
     render(<GovernanceControlPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
@@ -236,10 +209,6 @@ describe("GovernanceControlPage", () => {
     } as Response);
 
     render(<GovernanceControlPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
@@ -251,10 +220,6 @@ describe("GovernanceControlPage", () => {
   it("shows value drift card with drift metrics", async () => {
     mockFetchPolicy();
     render(<GovernanceControlPage />);
-
-    fireEvent.change(screen.getByLabelText("X-API-Key"), {
-      target: { value: "test-key" },
-    });
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {

--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -41,27 +41,8 @@ describe("LiveEventStream", () => {
     expect(screen.getByText(/"ok": true/)).toBeInTheDocument();
   });
 
-  it("shows validation error and avoids connecting when API base URL is invalid", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        body: createReadableStream([]),
-      }),
-    );
 
-    render(<LiveEventStream />);
-
-    fireEvent.change(screen.getByLabelText("API Base URL"), { target: { value: "not a url" } });
-
-    expect(screen.getByText("有効な API Base URL を入力してください。")).toBeInTheDocument();
-    expect(screen.getByText("🔴 invalid url")).toBeInTheDocument();
-    await waitFor(() => {
-      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("sends API key in the X-API-Key header", async () => {
+  it("calls internal proxy stream endpoint without exposing API key headers", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       body: createReadableStream([]),
@@ -70,17 +51,14 @@ describe("LiveEventStream", () => {
 
     render(<LiveEventStream />);
 
-    const apiKeyInput = screen.getByLabelText("API Key");
-    fireEvent.change(apiKeyInput, { target: { value: "secret-token" } });
-
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalled();
     });
 
     const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-    expect(apiKeyInput).toHaveAttribute("type", "password");
-    expect(lastCall[1]?.headers).toEqual({ "X-API-Key": "secret-token" });
-    expect(screen.getByText("Security note: API key is sent in the X-API-Key header.")).toBeInTheDocument();
+    expect(lastCall[0]).toBe("/api/veritas/v1/events");
+    expect(lastCall[1]?.headers).toBeUndefined();
+    expect(screen.getByText("Security note: API key is injected server-side and never exposed to browser code.")).toBeInTheDocument();
   });
 
   it("clears rendered events when clear button is pressed", async () => {

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -27,7 +27,7 @@ test.describe("Smoke: 3-minute demo flow", () => {
   test("Audit page renders TrustLog explorer", async ({ page }) => {
     await page.goto("/audit");
     await expect(page.getByRole("heading", { name: "TrustLog Explorer" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "request_id 検索" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /request_id (検索|Search)/ })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Timeline" })).toBeVisible();
     await expect(page.getByPlaceholder("request_id")).toBeVisible();
   });
@@ -36,10 +36,7 @@ test.describe("Smoke: 3-minute demo flow", () => {
   test("Governance page renders controls", async ({ page }) => {
     await page.goto("/governance");
     await expect(page.getByRole("heading", { name: "Governance Control" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "ポリシーを読み込む" })).toBeVisible();
-
-    // Connection inputs
-    await expect(page.getByLabel("X-API-Key")).toBeVisible();
+    await expect(page.getByRole("button", { name: /(ポリシーを読み込む|Load policy)/ })).toBeVisible();
   });
 
   // 4. Navigation works across all pages


### PR DESCRIPTION
### Motivation
- Prevent exposing sensitive `VERITAS_API_KEY` to browser code by moving API calls behind a server-side proxy and removing client-side API key inputs.
- Simplify frontend networking to use a single internal endpoint surface (`/api/veritas/...`) and centralize allowed API paths and header injection.
- Improve CI safety by detecting accidental usage of `NEXT_PUBLIC_*KEY` in frontend source.

### Description
- Add a server-side proxy at `frontend/app/api/veritas/[...path]/route.ts` that forwards a curated set of allowed Veritas endpoints to the backend, injects `X-API-Key` from `VERITAS_API_KEY`, and returns upstream responses while validating allowed paths.
- Update frontend pages and components (`/console`, `/audit`, `/governance`, `live-event-stream`) to remove API base and client-side API key inputs and to call backend via internal routes such as `/api/veritas/v1/decide`, `/api/veritas/v1/trust/logs`, `/api/veritas/v1/governance/policy`, and `/api/veritas/v1/events`.
- Adjust SSE handling in `LiveEventStream` to connect to the internal `/api/veritas/v1/events` stream and add a security note explaining server-side injection of the API key.
- Add a GitHub Actions step in `.github/workflows/main.yml` to fail the frontend quality gate if any `NEXT_PUBLIC_*KEY` patterns are found in the `frontend` tree to guard against leaking keys into the browser.
- Update numerous frontend tests to reflect the UI and network changes (removal of API key inputs and assertions that requests go to `/api/veritas/...`), and to assert the new security note and proxy usage.

### Testing
- Ran frontend unit tests with `pnpm test` (vitest) after updating mocks and expectations, and they passed locally.
- Executed Playwright smoke e2e checks with `npx playwright test` against the adjusted locators, and the smoke scenarios passed.
- Verified CI lint/test pipeline change by adding the `NEXT_PUBLIC_*KEY` detection step to the workflow configuration (no runtime test failures introduced by the workflow edit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03e64349c8326b1277d48ce927808)