### PR TITLE
Improve enterprise P1 readiness: add SLO/SLI runbook and enforce trace-id propagation

### DIFF
--- a/docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md
+++ b/docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md
@@ -1,0 +1,83 @@
+# Enterprise SLO/SLI & 運用Runbook（2026-03-06）
+
+## 目的
+本ドキュメントは、エンタープライズ運用に必要な SLO/SLI と、障害時の標準運用手順を定義する。
+対象は Veritas API（`veritas_os/api`）およびフロント BFF（`frontend/app/api/veritas/[...path]`）。
+
+## 1. SLI 定義
+
+### 1.1 可用性（Availability）
+- 指標: `2xx + 4xx` を成功、`5xx` を失敗として 5分窓で計測
+- 対象: `/health`, `/v1/decide`, `/v1/fuji/validate`, `/v1/trust/*`
+- 収集キー: `service`, `route`, `status_class`, `trace_id`
+
+### 1.2 レイテンシ（Latency）
+- 指標: P50 / P95 / P99 の応答時間
+- 対象: `/v1/decide`（主監視）、その他主要 API
+- 収集キー: `route`, `method`, `status`, `trace_id`
+
+### 1.3 エラーレート（Error rate）
+- 指標: `5xx / total_requests`
+- 収集キー: `route`, `error_type`, `trace_id`
+
+### 1.4 BFF→API 相関（Trace propagation）
+- 指標: BFF リクエストのうち、`X-Trace-Id` が API レスポンスまで維持される割合
+- 目標値: 99.9% 以上
+- 検証方法: BFF/ API のアクセスログを `trace_id` で突合
+
+## 2. SLO 目標値
+
+| 区分 | SLO | 評価窓 |
+|---|---|---|
+| 可用性 | 99.9% 以上 | 30日 |
+| `/v1/decide` P95 | 1200ms 以下 | 7日 |
+| `/v1/decide` P99 | 2500ms 以下 | 7日 |
+| 5xx エラーレート | 0.5% 未満 | 1日 |
+| Trace 伝播成功率 | 99.9% 以上 | 7日 |
+
+## 3. Error Budget 運用
+- 月次 Error Budget: 43.2分（99.9% 前提）
+- 消費率 50% 到達時:
+  - 新規機能投入を凍結し、安定化対応を優先
+  - 直近7日の `trace_id` 上位障害クラスタを分析
+- 消費率 100% 到達時:
+  - 重大変更の本番反映を停止
+  - 24時間以内に RCA（Root Cause Analysis）を作成
+
+## 4. 監視とアラート
+
+### 4.1 アラート条件（推奨）
+1. `5xx rate > 1%` が 10分継続
+2. `/v1/decide` P95 > 1200ms が 15分継続
+3. Trace 伝播成功率 < 99.9% が 30分継続
+
+### 4.2 アラート通知先
+- Primary: on-call backend
+- Secondary: platform/security
+
+## 5. 障害対応 Runbook
+
+### 5.1 初動（0–15分）
+1. `/health` と主要 API の状態確認
+2. エラー増加の route を特定
+3. 代表 `trace_id` を抽出して BFF→API 連鎖を確認
+
+### 5.2 切り分け（15–45分）
+1. API 側 5xx の発生ポイントを特定
+2. BFF 側で認証失敗 / payload 制限 / upstream 失敗を分類
+3. 影響範囲（顧客・機能・時間帯）を記録
+
+### 5.3 緩和策（45–90分）
+1. 高リスクエンドポイントにレート制限を強化
+2. 必要に応じて feature flag / canary rollback を実施
+3. 監査向けに対応ログと `trace_id` 一覧を保全
+
+### 5.4 復旧後（24時間以内）
+1. RCA を作成し、再発防止策をチケット化
+2. SLO 逸脱分を Error Budget 台帳へ反映
+3. アラート閾値と runbook の妥当性を再評価
+
+## 6. セキュリティ上の警告
+- `trace_id` は監査相関用であり、認可判定には使用しない。
+- 外部入力の `trace_id` は形式検証を行い、ヘッダ/ログインジェクションを防止する。
+- `trace_id` に秘密情報（APIキー、トークン、PII）を含めない。

