### PR TITLE
Add exponential backoff with jitter for SSE reconnects and update tests

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -17,6 +17,7 @@ function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
 
 describe("LiveEventStream", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -41,7 +42,6 @@ describe("LiveEventStream", () => {
     expect(screen.getByText(/"ok": true/)).toBeInTheDocument();
   });
 
-
   it("calls internal proxy stream endpoint without exposing API key headers", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -59,6 +59,26 @@ describe("LiveEventStream", () => {
     expect(lastCall[0]).toBe("/api/veritas/v1/events");
     expect(lastCall[1]?.headers).toBeUndefined();
     expect(screen.getByText("Security note: API key is injected server-side and never exposed to browser code.")).toBeInTheDocument();
+  });
+
+  it("uses exponential backoff with jitter for reconnect attempts", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<LiveEventStream />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+
+    vi.useRealTimers();
   });
 
   it("clears rendered events when clear button is pressed", async () => {

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -11,6 +11,30 @@ interface StreamEvent {
   payload: unknown;
 }
 
+const BASE_RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECT_DELAY_MS = 30000;
+
+/**
+ * Compute a reconnect delay using exponential backoff and bounded jitter.
+ *
+ * Jitter is constrained to ±20% so retries are de-synchronized without
+ * producing extreme delays.
+ */
+function getReconnectDelayMs(
+  attempt: number,
+  randomValue: number = Math.random(),
+): number {
+  const boundedAttempt = Math.max(0, attempt);
+  const exponentialDelay = Math.min(
+    BASE_RECONNECT_DELAY_MS * (2 ** boundedAttempt),
+    MAX_RECONNECT_DELAY_MS,
+  );
+  const boundedRandom = Math.min(1, Math.max(0, randomValue));
+  const jitterFactor = 0.8 + (boundedRandom * 0.4);
+  const jitteredDelay = Math.round(exponentialDelay * jitterFactor);
+  return Math.min(MAX_RECONNECT_DELAY_MS, jitteredDelay);
+}
+
 /**
  * Parse and dispatch SSE payload chunks emitted by the backend stream.
  *
@@ -53,6 +77,7 @@ export function LiveEventStream(): JSX.Element {
   const [events, setEvents] = useState<StreamEvent[]>([]);
   const [connected, setConnected] = useState(false);
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptRef = useRef(0);
 
   const streamUrl = "/api/veritas/v1/events";
   const streamStatus = connected ? "🟢 connected" : "🟡 reconnecting";
@@ -82,6 +107,7 @@ export function LiveEventStream(): JSX.Element {
         }
 
         setConnected(true);
+        reconnectAttemptRef.current = 0;
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let carry = "";
@@ -92,14 +118,18 @@ export function LiveEventStream(): JSX.Element {
             break;
           }
 
-          carry = processSseChunk(decoder.decode(value, { stream: true }), carry, (payload) => {
-            try {
-              const parsed = JSON.parse(payload) as StreamEvent;
-              setEvents((prev) => [parsed, ...prev].slice(0, 30));
-            } catch {
-              // no-op: ignore malformed event payload
-            }
-          });
+          carry = processSseChunk(
+            decoder.decode(value, { stream: true }),
+            carry,
+            (payload) => {
+              try {
+                const parsed = JSON.parse(payload) as StreamEvent;
+                setEvents((prev) => [parsed, ...prev].slice(0, 30));
+              } catch {
+                // no-op: ignore malformed event payload
+              }
+            },
+          );
         }
       } catch {
         // no-op: reconnection handled below
@@ -107,7 +137,9 @@ export function LiveEventStream(): JSX.Element {
 
       if (mounted) {
         setConnected(false);
-        reconnectRef.current = setTimeout(connect, 1500);
+        const delayMs = getReconnectDelayMs(reconnectAttemptRef.current);
+        reconnectAttemptRef.current += 1;
+        reconnectRef.current = setTimeout(connect, delayMs);
       }
     };
 


### PR DESCRIPTION
### Motivation

- Improve robustness of the client SSE reconnection logic by replacing a fixed reconnect delay with exponential backoff and bounded jitter to reduce thundering reconnection attempts.

### Description

- Add `BASE_RECONNECT_DELAY_MS` and `MAX_RECONNECT_DELAY_MS` constants and implement `getReconnectDelayMs` to compute exponential backoff with ±20% jitter.
- Track reconnect attempts with `reconnectAttemptRef` and use the computed delay when scheduling `setTimeout(connect, delayMs)` instead of a fixed 1500ms delay.
- Keep existing SSE parsing logic in `processSseChunk` and reset the attempt counter on successful connection, while preserving maximum event buffer behavior.
- Update tests in `live-event-stream.test.tsx` to restore real timers in `afterEach` and add a new test that uses `vi.useFakeTimers()` and a `Math.random` spy to assert the backoff `setTimeout` is scheduled (expecting initial delay of `1000`ms given the mocked random value).

### Testing

- Ran unit tests with `vitest` for the `frontend/components` tests including the updated `live-event-stream.test.tsx` and the new reconnect backoff test; all tests passed.
- The new test asserts `fetch` is called once and that `setTimeout` is scheduled with the expected backoff delay, and it succeeded under the `vi.useFakeTimers()` setup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4eb2f62a08326b53bfa7f5be4bdb3)