### PR TITLE
tests: switch replay API payloads to `content=` to avoid httpx deprecation

### DIFF
--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -166,7 +166,7 @@ def test_replay_api_endpoint_with_hmac_headers(monkeypatch):
             "X-VERITAS-SIGNATURE": signature,
             "Content-Type": "application/json",
         },
-        data=body,
+        content=body,
     )
 
     assert response.status_code == 200
@@ -205,7 +205,7 @@ def test_replay_api_endpoint_not_found_hides_exception(monkeypatch):
             "X-VERITAS-SIGNATURE": signature,
             "Content-Type": "application/json",
         },
-        data=body,
+        content=body,
     )
 
     assert response.status_code == 404


### PR DESCRIPTION
### Motivation
- Follow the CODE_REVIEW_FULL_2026_03_13_JP recommendation to move tests away from httpx's deprecated raw bytes/text upload API by sending raw JSON bodies with `content=` instead of `data=`, while keeping responsibility boundaries unchanged and warning that leaving deprecated API paths may cause future authentication/behavioral regressions.

### Description
- Replaced two calls in `veritas_os/tests/test_api_server_extra.py` from `client.post(..., data=body)` to `client.post(..., content=body)`; the change is a minimal, PEP8-preserving diff limited to tests only and committed.

### Testing
- Ran targeted pytest commands `python -m pytest -q veritas_os/tests/test_api_server_extra.py -k "replay_api_endpoint_with_hmac_headers or replay_api_endpoint_not_found_hides_exception"` and the same with `-W default`; both runs passed (`2 passed, 78 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f09479048326bd7eef76815c327c)