### PR TITLE
chore: expand .pre-commit-config to include ruff, black, bandit, and mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,35 @@ repos:
         args:
           - --no-banner
           - --redact
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.13
+    hooks:
+      - id: ruff-check
+        args:
+          - --fix
+      - id: ruff-format
+
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        language_version: python3.11
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.10
+    hooks:
+      - id: bandit
+        args:
+          - -q
+          - -r
+          - veritas_os
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        args:
+          - --python-version=3.11
+          - --ignore-missing-imports
+        files: ^veritas_os/.*\.py$


### PR DESCRIPTION
### Motivation
- Address review item `M-16` in `docs/review/CODE_REVIEW_2026_02_27_FULL_JP.md` which flagged that `.pre-commit-config.yaml` only contained `gitleaks` and lacked quality and security hooks. 
- Improve early detection of style, type, and common security issues before commit by adding standard tooling without changing application code. 

### Description
- Updated `/.pre-commit-config.yaml` to add `ruff` (`ruff-check --fix`, `ruff-format`), `black` (pinned to `python3.11`), `bandit` (recursive scan of `veritas_os`), and `mypy` (scoped to `veritas_os/*.py`).
- Kept the original `gitleaks` hook and ensured the file remains the only modified artifact, respecting module responsibility boundaries.

### Testing
- Validated YAML syntax by running `python -c` with `yaml.safe_load` to parse `.pre-commit-config.yaml`, which succeeded (`repos: 5`).
- Attempted `pre-commit validate-config` but it failed because `pre-commit` is not installed in the environment, so full hook validation could not be performed.
- No unit tests were required for this tooling-only change and none were added.

Security note: Adding `bandit` and `gitleaks` improves automated detection of security issues and secret leaks but hooks can be bypassed locally (e.g., `--no-verify`), so enforcement in CI is recommended to remove that operational gap.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45e013bf483269cef29c7a6b9e120)