### PR TITLE
Narrow replay pipeline version exception handling

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加9 / 優先対応)**: `replay/replay_engine.py:_pipeline_version()` の broad `except Exception` を `subprocess.CalledProcessError` / `FileNotFoundError` / `OSError` に縮小し、想定外の `RuntimeError` を握りつぶさないよう改善。`test_replay_engine.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加8 / 優先対応・互換調整済み)**: `core/reason.py` の `generate_reason()` / `generate_reflection_template()` は、CI 互換性（`kernel.decide()` の graceful fallback 契約）を優先して LLM 呼び出し例外を継続捕捉する実装へ調整。`test_reason.py` / `test_coverage_boost.py` / `kernel*` 系テストで回帰なしを確認。今後は `llm_client` 側で例外型を細分化したうえで再度段階縮小を行う。
 - ✅ **L-5 Partial (追加7 / 優先対応)**: `core/reason.py` の `generate_reflection_template()` で broad `except` を `JSONDecodeError` / `(TypeError, ValueError)` / `OSError` に縮小し、想定外 `RuntimeError` などの握りつぶしを抑止。対応テストにより既存挙動を維持確認。
 - ✅ **L-5 Partial (追加6 / 優先対応)**: `compliance/report_engine.py` の `_iter_decision_logs()` / `_latest_replay_result()` で broad `except` を `OSError` / `JSONDecodeError` に縮小し、想定外の `RuntimeError` を握りつぶさないよう改善。回帰テストを追加して異常系挙動を固定。

--- a/veritas_os/replay/replay_engine.py
+++ b/veritas_os/replay/replay_engine.py
@@ -44,6 +44,12 @@ def _strict_mode_enabled() -> bool:
 
 
 def _pipeline_version() -> str:
+    """Return the current git short SHA when available.
+
+    Security note:
+        We intentionally do not swallow arbitrary exceptions here so that
+        unexpected runtime errors are surfaced during diagnostics.
+    """
     try:
         out = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"],
@@ -53,7 +59,7 @@ def _pipeline_version() -> str:
         version = out.strip()
         if version:
             return version
-    except Exception:
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return "unknown"
     return "unknown"
 
@@ -240,4 +246,3 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
         diff=diff,
         diff_summary=_diff_summary(diff),
     )
-

--- a/veritas_os/tests/test_replay_engine.py
+++ b/veritas_os/tests/test_replay_engine.py
@@ -1,11 +1,31 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from veritas_os.replay import replay_engine
+
+
+def test_pipeline_version_returns_unknown_on_expected_subprocess_failures(monkeypatch) -> None:
+    def _raise_called_process_error(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(1, ["git"])
+
+    monkeypatch.setattr(replay_engine.subprocess, "check_output", _raise_called_process_error)
+
+    assert replay_engine._pipeline_version() == "unknown"
+
+
+def test_pipeline_version_does_not_swallow_unexpected_errors(monkeypatch) -> None:
+    def _raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(replay_engine.subprocess, "check_output", _raise_runtime_error)
+
+    with pytest.raises(RuntimeError):
+        replay_engine._pipeline_version()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Reduce a broad `except Exception` in the replay pipeline metadata path to avoid silently swallowing unexpected runtime errors and improve debuggability/security. 
- This addresses an L-5 item (bare/broad except reduction) tracked in `docs/review/CODE_REVIEW_STATUS.md` while staying within component responsibility boundaries. 

### Description
- In `veritas_os/replay/replay_engine.py` narrowed `_pipeline_version()` exception handling to catch only `subprocess.CalledProcessError`, `FileNotFoundError`, and `OSError`, and added a docstring explaining the intent to not swallow unexpected errors. 
- Added two unit tests in `veritas_os/tests/test_replay_engine.py` to assert that `_pipeline_version()` returns `"unknown"` for expected subprocess failures and re-raises unexpected `RuntimeError`. 
- Updated `docs/review/CODE_REVIEW_STATUS.md` to record this L-5 partial improvement. 

### Testing
- Ran `pytest -q veritas_os/tests/test_replay_engine.py` and all tests passed (`4 passed`).
- New tests exercise the expected failure path (`subprocess.CalledProcessError`) and verify that unexpected exceptions are not swallowed (raises `RuntimeError`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c4b414f08326a015c1fe3c86770e)