### PR TITLE
backend: fix atomic writes, add policy audit trail, observability improvements

### DIFF
--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -10,20 +10,36 @@ from __future__ import annotations
 import json
 import logging
 import threading
+from collections import deque
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 from pydantic import BaseModel, Field
+
+try:
+    from veritas_os.core.atomic_io import atomic_write_json as _atomic_write_json
+    _HAS_ATOMIC_IO = True
+except Exception:  # pragma: no cover
+    _HAS_ATOMIC_IO = False
 
 logger = logging.getLogger(__name__)
 
 # ---------- storage path ----------
 _DEFAULT_POLICY_PATH = Path(__file__).resolve().parent / "governance.json"
+_POLICY_HISTORY_PATH = Path(__file__).resolve().parent / "governance_history.jsonl"
+
+# Maximum number of policy change records kept in the history file
+_POLICY_HISTORY_MAX = 500
 
 # Thread-safe lock for file I/O
 _policy_lock = threading.Lock()
+
+# Callbacks invoked after each successful policy update (e.g. for FUJI hot-reload).
+# Each callable receives the full updated policy dict.
+_policy_update_callbacks: List[Callable[[Dict[str, Any]], None]] = []
+_callbacks_lock = threading.Lock()
 
 _VALUE_HISTORY_PATHS = (
     Path(__file__).resolve().parents[1] / ".veritas" / "value_stats.json",
@@ -111,13 +127,98 @@ def _load() -> Dict[str, Any]:
 
 
 def _save(data: Dict[str, Any]) -> None:
-    """Save governance policy to JSON file."""
+    """Save governance policy to JSON file atomically (crash-safe)."""
     path = _policy_path()
     with _policy_lock:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-            f.write("\n")
+        if _HAS_ATOMIC_IO:
+            _atomic_write_json(path, data, indent=2)
+        else:
+            # Fallback: write to temp file then rename for best-effort atomicity
+            tmp = path.with_suffix(".tmp")
+            try:
+                with open(tmp, "w", encoding="utf-8") as f:
+                    json.dump(data, f, ensure_ascii=False, indent=2)
+                    f.write("\n")
+                    f.flush()
+                    import os as _os
+                    _os.fsync(f.fileno())
+                tmp.replace(path)
+            except Exception:
+                try:
+                    tmp.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                raise
+
+
+def _append_policy_history(previous: Dict[str, Any], updated: Dict[str, Any]) -> None:
+    """Append a policy change record to the audit history JSONL (best-effort)."""
+    record = {
+        "changed_at": updated.get("updated_at", datetime.now(timezone.utc).isoformat()),
+        "changed_by": updated.get("updated_by", "unknown"),
+        "previous_version": previous.get("version"),
+        "new_version": updated.get("version"),
+        "previous_policy": previous,
+        "new_policy": updated,
+    }
+    line = json.dumps(record, ensure_ascii=False)
+    try:
+        _POLICY_HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(_POLICY_HISTORY_PATH, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+        _trim_policy_history()
+    except Exception as e:
+        logger.warning("Failed to append governance policy history: %s", e)
+
+
+def _trim_policy_history() -> None:
+    """Keep only the most recent _POLICY_HISTORY_MAX records in the history file."""
+    try:
+        if not _POLICY_HISTORY_PATH.exists():
+            return
+        lines = _POLICY_HISTORY_PATH.read_text(encoding="utf-8").splitlines(keepends=True)
+        if len(lines) > _POLICY_HISTORY_MAX:
+            trimmed = "".join(lines[-_POLICY_HISTORY_MAX:])
+            tmp = _POLICY_HISTORY_PATH.with_suffix(".tmp")
+            tmp.write_text(trimmed, encoding="utf-8")
+            tmp.replace(_POLICY_HISTORY_PATH)
+    except Exception as e:
+        logger.warning("Failed to trim governance policy history: %s", e)
+
+
+def _notify_policy_update(policy: Dict[str, Any]) -> None:
+    """Call all registered callbacks with the updated policy (best-effort)."""
+    with _callbacks_lock:
+        callbacks = list(_policy_update_callbacks)
+    for cb in callbacks:
+        try:
+            cb(policy)
+        except Exception as e:
+            logger.warning("Policy update callback %r raised: %s", cb, e)
+
+
+def register_policy_update_callback(callback: Callable[[Dict[str, Any]], None]) -> None:
+    """Register a callback to be invoked after each successful policy update.
+
+    This enables hot-reload: components like FUJI can register here and
+    refresh their cached policy without requiring a process restart.
+
+    Args:
+        callback: Callable accepting the full updated policy dict.
+    """
+    with _callbacks_lock:
+        if callback not in _policy_update_callbacks:
+            _policy_update_callbacks.append(callback)
+
+
+def unregister_policy_update_callback(callback: Callable[[Dict[str, Any]], None]) -> None:
+    """Remove a previously registered policy update callback."""
+    with _callbacks_lock:
+        try:
+            _policy_update_callbacks.remove(callback)
+        except ValueError:
+            pass
 
 
 def _coerce_metric_point(raw: Any, fallback_index: int) -> Dict[str, Any] | None:
@@ -179,9 +280,13 @@ def update_policy(patch: Dict[str, Any]) -> Dict[str, Any]:
     """
     Merge *patch* into the current governance policy and persist.
 
+    Changes are written atomically and appended to the audit history log.
+    All registered callbacks (e.g. FUJI hot-reload) are notified after save.
+
     Returns the full updated policy.
     """
-    current = _load()
+    previous = _load()
+    current = deepcopy(previous)
 
     # Validate and deep-merge nested patches immediately.
     # This prevents silently skipping non-dict payloads and validates each
@@ -219,7 +324,42 @@ def update_policy(patch: Dict[str, Any]) -> Dict[str, Any]:
     result = validated.model_dump()
 
     _save(result)
+
+    # Record what changed for compliance audit trail
+    _append_policy_history(previous, result)
+
+    # Notify subscribers (e.g. FUJI hot-reload) — best-effort, non-blocking
+    _notify_policy_update(result)
+
     return result
+
+
+def get_policy_history(limit: int = 50) -> List[Dict[str, Any]]:
+    """Return recent policy change records from the audit history, newest first.
+
+    Args:
+        limit: Maximum number of records to return (capped at _POLICY_HISTORY_MAX).
+    """
+    limit = max(1, min(limit, _POLICY_HISTORY_MAX))
+    if not _POLICY_HISTORY_PATH.exists():
+        return []
+    try:
+        lines = _POLICY_HISTORY_PATH.read_text(encoding="utf-8").splitlines()
+        records: List[Dict[str, Any]] = []
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+            if len(records) >= limit:
+                break
+        return records
+    except Exception as e:
+        logger.warning("Failed to read governance policy history: %s", e)
+        return []
 
 
 def get_value_drift(telos_baseline: float = DEFAULT_TELOS_BASELINE) -> Dict[str, Any]:

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -54,7 +54,7 @@ from veritas_os.api.schemas import (
     MemorySearchRequest,
     TrustFeedbackRequest,
 )
-from veritas_os.api.governance import get_policy, get_value_drift, update_policy
+from veritas_os.api.governance import get_policy, get_policy_history, get_value_drift, update_policy
 from veritas_os.compliance.report_engine import (
     generate_eu_ai_act_report,
     generate_internal_governance_report,
@@ -714,6 +714,7 @@ async def _app_lifespan(_: FastAPI):
     _check_runtime_feature_health()
     _check_multiworker_auth_store()
     _start_nonce_cleanup_scheduler()
+    _start_rate_cleanup_scheduler()
     try:
         yield
     finally:
@@ -738,6 +739,7 @@ async def _app_lifespan(_: FastAPI):
         else:
             logger.info("All in-flight requests drained, shutting down cleanly")
         _stop_nonce_cleanup_scheduler()
+        _stop_rate_cleanup_scheduler()
         if _close_llm_pool is not None:
             _close_llm_pool()
 
@@ -1643,6 +1645,52 @@ def _stop_nonce_cleanup_scheduler() -> None:
     with _nonce_cleanup_timer_lock:
         timer = _nonce_cleanup_timer
         _nonce_cleanup_timer = None
+    if timer is not None:
+        timer.cancel()
+
+
+# ---- Rate bucket periodic cleanup scheduler ----
+# Without scheduled cleanup, stale rate-limit buckets accumulate indefinitely
+# when traffic drops. The lazy cleanup inside enforce_rate_limit only runs on
+# incoming requests, so low-traffic deployments can leak memory over time.
+_rate_cleanup_timer: threading.Timer | None = None
+_rate_cleanup_timer_lock = threading.Lock()
+_RATE_CLEANUP_INTERVAL = 120.0  # seconds between scheduled sweeps
+
+
+def _schedule_rate_bucket_cleanup() -> None:
+    """Periodically sweep expired rate-limit buckets in the background."""
+    global _rate_cleanup_timer
+    try:
+        _cleanup_rate_bucket()
+    except Exception as e:
+        logger.warning("scheduled rate bucket cleanup failed: %s", e)
+    with _rate_cleanup_timer_lock:
+        if _rate_cleanup_timer is None:
+            return
+        next_timer = threading.Timer(_RATE_CLEANUP_INTERVAL, _schedule_rate_bucket_cleanup)
+        next_timer.daemon = True
+        _rate_cleanup_timer = next_timer
+        next_timer.start()
+
+
+def _start_rate_cleanup_scheduler() -> None:
+    """Start rate bucket cleanup timer once per process lifecycle."""
+    global _rate_cleanup_timer
+    with _rate_cleanup_timer_lock:
+        if _rate_cleanup_timer is not None:
+            return
+        _rate_cleanup_timer = threading.Timer(_RATE_CLEANUP_INTERVAL, _schedule_rate_bucket_cleanup)
+        _rate_cleanup_timer.daemon = True
+        _rate_cleanup_timer.start()
+
+
+def _stop_rate_cleanup_scheduler() -> None:
+    """Stop rate bucket cleanup timer if running."""
+    global _rate_cleanup_timer
+    with _rate_cleanup_timer_lock:
+        timer = _rate_cleanup_timer
+        _rate_cleanup_timer = None
     if timer is not None:
         timer.cancel()
 
@@ -3115,6 +3163,43 @@ def governance_put(body: dict):
         return JSONResponse(
             status_code=500,
             content={"ok": False, "error": "Failed to update governance policy"},
+        )
+
+
+@app.get("/v1/governance/policy/history", dependencies=[Depends(require_api_key)])
+def governance_policy_history(limit: int = Query(default=50, ge=1, le=500)):
+    """Return recent governance policy change history (newest first).
+
+    Each record contains the previous and new policy state along with who
+    made the change and when, providing a full compliance audit trail.
+    """
+    try:
+        records = get_policy_history(limit=limit)
+        return {"ok": True, "count": len(records), "history": records}
+    except Exception as e:
+        logger.error("governance_policy_history failed: %s", e)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": "Failed to load governance policy history"},
+        )
+
+
+@app.get("/v1/trust/stats", dependencies=[Depends(require_api_key)])
+def trust_log_stats():
+    """Return TrustLog append success/failure counters for operational monitoring.
+
+    Persistent failures indicate a broken hash chain or storage issue and
+    should trigger an alert in production environments.
+    """
+    try:
+        from veritas_os.logging.trust_log import get_trust_log_stats
+        stats = get_trust_log_stats()
+        return {"ok": True, **stats}
+    except Exception as e:
+        logger.error("trust_log_stats failed: %s", e)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": "Failed to read trust log stats"},
         )
 
 

--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -54,6 +54,24 @@ MAX_JSON_ITEMS = 2000
 _trust_log_lock = threading.RLock()
 trust_log_lock = _trust_log_lock  # 公開 API（server.py 等から参照用）
 
+# Counters for operational observability
+_append_success_count: int = 0
+_append_failure_count: int = 0
+_append_stats_lock = threading.Lock()
+
+
+def get_trust_log_stats() -> dict:
+    """Return append success/failure counts for monitoring.
+
+    These counters are process-local and reset on restart.
+    Expose via health or metrics endpoints for alerting on persistent failures.
+    """
+    with _append_stats_lock:
+        return {
+            "append_success": _append_success_count,
+            "append_failure": _append_failure_count,
+        }
+
 
 # =============================================================================
 # ヘルパー関数
@@ -342,69 +360,85 @@ def append_trust_log(entry: dict) -> Dict[str, Any]:
     import os
 
     # ★ スレッドセーフ: ハッシュチェーンの整合性を保証するためロックを取得
-    with _trust_log_lock:
-        LOG_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        with _trust_log_lock:
+            LOG_DIR.mkdir(parents=True, exist_ok=True)
 
-        # ---- 直前ハッシュの取得（JSONL 側を正とする）----
-        # ★ 修正: JSON (MAX_JSON_ITEMS 件に制限) ではなく JSONL (全件) から
-        #   直前ハッシュを取得する。JSON が 2000 件で切られている場合、
-        #   JSON の末尾と JSONL の末尾が乖離してチェーンが壊れる問題を修正。
-        sha256_prev = get_last_hash()
+            # ---- 直前ハッシュの取得（JSONL 側を正とする）----
+            # ★ 修正: JSON (MAX_JSON_ITEMS 件に制限) ではなく JSONL (全件) から
+            #   直前ハッシュを取得する。JSON が 2000 件で切られている場合、
+            #   JSON の末尾と JSONL の末尾が乖離してチェーンが壊れる問題を修正。
+            sha256_prev = get_last_hash()
 
-        items = _load_logs_json()
+            items = _load_logs_json()
 
-        # 元 entry を壊さないようにコピー
-        entry = dict(entry)
-        entry.setdefault("created_at", datetime.now(timezone.utc).isoformat())
-        entry["sha256_prev"] = sha256_prev
+            # 元 entry を壊さないようにコピー
+            entry = dict(entry)
+            entry.setdefault("created_at", datetime.now(timezone.utc).isoformat())
+            entry["sha256_prev"] = sha256_prev
 
-        # ✅ 論文の式に準拠: hₜ = SHA256(hₜ₋₁ || rₜ)
-        # エントリから sha256 と sha256_prev を除外（これが rₜ）
-        hash_payload = dict(entry)
-        hash_payload.pop("sha256", None)
-        hash_payload.pop("sha256_prev", None)  # ⚠️ 重要: sha256_prev をハッシュ計算から除外
+            # ✅ 論文の式に準拠: hₜ = SHA256(hₜ₋₁ || rₜ)
+            # エントリから sha256 と sha256_prev を除外（これが rₜ）
+            hash_payload = dict(entry)
+            hash_payload.pop("sha256", None)
+            hash_payload.pop("sha256_prev", None)  # ⚠️ 重要: sha256_prev をハッシュ計算から除外
 
-        # rₜ を RFC 8785 canonical JSON化（キーソート・空白なし・一意性保証）
-        entry_json = _normalize_entry_for_hash(entry)
+            # rₜ を RFC 8785 canonical JSON化（キーソート・空白なし・一意性保証）
+            entry_json = _normalize_entry_for_hash(entry)
 
-        # hₜ₋₁ || rₜ を結合
-        if sha256_prev:
-            combined = sha256_prev + entry_json
-        else:
-            # 最初のエントリの場合は rₜ のみ
-            combined = entry_json
+            # hₜ₋₁ || rₜ を結合
+            if sha256_prev:
+                combined = sha256_prev + entry_json
+            else:
+                # 最初のエントリの場合は rₜ のみ
+                combined = entry_json
 
-        # SHA-256計算: hₜ = SHA256(hₜ₋₁ || rₜ)
-        entry["sha256"] = hashlib.sha256(combined.encode("utf-8")).hexdigest()
+            # SHA-256計算: hₜ = SHA256(hₜ₋₁ || rₜ)
+            entry["sha256"] = hashlib.sha256(combined.encode("utf-8")).hexdigest()
 
-        # ---- JSONL に1行追記 (with fsync for durability) ----
-        # P3-2: Optionally encrypt the line before writing
-        line = json.dumps(entry, ensure_ascii=False)
-        if is_encryption_enabled():
-            line = _encrypt_line(line)
-        with open_trust_log_for_append() as f:
-            f.write(line + "\n")
-            f.flush()
-            os.fsync(f.fileno())
+            # ---- JSONL に1行追記 (with fsync for durability) ----
+            # P3-2: Optionally encrypt the line before writing
+            line = json.dumps(entry, ensure_ascii=False)
+            if is_encryption_enabled():
+                line = _encrypt_line(line)
+            with open_trust_log_for_append() as f:
+                f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
 
-        # ---- JSON(配列) を更新（最新 N 件だけ残す）----
-        items.append(entry)
-        if len(items) > MAX_JSON_ITEMS:
-            items = items[-MAX_JSON_ITEMS:]
+            # ---- JSON(配列) を更新（最新 N 件だけ残す）----
+            items.append(entry)
+            if len(items) > MAX_JSON_ITEMS:
+                items = items[-MAX_JSON_ITEMS:]
 
-        _save_json(items)
+            _save_json(items)
 
-        # Signed TrustLog (append-only JSONL) is best-effort and must not
-        # break the existing decision pipeline.
-        try:
-            append_signed_decision(entry)
-        except Exception:
-            logger.warning(
-                "append_signed_decision failed; continuing with legacy trust log",
-                exc_info=True,
-            )
+            # Signed TrustLog (append-only JSONL) is best-effort and must not
+            # break the existing decision pipeline.
+            try:
+                append_signed_decision(entry)
+            except Exception:
+                logger.warning(
+                    "append_signed_decision failed; continuing with legacy trust log",
+                    exc_info=True,
+                )
 
-        return entry
+            with _append_stats_lock:
+                global _append_success_count
+                _append_success_count += 1
+
+            return entry
+
+    except Exception:
+        with _append_stats_lock:
+            global _append_failure_count
+            _append_failure_count += 1
+        logger.error(
+            "append_trust_log failed (failure #%d); hash chain integrity may be affected",
+            _append_failure_count,
+            exc_info=True,
+        )
+        raise
 
 
 def write_shadow_decide(
@@ -767,6 +801,7 @@ __all__ = [
     "write_shadow_decide",
     "get_last_hash",
     "calc_sha256",
+    "get_trust_log_stats",
     "trust_log_lock",
     "LOG_JSON",
     "LOG_JSONL",


### PR DESCRIPTION
- governance.py: replace plain open() write with atomic_write_json() to prevent
  file corruption on crash; add full policy change audit trail (JSONL history),
  hot-reload callback registration API, and get_policy_history() function

- trust_log.py: wrap append_trust_log() in try/except to track and log append
  failures with a process-local counter; add get_trust_log_stats() for monitoring

- server.py: add periodic rate-limit bucket cleanup scheduler (mirrors nonce
  cleanup pattern) to prevent stale bucket accumulation during low-traffic
  periods; expose GET /v1/governance/policy/history and GET /v1/trust/stats
  endpoints

https://claude.ai/code/session_01399XU1NkfzKaYAZfNtyLKH