### PR TITLE
Optimize Gemini request formatting to avoid O(n²) string growth

### DIFF
--- a/veritas_os/core/llm_client.py
+++ b/veritas_os/core/llm_client.py
@@ -295,11 +295,13 @@ def _format_request(
     if provider == LLMProvider.GOOGLE.value:
         # Gemini generateContent:
         # system + user + extra を 1 テキストにまとめる簡易実装
-        extra_text = ""
+        extra_parts: List[str] = []
         for m in extra_messages:
             role = m["role"]
             content = m["content"]
-            extra_text += f"\n\n[{role}]\n{content}"
+            extra_parts.append(f"\n\n[{role}]\n{content}")
+
+        extra_text = "".join(extra_parts)
 
         full_text = f"{system_prompt}\n\n{user_prompt}{extra_text}"
 

--- a/veritas_os/tests/test_llm_client.py
+++ b/veritas_os/tests/test_llm_client.py
@@ -174,6 +174,27 @@ def test_format_request_gemini_combines_text():
     assert "Q2" in text
 
 
+def test_format_request_gemini_many_extra_messages_keeps_order():
+    extra = [
+        {"role": "assistant", "content": f"A{i}"} for i in range(5)
+    ]
+
+    payload = _format_request(
+        provider=LLMProvider.GOOGLE,
+        system_prompt="SYS",
+        user_prompt="USER",
+        model="gemini-pro",
+        temperature=0.5,
+        max_tokens=256,
+        extra_messages=extra,
+    )
+
+    text = payload["contents"][0]["parts"][0]["text"]
+    assert "[assistant]\nA0" in text
+    assert "[assistant]\nA4" in text
+    assert text.index("A0") < text.index("A1") < text.index("A2") < text.index("A3") < text.index("A4")
+
+
 def test_format_request_ollama_with_extra_messages():
     extra = [
         {"role": "assistant", "content": "A1"},


### PR DESCRIPTION
### Motivation
- Fix the performance issue identified as L-3 in `docs/review/CODE_REVIEW_2026_02_27_FULL_JP.md` where repeated `extra_text += ...` in a loop causes quadratic-time string growth when building Gemini (`GOOGLE`) requests.

### Description
- Replace in-loop string concatenation with a `List[str]` accumulator and `"".join()` in `_format_request` for `provider == LLMProvider.GOOGLE.value` in `veritas_os/core/llm_client.py` to avoid repeated reallocations.
- Add a focused regression test `test_format_request_gemini_many_extra_messages_keeps_order()` to `veritas_os/tests/test_llm_client.py` that verifies ordering and inclusion of multiple `extra_messages` in the Gemini payload.
- Changes are limited to `veritas_os/core/llm_client.py` and the related test file only, and adhere to existing module responsibilities and coding conventions.

### Testing
- Ran `pytest -q veritas_os/tests/test_llm_client.py -k "format_request_gemini"` which reported `2 passed, 48 deselected`.
- The new test validates correct ordering and concatenation behavior and passed as part of the targeted test run.
- Note: the function still relies on the existing `extra_messages` length cap (`_MAX_EXTRA_MESSAGES`) for DoS mitigation, so changing that limit should be considered carefully in future performance/security evaluations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46ee9013083268c5590745b6a9ad2)