### PR TITLE
Harden SSE authentication and manage nonce cleanup lifecycle safely

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -546,6 +546,18 @@ app.add_middleware(
 )
 
 
+@app.on_event("startup")
+async def _startup_nonce_cleanup_scheduler() -> None:
+    """Start background nonce cleanup under FastAPI lifecycle management."""
+    _start_nonce_cleanup_scheduler()
+
+
+@app.on_event("shutdown")
+async def _shutdown_nonce_cleanup_scheduler() -> None:
+    """Stop background nonce cleanup timer when app is shutting down."""
+    _stop_nonce_cleanup_scheduler()
+
+
 # ★ C-3 継続改善: リクエストボディサイズ制限 (DoS対策)
 # 運用プロファイルごとの推奨値を定義しつつ、環境変数で上書き可能にする。
 DEFAULT_MAX_REQUEST_BODY_SIZE = 10 * 1024 * 1024
@@ -862,17 +874,42 @@ def require_api_key_header_or_query(
     x_api_key: Optional[str] = Security(api_key_scheme),
     api_key: Optional[str] = Query(default=None),
 ):
-    """Authenticate by header (preferred) or query parameter for SSE clients."""
+    """Authenticate SSE requests with header-first policy.
+
+    Security:
+        Query-string API keys are disabled by default because they can leak via
+        access logs, browser history, and monitoring URLs. To preserve migration
+        flexibility, operators may temporarily enable query auth with the
+        ``VERITAS_ALLOW_SSE_QUERY_API_KEY=1`` feature flag.
+    """
     expected = (_get_expected_api_key() or "").strip()
     if not expected:
         raise HTTPException(status_code=500, detail="Server API key not configured")
 
-    candidate = (x_api_key or api_key or "").strip()
+    header_candidate = (x_api_key or "").strip()
+    query_candidate = (api_key or "").strip()
+
+    candidate = header_candidate
+    if not candidate and query_candidate:
+        if not _allow_sse_query_api_key():
+            raise HTTPException(status_code=401, detail="Query API key is disabled; use X-API-Key header")
+        logger.warning(
+            "SSE auth accepted query api_key due to VERITAS_ALLOW_SSE_QUERY_API_KEY=1. "
+            "This mode increases credential exposure risk.",
+        )
+        candidate = query_candidate
+
     if not candidate:
         raise HTTPException(status_code=401, detail="Missing API key")
     if not secrets.compare_digest(candidate, expected):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
