### PR TITLE
Revamp pipeline visualizer, FUJI Gate panel, and Result layout; update tests

### DIFF
--- a/frontend/app/console/page.test.tsx
+++ b/frontend/app/console/page.test.tsx
@@ -11,8 +11,8 @@ describe("DecisionConsolePage", () => {
     render(<DecisionConsolePage />);
 
     expect(screen.getByText("1.", { exact: false })).toBeInTheDocument();
-    expect(screen.getByText("Evidence")).toBeInTheDocument();
-    expect(screen.getByText("TrustLog")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Evidence/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /TrustLog/i })).toBeInTheDocument();
   });
 
 
@@ -58,8 +58,8 @@ describe("DecisionConsolePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "送信" }));
 
     await waitFor(() => {
-      expect(screen.getByText("decision_status / chosen")).toBeInTheDocument();
-      expect(screen.getByText("memory_citations / memory_used_count")).toBeInTheDocument();
+      expect(screen.getByText("Chosen")).toBeInTheDocument();
+      expect(screen.getByText("Alternatives")).toBeInTheDocument();
       expect(screen.getByText("Cost-Benefit Analytics")).toBeInTheDocument();
       expect(screen.getByText("Total Token Cost")).toBeInTheDocument();
       expect(screen.getByRole("list", { name: "chat messages" })).toBeInTheDocument();
@@ -174,9 +174,9 @@ describe("DecisionConsolePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "送信" }));
 
     await waitFor(() => {
-      expect(screen.getAllByText("Debate").length).toBeGreaterThan(1);
-      expect(screen.getAllByText("520").length).toBeGreaterThan(1);
-      expect(screen.getAllByText("17.0%").length).toBeGreaterThan(1);
+      expect(screen.getAllByText("Debate").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("520").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("17.0%").length).toBeGreaterThan(0);
     });
   });
 
@@ -224,10 +224,11 @@ describe("DecisionConsolePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "送信" }));
 
     await waitFor(() => {
-      expect(screen.getByText("FUJI Gate Violation Analysis")).toBeInTheDocument();
-      expect(screen.getByText(/Rejection reason:/i)).toBeInTheDocument();
+      expect(screen.getByText("rule hit")).toBeInTheDocument();
+      expect(screen.getByText("severity")).toBeInTheDocument();
       expect(screen.getByText("Stage Drilldown")).toBeInTheDocument();
       expect(screen.getByText("Mask PII · Planner generated step", { exact: false })).toBeInTheDocument();
+      expect(screen.getByText(/decision_id:/i)).toBeInTheDocument();
     });
   });
 

--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Card } from "@veritas/design-system";
 import { useI18n } from "../../components/i18n-provider";
 import { renderValue, toArray } from "../../features/console/analytics/utils";
@@ -28,6 +29,7 @@ export default function DecisionConsolePage(): JSX.Element {
     setShowDriftAlert,
     governanceDriftAlert,
   } = useConsoleState();
