### PR TITLE
Unify timestamps to UTC ISO8601 and narrow broad exception handling

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -31,14 +31,14 @@ updated_at: 2026-03-13
 
 | 項目 | 現在値 | 補足 |
 |---|---:|---|
-| 完了率（件数ベース） | **80% (36/45)** | CRITICAL/HIGH は 100% 解消 |
-| 統合品質評価 | **80%** | Deferred の構造課題を反映 |
+| 完了率（件数ベース） | **82% (37/45)** | CRITICAL/HIGH は 100% 解消 |
+| 統合品質評価 | **82%** | Deferred の構造課題を反映 |
 | 未解決 CRITICAL/HIGH の直接セキュリティ欠陥 | **0 件** | 継続監視項目は watchlist で管理 |
 | 運用上の最大注意点 | **旧 `.pkl` 資産** | 任意コード実行リスクのため本番配置禁止 |
 
 ### Consolidated Assessment Basis
 
-1. 指摘45件中36件を対応（80%）。
+1. 指摘45件中37件を対応（82%）。
 2. `ruff check veritas_os` 通過。
 3. `test_code_review_fixes*.py` 代表テスト群（25件）通過。
 4. import 時副作用・設計再編などの Deferred が残存。
@@ -64,8 +64,8 @@ updated_at: 2026-03-13
 | CRITICAL | 3     | 3     | 0                   | 100%      |
 | HIGH     | 12    | 12    | 0                   | 100%      |
 | MEDIUM   | 20    | 17    | 3                   | 85%       |
-| LOW      | 10    | 3     | 7                   | 30%       |
-| **TOTAL**| 45    | 36    | 9                   | **80%**   |
+| LOW      | 10    | 4     | 6                   | 40%       |
+| **TOTAL**| 45    | 37    | 8                   | **82%**   |
 
 ---
 
@@ -115,9 +115,9 @@ updated_at: 2026-03-13
 - ✅ **M-19**: `atomic_append_line()` 生成ファイル権限を 0o600 へ強化。
 - ✅ **M-20**: `world.py` lock file 権限を 0o600 へ強化。
 
-### LOW (3 Fixed / 7 Deferred or Accepted)
+### LOW (4 Fixed / 6 Deferred or Accepted)
 
-- ⏸️ **L-1 (Deferred)**: timestamp 形式の統一。
+- ✅ **L-1**: `core/reason.py` / `core/value_core.py` の時刻出力を `core/time_utils.utc_now_iso_z()` に寄せ、UTC ISO8601 (`Z`) へ統一。
 - ✅ **L-2**: `api/evolver.py` の `print()` を logger へ置換。
 - ⏸️ **L-3 (Accepted)**: `rsi.py` は sample 実装として維持。
 - ✅ **L-4 (Accepted)**: `core/reflection.py` の forward-compat `hasattr()` 分岐は意図的。
@@ -131,8 +131,10 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-1 Completed**: `core/reason.py` / `core/value_core.py` の timestamp を `utc_now_iso_z(timespec="seconds")` に統一。
+- ✅ **L-5 Partial**: `core/reason.py` の `reflect()` でログ書き込み時の broad `except` を `OSError` 捕捉へ縮小。
 - ✅ **H-Status Integrity**: HIGH 集計の不整合（11 Fixed / 1 Deferred 表記）を解消し、実態に合わせて **12/12 Fixed** へ更新。
-- ✅ **Progress Metrics Sync**: 完了率・統合品質評価・Severity集計テーブルを **80% (36/45)** に同期。
+- ✅ **Progress Metrics Sync**: 完了率・統合品質評価・Severity集計テーブルを **82% (37/45)** に同期。
 - ✅ **Status Note Updated**: 本書に「改善済み（集計反映済み）」として追記。
 
 ### Earlier Updates (2026-03-13)

--- a/veritas_os/core/reason.py
+++ b/veritas_os/core/reason.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List
 from veritas_os.logging.paths import LOG_DIR as SHARED_LOG_DIR
 
 from . import llm_client
