### PR TITLE
Prevent mutation in affect.apply_style_to_messages and add regression test

### DIFF
--- a/veritas_os/core/affect.py
+++ b/veritas_os/core/affect.py
@@ -160,19 +160,22 @@ def apply_style(prompt: str, style: Any) -> str:
 
 
 def apply_style_to_messages(messages: List[ChatMessage], style: Any) -> List[ChatMessage]:
-    """Chat messages 先頭に system 規範を差し込む。"""
+    """Chat messages 先頭に system 規範を差し込む。
+
+    入力 ``messages`` 自体は変更せず、新しいリストを返す。
+    """
     instr = style_instructions(style).strip()
     if not instr:
         return list(messages or [])
 
-    msgs = list(messages or [])
-    if msgs and msgs[0].get("role") == "system":
-        prev = msgs[0].get("content", "")
+    source_messages = list(messages or [])
+    if source_messages and source_messages[0].get("role") == "system":
+        prev = source_messages[0].get("content", "")
         merged = f"{instr}\n\n{prev}".strip() if prev else instr
-        msgs[0] = {**msgs[0], "content": merged}
-        return msgs
+        merged_first = {**source_messages[0], "content": merged}
+        return [merged_first, *source_messages[1:]]
 
-    return [{"role": "system", "content": instr}, *msgs]
+    return [{"role": "system", "content": instr}, *source_messages]
 
 
 def as_dict(state: AffectState) -> Dict[str, str]:
@@ -213,5 +216,4 @@ __all__ = [
     "generate_reason",
     "generate_reflection_template",
 ]
-
 

--- a/veritas_os/tests/test_affect_extra.py
+++ b/veritas_os/tests/test_affect_extra.py
@@ -118,6 +118,20 @@ class TestApplyStyleToMessages:
         assert "You are helpful" in result[0]["content"]
         assert "STYLE=neutral" in result[0]["content"]
 
+
+    def test_existing_system_input_is_not_mutated(self):
+        """Original input list should remain unchanged when merging system."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+
+        original_first = dict(messages[0])
+        result = affect_mod.apply_style_to_messages(messages, "neutral")
+
+        assert messages[0] == original_first
+        assert result[0] is not messages[0]
+
     def test_empty_messages(self):
         """Empty messages should get system message added."""
         result = affect_mod.apply_style_to_messages([], "warm")


### PR DESCRIPTION
### Motivation
- Fix review item L-4 by removing an unexpected side effect where `apply_style_to_messages` could mutate caller-provided message dictionaries when the first message was a `system` message, improving API safety.

### Description
- Change `veritas_os/core/affect.py` so `apply_style_to_messages` returns a new list and constructs a fresh first-message dict when merging system instructions, and update the docstring to state the immutability guarantee.
- Add `test_existing_system_input_is_not_mutated` to `veritas_os/tests/test_affect_extra.py` to assert the original input is unchanged and the returned first message is a distinct object.

### Testing
- Ran `pytest -q veritas_os/tests/test_affect_extra.py` and all tests passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4cadff50c8326bed5801dc65f4318)