### PR TITLE
Reduce broad exception handling in trust_log.append_trust_log

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -134,6 +134,7 @@ updated_at: 2026-03-13
 - ✅ **L-1 Completed**: `core/reason.py` / `core/value_core.py` の timestamp を `utc_now_iso_z(timespec="seconds")` に統一。
 - ✅ **L-5 Partial**: `core/reason.py` の `reflect()` でログ書き込み時の broad `except` を `OSError` 捕捉へ縮小。
 - ✅ **L-5 Partial (追加)**: `logging/trust_log.py` の `_recover_last_hash_from_rotated_log()` / `get_last_hash()` / `iter_trust_log()` / `verify_trust_log()` などで broad `except` を `OSError` / `JSONDecodeError` へ段階縮小。
+- ✅ **L-5 Partial (追加2)**: `logging/trust_log.py:append_trust_log()` の外側例外捕捉を broad `except` から `OSError` / `TypeError` / `ValueError` / `JSONDecodeError` へ縮小し、想定外 `RuntimeError` の握りつぶしを防止。
 - ✅ **H-Status Integrity**: HIGH 集計の不整合（11 Fixed / 1 Deferred 表記）を解消し、実態に合わせて **12/12 Fixed** へ更新。
 - ✅ **Progress Metrics Sync**: 完了率・統合品質評価・Severity集計テーブルを **82% (37/45)** に同期。
 - ✅ **Status Note Updated**: 本書に「改善済み（集計反映済み）」として追記。

--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -356,6 +356,11 @@ def append_trust_log(entry: dict) -> Dict[str, Any]:
 
     Returns:
         sha256, sha256_prev が付与されたエントリ（渡された entry も更新される）
+
+    Raises:
+        OSError: ファイル I/O（mkdir/open/fsync/rename 等）に失敗した場合。
+        TypeError: エントリが JSON へシリアライズ不能な型を含む場合。
+        ValueError: 不正なエントリ値や JSON 変換エラーが発生した場合。
     """
     import os
 
@@ -376,12 +381,6 @@ def append_trust_log(entry: dict) -> Dict[str, Any]:
             entry = dict(entry)
             entry.setdefault("created_at", datetime.now(timezone.utc).isoformat())
             entry["sha256_prev"] = sha256_prev
-
-            # ✅ 論文の式に準拠: hₜ = SHA256(hₜ₋₁ || rₜ)
-            # エントリから sha256 と sha256_prev を除外（これが rₜ）
-            hash_payload = dict(entry)
-            hash_payload.pop("sha256", None)
-            hash_payload.pop("sha256_prev", None)  # ⚠️ 重要: sha256_prev をハッシュ計算から除外
 
             # rₜ を RFC 8785 canonical JSON化（キーソート・空白なし・一意性保証）
             entry_json = _normalize_entry_for_hash(entry)
@@ -429,7 +428,7 @@ def append_trust_log(entry: dict) -> Dict[str, Any]:
 
             return entry
 
-    except Exception:
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
         with _append_stats_lock:
             global _append_failure_count
             _append_failure_count += 1

--- a/veritas_os/tests/test_trust_log.py
+++ b/veritas_os/tests/test_trust_log.py
@@ -347,6 +347,37 @@ def test_append_trust_log_max_items_rotation(temp_log_env, monkeypatch):
 # ============================
 
 
+
+
+def test_append_trust_log_increments_failure_count_on_oserror(temp_log_env, monkeypatch):
+    monkeypatch.setattr(trust_log, "_append_failure_count", 0, raising=False)
+
+    def _raise_oserror(*_args, **_kwargs):
+        raise OSError("disk-full")
+
+    monkeypatch.setattr(trust_log, "_save_json", _raise_oserror, raising=False)
+
+    with pytest.raises(OSError):
+        trust_log.append_trust_log({"request_id": "req-oserr"})
+
+    stats = trust_log.get_trust_log_stats()
+    assert stats["append_failure"] >= 1
+
+
+def test_append_trust_log_does_not_swallow_unexpected_runtime_error(temp_log_env, monkeypatch):
+    monkeypatch.setattr(trust_log, "_append_failure_count", 0, raising=False)
+
+    def _raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(trust_log, "_save_json", _raise_runtime_error, raising=False)
+
+    with pytest.raises(RuntimeError):
+        trust_log.append_trust_log({"request_id": "req-runtime"})
+
+    stats = trust_log.get_trust_log_stats()
+    assert stats["append_failure"] == 0
+
 def test_write_shadow_decide_creates_snapshot_file(temp_log_env):
     # LOG_DIR を tmp にした状態で write_shadow_decide を呼ぶ
     request_id = "req-123"


### PR DESCRIPTION
### Motivation

- `append_trust_log()` が外側で broad `except` によって想定外の例外を握りつぶしており、デバッグ性とセキュリティ監視を阻害していたため具体的な例外に限定して保護する必要があった。 

### Description

- `veritas_os/logging/trust_log.py` の `append_trust_log()` で外側の `except Exception` を `except (OSError, TypeError, ValueError, json.JSONDecodeError)` に変更し、想定外の `RuntimeError` 等が握りつぶされないようにした。  
- `append_trust_log()` の docstring に `Raises` セクションを追加して失敗契約（`OSError` / `TypeError` / `ValueError`）を明確化した。  
- 使われていなかった中間変数 `hash_payload` のブロックを削除してコードを簡素化した。  
- 回帰防止のため `veritas_os/tests/test_trust_log.py` に I/O エラー時に失敗カウンタが増えることと、想定外の `RuntimeError` がもはや握りつぶされないことを検証するテストを追加した。  
- ドキュメント `docs/review/CODE_REVIEW_STATUS.md` に本対応を反映して L-5 の部分改善として追記した。 

### Testing

- `ruff check veritas_os/logging/trust_log.py veritas_os/tests/test_trust_log.py` を実行して静的チェックは通過した（All checks passed）。  
- `pytest -q veritas_os/tests/test_trust_log.py` を実行し `23 passed` でテストはすべて成功した。  

⚠️ セキュリティ注意: リポジトリ内には他にも broad / bare `except` を残す箇所があり（watchlist の L-5）、それらは継続的に段階的に削減する必要がある。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3a2acae5483268eab9f9162be71b5)