### PR TITLE
fuji: make policy-load failures observable and add strict deny fallback

### DIFF
--- a/veritas_os/core/fuji.py
+++ b/veritas_os/core/fuji.py
@@ -534,13 +534,66 @@ _DEFAULT_POLICY: Dict[str, Any] = {
     },
 }
 
+_STRICT_DENY_POLICY: Dict[str, Any] = {
+    "version": "fuji_v2_strict_deny",
+    "base_thresholds": {
+        "default": 0.0,
+        "high_stakes": 0.0,
+        "low_stakes": 0.0,
+    },
+    "categories": {},
+    "actions": {
+        "deny": {"risk_upper": 1.0},
+    },
+}
+
+
+def _strict_policy_load_enabled() -> bool:
+    """Return True when strict policy-load mode is enabled via env var."""
+    raw = os.getenv("VERITAS_FUJI_STRICT_POLICY_LOAD", "0")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _fallback_policy(*, path: Path | None, reason: str, exc: Exception | None = None) -> Dict[str, Any]:
+    """Return fallback policy and emit an operation-visible warning/error log."""
+    path_label = str(path) if path is not None else "<none>"
+    strict_mode = _strict_policy_load_enabled()
+
+    if exc is None:
+        _logger.warning(
+            "FUJI policy fallback triggered: reason=%s path=%s strict=%s",
+            reason,
+            path_label,
+            strict_mode,
+        )
+    else:
+        _logger.warning(
+            "FUJI policy fallback triggered: reason=%s path=%s exc_type=%s strict=%s",
+            reason,
+            path_label,
+            type(exc).__name__,
+            strict_mode,
+            exc_info=True,
+        )
+
+    if strict_mode:
+        _logger.error(
+            "FUJI strict policy-load mode active. Deny policy is enforced due to policy load failure. "
+            "path=%s reason=%s",
+            path_label,
+            reason,
+        )
+        return dict(_STRICT_DENY_POLICY)
+
+    return dict(_DEFAULT_POLICY)
+
 
 def _load_policy(path: Path | None) -> Dict[str, Any]:
     if not capability_cfg.enable_fuji_yaml_policy or yaml is None:
         return dict(_DEFAULT_POLICY)
 
     if path is None or not path.exists():
-        return dict(_DEFAULT_POLICY)
+        return _fallback_policy(path=path, reason="missing_policy_file")
 
     yaml_error = getattr(yaml, "YAMLError", None)
     yaml_errors = (yaml_error,) if isinstance(yaml_error, type) else ()
