### PR TITLE
Add httpx raw-upload deprecation guard to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Responsibility boundary check
         run: python scripts/architecture/check_responsibility_boundaries.py --report-format json
 
+      - name: httpx raw upload deprecation check
+        run: python scripts/security/check_httpx_raw_upload_usage.py
+
       - name: Bandit security scan
         run: |
           bandit -r veritas_os/core veritas_os/api veritas_os/tools \

--- a/scripts/security/check_httpx_raw_upload_usage.py
+++ b/scripts/security/check_httpx_raw_upload_usage.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Detect deprecated httpx raw upload call patterns.
+
+httpx warns when raw text/bytes are sent through ``data=``. Projects should use
+``content=`` for raw payloads to preserve forward compatibility across httpx
+releases. This script scans Python source files and fails when obviously
+deprecated usages are found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCAN_ROOTS = (
+    REPO_ROOT / "veritas_os",
+    REPO_ROOT / "scripts",
+)
+SKIP_DIR_NAMES = {".git", "__pycache__", ".pytest_cache", ".mypy_cache", ".venv", "node_modules"}
+HTTPX_METHODS = {"post", "put", "patch", "request"}
+
+
+@dataclass(frozen=True)
+class Violation:
+    """Represents a deprecated raw upload pattern discovered in source."""
+
+    path: Path
+    line: int
+    message: str
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check Python source for deprecated httpx raw upload usage "
+            "(data=<str|bytes>)."
+        )
+    )
+    parser.add_argument(
+        "--scan-root",
+        action="append",
+        default=[],
+        help="Optional directory/file to scan. Can be provided multiple times.",
+    )
+    return parser.parse_args(argv)
+
+
+def _iter_python_files(scan_roots: list[Path]) -> list[Path]:
+    """Return Python files under the provided roots, excluding cache/vendor dirs."""
+    files: list[Path] = []
+    for root in scan_roots:
+        resolved = root.resolve(strict=False)
+        if not resolved.exists():
+            continue
+        if resolved.is_file() and resolved.suffix == ".py":
+            files.append(resolved)
+            continue
+
+        for path in resolved.rglob("*.py"):
+            if any(part in SKIP_DIR_NAMES for part in path.parts):
+                continue
+            files.append(path)
+    return files
+
+
+def _looks_like_raw_payload(node: ast.AST) -> bool:
+    """Return True when AST node is an obvious raw text/bytes payload literal."""
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, (str, bytes))
+    return isinstance(node, ast.JoinedStr)
+
+
+def _is_httpx_call(call: ast.Call) -> bool:
+    """Check whether this call targets a common httpx request method."""
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr in HTTPX_METHODS
+    return False
+
+
+def _scan_file(path: Path) -> list[Violation]:
+    """Scan one Python file and return detected violations."""
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_httpx_call(node):
+            continue
+
+        for keyword in node.keywords:
+            if keyword.arg != "data":
+                continue
+            if _looks_like_raw_payload(keyword.value):
+                violations.append(
+                    Violation(
+                        path=path,
+                        line=keyword.value.lineno,
+                        message="httpx raw payload in data= detected; use content= instead",
+                    )
+                )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run scan and return shell exit code."""
+    parsed = _parse_args(argv or sys.argv[1:])
+    scan_roots = DEFAULT_SCAN_ROOTS + tuple(Path(p) for p in parsed.scan_root)
+
+    violations: list[Violation] = []
+    for file_path in _iter_python_files(list(scan_roots)):
+        violations.extend(_scan_file(file_path))
+
+    if not violations:
+        print("No deprecated httpx raw upload usage detected.")
+        return 0
+
+    print("Deprecated httpx raw upload usage detected:")
+    for item in sorted(violations, key=lambda it: (str(it.path), it.line)):
+        try:
+            relative = item.path.relative_to(REPO_ROOT)
+        except ValueError:
+            relative = item.path
+        print(f"- {relative}:{item.line}: {item.message}")
+
+    print("\nReplace data=<str|bytes> with content=<str|bytes> for httpx requests.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_check_httpx_raw_upload_usage.py
+++ b/veritas_os/tests/test_check_httpx_raw_upload_usage.py
@@ -1,0 +1,89 @@
+"""Tests for scripts.security.check_httpx_raw_upload_usage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.security import check_httpx_raw_upload_usage as checker
+
+
+def test_scan_file_detects_data_with_bytes_or_string(tmp_path: Path) -> None:
+    """The scanner flags obvious deprecated raw payload usage in data=."""
+    source = tmp_path / "sample.py"
+    source.write_text(
+        "\n".join(
+            [
+                "import httpx",
+                "httpx.post('https://x.example', data='hello')",
+                "httpx.put('https://x.example', data=b'hello')",
+                "httpx.patch('https://x.example', content='safe')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert len(violations) == 2
+    assert violations[0].line == 2
+    assert violations[1].line == 3
+
+
+def test_scan_file_ignores_non_raw_data_literal(tmp_path: Path) -> None:
+    """Form-like data payloads are not flagged by this guard."""
+    source = tmp_path / "sample.py"
+    source.write_text(
+        "\n".join(
+            [
+                "import httpx",
+                "httpx.post('https://x.example', data={'k': 'v'})",
+                "httpx.post('https://x.example', files={'f': b'1'})",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert violations == []
+
+
+def test_main_returns_non_zero_when_violation_found(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    """The command returns 1 and prints remediation guidance on violations."""
+    source = tmp_path / "bad.py"
+    source.write_text(
+        "import httpx\nhttpx.post('https://x.example', data='raw')\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(checker, "DEFAULT_SCAN_ROOTS", ())
+    exit_code = checker.main(["--scan-root", str(source)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Deprecated httpx raw upload usage detected" in output
+    assert "use content=" in output
+
+
+def test_main_returns_zero_when_clean(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    """The command returns 0 when no deprecated usage is found."""
+    source = tmp_path / "good.py"
+    source.write_text(
+        "import httpx\nhttpx.post('https://x.example', content='raw')\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(checker, "DEFAULT_SCAN_ROOTS", ())
+    exit_code = checker.main(["--scan-root", str(source)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "No deprecated httpx raw upload usage detected" in output


### PR DESCRIPTION
### Motivation
- `docs/review/CODE_REVIEW_FULL_2026_03_13_JP.md` の指摘に従い、`httpx` の raw upload に関する `DeprecationWarning` 発生リスクを事前に検出して依存更新による振る舞い変化を防止するための自動検出を追加した。 
- 静的解析で検出可能なパターン（`data=<str|bytes>` のリテラル渡し）に限定して早期警告を出す運用上の改善を行った。 
- 注意: 静的解析は動的に組み立てられた payload を見逃す可能性があるため、CI ログでの `DeprecationWarning` 監視を継続することを推奨する（潜在的なセキュリティ/互換性リスクを軽減するため）。

### Description
- 新規スクリプト `scripts/security/check_httpx_raw_upload_usage.py` を追加し、AST で `httpx.post/put/patch/request(..., data=<str|bytes>)` の明白なケースを検出して修正案（`content=` へ置換）を提示するよう実装した。 
- 新規ユニットテスト `veritas_os/tests/test_check_httpx_raw_upload_usage.py` を追加して検出ケース・誤検知抑制・`main()` の正常/異常終了を検証する 4 件のテストを用意した。 
- CI の lint ジョブ (`.github/workflows/main.yml`) に新しいチェックを挿入してプルリク時に回帰をブロックするよう組み込んだ。 
- 付記: 追加コードには docstring を付与し PEP8 に準拠する形で実装しており、Planner / Kernel / Fuji / MemoryOS の責務は変更していない。

### Testing
- `python -m pytest -q veritas_os/tests/test_check_httpx_raw_upload_usage.py` は `4 passed` で成功した。 
- 新スクリプト単体実行 `python scripts/security/check_httpx_raw_upload_usage.py` は問題なし（問題があれば非ゼロ終了する設計）。
- リポジトリ全体のテストスイート `python -m pytest -q` は `3262 passed, 3 skipped` で成功しており、責務チェック `python scripts/architecture/check_responsibility_boundaries.py` も通過した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fd45935c8326a45a2c973b1abbf6)