### PR TITLE
feat(audit): evolve TrustLog Explorer into full audit interface

### DIFF
--- a/frontend/app/audit/audit-types.ts
+++ b/frontend/app/audit/audit-types.ts
@@ -1,0 +1,195 @@
+/**
+ * Audit-specific type definitions for the TrustLog Explorer.
+ *
+ * Separates audit / UI concerns from the raw API shapes defined in
+ * `lib/api-validators.ts` and `@veritas/types`.
+ *
+ * Future API integration points are marked with `@api-hook` comments.
+ */
+
+import type { TrustLogItem } from "../../lib/api-validators";
+
+/* ------------------------------------------------------------------ */
+/*  Chain verification                                                 */
+/* ------------------------------------------------------------------ */
+
+export type VerificationStatus = "verified" | "broken" | "missing" | "orphan";
+
+export interface ChainResult {
+  status: VerificationStatus;
+  reason: string;
+}
+
+export interface ChainLink {
+  previous: TrustLogItem | null;
+  current: TrustLogItem;
+  next: TrustLogItem | null;
+  result: ChainResult;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Audit summary                                                      */
+/* ------------------------------------------------------------------ */
+
+export interface AuditSummary {
+  total: number;
+  verified: number;
+  broken: number;
+  missing: number;
+  orphan: number;
+  replayLinked: number;
+  /** policy_version → count */
+  policyVersions: Record<string, number>;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Timeline row (derived from TrustLogItem for display)               */
+/* ------------------------------------------------------------------ */
+
+export interface TimelineRow {
+  item: TrustLogItem;
+  chain: ChainResult;
+  severity: string;
+  stage: string;
+  timestamp: string;
+  requestId: string;
+  decisionId: string;
+  replayId: string;
+  policyVersion: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Selected audit detail tabs                                         */
+/* ------------------------------------------------------------------ */
+
+export type DetailTab = "summary" | "metadata" | "hash" | "related" | "raw";
+
+export interface SelectedAuditDetail {
+  item: TrustLogItem;
+  chain: ChainLink;
+  humanSummary: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Cross-search                                                       */
+/* ------------------------------------------------------------------ */
+
+export type SearchField = "all" | "decision_id" | "request_id" | "replay_id" | "policy_version";
+
+export interface CrossSearchParams {
+  query: string;
+  field: SearchField;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Export                                                              */
+/* ------------------------------------------------------------------ */
+
+export type ExportFormat = "json" | "pdf";
+export type RedactionMode = "full" | "redacted" | "metadata-only";
+
+export interface ExportConfig {
+  format: ExportFormat;
+  redaction: RedactionMode;
+  startDate: string;
+  endDate: string;
+  piiAcknowledged: boolean;
+}
+
+export interface RegulatoryReport {
+  generatedAt: string;
+  totalEntries: number;
+  verified: number;
+  broken: number;
+  missing: number;
+  orphan: number;
+  mismatchLinks: number;
+  brokenCount: number;
+  redactionMode: RedactionMode;
+  policyVersions: Record<string, number>;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+export function getString(item: TrustLogItem, key: string): string {
+  const value = item[key];
+  return typeof value === "string" ? value : "-";
+}
+
+export function shortHash(value: string | undefined | null): string {
+  if (!value) return "---";
+  if (value.length <= 18) return value;
+  return `${value.slice(0, 10)}...${value.slice(-6)}`;
+}
+
+export function toPrettyJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Classifies a single hash-chain link for audit visualization.
+ */
+export function classifyChain(
+  item: TrustLogItem,
+  previous: TrustLogItem | null,
+): ChainResult {
+  if (!item.sha256) {
+    return { status: "missing", reason: "current sha256 missing" };
+  }
+  if (!item.sha256_prev) {
+    return previous
+      ? { status: "orphan", reason: "no sha256_prev while previous exists" }
+      : { status: "verified", reason: "genesis entry" };
+  }
+  if (!previous?.sha256) {
+    return { status: "missing", reason: "previous sha256 missing" };
+  }
+  if (item.sha256_prev !== previous.sha256) {
+    return { status: "broken", reason: "sha256_prev does not match previous sha256" };
+  }
+  return { status: "verified", reason: "hash chain match" };
+}
+
+/**
+ * Build a human-readable one-line summary for an audit entry.
+ */
+export function buildHumanSummary(item: TrustLogItem): string {
+  const stage = getString(item, "stage") || "UNKNOWN";
+  const status = getString(item, "status");
+  const reqId = item.request_id ?? "-";
+  const severity = getString(item, "severity");
+  const parts: string[] = [`Stage "${stage}"`];
+  if (status !== "-") parts.push(`returned ${status}`);
+  parts.push(`for request ${reqId}`);
+  if (severity !== "-") parts.push(`(severity: ${severity})`);
+  return parts.join(" ");
+}
+
+/**
+ * Compute a full AuditSummary from a list of items.
+ */
+export function computeAuditSummary(items: TrustLogItem[]): AuditSummary {
+  let verified = 0;
+  let broken = 0;
+  let missing = 0;
+  let orphan = 0;
+  let replayLinked = 0;
+  const policyVersions: Record<string, number> = {};
+
+  for (let i = 0; i < items.length; i += 1) {
+    const status = classifyChain(items[i], items[i + 1] ?? null).status;
+    if (status === "verified") verified += 1;
+    else if (status === "broken") broken += 1;
+    else if (status === "missing") missing += 1;
+    else if (status === "orphan") orphan += 1;
+
+    if (typeof items[i].replay_id === "string") replayLinked += 1;
+
+    const pv = getString(items[i], "policy_version");
+    if (pv !== "-") policyVersions[pv] = (policyVersions[pv] ?? 0) + 1;
+  }
+
+  return { total: items.length, verified, broken, missing, orphan, replayLinked, policyVersions };
+}

--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -311,6 +311,7 @@ describe("TrustLogExplorerPage", () => {
     render(<TrustLogExplorerPage />);
 
     expect(screen.getByText("墨消しモード")).toBeInTheDocument();
+    expect(screen.getByText("出力形式")).toBeInTheDocument();
     expect(screen.getByDisplayValue("full")).toBeInTheDocument();
     expect(screen.getByDisplayValue("redacted")).toBeInTheDocument();
     expect(screen.getByDisplayValue("metadata-only")).toBeInTheDocument();

--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -7,26 +7,69 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+const MOCK_ITEMS_CHAINED = [
+  {
+    request_id: "req-100",
+    stage: "value_core",
+    severity: "low",
+    status: "allow",
+    created_at: "2026-02-12T00:00:00Z",
+    sha256: "cccccccccccccccccccccccccccccccc",
+    sha256_prev: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    decision_id: "dec-100",
+    policy_version: "v1.2",
+  },
+  {
+    request_id: "req-099",
+    stage: "planner",
+    severity: "medium",
+    status: "allow",
+    created_at: "2026-02-11T00:00:00Z",
+    sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    sha256_prev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    decision_id: "dec-099",
+    replay_id: "rpl-001",
+    policy_version: "v1.1",
+  },
+];
+
+function mockFetchWithItems(items: unknown[] = MOCK_ITEMS_CHAINED) {
+  return vi.spyOn(global, "fetch").mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      items,
+      cursor: "0",
+      next_cursor: items.length >= 50 ? "2" : null,
+      limit: 50,
+      has_more: items.length >= 50,
+    }),
+  } as Response);
+}
+
+async function loadLogs() {
+  fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
+  await waitFor(() => {
+    expect(screen.getByText(/表示件数: /)).toBeInTheDocument();
+  });
+}
+
 describe("TrustLogExplorerPage", () => {
   it("loads paged trust logs and renders timeline items", async () => {
-    const fetchMock = vi
-      .spyOn(global, "fetch")
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            { request_id: "req-1", stage: "value", created_at: "2026-02-12T00:00:00Z" },
-            { request_id: "req-2", stage: "fuji", created_at: "2026-02-11T00:00:00Z" },
-          ],
-          cursor: "0",
-          next_cursor: "2",
-          limit: 50,
-          has_more: true,
-        }),
-      } as Response);
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          { request_id: "req-1", stage: "value", created_at: "2026-02-12T00:00:00Z" },
+          { request_id: "req-2", stage: "fuji", created_at: "2026-02-11T00:00:00Z" },
+        ],
+        cursor: "0",
+        next_cursor: "2",
+        limit: 50,
+        has_more: true,
+      }),
+    } as Response);
 
     render(<TrustLogExplorerPage />);
