### PR TITLE
Harden pipeline: redact web-query logs, validate env paths, and strengthen call signature handling

### DIFF
--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -459,18 +459,52 @@ def _safe_paths() -> Tuple[Path, Path, Path, Path]:
     env_log = (os.getenv("VERITAS_LOG_DIR") or "").strip()
     env_ds = (os.getenv("VERITAS_DATASET_DIR") or "").strip()
 
+    def _resolve_within_repo(path_text: str, *, env_name: str) -> Optional[Path]:
+        """Resolve and validate environment override directory.
+
+        Security policy:
+        - By default, only paths under ``REPO_ROOT`` are accepted.
+        - External paths can be explicitly allowed by setting
+          ``VERITAS_ALLOW_EXTERNAL_PATHS=1``.
+        """
+        if not path_text:
+            return None
+
+        candidate = Path(path_text).resolve()
+        allow_external = _to_bool(os.getenv("VERITAS_ALLOW_EXTERNAL_PATHS", "0"))
+        if allow_external:
+            return candidate
+
+        try:
+            candidate.relative_to(REPO_ROOT)
+            return candidate
+        except ValueError:
+            logger.warning(
+                "[SECURITY][pipeline] Ignoring %s=%r outside REPO_ROOT (%s). "
+                "Set VERITAS_ALLOW_EXTERNAL_PATHS=1 to allow explicitly.",
+                env_name,
+                path_text,
+                REPO_ROOT,
+            )
+            return None
+
     try:
         from veritas_os.logging import paths as lp  # type: ignore
 
-        LOG_DIR = Path(env_log).resolve() if env_log else Path(getattr(lp, "LOG_DIR")).resolve()
-        DATASET_DIR = Path(env_ds).resolve() if env_ds else Path(getattr(lp, "DATASET_DIR")).resolve()
+        env_log_path = _resolve_within_repo(env_log, env_name="VERITAS_LOG_DIR")
+        env_ds_path = _resolve_within_repo(env_ds, env_name="VERITAS_DATASET_DIR")
+
+        LOG_DIR = env_log_path or Path(getattr(lp, "LOG_DIR")).resolve()
+        DATASET_DIR = env_ds_path or Path(getattr(lp, "DATASET_DIR")).resolve()
         VAL_JSON = Path(getattr(lp, "VAL_JSON")).resolve()
         META_LOG = Path(getattr(lp, "META_LOG")).resolve()
         return LOG_DIR, DATASET_DIR, VAL_JSON, META_LOG
     except (ImportError, AttributeError, OSError) as e:
         _warn(f"[WARN][pipeline] logging.paths import failed -> fallback: {repr(e)}")
-        LOG_DIR = (Path(env_log).resolve() if env_log else (REPO_ROOT / "logs").resolve())
-        DATASET_DIR = (Path(env_ds).resolve() if env_ds else (REPO_ROOT / "dataset").resolve())
+        env_log_path = _resolve_within_repo(env_log, env_name="VERITAS_LOG_DIR")
+        env_ds_path = _resolve_within_repo(env_ds, env_name="VERITAS_DATASET_DIR")
+        LOG_DIR = env_log_path or (REPO_ROOT / "logs").resolve()
+        DATASET_DIR = env_ds_path or (REPO_ROOT / "dataset").resolve()
         VAL_JSON = (LOG_DIR / "value_ema.json").resolve()
         META_LOG = (LOG_DIR / "meta.log").resolve()
         return LOG_DIR, DATASET_DIR, VAL_JSON, META_LOG
