### PR TITLE
Harden web_search _normalize_str exception handling

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加12 / 優先対応)**: `tools/web_search.py:_normalize_str()` の broad `except Exception` を `TypeError` / `ValueError` に縮小し、想定外 `RuntimeError` を握りつぶさないよう改善。`test_web_search_extra.py` に回帰テストを追加して異常系挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加11 / 優先対応)**: `core/experiments.py` の `_to_int()` および `VERITAS_EXPERIMENTS_PER_DAY` 読込で broad `except Exception` を `TypeError` / `ValueError` / `OverflowError` に縮小し、想定外 `RuntimeError` の握りつぶしを防止。`test_experiments.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加10 / 優先対応)**: `tools/coverage_map_pipeline.py` の broad `except` を `TypeError` / `ValueError` / `OverflowError` / `OSError` / `JSONDecodeError` / `SyntaxError` などへ縮小し、想定外 `RuntimeError` を握りつぶさないよう改善。`test_coverage_map_extra.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加9 / 優先対応)**: `replay/replay_engine.py:_pipeline_version()` の broad `except Exception` を `subprocess.CalledProcessError` / `FileNotFoundError` / `OSError` に縮小し、想定外の `RuntimeError` を握りつぶさないよう改善。`test_replay_engine.py` に異常系テストを追加して挙動を固定（改善済み）。

--- a/veritas_os/tests/test_web_search_extra.py
+++ b/veritas_os/tests/test_web_search_extra.py
@@ -60,6 +60,14 @@ class TestNormalizeStr:
         result = web_search_mod._normalize_str(BadStr())
         assert "BadStr" in result  # repr fallback
 
+    def test_unexpected_exception_in_str_conversion_is_raised(self):
+        class RuntimeBadStr:
+            def __str__(self):
+                raise RuntimeError("unexpected")
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            web_search_mod._normalize_str(RuntimeBadStr())
+
 
 class TestSafeIntHelpers:
     """Tests for integer environment helper functions."""

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -258,7 +258,7 @@ RE_BUREAUVERITAS = re.compile(r"(^|\.)bureauveritas\.[a-z]{2,}$", re.IGNORECASE)
 def _normalize_str(x: Any, *, limit: int = 4000) -> str:
     try:
         s = "" if x is None else str(x)
-    except Exception:
+    except (TypeError, ValueError):
         s = repr(x)
     if limit and len(s) > limit:
         return s[:limit]


### PR DESCRIPTION
### Motivation
- Reduce a broad `except Exception` in `tools/web_search.py:_normalize_str()` per the L-5 priority in the code review status to avoid masking unexpected runtime errors. 
- Preserve the intended fallback behavior for expected conversion errors while allowing truly unexpected errors to surface for diagnostics and security monitoring.

### Description
- Narrowed the exception handler in `_normalize_str()` from `except Exception` to `except (TypeError, ValueError)` so only expected conversion failures use the `repr()` fallback. 
- Added a regression test `test_unexpected_exception_in_str_conversion_is_raised` in `veritas_os/tests/test_web_search_extra.py` to assert that `RuntimeError` raised by `__str__()` now propagates. 
- Updated `docs/review/CODE_REVIEW_STATUS.md` to record this fix as `L-5 Partial (追加12 / 優先対応)` and mark it as 改善済み.

### Testing
- Ran `pytest -q veritas_os/tests/test_web_search_extra.py::TestNormalizeStr -q` and the targeted test class passed (`.....`).
- The change is a minimal behavioral hardening that preserves prior fallback semantics for `TypeError`/`ValueError` and causes unexpected `RuntimeError` to surface, which improves diagnosability and aligns with the review guidance.
- Security note: this reduces one instance of broad exception swallowing, but broad/bare `except` usage remains in other modules and is tracked on the review watchlist as a continuing risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d25dd8048326ad9a8898c75f7384)