### PR TITLE
docs: fix README code fence and remove duplicate Operational Security Deep Dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pipeline mental model:
 
 ```text
 Options → Evidence → Critique → Debate → Planner → ValueCore → FUJI → TrustLog
-````
+```
 
 Bundled subsystems:
 
@@ -171,18 +171,6 @@ Example payload:
   }
 }
 ```
-
----
-
-## Operational Security Deep Dive
-
-- **Never use placeholder or short secrets**: `VERITAS_API_SECRET` should be a long,
-  random value (32+ chars recommended). Placeholder or short secrets can effectively
-  disable or weaken HMAC protection.
-- **CORS safety**: avoid wildcard origins (`*`) when `allow_credentials` is enabled.
-  Configure explicit trusted origins only.
-- **Legacy pickle migration is risky**: if you enable legacy pickle migration for
-  MemoryOS, treat it as a short-lived migration path and disable it afterward.
 
 ---
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -172,14 +172,6 @@ python -m uvicorn veritas_os.api.server:app --reload --port 8000
 
 ---
 
-## Operational Security Deep Dive
-
-- **プレースホルダ/短いシークレットは使用しない**: `VERITAS_API_SECRET` は長くランダムな値（推奨32文字以上）を設定してください。短い値や既知値はHMAC保護を実質的に弱体化します。
-- **CORS安全性**: `allow_credentials` が有効な場合、ワイルドカードオリジン（`*`）は避け、信頼済みオリジンを明示してください。
-- **Legacy pickle移行は高リスク**: MemoryOS で旧pickle移行を有効化する場合、短期移行用途に限定し、完了後は無効化してください。
-
----
-
 ## Docker（GHCR）
 
 最新イメージ取得:


### PR DESCRIPTION
### Motivation
- Fix a Markdown rendering bug in `README.md` where a code-fence terminator used four backticks and could break subsequent rendering. 
- Eliminate duplicated `Operational Security Deep Dive` blocks in `README.md` and `README_JP.md` to remove ambiguity and reduce EN/JP drift risk. 
- Keep all canonical security guidance consolidated under the existing `Security Notes (Important)` / `セキュリティ注意（重要）` section to make operational recommendations (secrets, CORS, PII) unambiguous. 
- No runtime code or pipeline logic (Planner / Kernel / FUJI / MemoryOS) was changed as part of this update. 

### Description
- Corrected the code-fence terminator in the `Pipeline mental model` block in `README.md` from ```` to ````` (now ` ``` `) to restore proper Markdown rendering. 
- Removed the duplicated `## Operational Security Deep Dive` sections from both `README.md` and `README_JP.md`. 
- Consolidated security guidance to the single canonical security section (`Security Notes (Important)` / `セキュリティ注意（重要）`) and left the substantive warnings (e.g., `VERITAS_API_SECRET` entropy, CORS `allow_credentials`, PII masking) intact. 
- Changes are documentation-only edits to `README.md` and `README_JP.md` and do not modify application behavior or core subsystems. 

### Testing
- Ran `git diff -- README.md README_JP.md` to validate the produced diff and confirm the intended edits, and the diff matched expectations (succeeded). 
- Searched for remaining occurrences with `rg -n '````|## Operational Security Deep Dive' README.md README_JP.md || true` and confirmed no remaining matches (succeeded). 
- Performed commit with `git commit -m "docs: fix README fence and unify security section structure"` which completed successfully. 
- No unit or integration tests were required because this is a documentation-only change; no automated test failures occurred during the verification commands above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61fc63b0c8326b3fb381438cc85d4)