### PR TITLE
planner: surface code_planner fallback reason and warn on failures (P-01)

### DIFF
--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -1104,6 +1104,7 @@ def generate_code_tasks(
     """
     bench = bench or {}
     bench_id = bench.get("bench_id") or "agi_veritas_self_hosting"
+    planner_fallback_reason: Optional[str] = None
 
     # ---- (0) bench直読みがあるなら code_planner を使わない（重要） ----
     bench_changes = bench.get("changes")
@@ -1157,9 +1158,15 @@ def generate_code_tasks(
                 "tasks": tasks,
             }
 
-        except (AttributeError, TypeError, ValueError):
-            # code_planner が落ちたら純ロジックへ
-            pass
+        except (AttributeError, TypeError, ValueError) as exc:
+            planner_fallback_reason = (
+                f"{type(exc).__name__}: code_planner.generate_code_change_plan failed"
+            )
+            logger.warning(
+                "generate_code_tasks: fallback to inline planner logic (%s)",
+                planner_fallback_reason,
+                exc_info=True,
+            )
 
     # ---- (B) bench直読みの純ロジック経路 ----
     world_snap = bench.get("world_snapshot") or {}
@@ -1276,6 +1283,7 @@ def generate_code_tasks(
         "doctor_issue_count": len(dr_issues),
         "source": "planner.generate_code_tasks",
         "prefer_inline_bench": bool(prefer_inline),
+        "planner_fallback_reason": planner_fallback_reason,
     }
 
     try:

--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -520,6 +520,40 @@ def test_generate_code_tasks_creates_tasks_from_bench_and_doctor(monkeypatch):
     assert meta["decision_count"] == 42
     assert meta["doctor_issue_count"] == 1
     assert meta["source"] == "planner.generate_code_tasks"
+    assert meta["planner_fallback_reason"] is None
+
+
+def test_generate_code_tasks_logs_fallback_reason_when_code_planner_fails(
+    monkeypatch,
+    caplog,
+):
+    class DummyError(ValueError):
+        """Test-only error to simulate planner integration failure."""
+
+    def raise_integration_error(**_kwargs):
+        raise DummyError("bad plan")
+
+    monkeypatch.setattr(
+        planner_core.code_planner,
+        "generate_code_change_plan",
+        raise_integration_error,
+    )
+
+    with caplog.at_level("WARNING"):
+        result = planner_core.generate_code_tasks(
+            bench={"bench_id": "fallback_test"},
+            world_state={"veritas": {"progress": 0.1, "decision_count": 1}},
+            doctor_report={},
+        )
+
+    assert result["tasks"] == []
+    meta = result["meta"]
+    assert meta["bench_id"] == "fallback_test"
+    assert "DummyError" in (meta["planner_fallback_reason"] or "")
+    assert any(
+        "fallback to inline planner logic" in record.message
+        for record in caplog.records
+    )
 
 
 # -------------------------------


### PR DESCRIPTION
### Motivation
- Planner の `code_planner` 連携失敗時に例外を `pass` してサイレントにフォールバックしていたため可観測性が低く、運用での原因追跡が困難だったため改善する。 
- レビュー指摘 P-01 に従い、最小限の変更でフォールバック理由を記録しつつ既存のフォールバック挙動は維持する。 

### Description
- `generate_code_tasks` に `planner_fallback_reason: Optional[str]` を追加して、`code_planner.generate_code_change_plan` が失敗した際に例外型名を含む説明文字列を設定するようにした。 
- 例外発生時に `logger.warning(..., exc_info=True)` で警告とスタックトレースを出力するようにしてサイレント握りつぶしを解消した。 
- 返却される `meta` に `planner_fallback_reason` を追加して後段で原因分析できるようにした。 
- テストを追加・更新して振る舞いを保証しており、`veritas_os/tests/test_planner.py` に正常系で `planner_fallback_reason is None` を確認するアサーションと、`code_planner` 故障時にログ出力と `planner_fallback_reason` が設定されることを検証するテストを追加した。 

### Testing
- 実行コマンド: `pytest -q veritas_os/tests/test_planner.py`. 
- 結果: `50 passed`（全テスト成功）。 
- 新規テスト: `test_generate_code_tasks_logs_fallback_reason_when_code_planner_fails` が追加され、フォールバック理由のメタ反映と警告ログ出力を検証している（合格）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5998a46d08326bace70cdb347a7ec)