### PR TITLE
Add Compliance Report Engine and API endpoints for EU AI Act / Governance reports

### DIFF
--- a/veritas_os/compliance/__init__.py
+++ b/veritas_os/compliance/__init__.py
@@ -1,0 +1,13 @@
+"""Compliance package for report generation engines."""
+
+from veritas_os.compliance.report_engine import (
+    generate_eu_ai_act_report,
+    generate_internal_governance_report,
+    generate_risk_summary_report,
+)
+
+__all__ = [
+    "generate_eu_ai_act_report",
+    "generate_internal_governance_report",
+    "generate_risk_summary_report",
+]

--- a/veritas_os/compliance/report_engine.py
+++ b/veritas_os/compliance/report_engine.py
@@ -1,0 +1,271 @@
+"""Compliance report engine for enterprise-grade audit exports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import json
+
+from veritas_os.audit.trustlog_signed import (
+    PRIVATE_KEY_PATH,
+    PUBLIC_KEY_PATH,
+    store_keypair,
+    verify_trustlog_chain,
+)
+from veritas_os.core.pipeline import LOG_DIR, REPLAY_REPORT_DIR
+from veritas_os.logging.trust_log import verify_trust_log
+from veritas_os.reporting.exporters import persist_report_json, persist_report_pdf
+from veritas_os.security.hash import sha256_of_canonical_json
+from veritas_os.security.signing import sign_payload_hash
+
+REPORT_DIR = (Path(LOG_DIR) / "compliance_reports").resolve()
+
+
+@dataclass(frozen=True)
+class ReportArtifact:
+    """Container for generated report payload and persisted artifacts."""
+
+    report: Dict[str, Any]
+    json_path: Path
+    pdf_path: Path
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _iter_decision_logs() -> Iterable[Dict[str, Any]]:
+    log_dir = Path(LOG_DIR)
+    if not log_dir.exists():
+        return []
+
+    records: List[Dict[str, Any]] = []
+    for path in sorted(log_dir.glob("decide_*.json"), reverse=True):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if isinstance(payload, dict):
+            payload["_source_path"] = str(path)
+            records.append(payload)
+    return records
+
+
+def _find_decision(decision_id: str) -> Optional[Dict[str, Any]]:
+    for rec in _iter_decision_logs():
+        rid = str(rec.get("request_id") or "")
+        did = str(rec.get("decision_id") or "")
+        if decision_id in {rid, did}:
+            return rec
+    return None
+
+
+def _classify_risk(score: float) -> str:
+    if score >= 0.8:
+        return "critical"
+    if score >= 0.5:
+        return "high"
+    if score >= 0.3:
+        return "medium"
+    return "low"
+
+
+def _latest_replay_result(decision_id: str) -> Dict[str, Any]:
+    replay_dir = Path(REPLAY_REPORT_DIR)
+    if not replay_dir.exists():
+        return {"available": False, "result": "missing"}
+
+    candidates = sorted(replay_dir.glob(f"replay_{decision_id}_*.json"), reverse=True)
+    if not candidates:
+        return {"available": False, "result": "missing"}
+
+    try:
+        payload = json.loads(candidates[0].read_text(encoding="utf-8"))
+    except Exception:
+        return {"available": False, "result": "unreadable"}
+
+    if not isinstance(payload, dict):
+        return {"available": False, "result": "invalid"}
+
+    return {
+        "available": True,
+        "match": bool(payload.get("match")),
+        "diff": payload.get("diff", {}),
+        "replay_time_ms": payload.get("replay_time_ms"),
+        "source": str(candidates[0]),
+    }
+
+
+def _build_decision_section(rec: Dict[str, Any]) -> Dict[str, Any]:
+    gate = rec.get("gate") if isinstance(rec.get("gate"), dict) else {}
+    fuji = rec.get("fuji") if isinstance(rec.get("fuji"), dict) else {}
+    risk_score = float(gate.get("risk", rec.get("gate_risk", 0.0)) or 0.0)
+
+    return {
+        "decision_overview": {
+            "decision_id": rec.get("decision_id") or rec.get("request_id"),
+            "request_id": rec.get("request_id"),
+            "timestamp": rec.get("ts") or rec.get("created_at"),
+            "query": rec.get("query"),
+            "decision_status": rec.get("decision_status"),
+            "chosen": rec.get("chosen"),
+            "source": rec.get("_source_path"),
+        },
+        "risk_classification": {
+            "risk_score": risk_score,
+            "risk_level": _classify_risk(risk_score),
+            "fuji_status": fuji.get("status", rec.get("fuji_status")),
+            "violations": fuji.get("violations", []),
+        },
+        "mitigation_actions": fuji.get("modifications", []),
+        "policy_application_evidence": {
+            "fuji": fuji,
+            "gate": gate,
+            "critique_mode": rec.get("critique_mode"),
+            "critique_ok": rec.get("critique_ok"),
+        },
+    }
+
+
+def _build_integrity_section(decision_id: str) -> Dict[str, Any]:
+    signed = verify_trustlog_chain()
+    legacy = verify_trust_log()
+    replay = _latest_replay_result(decision_id)
+
+    return {
+        "signature_verification": {
+            "ok": bool(signed.get("ok")),
+            "entries_checked": signed.get("entries_checked", 0),
+            "issues": signed.get("issues", []),
+            "public_key_path": str(PUBLIC_KEY_PATH),
+        },
+        "replay_verification": replay,
+        "hash_chain_integrity": {
+            "ok": bool(legacy.get("ok")),
+            "checked": legacy.get("checked", 0),
+            "broken": bool(legacy.get("broken", False)),
+            "broken_reason": legacy.get("broken_reason"),
+        },
+    }
+
+
+def _finalize_report(report_type: str, payload: Dict[str, Any]) -> ReportArtifact:
+    body = {
+        "report_type": report_type,
+        "generated_at": _utc_now(),
+        **payload,
+    }
+    report_hash = sha256_of_canonical_json(body)
+
+    if not PRIVATE_KEY_PATH.exists() or not PUBLIC_KEY_PATH.exists():
+        store_keypair(PRIVATE_KEY_PATH, PUBLIC_KEY_PATH)
+    signature = sign_payload_hash(report_hash, PRIVATE_KEY_PATH)
+
+    body["signed_report_hash"] = {
+        "algorithm": "SHA-256+Ed25519",
+        "report_hash": report_hash,
+        "signature": signature,
+        "public_key_path": str(PUBLIC_KEY_PATH),
+    }
+
+    report_id = f"{report_type}_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    json_path = REPORT_DIR / f"{report_id}.json"
+    pdf_path = REPORT_DIR / f"{report_id}.pdf"
+    persist_report_json(json_path, body)
+    persist_report_pdf(pdf_path, body)
+
+    body["artifacts"] = {
+        "json_path": str(json_path),
+        "pdf_path": str(pdf_path),
+    }
+    return ReportArtifact(report=body, json_path=json_path, pdf_path=pdf_path)
+
+
+def generate_eu_ai_act_report(decision_id: str) -> Dict[str, Any]:
+    """Generate EU AI Act-ready report for a single decision."""
+    rec = _find_decision(decision_id)
+    if rec is None:
+        return {
+            "ok": False,
+            "error": "decision_not_found",
+            "decision_id": decision_id,
+        }
+
+    payload = {
+        "scope": "eu_ai_act",
+        **_build_decision_section(rec),
+        **_build_integrity_section(str(rec.get("request_id") or decision_id)),
+        "summary": {
+            "regulation": "EU AI Act",
+            "compliance_status": "pass"
+            if rec.get("decision_status") != "rejected"
+            else "review_required",
+        },
+    }
+    return {"ok": True, **_finalize_report("eu_ai_act", payload).report}
+
+
+def generate_internal_governance_report(
+    date_range: Tuple[str, str],
+) -> Dict[str, Any]:
+    """Generate internal governance report for a UTC date range."""
+    start_raw, end_raw = date_range
+    start = datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
+    end = datetime.fromisoformat(end_raw.replace("Z", "+00:00"))
+
+    matched: List[Dict[str, Any]] = []
+    for rec in _iter_decision_logs():
+        ts_raw = str(rec.get("ts") or rec.get("created_at") or "")
+        if not ts_raw:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if start <= ts <= end:
+            matched.append(rec)
+
+    decisions = [_build_decision_section(rec) for rec in matched]
+    high_risk = sum(
+        1
+        for item in decisions
+        if item["risk_classification"]["risk_level"] in {"high", "critical"}
+    )
+
+    payload = {
+        "scope": "internal_governance",
+        "date_range": {"from": start_raw, "to": end_raw},
+        "decision_count": len(matched),
+        "decisions": decisions,
+        **_build_integrity_section(matched[0].get("request_id", "unknown") if matched else "unknown"),
+        "summary": {
+            "high_risk_decisions": high_risk,
+            "risk_ratio": round(high_risk / len(matched), 4) if matched else 0.0,
+        },
+    }
+    return {"ok": True, **_finalize_report("governance", payload).report}
+
+
+def generate_risk_summary_report() -> Dict[str, Any]:
+    """Generate cross-decision risk summary for enterprise audits."""
+    all_logs = list(_iter_decision_logs())
+    buckets = {"low": 0, "medium": 0, "high": 0, "critical": 0}
+
+    for rec in all_logs:
+        gate = rec.get("gate") if isinstance(rec.get("gate"), dict) else {}
+        risk_score = float(gate.get("risk", rec.get("gate_risk", 0.0)) or 0.0)
+        buckets[_classify_risk(risk_score)] += 1
+
+    payload = {
+        "scope": "risk_summary",
+        "decision_count": len(all_logs),
+        "risk_distribution": buckets,
+        **_build_integrity_section("summary"),
+        "summary": {"top_risk_level": max(buckets, key=buckets.get) if all_logs else "none"},
+    }
+    return {"ok": True, **_finalize_report("risk_summary", payload).report}

--- a/veritas_os/reporting/__init__.py
+++ b/veritas_os/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting package exports."""

