### PR TITLE
Harden web search max_results sanitization in pipeline

### DIFF
--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -791,8 +791,18 @@ async def _safe_web_search(query: str, *, max_results: int = 5) -> Optional[dict
     Resolution order:
       1. module-level ``web_search`` (set by monkeypatch in tests)
       2. ``_tool_web_search`` (imported from tools.web_search)
+
+    ``max_results`` is sanitized to an integer in [1, 20] to avoid
+    accidentally passing unbounded values to external adapters.
     """
     import sys
+
+    try:
+        max_results_int = int(max_results)
+    except (TypeError, ValueError):
+        max_results_int = 5
+    max_results_int = max(1, min(20, max_results_int))
+
     _this = sys.modules[__name__]
     fn = getattr(_this, "web_search", None)
     if not callable(fn):
@@ -801,7 +811,7 @@ async def _safe_web_search(query: str, *, max_results: int = 5) -> Optional[dict
         return None
 
     try:
-        ws = fn(query, max_results=max_results)  # type: ignore[misc]
+        ws = fn(query, max_results=max_results_int)  # type: ignore[misc]
         if inspect.isawaitable(ws):
             ws = await ws
         return ws if isinstance(ws, dict) else None

--- a/veritas_os/tests/test_api_pipeline.py
+++ b/veritas_os/tests/test_api_pipeline.py
@@ -195,6 +195,22 @@ async def test_call_core_decide_sync_and_async():
     assert calls[1]["query"] == "Q2"
 
 
+@pytest.mark.anyio
+async def test_safe_web_search_sanitizes_max_results(monkeypatch):
+    calls: List[int] = []
+
+    def fake_ws(query: str, max_results: int = 5) -> Dict[str, Any]:
+        calls.append(max_results)
+        return {"ok": True, "results": []}
+
+    monkeypatch.setattr(api_pipeline, "web_search", fake_ws, raising=False)
+
+    await api_pipeline._safe_web_search("q", max_results="999")
+    await api_pipeline._safe_web_search("q", max_results="bad")
+
+    assert calls == [20, 5]
+
+
 # =========================================================
 # run_decide_pipeline のためのダミー型
 # =========================================================


### PR DESCRIPTION
### Motivation
- `_safe_web_search` could be invoked without Stage 2b normalization and receive unbounded or malformed `max_results`, which risks excessive external calls or unexpected adapter behavior, so add a local defense-in-depth guard.

### Description
- Sanitize `max_results` in `veritas_os/core/pipeline.py::_safe_web_search` by coercing to `int`, clamping to the range `[1, 20]`, and falling back to `5` on invalid input, and pass the sanitized value to the web search adapter; docstring updated to document this behavior.
- Added a regression test `test_safe_web_search_sanitizes_max_results` in `veritas_os/tests/test_api_pipeline.py` that verifies clamping (`"999" -> 20`) and fallback (`"bad" -> 5`).

### Testing
- Ran the focused tests `pytest -q veritas_os/tests/test_api_pipeline.py::test_safe_web_search_sanitizes_max_results veritas_os/tests/test_api_pipeline.py::test_run_decide_pipeline_web_search_results_increase_web_hits` and they passed (`4 passed`).
- Ran the broader suite `pytest -q veritas_os/tests/test_api_pipeline.py veritas_os/tests/test_integration_pipeline.py veritas_os/tests/test_tools_coverage_map_pipeline.py` and the suite succeeded (`79 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a84779588326ae9e2accf46d807f)