### PR TITLE
M-7対応: QA検出にクエリ長ガードを追加

### DIFF
--- a/veritas_os/core/kernel_qa.py
+++ b/veritas_os/core/kernel_qa.py
@@ -69,6 +69,10 @@ AGI_BLOCK_KEYWORDS = [
     "プロトagi", "proto-agi",
 ]
 
+# 正規表現評価前に許容するクエリ長の上限。
+# 極端に長い入力によるCPU/メモリ負荷を抑止する。
+MAX_QA_QUERY_LENGTH = 10_000
+
 
 def detect_simple_qa(q: str) -> str | None:
     """
@@ -81,6 +85,9 @@ def detect_simple_qa(q: str) -> str | None:
         検出されたQA種別（"time", "weekday", "date"）または None
     """
     q = (q or "").strip()
+    if len(q) > MAX_QA_QUERY_LENGTH:
+        return None
+
     ql = q.lower()
 
     # AGI関連クエリはブロック
@@ -271,6 +278,8 @@ def detect_knowledge_qa(q: str) -> bool:
         知識QAとして処理すべきかどうか
     """
     q = (q or "").strip()
+    if len(q) > MAX_QA_QUERY_LENGTH:
+        return False
 
     if len(q) < 4:
         return False

--- a/veritas_os/tests/test_kernel_core.py
+++ b/veritas_os/tests/test_kernel_core.py
@@ -69,6 +69,15 @@ def test_detect_simple_qa_mixed_language_and_spacing():
     assert kernel._detect_simple_qa("what day is it today??") == "weekday"
     assert kernel._detect_simple_qa("What is the date today?") == "date"
 
+
+
+def test_detect_qa_query_length_guard():
+    """過剰に長いクエリはQA検出をスキップすることを確認。"""
+    long_query = "a" * 10001
+
+    assert kernel._detect_simple_qa(long_query) is None
+    assert kernel._detect_knowledge_qa(long_query) is False
+
 def test_detect_knowledge_qa_patterns():
     # 「〜とは？」系
     assert kernel._detect_knowledge_qa("東京とは？") is True


### PR DESCRIPTION
### Motivation
- コードレビュー指摘 M-7（クエリ長バリデーション欠如）に対応するため、正規表現評価前に過度に長いクエリを早期に弾くガードを追加し、CPU/メモリ負荷によるDoSリスクを低減しました。 
- 変更はQA検出ロジック（simple/knowledge QA 判定）に限定し、Kernelの責務範囲内で実施しています。 
- 固定閾値 `MAX_QA_QUERY_LENGTH` を導入するため、運用環境に応じた閾値の監視・調整が必要であることに注意してください。 

### Description
- `veritas_os/core/kernel_qa.py` に `MAX_QA_QUERY_LENGTH = 10_000` を追加しました。 
- `detect_simple_qa()` の冒頭で `len(q) > MAX_QA_QUERY_LENGTH` の場合に早期に `None` を返すガードを追加しました。 
- `detect_knowledge_qa()` の冒頭で `len(q) > MAX_QA_QUERY_LENGTH` の場合に早期に `False` を返すガードを追加しました。 
- `veritas_os/tests/test_kernel_core.py` に `test_detect_qa_query_length_guard` を追加して、10001文字の入力がそれぞれスキップされることを検証しました。 
- 変更点はQA検出箇所のみに限定しており、既存のdocstring保持とPEP8準拠を意識して実装しています。 

### Testing
- 実行したコマンド: `pytest -q veritas_os/tests/test_kernel_core.py -k 'detect_simple_qa_patterns or detect_simple_qa_mixed_language_and_spacing or detect_knowledge_qa_patterns or detect_qa_query_length_guard'`. 
- 結果: `4 passed, 8 deselected`, すべての実行対象テストが成功しました。 
- 追加テストは単体のガード動作を確認するもので、他モジュールの責務や動作には影響しないことを確認しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a422bd0c5c83269f671521e0c1b74c)