### PR TITLE
Migrate API startup hooks to lifespan and enforce prod fail-fast validation

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -14,6 +14,7 @@ import re
 import secrets
 import threading
 import time
+from contextlib import asynccontextmanager
 from collections import deque
 from dataclasses import dataclass
 from functools import lru_cache
@@ -507,7 +508,50 @@ def get_memory_store() -> Optional[Any]:
 
 cfg = get_cfg()
 
-app = FastAPI(title="VERITAS Public API", version="1.0.3")
+def _should_fail_fast_startup(profile: Optional[str] = None) -> bool:
+    """Return whether startup validation failures should stop app boot.
+
+    Production profiles must fail fast to avoid running with insecure or
+    incomplete runtime configuration.
+    """
+    resolved_profile = (
+        profile if profile is not None else os.getenv("VERITAS_ENV", "")
+    )
+    normalized_profile = resolved_profile.strip().lower()
+    return normalized_profile in {"prod", "production"}
+
+
+def _run_startup_config_validation() -> None:
+    """Validate startup configuration with environment-specific strictness."""
+    try:
+        validator = globals().get("validate_startup_config")
+        if validator is None:
+            from veritas_os.core.config import validate_startup_config as validator
+
+        validator()
+    except Exception:
+        fail_fast = _should_fail_fast_startup()
+        logger.warning(
+            "startup config validation failed (fail_fast=%s)",
+            fail_fast,
+            exc_info=True,
+        )
+        if fail_fast:
+            raise
+
+
+@asynccontextmanager
+async def _app_lifespan(_: FastAPI):
+    """Manage startup/shutdown actions using FastAPI lifespan API."""
+    _run_startup_config_validation()
+    _start_nonce_cleanup_scheduler()
+    try:
+        yield
+    finally:
+        _stop_nonce_cleanup_scheduler()
+
+
+app = FastAPI(title="VERITAS Public API", version="1.0.3", lifespan=_app_lifespan)
 
 # ★ セキュリティ: allow_credentials は明示的なオリジンが設定されている場合のみ True
 # 空の場合に True にすると、ブラウザの CORS チェックを意図せずバイパスするリスクがある
@@ -557,33 +601,6 @@ app.add_middleware(
         "Authorization",
     ],
 )
-
-
-@app.on_event("startup")
-async def _startup_validate_config() -> None:
-    """Validate critical configuration at server startup, not at import time.
-
-    This prevents import-time side effects and ensures validation errors
-    surface clearly during the startup lifecycle.
-    """
-    try:
-        from veritas_os.core.config import validate_startup_config
-        validate_startup_config()
-    except Exception:
-        logger.warning("startup config validation failed", exc_info=True)
-
-
-@app.on_event("startup")
-async def _startup_nonce_cleanup_scheduler() -> None:
-    """Start background nonce cleanup under FastAPI lifecycle management."""
-    _start_nonce_cleanup_scheduler()
-
-
-@app.on_event("shutdown")
-async def _shutdown_nonce_cleanup_scheduler() -> None:
-    """Stop background nonce cleanup timer when app is shutting down."""
-    _stop_nonce_cleanup_scheduler()
-
 
 # ★ C-3 継続改善: リクエストボディサイズ制限 (DoS対策)
 # 運用プロファイルごとの推奨値を定義しつつ、環境変数で上書き可能にする。

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -1495,6 +1495,51 @@ def test_resolve_max_request_body_size_rejects_non_positive_override(monkeypatch
     assert resolved == 8 * 1024 * 1024
 
 
+def test_should_fail_fast_startup_for_production_profiles():
+    """Production-like profiles must fail fast during startup validation."""
+    assert server._should_fail_fast_startup("production") is True
+    assert server._should_fail_fast_startup("prod") is True
+    assert server._should_fail_fast_startup("staging") is False
+
+
+def test_run_startup_config_validation_raises_in_production(monkeypatch):
+    """Startup validation errors should stop boot in production profile."""
+
+    def _raise_validation_error():
+        raise RuntimeError("config invalid")
+
+    monkeypatch.setattr(
+        server,
+        "validate_startup_config",
+        _raise_validation_error,
+        raising=False,
+    )
+    monkeypatch.setenv("VERITAS_ENV", "production")
+
+    with pytest.raises(RuntimeError, match="config invalid"):
+        server._run_startup_config_validation()
+
+
+def test_run_startup_config_validation_warns_only_in_staging(monkeypatch, caplog):
+    """Non-production profiles should keep warning-only startup behavior."""
+
+    def _raise_validation_error():
+        raise RuntimeError("staging config invalid")
+
+    monkeypatch.setattr(
+        server,
+        "validate_startup_config",
+        _raise_validation_error,
+        raising=False,
+    )
+    monkeypatch.setenv("VERITAS_ENV", "staging")
+
+    with caplog.at_level("WARNING"):
+        server._run_startup_config_validation()
+
+    assert "startup config validation failed" in caplog.text
+
+
 def test_events_requires_api_key_header_only_by_default(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
     monkeypatch.delenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", raising=False)


### PR DESCRIPTION
### Motivation
- Address code review findings by replacing deprecated `@app.on_event` lifecycle handlers with FastAPI `lifespan` and centralize startup/shutdown logic. 
- Ensure startup configuration validation does not silently allow the app to run with invalid critical settings in production by enforcing fail-fast behavior for `VERITAS_ENV=prod|production`. 
- Preserve existing warning-first ergonomics for non-production profiles to avoid disrupting developer workflows. 

### Description
- Replaced separate `@app.on_event("startup")`/`@app.on_event("shutdown")` handlers with a single `lifespan` context implemented as `_app_lifespan` and wired into `FastAPI(..., lifespan=_app_lifespan)`. 
- Added `_should_fail_fast_startup(profile: Optional[str]) -> bool` to determine production fail-fast semantics and `_run_startup_config_validation()` to centralize config validation and raise in production while only logging warnings otherwise. 
- Moved nonce cleanup start/stop into the new lifespan flow (`_start_nonce_cleanup_scheduler()` / `_stop_nonce_cleanup_scheduler()`) so startup/shutdown behavior is managed in one place. 
- Added tests in `veritas_os/tests/test_api_server_extra.py` covering `_should_fail_fast_startup` logic and `_run_startup_config_validation` behavior for production and non-production profiles. 

### Testing
- Ran targeted unit tests with `pytest -q veritas_os/tests/test_api_server_extra.py -k "startup_config_validation or should_fail_fast_startup or resolve_max_request_body_size"` which completed with `6 passed, 61 deselected`. 
- Executed responsibility boundary check via `python scripts/architecture/check_responsibility_boundaries.py` which passed. 
- Executed public-key exposure check via `python scripts/security/check_next_public_key_exposure.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a831f8d68883269564d78e940e526f)