### PR TITLE
test(frontend): jsdom canvasスタブ追加とact警告回避のテスト修正

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -156,10 +156,11 @@ describe("LiveEventStream", () => {
   it("does not render raw i18n keys in the UI", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        body: createReadableStream([]),
-      }),
+      vi.fn().mockImplementation(
+        () => new Promise<Response>(() => {
+          // keep pending so no async state updates are scheduled during this assertion-only test
+        }),
+      ),
     );
 
     render(

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -17,3 +17,20 @@ if (typeof globalThis.EventSource === "undefined") {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).EventSource = MockEventSource;
 }
+
+const CANVAS_CONTEXT_STUB = {
+  setTransform: () => undefined,
+  clearRect: () => undefined,
+  beginPath: () => undefined,
+  arc: () => undefined,
+  fill: () => undefined,
+  fillStyle: "",
+  globalAlpha: 1,
+};
+
+if (typeof HTMLCanvasElement !== "undefined") {
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    value: () => CANVAS_CONTEXT_STUB,
+  });
+}


### PR DESCRIPTION
### Motivation
- jsdom の `HTMLCanvasElement.getContext` 未実装エラーと React の `act(...)` 警告がテストログにノイズを与えていたため、テストの安定性とCIログの可読性を向上させる目的で修正しました。
- いずれの変更もテストハーネス側に限定し、プロダクトのランタイム動作や責務境界（Planner / Kernel / Fuji / MemoryOS）を越える変更は行っていません。

### Description
- `frontend/vitest.setup.ts` に軽量な `HTMLCanvasElement.getContext` スタブを追加し、キャンバス依存のテストで発生する「Not implemented」警告を抑止するようにしました。
- `frontend/components/live-event-stream.test.tsx` の i18n キー表示チェックを、非同期ステート更新が発生しないように `fetch` を保留の `Promise` に差し替えて `act(...)` 警告を回避するように変更しました。
- いずれもテストセットアップ／テストコードのみの変更で、製品コードや責務境界には影響を与えていません。

### Testing
- `pnpm --filter frontend test -- live-event-stream.test.tsx app/risk/page.test.tsx` を実行し、両ファイルとも成功して合計 `8` テストが全てパスしました（テスト実行時の `act` 警告および JSDOM の `getContext` 警告は発生しませんでした）。
- 変更はテストハーネスに限定されているため、必要に応じて Canvas の実挙動を検証する統合/E2E テストは別途維持してください（Canvas スタブは描画挙動のテストを無効化するリスクがあります）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a929cbea148326ad7203dd2731e83f)