--- a/veritas_os/reporting/exporters.py
+++ b/veritas_os/reporting/exporters.py
@@ -1,0 +1,88 @@
+"""Reporting export helpers for compliance artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from veritas_os.core.atomic_io import atomic_write_json
+
+
+def _escape_pdf_text(value: str) -> str:
+    """Escape PDF text operators for literal text rendering."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace("(", "\\(")
+        .replace(")", "\\)")
+    )
+
+
+def build_pdf_bytes(report: Dict[str, Any]) -> bytes:
+    """Build a compact audit PDF from report content.
+
+    This exporter intentionally emits a simple single-page PDF for portability
+    in restricted runtime environments where external PDF engines may be
+    unavailable.
+    """
+    lines = [
+        "VERITAS OS Compliance Report",
+        f"Report Type: {report.get('report_type', 'unknown')}",
+        f"Generated At: {report.get('generated_at', 'unknown')}",
+        "---",
+    ]
+    summary = json.dumps(report.get("summary", {}), ensure_ascii=True, sort_keys=True)
+    lines.extend([summary[i:i + 100] for i in range(0, len(summary), 100)])
+
+    text_ops = ["BT", "/F1 10 Tf", "50 780 Td", "14 TL"]
+    for index, line in enumerate(lines):
+        escaped = _escape_pdf_text(line)
+        if index == 0:
+            text_ops.append(f"({escaped}) Tj")
+        else:
+            text_ops.append(f"T* ({escaped}) Tj")
+    text_ops.append("ET")
+    stream = "\n".join(text_ops).encode("utf-8")
+
+    objects = [
+        b"1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n",
+        b"2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj\n",
+        b"3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>endobj\n",
+        b"4 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n",
+        f"5 0 obj<< /Length {len(stream)} >>stream\n".encode("utf-8")
+        + stream
+        + b"\nendstream\nendobj\n",
+    ]
+
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for obj in objects:
+        offsets.append(len(pdf))
+        pdf.extend(obj)
+
+    xref_offset = len(pdf)
+    pdf.extend(f"xref\n0 {len(offsets)}\n".encode("utf-8"))
+    pdf.extend(b"0000000000 65535 f \n")
+    for off in offsets[1:]:
+        pdf.extend(f"{off:010d} 00000 n \n".encode("utf-8"))
+
+    pdf.extend(
+        (
+            f"trailer<< /Size {len(offsets)} /Root 1 0 R >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode("utf-8")
+    )
+    return bytes(pdf)
+
+
+def persist_report_json(path: Path, payload: Dict[str, Any]) -> None:
+    """Persist report JSON with atomic write guarantees."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(path, payload, indent=2)
+
+
+def persist_report_pdf(path: Path, payload: Dict[str, Any]) -> None:
+    """Persist report PDF bytes to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(build_pdf_bytes(payload))

--- a/veritas_os/tests/test_compliance_report_engine.py
+++ b/veritas_os/tests/test_compliance_report_engine.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("VERITAS_API_KEY", "test-governance-key")
+
+from veritas_os.api import server as srv
+from veritas_os.compliance import report_engine
+
+HEADERS = {"X-API-Key": "test-governance-key"}
+
+
+def _write_decision(path: Path, request_id: str, risk: float = 0.2) -> None:
+    payload = {
+        "request_id": request_id,
+        "decision_status": "allow",
+        "ts": "2026-01-01T12:00:00Z",
+        "query": "test query",
+        "chosen": {"action": "safe"},
+        "gate": {"risk": risk},
+        "fuji": {
+            "status": "allow",
+            "violations": [],
+            "modifications": ["redact_sensitive_fields"],
+        },
+        "critique_ok": True,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def test_generate_eu_ai_act_report_outputs_json_pdf_and_signature(
+    monkeypatch,
+    tmp_path: Path,
+):
+    log_dir = tmp_path / "logs"
+    replay_dir = tmp_path / "replay"
+    report_dir = tmp_path / "reports"
+    key_dir = tmp_path / "keys"
+    log_dir.mkdir(parents=True)
+    replay_dir.mkdir(parents=True)
+
+    _write_decision(log_dir / "decide_001.json", "dec-001", risk=0.7)
+    replay_dir.joinpath("replay_dec-001_1.json").write_text(
+        json.dumps({"match": True, "diff": {"changed": False}, "replay_time_ms": 11}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(report_engine, "LOG_DIR", log_dir)
+    monkeypatch.setattr(report_engine, "REPORT_DIR", report_dir)
+    monkeypatch.setattr(report_engine, "REPLAY_REPORT_DIR", replay_dir)
+    monkeypatch.setattr(report_engine, "PRIVATE_KEY_PATH", key_dir / "private.key")
+    monkeypatch.setattr(report_engine, "PUBLIC_KEY_PATH", key_dir / "public.key")
+    monkeypatch.setattr(
+        report_engine,
+        "verify_trustlog_chain",
+        lambda: {"ok": True, "entries_checked": 1, "issues": []},
+    )
+    monkeypatch.setattr(
+        report_engine,
+        "verify_trust_log",
+        lambda: {"ok": True, "checked": 1, "broken": False, "broken_reason": None},
+    )
+
+    result = report_engine.generate_eu_ai_act_report("dec-001")
+
+    assert result["ok"] is True
+    assert result["risk_classification"]["risk_level"] == "high"
+    assert "signature" in result["signed_report_hash"]
+    assert Path(result["artifacts"]["json_path"]).exists()
+    assert Path(result["artifacts"]["pdf_path"]).exists()
+
+
+def test_report_api_endpoints(monkeypatch):
+    client = TestClient(srv.app)
+
+    monkeypatch.setattr(
+        srv,
+        "generate_eu_ai_act_report",
+        lambda decision_id: {
+            "ok": True,
+            "report_type": "eu_ai_act",
+            "decision_id": decision_id,
+        },
+    )
+    monkeypatch.setattr(
+        srv,
+        "generate_internal_governance_report",
+        lambda date_range: {
+            "ok": True,
+            "report_type": "governance",
+            "date_range": date_range,
+        },
+    )
+
+    eu_resp = client.get("/v1/report/eu_ai_act/dec-abc", headers=HEADERS)
+    assert eu_resp.status_code == 200
+    assert eu_resp.json()["decision_id"] == "dec-abc"
+
+    gov_resp = client.get(
+        "/v1/report/governance",
+        params={"from": "2026-01-01T00:00:00Z", "to": "2026-01-31T23:59:59Z"},
+        headers=HEADERS,
+    )
+    assert gov_resp.status_code == 200
+    assert gov_resp.json()["date_range"] == [
+        "2026-01-01T00:00:00Z",
+        "2026-01-31T23:59:59Z",
+    ]
+
+
+def test_report_governance_invalid_date(monkeypatch):
+    client = TestClient(srv.app)
+
+    def _raise_value_error(date_range):
+        raise ValueError("invalid")
+
+    monkeypatch.setattr(srv, "generate_internal_governance_report", _raise_value_error)
+    response = client.get(
+        "/v1/report/governance",
+        params={"from": "bad", "to": "bad"},
+        headers=HEADERS,
+    )
+    assert response.status_code == 400
+    assert response.json()["ok"] is False

--- a/veritas_os/tests/test_compliance_report_engine.py
+++ b/veritas_os/tests/test_compliance_report_engine.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
-
-os.environ.setdefault("VERITAS_API_KEY", "test-governance-key")
 
 from veritas_os.api import server as srv
 from veritas_os.compliance import report_engine
 
 HEADERS = {"X-API-Key": "test-governance-key"}
+
+
+@pytest.fixture(autouse=True)
+def _set_test_api_key(monkeypatch):
+    """Ensure API key protected endpoints are testable in isolated runs."""
+    monkeypatch.setenv("VERITAS_API_KEY", "test-governance-key")
+    monkeypatch.setattr(srv, "API_KEY_DEFAULT", "test-governance-key")
 
 
 def _write_decision(path: Path, request_id: str, risk: float = 0.2) -> None:


### PR DESCRIPTION
### Motivation
- Provide an enterprise-grade Compliance Report Engine that automatically generates audit-ready reports from persisted decision logs, covering regulatory (EU AI Act) and internal governance needs.
- Ensure reports include decision context, risk classification, mitigation actions, policy application evidence, signature and replay verification, and hash-chain integrity so they are suitable for enterprise audits.
- Offer portable artifact outputs (JSON, deterministic single-page PDF) and a signed report hash to support verifiable distribution and archival.

### Description
- Added a new compliance engine at `veritas_os/compliance/report_engine.py` implementing `generate_eu_ai_act_report(decision_id)`, `generate_internal_governance_report(date_range)`, and `generate_risk_summary_report()` that aggregate decision overview, risk classification, mitigations, policy evidence, signature verification, replay verification, and hash-chain integrity.
- Implemented deterministic artifact exporters in `veritas_os/reporting/exporters.py` including atomic JSON persistence and a minimal, dependency-free PDF generator; report persistence and PDF/JSON artifact metadata are embedded in the report.
- Added API endpoints to `veritas_os/api/server.py`: `GET /v1/report/eu_ai_act/{decision_id}` and `GET /v1/report/governance?from=...&to=...`, with appropriate error handling for not-found, bad request and server errors.
- Added test coverage and package exports: new tests in `veritas_os/tests/test_compliance_report_engine.py` and package init files under `veritas_os/compliance` and `veritas_os/reporting`; docstrings were added for major components and functions.
- Security note: report signing uses local Ed25519 key files (created/stored under existing keys path), so production deployment must secure key files, implement rotation/KMS, and restrict permissions.

### Testing
- Ran `pytest -q veritas_os/tests/test_compliance_report_engine.py` with the new engine and exporter mocks: 3 passed (success).
- Ran `pytest -q veritas_os/tests/test_openapi_spec.py` to validate runtime paths in OpenAPI: 3 passed (success).
- A targeted test name specified earlier was not found and resulted in a not-found invocation (no code change impact); all tests touching the new code passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a12b32dca48326897ea0d96c50ce85)