### PR TITLE
Harden VERITAS_MEMORY_DIR path validation in MemoryStore

### DIFF
--- a/veritas_os/memory/store.py
+++ b/veritas_os/memory/store.py
@@ -39,7 +39,17 @@ def _resolve_memory_dir() -> Path:
         logger.info("[MemoryStore] memory directory resolved to %s", resolved_default)
         return default_path
 
-    candidate = Path(env_memory_dir)
+    candidate = Path(env_memory_dir).expanduser()
+    if not candidate.is_absolute() or ".." in candidate.parts:
+        logger.warning(
+            "[SECURITY] VERITAS_MEMORY_DIR=%s rejected because only "
+            "absolute non-traversal paths are allowed. "
+            "Falling back to default path=%s",
+            env_memory_dir,
+            default_path.resolve(strict=False),
+        )
+        return default_path
+
     resolved_candidate = candidate.resolve(strict=False)
 
     if is_production:

--- a/veritas_os/tests/test_memory_store.py
+++ b/veritas_os/tests/test_memory_store.py
@@ -496,6 +496,38 @@ def test_resolve_memory_dir_accepts_allowlisted_path_in_production(
     assert str(allowed_dir.resolve(strict=False)) in caplog.text
 
 
+def test_resolve_memory_dir_rejects_relative_path(memory_env, monkeypatch, caplog, tmp_path):
+    """相対パスの VERITAS_MEMORY_DIR は安全上の理由で拒否する。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    default_dir = tmp_path / "default-memory"
+    monkeypatch.setattr(store, "_default_memory_dir", lambda: default_dir)
+    monkeypatch.setenv("VERITAS_MEMORY_DIR", "relative/memory")
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+
+    caplog.set_level("WARNING")
+    resolved = store._resolve_memory_dir()
+
+    assert resolved == default_dir
+    assert "[SECURITY]" in caplog.text
+
+
+def test_resolve_memory_dir_rejects_path_traversal(memory_env, monkeypatch, caplog, tmp_path):
+    """`..` を含む VERITAS_MEMORY_DIR はパストラバーサル対策で拒否する。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    default_dir = tmp_path / "default-memory"
+    monkeypatch.setattr(store, "_default_memory_dir", lambda: default_dir)
+    monkeypatch.setenv("VERITAS_MEMORY_DIR", "/tmp/../unsafe")
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+
+    caplog.set_level("WARNING")
+    resolved = store._resolve_memory_dir()
+
+    assert resolved == default_dir
+    assert "[SECURITY]" in caplog.text
+
+
 # ---------------------------------------------------------
 # put_episode: kind="episodic" で put に委譲
 # ---------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Address a security/reliability watchpoint from `docs/review/CODE_REVIEW_STATUS.md` about unsafe path configurations for MemoryOS runtime directories.
- Prevent ambiguous or traversal-prone `VERITAS_MEMORY_DIR` values (relative paths or `..`) which can lead to misconfiguration or security exposure at runtime.

### Description
- In `veritas_os/memory/store.py` `_resolve_memory_dir()` now uses `Path(env).expanduser()` and rejects values that are not absolute or that contain `..`, emitting a `[SECURITY]` warning and falling back to the safe default returned by `_default_memory_dir()`.
- Preservation of existing production allowlist logic (`VERITAS_MEMORY_DIR_ALLOWLIST`) is maintained and applied after the new pre-validation.
- Added two regression tests in `veritas_os/tests/test_memory_store.py` to assert rejection of relative paths and paths containing `..` for `VERITAS_MEMORY_DIR`.
- All changes adhere to the stated responsibility boundaries (no changes outside MemoryOS concerns) and include logging of security warnings.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_store.py -k 'resolve_memory_dir'` which succeeded (`5 passed, 13 deselected`).
- Ran `ruff check veritas_os/memory/store.py veritas_os/tests/test_memory_store.py` which returned `All checks passed!`.
- Existing runtime-pickle CI guard tests also remain green (`pytest -q veritas_os/tests/test_check_runtime_pickle_artifacts.py` showed `3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27502837c8326966b257b400e82f9)