### PR TITLE
feat(console): transform Decision Console into end-to-end decision pipeline operations view

### DIFF
--- a/frontend/app/console/page.test.tsx
+++ b/frontend/app/console/page.test.tsx
@@ -13,6 +13,7 @@ describe("DecisionConsolePage", () => {
     expect(screen.getByText("1.", { exact: false })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Evidence/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /TrustLog/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Input/i })).toBeInTheDocument();
   });
 
 
@@ -58,8 +59,8 @@ describe("DecisionConsolePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "送信" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Chosen")).toBeInTheDocument();
-      expect(screen.getByText("Alternatives")).toBeInTheDocument();
+      expect(screen.getByText("final decision:", { exact: false })).toBeInTheDocument();
+      expect(screen.getByText("Rejected reasons")).toBeInTheDocument();
       expect(screen.getByText("Cost-Benefit Analytics")).toBeInTheDocument();
       expect(screen.getByText("Total Token Cost")).toBeInTheDocument();
       expect(screen.getByRole("list", { name: "chat messages" })).toBeInTheDocument();
@@ -229,6 +230,7 @@ describe("DecisionConsolePage", () => {
       expect(screen.getByText("Stage Drilldown")).toBeInTheDocument();
       expect(screen.getByText("Mask PII · Planner generated step", { exact: false })).toBeInTheDocument();
       expect(screen.getByText(/decision_id:/i)).toBeInTheDocument();
+      expect(screen.getByText("risky text fragment preview")).toBeInTheDocument();
     });
   });
 

--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -122,7 +122,7 @@ export default function DecisionConsolePage(): JSX.Element {
         ) : (
           <div className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
             <p className="font-semibold text-foreground">Start with a real decision question.</p>
-            <p className="mt-1">Try prompts like: "Should we delay launch by 2 weeks for security hardening?" or "Choose vendor A vs B under strict budget and compliance constraints."</p>
+            <p className="mt-1">Try prompts like: &quot;Should we delay launch by 2 weeks for security hardening?&quot; or &quot;Choose vendor A vs B under strict budget and compliance constraints.&quot;</p>
             <p className="mt-1">You will see stage progression, FUJI safety checks, chosen vs alternatives, rejection reasons, and direct TrustLog/Replay links.</p>
           </div>
         )}

--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -7,6 +7,7 @@ import { renderValue, toArray } from "../../features/console/analytics/utils";
 import { useDecide } from "../../features/console/api/useDecide";
 import { ChatPanel } from "../../features/console/components/chat-panel";
 import { CostBenefitPanel } from "../../features/console/components/cost-benefit-panel";
+import { DecisionResultPanel } from "../../features/console/components/decision-result-panel";
 import { DriftAlert } from "../../features/console/components/drift-alert";
 import { EUAIActDisclosure } from "../../features/console/components/eu-ai-act-disclosure";
 import { FujiGateStatusPanel } from "../../features/console/components/fuji-gate-status-panel";
