### PR TITLE
Fix security-sensitive path matching in PR impact summary

### DIFF
--- a/veritas_os/scripts/pr_impact_summary.py
+++ b/veritas_os/scripts/pr_impact_summary.py
@@ -70,8 +70,12 @@ def _contains_security_sensitive_parts(parts: Iterable[str]) -> bool:
         "sanitize",
         "llm_safety",
     }
-    lowered = {part.lower() for part in parts}
-    return any(token in lowered for token in sensitive_tokens)
+    normalized_parts = [part.lower().replace("_", "-") for part in parts]
+    return any(
+        token in part
+        for part in normalized_parts
+        for token in sensitive_tokens
+    )
 
 
 def infer_impact(file_path: str) -> ImpactRow:


### PR DESCRIPTION
### Motivation
- Improve detection of security-sensitive file paths in `veritas_os/scripts/pr_impact_summary.py` so embedded tokens (e.g. `token_guard.py`) are not missed by the auto-generated PR impact summary.

### Description
- Update `_contains_security_sensitive_parts` to normalize path parts with `part.lower().replace("_", "-")` and perform substring matching against the `sensitive_tokens` set, making detection more robust and keeping the change localized and low-risk.

### Testing
- Ran `pytest -q veritas_os/tests/test_pr_impact_summary.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a525c524d083268806962d9fe22181)