### PR TITLE
Pause SSE reconnects on 401/403 and show re-auth guidance

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -95,6 +95,38 @@ describe("LiveEventStream", () => {
     vi.useRealTimers();
   });
 
+  it("pauses retries and shows re-auth guidance after 401/403", async () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      body: null,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 60000);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "認証エラー (401/403) を検知しました。再認証後に再接続してください。",
+    );
+    expect(screen.getByText(/17:40/)).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
   it("clears rendered events when clear button is pressed", async () => {
     vi.stubGlobal(
       "fetch",
@@ -136,7 +168,13 @@ describe("LiveEventStream", () => {
       </I18nProvider>,
     );
 
-    const untranslatedKeys = ["clearEvents", "liveEventStreamTitle", "streamSecurityNote"];
+    const untranslatedKeys = [
+      "clearEvents",
+      "liveEventStreamTitle",
+      "streamSecurityNote",
+      "streamAuthRecoveryHint",
+      "streamAuthRetryPausedUntil",
+    ];
     for (const key of untranslatedKeys) {
       expect(screen.queryByText(key)).not.toBeInTheDocument();
     }

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -13,6 +13,7 @@ interface StreamEvent {
 
 const BASE_RECONNECT_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 30000;
+const AUTH_RETRY_PAUSE_MS = 60000;
 
 function getReconnectDelayMs(attempt: number): number {
   const boundedAttempt = Math.max(0, attempt);
@@ -83,8 +84,10 @@ export function LiveEventStream(): JSX.Element {
   const { t, tk } = useI18n();
   const [events, setEvents] = useState<StreamEvent[]>([]);
   const [connected, setConnected] = useState(false);
+  const [authRecoveryAt, setAuthRecoveryAt] = useState<number | null>(null);
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptRef = useRef(0);
+  const authPauseRef = useRef(false);
 
   const streamUrl = "/api/veritas/v1/events";
 
@@ -109,9 +112,18 @@ export function LiveEventStream(): JSX.Element {
         });
 
         if (!response.ok || !response.body) {
+          if (response.status === 401 || response.status === 403) {
+            const recoveryAt = Date.now() + AUTH_RETRY_PAUSE_MS;
+            authPauseRef.current = true;
+            setAuthRecoveryAt(recoveryAt);
+            reconnectRef.current = setTimeout(connect, AUTH_RETRY_PAUSE_MS);
+            return;
+          }
           throw new Error(`stream connection failed: ${response.status}`);
         }
 
+        authPauseRef.current = false;
+        setAuthRecoveryAt(null);
         setConnected(true);
         reconnectAttemptRef.current = 0;
         const reader = response.body.getReader();
@@ -139,6 +151,9 @@ export function LiveEventStream(): JSX.Element {
 
       if (mounted) {
         setConnected(false);
+        if (authPauseRef.current) {
+          return;
+        }
         const delayMs = getReconnectDelayMs(reconnectAttemptRef.current);
         reconnectAttemptRef.current += 1;
         reconnectRef.current = setTimeout(connect, delayMs);
@@ -198,6 +213,20 @@ export function LiveEventStream(): JSX.Element {
           {tk("streamSecurityNote")}
         </p>
       </div>
+
+      {authRecoveryAt !== null ? (
+        <div
+          className="mb-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning"
+          role="alert"
+        >
+          <p>{tk("streamAuthRecoveryHint")}</p>
+          <p className="mt-1 text-[11px] text-warning/90">
+            {tk("streamAuthRetryPausedUntil")}
+            {" "}
+            {new Date(authRecoveryAt).toLocaleTimeString()}
+          </p>
+        </div>
+      ) : null}
 
       {/* Event list */}
       <div

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -19,4 +19,6 @@ export const en: Record<LocaleKey, string> = {
   liveEventStreamTitle: "Live Event Stream",
   clearEvents: "Clear events",
   streamSecurityNote: "Security note: API key is injected server-side and never exposed to browser code.",
+  streamAuthRecoveryHint: "Detected authentication error (401/403). Please re-authenticate, then reconnect.",
+  streamAuthRetryPausedUntil: "Retry paused temporarily (scheduled resume):",
 };

--- a/frontend/locales/ja.ts
+++ b/frontend/locales/ja.ts
@@ -17,6 +17,8 @@ export const ja = {
   liveEventStreamTitle: "ライブイベントストリーム",
   clearEvents: "イベントをクリア",
   streamSecurityNote: "セキュリティ注記: APIキーはサーバー側で注入され、ブラウザーコードには公開されません。",
+  streamAuthRecoveryHint: "認証エラー (401/403) を検知しました。再認証後に再接続してください。",
+  streamAuthRetryPausedUntil: "再試行を一時停止中（再開予定）:",
 } as const;
 
 export type LocaleKey = keyof typeof ja;


### PR DESCRIPTION
### Motivation
- The existing SSE reconnect loop continuously retries on all failures, which causes wasted retries and noisy traffic when the server returns permanent auth errors (401/403). 
- Operators need a clear UI signal and a temporary stop of retries so they can re-authenticate instead of the client hammering the endpoint.
- This change follows the review recommendation to treat 401/403 as an auth-recovery flow rather than a transient network retry.
- Note: this does not change the underlying SSE authentication scheme (e.g. query-string API key exposure), which remains a separate security concern.

### Description
- Added a 60s auth-retry pause constant (`AUTH_RETRY_PAUSE_MS`) and component state (`authRecoveryAt`) plus an `authPauseRef` to track auth-recovery mode in `LiveEventStream`.
- On `fetch` responses with status `401` or `403`, the component now sets the pause window, schedules a single retry after the pause, and avoids exponential-backoff retries while paused.
- Added an in-UI alert (`role="alert"`) that displays re-auth guidance and the scheduled resume time when an auth error is detected.
- Added i18n keys (`streamAuthRecoveryHint`, `streamAuthRetryPausedUntil`) in both Japanese and English and updated/added unit tests to verify the new behavior and translation handling.

### Testing
- Ran the component unit tests with Vitest: `npm --prefix frontend test -- live-event-stream.test.tsx`, and the targeted test file passed (6 tests, all green).
- The new test asserts that a `401` triggers a single scheduled retry (60k ms) and that the UI shows the re-auth guidance and resume time.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a70d5159d0832690cf8efe44456f20)