### PR TITLE
プロキシのリクエスト上限を UTF-8 バイト基準へ修正しテストを追加

### DIFF
--- a/docs/review/CODE_REVIEW_FULL_2026_03_05_AGENT2_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_05_AGENT2_JP.md
@@ -67,3 +67,12 @@
   - 本指摘はコード修正よりも運用ポリシー（本番で `VERITAS_ALLOW_SSE_QUERY_API_KEY=0` を徹底）に依存するため。
 - セキュリティ警告:
   - `VERITAS_ALLOW_SSE_QUERY_API_KEY=1` を有効化すると、URL 経由で資格情報がログ/履歴等へ露出するリスクがあります。短時間・限定環境以外での有効化は避けてください。
+
+### 追加対応（CI失敗修正）
+- 事象:
+  - Next.js Route Handler の制約により、`route.ts` で `GET/POST/PUT` 以外の named export（`getBodySizeBytes`）を公開すると build 時に型エラーとなる。
+- 修正:
+  - `getBodySizeBytes` を `frontend/app/api/veritas/[...path]/body-size.ts` へ分離し、`route.ts` では import のみ行う構成に変更。
+  - テストも `route.ts` 直接 import から `body-size.ts` import へ切替。
+- 結果:
+  - `frontend build`（`next build`）が成功することを確認。

--- a/docs/review/CODE_REVIEW_FULL_2026_03_05_AGENT2_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_05_AGENT2_JP.md
@@ -50,3 +50,20 @@
 ## 追跡提案（任意）
 - 次回リリース前にフロント API proxy のサイズ計測を bytes 基準へ統一。
 - 運用 Runbook に `VERITAS_ALLOW_SSE_QUERY_API_KEY` の禁止ポリシーを明文化。
+
+## 対応状況（2026-03-05 追記）
+
+### 対応済み: 1) フロントのリクエストサイズ上限が「文字数」ベース
+- 変更対象: `frontend/app/api/veritas/[...path]/route.ts`
+- 対応内容:
+  - UTF-8 バイト長を正確に計測する `getBodySizeBytes` を追加。
+  - 上限判定を `body.length` から `getBodySizeBytes(body)` に置換。
+- 追加テスト: `frontend/app/api/veritas/[...path]/route.test.ts`
+  - ASCII 文字列のバイト長が文字数と一致することを確認。
+  - 日本語・絵文字などマルチバイト文字で UTF-8 バイト長を正しく計測することを確認。
+
+### 未対応（運用ポリシー事項）: 2) SSE query API key 許可フラグ
+- 理由:
+  - 本指摘はコード修正よりも運用ポリシー（本番で `VERITAS_ALLOW_SSE_QUERY_API_KEY=0` を徹底）に依存するため。
+- セキュリティ警告:
+  - `VERITAS_ALLOW_SSE_QUERY_API_KEY=1` を有効化すると、URL 経由で資格情報がログ/履歴等へ露出するリスクがあります。短時間・限定環境以外での有効化は避けてください。

--- a/frontend/app/api/veritas/[...path]/body-size.ts
+++ b/frontend/app/api/veritas/[...path]/body-size.ts
@@ -1,0 +1,8 @@
+const TEXT_ENCODER = new TextEncoder();
+
+/**
+ * Calculate payload size using UTF-8 bytes to enforce byte-accurate limits.
+ */
+export function getBodySizeBytes(body: string): number {
+  return TEXT_ENCODER.encode(body).length;
+}

--- a/frontend/app/api/veritas/[...path]/route.test.ts
+++ b/frontend/app/api/veritas/[...path]/route.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBodySizeBytes } from './route';
+
+describe('getBodySizeBytes', () => {
+  it('returns ASCII length as bytes', () => {
+    expect(getBodySizeBytes('abcd')).toBe(4);
+  });
+
+  it('counts multibyte UTF-8 characters correctly', () => {
+    expect(getBodySizeBytes('あ')).toBe(3);
+    expect(getBodySizeBytes('😀')).toBe(4);
+  });
+});

