### PR TITLE
Accept uppercase SHA-256 in trust_log parsing

### DIFF
--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -38,7 +38,7 @@ except Exception as _import_err:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
-_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
 
 # trust_log の JSON/JSONL は LOG_DIR 直下に置く
 LOG_JSON = LOG_DIR / "trust_log.json"

--- a/veritas_os/tests/test_trust_log.py
+++ b/veritas_os/tests/test_trust_log.py
@@ -237,6 +237,14 @@ def test_extract_last_sha256_from_lines_ignores_invalid_entries():
     assert trust_log._extract_last_sha256_from_lines(lines) == valid_hash
 
 
+
+
+def test_extract_last_sha256_from_lines_accepts_uppercase_hex():
+    uppercase_hash = "A" * 64
+    lines = [json.dumps({"sha256": uppercase_hash})]
+
+    assert trust_log._extract_last_sha256_from_lines(lines) == uppercase_hash
+
 def test_extract_last_sha256_from_lines_falls_back_to_non_hex_sha256():
     lines = [
         json.dumps({"sha256": "g" * 64}),


### PR DESCRIPTION
### Motivation
- 対象レビュー項目 `L-10` の指摘に対応するため、`trust_log` の末尾から抽出する SHA-256 判定で大文字 16 進を拒否していた不具合を修正し、互換性を回復します（正規表現を大文字/小文字を区別しないものに変更しても信頼境界は拡張されないためセキュリティリスクはありません）。

### Description
- `veritas_os/logging/trust_log.py` の `_SHA256_HEX_RE` を `re.IGNORECASE` 付きでコンパイルするよう変更しました（`re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)`）。
- 回帰防止のため `veritas_os/tests/test_trust_log.py` に `test_extract_last_sha256_from_lines_accepts_uppercase_hex` を追加しました。

### Testing
- 実行した自動テスト: `pytest -q veritas_os/tests/test_trust_log.py -k extract_last_sha256_from_lines` が成功し `3 passed` でした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e06cddf08326808e1dcf31a7fa91)