### PR TITLE
fix(frontend): prevent stale audit request_id search updates

### DIFF
--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@veritas/design-system";
 import { isRequestLogResponse, isTrustLogsResponse, type RequestLogResponse, type TrustLogItem } from "../../lib/api-validators";
 import { useI18n } from "../../components/i18n-provider";
@@ -138,6 +138,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
   const [reportEndDate, setReportEndDate] = useState("");
   const [reportError, setReportError] = useState<string | null>(null);
   const [latestReport, setLatestReport] = useState<RegulatoryReport | null>(null);
+  const requestSearchNonceRef = useRef(0);
 
   const stageOptions = useMemo(() => {
     const stages = new Set<string>();
@@ -490,6 +491,8 @@ export default function TrustLogExplorerPage(): JSX.Element {
 
   const searchByRequestId = async (): Promise<void> => {
     const value = requestId.trim();
+    requestSearchNonceRef.current += 1;
+    const requestNonce = requestSearchNonceRef.current;
     setRequestResult(null);
     setError(null);
     if (!value) {
@@ -507,6 +510,9 @@ export default function TrustLogExplorerPage(): JSX.Element {
       }
 
       const payload: unknown = await response.json();
+      if (requestNonce !== requestSearchNonceRef.current) {
+        return;
+      }
       if (!isRequestLogResponse(payload)) {
         setError(t("レスポンス形式エラー: request_id 応答の形式が不正です。", "Response format error: request_id payload is invalid."));
         return;
@@ -516,13 +522,18 @@ export default function TrustLogExplorerPage(): JSX.Element {
         setSelected(payload.items[payload.items.length - 1]);
       }
     } catch (caught: unknown) {
+      if (requestNonce !== requestSearchNonceRef.current) {
+        return;
+      }
       if (caught instanceof DOMException && caught.name === "AbortError") {
         setError(t("タイムアウト: request_id 検索が時間内に完了しませんでした。", "Timeout: request_id search did not complete in time."));
         return;
       }
       setError(t("ネットワークエラー: request_id 検索に失敗しました。", "Network error: failed to search request_id."));
     } finally {
-      setLoading(false);
+      if (requestNonce === requestSearchNonceRef.current) {
+        setLoading(false);
+      }
     }
   };
 


### PR DESCRIPTION
### Motivation

- Address L-11 in `docs/review/CODE_REVIEW_2026_02_27_FULL_JP.md` which reported a race condition in frontend request_id searches where out-of-order responses could overwrite newer UI state. 
- Improve UI correctness during audit investigations by ensuring only the latest search updates state while keeping the change scoped to the frontend.

### Description

- Add a monotonic request nonce via `useRef` (`requestSearchNonceRef`) in `frontend/app/audit/page.tsx` and import `useRef`.
- Increment the nonce at each `searchByRequestId()` invocation and capture it as `requestNonce` to identify the current request.
- After `response.json()` and inside `catch`/`finally`, ignore results or state updates when `requestNonce !== requestSearchNonceRef.current`, and only clear the `loading` state if the completing request matches the latest nonce.
- Change surface is limited to `frontend/app/audit/page.tsx` and does not alter backend responsibilities or core modules.

### Testing

- Ran the audit page unit tests with Vitest: `cd frontend && pnpm -s vitest run app/audit/page.test.tsx`, and the test file passed (8 tests passed). 
- Verified the UI test scenario for stale-out-of-order responses during development; the implementation prevents stale responses from overwriting newer results.

Security note: this is a client-side mitigation to UI inconsistency; backend validation and audit integrity guarantees must still be enforced server-side to prevent authoritative data races or tampering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e20a1de08326a048c2e136ce7f02)