### PR TITLE
fix: フロントエンド・バックエンド整合性の包括的修正

### DIFF
--- a/frontend/app/api/veritas/[...path]/route-auth.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.ts
@@ -31,6 +31,11 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
     roles: ["viewer", "operator", "admin"],
   },
   { pathPattern: /^v1\/governance\/policy$/, method: "PUT", roles: ["admin"] },
+  {
+    pathPattern: /^v1\/governance\/policy\/history$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
 
   // Trust logs
   {
@@ -47,6 +52,12 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
     pathPattern: /^v1\/trust\/feedback$/,
     method: "POST",
     roles: ["operator", "admin"],
+  },
+
+  {
+    pathPattern: /^v1\/trust\/stats$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
   },
 
   // Trust log chain (signed)

--- a/frontend/app/governance/page.test.tsx
+++ b/frontend/app/governance/page.test.tsx
@@ -200,11 +200,19 @@ describe("GovernanceControlPage", () => {
   });
 
   it("shows validation error for malformed policy responses", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ ok: true, policy: { updated_by: 123 } }),
-    } as Response);
+    vi.spyOn(global, "fetch")
+      // First call: EUAIActGovernanceDashboard compliance/config on mount
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ config: { eu_ai_act_mode: false, safety_threshold: 0.8 } }),
+      } as Response)
+      // Second call: governance/policy triggered by button click
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, policy: { updated_by: 123 } }),
+      } as Response);
 
     render(<GovernanceControlPage />);
     fireEvent.click(screen.getByRole("button", { name: "ポリシーを読み込む" }));

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -192,7 +192,7 @@ export function LiveEventStream(): JSX.Element {
       controller = new AbortController();
 
       try {
-        const response = await fetch(streamUrl, { signal: controller.signal });
+        const response = await fetch(streamUrl, { signal: controller.signal, credentials: "same-origin" });
         if (!response.ok || !response.body) {
           if (response.status === 401 || response.status === 403) {
             const recoveryAt = Date.now() + AUTH_RETRY_PAUSE_MS;

--- a/frontend/features/console/components/eu-ai-act-governance-dashboard.tsx
+++ b/frontend/features/console/components/eu-ai-act-governance-dashboard.tsx
@@ -50,6 +50,22 @@ export function EUAIActGovernanceDashboard(): JSX.Element {
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
+    veritasFetch("/api/veritas/v1/compliance/config")
+      .then(async (res) => {
+        if (!res.ok || cancelled) return;
+        const payload = await res.json();
+        if (!cancelled && payload?.config) {
+          setConfig(payload.config as ComplianceConfig);
+        }
+      })
+      .catch(() => {
+        // keep hardcoded defaults on failure
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
     if (typeof EventSource === "undefined") {
       return () => undefined;
     }

--- a/frontend/lib/api-validators.ts
+++ b/frontend/lib/api-validators.ts
@@ -42,12 +42,14 @@ export interface TrustLogsResponse {
   has_more: boolean;
 }
 
+export type VerificationResult = "ok" | "broken" | "not_found";
+
 export interface RequestLogResponse {
   request_id: string;
   items: TrustLog[];
   count: number;
   chain_ok: boolean;
-  verification_result: string;
+  verification_result: VerificationResult;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -391,6 +393,8 @@ export function isRequestLogResponse(value: unknown): value is RequestLogRespons
     return false;
   }
 
+  const VALID_VERIFICATION_RESULTS: ReadonlySet<string> = new Set(["ok", "broken", "not_found"]);
+
   return (
     hasStringField(value, "request_id")
     && Array.isArray(value.items)
@@ -398,5 +402,6 @@ export function isRequestLogResponse(value: unknown): value is RequestLogRespons
     && hasNumberField(value, "count")
     && hasBooleanField(value, "chain_ok")
     && hasStringField(value, "verification_result")
+    && VALID_VERIFICATION_RESULTS.has(value.verification_result as string)
   );
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -178,6 +178,26 @@ components:
           type: array
           items:
             type: string
+        rule_hit:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: "トリガーされたポリシールールまたはキーワード"
+        severity:
+          type: string
+          nullable: true
+          maxLength: 50
+          description: "リスク重大度 (low / medium / high / critical)"
+        remediation_hint:
+          type: string
+          nullable: true
+          maxLength: 1000
+          description: "ゲート発火時のオペレーター向け修正提案"
+        risky_text_fragment:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: "ポリシールールをトリガーした入力の抜粋"
 
     GateOut:
       type: object
@@ -205,6 +225,26 @@ components:
               - type: string
               - type: object
                 additionalProperties: true
+        rule_hit:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: "トリガーされたポリシールールまたはキーワード"
+        severity:
+          type: string
+          nullable: true
+          maxLength: 50
+          description: "リスク重大度 (low / medium / high / critical)"
+        remediation_hint:
+          type: string
+          nullable: true
+          maxLength: 1000
+          description: "ゲート発火時のオペレーター向け修正提案"
+        risky_text_fragment:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: "ポリシールールをトリガーした入力の抜粋"
 
     ValuesOut:
       type: object
@@ -373,7 +413,7 @@ components:
         audit_level:
           type: string
           default: "full"
-          enum: ["none", "minimal", "standard", "full", "strict"]
+          enum: ["none", "minimal", "summary", "standard", "full", "strict"]
         include_fields:
           type: array
           items:

--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -41,6 +41,42 @@ export type ResponseStyle = "logic" | "emotional" | "business" | "expert" | "cas
 export type RetentionClass = "short" | "standard" | "long" | "regulated";
 
 /**
+ * User context information passed alongside a decision request.
+ *
+ * Source of truth: veritas_os/api/schemas.py — Context
+ */
+export interface Context {
+  user_id?: string;
+  session_id?: string;
+  query?: string;
+  goals?: string[];
+  constraints?: string[];
+  tools_allowed?: string[];
+  time_horizon?: TimeHorizon;
+  preferences?: string[];
+  response_style?: ResponseStyle;
+  telos_weights?: Record<string, number>;
+  affect_hint?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+/**
+ * Input candidate option for /v1/decide requests.
+ *
+ * Source of truth: veritas_os/api/schemas.py — Option
+ */
+export interface Option {
+  id?: string;
+  title?: string;
+  /** @deprecated Alias for title (backward-compatible). */
+  text?: string;
+  description?: string;
+  score?: number;
+  score_raw?: number | null;
+  [key: string]: unknown;
+}
+
+/**
  * A single critique entry from the critique pipeline stage.
  *
  * Source of truth: veritas_os/api/schemas.py — CritiqueItem
@@ -552,11 +588,11 @@ export function isTrustFeedbackRequest(value: unknown): value is TrustFeedbackRe
  */
 export interface DecideRequest {
   query?: string;
-  context?: Record<string, unknown>;
+  context?: Context | Record<string, unknown>;
   /** Canonical candidate list. */
-  alternatives?: Record<string, unknown>[];
+  alternatives?: Array<Option | Record<string, unknown>>;
   /** @deprecated Use `alternatives`. Kept for backward compatibility; backend syncs to `alternatives`. */
-  options?: Record<string, unknown>[];
+  options?: Array<Option | Record<string, unknown>>;
   min_evidence?: number;
   memory_auto_put?: boolean;
   persona_evolve?: boolean;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -57,6 +57,7 @@ export {
 
 export type {
   ChatRequest,
+  Context,
   CritiqueItem,
   CritiqueSeverity,
   DebateView,
@@ -74,6 +75,7 @@ export type {
   MemoryKind,
   MemoryPutRequest,
   MemorySearchRequest,
+  Option,
   PersonaState,
   ResponseStyle,
   RetentionClass,


### PR DESCRIPTION
- OpenAPI: FujiDecision/GateOutにrule_hit,severity,remediation_hint,risky_text_fragmentを追加
- OpenAPI: LogRetention.audit_levelにsummaryを追加（バックエンドと一致）
- Frontend types: Context/Optionの型付きインターフェースを追加しDecideRequestで使用
- Frontend types: verification_resultをstringからenum型に修正
- BFF proxy: governance/policy/historyとtrust/statsルートを追加
- live-event-stream: credentials: "same-origin"を追加（認証Cookie送信漏れ修正）
- EU AI Act dashboard: マウント時にGET /v1/compliance/configで初期設定を取得

https://claude.ai/code/session_01GfMZMVvdVVKjDaSGkvHAsD