### PR TITLE
Add deterministic replay for decisions and /v1/decision/replay API

### DIFF
--- a/veritas_os/tests/test_decision_replay.py
+++ b/veritas_os/tests/test_decision_replay.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from veritas_os.core import pipeline
+
+
+@pytest.mark.asyncio
+async def test_replay_decision_returns_not_found_when_snapshot_missing() -> None:
+    result = await pipeline.replay_decision("missing-id")
+
+    assert result["match"] is False
+    assert result["diff"]["error"] == "decision_not_found"
+    assert result["replay_time_ms"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_replay_decision_generates_report(monkeypatch, tmp_path: Path) -> None:
+    snapshot = {
+        "request_id": "dec-123",
+        "query": "hello",
+        "deterministic_replay": {
+            "seed": 7,
+            "temperature": 0,
+            "request_body": {"query": "hello", "context": {"user_id": "u1"}},
+            "final_output": {"decision": "allow", "meta": {"x": 1}},
+        },
+    }
+
+    async def _fake_run_decide_pipeline(req, request):
+        return {"decision": "allow", "meta": {"x": 1}}
+
+    monkeypatch.setattr(pipeline, "_load_persisted_decision", lambda _: snapshot)
+    monkeypatch.setattr(pipeline, "run_decide_pipeline", _fake_run_decide_pipeline)
+    monkeypatch.setattr(pipeline, "REPLAY_REPORT_DIR", tmp_path)
+
+    result = await pipeline.replay_decision("dec-123")
+
+    assert result["match"] is True
+    assert result["diff"]["changed"] is False
+    assert result["replay_time_ms"] >= 1
+    reports = list(tmp_path.glob("replay_dec-123_*.json"))
+    assert reports
+
+
+def test_build_replay_diff_detects_changes() -> None:
+    original = {"decision": "allow", "meta": {"status": "ok"}}
+    replayed = {"decision": "reject", "meta": {"status": "ok"}}
+
+    diff = pipeline._build_replay_diff(original, replayed)
+
+    assert diff["changed"] is True
+    assert "decision" in diff["keys"]


### PR DESCRIPTION
### Motivation
- Enable deterministic replay (reproducible rerun) of VERITAS decision pipeline executions for audit and debugging by capturing required snapshots and providing a replay API. 
- Ensure replays are deterministic by fixing RNG with the saved `seed`, disabling external randomness, and allowing external APIs to be mocked during replay. 
- Produce concise structural diffs between original and replayed outputs to surface behavioral changes. 
- Security note: replay snapshots and diff reports may contain sensitive data; operators must protect `logs` and `veritas_os/audit/replay_reports/` with appropriate access controls and retention policies.

### Description
- Implemented `replay_decision(decision_id: str, mock_external_apis: bool = True)` in `veritas_os.core.pipeline` that: loads a persisted decision snapshot, re-runs the pipeline in replay mode, compares original vs replay outputs, builds a structural diff, and writes an audit report under `veritas_os/audit/replay_reports/`.
- On each decision persist, record a replay-ready snapshot at the end of `run_decide_pipeline` in `payload["deterministic_replay"]` including `input_prompt`, `evidence_snapshot`, `policy_snapshot`, `model_version`, `temperature`, `seed`, `tool_calls`, and per-stage `stage_outputs`; `final_output` is saved without self-references to avoid circular serialization.
- Added deterministic controls in `run_decide_pipeline`: seed-based `random.seed(seed)`, `replay_mode` and `mock_external_apis` context flags, and optional mocking of web-search responses during replay to remove external variability.
- Exposed API endpoint `POST /v1/decision/replay/{decision_id}` in `veritas_os.api.server` with `mock_external_apis` query parameter; response shape is `{ "match": bool, "diff": {...}, "replay_time_ms": ... }`.
- Auxiliary utilities: `_load_persisted_decision`, `_build_replay_diff`, `_sanitize_for_diff`, and a minimal `_ReplayRequest` shim to call `run_decide_pipeline` during replay.
- Files changed: `veritas_os/core/pipeline.py`, `veritas_os/api/server.py`, tests added/updated: `veritas_os/tests/test_decision_replay.py`, `veritas_os/tests/test_api_server_extra.py`.

### Testing
- Added unit tests `veritas_os/tests/test_decision_replay.py` and extended `veritas_os/tests/test_api_server_extra.py` for the new endpoint.
- Ran targeted test session: `pytest -q veritas_os/tests/test_decision_replay.py veritas_os/tests/test_api_server_extra.py::test_replay_decision_endpoint veritas_os/tests/test_api_server_extra.py::test_decide_validation_error_handler_returns_hint veritas_os/tests/test_api_server_extra.py::test_request_body_size_limit_allows_normal_payload` and all ran successfully (`6 passed`).
- Also executed the new endpoint test which passed; diff generation unit tests confirm detection of changes and successful report write to the replay report directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a12347c2c883269685b7048d4defb6)