### PR TITLE
Harden runtime pickle artifact scanner for missing scan targets

### DIFF
--- a/scripts/security/check_runtime_pickle_artifacts.py
+++ b/scripts/security/check_runtime_pickle_artifacts.py
@@ -41,29 +41,48 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _iter_unique_existing_dirs(paths: list[Path]) -> list[Path]:
-    """Return deduplicated, existing directories preserving first-seen order."""
+def _iter_unique_existing_dirs(
+    paths: list[Path],
+) -> tuple[list[Path], list[Path]]:
+    """Return unique existing dirs and non-existing path inputs.
+
+    Returns:
+        tuple[list[Path], list[Path]]: Existing directories in first-seen order
+        and paths that do not exist.
+    """
     unique_dirs: list[Path] = []
+    missing_dirs: list[Path] = []
     seen: set[Path] = set()
 
     for path in paths:
         resolved = path.resolve(strict=False)
-        if resolved in seen or not resolved.exists() or not resolved.is_dir():
+        if resolved in seen:
+            continue
+        if not resolved.exists():
+            missing_dirs.append(resolved)
+            seen.add(resolved)
+            continue
+        if not resolved.is_dir():
+            seen.add(resolved)
             continue
         seen.add(resolved)
         unique_dirs.append(resolved)
 
-    return unique_dirs
+    return unique_dirs, missing_dirs
 
 
-def _find_legacy_pickles(scan_dirs: list[Path]) -> list[Path]:
+def _find_legacy_pickles(scan_dirs: list[Path]) -> tuple[list[Path], list[Path]]:
     """Find `.pkl`/`.joblib` files recursively under each scan directory.
 
     The scan is case-insensitive (`.pkl` / `.PKL`, `.joblib` / `.JOBLIB`) so
     renamed legacy artifacts cannot bypass detection by filename casing alone.
     """
     findings: list[Path] = []
-    for directory in _iter_unique_existing_dirs(scan_dirs):
+    missing_dirs: list[Path] = []
+    directories, missing = _iter_unique_existing_dirs(scan_dirs)
+    missing_dirs.extend(missing)
+
+    for directory in directories:
         findings.extend(
             sorted(
                 path
@@ -71,14 +90,24 @@ def _find_legacy_pickles(scan_dirs: list[Path]) -> list[Path]:
                 if path.is_file() and path.suffix.lower() in LEGACY_EXTENSIONS
             )
         )
-    return findings
+    return findings, missing_dirs
 
 
 def main(argv: list[str] | None = None) -> int:
     """Run the runtime pickle artifact check and return process exit code."""
     parsed = _parse_args(argv or sys.argv[1:])
     scan_dirs = DEFAULT_SCAN_DIRS + [Path(raw) for raw in parsed.scan_dirs]
-    findings = _find_legacy_pickles(scan_dirs)
+    findings, missing_dirs = _find_legacy_pickles(scan_dirs)
+
+    if missing_dirs:
+        print("[SECURITY] Scan target not found (check deployment path):")
+        for missing in missing_dirs:
+            try:
+                relative = missing.relative_to(REPO_ROOT)
+            except ValueError:
+                relative = missing
+            print(f"- {relative}")
+        print("Proceeding with remaining existing directories.\n")
 
     if not findings:
         print("No legacy runtime pickle artifacts detected in scanned directories.")

--- a/veritas_os/tests/test_check_runtime_pickle_artifacts.py
+++ b/veritas_os/tests/test_check_runtime_pickle_artifacts.py
@@ -26,9 +26,21 @@ def test_find_legacy_pickles_recursive_and_case_insensitive(tmp_path: Path) -> N
     upper_joblib = tmp_path / "INDEX.JOBLIB"
     upper_joblib.write_bytes(b"legacy")
 
-    findings = checker._find_legacy_pickles([tmp_path])
+    findings, missing_dirs = checker._find_legacy_pickles([tmp_path])
 
     assert findings == [upper_joblib, upper, joblib, direct, nested]
+    assert missing_dirs == []
+
+
+
+def test_find_legacy_pickles_reports_missing_scan_dirs(tmp_path: Path) -> None:
+    """Missing scan paths are reported separately from findings."""
+    missing = tmp_path / "does_not_exist"
+
+    findings, missing_dirs = checker._find_legacy_pickles([missing])
+
+    assert findings == []
+    assert missing_dirs == [missing.resolve(strict=False)]
 
 
 def test_main_returns_error_when_findings_exist(


### PR DESCRIPTION
### Motivation
- Implement the short-term recommendation from the code-review status to strengthen CI guardrails that prevent legacy `.pkl`/`.joblib` artifacts from being deployed.
- Prevent silent false negatives when a configured scan target does not exist by surfacing missing scan paths in CI logs so misconfigured scans are visible.
- Warn that `.pkl`/`.joblib` artifacts pose an RCE risk and must not be present in runtime paths.

### Description
- Change `_iter_unique_existing_dirs` to return a tuple of existing directories and missing paths and add a docstring describing the return values. 
- Change `_find_legacy_pickles` to return `(findings, missing_dirs)` and collect missing scan directories while preserving case-insensitive recursive discovery of legacy artifacts. 
- Update `main` to print a `[SECURITY] Scan target not found (check deployment path):` warning when configured scan targets are missing and continue scanning existing directories, while preserving the existing exit behavior that returns non-zero when artifacts are found. 
- Add a regression test `test_find_legacy_pickles_reports_missing_scan_dirs` and update existing tests to assert the new helper return types in `veritas_os/tests/test_check_runtime_pickle_artifacts.py`.

### Testing
- Ran `pytest -q veritas_os/tests/test_check_runtime_pickle_artifacts.py` and all tests passed (`4 passed`).
- Ran `ruff check scripts/security/check_runtime_pickle_artifacts.py veritas_os/tests/test_check_runtime_pickle_artifacts.py` and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b0f4eb3883268befe5bde4431e53)