### PR TITLE
L-5優先対応: github_adapter の broad except 縮小

### DIFF
--- a/docs/review/CODE_REVIEW_STATUS.md
+++ b/docs/review/CODE_REVIEW_STATUS.md
@@ -131,6 +131,7 @@ updated_at: 2026-03-13
 
 ### Recent Updates (2026-03-13)
 
+- ✅ **L-5 Partial (追加13 / 優先対応)**: `tools/github_adapter.py:github_search_repos()` の GitHub 呼び出し周辺で broad `except Exception` を `requests.RequestException` / `TypeError` / `ValueError` に縮小し、想定外 `RuntimeError` の握りつぶしを防止。`test_github_adapter.py` に回帰テストを追加して、通信系・JSON整形系の失敗は従来どおり安全側で処理しつつ、予期しない実行時例外は顕在化することを確認（改善済み）。
 - ✅ **L-5 Partial (追加12 / 優先対応)**: `tools/web_search.py:_normalize_str()` の broad `except Exception` を `TypeError` / `ValueError` に縮小し、想定外 `RuntimeError` を握りつぶさないよう改善。`test_web_search_extra.py` に回帰テストを追加して異常系挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加11 / 優先対応)**: `core/experiments.py` の `_to_int()` および `VERITAS_EXPERIMENTS_PER_DAY` 読込で broad `except Exception` を `TypeError` / `ValueError` / `OverflowError` に縮小し、想定外 `RuntimeError` の握りつぶしを防止。`test_experiments.py` に異常系テストを追加して挙動を固定（改善済み）。
 - ✅ **L-5 Partial (追加10 / 優先対応)**: `tools/coverage_map_pipeline.py` の broad `except` を `TypeError` / `ValueError` / `OverflowError` / `OSError` / `JSONDecodeError` / `SyntaxError` などへ縮小し、想定外 `RuntimeError` を握りつぶさないよう改善。`test_coverage_map_extra.py` に異常系テストを追加して挙動を固定（改善済み）。

--- a/veritas_os/tests/test_github_adapter.py
+++ b/veritas_os/tests/test_github_adapter.py
@@ -1,6 +1,8 @@
 # veritas_os/tests/test_github_adapter.py
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from veritas_os.tools import github_adapter
 
 
@@ -121,7 +123,7 @@ def test_github_search_repos_handles_api_error(monkeypatch):
     monkeypatch.setenv("VERITAS_GITHUB_TOKEN", "dummy-token")
 
     def fake_get(*args, **kwargs):
-        raise RuntimeError("boom")
+        raise github_adapter.requests.exceptions.Timeout("boom")
 
     monkeypatch.setattr(github_adapter.requests, "get", fake_get)
 
@@ -131,6 +133,20 @@ def test_github_search_repos_handles_api_error(monkeypatch):
     assert res["results"] == []
     assert "GitHub API error:" in res["error"]
 
+
+
+
+def test_github_search_repos_raises_unexpected_runtime_error(monkeypatch):
+    """想定外例外は握りつぶさずに顕在化させる。"""
+    monkeypatch.setenv("VERITAS_GITHUB_TOKEN", "dummy-token")
+
+    def fake_get_with_retry(*args, **kwargs):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(github_adapter, "_get_with_retry", fake_get_with_retry)
+
+    with pytest.raises(RuntimeError, match="unexpected"):
+        github_adapter.github_search_repos("veritas_os")
 
 def test_github_search_repos_retries_on_timeout(monkeypatch):
     """一時的なタイムアウト時に再試行する。"""

--- a/veritas_os/tools/github_adapter.py
+++ b/veritas_os/tools/github_adapter.py
@@ -364,7 +364,7 @@ def github_search_repos(query: str, max_results: int = 5) -> dict:
     try:
         r = _get_with_retry(url, headers=headers, params=params, timeout=20)
         data = r.json()
-    except Exception as e:
+    except (requests.RequestException, ValueError, TypeError) as e:
         # ★ セキュリティ修正: 内部例外の詳細をレスポンスに含めない
         logger.warning("GitHub API error: %s: %s", type(e).__name__, e)
         return {


### PR DESCRIPTION
### Motivation
- L-5（bare `except` の段階的削減）対応の一環として、`github_search_repos()` の外側で広く例外を握りつぶしていた箇所を安全に縮小し、予期しないランタイム例外を顕在化させて障害解析とセキュリティ検知を改善する目的で修正した。
- 通信/JSON 整形周りは従来どおり安全運用（通信エラーはフォールバック）を維持しつつ、想定外の `RuntimeError` 等を無視しない方針へ変更することが狙いである。
- プロジェクト全体ではまだ bare `except` が残存しているため、段階的縮小を継続する必要がある点を警告する。

### Description
- `veritas_os/tools/github_adapter.py` の `github_search_repos()` における `except Exception` を `except (requests.RequestException, ValueError, TypeError)` に限定し、通信系/JSON整形エラーのみを安全にハンドルするよう変更した。
- 想定外の実行時例外は握りつぶさず呼び出し元へ伝播するよう挙動を明確化した（早期検知による運用性向上）。
- 回帰テスト `veritas_os/tests/test_github_adapter.py` を更新し、通信系例外は従来どおり安全に処理されることと、想定外 `RuntimeError` が顕在化することを検証する `test_github_search_repos_raises_unexpected_runtime_error` を追加した。
- ドキュメント `docs/review/CODE_REVIEW_STATUS.md` の Recent Updates に今回の対応（L-5 Partial 追加13）を追記して改善済みとした。

### Testing
- `pytest -q veritas_os/tests/test_github_adapter.py` を実行し全テストが成功しており、結果は `26 passed` である。
- `ruff check veritas_os/tools/github_adapter.py veritas_os/tests/test_github_adapter.py` を実行し、PEP8/ruff チェックはすべて通過した。
- 変更は通信エラーおよび JSON 処理エラーに対して安全側の挙動を維持しつつ、予期しないランタイム例外の顕在化を確認する自動テストで検証済みである。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3dce424b883268d5bc91d7a79c11d)