### PR TITLE
Suppress known dependency warning noise during pytest runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,9 @@ veritas_os = [
   "sample_data/memory/*.jsonl",
   "templates/**/*.txt",
 ]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+  "ignore:\"content=<...>\" is deprecated\\. Use 'data=<...>' instead:DeprecationWarning:httpx\\..*",
+  "ignore:invalid escape sequence.*:SyntaxWarning:sentence_transformers\\..*",
+]


### PR DESCRIPTION
### Motivation
- Reduce non-actionable warning noise from third-party dependencies during test runs by configuring pytest `filterwarnings` so CI output stays focused on real regressions while avoiding edits to core responsibilities.

### Description
- Added `[tool.pytest.ini_options]` to `pyproject.toml` with `filterwarnings` entries that ignore a specific `httpx` `DeprecationWarning` pattern and a `sentence_transformers` `SyntaxWarning` pattern, scoped to the originating modules to minimize overreach; the change only affects test runner configuration.
- Note: suppressing warnings can hide useful upstream signals, so reviewers should be aware and plan to revisit these filters when dependencies are upgraded.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_embedder.py -W default` and it passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b46aa9e48326a22cc3f5a3b072eb)