### PR TITLE
Add strict decision Replay API and replay_engine with persisted replay reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,50 @@ All protected endpoints require `X-API-Key`.
 | GET    | `/health`             | Health check                      |
 | POST   | `/v1/decide`          | Full decision loop                |
 | POST   | `/v1/fuji/validate`   | Validate a single action via FUJI |
+| POST   | `/v1/replay/{decision_id}` | Re-run a stored decision and persist replay report |
 | POST   | `/v1/memory/put`      | Persist memory                    |
 | GET    | `/v1/memory/get`      | Retrieve memory                   |
 | GET    | `/v1/logs/trust/{id}` | TrustLog entry by ID              |
+
+---
+
+
+## Replay
+
+`POST /v1/replay/{decision_id}` re-executes a stored decision using the original recorded inputs and writes a replay artifact to `REPLAY_REPORT_DIR` (`audit/replay_reports` by default) as:
+
+- `replay_{decision_id}_{YYYYMMDD_HHMMSS}.json`
+
+When `VERITAS_REPLAY_STRICT=1`, replay enforces deterministic settings (`temperature=0`, fixed seed, and mocked external retrieval side effects).
+
+```bash
+BODY='{"strict":true}'
+TS=$(date +%s)
+NONCE="replay-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+SIG=$(python - <<'PY'
+import hashlib
+import hmac
+import os
+
+secret=os.environ["VERITAS_API_SECRET"].encode("utf-8")
+ts=os.environ["TS"]
+nonce=os.environ["NONCE"]
+body=os.environ["BODY"]
+payload=f"{ts}\n{nonce}\n{body}"
+print(hmac.new(secret, payload.encode("utf-8"), hashlib.sha256).hexdigest())
+PY
+)
+
+curl -X POST "http://127.0.0.1:8000/v1/replay/DECISION_ID" \
+  -H "X-API-Key: ${VERITAS_API_KEY}" \
+  -H "X-VERITAS-TIMESTAMP: ${TS}" \
+  -H "X-VERITAS-NONCE: ${NONCE}" \
+  -H "X-VERITAS-SIGNATURE: ${SIG}" \
+  -H "Content-Type: application/json" \
+  -d "${BODY}"
+```
+
+EU AI Act report generation already reads `replay_{decision_id}_*.json`, so invoking the Replay API updates replay verification data consumed by compliance reporting automatically.
 
 ---
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -226,6 +226,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/DecideResponse'
 
+
+  /v1/replay/{decision_id}:
+    post:
+      summary: Replay a persisted decision and store replay report
+      parameters:
+        - in: path
+          name: decision_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Replay execution result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  decision_id:
+                    type: string
+                  replay_path:
+                    type: string
+                  match:
+                    type: boolean
+                  diff_summary:
+                    type: string
+                  replay_time_ms:
+                    type: integer
+
   /v1/fuji/validate:
     post:
       summary: Safety/ethics validation for a candidate action

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -38,6 +38,7 @@ from veritas_os.compliance.report_engine import (
     generate_eu_ai_act_report,
     generate_internal_governance_report,
 )
