### PR TITLE
Persist self-healing budget state and close M-12 review item

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -3,12 +3,12 @@ title: VERITAS OS - Code Review Status Update
 doc_type: review_status
 latest: true
 lifecycle: active
-updated_at: 2026-03-12
+updated_at: 2026-03-13
 ---
 
 # VERITAS OS - Code Review Status Update
 
-**Date**: 2026-03-12
+**Date**: 2026-03-13
 **Status**: Active (single source of truth)
 **PR**: copilot/review-all-code-improvements
 
@@ -31,14 +31,14 @@ updated_at: 2026-03-12
 
 | 項目 | 現在値 | 補足 |
 |---|---:|---|
-| 完了率（件数ベース） | **76% (34/45)** | CRITICAL は 100% 解消 |
-| 統合品質評価 | **76%** | Deferred の構造課題を反映 |
+| 完了率（件数ベース） | **78% (35/45)** | CRITICAL は 100% 解消 |
+| 統合品質評価 | **78%** | Deferred の構造課題を反映 |
 | 未解決 CRITICAL/HIGH の直接セキュリティ欠陥 | **0 件** | 継続監視項目は watchlist で管理 |
 | 運用上の最大注意点 | **旧 `.pkl` 資産** | 任意コード実行リスクのため本番配置禁止 |
 
 ### Consolidated Assessment Basis
 
-1. 指摘45件中34件を対応（76%）。
+1. 指摘45件中35件を対応（78%）。
 2. `ruff check veritas_os` 通過。
 3. `test_code_review_fixes*.py` 代表テスト群（25件）通過。
 4. import 時副作用・設計再編などの Deferred が残存。
@@ -63,9 +63,9 @@ updated_at: 2026-03-12
 |----------|-------|-------|---------------------|-----------|
 | CRITICAL | 3     | 3     | 0                   | 100%      |
 | HIGH     | 12    | 11    | 1                   | 92%       |
-| MEDIUM   | 20    | 16    | 4                   | 80%       |
+| MEDIUM   | 20    | 17    | 3                   | 85%       |
 | LOW      | 10    | 3     | 7                   | 30%       |
-| **TOTAL**| 45    | 34    | 11                  | **76%**   |
+| **TOTAL**| 45    | 35    | 10                  | **78%**   |
 
 ---
 
@@ -92,7 +92,7 @@ updated_at: 2026-03-12
 - ✅ **H-11**: H-7 + H-12 の組合せで `rotate.py` 競合経路を封止。
 - ✅ **H-12**: `logging/trust_log.py:get_last_hash()` に `_trust_log_lock` を適用。
 
-### MEDIUM (16 Fixed / 4 Deferred or Accepted)
+### MEDIUM (17 Fixed / 3 Deferred or Accepted)
 
 - ✅ **M-1**: `core/atomic_io.py` rename 後の directory fsync を追加。
 - ✅ **M-2**: `logging/paths.py` の import-time side effect を解消し、明示的な `ensure_runtime_dirs()` 呼び出し時のみディレクトリ作成を実施。
@@ -105,7 +105,7 @@ updated_at: 2026-03-12
 - ✅ **M-9**: `core/reason.py` のハードコードログパスを共通設定 (`logging.paths.LOG_DIR`) に統合。
 - ⏸️ **M-10 (Accepted)**: `predict_gate_label()` の 0.5 fallback。
 - ✅ **M-11**: `critique.py` のパディングテンプレートを不変化し、ネスト dict の参照共有を防止。
-- ⏸️ **M-12 (Deferred)**: `core/self_healing.py` budget 永続化。
+- ✅ **M-12**: `core/self_healing.py` の self-healing budget/state を request_id 単位で永続化。
 - ✅ **M-13**: `/status` の内部エラー詳細を debug mode 時のみ公開。
 - ✅ **M-14**: HTTP security headers を追加。
 - ✅ **M-15**: `web_search` の `max_results` 上限を 100 に制限。
@@ -160,7 +160,6 @@ updated_at: 2026-03-12
 1. L-1 対応として timestamp 形式を全体統一。
 2. L-5 対応として bare except を段階的に削減。
 3. L-7 対応として dead code / 未使用 import を整理。
-4. M-12 対応として self-healing budget の永続化設計を導入。
 
 ---
 