+  const [activeResultTab, setActiveResultTab] = useState<"insights" | "raw">("insights");
 
   const { loading, error, runDecision } = useDecide({
     t,
@@ -38,6 +40,8 @@ export default function DecisionConsolePage(): JSX.Element {
     setChatMessages,
   });
 
+  const decisionId = String((result?.chosen as Record<string, unknown> | undefined)?.id ?? result?.request_id ?? "");
+
   return (
     <div className="space-y-6">
       <Card
@@ -47,7 +51,9 @@ export default function DecisionConsolePage(): JSX.Element {
         accent="primary"
         className="border-primary/20"
       >
-        <div />
+        <div className="text-sm text-muted-foreground">
+          Input → pipeline execution → FUJI safety judgment → decision comparison → TrustLog and Replay.
+        </div>
       </Card>
 
       <ChatPanel
@@ -61,7 +67,7 @@ export default function DecisionConsolePage(): JSX.Element {
         runDecision={runDecision}
       />
 
-      <PipelineVisualizer />
+      <PipelineVisualizer loading={loading} result={result} error={error} />
 
       <FujiGateStatusPanel result={result} />
 
@@ -77,63 +83,48 @@ export default function DecisionConsolePage(): JSX.Element {
         {result ? (
           <div className="space-y-4">
             <EUAIActDisclosure result={result} />
-            <ResultSection
-              title="decision_status / chosen"
-              value={{ decision_status: result.decision_status, chosen: result.chosen }}
-            />
-            <ResultSection
-              title="chosen / rationale"
-              value={{ chosen: result.chosen, rejected_reason: result.rejection_reason, reason: result.reason }}
-            />
-            <ResultSection
-              title="alternatives/options"
-              value={{ alternatives: toArray(result.alternatives), options: toArray(result.options) }}
-            />
-            <ResultSection
-              title="fuji/gate"
-              value={{ fuji: result.fuji, gate: result.gate, rejection_reason: result.rejection_reason }}
-            />
-            <ResultSection
-              title="evidence/critique/debate"
-              value={{
-                evidence: toArray(result.evidence),
-                critique: toArray(result.critique),
-                debate: toArray(result.debate),
-              }}
-            />
+            <div className="grid gap-3 md:grid-cols-3">
+              <ResultSection title="Chosen" value={result.chosen} />
+              <ResultSection title="Alternatives" value={toArray(result.alternatives)} />
+              <ResultSection
+                title="Rejected reasons"
+                value={{ rejection_reason: result.rejection_reason, gate_reason: (result.gate as Record<string, unknown>).reason }}
+              />
+            </div>
+            <div className="grid gap-3 md:grid-cols-3">
+              <ResultSection title="Evidence sources" value={toArray(result.evidence).map((item) => (item as Record<string, unknown>).source)} />
+              <ResultSection title="Critique highlights" value={toArray(result.critique).slice(0, 5)} />
+              <ResultSection title="Debate summary" value={toArray(result.debate).slice(0, 5)} />
+            </div>
             <CostBenefitPanel result={result} />
-            <ResultSection
-              title="telos_score/values"
-              value={{ telos_score: result.telos_score, values: result.values }}
-            />
-            <ResultSection
-              title="memory_citations / memory_used_count"
-              value={{
-                memory_citations: toArray(result.memory_citations),
-                memory_used_count: result.memory_used_count,
-              }}
-            />
-            <ResultSection title="trust_log" value={result.trust_log ?? null} />
             <div className="flex flex-wrap gap-2">
+              <span className="rounded-md border border-border px-2 py-1 text-xs">decision_id: {decisionId}</span>
               <a className="rounded-md border border-border px-2 py-1 text-xs" href={`/audit?request_id=${encodeURIComponent(result.request_id)}`}>
-                Open TrustLog Explorer
+                Trust Log
               </a>
-              <a className="rounded-md border border-border px-2 py-1 text-xs" href={`/console?decision_id=${encodeURIComponent(String((result.chosen as Record<string, unknown>).id ?? result.request_id))}`}>
-                Replay this decision
-              </a>
+              <button type="button" className="rounded-md border border-border px-2 py-1 text-xs" onClick={() => {
+                window.location.href = `/console?decision_id=${encodeURIComponent(decisionId)}`;
+              }}>
+                Replay
+              </button>
+            </div>
+            <div className="space-y-2">
+              <div className="flex gap-2 text-xs">
+                <button type="button" className="rounded border border-border px-2 py-1" onClick={() => setActiveResultTab("insights")}>Insights</button>
+                <button type="button" className="rounded border border-border px-2 py-1" onClick={() => setActiveResultTab("raw")}>Raw JSON</button>
+              </div>
+              {activeResultTab === "insights" ? (
+                <ResultSection title="trust_log" value={result.trust_log ?? null} />
+              ) : (
+                <pre className="overflow-x-auto rounded-md border border-border bg-muted/20 p-3 text-xs">{renderValue(result)}</pre>
+              )}
             </div>
             <ReplayDiffViewer result={result} />
-            <details>
-              <summary className="cursor-pointer text-sm font-semibold text-foreground">extras</summary>
-              <pre className="mt-3 overflow-x-auto rounded-lg border border-border/50 bg-muted/30 p-3 text-xs leading-relaxed text-foreground">
-                {renderValue(result.extras ?? {})}
-              </pre>
-            </details>
           </div>
         ) : (
-          <div className="flex items-center gap-3 py-2 text-muted-foreground">
-            <span className="h-2 w-2 rounded-full bg-muted-foreground/30 status-dot-live" aria-hidden="true" />
-            <p className="text-sm">{tk("noResultsYet")}</p>
+          <div className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+            <p className="font-semibold text-foreground">Start with a real decision question.</p>
+            <p className="mt-1">You will see live pipeline progression, FUJI safety checks, alternatives trade-offs, and auditable TrustLog links in one run.</p>
           </div>
         )}
       </Card>

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -11,8 +11,8 @@ test.describe("Smoke: 3-minute demo flow", () => {
     await page.goto("/console");
     // Use heading role to avoid strict-mode clash with the sidebar nav text
     await expect(page.getByRole("heading", { name: "Decision Console" })).toBeVisible();
-    await expect(page.getByText("Pipeline Visualizer")).toBeVisible();
-    await expect(page.getByText("Evidence")).toBeVisible();
+    await expect(page.getByText("Pipeline Operations View")).toBeVisible();
+    await expect(page.locator("li", { hasText: "Evidence" })).toBeVisible();
     // Scope to <li> so strict mode won't match the separate "FUJI Gate Status" heading
     await expect(page.locator("li", { hasText: "FUJI" })).toBeVisible();
     // Scope to <li> to avoid matching sidebar's "TrustLog Explorer"

--- a/frontend/features/console/components/fuji-gate-status-panel.tsx
+++ b/frontend/features/console/components/fuji-gate-status-panel.tsx
@@ -1,23 +1,13 @@
 import { type DecideResponse } from "@veritas/types";
-import { toFiniteNumber } from "../analytics/utils";
 
-function toViolationEntries(result: DecideResponse): Array<{ key: string; value: unknown }> {
-  const fuji = (result.fuji ?? {}) as Record<string, unknown>;
-  const gate = (result.gate ?? {}) as Record<string, unknown>;
-
-  return Object.entries({ ...fuji, ...gate }).filter(([, value]) => {
-    if (typeof value === "boolean") {
+function readFujiField(data: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = data[key];
+    if (typeof value === "string" && value.trim()) {
       return value;
     }
-    if (typeof value === "string") {
-      const lower = value.toLowerCase();
-      return ["deny", "reject", "fail", "violation"].some((token) => lower.includes(token));
-    }
-    if (typeof value === "number") {
-      return value >= 0.7;
-    }
-    return false;
-  }).map(([key, value]) => ({ key, value }));
+  }
+  return "n/a";
 }
 
 export function FujiGateStatusPanel({ result }: { result: DecideResponse | null }): JSX.Element {
@@ -25,31 +15,40 @@ export function FujiGateStatusPanel({ result }: { result: DecideResponse | null 
     return (
       <section className="rounded-md border border-border bg-background/60 p-3" aria-label="fuji gate status">
         <h3 className="text-sm font-semibold text-foreground">FUJI Gate Status</h3>
-        <p className="mt-2 text-xs text-muted-foreground">No evaluation yet.</p>
+        <p className="mt-2 text-xs text-muted-foreground">Run a decision to inspect FUJI rules, severity, and remediation hints.</p>
       </section>
     );
   }
 
   const gate = (result.gate ?? {}) as Record<string, unknown>;
-  const status = typeof gate.decision_status === "string" ? gate.decision_status : "unknown";
-  const risk = toFiniteNumber(gate.risk);
-  const violations = toViolationEntries(result);
+  const fuji = (result.fuji ?? {}) as Record<string, unknown>;
+  const merged = { ...fuji, ...gate };
+
+  const decision = readFujiField(merged, "decision_status", "status");
+  const ruleHit = readFujiField(merged, "rule_hit", "rule", "policy_rule", "code");
+  const severity = readFujiField(merged, "severity", "risk_level");
+  const remediationHint = readFujiField(merged, "remediation_hint", "hint", "action");
 
   return (
     <section className="rounded-md border border-border bg-background/60 p-3" aria-label="fuji gate status">
-      <h3 className="text-sm font-semibold text-foreground">FUJI Gate Violation Analysis</h3>
-      <p className="mt-1 text-xs text-muted-foreground">Decision: {status.toUpperCase()} · Risk {risk?.toFixed(3) ?? "n/a"}</p>
-      <p className="mt-1 text-xs text-muted-foreground">Rejection reason: {result.rejection_reason ?? "none"}</p>
-      <div className="mt-3 space-y-2">
-        {violations.length === 0 ? (
-          <p className="rounded-md border border-success/30 bg-success/10 px-2 py-1 text-xs text-success">No active violations.</p>
-        ) : (
-          violations.map((item) => (
-            <div key={item.key} className="rounded-md border border-danger/30 bg-danger/8 px-2 py-1.5 text-xs text-danger">
-              <span className="font-semibold">{item.key}</span>: {String(item.value)}
-            </div>
-          ))
-        )}
+      <h3 className="text-sm font-semibold text-foreground">FUJI Gate</h3>
+      <div className="mt-2 grid gap-2 text-xs md:grid-cols-4">
+        <div className="rounded border border-border/70 bg-background/70 p-2">
+          <p className="text-muted-foreground">decision</p>
+          <p className="font-semibold text-foreground">{decision}</p>
+        </div>
+        <div className="rounded border border-border/70 bg-background/70 p-2">
+          <p className="text-muted-foreground">rule hit</p>
+          <p className="font-semibold text-foreground">{ruleHit}</p>
+        </div>
+        <div className="rounded border border-border/70 bg-background/70 p-2">
+          <p className="text-muted-foreground">severity</p>
+          <p className="font-semibold text-foreground">{severity}</p>
+        </div>
+        <div className="rounded border border-border/70 bg-background/70 p-2">
+          <p className="text-muted-foreground">remediation hint</p>
+          <p className="font-semibold text-foreground">{remediationHint}</p>
+        </div>
       </div>
     </section>
   );

--- a/frontend/features/console/components/pipeline-visualizer.test.tsx
+++ b/frontend/features/console/components/pipeline-visualizer.test.tsx
@@ -1,41 +1,46 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PipelineVisualizer } from "./pipeline-visualizer";
 
+/**
+ * Pipeline visualizer behavior tests.
+ *
+ * Ensures stage cards render consistently and live timers are cleaned up
+ * when the component is unmounted during an active run.
+ */
 describe("PipelineVisualizer", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("renders all pipeline stages with initial idle state", () => {
-    render(<PipelineVisualizer />);
-    expect(screen.getByText("Pipeline Visualizer")).toBeInTheDocument();
-    expect(screen.getByText("Evidence")).toBeInTheDocument();
-    expect(screen.getByText("TrustLog")).toBeInTheDocument();
+  it("renders all pipeline stages and supports stage drilldown", () => {
+    render(<PipelineVisualizer loading={false} result={null} error={null} />);
+
+    expect(screen.getByText("Pipeline Operations View")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /1\. Evidence/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /7\. TrustLog/i })).toBeInTheDocument();
 
     const items = screen.getAllByRole("listitem");
     expect(items).toHaveLength(7);
-    for (const item of items) {
-      expect(item.querySelector("p")?.textContent).toBe("idle");
-    }
+
+    fireEvent.click(screen.getByRole("button", { name: /2\. Critique/i }));
+    expect(screen.getByText("Critique details")).toBeInTheDocument();
+    expect(screen.getByText("status: idle")).toBeInTheDocument();
   });
 
-  it("clears both interval and timeout on unmount (no leak)", () => {
+  it("clears interval on unmount during live execution", () => {
     vi.useFakeTimers();
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
-    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
-    const { unmount } = render(<PipelineVisualizer />);
+    const { unmount } = render(<PipelineVisualizer loading result={null} error={null} />);
 
-    // Advance enough to trigger the setTimeout inside setInterval (7 stages × 900ms)
     act(() => {
-      vi.advanceTimersByTime(900 * 7);
+      vi.advanceTimersByTime(1300);
     });
 
     unmount();
 
     expect(clearIntervalSpy).toHaveBeenCalled();
-    expect(clearTimeoutSpy).toHaveBeenCalled();
   });
 });

--- a/frontend/features/console/components/pipeline-visualizer.tsx
+++ b/frontend/features/console/components/pipeline-visualizer.tsx
@@ -1,79 +1,142 @@
-import { useEffect, useRef, useState } from "react";
+import { type DecideResponse } from "@veritas/types";
+import { useEffect, useMemo, useState } from "react";
 import { PIPELINE_STAGES } from "../constants";
 
-export function PipelineVisualizer(): JSX.Element {
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
-  const [stageStatuses, setStageStatuses] = useState<Record<string, "idle" | "pass" | "adjusted">>(
-    () =>
-      Object.fromEntries(
-        PIPELINE_STAGES.map((stage) => [stage, "idle"]),
-      ) as Record<string, "idle" | "pass" | "adjusted">,
-  );
-  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+type StageState = "idle" | "running" | "complete" | "warning" | "failed";
+
+interface PipelineVisualizerProps {
+  loading: boolean;
+  result: DecideResponse | null;
+  error: string | null;
+}
+
+interface StageCard {
+  name: (typeof PIPELINE_STAGES)[number];
+  status: StageState;
+  latencyMs: number | null;
+  summary: string;
+  rawDetail: Record<string, unknown>;
+}
+
+
+function extractStageCards(result: DecideResponse | null, error: string | null): StageCard[] {
+  const metrics = ((result?.extras?.stage_metrics ?? {}) as Record<string, unknown>);
+
+  return PIPELINE_STAGES.map((stage) => {
+    const key = stage.toLowerCase();
+    const row = (metrics[key] ?? metrics[stage] ?? {}) as Record<string, unknown>;
+    const latencyMs = typeof row.latency_ms === "number" ? row.latency_ms : null;
+    const health = typeof row.health === "string" ? row.health : "unknown";
+
+    let status: StageState = "idle";
+    if (result) {
+      status = "complete";
+    }
+    if (health === "warning") {
+      status = "warning";
+    }
+    if (health === "failed") {
+      status = "failed";
+    }
+
+    if (error && !result && stage === "Evidence") {
+      status = "failed";
+    }
+
+    const summary = typeof row.summary === "string"
+      ? row.summary
+      : status === "complete"
+        ? "Stage finished"
+        : status === "failed"
+          ? "Execution stopped"
+          : "Waiting";
+
+    return {
+      name: stage,
+      status,
+      latencyMs,
+      summary,
+      rawDetail: row,
+    };
+  });
+}
+
+/**
+ * Renders live decision pipeline cards and per-stage details.
+ * While loading, cards progress sequentially so operators can track execution.
+ */
+export function PipelineVisualizer({ loading, result, error }: PipelineVisualizerProps): JSX.Element {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [selectedStage, setSelectedStage] = useState<(typeof PIPELINE_STAGES)[number]>(PIPELINE_STAGES[0]);
+
+  const cards = useMemo(() => extractStageCards(result, error), [result, error]);
 
   useEffect(() => {
-    let index = 0;
-    const intervalId = setInterval(() => {
-      setActiveIndex(index);
-      setStageStatuses((prev) => {
-        const next = { ...prev };
-        const currentStage = PIPELINE_STAGES[index];
-        if (currentStage) {
-          next[currentStage] =
-            currentStage === "Critique" || currentStage === "Value" ? "adjusted" : "pass";
-        }
-        return next;
-      });
+    if (!loading) {
+      return;
+    }
 
-      index += 1;
-      if (index >= PIPELINE_STAGES.length) {
-        index = 0;
-        resetTimerRef.current = setTimeout(() => {
-          setStageStatuses(
-            Object.fromEntries(
-              PIPELINE_STAGES.map((stage) => [stage, "idle"]),
-            ) as Record<string, "idle" | "pass" | "adjusted">,
-          );
-        }, 500);
-      }
-    }, 900);
+    const intervalId = window.setInterval(() => {
+      setActiveIndex((previous) => (previous + 1) % PIPELINE_STAGES.length);
+    }, 650);
 
-    return () => {
-      clearInterval(intervalId);
-      if (resetTimerRef.current !== null) {
-        clearTimeout(resetTimerRef.current);
-      }
-    };
-  }, []);
+    return () => window.clearInterval(intervalId);
+  }, [loading]);
+
+  const selected = cards.find((card) => card.name === selectedStage) ?? cards[0];
 
   return (
-    <section aria-label="pipeline visualizer" className="space-y-2">
-      <h2 className="text-sm font-semibold text-foreground">Pipeline Visualizer</h2>
+    <section aria-label="pipeline visualizer" className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-foreground">Pipeline Operations View</h2>
+        <span className="text-xs text-muted-foreground">
+          {loading ? "Live execution in progress" : "Latest execution snapshot"}
+        </span>
+      </div>
       <ol className="grid gap-2 text-xs md:grid-cols-7">
-        {PIPELINE_STAGES.map((stage, index) => (
-          <li
-            key={stage}
-            className={[
-              "rounded-md border px-2 py-2 text-center text-foreground transition-all duration-300",
-              activeIndex === index
-                ? "animate-pulse border-primary/60 bg-primary/15"
-                : "border-border bg-background/60",
-              stageStatuses[stage] === "pass" ? "border-emerald-500/50 bg-emerald-500/10" : "",
-              stageStatuses[stage] === "adjusted" ? "border-amber-500/50 bg-amber-500/10" : "",
-            ].join(" ")}
-          >
-            <span className="mr-1 text-muted-foreground">{index + 1}.</span>
-            {stage}
-            <p className="mt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-              {stageStatuses[stage] === "pass"
-                ? "green"
-                : stageStatuses[stage] === "adjusted"
-                  ? "yellow"
-                  : "idle"}
-            </p>
-          </li>
-        ))}
+        {cards.map((card, index) => {
+          const live = loading && activeIndex === index;
+          const color = card.status === "failed"
+            ? "border-danger/50 bg-danger/10"
+            : card.status === "warning"
+              ? "border-amber-500/50 bg-amber-500/10"
+              : card.status === "complete"
+                ? "border-emerald-500/50 bg-emerald-500/10"
+                : "border-border bg-background/60";
+
+          return (
+            <li key={card.name}>
+              <button
+                type="button"
+                className={[
+                  "w-full rounded-md border px-2 py-2 text-left text-foreground transition-all duration-300",
+                  color,
+                  live ? "animate-pulse border-primary/60" : "",
+                  selectedStage === card.name ? "ring-1 ring-primary/60" : "",
+                ].join(" ")}
+                onClick={() => setSelectedStage(card.name)}
+              >
+                <p className="font-semibold">{index + 1}. {card.name}</p>
+                <p className="mt-1 text-[10px] uppercase tracking-wide text-muted-foreground">{card.status}</p>
+              </button>
+            </li>
+          );
+        })}
       </ol>
+      {selected && (
+        <div className="rounded-md border border-border bg-background/70 p-3 text-xs">
+          <p className="font-semibold text-foreground">{selected.name} details</p>
+          <p className="mt-1 text-muted-foreground">status: {selected.status}</p>
+          <p className="text-muted-foreground">latency: {selected.latencyMs !== null ? `${selected.latencyMs.toFixed(0)} ms` : "n/a"}</p>
+          <p className="mt-2 text-foreground">{selected.summary}</p>
+          <details className="mt-2">
+            <summary className="cursor-pointer text-muted-foreground">raw detail</summary>
+            <pre className="mt-1 overflow-x-auto rounded-md border border-border bg-background/80 p-2 text-[11px] text-foreground">
+              {JSON.stringify(selected.rawDetail, null, 2)}
+            </pre>
+          </details>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
### Motivation

- Improve operator visibility into pipeline execution with richer per-stage details and live progression indicators.
- Surface FUJI gate information (decision, rule hit, severity, remediation hint) more clearly and robustly handle different result shapes.
- Simplify and reorganize the Result card to present chosen/alternatives, evidence/critique/debate, TrustLog access, and a toggleable raw JSON view.

### Description

- Reworked `PipelineVisualizer` into a props-driven component that accepts `loading`, `result`, and `error`, introduces `StageCard` extraction via `extractStageCards`, per-stage details, selection, and a safer live interval lifecycle.
- Updated `DecisionConsolePage` to add `activeResultTab` state, compute `decisionId`, show a compact pipeline description, pass props to `PipelineVisualizer`, reorganize `ResultSection` layout into grids, add `Trust Log` and `Replay` actions, and provide an `Insights` / `Raw JSON` toggle rendering `renderValue(result)`.
- Replaced the old FUJI Gate display with `FujiGateStatusPanel` changes: added `readFujiField` helper, merged FUJI/gate fields, and rendered `decision`, `rule hit`, `severity`, and `remediation hint` in a compact grid with updated helper copy when no result is present.
- Adjusted copy and structure across the console (empty state, panel titles) and removed the previous `extras` details block in favor of the new raw view.
- Updated unit and E2E tests to match the new UI and behaviors: `frontend/app/console/page.test.tsx`, `pipeline-visualizer.test.tsx`, `fuji-gate-status-panel` expectations, and the Playwright smoke test `frontend/e2e/smoke.spec.ts`.

### Testing

- Ran unit tests with `vitest` including `page.test.tsx` and `pipeline-visualizer.test.tsx`, and the updated tests passed.
- Executed Playwright smoke E2E tests (`frontend/e2e/smoke.spec.ts`) to validate page rendering and pipeline/preset expectations, and they passed.
- Verified component behavior locally by exercising `PipelineVisualizer` live mode and toggling the Result `Insights`/`Raw JSON` tab during manual test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae194f6478832684e9ad9552e0e924)