### PR TITLE
api: classify decide pipeline failures for safer triage

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -317,6 +317,17 @@ def _log_decide_failure(message: str, err: Optional[Exception | str]) -> None:
     logger.error("decide failed: %s (%s)", message, err_detail)
 
 
+def _classify_decide_failure(err: BaseException) -> str:
+    """Classify decide failure causes for safe-side operational diagnostics."""
+    if isinstance(err, TimeoutError):
+        return "timeout"
+    if isinstance(err, PermissionError):
+        return "permission_denied"
+    if isinstance(err, (ValueError, TypeError, KeyError)):
+        return "invalid_input"
+    return "internal"
+
+
 def get_cfg() -> Any:
     """
     cfg は “無い/壊れてる” 可能性があるので必ずフォールバックを返す。
@@ -1548,14 +1559,23 @@ async def decide(req: DecideRequest, request: Request):
     try:
         payload = await p.run_decide_pipeline(req=req, request=request)
     except Exception as e:
+        failure_category = _classify_decide_failure(e)
         _log_decide_failure("decision_pipeline execution failed", e)
-        _publish_event("decide.completed", {"ok": False, "error": DECIDE_GENERIC_ERROR})
+        _publish_event(
+            "decide.completed",
+            {
+                "ok": False,
+                "error": DECIDE_GENERIC_ERROR,
+                "failure_category": failure_category,
+            },
+        )
         return JSONResponse(
             status_code=503,
             content={
                 "ok": False,
                 "error": DECIDE_GENERIC_ERROR,
                 "detail": DECIDE_GENERIC_ERROR,
+                "failure_category": failure_category,
                 "trust_log": None,  # ★互換
             },
         )

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -685,6 +685,53 @@ def test_decide_pipeline_execution_failure_hides_detail(monkeypatch):
 # -------------------------------------------------
 
 
+
+def test_decide_pipeline_execution_failure_classifies_timeout(monkeypatch):
+    """/v1/decide failures should expose timeout category without leaking internals."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            raise TimeoutError("operation timed out")
+
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["error"] == server.DECIDE_GENERIC_ERROR
+    assert data["failure_category"] == "timeout"
+    assert data["detail"] == server.DECIDE_GENERIC_ERROR
+
+
+def test_decide_pipeline_execution_failure_classifies_invalid_input(monkeypatch):
+    """/v1/decide failures should expose invalid_input category for input-shape errors."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            raise ValueError("bad request shape")
+
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["error"] == server.DECIDE_GENERIC_ERROR
+    assert data["failure_category"] == "invalid_input"
+    assert data["detail"] == server.DECIDE_GENERIC_ERROR
+
+
 def test_fuji_validate_uses_validate_action(monkeypatch):
     """
     fuji_core.validate_action がある場合、その経路が使われる


### PR DESCRIPTION
### Motivation
- Implement a machine-readable failure classification for `/v1/decide` to improve operational triage as recommended by the SYSTEM_SCORECARD P0 items.
- Provide coarse-grained cause classification while preserving generic client-facing error details to avoid leaking internal state.

### Description
- Add `_classify_decide_failure(err: BaseException) -> str` which maps `TimeoutError` -> `"timeout"`, `PermissionError` -> `"permission_denied"`, `ValueError|TypeError|KeyError` -> `"invalid_input"`, and otherwise `"internal"`.
- When `run_decide_pipeline` raises, include `failure_category` in the SSE `decide.completed` event payload and in the 503 JSON response while keeping `detail` set to `DECIDE_GENERIC_ERROR`.
- Add two regression tests to `veritas_os/tests/test_api_server_extra.py` that assert `failure_category` is set for `TimeoutError` and `ValueError` pipeline failures.
- Preserve existing behavior of hiding internal error details from clients and do not change responsibility boundaries.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_server_extra.py -k "execution_failure"` and the targeted tests passed (`3 passed, 58 deselected`).
- Ran the responsibility boundary check with `python scripts/architecture/check_responsibility_boundaries.py` and it reported `Responsibility boundary check passed.`.
- Ran linting with `ruff check veritas_os/api/server.py veritas_os/tests/test_api_server_extra.py` and received `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5aac732e083269063bb03a069ff1a)