### PR TITLE
Harden MemoryStore path handling for M-01 risk

### DIFF
--- a/veritas_os/memory/store.py
+++ b/veritas_os/memory/store.py
@@ -13,16 +13,69 @@ from veritas_os.core.atomic_io import atomic_append_line
 
 logger = logging.getLogger(__name__)
 
-# ★ M-3 修正: メモリディレクトリを環境変数で設定可能にする
-# VERITAS_MEMORY_DIR が設定されていればそちらを使用、未設定ならプロジェクト内のデフォルト
-_env_memory_dir = os.getenv("VERITAS_MEMORY_DIR", "").strip()
-if _env_memory_dir:
-    HOME_MEMORY = Path(_env_memory_dir)
-else:
-    BASE_DIR = Path(__file__).resolve().parents[2]      # veritas_clean_test2
-    VERITAS_DIR = BASE_DIR / "veritas_os"
-    HOME_MEMORY = VERITAS_DIR / "memory"               # ← プロジェクト内メモリ
-HOME_MEMORY.mkdir(parents=True, exist_ok=True)
+def _default_memory_dir() -> Path:
+    """Return the project-local memory directory path."""
+    base_dir = Path(__file__).resolve().parents[2]
+    veritas_dir = base_dir / "veritas_os"
+    return veritas_dir / "memory"
+
+
+def _resolve_memory_dir() -> Path:
+    """Resolve and validate memory directory from environment settings.
+
+    Security hardening:
+    - Always logs the resolved directory path for operational auditability.
+    - In production, `VERITAS_MEMORY_DIR` must match an allowlisted prefix
+      from `VERITAS_MEMORY_DIR_ALLOWLIST` (comma-separated), otherwise the
+      configuration is rejected and the safe project-local default is used.
+    """
+    default_path = _default_memory_dir()
+    env_memory_dir = os.getenv("VERITAS_MEMORY_DIR", "").strip()
+    profile = (os.getenv("VERITAS_ENV", "") or "").strip().lower()
+    is_production = profile == "production"
+
+    if not env_memory_dir:
+        resolved_default = default_path.resolve(strict=False)
+        logger.info("[MemoryStore] memory directory resolved to %s", resolved_default)
+        return default_path
+
+    candidate = Path(env_memory_dir)
+    resolved_candidate = candidate.resolve(strict=False)
+
+    if is_production:
+        raw_allowlist = os.getenv("VERITAS_MEMORY_DIR_ALLOWLIST", "")
+        allow_prefixes = [
+            Path(raw_prefix.strip()).resolve(strict=False)
+            for raw_prefix in raw_allowlist.split(",")
+            if raw_prefix.strip()
+        ]
+        if not allow_prefixes:
+            logger.warning(
+                "[MemoryStore] VERITAS_MEMORY_DIR ignored in production because "
+                "VERITAS_MEMORY_DIR_ALLOWLIST is empty; using default path=%s",
+                default_path.resolve(strict=False),
+            )
+            return default_path
+
+        if not any(
+            resolved_candidate == prefix or prefix in resolved_candidate.parents
+            for prefix in allow_prefixes
+        ):
+            logger.warning(
+                "[MemoryStore] VERITAS_MEMORY_DIR=%s rejected in production; "
+                "allowed_prefixes=%s. Falling back to default path=%s",
+                resolved_candidate,
+                [str(prefix) for prefix in allow_prefixes],
+                default_path.resolve(strict=False),
+            )
+            return default_path
+
+    logger.info("[MemoryStore] memory directory resolved to %s", resolved_candidate)
+    return candidate
+
+
+HOME_MEMORY = _resolve_memory_dir()
+HOME_MEMORY.mkdir(mode=0o700, parents=True, exist_ok=True)
 
 BASE = HOME_MEMORY
 

--- a/veritas_os/tests/test_memory_store.py
+++ b/veritas_os/tests/test_memory_store.py
@@ -432,6 +432,70 @@ def test_search_handles_index_error_gracefully(memory_env, monkeypatch):
     assert res["episodic"] == []
 
 
+def test_resolve_memory_dir_logs_default_path(memory_env, monkeypatch, caplog, tmp_path):
+    """環境変数未指定時は既定パスを監査ログに出して返す。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    default_dir = tmp_path / "default-memory"
+    monkeypatch.delenv("VERITAS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+    monkeypatch.setattr(store, "_default_memory_dir", lambda: default_dir)
+
+    caplog.set_level("INFO")
+    resolved = store._resolve_memory_dir()
+
+    assert resolved == default_dir
+    assert str(default_dir.resolve(strict=False)) in caplog.text
+
+
+def test_resolve_memory_dir_rejects_non_allowlisted_path_in_production(
+    memory_env,
+    monkeypatch,
+    caplog,
+    tmp_path,
+):
+    """production では allowlist 外の VERITAS_MEMORY_DIR を拒否する。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    default_dir = tmp_path / "default-memory"
+    allowed_root = tmp_path / "allowed"
+    denied_dir = tmp_path / "denied" / "memory"
+    monkeypatch.setattr(store, "_default_memory_dir", lambda: default_dir)
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_MEMORY_DIR", str(denied_dir))
+    monkeypatch.setenv("VERITAS_MEMORY_DIR_ALLOWLIST", str(allowed_root))
+
+    caplog.set_level("WARNING")
+    resolved = store._resolve_memory_dir()
+
+    assert resolved == default_dir
+    assert "rejected in production" in caplog.text
+
+
+def test_resolve_memory_dir_accepts_allowlisted_path_in_production(
+    memory_env,
+    monkeypatch,
+    caplog,
+    tmp_path,
+):
+    """production でも allowlist 配下の VERITAS_MEMORY_DIR は許可される。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    default_dir = tmp_path / "default-memory"
+    allowed_root = tmp_path / "allowed"
+    allowed_dir = allowed_root / "memory"
+    monkeypatch.setattr(store, "_default_memory_dir", lambda: default_dir)
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_MEMORY_DIR", str(allowed_dir))
+    monkeypatch.setenv("VERITAS_MEMORY_DIR_ALLOWLIST", str(allowed_root))
+
+    caplog.set_level("INFO")
+    resolved = store._resolve_memory_dir()
+
+    assert resolved == allowed_dir
+    assert str(allowed_dir.resolve(strict=False)) in caplog.text
+
+
 # ---------------------------------------------------------
 # put_episode: kind="episodic" で put に委譲
 # ---------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Address M-01 from the backend review by preventing silent/unrestricted overrides of the memory storage directory via `VERITAS_MEMORY_DIR` and improving auditability. 
- Ensure production deployments cannot accidentally write memory data to arbitrary paths without an explicit allowlist. 
- Provide clear operational visibility by logging the resolved memory directory at startup.

### Description
- Added `_default_memory_dir()` and `_resolve_memory_dir()` helpers in `veritas_os/memory/store.py` to centralize memory path resolution and validation. 
- Implemented production-mode validation using `VERITAS_MEMORY_DIR_ALLOWLIST` (comma-separated prefixes) and fallback to the project-local default when validation fails. 
- Emit `INFO`/`WARNING` logs that include the resolved candidate/default path for operational auditability and create the directory with explicit `mode=0o700`. 
- Added unit tests in `veritas_os/tests/test_memory_store.py` that cover default-path logging, production allowlist rejection, and production allowlist acceptance, and included docstrings for the new helpers.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_store.py` and all tests passed (`16 passed`). 
- The change includes unit tests for the new `_resolve_memory_dir()` behavior which were executed successfully.
- No other test suites were modified or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a596f3388c8326bdd8c37ddc68fc0c)