### PR TITLE
test: add permission-denied contract coverage for /v1/decide failures

### DIFF
--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -732,6 +732,29 @@ def test_decide_pipeline_execution_failure_classifies_invalid_input(monkeypatch)
     assert data["detail"] == server.DECIDE_GENERIC_ERROR
 
 
+def test_decide_pipeline_execution_failure_classifies_permission_denied(monkeypatch):
+    """/v1/decide failures should expose permission_denied category safely."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            raise PermissionError("operation is not permitted")
+
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["error"] == server.DECIDE_GENERIC_ERROR
+    assert data["failure_category"] == "permission_denied"
+    assert data["detail"] == server.DECIDE_GENERIC_ERROR
+
+
 def test_fuji_validate_uses_validate_action(monkeypatch):
     """
     fuji_core.validate_action がある場合、その経路が使われる


### PR DESCRIPTION
### Motivation
- Add a contract test to follow the SYSTEM_SCORECARD recommendation to cover abnormal-paths (timeout / invalid input / permission) by verifying that `PermissionError` in the decide pipeline is classified as `failure_category="permission_denied"` while the exposed `detail` remains the safe generic `service_unavailable`; note that secret management and input-sanitization risks remain and should be mitigated operationally. 

### Description
- Added a new API test in `veritas_os/tests/test_api_server_extra.py` that injects a `PermissionError` from the decision pipeline and asserts `failure_category == "permission_denied"` and `detail == server.DECIDE_GENERIC_ERROR` (test-only change, no runtime behavior changes). 

### Testing
- Ran `pytest -q veritas_os/tests/test_api_server_extra.py -k 'classifies_permission_denied or classifies_timeout or classifies_invalid_input'` which passed (3 tests), and `ruff check veritas_os/tests/test_api_server_extra.py scripts/architecture/check_responsibility_boundaries.py` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6294163b0832682bc3789039d58ae)