--- a/veritas_os/core/pipeline_execute.py
+++ b/veritas_os/core/pipeline_execute.py
@@ -56,7 +56,7 @@ async def stage_core_execute(
         core_decide = None
 
     healing_enabled = self_healing.is_healing_enabled(ctx.context or {})
-    healing_state = self_healing.HealingState()
+    healing_state = self_healing.load_healing_state(ctx.request_id)
     healing_budget = self_healing.HealingBudget()
     prev_healing_input: Optional[Dict[str, Any]] = None
 
@@ -159,6 +159,7 @@ async def stage_core_execute(
 
             if stop_reason:
                 ctx.healing_stop_reason = stop_reason
+                self_healing.clear_healing_state(ctx.request_id)
                 break
 
             self_healing.advance_state(
@@ -166,6 +167,7 @@ async def stage_core_execute(
                 error_code=str(error_code),
                 input_signature=input_signature,
             )
+            self_healing.persist_healing_state(ctx.request_id, healing_state)
 
             current_context = dict(core_context)
             current_context["healing"] = {
@@ -187,6 +189,7 @@ async def stage_core_execute(
             except Exception as e:  # subsystem resilience: intentionally broad
                 _warn(f"[self_healing] retry failed: {repr(e)}")
                 ctx.healing_stop_reason = "retry_execution_failed"
+                self_healing.persist_healing_state(ctx.request_id, healing_state)
                 break
 
         if ctx.healing_attempts:
@@ -200,3 +203,5 @@ async def stage_core_execute(
                         "input": latest_healing_input,
                     }
                 )
+            if ctx.healing_stop_reason is None:
+                self_healing.clear_healing_state(ctx.request_id)

--- a/veritas_os/core/self_healing.py
+++ b/veritas_os/core/self_healing.py
@@ -13,10 +13,14 @@ from dataclasses import dataclass, field
 import json
 import logging
 import os
+from pathlib import Path
+import re
 import time
 from typing import Any, Dict, Optional
 
+from .atomic_io import atomic_write_json
 from .fuji_codes import FujiAction
+from veritas_os.logging.paths import LOG_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +50,8 @@ MAX_HEALING_ATTEMPTS = _env_int("VERITAS_MAX_HEALING_ATTEMPTS", 3)
 MAX_HEALING_STEPS = _env_int("VERITAS_HEALING_MAX_STEPS", 6)
 MAX_HEALING_SECONDS = _env_float("VERITAS_HEALING_MAX_SECONDS", 20.0)
 MAX_CONSECUTIVE_SAME_ERROR = _env_int("VERITAS_HEALING_MAX_SAME_ERROR", 2)
+HEALING_STATE_DIR = LOG_DIR / "self_healing"
+_REQUEST_ID_SAFE_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
 
 
 @dataclass(frozen=True)
@@ -77,6 +83,74 @@ class HealingDecision:
     allow: bool
     reason: str
     stop_reason: Optional[str] = None
+
+
+def _validate_request_id(request_id: str) -> str:
+    """Validate request_id before using it in persistent state paths."""
+    rid = str(request_id or "").strip()
+    if not _REQUEST_ID_SAFE_PATTERN.fullmatch(rid):
+        raise ValueError("invalid request_id for self-healing persistence")
+    return rid
+
+
+def healing_state_path(request_id: str) -> Path:
+    """Return the persistence path for a self-healing state snapshot."""
+    safe_request_id = _validate_request_id(request_id)
+    return HEALING_STATE_DIR / f"{safe_request_id}.json"
+
+
+def load_healing_state(request_id: str) -> HealingState:
+    """Load persisted self-healing state; return defaults when unavailable."""
+    path = healing_state_path(request_id)
+    if not path.exists():
+        return HealingState()
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError) as exc:
+        logger.warning("failed to load self-healing state: %s", exc)
+        return HealingState()
+
+    if not isinstance(payload, dict):
+        return HealingState()
+
+    return HealingState(
+        attempt=int(payload.get("attempt", 0) or 0),
+        steps_used=int(payload.get("steps_used", 0) or 0),
+        start_time=float(payload.get("start_time", time.monotonic())),
+        last_error_code=payload.get("last_error_code"),
+        same_error_count=int(payload.get("same_error_count", 0) or 0),
+        last_input_signature=payload.get("last_input_signature"),
+    )
+
+
+def persist_healing_state(request_id: str, state: HealingState) -> None:
+    """Persist the mutable self-healing state as JSON."""
+    path = healing_state_path(request_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(
+        path,
+        {
+            "attempt": int(state.attempt),
+            "steps_used": int(state.steps_used),
+            "start_time": float(state.start_time),
+            "last_error_code": state.last_error_code,
+            "same_error_count": int(state.same_error_count),
+            "last_input_signature": state.last_input_signature,
+        },
+        sort_keys=True,
+    )
+
+
+def clear_healing_state(request_id: str) -> None:
+    """Delete persisted self-healing state if present."""
+    path = healing_state_path(request_id)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning("failed to clear self-healing state: %s", exc)
 
 
 def is_healing_enabled(context: Dict[str, Any]) -> bool:
@@ -309,4 +383,3 @@ def build_healing_trust_log_entry(
     if stop_reason:
         entry["stop_reason"] = stop_reason
     return entry
-

--- a/veritas_os/tests/test_self_healing_coverage.py
+++ b/veritas_os/tests/test_self_healing_coverage.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import time
 from unittest import mock
+
+import pytest
 
 from veritas_os.core import self_healing
 from veritas_os.core.fuji_codes import FujiAction
@@ -15,9 +18,13 @@ from veritas_os.core.self_healing import (
     budget_remaining,
     build_healing_input,
     check_guardrails,
+    clear_healing_state,
     decide_healing_action,
     diff_summary,
+    healing_state_path,
     is_healing_enabled,
+    load_healing_state,
+    persist_healing_state,
 )
 
 
@@ -167,3 +174,56 @@ def test_safe_float_invalid_value() -> None:
     with mock.patch.dict(os.environ, {"VERITAS_TEST_FLOAT": "notafloat"}):
         result = self_healing._env_float("VERITAS_TEST_FLOAT", 3.14)
         assert result == 3.14
+
+
+# ── healing state persistence ───────────────────────────────────────
+
+def test_healing_state_roundtrip(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(self_healing, "HEALING_STATE_DIR", tmp_path)
+    state = HealingState(
+        attempt=2,
+        steps_used=3,
+        start_time=1234.5,
+        last_error_code="F-1002",
+        same_error_count=2,
+        last_input_signature="sig",
+    )
+
+    persist_healing_state("req-1", state)
+    loaded = load_healing_state("req-1")
+
+    assert loaded.attempt == 2
+    assert loaded.steps_used == 3
+    assert loaded.start_time == 1234.5
+    assert loaded.last_error_code == "F-1002"
+    assert loaded.same_error_count == 2
+    assert loaded.last_input_signature == "sig"
+
+
+def test_healing_state_invalid_request_id(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(self_healing, "HEALING_STATE_DIR", tmp_path)
+    with pytest.raises(ValueError):
+        healing_state_path("../invalid")
+
+
+def test_clear_healing_state_deletes_file(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(self_healing, "HEALING_STATE_DIR", tmp_path)
+    persist_healing_state("req-clear", HealingState(attempt=1))
+    path = healing_state_path("req-clear")
+    assert path.exists()
+
+    clear_healing_state("req-clear")
+
+    assert not path.exists()
+
+
+def test_load_healing_state_corrupt_file(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(self_healing, "HEALING_STATE_DIR", tmp_path)
+    path = healing_state_path("req-corrupt")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not-json", encoding="utf-8")
+
+    loaded = load_healing_state("req-corrupt")
+
+    assert loaded.attempt == 0
+    assert loaded.steps_used == 0


### PR DESCRIPTION
### Motivation
- Close the review item M-12 which reported that `self_healing` budget/state is in-memory only and lost across process restarts. 
- Ensure self-healing retry budget is durable per `request_id` to prevent accidental unbounded retries after a restart. 
- Minimize persistence-related security risks (path traversal / unexpected filenames) and ensure atomic writes to avoid corruption. 

### Description
- Added request-scoped persistence helpers in `veritas_os/core/self_healing.py`: `healing_state_path`, `load_healing_state`, `persist_healing_state`, and `clear_healing_state`, plus a `request_id` allowlist validator to prevent path-traversal or invalid filenames. 
- Implemented durable JSON writes using existing `atomic_write_json` and placed persisted files under `logging`'s `LOG_DIR/self_healing`. 
- Integrated persistence into the self-healing loop in `veritas_os/core/pipeline_execute.py` by loading state at loop start, persisting after each scheduled retry (and on retry failure), and clearing state on terminal stop or successful completion. 
- Added unit tests in `veritas_os/tests/test_self_healing_coverage.py` to cover round-trip persistence, invalid `request_id` rejection, clear/delete behavior, and corrupt-file fallback, and updated `docs/review/CODE_REVIEW_STATUS.md` to mark M-12 as fixed and refresh summary metrics. 
- Security note: added strict `request_id` validation and used atomic writes for durability; residual `bare except` patterns remain on the watchlist and were not changed in this scope. 

### Testing
- Ran `pytest -q veritas_os/tests/test_self_healing_coverage.py veritas_os/tests/test_self_healing_loop.py` and got all tests passing (`28 passed`).
- Ran `pytest -q veritas_os/tests/test_pipeline_coverage_more.py -k self_healing` and observed the self-healing related pipeline tests pass (`2 passed, 7 deselected`).
- Ran static checks with `ruff` on the modified files and confirmed linting passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b38648f1148326b11a914e00cfb6e5)