### PR TITLE
Add expiring pytest warning allowlist policy check (P2 improvement)

### DIFF
--- a/config/test_warning_allowlist.json
+++ b/config/test_warning_allowlist.json
@@ -1,0 +1,16 @@
+{
+  "entries": [
+    {
+      "rule": "ignore:\"content=<...>\" is deprecated\\. Use 'data=<...>' instead:DeprecationWarning:httpx\\..*",
+      "expires_on": "2026-09-30",
+      "owner": "platform-backend",
+      "reason": "httpx upstream deprecation migration window"
+    },
+    {
+      "rule": "ignore:invalid escape sequence.*:SyntaxWarning:sentence_transformers\\..*",
+      "expires_on": "2026-09-30",
+      "owner": "ml-platform",
+      "reason": "third-party warning until upstream package cleanup"
+    }
+  ]
+}

--- a/docs/review/ENTERPRISE_READINESS_REVIEW_2026_03_06_JP.md
+++ b/docs/review/ENTERPRISE_READINESS_REVIEW_2026_03_06_JP.md
@@ -65,7 +65,7 @@
 2. **P0**: CIに `pip-audit` / `npm audit --production` を追加し、重大CVSSでデプロイブロック。
 3. **P1（対応済み）**: 監査向けにSLO/SLI（API latency, error budget）と運用Runbookを `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に明文化。
 4. **P1（対応済み）**: BFFとAPI双方で相関ID（`X-Trace-Id` / `X-Request-Id`）を必須伝播し、監査容易性を向上。
-5. **P2**: 警告ゼロ運用（または期限付き警告管理）へ移行。
+5. **P2（対応済み）**: `scripts/quality/check_warning_allowlist.py` と `config/test_warning_allowlist.json` を追加し、`pytest` の ignore 警告を期限付きallowlistで管理（期限切れ・メタデータ欠落でfail）。
 
 ## 結論
 - 現状は、**テスト網羅・責務境界・基本セキュリティ機構**の観点で高水準。

--- a/scripts/quality/check_warning_allowlist.py
+++ b/scripts/quality/check_warning_allowlist.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Validate pytest warning allowlist entries with expiration dates.
+
+This script enforces a warning governance policy by checking that each
+"ignore" entry in ``[tool.pytest.ini_options].filterwarnings`` has a matching
+allowlist record with an owner, reason, and non-expired deadline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+import tomllib
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    """Single allowlisted warning rule with governance metadata."""
+
+    rule: str
+    expires_on: date
+    owner: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Result container for policy validation."""
+
+    errors: list[str]
+
+    @property
+    def is_valid(self) -> bool:
+        """Return True when no validation errors are found."""
+        return not self.errors
+
+
+def _load_pytest_ignore_rules(pyproject_path: Path) -> list[str]:
+    """Load only ``ignore:`` warning filter rules from pyproject.toml."""
+    content = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    tool_section = content.get("tool", {})
+    pytest_section = tool_section.get("pytest", {})
+    ini_options = pytest_section.get("ini_options", {})
+    raw_rules = ini_options.get("filterwarnings", [])
+    return [str(rule) for rule in raw_rules if str(rule).startswith("ignore:")]
+
+
+def _load_allowlist(allowlist_path: Path) -> dict[str, AllowlistEntry]:
+    """Load allowlist entries from JSON keyed by warning rule string."""
+    payload = json.loads(allowlist_path.read_text(encoding="utf-8"))
+    entries: dict[str, AllowlistEntry] = {}
+
+    for item in payload.get("entries", []):
+        expires_on = datetime.strptime(item["expires_on"], "%Y-%m-%d").date()
+        entry = AllowlistEntry(
+            rule=item["rule"],
+            expires_on=expires_on,
+            owner=item["owner"],
+            reason=item["reason"],
+        )
+        entries[entry.rule] = entry
+
+    return entries
+
+
+def validate_warning_allowlist(
+    pyproject_path: Path,
+    allowlist_path: Path,
+    *,
+    today: date | None = None,
+) -> ValidationResult:
+    """Validate pytest ignore rules against the warning allowlist policy."""
+    check_date = today or datetime.now(tz=UTC).date()
+    errors: list[str] = []
+
+    ignore_rules = _load_pytest_ignore_rules(pyproject_path)
+    allowlist_entries = _load_allowlist(allowlist_path)
+
+    for rule in ignore_rules:
+        entry = allowlist_entries.get(rule)
+        if entry is None:
+            errors.append(
+                "Missing allowlist metadata for pytest warning rule: "
+                f"{rule}"
+            )
+            continue
+        if entry.expires_on < check_date:
+            errors.append(
+                "Expired warning allowlist entry: "
+                f"{rule} (expired {entry.expires_on.isoformat()})"
+            )
+
+    for rule in allowlist_entries:
+        if rule not in ignore_rules:
+            errors.append(
+                "Allowlist contains stale entry that no longer exists in "
+                f"pyproject.toml: {rule}"
+            )
+
+    return ValidationResult(errors=errors)
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Path to pyproject.toml",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=Path("config/test_warning_allowlist.json"),
+        help="Path to warning allowlist JSON",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run warning allowlist validation and print policy violations."""
+    args = _parse_args()
+    result = validate_warning_allowlist(args.pyproject, args.allowlist)
+
+    if result.is_valid:
+        print("Warning allowlist policy check passed.")
+        return 0
+
+    print("Warning allowlist policy check failed:")
+    for error in result.errors:
+        print(f"- {error}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_warning_allowlist_policy.py
+++ b/veritas_os/tests/test_warning_allowlist_policy.py
@@ -1,0 +1,116 @@
+"""Tests for warning allowlist governance policy checks."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from scripts.quality.check_warning_allowlist import validate_warning_allowlist
+
+
+def _write_pyproject(path: Path, filterwarnings: list[str]) -> None:
+    content = "\n".join(
+        [
+            "[tool.pytest.ini_options]",
+            "filterwarnings = [",
+            *[f'  "{rule.replace(chr(92), chr(92) * 2)}",' for rule in filterwarnings],
+            "]",
+        ]
+    )
+    path.write_text(content + "\n", encoding="utf-8")
+
+
+def _write_allowlist(path: Path, entries: list[dict[str, str]]) -> None:
+    payload = {"entries": entries}
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def test_validate_warning_allowlist_passes_with_valid_entries(tmp_path: Path) -> None:
+    rule = "ignore:sample warning:DeprecationWarning:sample\\..*"
+    pyproject_path = tmp_path / "pyproject.toml"
+    allowlist_path = tmp_path / "allowlist.json"
+
+    _write_pyproject(pyproject_path, [rule])
+    _write_allowlist(
+        allowlist_path,
+        [
+            {
+                "rule": rule,
+                "expires_on": "2099-01-01",
+                "owner": "qa",
+                "reason": "temporary upstream noise",
+            }
+        ],
+    )
+
+    result = validate_warning_allowlist(
+        pyproject_path,
+        allowlist_path,
+        today=date(2026, 3, 6),
+    )
+
+    assert result.is_valid is True
+
+
+def test_validate_warning_allowlist_fails_on_expired_entry(tmp_path: Path) -> None:
+    rule = "ignore:sample warning:DeprecationWarning:sample\\..*"
+    pyproject_path = tmp_path / "pyproject.toml"
+    allowlist_path = tmp_path / "allowlist.json"
+
+    _write_pyproject(pyproject_path, [rule])
+    _write_allowlist(
+        allowlist_path,
+        [
+            {
+                "rule": rule,
+                "expires_on": "2026-01-01",
+                "owner": "qa",
+                "reason": "temporary upstream noise",
+            }
+        ],
+    )
+
+    result = validate_warning_allowlist(
+        pyproject_path,
+        allowlist_path,
+        today=date(2026, 3, 6),
+    )
+
+    assert result.is_valid is False
+    assert any("Expired warning allowlist entry" in error for error in result.errors)
+
+
+def test_validate_warning_allowlist_fails_on_missing_metadata(tmp_path: Path) -> None:
+    pyproject_rule = "ignore:py warning:DeprecationWarning:pkg\\..*"
+    stale_rule = "ignore:stale warning:DeprecationWarning:stale\\..*"
+
+    pyproject_path = tmp_path / "pyproject.toml"
+    allowlist_path = tmp_path / "allowlist.json"
+
+    _write_pyproject(pyproject_path, [pyproject_rule])
+    _write_allowlist(
+        allowlist_path,
+        [
+            {
+                "rule": stale_rule,
+                "expires_on": "2099-01-01",
+                "owner": "qa",
+                "reason": "leftover",
+            }
+        ],
+    )
+
+    result = validate_warning_allowlist(
+        pyproject_path,
+        allowlist_path,
+        today=date(2026, 3, 6),
+    )
+
+    assert result.is_valid is False
+    assert any(
+        "Missing allowlist metadata" in error for error in result.errors
+    )
+    assert any(
+        "Allowlist contains stale entry" in error for error in result.errors
+    )


### PR DESCRIPTION
### Motivation
- P2 の改善として、`pytest` の `filterwarnings` に対する恒常的な `ignore:` ルールが重大な警告を埋没させるリスクを解消するため、期限付きの allowlist によるガバナンスを導入します。 
- 変更はドキュメンテーション・docstring・ユニットテストを伴い、運用側で期限更新を怠ると検知できるようにすることを目的としています。 
- 注意: 本施策は「警告の盲点化」を減らしますが、外部ライブラリ由来の Warning を自動的に除去するものではないため、CI で本チェックを必須化する運用が必要です。 

### Description
- 追加: `scripts/quality/check_warning_allowlist.py` を実装し、`pyproject.toml` の `filterwarnings` 中の `ignore:` ルールを読み取り、`config/test_warning_allowlist.json` の allowlist エントリ（`rule` / `owner` / `reason` / `expires_on`）と照合して期限切れ・欠落・不要エントリを検出します。 
- 追加: ガバナンス用データ `config/test_warning_allowlist.json` を作成し、現在の ignore ルール向けの `owner`/`reason`/`expires_on` を登録しました。 
- 追加: 重大変更に対応するユニットテスト `veritas_os/tests/test_warning_allowlist_policy.py` を追加し、正常系（期限内）、期限切れ、欠落／stale エントリのケースを検証しています。 
- ドキュメント: `docs/review/ENTERPRISE_READINESS_REVIEW_2026_03_06_JP.md` の P2 を `対応済み` に更新しました。 
- 実装は docstring を含み PEP8 準拠を意識して作成しています。 

### Testing
- 実行: `python scripts/quality/check_warning_allowlist.py` は `Warning allowlist policy check passed.` を返し成功しました。 
- 単体テスト: `pytest -q veritas_os/tests/test_warning_allowlist_policy.py` を実行し `3 passed` で成功しました。 
- 動作保証: テスト群は期限切れ・メタデータ欠落・stale の各失敗ケースをカバーしており、それらが検出された場合は非ゼロ終了となることを検証しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa67175ef08326a39a780d48305cac)