### PR TITLE
ci: block NEXT_PUBLIC secret-like environment variable names

### DIFF
--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -75,3 +75,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ARGS: --no-banner --redact --verbose
+
+  next-public-secret-guard:
+    name: Guard NEXT_PUBLIC secret-like variables
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Block NEXT_PUBLIC_*KEY style exposures
+        run: python scripts/security/check_next_public_key_exposure.py

--- a/scripts/security/check_next_public_key_exposure.py
+++ b/scripts/security/check_next_public_key_exposure.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Fail CI when public Next.js environment variables look like secrets.
+
+This script checks source files for `NEXT_PUBLIC_...` variable names that include
+sensitive suffixes (for example, `KEY`, `TOKEN`, or `SECRET`). Such variables are
+embedded into browser bundles by design and must not store confidential values.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+CHECK_EXTENSIONS = {
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".json",
+    ".env",
+    ".example",
+}
+
+SKIP_DIRS = {
+    ".git",
+    "node_modules",
+    ".next",
+    "dist",
+    "build",
+    "coverage",
+}
+
+TARGET_DIRS = [
+    REPO_ROOT / "frontend",
+    REPO_ROOT / ".github",
+]
+
+DISALLOWED_PATTERN = re.compile(
+    r"NEXT_PUBLIC_[A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*"
+)
+
+
+def _iter_files() -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    for target in TARGET_DIRS:
+        if not target.exists():
+            continue
+
+        for path in target.rglob("*"):
+            if not path.is_file():
+                continue
+            if any(part in SKIP_DIRS for part in path.parts):
+                continue
+
+            suffix = path.suffix.lower()
+            if suffix in CHECK_EXTENSIONS or path.name.startswith(".env"):
+                files.append(path)
+    return files
+
+
+def _scan_file(path: pathlib.Path) -> list[tuple[int, str]]:
+    findings: list[tuple[int, str]] = []
+    content = path.read_text(encoding="utf-8", errors="ignore")
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        if "NEXT_PUBLIC_" not in line:
+            continue
+        if DISALLOWED_PATTERN.search(line):
+            findings.append((line_number, line.strip()))
+    return findings
+
+
+def main() -> int:
+    violations: list[tuple[pathlib.Path, int, str]] = []
+    for file_path in _iter_files():
+        for line_number, line in _scan_file(file_path):
+            violations.append((file_path, line_number, line))
+
+    if not violations:
+        print("No disallowed NEXT_PUBLIC secret-like variable names found.")
+        return 0
+
+    print("Disallowed NEXT_PUBLIC secret-like variable names detected:")
+    for file_path, line_number, line in violations:
+        relative = file_path.relative_to(REPO_ROOT)
+        print(f"- {relative}:{line_number}: {line}")
+
+    print(
+        "\nUse server-side environment variables (without NEXT_PUBLIC_) for "
+        "sensitive values."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Prevent accidental client-side exposure of secrets by failing CI when `NEXT_PUBLIC_*` variable names contain secret-like suffixes such as `KEY`, `TOKEN`, `SECRET`, or `PASSWORD`.
- Provide an operational guard to complement server-side usage of `VERITAS_API_KEY` and reduce regression risk from future front-end changes.

### Description
- Add `scripts/security/check_next_public_key_exposure.py`, a scanning script (with docstring) that searches `frontend/` and `.github/` for `NEXT_PUBLIC_` names matching the disallowed pattern and reports file and line numbers.
- The script checks files with common front-end extensions (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.json`, `.env`, `.example`), skips build/vendor dirs, and returns exit code `1` on any violation.
- Add a `next-public-secret-guard` job to `.github/workflows/security-gates.yml` that runs the script on push/PR using Python `3.12`.

### Testing
- Ran `python scripts/security/check_next_public_key_exposure.py` locally and it exited with success showing `No disallowed NEXT_PUBLIC secret-like variable names found.`
- Confirmed the workflow file update by running the linter/commit steps (files staged and committed) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a109315dec83268eec88b927b2298d)