### PR TITLE
H-6: remove legacy pickle deserialization path from CosineIndex

### DIFF
--- a/veritas_os/tests/test_memory_index_cosine.py
+++ b/veritas_os/tests/test_memory_index_cosine.py
@@ -133,38 +133,18 @@ def test_cosine_index_refuses_path_under_symlink_directory(tmp_path):
     assert idx.ids == []
 
 
-def test_cosine_index_legacy_npz_requires_opt_in(tmp_path, monkeypatch):
-    """レガシーnpz(allow_pickleが必要)はopt-inしないと無視される。"""
+def test_cosine_index_legacy_npz_is_always_rejected(tmp_path):
+    """レガシーnpz(allow_pickleが必要)は常に拒否して空インデックスへフォールバック。"""
     p = tmp_path / "legacy_index.npz"
     vecs = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
     ids = np.array(["a", "b"], dtype=object)
     np.savez(p, vecs=vecs, ids=ids)
 
-    monkeypatch.delenv("VERITAS_MEMORY_ALLOW_LEGACY_NPZ", raising=False)
     idx = CosineIndex(dim=2, path=p)
 
     assert idx.size == 0
     assert idx.vecs.shape == (0, 2)
     assert idx.ids == []
-
-
-def test_cosine_index_legacy_npz_migrates_on_opt_in(tmp_path, monkeypatch):
-    """opt-in時はレガシーnpzをロードし安全形式へ保存し直す。"""
-    p = tmp_path / "legacy_index.npz"
-    vecs = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
-    ids = np.array(["a", "b"], dtype=object)
-    np.savez(p, vecs=vecs, ids=ids)
-
-    monkeypatch.setenv("VERITAS_MEMORY_ALLOW_LEGACY_NPZ", "1")
-    idx = CosineIndex(dim=2, path=p)
-
-    assert idx.size == 2
-    assert idx.ids == ["a", "b"]
-
-    monkeypatch.delenv("VERITAS_MEMORY_ALLOW_LEGACY_NPZ", raising=False)
-    idx_reloaded = CosineIndex(dim=2, path=p)
-    assert idx_reloaded.size == 2
-    assert idx_reloaded.ids == ["a", "b"]
 
 
 def test_cosine_index_load_dim_mismatch_resets_to_empty(tmp_path):


### PR DESCRIPTION
### Motivation
- The review item H-6 flagged a high-severity RCE risk from enabling pickle deserialization for legacy `.npz` index files, so the runtime pathway that could execute arbitrary code must be eliminated. 
- Legacy `.npz` files that rely on `allow_pickle=True` are unsafe to load and should not be opt-in at runtime. 
- Keep the memory index secure by refusing any pickle-backed load and forcing explicit, offline migration of legacy data.

### Description
- Removed the legacy pickle opt-in path and helper code: deleted `VERITAS_MEMORY_ALLOW_LEGACY_NPZ` handling and the `PickleSecurityWarning` / `_allow_legacy_pickle_npz()` helper, and removed `allow_pickle=True` usage from `CosineIndex._load()` so legacy reads can no longer be enabled at runtime. 
- Changed `CosineIndex._load()` to attempt `np.load(..., allow_pickle=False)` and, on failure, log a security warning and reset to an empty index instead of trying a pickle-based fallback. 
- Updated tests to reflect the new secure policy by replacing the opt-in migration tests with one that asserts legacy/object-typed `.npz` files are always rejected; the test file `veritas_os/tests/test_memory_index_cosine.py` and module `veritas_os/memory/index_cosine.py` were modified.

### Testing
- Ran the unit tests for the memory index: `pytest -q veritas_os/tests/test_memory_index_cosine.py veritas_os/tests/test_index_cosine.py` and all tests passed. 
- Test summary: `37 passed` (full run shown in CI-local invocation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a8160c44832695e29b63c92fdcbd)