### PR TITLE
frontend: add report-only CSP and baseline security headers

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,6 +1,64 @@
+const cspReportOnly = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "form-action 'self'",
+  "upgrade-insecure-requests",
+  "block-all-mixed-content"
+].join('; ');
+
+/**
+ * Returns baseline security headers for all routes.
+ *
+ * CSP is introduced in report-only mode first so we can audit violations
+ * before switching to enforce mode.
+ */
+function getSecurityHeaders() {
+  return [
+    {
+      key: 'Content-Security-Policy-Report-Only',
+      value: cspReportOnly
+    },
+    {
+      key: 'X-Frame-Options',
+      value: 'DENY'
+    },
+    {
+      key: 'Referrer-Policy',
+      value: 'strict-origin-when-cross-origin'
+    },
+    {
+      key: 'Permissions-Policy',
+      value: 'camera=(), microphone=(), geolocation=()'
+    },
+    {
+      key: 'Strict-Transport-Security',
+      value: 'max-age=31536000; includeSubDomains; preload'
+    },
+    {
+      key: 'X-Content-Type-Options',
+      value: 'nosniff'
+    }
+  ];
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ["@veritas/design-system", "@veritas/types"]
+  transpilePackages: ['@veritas/design-system', '@veritas/types'],
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: getSecurityHeaders()
+      }
+    ];
+  }
 };
 
 export default nextConfig;

--- a/frontend/next.config.test.ts
+++ b/frontend/next.config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import nextConfig from './next.config.mjs';
+
+describe('next.config headers', () => {
+  it('defines baseline security headers for all routes', async () => {
+    const routes = await nextConfig.headers?.();
+
+    expect(routes).toBeDefined();
+    expect(routes).toHaveLength(1);
+    expect(routes?.[0]).toMatchObject({ source: '/:path*' });
+
+    const headerMap = new Map(routes?.[0].headers.map((item) => [item.key, item.value]));
+
+    expect(headerMap.get('Content-Security-Policy-Report-Only')).toContain("default-src 'self'");
+    expect(headerMap.get('X-Frame-Options')).toBe('DENY');
+    expect(headerMap.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(headerMap.get('Permissions-Policy')).toContain('camera=()');
+    expect(headerMap.get('Strict-Transport-Security')).toContain('max-age=31536000');
+    expect(headerMap.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+});


### PR DESCRIPTION
### Motivation
- Centralize browser security headers so route protection does not rely on per-page implementations.
- Introduce a staged Content-Security-Policy to observe violations before switching to enforcement for safer rollout.
- Provide a minimal automated assertion to prevent regressions in header configuration.

### Description
- Added a `cspReportOnly` policy and `getSecurityHeaders()` helper in `frontend/next.config.mjs` and wired it into `nextConfig.headers()` for all routes (`/:path*`).
- Configured baseline headers: `Content-Security-Policy-Report-Only`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`, and `X-Content-Type-Options`.
- Included explanatory comments (CSP introduced in report-only mode) adjacent to the new helper function.
- Added `frontend/next.config.test.ts` (Vitest) to assert the presence and basic contents of the configured headers.

### Testing
- Ran `pnpm --filter frontend test -- next.config.test.ts` which passed (`1 test, 1 passed`).
- Ran `pnpm --filter frontend typecheck` (`tsc --noEmit`) which completed without errors.
- Note: the test file is `frontend/next.config.test.ts` and it validates header keys and key directive strings.

Security note: `script-src` currently includes `'unsafe-inline'` for compatibility; migrate to nonce/hash-based scripts before moving CSP to enforce mode, and confirm HTTPS everywhere before relying on the global HSTS preload directive.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a050d6e7cc8326a936ecb462244b63)