### PR TITLE
frontend: localize LiveEventStream UI strings and add untranslated-key test

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LiveEventStream } from "./live-event-stream";
+import { I18nProvider } from "./i18n-provider";
 
 function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
@@ -33,9 +34,13 @@ describe("LiveEventStream", () => {
       }),
     );
 
-    render(<LiveEventStream />);
+    render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
 
-    expect(screen.getByText("Live Event Stream")).toBeInTheDocument();
+    expect(screen.getByText("ライブイベントストリーム")).toBeInTheDocument();
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
     expect(await screen.findByText("decide.completed")).toBeInTheDocument();
@@ -50,7 +55,11 @@ describe("LiveEventStream", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<LiveEventStream />);
+    render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalled();
@@ -59,7 +68,7 @@ describe("LiveEventStream", () => {
     const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
     expect(lastCall[0]).toBe("/api/veritas/v1/events");
     expect(lastCall[1]?.headers).toBeUndefined();
-    expect(screen.getByText("Security note: API key is injected server-side and never exposed to browser code.")).toBeInTheDocument();
+    expect(screen.getByText("セキュリティ注記: APIキーはサーバー側で注入され、ブラウザーコードには公開されません。")).toBeInTheDocument();
   });
 
   it("uses exponential backoff with jitter for reconnect attempts", async () => {
@@ -70,7 +79,11 @@ describe("LiveEventStream", () => {
     const fetchMock = vi.fn().mockRejectedValueOnce(new Error("network down"));
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<LiveEventStream />);
+    render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
 
     await act(async () => {
       await Promise.resolve();
@@ -93,14 +106,40 @@ describe("LiveEventStream", () => {
       }),
     );
 
-    render(<LiveEventStream />);
+    render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
 
     await act(async () => {
       await Promise.resolve();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Clear events" }));
+    fireEvent.click(screen.getByRole("button", { name: "イベントをクリア" }));
 
     expect(screen.getByText("イベント待機中...")).toBeInTheDocument();
   });
+
+  it("does not render raw i18n keys in the UI", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: createReadableStream([]),
+      }),
+    );
+
+    render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
+
+    const untranslatedKeys = ["clearEvents", "liveEventStreamTitle", "streamSecurityNote"];
+    for (const key of untranslatedKeys) {
+      expect(screen.queryByText(key)).not.toBeInTheDocument();
+    }
+  });
+
 });

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -80,7 +80,7 @@ function getEventTypeStyle(type: string): { dot: string; label: string } {
 }
 
 export function LiveEventStream(): JSX.Element {
-  const { t } = useI18n();
+  const { t, tk } = useI18n();
   const [events, setEvents] = useState<StreamEvent[]>([]);
   const [connected, setConnected] = useState(false);
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -162,13 +162,13 @@ export function LiveEventStream(): JSX.Element {
       onClick={() => setEvents([])}
       className="rounded-md border border-border/70 bg-muted/50 px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
     >
-      Clear events
+      {tk("clearEvents")}
     </button>
   );
 
   return (
     <Card
-      title="Live Event Stream"
+      title={tk("liveEventStreamTitle")}
       titleSize="md"
       variant="glass"
       actions={clearAction}
@@ -195,7 +195,7 @@ export function LiveEventStream(): JSX.Element {
           </span>
         </div>
         <p className="text-xs text-emerald-700 dark:text-emerald-500">
-          Security note: API key is injected server-side and never exposed to browser code.
+          {tk("streamSecurityNote")}
         </p>
       </div>
 

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -16,4 +16,7 @@ export const en: Record<LocaleKey, string> = {
   dangerPresets: "Danger presets (for safety rejection checks)",
   sending: "Sending...",
   send: "Send",
+  liveEventStreamTitle: "Live Event Stream",
+  clearEvents: "Clear events",
+  streamSecurityNote: "Security note: API key is injected server-side and never exposed to browser code.",
 };

--- a/frontend/locales/ja.ts
+++ b/frontend/locales/ja.ts
@@ -14,6 +14,9 @@ export const ja = {
   dangerPresets: "危険プリセット（安全拒否確認用）",
   sending: "送信中...",
   send: "送信",
+  liveEventStreamTitle: "ライブイベントストリーム",
+  clearEvents: "イベントをクリア",
+  streamSecurityNote: "セキュリティ注記: APIキーはサーバー側で注入され、ブラウザーコードには公開されません。",
 } as const;
 
 export type LocaleKey = keyof typeof ja;


### PR DESCRIPTION
### Motivation
- Some LiveEventStream UI strings (e.g. "Clear events" and the security note) were hardcoded and not using the i18n helper, causing localization gaps and potential duplication of text management.
- Add a test that detects untranslated/raw i18n keys to prevent regressions where keys are shown instead of localized text.

### Description
- Replaced hardcoded LiveEventStream strings with `tk()` lookups and retrieved `tk` from `useI18n()` in `frontend/components/live-event-stream.tsx`.
- Added new locale entries `liveEventStreamTitle`, `clearEvents`, and `streamSecurityNote` to `frontend/locales/ja.ts` and `frontend/locales/en.ts` to provide Japanese and English text.
- Updated `frontend/components/live-event-stream.test.tsx` to render the component inside `I18nProvider`, adjusted expectations for localized text, and added a regression test `does not render raw i18n keys in the UI` that asserts no untranslated keys appear.

### Testing
- Ran the component unit tests with `cd frontend && npm run test -- components/live-event-stream.test.tsx`, and the full test file passed (`5 tests` passed).
- Attempted an automated Playwright rendering/check (screenshot) while running the dev server, but the Chromium process crashed with a SIGSEGV in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6fde027748326930045c8f6582f5c)