### PR TITLE
Require dual opt-in for SSE query API key and update docs/tests

### DIFF
--- a/docs/review/CODE_REVIEW_FULL_2026_03_05_AGENT2_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_05_AGENT2_JP.md
@@ -76,3 +76,19 @@
   - テストも `route.ts` 直接 import から `body-size.ts` import へ切替。
 - 結果:
   - `frontend build`（`next build`）が成功することを確認。
+
+
+### 対応済み: 2) SSE query API key 許可フラグ（誤設定耐性の強化）
+- 変更対象: `veritas_os/api/server.py`
+- 対応内容:
+  - `VERITAS_ALLOW_SSE_QUERY_API_KEY` 単独では有効化されないように変更。
+  - 追加の明示同意フラグ `VERITAS_ACK_SSE_QUERY_API_KEY_RISK` を導入し、**2フラグ同時ON** のときのみ query API key を許可。
+  - 同意フラグ未設定時は warning ログを出し、安全側（拒否）にフォールバック。
+- 追加テスト:
+  - `veritas_os/tests/test_coverage_boost.py`
+    - 同意フラグ未設定時は `False`、設定時は `True` になることを確認。
+  - `veritas_os/tests/test_api_server_extra.py`
+    - 2フラグ同時ONで query API key を受理することを確認。
+    - 許可フラグのみON（同意フラグなし）では 401 拒否となることを確認。
+- セキュリティ警告（継続）:
+  - query API key は URL 経由の漏えい面積が広いため、移行期間の一時用途に限定し、本番常用は避けること。

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -973,9 +973,30 @@ def require_api_key_header_or_query(
 
 
 def _allow_sse_query_api_key() -> bool:
-    """Return True when SSE query-string API key auth is explicitly enabled."""
-    raw = (os.getenv("VERITAS_ALLOW_SSE_QUERY_API_KEY") or "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
+    """Return True only when dual opt-in flags enable SSE query auth.
+
+    Security note:
+        Query-string API keys can leak through logs and browser history.
+        To reduce accidental exposure, enabling this mode requires two flags:
+        ``VERITAS_ALLOW_SSE_QUERY_API_KEY`` and
+        ``VERITAS_ACK_SSE_QUERY_API_KEY_RISK``.
+    """
+    allow_raw = (os.getenv("VERITAS_ALLOW_SSE_QUERY_API_KEY") or "").strip().lower()
+    allow_query_auth = allow_raw in {"1", "true", "yes", "on"}
+    if not allow_query_auth:
+        return False
+
+    ack_raw = (os.getenv("VERITAS_ACK_SSE_QUERY_API_KEY_RISK") or "").strip().lower()
+    acknowledged = ack_raw in {"1", "true", "yes", "on"}
+    if not acknowledged:
+        logger.warning(
+            "SSE query api_key enable flag ignored because "
+            "VERITAS_ACK_SSE_QUERY_API_KEY_RISK is not set. "
+            "Set both flags only for temporary migration windows.",
+        )
+        return False
+
+    return True
 
 
 # ---- HMAC signature / replay (optional) ----

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -1613,14 +1613,28 @@ def test_events_requires_api_key_header_only_by_default(monkeypatch):
     assert exc.value.status_code == 401
 
 
-def test_events_accepts_query_api_key_only_when_flag_enabled(monkeypatch):
+def test_events_accepts_query_api_key_only_when_dual_flags_enabled(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
     monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "1")
+    monkeypatch.setenv("VERITAS_ACK_SSE_QUERY_API_KEY_RISK", "true")
 
     assert server.require_api_key_header_or_query(
         x_api_key=None,
         api_key=_TEST_API_KEY,
     ) is True
+
+
+def test_events_rejects_query_api_key_without_risk_ack(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "1")
+    monkeypatch.delenv("VERITAS_ACK_SSE_QUERY_API_KEY_RISK", raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        server.require_api_key_header_or_query(
+            x_api_key=None,
+            api_key=_TEST_API_KEY,
+        )
+    assert exc.value.status_code == 401
 
 
 def test_decide_failure_publishes_sse_event(monkeypatch):

--- a/veritas_os/tests/test_coverage_boost.py
+++ b/veritas_os/tests/test_coverage_boost.py
@@ -943,8 +943,12 @@ class TestServerMiscCoverage:
         assert result is True
 
     def test_allow_sse_query_api_key_flag_values(self, monkeypatch):
-        """Feature flag should accept common truthy values only."""
+        """Feature flag requires explicit risk acknowledgement."""
         monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "yes")
+        monkeypatch.delenv("VERITAS_ACK_SSE_QUERY_API_KEY_RISK", raising=False)
+        assert server._allow_sse_query_api_key() is False
+
+        monkeypatch.setenv("VERITAS_ACK_SSE_QUERY_API_KEY_RISK", "on")
         assert server._allow_sse_query_api_key() is True
 
         monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "0")


### PR DESCRIPTION
### Motivation
- Reduce accidental credential exposure by preventing a single environment flag from enabling SSE query-string API key authentication.
- Query-string API keys can leak via logs, monitoring URLs, and browser history, so enabling them should require explicit operator acknowledgement.
- Keep the system default secure (header-only authentication) while allowing a tightly-scoped migration mechanism.

### Description
- Change `veritas_os/api/server.py` so `_allow_sse_query_api_key()` requires both `VERITAS_ALLOW_SSE_QUERY_API_KEY` and `VERITAS_ACK_SSE_QUERY_API_KEY_RISK`, and emit a warning if the acknowledgement flag is missing.
- Add explanatory docstring and a warning log to clearly document the dual-opt-in behavior and security rationale. 
- Update tests in `veritas_os/tests/test_coverage_boost.py` and `veritas_os/tests/test_api_server_extra.py` to assert that the feature only enables when both flags are set and rejects when the ack flag is absent. 
- Append a summary of the implementation and test coverage to `docs/review/CODE_REVIEW_FULL_2026_03_05_AGENT2_JP.md` without changing responsibilities beyond the API auth layer.

### Testing
- Ran `pytest -q veritas_os/tests/test_coverage_boost.py -k allow_sse_query_api_key_flag_values veritas_os/tests/test_api_server_extra.py -k 'dual_flags_enabled or without_risk_ack'` and observed `2 passed, 201 deselected` indicating the modified tests behaved as expected. 
- Ran `pytest -q veritas_os/tests/test_api_server_extra.py::test_events_accepts_query_api_key_only_when_dual_flags_enabled veritas_os/tests/test_api_server_extra.py::test_events_rejects_query_api_key_without_risk_ack` and observed `2 passed` confirming both acceptance and rejection paths. 
- Ran `pytest -q veritas_os/tests/test_coverage_boost.py::TestServerMiscCoverage::test_allow_sse_query_api_key_flag_values` and observed `1 passed` verifying the feature-flag semantics at unit-test scope.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97f36e3d483269856b5ba833f4dc9)