### PR TITLE
Harden governance policy patch validation

### DIFF
--- a/veritas_os/tests/test_governance_api.py
+++ b/veritas_os/tests/test_governance_api.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 os.environ["VERITAS_API_KEY"] = "test-governance-key"
 
@@ -190,6 +191,17 @@ class TestGovernanceModule:
         with patch.object(gov_mod, "_DEFAULT_POLICY_PATH", p):
             result = gov_mod.update_policy({"version": "custom_v9"})
         assert result["version"] == "custom_v9"
+
+    def test_update_policy_rejects_non_object_nested_patch(self):
+        """Nested governance sections must be provided as objects."""
+        with pytest.raises(ValueError, match="fuji_rules must be an object"):
+            gov_mod.update_policy({"fuji_rules": True})
+
+    def test_update_policy_validates_merged_nested_patch(self):
+        """Merged nested section is validated before assignment and save."""
+        with pytest.raises(ValidationError):
+            gov_mod.update_policy({"risk_thresholds": {"allow_upper": 1.5}})
+
 
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Address M-2 from the code review by preventing partial-update patches from bypassing Pydantic validation for governance policy sections.
- Prevent silent acceptance of non-object nested patches which could lead to inconsistent in-memory state or invalid persisted policy.
- Keep changes scoped to the Governance API surface without touching unrelated subsystems.

### Description
- Added `_NESTED_POLICY_MODELS` and changed `update_policy()` in `veritas_os/api/governance.py` to deep-merge each nested section (`fuji_rules`, `risk_thresholds`, `auto_stop`, `log_retention`) and immediately validate the merged section with the corresponding Pydantic model via `model_validate()` before assignment.
- `update_policy()` now raises a `ValueError` when a nested patch value is not an object, replacing the previous silent-skip behavior.
- Kept final full-policy validation (`GovernancePolicy.model_validate`) and persistence behavior unchanged, and limited edits to `veritas_os/api/governance.py` and tests in `veritas_os/tests/test_governance_api.py`.

### Testing
- Added tests `test_update_policy_rejects_non_object_nested_patch` and `test_update_policy_validates_merged_nested_patch` and imported `ValidationError` in `veritas_os/tests/test_governance_api.py` to cover the new behaviors.
- Ran `pytest -q veritas_os/tests/test_governance_api.py` and all tests passed: `27 passed`.

Security note: this reduces validation bypass risk for governance patches, but API-layer exception-to-HTTP mapping should be reviewed to ensure error details are not over-exposed to callers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d72fec2483268d227fd0cf2f2b5a)