### PR TITLE
Recover trust-log hash after rotation when marker is missing (H-10)

### DIFF
--- a/veritas_os/tests/test_trust_log.py
+++ b/veritas_os/tests/test_trust_log.py
@@ -201,6 +201,28 @@ def test_get_last_hash_skips_trailing_partial_json_line(temp_log_env):
     assert trust_log.get_last_hash() == "d" * 64
 
 
+def test_get_last_hash_recovers_from_rotated_log_when_marker_missing(temp_log_env):
+    rotated = temp_log_env["jsonl"].with_name("trust_log_old.jsonl")
+    entries = [
+        {"sha256": "e" * 64},
+        {"sha256": "f" * 64},
+    ]
+    with open(rotated, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    assert trust_log.get_last_hash() == "f" * 64
+
+
+def test_get_last_hash_recovers_from_rotated_log_when_active_empty(temp_log_env):
+    temp_log_env["jsonl"].write_text("", encoding="utf-8")
+
+    rotated = temp_log_env["jsonl"].with_name("trust_log_old.jsonl")
+    rotated.write_text(json.dumps({"sha256": "1" * 64}) + "\n", encoding="utf-8")
+
+    assert trust_log.get_last_hash() == "1" * 64
+
+
 def test_extract_last_sha256_from_lines_ignores_invalid_entries():
     valid_hash = "a" * 64
     lines = [


### PR DESCRIPTION
### Motivation
- Prevent silent trust-chain breaks reported in issue H-10 by adding a recovery path when the rotation marker is missing after log rotation. 
- Improve observability by emitting warnings when the marker is missing and a fallback is attempted. 
- Keep normal behavior if recovery fails by returning `None` as before to avoid introducing undetected changes to chain logic. 
- Security warning: reliance on a rotated log for recovery does not eliminate the risk of a tampered `trust_log_old.jsonl`, so monitoring of the warning logs and secure handling of log files is recommended.

### Description
- Added `_recover_last_hash_from_rotated_log()` helper with a docstring that scans `trust_log_old.jsonl` tail in chunks and extracts the newest usable `sha256` safely. 
- Updated `get_last_hash()` to first attempt `load_last_hash_marker()` and then, when the marker is missing and the active log is absent/empty, call the rotated-log recovery helper and emit warning logs. 
- Added warning messages to clarify when marker loss recovery is attempted or when recovery fails. 
- Added two regression tests in `veritas_os/tests/test_trust_log.py`: `test_get_last_hash_recovers_from_rotated_log_when_marker_missing` and `test_get_last_hash_recovers_from_rotated_log_when_active_empty`.

### Testing
- Ran `pytest -q veritas_os/tests/test_trust_log.py` and observed `20 passed`.
- New tests exercise both recovery scenarios (active missing and active empty) and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39c79ec188326b8846a3f34c56394)