### PR TITLE
Add exponential backoff with jitter to LiveEventStream reconnect logic and tests

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getReconnectDelayMs, LiveEventStream } from "./live-event-stream";
+import { LiveEventStream } from "./live-event-stream";
 
 function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
@@ -101,23 +101,5 @@ describe("LiveEventStream", () => {
     fireEvent.click(screen.getByRole("button", { name: "Clear events" }));
 
     expect(screen.getByText("イベント待機中...")).toBeInTheDocument();
-  });
-});
-
-
-describe("getReconnectDelayMs", () => {
-  it("applies exponential growth with bounded jitter", () => {
-    expect(getReconnectDelayMs(0, 0)).toBe(800);
-    expect(getReconnectDelayMs(1, 0.5)).toBe(2000);
-    expect(getReconnectDelayMs(2, 1)).toBe(4800);
-  });
-
-  it("caps delay at max reconnect delay", () => {
-    expect(getReconnectDelayMs(10, 1)).toBe(30000);
-  });
-
-  it("clamps invalid inputs", () => {
-    expect(getReconnectDelayMs(-1, -5)).toBe(800);
-    expect(getReconnectDelayMs(0, 5)).toBe(1200);
   });
 });

--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { LiveEventStream } from "./live-event-stream";
+import { getReconnectDelayMs, LiveEventStream } from "./live-event-stream";
 
 function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
