### PR TITLE
Normalize Dockerfile requirements copy/install path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY veritas_os/requirements.txt ./requirements.txt
+COPY ./veritas_os/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
+    && pip install --no-cache-dir -r /tmp/requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
### Motivation
- Address L-7 from the code review by making the source path for Python dependencies explicit during the image build, and no skill was required because this is a localized Dockerfile fix.

### Description
- Change `COPY veritas_os/requirements.txt ./requirements.txt` to `COPY ./veritas_os/requirements.txt /tmp/requirements.txt` and update `pip install -r` to use `/tmp/requirements.txt`, which removes working-directory ambiguity for the build-time dependency installation and leaves runtime behavior unchanged while noting a remaining supply-chain risk that should be mitigated by pinning/locking dependencies.

### Testing
- Executed `git diff --check`, `git status --short`, and `git diff -- Dockerfile`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d6303be88326aa9cc2821f066b0b)