### PR TITLE
Improve P1 boundary-check CI remediation guidance

### DIFF
--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -21,6 +21,15 @@ class BoundaryRule:
     forbidden_imports: frozenset[str]
 
 
+@dataclass(frozen=True)
+class ViolationDetail:
+    """Structured details for a single responsibility-boundary violation."""
+
+    source_module: str
+    forbidden_module: str
+    path: Path
+
+
 DEFAULT_RULES: tuple[BoundaryRule, ...] = (
     BoundaryRule(
         source_module="planner",
@@ -35,6 +44,31 @@ DEFAULT_RULES: tuple[BoundaryRule, ...] = (
         forbidden_imports=frozenset({"kernel", "planner", "fuji"}),
     ),
 )
+
+
+ALLOWED_DEPENDENCY_GUIDE: dict[str, tuple[str, ...]] = {
+    "planner": (
+        "veritas_os.core.memory",
+        "veritas_os.core.world_model",
+        "veritas_os.core.strategy",
+    ),
+    "kernel": (
+        "veritas_os.core.planner",
+        "veritas_os.core.fuji",
+        "veritas_os.core.memory",
+    ),
+    "fuji": (
+        "veritas_os.core.fuji_codes",
+        "veritas_os.core.sanitize",
+    ),
+    "memory": (
+        "veritas_os.utils.atomic_io",
+        "veritas_os.core.memory_vector",
+    ),
+}
+
+
+REMEDIATION_LINK = "docs/review/SYSTEM_SCORECARD_2026_03_02.md#実装方針責務境界を越えない範囲"
 
 
 def _normalize_module_name(module_name: str) -> str:
@@ -75,6 +109,60 @@ def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
     ]
 
 
+def _collect_violations(
+    core_dir: Path,
+    rules: Iterable[BoundaryRule] = DEFAULT_RULES,
+) -> list[ViolationDetail]:
+    """Collect structured violation details for remediation guidance output."""
+    violation_details: list[ViolationDetail] = []
+    for rule in rules:
+        path = core_dir / f"{rule.source_module}.py"
+        try:
+            source = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            continue
+        tree = ast.parse(source, filename=str(path))
+        imported = _collect_imported_names(tree)
+        violations = sorted(imported & rule.forbidden_imports)
+        for forbidden_module in violations:
+            violation_details.append(
+                ViolationDetail(
+                    source_module=rule.source_module,
+                    forbidden_module=forbidden_module,
+                    path=path,
+                )
+            )
+    return violation_details
+
+
+def build_remediation_guide(
+    violations: Iterable[ViolationDetail],
+    remediation_link: str = REMEDIATION_LINK,
+) -> str:
+    """Build a CI-friendly remediation guide for boundary violations."""
+    rows: list[str] = []
+    for violation in violations:
+        alternatives = ", ".join(ALLOWED_DEPENDENCY_GUIDE.get(violation.source_module, ("N/A",)))
+        rows.append(
+            " | ".join(
+                (
+                    f"{violation.source_module} -> {violation.forbidden_module}",
+                    alternatives,
+                    remediation_link,
+                )
+            )
+        )
+
+    if not rows:
+        return ""
+
+    header = (
+        "\n=== Responsibility Boundary Remediation Guide ===\n"
+        "禁止依存 | 代替実装先（許可依存） | 修正例リンク\n"
+    )
+    return header + "\n".join(rows)
+
+
 def check_boundaries(core_dir: Path, rules: Iterable[BoundaryRule] = DEFAULT_RULES) -> list[str]:
     """Run all boundary rules and return all violation messages."""
     issues: list[str] = []
@@ -102,8 +190,12 @@ def main() -> int:
     issues = check_boundaries(core_dir=args.core_dir)
 
     if issues:
+        violations = _collect_violations(core_dir=args.core_dir)
         for issue in issues:
             print(issue)
+        remediation_guide = build_remediation_guide(violations)
+        if remediation_guide:
+            print(remediation_guide)
         return 1
 
     print("Responsibility boundary check passed.")

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from scripts.architecture.check_responsibility_boundaries import (
+    REMEDIATION_LINK,
+    ViolationDetail,
+    build_remediation_guide,
     BoundaryRule,
     check_boundaries,
 )
@@ -61,3 +64,29 @@ def test_check_boundaries_supports_custom_rules(tmp_path: Path) -> None:
     assert len(issues) == 1
     assert "kernel" in issues[0]
     assert "memory" in issues[0]
+
+
+def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
+    """Remediation guide should include forbidden dependency, alternatives, and link."""
+    violations = [
+        ViolationDetail(
+            source_module="planner",
+            forbidden_module="kernel",
+            path=tmp_path / "planner.py",
+        ),
+    ]
+
+    guide = build_remediation_guide(violations)
+
+    assert "禁止依存" in guide
+    assert "代替実装先（許可依存）" in guide
+    assert "planner -> kernel" in guide
+    assert "veritas_os.core.memory" in guide
+    assert REMEDIATION_LINK in guide
+
+
+def test_build_remediation_guide_returns_empty_for_no_violations() -> None:
+    """No remediation guide should be emitted when violations are absent."""
+    guide = build_remediation_guide([])
+
+    assert guide == ""


### PR DESCRIPTION
### Motivation
- Implement the P1 item from `docs/review/SYSTEM_SCORECARD_2026_03_02.md` to surface "禁止依存 / 代替実装先 / 修正例リンク" in CI logs so developers can remediate boundary violations faster. 
- Improve CI failure output for the `Planner / Kernel / Fuji / MemoryOS` responsibility checker without changing runtime behavior or module responsibilities. 
- Security warning: this change only enhances static analysis output and does not address secret/key management or LLM input-sanitization risks, which require separate operational controls. 

### Description
- Added a `ViolationDetail` dataclass and `ALLOWED_DEPENDENCY_GUIDE` plus `REMEDIATION_LINK` constants to structure violations and suggested alternatives. 
- Implemented `_collect_violations()` and `build_remediation_guide()` and wired the remediation guide to be printed by the CLI `main()` when boundary violations are detected. 
- Kept existing `check_boundaries()` logic intact, and added unit tests in `veritas_os/tests/test_responsibility_boundary_checker.py` to verify remediation-guide content and empty-output behavior; all new functions include docstrings and changes were made only to the boundary checker and its tests. 

### Testing
- Ran `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py` and the suite succeeded (`5 passed`). 
- Executed `python scripts/architecture/check_responsibility_boundaries.py` which reported `Responsibility boundary check passed.`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ada3ad8083268afe0b3806ff3653)