+
+
+def _allow_sse_query_api_key() -> bool:
+    """Return True when SSE query-string API key auth is explicitly enabled."""
+    raw = (os.getenv("VERITAS_ALLOW_SSE_QUERY_API_KEY") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 # ---- HMAC signature / replay (optional) ----
@@ -949,22 +986,44 @@ def _cleanup_nonces() -> None:
 
 # ★ M-11 修正: 定期的なノンスクリーンアップ（60秒ごと）
 _nonce_cleanup_timer: threading.Timer | None = None
+_nonce_cleanup_timer_lock = threading.Lock()
 
 
 def _schedule_nonce_cleanup() -> None:
-    """バックグラウンドでノンスストアを定期クリーンアップする"""
+    """バックグラウンドでノンスストアを定期クリーンアップする。"""
     global _nonce_cleanup_timer
     try:
         _cleanup_nonces()
     except Exception as e:
         logger.warning("nonce cleanup failed: %s", e)
-    _nonce_cleanup_timer = threading.Timer(60.0, _schedule_nonce_cleanup)
-    _nonce_cleanup_timer.daemon = True
-    _nonce_cleanup_timer.start()
+    with _nonce_cleanup_timer_lock:
+        if _nonce_cleanup_timer is None:
+            return
+        next_timer = threading.Timer(60.0, _schedule_nonce_cleanup)
+        next_timer.daemon = True
+        _nonce_cleanup_timer = next_timer
+        next_timer.start()
 
 
-# 初回スケジュール
-_schedule_nonce_cleanup()
+def _start_nonce_cleanup_scheduler() -> None:
+    """Start nonce cleanup timer once per process lifecycle."""
+    global _nonce_cleanup_timer
+    with _nonce_cleanup_timer_lock:
+        if _nonce_cleanup_timer is not None:
+            return
+        _nonce_cleanup_timer = threading.Timer(60.0, _schedule_nonce_cleanup)
+        _nonce_cleanup_timer.daemon = True
+        _nonce_cleanup_timer.start()
+
+
+def _stop_nonce_cleanup_scheduler() -> None:
+    """Stop nonce cleanup timer if running."""
+    global _nonce_cleanup_timer
+    with _nonce_cleanup_timer_lock:
+        timer = _nonce_cleanup_timer
+        _nonce_cleanup_timer = None
+    if timer is not None:
+        timer.cancel()
 
 
 def _check_and_register_nonce(nonce: str) -> bool:

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -1342,11 +1342,24 @@ def test_resolve_max_request_body_size_rejects_non_positive_override(monkeypatch
     assert resolved == 8 * 1024 * 1024
 
 
-def test_events_requires_api_key_query_or_header(monkeypatch):
+def test_events_requires_api_key_header_only_by_default(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.delenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", raising=False)
 
     no_auth = client.get("/v1/events")
     assert no_auth.status_code == 401
+
+    with pytest.raises(HTTPException) as exc:
+        server.require_api_key_header_or_query(
+            x_api_key=None,
+            api_key=_TEST_API_KEY,
+        )
+    assert exc.value.status_code == 401
+
+
+def test_events_accepts_query_api_key_only_when_flag_enabled(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "1")
 
     assert server.require_api_key_header_or_query(
         x_api_key=None,

--- a/veritas_os/tests/test_coverage_boost.py
+++ b/veritas_os/tests/test_coverage_boost.py
@@ -942,6 +942,46 @@ class TestServerMiscCoverage:
         result = server.require_api_key_header_or_query(x_api_key=_TEST_KEY, api_key=None)
         assert result is True
 
+    def test_allow_sse_query_api_key_flag_values(self, monkeypatch):
+        """Feature flag should accept common truthy values only."""
+        monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "yes")
+        assert server._allow_sse_query_api_key() is True
+
+        monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "0")
+        assert server._allow_sse_query_api_key() is False
+
+    def test_nonce_cleanup_scheduler_start_stop(self, monkeypatch):
+        """Nonce cleanup scheduler should be singleton and stoppable."""
+
+        class _FakeTimer:
+            def __init__(self, interval, callback):
+                self.interval = interval
+                self.callback = callback
+                self.daemon = False
+                self.started = False
+                self.canceled = False
+
+            def start(self):
+                self.started = True
+
+            def cancel(self):
+                self.canceled = True
+
+        monkeypatch.setattr(server.threading, "Timer", _FakeTimer)
+        server._stop_nonce_cleanup_scheduler()
+
+        server._start_nonce_cleanup_scheduler()
+        first_timer = server._nonce_cleanup_timer
+        assert first_timer is not None
+        assert first_timer.started is True
+
+        server._start_nonce_cleanup_scheduler()
+        assert server._nonce_cleanup_timer is first_timer
+
+        server._stop_nonce_cleanup_scheduler()
+        assert first_timer.canceled is True
+        assert server._nonce_cleanup_timer is None
+
     def test_verify_signature_bad_utf8(self, monkeypatch):
         """Non-UTF-8 body raises 400."""
         monkeypatch.setattr(server, "API_SECRET", b"secret-for-test-1234567890abcdef")


### PR DESCRIPTION
### Motivation
- CODE_REVIEW identified two priority issues: SSE `/v1/events` accepting `api_key` in query strings (high leakage risk), and an import-time recursive `threading.Timer` for nonce cleanup that can spawn orphan background threads under multi-worker/test runs. 
- Changes must be limited to API server lifecycle/auth hardening without altering Planner/Kernel/Fuji/MemoryOS responsibilities.

### Description
- Enforce header-first SSE auth in `require_api_key_header_or_query`, and add an explicit opt-in feature flag `VERITAS_ALLOW_SSE_QUERY_API_KEY` to temporarily allow query-string keys with a warning log when used. 
- Add `_allow_sse_query_api_key()` helper and extend the function docstring to document the security rationale. 
- Refactor nonce cleanup scheduling: add `_nonce_cleanup_timer_lock`, implement `_start_nonce_cleanup_scheduler()` and `_stop_nonce_cleanup_scheduler()` to ensure singleton start/stop semantics, remove import-time auto-start, and hook the scheduler into FastAPI lifecycle via `@app.on_event("startup")` and `@app.on_event("shutdown")`. 
- Add/update tests to cover header-only default behavior, flag-enabled query auth, feature-flag parsing, and scheduler start/stop singleton and cancel behavior, and include docstrings/comments for the security changes.

### Testing
- Ran targeted SSE and scheduler tests: `pytest -q veritas_os/tests/test_api_server_extra.py::test_events_requires_api_key_header_only_by_default veritas_os/tests/test_api_server_extra.py::test_events_accepts_query_api_key_only_when_flag_enabled veritas_os/tests/test_coverage_boost.py::TestServerMiscCoverage::test_allow_sse_query_api_key_flag_values veritas_os/tests/test_coverage_boost.py::TestServerMiscCoverage::test_nonce_cleanup_scheduler_start_stop` and they all passed (4 passed). 
- Ran core regressions `pytest -q veritas_os/tests/test_kernel.py veritas_os/tests/test_memory_engine.py veritas_os/tests/test_trust_log_api.py` and they passed (10 passed total). 
- Executed validation scripts `python scripts/security/check_next_public_key_exposure.py` and `python scripts/architecture/check_responsibility_boundaries.py`, and both returned OK. 
- Note: FastAPI emitted deprecation warnings about `@app.on_event` (lifespan handlers are preferred), but tests succeeded; replacing with lifespan handlers can be done in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5589c70c48326b8e8d1aa5df9edbe)