### PR TITLE
Tighten web_search exception handling and add regression tests

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -150,6 +150,7 @@ updated_at: 2026-03-13
 
 ### Earlier Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加8 / 優先対応)**: `tools/web_search.py:web_search()` の外側 broad `except Exception` を `requests.RequestException` / `OSError` / `TypeError` / `ValueError` へ縮小し、想定外 `RuntimeError` の握りつぶしを防止。`test_web_search.py` に回帰テストを追加し、通信例外は従来どおり安全側でハンドリングしつつ、予期しない実行時例外は顕在化することを確認。
 - ✅ **L-5 Partial**: `logging/rotate.py` の marker 保存/読込で broad `except Exception` を縮小し、予期しない例外を顕在化。
 - ✅ **L-5 Partial (追加)**: `logging/trust_log.py` で `append_signed_decision()` のフォールバック捕捉を `SignedTrustLogWriteError` に限定し、想定外例外の握りつぶしを防止。
 - ✅ **Status Note Updated**: 本書に「改善済み（部分対応）」として追記。

--- a/veritas_os/tests/test_web_search.py
+++ b/veritas_os/tests/test_web_search.py
@@ -642,14 +642,14 @@ def test_web_search_agi_query_no_agi_like_results(monkeypatch, _bypass_ssrf) -> 
 
 
 def test_web_search_handles_request_exception(monkeypatch, _bypass_ssrf) -> None:
-    """requests.post で例外が出た場合に、エラーとしてハンドリングされること"""
+    """requests.post で通信例外が出た場合に、エラーとしてハンドリングされること。"""
     monkeypatch.setattr(
         web_search_mod, "WEBSEARCH_URL", "https://example.com/serper", raising=False
     )
     monkeypatch.setattr(web_search_mod, "WEBSEARCH_KEY", "dummy-key", raising=False)
 
     def fake_post(*args, **kwargs):
-        raise RuntimeError("network failure")
+        raise web_search_mod.requests.RequestException("network failure")
 
     monkeypatch.setattr(web_search_mod.requests, "post", fake_post)
 
@@ -658,6 +658,25 @@ def test_web_search_handles_request_exception(monkeypatch, _bypass_ssrf) -> None
     assert resp["ok"] is False
     assert resp["results"] == []
     assert "WEBSEARCH_API error" in resp["error"]
+
+
+def test_web_search_does_not_swallow_unexpected_runtime_error(
+    monkeypatch,
+    _bypass_ssrf,
+) -> None:
+    """想定外の実行時例外は握りつぶさずに送出する。"""
+    monkeypatch.setattr(
+        web_search_mod, "WEBSEARCH_URL", "https://example.com/serper", raising=False
+    )
+    monkeypatch.setattr(web_search_mod, "WEBSEARCH_KEY", "dummy-key", raising=False)
+
+    def fake_post(*_args: Any, **_kwargs: Any):
+        raise RuntimeError("unexpected failure")
+
+    monkeypatch.setattr(web_search_mod.requests, "post", fake_post)
+
+    with pytest.raises(RuntimeError, match="unexpected failure"):
+        web_search_mod.web_search("some query", max_results=2)
 
 
 def test_web_search_rejects_non_json_content_type(monkeypatch, _bypass_ssrf) -> None:

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -1126,7 +1126,12 @@ def web_search(query: str, max_results: int = 5) -> Dict[str, Any]:
             ),
         }
 
-    except Exception as e:
+    except (
+        OSError,
+        TypeError,
+        ValueError,
+        requests.RequestException,
+    ) as e:
         # ★ セキュリティ修正: 内部例外の詳細をレスポンスに含めない
         # 詳細はログに記録し、クライアントには汎用的なエラーメッセージのみ返す
         logger.warning(


### PR DESCRIPTION
### Motivation

- 対象は `CODE_REVIEW_STATUS.md` の優先項目 (L-5: broad `except` の削減) で、`web_search()` の外側で汎用的に例外を握りつぶしていたため想定外の `RuntimeError` 等が隠蔽されていた問題を解消するため。 
- 例外の粒度を狭めて運用観測性を改善し、重大なランタイム障害の早期検出を可能にすることを目的とする。

### Description

- `veritas_os/tools/web_search.py` の外側 `except Exception` を `except (OSError, TypeError, ValueError, requests.RequestException) as e:` に縮小して、通信系/運用系の想定エラーは安全に処理しつつ予期しない `RuntimeError` 等は顕在化するようにした。 
- `veritas_os/tests/test_web_search.py` を更新し、既存の通信例外ハンドリングを保持するテストを修正して `requests.RequestException` を用いるようにし、さらに `test_web_search_does_not_swallow_unexpected_runtime_error` を追加して `RuntimeError` が握りつぶされないことを検証する回帰テストを追加した。 
- `docs/review/CODE_REVIEW_STATUS.md` を更新して本対応（L-5 Partial 追加8）を反映した。 

### Testing

- 実行したユニットテスト: `pytest -q veritas_os/tests/test_web_search.py -k "request_exception or unexpected_runtime_error"` が `2 passed, 38 deselected` で成功した。 
- スタイル/静的チェック: `python -m ruff check veritas_os/tools/web_search.py veritas_os/tests/test_web_search.py` が `All checks passed!` で成功した。 
- セキュリティ注意: 想定外例外の握りつぶしを減らしたことで障害検出性は改善されるが、リポジトリ内には依然として他箇所に `bare except` が残存しているため引き続き段階的な削減が必要であることを警告する。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ce2943d483268a77efee018b2ce4)