### PR TITLE
Harden CORS settings: forbid wildcard origin with credentials (M-1)

### DIFF
--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -1342,3 +1342,21 @@ def test_decide_failure_publishes_sse_event(monkeypatch):
     item = subscriber.get(timeout=0.5)
     assert item["type"] == "decide.completed"
     assert item["payload"]["ok"] is False
+
+
+def test_resolve_cors_settings_rejects_wildcard_credentials():
+    """Wildcard origins must never enable credentialed CORS responses."""
+    origins, allow_credentials = server._resolve_cors_settings(["*"])
+
+    assert origins == ["*"]
+    assert allow_credentials is False
+
+
+def test_resolve_cors_settings_allows_explicit_origins_only():
+    """Explicit origin list enables credentials and strips invalid entries."""
+    origins, allow_credentials = server._resolve_cors_settings(
+        ["https://example.com", "", None, " https://app.example.com "],
+    )
+
+    assert origins == ["https://example.com", "https://app.example.com"]
+    assert allow_credentials is True


### PR DESCRIPTION
### Motivation
- The review item M-1 flagged a risky combination where `cors_allow_origins` can be `["*"]` while credentialed CORS is enabled, which can leak credentials in browser contexts. 

### Description
- Added `_resolve_cors_settings(origins: Any) -> tuple[list[str], bool]` in `veritas_os/api/server.py` to normalize origin values, filter invalid entries, and decide a safe `allow_credentials` flag with a docstring explaining the security rationale. 
- When a wildcard origin (`"*"`) is detected the resolver now forces `allow_credentials=False` and emits a warning log to avoid the insecure `"*" + credentials` combination. 
- Replaced the previous `bool(_cors_origins)` logic with the resolved `(origins, allow_credentials)` pair when initializing `CORSMiddleware`. 
- Added unit tests in `veritas_os/tests/test_api_server_extra.py` that verify wildcard behavior and explicit-origin normalization and credential enabling. 

### Testing
- Ran `pytest -q veritas_os/tests/test_api_server_extra.py -k cors_settings` which executed the new CORS-focused tests and they passed (`2 passed, 55 deselected`).
- Ran full file tests with `pytest -q veritas_os/tests/test_api_server_extra.py` and the suite passed (`57 passed`).
- The new function includes a docstring and the change is limited to the API server CORS initialization and tests, with PEP8-style formatting and no modifications to other subsystem responsibilities.
- Security note: existing deployments that rely on `cors_allow_origins=["*"]` with credentialed flows will stop sending credentials by design and should migrate to an explicit origin list to retain credentialed behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d25fef088326be37c7f70984f5a1)