### PR TITLE
Add FUJI policy replay diff and deterministic canary rollout utilities

### DIFF
--- a/veritas_os/core/fuji_policy_rollout.py
+++ b/veritas_os/core/fuji_policy_rollout.py
@@ -1,0 +1,147 @@
+"""FUJI policy diff replay and canary rollout utilities.
+
+This module provides P0-3 controls described in the code review:
+- deterministic A/B replay against old/new policies
+- allow/hold/deny transition metrics
+- false-positive / false-negative estimates when expected labels exist
+- deterministic canary assignment by request id
+
+The implementation is scoped to FUJI policy evaluation only.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import hashlib
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from veritas_os.core import fuji
+
+_ALLOWED_DECISIONS = {"allow", "hold", "deny"}
+
+
+@dataclass(frozen=True)
+class PolicyReplaySample:
+    """Single replay sample used for old/new policy comparison."""
+
+    sample_id: str
+    risk: float
+    categories: List[str]
+    stakes: float = 0.5
+    telos_score: float = 0.5
+    expected_decision: Optional[str] = None
+
+
+
+def _normalize_expected_decision(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    norm = str(value).strip().lower()
+    return norm if norm in _ALLOWED_DECISIONS else None
+
+
+
+def _evaluate_sample(sample: PolicyReplaySample, policy: Mapping[str, Any]) -> str:
+    """Evaluate one sample through FUJI's policy rule engine."""
+    result = fuji._apply_policy(  # pylint: disable=protected-access
+        risk=float(sample.risk),
+        categories=list(sample.categories),
+        stakes=float(sample.stakes),
+        telos_score=float(sample.telos_score),
+        policy=dict(policy),
+    )
+    decision = str(result.get("decision_status", "hold")).lower()
+    if decision not in _ALLOWED_DECISIONS:
+        return "hold"
+    return decision
+
+
+
+def replay_policy_diff(
+    samples: Iterable[PolicyReplaySample],
+    stable_policy: Mapping[str, Any],
+    canary_policy: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Replay identical samples against stable/canary FUJI policies.
+
+    Args:
+        samples: Input sample iterator for replay.
+        stable_policy: Current production FUJI policy.
+        canary_policy: Candidate FUJI policy.
+
+    Returns:
+        Aggregated metrics and per-sample outcomes.
+    """
+    transition_counter: Counter[str] = Counter()
+    outcomes: List[Dict[str, Any]] = []
+
+    total = 0
+    changed = 0
+    fp = 0
+    fn = 0
+    labeled = 0
+
+    for sample in samples:
+        total += 1
+        before = _evaluate_sample(sample, stable_policy)
+        after = _evaluate_sample(sample, canary_policy)
+        expected = _normalize_expected_decision(sample.expected_decision)
+        is_changed = before != after
+        changed += int(is_changed)
+
+        transition_counter[f"{before}->{after}"] += 1
+
+        is_fp = False
+        is_fn = False
+        if expected is not None:
+            labeled += 1
+            if after in {"hold", "deny"} and expected == "allow":
+                fp += 1
+                is_fp = True
+            elif after == "allow" and expected in {"hold", "deny"}:
+                fn += 1
+                is_fn = True
+
+        outcomes.append(
+            {
+                "sample_id": sample.sample_id,
+                "stable": before,
+                "canary": after,
+                "changed": is_changed,
+                "expected": expected,
+                "false_positive": is_fp,
+                "false_negative": is_fn,
+            }
+        )
+
+    change_rate = (changed / total) if total else 0.0
+    fp_rate = (fp / labeled) if labeled else 0.0
+    fn_rate = (fn / labeled) if labeled else 0.0
+
+    return {
+        "total": total,
+        "changed": changed,
+        "change_rate": round(change_rate, 6),
+        "false_positive": fp,
+        "false_negative": fn,
+        "false_positive_rate": round(fp_rate, 6),
+        "false_negative_rate": round(fn_rate, 6),
+        "labeled": labeled,
+        "transitions": dict(sorted(transition_counter.items())),
+        "outcomes": outcomes,
+    }
+
+
+
+def canary_bucket(request_id: str, canary_ratio: float) -> str:
+    """Assign request to stable/canary bucket deterministically.
+
+    Security note:
+        This uses SHA-256 hash bucketing for stable assignment and avoids
+        random sources that could create inconsistent cross-node behavior.
+    """
+    ratio = max(0.0, min(1.0, float(canary_ratio)))
+    digest = hashlib.sha256(str(request_id).encode("utf-8")).digest()
+    point = int.from_bytes(digest[:8], "big") / float(2**64)
+    return "canary" if point < ratio else "stable"

--- a/veritas_os/tests/test_fuji_policy_rollout.py
+++ b/veritas_os/tests/test_fuji_policy_rollout.py
@@ -1,0 +1,70 @@
+"""Tests for FUJI policy diff replay and canary rollout utilities."""
+
+from __future__ import annotations
+
+from veritas_os.core.fuji import _DEFAULT_POLICY
+from veritas_os.core.fuji_policy_rollout import (
+    PolicyReplaySample,
+    canary_bucket,
+    replay_policy_diff,
+)
+
+
+def _strict_policy() -> dict:
+    policy = dict(_DEFAULT_POLICY)
+    policy["actions"] = {
+        "allow": {"risk_upper": 0.20},
+        "warn": {"risk_upper": 0.35},
+        "human_review": {"risk_upper": 0.50},
+        "deny": {"risk_upper": 1.00},
+    }
+    return policy
+
+
+def test_replay_policy_diff_returns_transition_metrics() -> None:
+    stable = dict(_DEFAULT_POLICY)
+    canary = _strict_policy()
+
+    samples = [
+        PolicyReplaySample(sample_id="s1", risk=0.1, categories=[]),
+        PolicyReplaySample(sample_id="s2", risk=0.45, categories=[]),
+        PolicyReplaySample(sample_id="s3", risk=0.7, categories=[]),
+    ]
+
+    result = replay_policy_diff(samples=samples, stable_policy=stable, canary_policy=canary)
+
+    assert result["total"] == 3
+    assert result["changed"] >= 1
+    assert "allow->hold" in result["transitions"] or "hold->deny" in result["transitions"]
+    assert len(result["outcomes"]) == 3
+
+
+def test_replay_policy_diff_calculates_fp_fn_when_labels_exist() -> None:
+    stable = dict(_DEFAULT_POLICY)
+    canary = _strict_policy()
+
+    samples = [
+        PolicyReplaySample(sample_id="s1", risk=0.25, categories=[], expected_decision="allow"),
+        PolicyReplaySample(sample_id="s2", risk=0.05, categories=[], expected_decision="allow"),
+        PolicyReplaySample(sample_id="s3", risk=0.9, categories=[], expected_decision="deny"),
+    ]
+
+    result = replay_policy_diff(samples=samples, stable_policy=stable, canary_policy=canary)
+
+    assert result["labeled"] == 3
+    assert result["false_positive"] >= 0
+    assert result["false_negative"] >= 0
+    assert 0.0 <= result["false_positive_rate"] <= 1.0
+    assert 0.0 <= result["false_negative_rate"] <= 1.0
+
+
+def test_canary_bucket_is_deterministic_and_respects_ratio() -> None:
+    request_id = "req-12345"
+    bucket1 = canary_bucket(request_id, 0.25)
+    bucket2 = canary_bucket(request_id, 0.25)
+
+    assert bucket1 in {"stable", "canary"}
+    assert bucket1 == bucket2
+
+    assert canary_bucket(request_id, 0.0) == "stable"
+    assert canary_bucket(request_id, 1.0) == "canary"


### PR DESCRIPTION
### Motivation
- P0-3（Policy-as-Code の差分検証と Canary 運用）に対応するため、FUJI 層に限定した差分リプレイ／カナリア支援ユーティリティを追加しました。 
- 同一サンプルを用いた A/B リプレイで `allow/hold/deny` の遷移を可視化し、ポリシー更新前後の振る舞い差分を定量化することが目的です。 
- 分散環境での割当ぶれを避けるため、`request_id` に基づく決定論的バケッティングを提供します。 
- セキュリティ注意: FP/FN 指標はラベル品質に依存するため、運用では検証済みラベルセットと監査を併用する必要があります。 

### Description
- 追加ファイル `veritas_os/core/fuji_policy_rollout.py` に `PolicyReplaySample` データクラス、`replay_policy_diff`（stable/canary で同一サンプルを評価して遷移・FP/FN を集計）、および `canary_bucket`（SHA-256 による決定論的バケット割当）を実装しました. 
- `replay_policy_diff` は内部で FUJI のルールエンジン呼び出しに `fuji._apply_policy` を用いてポリシー適用結果（`decision_status`）を比較します（FUJI 責務内で完結）。 
- 影響範囲は FUJI 層に限定し、Planner/Kernel/MemoryOS の責務は変更していません。 
- 主要なコードにはモジュール docstring を追加し、PEP8/linters を通過する形で実装しています。 

### Testing
- 自動テストとして `pytest -q veritas_os/tests/test_fuji_policy_rollout.py` を実行し、`3 passed` を確認しました. 
- スタイル／静的解析として `ruff check veritas_os/core/fuji_policy_rollout.py veritas_os/tests/test_fuji_policy_rollout.py` を実行し、`All checks passed!` を確認しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7b2818008326a9717bc08801079f)