### PR TITLE
Improve MemoryOS lockfile diagnostics on mtime failures

### DIFF
--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -756,8 +756,12 @@ def locked_memory(path: Path, timeout: float = 5.0) -> Any:
                         )
                         lockfile.unlink(missing_ok=True)
                         continue
-                except OSError:
-                    pass
+                except OSError as e:
+                    logger.debug(
+                        "[MemoryOS] lockfile mtime check failed: %s (%s)",
+                        lockfile,
+                        e,
+                    )
                 if time.time() - start > timeout:
                     raise TimeoutError(f"failed to acquire lock for {path}")
                 time.sleep(backoff)

--- a/veritas_os/tests/test_memory_extra_v2.py
+++ b/veritas_os/tests/test_memory_extra_v2.py
@@ -673,6 +673,44 @@ class TestLockedMemoryWindowsPath:
 
         assert "inside" in accessed
 
+    def test_windows_path_mtime_check_oserror_logs_debug(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        """Lock mtime check OSError is logged at debug and lock acquisition continues."""
+        monkeypatch.setattr(memory, "fcntl", None)
+
+        path = tmp_path / "memory.json"
+        path.write_text("[]", encoding="utf-8")
+
+        attempts = {"count": 0}
+
+        def _fake_open(*args, **kwargs):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise FileExistsError
+            return 123
+
+        monkeypatch.setattr(memory.os, "open", _fake_open)
+        monkeypatch.setattr(memory.os, "close", lambda _fd: None)
+        monkeypatch.setattr(
+            memory.os.path,
+            "getmtime",
+            lambda _p: (_ for _ in ()).throw(OSError("mtime failed")),
+        )
+        monkeypatch.setattr(memory.time, "sleep", lambda _s: None)
+
+        lockfile = path.with_suffix(path.suffix + ".lock")
+        lockfile.write_text("exists", encoding="utf-8")
+
+        with caplog.at_level("DEBUG"):
+            with memory.locked_memory(path, timeout=0.2):
+                pass
+
+        assert "lockfile mtime check failed" in caplog.text
+
 
 # =========================================================
 # predict_gate_label with MEM_CLF


### PR DESCRIPTION
### Motivation
- Reduce silent swallowing of exceptions in `locked_memory()` to improve observability for stale lockfile mtime check failures (addresses L-5 in review status).

### Description
- Log `OSError` from the lockfile `getmtime()` check at DEBUG in `veritas_os/core/memory.py` instead of silently ignoring it.
- Add regression test `test_windows_path_mtime_check_oserror_logs_debug` in `veritas_os/tests/test_memory_extra_v2.py` to verify the debug log is emitted and lock acquisition continues.
- Changes are limited to the MemoryOS locking logic and tests, adhere to subsystem boundaries, and follow PEP8 formatting.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_extra_v2.py -k 'windows_path_mtime_check_oserror_logs_debug or windows_path_stale_lock_removed or windows_path_basic'` and received `3 passed, 57 deselected`.
- The added test confirms that an `OSError` during mtime checking is logged at DEBUG and does not prevent lock acquisition.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2800476f08326bc68fa2427bf5ba4)