### PR TITLE
Harden pipeline path policy and add diagnostics to core decide binding

### DIFF
--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -519,8 +519,16 @@ def _safe_paths() -> Tuple[Path, Path, Path, Path]:
             or default_dataset_dir
             or (REPO_ROOT / "dataset").resolve()
         )
-        VAL_JSON = Path(getattr(lp, "VAL_JSON")).resolve()
-        META_LOG = Path(getattr(lp, "META_LOG")).resolve()
+        default_val_json = _enforce_path_policy(
+            Path(getattr(lp, "VAL_JSON")),
+            source_name="logging.paths.VAL_JSON",
+        )
+        default_meta_log = _enforce_path_policy(
+            Path(getattr(lp, "META_LOG")),
+            source_name="logging.paths.META_LOG",
+        )
+        VAL_JSON = default_val_json or (LOG_DIR / "value_ema.json").resolve()
+        META_LOG = default_meta_log or (LOG_DIR / "meta.log").resolve()
         return LOG_DIR, DATASET_DIR, VAL_JSON, META_LOG
     except (ImportError, AttributeError, OSError) as e:
         _warn(f"[WARN][pipeline] logging.paths import failed -> fallback: {repr(e)}")
@@ -777,6 +785,7 @@ async def call_core_decide(
 
     p = _params(core_fn)
     attempted_patterns: List[str] = []
+    diagnostic_rows: List[str] = []
 
     # ---- Try A: ctx/options style ----
     kwargs_a = {
@@ -785,7 +794,11 @@ async def call_core_decide(
         "min_evidence": min_evidence,
         "query": query,
     }
-    if (("ctx" in p) or ("options" in p)) and _can_bind(**kwargs_a):
+    can_bind_a = (("ctx" in p) or ("options" in p)) and _can_bind(**kwargs_a)
+    diagnostic_rows.append(
+        f"A(can_bind={can_bind_a},keys={sorted(kwargs_a.keys())})"
+    )
+    if can_bind_a:
         attempted_patterns.append("A")
         res = core_fn(**kwargs_a)
         return await res if _is_awaitable(res) else res
@@ -812,21 +825,31 @@ async def call_core_decide(
     if "min_evidence" in p:
         kw["min_evidence"] = min_evidence
 
-    if _can_bind(**kw):
+    can_bind_b = _can_bind(**kw)
+    diagnostic_rows.append(f"B(can_bind={can_bind_b},keys={sorted(kw.keys())})")
+    if can_bind_b:
         attempted_patterns.append("B")
         res = core_fn(**kw)
         return await res if _is_awaitable(res) else res
 
     # ---- Try C: positional (last resort) ----
-    if _can_bind(ctx, query, opts, min_evidence):
+    can_bind_c = _can_bind(ctx, query, opts, min_evidence)
+    diagnostic_rows.append("C(can_bind=%s,keys=%s)" % (can_bind_c, ["args"]))
+    if can_bind_c:
         attempted_patterns.append("C")
         res = core_fn(ctx, query, opts, min_evidence)
         return await res if _is_awaitable(res) else res
 
+    logger.error(
+        "call_core_decide failed signature negotiation: fn=%r diagnostics=%s",
+        core_fn,
+        "; ".join(diagnostic_rows),
+    )
     raise TypeError(
         f"call_core_decide: all calling conventions failed for {core_fn!r}. "
         f"Attempted={attempted_patterns or ['none']}, "
-        f"kwargsB={sorted(kw.keys())}, last_error=pattern C signature mismatch"
+        f"kwargsB={sorted(kw.keys())}, diagnostics={diagnostic_rows}, "
+        "last_error=pattern C signature mismatch"
     )
 
 

--- a/veritas_os/tests/test_pipeline_review_fixes.py
+++ b/veritas_os/tests/test_pipeline_review_fixes.py
@@ -473,3 +473,33 @@ class TestSecurityHardening:
 
         assert log_dir == (tmp_path / "logs").resolve()
         assert dataset_dir == (tmp_path / "dataset").resolve()
+
+    def test_safe_paths_rejects_external_lp_file_targets_by_default(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        """VAL_JSON/META_LOG from logging.paths must also follow path policy."""
+        import veritas_os.core.pipeline as pipeline_mod
+
+        from veritas_os.logging import paths as lp
+
+        monkeypatch.delenv("VERITAS_ALLOW_EXTERNAL_PATHS", raising=False)
+        monkeypatch.setattr(lp, "LOG_DIR", str(pipeline_mod.REPO_ROOT / "logs"))
+        monkeypatch.setattr(lp, "DATASET_DIR", str(pipeline_mod.REPO_ROOT / "dataset"))
+        monkeypatch.setattr(lp, "VAL_JSON", "/tmp/veritas_external_value_ema.json")
+        monkeypatch.setattr(lp, "META_LOG", "/tmp/veritas_external_meta.log")
+
+        with caplog.at_level(logging.WARNING, logger="veritas_os.core.pipeline"):
+            _, _, val_json, meta_log = pipeline_mod._safe_paths()
+
+        assert val_json == (pipeline_mod.REPO_ROOT / "logs" / "value_ema.json").resolve()
+        assert meta_log == (pipeline_mod.REPO_ROOT / "logs" / "meta.log").resolve()
+        assert any(
+            "[SECURITY][pipeline] Ignoring logging.paths.VAL_JSON" in record.getMessage()
+            for record in caplog.records
+        )
+        assert any(
+            "[SECURITY][pipeline] Ignoring logging.paths.META_LOG" in record.getMessage()
+            for record in caplog.records
+        )


### PR DESCRIPTION
### Motivation
- Address precision-review security finding by ensuring file targets from `logging.paths` (VAL_JSON/META_LOG) respect the same REPO-root write policy as log/dataset directories.
- Improve reliability and operability when `call_core_decide()` fails to match a core function signature by surfacing per-pattern bind diagnostics to aid troubleshooting.
- Keep changes confined to the orchestrator responsibilities (pipeline) without crossing Planner/Kernel/Fuji/MemoryOS boundaries.

### Description
- Strengthened `veritas_os/core/pipeline.py::_safe_paths()` to validate `logging.paths.VAL_JSON` and `logging.paths.META_LOG` via `_enforce_path_policy`, and fall back to `LOG_DIR/value_ema.json` and `LOG_DIR/meta.log` when external file targets are rejected.
- Enhanced `veritas_os/core/pipeline.py::call_core_decide()` to capture per-pattern (A/B/C) bindability diagnostics in `diagnostic_rows`, log a structured error on complete negotiation failure, and include diagnostics in the raised `TypeError` message.
- Added a regression test `test_safe_paths_rejects_external_lp_file_targets_by_default` in `veritas_os/tests/test_pipeline_review_fixes.py` to assert file-targets from `logging.paths` are rejected by default and produce a warning log.
- Maintained existing docstrings and kept responsibility boundaries intact; no changes were made to Planner/Kernel/FUJI/MemoryOS logic.

### Testing
- Ran style checks: `ruff check veritas_os/core/pipeline.py veritas_os/tests/test_pipeline_review_fixes.py` and it passed.
- Ran focused unit tests: `pytest -q veritas_os/tests/test_pipeline_review_fixes.py::TestSecurityHardening veritas_os/tests/test_pipeline_review_fixes.py::TestCallCoreDecideTypeErrorPropagation` and all selected tests passed (`6 passed`).
- Ran related helpers tests: `python -m pytest -q veritas_os/tests/test_pipeline_helpers_v2.py -k "safe_paths or call_core_decide or safe_web_search"` and they passed (`1 passed, 61 deselected`).

Security note: enabling `VERITAS_ALLOW_EXTERNAL_PATHS=1` will permit external paths to be accepted; keep this unset in production unless explicitly required and reviewed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b224c61b8c8326a5cced1187ef1b4b)