### PR TITLE
Mitigate DNS rebinding TOCTOU risk in web_search endpoint calls

### DIFF
--- a/veritas_os/tests/test_web_search.py
+++ b/veritas_os/tests/test_web_search.py
@@ -471,6 +471,61 @@ def test_web_search_retries_on_timeout(monkeypatch, _bypass_ssrf) -> None:
     assert resp["results"][0]["title"] == "Result 1"
 
 
+def test_post_with_retry_blocks_dns_rebinding_mismatch(monkeypatch) -> None:
+    """DNS再解決結果が事前検証と不一致なら送信前に遮断する。"""
+    monkeypatch.setattr(web_search_mod, "WEBSEARCH_MAX_RETRIES", 1, raising=False)
+
+    called = {"value": False}
+
+    def fake_post(*_args: Any, **_kwargs: Any) -> DummyResponse:
+        called["value"] = True
+        return DummyResponse({"organic": []})
+
+    monkeypatch.setattr(web_search_mod.requests, "post", fake_post)
+
+    with pytest.raises(ValueError, match="DNS result changed"):
+        web_search_mod._post_with_retry(
+            "https://example.com/search",
+            headers={"X-API-KEY": "k"},
+            payload={"q": "test", "num": 1},
+            timeout=5,
+            expected_ips={"93.184.216.34"},
+        )
+
+    assert called["value"] is False
+
+
+def test_web_search_returns_unavailable_on_preflight_dns_guard(monkeypatch) -> None:
+    """事前DNS検証で遮断されたURLはunavailableを返す。"""
+    monkeypatch.setattr(
+        web_search_mod,
+        "WEBSEARCH_URL",
+        "https://example.com/serper",
+        raising=False,
+    )
+    monkeypatch.setattr(web_search_mod, "WEBSEARCH_KEY", "dummy-key", raising=False)
+    monkeypatch.setattr(web_search_mod, "_is_allowed_websearch_url", lambda _url: True)
+    monkeypatch.setattr(
+        web_search_mod,
+        "_extract_public_ips_for_url",
+        lambda _url: (_ for _ in ()).throw(ValueError("boom")),
+    )
+
+    called = {"value": False}
+
+    def fake_post(*_args: Any, **_kwargs: Any) -> DummyResponse:
+        called["value"] = True
+        return DummyResponse({"organic": []})
+
+    monkeypatch.setattr(web_search_mod.requests, "post", fake_post)
+
+    resp = web_search_mod.web_search("normal query", max_results=1)
+
+    assert resp["ok"] is False
+    assert resp["error"] == "WEBSEARCH_API unavailable"
+    assert called["value"] is False
+
+
 def test_web_search_agi_query_filters_and_trims(monkeypatch, _bypass_ssrf) -> None:
     """AGI クエリではブースト + フィルタがかかる"""
     monkeypatch.setattr(
@@ -651,4 +706,3 @@ def test_web_search_rejects_too_large_response_body_without_content_length(monke
     assert response["ok"] is False
     assert response["results"] == []
     assert response["error"] == "WEBSEARCH_API error: request failed"
-

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -274,6 +274,7 @@ def _post_with_retry(
     headers: Dict[str, Any],
     payload: Dict[str, Any],
     timeout: int,
+    expected_ips: Optional[set[str]] = None,
 ) -> requests.Response:
     """外部API呼び出しを再試行しつつ実行する。
 
@@ -287,6 +288,9 @@ def _post_with_retry(
 
     for attempt in range(1, WEBSEARCH_MAX_RETRIES + 1):
         try:
+            if expected_ips is not None:
+                _validate_rebinding_guard(url, expected_ips)
+
             response = requests.post(
                 url,
                 headers=headers,
@@ -424,6 +428,63 @@ def _is_private_or_local_host(hostname: str) -> bool:
         if not ip.is_global:
             return True
     return False
+
+
+def _resolve_public_ips_uncached(hostname: str) -> set[str]:
+    """Resolve hostname without cache and require globally routable IPs.
+
+    This request-time lookup narrows DNS rebinding / TOCTOU windows between
+    endpoint validation and the outbound web-search request.
+
+    Args:
+        hostname: Endpoint hostname to resolve.
+
+    Returns:
+        Set of resolved global IP literals.
+
+    Raises:
+        ValueError: Hostname is empty, invalid, unresolvable, or non-global.
+    """
+    host = _canonicalize_hostname(hostname)
+    if _is_obviously_private_or_local_host(host):
+        raise ValueError("host is private or local")
+
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except (socket.gaierror, OSError, UnicodeError) as exc:
+        raise ValueError("host is not resolvable") from exc
+
+    resolved_ips: set[str] = set()
+    for info in infos:
+        ip_text = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_text)
+        except ValueError as exc:
+            raise ValueError("host resolved to invalid IP") from exc
+        if not ip.is_global:
+            raise ValueError("host resolved to non-global IP")
+        resolved_ips.add(str(ip))
+
+    if not resolved_ips:
+        raise ValueError("host resolved to no valid IPs")
+
+    return resolved_ips
+
+
+def _extract_public_ips_for_url(url: str) -> set[str]:
+    """Extract URL host and resolve it to global IPs without cache."""
+    parsed = urlparse((url or "").strip())
+    host = _canonicalize_hostname(parsed.hostname or "")
+    if not host:
+        raise ValueError("url has no hostname")
+    return _resolve_public_ips_uncached(host)
+
+
+def _validate_rebinding_guard(url: str, expected_ips: set[str]) -> None:
+    """Ensure request-time DNS answers match preflight-resolved IPs."""
+    current_ips = _extract_public_ips_for_url(url)
+    if current_ips != expected_ips:
+        raise ValueError("websearch endpoint DNS result changed during request")
 
 
 def _clear_private_host_cache() -> None:
@@ -773,6 +834,12 @@ def web_search(query: str, max_results: int = 5) -> Dict[str, Any]:
         logger.warning("WEBSEARCH_URL blocked by SSRF guard: %s", websearch_url)
         return unavailable_response
 
+    try:
+        resolved_websearch_ips = _extract_public_ips_for_url(websearch_url)
+    except ValueError:
+        logger.warning("WEBSEARCH_URL blocked by DNS rebinding guard: %s", websearch_url)
+        return unavailable_response
+
     # max_results の下限・上限を守る（極端値対策）
     # ★ M-15 修正: 上限を追加してリソース枯渇を防止
     mr = _sanitize_max_results(max_results)
@@ -831,6 +898,7 @@ def web_search(query: str, max_results: int = 5) -> Dict[str, Any]:
             headers=headers,
             payload=payload,
             timeout=timeout_seconds,
+            expected_ips=resolved_websearch_ips,
         )
         max_response_bytes = _sanitize_response_size_bytes(WEBSEARCH_MAX_RESPONSE_BYTES)
         response_headers = getattr(resp, "headers", {}) or {}


### PR DESCRIPTION
### Motivation
- 対象レビュー項目 `M-11` に従い、`web_search` の外部エンドポイント呼び出しにおける DNS TOCTOU / rebinding リスクを低減するための保護を追加しました。 
- 送信前の DNS 結果とリクエスト時の DNS 結果が乖離した場合は送信を中止して fail-closed とすることで SSRF リスクを抑制します。 
- スコープは `tools/web_search.py` とそのテストに限定し、Planner/Kernel/Fuji/MemoryOS の責務は超えていません。 
- スキルは利用していません（該当なし）。

### Description
- 事前/リクエスト時に未キャッシュで公開 IP のみを解決するヘルパーを追加して `web_search` 呼び出し前に公開 IP を確定するようにし、関数名は `
  _resolve_public_ips_uncached`, `_extract_public_ips_for_url`, `_validate_rebinding_guard`
  です。
- 再試行処理関数 `__post_with_retry` に `expected_ips: Optional[set[str]]` 引数を追加し、各リトライ送信前に `expected_ips` と現時点の DNS 解決結果が一致することを検証するようにしました。 
- `web_search()` 内に事前 DNS ガードを導入し、事前解決で公開 IP が得られない場合は fail-closed で `WEBSEARCH_API unavailable` を返すようにしました。 
- 上記変更に合わせてテスト `veritas_os/tests/test_web_search.py` に `DNS 再解決不一致で送信を遮断する` と `事前 DNS ガード失敗時に unavailable を返す` の 2 件を追加しました。 

### Testing
- 追加・変更したテスト群を含めて `pytest -q veritas_os/tests/test_web_search.py` を実行し、`38 passed in 2.02s` で全テストが成功しました。 
- 追加テストは `test_post_with_retry_blocks_dns_rebinding_mismatch` と `test_web_search_returns_unavailable_on_preflight_dns_guard` で、いずれも期待どおり動作しました。 
- セキュリティ注意: 本対策は DNS rebinding 窓を縮小し fail-closed を採るものであり、DNS 関連の攻撃ベクトルを完全に排除するものではないため運用上の注意（DNS 設定の管理、監査ログの監視など）が依然として必要です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44b294ab883268026451f3bf8bf32)