### PR TITLE
Remove unused locals in code_planner.generate_code_change_plan (fix L-5)

### DIFF
--- a/veritas_os/core/code_planner.py
+++ b/veritas_os/core/code_planner.py
@@ -263,9 +263,6 @@ def generate_code_change_plan(
     tests: List[TestSuggestion] = []
 
     progress = _safe_float(world_snap.get("progress"), 0.0)
-    _decision_count = int(world_snap.get("decision_count") or 0)  # noqa: F841
-    _last_risk = _safe_float(world_snap.get("last_risk"), 0.3)  # noqa: F841
-
     # --- ターゲット選定（どのモジュールを触るか） ---
 
     # 1) world_model 関連 (進捗・hint・snapshot周り)


### PR DESCRIPTION
### Motivation
- 対象ドキュメント `docs/review/CODE_REVIEW_2026_02_27_FULL_JP.md` の L-5 指摘に対応するため、未使用のローカル変数を削除してコード品質（不要な `# noqa: F841`）を改善しました。 

### Description
- `veritas_os/core/code_planner.py` の `generate_code_change_plan` から未使用のローカル変数 `_decision_count` と `_last_risk` を削除し、動作に影響を与えないクリーンアップを行いました。 

### Testing
- 実行した自動テスト: `pytest -q veritas_os/tests/test_code_planner.py`, 結果: `9 passed` (成功)。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4cd2615d483268d70038334dd582a)