### PR TITLE
Improve kernel score_alternatives fallback observability

### DIFF
--- a/veritas_os/core/kernel_stages.py
+++ b/veritas_os/core/kernel_stages.py
@@ -282,7 +282,15 @@ def score_alternatives(
         vc_compute = getattr(value_core, "compute_value_score", None)
         OptionScore = getattr(value_core, "OptionScore", None)
         has_value_core = callable(vc_compute) and OptionScore is not None
-    except Exception:
+        if not has_value_core:
+            log.debug(
+                "value_core API unavailable in score_alternatives: "
+                "compute_value_score=%s OptionScore=%s",
+                callable(vc_compute),
+                OptionScore is not None,
+            )
+    except Exception as e:
+        log.debug("value_core import unavailable in score_alternatives: %s", e)
         has_value_core = False
         vc_compute = None
         OptionScore = None
@@ -290,7 +298,8 @@ def score_alternatives(
     # adapt モジュール
     try:
         from . import adapt
-    except Exception:
+    except Exception as e:
+        log.debug("adapt import unavailable in score_alternatives: %s", e)
         adapt = None
 
     def _kw_hit(title: str, kws: List[str]) -> bool:
@@ -357,7 +366,11 @@ def score_alternatives(
                 if math.isfinite(vscore):
                     base *= vscore
             except Exception:
-                pass
+                log.debug(
+                    "value_core scoring failed for alternative id=%s",
+                    a.get("id"),
+                    exc_info=True,
+                )
 
         a["score_raw"] = _safe_float(a.get("score"), 1.0)
         a["score"] = round(base, 4)

--- a/veritas_os/tests/test_kernel_stages.py
+++ b/veritas_os/tests/test_kernel_stages.py
@@ -203,6 +203,54 @@ class TestRunEnvironmentTools:
 class TestScoreAlternativesDetailed:
     """score_alternatives 関数の詳細テスト"""
 
+    def test_logs_when_value_core_api_is_unavailable(self, caplog):
+        """value_core API 不足時に debug ログを残すか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+
+        with caplog.at_level("DEBUG", logger="veritas_os.core.kernel_stages"):
+            score_alternatives(
+                intent="plan",
+                query="test",
+                alternatives=[{"id": "1", "title": "test", "score": 1.0}],
+                telos_score=0.5,
+                stakes=0.5,
+                persona_bias=None,
+            )
+
+        assert "value_core API unavailable in score_alternatives" in caplog.text
+
+    def test_logs_when_value_core_scoring_fails(self, caplog):
+        """value_core スコア計算失敗時に debug ログを残すか"""
+        from veritas_os.core.kernel_stages import score_alternatives
+        import veritas_os.core.value_core as value_core
+
+        class DummyOptionScore:
+            """テスト用 OptionScore 互換オブジェクト。"""
+
+            def __init__(self, **kwargs):
+                self.payload = kwargs
+
+        def broken_value_score(_):
+            raise RuntimeError("simulated value scoring failure")
+
+        with patch.object(
+            value_core,
+            "compute_value_score",
+            broken_value_score,
+            create=True,
+        ), patch.object(value_core, "OptionScore", DummyOptionScore, create=True):
+            with caplog.at_level("DEBUG", logger="veritas_os.core.kernel_stages"):
+                score_alternatives(
+                    intent="plan",
+                    query="test",
+                    alternatives=[{"id": "opt-1", "title": "test", "score": 1.0}],
+                    telos_score=0.5,
+                    stakes=0.5,
+                    persona_bias=None,
+                )
+
+        assert "value_core scoring failed for alternative id=opt-1" in caplog.text
+
     def test_weather_intent_bonus(self):
         """weather intent のボーナスが適用されるか"""
         from veritas_os.core.kernel_stages import score_alternatives


### PR DESCRIPTION
### Motivation
- Reduce silent failure modes flagged in the code review (L-5: bare `except`) by surfacing optional-dependency failures inside the Kernel scoring stage without changing its fallback behavior.

### Description
- Add `log.debug` messages in `score_alternatives` to report when `value_core` import fails, when `value_core` is present but missing the expected API (`compute_value_score` / `OptionScore`), and when value scoring raises an exception (includes traceback).
- Add two unit tests in `veritas_os/tests/test_kernel_stages.py` that assert debug logs are emitted for the API-unavailable path and for a runtime exception during value scoring.
- Changes are limited to Kernel observability and keep existing fallbacks and responsibilities (Planner/Fuji/MemoryOS) unchanged.

### Testing
- Ran `pytest -q veritas_os/tests/test_kernel_stages.py -k 'logs_when_value_core_api_is_unavailable or logs_when_value_core_scoring_fails'` and both targeted tests passed.
- Ran full `pytest -q veritas_os/tests/test_kernel_stages.py` and `34` tests passed (0 failed).
- The changes are observability-only and did not alter scoring semantics in existing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27a9581a483268576adadf7e769b5)