### PR TITLE
security: extend runtime legacy artifact guard to .joblib files

### DIFF
--- a/scripts/security/check_runtime_pickle_artifacts.py
+++ b/scripts/security/check_runtime_pickle_artifacts.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Fail CI when legacy pickle artifacts are found in MemoryOS runtime directories.
+"""Fail CI when legacy pickle-derived artifacts are found in runtime dirs.
 
-This check enforces the runtime policy that `.pkl` artifacts must not be placed in
-MemoryOS runtime paths because pickle deserialization can lead to arbitrary code
-execution (RCE). The runtime already blocks loading; this script adds CI guardrails
-so risky files are rejected before deployment.
+This check enforces the runtime policy that `.pkl` / `.joblib` artifacts must not
+be placed in MemoryOS runtime paths because pickle deserialization can lead to
+arbitrary code execution (RCE). The runtime already blocks loading; this script
+adds CI guardrails so risky files are rejected before deployment.
 """
 
 from __future__ import annotations
@@ -17,13 +17,15 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SCAN_DIRS = [
     REPO_ROOT / "veritas_os" / "core" / "models",
 ]
+LEGACY_EXTENSIONS = frozenset({".pkl", ".joblib"})
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse CLI arguments for optional scan root overrides."""
     parser = argparse.ArgumentParser(
         description=(
-            "Detect legacy .pkl artifacts in MemoryOS runtime directories "
+            "Detect legacy .pkl/.joblib artifacts in MemoryOS runtime "
+            "directories "
             "and fail if any are present."
         )
     )
@@ -33,8 +35,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         action="append",
         default=[],
         help=(
-            "Additional directory to scan. Can be passed multiple times. "
-            "Only direct children (*.pkl) are checked to match runtime behavior."
+            "Additional directory to scan. Can be passed multiple times."
         ),
     )
     return parser.parse_args(argv)
@@ -56,10 +57,10 @@ def _iter_unique_existing_dirs(paths: list[Path]) -> list[Path]:
 
 
 def _find_legacy_pickles(scan_dirs: list[Path]) -> list[Path]:
-    """Find `.pkl` files recursively under each scan directory.
+    """Find `.pkl`/`.joblib` files recursively under each scan directory.
 
-    The scan is case-insensitive (`.pkl` / `.PKL`) so renamed legacy artifacts
-    cannot bypass detection by filename casing alone.
+    The scan is case-insensitive (`.pkl` / `.PKL`, `.joblib` / `.JOBLIB`) so
+    renamed legacy artifacts cannot bypass detection by filename casing alone.
     """
     findings: list[Path] = []
     for directory in _iter_unique_existing_dirs(scan_dirs):
@@ -67,7 +68,7 @@ def _find_legacy_pickles(scan_dirs: list[Path]) -> list[Path]:
             sorted(
                 path
                 for path in directory.rglob("*")
-                if path.is_file() and path.suffix.lower() == ".pkl"
+                if path.is_file() and path.suffix.lower() in LEGACY_EXTENSIONS
             )
         )
     return findings

--- a/veritas_os/tests/test_check_runtime_pickle_artifacts.py
+++ b/veritas_os/tests/test_check_runtime_pickle_artifacts.py
@@ -8,7 +8,7 @@ from scripts.security import check_runtime_pickle_artifacts as checker
 
 
 def test_find_legacy_pickles_recursive_and_case_insensitive(tmp_path: Path) -> None:
-    """Both nested and uppercase-extension pickle files are detected."""
+    """Nested and mixed-case legacy artifact files are detected."""
     direct = tmp_path / "legacy.pkl"
     direct.write_bytes(b"legacy")
 
@@ -20,9 +20,15 @@ def test_find_legacy_pickles_recursive_and_case_insensitive(tmp_path: Path) -> N
     upper = tmp_path / "MODEL.PKL"
     upper.write_bytes(b"legacy")
 
+    joblib = tmp_path / "embedder.joblib"
+    joblib.write_bytes(b"legacy")
+
+    upper_joblib = tmp_path / "INDEX.JOBLIB"
+    upper_joblib.write_bytes(b"legacy")
+
     findings = checker._find_legacy_pickles([tmp_path])
 
-    assert findings == [upper, direct, nested]
+    assert findings == [upper_joblib, upper, joblib, direct, nested]
 
 
 def test_main_returns_error_when_findings_exist(


### PR DESCRIPTION
### Motivation

- CODE_REVIEW_STATUS.md requires blocking runtime pickle artifacts to avoid RCE, and `joblib` uses pickle internally so it presents the same risk as `.pkl` files.

### Description

- Updated `scripts/security/check_runtime_pickle_artifacts.py` to add `LEGACY_EXTENSIONS = frozenset({".pkl", ".joblib"})` and make the recursive detection case-insensitive for both extensions.
- Revised module docstrings/CLI help and printed guidance to explicitly mention `.joblib` alongside `.pkl`.
- Extended `veritas_os/tests/test_check_runtime_pickle_artifacts.py` to add `.joblib` / `.JOBLIB` test artifacts and adjusted the expected sorted findings.

### Testing

- Ran `pytest -q veritas_os/tests/test_check_runtime_pickle_artifacts.py` and all tests passed (`3 passed`).
- Executed the scanner script manually: `python scripts/security/check_runtime_pickle_artifacts.py --scan-dir "$(mktemp -d)"` returned success when clean and returned a non-zero exit with a `[SECURITY]` listing when artifacts were present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b28dd1293c8326be9ef616f1807624)