### PR TITLE
fix: address code review findings in boundary checker and pr impact s…

### DIFF
--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -59,20 +59,19 @@ def _collect_imported_names(tree: ast.Module) -> set[str]:
 
 
 def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
-    """Check one rule and return violation messages."""
+    """Check one rule and return violation messages, one per forbidden import found."""
     path = core_dir / f"{rule.source_module}.py"
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    try:
+        source = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return [f"Boundary check error: '{rule.source_module}' not found at {path}"]
+    tree = ast.parse(source, filename=str(path))
     imported = _collect_imported_names(tree)
-    violations = sorted(imported & set(rule.forbidden_imports))
+    violations = sorted(imported & rule.forbidden_imports)
 
-    if not violations:
-        return []
-    joined = ", ".join(violations)
     return [
-        (
-            f"Boundary violation: '{rule.source_module}' imports forbidden core module(s): "
-            f"{joined} ({path})"
-        )
+        f"Boundary violation: '{rule.source_module}' imports forbidden module '{v}' ({path})"
+        for v in violations
     ]
 
 

--- a/veritas_os/scripts/pr_impact_summary.py
+++ b/veritas_os/scripts/pr_impact_summary.py
@@ -70,10 +70,9 @@ def _contains_security_sensitive_parts(parts: Iterable[str]) -> bool:
         "sanitize",
         "llm_safety",
     }
-    normalized_parts = [part.lower().replace("_", "-") for part in parts]
     return any(
-        token in part
-        for part in normalized_parts
+        token in part.lower().replace("-", "_")
+        for part in parts
         for token in sensitive_tokens
     )
 


### PR DESCRIPTION
…ummary

- pr_impact_summary: fix llm_safety token never matching due to underscore→hyphen normalization; flip to replace("-","_") so parts match token literals, and inline normalization into the generator to avoid materialising the intermediate list before any() runs

- check_responsibility_boundaries: remove redundant set() wrapping of an already-frozenset field (imported & rule.forbidden_imports); add FileNotFoundError handling in _check_rule so CI gets a clear error message instead of an unhandled exception when a module file is missing; return one message per violated import so list[str] is semantically correct (was always 0 or 1 elements previously)

https://claude.ai/code/session_0125jibna5aZ6U9GRivyRNJe