### PR TITLE
Strengthen governance API validation with semantic constraints

### DIFF
--- a/frontend/app/governance/page.test.tsx
+++ b/frontend/app/governance/page.test.tsx
@@ -212,7 +212,9 @@ describe("GovernanceControlPage", () => {
     fireEvent.click(screen.getByText("ポリシーを読み込む"));
 
     await waitFor(() => {
-      expect(screen.getByText("レスポンス形式エラー: policy の形式が不正です。")).toBeInTheDocument();
+      expect(
+        screen.getByText(/^レスポンス形式エラー: policy\./),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { Card } from "@veritas/design-system";
-import { isGovernancePolicyResponse } from "../../lib/api-validators";
+import { validateGovernancePolicyResponse } from "../../lib/api-validators";
 
 
 /* ---------- types ---------- */
@@ -328,12 +328,19 @@ export default function GovernanceControlPage(): JSX.Element {
         return;
       }
       const body: unknown = await res.json();
-      if (!isGovernancePolicyResponse(body)) {
-        setError("レスポンス形式エラー: policy の形式が不正です。");
+      const validation = validateGovernancePolicyResponse(body);
+      if (!validation.ok) {
+        const semanticIssue = validation.issues.find((issue) => issue.category === "semantic");
+        if (semanticIssue) {
+          setError(`レスポンス意味エラー: ${semanticIssue.path} ${semanticIssue.message}`);
+        } else {
+          const formatIssue = validation.issues[0];
+          setError(`レスポンス形式エラー: ${formatIssue.path} ${formatIssue.message}`);
+        }
         return;
       }
-      setSavedPolicy(body.policy);
-      setDraft(structuredClone(body.policy));
+      setSavedPolicy(validation.data.policy);
+      setDraft(structuredClone(validation.data.policy));
       void fetchValueDrift();
     } catch {
       setError("ネットワークエラー: バックエンドへ接続できません。");
@@ -361,12 +368,19 @@ export default function GovernanceControlPage(): JSX.Element {
         return;
       }
       const body: unknown = await res.json();
-      if (!isGovernancePolicyResponse(body)) {
-        setError("レスポンス形式エラー: policy の形式が不正です。");
+      const validation = validateGovernancePolicyResponse(body);
+      if (!validation.ok) {
+        const semanticIssue = validation.issues.find((issue) => issue.category === "semantic");
+        if (semanticIssue) {
+          setError(`レスポンス意味エラー: ${semanticIssue.path} ${semanticIssue.message}`);
+        } else {
+          const formatIssue = validation.issues[0];
+          setError(`レスポンス形式エラー: ${formatIssue.path} ${formatIssue.message}`);
+        }
         return;
       }
-      setSavedPolicy(body.policy);
-      setDraft(structuredClone(body.policy));
+      setSavedPolicy(validation.data.policy);
+      setDraft(structuredClone(validation.data.policy));
       setSuccess("ポリシーを更新しました。");
     } catch {
       setError("ネットワークエラー: バックエンドへ接続できません。");


### PR DESCRIPTION
### Motivation
- Backend governance payloads were validated only by basic type checks, allowing semantically invalid values (e.g. negative/ordered thresholds, unsupported enums, non-ISO timestamps) to slip through.
- The UI could not distinguish formatting problems from domain/semantic violations, making operator errors harder to diagnose and increasing risk of misconfiguration.

### Description
- Added a new validator `validateGovernancePolicyResponse` in `frontend/lib/api-validators.ts` that returns `ok | issues` and classifies failures as `format` or `semantic` with path/message details. 
- Enforced domain constraints including risk threshold ranges and ordering (`0 <= allow <= warn <= human_review <= deny <= 1`), `audit_level` allow-list, ISO‑8601 check for `updated_at`, and numeric invariants for `auto_stop` and `log_retention` fields.
- Updated `frontend/app/governance/page.tsx` to use the new validator and surface separate UI messages for "レスポンス形式エラー" (format) and "レスポンス意味エラー" (semantic).
- Expanded `frontend/lib/api-validators.test.ts` with tests for semantic classifications (invalid ISO timestamp, threshold ordering, unsupported `audit_level`) and kept existing shape tests.

### Testing
- Ran unit tests: `pnpm --filter frontend test -- api-validators.test.ts`, all tests passed (9/9).
- Ran TypeScript check: `pnpm --filter frontend typecheck`, succeeded with no errors.
- Attempted to add `zod` as originally proposed, but `pnpm` failed to fetch the package due to registry auth (`ERR_PNPM_FETCH_403`), so the implementation uses an equivalent in-module validation; the install failure did not block tests or typecheck.
- Security note: this change reduces the risk of accepting semantically invalid governance policies that could cause misconfiguration or unsafe operator decisions; reviewers should still consider hardening server-side validation and logging of rejected payloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f0d67a848326940e7c1eebddeaf3)