### PR TITLE
test: core.reason の分岐ケースを追加してカバレッジ向上

### DIFF
--- a/veritas_os/tests/test_reason.py
+++ b/veritas_os/tests/test_reason.py
@@ -138,6 +138,35 @@ def test_generate_reason_calls_llm_client(monkeypatch):
     assert "# Context" in up
 
 
+def test_generate_reason_with_string_response(monkeypatch):
+    """LLM が文字列を返した場合のフォールバック値を検証する。"""
+
+    def stub_chat(*args, **kwargs):
+        return "テキストのみの理由"
+
+    monkeypatch.setattr(reason.llm_client, "chat", stub_chat)
+
+    res = reason.generate_reason(query="fallback test")
+
+    assert res == {
+        "text": "テキストのみの理由",
+        "source": "openai_llm",
+    }
+
+
+def test_generate_reason_llm_error(monkeypatch):
+    """LLM 呼び出し例外時に error ソースで空文字を返す。"""
+
+    def stub_chat(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(reason.llm_client, "chat", stub_chat)
+
+    res = reason.generate_reason(query="error test")
+
+    assert res == {"text": "", "source": "error"}
+
+
 # ------------------------------
 # generate_reflection_template
 # ------------------------------
@@ -241,4 +270,57 @@ def test_generate_reflection_template_bad_json(monkeypatch, tmp_path):
     # JSONパース失敗してもログには何も書かれないはず
     assert not meta_path.exists()
 
+
+def test_generate_reflection_template_validates_required_inputs():
+    """query または chosen が欠ける場合は即時に空辞書を返す。"""
+
+    no_query = asyncio.run(
+        reason.generate_reflection_template(
+            query="",
+            chosen={"title": "X"},
+            gate={"risk": 0.1, "decision_status": "allow"},
+            values={"total": 0.5, "ema": 0.5},
+            planner={},
+        )
+    )
+    no_chosen = asyncio.run(
+        reason.generate_reflection_template(
+            query="テスト",
+            chosen={},
+            gate={"risk": 0.1, "decision_status": "allow"},
+            values={"total": 0.5, "ema": 0.5},
+            planner={},
+        )
+    )
+
+    assert no_query == {}
+    assert no_chosen == {}
+
+
+def test_generate_reflection_template_normalizes_tags_and_priority(monkeypatch):
+    """tags 非配列と priority 範囲外値の正規化を検証する。"""
+
+    def stub_chat(*args, **kwargs):
+        payload = {
+            "pattern": "相談パターン",
+            "guidance": "追加ヒント",
+            "tags": "not-a-list",
+            "priority": "2.4",
+        }
+        return {"text": json.dumps(payload, ensure_ascii=False), "source": "stub"}
+
+    monkeypatch.setattr(reason.llm_client, "chat", stub_chat)
+
+    tmpl = asyncio.run(
+        reason.generate_reflection_template(
+            query="テスト",
+            chosen={"title": "X"},
+            gate={"risk": 0.1, "decision_status": "allow"},
+            values={"total": 0.5, "ema": 0.5},
+            planner={},
+        )
+    )
+
+    assert tmpl["tags"] == ["reflection"]
+    assert tmpl["priority"] == 1.0
 


### PR DESCRIPTION
### Motivation
- core の Reason ロジック (`core/reason.py`) の未到達分岐をテストで網羅してコア部分のカバレッジを向上させるため。 
- Planner / Kernel / Fuji / MemoryOS の責務は変更せず、テストのみで振る舞いの境界を強化するため。 

### Description
- `veritas_os/tests/test_reason.py` に `generate_reason` の文字列応答フォールバックと LLM 例外時のエラー経路を検証するテストを追加した。 
- `veritas_os/tests/test_reason.py` に `generate_reflection_template` の必須入力チェック（`query`/`chosen`）と、`tags` が配列でない場合の正規化および `priority` のクリップを検証するテストを追加した。 
- 変更はテストコードのみで、プロダクションコードのロジックや外部責務は変更していない（ファイル改変は `veritas_os/tests/test_reason.py` のみ）。 

### Testing
- `pytest -q veritas_os/tests/test_reason.py` を実行し `11 passed` を確認した。 
- リポジトリ全体のテストスイートは `pytest -q` 実行時に `2736 passed, 3 skipped` を確認している（この環境での既存実行結果）。 
- カバレッジ測定 (`make test-cov` / `python -m coverage`) は現在の環境で PyPI 依存の取得や `coverage` モジュール未インストールにより完全な計測ができなかったため失敗した。 

Security note: 変更はテストのみでリスクは低いですが、`core.reason` 実装はクエリ内容をメタログ (`META_LOG`) に書き込むため、本番環境でログに機密情報が含まれないよう運用上の注意と必要に応じたマスキングを推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2477e3fc8326865016971cfe9402)