### PR TITLE
llm_safety のプロンプト入力サニタイズ強化（M-12）

### DIFF
--- a/veritas_os/tests/test_llm_safety.py
+++ b/veritas_os/tests/test_llm_safety.py
@@ -191,6 +191,59 @@ def test_normalize_categories_respects_non_positive_limit():
     assert normalized == []
 
 
+
+def test_sanitize_text_for_prompt_removes_controls_and_truncates():
+    """プロンプト入力サニタイズで制御文字除去と文字数制限が効く。"""
+    raw = "  hi\x00there\n\tworld  "
+    sanitized = llm_safety._sanitize_text_for_prompt(raw, max_chars=8)
+
+    assert sanitized == "hi there"
+
+
+def test_analyze_with_llm_sanitizes_text_payload(monkeypatch):
+    """LLM へ渡す payload.text はサニタイズ済みである。"""
+
+    class DummyOutputItem:
+        def __init__(self, parsed: Dict[str, Any]):
+            self.parsed = parsed
+
+    class DummyResponse:
+        def __init__(self):
+            self.output: List[DummyOutputItem] = [
+                DummyOutputItem(
+                    {
+                        "risk_score": 0.2,
+                        "categories": ["PII"],
+                        "rationale": "ok",
+                    }
+                )
+            ]
+
+        def model_dump_json(self) -> str:
+            return '{"dummy": true}'
+
+    class DummyResponses:
+        last_kwargs: Dict[str, Any] | None = None
+
+        def create(self, **kwargs: Any) -> DummyResponse:
+            DummyResponses.last_kwargs = kwargs
+            return DummyResponse()
+
+    class DummyClient:
+        def __init__(self, api_key: str | None = None):
+            self.api_key = api_key
+            self.responses = DummyResponses()
+
+    monkeypatch.setattr(llm_safety, "OpenAI", DummyClient)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-sanitize")
+
+    llm_safety._analyze_with_llm("unsafe\x00\ntext", max_categories=5)
+
+    user_message = DummyResponses.last_kwargs["input"][1]["content"]
+    assert "unsafe text" in user_message
+    assert "\x00" not in user_message
+
+
 # -----------------------------
 # run() の挙動テスト
 # -----------------------------

--- a/veritas_os/tools/llm_safety.py
+++ b/veritas_os/tools/llm_safety.py
@@ -70,6 +70,26 @@ _RE_ADDRJP = re.compile(r'(東京都|道府県|市|区|町|村).{0,20}\d')
 # 例: "山田太郎さん", "田中 様", "鈴木先生"
 _RE_NAMEJP = re.compile(r'[\u4e00-\u9fff]{2,4}\s*(?:さん|様|氏|先生|殿)')
 _RE_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_MAX_PROMPT_TEXT_CHARS = 8000
+
+
+def _sanitize_text_for_prompt(text: str, max_chars: int = _MAX_PROMPT_TEXT_CHARS) -> str:
+    """LLM へ渡すユーザー入力をプロンプト安全な文字列に正規化する。
+
+    - 制御文字を除去して、改行・タブなどを空白へ圧縮する
+    - 過大入力によるプロンプト汚染やコスト増を防ぐため文字数を上限制限する
+
+    Args:
+        text: ユーザー入力。
+        max_chars: 文字数上限（0 以下は 1 として扱う）。
+
+    Returns:
+        安全化済みの文字列。
+    """
+    safe_limit = max(1, int(max_chars))
+    cleaned = _RE_CONTROL_CHARS.sub(" ", str(text or ""))
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned[:safe_limit]
 
 
 def _norm(s: str) -> str:
@@ -236,8 +256,9 @@ def _analyze_with_llm(
         "Think in terms of OpenAI-like safety categories: PII, self_harm, illicit, violence, hate, minors, etc."
     )
 
+    sanitized_text = _sanitize_text_for_prompt(text)
     user_payload = {
-        "text": text,
+        "text": sanitized_text,
         "stakes": stakes,
         "alternatives_preview": [
             a.get("title") or a.get("description") or ""


### PR DESCRIPTION
### Motivation
- CODE_REVIEW_2026_02_27_FULL_JP の M-12 指摘（ユーザー入力を LLM プロンプトへ直接埋め込み）を緩和するための実装です。

### Description
- `veritas_os/tools/llm_safety.py` に `_sanitize_text_for_prompt` を追加し制御文字の置換、空白圧縮、トリム、文字数上限（`_MAX_PROMPT_TEXT_CHARS = 8000`）を行う docstring 付きユーティリティを実装しました。
- `_analyze_with_llm` 内で `user_payload["text"]` に生入力ではなくサニタイズ済み文字列を使うよう変更しました。
- 変更は FUJI の安全ヘッド責務内に留め、Planner/Kernel/MemoryOS の責務は越えていません。
- `veritas_os/tests/test_llm_safety.py` に `test_sanitize_text_for_prompt_removes_controls_and_truncates` と `test_analyze_with_llm_sanitizes_text_payload` を追加し docstring を伴うテストを整備しました。

### Testing
- 単体テストを実行して `pytest -q veritas_os/tests/test_llm_safety.py` を実行し、追加分を含めて `15 passed` で全て成功しました。
- テストはヒューリスティック挙動とダミーLLMクライアント経由での payload 検証をカバーしています。

注意（セキュリティ）: この変更はプロンプト埋め込み前の入力正規化による防御であり、LLM 側の完全なプロンプトインジェクション耐性や二次的攻撃を保証するものではないため、必要に応じてホワイトリスト化や出力サニタイズ、より厳格なプロンプト設計の併用を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44f0a6e148326ab01fc7398b25b6f)