### PR TITLE
feat(trustlog): add optional WORM mirror and key fingerprint visibility for P0-2

### DIFF
--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -7,6 +7,7 @@ structured decision audit logs.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import uuid
 from dataclasses import dataclass
@@ -17,6 +18,7 @@ from typing import Any, Dict, List, Optional
 from veritas_os.logging.paths import LOG_DIR
 from veritas_os.security.hash import canonical_json_dumps, sha256_hex, sha256_of_canonical_json
 from veritas_os.security.signing import (
+    public_key_fingerprint,
     sign_payload_hash,
     store_keypair,
     verify_payload_signature,
@@ -28,6 +30,45 @@ PRIVATE_KEY_PATH = SIGNED_TRUSTLOG_KEYS / "trustlog_ed25519_private.key"
 PUBLIC_KEY_PATH = SIGNED_TRUSTLOG_KEYS / "trustlog_ed25519_public.key"
 
 _lock = threading.RLock()
+
+
+def _worm_mirror_path() -> Optional[Path]:
+    """Resolve optional immutable mirror destination for TrustLog JSONL.
+
+    The path is configured via ``VERITAS_TRUSTLOG_WORM_MIRROR_PATH`` and is
+    intended to point to a WORM/object-lock mounted location managed by
+    infrastructure.
+    """
+    mirror = os.getenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "").strip()
+    if not mirror:
+        return None
+    return Path(mirror)
+
+
+def _append_line(path: Path, line: str) -> None:
+    """Append a line to ``path``, creating parent directories when required."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(line)
+
+
+def _mirror_to_worm(line: str) -> Dict[str, Any]:
+    """Best-effort append to configured WORM mirror destination."""
+    path = _worm_mirror_path()
+    if path is None:
+        return {"configured": False, "ok": False, "path": None}
+
+    try:
+        _append_line(path, line)
+    except OSError as exc:
+        return {
+            "configured": True,
+            "ok": False,
+            "path": str(path),
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+
+    return {"configured": True, "ok": True, "path": str(path)}
 
 
 @dataclass
@@ -103,11 +144,13 @@ def append_signed_decision(decision_payload: Dict[str, Any]) -> Dict[str, Any]:
             "decision_payload": decision_payload,
             "payload_hash": payload_hash,
             "signature": signature,
+            "signature_key_fingerprint": public_key_fingerprint(PUBLIC_KEY_PATH),
         }
 
-        SIGNED_TRUSTLOG_JSONL.parent.mkdir(parents=True, exist_ok=True)
-        with SIGNED_TRUSTLOG_JSONL.open("a", encoding="utf-8") as file:
-            file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        line = json.dumps(entry, ensure_ascii=False) + "\n"
+        _append_line(SIGNED_TRUSTLOG_JSONL, line)
+        mirror = _mirror_to_worm(line)
+        entry["worm_mirror"] = mirror
 
     return entry
 
@@ -127,7 +170,12 @@ def verify_signature(entry: Dict[str, Any]) -> bool:
 
 
 def verify_trustlog_chain(path: Optional[Path] = None) -> Dict[str, Any]:
-    """Verify the full signed TrustLog chain and per-entry signatures."""
+    """Verify the full signed TrustLog chain and per-entry signatures.
+
+    The response includes optional WORM mirror status and key metadata when
+    available, so operators can schedule this function as a periodic integrity
+    job and alert on any drift.
+    """
     entries = _read_all_entries(path)
     issues: List[TrustLogIssue] = []
     previous_hash: Optional[str] = None
@@ -145,10 +193,25 @@ def verify_trustlog_chain(path: Optional[Path] = None) -> Dict[str, Any]:
 
         previous_hash = _entry_chain_hash(entry)
 
+    worm_path = _worm_mirror_path()
+    worm_status: Dict[str, Any] = {"configured": worm_path is not None}
+    if worm_path is not None:
+        worm_status.update({
+            "path": str(worm_path),
+            "exists": worm_path.exists(),
+            "entries": len(_read_all_entries(worm_path)) if worm_path.exists() else 0,
+        })
+
+    key_meta: Dict[str, Any] = {"public_key_present": PUBLIC_KEY_PATH.exists()}
+    if PUBLIC_KEY_PATH.exists():
+        key_meta["fingerprint"] = public_key_fingerprint(PUBLIC_KEY_PATH)
+
     return {
         "ok": len(issues) == 0,
         "entries_checked": len(entries),
         "issues": [issue.__dict__ for issue in issues],
+        "worm_mirror": worm_status,
+        "key_management": key_meta,
     }
 
 

--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -33,6 +33,8 @@ import stat
 from pathlib import Path
 from typing import Tuple
 
+from veritas_os.security.hash import sha256_hex
+
 logger = logging.getLogger(__name__)
 
 from cryptography.exceptions import InvalidSignature
@@ -146,3 +148,13 @@ def verify_payload_signature(
     except InvalidSignature:
         return False
     return True
+
+
+def public_key_fingerprint(public_key_path: Path, *, length: int = 16) -> str:
+    """Return a short, stable fingerprint for a public signing key.
+
+    The fingerprint is derived from SHA-256 over the raw public-key bytes and is
+    intended for lightweight key-id tagging in TrustLog entries.
+    """
+    raw = base64.urlsafe_b64decode(public_key_path.read_text(encoding="utf-8"))
+    return sha256_hex(raw.hex())[:length]

--- a/veritas_os/tests/test_signed_trustlog.py
+++ b/veritas_os/tests/test_signed_trustlog.py
@@ -76,3 +76,31 @@ def test_trustlog_verify_and_export_api(client, monkeypatch, tmp_path):
     body = export_resp.json()
     assert body["count"] == 1
     assert body["entries"][0]["decision_payload"]["request_id"] == "r-api"
+
+
+def test_worm_mirror_and_verify_metadata(monkeypatch, tmp_path):
+    log_path = tmp_path / "trustlog.jsonl"
+    mirror_path = tmp_path / "worm" / "trustlog_mirror.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", str(mirror_path))
+
+    entry = trustlog_signed.append_signed_decision(
+        {"request_id": "r-worm", "decision": "allow"}
+    )
+
+    assert entry["worm_mirror"]["configured"] is True
+    assert entry["worm_mirror"]["ok"] is True
+    assert mirror_path.exists()
+
+    verify_result = trustlog_signed.verify_trustlog_chain(path=log_path)
+    assert verify_result["ok"] is True
+    assert verify_result["worm_mirror"]["configured"] is True
+    assert verify_result["worm_mirror"]["exists"] is True
+    assert verify_result["worm_mirror"]["entries"] == 1
+    assert verify_result["key_management"]["public_key_present"] is True
+    assert verify_result["key_management"]["fingerprint"]


### PR DESCRIPTION
### Motivation
- Address P0-2 from the review by improving TrustLog operational immutability and key-management observability without changing Planner/Kernel/FUJI/MemoryOS responsibilities.
- Provide an operator-friendly way to surface WORM/mirror write failures and expose a stable public-key identifier to aid rotation and provenance checks.

### Description
- Added an optional WORM mirror write path driven by `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` and best-effort mirror helpers in `veritas_os/audit/trustlog_signed.py` so entries are mirrored to an immutable destination when configured.
- Recorded `signature_key_fingerprint` in each TrustLog entry and implemented `public_key_fingerprint` in `veritas_os/security/signing.py` to create a short, stable key identifier from the public key.
- Extended `verify_trustlog_chain` to return `worm_mirror` status and `key_management` metadata (public key presence and fingerprint) to make periodic integrity jobs and alerts actionable.
- Added a regression test `test_worm_mirror_and_verify_metadata` in `veritas_os/tests/test_signed_trustlog.py` that validates mirror writes and verification metadata, and kept existing tests intact.

### Testing
- Ran `pytest -q veritas_os/tests/test_signed_trustlog.py` which executed the suite and reported `4 passed` (success).
- Ran `ruff check veritas_os/audit/trustlog_signed.py veritas_os/security/signing.py veritas_os/tests/test_signed_trustlog.py` and all lint checks passed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa77eb83a08326a7e1b1968c37a79f)