### PR TITLE
Harden web-search query sanitization in decision pipeline

### DIFF
--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -797,6 +797,18 @@ async def _safe_web_search(query: str, *, max_results: int = 5) -> Optional[dict
     """
     import sys
 
+    query_text = str(query or "").strip()
+    if not query_text:
+        return None
+    if len(query_text) > 512:
+        query_text = query_text[:512]
+
+    # Block control characters to reduce risk of log injection /
+    # unsafe propagation into external adapters.
+    query_text = re.sub(r"[\x00-\x1f\x7f]", "", query_text)
+    if not query_text:
+        return None
+
     try:
         max_results_int = int(max_results)
     except (TypeError, ValueError):
@@ -811,7 +823,7 @@ async def _safe_web_search(query: str, *, max_results: int = 5) -> Optional[dict
         return None
 
     try:
-        ws = fn(query, max_results=max_results_int)  # type: ignore[misc]
+        ws = fn(query_text, max_results=max_results_int)  # type: ignore[misc]
         if inspect.isawaitable(ws):
             ws = await ws
         return ws if isinstance(ws, dict) else None

--- a/veritas_os/tests/test_api_pipeline.py
+++ b/veritas_os/tests/test_api_pipeline.py
@@ -211,6 +211,27 @@ async def test_safe_web_search_sanitizes_max_results(monkeypatch):
     assert calls == [20, 5]
 
 
+@pytest.mark.anyio
+async def test_safe_web_search_sanitizes_query_and_rejects_empty(monkeypatch):
+    calls: List[str] = []
+
+    def fake_ws(query: str, max_results: int = 5) -> Dict[str, Any]:
+        calls.append(query)
+        return {"ok": True, "results": []}
+
+    monkeypatch.setattr(api_pipeline, "web_search", fake_ws, raising=False)
+
+    assert await api_pipeline._safe_web_search("   ") is None
+
+    long_query = ("a" * 520) + "\x00\x1f"
+    await api_pipeline._safe_web_search(long_query)
+
+    assert len(calls) == 1
+    assert len(calls[0]) == 512
+    assert "\x00" not in calls[0]
+    assert "\x1f" not in calls[0]
+
+
 # =========================================================
 # run_decide_pipeline のためのダミー型
 # =========================================================
@@ -1101,7 +1122,6 @@ async def test_run_decide_pipeline_trustlog_and_shadow_exception_swallowed(monke
     assert isinstance(metrics, dict)
     assert "effective_risk" in metrics
     assert "gate" in payload
-
 
 
 


### PR DESCRIPTION
### Motivation
- `_safe_web_search` previously passed the raw `query` through to external adapters which could allow control characters or very long payloads to propagate into logs or downstream systems. 
- The change aims to reduce log-injection and adapter-processing risks by normalizing query text inside the pipeline boundary without changing core responsibilities. 
- This update keeps the pipeline / Planner / Kernel / Fuji / MemoryOS responsibilities unchanged and confines sanitization to the web-search adapter call. 
- Security warning: this mitigates control-character and length-based risks but does not replace output-encoding or adapter-side validation, so downstream adapters may still introduce risks if untrusted input is used unsafely. 

### Description
- Updated `veritas_os/core/pipeline.py:: _safe_web_search` to normalize the `query` into `query_text` by trimming whitespace, returning `None` for blank queries, truncating to `512` characters, and stripping ASCII control characters (`\x00-\x1f`, `\x7f`) before invocation. 
- The sanitized `query_text` is now passed to the adapter call instead of the original `query`, while the existing `max_results` sanitization (`[1,20]`) is preserved. 
- Added a regression test `test_safe_web_search_sanitizes_query_and_rejects_empty` in `veritas_os/tests/test_api_pipeline.py` to verify blank-query rejection, truncation to `512` chars, and removal of control characters. 
- Included inline comments documenting the rationale and risk mitigation; no changes were made outside the pipeline adapter sanitization scope. 

### Testing
- Ran `pytest -q veritas_os/tests/test_api_pipeline.py -k safe_web_search`, which completed successfully with `4 passed, 45 deselected`. 
- The new test `test_safe_web_search_sanitizes_query_and_rejects_empty` passed as part of the above run. 
- No other automated tests were modified or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2060185b48326b64cfa1a6088703a)