### PR TITLE
frontend: add request timeouts for audit + decision fetches (H-12)

### DIFF
--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -59,6 +59,33 @@ describe("TrustLogExplorerPage", () => {
     });
   });
 
+  it("shows timeout error when trust logs request is aborted", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValueOnce(new DOMException("Aborted", "AbortError"));
+
+    render(<TrustLogExplorerPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("タイムアウト: trust logs 取得が時間内に完了しませんでした。")).toBeInTheDocument();
+    });
+  });
+
+  it("shows timeout error when request_id search is aborted", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValueOnce(new DOMException("Aborted", "AbortError"));
+
+    render(<TrustLogExplorerPage />);
+
+    fireEvent.change(screen.getByLabelText("request_id"), {
+      target: { value: "req-timeout" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "検索" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("タイムアウト: request_id 検索が時間内に完了しませんでした。")).toBeInTheDocument();
+    });
+  });
+
   it("verifies hash chain and shows tamper-proof stamp", async () => {
     vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
### Motivation
- Address review item `H-12` from the code review which flagged missing timeout handling on frontend `fetch` calls that can hang the UI. 
- Prevent long-running or stalled network requests from leaving the TrustLog Explorer and Decision Console in an indeterminate state.

### Description
- Add a `fetchWithTimeout` helper (default 15_000 ms) and use it for the TrustLog Explorer endpoints (`/api/veritas/v1/trust/logs` and `/api/veritas/v1/trust/{request_id}`) in `frontend/app/audit/page.tsx` to ensure requests are aborted after the timeout. 
- Surface explicit timeout-specific user error messages when an `AbortError` occurs for trust-log list and request-id searches. 
- Add a decision request timeout (`DECIDE_TIMEOUT_MS = 20_000`) in `frontend/features/console/api/useDecide.ts` that aborts `/api/veritas/v1/decide` calls and reports a clear timeout error to the UI while preserving the existing stale-response safety logic. 
- Extend `frontend/app/audit/page.test.tsx` with tests that assert timeout handling for both trust-log loading and request-id search. 

### Testing
- Ran targeted frontend unit tests with `pnpm --filter frontend test app/audit/page.test.tsx features/console/api/useDecide.test.ts` and all selected tests passed (`2 files, 10 tests` passed). 
- An earlier attempt with incorrect test path failed due to no files matching the provided globs, but the corrected command above succeeded. 
- Launched the frontend dev server and exercised the `/audit` page to validate runtime behavior (server started and page compiled during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ca86c2b883269909bb6f1748776e)