### PR TITLE
Add CI static checker to enforce Planner/Kernel/Fuji/MemoryOS responsibility boundaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Ruff check (lint)
         run: ruff check veritas_os/
 
+      - name: Responsibility boundary check
+        run: python scripts/architecture/check_responsibility_boundaries.py
+
       - name: Bandit security scan
         run: |
           bandit -r veritas_os/core veritas_os/api veritas_os/tools \

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -1,0 +1,115 @@
+"""Static checker for Planner / Kernel / Fuji / MemoryOS import boundaries.
+
+This script enforces directional dependency constraints between core modules.
+It is intended for CI use and returns non-zero when violations are detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class BoundaryRule:
+    """A dependency rule for one source module against forbidden imports."""
+
+    source_module: str
+    forbidden_imports: frozenset[str]
+
+
+DEFAULT_RULES: tuple[BoundaryRule, ...] = (
+    BoundaryRule(
+        source_module="planner",
+        forbidden_imports=frozenset({"kernel", "fuji"}),
+    ),
+    BoundaryRule(
+        source_module="fuji",
+        forbidden_imports=frozenset({"kernel", "planner"}),
+    ),
+    BoundaryRule(
+        source_module="memory",
+        forbidden_imports=frozenset({"kernel", "planner", "fuji"}),
+    ),
+)
+
+
+def _normalize_module_name(module_name: str) -> str:
+    """Normalize import paths to the core module leaf name."""
+    return module_name.rsplit(".", maxsplit=1)[-1]
+
+
+def _collect_imported_names(tree: ast.Module) -> set[str]:
+    """Collect imported module names from a module AST."""
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(_normalize_module_name(alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imported.add(_normalize_module_name(node.module))
+            else:
+                for alias in node.names:
+                    imported.add(_normalize_module_name(alias.name))
+    return imported
+
+
+def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
+    """Check one rule and return violation messages."""
+    path = core_dir / f"{rule.source_module}.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported = _collect_imported_names(tree)
+    violations = sorted(imported & set(rule.forbidden_imports))
+
+    if not violations:
+        return []
+    joined = ", ".join(violations)
+    return [
+        (
+            f"Boundary violation: '{rule.source_module}' imports forbidden core module(s): "
+            f"{joined} ({path})"
+        )
+    ]
+
+
+def check_boundaries(core_dir: Path, rules: Iterable[BoundaryRule] = DEFAULT_RULES) -> list[str]:
+    """Run all boundary rules and return all violation messages."""
+    issues: list[str] = []
+    for rule in rules:
+        issues.extend(_check_rule(core_dir=core_dir, rule=rule))
+    return issues
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--core-dir",
+        type=Path,
+        default=Path("veritas_os/core"),
+        help="Path to the core module directory (default: veritas_os/core).",
+    )
+    return parser
+
+
+def main() -> int:
+    """CLI entrypoint for CI execution."""
+    parser = _build_parser()
+    args = parser.parse_args()
+    issues = check_boundaries(core_dir=args.core_dir)
+
+    if issues:
+        for issue in issues:
+            print(issue)
+        return 1
+
+    print("Responsibility boundary check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -1,0 +1,63 @@
+"""Tests for static responsibility boundary checker script."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.architecture.check_responsibility_boundaries import (
+    BoundaryRule,
+    check_boundaries,
+)
+
+
+def _write_module(path: Path, source: str) -> None:
+    """Write UTF-8 source code to a module path."""
+    path.write_text(source, encoding="utf-8")
+
+
+def test_check_boundaries_reports_forbidden_import(tmp_path: Path) -> None:
+    """Checker should report violations when forbidden imports exist."""
+    _write_module(tmp_path / "planner.py", "import veritas_os.core.kernel\n")
+    _write_module(tmp_path / "kernel.py", "# kernel module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+
+    issues = check_boundaries(core_dir=tmp_path)
+
+    assert len(issues) == 1
+    assert "planner" in issues[0]
+    assert "kernel" in issues[0]
+
+
+def test_check_boundaries_accepts_valid_dependency_directions(tmp_path: Path) -> None:
+    """Checker should pass when no forbidden cross-module imports are present."""
+    _write_module(tmp_path / "planner.py", "from veritas_os.core.memory import summarize_for_planner\n")
+    _write_module(tmp_path / "kernel.py", "from veritas_os.core.planner import plan_for_veritas_agi\n")
+    _write_module(tmp_path / "fuji.py", "from veritas_os.core.fuji_codes import FujiAction\n")
+    _write_module(tmp_path / "memory.py", "import json\n")
+
+    issues = check_boundaries(core_dir=tmp_path)
+
+    assert issues == []
+
+
+def test_check_boundaries_supports_custom_rules(tmp_path: Path) -> None:
+    """Checker should evaluate custom rules provided by callers."""
+    _write_module(tmp_path / "kernel.py", "from veritas_os.core.memory import add\n")
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+
+    issues = check_boundaries(
+        core_dir=tmp_path,
+        rules=(
+            BoundaryRule(
+                source_module="kernel",
+                forbidden_imports=frozenset({"memory"}),
+            ),
+        ),
+    )
+
+    assert len(issues) == 1
+    assert "kernel" in issues[0]
+    assert "memory" in issues[0]


### PR DESCRIPTION
### Motivation
- Implement the scorecard recommendation to automatically enforce `Planner / Kernel / Fuji / MemoryOS` dependency directions so responsibility drift is detected at PR time.
- Provide a small, maintainable CI-friendly tool that fails fast on forbidden cross-module imports while keeping changes limited to architecture checks and tests.
- Security note: this check reduces architectural coupling risk but does not replace runtime controls such as key rotation, secret management, or input-sanitization and those must continue to be audited.

### Description
- Added `scripts/architecture/check_responsibility_boundaries.py`, a static AST-based checker that defines `BoundaryRule` and verifies forbidden import directions for core modules.
- Added unit tests in `veritas_os/tests/test_responsibility_boundary_checker.py` that cover forbidden-import detection, valid import passes, and custom-rule support.
- Wired the checker into the lint stage of the GitHub Actions workflow by adding a step that runs `python scripts/architecture/check_responsibility_boundaries.py` in `.github/workflows/main.yml`.
- Ensured lint/tests were run locally and code adheres to style checks (`ruff`) and includes a module-level docstring per the change policy.

### Testing
- Ran `ruff check scripts/architecture/check_responsibility_boundaries.py veritas_os/tests/test_responsibility_boundary_checker.py` and it passed.
- Ran `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py veritas_os/tests/test_responsibility_boundaries.py` and all tests passed (`8 passed`).
- Executed `python scripts/architecture/check_responsibility_boundaries.py` which printed `Responsibility boundary check passed.` and exited with status `0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a53af4f4bc832694048c2f802b6384)