### PR TITLE
Record kernel degradation telemetry for strategy scoring and planner fallback

### DIFF
--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -466,12 +466,26 @@ def _score_alternatives(
     stakes: float,
     persona_bias: Dict[str, float] | None,
     ctx: Dict[str, Any] | None = None,
-) -> None:
+    telemetry: Dict[str, Any] | None = None,
+) -> bool:
     """
     alternatives に対してスコアリングを行う。
 
     ★ リファクタリング: kernel_stages.score_alternatives() に委譲。
     設定値は config.scoring_cfg から取得されるため、マジックナンバーが排除されています。
+
+    Args:
+        intent: 推定意図。
+        q: ユーザー入力テキスト。
+        alts: スコアリング対象の候補。
+        telos_score: 価値評価スコア。
+        stakes: 意思決定の重要度。
+        persona_bias: ペルソナ重み。
+        ctx: 追加文脈。
+        telemetry: 劣化運転情報を反映する辞書。
+
+    Returns:
+        bool: strategy_core による追加スコアリングが成功した場合 ``True``。
     """
     from .kernel_stages import score_alternatives as _score_alts_impl
 
@@ -518,8 +532,16 @@ def _score_alternatives(
                         continue
                     if oid in score_map:
                         a["score"] = round(score_map[oid], 4)
+            return True
         except (TypeError, ValueError, RuntimeError):
             logger.warning("[Kernel] _score_alternatives strategy scoring failed", exc_info=True)
+            if isinstance(telemetry, dict):
+                telemetry.setdefault("degraded_subsystems", [])
+                telemetry.setdefault("metrics", {})
+                telemetry["degraded_subsystems"].append("strategy_scoring")
+                telemetry["metrics"]["strategy_scoring_degraded"] = True
+            return False
+    return False
 
 
 def _score_alternatives_with_value_core_and_persona(
@@ -530,7 +552,8 @@ def _score_alternatives_with_value_core_and_persona(
     stakes: float,
     persona_bias: Dict[str, float] | None,
     ctx: Dict[str, Any] | None = None,
-) -> None:
+    telemetry: Dict[str, Any] | None = None,
+) -> bool:
     """
     ★ 後方互換ラッパ
     旧バージョンから呼ばれている名前を維持するための薄い wrapper。
@@ -544,6 +567,7 @@ def _score_alternatives_with_value_core_and_persona(
         stakes=stakes,
         persona_bias=persona_bias,
         ctx=ctx,
+        telemetry=telemetry,
     )
 
 # ============================================================
@@ -581,6 +605,9 @@ async def decide(
     debate_logs: List[Dict[str, Any]] = []
     extras: Dict[str, Any] = {}
     memory_evidence_count: int = 0
+    degraded_subsystems: List[str] = []
+
+    extras.setdefault("metrics", {})
 
     mode = ctx.get("mode") or ""
     tw = (ctx.get("telos_weights") or {})
@@ -676,6 +703,8 @@ async def decide(
                 alts.append(alt)
 
     if not alts and planner_obj is None:
+        degraded_subsystems.append("planner_fallback")
+        extras["metrics"]["planner_fallback_used"] = True
         try:
             planner_obj = planner_core.plan_for_veritas_agi(
                 context=ctx,
@@ -703,7 +732,20 @@ async def decide(
 
     # alternatives 整形・スコアリング
     alts = _dedupe_alts(alts)
-    _score_alternatives(intent, q_text, alts, telos_score, stakes, persona_bias, ctx)
+    strategy_scored = _score_alternatives(
+        intent,
+        q_text,
+        alts,
+        telos_score,
+        stakes,
+        persona_bias,
+        ctx,
+        {
+            "degraded_subsystems": degraded_subsystems,
+            "metrics": extras["metrics"],
+        },
+    )
+    extras["metrics"]["strategy_scoring_applied"] = bool(strategy_scored)
 
     # =======================================================
     # DebateOS
@@ -954,10 +996,12 @@ async def decide(
 
     try:
         latency_ms = int((time.time() - start_ts) * 1000)
-        extras.setdefault("metrics", {})
         extras["metrics"]["latency_ms"] = latency_ms
     except (TypeError, ValueError, OverflowError):
         pass
+
+    if degraded_subsystems:
+        extras["degraded_subsystems"] = sorted(set(degraded_subsystems))
 
     legacy_flag_map = {
         "_world_state_injected": ("world_model_inject", "already_injected_by_pipeline"),

--- a/veritas_os/tests/test_kernel.py
+++ b/veritas_os/tests/test_kernel.py
@@ -19,7 +19,7 @@ class _DummyMemoryStore:
         return None
 
 
-def _patch_minimal_decide_dependencies(monkeypatch) -> None:
+def _patch_minimal_decide_dependencies(monkeypatch, stub_scoring: bool = True) -> None:
     """Patch heavyweight dependencies so ``kernel.decide`` can run deterministically."""
 
     monkeypatch.setattr(
@@ -46,7 +46,8 @@ def _patch_minimal_decide_dependencies(monkeypatch) -> None:
             "steps": [{"id": "s1", "title": "Collect facts", "detail": "A"}]
         },
     )
-    monkeypatch.setattr(kernel, "_score_alternatives", lambda *args, **kwargs: None)
+    if stub_scoring:
+        monkeypatch.setattr(kernel, "_score_alternatives", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         kernel.fuji_core,
         "evaluate",
@@ -137,3 +138,48 @@ def test_decide_auto_doctor_warns_without_confinement(monkeypatch) -> None:
 
     assert result["extras"]["doctor"]["skipped"] == "confinement_required"
     assert "security_warning" in result["extras"]["doctor"]
+
+
+def test_decide_records_strategy_scoring_degradation(monkeypatch) -> None:
+    """Strategy scoring failure must be visible in metrics and degraded subsystems."""
+
+    _patch_minimal_decide_dependencies(monkeypatch, stub_scoring=False)
+    monkeypatch.setattr(
+        kernel._strategy_core,
+        "score_options",
+        lambda *args, **kwargs: (_ for _ in ()).throw(TypeError("boom")),
+    )
+    monkeypatch.setattr(kernel, "strategy_core", kernel._strategy_core)
+
+    context: Dict[str, Any] = {
+        "user_id": "u-4",
+        "fast": True,
+        "_episode_saved_by_pipeline": True,
+        "_world_state_updated_by_pipeline": True,
+        "_daily_plans_generated_by_pipeline": True,
+    }
+
+    result = asyncio.run(kernel.decide(context, "query", alternatives=None))
+
+    assert result["extras"]["metrics"]["strategy_scoring_applied"] is False
+    assert result["extras"]["metrics"]["strategy_scoring_degraded"] is True
+    assert "strategy_scoring" in result["extras"]["degraded_subsystems"]
+
+
+def test_decide_marks_planner_fallback_degradation(monkeypatch) -> None:
+    """Kernel planner fallback path must be marked as degraded orchestration."""
+
+    _patch_minimal_decide_dependencies(monkeypatch)
+
+    context: Dict[str, Any] = {
+        "user_id": "u-5",
+        "fast": True,
+        "_episode_saved_by_pipeline": True,
+        "_world_state_updated_by_pipeline": True,
+        "_daily_plans_generated_by_pipeline": True,
+    }
+
+    result = asyncio.run(kernel.decide(context, "query", alternatives=[]))
+
+    assert result["extras"]["metrics"]["planner_fallback_used"] is True
+    assert "planner_fallback" in result["extras"]["degraded_subsystems"]


### PR DESCRIPTION
### Motivation
- Strategy scoring errors were previously swallowed as warnings, causing silent quality degradation; these failures must be observable in telemetry and diagnostics.
- Kernel-side planner fallback (calling `planner_core.plan_for_veritas_agi` when no planner is provided) is an important degraded path that should be reported to observability rather than hidden.
- Keep `decide()` focused on decision computation while adding minimal, safe telemetry to surface degraded subsystems and metrics for incident detection.

### Description
- Update `kernel._score_alternatives(...)` to accept a `telemetry: Dict[str, Any] | None` sink and return `bool` indicating whether `strategy_core`-based scoring succeeded, and add a docstring describing the arguments/return value.
- When `strategy_core.score_options(...)` raises `(TypeError, ValueError, RuntimeError)`, record the degradation into the provided telemetry sink by appending `"strategy_scoring"` to `degraded_subsystems` and setting `metrics["strategy_scoring_degraded"] = True` in addition to logging the warning.
- Make `_score_alternatives_with_value_core_and_persona(...)` forward the `telemetry` argument and return the boolean result for compatibility.
- In `decide()`, initialize `extras["metrics"]` and a `degraded_subsystems` list, mark planner fallback usage by setting `extras["metrics"]["planner_fallback_used"] = True` and adding `"planner_fallback"` to `degraded_subsystems` when the kernel-side planner fallback branch is entered, and pass telemetry into `_score_alternatives` to propagate strategy-scoring degradation into `extras`.
- Populate `extras["metrics"]["strategy_scoring_applied"]` with the boolean returned from `_score_alternatives` and expose `extras["degraded_subsystems"]` at the end of `decide()` if any degradations occurred.
- Add regression tests in `veritas_os/tests/test_kernel.py` to assert that strategy scoring failures produce `extras.metrics.strategy_scoring_degraded` and `extras.degraded_subsystems` entries, and that the planner fallback sets `planner_fallback_used` and marks `planner_fallback` as degraded.
- Files changed: `veritas_os/core/kernel.py`, `veritas_os/tests/test_kernel.py` (tests and helper patched to allow running the real scoring path).

Security note: this change is limited to telemetry/logging; however `decide()` still contains `auto_doctor` logic that can lead to subprocess activity and is guarded by confinement checks (`seccomp`/AppArmor). Keep this in mind when enabling `auto_doctor` in less-restricted environments.

### Testing
- Ran `python -m py_compile veritas_os/core/kernel.py` which succeeded to validate syntax.
- Ran `pytest -q veritas_os/tests/test_kernel.py` and observed `5 passed` (all tests in the file passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0da1968f883269f28871895252cd6)