### PR TITLE
Add telemetry for strategy scoring and mark planner fallback degradation

### DIFF
--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -466,12 +466,26 @@ def _score_alternatives(
     stakes: float,
     persona_bias: Dict[str, float] | None,
     ctx: Dict[str, Any] | None = None,
-) -> None:
+    telemetry: Dict[str, Any] | None = None,
+) -> bool:
     """
     alternatives に対してスコアリングを行う。
 
     ★ リファクタリング: kernel_stages.score_alternatives() に委譲。
     設定値は config.scoring_cfg から取得されるため、マジックナンバーが排除されています。
+
+    Args:
+        intent: 推定意図。
+        q: ユーザー入力テキスト。
+        alts: スコアリング対象の候補。
+        telos_score: 価値評価スコア。
+        stakes: 意思決定の重要度。
+        persona_bias: ペルソナ重み。
+        ctx: 追加文脈。
+        telemetry: 劣化運転情報を反映する辞書。
+
+    Returns:
+        bool: strategy_core による追加スコアリングが成功した場合 ``True``。
     """
     from .kernel_stages import score_alternatives as _score_alts_impl
 
@@ -518,8 +532,16 @@ def _score_alternatives(
                         continue
                     if oid in score_map:
                         a["score"] = round(score_map[oid], 4)
+            return True
         except (TypeError, ValueError, RuntimeError):
             logger.warning("[Kernel] _score_alternatives strategy scoring failed", exc_info=True)
+            if isinstance(telemetry, dict):
+                telemetry.setdefault("degraded_subsystems", [])
+                telemetry.setdefault("metrics", {})
+                telemetry["degraded_subsystems"].append("strategy_scoring")
+                telemetry["metrics"]["strategy_scoring_degraded"] = True
+            return False
+    return False
 
 
 def _score_alternatives_with_value_core_and_persona(
@@ -530,21 +552,25 @@ def _score_alternatives_with_value_core_and_persona(
     stakes: float,
     persona_bias: Dict[str, float] | None,
     ctx: Dict[str, Any] | None = None,
-) -> None:
+    telemetry: Dict[str, Any] | None = None,
+) -> bool:
     """
     ★ 後方互換ラッパ
     旧バージョンから呼ばれている名前を維持するための薄い wrapper。
     実装は _score_alternatives() に委譲する。
     """
-    return _score_alternatives(
-        intent=intent,
-        q=q,
-        alts=alts,
-        telos_score=telos_score,
-        stakes=stakes,
-        persona_bias=persona_bias,
-        ctx=ctx,
-    )
+    score_kwargs: Dict[str, Any] = {
+        "intent": intent,
+        "q": q,
+        "alts": alts,
+        "telos_score": telos_score,
+        "stakes": stakes,
+        "persona_bias": persona_bias,
+        "ctx": ctx,
+    }
+    if telemetry is not None:
+        score_kwargs["telemetry"] = telemetry
+    return bool(_score_alternatives(**score_kwargs))
 
 # ============================================================
 # decide 本体 (v2-compatible)
@@ -581,6 +607,9 @@ async def decide(
     debate_logs: List[Dict[str, Any]] = []
     extras: Dict[str, Any] = {}
     memory_evidence_count: int = 0
+    degraded_subsystems: List[str] = []
+
+    extras.setdefault("metrics", {})
 
     mode = ctx.get("mode") or ""
     tw = (ctx.get("telos_weights") or {})
@@ -676,6 +705,8 @@ async def decide(
                 alts.append(alt)
 
     if not alts and planner_obj is None:
+        degraded_subsystems.append("planner_fallback")
+        extras["metrics"]["planner_fallback_used"] = True
         try:
             planner_obj = planner_core.plan_for_veritas_agi(
                 context=ctx,
@@ -703,7 +734,20 @@ async def decide(
 
     # alternatives 整形・スコアリング
     alts = _dedupe_alts(alts)
-    _score_alternatives(intent, q_text, alts, telos_score, stakes, persona_bias, ctx)
+    strategy_scored = _score_alternatives(
+        intent,
+        q_text,
+        alts,
+        telos_score,
+        stakes,
+        persona_bias,
+        ctx,
+        {
+            "degraded_subsystems": degraded_subsystems,
+            "metrics": extras["metrics"],
+        },
+    )
+    extras["metrics"]["strategy_scoring_applied"] = bool(strategy_scored)
 
     # =======================================================
     # DebateOS
@@ -954,10 +998,12 @@ async def decide(
 
     try:
         latency_ms = int((time.time() - start_ts) * 1000)
-        extras.setdefault("metrics", {})
         extras["metrics"]["latency_ms"] = latency_ms
     except (TypeError, ValueError, OverflowError):
         pass
+
+    if degraded_subsystems:
+        extras["degraded_subsystems"] = sorted(set(degraded_subsystems))
 
     legacy_flag_map = {
         "_world_state_injected": ("world_model_inject", "already_injected_by_pipeline"),

--- a/veritas_os/tests/test_kernel.py
+++ b/veritas_os/tests/test_kernel.py
@@ -19,7 +19,7 @@ class _DummyMemoryStore:
         return None
 
 
-def _patch_minimal_decide_dependencies(monkeypatch) -> None:
+def _patch_minimal_decide_dependencies(monkeypatch, stub_scoring: bool = True) -> None:
     """Patch heavyweight dependencies so ``kernel.decide`` can run deterministically."""
 
     monkeypatch.setattr(
@@ -46,7 +46,8 @@ def _patch_minimal_decide_dependencies(monkeypatch) -> None:
             "steps": [{"id": "s1", "title": "Collect facts", "detail": "A"}]
         },
     )
-    monkeypatch.setattr(kernel, "_score_alternatives", lambda *args, **kwargs: None)
+    if stub_scoring:
+        monkeypatch.setattr(kernel, "_score_alternatives", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         kernel.fuji_core,
         "evaluate",
@@ -137,3 +138,48 @@ def test_decide_auto_doctor_warns_without_confinement(monkeypatch) -> None:
 
     assert result["extras"]["doctor"]["skipped"] == "confinement_required"
     assert "security_warning" in result["extras"]["doctor"]
+
+
+def test_decide_records_strategy_scoring_degradation(monkeypatch) -> None:
+    """Strategy scoring failure must be visible in metrics and degraded subsystems."""
+
+    _patch_minimal_decide_dependencies(monkeypatch, stub_scoring=False)
+    monkeypatch.setattr(
+        kernel._strategy_core,
+        "score_options",
+        lambda *args, **kwargs: (_ for _ in ()).throw(TypeError("boom")),
+    )
+    monkeypatch.setattr(kernel, "strategy_core", kernel._strategy_core)
+
+    context: Dict[str, Any] = {
+        "user_id": "u-4",
+        "fast": True,
+        "_episode_saved_by_pipeline": True,
+        "_world_state_updated_by_pipeline": True,
+        "_daily_plans_generated_by_pipeline": True,
+    }
+
+    result = asyncio.run(kernel.decide(context, "query", alternatives=None))
+
+    assert result["extras"]["metrics"]["strategy_scoring_applied"] is False
+    assert result["extras"]["metrics"]["strategy_scoring_degraded"] is True
+    assert "strategy_scoring" in result["extras"]["degraded_subsystems"]
+
+
+def test_decide_marks_planner_fallback_degradation(monkeypatch) -> None:
+    """Kernel planner fallback path must be marked as degraded orchestration."""
+
+    _patch_minimal_decide_dependencies(monkeypatch)
+
+    context: Dict[str, Any] = {
+        "user_id": "u-5",
+        "fast": True,
+        "_episode_saved_by_pipeline": True,
+        "_world_state_updated_by_pipeline": True,
+        "_daily_plans_generated_by_pipeline": True,
+    }
+
+    result = asyncio.run(kernel.decide(context, "query", alternatives=[]))
+
+    assert result["extras"]["metrics"]["planner_fallback_used"] is True
+    assert "planner_fallback" in result["extras"]["degraded_subsystems"]


### PR DESCRIPTION
### Motivation

- Improve observability and robustness by surfacing degraded subsystems and metrics when optional scoring or planner fallbacks fail.
- Make strategy-level scoring resilient and report whether additional scoring succeeded so orchestration can react.

### Description

- Change `_score_alternatives` to accept an optional `telemetry` dict and return `bool` indicating whether `strategy_core.score_options` succeeded, and populate `telemetry` on failure.
- Update the backward-compatible wrapper `_score_alternatives_with_value_core_and_persona` to forward telemetry and return a boolean result.
- Track `degraded_subsystems` and `extras["metrics"]` in `decide`, mark planner fallback usage with `planner_fallback_used`, pass a telemetry payload into `_score_alternatives`, and record `strategy_scoring_applied` and any `degraded_subsystems` into `extras`.
- Update tests to allow toggling the scoring stub and add two tests: `test_decide_records_strategy_scoring_degradation` and `test_decide_marks_planner_fallback_degradation` which assert metric flags and degraded subsystem reporting.

### Testing

- Ran the kernel unit tests in `veritas_os/tests/test_kernel.py` including `test_decide_records_strategy_scoring_degradation` and `test_decide_marks_planner_fallback_degradation` which assert telemetry and degraded subsystem metrics, and they passed.
- Existing decide-related regression tests were executed and remained green after the changes.
- Tests were run with the modified `_patch_minimal_decide_dependencies` that can disable the scoring stub to exercise the new telemetry/error path, and assertions on `extras["metrics"]` and `extras["degraded_subsystems"]` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0da1968f883269f28871895252cd6)