--- a/frontend/app/api/veritas/[...path]/route.test.ts
+++ b/frontend/app/api/veritas/[...path]/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getBodySizeBytes } from './route';
+import { getBodySizeBytes } from './body-size';
 
 describe('getBodySizeBytes', () => {
   it('returns ASCII length as bytes', () => {

--- a/frontend/app/api/veritas/[...path]/route.ts
+++ b/frontend/app/api/veritas/[...path]/route.ts
@@ -5,6 +5,14 @@ const API_KEY = process.env.VERITAS_API_KEY ?? "";
 
 /** Max request body size for proxied requests (1MB). */
 const MAX_PROXY_BODY_BYTES = 1 * 1024 * 1024;
+const TEXT_ENCODER = new TextEncoder();
+
+/**
+ * Calculate payload size using UTF-8 bytes to enforce byte-accurate limits.
+ */
+export function getBodySizeBytes(body: string): number {
+  return TEXT_ENCODER.encode(body).length;
+}
 
 /**
  * Reject path segments that could cause path traversal or URL manipulation.
@@ -84,7 +92,7 @@ async function handleProxy(request: NextRequest, pathSegments: string[]): Promis
   let body: string | undefined;
   if (hasBody) {
     body = await request.text();
-    if (body.length > MAX_PROXY_BODY_BYTES) {
+    if (getBodySizeBytes(body) > MAX_PROXY_BODY_BYTES) {
       return NextResponse.json({ error: "payload_too_large" }, { status: 413 });
     }
   }

--- a/frontend/app/api/veritas/[...path]/route.ts
+++ b/frontend/app/api/veritas/[...path]/route.ts
@@ -1,18 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getBodySizeBytes } from "./body-size";
+
 const API_BASE = process.env.VERITAS_API_BASE_URL ?? process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL ?? "http://localhost:8000";
 const API_KEY = process.env.VERITAS_API_KEY ?? "";
 
 /** Max request body size for proxied requests (1MB). */
 const MAX_PROXY_BODY_BYTES = 1 * 1024 * 1024;
-const TEXT_ENCODER = new TextEncoder();
-
-/**
- * Calculate payload size using UTF-8 bytes to enforce byte-accurate limits.
- */
-export function getBodySizeBytes(body: string): number {
-  return TEXT_ENCODER.encode(body).length;
-}
 
 /**
  * Reject path segments that could cause path traversal or URL manipulation.


### PR DESCRIPTION
### Motivation
- フロントエンドのプロキシで `MAX_PROXY_BODY_BYTES` がバイト基準を想定している一方で判定に `body.length`（文字数/UTF-16コードユニット）を使っており、マルチバイト文字で実バイト数とずれる問題を修正するため。 
- レビュー指摘に従いコード修正と運用上の注意（SSE の query API key フラグのリスク）をドキュメントへ追記するため。 

### Description
- `frontend/app/api/veritas/[...path]/route.ts` に `TextEncoder` を使った `getBodySizeBytes` ヘルパーを追加し、エクスポートしました。 
- リクエスト上限判定を `body.length` から `getBodySizeBytes(body)` に置換してバイト単位で評価するように変更しました。 
- `frontend/app/api/veritas/[...path]/route.test.ts` を追加して ASCII とマルチバイト（日本語・絵文字）の UTF-8 バイト長を検証するユニットテストを作成しました。 
- レビュー報告書 `docs/review/CODE_REVIEW_FULL_2026_03_05_AGENT2_JP.md` に対応状況を追記し、`VERITAS_ALLOW_SSE_QUERY_API_KEY` を有効化する運用リスクの警告を明記しました。 

### Testing
- 新規ユニットテストを `cd frontend && npm run test -- app/api/veritas/[...path]/route.test.ts` で実行し、テストはすべて成功しました。 
- `cd frontend && npm run lint`（`next lint` → ESLint 実行）を実行し、Lint はエラー/警告なしで成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9773e6bfc8326bf8e293347b3a80f)