### PR TITLE
H-2 修正: agi_goals の正規化でゼロ/非有限合計をガード

### DIFF
--- a/veritas_os/tests/test_agi_goals.py
+++ b/veritas_os/tests/test_agi_goals.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Tests for AGI goal auto-adjust normalization safeguards."""
+
+from veritas_os.core.agi_goals import auto_adjust_goals
+
+
+def test_auto_adjust_goals_zero_total_falls_back_to_uniform() -> None:
+    """When all weights are zero, auto_adjust_goals should return uniform weights."""
+    result = auto_adjust_goals({"a": 0.0, "b": 0.0})
+
+    assert result == {"a": 0.5, "b": 0.5}
+
+
+def test_auto_adjust_goals_avoids_division_by_zero_with_tiny_total() -> None:
+    """Very small totals should be normalized with a positive epsilon denominator."""
+    weights = {"a": 1e-320, "b": 1e-320}
+
+    result = auto_adjust_goals(weights)
+
+    assert set(result.keys()) == {"a", "b"}
+    assert result["a"] > 0.0
+    assert result["b"] > 0.0


### PR DESCRIPTION
### Motivation
- CODE_REVIEW の指摘 H-2（`agi_goals.py` のゼロ除算リスク）に対処するため、`auto_adjust_goals()` の正規化処理を堅牢化します。 
- 小さな数値や非有限値（NaN/inf）が合計に混入した場合のランタイム例外や NaN 伝播を防ぎ、意思決定ループの可用性を向上させる目的です。
- 修正は AGI ゴール管理ロジック内に限定し、他モジュールの責務を越えないようにしました。
- セキュリティ観点では、新たな脆弱性は導入せず信頼性向上を狙った変更です。

### Description
- `veritas_os/core/agi_goals.py` に `import math` を追加し、関数 docstring を更新して正規化安全化の意図を明記しました.
- 正規化のガード条件を `total <= 0` から `total <= 0 or not math.isfinite(total)` に拡張しました.
- 分母を `safe_total = max(total, 1e-8)` として小さな正値でクリップし、ゼロ除算や極小値による不安定化を防止しました.
- `veritas_os/tests/test_agi_goals.py` を追加し、合計0時のフォールバックと極小合計値での安全性を検証するユニットテストを導入しました.

### Testing
- 実行したテストは `python -m pytest -q veritas_os/tests/test_agi_goals.py` で、結果は `2 passed` でした.
- 変更は該当モジュール内に限定され、既存のテストスイートへの回帰は確認していません（今回追加のテストは通過しています）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a204319e34832689a4c6f8718ece2b)