-
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
     await waitFor(() => {
@@ -51,7 +94,6 @@ describe("TrustLogExplorerPage", () => {
     } as Response);
 
     render(<TrustLogExplorerPage />);
-
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
     await waitFor(() => {
@@ -63,7 +105,6 @@ describe("TrustLogExplorerPage", () => {
     vi.spyOn(global, "fetch").mockRejectedValueOnce(new DOMException("Aborted", "AbortError"));
 
     render(<TrustLogExplorerPage />);
-
     fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
 
     await waitFor(() => {
@@ -75,7 +116,6 @@ describe("TrustLogExplorerPage", () => {
     vi.spyOn(global, "fetch").mockRejectedValueOnce(new DOMException("Aborted", "AbortError"));
 
     render(<TrustLogExplorerPage />);
-
     fireEvent.change(screen.getByLabelText("リクエストIDで検索"), {
       target: { value: "req-timeout" },
     });
@@ -87,43 +127,12 @@ describe("TrustLogExplorerPage", () => {
   });
 
   it("verifies hash chain and shows tamper-proof stamp", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        items: [
-          {
-            request_id: "req-100",
-            stage: "value_core",
-            created_at: "2026-02-12T00:00:00Z",
-            sha256: "cccccccccccccccccccccccccccccccc",
-            sha256_prev: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          },
-          {
-            request_id: "req-099",
-            stage: "planner",
-            created_at: "2026-02-11T00:00:00Z",
-            sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            sha256_prev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          },
-        ],
-        cursor: "0",
-        next_cursor: null,
-        limit: 50,
-        has_more: false,
-      }),
-    } as Response);
-
+    mockFetchWithItems();
     render(<TrustLogExplorerPage />);
-    fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
+    await loadLogs();
 
-    await waitFor(() => {
-      expect(screen.getByText(/表示件数: 2/)).toBeInTheDocument();
-    });
-
-    const comboBoxes = screen.getAllByRole("combobox");
-    fireEvent.change(comboBoxes[1], {
-      target: { value: "req-100" },
-    });
+    const decisionSelect = screen.getByLabelText("検証対象の意思決定ID");
+    fireEvent.change(decisionSelect, { target: { value: "dec-100" } });
     fireEvent.click(screen.getByRole("button", { name: "ハッシュチェーン検証" }));
 
     await waitFor(() => {
@@ -133,7 +142,6 @@ describe("TrustLogExplorerPage", () => {
 
   it("shows period validation error when generating report without dates", async () => {
     render(<TrustLogExplorerPage />);
-
     fireEvent.click(screen.getByRole("button", { name: "JSON生成" }));
 
     await waitFor(() => {
@@ -142,33 +150,7 @@ describe("TrustLogExplorerPage", () => {
   });
 
   it("builds regulatory report summary from selected period", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        items: [
-          {
-            request_id: "req-100",
-            stage: "fuji",
-            status: "rejected",
-            created_at: "2026-02-12T10:00:00Z",
-            sha256: "cccccccccccccccccccccccccccccccc",
-            sha256_prev: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          },
-          {
-            request_id: "req-099",
-            stage: "fuji",
-            status: "allow",
-            created_at: "2026-02-11T10:00:00Z",
-            sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            sha256_prev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          },
-        ],
-        cursor: "0",
-        next_cursor: null,
-        limit: 50,
-        has_more: false,
-      }),
-    } as Response);
+    mockFetchWithItems();
 
     const createObjectUrlMock = vi.fn(() => "blob:report");
     const revokeObjectUrlMock = vi.fn();
@@ -179,21 +161,19 @@ describe("TrustLogExplorerPage", () => {
     const clickMock = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
 
     render(<TrustLogExplorerPage />);
-    fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/表示件数: 2/)).toBeInTheDocument();
-    });
+    await loadLogs();
 
     const dateInputs = document.querySelectorAll('input[type="date"]');
     fireEvent.change(dateInputs[0], { target: { value: "2026-02-10" } });
     fireEvent.change(dateInputs[1], { target: { value: "2026-02-12" } });
 
-    fireEvent.click(screen.getByRole("checkbox"));
+    // Check the PII acknowledgement checkbox
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]);
     fireEvent.click(screen.getByRole("button", { name: "JSON生成" }));
 
     await waitFor(() => {
-      expect(screen.getByText("entries: 2 / mismatches: 0")).toBeInTheDocument();
+      expect(screen.getByText(/entries: 2/)).toBeInTheDocument();
     });
 
     expect(createObjectUrlMock).toHaveBeenCalledTimes(1);
@@ -205,35 +185,8 @@ describe("TrustLogExplorerPage", () => {
     clickMock.mockRestore();
   });
 
-
   it("generates printable report without using HTML string injection", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        items: [
-          {
-            request_id: "req-safe-1",
-            stage: "fuji",
-            status: "allow",
-            created_at: "2026-02-12T10:00:00Z",
-            sha256: "cccccccccccccccccccccccccccccccc",
-            sha256_prev: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          },
-          {
-            request_id: "req-safe-2",
-            stage: "planner",
-            status: "approved",
-            created_at: "2026-02-11T10:00:00Z",
-            sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            sha256_prev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          },
-        ],
-        cursor: "0",
-        next_cursor: null,
-        limit: 50,
-        has_more: false,
-      }),
-    } as Response);
+    mockFetchWithItems();
 
     const printDocument = document.implementation.createHTMLDocument("report");
     const printMock = vi.fn();
@@ -245,17 +198,18 @@ describe("TrustLogExplorerPage", () => {
     } as unknown as Window);
 
     render(<TrustLogExplorerPage />);
-    fireEvent.click(screen.getByRole("button", { name: "最新ログを読み込み" }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/表示件数: 2/)).toBeInTheDocument();
-    });
+    await loadLogs();
 
     const dateInputs = document.querySelectorAll('input[type="date"]');
     fireEvent.change(dateInputs[0], { target: { value: "2026-02-10" } });
     fireEvent.change(dateInputs[1], { target: { value: "2026-02-12" } });
 
-    fireEvent.click(screen.getByRole("checkbox"));
+    // Select PDF format and acknowledge PII
+    const pdfRadio = screen.getByDisplayValue("pdf");
+    fireEvent.click(pdfRadio);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]);
     fireEvent.click(screen.getByRole("button", { name: "PDF生成" }));
 
     await waitFor(() => {
@@ -273,4 +227,112 @@ describe("TrustLogExplorerPage", () => {
     expect(screen.getByLabelText("監査レポート終了日")).toBeInTheDocument();
   });
 
+  /* ================================================================ */
+  /*  New tests for enhanced audit interface                           */
+  /* ================================================================ */
+
+  it("renders enhanced audit summary with verified/broken/missing/orphan counts", async () => {
+    mockFetchWithItems();
+    render(<TrustLogExplorerPage />);
+    await loadLogs();
+
+    // Should show summary grid
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+    expect(screen.getByText("Broken")).toBeInTheDocument();
+    expect(screen.getByText("Missing")).toBeInTheDocument();
+    expect(screen.getByText("Orphan")).toBeInTheDocument();
+    expect(screen.getByText("リプレイ連携")).toBeInTheDocument();
+    // Chain integrity percentage
+    expect(screen.getByText(/チェーン整合率/)).toBeInTheDocument();
+  });
+
+  it("shows policy version distribution when data includes policy_version", async () => {
+    mockFetchWithItems();
+    render(<TrustLogExplorerPage />);
+    await loadLogs();
+
+    expect(screen.getByText("ポリシーバージョン分布")).toBeInTheDocument();
+    expect(screen.getByText(/v1\.2: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/v1\.1: 1/)).toBeInTheDocument();
+  });
+
+  it("shows cross-search field selector and filters by decision_id", async () => {
+    mockFetchWithItems();
+    render(<TrustLogExplorerPage />);
+    await loadLogs();
+
+    const fieldSelect = screen.getByLabelText("検索フィールド");
+    expect(fieldSelect).toBeInTheDocument();
+
+    // Switch to decision_id field and search
+    fireEvent.change(fieldSelect, { target: { value: "decision_id" } });
+    const searchInput = screen.getByLabelText("cross-search");
+    fireEvent.change(searchInput, { target: { value: "dec-100" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/一致: 1/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders detail tabs and switches between them", async () => {
+    mockFetchWithItems();
+    render(<TrustLogExplorerPage />);
+    await loadLogs();
+
+    // Summary tab should be visible by default
+    expect(screen.getByText("サマリー")).toBeInTheDocument();
+    expect(screen.getByText("メタデータ")).toBeInTheDocument();
+    expect(screen.getByText("ハッシュ")).toBeInTheDocument();
+    expect(screen.getByText("関連ID")).toBeInTheDocument();
+    expect(screen.getByText("Raw JSON")).toBeInTheDocument();
+
+    // Click Hash tab
+    fireEvent.click(screen.getByText("ハッシュ"));
+    await waitFor(() => {
+      expect(screen.getByText("現在")).toBeInTheDocument();
+    });
+  });
+
+  it("shows export target count preview when dates are selected", async () => {
+    mockFetchWithItems();
+    render(<TrustLogExplorerPage />);
+    await loadLogs();
+
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    fireEvent.change(dateInputs[0], { target: { value: "2026-02-10" } });
+    fireEvent.change(dateInputs[1], { target: { value: "2026-02-12" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/エクスポート対象: 2/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows redaction mode options in export section", () => {
+    render(<TrustLogExplorerPage />);
+
+    expect(screen.getByText("墨消しモード")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("full")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("redacted")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("metadata-only")).toBeInTheDocument();
+  });
+
+  it("displays empty state guidance when no logs are loaded", () => {
+    render(<TrustLogExplorerPage />);
+
+    expect(screen.getByRole("button", { name: "最新ログを読み込み" })).toBeInTheDocument();
+    // Empty state guidance
+    expect(screen.getByText(/まず「最新ログを読み込み」で監査ログを取得してください/)).toBeInTheDocument();
+    // Audit summary empty state
+    expect(screen.getByText(/ログを読み込むと、ここに全体の監査サマリーが表示されます/)).toBeInTheDocument();
+  });
+
+  it("renders timeline column headers when items are loaded", async () => {
+    mockFetchWithItems();
+    render(<TrustLogExplorerPage />);
+    await loadLogs();
+
+    expect(screen.getByText("重要度")).toBeInTheDocument();
+    expect(screen.getByText("タイムスタンプ")).toBeInTheDocument();
+    expect(screen.getByText("チェーン")).toBeInTheDocument();
+  });
 });

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -1194,6 +1194,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
               ).map((opt) => (
                 <label key={opt.value} className="flex items-start gap-1.5">
                   <input
+                    aria-label={opt.label}
                     type="radio"
                     name="redaction"
                     value={opt.value}
@@ -1221,6 +1222,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
             <div className="flex gap-4 text-xs">
               <label className="flex items-start gap-1.5">
                 <input
+                  aria-label="JSON"
                   type="radio"
                   name="exportFormat"
                   value="json"
@@ -1241,6 +1243,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
               </label>
               <label className="flex items-start gap-1.5">
                 <input
+                  aria-label="PDF"
                   type="radio"
                   name="exportFormat"
                   value="pdf"
@@ -1266,6 +1269,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
           <div className="rounded border border-warning/30 bg-warning/5 p-3">
             <label className="flex items-start gap-2 text-xs">
               <input
+                aria-label={t("PII/metadata warningの確認", "Acknowledge PII/metadata warning")}
                 type="checkbox"
                 checked={confirmPiiRisk}
                 onChange={(e) => setConfirmPiiRisk(e.target.checked)}

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -3,94 +3,106 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@veritas/design-system";
 import { veritasFetch } from "../../lib/api-client";
-import { isRequestLogResponse, isTrustLogsResponse, type RequestLogResponse, type TrustLogItem } from "../../lib/api-validators";
+import {
+  isRequestLogResponse,
+  isTrustLogsResponse,
+  type RequestLogResponse,
+  type TrustLogItem,
+} from "../../lib/api-validators";
 import { useI18n } from "../../components/i18n-provider";
+import {
+  classifyChain,
+  computeAuditSummary,
+  buildHumanSummary,
+  getString,
+  shortHash,
+  toPrettyJson,
+  type AuditSummary,
+  type ChainResult,
+  type CrossSearchParams,
+  type DetailTab,
+  type ExportFormat,
+  type RedactionMode,
+  type RegulatoryReport,
+  type SearchField,
+  type VerificationStatus,
+} from "./audit-types";
 
 const PAGE_LIMIT = 50;
 
-type VerificationStatus = "verified" | "broken" | "missing" | "orphan";
+/* ------------------------------------------------------------------ */
+/*  Status colors                                                      */
+/* ------------------------------------------------------------------ */
 
-interface RegulatoryReport {
-  generatedAt: string;
-  totalEntries: number;
-  mismatchLinks: number;
-  brokenCount: number;
-}
+const STATUS_COLORS: Record<VerificationStatus, string> = {
+  verified: "text-success",
+  broken: "text-danger",
+  missing: "text-warning",
+  orphan: "text-info",
+};
 
-interface ChainResult {
-  status: VerificationStatus;
-  reason: string;
-}
+const STATUS_BG: Record<VerificationStatus, string> = {
+  verified: "bg-success/10 border-success/30",
+  broken: "bg-danger/10 border-danger/30",
+  missing: "bg-warning/10 border-warning/30",
+  orphan: "bg-info/10 border-info/30",
+};
 
-function toPrettyJson(value: unknown): string {
-  return JSON.stringify(value, null, 2);
-}
+const STATUS_DOT: Record<VerificationStatus, string> = {
+  verified: "bg-success",
+  broken: "bg-danger",
+  missing: "bg-warning",
+  orphan: "bg-info",
+};
 
-function shortHash(value: string | undefined): string {
-  if (!value) {
-    return "missing";
-  }
-
-  if (value.length <= 18) {
-    return value;
-  }
-
-  return `${value.slice(0, 10)}...${value.slice(-6)}`;
-}
-
-function getString(item: TrustLogItem, key: string): string {
-  const value = item[key];
-  return typeof value === "string" ? value : "-";
-}
-
-/**
- * Classifies a single hash chain link for audit visualization.
- */
-function classifyChain(item: TrustLogItem, previous: TrustLogItem | null): ChainResult {
-  if (!item.sha256) {
-    return { status: "missing", reason: "current sha256 missing" };
-  }
-
-  if (!item.sha256_prev) {
-    return previous
-      ? { status: "orphan", reason: "no sha256_prev while previous exists" }
-      : { status: "verified", reason: "genesis entry" };
-  }
-
-  if (!previous?.sha256) {
-    return { status: "missing", reason: "previous sha256 missing" };
-  }
-
-  if (item.sha256_prev !== previous.sha256) {
-    return { status: "broken", reason: "sha256_prev does not match previous sha256" };
-  }
-
-  return { status: "verified", reason: "hash chain match" };
-}
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
 
 export default function TrustLogExplorerPage(): JSX.Element {
   const { t } = useI18n();
+
+  /* -- data state -------------------------------------------------- */
   const [cursor, setCursor] = useState<string | null>(null);
   const [items, setItems] = useState<TrustLogItem[]>([]);
   const [selected, setSelected] = useState<TrustLogItem | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
+
+  /* -- search state ------------------------------------------------ */
   const [requestId, setRequestId] = useState("");
   const [requestResult, setRequestResult] = useState<RequestLogResponse | null>(null);
   const [stageFilter, setStageFilter] = useState("ALL");
-  const [searchKey, setSearchKey] = useState("");
+  const [crossSearch, setCrossSearch] = useState<CrossSearchParams>({ query: "", field: "all" });
   const [selectedDecisionId, setSelectedDecisionId] = useState("");
   const [verificationMessage, setVerificationMessage] = useState("");
+
+  /* -- detail tab state -------------------------------------------- */
+  const [detailTab, setDetailTab] = useState<DetailTab>("summary");
+
+  /* -- export state ------------------------------------------------ */
   const [reportStartDate, setReportStartDate] = useState("");
   const [reportEndDate, setReportEndDate] = useState("");
   const [reportError, setReportError] = useState<string | null>(null);
   const [latestReport, setLatestReport] = useState<RegulatoryReport | null>(null);
   const [confirmPiiRisk, setConfirmPiiRisk] = useState(false);
+  const [redactionMode, setRedactionMode] = useState<RedactionMode>("full");
+  const [exportFormat, setExportFormat] = useState<ExportFormat>("json");
+
   const requestSearchNonceRef = useRef(0);
 
+  /* ---------------------------------------------------------------- */
+  /*  Derived data                                                     */
+  /* ---------------------------------------------------------------- */
+
   const sortedItems = useMemo(
-    () => [...items].sort((a, b) => new Date(b.created_at ?? "").getTime() - new Date(a.created_at ?? "").getTime()),
+    () =>
+      [...items].sort(
+        (a, b) =>
+          new Date(b.created_at ?? "").getTime() -
+          new Date(a.created_at ?? "").getTime(),
+      ),
     [items],
   );
 
@@ -103,75 +115,96 @@ export default function TrustLogExplorerPage(): JSX.Element {
   }, [sortedItems]);
 
   const filteredItems = useMemo(() => {
-    const query = searchKey.trim().toLowerCase();
+    const query = crossSearch.query.trim().toLowerCase();
     return sortedItems.filter((item) => {
-      if (stageFilter !== "ALL" && item.stage !== stageFilter) {
-        return false;
-      }
-      if (!query) {
-        return true;
-      }
-      const decisionId = String(item.decision_id ?? "").toLowerCase();
-      const request = String(item.request_id ?? "").toLowerCase();
-      return request.includes(query) || decisionId.includes(query);
+      if (stageFilter !== "ALL" && item.stage !== stageFilter) return false;
+      if (!query) return true;
+
+      const field = crossSearch.field;
+      if (field === "decision_id") return String(item.decision_id ?? "").toLowerCase().includes(query);
+      if (field === "request_id") return String(item.request_id ?? "").toLowerCase().includes(query);
+      if (field === "replay_id") return String(item.replay_id ?? "").toLowerCase().includes(query);
+      if (field === "policy_version") return String(item.policy_version ?? "").toLowerCase().includes(query);
+
+      // "all" — search across all relevant fields
+      const haystack = [
+        item.request_id,
+        item.decision_id,
+        item.replay_id,
+        item.policy_version,
+      ]
+        .map((v) => String(v ?? "").toLowerCase())
+        .join(" ");
+      return haystack.includes(query);
     });
-  }, [searchKey, sortedItems, stageFilter]);
+  }, [crossSearch, sortedItems, stageFilter]);
+
+  const auditSummary: AuditSummary = useMemo(
+    () => computeAuditSummary(filteredItems),
+    [filteredItems],
+  );
 
   const decisionIds = useMemo(() => {
     const ids = new Set<string>();
     for (const item of sortedItems) {
       const decisionId = item.decision_id;
       const fallback = item.request_id;
-      if (typeof decisionId === "string" && decisionId.length > 0) {
-        ids.add(decisionId);
-      } else if (typeof fallback === "string" && fallback.length > 0) {
-        ids.add(fallback);
-      }
+      if (typeof decisionId === "string" && decisionId.length > 0) ids.add(decisionId);
+      else if (typeof fallback === "string" && fallback.length > 0) ids.add(fallback);
     }
     return Array.from(ids).sort();
   }, [sortedItems]);
 
   const selectedDecisionEntry = useMemo(() => {
-    if (!selectedDecisionId) {
-      return null;
-    }
-    return sortedItems.find(
-      (item) => item.decision_id === selectedDecisionId || item.request_id === selectedDecisionId,
-    ) ?? null;
+    if (!selectedDecisionId) return null;
+    return (
+      sortedItems.find(
+        (item) =>
+          item.decision_id === selectedDecisionId ||
+          item.request_id === selectedDecisionId,
+      ) ?? null
+    );
   }, [selectedDecisionId, sortedItems]);
 
   const selectedIndex = useMemo(
     () => (selected ? filteredItems.findIndex((item) => item === selected) : -1),
     [filteredItems, selected],
   );
-  const previousEntry = selectedIndex >= 0 ? filteredItems[selectedIndex + 1] ?? null : null;
-  const nextEntry = selectedIndex > 0 ? filteredItems[selectedIndex - 1] ?? null : null;
+  const previousEntry =
+    selectedIndex >= 0 ? filteredItems[selectedIndex + 1] ?? null : null;
+  const nextEntry =
+    selectedIndex > 0 ? filteredItems[selectedIndex - 1] ?? null : null;
 
-  const selectedChain = useMemo(
+  const selectedChain: ChainResult | null = useMemo(
     () => (selected ? classifyChain(selected, previousEntry) : null),
     [previousEntry, selected],
   );
 
-  const auditSummary = useMemo(() => {
-    let mismatches = 0;
-    let brokenCount = 0;
-    for (let index = 0; index < filteredItems.length; index += 1) {
-      const status = classifyChain(filteredItems[index], filteredItems[index + 1] ?? null).status;
-      if (status === "broken") {
-        mismatches += 1;
-        brokenCount += 1;
-      }
-    }
-    return { total: filteredItems.length, mismatches, brokenCount };
-  }, [filteredItems]);
+  /* -- export helpers ---------------------------------------------- */
+
+  const exportTargetCount = useMemo(() => {
+    if (!reportStartDate || !reportEndDate) return 0;
+    const start = new Date(`${reportStartDate}T00:00:00.000Z`).getTime();
+    const end = new Date(`${reportEndDate}T23:59:59.999Z`).getTime();
+    return sortedItems.filter((item) => {
+      const stamp = new Date(item.created_at ?? "").getTime();
+      return Number.isFinite(stamp) && stamp >= start && stamp <= end;
+    }).length;
+  }, [reportStartDate, reportEndDate, sortedItems]);
+
+  /* ---------------------------------------------------------------- */
+  /*  Actions                                                          */
+  /* ---------------------------------------------------------------- */
 
   const verifySelectedDecision = (): void => {
     if (!selectedDecisionEntry) {
-      setVerificationMessage(t("意思決定IDを選択してください。", "Please select a decision ID."));
+      setVerificationMessage(
+        t("意思決定IDを選択してください。", "Please select a decision ID."),
+      );
       return;
     }
-    const selectedIndexInAll = sortedItems.findIndex((item) => item === selectedDecisionEntry);
-    const previous = selectedIndexInAll >= 0 ? sortedItems[selectedIndexInAll + 1] ?? null : null;
+    const idx = sortedItems.findIndex((item) => item === selectedDecisionEntry);
+    const previous = idx >= 0 ? sortedItems[idx + 1] ?? null : null;
     const result = classifyChain(selectedDecisionEntry, previous);
     if (result.status === "verified") {
       setVerificationMessage("TAMPER-PROOF ✅");
@@ -183,11 +216,18 @@ export default function TrustLogExplorerPage(): JSX.Element {
   const createRegulatoryReport = (): RegulatoryReport | null => {
     setReportError(null);
     if (!confirmPiiRisk) {
-      setReportError(t("PII/metadata warning を確認してください。", "Please acknowledge the PII/metadata warning."));
+      setReportError(
+        t(
+          "PII/metadata warning を確認してください。",
+          "Please acknowledge the PII/metadata warning.",
+        ),
+      );
       return null;
     }
     if (!reportStartDate || !reportEndDate) {
-      setReportError(t("期間を指定してください。", "Please select both start and end dates."));
+      setReportError(
+        t("期間を指定してください。", "Please select both start and end dates."),
+      );
       return null;
     }
     const start = new Date(`${reportStartDate}T00:00:00.000Z`).getTime();
@@ -197,20 +237,28 @@ export default function TrustLogExplorerPage(): JSX.Element {
       return Number.isFinite(stamp) && stamp >= start && stamp <= end;
     });
     if (periodItems.length === 0) {
-      setReportError(t("指定期間にデータがありません。", "No logs found for the selected period."));
+      setReportError(
+        t(
+          "指定期間にデータがありません。",
+          "No logs found for the selected period.",
+        ),
+      );
       return null;
     }
 
-    const mismatchLinks = periodItems.reduce((count, item, index) => {
-      const next = periodItems[index + 1] ?? null;
-      return count + (classifyChain(item, next).status === "broken" ? 1 : 0);
-    }, 0);
+    const summary = computeAuditSummary(periodItems);
 
     const report: RegulatoryReport = {
       generatedAt: new Date().toISOString(),
-      totalEntries: periodItems.length,
-      mismatchLinks,
-      brokenCount: mismatchLinks,
+      totalEntries: summary.total,
+      verified: summary.verified,
+      broken: summary.broken,
+      missing: summary.missing,
+      orphan: summary.orphan,
+      mismatchLinks: summary.broken,
+      brokenCount: summary.broken,
+      redactionMode,
+      policyVersions: summary.policyVersions,
     };
     setLatestReport(report);
     return report;
@@ -218,10 +266,10 @@ export default function TrustLogExplorerPage(): JSX.Element {
 
   const downloadJsonReport = (): void => {
     const report = createRegulatoryReport();
-    if (!report) {
-      return;
-    }
-    const reportBlob = new Blob([JSON.stringify(report, null, 2)], { type: "application/json" });
+    if (!report) return;
+    const reportBlob = new Blob([JSON.stringify(report, null, 2)], {
+      type: "application/json",
+    });
     const objectUrl = URL.createObjectURL(reportBlob);
     const anchor = document.createElement("a");
     anchor.href = objectUrl;
@@ -235,57 +283,95 @@ export default function TrustLogExplorerPage(): JSX.Element {
    */
   const generatePdfReport = (): void => {
     const report = createRegulatoryReport();
-    if (!report) {
-      return;
-    }
-    const printWindow = window.open("", "_blank", "noopener,noreferrer,width=900,height=700");
+    if (!report) return;
+    const printWindow = window.open(
+      "",
+      "_blank",
+      "noopener,noreferrer,width=900,height=700",
+    );
     if (!printWindow) {
-      setReportError(t("PDFウィンドウを開けませんでした。", "Failed to open PDF print window."));
+      setReportError(
+        t(
+          "PDFウィンドウを開けませんでした。",
+          "Failed to open PDF print window.",
+        ),
+      );
       return;
     }
-    const title = printWindow.document.createElement("h1");
+    const doc = printWindow.document;
+    const title = doc.createElement("h1");
     title.textContent = "Regulatory Report Generator";
-    const warning = printWindow.document.createElement("p");
-    warning.textContent = "Security note: Report may include PII and sensitive metadata.";
-    printWindow.document.body.appendChild(title);
-    printWindow.document.body.appendChild(warning);
-    printWindow.document.body.appendChild(printWindow.document.createTextNode(JSON.stringify(report, null, 2)));
-    printWindow.document.close();
+    const warning = doc.createElement("p");
+    warning.textContent =
+      "Security note: Report may include PII and sensitive metadata.";
+    const redactNote = doc.createElement("p");
+    redactNote.textContent = `Redaction mode: ${report.redactionMode}`;
+    doc.body.appendChild(title);
+    doc.body.appendChild(warning);
+    doc.body.appendChild(redactNote);
+    doc.body.appendChild(doc.createTextNode(JSON.stringify(report, null, 2)));
+    doc.close();
     printWindow.focus();
     printWindow.print();
   };
 
-  const loadLogs = async (nextCursor: string | null, replace: boolean): Promise<void> => {
+  const handleExport = (): void => {
+    if (exportFormat === "pdf") {
+      generatePdfReport();
+    } else {
+      downloadJsonReport();
+    }
+  };
+
+  const loadLogs = async (
+    nextCursor: string | null,
+    replace: boolean,
+  ): Promise<void> => {
     setError(null);
     setLoading(true);
     try {
       const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
-      if (nextCursor) {
-        params.set("cursor", nextCursor);
-      }
-      const response = await veritasFetch(`/api/veritas/v1/trust/logs?${params.toString()}`);
+      if (nextCursor) params.set("cursor", nextCursor);
+      const response = await veritasFetch(
+        `/api/veritas/v1/trust/logs?${params.toString()}`,
+      );
       if (!response.ok) {
-        setError(`HTTP ${response.status}: ${t("trust logs取得に失敗しました。", "Failed to fetch trust logs.")}`);
+        setError(
+          `HTTP ${response.status}: ${t("trust logs取得に失敗しました。", "Failed to fetch trust logs.")}`,
+        );
         return;
       }
       const payload: unknown = await response.json();
       if (!isTrustLogsResponse(payload)) {
-        setError(t("レスポンス形式エラー: trust logs の形式が不正です。", "Response format error: trust logs payload is invalid."));
+        setError(
+          t(
+            "レスポンス形式エラー: trust logs の形式が不正です。",
+            "Response format error: trust logs payload is invalid.",
+          ),
+        );
         return;
       }
       const nextItems = payload.items;
       setItems((prev) => (replace ? nextItems : [...prev, ...nextItems]));
       setCursor(payload.next_cursor);
       setHasMore(Boolean(payload.has_more));
-      if (replace && nextItems.length > 0) {
-        setSelected(nextItems[0]);
-      }
+      if (replace && nextItems.length > 0) setSelected(nextItems[0]);
     } catch (caught: unknown) {
       if (caught instanceof DOMException && caught.name === "AbortError") {
-        setError(t("タイムアウト: trust logs 取得が時間内に完了しませんでした。", "Timeout: trust logs request did not complete in time."));
+        setError(
+          t(
+            "タイムアウト: trust logs 取得が時間内に完了しませんでした。",
+            "Timeout: trust logs request did not complete in time.",
+          ),
+        );
         return;
       }
-      setError(t("ネットワークエラー: trust logs 取得に失敗しました。", "Network error: failed to fetch trust logs."));
+      setError(
+        t(
+          "ネットワークエラー: trust logs 取得に失敗しました。",
+          "Network error: failed to fetch trust logs.",
+        ),
+      );
     } finally {
       setLoading(false);
     }
@@ -303,85 +389,413 @@ export default function TrustLogExplorerPage(): JSX.Element {
     }
     setLoading(true);
     try {
-      const response = await veritasFetch(`/api/veritas/v1/trust/${encodeURIComponent(value)}`);
+      const response = await veritasFetch(
+        `/api/veritas/v1/trust/${encodeURIComponent(value)}`,
+      );
       if (!response.ok) {
-        setError(`HTTP ${response.status}: ${t("request_id 検索に失敗しました。", "Failed to search request_id.")}`);
+        setError(
+          `HTTP ${response.status}: ${t("request_id 検索に失敗しました。", "Failed to search request_id.")}`,
+        );
         return;
       }
       const payload: unknown = await response.json();
-      if (requestNonce !== requestSearchNonceRef.current) {
-        return;
-      }
+      if (requestNonce !== requestSearchNonceRef.current) return;
       if (!isRequestLogResponse(payload)) {
-        setError(t("レスポンス形式エラー: request_id 応答の形式が不正です。", "Response format error: request_id payload is invalid."));
+        setError(
+          t(
+            "レスポンス形式エラー: request_id 応答の形式が不正です。",
+            "Response format error: request_id payload is invalid.",
+          ),
+        );
         return;
       }
       setRequestResult(payload);
-      if (payload.items.length > 0) {
+      if (payload.items.length > 0)
         setSelected(payload.items[payload.items.length - 1]);
-      }
     } catch (caught: unknown) {
       if (caught instanceof DOMException && caught.name === "AbortError") {
-        setError(t("タイムアウト: request_id 検索が時間内に完了しませんでした。", "Timeout: request_id search did not complete in time."));
+        setError(
+          t(
+            "タイムアウト: request_id 検索が時間内に完了しませんでした。",
+            "Timeout: request_id search did not complete in time.",
+          ),
+        );
         return;
       }
-      setError(t("ネットワークエラー: request_id 検索に失敗しました。", "Network error: failed to search request_id."));
+      setError(
+        t(
+          "ネットワークエラー: request_id 検索に失敗しました。",
+          "Network error: failed to search request_id.",
+        ),
+      );
     } finally {
-      if (requestNonce === requestSearchNonceRef.current) {
-        setLoading(false);
-      }
+      if (requestNonce === requestSearchNonceRef.current) setLoading(false);
     }
   };
 
   useEffect(() => {
-    if (!selected && filteredItems.length > 0) {
-      setSelected(filteredItems[0]);
-    }
+    if (!selected && filteredItems.length > 0) setSelected(filteredItems[0]);
   }, [filteredItems, selected]);
+
+  /* ---------------------------------------------------------------- */
+  /*  Render helpers                                                   */
+  /* ---------------------------------------------------------------- */
+
+  const SEARCH_FIELDS: { value: SearchField; label: string }[] = [
+    { value: "all", label: t("すべて", "All fields") },
+    { value: "decision_id", label: "decision_id" },
+    { value: "request_id", label: "request_id" },
+    { value: "replay_id", label: "replay_id" },
+    { value: "policy_version", label: "policy_version" },
+  ];
+
+  const DETAIL_TABS: { value: DetailTab; label: string }[] = [
+    { value: "summary", label: t("サマリー", "Summary") },
+    { value: "metadata", label: t("メタデータ", "Metadata") },
+    { value: "hash", label: t("ハッシュ", "Hash") },
+    { value: "related", label: t("関連ID", "Related") },
+    { value: "raw", label: "Raw JSON" },
+  ];
+
+  /* ---------------------------------------------------------------- */
+  /*  Render                                                           */
+  /* ---------------------------------------------------------------- */
 
   return (
     <div className="space-y-6">
-      <Card title="TrustLog Explorer" description="Hash-chained audit trail for human verification and export" variant="glass" accent="info">
-        <p className="text-xs text-muted-foreground">{t("空状態でも監査できる項目を確認できます。", "Use this page to inspect timeline, chain validity, replay links, and export evidence.")}</p>
+      {/* =========================================================== */}
+      {/* Req 7: Empty-state hero / page purpose                       */}
+      {/* =========================================================== */}
+      <Card
+        title="TrustLog Explorer"
+        description={t(
+          "ハッシュチェーン監査証跡の人間検証・エクスポート",
+          "Hash-chained audit trail for human verification and export",
+        )}
+        variant="glass"
+        accent="info"
+      >
+        <div className="space-y-1 text-xs text-muted-foreground">
+          <p>
+            {t(
+              "この画面では、AI意思決定のハッシュチェーン整合性の検証、タイムライン上での監査対象の特定、decision / replay / metadata の追跡、安全なエクスポートを行えます。",
+              "Use this page to verify hash-chain integrity of AI decisions, identify audit targets on the timeline, trace decision / replay / metadata links, and export evidence safely.",
+            )}
+          </p>
+          {items.length === 0 && (
+            <p className="mt-2 rounded border border-info/20 bg-info/5 px-3 py-2">
+              {t(
+                "まず「最新ログを読み込み」で監査ログを取得してください。読み込み後、タイムラインにエントリが表示され、ハッシュチェーン検証・横断検索・エクスポートが可能になります。",
+                "Start by clicking \"Load latest logs\" to fetch audit entries. Once loaded, the timeline will populate and you can verify hash chains, cross-search, and export evidence.",
+              )}
+            </p>
+          )}
+        </div>
       </Card>
 
-      <Card title={t("接続・読み込み", "Connection")} titleSize="sm" variant="elevated">
+      {/* =========================================================== */}
+      {/* Connection                                                    */}
+      {/* =========================================================== */}
+      <Card
+        title={t("接続・読み込み", "Connection")}
+        titleSize="sm"
+        variant="elevated"
+      >
         <div className="flex flex-wrap gap-2">
-          <button type="button" className="rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm" disabled={loading} onClick={() => void loadLogs(null, true)}>{loading ? t("読み込み中...", "Loading...") : t("最新ログを読み込み", "Load latest logs")}</button>
-          <button type="button" className="rounded-lg border border-border px-4 py-2 text-sm" disabled={loading || !hasMore || !cursor} onClick={() => void loadLogs(cursor, false)}>{t("追加読み込み", "Load more")}</button>
+          <button
+            type="button"
+            className="rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm"
+            disabled={loading}
+            onClick={() => void loadLogs(null, true)}
+          >
+            {loading
+              ? t("読み込み中...", "Loading...")
+              : t("最新ログを読み込み", "Load latest logs")}
+          </button>
+          <button
+            type="button"
+            className="rounded-lg border border-border px-4 py-2 text-sm"
+            disabled={loading || !hasMore || !cursor}
+            onClick={() => void loadLogs(cursor, false)}
+          >
+            {t("追加読み込み", "Load more")}
+          </button>
         </div>
       </Card>
 
-      <Card title={t("request_id 検索", "request_id Search")} titleSize="sm" variant="elevated">
+      {/* =========================================================== */}
+      {/* request_id search                                            */}
+      {/* =========================================================== */}
+      <Card
+        title={t("request_id 検索", "request_id Search")}
+        titleSize="sm"
+        variant="elevated"
+      >
         <div className="flex gap-2">
-          <input aria-label={t("リクエストIDで検索", "Search by request ID")} className="w-full rounded-lg border border-border px-3 py-2 text-sm" value={requestId} onChange={(event) => setRequestId(event.target.value)} placeholder="request_id" />
-          <button type="button" className="rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm" disabled={loading} onClick={() => void searchByRequestId()}>{t("検索", "Search")}</button>
+          <input
+            aria-label={t("リクエストIDで検索", "Search by request ID")}
+            className="w-full rounded-lg border border-border px-3 py-2 text-sm"
+            value={requestId}
+            onChange={(e) => setRequestId(e.target.value)}
+            placeholder="request_id"
+          />
+          <button
+            type="button"
+            className="rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm"
+            disabled={loading}
+            onClick={() => void searchByRequestId()}
+          >
+            {t("検索", "Search")}
+          </button>
         </div>
-        {requestResult ? <p className="mt-2 text-xs">count: {requestResult.count} / chain_ok: {String(requestResult.chain_ok)} / result: {requestResult.verification_result}</p> : null}
+        {requestResult ? (
+          <p className="mt-2 text-xs">
+            count: {requestResult.count} / chain_ok:{" "}
+            {String(requestResult.chain_ok)} / result:{" "}
+            {requestResult.verification_result}
+          </p>
+        ) : null}
       </Card>
 
-      <Card title={t("横断検索", "Cross-search")} titleSize="sm" variant="elevated">
-        <input aria-label="cross-search" className="w-full rounded-lg border border-border px-3 py-2 text-sm" value={searchKey} onChange={(event) => setSearchKey(event.target.value)} placeholder="decision_id or linked ID" />
+      {/* =========================================================== */}
+      {/* Req 5: Cross-search with field selector                      */}
+      {/* =========================================================== */}
+      <Card
+        title={t("横断検索", "Cross-search")}
+        titleSize="sm"
+        variant="elevated"
+      >
+        <div className="flex gap-2">
+          <select
+            aria-label={t("検索フィールド", "Search field")}
+            className="rounded-lg border border-border px-2 py-2 text-sm"
+            value={crossSearch.field}
+            onChange={(e) =>
+              setCrossSearch((prev) => ({
+                ...prev,
+                field: e.target.value as SearchField,
+              }))
+            }
+          >
+            {SEARCH_FIELDS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+          <input
+            aria-label="cross-search"
+            className="w-full rounded-lg border border-border px-3 py-2 text-sm"
+            value={crossSearch.query}
+            onChange={(e) =>
+              setCrossSearch((prev) => ({ ...prev, query: e.target.value }))
+            }
+            placeholder={t(
+              "decision_id / request_id / replay_id / policy_version",
+              "decision_id / request_id / replay_id / policy_version",
+            )}
+          />
+        </div>
+        {crossSearch.query && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t("一致", "Matches")}: {filteredItems.length}
+          </p>
+        )}
       </Card>
 
-      {error ? <p className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">{error}</p> : null}
+      {error ? (
+        <p className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+          {error}
+        </p>
+      ) : null}
 
+      {/* =========================================================== */}
+      {/* Req 1: Enhanced Audit Summary                                */}
+      {/* =========================================================== */}
       <Card title="Audit Summary" titleSize="sm" variant="elevated">
-        <p className="text-xs">Entries: {auditSummary.total} / Chain mismatch: {auditSummary.mismatches} / Broken: {auditSummary.brokenCount}</p>
+        {filteredItems.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            {t(
+              "ログを読み込むと、ここに全体の監査サマリーが表示されます。",
+              "Load logs to see the overall audit summary here.",
+            )}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {/* Status bar */}
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-3 lg:grid-cols-6">
+              <div className="rounded border border-border px-3 py-2 text-center">
+                <p className="text-lg font-semibold">{auditSummary.total}</p>
+                <p className="text-2xs text-muted-foreground">
+                  {t("全エントリ", "Total")}
+                </p>
+              </div>
+              <div
+                className={`rounded border px-3 py-2 text-center ${STATUS_BG.verified}`}
+              >
+                <p className="text-lg font-semibold text-success">
+                  {auditSummary.verified}
+                </p>
+                <p className="text-2xs text-muted-foreground">Verified</p>
+              </div>
+              <div
+                className={`rounded border px-3 py-2 text-center ${STATUS_BG.broken}`}
+              >
+                <p className="text-lg font-semibold text-danger">
+                  {auditSummary.broken}
+                </p>
+                <p className="text-2xs text-muted-foreground">Broken</p>
+              </div>
+              <div
+                className={`rounded border px-3 py-2 text-center ${STATUS_BG.missing}`}
+              >
+                <p className="text-lg font-semibold text-warning">
+                  {auditSummary.missing}
+                </p>
+                <p className="text-2xs text-muted-foreground">Missing</p>
+              </div>
+              <div
+                className={`rounded border px-3 py-2 text-center ${STATUS_BG.orphan}`}
+              >
+                <p className="text-lg font-semibold text-info">
+                  {auditSummary.orphan}
+                </p>
+                <p className="text-2xs text-muted-foreground">Orphan</p>
+              </div>
+              <div className="rounded border border-border px-3 py-2 text-center">
+                <p className="text-lg font-semibold">
+                  {auditSummary.replayLinked}
+                </p>
+                <p className="text-2xs text-muted-foreground">
+                  {t("リプレイ連携", "Replay Linked")}
+                </p>
+              </div>
+            </div>
+
+            {/* Policy version distribution */}
+            {Object.keys(auditSummary.policyVersions).length > 0 && (
+              <div>
+                <p className="mb-1 text-xs font-semibold">
+                  {t("ポリシーバージョン分布", "Policy Version Distribution")}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(auditSummary.policyVersions).map(
+                    ([version, count]) => (
+                      <span
+                        key={version}
+                        className="rounded border border-border px-2 py-0.5 font-mono text-2xs"
+                      >
+                        {version}: {count}
+                      </span>
+                    ),
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Integrity bar */}
+            {auditSummary.total > 0 && (
+              <div>
+                <div className="flex h-2 overflow-hidden rounded-full">
+                  {auditSummary.verified > 0 && (
+                    <div
+                      className="bg-success"
+                      style={{
+                        width: `${(auditSummary.verified / auditSummary.total) * 100}%`,
+                      }}
+                    />
+                  )}
+                  {auditSummary.broken > 0 && (
+                    <div
+                      className="bg-danger"
+                      style={{
+                        width: `${(auditSummary.broken / auditSummary.total) * 100}%`,
+                      }}
+                    />
+                  )}
+                  {auditSummary.missing > 0 && (
+                    <div
+                      className="bg-warning"
+                      style={{
+                        width: `${(auditSummary.missing / auditSummary.total) * 100}%`,
+                      }}
+                    />
+                  )}
+                  {auditSummary.orphan > 0 && (
+                    <div
+                      className="bg-info"
+                      style={{
+                        width: `${(auditSummary.orphan / auditSummary.total) * 100}%`,
+                      }}
+                    />
+                  )}
+                </div>
+                <p className="mt-1 text-2xs text-muted-foreground">
+                  {t("チェーン整合率", "Chain integrity")}:{" "}
+                  {Math.round(
+                    (auditSummary.verified / auditSummary.total) * 100,
+                  )}
+                  %
+                </p>
+              </div>
+            )}
+          </div>
+        )}
       </Card>
 
+      {/* =========================================================== */}
+      {/* Req 2: Enhanced Timeline                                     */}
+      {/* =========================================================== */}
       <Card title="Timeline" titleSize="md" variant="elevated">
         <div className="mb-2 flex items-center gap-2">
-          <label htmlFor="stage-filter" className="text-xs">Stage</label>
-          <select id="stage-filter" value={stageFilter} onChange={(event) => setStageFilter(event.target.value)} className="rounded border border-border px-2 py-1 text-xs">
-            {stageOptions.map((stage) => <option key={stage} value={stage}>{stage}</option>)}
+          <label htmlFor="stage-filter" className="text-xs">
+            Stage
+          </label>
+          <select
+            id="stage-filter"
+            value={stageFilter}
+            onChange={(e) => setStageFilter(e.target.value)}
+            className="rounded border border-border px-2 py-1 text-xs"
+          >
+            {stageOptions.map((stage) => (
+              <option key={stage} value={stage}>
+                {stage}
+              </option>
+            ))}
           </select>
-          <span className="ml-auto text-xs">{t("表示件数", "Visible")}: {filteredItems.length}</span>
+          <span className="ml-auto text-xs">
+            {t("表示件数", "Visible")}: {filteredItems.length}
+          </span>
         </div>
-        {filteredItems.length === 0 ? <p className="text-xs text-muted-foreground">{t("監査対象が未読込です。request_id/decision_id・ハッシュ整合・リプレイ関連をここで確認できます。", "No logs loaded yet. This timeline verifies request/decision IDs, hash chain, and replay linkage.")}</p> : null}
-        <ol className="space-y-2">
+        {filteredItems.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            {t(
+              "監査対象が未読込です。request_id/decision_id・ハッシュ整合・リプレイ関連をここで確認できます。",
+              "No logs loaded yet. This timeline verifies request/decision IDs, hash chain, and replay linkage.",
+            )}
+          </p>
+        ) : null}
+
+        {/* Column header */}
+        {filteredItems.length > 0 && (
+          <div className="mb-1 grid grid-cols-2 gap-1 px-3 text-2xs font-semibold text-muted-foreground md:grid-cols-7">
+            <span>{t("重要度", "Severity")}</span>
+            <span>Stage</span>
+            <span>{t("タイムスタンプ", "Timestamp")}</span>
+            <span>request_id</span>
+            <span>decision_id</span>
+            <span>{t("チェーン", "Chain")}</span>
+            <span>Replay</span>
+          </div>
+        )}
+
+        <ol className="space-y-1">
           {filteredItems.map((item, index) => {
-            const chain = classifyChain(item, filteredItems[index + 1] ?? null);
+            const chain = classifyChain(
+              item,
+              filteredItems[index + 1] ?? null,
+            );
+            const isSelected = selected === item;
             const timelineKey = [
               item.request_id ?? "unknown",
               String(item.decision_id ?? "no-decision"),
@@ -391,14 +805,43 @@ export default function TrustLogExplorerPage(): JSX.Element {
             ].join("-");
             return (
               <li key={timelineKey}>
-                <button type="button" onClick={() => setSelected(item)} className="w-full rounded border border-border px-3 py-2 text-left text-xs">
-                  <div className="grid grid-cols-2 gap-1 md:grid-cols-6">
-                    <span>{getString(item, "severity")}</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelected(item);
+                    setDetailTab("summary");
+                  }}
+                  className={`w-full rounded border px-3 py-2 text-left text-xs transition-colors ${
+                    isSelected
+                      ? "border-primary/50 bg-primary/5"
+                      : "border-border hover:bg-muted/30"
+                  }`}
+                >
+                  <div className="grid grid-cols-2 gap-1 md:grid-cols-7">
+                    <span className="font-medium">
+                      {getString(item, "severity")}
+                    </span>
                     <span>{item.stage ?? "UNKNOWN"}</span>
-                    <span>{getString(item, "status")}</span>
-                    <span className="font-mono">{item.created_at ?? "-"}</span>
-                    <span className="font-mono">req:{item.request_id ?? "-"}</span>
-                    <span className={chain.status === "verified" ? "text-success" : chain.status === "broken" ? "text-danger" : "text-warning"}>{chain.status}</span>
+                    <span className="font-mono text-2xs">
+                      {item.created_at ?? "-"}
+                    </span>
+                    <span className="truncate font-mono text-2xs">
+                      {item.request_id ?? "-"}
+                    </span>
+                    <span className="truncate font-mono text-2xs">
+                      {String(item.decision_id ?? "-")}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span
+                        className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT[chain.status]}`}
+                      />
+                      <span className={STATUS_COLORS[chain.status]}>
+                        {chain.status}
+                      </span>
+                    </span>
+                    <span className="text-2xs">
+                      {typeof item.replay_id === "string" ? "linked" : "-"}
+                    </span>
                   </div>
                 </button>
               </li>
@@ -407,60 +850,466 @@ export default function TrustLogExplorerPage(): JSX.Element {
         </ol>
       </Card>
 
+      {/* =========================================================== */}
+      {/* Req 3: Enhanced Selected Audit with tabs                     */}
+      {/* =========================================================== */}
       <Card title="Selected Audit" titleSize="md" variant="elevated">
         {selected ? (
           <div className="space-y-3 text-xs">
-            <div className="grid gap-2 rounded border border-border p-3 md:grid-cols-2">
-              <p><strong>Summary:</strong> {`Stage ${selected.stage ?? "UNKNOWN"} returned ${getString(selected, "status")} for request ${selected.request_id ?? "-"}.`}</p>
-              <p><strong>Policy Version:</strong> {getString(selected, "policy_version")}</p>
-              <p><strong>Metadata:</strong> {toPrettyJson(selected.metadata ?? {})}</p>
-              <p><strong>Replay report:</strong> {typeof selected.replay_id === "string" ? <a className="underline" href={`/replay?replay_id=${encodeURIComponent(selected.replay_id)}`}>{selected.replay_id}</a> : "-"}</p>
-              <p><strong>Hash:</strong> {shortHash(selected.sha256)} / prev {shortHash(selected.sha256_prev)}</p>
-              <p><strong>Chain:</strong> {selectedChain?.status ?? "-"}</p>
+            {/* Tab bar */}
+            <div className="flex gap-1 border-b border-border pb-1">
+              {DETAIL_TABS.map((tab) => (
+                <button
+                  key={tab.value}
+                  type="button"
+                  onClick={() => setDetailTab(tab.value)}
+                  className={`rounded-t px-3 py-1.5 text-xs transition-colors ${
+                    detailTab === tab.value
+                      ? "border-b-2 border-primary bg-primary/5 font-semibold"
+                      : "text-muted-foreground hover:bg-muted/20"
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
             </div>
-            <div className="rounded border border-border p-3">
-              <p><strong>Previous log:</strong> {previousEntry ? shortHash(previousEntry.sha256) : "-"}</p>
-              <p><strong>Next log:</strong> {nextEntry ? shortHash(nextEntry.sha256) : "-"}</p>
-            </div>
-            <details open>
-              <summary className="cursor-pointer font-semibold">{t("JSON 展開", "Expand JSON")}</summary>
-              <pre className="mt-2 overflow-x-auto rounded border border-border bg-muted/20 p-3">{toPrettyJson(selected)}</pre>
-            </details>
+
+            {/* Tab: Summary */}
+            {detailTab === "summary" && (
+              <div className="space-y-3">
+                <div
+                  className={`rounded border p-3 ${selectedChain ? STATUS_BG[selectedChain.status] : "border-border"}`}
+                >
+                  <p className="text-sm font-medium">
+                    {buildHumanSummary(selected)}
+                  </p>
+                  {selectedChain && (
+                    <p className="mt-1">
+                      <span className="font-semibold">
+                        {t("チェーン状態", "Chain status")}:
+                      </span>{" "}
+                      <span className={STATUS_COLORS[selectedChain.status]}>
+                        {selectedChain.status.toUpperCase()}
+                      </span>{" "}
+                      — {selectedChain.reason}
+                    </p>
+                  )}
+                </div>
+                <div className="grid gap-2 rounded border border-border p-3 md:grid-cols-2">
+                  <p>
+                    <strong>Stage:</strong> {selected.stage ?? "UNKNOWN"}
+                  </p>
+                  <p>
+                    <strong>Status:</strong> {getString(selected, "status")}
+                  </p>
+                  <p>
+                    <strong>Policy Version:</strong>{" "}
+                    {getString(selected, "policy_version")}
+                  </p>
+                  <p>
+                    <strong>Severity:</strong>{" "}
+                    {getString(selected, "severity")}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Tab: Metadata */}
+            {detailTab === "metadata" && (
+              <div className="rounded border border-border p-3">
+                <p className="mb-2 font-semibold">
+                  {t("メタデータカード", "Metadata Card")}
+                </p>
+                <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-muted/20 p-2 text-2xs">
+                  {toPrettyJson(selected.metadata ?? {})}
+                </pre>
+              </div>
+            )}
+
+            {/* Tab: Hash */}
+            {detailTab === "hash" && (
+              <div className="space-y-2">
+                <div className="grid gap-2 md:grid-cols-3">
+                  <div className="rounded border border-border p-3 text-center">
+                    <p className="text-2xs text-muted-foreground">
+                      {t("前ログ", "Previous")}
+                    </p>
+                    <p className="mt-1 font-mono text-2xs">
+                      {previousEntry
+                        ? shortHash(previousEntry.sha256)
+                        : t("なし", "none")}
+                    </p>
+                  </div>
+                  <div
+                    className={`rounded border p-3 text-center ${selectedChain ? STATUS_BG[selectedChain.status] : "border-border"}`}
+                  >
+                    <p className="text-2xs font-semibold">
+                      {t("現在", "Current")}
+                    </p>
+                    <p className="mt-1 font-mono text-2xs">
+                      {shortHash(selected.sha256)}
+                    </p>
+                    <p className="mt-0.5 font-mono text-2xs text-muted-foreground">
+                      prev: {shortHash(selected.sha256_prev)}
+                    </p>
+                  </div>
+                  <div className="rounded border border-border p-3 text-center">
+                    <p className="text-2xs text-muted-foreground">
+                      {t("次ログ", "Next")}
+                    </p>
+                    <p className="mt-1 font-mono text-2xs">
+                      {nextEntry
+                        ? shortHash(nextEntry.sha256)
+                        : t("なし", "none")}
+                    </p>
+                  </div>
+                </div>
+                {selectedChain && selectedChain.status !== "verified" && (
+                  <div
+                    className={`rounded border p-3 ${STATUS_BG[selectedChain.status]}`}
+                  >
+                    <p className="font-semibold">
+                      {selectedChain.status === "broken" &&
+                        t(
+                          "チェーン破損: ハッシュの不一致が検出されました。このエントリまたは前のエントリが改竄された可能性があります。",
+                          "Chain broken: Hash mismatch detected. This entry or the previous one may have been tampered with.",
+                        )}
+                      {selectedChain.status === "missing" &&
+                        t(
+                          "ハッシュ欠損: 検証に必要なハッシュ値が存在しません。ログの欠落が考えられます。",
+                          "Hash missing: A required hash value is absent. Log entries may be missing.",
+                        )}
+                      {selectedChain.status === "orphan" &&
+                        t(
+                          "孤立エントリ: 前のエントリが存在するにもかかわらず、sha256_prevが設定されていません。",
+                          "Orphan entry: Previous entry exists but sha256_prev is not set on this entry.",
+                        )}
+                    </p>
+                    <p className="mt-1 text-2xs">
+                      {t("理由", "Reason")}: {selectedChain.reason}
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Tab: Related IDs */}
+            {detailTab === "related" && (
+              <div className="grid gap-2 rounded border border-border p-3 md:grid-cols-2">
+                <p>
+                  <strong>request_id:</strong>{" "}
+                  <span className="font-mono">
+                    {selected.request_id ?? "-"}
+                  </span>
+                </p>
+                <p>
+                  <strong>decision_id:</strong>{" "}
+                  <span className="font-mono">
+                    {String(selected.decision_id ?? "-")}
+                  </span>
+                </p>
+                <p>
+                  <strong>replay_id:</strong>{" "}
+                  {typeof selected.replay_id === "string" ? (
+                    <a
+                      className="font-mono underline"
+                      href={`/replay?replay_id=${encodeURIComponent(selected.replay_id)}`}
+                    >
+                      {selected.replay_id}
+                    </a>
+                  ) : (
+                    "-"
+                  )}
+                </p>
+                <p>
+                  <strong>policy_version:</strong>{" "}
+                  <span className="font-mono">
+                    {getString(selected, "policy_version")}
+                  </span>
+                </p>
+              </div>
+            )}
+
+            {/* Tab: Raw JSON */}
+            {detailTab === "raw" && (
+              <details open>
+                <summary className="cursor-pointer font-semibold">
+                  {t("JSON 展開", "Expand JSON")}
+                </summary>
+                <pre className="mt-2 overflow-x-auto rounded border border-border bg-muted/20 p-3">
+                  {toPrettyJson(selected)}
+                </pre>
+              </details>
+            )}
           </div>
-        ) : <p className="text-sm text-muted-foreground">{t("ログを選択してください。", "Select a log.")}</p>}
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {t(
+              "タイムラインからログを選択すると、ここに詳細が表示されます。サマリー・メタデータ・ハッシュ検証・関連ID・生JSONの各タブで確認できます。",
+              "Select a log from the timeline to see details. Tabs include summary, metadata, hash verification, related IDs, and raw JSON.",
+            )}
+          </p>
+        )}
       </Card>
 
-      <Card title={t("TrustLog インタラクティブ検証", "TrustLog Interactive Verification")} titleSize="md" variant="elevated" accent="success">
+      {/* =========================================================== */}
+      {/* Req 4: Enhanced Hash Chain Verification                      */}
+      {/* =========================================================== */}
+      <Card
+        title={t(
+          "TrustLog インタラクティブ検証",
+          "TrustLog Interactive Verification",
+        )}
+        titleSize="md"
+        variant="elevated"
+        accent="success"
+      >
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <select aria-label={t("検証対象の意思決定ID", "Decision ID for verification")} className="rounded border border-border px-2 py-1 text-xs" value={selectedDecisionId} onChange={(event) => setSelectedDecisionId(event.target.value)}>
-              <option value="">{t("意思決定IDを選択", "Select a decision ID")}</option>
-              {decisionIds.map((id) => <option key={id} value={id}>{id}</option>)}
+            <select
+              aria-label={t(
+                "検証対象の意思決定ID",
+                "Decision ID for verification",
+              )}
+              className="rounded border border-border px-2 py-1 text-xs"
+              value={selectedDecisionId}
+              onChange={(e) => setSelectedDecisionId(e.target.value)}
+            >
+              <option value="">
+                {t("意思決定IDを選択", "Select a decision ID")}
+              </option>
+              {decisionIds.map((id) => (
+                <option key={id} value={id}>
+                  {id}
+                </option>
+              ))}
             </select>
-            <button type="button" className="rounded border border-primary/40 bg-primary/10 px-3 py-1.5 text-xs" onClick={verifySelectedDecision}>{t("ハッシュチェーン検証", "Verify hash chain")}</button>
+            <button
+              type="button"
+              className="rounded border border-primary/40 bg-primary/10 px-3 py-1.5 text-xs"
+              onClick={verifySelectedDecision}
+            >
+              {t("ハッシュチェーン検証", "Verify hash chain")}
+            </button>
           </div>
-          {verificationMessage ? <p className="text-xs">{verificationMessage}</p> : null}
-          <p className="text-xs text-muted-foreground">verified / broken / missing / orphan</p>
+          {verificationMessage ? (
+            <p className="text-xs">{verificationMessage}</p>
+          ) : null}
+          <div className="flex flex-wrap gap-2 text-2xs">
+            <span className="flex items-center gap-1">
+              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT.verified}`} />
+              verified
+            </span>
+            <span className="flex items-center gap-1">
+              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT.broken}`} />
+              broken
+            </span>
+            <span className="flex items-center gap-1">
+              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT.missing}`} />
+              missing
+            </span>
+            <span className="flex items-center gap-1">
+              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT.orphan}`} />
+              orphan
+            </span>
+          </div>
         </div>
       </Card>
 
-      <Card title={t("第三者監査用エクスポート", "Regulatory Report Generator")} titleSize="md" variant="elevated" accent="warning">
-        <div className="space-y-3 text-sm">
-          <div className="grid gap-3 md:grid-cols-2">
-            <input aria-label={t("監査レポート開始日", "Audit report start date")} type="date" value={reportStartDate} onChange={(event) => setReportStartDate(event.target.value)} className="rounded border border-border px-3 py-2" />
-            <input aria-label={t("監査レポート終了日", "Audit report end date")} type="date" value={reportEndDate} onChange={(event) => setReportEndDate(event.target.value)} className="rounded border border-border px-3 py-2" />
+      {/* =========================================================== */}
+      {/* Req 6: Enhanced Export UX                                     */}
+      {/* =========================================================== */}
+      <Card
+        title={t(
+          "第三者監査用エクスポート",
+          "Regulatory Report Generator",
+        )}
+        titleSize="md"
+        variant="elevated"
+        accent="warning"
+      >
+        <div className="space-y-4 text-sm">
+          {/* Period selection */}
+          <div>
+            <p className="mb-1 text-xs font-semibold">
+              {t("対象期間", "Export Period")}
+            </p>
+            <div className="grid gap-3 md:grid-cols-2">
+              <input
+                aria-label={t("監査レポート開始日", "Audit report start date")}
+                type="date"
+                value={reportStartDate}
+                onChange={(e) => setReportStartDate(e.target.value)}
+                className="rounded border border-border px-3 py-2"
+              />
+              <input
+                aria-label={t("監査レポート終了日", "Audit report end date")}
+                type="date"
+                value={reportEndDate}
+                onChange={(e) => setReportEndDate(e.target.value)}
+                className="rounded border border-border px-3 py-2"
+              />
+            </div>
+            {reportStartDate && reportEndDate && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t("エクスポート対象", "Export target")}: {exportTargetCount}{" "}
+                {t("件", "entries")}
+              </p>
+            )}
           </div>
-          <label className="flex items-start gap-2 text-xs">
-            <input type="checkbox" checked={confirmPiiRisk} onChange={(event) => setConfirmPiiRisk(event.target.checked)} />
-            <span>{t("PII/metadata warning を理解し、社内ポリシーに従って取り扱います。", "I acknowledge PII/metadata warning and will handle exports under policy.")}</span>
-          </label>
-          <div className="flex gap-2">
-            <button type="button" className="rounded border border-primary/40 bg-primary/10 px-4 py-2 text-sm" onClick={downloadJsonReport}>{t("JSON生成", "Generate JSON")}</button>
-            <button type="button" className="rounded border border-primary/40 bg-primary/10 px-4 py-2 text-sm" onClick={generatePdfReport}>{t("PDF生成", "Generate PDF")}</button>
+
+          {/* Redaction mode */}
+          <div>
+            <p className="mb-1 text-xs font-semibold">
+              {t("墨消しモード", "Redaction Mode")}
+            </p>
+            <div className="flex gap-3 text-xs">
+              {(
+                [
+                  {
+                    value: "full" as const,
+                    label: t("完全出力", "Full"),
+                    desc: t(
+                      "すべてのフィールドを含む",
+                      "Includes all fields",
+                    ),
+                  },
+                  {
+                    value: "redacted" as const,
+                    label: t("墨消し", "Redacted"),
+                    desc: t(
+                      "PII関連フィールドを除外",
+                      "PII fields removed",
+                    ),
+                  },
+                  {
+                    value: "metadata-only" as const,
+                    label: t("メタデータのみ", "Metadata only"),
+                    desc: t(
+                      "監査メタデータのみ",
+                      "Audit metadata only",
+                    ),
+                  },
+                ] as const
+              ).map((opt) => (
+                <label key={opt.value} className="flex items-start gap-1.5">
+                  <input
+                    type="radio"
+                    name="redaction"
+                    value={opt.value}
+                    checked={redactionMode === opt.value}
+                    onChange={() => setRedactionMode(opt.value)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <span className="font-medium">{opt.label}</span>
+                    <br />
+                    <span className="text-2xs text-muted-foreground">
+                      {opt.desc}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
           </div>
-          {reportError ? <p className="text-xs text-warning">{reportError}</p> : null}
-          {latestReport ? <p className="text-xs">entries: {latestReport.totalEntries} / mismatches: {latestReport.mismatchLinks}</p> : null}
-          <p className="text-xs text-warning">{t("セキュリティ警告: 出力にはPIIや監査メタデータが含まれる可能性があります。", "Security warning: export may include PII and audit metadata.")}</p>
+
+          {/* Format selection */}
+          <div>
+            <p className="mb-1 text-xs font-semibold">
+              {t("出力形式", "Export Format")}
+            </p>
+            <div className="flex gap-4 text-xs">
+              <label className="flex items-start gap-1.5">
+                <input
+                  type="radio"
+                  name="exportFormat"
+                  value="json"
+                  checked={exportFormat === "json"}
+                  onChange={() => setExportFormat("json")}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-medium">JSON</span>
+                  <br />
+                  <span className="text-2xs text-muted-foreground">
+                    {t(
+                      "機械可読形式。APIやスクリプトでの処理に最適",
+                      "Machine-readable. Best for API and script processing",
+                    )}
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-1.5">
+                <input
+                  type="radio"
+                  name="exportFormat"
+                  value="pdf"
+                  checked={exportFormat === "pdf"}
+                  onChange={() => setExportFormat("pdf")}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-medium">PDF</span>
+                  <br />
+                  <span className="text-2xs text-muted-foreground">
+                    {t(
+                      "印刷用。第三者監査提出に適した形式",
+                      "Printable. Suitable for third-party audit submission",
+                    )}
+                  </span>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* PII acknowledgement */}
+          <div className="rounded border border-warning/30 bg-warning/5 p-3">
+            <label className="flex items-start gap-2 text-xs">
+              <input
+                type="checkbox"
+                checked={confirmPiiRisk}
+                onChange={(e) => setConfirmPiiRisk(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>
+                {t(
+                  "PII/metadata warning を理解し、社内ポリシーに従って取り扱います。",
+                  "I acknowledge PII/metadata warning and will handle exports under policy.",
+                )}
+              </span>
+            </label>
+            <p className="mt-2 text-2xs text-warning">
+              {t(
+                "セキュリティ警告: エクスポートにはPII（個人識別情報）や監査メタデータが含まれる可能性があります。社内の情報セキュリティポリシーに従い、安全に取り扱ってください。",
+                "Security warning: Exports may include PII (personally identifiable information) and audit metadata. Handle according to your organization's information security policy.",
+              )}
+            </p>
+          </div>
+
+          {/* Export button */}
+          <button
+            type="button"
+            className="rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm"
+            onClick={handleExport}
+          >
+            {exportFormat === "json"
+              ? t("JSON生成", "Generate JSON")
+              : t("PDF生成", "Generate PDF")}
+          </button>
+
+          {reportError ? (
+            <p className="text-xs text-warning">{reportError}</p>
+          ) : null}
+          {latestReport ? (
+            <div className="rounded border border-border p-2 text-xs">
+              <p>
+                entries: {latestReport.totalEntries} / verified:{" "}
+                {latestReport.verified} / broken: {latestReport.broken} /
+                missing: {latestReport.missing} / orphan:{" "}
+                {latestReport.orphan} / mismatches: {latestReport.mismatchLinks}
+              </p>
+            </div>
+          ) : null}
         </div>
       </Card>
     </div>

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -1159,10 +1159,10 @@ export default function TrustLogExplorerPage(): JSX.Element {
           </div>
 
           {/* Redaction mode */}
-          <div>
-            <p className="mb-1 text-xs font-semibold">
+          <fieldset className="space-y-1">
+            <legend className="text-xs font-semibold">
               {t("墨消しモード", "Redaction Mode")}
-            </p>
+            </legend>
             <div className="flex gap-3 text-xs">
               {(
                 [
@@ -1205,20 +1205,20 @@ export default function TrustLogExplorerPage(): JSX.Element {
                   <span>
                     <span className="font-medium">{opt.label}</span>
                     <br />
-                    <span className="text-2xs text-muted-foreground">
+                    <span className="text-xs text-muted-foreground">
                       {opt.desc}
                     </span>
                   </span>
                 </label>
               ))}
             </div>
-          </div>
+          </fieldset>
 
           {/* Format selection */}
-          <div>
-            <p className="mb-1 text-xs font-semibold">
+          <fieldset className="space-y-1">
+            <legend className="text-xs font-semibold">
               {t("出力形式", "Export Format")}
-            </p>
+            </legend>
             <div className="flex gap-4 text-xs">
               <label className="flex items-start gap-1.5">
                 <input
@@ -1233,7 +1233,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
                 <span>
                   <span className="font-medium">JSON</span>
                   <br />
-                  <span className="text-2xs text-muted-foreground">
+                  <span className="text-xs text-muted-foreground">
                     {t(
                       "機械可読形式。APIやスクリプトでの処理に最適",
                       "Machine-readable. Best for API and script processing",
@@ -1254,7 +1254,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
                 <span>
                   <span className="font-medium">PDF</span>
                   <br />
-                  <span className="text-2xs text-muted-foreground">
+                  <span className="text-xs text-muted-foreground">
                     {t(
                       "印刷用。第三者監査提出に適した形式",
                       "Printable. Suitable for third-party audit submission",
@@ -1263,7 +1263,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
                 </span>
               </label>
             </div>
-          </div>
+          </fieldset>
 
           {/* PII acknowledgement */}
           <div className="rounded border border-warning/30 bg-warning/5 p-3">

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -591,8 +591,8 @@ export default function TrustLogExplorerPage(): JSX.Element {
               setCrossSearch((prev) => ({ ...prev, query: e.target.value }))
             }
             placeholder={t(
-              "decision_id / request_id / replay_id / policy_version",
-              "decision_id / request_id / replay_id / policy_version",
+              "ID・ポリシーバージョンで検索",
+              "Search by ID or policy version",
             )}
           />
         </div>


### PR DESCRIPTION
- Enhanced Audit Summary with verified/broken/missing/orphan counts,
  replay-linked count, policy version distribution, and integrity bar
- Improved Timeline with severity, stage, timestamp, request_id,
  decision_id, chain status, replay status columns with color-coded dots
- Enhanced Selected Audit with tabbed UI (summary/metadata/hash/related/raw)
  including human-readable summaries and broken-chain explanations
- Improved hash chain verification with 3-column prev/current/next view,
  clear color coding, and detailed broken-chain reason messages
- Real cross-search with field selector (decision_id/request_id/replay_id/
  policy_version) and match count display
- Enhanced export UX with redaction mode (full/redacted/metadata-only),
  format explanation (JSON vs PDF), PII warning panel, and target count preview
- Empty state guidance explaining what the page does before logs are loaded
- Separated audit type definitions into audit-types.ts for maintainability

https://claude.ai/code/session_01MfyVqCTLBXn39Sx6x8PjVS