### PR TITLE
ci: tighten Bandit suppressions and add targeted nosec annotations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Bandit security scan
         run: |
           bandit -r veritas_os/core veritas_os/api veritas_os/tools \
-            -s B101,B104,B311,B404,B603,B607 \
+            -s B101 \
             --severity-level medium \
             -f txt
 

--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import re
-import subprocess
+import subprocess  # nosec B404 - subprocess use is required and hardened below
 import sys
 import time
 import uuid
@@ -1246,7 +1246,7 @@ async def decide(
                     try:
                         os.write(fd, f"\n--- Doctor started at {datetime.now(timezone.utc).isoformat()} ---\n".encode("utf-8"))
                         doctor_timeout = 300  # 5 minutes max
-                        proc = subprocess.Popen(
+                        proc = subprocess.Popen(  # nosec B603 - fixed argv list, shell disabled
                             [python_executable, "-m", "veritas_os.scripts.doctor"],
                             stdout=fd,
                             stderr=subprocess.STDOUT,

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -28,7 +28,7 @@ import inspect
 import json
 import logging
 import os
-import random
+import random  # nosec B311 - deterministic test seeding only
 import re
 import secrets
 import time

--- a/veritas_os/tools/github_adapter.py
+++ b/veritas_os/tools/github_adapter.py
@@ -9,7 +9,7 @@ GitHub Adapter for VERITAS Environment Tools
 import logging
 import math
 import os
-import random
+import random  # nosec B311 - jitter for retry backoff, not security-sensitive
 import re
 import time
 from urllib.parse import urlsplit
@@ -246,7 +246,7 @@ def _compute_backoff(
     jitter = max(retry_jitter, 0.0)
     delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
     if jitter:
-        delay += random.uniform(0, delay * jitter)
+        delay += random.uniform(0, delay * jitter)  # nosec B311 - non-cryptographic retry jitter
     return delay
 
 

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import logging
 import math
 import os
-import random
+import random  # nosec B311 - jitter for retry backoff, not security-sensitive
 import re
 import time
 import ipaddress
@@ -260,7 +260,7 @@ def _compute_backoff(attempt: int) -> float:
     jitter = max(WEBSEARCH_RETRY_JITTER, 0.0)
     delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
     if jitter:
-        delay += random.uniform(0, delay * jitter)
+        delay += random.uniform(0, delay * jitter)  # nosec B311 - non-cryptographic retry jitter
     return delay
 
 


### PR DESCRIPTION
### Motivation
- Address M-17 from the code review which flagged overly broad Bandit rule exclusions in CI to reduce security blind spots.
- Replace global suppression of many rules with a minimal global suppression and move intentional exceptions to locally documented `# nosec` annotations.
- Make exceptions auditable by providing rationale next to the code that requires a rule suppression.

### Description
- Updated CI Bandit invocation in `.github/workflows/main.yml` to only suppress `B101` (`bandit -r veritas_os/core veritas_os/api veritas_os/tools -s B101`).
- Added `# nosec B311` comments to `veritas_os/tools/web_search.py` and `veritas_os/tools/github_adapter.py` for non-cryptographic retry jitter using `random.uniform`.
- Added `# nosec B311` comment to `veritas_os/core/pipeline.py` where `random` is used for deterministic test seeding.
- Added `# nosec B404` on the `subprocess` import and `# nosec B603` on the call site of `subprocess.Popen` in `veritas_os/core/kernel.py` with the rationale that a fixed-argv, `shell=False` subprocess invocation is intentional and hardened.

### Testing
- Ran `python -m compileall` on the changed modules (`veritas_os/core/kernel.py`, `veritas_os/core/pipeline.py`, `veritas_os/tools/web_search.py`, `veritas_os/tools/github_adapter.py`) and compilation succeeded.
- Attempted to install and run `bandit` locally but `pip` installation failed due to proxy/network restrictions, so local Bandit checks could not be executed.
- CI remains configured to run the `lint` job (including Bandit) and will validate the tightened suppression and inline exceptions when the workflow runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46139e9448326b174c6822674525c)