### PR TITLE
security: widen runtime pickle artifact scan coverage

### DIFF
--- a/scripts/security/check_runtime_pickle_artifacts.py
+++ b/scripts/security/check_runtime_pickle_artifacts.py
@@ -10,14 +10,29 @@ adds CI guardrails so risky files are rejected before deployment.
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 import sys
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_SCAN_DIRS = [
-    REPO_ROOT / "veritas_os" / "core" / "models",
-]
 LEGACY_EXTENSIONS = frozenset({".pkl", ".joblib"})
+
+
+def _default_scan_dirs() -> list[Path]:
+    """Return runtime directories that must not contain pickle/joblib artifacts.
+
+    Includes the current MemoryOS model directory, the historical memory
+    directory used by older deployments, and optional `VERITAS_MEMORY_DIR` when
+    configured.
+    """
+    runtime_dirs = [
+        REPO_ROOT / "veritas_os" / "core" / "models",
+        REPO_ROOT / "veritas_os" / "memory",
+    ]
+    configured_memory_dir = os.getenv("VERITAS_MEMORY_DIR", "").strip()
+    if configured_memory_dir:
+        runtime_dirs.append(Path(configured_memory_dir))
+    return runtime_dirs
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -96,7 +111,7 @@ def _find_legacy_pickles(scan_dirs: list[Path]) -> tuple[list[Path], list[Path]]
 def main(argv: list[str] | None = None) -> int:
     """Run the runtime pickle artifact check and return process exit code."""
     parsed = _parse_args(argv or sys.argv[1:])
-    scan_dirs = DEFAULT_SCAN_DIRS + [Path(raw) for raw in parsed.scan_dirs]
+    scan_dirs = _default_scan_dirs() + [Path(raw) for raw in parsed.scan_dirs]
     findings, missing_dirs = _find_legacy_pickles(scan_dirs)
 
     if missing_dirs:

--- a/veritas_os/tests/test_check_runtime_pickle_artifacts.py
+++ b/veritas_os/tests/test_check_runtime_pickle_artifacts.py
@@ -50,7 +50,7 @@ def test_main_returns_error_when_findings_exist(
     legacy = tmp_path / "artifact.pkl"
     legacy.write_bytes(b"legacy")
 
-    monkeypatch.setattr(checker, "DEFAULT_SCAN_DIRS", [])
+    monkeypatch.setattr(checker, "_default_scan_dirs", lambda: [])
     exit_code = checker.main(["--scan-dir", str(tmp_path)])
     output = capsys.readouterr().out
 
@@ -66,9 +66,20 @@ def test_main_returns_success_when_no_findings(
     clean_file = tmp_path / "artifact.json"
     clean_file.write_text("{}", encoding="utf-8")
 
-    monkeypatch.setattr(checker, "DEFAULT_SCAN_DIRS", [])
+    monkeypatch.setattr(checker, "_default_scan_dirs", lambda: [])
     exit_code = checker.main(["--scan-dir", str(tmp_path)])
     output = capsys.readouterr().out
 
     assert exit_code == 0
     assert "No legacy runtime pickle artifacts detected" in output
+
+
+def test_default_scan_dirs_includes_optional_veritas_memory_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Environment-configured runtime memory dir is included in scan targets."""
+    monkeypatch.setenv("VERITAS_MEMORY_DIR", str(tmp_path / "runtime_memory"))
+
+    scan_dirs = checker._default_scan_dirs()
+
+    assert tmp_path / "runtime_memory" in scan_dirs


### PR DESCRIPTION
### Motivation
- CI/runtime guardrails must detect legacy `.pkl`/`.joblib` artifacts in both current and historical MemoryOS runtime locations to reduce RCE risk. 
- Hardcoded scan targets prevented deployment-specific memory dirs from being scanned.

### Description
- Replaced static `DEFAULT_SCAN_DIRS` with a runtime-resolved helper ` _default_scan_dirs()` in `scripts/security/check_runtime_pickle_artifacts.py` that returns `veritas_os/core/models`, `veritas_os/memory` (legacy path), and an optional `VERITAS_MEMORY_DIR` when set.
- Updated `main()` to use ` _default_scan_dirs()` and added a docstring for the new helper.
- Updated tests in `veritas_os/tests/test_check_runtime_pickle_artifacts.py` to monkeypatch the new helper and added `test_default_scan_dirs_includes_optional_veritas_memory_dir` to verify `VERITAS_MEMORY_DIR` is included when configured.
- No runtime pickle deserialization was added; this expands detection only and keeps the runtime-loading block in place.

### Testing
- Ran `pytest -q veritas_os/tests/test_check_runtime_pickle_artifacts.py` which succeeded (`5 passed`).
- Ran `ruff check scripts/security/check_runtime_pickle_artifacts.py veritas_os/tests/test_check_runtime_pickle_artifacts.py` which passed with no findings.
- Verified the modified files: `scripts/security/check_runtime_pickle_artifacts.py` and `veritas_os/tests/test_check_runtime_pickle_artifacts.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b815530483269872fb2c1dca5b46)