### PR TITLE
Memory: ランタイム直下のレガシー .pkl 検知を追加

### DIFF
--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -63,6 +63,27 @@ def _emit_legacy_pickle_runtime_blocked(path: Path, artifact_name: str) -> None:
     )
 
 
+def _warn_for_legacy_pickle_artifacts(scan_roots: List[Path]) -> None:
+    """Emit security warnings when legacy pickle artifacts are present.
+
+    This runtime guardrail does not deserialize any pickle payloads.
+    It only scans direct children of known MemoryOS runtime directories and
+    emits migration guidance so operators can remove risky artifacts.
+    """
+    checked_roots = set()
+    for raw_root in scan_roots:
+        root = raw_root.resolve(strict=False)
+        if root in checked_roots or not root.exists() or not root.is_dir():
+            continue
+        checked_roots.add(root)
+
+        for legacy_file in root.glob("*.pkl"):
+            _emit_legacy_pickle_runtime_blocked(
+                path=legacy_file,
+                artifact_name="runtime artifact",
+            )
+
+
 # OS 判定
 IS_WIN = os.name == "nt"
 
@@ -543,6 +564,12 @@ if MEM_VEC_EXTERNAL is not None and MEM_VEC_EXTERNAL.__class__.__name__ == "Simp
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODELS_DIR = REPO_ROOT / "core" / "models"
 MODELS_DIR.mkdir(parents=True, exist_ok=True)
+
+runtime_scan_roots = [MODELS_DIR]
+configured_memory_dir = os.getenv("VERITAS_MEMORY_DIR", "").strip()
+if configured_memory_dir:
+    runtime_scan_roots.append(Path(configured_memory_dir))
+_warn_for_legacy_pickle_artifacts(runtime_scan_roots)
 
 MEMORY_MODEL_PATH = MODELS_DIR / "memory_model.onnx"
 VECTOR_INDEX_PATH = MODELS_DIR / "vector_index.json"

--- a/veritas_os/tests/test_memory_vector.py
+++ b/veritas_os/tests/test_memory_vector.py
@@ -242,6 +242,39 @@ def test_vector_memory_add_and_search_performance():
     assert search_time < 5.0
 
 
+
+
+def test_warn_for_legacy_pickle_artifacts_scans_direct_children(tmp_path: Path, caplog):
+    """ランタイムディレクトリ直下の .pkl を検知して警告ログを出す。"""
+    import logging
+
+    root = tmp_path / "runtime"
+    root.mkdir()
+    direct = root / "legacy.pkl"
+    nested = root / "nested" / "ignored.pkl"
+    nested.parent.mkdir()
+    direct.write_bytes(b"x")
+    nested.write_bytes(b"x")
+
+    with caplog.at_level(logging.ERROR, logger="veritas_os.core.memory"):
+        memory._warn_for_legacy_pickle_artifacts([root, root])
+
+    assert "Legacy runtime artifact pickle detected" in caplog.text
+    assert str(direct) in caplog.text
+    assert str(nested) not in caplog.text
+
+
+def test_warn_for_legacy_pickle_artifacts_ignores_missing_paths(caplog):
+    """存在しないパスやファイルパスを渡しても例外にならない。"""
+    import logging
+
+    missing = Path("/tmp/veritas_missing_pickle_dir")
+    file_path = Path(__file__)
+
+    with caplog.at_level(logging.ERROR, logger="veritas_os.core.memory"):
+        memory._warn_for_legacy_pickle_artifacts([missing, file_path])
+
+    assert caplog.text == ""
 def test_legacy_pickle_migration_disabled_by_default(tmp_path: Path, monkeypatch):
     """オプトインなしではレガシーpickleを読み込まないことを確認する。"""
     import numpy as np


### PR DESCRIPTION
### Motivation
- `CODE_REVIEW_STATUS.md` の H-8 ポリシーに沿い、ランタイムでの pickle デシリアライズを許可しない方針を補強するために、混入した `.pkl` を早期に検知して運用者に警告する仕組みを追加しました。 

### Description
- `veritas_os/core/memory.py` に `_warn_for_legacy_pickle_artifacts(scan_roots: List[Path])` を追加し、与えたルート配下の直下ファイル（`*.pkl`）を走査して既存の `_emit_legacy_pickle_runtime_blocked()` ログを出すようにしました。 
- 初期化時に `MODELS_DIR` と設定されている場合は `VERITAS_MEMORY_DIR` を走査対象に追加して自動検知するようにしました（スキャンは直下のみ・重複ルートは無視・存在しないパスは無視）。 
- `veritas_os/tests/test_memory_vector.py` に 2 件のユニットテストを追加し、直下の `.pkl` のみが検知されることと、存在しない/ファイルパスを渡しても例外にならないことを検証しました。 
- 変更はロードやデシリアライズを一切行わない防御的な検知ロジックであり、ランタイムの振る舞いを変えずに運用可視性を向上させます。 

### Testing
- 実行した自動テスト: `pytest -q veritas_os/tests/test_memory_vector.py::test_warn_for_legacy_pickle_artifacts_scans_direct_children veritas_os/tests/test_memory_vector.py::test_warn_for_legacy_pickle_artifacts_ignores_missing_paths veritas_os/tests/test_memory_vector.py::test_legacy_pickle_detection_log_includes_migration_guidance` — 全て成功（3 passed）。
- 静的解析: `ruff check veritas_os/core/memory.py veritas_os/tests/test_memory_vector.py` — 全チェック通過。

注意（セキュリティ）: この変更は `.pkl` の検知と警告のみを行い、デシリアライズは一切行いませんが、`.pkl` ファイルは任意コード実行（RCE）のリスクがあるため、引き続き運用環境への配置を禁止してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b26847a6808326a1109ff483e10104)