### PR TITLE
Harden encryption exception handling and add regression tests

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加4 / 優先対応)**: `logging/encryption.py` の `encrypt()` / `decrypt()` で broad `except Exception` を `AttributeError` / `TypeError` / `ValueError` に縮小し、想定外例外の握りつぶしを防止。異常系テストを追加して挙動を固定。
 - ✅ **L-5 Partial (追加3)**: `logging/dataset_writer.py` の `append_dataset_record()` / `_sha256_dict()` で broad `except` を `OSError` / `TypeError` / `ValueError` / `OverflowError` へ縮小し、想定外の `RuntimeError` 握りつぶしを防止。
 - ✅ **L-1 Completed**: `core/reason.py` / `core/value_core.py` の timestamp を `utc_now_iso_z(timespec="seconds")` に統一。
 - ✅ **L-5 Partial**: `core/reason.py` の `reflect()` でログ書き込み時の broad `except` を `OSError` 捕捉へ縮小。

--- a/veritas_os/logging/encryption.py
+++ b/veritas_os/logging/encryption.py
@@ -147,7 +147,7 @@ def encrypt(plaintext: str) -> str:
         tag = hmac.new(hmac_key, payload, hashlib.sha256).digest()
 
         return "ENC:" + base64.urlsafe_b64encode(tag + payload).decode("ascii")
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         logger.warning("Encryption failed; returning plaintext", exc_info=True)
         return plaintext
 
@@ -187,7 +187,7 @@ def decrypt(ciphertext: str) -> str:
         # the forward mapping, which is handled by the cryptography backend.
         return ciphertext
 
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         logger.warning("Decryption failed", exc_info=True)
         return ciphertext
 

--- a/veritas_os/tests/test_eu_ai_act_p3_improvements.py
+++ b/veritas_os/tests/test_eu_ai_act_p3_improvements.py
@@ -23,6 +23,7 @@ from veritas_os.core.eu_ai_act_compliance_module import (
     get_retention_config,
 )
 from veritas_os.logging.encryption import (
+    decrypt,
     encrypt,
     generate_key,
     get_encryption_status,
@@ -154,6 +155,34 @@ class TestEncryption:
             assert is_encryption_enabled() is False
             plaintext = '{"security": "check"}'
             assert encrypt(plaintext) == plaintext
+        finally:
+            if old is not None:
+                os.environ["VERITAS_ENCRYPTION_KEY"] = old
+            else:
+                os.environ.pop("VERITAS_ENCRYPTION_KEY", None)
+
+    def test_encrypt_returns_input_for_non_string_payload(self) -> None:
+        """Unexpected payload type should fail closed without swallowing all exceptions."""
+        key = generate_key()
+        old = os.environ.get("VERITAS_ENCRYPTION_KEY")
+        os.environ["VERITAS_ENCRYPTION_KEY"] = key
+        try:
+            non_string_payload = 12345
+            assert encrypt(non_string_payload) == non_string_payload
+        finally:
+            if old is not None:
+                os.environ["VERITAS_ENCRYPTION_KEY"] = old
+            else:
+                os.environ.pop("VERITAS_ENCRYPTION_KEY", None)
+
+    def test_decrypt_returns_input_for_invalid_base64_ciphertext(self) -> None:
+        """Malformed ciphertext should safely return the original input."""
+        key = generate_key()
+        old = os.environ.get("VERITAS_ENCRYPTION_KEY")
+        os.environ["VERITAS_ENCRYPTION_KEY"] = key
+        try:
+            malformed = "ENC:###"
+            assert decrypt(malformed) == malformed
         finally:
             if old is not None:
                 os.environ["VERITAS_ENCRYPTION_KEY"] = old


### PR DESCRIPTION
### Motivation

- Reduce broad exception swallowing in a security-sensitive module by addressing a prioritized L-5 code-review item so failures in `encrypt()`/`decrypt()` are visible and debuggable. 
- Preserve the module's fail-safe behavior while preventing unexpected exceptions from being hidden in the encryption path.

### Description

- Narrowed the broad `except Exception` in `veritas_os/logging/encryption.py` to explicit `AttributeError`, `TypeError`, and `ValueError` for both `encrypt()` and `decrypt()` so only anticipated error classes are swallowed. 
- Added regression tests to `veritas_os/tests/test_eu_ai_act_p3_improvements.py` to validate fail-safe behavior for non-string payloads (`test_encrypt_returns_input_for_non_string_payload`) and malformed ciphertext (`test_decrypt_returns_input_for_invalid_base64_ciphertext`) and imported `decrypt` where needed. 
- Updated `docs/review/CODE_REVIEW_STATUS.md` to record this L-5 partial improvement as a priority-handled update and to note that abnormal-case tests were added. 
- Kept existing fail-safe semantics (returns original input on failure) and ensured changes are limited to the logging/encryption area, following the repository responsibility guardrails.

### Testing

- Ran the targeted pytest selection with `pytest -q veritas_os/tests/test_eu_ai_act_p3_improvements.py -k 'encrypt or decrypt or invalid_base64_key'` and observed `9 passed, 25 deselected`. 
- Ran style checks with `ruff check veritas_os/logging/encryption.py veritas_os/tests/test_eu_ai_act_p3_improvements.py`, and all checks passed. 
- These automated checks succeeded and validate the introduced behavior and formatting.

Security warning: this is a partial remediation of L-5 (bare `except` residuals remain elsewhere in the codebase), so continued removal of broad exception handlers is recommended in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3a92f7db88326a42a874cdf894a62)