### PR TITLE
Improve curriculum user-task cache with LRU eviction

### DIFF
--- a/veritas_os/core/curriculum.py
+++ b/veritas_os/core/curriculum.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import threading
+from collections import OrderedDict
 from dataclasses import dataclass, asdict
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timezone
@@ -9,8 +10,14 @@ from datetime import datetime, timezone
 # 超簡易なインメモリ保存（とりあえず動かす用）
 # ★ メモリリーク防止: ユーザー数の上限を設ける
 _MAX_USERS = 1000
-_USER_TASKS: Dict[str, List["CurriculumTask"]] = {}
+_USER_TASKS: "OrderedDict[str, List[CurriculumTask]]" = OrderedDict()
 _USER_TASKS_LOCK = threading.Lock()
+
+
+def _touch_user_cache(user_id: str) -> None:
+    """Mark cached tasks for `user_id` as recently used in the LRU map."""
+    if user_id in _USER_TASKS:
+        _USER_TASKS.move_to_end(user_id)
 
 
 @dataclass
@@ -47,6 +54,7 @@ def load_tasks(user_id: str) -> List[CurriculumTask]:
     """
     with _USER_TASKS_LOCK:
         tasks = _USER_TASKS.get(user_id, [])
+        _touch_user_cache(user_id)
     today = _today_str()
     return [t for t in tasks if t.id.startswith(today)]
 
@@ -185,13 +193,12 @@ def generate_daily_curriculum(
         )
     )
 
-    # ★ メモリリーク防止: ユーザー数上限を超えたら最古のエントリを削除
-    # Python 3.7+ では dict は挿入順を保持するため、next(iter(...)) は FIFO
+    # ★ メモリリーク防止: ユーザー数上限を超えたらLRUでエントリを削除
     with _USER_TASKS_LOCK:
         if len(_USER_TASKS) >= _MAX_USERS and user_id not in _USER_TASKS:
-            oldest_key = next(iter(_USER_TASKS))
-            del _USER_TASKS[oldest_key]
+            _USER_TASKS.popitem(last=False)
         _USER_TASKS[user_id] = tasks
+        _touch_user_cache(user_id)
     return tasks
 
 
@@ -212,4 +219,3 @@ def plan_today(
         world_state=world_state,
         value_ema=value_ema,
     )
-

--- a/veritas_os/tests/test_curriculum.py
+++ b/veritas_os/tests/test_curriculum.py
@@ -234,3 +234,24 @@ def test_plan_today_generates_once_and_reuses():
     assert len(curriculum._USER_TASKS[user_id]) == 3  # type: ignore[attr-defined]
 
 
+def test_generate_daily_curriculum_evicts_least_recently_used_user():
+    """ユーザー上限到達時はLRU順で古いユーザーを退避させる。"""
+    _reset_user_tasks()
+
+    original_max_users = curriculum._MAX_USERS  # type: ignore[attr-defined]
+    curriculum._MAX_USERS = 2  # type: ignore[attr-defined]
+    try:
+        curriculum.generate_daily_curriculum("user_a")
+        curriculum.generate_daily_curriculum("user_b")
+
+        # user_a を参照して最新化する
+        assert curriculum.load_tasks("user_a")
+
+        curriculum.generate_daily_curriculum("user_c")
+
+        assert "user_a" in curriculum._USER_TASKS  # type: ignore[attr-defined]
+        assert "user_b" not in curriculum._USER_TASKS  # type: ignore[attr-defined]
+        assert "user_c" in curriculum._USER_TASKS  # type: ignore[attr-defined]
+    finally:
+        curriculum._MAX_USERS = original_max_users  # type: ignore[attr-defined]
+


### PR DESCRIPTION
### Motivation
- 対象モジュールの `_USER_TASKS` が無制限に増加し得る L-2 問題を軽減するため、古いエントリを単純削除する代わりに最近使われたユーザーを優先して残す LRU 挙動を導入しました。 
- キャッシュはプロセス内インメモリのままでありマルチワーカー間で共有されないため、ワーカー分散やプロセスメモリ使用量の観点で運用上の注意が必要です。 

### Description
- `_USER_TASKS` を `dict` から `OrderedDict` (`OrderedDict[str, List[CurriculumTask]]`) に置き換え、LRU 管理を可能にしました. 
- `_touch_user_cache(user_id: str)` ヘルパー（docstring付き）を追加し、アクセス時に `move_to_end` で使用順序を更新するようにしました。 
- `load_tasks()` で参照時に LRU を更新し、`generate_daily_curriculum()` では `_MAX_USERS` 到達時に `_USER_TASKS.popitem(last=False)` で最も古い（LRU）エントリを退避するよう変更しました。 
- LRU 仕様を検証するために `veritas_os/tests/test_curriculum.py` に `test_generate_daily_curriculum_evicts_least_recently_used_user` を追加しました。 

### Testing
- 実行コマンド `pytest -q veritas_os/tests/test_curriculum.py` を実行し、テストはすべて成功して `7 passed` でした。 
- 追加テストは一時的に `curriculum._MAX_USERS` を `2` に下げて容量圧迫時の LRU 退避動作を検証しており成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46a0b74f48326b3f10b459b1e9367)