### PR TITLE
Fix race condition in persona bias auto-adjust updates (M-8)

### DIFF
--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -1080,33 +1080,34 @@ async def decide(
     # 学習＋AGIゴール自己調整
     if not fast_mode and not ctx.get("_agi_goals_adjusted_by_pipeline"):
         try:
-            persona2 = adapt.update_persona_bias_from_history(window=50)
+            with adapt.PERSONA_UPDATE_LOCK:
+                persona2 = adapt.update_persona_bias_from_history(window=50)
 
-            b = dict(persona2.get("bias_weights") or {})
-            key = (chosen.get("title") or "").strip().lower() or f"@id:{chosen.get('id')}"
-            if key:
-                b[key] = b.get(key, 0.0) + 0.05
+                b = dict(persona2.get("bias_weights") or {})
+                key = (chosen.get("title") or "").strip().lower() or f"@id:{chosen.get('id')}"
+                if key:
+                    b[key] = b.get(key, 0.0) + 0.05
 
-            s = sum(b.values()) or 1.0
-            b = {kk: vv / s for kk, vv in b.items()}
-            b = adapt.clean_bias_weights(b)
+                s = sum(b.values()) or 1.0
+                b = {kk: vv / s for kk, vv in b.items()}
+                b = adapt.clean_bias_weights(b)
 
-            world_snap: Dict[str, Any] = {}
-            if isinstance(world_sim, dict):
-                world_snap = dict(world_sim)
+                world_snap: Dict[str, Any] = {}
+                if isinstance(world_sim, dict):
+                    world_snap = dict(world_sim)
 
-            value_ema = float(telos_score)
-            fuji_risk = float(fuji_result.get("risk", 0.05))
+                value_ema = float(telos_score)
+                fuji_risk = float(fuji_result.get("risk", 0.05))
 
-            new_bias = agi_goals.auto_adjust_goals(
-                bias_weights=b,
-                world_snap=world_snap,
-                value_ema=value_ema,
-                fuji_risk=fuji_risk,
-            )
+                new_bias = agi_goals.auto_adjust_goals(
+                    bias_weights=b,
+                    world_snap=world_snap,
+                    value_ema=value_ema,
+                    fuji_risk=fuji_risk,
+                )
 
-            persona2["bias_weights"] = new_bias
-            adapt.save_persona(persona2)
+                persona2["bias_weights"] = new_bias
+                adapt.save_persona(persona2)
 
             extras.setdefault("agi_goals", {})
             extras["agi_goals"]["last_auto_adjust"] = {


### PR DESCRIPTION
### Motivation
- docs/review/CODE_REVIEW_2026_02_27_FULL_JP.md の M-8 指摘に従い、並行 `decide()` 呼び出し時に `bias_weights` の read-modify-write が競合して上書きされる問題を防止するための修正。

### Description
- 追加: プロセス内での再入可能ロック `PERSONA_UPDATE_LOCK` を `veritas_os/core/adapt.py` に導入し、`update_persona_bias_from_history()` をこのロック下で実行するように変更した。
- 保護: `veritas_os/core/kernel.py` と `veritas_os/core/kernel_stages.py` のゴール自動調整→重み更新→`save_persona()` を同一ロックで囲むことで、同一プロセス内での競合を抑止した。
- テスト: `veritas_os/tests/test_adapt.py` に `test_update_persona_bias_from_history_uses_lock` を追加して、ロックが実行され保存が行われることを検証した。
- ドキュメント: `update_persona_bias_from_history()` にノートを追加し、修正の意図と注意点（プロセス間ロックは導入していない）を明記した。

### Testing
- 実行: `pytest -q veritas_os/tests/test_adapt.py veritas_os/tests/test_kernel_stages.py -q` を実行し、対象テストは全て成功（100%）。
- 対象ファイル: `veritas_os/core/adapt.py`, `veritas_os/core/kernel.py`, `veritas_os/core/kernel_stages.py`, `veritas_os/tests/test_adapt.py` の変更に対して自動テストが通過した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43d1cb8348326ad2a08430e489c7a)