### PR TITLE
Centralize web_search timeout defaults and configurable max

### DIFF
--- a/veritas_os/tests/test_web_search.py
+++ b/veritas_os/tests/test_web_search.py
@@ -105,6 +105,16 @@ def test_sanitize_timeout_seconds_clamps_values() -> None:
     assert web_search_mod._sanitize_timeout_seconds("abc") == 15
 
 
+def test_sanitize_timeout_seconds_respects_configurable_max(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_WEBSEARCH_TIMEOUT_MAX", "45")
+    reloaded = importlib.reload(web_search_mod)
+    try:
+        assert reloaded._sanitize_timeout_seconds(120) == 45
+    finally:
+        monkeypatch.delenv("VERITAS_WEBSEARCH_TIMEOUT_MAX", raising=False)
+        importlib.reload(reloaded)
+
+
 def test_sanitize_response_size_bytes_clamps_values() -> None:
     assert web_search_mod._sanitize_response_size_bytes(100) == 1024
     assert web_search_mod._sanitize_response_size_bytes(9_999_999) == 2_000_000

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -186,6 +186,18 @@ WEBSEARCH_TIMEOUT_SECONDS = _safe_int_with_bounds(
     1,
     300,
 )
+WEBSEARCH_TIMEOUT_DEFAULT_SECONDS = _safe_int_with_bounds(
+    "VERITAS_WEBSEARCH_TIMEOUT_DEFAULT",
+    15,
+    1,
+    60,
+)
+WEBSEARCH_TIMEOUT_MAX_SECONDS = _safe_int_with_bounds(
+    "VERITAS_WEBSEARCH_TIMEOUT_MAX",
+    60,
+    1,
+    300,
+)
 WEBSEARCH_MAX_RESPONSE_BYTES = _safe_int_with_bounds(
     "VERITAS_WEBSEARCH_MAX_RESPONSE_BYTES",
     500_000,
@@ -683,13 +695,21 @@ def _sanitize_max_results(max_results: Any, *, default: int = 5) -> int:
     return min(max(result, 1), 100)
 
 
-def _sanitize_timeout_seconds(timeout_seconds: Any, *, default: int = 15) -> int:
-    """HTTP timeout(秒)を安全な範囲に丸める。"""
+def _sanitize_timeout_seconds(
+    timeout_seconds: Any,
+    *,
+    default: int = WEBSEARCH_TIMEOUT_DEFAULT_SECONDS,
+) -> int:
+    """HTTP timeout(秒)を安全な範囲に丸める。
+
+    L-6 対応として、デフォルト値と上限値はモジュール定数で一元化し、
+    マジックナンバーの散在を防ぐ。
+    """
     try:
         timeout = int(timeout_seconds)
     except (TypeError, ValueError):
         timeout = default
-    return min(max(timeout, 1), 60)
+    return min(max(timeout, 1), WEBSEARCH_TIMEOUT_MAX_SECONDS)
 
 
 def _sanitize_response_size_bytes(


### PR DESCRIPTION
### Motivation
- Address review item `L-6` by removing scattered timeout magic numbers and centralizing default and max timeout values for the web search adapter.
- Make timeout tuning safer and more maintainable by allowing environment overrides while keeping sensible bounds.

### Description
- Added `WEBSEARCH_TIMEOUT_DEFAULT_SECONDS` and `WEBSEARCH_TIMEOUT_MAX_SECONDS` (env-overridable via `VERITAS_WEBSEARCH_TIMEOUT_DEFAULT` and `VERITAS_WEBSEARCH_TIMEOUT_MAX`) to `veritas_os/tools/web_search.py` to centralize timeout configuration.
- Updated `_sanitize_timeout_seconds()` to use the new `WEBSEARCH_TIMEOUT_DEFAULT_SECONDS` as the default and to clamp values against `WEBSEARCH_TIMEOUT_MAX_SECONDS`, and expanded the function docstring to explain the change.
- Added a unit test `test_sanitize_timeout_seconds_respects_configurable_max` to `veritas_os/tests/test_web_search.py` to verify that changing the `VERITAS_WEBSEARCH_TIMEOUT_MAX` env var is respected after module reload.
- Changes are scoped to `veritas_os/tools/web_search.py` and related tests only, and include a docstring; no cross-cutting responsibility changes were made.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search.py::test_sanitize_timeout_seconds_clamps_values veritas_os/tests/test_web_search.py::test_sanitize_timeout_seconds_respects_configurable_max` and both tests passed (`2 passed`).
- Ran `pytest -q veritas_os/tests/test_web_search.py veritas_os/tests/test_web_search_extra.py` and the suite passed (`100 passed`).

Security note: allowing an env-overridable timeout max increases the need for operational discipline, but the value is constrained by `_safe_int_with_bounds(..., 1, 300)` and the sanitize clamp, which prevents unbounded waits and reduces resource-exhaustion risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d3dbf0b083268169cfa9a240a319)