### PR TITLE
Narrow broad exception handling in Reason.generate_reflection_template

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加7 / 優先対応)**: `core/reason.py` の `generate_reflection_template()` で broad `except` を `JSONDecodeError` / `(TypeError, ValueError)` / `OSError` に縮小し、想定外 `RuntimeError` などの握りつぶしを抑止。対応テストにより既存挙動を維持確認。
 - ✅ **L-5 Partial (追加6 / 優先対応)**: `compliance/report_engine.py` の `_iter_decision_logs()` / `_latest_replay_result()` で broad `except` を `OSError` / `JSONDecodeError` に縮小し、想定外の `RuntimeError` を握りつぶさないよう改善。回帰テストを追加して異常系挙動を固定。
 - ✅ **L-5 Partial (追加5 / 優先対応)**: `logging/trust_log.py` の `mask_pii` import フォールバックを `ImportError` / `AttributeError` に限定し、想定外の import-time 例外 (`RuntimeError` 等) を握りつぶさないよう改善。テストで異常系を固定。
 - ✅ **L-5 Partial (追加4 / 優先対応)**: `logging/encryption.py` の `encrypt()` / `decrypt()` で broad `except Exception` を `AttributeError` / `TypeError` / `ValueError` に縮小し、想定外例外の握りつぶしを防止。異常系テストを追加して挙動を固定。

--- a/veritas_os/core/reason.py
+++ b/veritas_os/core/reason.py
@@ -253,7 +253,7 @@ async def generate_reflection_template(
     # LLM 出力を JSON として解釈
     try:
         data = json.loads(text)
-    except Exception as e:
+    except json.JSONDecodeError as e:
         logger.warning("[ReasonOS] reflection_template json parse failed: %s", e)
         return {}
 
@@ -273,7 +273,7 @@ async def generate_reflection_template(
 
     try:
         priority = float(priority)
-    except Exception:
+    except (TypeError, ValueError):
         priority = 0.5
 
     # クリップ
@@ -301,7 +301,7 @@ async def generate_reflection_template(
         }
         with open(META_LOG, "a", encoding="utf-8") as f:
             f.write(json.dumps(meta, ensure_ascii=False) + "\n")
-    except Exception as e:
+    except OSError as e:
         logger.debug("[ReasonOS] reflection_template meta_log skipped: %s", e)
 
     return tmpl


### PR DESCRIPTION
### Motivation
- Reduce broad/bare `except` usage in a high-priority L-5 path to avoid masking unexpected runtime errors while keeping changes local to the Reason component.

### Description
- Tighten exception handling in `veritas_os/core/reason.py:generate_reflection_template()` by changing JSON parse fallback to `json.JSONDecodeError`, `priority` conversion fallback to `(TypeError, ValueError)`, and meta-log write fallback to `OSError`; update `docs/review/CODE_REVIEW_STATUS.md` to mark this L-5 partial improvement as completed.

### Testing
- Ran targeted unit tests: `pytest -q veritas_os/tests/test_reason.py::test_generate_reflection_template_bad_json veritas_os/tests/test_reason.py::test_generate_reflection_template_normalizes_tags_and_priority veritas_os/tests/test_reason.py::test_generate_reflection_template_success` and all 3 passed.
- Ran linter: `ruff check veritas_os/core/reason.py` passed for the modified module, and `ruff` over both files failed because the markdown file was (incorrectly) fed to the Python linter; this is a tooling invocation issue rather than a code-style regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b69fb72483268fd9fefc9c45bc05)