+from veritas_os.replay.replay_engine import run_replay
 from veritas_os.api.constants import (
     DECISION_ALLOW,
     DECISION_REJECTED,
@@ -553,7 +554,17 @@ app.add_middleware(
     allow_origins=_cors_origins,
     allow_credentials=_cors_allow_credentials,
     allow_methods=["GET", "POST", "PUT", "OPTIONS"],
-    allow_headers=["X-API-Key", "X-Timestamp", "X-Nonce", "X-Signature", "Content-Type", "Authorization"],
+    allow_headers=[
+        "X-API-Key",
+        "X-Timestamp",
+        "X-Nonce",
+        "X-Signature",
+        "X-VERITAS-TIMESTAMP",
+        "X-VERITAS-NONCE",
+        "X-VERITAS-SIGNATURE",
+        "Content-Type",
+        "Authorization",
+    ],
 )
 
 
@@ -1069,6 +1080,9 @@ async def verify_signature(
     x_timestamp: Optional[str] = Header(default=None, alias="X-Timestamp"),
     x_nonce: Optional[str] = Header(default=None, alias="X-Nonce"),
     x_signature: Optional[str] = Header(default=None, alias="X-Signature"),
+    x_veritas_timestamp: Optional[str] = Header(default=None, alias="X-VERITAS-TIMESTAMP"),
+    x_veritas_nonce: Optional[str] = Header(default=None, alias="X-VERITAS-NONCE"),
+    x_veritas_signature: Optional[str] = Header(default=None, alias="X-VERITAS-SIGNATURE"),
 ):
     """
     HMAC 認証を使う場合のみ dependencies に入れて使う想定。
@@ -1078,15 +1092,19 @@ async def verify_signature(
     api_secret = _get_api_secret()
     if not api_secret:
         raise HTTPException(status_code=500, detail="Server secret missing")
-    if not (x_api_key and x_timestamp and x_nonce and x_signature):
+    timestamp = x_veritas_timestamp or x_timestamp
+    nonce = x_veritas_nonce or x_nonce
+    signature = x_veritas_signature or x_signature
+
+    if not (x_api_key and timestamp and nonce and signature):
         raise HTTPException(status_code=401, detail="Missing auth headers")
     try:
-        ts = int(x_timestamp)
+        ts = int(timestamp)
     except (ValueError, TypeError):
         raise HTTPException(status_code=401, detail="Invalid timestamp") from None
     if abs(int(time.time()) - ts) > _NONCE_TTL_SEC:
         raise HTTPException(status_code=401, detail="Timestamp out of range")
-    if not _check_and_register_nonce(x_nonce):
+    if not _check_and_register_nonce(nonce):
         raise HTTPException(status_code=401, detail="Replay detected")
 
     body_bytes = await request.body()
@@ -1094,9 +1112,9 @@ async def verify_signature(
         body = body_bytes.decode("utf-8") if body_bytes else ""
     except UnicodeDecodeError:
         raise HTTPException(status_code=400, detail="Request body is not valid UTF-8") from None
-    payload = f"{ts}\n{x_nonce}\n{body}"
+    payload = f"{ts}\n{nonce}\n{body}"
     mac = hmac.new(api_secret, payload.encode("utf-8"), hashlib.sha256).hexdigest().lower()
-    if not hmac.compare_digest(mac, (x_signature or "").lower()):
+    if not hmac.compare_digest(mac, signature.lower()):
         raise HTTPException(status_code=401, detail="Invalid signature")
     return True
 
@@ -1623,6 +1641,36 @@ async def decide(req: DecideRequest, request: Request):
             status_code=200,
             content=content,
         )
+
+
+@app.post(
+    "/v1/replay/{decision_id}",
+    dependencies=[Depends(require_api_key), Depends(enforce_rate_limit), Depends(verify_signature)],
+)
+async def replay_endpoint(decision_id: str):
+    """Replay one persisted decision and write replay report JSON."""
+    try:
+        result = await run_replay(decision_id=decision_id)
+    except ValueError as e:
+        return JSONResponse(
+            status_code=404,
+            content={"ok": False, "decision_id": decision_id, "error": str(e)},
+        )
+    except Exception as e:
+        logger.error("replay endpoint failed: %s", _errstr(e))
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "decision_id": decision_id, "error": "replay_failed"},
+        )
+
+    return {
+        "ok": True,
+        "decision_id": result.decision_id,
+        "replay_path": result.replay_path,
+        "match": result.match,
+        "diff_summary": result.diff_summary,
+        "replay_time_ms": result.replay_time_ms,
+    }
 
 
 @app.post(

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -1092,11 +1092,22 @@ async def verify_signature(
     api_secret = _get_api_secret()
     if not api_secret:
         raise HTTPException(status_code=500, detail="Server secret missing")
-    timestamp = x_veritas_timestamp or x_timestamp
-    nonce = x_veritas_nonce or x_nonce
-    signature = x_veritas_signature or x_signature
 
-    if not (x_api_key and timestamp and nonce and signature):
+    def _header_or_none(value: Any) -> Optional[str]:
+        """Normalize dependency-injected Header defaults for direct unit test calls."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            trimmed = value.strip()
+            return trimmed if trimmed else None
+        return None
+
+    timestamp = _header_or_none(x_veritas_timestamp) or _header_or_none(x_timestamp)
+    nonce = _header_or_none(x_veritas_nonce) or _header_or_none(x_nonce)
+    signature = _header_or_none(x_veritas_signature) or _header_or_none(x_signature)
+    api_key = _header_or_none(x_api_key)
+
+    if not (api_key and timestamp and nonce and signature):
         raise HTTPException(status_code=401, detail="Missing auth headers")
     try:
         ts = int(timestamp)
@@ -1651,10 +1662,10 @@ async def replay_endpoint(decision_id: str):
     """Replay one persisted decision and write replay report JSON."""
     try:
         result = await run_replay(decision_id=decision_id)
-    except ValueError as e:
+    except ValueError:
         return JSONResponse(
             status_code=404,
-            content={"ok": False, "decision_id": decision_id, "error": str(e)},
+            content={"ok": False, "decision_id": decision_id, "error": "decision_not_found"},
         )
     except Exception as e:
         logger.error("replay endpoint failed: %s", _errstr(e))

--- a/veritas_os/replay/__init__.py
+++ b/veritas_os/replay/__init__.py
@@ -1,0 +1,5 @@
+"""Replay utilities for deterministic decision re-execution."""
+
+from veritas_os.replay.replay_engine import ReplayResult, run_replay
+
+__all__ = ["ReplayResult", "run_replay"]

--- a/veritas_os/replay/replay_engine.py
+++ b/veritas_os/replay/replay_engine.py
@@ -1,0 +1,233 @@
+"""Decision replay engine for deterministic reproducibility checks."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List
+
+from veritas_os.api.schemas import DecideRequest
+from veritas_os.core import pipeline
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Replay execution result used by API and compliance reports."""
+
+    decision_id: str
+    replay_path: str
+    replay_time_ms: int
+    strict: bool
+    match: bool
+    diff: Dict[str, Any]
+    diff_summary: str
+
+
+def _strict_mode_enabled() -> bool:
+    raw = (os.getenv("VERITAS_REPLAY_STRICT") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _pipeline_version() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            text=True,
+        )
+        version = out.strip()
+        if version:
+            return version
+    except Exception:
+        return "unknown"
+    return "unknown"
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _replay_file_name(decision_id: str) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    return f"replay_{decision_id}_{stamp}.json"
+
+
+def _sort_evidence(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _key(item: Dict[str, Any]) -> str:
+        return str(
+            item.get("id")
+            or item.get("title")
+            or item.get("url")
+            or item.get("uri")
+            or item.get("source")
+            or ""
+        ).lower()
+
+    return sorted(items, key=_key)
+
+
+def _normalized_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract stable fields for replay comparison."""
+    decision = payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    fuji = payload.get("fuji") if isinstance(payload.get("fuji"), dict) else {}
+    extras = payload.get("extras") if isinstance(payload.get("extras"), dict) else {}
+
+    decision_output = decision.get("output")
+    decision_answer = decision.get("answer")
+    fuji_result = fuji.get("result")
+    value_scores = payload.get("value_scores")
+    evidence = payload.get("evidence")
+
+    if not isinstance(evidence, list):
+        evidence = extras.get("evidence") if isinstance(extras.get("evidence"), list) else []
+
+    stable_evidence = []
+    for item in evidence:
+        if not isinstance(item, dict):
+            continue
+        stable_evidence.append(
+            {
+                "id": item.get("id"),
+                "title": item.get("title"),
+                "url": item.get("url") or item.get("uri"),
+                "source": item.get("source"),
+                "snippet": item.get("snippet"),
+            }
+        )
+
+    return {
+        "decision": {
+            "output": decision_output,
+            "answer": decision_answer,
+        },
+        "fuji": {
+            "result": fuji_result,
+            "status": fuji.get("status"),
+        },
+        "value_scores": value_scores,
+        "evidence": _sort_evidence(stable_evidence),
+    }
+
+
+def _build_diff(before: Dict[str, Any], after: Dict[str, Any]) -> Dict[str, Any]:
+    fields_changed: List[str] = []
+    high_level: List[str] = []
+
+    for key in sorted(set(before.keys()) | set(after.keys())):
+        if before.get(key) != after.get(key):
+            fields_changed.append(key)
+
+    if "decision" in fields_changed:
+        high_level.append("Decision output differs.")
+    if "fuji" in fields_changed:
+        high_level.append("Fuji result differs.")
+    if "value_scores" in fields_changed:
+        high_level.append("Value scores differ.")
+    if "evidence" in fields_changed:
+        high_level.append("Evidence set differs.")
+    if not high_level:
+        high_level.append("No high-level differences.")
+
+    return {
+        "high_level": high_level,
+        "fields_changed": fields_changed,
+        "before": before,
+        "after": after,
+    }
+
+
+def _diff_summary(diff: Dict[str, Any]) -> str:
+    changed = diff.get("fields_changed") or []
+    if not changed:
+        return "no_diff"
+    return f"fields_changed={','.join(str(v) for v in changed)}"
+
+
+@contextmanager
+def _strict_tool_lock() -> Iterator[None]:
+    """Disable external retrieval side-effects for strict replay mode."""
+    original_get_memory_store = pipeline._get_memory_store
+    try:
+        pipeline._get_memory_store = lambda: None
+        yield
+    finally:
+        pipeline._get_memory_store = original_get_memory_store
+
+
+async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResult:
+    """Replay a persisted decision with deterministic controls and save a report."""
+    started = time.time()
+    strict_mode = _strict_mode_enabled() if strict is None else bool(strict)
+
+    snapshot = pipeline._load_persisted_decision(decision_id)
+    if snapshot is None:
+        raise ValueError(f"decision_not_found: {decision_id}")
+
+    replay_meta = snapshot.get("deterministic_replay") if isinstance(snapshot.get("deterministic_replay"), dict) else {}
+    req_body = replay_meta.get("request_body") if isinstance(replay_meta.get("request_body"), dict) else {}
+    req_body = dict(req_body)
+
+    req_body.setdefault("query", snapshot.get("query") or "")
+    context = req_body.get("context") if isinstance(req_body.get("context"), dict) else {}
+    req_body["context"] = dict(context)
+    req_body["context"]["_replay_mode"] = True
+    req_body["context"]["_mock_external_apis"] = strict_mode
+
+    if strict_mode:
+        req_body["temperature"] = 0
+        req_body["seed"] = int(replay_meta.get("seed", req_body.get("seed", 0)) or 0)
+    else:
+        req_body.setdefault("temperature", replay_meta.get("temperature", 0))
+        req_body.setdefault("seed", replay_meta.get("seed", 0))
+
+    req_body["request_id"] = str(snapshot.get("request_id") or decision_id)
+
+    replay_req = DecideRequest.model_validate(req_body)
+
+    if strict_mode:
+        with _strict_tool_lock():
+            replay_output = await pipeline.run_decide_pipeline(replay_req, pipeline._ReplayRequest())
+    else:
+        replay_output = await pipeline.run_decide_pipeline(replay_req, pipeline._ReplayRequest())
+
+    original_output = replay_meta.get("final_output") if isinstance(replay_meta.get("final_output"), dict) else snapshot
+    before = _normalized_payload(original_output)
+    after = _normalized_payload(replay_output if isinstance(replay_output, dict) else {})
+    diff = _build_diff(before, after)
+    match = not bool(diff["fields_changed"])
+
+    replay_time_ms = max(1, int((time.time() - started) * 1000))
+
+    report_payload: Dict[str, Any] = {
+        "decision_id": str(snapshot.get("request_id") or decision_id),
+        "replay_time_ms": replay_time_ms,
+        "strict": strict_mode,
+        "match": match,
+        "diff": diff,
+        "meta": {
+            "created_at": _iso_now(),
+            "pipeline_version": _pipeline_version(),
+            "notes": "strict mode reuses deterministic replay snapshot and disables external tools.",
+        },
+    }
+
+    pipeline.REPLAY_REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    report_path = pipeline.REPLAY_REPORT_DIR / _replay_file_name(str(snapshot.get("request_id") or decision_id))
+    report_path.write_text(json.dumps(report_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    return ReplayResult(
+        decision_id=str(snapshot.get("request_id") or decision_id),
+        replay_path=str(report_path),
+        replay_time_ms=replay_time_ms,
+        strict=strict_mode,
+        match=match,
+        diff=diff,
+        diff_summary=_diff_summary(diff),
+    )
+

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -6,6 +6,7 @@ import json
 import os
 import time
 import hmac
+import hashlib
 
 # ★ テスト用APIキーを設定（認証付きエンドポイントのテスト用）
 # server import 前に設定して、起動時の警告を抑制
@@ -85,6 +86,50 @@ def test_health_and_status_and_metrics(monkeypatch):
     assert "last_decide_at" in data
     assert "server_time" in data
 
+
+
+
+def test_replay_api_endpoint_with_hmac_headers(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setattr(server, "API_KEY_DEFAULT", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_API_SECRET", "a" * 32)
+    monkeypatch.setattr(server, "API_SECRET", b"")
+
+    async def _fake_run_replay(decision_id: str, strict=None):
+        return server.SimpleNamespace(
+            decision_id=decision_id,
+            replay_path="/tmp/replay.json",
+            match=True,
+            diff_summary="no_diff",
+            replay_time_ms=9,
+        )
+
+    monkeypatch.setattr(server, "run_replay", _fake_run_replay)
+
+    body = json.dumps({"strict": True}, separators=(",", ":"))
+    ts = str(int(time.time()))
+    nonce = "nonce-replay-endpoint"
+    payload = f"{ts}\n{nonce}\n{body}"
+    signature = hmac.new(("a" * 32).encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    response = client.post(
+        "/v1/replay/dec-9",
+        headers={
+            "X-API-Key": _TEST_API_KEY,
+            "X-VERITAS-TIMESTAMP": ts,
+            "X-VERITAS-NONCE": nonce,
+            "X-VERITAS-SIGNATURE": signature,
+            "Content-Type": "application/json",
+        },
+        data=body,
+    )
+
+    assert response.status_code == 200
+    payload_json = response.json()
+    assert payload_json["ok"] is True
+    assert payload_json["decision_id"] == "dec-9"
+    assert payload_json["match"] is True
+    assert payload_json["replay_time_ms"] == 9
 
 def test_replay_decision_endpoint(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -131,6 +131,44 @@ def test_replay_api_endpoint_with_hmac_headers(monkeypatch):
     assert payload_json["match"] is True
     assert payload_json["replay_time_ms"] == 9
 
+
+
+def test_replay_api_endpoint_not_found_hides_exception(monkeypatch):
+    """Replay not-found errors must not expose internal exception details."""
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setattr(server, "API_KEY_DEFAULT", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_API_SECRET", "b" * 32)
+    monkeypatch.setattr(server, "API_SECRET", b"")
+
+    async def _fake_run_replay(decision_id: str, strict=None):
+        raise ValueError(f"decision_not_found: {decision_id}")
+
+    monkeypatch.setattr(server, "run_replay", _fake_run_replay)
+
+    body = "{}"
+    ts = str(int(time.time()))
+    nonce = "nonce-replay-not-found"
+    payload = f"{ts}\n{nonce}\n{body}"
+    signature = hmac.new(("b" * 32).encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    response = client.post(
+        "/v1/replay/dec-missing",
+        headers={
+            "X-API-Key": _TEST_API_KEY,
+            "X-VERITAS-TIMESTAMP": ts,
+            "X-VERITAS-NONCE": nonce,
+            "X-VERITAS-SIGNATURE": signature,
+            "Content-Type": "application/json",
+        },
+        data=body,
+    )
+
+    assert response.status_code == 404
+    payload_json = response.json()
+    assert payload_json["ok"] is False
+    assert payload_json["error"] == "decision_not_found"
+    assert payload_json["decision_id"] == "dec-missing"
+
 def test_replay_decision_endpoint(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
     monkeypatch.setattr(server, "API_KEY_DEFAULT", _TEST_API_KEY)

--- a/veritas_os/tests/test_replay_engine.py
+++ b/veritas_os/tests/test_replay_engine.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from veritas_os.replay import replay_engine
+
+
+@pytest.mark.asyncio
+async def test_run_replay_strict_mode_skips_tools_and_matches(monkeypatch, tmp_path: Path) -> None:
+    snapshot = {
+        "request_id": "dec-100",
+        "query": "hello",
+        "deterministic_replay": {
+            "seed": 42,
+            "temperature": 0,
+            "request_body": {"query": "hello", "context": {"user_id": "u1"}},
+            "final_output": {
+                "decision": {"output": "allow", "answer": "ok"},
+                "fuji": {"result": "allow", "status": "allow"},
+                "value_scores": {"safety": 0.9},
+                "evidence": [{"id": "2", "title": "B"}, {"id": "1", "title": "A"}],
+            },
+        },
+    }
+
+    captured = {}
+
+    async def _fake_run(req, _request):
+        body = req.model_dump()
+        captured["temperature"] = body.get("temperature")
+        captured["seed"] = body.get("seed")
+        captured["mock_external"] = body.get("context", {}).get("_mock_external_apis")
+        return {
+            "decision": {"output": "allow", "answer": "ok"},
+            "fuji": {"result": "allow", "status": "allow"},
+            "value_scores": {"safety": 0.9},
+            "evidence": [{"id": "1", "title": "A"}, {"id": "2", "title": "B"}],
+        }
+
+    monkeypatch.setattr(replay_engine.pipeline, "_load_persisted_decision", lambda _id: snapshot)
+    monkeypatch.setattr(replay_engine.pipeline, "run_decide_pipeline", _fake_run)
+    monkeypatch.setattr(replay_engine.pipeline, "REPLAY_REPORT_DIR", tmp_path)
+    monkeypatch.setenv("VERITAS_REPLAY_STRICT", "1")
+
+    result = await replay_engine.run_replay("dec-100")
+
+    assert result.match is True
+    assert captured["temperature"] == 0
+    assert captured["seed"] == 42
+    assert captured["mock_external"] is True
+    reports = list(tmp_path.glob("replay_dec-100_*.json"))
+    assert len(reports) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_replay_writes_expected_diff_schema(monkeypatch, tmp_path: Path) -> None:
+    snapshot = {
+        "request_id": "dec-200",
+        "query": "hello",
+        "deterministic_replay": {
+            "request_body": {"query": "hello", "context": {}},
+            "final_output": {
+                "decision": {"output": "allow", "answer": "ok"},
+                "fuji": {"result": "allow", "status": "allow"},
+                "value_scores": {"safety": 1.0},
+                "evidence": [{"title": "X"}],
+            },
+        },
+    }
+
+    async def _fake_run(_req, _request):
+        return {
+            "decision": {"output": "reject", "answer": "ng"},
+            "fuji": {"result": "reject", "status": "reject"},
+            "value_scores": {"safety": 0.2},
+            "evidence": [{"title": "Y"}],
+        }
+
+    monkeypatch.setattr(replay_engine.pipeline, "_load_persisted_decision", lambda _id: snapshot)
+    monkeypatch.setattr(replay_engine.pipeline, "run_decide_pipeline", _fake_run)
+    monkeypatch.setattr(replay_engine.pipeline, "REPLAY_REPORT_DIR", tmp_path)
+
+    result = await replay_engine.run_replay("dec-200", strict=False)
+
+    assert result.match is False
+    assert "decision" in result.diff["fields_changed"]
+    assert "before" in result.diff
+    assert "after" in result.diff
+
+    report_path = Path(result.replay_path)
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["decision_id"] == "dec-200"
+    assert "meta" in payload
+    assert "pipeline_version" in payload["meta"]


### PR DESCRIPTION
### Motivation
- Provide a concrete API to re-run a past decision (Replay) and persist a deterministic replay report that the compliance/reporting pipeline can consume. 
- Ensure replays can be run in a deterministic “strict” mode (fixed temperature/seed, mocked external retrieval) so EU AI Act reports can include reproducibility checks.

### Description
- Add a new replay engine module `veritas_os/replay/replay_engine.py` exposing `run_replay(decision_id, strict)` which loads a persisted decision snapshot, enforces deterministic controls for strict mode, reruns the decision pipeline, computes a normalized diff (high_level/fields_changed/before/after), persists `replay_{decision_id}_{YYYYMMDD_HHMMSS}.json` to `REPLAY_REPORT_DIR`, and returns a `ReplayResult` dataclass.
- Add `POST /v1/replay/{decision_id}` to `veritas_os/api/server.py` that calls `run_replay` and returns `{"ok": true, "decision_id": ..., "replay_path": ..., "match": bool, "diff_summary": ..., "replay_time_ms": int}` and reuse existing HMAC auth via `verify_signature`.
- Extend HMAC verification to accept the `X-VERITAS-TIMESTAMP`, `X-VERITAS-NONCE`, and `X-VERITAS-SIGNATURE` header names (while preserving legacy aliases) and add those names to the CORS allow-list.
- Implement stable normalization/sorting rules for evidence and exclusion of volatile fields, include metadata (`created_at`, `pipeline_version`, `notes`) in persisted reports, and update `openapi.yaml` and `README.md` with the new endpoint and curl example.
- Add unit/integration tests under `veritas_os/tests/test_replay_engine.py` and extend `veritas_os/tests/test_api_server_extra.py` to cover strict-mode behavior, replay file creation, diff schema, and HMAC-authenticated API call.

### Testing
- Ran targeted pytest: `veritas_os/tests/test_replay_engine.py`, `veritas_os/tests/test_api_server_extra.py::test_replay_api_endpoint_with_hmac_headers`, and `veritas_os/tests/test_decision_replay.py`, and all executed tests passed (6 passed in the reported run).
- Ran `pytest -q veritas_os/tests/test_openapi_spec.py` which passed (3 passed), and `ruff` checks on changed files passed with no issues.
- Attempted full `make test` but it could not complete in this environment due to external package index connectivity failures to `pypi.org`; this is an environment/network issue and not a code regression.

Security note: the Replay API enforces HMAC signing, but if `VERITAS_API_SECRET` is missing or set to a weak/placeholder value the server will log a warning and HMAC verification will be effectively disabled, so operators must set a strong secret in production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a712a4afc88326a6b52cf27e372269)