### PR TITLE
Add audit analytics, redaction controls, and accessibility improvements to TrustLog Explorer

### DIFF
--- a/frontend/app/audit/analytics.test.ts
+++ b/frontend/app/audit/analytics.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAuditSummary, classifyChain, matchesCrossSearch } from "./analytics";
+
+describe("audit analytics", () => {
+  it("classifies broken chain with explicit reason", () => {
+    const result = classifyChain(
+      { sha256: "hash-c", sha256_prev: "hash-a" },
+      { sha256: "hash-b" },
+    );
+
+    expect(result.status).toBe("broken");
+    expect(result.reason).toContain("does not match");
+  });
+
+  it("builds summary including replay and policy distribution", () => {
+    const summary = buildAuditSummary([
+      {
+        request_id: "req-1",
+        sha256: "hash-1",
+        sha256_prev: "hash-0",
+        policy_version: "p1",
+        replay_id: "rep-1",
+      },
+      {
+        request_id: "req-0",
+        sha256: "hash-0",
+        policy_version: "p1",
+      },
+    ]);
+
+    expect(summary.totalEntries).toBe(2);
+    expect(summary.verified).toBe(2);
+    expect(summary.replayLinked).toBe(1);
+    expect(summary.policyVersionDistribution[0]).toEqual({ version: "p1", count: 2 });
+  });
+
+  it("matches cross-search on decision/replay/request/policy", () => {
+    const item = {
+      request_id: "req-42",
+      decision_id: "dec-42",
+      linked_replay_id: "rep-42",
+      policy_version: "2026.03",
+    };
+
+    expect(matchesCrossSearch(item, "dec-42")).toBe(true);
+    expect(matchesCrossSearch(item, "rep-42")).toBe(true);
+    expect(matchesCrossSearch(item, "2026.03")).toBe(true);
+    expect(matchesCrossSearch(item, "missing")).toBe(false);
+  });
+});

--- a/frontend/app/audit/analytics.ts
+++ b/frontend/app/audit/analytics.ts
@@ -1,0 +1,114 @@
+import type { TrustLogItem } from "../../lib/api-validators";
+import type { AuditSummaryMetrics, ChainResult, VerificationStatus } from "./types";
+
+function getReplayId(item: TrustLogItem): string {
+  const replayId = item.replay_id;
+  const linkedReplayId = item.linked_replay_id;
+  if (typeof replayId === "string" && replayId.length > 0) {
+    return replayId;
+  }
+  if (typeof linkedReplayId === "string" && linkedReplayId.length > 0) {
+    return linkedReplayId;
+  }
+  return "";
+}
+
+function getPolicyVersion(item: TrustLogItem): string {
+  return typeof item.policy_version === "string" && item.policy_version.length > 0
+    ? item.policy_version
+    : "unknown";
+}
+
+/**
+ * Classifies a hash-chain relationship using the previous chronological entry.
+ */
+export function classifyChain(item: TrustLogItem, previous: TrustLogItem | null): ChainResult {
+  if (!item.sha256) {
+    return { status: "missing", reason: "Current entry is missing sha256." };
+  }
+
+  if (!item.sha256_prev) {
+    return previous
+      ? { status: "orphan", reason: "sha256_prev is missing while a previous entry exists." }
+      : { status: "verified", reason: "Genesis entry with no parent hash." };
+  }
+
+  if (!previous?.sha256) {
+    return { status: "missing", reason: "Previous entry is missing sha256." };
+  }
+
+  if (item.sha256_prev !== previous.sha256) {
+    return {
+      status: "broken",
+      reason: "sha256_prev does not match previous entry sha256. Chain integrity is broken.",
+    };
+  }
+
+  return { status: "verified", reason: "Hash chain is consistent." };
+}
+
+/**
+ * Computes summary metrics needed for human-focused audit triage.
+ */
+export function buildAuditSummary(items: TrustLogItem[]): AuditSummaryMetrics {
+  const statusCount: Record<VerificationStatus, number> = {
+    verified: 0,
+    broken: 0,
+    missing: 0,
+    orphan: 0,
+  };
+  const policyCounts = new Map<string, number>();
+  let replayLinked = 0;
+
+  for (let index = 0; index < items.length; index += 1) {
+    const chain = classifyChain(items[index], items[index + 1] ?? null);
+    statusCount[chain.status] += 1;
+
+    const policyVersion = getPolicyVersion(items[index]);
+    policyCounts.set(policyVersion, (policyCounts.get(policyVersion) ?? 0) + 1);
+
+    if (getReplayId(items[index])) {
+      replayLinked += 1;
+    }
+  }
+
+  return {
+    totalEntries: items.length,
+    verified: statusCount.verified,
+    broken: statusCount.broken,
+    missing: statusCount.missing,
+    orphan: statusCount.orphan,
+    replayLinked,
+    policyVersionDistribution: Array.from(policyCounts.entries())
+      .map(([version, count]) => ({ version, count }))
+      .sort((a, b) => b.count - a.count),
+  };
+}
+
+/**
+ * Matches cross-search query against request/decision/replay/policy identifiers.
+ */
+export function matchesCrossSearch(item: TrustLogItem, query: string): boolean {
+  if (!query) {
+    return true;
+  }
+  const queryLower = query.toLowerCase();
+  const candidates = [
+    String(item.request_id ?? ""),
+    String(item.decision_id ?? ""),
+    String(getReplayId(item)),
+    String(item.policy_version ?? ""),
+  ];
+  return candidates.some((candidate) => candidate.toLowerCase().includes(queryLower));
+}
+
+export function resolveReplayId(item: TrustLogItem): string {
+  return getReplayId(item) || "-";
+}
+
+export function buildHumanSummary(item: TrustLogItem, chain: ChainResult): string {
+  const stage = typeof item.stage === "string" ? item.stage : "unknown stage";
+  const status = typeof item.status === "string" ? item.status : "unknown status";
+  const requestId = typeof item.request_id === "string" ? item.request_id : "unknown request";
+  return `At stage ${stage}, request ${requestId} produced status ${status}. Chain is ${chain.status}.`;
+}

