### PR TITLE
Harden coverage_map_pipeline exception handling and record L-5 progress

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -121,7 +121,7 @@ updated_at: 2026-03-13
 - ✅ **L-2**: `api/evolver.py` の `print()` を logger へ置換。
 - ⏸️ **L-3 (Accepted)**: `rsi.py` は sample 実装として維持。
 - ✅ **L-4 (Accepted)**: `core/reflection.py` の forward-compat `hasattr()` 分岐は意図的。
-- ⏸️ **L-5 (Deferred/Partial)**: bare except の段階的削減（`logging/rotate.py` の marker 処理に加え、`logging/trust_log.py` の署名付き追記フォールバックを `SignedTrustLogWriteError` のみ捕捉する形へ改善済み）。
+- ⏸️ **L-5 (Deferred/Partial)**: bare except の段階的削減（`logging/rotate.py` の marker 処理、`logging/trust_log.py` の署名付き追記フォールバック限定、`tools/coverage_map_pipeline.py` の型変換/JSON読込/AST解析の捕捉縮小まで改善済み）。
 - ⏸️ **L-6 (Deferred)**: `MemoryStore` 名称衝突。
 - ⏸️ **L-7 (Deferred)**: 未使用 import / dead code 整理。
 - ✅ **L-8**: `value_core.py` のコメントインデント不整合を修正。
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加10 / 優先対応)**: `tools/coverage_map_pipeline.py` の broad `except` を `TypeError` / `ValueError` / `OverflowError` / `OSError` / `JSONDecodeError` / `SyntaxError` などへ縮小し、想定外 `RuntimeError` を握りつぶさないよう改善。`test_coverage_map_extra.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加9 / 優先対応)**: `replay/replay_engine.py:_pipeline_version()` の broad `except Exception` を `subprocess.CalledProcessError` / `FileNotFoundError` / `OSError` に縮小し、想定外の `RuntimeError` を握りつぶさないよう改善。`test_replay_engine.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加8 / 優先対応・互換調整済み)**: `core/reason.py` の `generate_reason()` / `generate_reflection_template()` は、CI 互換性（`kernel.decide()` の graceful fallback 契約）を優先して LLM 呼び出し例外を継続捕捉する実装へ調整。`test_reason.py` / `test_coverage_boost.py` / `kernel*` 系テストで回帰なしを確認。今後は `llm_client` 側で例外型を細分化したうえで再度段階縮小を行う。
 - ✅ **L-5 Partial (追加7 / 優先対応)**: `core/reason.py` の `generate_reflection_template()` で broad `except` を `JSONDecodeError` / `(TypeError, ValueError)` / `OSError` に縮小し、想定外 `RuntimeError` などの握りつぶしを抑止。対応テストにより既存挙動を維持確認。

--- a/veritas_os/tests/test_coverage_map_extra.py
+++ b/veritas_os/tests/test_coverage_map_extra.py
@@ -71,6 +71,18 @@ class TestCovFileEntryEdgeCases:
         assert result.executed_branches == []
 
 
+    def test_missing_lines_unexpected_runtime_error_propagates(self):
+        """Unexpected RuntimeError should not be swallowed."""
+
+        class _BadStr:
+            def __str__(self) -> str:
+                raise RuntimeError("boom")
+
+        entry = {"missing_lines": [_BadStr()]}
+        with pytest.raises(RuntimeError, match="boom"):
+            m.CovFileEntry.from_cov(entry)
+
+
 class TestResolveCovJson:
     """Test _resolve_cov_json edge cases."""
 
@@ -157,6 +169,18 @@ class TestLoadCov:
 
         captured = capsys.readouterr()
         assert "failed to parse" in captured.err
+
+
+    def test_load_cov_unexpected_runtime_error_propagates(self, monkeypatch, tmp_path):
+        """Unexpected RuntimeError from read_text should propagate."""
+
+        class _BadPath:
+            def read_text(self, encoding: str = "utf-8") -> str:
+                raise RuntimeError("unexpected")
+
+        monkeypatch.setattr(m, "_resolve_cov_json", lambda: _BadPath())
+        with pytest.raises(RuntimeError, match="unexpected"):
+            m.load_cov()
 
 
 class TestFindTargetFile:

--- a/veritas_os/tools/coverage_map_pipeline.py
+++ b/veritas_os/tools/coverage_map_pipeline.py
@@ -66,7 +66,7 @@ class CovFileEntry:
                 s = str(x).strip()
                 if s.lstrip("-").isdigit():
                     ml2.append(int(float(s)))
-            except Exception:
+            except (TypeError, ValueError, OverflowError):
                 continue
 
         mb2: List[List[int]] = []
