### PR TITLE
Improve audit search input aria-label clarity

### DIFF
--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -76,7 +76,7 @@ describe("TrustLogExplorerPage", () => {
 
     render(<TrustLogExplorerPage />);
 
-    fireEvent.change(screen.getByLabelText("request_id"), {
+    fireEvent.change(screen.getByLabelText("リクエストIDで検索"), {
       target: { value: "req-timeout" },
     });
     fireEvent.click(screen.getByRole("button", { name: "検索" }));

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -561,7 +561,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
 
       <Card title={t("request_id 検索", "request_id Search")} className="bg-background/75">
         <div className="flex flex-col gap-2 md:flex-row">
-          <input aria-label="request_id" className="w-full rounded-md border border-border bg-background px-2 py-2 text-sm" placeholder="request_id" value={requestId} onChange={(event) => setRequestId(event.target.value)} />
+          <input aria-label={t("リクエストIDで検索", "Search by request ID")} className="w-full rounded-md border border-border bg-background px-2 py-2 text-sm" placeholder="request_id" value={requestId} onChange={(event) => setRequestId(event.target.value)} />
           <button type="button" className="rounded-md border border-primary/60 bg-primary/20 px-3 py-2 text-sm" disabled={loading} onClick={() => void searchByRequestId()}>
             {t("検索", "Search")}
           </button>


### PR DESCRIPTION
### Motivation
- L-13 の指摘に従い、監査画面の検索入力の `aria-label` を技術的な識別子（`request_id`）からユーザー向けのローカライズ文言 `リクエストIDで検索`（英語フォールバック `Search by request ID`）に変更してスクリーンリーダーの可読性を向上させました。

### Description
- 変更点: `frontend/app/audit/page.tsx` の検索入力の `aria-label` を `t("リクエストIDで検索", "Search by request ID")` に差し替え、対応するUIテスト `frontend/app/audit/page.test.tsx` の `getByLabelText` 参照を `リクエストIDで検索` に更新しました、ロジックには手を入れておらずセキュリティリスクは導入していません。

### Testing
- 実行した自動テスト: `pnpm --dir frontend test -- app/audit/page.test.tsx` を実行し、対象テストファイル1件・合計8テストがすべて成功しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4fe2688108326a9542a84e578b0c7)