@@ -52,7 +53,7 @@ export default function DecisionConsolePage(): JSX.Element {
         className="border-primary/20"
       >
         <div className="text-sm text-muted-foreground">
-          Input → pipeline execution → FUJI safety judgment → decision comparison → TrustLog and Replay.
+          Input → Evidence → Critique → Debate → Plan → Value → FUJI → TrustLog.
         </div>
       </Card>
 
@@ -83,14 +84,7 @@ export default function DecisionConsolePage(): JSX.Element {
         {result ? (
           <div className="space-y-4">
             <EUAIActDisclosure result={result} />
-            <div className="grid gap-3 md:grid-cols-3">
-              <ResultSection title="Chosen" value={result.chosen} />
-              <ResultSection title="Alternatives" value={toArray(result.alternatives)} />
-              <ResultSection
-                title="Rejected reasons"
-                value={{ rejection_reason: result.rejection_reason, gate_reason: (result.gate as Record<string, unknown>).reason }}
-              />
-            </div>
+            <DecisionResultPanel result={result} />
             <div className="grid gap-3 md:grid-cols-3">
               <ResultSection title="Evidence sources" value={toArray(result.evidence).map((item) => (item as Record<string, unknown>).source)} />
               <ResultSection title="Critique highlights" value={toArray(result.critique).slice(0, 5)} />
@@ -100,11 +94,15 @@ export default function DecisionConsolePage(): JSX.Element {
             <div className="flex flex-wrap gap-2">
               <span className="rounded-md border border-border px-2 py-1 text-xs">decision_id: {decisionId}</span>
               <a className="rounded-md border border-border px-2 py-1 text-xs" href={`/audit?request_id=${encodeURIComponent(result.request_id)}`}>
-                Trust Log
+                TrustLog
               </a>
-              <button type="button" className="rounded-md border border-border px-2 py-1 text-xs" onClick={() => {
-                window.location.href = `/console?decision_id=${encodeURIComponent(decisionId)}`;
-              }}>
+              <button
+                type="button"
+                className="rounded-md border border-border px-2 py-1 text-xs"
+                onClick={() => {
+                  window.location.href = `/console?decision_id=${encodeURIComponent(decisionId)}`;
+                }}
+              >
                 Replay
               </button>
             </div>
@@ -124,7 +122,8 @@ export default function DecisionConsolePage(): JSX.Element {
         ) : (
           <div className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
             <p className="font-semibold text-foreground">Start with a real decision question.</p>
-            <p className="mt-1">You will see live pipeline progression, FUJI safety checks, alternatives trade-offs, and auditable TrustLog links in one run.</p>
+            <p className="mt-1">Try prompts like: "Should we delay launch by 2 weeks for security hardening?" or "Choose vendor A vs B under strict budget and compliance constraints."</p>
+            <p className="mt-1">You will see stage progression, FUJI safety checks, chosen vs alternatives, rejection reasons, and direct TrustLog/Replay links.</p>
           </div>
         )}
       </Card>

--- a/frontend/features/console/adapters/decision-view.ts
+++ b/frontend/features/console/adapters/decision-view.ts
@@ -1,0 +1,166 @@
+import { type DecideResponse } from "@veritas/types";
+import { toArray } from "../analytics/utils";
+import { PIPELINE_STAGES, type PipelineStageName } from "../constants";
+import {
+  type DecisionResultView,
+  type FujiGateView,
+  type PipelineStageStatus,
+  type PipelineStageView,
+} from "../types";
+
+const STAGE_ALIASES: Record<PipelineStageName, string[]> = {
+  Input: ["input"],
+  Evidence: ["evidence"],
+  Critique: ["critique"],
+  Debate: ["debate"],
+  Plan: ["plan", "planner"],
+  Value: ["value", "values"],
+  FUJI: ["fuji", "gate"],
+  TrustLog: ["trustlog", "trust_log"],
+};
+
+function toStageStatus(
+  result: DecideResponse | null,
+  loading: boolean,
+  hasError: boolean,
+  stageIndex: number,
+  activeIndex: number,
+  health: string,
+): PipelineStageStatus {
+  if (health === "failed") {
+    return "failed";
+  }
+  if (health === "warning") {
+    return "warning";
+  }
+  if (hasError && stageIndex <= activeIndex) {
+    return "failed";
+  }
+  if (result) {
+    return "complete";
+  }
+  if (loading && stageIndex === activeIndex) {
+    return "running";
+  }
+  if (loading && stageIndex < activeIndex) {
+    return "complete";
+  }
+  return "idle";
+}
+
+/**
+ * Maps `/v1/decide` payloads into a stable UI model.
+ *
+ * This adapter keeps view-specific fallback rules out of React components and
+ * prepares for future backend schema evolution.
+ */
+export function toPipelineStageViews(
+  result: DecideResponse | null,
+  loading: boolean,
+  error: string | null,
+  activeIndex: number,
+): PipelineStageView[] {
+  const metrics = (result?.extras?.stage_metrics ?? {}) as Record<string, unknown>;
+  const hasError = Boolean(error && !result);
+
+  return PIPELINE_STAGES.map((stage, stageIndex) => {
+    const aliases = STAGE_ALIASES[stage];
+    const row = aliases
+      .map((alias) => metrics[alias])
+      .find((value) => value && typeof value === "object") as Record<string, unknown> | undefined;
+    const latencyValue = row?.latency_ms;
+    const latencyMs = typeof latencyValue === "number" ? latencyValue : null;
+    const health = typeof row?.health === "string" ? row.health : "unknown";
+    const status = toStageStatus(result, loading, hasError, stageIndex, activeIndex, health);
+
+    const detail = typeof row?.detail === "string"
+      ? row.detail
+      : typeof row?.reason === "string"
+        ? row.reason
+        : status === "failed"
+          ? "Execution stopped before completion."
+          : "No detailed diagnostics provided.";
+
+    const summary = typeof row?.summary === "string"
+      ? row.summary
+      : status === "complete"
+        ? "Stage finished."
+        : status === "running"
+          ? "Processing..."
+          : "Waiting for execution.";
+
+    return {
+      name: stage,
+      status,
+      latencyMs,
+      summary,
+      detail,
+      raw: row ?? {},
+    };
+  });
+}
+
+function readText(record: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return "n/a";
+}
+
+export function toFujiGateView(result: DecideResponse | null): FujiGateView {
+  if (!result) {
+    return {
+      decision: "n/a",
+      ruleHit: "n/a",
+      severity: "n/a",
+      remediationHint: "n/a",
+      riskyFragmentPreview: "n/a",
+    };
+  }
+
+  const merged = {
+    ...(result.fuji as Record<string, unknown>),
+    ...(result.gate as Record<string, unknown>),
+  };
+
+  return {
+    decision: readText(merged, "decision_status", "status"),
+    ruleHit: readText(merged, "rule_hit", "rule", "policy_rule", "code"),
+    severity: readText(merged, "severity", "risk_level"),
+    remediationHint: readText(merged, "remediation_hint", "hint", "action"),
+    riskyFragmentPreview: readText(merged, "risky_text_fragment", "snippet", "fragment"),
+  };
+}
+
+export function toDecisionResultView(result: DecideResponse): DecisionResultView {
+  const chosen = result.chosen as Record<string, unknown>;
+  const alternatives = toArray(result.alternatives) as Array<Record<string, unknown>>;
+  const evidenceSources = toArray(result.evidence)
+    .map((item) => (item as Record<string, unknown>).source)
+    .filter((value): value is string => typeof value === "string");
+
+  return {
+    chosen: {
+      finalDecision: readText(chosen, "title", "decision", "id"),
+      whyChosen: readText(chosen, "why", "rationale", "reason"),
+      supportingEvidenceSummary: evidenceSources.length > 0 ? evidenceSources.slice(0, 3).join(", ") : "n/a",
+      valueRationale: readText((result.values ?? {}) as Record<string, unknown>, "rationale"),
+    },
+    alternatives: alternatives.map((item, index) => ({
+      optionSummary: readText(item, "title", "description", "id") || `Option ${index + 1}`,
+      tradeOff: readText(item, "trade_off", "tradeoff", "impact", "description"),
+      relativeWeakness: readText(item, "weakness", "relative_weakness", "risk"),
+    })),
+    rejectedReasons: {
+      fujiBlock: readText((result.gate ?? {}) as Record<string, unknown>, "reason"),
+      weakEvidence: typeof result.evidence[0]?.confidence === "number" && result.evidence[0].confidence < 0.6
+        ? "Low confidence evidence detected."
+        : "n/a",
+      poorDebateOutcome: result.debate.length === 0 ? "Debate did not provide decisive support." : "n/a",
+      valueConflict: readText((result.values ?? {}) as Record<string, unknown>, "conflict", "warning"),
+    },
+  };
+}

--- a/frontend/features/console/components/decision-result-panel.tsx
+++ b/frontend/features/console/components/decision-result-panel.tsx
@@ -1,0 +1,48 @@
+import { type DecideResponse } from "@veritas/types";
+import { toDecisionResultView } from "../adapters/decision-view";
+
+interface DecisionResultPanelProps {
+  result: DecideResponse;
+}
+
+/**
+ * Structured decision result panel for operator review.
+ */
+export function DecisionResultPanel({ result }: DecisionResultPanelProps): JSX.Element {
+  const view = toDecisionResultView(result);
+
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      <section className="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs">
+        <h3 className="text-sm font-semibold text-foreground">Chosen</h3>
+        <p><span className="text-muted-foreground">final decision:</span> {view.chosen.finalDecision}</p>
+        <p><span className="text-muted-foreground">why chosen:</span> {view.chosen.whyChosen}</p>
+        <p><span className="text-muted-foreground">supporting evidence summary:</span> {view.chosen.supportingEvidenceSummary}</p>
+        <p><span className="text-muted-foreground">value rationale:</span> {view.chosen.valueRationale}</p>
+      </section>
+
+      <section className="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs">
+        <h3 className="text-sm font-semibold text-foreground">Alternatives</h3>
+        {view.alternatives.length === 0 ? (
+          <p className="text-muted-foreground">No alternatives provided.</p>
+        ) : (
+          view.alternatives.map((item, index) => (
+            <div key={`${item.optionSummary}-${index}`} className="rounded border border-border/70 bg-background/70 p-2">
+              <p><span className="text-muted-foreground">option summary:</span> {item.optionSummary}</p>
+              <p><span className="text-muted-foreground">trade-off:</span> {item.tradeOff}</p>
+              <p><span className="text-muted-foreground">relative weakness:</span> {item.relativeWeakness}</p>
+            </div>
+          ))
+        )}
+      </section>
+
+      <section className="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs">
+        <h3 className="text-sm font-semibold text-foreground">Rejected reasons</h3>
+        <p><span className="text-muted-foreground">FUJI block:</span> {view.rejectedReasons.fujiBlock}</p>
+        <p><span className="text-muted-foreground">weak evidence:</span> {view.rejectedReasons.weakEvidence}</p>
+        <p><span className="text-muted-foreground">poor debate outcome:</span> {view.rejectedReasons.poorDebateOutcome}</p>
+        <p><span className="text-muted-foreground">value conflict:</span> {view.rejectedReasons.valueConflict}</p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/features/console/components/fuji-gate-status-panel.tsx
+++ b/frontend/features/console/components/fuji-gate-status-panel.tsx
@@ -1,53 +1,35 @@
 import { type DecideResponse } from "@veritas/types";
-
-function readFujiField(data: Record<string, unknown>, ...keys: string[]): string {
-  for (const key of keys) {
-    const value = data[key];
-    if (typeof value === "string" && value.trim()) {
-      return value;
-    }
-  }
-  return "n/a";
-}
+import { toFujiGateView } from "../adapters/decision-view";
 
 export function FujiGateStatusPanel({ result }: { result: DecideResponse | null }): JSX.Element {
-  if (!result) {
-    return (
-      <section className="rounded-md border border-border bg-background/60 p-3" aria-label="fuji gate status">
-        <h3 className="text-sm font-semibold text-foreground">FUJI Gate Status</h3>
-        <p className="mt-2 text-xs text-muted-foreground">Run a decision to inspect FUJI rules, severity, and remediation hints.</p>
-      </section>
-    );
-  }
-
-  const gate = (result.gate ?? {}) as Record<string, unknown>;
-  const fuji = (result.fuji ?? {}) as Record<string, unknown>;
-  const merged = { ...fuji, ...gate };
-
-  const decision = readFujiField(merged, "decision_status", "status");
-  const ruleHit = readFujiField(merged, "rule_hit", "rule", "policy_rule", "code");
-  const severity = readFujiField(merged, "severity", "risk_level");
-  const remediationHint = readFujiField(merged, "remediation_hint", "hint", "action");
+  const view = toFujiGateView(result);
 
   return (
     <section className="rounded-md border border-border bg-background/60 p-3" aria-label="fuji gate status">
       <h3 className="text-sm font-semibold text-foreground">FUJI Gate</h3>
-      <div className="mt-2 grid gap-2 text-xs md:grid-cols-4">
+      {!result && (
+        <p className="mt-2 text-xs text-muted-foreground">Run a decision to inspect FUJI rules, severity, and remediation hints.</p>
+      )}
+      <div className="mt-2 grid gap-2 text-xs md:grid-cols-5">
         <div className="rounded border border-border/70 bg-background/70 p-2">
-          <p className="text-muted-foreground">decision</p>
-          <p className="font-semibold text-foreground">{decision}</p>
+          <p className="text-muted-foreground">allow / modify / rejected</p>
+          <p className="font-semibold text-foreground">{view.decision}</p>
         </div>
         <div className="rounded border border-border/70 bg-background/70 p-2">
           <p className="text-muted-foreground">rule hit</p>
-          <p className="font-semibold text-foreground">{ruleHit}</p>
+          <p className="font-semibold text-foreground">{view.ruleHit}</p>
         </div>
         <div className="rounded border border-border/70 bg-background/70 p-2">
           <p className="text-muted-foreground">severity</p>
-          <p className="font-semibold text-foreground">{severity}</p>
+          <p className="font-semibold text-foreground">{view.severity}</p>
         </div>
         <div className="rounded border border-border/70 bg-background/70 p-2">
           <p className="text-muted-foreground">remediation hint</p>
-          <p className="font-semibold text-foreground">{remediationHint}</p>
+          <p className="font-semibold text-foreground">{view.remediationHint}</p>
+        </div>
+        <div className="rounded border border-border/70 bg-background/70 p-2">
+          <p className="text-muted-foreground">risky text fragment preview</p>
+          <p className="font-semibold text-foreground">{view.riskyFragmentPreview}</p>
         </div>
       </div>
     </section>

--- a/frontend/features/console/components/pipeline-visualizer.test.tsx
+++ b/frontend/features/console/components/pipeline-visualizer.test.tsx
@@ -18,13 +18,13 @@ describe("PipelineVisualizer", () => {
     render(<PipelineVisualizer loading={false} result={null} error={null} />);
 
     expect(screen.getByText("Pipeline Operations View")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /1\. Evidence/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /7\. TrustLog/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /1\. Input/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /8\. TrustLog/i })).toBeInTheDocument();
 
     const items = screen.getAllByRole("listitem");
-    expect(items).toHaveLength(7);
+    expect(items).toHaveLength(8);
 
-    fireEvent.click(screen.getByRole("button", { name: /2\. Critique/i }));
+    fireEvent.click(screen.getByRole("button", { name: /3\. Critique/i }));
     expect(screen.getByText("Critique details")).toBeInTheDocument();
     expect(screen.getByText("status: idle")).toBeInTheDocument();
   });

--- a/frontend/features/console/components/pipeline-visualizer.tsx
+++ b/frontend/features/console/components/pipeline-visualizer.tsx
@@ -1,64 +1,12 @@
 import { type DecideResponse } from "@veritas/types";
 import { useEffect, useMemo, useState } from "react";
+import { toPipelineStageViews } from "../adapters/decision-view";
 import { PIPELINE_STAGES } from "../constants";
-
-type StageState = "idle" | "running" | "complete" | "warning" | "failed";
 
 interface PipelineVisualizerProps {
   loading: boolean;
   result: DecideResponse | null;
   error: string | null;
-}
-
-interface StageCard {
-  name: (typeof PIPELINE_STAGES)[number];
-  status: StageState;
-  latencyMs: number | null;
-  summary: string;
-  rawDetail: Record<string, unknown>;
-}
-
-
-function extractStageCards(result: DecideResponse | null, error: string | null): StageCard[] {
-  const metrics = ((result?.extras?.stage_metrics ?? {}) as Record<string, unknown>);
-
-  return PIPELINE_STAGES.map((stage) => {
-    const key = stage.toLowerCase();
-    const row = (metrics[key] ?? metrics[stage] ?? {}) as Record<string, unknown>;
-    const latencyMs = typeof row.latency_ms === "number" ? row.latency_ms : null;
-    const health = typeof row.health === "string" ? row.health : "unknown";
-
-    let status: StageState = "idle";
-    if (result) {
-      status = "complete";
-    }
-    if (health === "warning") {
-      status = "warning";
-    }
-    if (health === "failed") {
-      status = "failed";
-    }
-
-    if (error && !result && stage === "Evidence") {
-      status = "failed";
-    }
-
-    const summary = typeof row.summary === "string"
-      ? row.summary
-      : status === "complete"
-        ? "Stage finished"
-        : status === "failed"
-          ? "Execution stopped"
-          : "Waiting";
-
-    return {
-      name: stage,
-      status,
-      latencyMs,
-      summary,
-      rawDetail: row,
-    };
-  });
 }
 
 /**
@@ -69,7 +17,10 @@ export function PipelineVisualizer({ loading, result, error }: PipelineVisualize
   const [activeIndex, setActiveIndex] = useState(0);
   const [selectedStage, setSelectedStage] = useState<(typeof PIPELINE_STAGES)[number]>(PIPELINE_STAGES[0]);
 
-  const cards = useMemo(() => extractStageCards(result, error), [result, error]);
+  const cards = useMemo(
+    () => toPipelineStageViews(result, loading, error, activeIndex),
+    [result, loading, error, activeIndex],
+  );
 
   useEffect(() => {
     if (!loading) {
@@ -93,7 +44,7 @@ export function PipelineVisualizer({ loading, result, error }: PipelineVisualize
           {loading ? "Live execution in progress" : "Latest execution snapshot"}
         </span>
       </div>
-      <ol className="grid gap-2 text-xs md:grid-cols-7">
+      <ol className="grid gap-2 text-xs md:grid-cols-8">
         {cards.map((card, index) => {
           const live = loading && activeIndex === index;
           const color = card.status === "failed"
@@ -123,16 +74,24 @@ export function PipelineVisualizer({ loading, result, error }: PipelineVisualize
           );
         })}
       </ol>
+      {loading && (
+        <div className="grid gap-2 md:grid-cols-3" aria-label="pipeline loading skeleton">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={`sk-${index}`} className="h-12 animate-pulse rounded-md border border-border bg-muted/30" />
+          ))}
+        </div>
+      )}
       {selected && (
         <div className="rounded-md border border-border bg-background/70 p-3 text-xs">
           <p className="font-semibold text-foreground">{selected.name} details</p>
           <p className="mt-1 text-muted-foreground">status: {selected.status}</p>
           <p className="text-muted-foreground">latency: {selected.latencyMs !== null ? `${selected.latencyMs.toFixed(0)} ms` : "n/a"}</p>
-          <p className="mt-2 text-foreground">{selected.summary}</p>
+          <p className="mt-2 text-foreground">summary: {selected.summary}</p>
+          <p className="mt-1 text-muted-foreground">detail: {selected.detail}</p>
           <details className="mt-2">
-            <summary className="cursor-pointer text-muted-foreground">raw detail</summary>
+            <summary className="cursor-pointer text-muted-foreground">raw JSON</summary>
             <pre className="mt-1 overflow-x-auto rounded-md border border-border bg-background/80 p-2 text-[11px] text-foreground">
-              {JSON.stringify(selected.rawDetail, null, 2)}
+              {JSON.stringify(selected.raw, null, 2)}
             </pre>
           </details>
         </div>

--- a/frontend/features/console/constants.ts
+++ b/frontend/features/console/constants.ts
@@ -1,4 +1,5 @@
 export const PIPELINE_STAGES = [
+  "Input",
   "Evidence",
   "Critique",
   "Debate",
@@ -7,6 +8,8 @@ export const PIPELINE_STAGES = [
   "FUJI",
   "TrustLog",
 ] as const;
+
+export type PipelineStageName = (typeof PIPELINE_STAGES)[number];
 
 export const DANGER_PRESETS = [
   {

--- a/frontend/features/console/types.ts
+++ b/frontend/features/console/types.ts
@@ -24,6 +24,13 @@ export interface CostBenefitAnalytics {
 
 export type PipelineStageStatus = "idle" | "running" | "complete" | "warning" | "failed";
 
+export interface PipelineStepView {
+  name: string;
+  summary: string;
+  status: "complete" | "idle";
+  detail: string;
+}
+
 export interface PipelineStageView {
   name: PipelineStageName;
   summary: string;

--- a/frontend/features/console/types.ts
+++ b/frontend/features/console/types.ts
@@ -1,3 +1,5 @@
+import { type PipelineStageName } from "./constants";
+
 export interface ChatMessage {
   id: number;
   role: "user" | "assistant";
@@ -20,11 +22,49 @@ export interface CostBenefitAnalytics {
   inferred: boolean;
 }
 
-export interface PipelineStepView {
-  name: string;
+export type PipelineStageStatus = "idle" | "running" | "complete" | "warning" | "failed";
+
+export interface PipelineStageView {
+  name: PipelineStageName;
   summary: string;
-  status: "complete" | "idle";
+  status: PipelineStageStatus;
   detail: string;
+  latencyMs: number | null;
+  raw: Record<string, unknown>;
+}
+
+export interface FujiGateView {
+  decision: string;
+  ruleHit: string;
+  severity: string;
+  remediationHint: string;
+  riskyFragmentPreview: string;
+}
+
+export interface DecisionChosenView {
+  finalDecision: string;
+  whyChosen: string;
+  supportingEvidenceSummary: string;
+  valueRationale: string;
+}
+
+export interface DecisionAlternativeView {
+  optionSummary: string;
+  tradeOff: string;
+  relativeWeakness: string;
+}
+
+export interface DecisionRejectedReasonsView {
+  fujiBlock: string;
+  weakEvidence: string;
+  poorDebateOutcome: string;
+  valueConflict: string;
+}
+
+export interface DecisionResultView {
+  chosen: DecisionChosenView;
+  alternatives: DecisionAlternativeView[];
+  rejectedReasons: DecisionRejectedReasonsView;
 }
 
 export interface GovernanceDriftAlert {


### PR DESCRIPTION
### Motivation
- Evolve the Decision Console from a chat-style input form into an operator-facing pipeline operations view that makes structured decision stages (Input → Evidence → Critique → Debate → Plan → Value → FUJI → TrustLog) explicit and auditable.
- Surface why a choice was made and why alternatives were rejected so operators can understand chosen outcome, evidence, values, and FUJI safety reasoning in a single screen.
- Provide a stable UI adapter layer so frontend components do not tightly couple to backend /v1/decide schema and to make future backend integration easier.
- Security note: exposing raw JSON and risky-text previews increases auditability but must be paired with PII/masking policies before production use to avoid information leakage.

### Description
- Added a view adapter `frontend/features/console/adapters/decision-view.ts` that normalizes `/v1/decide` payloads into UI models: stage views (`toPipelineStageViews`), FUJI view (`toFujiGateView`) and structured result view (`toDecisionResultView`).
- Introduced `Input` as the first pipeline stage and formalized stage name/type exports by updating `frontend/features/console/constants.ts` and adding `PipelineStageName` and new typed models in `frontend/features/console/types.ts`.
- Reworked pipeline visualizer to use the adapter, support 8 stages, active-stage progression, explicit `running/complete/warning/failed` lifecycle, loading skeleton and expandable raw JSON (`frontend/features/console/components/pipeline-visualizer.tsx`).
- Replaced the flat result card with a dedicated `DecisionResultPanel` (`frontend/features/console/components/decision-result-panel.tsx`) that renders the 3-part Result (Chosen / Alternatives / Rejected reasons) with final decision, why chosen, supporting evidence summary, value rationale, trade-offs and rejection reasons.
- Enhanced FUJI gate view by pulling richer fields (allow/modify/rejected, rule hit, severity, remediation hint, risky fragment preview) into `frontend/features/console/components/fuji-gate-status-panel.tsx` via the adapter.
- Updated the top-level console page `frontend/app/console/page.tsx` to wire the new components, improve empty-state guidance with example prompts, and preserve TrustLog / Replay links and `decision_id` exposures for operators.
- Tests and test expectations were updated where stage ordering and UI text changed (tests under `frontend/app/console/page.test.tsx` and `frontend/features/console/components/pipeline-visualizer.test.tsx`).

### Testing
- Ran unit tests: `pnpm --filter frontend test -- --run app/console/page.test.tsx features/console/components/pipeline-visualizer.test.tsx` and all targeted tests passed (7 tests total) — success.
- Started local dev server with `pnpm --filter frontend dev --port 3100` and performed an automated browser check that navigated to `/console` and saved a screenshot artifact (visual smoke check) — server started and page rendered.
- Note: Tests were adapted to reflect the new pipeline order (Input added) and the new Result structure; the test run reported green for the updated files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae67d372888326bdb2b354d2d2dfd1)