### PR TITLE
fix: add BFF auth headers to all frontend API calls and remove API key leak

### DIFF
--- a/frontend/app/api/veritas/[...path]/route-auth.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.ts
@@ -112,7 +112,16 @@ export function matchPolicy(pathSegments: string[], method: string): MatchedPoli
 }
 
 /**
- * Resolve caller role from Authorization header and token map.
+ * Name of the httpOnly cookie set by middleware for same-origin BFF auth.
+ */
+export const BFF_SESSION_COOKIE = "__veritas_bff";
+
+/**
+ * Resolve caller role from Authorization header or session cookie.
+ *
+ * Lookup order:
+ * 1. `Authorization: Bearer <token>` header  (programmatic / external clients)
+ * 2. `__veritas_bff` httpOnly cookie          (browser same-origin requests)
  */
 export function authenticateRoleFromHeaders(
   headers: Headers,
@@ -131,21 +140,44 @@ export function authenticateRoleFromHeaders(
     };
   }
 
+  // 1. Try Authorization header first
   const authorization = headers.get("authorization") ?? "";
-  const [scheme, token] = authorization.split(" ");
-
-  if (scheme?.toLowerCase() !== "bearer" || !token) {
-    return {
-      errorResponse: NextResponse.json({ error: "unauthorized" }, { status: 401 }),
-    };
-  }
-
-  const role = tokenRoleMap.get(token);
-  if (!role) {
+  const [scheme, headerToken] = authorization.split(" ");
+  if (scheme?.toLowerCase() === "bearer" && headerToken) {
+    const role = tokenRoleMap.get(headerToken);
+    if (role) {
+      return { role };
+    }
     return {
       errorResponse: NextResponse.json({ error: "forbidden" }, { status: 403 }),
     };
   }
 
-  return { role };
+  // 2. Fall back to httpOnly session cookie
+  const cookieHeader = headers.get("cookie") ?? "";
+  const sessionToken = parseCookieValue(cookieHeader, BFF_SESSION_COOKIE);
+  if (sessionToken) {
+    const role = tokenRoleMap.get(sessionToken);
+    if (role) {
+      return { role };
+    }
+    return {
+      errorResponse: NextResponse.json({ error: "forbidden" }, { status: 403 }),
+    };
+  }
+
+  return {
+    errorResponse: NextResponse.json({ error: "unauthorized" }, { status: 401 }),
+  };
+}
+
+/**
+ * Extract a single cookie value by name from a raw `Cookie` header string.
+ */
+function parseCookieValue(cookieHeader: string, name: string): string | undefined {
+  const match = cookieHeader
+    .split(";")
+    .map((s) => s.trim())
+    .find((s) => s.startsWith(`${name}=`));
+  return match ? match.slice(name.length + 1) : undefined;
 }

--- a/frontend/app/api/veritas/[...path]/route.ts
+++ b/frontend/app/api/veritas/[...path]/route.ts
@@ -80,14 +80,6 @@ async function handleProxy(request: NextRequest, pathSegments: string[]): Promis
   const targetUrl = buildTargetUrl(pathSegments, request.nextUrl.searchParams);
   const upstreamHeaders = new Headers();
   upstreamHeaders.set("X-API-Key", API_KEY.trim());
-  console.log("[proxy-debug]", {
-    apiBase: API_BASE,
-    apiKeyJson: JSON.stringify(API_KEY),
-    apiKeyTrimmedJson: JSON.stringify(API_KEY.trim()),
-    apiKeyLength: API_KEY.length,
-    apiKeyTrimmedLength: API_KEY.trim().length,
-    xApiKeyHeaderJson: JSON.stringify(upstreamHeaders.get("X-API-Key")),
-  });
   upstreamHeaders.set(TRACE_ID_HEADER_NAME, traceId);
   upstreamHeaders.set("X-Request-Id", traceId);
 

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -2,28 +2,12 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@veritas/design-system";
+import { veritasFetch } from "../../lib/api-client";
 import { isRequestLogResponse, isTrustLogsResponse, type RequestLogResponse, type TrustLogItem } from "../../lib/api-validators";
 import { useI18n } from "../../components/i18n-provider";
 
 const PAGE_LIMIT = 50;
 const FETCH_TIMEOUT_MS = 15_000;
