### PR TITLE
Add MemoryOS lifecycle controls (retention/erase/legal-hold) and erase API

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -2265,6 +2265,12 @@ def memory_put(body: dict, x_api_key: Optional[str] = Header(default=None, alias
             return {"ok": False, "error": "too many tags (max 100)"}
         meta = body.get("meta") or {}
 
+        retention_class = str(
+            body.get("retention_class") or meta.get("retention_class") or "standard"
+        ).strip().lower()
+        expires_at = body.get("expires_at", meta.get("expires_at"))
+        legal_hold = bool(body.get("legal_hold", meta.get("legal_hold", False)))
+
         legacy_saved = False
         if value:
             try:
@@ -2284,6 +2290,9 @@ def memory_put(body: dict, x_api_key: Optional[str] = Header(default=None, alias
                 meta_for_store = dict(meta)
                 meta_for_store.setdefault("user_id", user_id)
                 meta_for_store.setdefault("kind", kind)
+                meta_for_store["retention_class"] = retention_class
+                meta_for_store["expires_at"] = expires_at
+                meta_for_store["legal_hold"] = legal_hold
 
                 if hasattr(store, "put"):
                     vector_item = {
@@ -2330,6 +2339,11 @@ def memory_put(body: dict, x_api_key: Optional[str] = Header(default=None, alias
                 "tags": tags if new_id else None,
             },
             "size": len(str(value)) if value else len(text),
+            "lifecycle": {
+                "retention_class": retention_class,
+                "expires_at": expires_at,
+                "legal_hold": legal_hold,
+            },
         }
 
     except Exception as e:
@@ -2427,6 +2441,35 @@ def memory_get(body: dict, x_api_key: Optional[str] = Header(default=None, alias
     except Exception as e:
         logger.error("memory_get failed: %s", e)
         return {"ok": False, "error": "memory retrieval failed", "value": None}
+
+
+@app.post(
+    "/v1/memory/erase",
+    dependencies=[Depends(require_api_key), Depends(enforce_rate_limit)],
+)
+def memory_erase(body: dict, x_api_key: Optional[str] = Header(default=None, alias="X-API-Key")):
+    """Erase a tenant's memories with legal-hold protection and audit log."""
+    store = get_memory_store()
+    if store is None:
+        return {"ok": False, "error": "memory store unavailable"}
+
+    try:
+        user_id = _resolve_memory_user_id(body.get("user_id"), x_api_key)
+        reason = str(body.get("reason") or "user_request").strip()[:500]
+        actor = str(body.get("actor") or "api").strip()[:200]
+
+        if hasattr(store, "erase_user"):
+            report = store.erase_user(user_id=user_id, reason=reason, actor=actor)
+            report.setdefault("ok", True)
+            return report
+
+        return {
+            "ok": False,
+            "error": "erase operation unsupported by active memory backend",
+        }
+    except Exception as e:
+        logger.error("memory_erase failed: %s", e)
+        return {"ok": False, "error": "memory erase failed"}
 
 
 # ==============================

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -910,8 +910,19 @@ class MemoryStore:
 
     @staticmethod
     def _normalize_lifecycle(value: Any) -> Any:
-        """Attach normalized lifecycle fields to value.meta for dict payloads."""
+        """Attach lifecycle fields only to memory-document style dict payloads.
+
+        Backward compatibility:
+        - Generic KVS dictionaries (e.g. ``{"foo": "bar"}``) must be
+          preserved as-is.
+        - Lifecycle normalization is applied only when the value looks like a
+          MemoryOS document (has any of ``text/kind/tags/meta`` keys).
+        """
         if not isinstance(value, dict):
+            return value
+
+        lifecycle_target_keys = {"text", "kind", "tags", "meta"}
+        if not any(key in value for key in lifecycle_target_keys):
             return value
 
         normalized = dict(value)

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -29,6 +29,15 @@ from .config import capability_cfg, emit_capability_manifest
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_RETENTION_CLASS = "standard"
+ALLOWED_RETENTION_CLASSES = {
+    "short",
+    "standard",
+    "long",
+    "regulated",
+}
+
+
 def _is_explicitly_enabled(env_key: str) -> bool:
     """Return True when the capability env var is explicitly set to a truthy value."""
     value = os.getenv(env_key)
@@ -824,14 +833,21 @@ class MemoryStore:
             return False
 
     def put(self, user_id: str, key: str, value: Any) -> bool:
-        """KVS put 操作"""
+        """KVS put 操作。
+
+        Lifecycle metadata policy (P1-4):
+        - value.meta.retention_class を標準化
+        - value.meta.expires_at をUTC ISO-8601へ正規化
+        - value.meta.legal_hold を bool 化
+        """
+        normalized_value = self._normalize_lifecycle(value)
         data = self._load_all(copy=True)
 
         # 既存レコードを探す
         found = False
         for r in data:
             if r.get("user_id") == user_id and r.get("key") == key:
-                r["value"] = value
+                r["value"] = normalized_value
                 r["ts"] = time.time()
                 found = True
                 break
@@ -842,7 +858,7 @@ class MemoryStore:
                 {
                     "user_id": user_id,
                     "key": key,
-                    "value": value,
+                    "value": normalized_value,
                     "ts": time.time(),
                 }
             )
@@ -854,15 +870,217 @@ class MemoryStore:
         data = self._load_all(copy=True)
         for r in data:
             if r.get("user_id") == user_id and r.get("key") == key:
+                if self._is_record_expired(r):
+                    return None
                 return r.get("value")
         return None
 
     def list_all(self, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
         """全レコードをリスト"""
         data = self._load_all(copy=True)
+        filtered_data = [r for r in data if not self._is_record_expired(r)]
         if user_id:
-            return [r for r in data if r.get("user_id") == user_id]
-        return data
+            return [r for r in filtered_data if r.get("user_id") == user_id]
+        return filtered_data
+
+    @staticmethod
+    def _parse_expires_at(expires_at: Any) -> Optional[str]:
+        """Normalize expires_at to UTC ISO8601 string, or None."""
+        if expires_at in (None, ""):
+            return None
+
+        if isinstance(expires_at, (int, float)):
+            dt = datetime.fromtimestamp(float(expires_at), tz=timezone.utc)
+            return dt.isoformat()
+
+        if isinstance(expires_at, str):
+            raw = expires_at.strip()
+            if not raw:
+                return None
+            iso = raw.replace("Z", "+00:00")
+            try:
+                dt = datetime.fromisoformat(iso)
+            except ValueError:
+                return None
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc).isoformat()
+
+        return None
+
+    @staticmethod
+    def _normalize_lifecycle(value: Any) -> Any:
+        """Attach normalized lifecycle fields to value.meta for dict payloads."""
+        if not isinstance(value, dict):
+            return value
+
+        normalized = dict(value)
+        meta = dict(normalized.get("meta") or {})
+
+        retention_class = str(
+            meta.get("retention_class") or DEFAULT_RETENTION_CLASS
+        ).strip().lower()
+        if retention_class not in ALLOWED_RETENTION_CLASSES:
+            retention_class = DEFAULT_RETENTION_CLASS
+
+        legal_hold = bool(meta.get("legal_hold", False))
+        normalized_expires_at = MemoryStore._parse_expires_at(meta.get("expires_at"))
+
+        meta["retention_class"] = retention_class
+        meta["legal_hold"] = legal_hold
+        meta["expires_at"] = normalized_expires_at
+
+        normalized["meta"] = meta
+        return normalized
+
+    @staticmethod
+    def _is_record_expired(record: Dict[str, Any], now_ts: Optional[float] = None) -> bool:
+        """Return True if record has passed expires_at and is not on legal hold."""
+        value = record.get("value") or {}
+        if not isinstance(value, dict):
+            return False
+
+        meta = value.get("meta") or {}
+        if not isinstance(meta, dict):
+            return False
+
+        if bool(meta.get("legal_hold", False)):
+            return False
+
+        expires_at = MemoryStore._parse_expires_at(meta.get("expires_at"))
+        if not expires_at:
+            return False
+
+        try:
+            expire_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+
+        now = now_ts if now_ts is not None else time.time()
+        return expire_dt.timestamp() <= float(now)
+
+    def erase_user(
+        self,
+        user_id: str,
+        reason: str,
+        actor: str,
+    ) -> Dict[str, Any]:
+        """Erase user records while honoring legal hold, with audit trail.
+
+        Also cascades deletion to semantic memories distilled from erased
+        episodic records via ``meta.source_episode_keys`` linkage.
+        """
+        data = self._load_all(copy=True, use_cache=False)
+        to_delete_keys: set[str] = set()
+        legal_hold_count = 0
+
+        for record in data:
+            if record.get("user_id") != user_id:
+                continue
+            if self._is_record_legal_hold(record):
+                legal_hold_count += 1
+                continue
+            value = record.get("value") or {}
+            if isinstance(value, dict):
+                source_keys = (value.get("meta") or {}).get("source_episode_keys")
+                if isinstance(source_keys, list) and source_keys:
+                    # semantic lineage records are deleted in cascade phase.
+                    continue
+            to_delete_keys.add(str(record.get("key") or ""))
+
+        cascade_deleted = 0
+        kept_records: List[Dict[str, Any]] = []
+        deleted_records = 0
+
+        for record in data:
+            record_user = record.get("user_id")
+            record_key = str(record.get("key") or "")
+
+            if record_user == user_id and record_key in to_delete_keys:
+                deleted_records += 1
+                continue
+
+            if self._should_cascade_delete_semantic(record, user_id, to_delete_keys):
+                cascade_deleted += 1
+                continue
+
+            kept_records.append(record)
+
+        report = {
+            "target_user_id": user_id,
+            "deleted_count": deleted_records,
+            "cascade_deleted_count": cascade_deleted,
+            "protected_by_legal_hold": legal_hold_count,
+            "reason": reason,
+            "actor": actor,
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        audit_record = {
+            "user_id": "__audit__",
+            "key": f"erase_{user_id}_{int(time.time())}",
+            "value": {
+                "kind": "audit",
+                "text": "memory erase executed",
+                "meta": {
+                    "event": "memory_erase",
+                    "payload": report,
+                    "retention_class": "regulated",
+                    "legal_hold": True,
+                    "expires_at": None,
+                },
+            },
+            "ts": time.time(),
+        }
+        kept_records.append(audit_record)
+
+        saved = self._save_all(kept_records)
+        report["ok"] = bool(saved)
+        return report
+
+    @staticmethod
+    def _is_record_legal_hold(record: Dict[str, Any]) -> bool:
+        """Return True when record carries legal hold metadata."""
+        value = record.get("value") or {}
+        if not isinstance(value, dict):
+            return False
+        meta = value.get("meta") or {}
+        if not isinstance(meta, dict):
+            return False
+        return bool(meta.get("legal_hold", False))
+
+    @staticmethod
+    def _should_cascade_delete_semantic(
+        record: Dict[str, Any],
+        user_id: str,
+        erased_keys: set[str],
+    ) -> bool:
+        """Check semantic distill lineage and decide cascade deletion."""
+        if not erased_keys:
+            return False
+
+        value = record.get("value") or {}
+        if not isinstance(value, dict):
+            return False
+
+        if str(value.get("kind") or "") != "semantic":
+            return False
+
+        meta = value.get("meta") or {}
+        if not isinstance(meta, dict):
+            return False
+
+        if str(meta.get("user_id") or "") != user_id:
+            return False
+
+        if bool(meta.get("legal_hold", False)):
+            return False
+
+        source_keys = meta.get("source_episode_keys") or []
+        if not isinstance(source_keys, list):
+            return False
+
+        return any(str(key) in erased_keys for key in source_keys)
 
     def append_history(self, user_id: str, record: Dict[str, Any]) -> bool:
         """履歴を追加"""
@@ -1633,6 +1851,7 @@ def distill_memory_for_user(
             continue
 
         ep = {
+            "source_key": r.get("key"),
             "text": text,
             "tags": ep_tags,
             "ts": r.get("ts") or time.time(),
@@ -1708,6 +1927,11 @@ def distill_memory_for_user(
     meta = {
         "user_id": user_id,
         "source": "distill_memory_for_user",
+        "source_episode_keys": [
+            str(ep.get("source_key"))
+            for ep in target_eps
+            if ep.get("source_key")
+        ],
         "item_count": len(target_eps),
         "created_at": datetime.now(timezone.utc).isoformat(),
     }

--- a/veritas_os/tests/test_api_extra.py
+++ b/veritas_os/tests/test_api_extra.py
@@ -170,6 +170,68 @@ class TestMemoryAPI:
         data = response.json()
         assert data["ok"] is True
 
+    def test_memory_erase_respects_legal_hold(self, client):
+        """/v1/memory/erase should preserve legal-hold records and audit."""
+        headers = {"X-API-Key": "test-key"}
+
+        client.post(
+            "/v1/memory/put",
+            headers=headers,
+            json={
+                "user_id": "erase_user",
+                "key": "erasable",
+                "value": {"text": "erase target", "kind": "episodic"},
+                "text": "erase target",
+                "kind": "episodic",
+            },
+        )
+        client.post(
+            "/v1/memory/put",
+            headers=headers,
+            json={
+                "user_id": "erase_user",
+                "key": "protected",
+                "value": {
+                    "text": "must keep",
+                    "kind": "episodic",
+                    "meta": {"legal_hold": True},
+                },
+                "text": "must keep",
+                "kind": "episodic",
+                "legal_hold": True,
+            },
+        )
+
+        erase_response = client.post(
+            "/v1/memory/erase",
+            headers=headers,
+            json={
+                "user_id": "erase_user",
+                "reason": "privacy_request",
+                "actor": "pytest",
+            },
+        )
+        assert erase_response.status_code == 200
+        erase_data = erase_response.json()
+        assert erase_data["ok"] is True
+        assert erase_data["protected_by_legal_hold"] >= 1
+
+        get_deleted = client.post(
+            "/v1/memory/get",
+            headers=headers,
+            json={"user_id": "erase_user", "key": "erasable"},
+        )
+        assert get_deleted.json()["value"] is None
+
+        get_protected = client.post(
+            "/v1/memory/get",
+            headers=headers,
+            json={"user_id": "erase_user", "key": "protected"},
+        )
+        value = get_protected.json()["value"]
+        assert isinstance(value, dict)
+        assert value["meta"]["legal_hold"] is True
+
 
 # =========================
 # Trust Feedback エンドポイント
@@ -512,4 +574,3 @@ class TestPerformance:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/veritas_os/tests/test_memory_core.py
+++ b/veritas_os/tests/test_memory_core.py
@@ -80,6 +80,18 @@ def test_memory_store_lifecycle_expiry_and_legal_hold(tmp_path: Path):
     assert "held" in listed_keys
 
 
+def test_memory_store_put_preserves_generic_kvs_dict(tmp_path: Path):
+    """Generic KVS dict values should remain unchanged for compatibility."""
+    path = tmp_path / "memory.json"
+    store = memory.MemoryStore(path)
+
+    payload = {"foo": "bar", "count": 1}
+    store.put("u1", "legacy", payload)
+
+    got = store.get("u1", "legacy")
+    assert got == payload
+
+
 def test_memory_store_erase_user_with_cascade_and_legal_hold(tmp_path: Path):
     """erase_user should keep legal hold records and cascade semantic delete."""
     path = tmp_path / "memory.json"

--- a/veritas_os/tests/test_memory_core.py
+++ b/veritas_os/tests/test_memory_core.py
@@ -42,6 +42,91 @@ def test_memory_store_put_get_list_recent(tmp_path: Path):
     assert recent[0]["key"] == "k1"
 
 
+def test_memory_store_lifecycle_expiry_and_legal_hold(tmp_path: Path):
+    """Retention lifecycle metadata should control visibility on reads."""
+    path = tmp_path / "memory.json"
+    store = memory.MemoryStore(path)
+
+    store.put(
+        "u1",
+        "expired",
+        {
+            "text": "expired item",
+            "meta": {
+                "expires_at": "2000-01-01T00:00:00+00:00",
+                "legal_hold": False,
+            },
+        },
+    )
+    store.put(
+        "u1",
+        "held",
+        {
+            "text": "legal hold item",
+            "meta": {
+                "expires_at": "2000-01-01T00:00:00+00:00",
+                "legal_hold": True,
+            },
+        },
+    )
+
+    assert store.get("u1", "expired") is None
+    held = store.get("u1", "held")
+    assert isinstance(held, dict)
+    assert held["meta"]["legal_hold"] is True
+
+    listed_keys = {item["key"] for item in store.list_all("u1")}
+    assert "expired" not in listed_keys
+    assert "held" in listed_keys
+
+
+def test_memory_store_erase_user_with_cascade_and_legal_hold(tmp_path: Path):
+    """erase_user should keep legal hold records and cascade semantic delete."""
+    path = tmp_path / "memory.json"
+    store = memory.MemoryStore(path)
+
+    store.put(
+        "u1",
+        "ep1",
+        {"kind": "episodic", "text": "to be erased", "meta": {"user_id": "u1"}},
+    )
+    store.put(
+        "u1",
+        "ep2",
+        {
+            "kind": "episodic",
+            "text": "protected",
+            "meta": {"user_id": "u1", "legal_hold": True},
+        },
+    )
+    store.put(
+        "u1",
+        "sem1",
+        {
+            "kind": "semantic",
+            "text": "distilled",
+            "meta": {
+                "user_id": "u1",
+                "source_episode_keys": ["ep1"],
+            },
+        },
+    )
+
+    report = store.erase_user(user_id="u1", reason="gdpr", actor="tester")
+
+    assert report["ok"] is True
+    assert report["deleted_count"] == 1
+    assert report["cascade_deleted_count"] == 1
+    assert report["protected_by_legal_hold"] == 1
+
+    remaining = store._load_all(copy=True, use_cache=False)
+    remaining_keys = {record["key"] for record in remaining}
+    assert "ep2" in remaining_keys
+    assert "ep1" not in remaining_keys
+    assert "sem1" not in remaining_keys
+    assert any(record["user_id"] == "__audit__" for record in remaining)
+
+
 # -------------------------------------------------
 # 1.5. Lazy MemoryStore initialization
 # -------------------------------------------------


### PR DESCRIPTION
### Motivation
- Implement P1-4: provide MemoryOS-native lifecycle controls so retention, erasure and legal-hold can be enforced inside the Memory subsystem without changing Planner/Kernel/FUJI responsibilities.
- Ensure distilled semantic notes record lineage so erase operations can cascade to derived semantic items when appropriate.
- Security note: lifecycle fields improve compliance, but `expires_at` is currently optional and no automatic TTL per `retention_class` is enforced, so policy must ensure sensible defaults to avoid accidental indefinite retention.

### Description
- Added lifecycle normalization and enforcement in `MemoryStore.put` / `MemoryStore.get` / `MemoryStore.list_all` by introducing `_parse_expires_at`, `_normalize_lifecycle`, and `_is_record_expired` to normalize `retention_class`, `expires_at`, and `legal_hold` in payload `meta` and hide expired records unless on legal hold (`veritas_os/core/memory.py`).
- Implemented `MemoryStore.erase_user(user_id, reason, actor)` which respects legal-hold, cascades deletion to `semantic` notes that reference erased episodic keys via `meta.source_episode_keys`, and appends an audit record under `user_id == "__audit__"` to preserve an audit trail (`veritas_os/core/memory.py`).
- Updated memory distill flow to persist source lineage as `source_episode_keys` in semantic note metadata so cascade deletion can be applied (`veritas_os/core/memory.py`, `distill_memory_for_user`).
- Extended API: `POST /v1/memory/put` now accepts and returns lifecycle inputs (`retention_class`, `expires_at`, `legal_hold`) and `POST /v1/memory/erase` was added to trigger `erase_user` on backends that implement it (`veritas_os/api/server.py`).
- Added unit/API tests validating expiry vs. legal-hold behavior, erase cascade and audit preservation: `test_memory_store_lifecycle_expiry_and_legal_hold`, `test_memory_store_erase_user_with_cascade_and_legal_hold`, and `TestMemoryAPI::test_memory_erase_respects_legal_hold` (`veritas_os/tests/*`).

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_core.py::test_memory_store_lifecycle_expiry_and_legal_hold veritas_os/tests/test_memory_core.py::test_memory_store_erase_user_with_cascade_and_legal_hold veritas_os/tests/test_api_extra.py::TestMemoryAPI::test_memory_erase_respects_legal_hold` and all three tests passed.
- Tests validate: lifecycle normalization, expired-item hiding, legal-hold protection, cascading deletion of semantic notes that reference erased episodic keys, and that the `erase` API produces an audit record.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7ef01c288326bb77c18f45f5c42e)