### PR TITLE
Harden evidence.collect_local against non-list `goals` (M-9)

### DIFF
--- a/veritas_os/tests/test_evidence_extra.py
+++ b/veritas_os/tests/test_evidence_extra.py
@@ -140,6 +140,25 @@ class TestCollectLocal:
         )
         assert not any(e["kind"] == "stakes" for e in result)
 
+    def test_goals_none_is_safe(self):
+        """None goals should not raise and should use fallback evidence."""
+        result = ev_mod.collect_local(
+            intent="test",
+            query="test query",
+            context={"goals": None},
+        )
+        assert len(result) >= 1
+        assert not any(e["kind"] == "fatigue" for e in result)
+
+    def test_goals_scalar_is_safe(self):
+        """Scalar goals should be normalized without TypeError."""
+        result = ev_mod.collect_local(
+            intent="test",
+            query="test query",
+            context={"goals": 123},
+        )
+        assert len(result) >= 1
+
 
 class TestStep1MinimumEvidence:
     """Tests for step1_minimum_evidence function."""


### PR DESCRIPTION
### Motivation
- Fix review item M-9 by preventing `TypeError` when `context["goals"]` is `None`, a scalar, or a mixed iterable so the evidence stage cannot crash on malformed context.
- Improve robustness of `collect_local()` heuristics that previously assumed `goals` was an iterable of strings.
- Security note: normalizing large or unbounded iterables can be a DoS vector, so callers should cap `goals` size if untrusted data is expected.

### Description
- Add `_normalize_goals(raw_goals: Any) -> List[str]` with a docstring to coerce `None`, scalars, strings, and generic iterables into a sanitized `List[str]` and filter out empty/None items in `veritas_os/core/evidence.py`.
- Update `collect_local()` to call `_normalize_goals(ctx.get("goals"))` and use the normalized list in the fatigue/health heuristic; also add `Iterable` to imports for typing.
- Add regression tests in `veritas_os/tests/test_evidence_extra.py` to cover `goals=None` and scalar `goals` inputs.

### Testing
- Ran `pytest -q veritas_os/tests/test_evidence_extra.py` and the test file passed with `20 passed`.
- The change only affects `veritas_os/core/evidence.py` and `veritas_os/tests/test_evidence_extra.py` and the added tests verify the regression behavior for malformed `goals` inputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4403795048326a4d15667e4dbe313)