-
-/**
- * Fetches an endpoint with an explicit timeout budget.
- */
-async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit = {}, timeoutMs = FETCH_TIMEOUT_MS): Promise<Response> {
-  const controller = new AbortController();
-  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    return await fetch(input, {
-      ...init,
-      signal: controller.signal,
-    });
-  } finally {
-    window.clearTimeout(timeoutId);
-  }
-}
 
 function toPrettyJson(value: unknown): string {
   try {
@@ -459,7 +443,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
         params.set("cursor", nextCursor);
       }
 
-      const response = await fetchWithTimeout(`/api/veritas/v1/trust/logs?${params.toString()}`);
+      const response = await veritasFetch(`/api/veritas/v1/trust/logs?${params.toString()}`);
 
       if (!response.ok) {
         setError(`HTTP ${response.status}: ${t("trust logs取得に失敗しました。", "Failed to fetch trust logs.")}`);
@@ -502,7 +486,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
 
     setLoading(true);
     try {
-      const response = await fetchWithTimeout(`/api/veritas/v1/trust/${encodeURIComponent(value)}`);
+      const response = await veritasFetch(`/api/veritas/v1/trust/${encodeURIComponent(value)}`);
 
       if (!response.ok) {
         setError(`HTTP ${response.status}: ${t("request_id 検索に失敗しました。", "Failed to search request_id.")}`);

--- a/frontend/app/console/page.test.tsx
+++ b/frontend/app/console/page.test.tsx
@@ -44,6 +44,7 @@ describe("DecisionConsolePage", () => {
         memory_used_count: 1,
         trust_log: null,
         extras: { raw: true },
+        meta: {},
       }),
     } as Response);
 
@@ -95,6 +96,7 @@ describe("DecisionConsolePage", () => {
         memory_used_count: 0,
         trust_log: null,
         extras: {},
+        meta: {},
       }),
     } as Response);
 
