### PR TITLE
frontend: add exponential backoff + jitter for SSE reconnect and tests

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -17,6 +17,7 @@ function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
 
 describe("LiveEventStream", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -59,6 +60,26 @@ describe("LiveEventStream", () => {
     expect(lastCall[0]).toBe("/api/veritas/v1/events");
     expect(lastCall[1]?.headers).toBeUndefined();
     expect(screen.getByText("Security note: API key is injected server-side and never exposed to browser code.")).toBeInTheDocument();
+  });
+
+  it("uses exponential backoff with jitter for reconnect attempts", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<LiveEventStream />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+
+    vi.useRealTimers();
   });
 
   it("clears rendered events when clear button is pressed", async () => {

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -11,6 +11,19 @@ interface StreamEvent {
   payload: unknown;
 }
 
+const BASE_RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECT_DELAY_MS = 30000;
+
+function getReconnectDelayMs(attempt: number): number {
+  const boundedAttempt = Math.max(0, attempt);
+  const exponentialDelay = Math.min(
+    BASE_RECONNECT_DELAY_MS * (2 ** boundedAttempt),
+    MAX_RECONNECT_DELAY_MS,
+  );
+  const jitterFactor = 0.8 + (Math.random() * 0.4);
+  return Math.round(exponentialDelay * jitterFactor);
+}
+
 /**
  * Parse and dispatch SSE payload chunks emitted by the backend stream.
  *
@@ -53,6 +66,7 @@ export function LiveEventStream(): JSX.Element {
   const [events, setEvents] = useState<StreamEvent[]>([]);
   const [connected, setConnected] = useState(false);
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptRef = useRef(0);
 
   const streamUrl = "/api/veritas/v1/events";
   const streamStatus = connected ? "🟢 connected" : "🟡 reconnecting";
@@ -82,6 +96,7 @@ export function LiveEventStream(): JSX.Element {
         }
 
         setConnected(true);
+        reconnectAttemptRef.current = 0;
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let carry = "";
@@ -107,7 +122,9 @@ export function LiveEventStream(): JSX.Element {
 
       if (mounted) {
         setConnected(false);
-        reconnectRef.current = setTimeout(connect, 1500);
+        const delayMs = getReconnectDelayMs(reconnectAttemptRef.current);
+        reconnectAttemptRef.current += 1;
+        reconnectRef.current = setTimeout(connect, delayMs);
       }
     };
 


### PR DESCRIPTION
### Motivation
- The SSE reconnect used a fixed 1500ms retry which can cause synchronized retry spikes and unnecessary load during outages. 
- Implement exponential backoff with jitter to improve resilience and reduce thundering-herd behavior. 
- Add unit test coverage for reconnect scheduling to prevent regressions. 

### Description
- Added reconnect configuration constants `BASE_RECONNECT_DELAY_MS` and `MAX_RECONNECT_DELAY_MS` and a helper `getReconnectDelayMs(attempt)` to compute exponential backoff with jitter. 
- Introduced `reconnectAttemptRef` and reset it on successful connection, replacing the fixed `setTimeout(..., 1500)` with a variable delay computed by `getReconnectDelayMs`. 
- Updated tests in `frontend/components/live-event-stream.test.tsx` to verify reconnect scheduling and added timer cleanup in `afterEach`. 
- Modified files: `frontend/components/live-event-stream.tsx` and `frontend/components/live-event-stream.test.tsx`. 

### Testing
- Ran `pnpm --dir frontend test components/live-event-stream.test.tsx` and the test suite for the file completed successfully with `4 tests passed` using Vitest. 
- Tests exercise rendering, event parsing, clear button behavior, and the reconnect scheduling logic (fake timers and `setTimeout` spy).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4eb2f62a08326b53bfa7f5be4bdb3)