### PR TITLE
fix(openapi): add created_at to TrustLog required fields; document risk page synthetic data

### DIFF
--- a/frontend/app/risk/page.tsx
+++ b/frontend/app/risk/page.tsx
@@ -17,6 +17,15 @@ const STREAM_TICK_MS = 2_000;
 const MAX_POINTS = 480;
 
 /**
+ * NOTE: This page uses client-side synthetic telemetry for the scatter visualization.
+ * The backend does not expose a per-request risk/uncertainty time-series endpoint.
+ * The `/v1/metrics` endpoint provides only aggregate counts (total decisions, last
+ * decision timestamp, pipeline health), which are not suitable for scatter plotting.
+ * If a per-request telemetry endpoint is added in the future, replace the synthetic
+ * generators below with a real API call and update `RiskPoint` accordingly.
+ */
+
+/**
  * Generates initial synthetic request telemetry distributed over the past 24h.
  */
 function createInitialPoints(now: number): RiskPoint[] {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -178,7 +178,7 @@ components:
 
     TrustLog:
       type: object
-      required: [request_id, sources, critics, checks, approver]
+      required: [request_id, created_at, sources, critics, checks, approver]
       properties:
         request_id:
           type: string


### PR DESCRIPTION
- openapi.yaml: Add `created_at` to `TrustLog.required` to match the backend
  `TrustLog` Pydantic model where `created_at: str` has no default value and
  is always populated by the server (server.py L1947). Closes the final
  schema inconsistency identified in the frontend-backend consistency review.

- frontend/app/risk/page.tsx: Add explanatory comment clarifying that the
  scatter visualization intentionally uses client-side synthetic telemetry.
  The backend `/v1/metrics` endpoint only provides aggregate counts, not the
  per-request uncertainty/risk time-series data needed for scatter plotting.
  This documents the design rationale so future developers know what API
  changes would be required to switch to real data.

https://claude.ai/code/session_01FfgYPfRuXi1DaQTkdFm8sS