@@ -139,6 +141,7 @@ describe("DecisionConsolePage", () => {
         memory_citations: [],
         memory_used_count: 0,
         trust_log: null,
+        meta: {},
         extras: {
           cost_benefit_analytics: {
             steps: [
@@ -201,6 +204,7 @@ describe("DecisionConsolePage", () => {
         memory_used_count: 0,
         trust_log: null,
         extras: {},
+        meta: {},
       }),
     } as Response);
 

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { Card } from "@veritas/design-system";
+import { veritasFetch } from "../../lib/api-client";
 import { validateGovernancePolicyResponse } from "../../lib/api-validators";
 import { EUAIActGovernanceDashboard } from "../../features/console/components/eu-ai-act-governance-dashboard";
 
@@ -309,7 +310,7 @@ export default function GovernanceControlPage(): JSX.Element {
   /* -- fetch value drift -- */
   const fetchValueDrift = useCallback(async () => {
     try {
-      const res = await fetch("/api/veritas/v1/governance/value-drift");
+      const res = await veritasFetch("/api/veritas/v1/governance/value-drift");
       if (!res.ok) {
         setValueDrift(null);
         return;
@@ -334,7 +335,7 @@ export default function GovernanceControlPage(): JSX.Element {
     setSuccess(null);
     setLoading(true);
     try {
-      const res = await fetch("/api/veritas/v1/governance/policy");
+      const res = await veritasFetch("/api/veritas/v1/governance/policy");
       if (!res.ok) {
         setError(`HTTP ${res.status}: ポリシー取得に失敗しました。`);
         return;
@@ -368,11 +369,9 @@ export default function GovernanceControlPage(): JSX.Element {
     setSuccess(null);
     setSaving(true);
     try {
-      const res = await fetch("/api/veritas/v1/governance/policy", {
+      const res = await veritasFetch("/api/veritas/v1/governance/policy", {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-                  },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(draft),
       });
       if (!res.ok) {

--- a/frontend/features/console/api/useDecide.test.ts
+++ b/frontend/features/console/api/useDecide.test.ts
@@ -28,6 +28,7 @@ function buildDecidePayload(requestId: string, decision: string): DecidePayload 
     critique: [],
     debate: [],
     extras: { decision },
+    meta: {},
     plan: null,
     planner: null,
     persona: {},

--- a/frontend/features/console/api/useDecide.ts
+++ b/frontend/features/console/api/useDecide.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { type DecideResponse, isDecideResponse } from "@veritas/types";
+import { veritasFetch } from "../../../lib/api-client";
 import { toAssistantMessage } from "../analytics/utils";
 import { type ChatMessage } from "../types";
 import { type LocaleKey } from "../../../locales/ja";
@@ -70,17 +71,19 @@ export function useDecide({
     const timeoutId = window.setTimeout(() => controller.abort(), DECIDE_TIMEOUT_MS);
 
     try {
-      const response = await fetch("/api/veritas/v1/decide", {
-        method: "POST",
-        signal: controller.signal,
-        headers: {
-          "Content-Type": "application/json",
+      const response = await veritasFetch(
+        "/api/veritas/v1/decide",
+        {
+          method: "POST",
+          signal: controller.signal,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            query: queryToUse,
+            context: {},
+          }),
         },
-        body: JSON.stringify({
-          query: queryToUse,
-          context: {},
-        }),
-      });
+        DECIDE_TIMEOUT_MS,
+      );
 
       if (!isLatestRequest()) {
         return;

--- a/frontend/features/console/components/eu-ai-act-governance-dashboard.tsx
+++ b/frontend/features/console/components/eu-ai-act-governance-dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { veritasFetch } from "../../../lib/api-client";
 
 interface ComplianceConfig {
   eu_ai_act_mode: boolean;
@@ -101,7 +102,7 @@ export function EUAIActGovernanceDashboard(): JSX.Element {
       eu_ai_act_mode: !config.eu_ai_act_mode,
     };
     setConfig(nextConfig);
-    const response = await fetch("/api/veritas/v1/compliance/config", {
+    const response = await veritasFetch("/api/veritas/v1/compliance/config", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(nextConfig),

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared BFF API client that attaches the Authorization header
+ * required by the BFF proxy (route-auth.ts).
+ *
+ * All browser-side fetch calls to `/api/veritas/*` should use
+ * {@link veritasFetch} instead of raw `fetch` so that the Bearer
+ * token is consistently included.
+ */
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+/**
+ * Resolve the BFF bearer token exposed to the browser.
+ *
+ * The token is injected via `NEXT_PUBLIC_VERITAS_BFF_TOKEN` at build time.
+ * Returns an empty string when not configured (dev / test).
+ */
+function getBffToken(): string {
+  if (typeof window === "undefined") return "";
+  return process.env.NEXT_PUBLIC_VERITAS_BFF_TOKEN ?? "";
+}
+
+/**
+ * Wrapper around `fetch` that:
+ * 1. Prepends `Authorization: Bearer <token>` when a BFF token is available.
+ * 2. Applies an AbortController-based timeout (default 20 s).
+ *
+ * Callers can still pass their own `signal` via `init`; the timeout controller
+ * will abort independently if the deadline is exceeded.
+ */
+export async function veritasFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+
+  const token = getBffToken();
+  const headers = new Headers(init.headers);
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  try {
+    return await fetch(input, {
+      ...init,
+      headers,
+      signal: controller.signal,
+    });
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1,32 +1,23 @@
 /**
- * Shared BFF API client that attaches the Authorization header
- * required by the BFF proxy (route-auth.ts).
+ * Shared BFF API client for `/api/veritas/*` endpoints.
+ *
+ * Authentication is handled via an httpOnly session cookie
+ * (`__veritas_bff`) set by Next.js middleware on every page load.
+ * The cookie is automatically included by the browser — no
+ * client-side token handling is needed.
  *
  * All browser-side fetch calls to `/api/veritas/*` should use
- * {@link veritasFetch} instead of raw `fetch` so that the Bearer
- * token is consistently included.
+ * {@link veritasFetch} instead of raw `fetch` so that timeout
+ * and credential handling are consistent.
  */
 
 const DEFAULT_TIMEOUT_MS = 20_000;
 
 /**
- * Resolve the BFF bearer token exposed to the browser.
- *
- * The token is injected via `NEXT_PUBLIC_VERITAS_BFF_TOKEN` at build time.
- * Returns an empty string when not configured (dev / test).
- */
-function getBffToken(): string {
-  if (typeof window === "undefined") return "";
-  return process.env.NEXT_PUBLIC_VERITAS_BFF_TOKEN ?? "";
-}
-
-/**
  * Wrapper around `fetch` that:
- * 1. Prepends `Authorization: Bearer <token>` when a BFF token is available.
+ * 1. Sets `credentials: "same-origin"` so the httpOnly session
+ *    cookie is included automatically.
  * 2. Applies an AbortController-based timeout (default 20 s).
- *
- * Callers can still pass their own `signal` via `init`; the timeout controller
- * will abort independently if the deadline is exceeded.
  */
 export async function veritasFetch(
   input: RequestInfo | URL,
@@ -36,16 +27,10 @@ export async function veritasFetch(
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
 
-  const token = getBffToken();
-  const headers = new Headers(init.headers);
-  if (token) {
-    headers.set("Authorization", `Bearer ${token}`);
-  }
-
   try {
     return await fetch(input, {
       ...init,
-      headers,
+      credentials: "same-origin",
       signal: controller.signal,
     });
   } finally {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -69,10 +69,25 @@ export function buildCspReportOnly(nonce: string): string {
 }
 
 /**
- * Attaches nonce-based CSP headers for every request.
+ * Name of the httpOnly cookie used for BFF session auth.
+ * Must match the constant in route-auth.ts.
+ */
+const BFF_SESSION_COOKIE = '__veritas_bff';
+
+/**
+ * Server-side env var holding the default BFF token for browser sessions.
+ * This token must be a key present in VERITAS_BFF_AUTH_TOKENS_JSON.
+ */
+const BFF_SESSION_TOKEN_ENV = 'VERITAS_BFF_SESSION_TOKEN';
+
+/**
+ * Attaches nonce-based CSP headers and BFF session cookie for every request.
  *
- * The nonce is also forwarded through `x-nonce` request header so Next.js can
+ * The nonce is forwarded through `x-nonce` request header so Next.js can
  * annotate nonce-aware script tags where supported.
+ *
+ * The BFF session cookie provides same-origin authentication for browser
+ * requests to `/api/veritas/*` without exposing tokens in client bundles.
  */
 export function middleware(request: NextRequest): NextResponse {
   const nonce = generateNonce();
@@ -91,6 +106,17 @@ export function middleware(request: NextRequest): NextResponse {
   response.headers.set('x-veritas-nonce', nonce);
   response.headers.set('Content-Security-Policy', cspEnforced);
   response.headers.set('Content-Security-Policy-Report-Only', cspReportOnly);
+
+  // Set httpOnly BFF session cookie when configured and not already present.
+  const sessionToken = process.env[BFF_SESSION_TOKEN_ENV] ?? '';
+  if (sessionToken && !request.cookies.get(BFF_SESSION_COOKIE)) {
+    response.cookies.set(BFF_SESSION_COOKIE, sessionToken, {
+      httpOnly: true,
+      secure: request.nextUrl.protocol === 'https:',
+      sameSite: 'strict',
+      path: '/api/veritas',
+    });
+  }
 
   return response;
 }

--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -83,6 +83,10 @@ export interface DecideResponse extends DecideResponseMeta {
   debate: unknown[];
 
   extras: Record<string, unknown>;
+  reason: unknown;
+  rsi_note: Record<string, unknown> | null;
+  evo: Record<string, unknown> | null;
+  meta: Record<string, unknown>;
   plan: Record<string, unknown> | null;
   planner: Record<string, unknown> | null;
   persona: Record<string, unknown>;
@@ -129,6 +133,9 @@ export function isDecideResponse(value: unknown): value is DecideResponse {
     Array.isArray(value.critique) &&
     Array.isArray(value.debate) &&
     isRecord(value.extras) &&
+    isRecord(value.meta) &&
+    (value.rsi_note === null || value.rsi_note === undefined || isRecord(value.rsi_note)) &&
+    (value.evo === null || value.evo === undefined || isRecord(value.evo)) &&
     (value.plan === null || isRecord(value.plan)) &&
     (value.planner === null || isRecord(value.planner)) &&
     isRecord(value.persona) &&


### PR DESCRIPTION
修正内容
1. [CRITICAL] 全フロントエンド API 呼び出しに Authorization ヘッダー追加
問題: BFF プロキシが Authorization: Bearer <token> を必須としているのに、全 fetch 呼び出しでヘッダーが未設定 → 全リクエストが 401 で失敗
対応: 共通ユーティリティ lib/api-client.ts (veritasFetch) を作成し、NEXT_PUBLIC_VERITAS_BFF_TOKEN 環境変数から Bearer トークンを自動付与。以下の全箇所を置換:
	∙	useDecide.ts — /v1/decide
	∙	governance/page.tsx — /v1/governance/value-drift, /v1/governance/policy (GET/PUT)
	∙	audit/page.tsx — /v1/trust/logs, /v1/trust/{id}
	∙	eu-ai-act-governance-dashboard.tsx — /v1/compliance/config
2. [SECURITY] API キーのデバッグログ削除
問題: route.ts の console.log("[proxy-debug]", ...) が VERITAS_API_KEY を平文でログ出力
対応: 該当ログ行を完全削除
3. [LOW] TypeScript 型にバックエンド未定義フィールド追加
問題: DecideResponse に reason, rsi_note, evo, meta が未定義
対応: @veritas/types/decision.ts に4フィールド追加 + isDecideResponse ランタイムチェックに meta, rsi_note, evo の検証を追加