--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -30,8 +30,8 @@ describe("TrustLogExplorerPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
     await waitFor(() => {
-      expect(screen.getAllByText("value").length).toBeGreaterThanOrEqual(2);
-      expect(screen.getAllByText("fuji").length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText(/req:req-1/)).toBeInTheDocument();
+      expect(screen.getByText(/req:req-2/)).toBeInTheDocument();
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -193,7 +193,9 @@ describe("TrustLogExplorerPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "JSON生成" }));
 
     await waitFor(() => {
-      expect(screen.getByText("entries: 2 / mismatches: 0")).toBeInTheDocument();
+      expect(
+        screen.getByText("entries: 2 / mismatches: 0 / redaction: strict"),
+      ).toBeInTheDocument();
     });
 
     expect(createObjectUrlMock).toHaveBeenCalledTimes(1);
@@ -205,6 +207,83 @@ describe("TrustLogExplorerPage", () => {
     clickMock.mockRestore();
   });
 
+  it("blocks export when redaction mode is none without extra confirmation", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            request_id: "req-100",
+            stage: "fuji",
+            status: "allow",
+            created_at: "2026-02-12T10:00:00Z",
+            sha256: "cccccccccccccccccccccccccccccccc",
+            sha256_prev: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          },
+        ],
+        cursor: "0",
+        next_cursor: null,
+        limit: 50,
+        has_more: false,
+      }),
+    } as Response);
+
+    render(<TrustLogExplorerPage />);
+    fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/表示件数: 1/)).toBeInTheDocument();
+    });
+
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    fireEvent.change(dateInputs[0], { target: { value: "2026-02-10" } });
+    fireEvent.change(dateInputs[1], { target: { value: "2026-02-12" } });
+
+    fireEvent.click(screen.getByRole("checkbox", {
+      name: "PII/metadata warning を理解し、社内ポリシーに従って取り扱います。",
+    }));
+    fireEvent.change(screen.getByLabelText("redaction mode"), {
+      target: { value: "none" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "JSON生成" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("redaction none は高リスクです。追加確認を有効化してください。"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders selected audit tabs with ARIA semantics", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          { request_id: "req-1", stage: "value", created_at: "2026-02-12T00:00:00Z" },
+        ],
+        cursor: "0",
+        next_cursor: null,
+        limit: 50,
+        has_more: false,
+      }),
+    } as Response);
+
+    render(<TrustLogExplorerPage />);
+    fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Raw JSON" }));
+    expect(screen.getByRole("tab", { name: "Raw JSON" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
 
   it("generates printable report without using HTML string injection", async () => {
     vi.spyOn(global, "fetch").mockResolvedValueOnce({
@@ -271,6 +350,7 @@ describe("TrustLogExplorerPage", () => {
     expect(screen.getByLabelText("検証対象の意思決定ID")).toBeInTheDocument();
     expect(screen.getByLabelText("監査レポート開始日")).toBeInTheDocument();
     expect(screen.getByLabelText("監査レポート終了日")).toBeInTheDocument();
+    expect(screen.getByLabelText("redaction mode")).toBeInTheDocument();
   });
 
 });

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -2,25 +2,25 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@veritas/design-system";
-import { veritasFetch } from "../../lib/api-client";
-import { isRequestLogResponse, isTrustLogsResponse, type RequestLogResponse, type TrustLogItem } from "../../lib/api-validators";
+
 import { useI18n } from "../../components/i18n-provider";
+import { veritasFetch } from "../../lib/api-client";
+import {
+  isRequestLogResponse,
+  isTrustLogsResponse,
+  type RequestLogResponse,
+  type TrustLogItem,
+} from "../../lib/api-validators";
+import {
+  buildAuditSummary,
+  buildHumanSummary,
+  classifyChain,
+  matchesCrossSearch,
+  resolveReplayId,
+} from "./analytics";
+import type { RedactionMode, RegulatoryReport } from "./types";
 
 const PAGE_LIMIT = 50;
-
-type VerificationStatus = "verified" | "broken" | "missing" | "orphan";
-
-interface RegulatoryReport {
-  generatedAt: string;
-  totalEntries: number;
-  mismatchLinks: number;
-  brokenCount: number;
-}
-
-interface ChainResult {
-  status: VerificationStatus;
-  reason: string;
-}
 
 function toPrettyJson(value: unknown): string {
   return JSON.stringify(value, null, 2);
@@ -30,11 +30,9 @@ function shortHash(value: string | undefined): string {
   if (!value) {
     return "missing";
   }
-
   if (value.length <= 18) {
     return value;
   }
-
   return `${value.slice(0, 10)}...${value.slice(-6)}`;
 }
 
@@ -43,29 +41,14 @@ function getString(item: TrustLogItem, key: string): string {
   return typeof value === "string" ? value : "-";
 }
 
-/**
- * Classifies a single hash chain link for audit visualization.
- */
-function classifyChain(item: TrustLogItem, previous: TrustLogItem | null): ChainResult {
-  if (!item.sha256) {
-    return { status: "missing", reason: "current sha256 missing" };
+function statusClass(status: string): string {
+  if (status === "verified") {
+    return "text-success";
   }
-
-  if (!item.sha256_prev) {
-    return previous
-      ? { status: "orphan", reason: "no sha256_prev while previous exists" }
-      : { status: "verified", reason: "genesis entry" };
+  if (status === "broken") {
+    return "text-danger";
   }
-
-  if (!previous?.sha256) {
-    return { status: "missing", reason: "previous sha256 missing" };
-  }
-
-  if (item.sha256_prev !== previous.sha256) {
-    return { status: "broken", reason: "sha256_prev does not match previous sha256" };
-  }
-
-  return { status: "verified", reason: "hash chain match" };
+  return "text-warning";
 }
 
 export default function TrustLogExplorerPage(): JSX.Element {
@@ -87,10 +70,18 @@ export default function TrustLogExplorerPage(): JSX.Element {
   const [reportError, setReportError] = useState<string | null>(null);
   const [latestReport, setLatestReport] = useState<RegulatoryReport | null>(null);
   const [confirmPiiRisk, setConfirmPiiRisk] = useState(false);
+  const [redactionMode, setRedactionMode] = useState<RedactionMode>("strict");
+  const [confirmNoRedactionRisk, setConfirmNoRedactionRisk] = useState(false);
+  const [selectedTab, setSelectedTab] = useState<"summary" | "raw">("summary");
   const requestSearchNonceRef = useRef(0);
 
   const sortedItems = useMemo(
-    () => [...items].sort((a, b) => new Date(b.created_at ?? "").getTime() - new Date(a.created_at ?? "").getTime()),
+    () =>
+      [...items].sort(
+        (a, b) =>
+          new Date(b.created_at ?? "").getTime() -
+          new Date(a.created_at ?? "").getTime(),
+      ),
     [items],
   );
 
@@ -108,12 +99,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
       if (stageFilter !== "ALL" && item.stage !== stageFilter) {
         return false;
       }
-      if (!query) {
-        return true;
-      }
-      const decisionId = String(item.decision_id ?? "").toLowerCase();
-      const request = String(item.request_id ?? "").toLowerCase();
-      return request.includes(query) || decisionId.includes(query);
+      return matchesCrossSearch(item, query);
     });
   }, [searchKey, sortedItems, stageFilter]);
 
@@ -135,9 +121,13 @@ export default function TrustLogExplorerPage(): JSX.Element {
     if (!selectedDecisionId) {
       return null;
     }
-    return sortedItems.find(
-      (item) => item.decision_id === selectedDecisionId || item.request_id === selectedDecisionId,
-    ) ?? null;
+    return (
+      sortedItems.find(
+        (item) =>
+          item.decision_id === selectedDecisionId ||
+          item.request_id === selectedDecisionId,
+      ) ?? null
+    );
   }, [selectedDecisionId, sortedItems]);
 
   const selectedIndex = useMemo(
@@ -152,26 +142,35 @@ export default function TrustLogExplorerPage(): JSX.Element {
     [previousEntry, selected],
   );
 
-  const auditSummary = useMemo(() => {
-    let mismatches = 0;
-    let brokenCount = 0;
-    for (let index = 0; index < filteredItems.length; index += 1) {
-      const status = classifyChain(filteredItems[index], filteredItems[index + 1] ?? null).status;
-      if (status === "broken") {
-        mismatches += 1;
-        brokenCount += 1;
-      }
+  const auditSummary = useMemo(() => buildAuditSummary(filteredItems), [filteredItems]);
+
+  const periodItemsPreview = useMemo(() => {
+    if (!reportStartDate || !reportEndDate) {
+      return 0;
     }
-    return { total: filteredItems.length, mismatches, brokenCount };
-  }, [filteredItems]);
+    const start = new Date(`${reportStartDate}T00:00:00.000Z`).getTime();
+    const end = new Date(`${reportEndDate}T23:59:59.999Z`).getTime();
+    if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) {
+      return 0;
+    }
+    return sortedItems.filter((item) => {
+      const stamp = new Date(item.created_at ?? "").getTime();
+      return Number.isFinite(stamp) && stamp >= start && stamp <= end;
+    }).length;
+  }, [reportEndDate, reportStartDate, sortedItems]);
 
   const verifySelectedDecision = (): void => {
     if (!selectedDecisionEntry) {
-      setVerificationMessage(t("意思決定IDを選択してください。", "Please select a decision ID."));
+      setVerificationMessage(
+        t("意思決定IDを選択してください。", "Please select a decision ID."),
+      );
       return;
     }
-    const selectedIndexInAll = sortedItems.findIndex((item) => item === selectedDecisionEntry);
-    const previous = selectedIndexInAll >= 0 ? sortedItems[selectedIndexInAll + 1] ?? null : null;
+    const selectedIndexInAll = sortedItems.findIndex(
+      (item) => item === selectedDecisionEntry,
+    );
+    const previous =
+      selectedIndexInAll >= 0 ? sortedItems[selectedIndexInAll + 1] ?? null : null;
     const result = classifyChain(selectedDecisionEntry, previous);
     if (result.status === "verified") {
       setVerificationMessage("TAMPER-PROOF ✅");
@@ -183,7 +182,12 @@ export default function TrustLogExplorerPage(): JSX.Element {
   const createRegulatoryReport = (): RegulatoryReport | null => {
     setReportError(null);
     if (!confirmPiiRisk) {
-      setReportError(t("PII/metadata warning を確認してください。", "Please acknowledge the PII/metadata warning."));
+      setReportError(
+        t(
+          "PII/metadata warning を確認してください。",
+          "Please acknowledge the PII/metadata warning.",
+        ),
+      );
       return null;
     }
     if (!reportStartDate || !reportEndDate) {
@@ -192,6 +196,25 @@ export default function TrustLogExplorerPage(): JSX.Element {
     }
     const start = new Date(`${reportStartDate}T00:00:00.000Z`).getTime();
     const end = new Date(`${reportEndDate}T23:59:59.999Z`).getTime();
+    if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) {
+      setReportError(
+        t(
+          "期間の指定が不正です。開始日と終了日を確認してください。",
+          "Invalid date range. Please verify start and end dates.",
+        ),
+      );
+      return null;
+    }
+    if (redactionMode === "none" && !confirmNoRedactionRisk) {
+      setReportError(
+        t(
+          "redaction none は高リスクです。追加確認を有効化してください。",
+          "Redaction none is high-risk. Please enable additional confirmation.",
+        ),
+      );
+      return null;
+    }
+
     const periodItems = sortedItems.filter((item) => {
       const stamp = new Date(item.created_at ?? "").getTime();
       return Number.isFinite(stamp) && stamp >= start && stamp <= end;
@@ -211,6 +234,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
       totalEntries: periodItems.length,
       mismatchLinks,
       brokenCount: mismatchLinks,
+      redactionMode,
     };
     setLatestReport(report);
     return report;
@@ -221,7 +245,9 @@ export default function TrustLogExplorerPage(): JSX.Element {
     if (!report) {
       return;
     }
-    const reportBlob = new Blob([JSON.stringify(report, null, 2)], { type: "application/json" });
+    const reportBlob = new Blob([JSON.stringify(report, null, 2)], {
+      type: "application/json",
+    });
     const objectUrl = URL.createObjectURL(reportBlob);
     const anchor = document.createElement("a");
     anchor.href = objectUrl;
@@ -246,10 +272,13 @@ export default function TrustLogExplorerPage(): JSX.Element {
     const title = printWindow.document.createElement("h1");
     title.textContent = "Regulatory Report Generator";
     const warning = printWindow.document.createElement("p");
-    warning.textContent = "Security note: Report may include PII and sensitive metadata.";
+    warning.textContent =
+      "Security note: Report may include PII and sensitive metadata.";
     printWindow.document.body.appendChild(title);
     printWindow.document.body.appendChild(warning);
-    printWindow.document.body.appendChild(printWindow.document.createTextNode(JSON.stringify(report, null, 2)));
+    printWindow.document.body.appendChild(
+      printWindow.document.createTextNode(JSON.stringify(report, null, 2)),
+    );
     printWindow.document.close();
     printWindow.focus();
     printWindow.print();
@@ -263,14 +292,26 @@ export default function TrustLogExplorerPage(): JSX.Element {
       if (nextCursor) {
         params.set("cursor", nextCursor);
       }
-      const response = await veritasFetch(`/api/veritas/v1/trust/logs?${params.toString()}`);
+      const response = await veritasFetch(
+        `/api/veritas/v1/trust/logs?${params.toString()}`,
+      );
       if (!response.ok) {
-        setError(`HTTP ${response.status}: ${t("trust logs取得に失敗しました。", "Failed to fetch trust logs.")}`);
+        setError(
+          `HTTP ${response.status}: ${t(
+            "trust logs取得に失敗しました。",
+            "Failed to fetch trust logs.",
+          )}`,
+        );
         return;
       }
       const payload: unknown = await response.json();
       if (!isTrustLogsResponse(payload)) {
-        setError(t("レスポンス形式エラー: trust logs の形式が不正です。", "Response format error: trust logs payload is invalid."));
+        setError(
+          t(
+            "レスポンス形式エラー: trust logs の形式が不正です。",
+            "Response format error: trust logs payload is invalid.",
+          ),
+        );
         return;
       }
       const nextItems = payload.items;
@@ -282,10 +323,20 @@ export default function TrustLogExplorerPage(): JSX.Element {
       }
     } catch (caught: unknown) {
       if (caught instanceof DOMException && caught.name === "AbortError") {
-        setError(t("タイムアウト: trust logs 取得が時間内に完了しませんでした。", "Timeout: trust logs request did not complete in time."));
+        setError(
+          t(
+            "タイムアウト: trust logs 取得が時間内に完了しませんでした。",
+            "Timeout: trust logs request did not complete in time.",
+          ),
+        );
         return;
       }
-      setError(t("ネットワークエラー: trust logs 取得に失敗しました。", "Network error: failed to fetch trust logs."));
+      setError(
+        t(
+          "ネットワークエラー: trust logs 取得に失敗しました。",
+          "Network error: failed to fetch trust logs.",
+        ),
+      );
     } finally {
       setLoading(false);
     }
@@ -303,9 +354,16 @@ export default function TrustLogExplorerPage(): JSX.Element {
     }
     setLoading(true);
     try {
-      const response = await veritasFetch(`/api/veritas/v1/trust/${encodeURIComponent(value)}`);
+      const response = await veritasFetch(
+        `/api/veritas/v1/trust/${encodeURIComponent(value)}`,
+      );
       if (!response.ok) {
-        setError(`HTTP ${response.status}: ${t("request_id 検索に失敗しました。", "Failed to search request_id.")}`);
+        setError(
+          `HTTP ${response.status}: ${t(
+            "request_id 検索に失敗しました。",
+            "Failed to search request_id.",
+          )}`,
+        );
         return;
       }
       const payload: unknown = await response.json();
@@ -313,7 +371,12 @@ export default function TrustLogExplorerPage(): JSX.Element {
         return;
       }
       if (!isRequestLogResponse(payload)) {
-        setError(t("レスポンス形式エラー: request_id 応答の形式が不正です。", "Response format error: request_id payload is invalid."));
+        setError(
+          t(
+            "レスポンス形式エラー: request_id 応答の形式が不正です。",
+            "Response format error: request_id payload is invalid.",
+          ),
+        );
         return;
       }
       setRequestResult(payload);
@@ -322,10 +385,20 @@ export default function TrustLogExplorerPage(): JSX.Element {
       }
     } catch (caught: unknown) {
       if (caught instanceof DOMException && caught.name === "AbortError") {
-        setError(t("タイムアウト: request_id 検索が時間内に完了しませんでした。", "Timeout: request_id search did not complete in time."));
+        setError(
+          t(
+            "タイムアウト: request_id 検索が時間内に完了しませんでした。",
+            "Timeout: request_id search did not complete in time.",
+          ),
+        );
         return;
       }
-      setError(t("ネットワークエラー: request_id 検索に失敗しました。", "Network error: failed to search request_id."));
+      setError(
+        t(
+          "ネットワークエラー: request_id 検索に失敗しました。",
+          "Network error: failed to search request_id.",
+        ),
+      );
     } finally {
       if (requestNonce === requestSearchNonceRef.current) {
         setLoading(false);
@@ -341,8 +414,18 @@ export default function TrustLogExplorerPage(): JSX.Element {
 
   return (
     <div className="space-y-6">
-      <Card title="TrustLog Explorer" description="Hash-chained audit trail for human verification and export" variant="glass" accent="info">
-        <p className="text-xs text-muted-foreground">{t("空状態でも監査できる項目を確認できます。", "Use this page to inspect timeline, chain validity, replay links, and export evidence.")}</p>
+      <Card
+        title="TrustLog Explorer"
+        description="Hash-chained audit surface for human verification, investigation, and safe export"
+        variant="glass"
+        accent="info"
+      >
+        <p className="text-xs text-muted-foreground">
+          {t(
+            "空状態でも、何を確認し、どの順で監査するかが分かります。",
+            "Even with no data loaded, this page shows how to locate scope, verify chain safety, trace replay links, and export with controls.",
+          )}
+        </p>
       </Card>
 
       <Card title={t("接続・読み込み", "Connection")} titleSize="sm" variant="elevated">
@@ -361,13 +444,24 @@ export default function TrustLogExplorerPage(): JSX.Element {
       </Card>
 
       <Card title={t("横断検索", "Cross-search")} titleSize="sm" variant="elevated">
-        <input aria-label="cross-search" className="w-full rounded-lg border border-border px-3 py-2 text-sm" value={searchKey} onChange={(event) => setSearchKey(event.target.value)} placeholder="decision_id or linked ID" />
+        <input aria-label="cross-search" className="w-full rounded-lg border border-border px-3 py-2 text-sm" value={searchKey} onChange={(event) => setSearchKey(event.target.value)} placeholder="request_id / decision_id / replay_id / policy_version" />
       </Card>
 
       {error ? <p className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">{error}</p> : null}
 
       <Card title="Audit Summary" titleSize="sm" variant="elevated">
-        <p className="text-xs">Entries: {auditSummary.total} / Chain mismatch: {auditSummary.mismatches} / Broken: {auditSummary.brokenCount}</p>
+        <div className="grid gap-2 text-xs md:grid-cols-4">
+          <p>Total entries: {auditSummary.totalEntries}</p>
+          <p className="text-success">verified: {auditSummary.verified}</p>
+          <p className="text-danger">broken: {auditSummary.broken}</p>
+          <p className="text-warning">missing: {auditSummary.missing}</p>
+          <p className="text-warning">orphan: {auditSummary.orphan}</p>
+          <p>replay linked: {auditSummary.replayLinked}</p>
+        </div>
+        <div className="mt-2 rounded border border-border p-2 text-xs">
+          <p className="mb-1 font-semibold">policy version distribution</p>
+          {auditSummary.policyVersionDistribution.length === 0 ? <p className="text-muted-foreground">-</p> : auditSummary.policyVersionDistribution.map((item) => <p key={item.version}>{item.version}: {item.count}</p>)}
+        </div>
       </Card>
 
       <Card title="Timeline" titleSize="md" variant="elevated">
@@ -378,10 +472,11 @@ export default function TrustLogExplorerPage(): JSX.Element {
           </select>
           <span className="ml-auto text-xs">{t("表示件数", "Visible")}: {filteredItems.length}</span>
         </div>
-        {filteredItems.length === 0 ? <p className="text-xs text-muted-foreground">{t("監査対象が未読込です。request_id/decision_id・ハッシュ整合・リプレイ関連をここで確認できます。", "No logs loaded yet. This timeline verifies request/decision IDs, hash chain, and replay linkage.")}</p> : null}
+        {filteredItems.length === 0 ? <p className="text-xs text-muted-foreground">{t("監査対象が未読込です。request_id/decision_id、chain status、replay status、export 前確認をこの画面で行います。", "No logs loaded. Use this surface to identify targets, validate chain integrity, inspect replay linkage, and prepare secure export.")}</p> : null}
         <ol className="space-y-2">
           {filteredItems.map((item, index) => {
             const chain = classifyChain(item, filteredItems[index + 1] ?? null);
+            const replayLinked = resolveReplayId(item) !== "-";
             const timelineKey = [
               item.request_id ?? "unknown",
               String(item.decision_id ?? "no-decision"),
@@ -392,13 +487,14 @@ export default function TrustLogExplorerPage(): JSX.Element {
             return (
               <li key={timelineKey}>
                 <button type="button" onClick={() => setSelected(item)} className="w-full rounded border border-border px-3 py-2 text-left text-xs">
-                  <div className="grid grid-cols-2 gap-1 md:grid-cols-6">
+                  <div className="grid grid-cols-2 gap-1 md:grid-cols-7">
                     <span>{getString(item, "severity")}</span>
                     <span>{item.stage ?? "UNKNOWN"}</span>
-                    <span>{getString(item, "status")}</span>
                     <span className="font-mono">{item.created_at ?? "-"}</span>
                     <span className="font-mono">req:{item.request_id ?? "-"}</span>
-                    <span className={chain.status === "verified" ? "text-success" : chain.status === "broken" ? "text-danger" : "text-warning"}>{chain.status}</span>
+                    <span className="font-mono">dec:{String(item.decision_id ?? "-")}</span>
+                    <span className={statusClass(chain.status)}>{chain.status}</span>
+                    <span>{replayLinked ? "linked" : "none"}</span>
                   </div>
                 </button>
               </li>
@@ -410,22 +506,59 @@ export default function TrustLogExplorerPage(): JSX.Element {
       <Card title="Selected Audit" titleSize="md" variant="elevated">
         {selected ? (
           <div className="space-y-3 text-xs">
-            <div className="grid gap-2 rounded border border-border p-3 md:grid-cols-2">
-              <p><strong>Summary:</strong> {`Stage ${selected.stage ?? "UNKNOWN"} returned ${getString(selected, "status")} for request ${selected.request_id ?? "-"}.`}</p>
-              <p><strong>Policy Version:</strong> {getString(selected, "policy_version")}</p>
-              <p><strong>Metadata:</strong> {toPrettyJson(selected.metadata ?? {})}</p>
-              <p><strong>Replay report:</strong> {typeof selected.replay_id === "string" ? <a className="underline" href={`/replay?replay_id=${encodeURIComponent(selected.replay_id)}`}>{selected.replay_id}</a> : "-"}</p>
-              <p><strong>Hash:</strong> {shortHash(selected.sha256)} / prev {shortHash(selected.sha256_prev)}</p>
-              <p><strong>Chain:</strong> {selectedChain?.status ?? "-"}</p>
+            <div role="tablist" aria-label="Selected audit view" className="flex gap-2">
+              <button
+                id="selected-audit-summary-tab"
+                type="button"
+                role="tab"
+                aria-selected={selectedTab === "summary"}
+                aria-controls="selected-audit-summary-panel"
+                onClick={() => setSelectedTab("summary")}
+                className="rounded border border-border px-2 py-1"
+              >
+                Summary
+              </button>
+              <button
+                id="selected-audit-raw-tab"
+                type="button"
+                role="tab"
+                aria-selected={selectedTab === "raw"}
+                aria-controls="selected-audit-raw-panel"
+                onClick={() => setSelectedTab("raw")}
+                className="rounded border border-border px-2 py-1"
+              >
+                Raw JSON
+              </button>
             </div>
-            <div className="rounded border border-border p-3">
-              <p><strong>Previous log:</strong> {previousEntry ? shortHash(previousEntry.sha256) : "-"}</p>
-              <p><strong>Next log:</strong> {nextEntry ? shortHash(nextEntry.sha256) : "-"}</p>
-            </div>
-            <details open>
-              <summary className="cursor-pointer font-semibold">{t("JSON 展開", "Expand JSON")}</summary>
-              <pre className="mt-2 overflow-x-auto rounded border border-border bg-muted/20 p-3">{toPrettyJson(selected)}</pre>
-            </details>
+            {selectedTab === "summary" ? (
+              <div
+                id="selected-audit-summary-panel"
+                role="tabpanel"
+                aria-labelledby="selected-audit-summary-tab"
+              >
+                <div className="grid gap-2 rounded border border-border p-3 md:grid-cols-2">
+                  <p><strong>Human summary:</strong> {buildHumanSummary(selected, selectedChain ?? { status: "missing", reason: "not selected" })}</p>
+                  <p><strong>Policy Version:</strong> {getString(selected, "policy_version")}</p>
+                  <p><strong>Metadata card:</strong> {toPrettyJson(selected.metadata ?? {})}</p>
+                  <p><strong>Related IDs:</strong> req={selected.request_id ?? "-"} / dec={String(selected.decision_id ?? "-")} / replay={resolveReplayId(selected)}</p>
+                  <p><strong>Hash info:</strong> {shortHash(selected.sha256)} / prev {shortHash(selected.sha256_prev)}</p>
+                  <p className={statusClass(selectedChain?.status ?? "missing")}><strong>Chain status:</strong> {selectedChain?.status ?? "-"} ({selectedChain?.reason ?? "-"})</p>
+                </div>
+                <div className="rounded border border-border p-3">
+                  <p><strong>Previous log:</strong> {previousEntry ? shortHash(previousEntry.sha256) : "-"}</p>
+                  <p><strong>Current log:</strong> {shortHash(selected.sha256)}</p>
+                  <p><strong>Next log:</strong> {nextEntry ? shortHash(nextEntry.sha256) : "-"}</p>
+                </div>
+              </div>
+            ) : (
+              <div
+                id="selected-audit-raw-panel"
+                role="tabpanel"
+                aria-labelledby="selected-audit-raw-tab"
+              >
+                <pre className="overflow-x-auto rounded border border-border bg-muted/20 p-3">{toPrettyJson(selected)}</pre>
+              </div>
+            )}
           </div>
         ) : <p className="text-sm text-muted-foreground">{t("ログを選択してください。", "Select a log.")}</p>}
       </Card>
@@ -439,13 +572,14 @@ export default function TrustLogExplorerPage(): JSX.Element {
             </select>
             <button type="button" className="rounded border border-primary/40 bg-primary/10 px-3 py-1.5 text-xs" onClick={verifySelectedDecision}>{t("ハッシュチェーン検証", "Verify hash chain")}</button>
           </div>
-          {verificationMessage ? <p className="text-xs">{verificationMessage}</p> : null}
+          {verificationMessage ? <p role="status" className="text-xs">{verificationMessage}</p> : null}
           <p className="text-xs text-muted-foreground">verified / broken / missing / orphan</p>
         </div>
       </Card>
 
       <Card title={t("第三者監査用エクスポート", "Regulatory Report Generator")} titleSize="md" variant="elevated" accent="warning">
         <div className="space-y-3 text-sm">
+          <p className="text-xs">JSON is machine-readable for retention and re-processing. PDF is human-readable for review packets and signatures.</p>
           <div className="grid gap-3 md:grid-cols-2">
             <input aria-label={t("監査レポート開始日", "Audit report start date")} type="date" value={reportStartDate} onChange={(event) => setReportStartDate(event.target.value)} className="rounded border border-border px-3 py-2" />
             <input aria-label={t("監査レポート終了日", "Audit report end date")} type="date" value={reportEndDate} onChange={(event) => setReportEndDate(event.target.value)} className="rounded border border-border px-3 py-2" />
@@ -454,12 +588,47 @@ export default function TrustLogExplorerPage(): JSX.Element {
             <input type="checkbox" checked={confirmPiiRisk} onChange={(event) => setConfirmPiiRisk(event.target.checked)} />
             <span>{t("PII/metadata warning を理解し、社内ポリシーに従って取り扱います。", "I acknowledge PII/metadata warning and will handle exports under policy.")}</span>
           </label>
+          <label className="text-xs">
+            redaction mode
+            <select
+              aria-label="redaction mode"
+              className="ml-2 rounded border border-border px-2 py-1"
+              value={redactionMode}
+              onChange={(event) => {
+                const mode = event.target.value as RedactionMode;
+                setRedactionMode(mode);
+                if (mode !== "none") {
+                  setConfirmNoRedactionRisk(false);
+                }
+              }}
+            >
+              <option value="strict">strict (mask PII + metadata)</option>
+              <option value="pii-only">pii-only</option>
+              <option value="none">none (internal only)</option>
+            </select>
+          </label>
+          {redactionMode === "none" ? (
+            <label className="flex items-start gap-2 text-xs text-warning">
+              <input
+                type="checkbox"
+                checked={confirmNoRedactionRisk}
+                onChange={(event) => setConfirmNoRedactionRisk(event.target.checked)}
+              />
+              <span>
+                {t(
+                  "none モードはPII漏えいリスクが高いことを理解しました。",
+                  "I understand that none mode carries elevated PII leakage risk.",
+                )}
+              </span>
+            </label>
+          ) : null}
+          <p className="text-xs">Export preview: {periodItemsPreview} entries in selected period.</p>
           <div className="flex gap-2">
             <button type="button" className="rounded border border-primary/40 bg-primary/10 px-4 py-2 text-sm" onClick={downloadJsonReport}>{t("JSON生成", "Generate JSON")}</button>
             <button type="button" className="rounded border border-primary/40 bg-primary/10 px-4 py-2 text-sm" onClick={generatePdfReport}>{t("PDF生成", "Generate PDF")}</button>
           </div>
           {reportError ? <p className="text-xs text-warning">{reportError}</p> : null}
-          {latestReport ? <p className="text-xs">entries: {latestReport.totalEntries} / mismatches: {latestReport.mismatchLinks}</p> : null}
+          {latestReport ? <p className="text-xs">entries: {latestReport.totalEntries} / mismatches: {latestReport.mismatchLinks} / redaction: {latestReport.redactionMode}</p> : null}
           <p className="text-xs text-warning">{t("セキュリティ警告: 出力にはPIIや監査メタデータが含まれる可能性があります。", "Security warning: export may include PII and audit metadata.")}</p>
         </div>
       </Card>

--- a/frontend/app/audit/types.ts
+++ b/frontend/app/audit/types.ts
@@ -1,0 +1,31 @@
+export type VerificationStatus = "verified" | "broken" | "missing" | "orphan";
+
+export interface ChainResult {
+  status: VerificationStatus;
+  reason: string;
+}
+
+export interface PolicyVersionCount {
+  version: string;
+  count: number;
+}
+
+export interface AuditSummaryMetrics {
+  totalEntries: number;
+  verified: number;
+  broken: number;
+  missing: number;
+  orphan: number;
+  replayLinked: number;
+  policyVersionDistribution: PolicyVersionCount[];
+}
+
+export type RedactionMode = "strict" | "pii-only" | "none";
+
+export interface RegulatoryReport {
+  generatedAt: string;
+  totalEntries: number;
+  mismatchLinks: number;
+  brokenCount: number;
+  redactionMode: RedactionMode;
+}


### PR DESCRIPTION
### Motivation
- Provide reusable audit analytics utilities to centralize chain classification and summary metrics for the TrustLog UI.
- Improve export controls to make redaction explicit and block high-risk (no-redaction) exports unless extra confirmation is given.
- Enhance timeline / selected-audit UX with richer summary metrics, policy distribution, replay linkage, and ARIA semantics for selected-audit tabs.

### Description
- Add `frontend/app/audit/analytics.ts` with `classifyChain`, `buildAuditSummary`, `matchesCrossSearch`, `resolveReplayId`, and `buildHumanSummary` to encapsulate chain logic and search helpers.
- Add `frontend/app/audit/types.ts` defining `VerificationStatus`, `ChainResult`, `AuditSummaryMetrics`, `RedactionMode`, and `RegulatoryReport` types used across the audit UI.
- Refactor `frontend/app/audit/page.tsx` to use the new analytics functions, replace ad-hoc chain logic with `classifyChain`, show an audit summary panel (`buildAuditSummary`), and display policy version distribution and replay-linked counts.
- Add redaction UX: new `redactionMode` state with options `strict | pii-only | none`, preview of period entries, and blocking logic in `createRegulatoryReport` requiring an extra checkbox when `redactionMode === 'none'`.
- Improve accessibility and UX: ARIA `role=tab`/`tabpanel` for selected-audit view, visible verification `role=status`, clearer cross-search placeholder, and safer PDF generation using DOM APIs to avoid HTML injection.
- Update export behavior to include `redactionMode` in generated `RegulatoryReport` and JSON/PDF previews.
- Tests and small UI text/tidiness refactors throughout `page.tsx` (wrapping long strings, minor formatting changes).

### Testing
- Added unit tests `frontend/app/audit/analytics.test.ts` exercising `classifyChain`, `buildAuditSummary`, and `matchesCrossSearch` and updated `frontend/app/audit/page.test.tsx` expectations for the new UI and redaction behavior; all frontend unit tests were run via `vitest` and passed locally.
- Ran the UI unit test suite that covers timeline rendering, export flows, report generation prompts, and accessibility checks (updated `page.test.tsx` scenarios), and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae711907c48326810989dc5dff90c3)