### PR TITLE
Unify LLM response parse errors with structured format

### DIFF
--- a/veritas_os/core/llm_client.py
+++ b/veritas_os/core/llm_client.py
@@ -161,6 +161,19 @@ def _redact_response_preview(response_text: Optional[str], limit: int = 200) -> 
     return _redact_text(response_text[:limit])
 
 
+def _format_llm_error(code: str, detail: str) -> str:
+    """Create a structured, consistent LLM error message.
+
+    Args:
+        code: Machine-readable error code.
+        detail: Human-readable detail message.
+
+    Returns:
+        Formatted error string following a single convention.
+    """
+    return f"{code}: {detail}"
+
+
 # =========================
 # Affect 注入
 # =========================
@@ -360,14 +373,24 @@ def _parse_response(provider: str, data: Dict[str, Any]) -> str:
         try:
             return data["content"][0]["text"]
         except (KeyError, IndexError, TypeError) as e:
-            raise LLMError(f"Anthropic response parse error: {type(e).__name__}") from e
+            raise LLMError(
+                _format_llm_error(
+                    "LLM_PARSE_ERROR",
+                    f"provider=anthropic cause={type(e).__name__}",
+                )
+            ) from e
 
     if provider == LLMProvider.GOOGLE.value:
         # Gemini: {"candidates":[{"content":{"parts":[{"text":"..."}]}}]}
         try:
             return data["candidates"][0]["content"]["parts"][0]["text"]
         except (KeyError, IndexError, TypeError) as e:
-            raise LLMError(f"Gemini response parse error: {type(e).__name__}") from e
+            raise LLMError(
+                _format_llm_error(
+                    "LLM_PARSE_ERROR",
+                    f"provider=google cause={type(e).__name__}",
+                )
+            ) from e
 
     if provider == LLMProvider.OLLAMA.value:
         # Ollama chat: {"message":{"role":"assistant","content":"..."}}
@@ -376,13 +399,23 @@ def _parse_response(provider: str, data: Dict[str, Any]) -> str:
             return data["message"].get("content", "")
         if "choices" in data and data["choices"]:
             return data["choices"][0]["message"]["content"]
-        raise LLMError("Ollama response format not recognized")
+        raise LLMError(
+            _format_llm_error(
+                "LLM_PARSE_ERROR",
+                "provider=ollama cause=UnexpectedResponseShape",
+            )
+        )
 
     # OpenAI / OpenRouter 互換
     try:
         return data["choices"][0]["message"]["content"]
     except (KeyError, IndexError, TypeError) as e:
-        raise LLMError(f"OpenAI-like response parse error: {type(e).__name__}") from e
+        raise LLMError(
+            _format_llm_error(
+                "LLM_PARSE_ERROR",
+                f"provider=openai_like cause={type(e).__name__}",
+            )
+        ) from e
 
 
 def _get_headers(provider: str) -> Dict[str, str]:

--- a/veritas_os/tests/test_llm_client.py
+++ b/veritas_os/tests/test_llm_client.py
@@ -284,18 +284,29 @@ def test_parse_response_various_providers(provider, data, expected):
 
 
 def test_parse_response_anthropic_invalid_raises():
-    with pytest.raises(LLMError):
+    with pytest.raises(LLMError, match=r"^LLM_PARSE_ERROR: provider=anthropic cause=IndexError$"):
         _parse_response(LLMProvider.ANTHROPIC, {"content": []})
 
 
 def test_parse_response_gemini_invalid_raises():
-    with pytest.raises(LLMError):
+    with pytest.raises(LLMError, match=r"^LLM_PARSE_ERROR: provider=google cause=IndexError$"):
         _parse_response(LLMProvider.GOOGLE, {"candidates": []})
 
 
 def test_parse_response_ollama_invalid_raises():
-    with pytest.raises(LLMError):
+    with pytest.raises(
+        LLMError,
+        match=r"^LLM_PARSE_ERROR: provider=ollama cause=UnexpectedResponseShape$",
+    ):
         _parse_response(LLMProvider.OLLAMA, {})
+
+
+def test_parse_response_openai_like_invalid_raises_structured_message():
+    with pytest.raises(
+        LLMError,
+        match=r"^LLM_PARSE_ERROR: provider=openai_like cause=KeyError$",
+    ):
+        _parse_response(LLMProvider.OPENAI, {})
 
 
 # ------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- `docs/review/CODE_REVIEW_2026_02_27_FULL_JP.md` の L-9 で指摘された `veritas_os/core/llm_client.py` におけるエラーメッセージの不統一を解消して運用・監視の一貫性を高めるため。 
- エラー出力が生のAPIレスポンスを含まない既存の安全方針を維持しつつ、解析失敗の原因を構造化して観測性を改善する必要があったため。 
- 構造化メッセージにより自動集計やアラートルールが簡潔に作成できる利点があるため。 
- 注意: 新フォーマットは `provider` と `cause` を明示的に露出するため、ログ閲覧権限の最小化など運用上のアクセス管理を継続する必要がある。 

### Description
- `veritas_os/core/llm_client.py` に `_format_llm_error(code, detail)` ヘルパーを追加し、docstring を付けてエラーメッセージ生成を統一した。 
- `_parse_response()` のパース失敗分岐（Anthropic / Google(Gemini) / Ollama / OpenAI-like）を変更して、`LLM_PARSE_ERROR: provider=<provider> cause=<ErrorType>` という一貫した構造化メッセージを返すようにした。 
- `veritas_os/tests/test_llm_client.py` の該当テストを更新および拡張して、各プロバイダーの不正ペイロード時に期待する構造化エラーメッセージが発生することを `pytest.raises(..., match=...)` で検証するようにした。 
- 変更は docstring を付与し PEP8 準拠で実装し、既存方針通り生のAPI応答はエラーに含めない実装を維持した。 

### Testing
- `pytest -q veritas_os/tests/test_llm_client.py` を実行し `51 passed` を確認した。 
- 変更は該当ユニットテスト群で自動検証され成功している。 
- フルテストスイートは今回実行しておらず、必要に応じて追加回帰テストを推奨する。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4de380e748326940d73dac9968c77)