### PR TITLE
frontend: migrate console UI copy to locale dictionary keys

### DIFF
--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -14,7 +14,7 @@ import { StepExpansionPanel } from "../../features/console/components/step-expan
 import { useConsoleState } from "../../features/console/state/useConsoleState";
 
 export default function DecisionConsolePage(): JSX.Element {
-  const { t } = useI18n();
+  const { t, tk } = useI18n();
   const {
     query,
     setQuery,
@@ -29,6 +29,7 @@ export default function DecisionConsolePage(): JSX.Element {
 
   const { loading, error, runDecision } = useDecide({
     t,
+    tk,
     query,
     setQuery,
     setResult,
@@ -39,15 +40,13 @@ export default function DecisionConsolePage(): JSX.Element {
     <div className="space-y-6">
       <Card title="Decision Console" className="border-primary/50 bg-surface/85">
         <p className="mb-3 text-sm text-muted-foreground">
-          {t(
-            "POST /v1/decide を直接実行し、意思決定パイプラインを可視化します。",
-            "Run POST /v1/decide directly and visualize the decision pipeline.",
-          )}
+          {tk("consoleDescription")}
         </p>
       </Card>
 
       <ChatPanel
         t={t}
+        tk={tk}
         chatMessages={chatMessages}
         query={query}
         loading={loading}
@@ -112,7 +111,7 @@ export default function DecisionConsolePage(): JSX.Element {
             </details>
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">{t("まだ結果はありません。", "No results yet.")}</p>
+          <p className="text-sm text-muted-foreground">{tk("noResultsYet")}</p>
         )}
       </Card>
     </div>

--- a/frontend/components/i18n-provider.tsx
+++ b/frontend/components/i18n-provider.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { en } from "../locales/en";
+import { ja, type LocaleKey } from "../locales/ja";
 
 type Language = "ja" | "en";
 
@@ -8,12 +10,14 @@ interface I18nContextValue {
   language: Language;
   setLanguage: (language: Language) => void;
   t: (ja: string, en: string) => string;
+  tk: (key: LocaleKey) => string;
 }
 
 const defaultI18nContext: I18nContextValue = {
   language: "ja",
   setLanguage: () => undefined,
   t: (ja: string, en: string) => ja ?? en,
+  tk: (key: LocaleKey) => ja[key],
 };
 
 const I18nContext = createContext<I18nContextValue>(defaultI18nContext);
@@ -38,6 +42,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }): JSX.E
       language,
       setLanguage,
       t: (ja: string, en: string) => (language === "ja" ? ja : en),
+      tk: (key: LocaleKey) => (language === "ja" ? ja[key] : en[key]),
     }),
     [language],
   );

