### PR TITLE
H-8: Harden web_search domain matching to prevent suffix attacks

### DIFF
--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -203,6 +203,22 @@ class TestIsBlockedResult:
             is True
         )
 
+    def test_hostname_matching_rejects_suffix_attack(self):
+        assert (
+            web_search_mod._is_hostname_exact_or_subdomain(
+                "evilveritas.com", "veritas.com"
+            )
+            is False
+        )
+
+    def test_hostname_matching_requires_dot_boundary(self):
+        assert (
+            web_search_mod._is_hostname_exact_or_subdomain(
+                "veritas.com.evil.org", "veritas.com"
+            )
+            is False
+        )
+
     def test_allows_clean_result(self):
         assert (
             web_search_mod._is_blocked_result(


### PR DESCRIPTION
### Motivation
- Fix the H-8 review finding where naive suffix checks could treat `evilveritas.com` or `veritas.com.evil.org` as matches for `veritas.com`, enabling domain-suffix misclassification. 
- Centralize hostname/domain comparison to avoid scattered ad-hoc endswith checks and reduce future regressions. 

### Description
- Added helper `_is_hostname_exact_or_subdomain(hostname: str, domain: str) -> bool` in `veritas_os/tools/web_search.py` with a docstring and canonicalization to allow only exact matches or dot-bounded subdomain matches. 
- Replaced the previous `host == site_host or host.endswith(f".{site_host}")` style checks in `_is_blocked_result()` with the new helper for `BLACKLIST_SITES` and the `veritas.com` check. 
- Added focused regression tests in `veritas_os/tests/test_web_search_extra.py` to assert that `evilveritas.com` and `veritas.com.evil.org` are not treated as `veritas.com` subdomains. 
- Kept change surface minimal and added a docstring for the new helper to satisfy documentation/test requirements.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search_extra.py -k "hostname_matching_rejects_suffix_attack or hostname_matching_requires_dot_boundary or blocks_veritas_com"` and received `4 passed, 57 deselected`, indicating the new helper and related checks behave as expected. 
- An earlier targeted run showed two failing tests before refactor, and those were fixed by introducing the helper and updating tests; the final focused test run passed. 
- No other test suites were modified or run in this change. 

Security note: Title/snippet keyword blacklist (`BLACKLIST_KEYWORDS` contains `"veritas.com"`) can still cause false positives when that string appears in content, so operators should be aware of potential over-blocking as an operational trade-off.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a302251aa88326a6569da8508f6e14)