### PR TITLE
MemoryOS: enforce pickle sunset messaging and add offline migration runbook

### DIFF
--- a/docs/operations/MEMORY_PICKLE_MIGRATION.md
+++ b/docs/operations/MEMORY_PICKLE_MIGRATION.md
@@ -1,0 +1,30 @@
+---
+title: MemoryOS Legacy Pickle Migration
+lifecycle: active
+updated_at: 2026-03-12
+---
+
+# MemoryOS Legacy Pickle Migration
+
+## Security policy
+
+- Runtime での `pickle` / `joblib` 読み込みは **禁止** です。
+- 理由: `pickle` は任意コード実行 (RCE) リスクを持つためです。
+- Runtime が `.pkl` を検知した場合、ロードせずに `[SECURITY]` ログを出力します。
+
+## Sunset deadline
+
+- Pickle runtime block policy deadline: **2026-06-30**
+- この日付以降、runtime 側での例外的な互換復帰は行いません。
+
+## Offline migration steps
+
+1. 信頼できる隔離環境で旧 `.pkl` を読み込みます。
+2. `VectorMemory` の JSON 形式 (`vector_index.json`) に変換します。
+3. モデルは ONNX (`memory_model.onnx`) へ変換します。
+4. 本番配置前に `.pkl` を削除し、JSON/ONNX のみを配置します。
+
+## Operational warning
+
+- 本番ディレクトリに未検証 `.pkl` を置かないでください。
+- CI/CD で `.pkl` ファイル混入を検知するチェックを推奨します。

--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -336,9 +336,9 @@ This document tracks the status of issues identified in `CODE_REVIEW_REPORT.md`.
 15. ✅ Fix get_last_hash thread safety with RLock (H-12)
 
 ### Short-term Recommendations (Next PR)
-1. Set hard deadline for pickle removal (H-8)
-2. Add deprecation warnings for pickle support
-3. Document migration path for pickle users
+1. ✅ Set hard deadline for pickle runtime block (2026-06-30) in MemoryOS runtime logs
+2. ✅ Document offline migration path for pickle users: `docs/operations/MEMORY_PICKLE_MIGRATION.md`
+3. Keep CI/runtime guardrails to prevent `.pkl` artifacts in production paths
 
 ### Long-term Recommendations (Next Major Version)
 1. Refactor module initialization to lazy pattern (H-4, M-2)

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -28,6 +28,9 @@ from .config import capability_cfg, emit_capability_manifest
 
 logger = logging.getLogger(__name__)
 
