### PR TITLE
Add root error boundary for App Router crash recovery

### DIFF
--- a/frontend/app/error.test.tsx
+++ b/frontend/app/error.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import GlobalErrorPage from "./error";
+
+describe("GlobalErrorPage", () => {
+  it("renders recovery UI and calls reset on retry", () => {
+    const reset = vi.fn();
+
+    render(
+      <GlobalErrorPage
+        error={new Error("boom")}
+        reset={reset}
+      />
+    );
+
+    expect(screen.getByText("問題が発生しました")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "再試行" }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs the routed error once mounted", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const error = new Error("route failure");
+
+    render(
+      <GlobalErrorPage
+        error={error}
+        reset={vi.fn()}
+      />
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Unhandled route error:", error);
+  });
+});

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+type GlobalErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+/**
+ * Next.js App Router のルートエラーバウンダリ。
+ *
+ * 予期しない実行時エラーで画面全体が崩壊することを防ぎ、
+ * ユーザーに復旧操作（再試行）を提供する。
+ */
+export default function GlobalErrorPage({
+  error,
+  reset,
+}: GlobalErrorPageProps): JSX.Element {
+  useEffect(() => {
+    console.error("Unhandled route error:", error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center gap-6 px-6 text-center">
+      <h1 className="text-3xl font-semibold text-zinc-100">問題が発生しました</h1>
+      <p className="text-sm text-zinc-300">
+        予期しないエラーが発生しました。しばらくしてから再試行してください。
+      </p>
+      <button
+        className="rounded-md border border-zinc-600 bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-100 transition hover:bg-zinc-800"
+        onClick={() => reset()}
+        type="button"
+      >
+        再試行
+      </button>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Address review item `C-4` from the code review report by preventing full-page crashes when an unhandled runtime exception occurs in the Next.js App Router.
- Provide a simple recovery UX and operational visibility so users can retry and operators can observe routed errors.

### Description
- Add `frontend/app/error.tsx` implementing a Next.js App Router root error boundary (`"use client"`) that renders a Japanese recovery UI with a `reset()` retry button and logs the routed error via `console.error`.
- Add `frontend/app/error.test.tsx` with two Vitest cases that verify the recovery UI calls `reset()` and that the boundary logs the error when mounted.

### Testing
- Ran `npm test -- error.test.tsx` which executed the Vitest suite for the new file and the tests passed.
- Ran `npm run typecheck` (`tsc --noEmit`) and the TypeScript type check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ece740808326ac437e1f951be1ed)