### PR TITLE
H-7: debate.py に options 累積ペイロード上限を追加

### DIFF
--- a/veritas_os/tests/test_debate_extra.py
+++ b/veritas_os/tests/test_debate_extra.py
@@ -127,6 +127,27 @@ class TestSafeJsonExtractLike:
         result = debate_mod._safe_json_extract_like(raw)
         assert "options" in result
 
+    def test_limits_total_options_payload_size(self):
+        """Oversized options payload should be truncated by cumulative size."""
+        option_summary = "x" * (debate_mod.MAX_OPTION_STRING_LENGTH - 10)
+        raw_options = [
+            {
+                "id": str(i),
+                "summary": option_summary,
+                "verdict": "採用推奨",
+                "safety_view": "safe",
+                "architect_view": "a" * 800,
+            }
+            for i in range(1, debate_mod.MAX_OPTIONS + 1)
+        ]
+        raw = {"options": raw_options}
+
+        result = debate_mod._safe_json_extract_like(
+            debate_mod.json.dumps(raw, ensure_ascii=False)
+        )
+
+        assert 0 < len(result["options"]) < len(raw_options)
+
 
 class TestSelectBestCandidate:
     """Tests for _select_best_candidate function."""


### PR DESCRIPTION
### Motivation
- LLM から返る `options` 配列が非常に大きい場合にメモリ枯渇や DoS を招くリスクがあり、H-7 で指摘された総ペイロード上限が必要です。 
- 既存の件数・文字列長制限だけでは総量制御が不十分なため、累積バイト相当の上限で防御を強化します。

### Description
- モジュール定数として `MAX_OPTION_STRING_LENGTH`, `MAX_OPTIONS`, `MAX_OPTIONS_PAYLOAD_BYTES` を追加しました。 
- `_estimate_option_payload_size(opt)` を追加して各 `option` の概算ペイロードを算出するようにしました。 
- `_sanitize_options()` を強化して各 option の概算サイズを累積し、`MAX_OPTIONS_PAYLOAD_BYTES` を超える直前で打ち切り・警告ログを出すようにしました。 
- 関連ヘルパーに簡潔な docstring を追加し、既存の `MAX_OPTIONS` / 文字列長チェックと組み合わせて防御を二重化しました。 

### Testing
- 追加テスト `veritas_os/tests/test_debate_extra.py::TestSafeJsonExtractLike::test_limits_total_options_payload_size` を実装して巨大 `options` 入力で途中切り詰めが発生することを検証しました。 
- 実行コマンド `pytest -q veritas_os/tests/test_debate_extra.py` の結果は `37 passed` で全テストが成功しました。 

⚠️ Security note: `_estimate_option_payload_size()` は値文字数の概算に基づく実装のためマルチバイト文字や JSON エスケープ後の実バイト長と差異があり得ます；将来的にはエンコード後のバイト長での制限や上位レイヤでのリクエストサイズ制御を併用することを推奨します.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2fce884b48326bda4f0733a847da6)