### PR TITLE
Restrict broad exception handling in signed TrustLog append; add domain error and tests

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -121,7 +121,7 @@ updated_at: 2026-03-13
 - ✅ **L-2**: `api/evolver.py` の `print()` を logger へ置換。
 - ⏸️ **L-3 (Accepted)**: `rsi.py` は sample 実装として維持。
 - ✅ **L-4 (Accepted)**: `core/reflection.py` の forward-compat `hasattr()` 分岐は意図的。
-- ⏸️ **L-5 (Deferred/Partial)**: bare except の段階的削減（`logging/rotate.py` の marker 処理は `OSError`/JSON系へ限定化を改善済み）。
+- ⏸️ **L-5 (Deferred/Partial)**: bare except の段階的削減（`logging/rotate.py` の marker 処理に加え、`logging/trust_log.py` の署名付き追記フォールバックを `SignedTrustLogWriteError` のみ捕捉する形へ改善済み）。
 - ⏸️ **L-6 (Deferred)**: `MemoryStore` 名称衝突。
 - ⏸️ **L-7 (Deferred)**: 未使用 import / dead code 整理。
 - ✅ **L-8**: `value_core.py` のコメントインデント不整合を修正。
@@ -132,6 +132,7 @@ updated_at: 2026-03-13
 ### Recent Updates (2026-03-13)
 
 - ✅ **L-5 Partial**: `logging/rotate.py` の marker 保存/読込で broad `except Exception` を縮小し、予期しない例外を顕在化。
+- ✅ **L-5 Partial (追加)**: `logging/trust_log.py` で `append_signed_decision()` のフォールバック捕捉を `SignedTrustLogWriteError` に限定し、想定外例外の握りつぶしを防止。
 - ✅ **Status Note Updated**: 本書に「改善済み（部分対応）」として追記。
 
 ## 6. Security Watchlist and Alerts

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -32,6 +32,10 @@ PUBLIC_KEY_PATH = SIGNED_TRUSTLOG_KEYS / "trustlog_ed25519_public.key"
 _lock = threading.RLock()
 
 
+class SignedTrustLogWriteError(RuntimeError):
+    """Raised when signed TrustLog append fails for expected runtime reasons."""
+
+
 def _worm_mirror_path() -> Optional[Path]:
     """Resolve optional immutable mirror destination for TrustLog JSONL.
 
@@ -129,30 +133,43 @@ def _read_all_entries(path: Optional[Path] = None) -> List[Dict[str, Any]]:
 
 
 def append_signed_decision(decision_payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Append a signed decision entry to append-only TrustLog JSONL."""
-    _ensure_signing_keys()
-    with _lock:
-        entries = _read_all_entries(SIGNED_TRUSTLOG_JSONL)
-        previous_hash = _entry_chain_hash(entries[-1]) if entries else None
-        payload_hash = sha256_of_canonical_json(decision_payload)
-        signature = sign_payload_hash(payload_hash, PRIVATE_KEY_PATH)
+    """Append a signed decision entry to append-only TrustLog JSONL.
 
-        entry = {
-            "decision_id": _uuid7(),
-            "timestamp": _utc_now_iso8601(),
-            "previous_hash": previous_hash,
-            "decision_payload": decision_payload,
-            "payload_hash": payload_hash,
-            "signature": signature,
-            "signature_key_fingerprint": public_key_fingerprint(PUBLIC_KEY_PATH),
-        }
+    Raises:
+        SignedTrustLogWriteError: If signing/write fails due to expected
+            runtime errors (filesystem, serialization, or value issues).
+    """
+    try:
+        _ensure_signing_keys()
+        with _lock:
+            entries = _read_all_entries(SIGNED_TRUSTLOG_JSONL)
+            previous_hash = _entry_chain_hash(entries[-1]) if entries else None
+            payload_hash = sha256_of_canonical_json(decision_payload)
+            signature = sign_payload_hash(payload_hash, PRIVATE_KEY_PATH)
 
-        line = json.dumps(entry, ensure_ascii=False) + "\n"
-        _append_line(SIGNED_TRUSTLOG_JSONL, line)
-        mirror = _mirror_to_worm(line)
-        entry["worm_mirror"] = mirror
+            entry = {
+                "decision_id": _uuid7(),
+                "timestamp": _utc_now_iso8601(),
+                "previous_hash": previous_hash,
+                "decision_payload": decision_payload,
+                "payload_hash": payload_hash,
+                "signature": signature,
+                "signature_key_fingerprint": public_key_fingerprint(PUBLIC_KEY_PATH),
+            }
 
