### PR TITLE
Reduce logging.paths import-time filesystem side effects

### DIFF
--- a/veritas_os/logging/paths.py
+++ b/veritas_os/logging/paths.py
@@ -99,8 +99,6 @@ def _ensure_secure_permissions(path: Path) -> None:
 
 # ★ 追加: VERITAS_DATA_DIR があればそちらを最優先で使う
 LOG_ROOT = _resolve_log_root()
-LOG_ROOT.mkdir(parents=True, exist_ok=True)
-_ensure_secure_permissions(LOG_ROOT)
 
 # trust_log など通常ログ
 LOG_DIR = LOG_ROOT
@@ -109,8 +107,6 @@ LOG_JSONL = LOG_DIR / "trust_log.jsonl"
 
 # decide_* や shadow 用
 DASH_DIR = LOG_ROOT / "DASH"
-DASH_DIR.mkdir(parents=True, exist_ok=True)
-_ensure_secure_permissions(DASH_DIR)
 
 # doctor/shadow decide 用ディレクトリ
 SHADOW_DIR = DASH_DIR
@@ -123,13 +119,23 @@ DATASET_DIR = DASH_DIR
 # プロジェクト直下 .../veritas_clean_test2/data
 PROJECT_ROOT = REPO_ROOT.parent
 DATA_DIR = PROJECT_ROOT / "data"
-DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 # ValueCore のEMA等
 VAL_JSON = DATA_DIR / "value_stats.json"
 
 # ReasonOS メタログ
 META_LOG = LOG_DIR / "meta_log.jsonl"
+
+
+def ensure_runtime_dirs() -> None:
+    """Create and harden runtime directories for logging paths.
+
+    This function is intentionally explicit so importing ``veritas_os.logging.paths``
+    does not mutate the filesystem (M-2 import-time side effect reduction).
+    """
+    for directory in (LOG_ROOT, DASH_DIR, DATA_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+        _ensure_secure_permissions(directory)
 
 __all__ = [
     "REPO_ROOT",
@@ -145,4 +151,5 @@ __all__ = [
     "DATA_DIR",
     "VAL_JSON",
     "META_LOG",
+    "ensure_runtime_dirs",
 ]

--- a/veritas_os/tests/test_logging_paths.py
+++ b/veritas_os/tests/test_logging_paths.py
@@ -26,6 +26,7 @@ def test_dataset_dir_is_path_and_exists(tmp_path, monkeypatch):
     assert str(paths.DATASET_DIR).startswith(str(tmp_path))
 
     # ディレクトリ自体は作成されているはず
+    paths.ensure_runtime_dirs()
     assert paths.DATASET_DIR.exists()
 
 
@@ -49,8 +50,26 @@ def test_log_root_permissions(tmp_path, monkeypatch):
     monkeypatch.delenv("VERITAS_REQUIRE_ENCRYPTED_LOG_DIR", raising=False)
 
     module = importlib.reload(paths)
+    module.ensure_runtime_dirs()
     log_mode = stat.S_IMODE(module.LOG_DIR.stat().st_mode)
     dash_mode = stat.S_IMODE(module.DASH_DIR.stat().st_mode)
 
     assert log_mode == 0o700
     assert dash_mode == 0o700
+
+
+def test_import_has_no_filesystem_side_effect(tmp_path, monkeypatch):
+    """Importing paths should not create directories until explicitly requested."""
+    monkeypatch.setenv("VERITAS_LOG_ROOT", str(tmp_path / "logs"))
+    monkeypatch.delenv("VERITAS_DATA_DIR", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTED_LOG_ROOT", raising=False)
+    monkeypatch.delenv("VERITAS_REQUIRE_ENCRYPTED_LOG_DIR", raising=False)
+
+    module = importlib.reload(paths)
+
+    assert not module.LOG_ROOT.exists()
+    assert not module.DASH_DIR.exists()
+
+    module.ensure_runtime_dirs()
+    assert module.LOG_ROOT.exists()
+    assert module.DASH_DIR.exists()


### PR DESCRIPTION
### Motivation
- Address the CODE_REVIEW_STATUS.md high-priority item M-2 to remove import-time filesystem mutations from `veritas_os.logging.paths`. 
- Avoid latent availability and initialization-order risks caused by modules creating directories or changing permissions on import. 

### Description
- Removed automatic `mkdir`/permission changes from module import in `veritas_os/logging/paths.py` and left `LOG_ROOT`, `DASH_DIR`, and `DATA_DIR` as path definitions only. 
- Added explicit initializer `ensure_runtime_dirs()` (with docstring) that creates runtime directories and applies owner-only permissions via `_ensure_secure_permissions()`. 
- Updated `veritas_os/tests/test_logging_paths.py` to call `ensure_runtime_dirs()` where needed and added `test_import_has_no_filesystem_side_effect` to assert import does not create directories. 
- Exported `ensure_runtime_dirs` in `__all__` and retained all existing path validation and permissions logic unchanged. 

### Testing
- Ran `pytest -q veritas_os/tests/test_logging_paths.py` which passed (`4 passed`).
- Ran `ruff check veritas_os/logging/paths.py veritas_os/tests/test_logging_paths.py` which reported `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c37a53248326998eb628b52bbce8)