### PR TITLE
L-5優先対応: dataset_writer の broad except を段階縮小

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加3)**: `logging/dataset_writer.py` の `append_dataset_record()` / `_sha256_dict()` で broad `except` を `OSError` / `TypeError` / `ValueError` / `OverflowError` へ縮小し、想定外の `RuntimeError` 握りつぶしを防止。
 - ✅ **L-1 Completed**: `core/reason.py` / `core/value_core.py` の timestamp を `utc_now_iso_z(timespec="seconds")` に統一。
 - ✅ **L-5 Partial**: `core/reason.py` の `reflect()` でログ書き込み時の broad `except` を `OSError` 捕捉へ縮小。
 - ✅ **L-5 Partial (追加)**: `logging/trust_log.py` の `_recover_last_hash_from_rotated_log()` / `get_last_hash()` / `iter_trust_log()` / `verify_trust_log()` などで broad `except` を `OSError` / `JSONDecodeError` へ段階縮小。

--- a/veritas_os/logging/dataset_writer.py
+++ b/veritas_os/logging/dataset_writer.py
@@ -61,7 +61,7 @@ def _sha256_dict(d: Dict[str, Any]) -> str:
     """辞書を安定化JSONにして SHA-256 ハッシュ化"""
     try:
         return sha256_of_canonical_json(d)
-    except Exception:
+    except (TypeError, ValueError, OverflowError):
         logger.debug("_sha256_dict: JSON serialization failed, using default=str fallback", exc_info=True)
         fallback_json = json.dumps(
             d,
@@ -269,7 +269,7 @@ def append_dataset_record(
         with _dataset_lock:
             _ensure_dataset_parent(path)
             atomic_append_line(path, json.dumps(record, ensure_ascii=False))
-    except Exception as e:
+    except (OSError, TypeError, ValueError) as e:
         logger.warning("append_dataset_record failed: %s", e)
 
 

--- a/veritas_os/tests/test_dataset_writer.py
+++ b/veritas_os/tests/test_dataset_writer.py
@@ -17,6 +17,7 @@ import tempfile
 from datetime import datetime, timezone
 
 import pytest
+import veritas_os.logging.dataset_writer as dataset_writer
 
 from veritas_os.logging.dataset_writer import (
     build_dataset_record,
@@ -396,6 +397,20 @@ class TestAppendDatasetRecord:
             assert path.parent.exists()
             assert path.exists()
 
+    def test_append_dataset_record_propagates_unexpected_errors(self, monkeypatch):
+        """想定外例外は握りつぶさず呼び出し元へ送出する。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "dataset.jsonl"
+            record = {"test": "data"}
+
+            def raise_runtime_error(*_args, **_kwargs):
+                raise RuntimeError("unexpected failure")
+
+            monkeypatch.setattr(dataset_writer, "atomic_append_line", raise_runtime_error)
+
+            with pytest.raises(RuntimeError, match="unexpected failure"):
+                append_dataset_record(record, path=path, validate=False)
+
 
 # =========================
 # 統計取得テスト
@@ -724,4 +739,3 @@ class TestDatasetWriterIntegration:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-


### PR DESCRIPTION
### Motivation
- CODE_REVIEW_STATUS.md の高優先項目である L-5（bare / broad `except` 残存）が障害解析・セキュリティ監視を阻害するため優先的に対処する。 
- `veritas_os/logging/dataset_writer.py` は運用時に例外を握りつぶしてしまう箇所があり、想定外の重大エラーが隠蔽され得るため修正が必要である。 
- 変更は Planner / Kernel / Fuji / MemoryOS の責務境界を越えず、局所的な堅牢化を狙う。 

### Description
- `veritas_os/logging/dataset_writer.py` の `_sha256_dict()` の例外捕捉を `except Exception` から `except (TypeError, ValueError, OverflowError)` に縮小して不必要な広捕捉を避けるようにした。 
- `veritas_os/logging/dataset_writer.py` の `append_dataset_record()` の例外捕捉を `except Exception` から `except (OSError, TypeError, ValueError)` に縮小して I/O やシリアライズ系の既知エラーのみをロギングし、それ以外は伝播させるようにした。 
- 回帰テスト `veritas_os/tests/test_dataset_writer.py` にて、`atomic_append_line` が runtime 例外を投げた場合に例外が伝播することを検証するテストを追加した。 
- ドキュメント `docs/review/CODE_REVIEW_STATUS.md` の Recent Updates に L-5 の部分対応（追加）として今回の改善を反映した。 

### Testing
- `pytest -q veritas_os/tests/test_dataset_writer.py` を実行し `29 passed` を確認した。 
- `ruff check veritas_os/logging/dataset_writer.py veritas_os/tests/test_dataset_writer.py` を実行し全てのスタイルチェックが通過した（All checks passed）。 
- セキュリティ的には broad `except` の縮小で予期しない例外の隠蔽リスクを低減しており、既存のランタイム警告（legacy `.pkl` 等）へは影響がないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3a50792c083268b1059920b70f543)