### PR TITLE
Harden runtime pickle artifact guardrail scanning

### DIFF
--- a/scripts/security/check_runtime_pickle_artifacts.py
+++ b/scripts/security/check_runtime_pickle_artifacts.py
@@ -56,11 +56,19 @@ def _iter_unique_existing_dirs(paths: list[Path]) -> list[Path]:
 
 
 def _find_legacy_pickles(scan_dirs: list[Path]) -> list[Path]:
-    """Find direct-child `.pkl` files under each scan directory."""
+    """Find `.pkl` files recursively under each scan directory.
+
+    The scan is case-insensitive (`.pkl` / `.PKL`) so renamed legacy artifacts
+    cannot bypass detection by filename casing alone.
+    """
     findings: list[Path] = []
     for directory in _iter_unique_existing_dirs(scan_dirs):
         findings.extend(
-            sorted(path for path in directory.glob("*.pkl") if path.is_file())
+            sorted(
+                path
+                for path in directory.rglob("*")
+                if path.is_file() and path.suffix.lower() == ".pkl"
+            )
         )
     return findings
 

--- a/veritas_os/tests/test_check_runtime_pickle_artifacts.py
+++ b/veritas_os/tests/test_check_runtime_pickle_artifacts.py
@@ -7,20 +7,22 @@ from pathlib import Path
 from scripts.security import check_runtime_pickle_artifacts as checker
 
 
-def test_find_legacy_pickles_direct_children_only(tmp_path: Path) -> None:
-    """Direct `.pkl` files are detected while nested files are ignored."""
+def test_find_legacy_pickles_recursive_and_case_insensitive(tmp_path: Path) -> None:
+    """Both nested and uppercase-extension pickle files are detected."""
     direct = tmp_path / "legacy.pkl"
     direct.write_bytes(b"legacy")
 
     nested_dir = tmp_path / "nested"
     nested_dir.mkdir()
-    nested = nested_dir / "ignored.pkl"
+    nested = nested_dir / "detected.pkl"
     nested.write_bytes(b"legacy")
+
+    upper = tmp_path / "MODEL.PKL"
+    upper.write_bytes(b"legacy")
 
     findings = checker._find_legacy_pickles([tmp_path])
 
-    assert findings == [direct]
-    assert nested not in findings
+    assert findings == [upper, direct, nested]
 
 
 def test_main_returns_error_when_findings_exist(


### PR DESCRIPTION
### Motivation
- CODE_REVIEW_STATUS.md 指摘のとおり、ランタイムにおける `.pkl` アーティファクト検出の抜け穴を塞ぎ、pickle による RCE リスクに対する CI/運用ガードレールを強化する。

### Description
- `scripts/security/check_runtime_pickle_artifacts.py` の `_find_legacy_pickles` を直接子のみの `glob('*.pkl')` から再帰検索 (`rglob('*')`) かつ拡張子を小文字比較する `path.suffix.lower() == '.pkl'` に変更してサブディレクトリと大文字拡張子を検出するようにした。 
- 上記の挙動に合わせて関数の `docstring` を更新した。 
- テスト `veritas_os/tests/test_check_runtime_pickle_artifacts.py` を更新して、入れ子ファイルと大文字拡張子 (`MODEL.PKL`) を検出する回帰テストに置き換えた。 

### Testing
- 実行した自動テスト: `pytest -q veritas_os/tests/test_check_runtime_pickle_artifacts.py` が成功し `3 passed` で終了した。 
- 変更はテストで検出対象の拡張子および再帰検出を検証しており、期待通り動作していることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b278054cbc8326a9ec14c6d88f8fa2)