### PR TITLE
Improve planner JSON input sanitization robustness

### DIFF
--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -26,9 +26,29 @@ _MAX_STEPS_OBJECT_EXTRACT_ATTEMPTS = 512
 _MAX_FENCED_BLOCK_SCAN_ATTEMPTS = 128
 
 
-def _truncate_json_extract_input(raw: str) -> str:
-    """Limit JSON extraction input size to reduce parser and regex DoS risk."""
+def _truncate_json_extract_input(raw: Any) -> str:
+    """Normalize and size-limit JSON extraction input.
+
+    The helper accepts arbitrary values because several planner call paths may
+    pass non-string payloads during fallback handling. It also removes a UTF-8
+    BOM and NUL bytes which frequently appear in streamed model output and can
+    break JSON parsing.
+    """
+    if raw is None:
+        return ""
+
+    if not isinstance(raw, str):
+        raw = str(raw)
+
     cleaned = raw.strip()
+    if cleaned.startswith("\ufeff"):
+        cleaned = cleaned.lstrip("\ufeff")
+        logger.warning("planner JSON extraction removed leading BOM")
+
+    if "\x00" in cleaned:
+        cleaned = cleaned.replace("\x00", "")
+        logger.warning("planner JSON extraction removed NUL bytes")
+
     if len(cleaned) <= _MAX_JSON_EXTRACT_CHARS:
         return cleaned
 

--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -46,7 +46,7 @@ def _truncate_json_extract_input(raw: Any) -> str:
         logger.warning("planner JSON extraction removed leading BOM")
 
     if "\x00" in cleaned:
-        cleaned = cleaned.replace("\x00", "")
+        cleaned = "".join(cleaned.split("\x00"))
         logger.warning("planner JSON extraction removed NUL bytes")
 
     if len(cleaned) <= _MAX_JSON_EXTRACT_CHARS:

--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -231,6 +231,24 @@ def test_safe_json_extract_ignores_leading_unbalanced_closing_brace():
     assert ids == ["ok1", "ok2"]
 
 
+
+
+def test_truncate_json_extract_input_accepts_non_string_and_strips_controls(caplog):
+    raw = "\ufeff{\"steps\": [{\"id\": \"s1\"}]}\x00"
+    with caplog.at_level("WARNING"):
+        cleaned = planner_core._truncate_json_extract_input(raw)
+
+    assert cleaned == '{"steps": [{"id": "s1"}]}'
+    assert any("removed leading BOM" in rec.message for rec in caplog.records)
+    assert any("removed NUL bytes" in rec.message for rec in caplog.records)
+
+
+def test_safe_parse_handles_non_string_payload_without_exception():
+    obj = planner_core._safe_parse(12345)
+
+    assert isinstance(obj, dict)
+    assert obj["steps"] == []
+
 def test_safe_json_extract_truncates_oversized_input(caplog):
     payload = json.dumps({"steps": [{"id": "ok1"}]})
     raw = ("x" * (planner_core._MAX_JSON_EXTRACT_CHARS + 100)) + payload


### PR DESCRIPTION
### Motivation
- LLM 出力やフォールバック経路で非文字列やストリーム由来の制御文字（UTF-8 BOM / NUL）が混入すると JSON 救出処理が失敗したりテストで例外になるため、入力前処理を堅牢化する必要があった。 
- 大きすぎる入力によるパーサ/正規表現の DoS リスクを継続的に抑えつつ、実運用でよく見る破損パターンを事前に除去して安定性を高める意図です。 
- 変更は Planner の入力正規化に限定しており、Planner / Kernel / Fuji / MemoryOS の責務外の変更は行っていません。 
- セキュリティ上の留意点として、新たなリスクは確認しておらず BOM/NUL を除去することでパース耐性と観測性が向上しますが、元データの変化が発生するため除去時に警告ログを出すようにしています。  

### Description
- `_truncate_json_extract_input` のシグネチャを `raw: Any` に変更し、`None` と非文字列を安全に文字列化して扱うようにしました。 
- 入力から先頭の UTF-8 BOM (`\ufeff`) と NUL バイト (`\x00`) を除去し、除去時に `logger.warning` を出すようにして観測性を確保しました。 
- 元の振る舞い（長大入力のトランケーション上限）を保持しつつ docstring を追加して意図を明確化しました。 
- Planner 用のユニットテストを追加して（BOM/NUL 除去の検証と非文字列入力の `_safe_parse` の安定性検証）、動作を保証しました (ファイル変更: `veritas_os/core/planner.py`, `veritas_os/tests/test_planner.py`)。 

### Testing
- 実行した自動化テスト: `pytest -q veritas_os/tests/test_planner.py`. 
- 結果: 全テストが成功し `52 passed` を確認しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0ab94ae08326adbde5c65c2f5988)