### PR TITLE
Narrow broad exception handling in `trust_log` and sync review status

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -133,6 +133,7 @@ updated_at: 2026-03-13
 
 - ✅ **L-1 Completed**: `core/reason.py` / `core/value_core.py` の timestamp を `utc_now_iso_z(timespec="seconds")` に統一。
 - ✅ **L-5 Partial**: `core/reason.py` の `reflect()` でログ書き込み時の broad `except` を `OSError` 捕捉へ縮小。
+- ✅ **L-5 Partial (追加)**: `logging/trust_log.py` の `_recover_last_hash_from_rotated_log()` / `get_last_hash()` / `iter_trust_log()` / `verify_trust_log()` などで broad `except` を `OSError` / `JSONDecodeError` へ段階縮小。
 - ✅ **H-Status Integrity**: HIGH 集計の不整合（11 Fixed / 1 Deferred 表記）を解消し、実態に合わせて **12/12 Fixed** へ更新。
 - ✅ **Progress Metrics Sync**: 完了率・統合品質評価・Severity集計テーブルを **82% (37/45)** に同期。
 - ✅ **Status Note Updated**: 本書に「改善済み（集計反映済み）」として追記。

--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -136,7 +136,7 @@ def _compute_sha256(payload: dict) -> str:
     """
     try:
         s = _canonical_json(payload)
-    except Exception:
+    except (TypeError, ValueError):
         logger.debug("_compute_sha256: canonical JSON failed, using safe fallback", exc_info=True)
         s = json.dumps(payload, sort_keys=True, separators=(",", ":"),
                        ensure_ascii=False, default=str).encode("utf-8")
@@ -220,7 +220,7 @@ def _recover_last_hash_from_rotated_log() -> str | None:
                 if start == 0:
                     return None
                 start = max(0, start - 65536)
-    except Exception:
+    except OSError:
         logger.warning("Failed to recover last hash from rotated trust log", exc_info=True)
     return None
 
@@ -279,7 +279,7 @@ def get_last_hash() -> str | None:
                     if start == 0:
                         return None
                     start = max(0, start - 65536)
-        except Exception as exc:
+        except OSError as exc:
             logger.warning("get_last_hash failed: %s", exc)
         return None
 
@@ -318,7 +318,7 @@ def _load_logs_json() -> list:
         return [x for x in items if isinstance(x, dict)]
     except FileNotFoundError:
         return []
-    except Exception:
+    except (OSError, json.JSONDecodeError):
         logger.warning("_load_logs_json: failed to load %s", LOG_JSON, exc_info=True)
         return []
 
@@ -535,7 +535,7 @@ def iter_trust_log(reverse: bool = False) -> Iterable[Dict[str, Any]]:
                     yield json.loads(line)
                 except json.JSONDecodeError:
                     continue
-    except Exception as e:
+    except OSError as e:
         logger.warning("trust_log iterate failed: %s", e)
         return
 
@@ -773,7 +773,7 @@ def verify_trust_log(max_entries: Optional[int] = None) -> Dict[str, Any]:
             "broken_reason": None,
         }
 
-    except Exception as e:
+    except OSError as e:
         logger.warning("verify_trust_log failed: %s", e)
         return {
             "ok": False,


### PR DESCRIPTION
### Motivation
- Reduce widespread `except Exception` usage in the trust/audit path to improve diagnosability and avoid silently swallowing unexpected errors while preserving intended resilience semantics. 
- Address a CODE_REVIEW_STATUS high-priority item (L-5 partial) by shrinking catch-all handlers in the trust log implementation. 
- Keep changes scoped to logging responsibilities and avoid crossing Planner/Kernel/Fuji/MemoryOS boundaries.

### Description
- Replaced broad `except Exception` with narrower exception types in `veritas_os/logging/trust_log.py`: `TypeError/ValueError` for canonical JSON fallback, `OSError` for file/IO error paths, and `json.JSONDecodeError` for JSON loading failures. 
- Kept existing fail-safe behavior in `append_trust_log()` (signed-append fallback remains best-effort and does not break decision pipeline). 
- Updated `docs/review/CODE_REVIEW_STATUS.md` to mark the L-5 partial improvement for `logging/trust_log.py` as applied.

### Testing
- Ran `pytest -q veritas_os/tests/test_trust_log.py` and all tests passed (`21 passed`).
- Ran `ruff check veritas_os/logging/trust_log.py veritas_os/tests/test_trust_log.py` and lint checks passed for the code and tests.
- Note: running `ruff` including the Markdown status doc produced parse errors because a non-Python file was passed to the tool, which does not indicate code quality regressions.

Security note: this change reduces the risk of masking errors in the trust log path, but residual broad/`bare except` usages remain elsewhere in the codebase and are tracked on the review watchlist (and `legacy .pkl` artifacts remain a separate operational security concern).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39f4b908483269750d55f01fcc011)