--- a/frontend/features/console/api/useDecide.test.ts
+++ b/frontend/features/console/api/useDecide.test.ts
@@ -87,6 +87,7 @@ describe("useDecide", () => {
     const { result } = renderHook(() =>
       useDecide({
         t: (_ja, en) => en,
+        tk: () => "",
         query: "q",
         setQuery,
         setResult,
@@ -125,6 +126,7 @@ describe("useDecide", () => {
     const { result } = renderHook(() =>
       useDecide({
         t: (_ja, en) => en,
+        tk: () => "",
         query: "q",
         setQuery,
         setResult,

--- a/frontend/features/console/api/useDecide.ts
+++ b/frontend/features/console/api/useDecide.ts
@@ -2,9 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { type DecideResponse, isDecideResponse } from "@veritas/types";
 import { toAssistantMessage } from "../analytics/utils";
 import { type ChatMessage } from "../types";
+import { type LocaleKey } from "../../../locales/ja";
 
 interface UseDecideParams {
   t: (ja: string, en: string) => string;
+  tk: (key: LocaleKey) => string;
   query: string;
   setQuery: (query: string) => void;
   setResult: (result: DecideResponse | null) => void;
@@ -26,6 +28,7 @@ interface UseDecideResult {
  */
 export function useDecide({
   t,
+  tk,
   query,
   setQuery,
   setResult,
@@ -49,7 +52,7 @@ export function useDecide({
     setError(null);
 
     if (!queryToUse) {
-      setError(t("query を入力してください。", "Please enter query."));
+      setError(tk("queryRequired"));
       return;
     }
 
@@ -81,14 +84,14 @@ export function useDecide({
       }
 
       if (response.status === 401) {
-        const authError = t("401: APIキー不足、または無効です。", "401: Missing or invalid API key.");
+        const authError = tk("authError");
         setError(authError);
         setChatMessages((prev) => [
           ...prev,
           {
             id: Date.now() + 1,
             role: "assistant",
-            content: t("401 エラー: APIキー不足、または無効です。", "401 error: Missing or invalid API key."),
+            content: tk("authErrorAssistant"),
           },
         ]);
         setResult(null);
@@ -96,20 +99,14 @@ export function useDecide({
       }
 
       if (response.status === 503) {
-        const unavailable = t(
-          "503: service_unavailable（バックエンド処理を実行できません）。",
-          "503: service_unavailable (backend execution unavailable).",
-        );
+        const unavailable = tk("serviceUnavailable");
         setError(unavailable);
         setChatMessages((prev) => [
           ...prev,
           {
             id: Date.now() + 1,
             role: "assistant",
-            content: t(
-              "503 エラー: service_unavailable（バックエンド処理を実行できません）。",
-              "503 error: service_unavailable (backend execution unavailable).",
-            ),
+            content: tk("serviceUnavailableAssistant"),
           },
         ]);
         setResult(null);
@@ -127,10 +124,7 @@ export function useDecide({
 
       const payload: unknown = await response.json();
       if (!isDecideResponse(payload)) {
-        const schemaError = t(
-          "schema不一致: レスポンスがオブジェクトではありません。",
-          "Schema mismatch: response is not an object.",
-        );
+        const schemaError = tk("schemaMismatch");
         setError(schemaError);
         setChatMessages((prev) => [...prev, { id: Date.now() + 1, role: "assistant", content: schemaError }]);
         setResult(null);
@@ -149,10 +143,7 @@ export function useDecide({
       if (!isLatestRequest()) {
         return;
       }
-      const networkError = t(
-        "ネットワークエラー: バックエンドへ接続できません。",
-        "Network error: cannot reach backend.",
-      );
+      const networkError = tk("networkError");
       setError(networkError);
       setChatMessages((prev) => [...prev, { id: Date.now() + 1, role: "assistant", content: networkError }]);
       setResult(null);

--- a/frontend/features/console/components/chat-panel.tsx
+++ b/frontend/features/console/components/chat-panel.tsx
@@ -1,9 +1,11 @@
+import { type LocaleKey } from "../../../locales/ja";
 import { Button, Card } from "@veritas/design-system";
 import { DANGER_PRESETS } from "../constants";
 import { type ChatMessage } from "../types";
 
 interface ChatPanelProps {
   t: (ja: string, en: string) => string;
+  tk: (key: LocaleKey) => string;
   chatMessages: ChatMessage[];
   query: string;
   loading: boolean;
@@ -14,6 +16,7 @@ interface ChatPanelProps {
 
 export function ChatPanel({
   t,
+  tk,
   chatMessages,
   query,
   loading,
@@ -24,7 +27,7 @@ export function ChatPanel({
   return (
     <Card title="Chat" className="bg-background/75">
       <div className="mb-4 rounded-md border border-border bg-background/60 p-3">
-        <p className="mb-2 text-xs font-medium text-muted-foreground">{t("チャット履歴", "Chat history")}</p>
+        <p className="mb-2 text-xs font-medium text-muted-foreground">{tk("chatHistory")}</p>
         {chatMessages.length > 0 ? (
           <ul className="space-y-2" aria-label="chat messages">
             {chatMessages.map((message) => (
@@ -42,7 +45,7 @@ export function ChatPanel({
             ))}
           </ul>
         ) : (
-          <p className="text-sm text-muted-foreground">{t("まだメッセージはありません。", "No messages yet.")}</p>
+          <p className="text-sm text-muted-foreground">{tk("noMessagesYet")}</p>
         )}
       </div>
 
@@ -59,13 +62,13 @@ export function ChatPanel({
             className="min-h-28 w-full rounded-md border border-border bg-background px-2 py-2"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder={t("メッセージを入力", "Enter a message")}
+            placeholder={tk("messagePlaceholder")}
           />
         </label>
 
         <div className="space-y-2">
           <p className="text-xs font-medium">
-            {t("危険プリセット（安全拒否確認用）", "Danger presets (for safety rejection checks)")}
+            {tk("dangerPresets")}
           </p>
           <div className="flex flex-wrap gap-2">
             {DANGER_PRESETS.map((preset) => (
@@ -83,7 +86,7 @@ export function ChatPanel({
         </div>
 
         <Button type="submit" disabled={loading}>
-          {loading ? t("送信中...", "Sending...") : t("送信", "Send")}
+          {loading ? tk("sending") : tk("send")}
         </Button>
 
         {error ? (

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -1,0 +1,19 @@
+import { type LocaleKey } from "./ja";
+
+export const en: Record<LocaleKey, string> = {
+  consoleDescription: "Run POST /v1/decide directly and visualize the decision pipeline.",
+  noResultsYet: "No results yet.",
+  queryRequired: "Please enter query.",
+  authError: "401: Missing or invalid API key.",
+  authErrorAssistant: "401 error: Missing or invalid API key.",
+  serviceUnavailable: "503: service_unavailable (backend execution unavailable).",
+  serviceUnavailableAssistant: "503 error: service_unavailable (backend execution unavailable).",
+  schemaMismatch: "Schema mismatch: response is not an object.",
+  networkError: "Network error: cannot reach backend.",
+  chatHistory: "Chat history",
+  noMessagesYet: "No messages yet.",
+  messagePlaceholder: "Enter a message",
+  dangerPresets: "Danger presets (for safety rejection checks)",
+  sending: "Sending...",
+  send: "Send",
+};

--- a/frontend/locales/ja.ts
+++ b/frontend/locales/ja.ts
@@ -1,0 +1,19 @@
+export const ja = {
+  consoleDescription: "POST /v1/decide を直接実行し、意思決定パイプラインを可視化します。",
+  noResultsYet: "まだ結果はありません。",
+  queryRequired: "query を入力してください。",
+  authError: "401: APIキー不足、または無効です。",
+  authErrorAssistant: "401 エラー: APIキー不足、または無効です。",
+  serviceUnavailable: "503: service_unavailable（バックエンド処理を実行できません）。",
+  serviceUnavailableAssistant: "503 エラー: service_unavailable（バックエンド処理を実行できません）。",
+  schemaMismatch: "schema不一致: レスポンスがオブジェクトではありません。",
+  networkError: "ネットワークエラー: バックエンドへ接続できません。",
+  chatHistory: "チャット履歴",
+  noMessagesYet: "まだメッセージはありません。",
+  messagePlaceholder: "メッセージを入力",
+  dangerPresets: "危険プリセット（安全拒否確認用）",
+  sending: "送信中...",
+  send: "送信",
+} as const;
+
+export type LocaleKey = keyof typeof ja;


### PR DESCRIPTION
### Motivation
- Reduce scattered inline bilingual strings by introducing centralized locale dictionaries for the Console UI to lower translation debt and enable staged migration to key-based copy management. 
- Provide a typed, backward-compatible accessor on the i18n provider so components can migrate incrementally from `t(ja,en)` to keyed `tk(key)`. 
- Keep runtime behavior unchanged while preparing for consistent terminology and easier translation workflows. 

### Description
- Added locale dictionaries `frontend/locales/ja.ts` and `frontend/locales/en.ts` and exported a `LocaleKey` type. 
- Extended `I18nProvider` (`frontend/components/i18n-provider.tsx`) with a typed `tk(key: LocaleKey)` accessor while preserving `t(ja,en)` for compatibility. 
- Migrated Console-area strings to use `tk(...)`: `frontend/app/console/page.tsx`, `frontend/features/console/components/chat-panel.tsx`, and error/display copy in `frontend/features/console/api/useDecide.ts`. 
- Updated `frontend/features/console/api/useDecide.test.ts` to supply the new `tk` dependency and preserved existing test semantics. 

### Testing
- Ran unit tests: `pnpm -C frontend test -- useDecide.test.ts` — tests passed (1 file, 2 tests). 
- Ran TypeScript checks: `pnpm -C frontend typecheck` (`tsc --noEmit`) — succeeded. 
- Ran linter: `pnpm -C frontend lint` (`next lint`) — no ESLint warnings or errors. 
- Note: No authentication/network logic changed; no new security issues were introduced by this refactor, but keyed lookup relies on the locale dictionaries being present and typed keys should be used to avoid runtime undefined values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1045d6f088326a1365cbfab5c4610)