### PR TITLE
fix(docker): ensure PID 1 signal handling with exec-form uvicorn and STOPSIGNAL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
-CMD ["python", "-m", "uvicorn", "veritas_os.api.server:app", "--host", "0.0.0.0", "--port", "8000"]
+STOPSIGNAL SIGTERM
+CMD ["uvicorn", "veritas_os.api.server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
### Motivation
- Address review item L-8 from `docs/review/CODE_REVIEW_2026_02_27_FULL_JP.md` by fixing Docker CMD so the application receives container signals correctly.

### Description
- Modify `Dockerfile` to add `STOPSIGNAL SIGTERM` and change the `CMD` from `["python", "-m", "uvicorn", ...]` to the exec-form `["uvicorn", "veritas_os.api.server:app", ...]` so `uvicorn` runs as PID 1.

### Testing
- Validated the change by running `git diff -- Dockerfile` and inspecting the resulting `Dockerfile` with `nl -ba Dockerfile`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d959b618832691d9df4d225a6f40)