### PR TITLE
Harden MemoryOS runtime legacy artifact detection

### DIFF
--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -67,8 +67,8 @@ def _warn_for_legacy_pickle_artifacts(scan_roots: List[Path]) -> None:
     """Emit security warnings when legacy pickle artifacts are present.
 
     This runtime guardrail does not deserialize any pickle payloads.
-    It only scans direct children of known MemoryOS runtime directories and
-    emits migration guidance so operators can remove risky artifacts.
+    It scans recursively under known MemoryOS runtime directories and emits
+    migration guidance so operators can remove risky artifacts.
     """
     checked_roots = set()
     for raw_root in scan_roots:
@@ -77,9 +77,15 @@ def _warn_for_legacy_pickle_artifacts(scan_roots: List[Path]) -> None:
             continue
         checked_roots.add(root)
 
-        for legacy_file in root.glob("*.pkl"):
+        for candidate in root.rglob("*"):
+            if not candidate.is_file():
+                continue
+
+            if candidate.suffix.lower() not in {".pkl", ".joblib"}:
+                continue
+
             _emit_legacy_pickle_runtime_blocked(
-                path=legacy_file,
+                path=candidate,
                 artifact_name="runtime artifact",
             )
 

--- a/veritas_os/tests/test_memory_vector.py
+++ b/veritas_os/tests/test_memory_vector.py
@@ -244,24 +244,27 @@ def test_vector_memory_add_and_search_performance():
 
 
 
-def test_warn_for_legacy_pickle_artifacts_scans_direct_children(tmp_path: Path, caplog):
-    """ランタイムディレクトリ直下の .pkl を検知して警告ログを出す。"""
+def test_warn_for_legacy_pickle_artifacts_scans_recursively(tmp_path: Path, caplog):
+    """ランタイム配下を再帰走査して危険拡張子を検知する。"""
     import logging
 
     root = tmp_path / "runtime"
     root.mkdir()
     direct = root / "legacy.pkl"
-    nested = root / "nested" / "ignored.pkl"
+    nested = root / "nested" / "detected.pkl"
+    legacy_joblib = root / "nested" / "model.joblib"
     nested.parent.mkdir()
     direct.write_bytes(b"x")
     nested.write_bytes(b"x")
+    legacy_joblib.write_bytes(b"x")
 
     with caplog.at_level(logging.ERROR, logger="veritas_os.core.memory"):
         memory._warn_for_legacy_pickle_artifacts([root, root])
 
     assert "Legacy runtime artifact pickle detected" in caplog.text
     assert str(direct) in caplog.text
-    assert str(nested) not in caplog.text
+    assert str(nested) in caplog.text
+    assert str(legacy_joblib) in caplog.text
 
 
 def test_warn_for_legacy_pickle_artifacts_ignores_missing_paths(caplog):


### PR DESCRIPTION
### Motivation
- Close a gap in runtime guardrails that previously scanned only direct children for legacy deserialization artifacts, which could miss nested `.pkl` files.
- Expand detection to other unsafe artifact formats used historically (`.joblib`) to reduce silent RCE exposure risk.
- Keep runtime behavior safe by only detecting and warning without performing any deserialization.

### Description
- Changed `_warn_for_legacy_pickle_artifacts()` in `veritas_os/core/memory.py` to perform a recursive scan using `root.rglob("*")` and filter files by suffix (case-insensitive) for `.pkl` and `.joblib` before emitting warnings.
- Updated the function docstring to reflect recursive scanning.
- Updated `veritas_os/tests/test_memory_vector.py` to validate recursive detection, nested `.pkl` detection, and `.joblib` detection, and renamed the test accordingly.
- No runtime pickle/joblib loading was added or enabled (`joblib_load` remains `None`) and the change stays within MemoryOS responsibilities.

### Testing
- Ran `ruff check veritas_os/core/memory.py veritas_os/tests/test_memory_vector.py` and it passed with no issues.
- Ran targeted pytest: `pytest -q veritas_os/tests/test_memory_vector.py::test_warn_for_legacy_pickle_artifacts_scans_recursively veritas_os/tests/test_memory_vector.py::test_warn_for_legacy_pickle_artifacts_ignores_missing_paths veritas_os/tests/test_check_runtime_pickle_artifacts.py -q` and all tests passed.
- Changes were committed and validated locally in the repository; no failing automated tests observed.

Security note: this PR improves detection and logging for legacy `.pkl`/`.joblib` artifacts but does not deserialize them; operators must still remove such files from runtime paths to avoid RCE risks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b9f83da483268d121ea7251f56b9)