@@ -74,7 +74,7 @@ class CovFileEntry:
             if isinstance(arc, (list, tuple)) and len(arc) == 2:
                 try:
                     mb2.append([int(arc[0]), int(arc[1])])
-                except Exception:
+                except (TypeError, ValueError, OverflowError):
                     continue
 
         eb2: List[List[int]] = []
@@ -82,7 +82,7 @@ class CovFileEntry:
             if isinstance(arc, (list, tuple)) and len(arc) == 2:
                 try:
                     eb2.append([int(arc[0]), int(arc[1])])
-                except Exception:
+                except (TypeError, ValueError, OverflowError):
                     continue
 
         return cls(missing_lines=ml2, missing_branches=mb2, executed_branches=eb2)
@@ -113,7 +113,7 @@ def _resolve_cov_json() -> Optional[Path]:
             p0r = (Path.cwd() / p0).resolve()
             if p0r.exists():
                 return p0r
-    except Exception:
+    except (TypeError, ValueError, OSError):
         pass
 
     # 2) env
@@ -131,7 +131,7 @@ def _resolve_cov_json() -> Optional[Path]:
             try:
                 if c.exists():
                     return c
-            except Exception:
+            except OSError:
                 continue
 
     return None
@@ -160,7 +160,7 @@ def load_cov() -> Dict[str, Any]:
 
     try:
         return json.loads(p.read_text(encoding="utf-8"))
-    except Exception as e:
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as e:
         _eprint(
             f"[coverage_map_pipeline] failed to parse coverage.json: {p}  err={repr(e)[:160]}"
         )
@@ -197,7 +197,7 @@ def find_target_file(cov: Dict[str, Any], target_suffix: str = TARGET_SUFFIX) ->
 def _safe_read_text(path: Path) -> Optional[str]:
     try:
         return path.read_text(encoding="utf-8")
-    except Exception as e:
+    except (OSError, UnicodeDecodeError) as e:
         _eprint(f"[coverage_map_pipeline] cannot read source: {path} err={repr(e)[:160]}")
         return None
 
@@ -270,7 +270,7 @@ def _parse_target_suffix(argv: List[str]) -> str:
         try:
             i = argv.index("--target")
             target_suffix = argv[i + 1].strip()
-        except Exception:
+        except (ValueError, IndexError, AttributeError):
             _eprint(
                 "[coverage_map_pipeline] invalid --target usage. example: --target veritas_os/core/pipeline.py"
             )
@@ -328,7 +328,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         try:
             tree = ast.parse(src)
             defs = index_defs(tree)
-        except Exception as e:
+        except (SyntaxError, ValueError, TypeError) as e:
             _eprint(
                 f"[coverage_map_pipeline] AST parse failed for {target}: {repr(e)[:160]}"
             )
@@ -386,7 +386,6 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
 
 
 


### PR DESCRIPTION
### Motivation

- Reduce broad/bare `except` usage flagged in `CODE_REVIEW_STATUS.md` (L-5) to avoid silently swallowing unexpected errors like `RuntimeError` and improve diagnosability and security posture. 
- Make targeted changes that stay within the existing subsystem boundaries (no Planner/Kernel/Fuji/MemoryOS responsibility crossing).

### Description

- Narrowed broad exception handlers in `veritas_os/tools/coverage_map_pipeline.py` for numeric normalization, coverage path resolution, candidate probing, JSON loading, source file reading, `--target` argument parsing, and AST parsing by replacing generic `except Exception` with specific exception tuples such as `TypeError`, `ValueError`, `OverflowError`, `OSError`, `json.JSONDecodeError`, `UnicodeDecodeError`, `SyntaxError`, and `IndexError` where appropriate. 
- Added regression tests in `veritas_os/tests/test_coverage_map_extra.py` to assert that unexpected runtime errors propagate (added tests that raise `RuntimeError` from a malformed `__str__` and from `read_text()`), ensuring we do not silently swallow such failures. 
- Updated `docs/review/CODE_REVIEW_STATUS.md` to record this L-5 partial improvement and reflect the change in the Recent Updates / LOW sections. 
- Modified files: `veritas_os/tools/coverage_map_pipeline.py`, `veritas_os/tests/test_coverage_map_extra.py`, and `docs/review/CODE_REVIEW_STATUS.md`.

Security note: this change improves error visibility and reduces the risk that security-relevant failures are hidden, but remaining bare `except` instances are still on the watchlist and require further phased reduction.

### Testing

- Ran the representative test suites: `pytest -q veritas_os/tests/test_tools_coverage_map_pipeline.py veritas_os/tests/test_coverage_map_extra.py`, and all tests passed: `40 passed`.
- The added tests specifically verify that unexpected `RuntimeError` instances are no longer swallowed and propagate as intended (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c77a41e88326be058981c3c47392)