### PR TITLE
H-3: Prevent symlink traversal in code_planner bench log discovery

### DIFF
--- a/veritas_os/core/code_planner.py
+++ b/veritas_os/core/code_planner.py
@@ -71,6 +71,10 @@ def _find_latest_bench_log(bench_id: str) -> Optional[Path]:
 
     candidates: List[Tuple[float, Path]] = []
     for p in BENCH_LOG_DIR.glob("*.json"):
+        if p.is_symlink():
+            logger.warning("[code_planner] Skipping symlink path: %s", p)
+            continue
+
         # ★ セキュリティ: シンボリックリンク経由のパストラバーサルを防止
         try:
             resolved_p = p.resolve()
@@ -446,4 +450,3 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     main_cli(bench_id=args.bench_id)
-

--- a/veritas_os/tests/test_code_planner.py
+++ b/veritas_os/tests/test_code_planner.py
@@ -146,6 +146,25 @@ def test_find_latest_bench_log(tmp_path: Path, monkeypatch):
     assert latest == f2
 
 
+def test_find_latest_bench_log_skips_symlink(tmp_path: Path, monkeypatch):
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    monkeypatch.setattr(code_planner, "BENCH_LOG_DIR", logs_dir)
+
+    real_file = logs_dir / "real.json"
+    real_file.write_text('{"bench": "bench_x"}', encoding="utf-8")
+
+    symlink_file = logs_dir / "symlink.json"
+    symlink_file.symlink_to(real_file)
+
+    import os
+
+    os.utime(real_file, (1_000, 1_000))
+
+    latest = code_planner._find_latest_bench_log("bench_x")
+    assert latest == real_file
+
+
 # =========================
 # CodeChangePlan / dataclass 系
 # =========================


### PR DESCRIPTION
### Motivation
- Review item H-3 identified that relying only on `resolve()` + `relative_to()` is insufficient to prevent symlink-based traversal when enumerating bench log files, so the planner should explicitly reject symlinked entries to reduce attack surface.

### Description
- Add an explicit `if p.is_symlink():` guard in `_find_latest_bench_log` to skip symlinked `*.json` entries and log a warning, and add a regression test `test_find_latest_bench_log_skips_symlink` in `veritas_os/tests/test_code_planner.py` to verify behavior; the change is limited to `veritas_os/core/code_planner.py` and its tests.

### Testing
- Ran `pytest -q veritas_os/tests/test_code_planner.py` which executed the suite including the new test and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a27febae1083268d09ec6074e3309d)