### PR TITLE
chore(test): remove stale httpx deprecation warning suppression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,5 @@ veritas_os = [
 
 [tool.pytest.ini_options]
 filterwarnings = [
-  "ignore:\"content=<...>\" is deprecated\\. Use 'data=<...>' instead:DeprecationWarning:httpx\\..*",
   "ignore:invalid escape sequence.*:SyntaxWarning:sentence_transformers\\..*",
 ]


### PR DESCRIPTION
### Motivation
- テスト実行時に `httpx` の生のアップロード API に関する `DeprecationWarning` が発生しており、将来の依存アップデートで実装挙動に差分が生じるリスクがあるため、警告を隠蔽する設定を削除し早期検知を可能にする運用改善を行った。 
- 変更は `Planner / Kernel / Fuji / MemoryOS` の責務境界を越えるものではなく、テスト設定レベルの運用改善に限定している。 

### Description
- `pyproject.toml` の `[tool.pytest.ini_options].filterwarnings` から `httpx` 固有の deprecation-ignore ルールを削除した（削除対象: `"ignore:\"content=<...>\" is deprecated...:DeprecationWarning:httpx\..*"`）。
- ランタイムやドメインロジックの修正は行っておらず、PEP8 に反するコード変更は含めていない。 
- 注意: 依存ライブラリの非推奨 API は将来の認証・リクエスト処理に影響し得るため、根本対応としてコード側の `content=` / `data=` の明示的移行を推奨する。 

### Testing
- 単体テスト全体を `python -m pytest -q` で実行し結果は `3262 passed, 3 skipped` で成功した。 
- 影響範囲の検証として `python -m pytest -q veritas_os/tests/test_api_server_extra.py veritas_os/tests/test_web_search.py` を実行し `120 passed`（該当テスト群は警告が表示される設定へ移行して正常実行）で成功した。 
- アーキテクチャ・セキュリティチェックとして `python scripts/architecture/check_responsibility_boundaries.py`, `python scripts/security/check_runtime_pickle_artifacts.py`, `python scripts/security/check_next_public_key_exposure.py` を実行しすべて `passed` / 問題なし。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f76045788326ac9bf56f5749bd40)