### PR TITLE
Narrow broad LLM exception handling in core/reason, add regression tests, and update review doc

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加8 / 優先対応)**: `core/reason.py` の `generate_reason()` / `generate_reflection_template()` で broad `except Exception` を `OSError` / `TypeError` / `ValueError` / `RuntimeError` へ縮小。従来互換（LLM 呼び出し失敗時の graceful fallback）を維持しつつ、捕捉範囲を明示化。回帰テストで `RuntimeError` を含むフォールバック挙動を固定。
 - ✅ **L-5 Partial (追加7 / 優先対応)**: `core/reason.py` の `generate_reflection_template()` で broad `except` を `JSONDecodeError` / `(TypeError, ValueError)` / `OSError` に縮小し、想定外 `RuntimeError` などの握りつぶしを抑止。対応テストにより既存挙動を維持確認。
 - ✅ **L-5 Partial (追加6 / 優先対応)**: `compliance/report_engine.py` の `_iter_decision_logs()` / `_latest_replay_result()` で broad `except` を `OSError` / `JSONDecodeError` に縮小し、想定外の `RuntimeError` を握りつぶさないよう改善。回帰テストを追加して異常系挙動を固定。
 - ✅ **L-5 Partial (追加5 / 優先対応)**: `logging/trust_log.py` の `mask_pii` import フォールバックを `ImportError` / `AttributeError` に限定し、想定外の import-time 例外 (`RuntimeError` 等) を握りつぶさないよう改善。テストで異常系を固定。

--- a/veritas_os/core/reason.py
+++ b/veritas_os/core/reason.py
@@ -167,7 +167,7 @@ def generate_reason(
             temperature=0.3,
             max_tokens=800,
         )
-    except Exception as e:
+    except (OSError, ValueError, TypeError, RuntimeError) as e:
         logger.error("[ReasonOS] generate_reason LLM error: %s", e)
         return {"text": "", "source": "error"}
 
@@ -237,7 +237,7 @@ async def generate_reflection_template(
                 max_tokens=600,
             ),
         )
-    except Exception as e:
+    except (OSError, ValueError, TypeError, RuntimeError) as e:
         logger.error("[ReasonOS] generate_reflection_template LLM error: %s", e)
         return {}
 

--- a/veritas_os/tests/test_reason.py
+++ b/veritas_os/tests/test_reason.py
@@ -197,7 +197,7 @@ def test_generate_reason_llm_error(monkeypatch):
     """LLM 呼び出し例外時に error ソースで空文字を返す。"""
 
     def stub_chat(*args, **kwargs):
-        raise RuntimeError("boom")
+        raise ValueError("boom")
 
     monkeypatch.setattr(reason.llm_client, "chat", stub_chat)
 
@@ -276,7 +276,41 @@ def test_generate_reflection_template_llm_error(monkeypatch):
     """
 
     def stub_chat(*args, **kwargs):
-        raise RuntimeError("LLM error")
+        raise ValueError("LLM error")
+
+    monkeypatch.setattr(reason.llm_client, "chat", stub_chat)
+
+    tmpl = asyncio.run(
+        reason.generate_reflection_template(
+            query="テスト",
+            chosen={"title": "X"},
+            gate={"risk": 0.1, "decision_status": "allow"},
+            values={"total": 0.5, "ema": 0.5},
+            planner={},
+        )
+    )
+
+    assert tmpl == {}
+
+
+def test_generate_reason_runtime_error_fallback(monkeypatch):
+    """LLM RuntimeError は互換維持のためフォールバック処理する。"""
+
+    def stub_chat(*args, **kwargs):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(reason.llm_client, "chat", stub_chat)
+
+    res = reason.generate_reason(query="error test")
+
+    assert res == {"text": "", "source": "error"}
+
+
+def test_generate_reflection_template_runtime_error_fallback(monkeypatch):
+    """LLM RuntimeError は互換維持のためフォールバック処理する。"""
+
+    def stub_chat(*args, **kwargs):
+        raise RuntimeError("unexpected")
 
     monkeypatch.setattr(reason.llm_client, "chat", stub_chat)
 


### PR DESCRIPTION
### Motivation

- Prevent broad `except Exception` in LLM call sites from swallowing unexpected errors while keeping graceful fallbacks for anticipated failures. 
- Ensure behavior is explicit and regression-tested so runtime/JSON errors surface appropriately during debugging and CI. 
- Record the change in the code-review status document for traceability.

### Description

- Replace `except Exception` with `except (OSError, ValueError, TypeError, RuntimeError)` in `generate_reason` and `generate_reflection_template` inside `veritas_os/core/reason.py` so only expected error classes are caught. 
- Update `veritas_os/tests/test_reason.py` to simulate `ValueError` for LLM error cases and add `test_generate_reason_runtime_error_fallback` and `test_generate_reflection_template_runtime_error_fallback` to verify `RuntimeError` still triggers the legacy fallback. 
- Update `docs/review/CODE_REVIEW_STATUS.md` to record the partial L-5 fixes and progress synchronization for this change.

### Testing

- Ran `pytest veritas_os/tests/test_reason.py` including `test_generate_reason_llm_error`, `test_generate_reflection_template_llm_error`, `test_generate_reason_runtime_error_fallback`, and `test_generate_reflection_template_runtime_error_fallback`, and all tests passed. 
- Existing reflection JSON parse and metadata-writing tests in the same file were executed and succeeded as part of the file-level test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b8e045cc8326b4a97398613fab6e)