### PR TITLE
trust_log: sanitize.mask_pii の import フォールバックを厳格化

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加5 / 優先対応)**: `logging/trust_log.py` の `mask_pii` import フォールバックを `ImportError` / `AttributeError` に限定し、想定外の import-time 例外 (`RuntimeError` 等) を握りつぶさないよう改善。テストで異常系を固定。
 - ✅ **L-5 Partial (追加4 / 優先対応)**: `logging/encryption.py` の `encrypt()` / `decrypt()` で broad `except Exception` を `AttributeError` / `TypeError` / `ValueError` に縮小し、想定外例外の握りつぶしを防止。異常系テストを追加して挙動を固定。
 - ✅ **L-5 Partial (追加3)**: `logging/dataset_writer.py` の `append_dataset_record()` / `_sha256_dict()` で broad `except` を `OSError` / `TypeError` / `ValueError` / `OverflowError` へ縮小し、想定外の `RuntimeError` 握りつぶしを防止。
 - ✅ **L-1 Completed**: `core/reason.py` / `core/value_core.py` の timestamp を `utc_now_iso_z(timespec="seconds")` に統一。

--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -32,14 +32,28 @@ from veritas_os.audit.trustlog_signed import (
 )
 from veritas_os.security.hash import sha256_hex
 
-try:
-    from veritas_os.core.sanitize import mask_pii as _mask_pii
-except Exception as _import_err:  # pragma: no cover
-    _mask_pii = None  # type: ignore[assignment]
-    logging.getLogger(__name__).warning(
-        "sanitize.mask_pii unavailable; shadow log PII masking disabled: %s",
-        _import_err,
-    )
+
+def _load_mask_pii():
+    """Load `sanitize.mask_pii` with narrow fallback handling.
+
+    Returns:
+        Callable mask function when available, otherwise ``None``.
+
+    Raises:
+        RuntimeError: Propagated for unexpected import-time failures.
+    """
+    try:
+        from veritas_os.core.sanitize import mask_pii
+    except (ImportError, AttributeError) as import_err:  # pragma: no cover
+        logging.getLogger(__name__).warning(
+            "sanitize.mask_pii unavailable; shadow log PII masking disabled: %s",
+            import_err,
+        )
+        return None
+    return mask_pii
+
+
+_mask_pii = _load_mask_pii()
 
 logger = logging.getLogger(__name__)
 

--- a/veritas_os/tests/test_trust_log.py
+++ b/veritas_os/tests/test_trust_log.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import hashlib
 import re
+import builtins
 from typing import Any, Dict
 
 from datetime import datetime
@@ -103,6 +104,21 @@ def test_calc_sha256_handles_unserializable_objects():
     payload = {"x": {1, 2, 3}}
     h = trust_log.calc_sha256(payload)
     assert re.fullmatch(r"[0-9a-f]{64}", h)
+
+
+def test_load_mask_pii_raises_runtime_error_on_unexpected_import_failure(monkeypatch):
+    """Unexpected import failures should not be swallowed silently."""
+    original_import = builtins.__import__
+
+    def _guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "veritas_os.core.sanitize":
+            raise RuntimeError("unexpected import failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _guarded_import)
+
+    with pytest.raises(RuntimeError, match="unexpected import failure"):
+        trust_log._load_mask_pii()
 
 
 # ============================
@@ -443,4 +459,3 @@ def test_write_shadow_decide_falls_back_to_context_query_and_none_fuji(temp_log_
     assert rec["request_id"] == request_id
     assert rec["query"] == "from context"
     assert rec["fuji"] is None
-


### PR DESCRIPTION
### Motivation
- `logging/trust_log.py` で optional な `sanitize.mask_pii` の import 時に広範な `except Exception` で例外を握りつぶしていたため、想定外の import-time 障害が隠蔽されていたので修正する必要があった。 
- この修正は `CODE_REVIEW_STATUS.md` の L-5（broad except の段階的削減）を優先的に改善する目的で行った。 
- セキュリティ面では、想定外例外を隠蔽しないことで障害検知と解析が容易になり安全性が向上する（ただしリポジトリ内の他の broad except は継続監視対象）。

### Description
- `veritas_os/logging/trust_log.py` に `_load_mask_pii()` ヘルパーを追加し、`mask_pii` の import フォールバックを `ImportError` / `AttributeError` のみに限定して想定外の import-time 例外を握りつぶさないようにした。 
- 既存の即時 import + broad except を削除して `_mask_pii = _load_mask_pii()` へ置換し、関数に docstring を付与して挙動を明確化した。 
- 回帰テスト `veritas_os/tests/test_trust_log.py` に、`veritas_os.core.sanitize` の import 時に `RuntimeError` が発生した場合にその例外が伝播することを検証するテストを追加した。 
- ドキュメント `docs/review/CODE_REVIEW_STATUS.md` の Recent Updates に今回の L-5 部分改善（mask_pii import フォールバックの厳格化）を追記した。

### Testing
- 実行した自動テスト: `pytest -q veritas_os/tests/test_trust_log.py -k load_mask_pii_raises_runtime_error_on_unexpected_import_failure` を実行し `1 passed, 23 deselected` で成功した。 
- 追加したテストは想定外の import-time 例外が隠蔽されないことを検証し成功している。 
- 注意: リポジトリ内には他にも broad `except` の箇所が残っているため、それらは継続監視／段階的対応が必要である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3abfcb3388326ba2f566588fdd693)