### PR TITLE
Narrow broad exception handling in compliance report engine

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加6 / 優先対応)**: `compliance/report_engine.py` の `_iter_decision_logs()` / `_latest_replay_result()` で broad `except` を `OSError` / `JSONDecodeError` に縮小し、想定外の `RuntimeError` を握りつぶさないよう改善。回帰テストを追加して異常系挙動を固定。
 - ✅ **L-5 Partial (追加5 / 優先対応)**: `logging/trust_log.py` の `mask_pii` import フォールバックを `ImportError` / `AttributeError` に限定し、想定外の import-time 例外 (`RuntimeError` 等) を握りつぶさないよう改善。テストで異常系を固定。
 - ✅ **L-5 Partial (追加4 / 優先対応)**: `logging/encryption.py` の `encrypt()` / `decrypt()` で broad `except Exception` を `AttributeError` / `TypeError` / `ValueError` に縮小し、想定外例外の握りつぶしを防止。異常系テストを追加して挙動を固定。
 - ✅ **L-5 Partial (追加3)**: `logging/dataset_writer.py` の `append_dataset_record()` / `_sha256_dict()` で broad `except` を `OSError` / `TypeError` / `ValueError` / `OverflowError` へ縮小し、想定外の `RuntimeError` 握りつぶしを防止。

--- a/veritas_os/compliance/report_engine.py
+++ b/veritas_os/compliance/report_engine.py
@@ -57,7 +57,7 @@ def _iter_decision_logs() -> Iterable[Dict[str, Any]]:
     for path in sorted(log_dir.glob("decide_*.json"), reverse=True):
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
+        except (OSError, json.JSONDecodeError):
             continue
         if isinstance(payload, dict):
             payload["_source_path"] = str(path)
@@ -96,7 +96,7 @@ def _latest_replay_result(decision_id: str) -> Dict[str, Any]:
 
     try:
         payload = json.loads(candidates[0].read_text(encoding="utf-8"))
-    except Exception:
+    except (OSError, json.JSONDecodeError):
         return {"available": False, "result": "unreadable"}
 
     if not isinstance(payload, dict):

--- a/veritas_os/tests/test_compliance_report_engine.py
+++ b/veritas_os/tests/test_compliance_report_engine.py
@@ -131,3 +131,36 @@ def test_report_governance_invalid_date(monkeypatch):
     )
     assert response.status_code == 400
     assert response.json()["ok"] is False
+
+
+def test_iter_decision_logs_reraises_unexpected_json_error(monkeypatch, tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True)
+    _write_decision(log_dir / "decide_001.json", "dec-001", risk=0.7)
+    monkeypatch.setattr(report_engine, "LOG_DIR", log_dir)
+
+    def _raise_runtime_error(_: str):
+        raise RuntimeError("unexpected parser failure")
+
+    monkeypatch.setattr(report_engine.json, "loads", _raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="unexpected parser failure"):
+        list(report_engine._iter_decision_logs())
+
+
+def test_latest_replay_result_reraises_unexpected_json_error(
+    monkeypatch,
+    tmp_path: Path,
+):
+    replay_dir = tmp_path / "replay"
+    replay_dir.mkdir(parents=True)
+    replay_dir.joinpath("replay_dec-001_1.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(report_engine, "REPLAY_REPORT_DIR", replay_dir)
+
+    def _raise_runtime_error(_: str):
+        raise RuntimeError("unexpected parser failure")
+
+    monkeypatch.setattr(report_engine.json, "loads", _raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="unexpected parser failure"):
+        report_engine._latest_replay_result("dec-001")


### PR DESCRIPTION
### Motivation
- Address remaining L-5 priority (bare `except`) by preventing masking of unexpected runtime errors in compliance report paths.
- Improve observability and security triage by only catching expected I/O and JSON decode failures and allowing unexpected exceptions (e.g., `RuntimeError`) to surface.
- Keep changes scoped to the compliance/reporting area and docs without crossing Planner/Kernel/Fuji/MemoryOS responsibility boundaries.

### Description
- Tighten exception handling in `veritas_os/compliance/report_engine.py` so `_iter_decision_logs()` and `_latest_replay_result()` catch only `OSError` and `json.JSONDecodeError` instead of a broad `except`.
- Add regression tests in `veritas_os/tests/test_compliance_report_engine.py` to assert that unexpected parser errors (raising `RuntimeError`) are re-raised and not swallowed by the loader paths.
- Update `docs/review/CODE_REVIEW_STATUS.md` to record this L-5 partial improvement (added entry: L-5 Partial (追加6)).
- Changes were limited to handling and tests; no public API behavior was altered and PEP8/linting style was enforced for the modified Python files.

### Testing
- Ran `pytest -q veritas_os/tests/test_compliance_report_engine.py` and all tests passed (`5 passed`).
- Ran `ruff check` against the modified Python files (`veritas_os/compliance/report_engine.py` and `veritas_os/tests/test_compliance_report_engine.py`) and checks passed for those files.
- Note: running `ruff` including the Markdown file produced a syntax error because Markdown was passed to the Python linter; this was not a problem with the Python changes themselves.
- The change prevents swallowing unexpected runtime exceptions in compliance report loading paths, reducing security/forensics risk while L-5 remains on the watchlist for broader remediation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b05d0f04832689f2e15132c127a6)