### PR TITLE
fix: バックエンドとフロントエンドの整合性を改善

### DIFF
--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { Card } from "@veritas/design-system";
-import type { GovernancePolicy as GovernancePolicyBase } from "@veritas/types";
+import type { FujiRules, GovernancePolicy as GovernancePolicyBase } from "@veritas/types";
 import { useI18n } from "../../components/i18n-provider";
 import { veritasFetch } from "../../lib/api-client";
 import { validateGovernancePolicyResponse } from "../../lib/api-validators";

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { Card } from "@veritas/design-system";
+import type { GovernancePolicy as GovernancePolicyBase } from "@veritas/types";
 import { useI18n } from "../../components/i18n-provider";
 import { veritasFetch } from "../../lib/api-client";
 import { validateGovernancePolicyResponse } from "../../lib/api-validators";
@@ -16,51 +17,15 @@ type PolicyActionMode = "apply" | "dry-run" | "shadow";
 type GovernanceMode = "standard" | "eu_ai_act";
 type ApprovalStatus = "approved" | "pending" | "rejected" | "draft";
 
-interface FujiRules {
-  pii_check: boolean;
-  self_harm_block: boolean;
-  illicit_block: boolean;
-  violence_review: boolean;
-  minors_review: boolean;
-  keyword_hard_block: boolean;
-  keyword_soft_flag: boolean;
-  llm_safety_head: boolean;
-}
-
-interface RiskThresholds {
-  allow_upper: number;
-  warn_upper: number;
-  human_review_upper: number;
-  deny_upper: number;
-}
-
-interface AutoStop {
-  enabled: boolean;
-  max_risk_score: number;
-  max_consecutive_rejects: number;
-  max_requests_per_minute: number;
-}
-
-interface LogRetention {
-  retention_days: number;
-  audit_level: string;
-  include_fields: string[];
-  redact_before_log: boolean;
-  max_log_size: number;
-}
-
-interface GovernancePolicy {
-  version: string;
+/**
+ * Extended governance policy with UI-only fields derived from the backend response.
+ * The base shape comes from @veritas/types (aligned to backend API).
+ */
+interface GovernancePolicy extends GovernancePolicyBase {
   draft_version?: string;
   effective_at?: string;
   last_applied?: string;
   approval_status: ApprovalStatus;
-  fuji_rules: FujiRules;
-  risk_thresholds: RiskThresholds;
-  auto_stop: AutoStop;
-  log_retention: LogRetention;
-  updated_at: string;
-  updated_by: string;
 }
 
 interface DiffChange {

--- a/frontend/features/console/components/eu-ai-act-governance-dashboard.tsx
+++ b/frontend/features/console/components/eu-ai-act-governance-dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import type { SSEEventPayload } from "@veritas/types";
 import { veritasFetch } from "../../../lib/api-client";
 
 interface ComplianceConfig {
@@ -13,13 +14,6 @@ interface TrustLogEvent {
   type: string;
   ts: string;
   payload: Record<string, unknown>;
-}
-
-interface SSEEventPayload {
-  type?: string;
-  ts?: string;
-  payload?: Record<string, unknown>;
-  id?: number;
 }
 
 const PIPELINE_STAGES = ["Evidence", "Debate", "Critique", "Safety"];

--- a/frontend/lib/api-validators.ts
+++ b/frontend/lib/api-validators.ts
@@ -1,50 +1,9 @@
-interface FujiRules {
-  pii_check: boolean;
-  self_harm_block: boolean;
-  illicit_block: boolean;
-  violence_review: boolean;
-  minors_review: boolean;
-  keyword_hard_block: boolean;
-  keyword_soft_flag: boolean;
-  llm_safety_head: boolean;
-}
+import type {
+  GovernancePolicy,
+  GovernancePolicyResponse,
+} from "@veritas/types";
 
-interface RiskThresholds {
-  allow_upper: number;
-  warn_upper: number;
-  human_review_upper: number;
-  deny_upper: number;
-}
-
-interface AutoStop {
-  enabled: boolean;
-  max_risk_score: number;
-  max_consecutive_rejects: number;
-  max_requests_per_minute: number;
-}
-
-interface LogRetention {
-  retention_days: number;
-  audit_level: string;
-  include_fields: string[];
-  redact_before_log: boolean;
-  max_log_size: number;
-}
-
-export interface GovernancePolicy {
-  version: string;
-  fuji_rules: FujiRules;
-  risk_thresholds: RiskThresholds;
-  auto_stop: AutoStop;
-  log_retention: LogRetention;
-  updated_at: string;
-  updated_by: string;
-}
-
-export interface GovernancePolicyResponse {
-  ok: boolean;
-  policy: GovernancePolicy;
-}
+export type { GovernancePolicy, GovernancePolicyResponse } from "@veritas/types";
 
 export interface GovernanceValidationIssue {
   category: "format" | "semantic";
@@ -66,13 +25,19 @@ export type GovernanceValidationResult = GovernanceValidationSuccess | Governanc
 
 const AUDIT_LEVELS = new Set(["none", "minimal", "standard", "full", "strict"]);
 
+/**
+ * TrustLogItem aligned to backend TrustLog schema (schemas.py).
+ *
+ * Backend guarantees default values for sources, critics, checks, and approver,
+ * so these are required here to match @veritas/types TrustLog.
+ */
 export interface TrustLogItem {
   request_id: string;
   created_at: string;
-  sources?: string[];
-  critics?: string[];
-  checks?: string[];
-  approver?: string;
+  sources: string[];
+  critics: string[];
+  checks: string[];
+  approver: string;
   fuji?: Record<string, unknown> | null;
   sha256?: string;
   sha256_prev?: string;
@@ -147,7 +112,7 @@ function validateFujiRules(value: unknown, pathPrefix: string): GovernanceValida
 
 function validateThresholdValue(
   obj: Record<string, unknown>,
-  key: keyof RiskThresholds,
+  key: string,
   pathPrefix: string,
 ): GovernanceValidationIssue[] {
   const path = `${pathPrefix}.${key}`;
@@ -356,10 +321,16 @@ export function isGovernancePolicyResponse(value: unknown): value is GovernanceP
   return validateGovernancePolicyResponse(value).ok;
 }
 
-function isOptionalStringArray(value: unknown): boolean {
-  return value === undefined || (Array.isArray(value) && value.every((s) => typeof s === "string"));
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((s) => typeof s === "string");
 }
 
+/**
+ * Runtime type guard for TrustLogItem.
+ *
+ * Aligned with backend TrustLog schema (schemas.py) where sources, critics,
+ * checks, and approver have default values and are always present.
+ */
 export function isTrustLogItem(value: unknown): value is TrustLogItem {
   if (!isRecord(value)) {
     return false;
@@ -373,11 +344,11 @@ export function isTrustLogItem(value: unknown): value is TrustLogItem {
     return false;
   }
 
-  if (!isOptionalStringArray(value.sources) || !isOptionalStringArray(value.critics) || !isOptionalStringArray(value.checks)) {
+  if (!isStringArray(value.sources) || !isStringArray(value.critics) || !isStringArray(value.checks)) {
     return false;
   }
 
-  if (value.approver !== undefined && typeof value.approver !== "string") {
+  if (typeof value.approver !== "string") {
     return false;
   }
 

--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -227,6 +227,18 @@ function isDecisionStatus(value: unknown): value is DecisionStatus {
   return value === "allow" || value === "modify" || value === "rejected" || value === "block" || value === "abstain";
 }
 
+/**
+ * Normalize legacy "rejected" status to the canonical "block".
+ *
+ * The backend keeps "rejected" for backward compatibility
+ * (see veritas_os/api/constants.py — DecisionStatus.REJECTED).
+ * Frontend code should use this helper to avoid treating "rejected"
+ * and "block" as distinct states.
+ */
+export function normalizeDecisionStatus(status: DecisionStatus): DecisionStatus {
+  return status === "rejected" ? "block" : status;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }

--- a/packages/types/src/governance.ts
+++ b/packages/types/src/governance.ts
@@ -1,0 +1,111 @@
+/**
+ * Governance policy types aligned to backend API endpoints.
+ *
+ * Source of truth:
+ * - veritas_os/api/server.py — GET/PUT /v1/governance/policy
+ * - veritas_os/logging/governance.py — persistence layer
+ */
+
+/* ------------------------------------------------------------------ */
+/*  FUJI safety-gate rule toggles                                      */
+/* ------------------------------------------------------------------ */
+
+export interface FujiRules {
+  pii_check: boolean;
+  self_harm_block: boolean;
+  illicit_block: boolean;
+  violence_review: boolean;
+  minors_review: boolean;
+  keyword_hard_block: boolean;
+  keyword_soft_flag: boolean;
+  llm_safety_head: boolean;
+  [key: string]: unknown;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Risk threshold boundaries                                          */
+/* ------------------------------------------------------------------ */
+
+export interface RiskThresholds {
+  /** Upper boundary for "allow" band (0–1). */
+  allow_upper: number;
+  /** Upper boundary for "warn" band (0–1). */
+  warn_upper: number;
+  /** Upper boundary for "human review" band (0–1). */
+  human_review_upper: number;
+  /** Upper boundary for "deny" band (0–1). */
+  deny_upper: number;
+  [key: string]: unknown;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Auto-stop circuit breaker                                          */
+/* ------------------------------------------------------------------ */
+
+export interface AutoStop {
+  enabled: boolean;
+  max_risk_score: number;
+  max_consecutive_rejects: number;
+  max_requests_per_minute: number;
+  [key: string]: unknown;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Log retention configuration                                        */
+/* ------------------------------------------------------------------ */
+
+export type AuditLevel = "none" | "minimal" | "standard" | "full" | "strict";
+
+export interface LogRetention {
+  retention_days: number;
+  audit_level: AuditLevel;
+  include_fields: string[];
+  redact_before_log: boolean;
+  max_log_size: number;
+  [key: string]: unknown;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Governance policy (backend canonical shape)                        */
+/* ------------------------------------------------------------------ */
+
+export interface GovernancePolicy {
+  version: string;
+  fuji_rules: FujiRules;
+  risk_thresholds: RiskThresholds;
+  auto_stop: AutoStop;
+  log_retention: LogRetention;
+  updated_at: string;
+  updated_by: string;
+  [key: string]: unknown;
+}
+
+/* ------------------------------------------------------------------ */
+/*  API response wrapper                                               */
+/* ------------------------------------------------------------------ */
+
+export interface GovernancePolicyResponse {
+  ok: boolean;
+  policy: GovernancePolicy;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Trust feedback (POST /v1/trust/feedback)                           */
+/* ------------------------------------------------------------------ */
+
+export interface TrustFeedbackResponse {
+  ok: boolean;
+  error: string | null;
+  user_id?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  SSE event payload (GET /v1/events)                                 */
+/* ------------------------------------------------------------------ */
+
+export interface SSEEventPayload {
+  type: string;
+  ts: string;
+  payload: Record<string, unknown>;
+  id?: number;
+}

--- a/packages/types/src/governance.ts
+++ b/packages/types/src/governance.ts
@@ -19,7 +19,6 @@ export interface FujiRules {
   keyword_hard_block: boolean;
   keyword_soft_flag: boolean;
   llm_safety_head: boolean;
-  [key: string]: unknown;
 }
 
 /* ------------------------------------------------------------------ */
@@ -35,7 +34,6 @@ export interface RiskThresholds {
   human_review_upper: number;
   /** Upper boundary for "deny" band (0–1). */
   deny_upper: number;
-  [key: string]: unknown;
 }
 
 /* ------------------------------------------------------------------ */
@@ -47,7 +45,6 @@ export interface AutoStop {
   max_risk_score: number;
   max_consecutive_rejects: number;
   max_requests_per_minute: number;
-  [key: string]: unknown;
 }
 
 /* ------------------------------------------------------------------ */
@@ -62,7 +59,6 @@ export interface LogRetention {
   include_fields: string[];
   redact_before_log: boolean;
   max_log_size: number;
-  [key: string]: unknown;
 }
 
 /* ------------------------------------------------------------------ */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -35,7 +35,7 @@ export function isHealthResponse(value: unknown): value is HealthResponse {
   return typeof checks.pipeline === "string" && typeof checks.memory === "string";
 }
 
-export { isDecideResponse } from "./decision";
+export { isDecideResponse, normalizeDecisionStatus } from "./decision";
 
 export type {
   CritiqueItem,
@@ -55,3 +55,15 @@ export type {
   TrustLog,
   ValuesOut
 } from "./decision";
+
+export type {
+  AuditLevel,
+  AutoStop,
+  FujiRules,
+  GovernancePolicy,
+  GovernancePolicyResponse,
+  LogRetention,
+  RiskThresholds,
+  SSEEventPayload,
+  TrustFeedbackResponse,
+} from "./governance";

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -2528,7 +2528,8 @@ def fuji_validate(payload: dict):
         return JSONResponse(
             status_code=200,
             content={
-                "status": "error",
+                "ok": False,
+                "error": "Validation failed",
                 "reasons": ["Validation failed"],
                 "violations": []
             }
@@ -2540,7 +2541,8 @@ def fuji_validate(payload: dict):
         return JSONResponse(
             status_code=200,
             content={
-                "status": "error",
+                "ok": False,
+                "error": "Validation failed",
                 "reasons": ["Validation failed"],
                 "violations": []
             }
@@ -3059,7 +3061,7 @@ def trust_feedback(body: TrustFeedbackRequest):
     vc = get_value_core()
     if vc is None:
         logger.warning("trust_feedback: value_core unavailable: %s", _value_core_state.err)
-        return {"status": "error", "detail": "value_core unavailable"}
+        return {"ok": False, "error": "value_core unavailable"}
 
     try:
         uid = str(body.user_id or "anon")[:500]
@@ -3080,14 +3082,14 @@ def trust_feedback(body: TrustFeedbackRequest):
                 "trustlog.appended",
                 {"kind": "feedback", "user_id": uid, "source": source},
             )
-            return {"status": "ok", "user_id": uid}
+            return {"ok": True, "error": None, "user_id": uid}
 
-        return {"status": "error", "detail": "value_core.append_trust_log not found"}
+        return {"ok": False, "error": "value_core.append_trust_log not found"}
 
     except Exception as e:
         # Log the detailed error server-side, but do not expose it to the client.
         logger.error("[Trust] feedback failed: %s", e)
-        return {"status": "error", "detail": "internal error in trust_feedback"}
+        return {"ok": False, "error": "internal error in trust_feedback"}
 
 
 @app.get("/v1/trustlog/verify", dependencies=[Depends(require_api_key), Depends(enforce_rate_limit)])

--- a/veritas_os/tests/test_api_extra.py
+++ b/veritas_os/tests/test_api_extra.py
@@ -276,7 +276,7 @@ class TestTrustFeedback:
         data = response.json()
         
         # レスポンス確認
-        assert data["status"] == "ok"
+        assert data["ok"] is True
         assert data["user_id"] == "feedback_user"
 
         # コア関数が正しく呼ばれているか確認

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -1345,7 +1345,7 @@ def test_trust_feedback_ok(monkeypatch):
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["status"] == "ok"
+    assert data["ok"] is True
     assert data["user_id"] == "user123"
 
     assert len(calls) == 1
@@ -1379,8 +1379,8 @@ def test_trust_feedback_error(monkeypatch):
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["status"] == "error"
-    assert "detail" in data
+    assert data["ok"] is False
+    assert "error" in data
 
 
 # -------------------------------------------------
@@ -1815,7 +1815,7 @@ def test_trust_feedback_coerces_bad_score_to_default():
         headers={"X-API-Key": "test-api-key"},
     )
     assert r.status_code == 200
-    assert r.json()["status"] in ("ok", "error")
+    assert r.json()["ok"] in (True, False)
 
 
 def test_memory_put_accepts_string_value():

--- a/veritas_os/tests/test_coverage_boost.py
+++ b/veritas_os/tests/test_coverage_boost.py
@@ -716,8 +716,8 @@ class TestServerTrustFeedback:
         monkeypatch.setattr(server, "get_value_core", lambda: None)
         resp = _client.post("/v1/trust/feedback", headers=_AUTH, json={"score": 0.5})
         body = resp.json()
-        assert body["status"] == "error"
-        assert "unavailable" in body["detail"]
+        assert body["ok"] is False
+        assert "unavailable" in body["error"]
 
     def test_trust_feedback_success(self, monkeypatch):
         calls = []
@@ -730,7 +730,7 @@ class TestServerTrustFeedback:
             "user_id": "u1", "score": 0.8, "note": "good",
         })
         body = resp.json()
-        assert body["status"] == "ok"
+        assert body["ok"] is True
         assert body["user_id"] == "u1"
         assert len(calls) == 1
 
@@ -746,7 +746,7 @@ class TestServerTrustFeedback:
             "score": "not-a-number",
         })
         body = resp.json()
-        assert body["status"] == "ok"
+        assert body["ok"] is True
         assert calls[0]["score"] == 0.5
 
     def test_trust_feedback_no_append_method(self, monkeypatch):
@@ -754,8 +754,8 @@ class TestServerTrustFeedback:
         monkeypatch.setattr(server, "get_value_core", lambda: SimpleNamespace())
         resp = _client.post("/v1/trust/feedback", headers=_AUTH, json={"score": 0.5})
         body = resp.json()
-        assert body["status"] == "error"
-        assert "not found" in body["detail"]
+        assert body["ok"] is False
+        assert "not found" in body["error"]
 
 
 class TestServerMetrics:
@@ -1347,7 +1347,7 @@ class TestServerExtraCoverage:
         monkeypatch.setattr(server, "get_value_core", lambda: BadVC)
         resp = _client.post("/v1/trust/feedback", headers=_AUTH, json={"score": 0.5})
         body = resp.json()
-        assert body["status"] == "error"
+        assert body["ok"] is False
 
     def test_redact_sanitize_fails_fallback(self, monkeypatch):
         def bad_mask(t):

--- a/veritas_os/tests/test_governance_api.py
+++ b/veritas_os/tests/test_governance_api.py
@@ -273,7 +273,8 @@ class TestFujiValidateErrorPaths:
         resp = client.post("/v1/fuji/validate", headers=HEADERS, json={"action": "x"})
         assert resp.status_code == 200
         body = resp.json()
-        assert body["status"] == "error"
+        assert body["ok"] is False
+        assert body["error"] == "Validation failed"
         assert body["reasons"] == ["Validation failed"]
 
     def test_general_exception_returns_error_structure(self, monkeypatch):
@@ -287,4 +288,5 @@ class TestFujiValidateErrorPaths:
         resp = client.post("/v1/fuji/validate", headers=HEADERS, json={"action": "x"})
         assert resp.status_code == 200
         body = resp.json()
-        assert body["status"] == "error"
+        assert body["ok"] is False
+        assert body["error"] == "Validation failed"


### PR DESCRIPTION
- エラーレスポンス形式を {"ok": bool, "error": ...} に統一 (trust/feedback, fuji_validate)
- GovernancePolicy/SSE/TrustFeedback 型を @veritas/types に一元化し重複定義を解消
- TrustLogItem の required/optional を backend TrustLog schema に合わせて統一
- normalizeDecisionStatus() ユーティリティで rejected→block を正規化
- governance/page.tsx の重複型定義を @veritas/types からの import に置換
- eu-ai-act-governance-dashboard の SSEEventPayload を共有型に統一

https://claude.ai/code/session_01WTdQNnbeqLzbS1D2WjbjE1