### PR TITLE
Reduce broad exception handling in experiments module

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加11 / 優先対応)**: `core/experiments.py` の `_to_int()` および `VERITAS_EXPERIMENTS_PER_DAY` 読込で broad `except Exception` を `TypeError` / `ValueError` / `OverflowError` に縮小し、想定外 `RuntimeError` の握りつぶしを防止。`test_experiments.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加10 / 優先対応)**: `tools/coverage_map_pipeline.py` の broad `except` を `TypeError` / `ValueError` / `OverflowError` / `OSError` / `JSONDecodeError` / `SyntaxError` などへ縮小し、想定外 `RuntimeError` を握りつぶさないよう改善。`test_coverage_map_extra.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加9 / 優先対応)**: `replay/replay_engine.py:_pipeline_version()` の broad `except Exception` を `subprocess.CalledProcessError` / `FileNotFoundError` / `OSError` に縮小し、想定外の `RuntimeError` を握りつぶさないよう改善。`test_replay_engine.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加8 / 優先対応・互換調整済み)**: `core/reason.py` の `generate_reason()` / `generate_reflection_template()` は、CI 互換性（`kernel.decide()` の graceful fallback 契約）を優先して LLM 呼び出し例外を継続捕捉する実装へ調整。`test_reason.py` / `test_coverage_boost.py` / `kernel*` 系テストで回帰なしを確認。今後は `llm_client` 側で例外型を細分化したうえで再度段階縮小を行う。

--- a/veritas_os/core/experiments.py
+++ b/veritas_os/core/experiments.py
@@ -25,7 +25,7 @@ def utc_now() -> datetime:
 def _to_int(x: Any, default: int = 0) -> int:
     try:
         return int(x)
-    except Exception:
+    except (TypeError, ValueError, OverflowError):
         return default
 
 
@@ -146,7 +146,7 @@ def propose_experiments_for_today(
     # 返す件数（環境変数で調整可）
     try:
         target_n = int(os.getenv("VERITAS_EXPERIMENTS_PER_DAY", "3"))
-    except Exception:
+    except (TypeError, ValueError):
         target_n = 3
     target_n = max(2, min(6, target_n))
 
@@ -259,5 +259,4 @@ def propose_experiments_for_today(
 
     # target_n に揃える（最低2、最大6）
     return exps[:target_n]
-
 

--- a/veritas_os/tests/test_experiments.py
+++ b/veritas_os/tests/test_experiments.py
@@ -178,3 +178,19 @@ def test_propose_experiments_value_ema_not_high_keeps_risk() -> None:
     assert pytest.approx(usecase.risk) == 0.15
 
 
+def test_to_int_overflow_returns_default() -> None:
+    """_to_int は OverflowError を安全に default へフォールバックする。"""
+    assert exp_module._to_int(float("inf"), default=7) == 7
+
+
+def test_target_n_env_invalid_falls_back_to_default(monkeypatch) -> None:
+    """環境変数が数値化できない場合、target_n は既定値 3 を使う。"""
+    monkeypatch.setenv("VERITAS_EXPERIMENTS_PER_DAY", "invalid")
+
+    exps = propose_experiments_for_today(
+        user_id="user-env",
+        world_state=None,
+        value_ema=0.5,
+    )
+
+    assert len(exps) == 3


### PR DESCRIPTION
### Motivation
- Narrow broad `except` handling to avoid swallowing unexpected runtime errors and improve observability for the L-5 (bare `except`) items in the code review status. 
- This change targets only `core/experiments.py` and related tests/docs without crossing Planner/Kernel/Fuji/MemoryOS responsibilities. 
- Security warning: broad `except` can hide real faults and security events; shrinking the catch sets reduces this risk. 

### Description
- Tighten `_to_int()` in `veritas_os/core/experiments.py` to catch only `TypeError`, `ValueError`, and `OverflowError` instead of a blanket `Exception`. 
- Restrict `VERITAS_EXPERIMENTS_PER_DAY` parsing to catch only `TypeError` and `ValueError`. 
- Add regression tests in `veritas_os/tests/test_experiments.py` (`test_to_int_overflow_returns_default` and `test_target_n_env_invalid_falls_back_to_default`). 
- Update `docs/review/CODE_REVIEW_STATUS.md` to record the L-5 partial improvement for `core/experiments.py`. 

### Testing
- Ran `pytest -q veritas_os/tests/test_experiments.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ca41f988832689f55c5147983ebb)