### PR TITLE
Harden VERITAS_ENCRYPTION_KEY Base64 validation in at-rest crypto module

### DIFF
--- a/veritas_os/logging/encryption.py
+++ b/veritas_os/logging/encryption.py
@@ -55,12 +55,17 @@ def generate_key() -> str:
 
 
 def _get_key_bytes() -> Optional[bytes]:
-    """Return the 32-byte master key from the environment, or None."""
+    """Return the 32-byte master key from the environment, or None.
+
+    Security hardening:
+        Uses strict Base64 validation (``validate=True``) so malformed
+        values are rejected instead of being silently accepted.
+    """
     raw = os.environ.get("VERITAS_ENCRYPTION_KEY")
     if not raw:
         return None
     try:
-        key = base64.urlsafe_b64decode(raw)
+        key = base64.b64decode(raw.encode("ascii"), altchars=b"-_", validate=True)
         if len(key) != 32:
             logger.warning(
                 "VERITAS_ENCRYPTION_KEY must decode to 32 bytes; got %d — encryption disabled",
@@ -68,7 +73,7 @@ def _get_key_bytes() -> Optional[bytes]:
             )
             return None
         return key
-    except Exception:
+    except (ValueError, TypeError, UnicodeEncodeError):
         logger.warning("VERITAS_ENCRYPTION_KEY is not valid base64 — encryption disabled")
         return None
 

--- a/veritas_os/tests/test_eu_ai_act_p3_improvements.py
+++ b/veritas_os/tests/test_eu_ai_act_p3_improvements.py
@@ -146,6 +146,20 @@ class TestEncryption:
             else:
                 os.environ.pop("VERITAS_ENCRYPTION_KEY", None)
 
+    def test_invalid_base64_key_is_rejected(self) -> None:
+        """Invalid Base64 should disable encryption instead of being tolerated."""
+        old = os.environ.get("VERITAS_ENCRYPTION_KEY")
+        os.environ["VERITAS_ENCRYPTION_KEY"] = "%%%not-base64%%%"
+        try:
+            assert is_encryption_enabled() is False
+            plaintext = '{"security": "check"}'
+            assert encrypt(plaintext) == plaintext
+        finally:
+            if old is not None:
+                os.environ["VERITAS_ENCRYPTION_KEY"] = old
+            else:
+                os.environ.pop("VERITAS_ENCRYPTION_KEY", None)
+
 
 # =====================================================================
 # P3-3: Continuous risk monitoring (GAP-15, Art. 9)


### PR DESCRIPTION
### Motivation
- Prevent malformed or ambiguous `VERITAS_ENCRYPTION_KEY` values from being accepted and accidentally enabling/using invalid key material, which is a configuration-level security risk. 
- Make key parsing fail-closed so encryption is reliably disabled when the environment is misconfigured.
- Keep the change narrowly scoped to the at-rest encryption utility to avoid crossing responsibility boundaries.

### Description
- Switched key decoding to strict Base64 validation using `base64.b64decode(..., altchars=b"-_", validate=True)` and explicit `UnicodeEncodeError`/`ValueError`/`TypeError` handling in `veritas_os/logging/encryption.py` to reject malformed keys instead of leniently accepting them. 
- Updated `_get_key_bytes()` docstring to document the hardening behavior and rationale. 
- Added a regression test `test_invalid_base64_key_is_rejected` in `veritas_os/tests/test_eu_ai_act_p3_improvements.py` which verifies that an invalid Base64 key disables encryption and that `encrypt()` falls back to plaintext passthrough. 

### Testing
- Ran `pytest -q veritas_os/tests/test_eu_ai_act_p3_improvements.py -k encryption` which produced `7 passed, 25 deselected` (all encryption-related tests passed). 
- Ran `ruff check veritas_os/logging/encryption.py veritas_os/tests/test_eu_ai_act_p3_improvements.py` and it reported all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24ce634b08326b278cb4bdcc88fda)