### PR TITLE
fix: resolve strategy scoring TypeError, safety head AttributeError, and DecideResponse extra keys

### DIFF
--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -492,6 +492,23 @@ class DecideResponse(BaseModel):
     planner: Optional[Dict[str, Any]] = None
     reason: Optional[Any] = None
 
+    # パイプラインが付与する追加フィールド（正式 schema 昇格）
+    # query: 元のユーザー入力。監査・再現・UI 表示で使用。
+    query: Optional[str] = Field(
+        default=None,
+        description="Original user query text, attached by pipeline for audit and replay.",
+    )
+    # pipeline_steps: EU AI Act 動的コンプライアンスステップ一覧。
+    pipeline_steps: Optional[List[str]] = Field(
+        default=None,
+        description="Dynamic pipeline steps resolved by the orchestrator (EU AI Act compliance).",
+    )
+    # deterministic_replay: 決定論的再現に必要なスナップショット。
+    deterministic_replay: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Snapshot for deterministic replay of this decision.",
+    )
+
     # persist 用 meta
     meta: Dict[str, Any] = Field(default_factory=dict)
     coercion_events: List[str] = Field(default_factory=list, exclude=True)

--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -490,21 +490,27 @@ def _score_alternatives(
         try:
             bias = persona_bias or {}
             scored = strategy_core.score_options(
+                alts,
+                ctx or {},
                 intent=intent,
                 query=q,
-                options=alts,
                 telos_score=telos_score,
                 stakes=stakes,
                 persona_bias=bias,
-                context=ctx or {},
             )
             if isinstance(scored, list) and scored:
                 score_map = {}
                 for o in scored:
-                    oid = o.get("id")
+                    # OptionScore dataclass or dict — extract id and score
+                    if hasattr(o, "option_id"):
+                        oid = o.option_id
+                        sc = getattr(o, "fusion_score", 0.0)
+                    else:
+                        oid = o.get("id")
+                        sc = o.get("score", o.get("fusion_score", 0.0))
                     if not oid:
                         continue
-                    score_map[oid] = _safe_float(o.get("score"), 0.0)
+                    score_map[oid] = _safe_float(sc, 0.0)
 
                 for a in alts:
                     oid = a.get("id")

--- a/veritas_os/core/strategy.py
+++ b/veritas_os/core/strategy.py
@@ -123,6 +123,9 @@ def _ensure_values(ctx: Dict[str, Any]) -> Dict[str, Any]:
 def score_options(
     options: List[Dict[str, Any]],
     ctx: Dict[str, Any],
+    *,
+    intent: str | None = None,
+    **kwargs: Any,
 ) -> List[OptionScore]:
     """
     各オプションに対して

--- a/veritas_os/tests/test_llm_safety.py
+++ b/veritas_os/tests/test_llm_safety.py
@@ -383,3 +383,65 @@ def test_run_uses_heuristic_when_no_llm(monkeypatch):
     assert res["ok"] is True
     assert res["model"] == "heuristic_fallback"
     assert res["risk_score"] == 0.05
+
+
+# -----------------------------
+# Chat Completions fallback テスト
+# -----------------------------
+
+
+def test_analyze_with_llm_falls_back_to_chat_completions(monkeypatch):
+    """client に .responses が無い場合、chat.completions にフォールバックする。"""
+    import json as _json
+
+    class DummyMessage:
+        def __init__(self, content: str):
+            self.content = content
+
+    class DummyChoice:
+        def __init__(self, content: str):
+            self.message = DummyMessage(content)
+
+    class DummyChatResponse:
+        def __init__(self):
+            self.choices = [
+                DummyChoice(
+                    _json.dumps({
+                        "risk_score": 0.3,
+                        "categories": ["PII"],
+                        "rationale": "chat fallback test",
+                    })
+                )
+            ]
+
+        def model_dump_json(self) -> str:
+            return '{"fallback": true}'
+
+    class DummyCompletions:
+        last_kwargs: Dict[str, Any] | None = None
+
+        def create(self, **kwargs: Any) -> DummyChatResponse:
+            DummyCompletions.last_kwargs = kwargs
+            return DummyChatResponse()
+
+    class DummyChat:
+        def __init__(self):
+            self.completions = DummyCompletions()
+
+    class DummyClientNoResponses:
+        """OpenAI client without .responses attribute."""
+        def __init__(self, api_key: str | None = None):
+            self.api_key = api_key
+            self.chat = DummyChat()
+            # NOTE: no .responses attribute
+
+    monkeypatch.setattr(llm_safety, "OpenAI", DummyClientNoResponses)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fallback")
+
+    res = llm_safety._analyze_with_llm("test text for chat fallback")
+
+    assert res["ok"] is True
+    assert res["risk_score"] >= 0.0
+    assert DummyCompletions.last_kwargs is not None
+    assert DummyCompletions.last_kwargs["temperature"] == 0
+    assert "messages" in DummyCompletions.last_kwargs

--- a/veritas_os/tests/test_schemas_extra.py
+++ b/veritas_os/tests/test_schemas_extra.py
@@ -195,3 +195,40 @@ class TestIsMapping:
         assert schemas_mod._is_mapping("string") is False
         assert schemas_mod._is_mapping(123) is False
         assert schemas_mod._is_mapping(None) is False
+
+
+class TestDecideResponsePipelineFields:
+    """query / pipeline_steps / deterministic_replay が extra keys 扱いにならないことを確認。"""
+
+    def test_query_accepted_without_extra_warning(self):
+        """query フィールドが正式 schema に含まれ、extra keys にならない。"""
+        resp = schemas_mod.DecideResponse(query="テストクエリ")
+        assert resp.query == "テストクエリ"
+        extras = getattr(resp, "__pydantic_extra__", None) or {}
+        assert "query" not in extras
+
+    def test_pipeline_steps_accepted_without_extra_warning(self):
+        """pipeline_steps が正式 schema に含まれる。"""
+        steps = ["evidence", "debate", "critique", "safety"]
+        resp = schemas_mod.DecideResponse(pipeline_steps=steps)
+        assert resp.pipeline_steps == steps
+        extras = getattr(resp, "__pydantic_extra__", None) or {}
+        assert "pipeline_steps" not in extras
+
+    def test_deterministic_replay_accepted_without_extra_warning(self):
+        """deterministic_replay が正式 schema に含まれる。"""
+        replay = {"seed": 42, "temperature": 0}
+        resp = schemas_mod.DecideResponse(deterministic_replay=replay)
+        assert resp.deterministic_replay == replay
+        extras = getattr(resp, "__pydantic_extra__", None) or {}
+        assert "deterministic_replay" not in extras
+
+    def test_all_three_fields_together(self):
+        """3 フィールド同時指定で extra keys ログが出ない。"""
+        resp = schemas_mod.DecideResponse(
+            query="hello",
+            pipeline_steps=["evidence"],
+            deterministic_replay={"seed": 1},
+        )
+        extras = getattr(resp, "__pydantic_extra__", None) or {}
+        assert not extras, f"unexpected extra keys: {sorted(extras.keys())}"

--- a/veritas_os/tests/test_strategy.py
+++ b/veritas_os/tests/test_strategy.py
@@ -253,3 +253,55 @@ def test_rank_fallback_on_score_error(monkeypatch):
     # フォールバック時は _veritas_scores は付かない
     assert "_veritas_scores" not in best
 
+
+# ----------------------------
+# score_options: intent / **kwargs 後方互換テスト
+# ----------------------------
+
+def test_score_options_accepts_intent_kwarg(monkeypatch):
+    """score_options(intent=...) で TypeError が発生しないことを確認。"""
+
+    def fake_evaluate(query: str, ctx: dict):
+        return DummyValueResult(0.5)
+
+    def fake_simulate(option: dict, state: dict):
+        return {"utility": 0.5, "confidence": 0.5}
+
+    monkeypatch.setattr(strategy.value_core, "evaluate", fake_evaluate)
+    monkeypatch.setattr(strategy.wm, "simulate", fake_simulate, raising=False)
+
+    options = [{"id": "A", "base_score": 0.7}]
+    ctx = {"query": "test", "fuji": {"risk": 0.1}}
+
+    # intent を渡しても落ちない
+    scores = strategy.score_options(options, ctx, intent="learn")
+    assert len(scores) == 1
+    assert 0.0 <= scores[0].fusion_score <= 1.0
+
+
+def test_score_options_accepts_extra_kwargs(monkeypatch):
+    """未知の追加キーワード引数で TypeError にならないことを確認。"""
+
+    def fake_evaluate(query: str, ctx: dict):
+        return DummyValueResult(0.5)
+
+    def fake_simulate(option: dict, state: dict):
+        return {"utility": 0.5, "confidence": 0.5}
+
+    monkeypatch.setattr(strategy.value_core, "evaluate", fake_evaluate)
+    monkeypatch.setattr(strategy.wm, "simulate", fake_simulate, raising=False)
+
+    options = [{"id": "A", "base_score": 0.7}]
+    ctx = {"query": "test"}
+
+    # 未知の kwargs でも落ちない
+    scores = strategy.score_options(
+        options, ctx,
+        intent="weather",
+        telos_score=0.8,
+        stakes=0.5,
+        persona_bias={"caution": 0.1},
+        some_future_arg="ignored",
+    )
+    assert len(scores) == 1
+

--- a/veritas_os/tools/llm_safety.py
+++ b/veritas_os/tools/llm_safety.py
@@ -266,52 +266,73 @@ def _analyze_with_llm(
         ],
     }
 
-    t0 = time.time()
-    resp = client.responses.create(
-        model=model_name,
-        reasoning={"effort": "low"},
-        temperature=0,
-        input=[
-            {
-                "role": "system",
-                "content": system,
-            },
-            {
-                "role": "user",
-                "content": f"CLASSIFY_THIS_INPUT:\n```json\n{json.dumps(user_payload, ensure_ascii=False)}\n```",
-            },
-        ],
-        response_format={
-            "type": "json_schema",
-            "json_schema": {
-                "name": "safety_head_output",
-                "schema": {
-                    "type": "object",
-                    "properties": {
-                        "risk_score": {"type": "number"},
-                        "categories": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "rationale": {"type": "string"},
-                    },
-                    "required": ["risk_score", "categories", "rationale"],
-                    "additionalProperties": True,
-                },
-                "strict": False,
-            },
-        },
-    )
-    latency_ms = int((time.time() - t0) * 1000)
+    user_content = f"CLASSIFY_THIS_INPUT:\n```json\n{json.dumps(user_payload, ensure_ascii=False)}\n```"
 
-    # Responses API の JSON 抜き出し
-    # ★ H-5 修正: output が空の場合の IndexError を防止
-    output = getattr(resp, "output", None)
-    if not output or len(output) == 0:
-        raise RuntimeError("LLM safety head returned empty output")
-    out = getattr(output[0], "parsed", None)
-    if out is None:
-        raise RuntimeError("LLM safety head returned unparseable output")
+    t0 = time.time()
+
+    # Responses API (.responses.create) を優先し、非対応の場合は
+    # Chat Completions API (.chat.completions.create) にフォールバックする。
+    # SDK バージョンや Azure ラッパーによって .responses が存在しない場合がある。
+    use_responses_api = hasattr(client, "responses") and hasattr(client.responses, "create")
+
+    if use_responses_api:
+        resp = client.responses.create(
+            model=model_name,
+            reasoning={"effort": "low"},
+            temperature=0,
+            input=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user_content},
+            ],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "safety_head_output",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "risk_score": {"type": "number"},
+                            "categories": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "rationale": {"type": "string"},
+                        },
+                        "required": ["risk_score", "categories", "rationale"],
+                        "additionalProperties": True,
+                    },
+                    "strict": False,
+                },
+            },
+        )
+        latency_ms = int((time.time() - t0) * 1000)
+
+        # Responses API の JSON 抜き出し
+        # ★ H-5 修正: output が空の場合の IndexError を防止
+        output = getattr(resp, "output", None)
+        if not output or len(output) == 0:
+            raise RuntimeError("LLM safety head returned empty output")
+        out = getattr(output[0], "parsed", None)
+        if out is None:
+            raise RuntimeError("LLM safety head returned unparseable output")
+    else:
+        # Fallback: Chat Completions API
+        logger.info("LLM safety head: .responses unavailable, using chat.completions fallback")
+        resp = client.chat.completions.create(
+            model=model_name,
+            temperature=0,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user_content},
+            ],
+            response_format={"type": "json_object"},
+        )
+        latency_ms = int((time.time() - t0) * 1000)
+
+        raw_text = (resp.choices[0].message.content or "").strip() if resp.choices else ""
+        if not raw_text:
+            raise RuntimeError("LLM safety head returned empty chat completion")
+        out = json.loads(raw_text)
 
     try:
         risk = float(out.get("risk_score", 0.05) or 0.05)
@@ -347,7 +368,7 @@ def _analyze_with_llm(
                 "heuristic_risk": scoring.get("heuristic_risk"),
                 "notes": scoring_notes,
             },
-            "response": resp.model_dump_json(),  # 監査用
+            "response": resp.model_dump_json() if hasattr(resp, "model_dump_json") else str(resp),  # 監査用
         },
     }
 


### PR DESCRIPTION
1. score_options(): Add `intent` and `**kwargs` params for backward compatibility.
   Fix caller in kernel._score_alternatives to pass positional args correctly
   and handle OptionScore dataclass results.

2. llm_safety: Add chat.completions fallback when OpenAI client lacks .responses
   attribute (SDK version/Azure wrapper differences). Defensive model_dump_json.

3. DecideResponse: Promote query, pipeline_steps, deterministic_replay from
   extra keys to formal schema fields with documentation.

4. Add regression tests for all three fixes.

https://claude.ai/code/session_01FsU5vyq9o3jLkcBTfqQgyW