### PR TITLE
fix(console): prevent stale decide responses with abort + request-id guard

### DIFF
--- a/frontend/features/console/api/useDecide.test.ts
+++ b/frontend/features/console/api/useDecide.test.ts
@@ -1,0 +1,158 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { useDecide } from "./useDecide";
+
+type DecidePayload = Record<string, unknown>;
+
+function buildDecidePayload(requestId: string, decision: string): DecidePayload {
+  return {
+    ok: true,
+    error: null,
+    request_id: requestId,
+    version: "test",
+    chosen: {},
+    alternatives: [],
+    options: [],
+    decision_status: "allow",
+    rejection_reason: null,
+    values: null,
+    telos_score: 0.5,
+    fuji: {},
+    gate: {
+      risk: 0.1,
+      telos_score: 0.5,
+      decision_status: "allow",
+      modifications: [],
+    },
+    evidence: [],
+    critique: [],
+    debate: [],
+    extras: { decision },
+    plan: null,
+    planner: null,
+    persona: {},
+    memory_citations: [],
+    memory_used_count: 0,
+    trust_log: null,
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useDecide", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("aborts an in-flight request when a new runDecision starts", async () => {
+    const first = createDeferred<Response>();
+    const secondPayload = buildDecidePayload("req-2", "latest");
+
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce((_input, init) => {
+        const signal = init?.signal as AbortSignal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+          void first.promise;
+        });
+      })
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(secondPayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setQuery = vi.fn();
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        query: "q",
+        setQuery,
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      void result.current.runDecision("first");
+      await Promise.resolve();
+      await result.current.runDecision("second");
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(setResult).toHaveBeenCalledWith(secondPayload);
+  });
+
+  it("ignores stale completion and only applies latest result", async () => {
+    const first = createDeferred<Response>();
+    const second = createDeferred<Response>();
+
+    const firstPayload = buildDecidePayload("req-1", "old");
+    const secondPayload = buildDecidePayload("req-2", "new");
+
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise);
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setQuery = vi.fn();
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        query: "q",
+        setQuery,
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      void result.current.runDecision("first");
+      await Promise.resolve();
+      void result.current.runDecision("second");
+      second.resolve(
+        new Response(JSON.stringify(secondPayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      await Promise.resolve();
+      first.resolve(
+        new Response(JSON.stringify(firstPayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(setResult).toHaveBeenCalledTimes(1);
+    expect(setResult).toHaveBeenCalledWith(secondPayload);
+  });
+});


### PR DESCRIPTION
### Motivation
- `runDecision` used `fetch` without cancellation which allowed delayed old responses to overwrite newer UI state during rapid sends or page navigation.
- Introduce an explicit cancellation and ordering guard so only the latest request updates `setResult`/`setLoading`/chat state.
- This reduces state-integrity races and does not introduce new external I/O or credential handling risk.

### Description
- Added `useEffect`, `useRef` imports and introduced `activeControllerRef`, `requestSequenceRef`, and `latestRequestIdRef` to `useDecide` for cancellation and monotonic request IDs.
- Abort any in-flight request before starting a new one, pass `signal` to `fetch`, and use `isLatestRequest()` checks to skip applying stale responses.
- Explicitly ignore `AbortError` in the `catch` path and only update `loading` in `finally` when the request is the latest, and abort in-flight requests on unmount.
- Added unit tests `frontend/features/console/api/useDecide.test.ts` that verify abort-on-replace and that stale completions do not overwrite the latest result.

### Testing
- Ran the unit tests with `cd frontend && npm test -- useDecide.test.ts` and the two new tests passed.
- Ran linter with `cd frontend && npm run lint` and there were no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10083060883269ea033094e2e497c)