### PR TITLE
docs(review): add full repository code review report (2026-03-13)

### DIFF
--- a/docs/review/CODE_REVIEW_FULL_2026_03_13_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_13_JP.md
@@ -1,0 +1,40 @@
+# CODE REVIEW FULL 2026-03-13 (JP)
+
+## 概要
+- リポジトリ全体に対して、既存テスト・責務境界・セキュリティ検査スクリプトを実行し、現時点の健全性を確認した。
+- **結論**: 致命的な不具合や責務逸脱は検出されなかったが、運用上の注意点として依存ライブラリ由来の非推奨警告がある。
+
+## 実施コマンド
+1. `python -m pytest -q`
+2. `python scripts/architecture/check_responsibility_boundaries.py`
+3. `python scripts/security/check_runtime_pickle_artifacts.py`
+4. `python scripts/security/check_next_public_key_exposure.py`
+5. `rg -n "\\beval\\(|\\bexec\\(|pickle\\.load|yaml\\.load\\(|subprocess\\.(Popen|run)\\(.*shell=True|NEXT_PUBLIC_.*(KEY|TOKEN|SECRET)" veritas_os frontend scripts`
+
+## レビュー結果
+
+### 1) テスト健全性
+- `pytest` は **3262 passed / 3 skipped / 2 warnings** で完走。
+- スキップは既存のテスト制御によるもので、失敗はなし。
+
+### 2) アーキテクチャ責務（Planner / Kernel / Fuji / MemoryOS）
+- `scripts/architecture/check_responsibility_boundaries.py` の結果は **passed**。
+- 既存の境界チェック上、責務を越える依存は検出されなかった。
+
+### 3) セキュリティ観点
+- ランタイム pickle 遺物チェックは **問題なし**。
+- `NEXT_PUBLIC_*` で秘密情報に該当しうるキー名チェックは **問題なし**。
+- 追加の簡易スキャンでも `eval/exec`, `pickle.load`, `yaml.load`, `shell=True` の危険パターンはコード本体から未検出（セキュリティ検査スクリプト内の検知用正規表現を除く）。
+
+## ⚠ セキュリティ警告（必読）
+- テスト実行時に `httpx` 側の `DeprecationWarning`（raw bytes/text upload API）が観測された。
+- 直接的な脆弱性ではないが、依存更新時に挙動差分を誘発し、認証ヘッダ処理や API 経路での予期せぬ不整合につながる可能性がある。
+- 推奨対応:
+  - `httpx` の推奨形式（`content=` の明示）へテスト・実装双方を段階的に寄せる。
+  - CI で `DeprecationWarning` を定期監視し、重大化前に解消する。
+
+## 優先アクション
+1. `DeprecationWarning` の発生テストを起点に、`httpx` 入力形式を将来互換に寄せる。
+2. 現行のセキュリティスクリプトを CI 必須ジョブとして維持（既に運用済みなら閾値管理を追加）。
+3. 境界チェックは本レビュー時点で問題ないため、機能追加時は同スクリプトの新規ルール追加で回帰を防ぐ。
+


### PR DESCRIPTION
### Motivation
- Add a persistent Japanese review that records full-repo test runs, architecture responsibility boundary checks, and security scans while surfacing an observed `httpx` `DeprecationWarning` that may indicate a future API compatibility risk.

### Description
- Create `docs/review/CODE_REVIEW_FULL_2026_03_13_JP.md` which lists executed commands (`python -m pytest -q`, boundary and security scripts, `rg` scan), summarizes findings, provides recommended mitigations, and makes no runtime code changes.

### Testing
- Executed `python -m pytest -q` (3262 passed, 3 skipped, 2 warnings), `python scripts/architecture/check_responsibility_boundaries.py` (passed), `python scripts/security/check_runtime_pickle_artifacts.py` (passed), `python scripts/security/check_next_public_key_exposure.py` (passed), and an `rg` scan for risky patterns (no matches in application code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e9f24d1c83268bf17e535dddd4de)