### PR TITLE
Sanitize console API error messages shown in UI

### DIFF
--- a/frontend/features/console/api/useDecide.test.ts
+++ b/frontend/features/console/api/useDecide.test.ts
@@ -105,6 +105,42 @@ describe("useDecide", () => {
     expect(setResult).toHaveBeenCalledWith(secondPayload);
   });
 
+
+
+  it("sanitizes non-ok error response and does not expose body text", async () => {
+    const sensitiveBody = '{"debug":"stack trace"}';
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(sensitiveBody, {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setQuery = vi.fn();
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: () => "",
+        query: "q",
+        setQuery,
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runDecision("question");
+    });
+
+    expect(result.current.error).toBe("HTTP 500: Request failed. Please try again later.");
+    expect(result.current.error).not.toContain("stack trace");
+    expect(setResult).toHaveBeenCalledWith(null);
+  });
   it("ignores stale completion and only applies latest result", async () => {
     const first = createDeferred<Response>();
     const second = createDeferred<Response>();

--- a/frontend/features/console/api/useDecide.ts
+++ b/frontend/features/console/api/useDecide.ts
@@ -117,8 +117,10 @@ export function useDecide({
       }
 
       if (!response.ok) {
-        const bodyText = await response.text();
-        const nextError = `HTTP ${response.status}: ${bodyText || "unknown error"}`;
+        const nextError = t(
+          `HTTP ${response.status}: リクエストに失敗しました。時間をおいて再試行してください。`,
+          `HTTP ${response.status}: Request failed. Please try again later.`,
+        );
         setError(nextError);
         setChatMessages((prev) => [...prev, { id: Date.now() + 1, role: "assistant", content: nextError }]);
         setResult(null);


### PR DESCRIPTION
### Motivation
- `FRONTEND_REVIEW.md` 指摘のうち「API エラーボディをそのまま UI 表示している」問題を解消し、上流の内部情報（スタックトレース等）がフロントエンドで露出するリスクを低減するための修正です。 
- 変更はフロントエンドの表示ロジックに限定し、Planner / Kernel / Fuji / MemoryOS の責務を越える改変は行っていません。

### Description
- `frontend/features/console/api/useDecide.ts` の `!response.ok` 分岐で `response.text()` を表示する代わりに、ステータスコードを含む定型のユーザ向けメッセージに置き換えました（ローカライズ済み via `t(...)`）。
- 上記に合わせて回帰防止用のユニットテストを `frontend/features/console/api/useDecide.test.ts` に追加し、上流が返す機微な本文（例: `stack trace`）がエラーメッセージに含まれないことを検証するテストを追加しました。
- 変更点はフロントエンドのエラーハンドリング層に限定しており、外部 API の挙動やサーバー側ログの扱いには影響を与えません。
- セキュリティ注意: 本修正で情報漏洩リスクは軽減されますが、`FRONTEND_REVIEW.md` にある CSP の `unsafe-inline` 問題は未対応のまま残っているため、XSS 緩和としては引き続き対応が必要です。

### Testing
- 実行したテスト: `cd frontend && pnpm vitest run features/console/api/useDecide.test.ts` を実行し、該当テストファイル内のテスト群がすべて成功しました（1ファイル、3テスト全てパス）。
- 追加テストは非公開な上流レスポンス本文を露出しないことを検証しており、期待どおりに合格しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a68ead11a88326a4b901d6142dca07)