+from .time_utils import utc_now_iso_z
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +90,7 @@ def reflect(decision: Dict[str, Any]) -> Dict[str, Any]:
         boost = -0.1
 
     out = {
-        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ"),
+        "ts": utc_now_iso_z(timespec="seconds"),
         "query": q[:200],
         "chosen_title": chosen.get("title"),
         "status": status,
@@ -105,7 +106,7 @@ def reflect(decision: Dict[str, Any]) -> Dict[str, Any]:
         _ensure_log_dir()
         with open(META_LOG, "a", encoding="utf-8") as f:
             f.write(json.dumps(out, ensure_ascii=False) + "\n")
-    except Exception as e:
+    except OSError as e:
         # ログ書き込み失敗は本体ロジックに影響させない
         logger.debug("meta_log write skipped: %s", e)
 

--- a/veritas_os/core/value_core.py
+++ b/veritas_os/core/value_core.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Any
@@ -13,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 # 共通ユーティリティをインポート
 from .utils import _to_float, _clip01
+from .time_utils import utc_now_iso_z
 
 
 def _normalize_weights(w: Dict[str, Any]) -> Dict[str, float]:
@@ -294,7 +294,7 @@ def rebalance_from_trust_log(log_path: str = str(TRUST_LOG_PATH)) -> None:
                 j = json.loads(line)
                 if "score" in j:
                     scores.append(float(j["score"]))
-            except Exception:
+            except (json.JSONDecodeError, TypeError, ValueError):
                 continue
 
     if not scores:
@@ -319,7 +319,10 @@ def rebalance_from_trust_log(log_path: str = str(TRUST_LOG_PATH)) -> None:
 
     prof.weights = _normalize_weights(w)
     prof.save()
-    logger.info("ValueCore rebalanced successfully at %s", time.strftime('%Y-%m-%d %H:%M:%S'))
+    logger.info(
+        "ValueCore rebalanced successfully at %s",
+        utc_now_iso_z(timespec="seconds"),
+    )
 
 # ==============================
 #   Trust Log への1行追記

--- a/veritas_os/tests/test_reason.py
+++ b/veritas_os/tests/test_reason.py
@@ -57,6 +57,8 @@ def test_reflect_basic_and_log_written(tmp_path, monkeypatch):
 
     row = json.loads(lines[0])
     assert row["query"] == "hello world"
+    assert row["ts"].endswith("Z")
+    assert "T" in row["ts"]
     assert "next_value_boost" in row
 
 

--- a/veritas_os/tests/test_value_core.py
+++ b/veritas_os/tests/test_value_core.py
@@ -268,6 +268,25 @@ monkeypatch):
     assert dummy.weights["efficiency"] >= 0.6
 
 
+def test_rebalance_from_trust_log_skips_invalid_rows(tmp_path, monkeypatch):
+    dummy = _DummyProfileForRebalance()
+    monkeypatch.setattr(
+        value_core.ValueProfile,
+        "load",
+        classmethod(lambda cls: dummy),
+    )
+
+    log_path = tmp_path / "trust_log_mixed.jsonl"
+    with log_path.open("w", encoding="utf-8") as f:
+        f.write("not-json\n")
+        f.write(json.dumps({"score": "oops"}) + "\n")
+        f.write(json.dumps({"score": 0.9}) + "\n")
+
+    value_core.rebalance_from_trust_log(str(log_path))
+
+    assert dummy.saved is True
+
+
 # ============
 # append_trust_log
 # ============
@@ -308,4 +327,3 @@ def test_append_trust_log_writes_jsonl(tmp_path, monkeypatch):
     # ★ 正規trust_logに委譲されたため、sha256ハッシュチェーンも付与される
     assert "sha256" in rec
     assert rec["type"] == "trust_feedback"
-


### PR DESCRIPTION
### Motivation

- L-1 の指摘に従い、プロジェクト内での時刻フォーマットを統一して監査ログの可搬性と可読性を向上させる目的です。 
- L-5 の指摘に対しては段階的に改善し、重要な箇所で不要に広い例外握りつぶしを縮小してデバッグ性と安全性を高める意図です。

### Description

- `veritas_os/core/reason.py`: `reflect()` の出力タイムスタンプを `datetime...strftime` から `core/time_utils.utc_now_iso_z(timespec="seconds")` に変更し、ログ書込時の broad `except Exception` を `except OSError` に限定しました。 
- `veritas_os/core/value_core.py`: `rebalance_from_trust_log()` のログ成功時メッセージで `utc_now_iso_z(timespec="seconds")` を使うように統一し、JSONL 読み取りの例外処理を `json.JSONDecodeError / TypeError / ValueError` に狭めて不正行を無害化する実装にしました。 
- テスト追加/修正: `veritas_os/tests/test_reason.py` に timestamp が ISO8601+Z 形式であることを確認するアサーションを追加し、`veritas_os/tests/test_value_core.py` に不正行を含む trust log をスキップして処理が続行されることを検証する `test_rebalance_from_trust_log_skips_invalid_rows` を追加しました。 
- ドキュメント更新: `docs/review/CODE_REVIEW_STATUS.md` を更新して L-1 を「改善済み」と明記し、進捗指標を 82% (37/45) に同期しました。
- 変更は Planner / Kernel / Fuji / MemoryOS の責務を越えない範囲に留め、信頼ログ整合性やセキュリティ境界の動作は変更していません。

### Testing

- `pytest -q veritas_os/tests/test_reason.py veritas_os/tests/test_value_core.py` を実行し `33 passed`（全テスト通過）を確認しました。 
- `ruff check` を対象の Python ソース (`veritas_os/core/reason.py`, `veritas_os/core/value_core.py`, `veritas_os/tests/test_reason.py`, `veritas_os/tests/test_value_core.py`) に対して実行し `All checks passed` を確認しました。 
- 注意: ドキュメント（Markdown）を `ruff` に誤って渡した際は構文エラーが発生したため、Lint は Python ファイルのみを対象に再実行して合格となっています。

Security note

- ⚠️ broad `except` の残存（L-5）はリポジトリ内にまだ点在しており、今回の対応は部分改善です。残存箇所は段階的に `except Exception as exc` + 構造化ログへ置換することを引き続き推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39c3dd14c832692baa09a162f5724)