+PICKLE_RUNTIME_BLOCK_DEADLINE = "2026-06-30"
+PICKLE_MIGRATION_GUIDE_PATH = "docs/operations/MEMORY_PICKLE_MIGRATION.md"
+
 
 DEFAULT_RETENTION_CLASS = "standard"
 ALLOWED_RETENTION_CLASSES = {
@@ -44,6 +47,20 @@ def _is_explicitly_enabled(env_key: str) -> bool:
     if value is None:
         return False
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _emit_legacy_pickle_runtime_blocked(path: Path, artifact_name: str) -> None:
+    """Log a security warning for legacy pickle artifacts blocked at runtime."""
+    logger.error(
+        "[SECURITY] Legacy %s pickle detected at %s. "
+        "Runtime pickle/joblib loading is disabled and will not be restored "
+        "after %s. Migrate artifacts offline using %s. "
+        "Never place untrusted .pkl files in runtime directories (RCE risk).",
+        artifact_name,
+        path,
+        PICKLE_RUNTIME_BLOCK_DEADLINE,
+        PICKLE_MIGRATION_GUIDE_PATH,
+    )
 
 
 # OS 判定
@@ -192,10 +209,9 @@ class VectorMemory:
 
             # 2) 旧pickle形式は runtime では読み込まない
             if legacy_pkl_path.exists() and legacy_pkl_path.suffix == ".pkl":
-                logger.error(
-                    "[SECURITY] Legacy pickle index detected at %s. "
-                    "Runtime migration has been removed; use offline migration.",
-                    legacy_pkl_path,
+                _emit_legacy_pickle_runtime_blocked(
+                    path=legacy_pkl_path,
+                    artifact_name="vector index",
                 )
                 return
 
@@ -536,10 +552,9 @@ logger.info("[MemoryModel] module loaded from: %s", __file__)
 MODEL = None
 legacy_model_path = MODELS_DIR / "memory_model.pkl"
 if legacy_model_path.exists():
-    logger.error(
-        "[SECURITY] Legacy model pickle detected at %s. "
-        "Runtime loading has been removed; export to ONNX for deployment.",
-        legacy_model_path,
+    _emit_legacy_pickle_runtime_blocked(
+        path=legacy_model_path,
+        artifact_name="model",
     )
 elif MEMORY_MODEL_PATH.exists():
     logger.info(

--- a/veritas_os/tests/test_memory_vector.py
+++ b/veritas_os/tests/test_memory_vector.py
@@ -279,9 +279,26 @@ def test_legacy_pickle_migration_opt_in(tmp_path: Path, monkeypatch):
     assert not idx_path.with_suffix(".json").exists()
 
 
+def test_legacy_pickle_detection_log_includes_migration_guidance(
+    tmp_path: Path, caplog
+):
+    """レガシーpickle検知ログに期限と移行ガイドを含むことを確認する。"""
+    import logging
+    import numpy as np
 
+    idx_path = tmp_path / "legacy_index.pkl"
+    documents = [
+        {"id": "doc_1", "kind": "semantic", "text": "legacy doc", "tags": []},
+    ]
+    embeddings = np.ones((1, 4), dtype="float32")
+    _write_legacy_pickle(idx_path, documents, embeddings)
 
+    with caplog.at_level(logging.ERROR, logger="veritas_os.core.memory"):
+        _new_vector_memory(index_path=idx_path, dim=4)
 
+    assert "[SECURITY] Legacy vector index pickle detected" in caplog.text
+    assert memory.PICKLE_RUNTIME_BLOCK_DEADLINE in caplog.text
+    assert memory.PICKLE_MIGRATION_GUIDE_PATH in caplog.text
 
 
 def test_load_model_is_thread_safe(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent runtime pickle/joblib deserialization RCE risk by making the decommission policy explicit and operator-visible. 
- Provide a concrete offline migration path and a hard deadline so operators stop relying on ad-hoc runtime migration.

### Description
- Added `PICKLE_RUNTIME_BLOCK_DEADLINE` and `PICKLE_MIGRATION_GUIDE_PATH` constants and a helper `_emit_legacy_pickle_runtime_blocked()` to centralize security guidance in `veritas_os/core/memory.py`.
- Replaced ad-hoc legacy `.pkl` error logs in `VectorMemory` index loading and legacy model detection to call the centralized helper so messages consistently include the deadline and migration guide.
- Added an operational runbook `docs/operations/MEMORY_PICKLE_MIGRATION.md` describing the policy, sunset deadline, offline migration steps (JSON/ONNX), and operational warnings.
- Updated `docs/review/CODE_REVIEW_STATUS.md` short-term recommendations to reflect the deadline and documented migration path.
- Added a regression test `test_legacy_pickle_detection_log_includes_migration_guidance` in `veritas_os/tests/test_memory_vector.py` to assert the security log contains the deadline and migration guide path.

### Testing
- Ran targeted pytest for the modified tests: `pytest -q veritas_os/tests/test_memory_vector.py::test_legacy_pickle_migration_disabled_by_default veritas_os/tests/test_memory_vector.py::test_legacy_pickle_migration_opt_in veritas_os/tests/test_memory_vector.py::test_legacy_pickle_detection_log_includes_migration_guidance` and all 3 tests passed.
- Ran `ruff check veritas_os/core/memory.py veritas_os/tests/test_memory_vector.py` and linting passed without issues.

Security note: runtime pickle/joblib loading remains fail-closed; operators must not place untrusted `.pkl` files in runtime directories as these can enable arbitrary code execution (RCE).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2614a5f908326b6f723f24f0165b5)