### PR TITLE
tests: isolate VERITAS_API_KEY setup in governance API tests

### DIFF
--- a/veritas_os/tests/test_governance_api.py
+++ b/veritas_os/tests/test_governance_api.py
@@ -3,16 +3,12 @@
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
-
-os.environ["VERITAS_API_KEY"] = "test-governance-key"
 
 from veritas_os.api import governance as gov_mod
 from veritas_os.api import server as srv


### PR DESCRIPTION
### Motivation
- Address M-18 (テスト環境変数汚染) by removing module-level `os.environ["VERITAS_API_KEY"]` which can leak across test modules and instead use fixture-scoped `monkeypatch.setenv(...)` to reduce cross-test contamination and flakiness.

### Description
- Remove module-level env mutation and now-unused imports (`os`, `tempfile`) from `veritas_os/tests/test_governance_api.py` and rely on the existing autouse fixture that sets `VERITAS_API_KEY` via `monkeypatch.setenv(...)`, keeping the change test-only and PEP8-clean.

### Testing
- Ran `pytest -q veritas_os/tests/test_governance_api.py` and all tests passed: `27 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a464f198dc83269c60ab19e6c03d1e)