### PR TITLE
docs(ui): add Japanese guide for previewing UI/UX pages

### DIFF
--- a/docs/ui/PREVIEW_PAGES_JP.md
+++ b/docs/ui/PREVIEW_PAGES_JP.md
@@ -1,0 +1,25 @@
+# UI/UX 各ページのプレビュー手順
+
+## 1. フロントエンドを起動
+
+```bash
+pnpm --filter frontend dev --hostname 0.0.0.0 --port 3000
+```
+
+## 2. ブラウザで各ページを確認
+
+- ホーム: `http://localhost:3000/`
+- Console: `http://localhost:3000/console`
+- Audit: `http://localhost:3000/audit`
+- Governance: `http://localhost:3000/governance`
+- Risk: `http://localhost:3000/risk`
+
+## 3. スクリーンショットを一括取得（任意）
+
+Playwright を使う場合は、ページにアクセスして `full_page=True` のスクリーンショットを取得すると、
+長いダッシュボードでも見切れにくく確認できます。
+
+## セキュリティ注意
+
+- `next dev` は開発サーバーです。本番用途で公開しないでください。
+- `--hostname 0.0.0.0` はローカルネットワークからアクセス可能になります。必要がない場合は `localhost` のみにしてください。


### PR DESCRIPTION
### Motivation
- Provide a simple, local workflow for engineers and designers to preview the current UI/UX pages and capture screenshots for review.

### Description
- Added `docs/ui/PREVIEW_PAGES_JP.md` with the `pnpm --filter frontend dev --hostname 0.0.0.0 --port 3000` startup command, the primary routes (`/`, `/console`, `/audit`, `/governance`, `/risk`), Playwright screenshot guidance, and security cautions about `next dev` and binding to `0.0.0.0`.

### Testing
- Verified by running `pnpm --filter frontend dev --hostname 0.0.0.0 --port 3000` and a Playwright script that captured full-page screenshots for `/`, `/console`, `/audit`, `/governance`, and `/risk`, which completed successfully and produced artifacts at `browser:/tmp/codex_browser_invocations/09ea50395690165c/artifacts/artifacts/home.png`, `browser:/tmp/codex_browser_invocations/09ea50395690165c/artifacts/artifacts/console.png`, `browser:/tmp/codex_browser_invocations/09ea50395690165c/artifacts/artifacts/audit.png`, `browser:/tmp/codex_browser_invocations/09ea50395690165c/artifacts/artifacts/governance.png`, and `browser:/tmp/codex_browser_invocations/09ea50395690165c/artifacts/artifacts/risk.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a63db7fe6083268de1862b6fffc265)