### PR TITLE
責務境界チェッカー: `from ... import ...` 形式を検出できるよう修正

### DIFF
--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -84,6 +84,12 @@ def _collect_imported_names(tree: ast.Module) -> set[str]:
             for alias in node.names:
                 imported.add(_normalize_module_name(alias.name))
         elif isinstance(node, ast.ImportFrom):
+            # Include imported symbols to detect patterns like:
+            #   from veritas_os.core import kernel
+            # This is a forbidden dependency equivalent to
+            #   import veritas_os.core.kernel
+            for alias in node.names:
+                imported.add(_normalize_module_name(alias.name))
             if node.module:
                 imported.add(_normalize_module_name(node.module))
             else:

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -66,6 +66,20 @@ def test_check_boundaries_supports_custom_rules(tmp_path: Path) -> None:
     assert "memory" in issues[0]
 
 
+def test_check_boundaries_detects_from_core_import_pattern(tmp_path: Path) -> None:
+    """Checker should catch `from veritas_os.core import <forbidden>` imports."""
+    _write_module(tmp_path / "planner.py", "from veritas_os.core import kernel\n")
+    _write_module(tmp_path / "kernel.py", "# kernel module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+
+    issues = check_boundaries(core_dir=tmp_path)
+
+    assert len(issues) == 1
+    assert "planner" in issues[0]
+    assert "kernel" in issues[0]
+
+
 def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
     """Remediation guide should include forbidden dependency, alternatives, and link."""
     violations = [


### PR DESCRIPTION
### Motivation
- 既存の境界チェッカーは `import veritas_os.core.kernel` のような明示的 import は検出できたが、`from veritas_os.core import kernel` という from-import 形式を見逃すことで責務境界違反が CI をすり抜ける可能性があった。 
- この修正は P2（責務境界の自動検査強化）に沿い、CI 上での検出漏れを減らしてセキュリティ／保守性リスクを低減することを目的としている。 

### Description
- `scripts/architecture/check_responsibility_boundaries.py` の `_collect_imported_names` を拡張して `ImportFrom` ノードの別名（`alias.name`）を収集するようにし、`from veritas_os.core import <module>` パターンを依存検出対象に追加した。 
- 回帰防止のために `veritas_os/tests/test_responsibility_boundary_checker.py` に `test_check_boundaries_detects_from_core_import_pattern` テストを追加し、期待される違反が報告されることを検証した。 
- 変更は該当チェッカーとテストに限定しており、`Planner / Kernel / Fuji / MemoryOS` の責務分離の範囲外の実装変更は行っていないことを維持した。 
- 変更は PEP8 準拠で実装してあり、既存のドキュメントへの参照リンク（`REMEDIATION_LINK`）はそのまま利用している。 

### Testing
- 自動化テストとして `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py` を実行し、`6 passed` で全テストが成功した。 
- 影響範囲はチェッカー本体と追加テストのみであり、既存 CI のリンター／テストジョブに組み込んだ場合も同様に動作する想定である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b428e65883269a7300d5d95065f0)