### PR TITLE
Add JSON machine-readable responsibility-boundary reports and enable in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         run: ruff check veritas_os/
 
       - name: Responsibility boundary check
-        run: python scripts/architecture/check_responsibility_boundaries.py
+        run: python scripts/architecture/check_responsibility_boundaries.py --report-format json
 
       - name: Bandit security scan
         run: |

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -28,6 +29,17 @@ class ViolationDetail:
     source_module: str
     forbidden_module: str
     path: Path
+
+
+@dataclass(frozen=True)
+class BoundaryIssue:
+    """Machine-readable issue produced by the boundary checker."""
+
+    code: str
+    message: str
+    path: Path
+    source_module: str
+    forbidden_module: str | None = None
 
 
 DEFAULT_RULES: tuple[BoundaryRule, ...] = (
@@ -115,6 +127,75 @@ def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
     ]
 
 
+def _parse_imported_names(path: Path) -> set[str]:
+    """Parse a module and return imported names from its AST."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    return _collect_imported_names(tree)
+
+
+def collect_boundary_issues(
+    core_dir: Path,
+    rules: Iterable[BoundaryRule] = DEFAULT_RULES,
+) -> list[BoundaryIssue]:
+    """Collect machine-classifiable boundary checker issues."""
+    issues: list[BoundaryIssue] = []
+    for rule in rules:
+        path = core_dir / f"{rule.source_module}.py"
+        try:
+            imported = _parse_imported_names(path)
+        except FileNotFoundError:
+            issues.append(
+                BoundaryIssue(
+                    code="input_invalid",
+                    message=f"Boundary check error: '{rule.source_module}' not found at {path}",
+                    path=path,
+                    source_module=rule.source_module,
+                )
+            )
+            continue
+        except PermissionError:
+            issues.append(
+                BoundaryIssue(
+                    code="permission_denied",
+                    message=f"Boundary check error: permission denied for {path}",
+                    path=path,
+                    source_module=rule.source_module,
+                )
+            )
+            continue
+        except SyntaxError as exc:
+            issues.append(
+                BoundaryIssue(
+                    code="input_invalid",
+                    message=(
+                        "Boundary check error: invalid Python syntax in "
+                        f"{path} at line {exc.lineno}"
+                    ),
+                    path=path,
+                    source_module=rule.source_module,
+                )
+            )
+            continue
+
+        violations = sorted(imported & rule.forbidden_imports)
+        for forbidden_module in violations:
+            issues.append(
+                BoundaryIssue(
+                    code="boundary_violation",
+                    message=(
+                        "Boundary violation: "
+                        f"'{rule.source_module}' imports forbidden module "
+                        f"'{forbidden_module}' ({path})"
+                    ),
+                    path=path,
+                    source_module=rule.source_module,
+                    forbidden_module=forbidden_module,
+                )
+            )
+    return issues
+
+
 def _collect_violations(
     core_dir: Path,
     rules: Iterable[BoundaryRule] = DEFAULT_RULES,
@@ -171,10 +252,38 @@ def build_remediation_guide(
 
 def check_boundaries(core_dir: Path, rules: Iterable[BoundaryRule] = DEFAULT_RULES) -> list[str]:
     """Run all boundary rules and return all violation messages."""
-    issues: list[str] = []
-    for rule in rules:
-        issues.extend(_check_rule(core_dir=core_dir, rule=rule))
-    return issues
+    return [issue.message for issue in collect_boundary_issues(core_dir=core_dir, rules=rules)]
+
+
+def build_machine_report(issues: Iterable[BoundaryIssue]) -> str:
+    """Build JSON report for CI log parsing and alert classification."""
+    issue_list = list(issues)
+    counts: dict[str, int] = {
+        "boundary_violation": 0,
+        "input_invalid": 0,
+        "permission_denied": 0,
+    }
+    for issue in issue_list:
+        if issue.code in counts:
+            counts[issue.code] += 1
+        else:
+            counts[issue.code] = counts.get(issue.code, 0) + 1
+
+    payload = {
+        "status": "failed" if issue_list else "passed",
+        "summary": counts,
+        "issues": [
+            {
+                "code": issue.code,
+                "source_module": issue.source_module,
+                "forbidden_module": issue.forbidden_module,
+                "path": str(issue.path),
+                "message": issue.message,
+            }
+            for issue in issue_list
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -186,6 +295,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=Path("veritas_os/core"),
         help="Path to the core module directory (default: veritas_os/core).",
     )
+    parser.add_argument(
+        "--report-format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for CI logs (default: text).",
+    )
     return parser
 
 
@@ -193,18 +308,25 @@ def main() -> int:
     """CLI entrypoint for CI execution."""
     parser = _build_parser()
     args = parser.parse_args()
-    issues = check_boundaries(core_dir=args.core_dir)
+    structured_issues = collect_boundary_issues(core_dir=args.core_dir)
+    issues = [issue.message for issue in structured_issues]
 
     if issues:
         violations = _collect_violations(core_dir=args.core_dir)
-        for issue in issues:
-            print(issue)
-        remediation_guide = build_remediation_guide(violations)
-        if remediation_guide:
-            print(remediation_guide)
+        if args.report_format == "json":
+            print(build_machine_report(structured_issues))
+        else:
+            for issue in issues:
+                print(issue)
+            remediation_guide = build_remediation_guide(violations)
+            if remediation_guide:
+                print(remediation_guide)
         return 1
 
-    print("Responsibility boundary check passed.")
+    if args.report_format == "json":
+        print(build_machine_report(structured_issues))
+    else:
+        print("Responsibility boundary check passed.")
     return 0
 
 

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from scripts.architecture.check_responsibility_boundaries import (
     REMEDIATION_LINK,
-    ViolationDetail,
-    build_remediation_guide,
+    BoundaryIssue,
     BoundaryRule,
+    ViolationDetail,
+    build_machine_report,
+    build_remediation_guide,
     check_boundaries,
+    collect_boundary_issues,
 )
 
 
@@ -104,3 +108,53 @@ def test_build_remediation_guide_returns_empty_for_no_violations() -> None:
     guide = build_remediation_guide([])
 
     assert guide == ""
+
+
+def test_collect_boundary_issues_classifies_missing_module(tmp_path: Path) -> None:
+    """Missing source modules should be classified as input_invalid."""
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(issue.code == "input_invalid" for issue in issues)
+
+
+def test_collect_boundary_issues_classifies_boundary_violation(tmp_path: Path) -> None:
+    """Forbidden import should be classified as boundary_violation."""
+    _write_module(tmp_path / "planner.py", "import veritas_os.core.kernel\n")
+    _write_module(tmp_path / "kernel.py", "# kernel module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert len(issues) == 1
+    assert issues[0].code == "boundary_violation"
+    assert issues[0].source_module == "planner"
+    assert issues[0].forbidden_module == "kernel"
+
+
+def test_build_machine_report_counts_by_code(tmp_path: Path) -> None:
+    """Machine report should summarize issue counts for CI parsers."""
+    issues = [
+        BoundaryIssue(
+            code="boundary_violation",
+            message="violation",
+            path=tmp_path / "planner.py",
+            source_module="planner",
+            forbidden_module="kernel",
+        ),
+        BoundaryIssue(
+            code="permission_denied",
+            message="permission denied",
+            path=tmp_path / "fuji.py",
+            source_module="fuji",
+        ),
+    ]
+
+    report = json.loads(build_machine_report(issues))
+
+    assert report["status"] == "failed"
+    assert report["summary"]["boundary_violation"] == 1
+    assert report["summary"]["permission_denied"] == 1
+    assert report["summary"]["input_invalid"] == 0


### PR DESCRIPTION
### Motivation
- The system scorecard recommends mechanical enforcement and machine-classifiable failure logs for responsibility-boundary checks so CI can automatically block and classify violations. 
- The change aims to make boundary-checker output parsable by CI/alerting systems while preserving the existing human remediation guide.

### Description
- Added a `BoundaryIssue` dataclass and `collect_boundary_issues()` to produce machine-classifiable issue objects (codes: `boundary_violation`, `input_invalid`, `permission_denied`).
- Added `build_machine_report()` and a `--report-format` CLI flag to emit JSON summaries suitable for CI log parsing while keeping text output and the existing remediation guide intact.
- Switched `check_boundaries()` to reuse the new collector and updated `main()` to support JSON output; preserved original behavior for text mode and remediation guidance.
- Updated CI invocation in `.github/workflows/main.yml` to run the checker with `--report-format json` and expanded unit tests in `veritas_os/tests/test_responsibility_boundary_checker.py` to validate classification and JSON summary counts.

### Testing
- Ran unit tests with `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py`, which succeeded (`9 passed`).
- Executed the checker in CI mode with `python scripts/architecture/check_responsibility_boundaries.py --report-format json` and verified it produced a structured JSON report indicating a passing state.
- All automated tests added/updated for this change passed successfully.

Security note: this change improves detection and machine-classification of boundary violations in CI but does not modify runtime responsibility boundaries nor address separate operational risks such as secret management or input-sanitization; those remain required follow-ups as noted in the system scorecard.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62e70205c8326b5371dbc42df1e7e)