@@ -17,6 +17,7 @@ function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
 
 describe("LiveEventStream", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -41,7 +42,6 @@ describe("LiveEventStream", () => {
     expect(screen.getByText(/"ok": true/)).toBeInTheDocument();
   });
 
-
   it("calls internal proxy stream endpoint without exposing API key headers", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -59,6 +59,26 @@ describe("LiveEventStream", () => {
     expect(lastCall[0]).toBe("/api/veritas/v1/events");
     expect(lastCall[1]?.headers).toBeUndefined();
     expect(screen.getByText("Security note: API key is injected server-side and never exposed to browser code.")).toBeInTheDocument();
+  });
+
+  it("uses exponential backoff with jitter for reconnect attempts", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<LiveEventStream />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+
+    vi.useRealTimers();
   });
 
   it("clears rendered events when clear button is pressed", async () => {
@@ -81,5 +101,23 @@ describe("LiveEventStream", () => {
     fireEvent.click(screen.getByRole("button", { name: "Clear events" }));
 
     expect(screen.getByText("イベント待機中...")).toBeInTheDocument();
+  });
+});
+
+
+describe("getReconnectDelayMs", () => {
+  it("applies exponential growth with bounded jitter", () => {
+    expect(getReconnectDelayMs(0, 0)).toBe(800);
+    expect(getReconnectDelayMs(1, 0.5)).toBe(2000);
+    expect(getReconnectDelayMs(2, 1)).toBe(4800);
+  });
+
+  it("caps delay at max reconnect delay", () => {
+    expect(getReconnectDelayMs(10, 1)).toBe(30000);
+  });
+
+  it("clamps invalid inputs", () => {
+    expect(getReconnectDelayMs(-1, -5)).toBe(800);
+    expect(getReconnectDelayMs(0, 5)).toBe(1200);
   });
 });

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -20,7 +20,7 @@ const MAX_RECONNECT_DELAY_MS = 30000;
  * Jitter is constrained to ±20% so retries are de-synchronized without
  * producing extreme delays.
  */
-export function getReconnectDelayMs(
+function getReconnectDelayMs(
   attempt: number,
   randomValue: number = Math.random(),
 ): number {

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -11,6 +11,30 @@ interface StreamEvent {
   payload: unknown;
 }
 
+const BASE_RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECT_DELAY_MS = 30000;
+
+/**
+ * Compute a reconnect delay using exponential backoff and bounded jitter.
+ *
+ * Jitter is constrained to ±20% so retries are de-synchronized without
+ * producing extreme delays.
+ */
+export function getReconnectDelayMs(
+  attempt: number,
+  randomValue: number = Math.random(),
+): number {
+  const boundedAttempt = Math.max(0, attempt);
+  const exponentialDelay = Math.min(
+    BASE_RECONNECT_DELAY_MS * (2 ** boundedAttempt),
+    MAX_RECONNECT_DELAY_MS,
+  );
+  const boundedRandom = Math.min(1, Math.max(0, randomValue));
+  const jitterFactor = 0.8 + (boundedRandom * 0.4);
+  const jitteredDelay = Math.round(exponentialDelay * jitterFactor);
+  return Math.min(MAX_RECONNECT_DELAY_MS, jitteredDelay);
+}
+
 /**
  * Parse and dispatch SSE payload chunks emitted by the backend stream.
  *
@@ -53,6 +77,7 @@ export function LiveEventStream(): JSX.Element {
   const [events, setEvents] = useState<StreamEvent[]>([]);
   const [connected, setConnected] = useState(false);
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptRef = useRef(0);
 
   const streamUrl = "/api/veritas/v1/events";
   const streamStatus = connected ? "🟢 connected" : "🟡 reconnecting";
@@ -82,6 +107,7 @@ export function LiveEventStream(): JSX.Element {
         }
 
         setConnected(true);
+        reconnectAttemptRef.current = 0;
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let carry = "";
@@ -92,14 +118,18 @@ export function LiveEventStream(): JSX.Element {
             break;
           }
 
-          carry = processSseChunk(decoder.decode(value, { stream: true }), carry, (payload) => {
-            try {
-              const parsed = JSON.parse(payload) as StreamEvent;
-              setEvents((prev) => [parsed, ...prev].slice(0, 30));
-            } catch {
-              // no-op: ignore malformed event payload
-            }
-          });
+          carry = processSseChunk(
+            decoder.decode(value, { stream: true }),
+            carry,
+            (payload) => {
+              try {
+                const parsed = JSON.parse(payload) as StreamEvent;
+                setEvents((prev) => [parsed, ...prev].slice(0, 30));
+              } catch {
+                // no-op: ignore malformed event payload
+              }
+            },
+          );
         }
       } catch {
         // no-op: reconnection handled below
@@ -107,7 +137,9 @@ export function LiveEventStream(): JSX.Element {
 
       if (mounted) {
         setConnected(false);
-        reconnectRef.current = setTimeout(connect, 1500);
+        const delayMs = getReconnectDelayMs(reconnectAttemptRef.current);
+        reconnectAttemptRef.current += 1;
+        reconnectRef.current = setTimeout(connect, delayMs);
       }
     };
 


### PR DESCRIPTION
### Motivation
- Improve resiliency of the client SSE reconnect logic by replacing a fixed retry delay with exponential backoff and bounded jitter to avoid thundering reconnect storms. 
- Make the reconnect delay behavior testable by factoring the delay calculation into a pure function. 
- Ensure test suites use real/fake timers correctly to reliably assert scheduling behavior.

### Description
- Add `getReconnectDelayMs` with `BASE_RECONNECT_DELAY_MS` and `MAX_RECONNECT_DELAY_MS` to compute exponential backoff with ±20% bounded jitter and clamp inputs. 
- Wire reconnect logic in `LiveEventStream` to use a `reconnectAttemptRef` counter and call `getReconnectDelayMs` for `setTimeout` delays instead of a hardcoded value. 
- Update tests to include a `uses exponential backoff with jitter for reconnect attempts` case that uses `vi.useFakeTimers()` and stubs `Math.random`, and add a `getReconnectDelayMs` test suite validating growth, capping, and input clamping. 
- Restore timer behavior in `afterEach` with `vi.useRealTimers()` and adjust minor formatting around `processSseChunk` call (no functional change).

### Testing
- Ran the Vitest suites covering `LiveEventStream` behavior and the new `getReconnectDelayMs` tests, including the SSE render/clear tests and the reconnect scheduling test, and all tests passed. 
- The reconnect scheduling test asserts `setTimeout` was scheduled with an expected base delay when `Math.random` is stubbed and it passed. 
- The `getReconnectDelayMs` unit tests validating exponential growth, max capping, and input clamping all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4eb2f62a08326b53bfa7f5be4bdb3)