-    return entry
+            line = json.dumps(entry, ensure_ascii=False) + "\n"
+            _append_line(SIGNED_TRUSTLOG_JSONL, line)
+            mirror = _mirror_to_worm(line)
+            entry["worm_mirror"] = mirror
+
+        return entry
+    except (
+        OSError,
+        ValueError,
+        TypeError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise SignedTrustLogWriteError("signed trust log append failed") from exc
 
 
 def verify_signature(entry: Dict[str, Any]) -> bool:

--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -26,7 +26,10 @@ from veritas_os.logging.paths import LOG_DIR
 from veritas_os.logging.rotate import open_trust_log_for_append, load_last_hash_marker
 from veritas_os.logging.encryption import encrypt as _encrypt_line, is_encryption_enabled
 from veritas_os.core.atomic_io import atomic_write_json, atomic_append_line
-from veritas_os.audit.trustlog_signed import append_signed_decision
+from veritas_os.audit.trustlog_signed import (
+    SignedTrustLogWriteError,
+    append_signed_decision,
+)
 from veritas_os.security.hash import sha256_hex
 
 try:
@@ -414,7 +417,7 @@ def append_trust_log(entry: dict) -> Dict[str, Any]:
             # break the existing decision pipeline.
             try:
                 append_signed_decision(entry)
-            except Exception:
+            except SignedTrustLogWriteError:
                 logger.warning(
                     "append_signed_decision failed; continuing with legacy trust log",
                     exc_info=True,

--- a/veritas_os/tests/test_trustlog_signed.py
+++ b/veritas_os/tests/test_trustlog_signed.py
@@ -1,0 +1,69 @@
+"""Tests for signed TrustLog error handling."""
+
+import json
+
+import pytest
+
+from veritas_os.audit import trustlog_signed
+from veritas_os.logging import trust_log
+
+
+def test_append_signed_decision_wraps_oserror(monkeypatch):
+    """Expected runtime write failures are wrapped in domain error."""
+
+    monkeypatch.setattr(trustlog_signed, "_ensure_signing_keys", lambda: None)
+    monkeypatch.setattr(trustlog_signed, "_read_all_entries", lambda _path: [])
+    monkeypatch.setattr(
+        trustlog_signed,
+        "sha256_of_canonical_json",
+        lambda _payload: "h" * 64,
+    )
+    monkeypatch.setattr(trustlog_signed, "sign_payload_hash", lambda *_args, **_kwargs: "sig")
+    monkeypatch.setattr(
+        trustlog_signed,
+        "public_key_fingerprint",
+        lambda _path: "fp",
+    )
+
+    def _raise_oserror(_path, _line):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(trustlog_signed, "_append_line", _raise_oserror)
+
+    with pytest.raises(trustlog_signed.SignedTrustLogWriteError):
+        trustlog_signed.append_signed_decision({"request_id": "req-1"})
+
+
+def test_append_trust_log_continues_on_signed_log_runtime_error(monkeypatch, tmp_path):
+    """Primary TrustLog append continues when signed append hits handled errors."""
+
+    monkeypatch.setattr(trust_log, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(trust_log, "LOG_JSON", tmp_path / "trust_log.json")
+    monkeypatch.setattr(trust_log, "LOG_JSONL", tmp_path / "trust_log.jsonl")
+    monkeypatch.setattr(trust_log, "get_last_hash", lambda: None)
+    monkeypatch.setattr(trust_log, "is_encryption_enabled", lambda: False)
+    monkeypatch.setattr(
+        trust_log,
+        "open_trust_log_for_append",
+        lambda: (tmp_path / "trust_log.jsonl").open("a", encoding="utf-8"),
+    )
+    monkeypatch.setattr(
+        trust_log,
+        "append_signed_decision",
+        lambda _entry: (_ for _ in ()).throw(
+            trust_log.SignedTrustLogWriteError("signed append failed")
+        ),
+    )
+
+    result = trust_log.append_trust_log({"request_id": "req-2", "decision_status": "allow"})
+
+    assert result["request_id"] == "req-2"
+    assert result["sha256"]
+    assert (tmp_path / "trust_log.jsonl").exists()
+
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / "trust_log.jsonl").read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    assert len(entries) == 1


### PR DESCRIPTION
### Motivation

- Reduce broad `except Exception` swallowing in the TrustLog signed-append path to avoid hiding unexpected failures and improve observability. 
- Ensure only expected runtime/signing/write errors are considered benign for the best-effort signed-audit path while leaving other exceptions visible for debugging and alerts. 

### Description

- Add a domain-specific exception `SignedTrustLogWriteError` in `veritas_os.audit.trustlog_signed` to represent expected runtime write/signing failures. 
- Update `append_signed_decision()` to wrap expected runtime errors (`OSError`, `ValueError`, `TypeError`, `json.JSONDecodeError`) and raise `SignedTrustLogWriteError`. 
- Change `veritas_os.logging.trust_log.append_trust_log` to catch only `SignedTrustLogWriteError` from the best-effort `append_signed_decision()` call so unexpected exceptions are not silently swallowed. 
- Add focused tests in `veritas_os/tests/test_trustlog_signed.py` and update `docs/review/CODE_REVIEW_STATUS.md` to note the partial L-5 improvement. 

### Testing

- Ran `pytest -q veritas_os/tests/test_trustlog_signed.py` which completed successfully (`2 passed`). 
- Ran `ruff check` on the modified Python files (`veritas_os/audit/trustlog_signed.py`, `veritas_os/logging/trust_log.py`, `veritas_os/tests/test_trustlog_signed.py`) and it passed. 
- Note: the change reduces the scope of swallowed exceptions for the signed-trustlog path but the overall `L-5` broad-`except` work remains a partial effort on the watchlist and should be continued in future cycles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3928bcb7c8326a2832d0504717488)