@@ -549,8 +602,8 @@ def _load_policy(path: Path | None) -> Dict[str, Any]:
     try:
         with path.open("r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-    except handled_errors:
-        return dict(_DEFAULT_POLICY)
+    except handled_errors as exc:
+        return _fallback_policy(path=path, reason="yaml_load_error", exc=exc)
 
     if "version" not in data:
         data["version"] = f"fuji_file_{path.name}"
@@ -568,8 +621,8 @@ def _load_policy_from_str(content: str, path: Path) -> Dict[str, Any]:
 
     try:
         data = yaml.safe_load(content) or {}
-    except handled_errors:
-        return dict(_DEFAULT_POLICY)
+    except handled_errors as exc:
+        return _fallback_policy(path=path, reason="yaml_parse_error", exc=exc)
     if "version" not in data:
         data["version"] = f"fuji_file_{path.name}"
     return data

--- a/veritas_os/tests/test_fuji_core.py
+++ b/veritas_os/tests/test_fuji_core.py
@@ -105,6 +105,60 @@ def test_reload_policy_respects_env(tmp_path, monkeypatch):
     assert pol.get("version") != "fuji_test_v1"
 
 
+def test_load_policy_logs_warning_on_yaml_error(tmp_path, monkeypatch, caplog):
+    """YAML ロード失敗時に warning ログを残し、既定ポリシーへフォールバックする。"""
+    caplog.set_level("WARNING", logger=fuji.__name__)
+
+    class DummyYaml:
+        class YAMLError(Exception):
+            pass
+
+        @staticmethod
+        def safe_load(_content):
+            raise DummyYaml.YAMLError("invalid yaml")
+
+    policy_file = tmp_path / "invalid.yaml"
+    policy_file.write_text("invalid: [", encoding="utf-8")
+    monkeypatch.setattr(fuji, "yaml", DummyYaml)
+    monkeypatch.setattr(
+        fuji.capability_cfg, "enable_fuji_yaml_policy", True
+    )
+    monkeypatch.setenv("VERITAS_FUJI_STRICT_POLICY_LOAD", "0")
+
+    policy = fuji._load_policy(policy_file)  # type: ignore[attr-defined]
+
+    assert policy["version"] == fuji._DEFAULT_POLICY["version"]  # type: ignore[attr-defined]
+    assert "FUJI policy fallback triggered" in caplog.text
+    assert "exc_type=YAMLError" in caplog.text
+
+
+def test_load_policy_strict_mode_enforces_deny_policy(tmp_path, monkeypatch, caplog):
+    """strict_policy_load 有効時はポリシー障害で deny 側へ倒す。"""
+    caplog.set_level("WARNING", logger=fuji.__name__)
+
+    class DummyYaml:
+        class YAMLError(Exception):
+            pass
+
+        @staticmethod
+        def safe_load(_content):
+            raise DummyYaml.YAMLError("invalid yaml")
+
+    policy_file = tmp_path / "invalid.yaml"
+    policy_file.write_text("invalid: [", encoding="utf-8")
+    monkeypatch.setattr(fuji, "yaml", DummyYaml)
+    monkeypatch.setattr(
+        fuji.capability_cfg, "enable_fuji_yaml_policy", True
+    )
+    monkeypatch.setenv("VERITAS_FUJI_STRICT_POLICY_LOAD", "1")
+
+    policy = fuji._load_policy(policy_file)  # type: ignore[attr-defined]
+
+    assert policy["version"] == "fuji_v2_strict_deny"
+    assert policy["actions"] == {"deny": {"risk_upper": 1.0}}
+    assert "strict policy-load mode active" in caplog.text.lower()
+
+
 # ---------------------------------------------------------
 # fallback_safety_head
 # ---------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent silent fallback to defaults when FUJI YAML policy load/parsing fails, which can hide policy drift and weaken security posture.  
- Provide an operationally explicit fail-closed option so environments that require deny-on-error can enforce it.  
- Keep the change confined to Fuji responsibility (policy loading/handling) and improve observability for operators.

### Description
- Added a deny-only fallback policy ` _STRICT_DENY_POLICY` and a helper ` _strict_policy_load_enabled()` driven by `VERITAS_FUJI_STRICT_POLICY_LOAD` to control fail-closed behavior.  
- Implemented `_fallback_policy(path, reason, exc)` which emits `warning` logs (including path, reason, and exception type) and an `error` when strict mode forces deny, and returns the appropriate fallback policy.  
- Replaced silent fallbacks in `_load_policy()` and `_load_policy_from_str()` to use `_fallback_policy()` for missing files and YAML load/parse errors.  
- Added focused unit tests in `veritas_os/tests/test_fuji_core.py` to assert logging on YAML errors and enforcement of the strict deny fallback, and added small docstrings for the new helpers.

### Testing
- Added two tests: `test_load_policy_logs_warning_on_yaml_error` and `test_load_policy_strict_mode_enforces_deny_policy` in `veritas_os/tests/test_fuji_core.py`.  
- Executed `pytest -q veritas_os/tests/test_fuji_core.py veritas_os/tests/test_fuji_coverage.py` and observed `97 passed`.  
- Verified that logging assertions for warning/error messages and strict-mode behavior succeed under the test harness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a593df0b488326912b6e3441f754ec)