### PR TITLE
fix: コードレビューで検出した4件のバグ・セキュリティ問題を修正

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -915,8 +915,10 @@ def _resolve_memory_user_id(body_user_id: Any, x_api_key: Optional[str]) -> str:
 
 
 def require_api_key_header_or_query(
+    request: Request = None,  # type: ignore[assignment]
     x_api_key: Optional[str] = Security(api_key_scheme),
     api_key: Optional[str] = Query(default=None),
+    x_forwarded_for: Optional[str] = Header(default=None, alias="X-Forwarded-For"),
 ):
     """Authenticate SSE requests with header-first policy.
 
@@ -925,17 +927,20 @@ def require_api_key_header_or_query(
         access logs, browser history, and monitoring URLs. To preserve migration
         flexibility, operators may temporarily enable query auth with the
         ``VERITAS_ALLOW_SSE_QUERY_API_KEY=1`` feature flag.
+        Auth failures are rate-limited per client IP (same policy as require_api_key).
     """
     expected = (_get_expected_api_key() or "").strip()
     if not expected:
         raise HTTPException(status_code=500, detail="Server API key not configured")
 
+    client_ip = _resolve_client_ip(request=request, x_forwarded_for=x_forwarded_for)
     header_candidate = (x_api_key or "").strip()
     query_candidate = (api_key or "").strip()
 
     candidate = header_candidate
     if not candidate and query_candidate:
         if not _allow_sse_query_api_key():
+            _enforce_auth_failure_rate_limit(client_ip)
             raise HTTPException(status_code=401, detail="Query API key is disabled; use X-API-Key header")
         logger.warning(
             "SSE auth accepted query api_key due to VERITAS_ALLOW_SSE_QUERY_API_KEY=1. "
@@ -944,8 +949,10 @@ def require_api_key_header_or_query(
         candidate = query_candidate
 
     if not candidate:
+        _enforce_auth_failure_rate_limit(client_ip)
         raise HTTPException(status_code=401, detail="Missing API key")
     if not secrets.compare_digest(candidate, expected):
+        _enforce_auth_failure_rate_limit(client_ip)
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
 

--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -37,9 +37,6 @@ class StrategyCapability(Protocol):
     def score_options(self, *args: Any, **kwargs: Any) -> Any:
         ...
 
-import threading as _threading
-
-
 def _read_proc_self_status_seccomp() -> int | None:
     """Read Linux seccomp mode from ``/proc/self/status``.
 

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -890,6 +890,24 @@ async def run_decide_pipeline(
     if not isinstance(context, dict):
         context = {}
 
+    # ★ セキュリティ修正: ユーザー提供コンテキストからパイプライン内部フィールドを除去
+    # "_pipeline_*" や "_orchestrated_by_pipeline" 等の内部制御フラグをユーザーが
+    # 外部API経由で注入するとエピソード保存のスキップや証拠の偽装が可能になるため、
+    # パイプライン制御フラグはここで削除し、パイプライン自身が後から設定する。
+    _PIPELINE_PRIVATE_PREFIXES = ("_pipeline_", "_orchestrated_by_pipeline", "_episode_saved",
+                                  "_world_state_", "_daily_plans_", "_world_sim_result")
+    _injected_private_keys = [
+        k for k in list(context.keys())
+        if isinstance(k, str) and any(k.startswith(p) for p in _PIPELINE_PRIVATE_PREFIXES)
+    ]
+    if _injected_private_keys:
+        logger.warning(
+            "Pipeline private fields stripped from user-supplied context: %s",
+            sorted(_injected_private_keys),
+        )
+        for _k in _injected_private_keys:
+            context.pop(_k, None)
+
     replay_mode = bool(context.get("_replay_mode", False))
     mock_external_apis = bool(context.get("_mock_external_apis", replay_mode))
     if replay_mode:

--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -558,14 +558,28 @@ def _coerce_pagination(cursor: Optional[str], limit: int, *, max_limit: int = 20
     return offset, safe_limit
 
 
+_TRUST_LOG_PAGE_WARN_THRESHOLD = 10_000  # 全件ロード時に警告するエントリ数の閾値
+
+
 def get_trust_log_page(cursor: Optional[str], limit: int) -> Dict[str, Any]:
     """最新→過去の順で TrustLog をページング取得する。
 
     Notes:
         API は必ず cursor/limit で返却し、全件返却を回避する。
+
+    Warning:
+        現実装は全エントリをメモリに読み込んでからスライスする。
+        エントリ数が多い場合はメモリ使用量に注意。
+        大規模運用では JSONL をオフセットシークするストリーミング実装への移行を推奨。
     """
     offset, safe_limit = _coerce_pagination(cursor, limit)
     entries = load_trust_log(limit=None)
+    if len(entries) > _TRUST_LOG_PAGE_WARN_THRESHOLD:
+        logger.warning(
+            "get_trust_log_page: loaded %d entries into memory. "
+            "Consider streaming implementation for large-scale deployments.",
+            len(entries),
+        )
     page_items = entries[offset: offset + safe_limit]
     next_offset = offset + len(page_items)
     has_more = next_offset < len(entries)


### PR DESCRIPTION
修正済み（4件）
🔴 [HIGH] パイプライン内部フィールドのユーザー注入（pipeline.py）
問題: DecideRequest.context が extra="allow" のため、_pipeline_evidence・_episode_saved_by_pipeline・_orchestrated_by_pipeline 等の内部制御フィールドを外部APIから注入できた。これにより：
	∙	_episode_saved_by_pipeline=True → エピソード保存をスキップ（監査ログの欠落）
	∙	_pipeline_evidence=[...] → 証拠リストの偽装
修正: run_decide_pipeline の入力処理の先頭で _pipeline_* 系フィールドを除去するように修正。

🟡 [MEDIUM] SSEエンドポイントの認証失敗レート制限不在（server.py）
問題: /v1/events（SSEエンドポイント）は require_api_key_header_or_query で認証しているが、失敗時のレート制限（_enforce_auth_failure_rate_limit）が呼ばれていなかった。/v1/decide と異なり、IPベースのブルートフォース保護が適用されない状態だった。
修正: require_api_key_header_or_query に request・x_forwarded_for パラメータを追加し、認証失敗時に _enforce_auth_failure_rate_limit を呼び出すよう修正。

🟡 [LOW] デッドインポート（kernel.py L40）
問題: import threading as _threading がモジュール内で一切使用されていない。
修正: 削除。

🟢 [INFO] get_trust_log_page のメモリスケーラビリティ（trust_log.py）
問題: 全エントリを load_trust_log(limit=None) でメモリにロードしてからスライスするため、ログが大規模になるとOOM圧力が発生する。
修正: 10,000件超時に警告ログを出力するように修正。長期的にはオフセットシークによるストリーミング実装への移行を推奨（コメントに明記）。