@@ -703,65 +737,70 @@ async def call_core_decide(
             logger.debug("call_core_decide: signature inspection failed for %r", fn)
             return set()
 
-    def _reraise_if_internal() -> None:
-        """Re-raise the current TypeError if it originated inside core_fn
-        (traceback depth > 1), rather than from a signature mismatch."""
-        import sys as _sys
-        _tb = _sys.exc_info()[2]
-        if _tb is not None and _tb.tb_next is not None:
-            raise
-        del _tb
+    def _can_bind(*args: Any, **kwargs: Any) -> bool:
+        """Return True if ``core_fn`` can accept the provided call pattern."""
+        try:
+            inspect.signature(core_fn).bind_partial(*args, **kwargs)
+            return True
+        except TypeError:
+            return False
+        except Exception:
+            return True
 
     p = _params(core_fn)
+    attempted_patterns: List[str] = []
 
     # ---- Try A: ctx/options style ----
-    try:
-        if ("ctx" in p) or ("options" in p):
-            res = core_fn(ctx=ctx, options=opts, min_evidence=min_evidence, query=query)
-            return await res if _is_awaitable(res) else res
-    except TypeError:
-        _reraise_if_internal()
+    kwargs_a = {
+        "ctx": ctx,
+        "options": opts,
+        "min_evidence": min_evidence,
+        "query": query,
+    }
+    if (("ctx" in p) or ("options" in p)) and _can_bind(**kwargs_a):
+        attempted_patterns.append("A")
+        res = core_fn(**kwargs_a)
+        return await res if _is_awaitable(res) else res
 
     # ---- Try B: context/query/alternatives style ----
-    try:
-        kw = {}
-        # context arg name
-        if "context" in p:
-            kw["context"] = ctx
-        elif "ctx" in p:
-            kw["ctx"] = ctx
-        else:
-            # fallback
-            kw["context"] = ctx
+    kw = {}
+    if "context" in p:
+        kw["context"] = ctx
+    elif "ctx" in p:
+        kw["ctx"] = ctx
+    else:
+        kw["context"] = ctx
 
-        # alternatives arg name
-        if "alternatives" in p:
-            kw["alternatives"] = opts
-        elif "options" in p:
-            kw["options"] = opts
-        else:
-            # fallback
-            kw["alternatives"] = opts
+    if "alternatives" in p:
+        kw["alternatives"] = opts
+    elif "options" in p:
+        kw["options"] = opts
+    else:
+        kw["alternatives"] = opts
 
-        if "query" in p:
-            kw["query"] = query
+    if "query" in p:
+        kw["query"] = query
 
-        if "min_evidence" in p:
-            kw["min_evidence"] = min_evidence
+    if "min_evidence" in p:
+        kw["min_evidence"] = min_evidence
 
+    if _can_bind(**kw):
+        attempted_patterns.append("B")
         res = core_fn(**kw)
         return await res if _is_awaitable(res) else res
-    except TypeError:
-        _reraise_if_internal()
 
     # ---- Try C: positional (last resort) ----
     try:
+        if not _can_bind(ctx, query, opts, min_evidence):
+            raise TypeError("pattern C signature mismatch")
+        attempted_patterns.append("C")
         res = core_fn(ctx, query, opts, min_evidence)
         return await res if _is_awaitable(res) else res
     except TypeError as e:
         raise TypeError(
             f"call_core_decide: all calling conventions failed for {core_fn!r}. "
-            f"Last error: {e}"
+            f"Attempted={attempted_patterns or ['none']}, "
+            f"kwargsB={sorted(kw.keys())}, last_error={e}"
         ) from e
 
 
@@ -828,7 +867,11 @@ async def _safe_web_search(query: str, *, max_results: int = 5) -> Optional[dict
             ws = await ws
         return ws if isinstance(ws, dict) else None
     except Exception:  # subsystem resilience: intentionally broad
-        logger.debug("_safe_web_search failed for query=%r", query, exc_info=True)
+        logger.debug(
+            "_safe_web_search failed for query=%r",
+            _redact_text(query_text),
+            exc_info=True,
+        )
         return None
 
 

--- a/veritas_os/tests/test_pipeline_coverage_boost2.py
+++ b/veritas_os/tests/test_pipeline_coverage_boost2.py
@@ -253,6 +253,7 @@ class TestSafePaths:
             assert isinstance(p, Path)
 
     def test_env_override_log_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VERITAS_ALLOW_EXTERNAL_PATHS", "1")
         monkeypatch.setenv("VERITAS_LOG_DIR", str(tmp_path / "logs"))
         monkeypatch.setenv("VERITAS_DATASET_DIR", str(tmp_path / "ds"))
         log_dir, ds_dir, _, _ = pipeline._safe_paths()

--- a/veritas_os/tests/test_pipeline_helpers_v2.py
+++ b/veritas_os/tests/test_pipeline_helpers_v2.py
@@ -137,6 +137,7 @@ class TestSafePaths:
         """Lines 337-343: fallback uses env vars when logging fails."""
         log_dir = str(tmp_path / "logs")
         ds_dir = str(tmp_path / "dataset")
+        monkeypatch.setenv("VERITAS_ALLOW_EXTERNAL_PATHS", "1")
         monkeypatch.setenv("VERITAS_LOG_DIR", log_dir)
         monkeypatch.setenv("VERITAS_DATASET_DIR", ds_dir)
 

--- a/veritas_os/tests/test_pipeline_review_fixes.py
+++ b/veritas_os/tests/test_pipeline_review_fixes.py
@@ -403,3 +403,58 @@ class TestToDictCircularRef:
 
         result = _to_dict(Normal())
         assert result == {"a": 1, "b": "hello"}
+
+
+# =========================================================
+# Security hardening
+# =========================================================
+
+
+class TestSecurityHardening:
+
+    @pytest.mark.asyncio
+    async def test_safe_web_search_logs_redacted_query(self, monkeypatch, caplog):
+        """Debug log should redact query text on adapter failure."""
+        import veritas_os.core.pipeline as pipeline_mod
+
+        def bad_search(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(pipeline_mod, "web_search", bad_search, raising=False)
+        with caplog.at_level(logging.DEBUG, logger="veritas_os.core.pipeline"):
+            result = await pipeline_mod._safe_web_search("mail me at a@example.com")
+
+        assert result is None
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("_safe_web_search failed for query=" in message for message in messages)
+        assert all("a@example.com" not in message for message in messages)
+
+    def test_safe_paths_rejects_external_env_dir_by_default(self, monkeypatch):
+        """External env paths should be ignored unless explicitly allowed."""
+        import veritas_os.core.pipeline as pipeline_mod
+
+        monkeypatch.delenv("VERITAS_ALLOW_EXTERNAL_PATHS", raising=False)
+        monkeypatch.setenv("VERITAS_LOG_DIR", "/tmp/veritas_external_logs")
+        monkeypatch.setenv("VERITAS_DATASET_DIR", "/tmp/veritas_external_dataset")
+
+        log_dir, dataset_dir, _, _ = pipeline_mod._safe_paths()
+
+        assert str(log_dir).startswith(str(pipeline_mod.REPO_ROOT))
+        assert str(dataset_dir).startswith(str(pipeline_mod.REPO_ROOT))
+
+    def test_safe_paths_accepts_external_env_dir_when_explicitly_allowed(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        """External env paths are allowed only with explicit opt-in."""
+        import veritas_os.core.pipeline as pipeline_mod
+
+        monkeypatch.setenv("VERITAS_ALLOW_EXTERNAL_PATHS", "1")
+        monkeypatch.setenv("VERITAS_LOG_DIR", str(tmp_path / "logs"))
+        monkeypatch.setenv("VERITAS_DATASET_DIR", str(tmp_path / "dataset"))
+
+        log_dir, dataset_dir, _, _ = pipeline_mod._safe_paths()
+
+        assert log_dir == (tmp_path / "logs").resolve()
+        assert dataset_dir == (tmp_path / "dataset").resolve()

--- a/veritas_os/tests/test_pipeline_review_fixes.py
+++ b/veritas_os/tests/test_pipeline_review_fixes.py
@@ -429,18 +429,33 @@ class TestSecurityHardening:
         assert any("_safe_web_search failed for query=" in message for message in messages)
         assert all("a@example.com" not in message for message in messages)
 
-    def test_safe_paths_rejects_external_env_dir_by_default(self, monkeypatch):
+    def test_safe_paths_rejects_external_env_dir_by_default(
+        self,
+        monkeypatch,
+        caplog,
+    ):
         """External env paths should be ignored unless explicitly allowed."""
         import veritas_os.core.pipeline as pipeline_mod
 
+        log_env = "/tmp/veritas_external_logs"
+        dataset_env = "/tmp/veritas_external_dataset"
         monkeypatch.delenv("VERITAS_ALLOW_EXTERNAL_PATHS", raising=False)
-        monkeypatch.setenv("VERITAS_LOG_DIR", "/tmp/veritas_external_logs")
-        monkeypatch.setenv("VERITAS_DATASET_DIR", "/tmp/veritas_external_dataset")
+        monkeypatch.setenv("VERITAS_LOG_DIR", log_env)
+        monkeypatch.setenv("VERITAS_DATASET_DIR", dataset_env)
 
-        log_dir, dataset_dir, _, _ = pipeline_mod._safe_paths()
+        with caplog.at_level(logging.WARNING, logger="veritas_os.core.pipeline"):
+            log_dir, dataset_dir, _, _ = pipeline_mod._safe_paths()
 
-        assert str(log_dir).startswith(str(pipeline_mod.REPO_ROOT))
-        assert str(dataset_dir).startswith(str(pipeline_mod.REPO_ROOT))
+        assert str(log_dir) != log_env
+        assert str(dataset_dir) != dataset_env
+        assert any(
+            "[SECURITY][pipeline] Ignoring VERITAS_LOG_DIR" in record.getMessage()
+            for record in caplog.records
+        )
+        assert any(
+            "[SECURITY][pipeline] Ignoring VERITAS_DATASET_DIR" in record.getMessage()
+            for record in caplog.records
+        )
 
     def test_safe_paths_accepts_external_env_dir_when_explicitly_allowed(
         self,


### PR DESCRIPTION
### Motivation
- Reduce security risk of leaking sensitive user input by avoiding raw query text in debug logs from `_safe_web_search`.
- Prevent accidental or malicious redirection of logs/datasets to arbitrary filesystem locations by validating `VERITAS_LOG_DIR`/`VERITAS_DATASET_DIR` overrides.
- Improve robustness and observability of `call_core_decide` by moving from traceback-depth heuristics to pre-binding signature checks for safer error propagation.

### Description
- `_safe_web_search`: redact the query in failure debug logs using ` _redact_text(query_text)` to avoid PII exposure in logs and preserve broad exception resilience.
- `_safe_paths`: added `_resolve_within_repo()` helper that resolves and validates env-path overrides; by default only paths under `REPO_ROOT` are accepted and external paths are ignored with a `[SECURITY]` warning unless `VERITAS_ALLOW_EXTERNAL_PATHS=1` is set.
- `call_core_decide`: replaced traceback-depth based internal-`TypeError` detection with `inspect.signature(...).bind_partial(...)` checks via a new `_can_bind()` helper and record attempted patterns in diagnostic output when all conventions fail.
- Tests: added/updated unit tests to cover redaction behavior and new path-allow opt-in semantics and adjusted existing env-dependent tests to explicitly opt into external paths when required.

### Testing
- Ran targeted test suite: `pytest -q veritas_os/tests/test_api_pipeline.py veritas_os/tests/test_pipeline_review_fixes.py veritas_os/tests/test_pipeline_coverage_boost2.py veritas_os/tests/test_pipeline_helpers_v2.py`.
- Result: all tests passed (`237 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b20b5b669c8326ab60152153a46c52)