--- a/docs/review/ENTERPRISE_READINESS_REVIEW_2026_03_06_JP.md
+++ b/docs/review/ENTERPRISE_READINESS_REVIEW_2026_03_06_JP.md
@@ -63,8 +63,8 @@
 ## 追加改善提案（優先度順）
 1. **P0**: `frontend/app/api/veritas/[...path]/route.ts` に強制認証と権限マトリクスを導入。
 2. **P0**: CIに `pip-audit` / `npm audit --production` を追加し、重大CVSSでデプロイブロック。
-3. **P1**: 監査向けにSLO/SLI（API latency, error budget）と運用Runbookを `docs/` に明文化。
-4. **P1**: BFFとAPI双方で相関ID（trace_id）を必須伝播して監査容易性を向上。
+3. **P1（対応済み）**: 監査向けにSLO/SLI（API latency, error budget）と運用Runbookを `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に明文化。
+4. **P1（対応済み）**: BFFとAPI双方で相関ID（`X-Trace-Id` / `X-Request-Id`）を必須伝播し、監査容易性を向上。
 5. **P2**: 警告ゼロ運用（または期限付き警告管理）へ移行。
 
 ## 結論

--- a/frontend/app/api/veritas/[...path]/route.test.ts
+++ b/frontend/app/api/veritas/[...path]/route.test.ts
@@ -7,6 +7,7 @@ import {
   parseAuthTokensConfig,
 } from "./route-auth";
 import { getBodySizeBytes } from "./body-size";
+import { resolveTraceId } from "./trace-id";
 
 describe("veritas bff route auth and authorization", () => {
   it("parses valid token-to-role config", () => {
@@ -76,5 +77,28 @@ describe("getBodySizeBytes", () => {
   it("counts multibyte UTF-8 characters correctly", () => {
     expect(getBodySizeBytes("あ")).toBe(3);
     expect(getBodySizeBytes("😀")).toBe(4);
+  });
+});
+
+describe("resolveTraceId", () => {
+  it("accepts a valid x-trace-id", () => {
+    const headers = new Headers({ "x-trace-id": "trace-abc12345" });
+
+    expect(resolveTraceId(headers)).toBe("trace-abc12345");
+  });
+
+  it("falls back to x-request-id", () => {
+    const headers = new Headers({ "x-request-id": "request-abc12345" });
+
+    expect(resolveTraceId(headers)).toBe("request-abc12345");
+  });
+
+  it("generates a uuid when provided ids are invalid", () => {
+    const headers = new Headers({ "x-trace-id": "..\n" });
+    const traceId = resolveTraceId(headers);
+
+    expect(traceId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
   });
 });

--- a/frontend/app/api/veritas/[...path]/route.ts
+++ b/frontend/app/api/veritas/[...path]/route.ts
@@ -6,6 +6,7 @@ import {
   parseAuthTokensConfig,
 } from "./route-auth";
 import { getBodySizeBytes } from "./body-size";
+import { resolveTraceId, TRACE_ID_HEADER_NAME } from "./trace-id";
 
 const API_BASE =
   process.env.VERITAS_API_BASE_URL ??
@@ -26,31 +27,61 @@ function buildTargetUrl(pathSegments: string[], searchParams: URLSearchParams): 
  * Proxies allowed Veritas API calls from browser to backend using server-side API key.
  */
 async function handleProxy(request: NextRequest, pathSegments: string[]): Promise<Response> {
+  const traceId = resolveTraceId(request.headers);
+
   const matched = matchPolicy(pathSegments, request.method);
   if (!matched) {
-    return NextResponse.json({ error: "unsupported_path" }, { status: 404 });
+    return NextResponse.json(
+      { error: "unsupported_path", trace_id: traceId },
+      {
+        status: 404,
+        headers: {
+          [TRACE_ID_HEADER_NAME]: traceId,
+        },
+      },
+    );
   }
 
   const tokenRoleMap = parseAuthTokensConfig(process.env.VERITAS_BFF_AUTH_TOKENS_JSON);
   const authResult = authenticateRoleFromHeaders(request.headers, tokenRoleMap);
   if (authResult.errorResponse) {
+    authResult.errorResponse.headers.set(TRACE_ID_HEADER_NAME, traceId);
     return authResult.errorResponse;
   }
 
   if (!authResult.role || !matched.policy.roles.includes(authResult.role)) {
-    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    return NextResponse.json(
+      { error: "forbidden", trace_id: traceId },
+      {
+        status: 403,
+        headers: {
+          [TRACE_ID_HEADER_NAME]: traceId,
+        },
+      },
+    );
   }
 
   if (!API_KEY.trim()) {
     return NextResponse.json(
-      { error: "server_misconfigured", detail: "VERITAS_API_KEY is not configured on server." },
-      { status: 503 },
+      {
+        error: "server_misconfigured",
+        detail: "VERITAS_API_KEY is not configured on server.",
+        trace_id: traceId,
+      },
+      {
+        status: 503,
+        headers: {
+          [TRACE_ID_HEADER_NAME]: traceId,
+        },
+      },
     );
   }
 
   const targetUrl = buildTargetUrl(pathSegments, request.nextUrl.searchParams);
   const upstreamHeaders = new Headers();
   upstreamHeaders.set("X-API-Key", API_KEY.trim());
+  upstreamHeaders.set(TRACE_ID_HEADER_NAME, traceId);
+  upstreamHeaders.set("X-Request-Id", traceId);
 
   const contentType = request.headers.get("content-type");
   if (contentType) {
@@ -62,7 +93,15 @@ async function handleProxy(request: NextRequest, pathSegments: string[]): Promis
   if (hasBody) {
     body = await request.text();
     if (getBodySizeBytes(body) > MAX_PROXY_BODY_BYTES) {
-      return NextResponse.json({ error: "payload_too_large" }, { status: 413 });
+      return NextResponse.json(
+        { error: "payload_too_large", trace_id: traceId },
+        {
+          status: 413,
+          headers: {
+            [TRACE_ID_HEADER_NAME]: traceId,
+          },
+        },
+      );
     }
   }
 
@@ -78,6 +117,7 @@ async function handleProxy(request: NextRequest, pathSegments: string[]): Promis
   if (upstreamContentType) {
     responseHeaders.set("Content-Type", upstreamContentType);
   }
+  responseHeaders.set(TRACE_ID_HEADER_NAME, traceId);
 
   return new Response(upstreamResponse.body, {
     status: upstreamResponse.status,

--- a/frontend/app/api/veritas/[...path]/trace-id.ts
+++ b/frontend/app/api/veritas/[...path]/trace-id.ts
@@ -1,0 +1,28 @@
+const TRACE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/;
+
+export const TRACE_ID_HEADER_NAME = "X-Trace-Id";
+
+/**
+ * Resolve trace id from incoming headers or generate a fresh id.
+ *
+ * Security:
+ * - Rejects malformed user-supplied values to prevent log/header injection.
+ * - Falls back to a cryptographically random UUID when unavailable.
+ */
+export function resolveTraceId(headers: Headers): string {
+  const candidates = [
+    headers.get(TRACE_ID_HEADER_NAME),
+    headers.get("x-trace-id"),
+    headers.get("X-Request-Id"),
+    headers.get("x-request-id"),
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = (candidate ?? "").trim();
+    if (TRACE_ID_PATTERN.test(normalized)) {
+      return normalized;
+    }
+  }
+
+  return crypto.randomUUID();
+}

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -660,6 +660,42 @@ def _resolve_max_request_body_size() -> int:
 
 
 MAX_REQUEST_BODY_SIZE = _resolve_max_request_body_size()
+TRACE_ID_HEADER_NAME = "X-Trace-Id"
+_TRACE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
+
+
+def _resolve_trace_id_from_request(request: Request) -> str:
+    """Resolve or mint a trace id for end-to-end audit correlation.
+
+    Security:
+        - Accept only a strict ASCII-safe format to avoid header/log injection.
+        - Prefer caller-provided ids (``X-Trace-Id`` / ``X-Request-Id``) when
+          valid, otherwise generate a cryptographically random fallback.
+    """
+    candidates = (
+        request.headers.get(TRACE_ID_HEADER_NAME),
+        request.headers.get("x-trace-id"),
+        request.headers.get("X-Request-Id"),
+        request.headers.get("x-request-id"),
+    )
+
+    for candidate in candidates:
+        normalized = (candidate or "").strip()
+        if _TRACE_ID_PATTERN.match(normalized):
+            return normalized
+
+    return secrets.token_hex(16)
+
+
+@app.middleware("http")
+async def attach_trace_id(request: Request, call_next):
+    """Attach a validated trace id to request state and response headers."""
+    trace_id = _resolve_trace_id_from_request(request)
+    request.state.trace_id = trace_id
+    response = await call_next(request)
+    response.headers[TRACE_ID_HEADER_NAME] = trace_id
+    response.headers.setdefault("X-Request-Id", trace_id)
+    return response
 
 
 @app.middleware("http")

--- a/veritas_os/tests/test_server_coverage.py
+++ b/veritas_os/tests/test_server_coverage.py
@@ -6,6 +6,7 @@ import hashlib
 import hmac
 import json
 import os
+import re
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -188,6 +189,23 @@ def test_security_headers_present():
         == "max-age=31536000; includeSubDomains"
     )
     assert resp.headers.get("Cache-Control") == "no-store"
+
+
+def test_trace_id_header_preserved_when_valid():
+    trace_id = "trace-12345678"
+    resp = client.get("/health", headers={"X-Trace-Id": trace_id})
+
+    assert resp.headers.get("X-Trace-Id") == trace_id
+    assert resp.headers.get("X-Request-Id") == trace_id
+
+
+def test_trace_id_header_generated_when_invalid():
+    resp = client.get("/health", headers={"X-Trace-Id": "\n"})
+    trace_id = resp.headers.get("X-Trace-Id")
+
+    assert trace_id is not None
+    assert re.fullmatch(r"[0-9a-f]{32}", trace_id) is not None
+    assert resp.headers.get("X-Request-Id") == trace_id
 
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Close two P1 gaps from the Enterprise Readiness review by providing an operations runbook and adding end-to-end correlation IDs for auditability. 
- Ensure BFF→API trace propagation is robust and safe to help SLI/SLO correlation and post-incident investigation.

### Description
- Added an operations runbook document at `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` containing SLI definitions, SLO targets, error-budget policy, alert thresholds, and incident runbook steps. 
- Implemented trace-id resolution/validation in the frontend BFF by adding `frontend/app/api/veritas/[...path]/trace-id.ts` and updating `frontend/app/api/veritas/[...path]/route.ts` to validate incoming `X-Trace-Id`/`X-Request-Id`, generate a safe fallback, forward correlation headers upstream, and include the trace id in error and success responses. 
- Added backend middleware in `veritas_os/api/server.py` to validate or mint trace ids, store the id on `request.state.trace_id`, and attach `X-Trace-Id`/`X-Request-Id` to responses for end-to-end correlation. 
- Added tests to verify trace id behavior: `frontend/app/api/veritas/[...path]/route.test.ts` (vitest) and `veritas_os/tests/test_server_coverage.py` (pytest), and updated the review doc `docs/review/ENTERPRISE_READINESS_REVIEW_2026_03_06_JP.md` to mark the P1 items as addressed. 
- Security: input trace ids are validated against a strict pattern to mitigate header/log injection and invalid IDs are never forwarded; documentation notes that trace ids must not be used for authorization and must not contain secrets. 

### Testing
- Ran `pytest -q veritas_os/tests/test_server_coverage.py -k 'trace_id_header or security_headers_present'` and the selected tests passed (`3 passed, 65 deselected`).
- Ran frontend unit tests with `pnpm --filter frontend test -- app/api/veritas/[...path]/route.test.ts` and the file's tests passed (`1 file, 12 tests passed`).
- No other automated test failures observed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6238125883269a202a2ce79d58e4)