### PR TITLE
Add BFF authorization for Veritas API and dependency-audit CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,50 @@ jobs:
             --severity-level medium \
             -f txt
 
+
+
+  dependency-audit:
+    name: dependency-audit
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pip-audit
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install pip-audit
+
+      - name: Block high/critical CVEs in Python dependencies
+        run: pip-audit -r veritas_os/requirements.txt --desc
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run npm audit (production-only)
+        working-directory: frontend
+        run: |
+          set -euxo pipefail
+          npm install --package-lock-only --ignore-scripts
+          npm audit --production --audit-level=high
+
   # ============================================================
   # Test matrix
   # ============================================================
   test:
     name: test (py${{ matrix.python-version }})
-    needs: lint
+    needs: [lint, dependency-audit]
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -143,7 +181,7 @@ jobs:
 
   test-slow:
     name: test-slow (py3.12)
-    needs: lint
+    needs: [lint, dependency-audit]
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -185,7 +223,7 @@ jobs:
   # ============================================================
   frontend-quality-gate:
     name: frontend-${{ matrix.gate }}
-    needs: lint
+    needs: [lint, dependency-audit]
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/frontend/app/api/veritas/[...path]/authz.ts
+++ b/frontend/app/api/veritas/[...path]/authz.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from "next/server";
+
+const SUPPORTED_BFF_ROLES = ["viewer", "operator", "admin"] as const;
+
+export type BffRole = (typeof SUPPORTED_BFF_ROLES)[number];
+
+interface RoutePolicy {
+  readonly pathPattern: RegExp;
+  readonly method: "GET" | "POST" | "PUT";
+  readonly roles: readonly BffRole[];
+}
+
+interface MatchedPolicy {
+  readonly policy: RoutePolicy;
+  readonly path: string;
+}
+
+const ROUTE_POLICIES: readonly RoutePolicy[] = [
+  { pathPattern: /^v1\/decide$/, method: "POST", roles: ["operator", "admin"] },
+  {
+    pathPattern: /^v1\/governance\/value-drift$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
+  {
+    pathPattern: /^v1\/governance\/policy$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
+  { pathPattern: /^v1\/governance\/policy$/, method: "PUT", roles: ["admin"] },
+  {
+    pathPattern: /^v1\/trust\/logs$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
+  { pathPattern: /^v1\/trust\/[^/]+$/, method: "GET", roles: ["viewer", "operator", "admin"] },
+  { pathPattern: /^v1\/events$/, method: "GET", roles: ["viewer", "operator", "admin"] },
+];
+
+/**
+ * Reject path segments that could cause path traversal or URL manipulation.
+ * Blocks "..", empty segments, and segments with encoded slashes or null bytes.
+ */
+export function hasUnsafeSegment(pathSegments: string[]): boolean {
+  return pathSegments.some(
+    (seg) => seg === ".." || seg === "." || seg === "" || /[%\x00/\\]/.test(seg),
+  );
+}
+
+/**
+ * Parse token-role mapping from `VERITAS_BFF_AUTH_TOKENS_JSON`.
+ * Expected format: {"tokenA":"viewer","tokenB":"admin"}.
+ */
+export function parseAuthTokensConfig(rawConfig: string | undefined): Map<string, BffRole> {
+  if (!rawConfig || !rawConfig.trim()) {
+    return new Map();
+  }
+
+  try {
+    const parsed = JSON.parse(rawConfig) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return new Map();
+    }
+
+    const entries = Object.entries(parsed).filter(([, value]) =>
+      typeof value === "string" && SUPPORTED_BFF_ROLES.includes(value as BffRole),
+    ) as Array<[string, BffRole]>;
+
+    return new Map(entries);
+  } catch {
+    return new Map();
+  }
+}
+
+/**
+ * Find matching route policy for path+method. Returns null for unsupported paths.
+ */
+export function matchPolicy(pathSegments: string[], method: string): MatchedPolicy | null {
+  if (hasUnsafeSegment(pathSegments)) {
+    return null;
+  }
+
+  const path = pathSegments.join("/");
+  const normalizedMethod = method.toUpperCase();
+
+  const policy = ROUTE_POLICIES.find(
+    (candidate) =>
+      candidate.method === normalizedMethod &&
+      candidate.pathPattern.test(path) &&
+      path.split("/").length === pathSegments.length,
+  );
+
+  if (!policy) {
+    return null;
+  }
+
+  return { policy, path };
+}
+
+/**
+ * Resolve caller role from Authorization header and token map.
+ */
+export function authenticateRoleFromHeaders(
+  headers: Headers,
+  tokenRoleMap: Map<string, BffRole>,
+): { readonly role?: BffRole; readonly errorResponse?: NextResponse } {
+  if (tokenRoleMap.size === 0) {
+    return {
+      errorResponse: NextResponse.json(
+        {
+          error: "server_misconfigured",
+          detail:
+            "VERITAS_BFF_AUTH_TOKENS_JSON must be configured with bearer token to role mapping.",
+        },
+        { status: 503 },
+      ),
+    };
+  }
+
+  const authorization = headers.get("authorization") ?? "";
+  const [scheme, token] = authorization.split(" ");
+
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
+    return {
+      errorResponse: NextResponse.json({ error: "unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const role = tokenRoleMap.get(token);
+  if (!role) {
+    return {
+      errorResponse: NextResponse.json({ error: "forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { role };
+}

--- a/frontend/app/api/veritas/[...path]/route.test.ts
+++ b/frontend/app/api/veritas/[...path]/route.test.ts
@@ -1,14 +1,81 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { getBodySizeBytes } from './body-size';
+import {
+  authenticateRoleFromHeaders,
+  hasUnsafeSegment,
+  matchPolicy,
+  parseAuthTokensConfig,
+} from "./authz";
+import { getBodySizeBytes } from "./body-size";
 
-describe('getBodySizeBytes', () => {
-  it('returns ASCII length as bytes', () => {
-    expect(getBodySizeBytes('abcd')).toBe(4);
+describe("veritas bff route auth and authorization", () => {
+  it("parses valid token-to-role config", () => {
+    const tokenMap = parseAuthTokensConfig(
+      '{"token-viewer":"viewer","token-admin":"admin","ignored":"bad-role"}',
+    );
+
+    expect(tokenMap.get("token-viewer")).toBe("viewer");
+    expect(tokenMap.get("token-admin")).toBe("admin");
+    expect(tokenMap.has("ignored")).toBe(false);
   });
 
-  it('counts multibyte UTF-8 characters correctly', () => {
-    expect(getBodySizeBytes('あ')).toBe(3);
-    expect(getBodySizeBytes('😀')).toBe(4);
+  it("rejects unsupported auth config format", () => {
+    const tokenMap = parseAuthTokensConfig("[]");
+
+    expect(tokenMap.size).toBe(0);
+  });
+
+  it("returns 503 when auth token map is missing", () => {
+    const result = authenticateRoleFromHeaders(new Headers(), new Map());
+
+    expect(result.role).toBeUndefined();
+    expect(result.errorResponse?.status).toBe(503);
+  });
+
+  it("returns 401 when bearer token is not provided", () => {
+    const headers = new Headers();
+    const result = authenticateRoleFromHeaders(headers, new Map([["token-admin", "admin"]]));
+
+    expect(result.role).toBeUndefined();
+    expect(result.errorResponse?.status).toBe(401);
+  });
+
+  it("returns role for valid bearer token", () => {
+    const headers = new Headers({ authorization: "Bearer token-operator" });
+    const result = authenticateRoleFromHeaders(
+      headers,
+      new Map([
+        ["token-viewer", "viewer"],
+        ["token-operator", "operator"],
+      ]),
+    );
+
+    expect(result.role).toBe("operator");
+    expect(result.errorResponse).toBeUndefined();
+  });
+
+  it("applies route policies for admin-only and operator endpoints", () => {
+    const governancePut = matchPolicy(["v1", "governance", "policy"], "PUT");
+    const decidePost = matchPolicy(["v1", "decide"], "POST");
+
+    expect(governancePut?.policy.roles).toEqual(["admin"]);
+    expect(decidePost?.policy.roles).toEqual(["operator", "admin"]);
+  });
+
+  it("blocks unsafe path segments", () => {
+    expect(hasUnsafeSegment(["v1", "..", "policy"])).toBe(true);
+    expect(matchPolicy(["v1", "..", "policy"], "GET")).toBeNull();
+  });
+});
+
+
+describe("getBodySizeBytes", () => {
+  it("returns ASCII length as bytes", () => {
+    expect(getBodySizeBytes("abcd")).toBe(4);
+  });
+
+  it("counts multibyte UTF-8 characters correctly", () => {
+    expect(getBodySizeBytes("あ")).toBe(3);
+    expect(getBodySizeBytes("😀")).toBe(4);
   });
 });

--- a/frontend/app/api/veritas/[...path]/route.ts
+++ b/frontend/app/api/veritas/[...path]/route.ts
@@ -1,22 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import {
+  authenticateRoleFromHeaders,
+  matchPolicy,
+  parseAuthTokensConfig,
+} from "./authz";
 import { getBodySizeBytes } from "./body-size";
 
-const API_BASE = process.env.VERITAS_API_BASE_URL ?? process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL ?? "http://localhost:8000";
+const API_BASE =
+  process.env.VERITAS_API_BASE_URL ??
+  process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL ??
+  "http://localhost:8000";
 const API_KEY = process.env.VERITAS_API_KEY ?? "";
 
 /** Max request body size for proxied requests (1MB). */
 const MAX_PROXY_BODY_BYTES = 1 * 1024 * 1024;
-
-/**
- * Reject path segments that could cause path traversal or URL manipulation.
- * Blocks "..", empty segments, and segments with encoded slashes or null bytes.
- */
-function hasUnsafeSegment(pathSegments: string[]): boolean {
-  return pathSegments.some(
-    (seg) => seg === ".." || seg === "." || seg === "" || /[%\x00/\\]/.test(seg),
-  );
-}
 
 function buildTargetUrl(pathSegments: string[], searchParams: URLSearchParams): URL {
   const baseUrl = API_BASE.replace(/\/$/, "");
@@ -24,46 +22,23 @@ function buildTargetUrl(pathSegments: string[], searchParams: URLSearchParams): 
   return new URL(`${baseUrl}/${safePath}?${searchParams.toString()}`);
 }
 
-function isAllowedPath(pathSegments: string[], method: string): boolean {
-  if (hasUnsafeSegment(pathSegments)) {
-    return false;
-  }
-
-  const path = pathSegments.join("/");
-
-  if (path === "v1/decide" && method === "POST") {
-    return true;
-  }
-
-  if (path === "v1/governance/value-drift" && method === "GET") {
-    return true;
-  }
-
-  if (path === "v1/governance/policy" && ["GET", "PUT"].includes(method)) {
-    return true;
-  }
-
-  if (path === "v1/trust/logs" && method === "GET") {
-    return true;
-  }
-
-  if (path.startsWith("v1/trust/") && pathSegments.length === 3 && method === "GET") {
-    return true;
-  }
-
-  if (path === "v1/events" && method === "GET") {
-    return true;
-  }
-
-  return false;
-}
-
 /**
  * Proxies allowed Veritas API calls from browser to backend using server-side API key.
  */
 async function handleProxy(request: NextRequest, pathSegments: string[]): Promise<Response> {
-  if (!isAllowedPath(pathSegments, request.method)) {
+  const matched = matchPolicy(pathSegments, request.method);
+  if (!matched) {
     return NextResponse.json({ error: "unsupported_path" }, { status: 404 });
+  }
+
+  const tokenRoleMap = parseAuthTokensConfig(process.env.VERITAS_BFF_AUTH_TOKENS_JSON);
+  const authResult = authenticateRoleFromHeaders(request.headers, tokenRoleMap);
+  if (authResult.errorResponse) {
+    return authResult.errorResponse;
+  }
+
+  if (!authResult.role || !matched.policy.roles.includes(authResult.role)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
   }
 
   if (!API_KEY.trim()) {
@@ -110,17 +85,26 @@ async function handleProxy(request: NextRequest, pathSegments: string[]): Promis
   });
 }
 
-export async function GET(request: NextRequest, context: { params: Promise<{ path: string[] }> }): Promise<Response> {
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
   const { path } = await context.params;
   return handleProxy(request, path);
 }
 
-export async function POST(request: NextRequest, context: { params: Promise<{ path: string[] }> }): Promise<Response> {
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
   const { path } = await context.params;
   return handleProxy(request, path);
 }
 
-export async function PUT(request: NextRequest, context: { params: Promise<{ path: string[] }> }): Promise<Response> {
+export async function PUT(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
   const { path } = await context.params;
   return handleProxy(request, path);
 }


### PR DESCRIPTION
### Motivation

- Prevent exposing server API key via the browser by proxying only allowed Veritas API routes and enforcing role-based access in the BFF.  
- Harden CI by adding automated dependency auditing for Python and Node dependencies before running tests.

### Description

- Add `frontend/app/api/veritas/[...path]/authz.ts` implementing route policies, safe-path checks (`hasUnsafeSegment`), token-to-role parsing (`parseAuthTokensConfig`), policy matching (`matchPolicy`), and header-based authentication (`authenticateRoleFromHeaders`).
- Update `frontend/app/api/veritas/[...path]/route.ts` to use the new authorization helpers, enforce role checks, and return appropriate error responses for unsupported paths, missing server API key, oversized payloads, and forbidden requests.  
- Add/extend unit tests in `frontend/app/api/veritas/[...path]/route.test.ts` to cover token parsing, authentication behavior, policy matching, unsafe-segment rejection, and existing body-size semantics.  
- Update GitHub Actions workflow (`.github/workflows/main.yml`) to add a new `dependency-audit` job that runs `pip-audit` against `veritas_os/requirements.txt` and `npm audit` (production-only) in `frontend`, and make test jobs depend on this audit job.

### Testing

- Frontend unit tests were added/updated and run with `vitest`, and the new tests for authz and `getBodySizeBytes` passed.  
- CI linting remains unchanged (runs `ruff` and `bandit`) and the workflow now includes `pip-audit` and `npm audit` steps as part of `dependency-audit` which is required before test jobs.  
- No automated test failures were observed when running the updated frontend unit tests locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4e1c14d48326abed70a09e2a9ea6)