### PR TITLE
docs(review): add full repository code review report (2026-03-04)

### DIFF
--- a/docs/review/CODE_REVIEW_FULL_2026_03_04_AGENT_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_04_AGENT_JP.md
@@ -1,0 +1,38 @@
+# CODE REVIEW FULL (2026-03-04, Agent)
+
+## 対象
+- リポジトリ全体（backend / frontend / scripts / packages）
+- 重点: Planner / Kernel / Fuji / MemoryOS の責務境界、テスト健全性、既知セキュリティチェック
+
+## 実行したチェック
+1. `python scripts/architecture/check_responsibility_boundaries.py`
+2. `python scripts/security/check_next_public_key_exposure.py`
+3. `pytest -q`
+
+## 結果サマリ
+- 責務境界チェック: **PASS**
+- Next.js 公開環境変数の秘密情報露出チェック: **PASS**
+- テスト: **2692 passed, 3 skipped**
+
+## 指摘事項（重要度順）
+
+### 1) Startup 設定検証失敗時に起動継続する挙動（中〜高）
+- `startup` フック内の設定検証で例外を包括捕捉し、warning ログのみで継続している。
+- 誤設定状態でAPIが起動し続けると、認証・監査・通信設定の意図しない緩和に気づきにくくなる。
+- 推奨:
+  - 本番 (`VERITAS_ENV=prod`) では fail-fast（例外再送出）を標準化。
+  - dev/stg のみ warning 継続を許可する運用分岐を明示。
+
+### 2) FastAPI `on_event` の非推奨API利用（中）
+- `@app.on_event("startup"|"shutdown")` は FastAPI の lifespan 移行対象。
+- 直近は動作するが、中長期で保守・互換性リスク。
+- 推奨:
+  - `lifespan` コンテキストへ移行し、起動/停止処理を一本化。
+
+## セキュリティ観点
+- 既存の自動チェックでは秘密情報露出の重大問題は未検出。
+- ただし上記「設定検証失敗時の起動継続」は**運用時セキュリティリスク**として監視対象にすべき。
+
+## 総評
+- テスト網羅と自動チェックの健全性は高い。
+- 一方で、起動ライフサイクルの fail-safe 設計と非推奨APIの解消は、次リリースで優先的に改善する価値がある。


### PR DESCRIPTION
### Motivation
- 全リポジトリの包括的なコードレビュー結果を記録し、責務境界・テスト健全性・既知のセキュリティ懸念を明確化する目的で追加しました。 
- 自動チェックの実行結果と優先度付き指摘（運用時の起動挙動、FastAPIの非推奨API利用）をチームへ周知するためです。

### Description
- 新規ファイル `docs/review/CODE_REVIEW_FULL_2026_03_04_AGENT_JP.md` を追加し、対象範囲・実施チェック・結果サマリ・優先度付き指摘を記載しました。 
- 指摘事項として、`startup` フック内の設定検証が例外を包括捕捉して起動継続する点について本番では fail-fast を推奨する旨を記載し、`@app.on_event` の非推奨化に伴う `lifespan` への移行を推奨しました。 

### Testing
- 実行した自動検査: `python scripts/architecture/check_responsibility_boundaries.py` — 合格。 
- 実行した自動検査: `python scripts/security/check_next_public_key_exposure.py` — 合格。 
- テストスイート: `pytest -q` — 成果: `2692 passed, 3 skipped`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8284bd62c8326a64f314d70419df8)