### PR TITLE
Remove pickle completely from MemoryOS and add safe migration CLI

### DIFF
--- a/docs/operations/MEMORY_PICKLE_MIGRATION.md
+++ b/docs/operations/MEMORY_PICKLE_MIGRATION.md
@@ -1,30 +1,85 @@
 ---
 title: MemoryOS Legacy Pickle Migration
 lifecycle: active
-updated_at: 2026-03-12
+updated_at: 2026-03-13
 ---
 
 # MemoryOS Legacy Pickle Migration
 
 ## Security policy
 
-- Runtime での `pickle` / `joblib` 読み込みは **禁止** です。
+- Runtime での `pickle` / `joblib` / `.pickle` 読み込みは **永久に禁止** です。
 - 理由: `pickle` は任意コード実行 (RCE) リスクを持つためです。
-- Runtime が `.pkl` を検知した場合、ロードせずに `[SECURITY]` ログを出力します。
+- Runtime が `.pkl` / `.joblib` / `.pickle` を検知した場合、ロードせずに `[SECURITY]` エラーログを出力します。
+- **自動移行は行いません** — 変換は明示的な CLI 操作のみで実行されます。
 
-## Sunset deadline
+## 旧形式の廃止
 
-- Pickle runtime block policy deadline: **2026-06-30**
-- この日付以降、runtime 側での例外的な互換復帰は行いません。
+- pickle / joblib のランタイム読み込みは **完全に廃止** されました（期限なし）。
+- `VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION` 環境変数は無効です。設定しても効果はありません。
+- `joblib_load` シンボルはメモリモジュールから削除されました。
+- `enable_memory_joblib_model` のデフォルトは `False` に変更されました。
 
-## Offline migration steps
+## Migration CLI
 
-1. 信頼できる隔離環境で旧 `.pkl` を読み込みます。
-2. `VectorMemory` の JSON 形式 (`vector_index.json`) に変換します。
-3. モデルは ONNX (`memory_model.onnx`) へ変換します。
-4. 本番配置前に `.pkl` を削除し、JSON/ONNX のみを配置します。
+旧 pickle 資産がある場合は、以下のコマンドで安全な JSON 形式に変換してください。
+
+### 基本コマンド
+
+```bash
+# デフォルトディレクトリ（core/models）をスキャン＆変換
+python -m veritas_os.scripts.migrate_pickle
+
+# 特定のディレクトリを指定
+python -m veritas_os.scripts.migrate_pickle --scan-dir /path/to/legacy/data
+
+# ドライラン（変換せず対象ファイルのみ表示）
+python -m veritas_os.scripts.migrate_pickle --dry-run
+
+# 詳細ログ
+python -m veritas_os.scripts.migrate_pickle --verbose
+```
+
+### 変換フロー
+
+1. CLI がスキャンディレクトリ内の `.pkl` / `.joblib` / `.pickle` ファイルを検出
+2. `RestrictedUnpickler` で安全なクラスのみを許可してデシリアライズ
+3. JSON 形式 (`*.json`) に変換して同ディレクトリに出力
+4. **元の pickle ファイルは自動削除されません** — 手動で削除してください
+
+### セキュリティ上の注意
+
+- 信頼できる隔離環境でのみ実行してください
+- 最大ファイルサイズ: 50 MiB
+- 許可クラスリスト外のオブジェクトを含む pickle は変換に失敗します
+- 不明な出自の `.pkl` ファイルに対しては **絶対に実行しないでください**
+
+## 変換先フォーマット
+
+| 旧形式 | 新形式 | 説明 |
+|--------|--------|------|
+| `vector_index.pkl` | `vector_index.json` | VectorMemory インデックス（embeddings は Base64 エンコード） |
+| `memory_model.pkl` | `memory_model.onnx` + `memory_model.metadata.json` | モデルは `memory_train.py` で ONNX にエクスポート |
+| その他 `.pkl` | `*.json` | 汎用変換（JSON シリアライズ可能な構造のみ） |
+
+## 運用手順
+
+### 移行作業
+
+1. **バックアップ**: 旧 pickle ファイルを安全な場所にコピー
+2. **隔離環境で変換**: `python -m veritas_os.scripts.migrate_pickle --scan-dir <path>`
+3. **検証**: 変換後の JSON ファイルが正しいことを確認
+4. **配置**: JSON ファイルを本番ディレクトリに配置
+5. **削除**: 旧 pickle ファイルを本番ディレクトリから削除
+6. **CI 確認**: `python scripts/security/check_runtime_pickle_artifacts.py` が通ることを確認
+
+### CI ガードレール
+
+- `scripts/security/check_runtime_pickle_artifacts.py` — ランタイムディレクトリに `.pkl` / `.joblib` / `.pickle` が存在しないことを検証
+- デプロイ前に必ず実行してください
 
 ## Operational warning
 
-- 本番ディレクトリに未検証 `.pkl` を置かないでください。
-- CI/CD で `.pkl` ファイル混入を検知するチェックを推奨します。
+- 本番ディレクトリに未検証 `.pkl` / `.joblib` / `.pickle` を置かないでください
+- CI/CD パイプラインでの `.pkl` ファイル混入検知を有効にしてください
+- 新規コードで `pickle.load()` / `joblib.load()` を使用しないでください

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "python-dotenv==1.0.1",
   "orjson==3.11.6",
   "PyYAML==6.0.1",
-  "joblib==1.4.2",
   "scikit-learn==1.5.2",
   "sentence-transformers==3.0.1",
   "openai==1.51.0",

--- a/scripts/security/check_runtime_pickle_artifacts.py
+++ b/scripts/security/check_runtime_pickle_artifacts.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import sys
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-LEGACY_EXTENSIONS = frozenset({".pkl", ".joblib"})
+LEGACY_EXTENSIONS = frozenset({".pkl", ".joblib", ".pickle"})
 
 
 def _default_scan_dirs() -> list[Path]:

--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -260,7 +260,7 @@ class CapabilityConfig:
         default_factory=lambda: _parse_bool("VERITAS_CAP_MEMORY_POSIX_FILE_LOCK", True)
     )
     enable_memory_joblib_model: bool = field(
-        default_factory=lambda: _parse_bool("VERITAS_CAP_MEMORY_JOBLIB_MODEL", True)
+        default_factory=lambda: _parse_bool("VERITAS_CAP_MEMORY_JOBLIB_MODEL", False)
     )
     enable_memory_sentence_transformers: bool = field(
         default_factory=lambda: _parse_bool(

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -28,7 +28,6 @@ from .config import capability_cfg, emit_capability_manifest
 
 logger = logging.getLogger(__name__)
 
-PICKLE_RUNTIME_BLOCK_DEADLINE = "2026-06-30"
 PICKLE_MIGRATION_GUIDE_PATH = "docs/operations/MEMORY_PICKLE_MIGRATION.md"
 
 
@@ -50,15 +49,19 @@ def _is_explicitly_enabled(env_key: str) -> bool:
 
 
 def _emit_legacy_pickle_runtime_blocked(path: Path, artifact_name: str) -> None:
-    """Log a security warning for legacy pickle artifacts blocked at runtime."""
+    """Log a security error for legacy pickle artifacts blocked at runtime.
+
+    Pickle/joblib deserialization is permanently removed due to arbitrary code
+    execution (RCE) risk.  Use the offline migration CLI to convert legacy
+    artifacts:  ``python -m veritas_os.scripts.migrate_pickle``
+    """
     logger.error(
         "[SECURITY] Legacy %s pickle detected at %s. "
-        "Runtime pickle/joblib loading is disabled and will not be restored "
-        "after %s. Migrate artifacts offline using %s. "
-        "Never place untrusted .pkl files in runtime directories (RCE risk).",
+        "Runtime pickle/joblib loading is permanently disabled (RCE risk). "
+        "Migrate artifacts offline: python -m veritas_os.scripts.migrate_pickle  "
+        "See %s for details.",
         artifact_name,
         path,
-        PICKLE_RUNTIME_BLOCK_DEADLINE,
         PICKLE_MIGRATION_GUIDE_PATH,
     )
 
@@ -81,7 +84,7 @@ def _warn_for_legacy_pickle_artifacts(scan_roots: List[Path]) -> None:
             if not candidate.is_file():
                 continue
 
-            if candidate.suffix.lower() not in {".pkl", ".joblib"}:
+            if candidate.suffix.lower() not in {".pkl", ".joblib", ".pickle"}:
                 continue
 
             _emit_legacy_pickle_runtime_blocked(
@@ -98,16 +101,11 @@ if not IS_WIN and capability_cfg.enable_memory_posix_file_lock:
 else:
     fcntl = None  # type: ignore
 
-# Backward-compatibility shim for tests/consumers that introspect this symbol.
-# Runtime pickle/joblib loading is intentionally decommissioned for security.
-joblib_load = None
-
 if capability_cfg.emit_manifest_on_import:
     emit_capability_manifest(
         component="memory",
         manifest={
             "posix_file_lock": bool(not IS_WIN and fcntl is not None),
-            "joblib_model": False,
             "sentence_transformers": (
                 capability_cfg.enable_memory_sentence_transformers
             ),
@@ -566,7 +564,7 @@ if MEM_VEC_EXTERNAL is not None and MEM_VEC_EXTERNAL.__class__.__name__ == "Simp
     )
     MEM_VEC_EXTERNAL = None
 
-# モデル関連（旧: memory_model.pkl）
+# モデル関連（ONNX / JSON のみ — pickle は完全廃止済み）
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODELS_DIR = REPO_ROOT / "core" / "models"
 

--- a/veritas_os/requirements.txt
+++ b/veritas_os/requirements.txt
@@ -14,7 +14,6 @@ orjson==3.11.6
 PyYAML==6.0.1
 
 # --- Model / Decision Engine ---
-joblib==1.4.2
 scikit-learn==1.5.2
 sentence-transformers==3.0.1
 

--- a/veritas_os/scripts/migrate_pickle.py
+++ b/veritas_os/scripts/migrate_pickle.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""One-way migration CLI: convert legacy pickle artifacts to safe JSON format.
+
+Usage
+-----
+    python -m veritas_os.scripts.migrate_pickle [--scan-dir DIR] [--dry-run]
+
+Security
+--------
+    pickle deserialization is inherently unsafe (arbitrary code execution).
+    This CLI uses ``RestrictedUnpickler`` with a strict class allow-list and
+    imposes a maximum file size to reduce risk.  **Run only in an isolated,
+    trusted environment** and never against untrusted ``.pkl`` files.
+
+After migration, remove the original ``.pkl`` / ``.joblib`` files.  The
+application will refuse to load them at runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import logging
+import pickle
+import struct
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+logger = logging.getLogger("veritas_os.migrate_pickle")
+
+# ---------------------------------------------------------------------------
+# Security constants
+# ---------------------------------------------------------------------------
+
+# Maximum pickle file size we are willing to process (50 MiB).
+MAX_PICKLE_BYTES = 50 * 1024 * 1024
+
+# Classes explicitly allowed during restricted unpickling.
+_ALLOWED_MODULES_CLASSES: Dict[str, set] = {
+    "builtins": {"dict", "list", "set", "frozenset", "tuple", "bytes", "bytearray"},
+    "numpy": {"ndarray", "dtype", "float32", "float64", "int64", "int32"},
+    "numpy.core.multiarray": {"scalar", "_reconstruct"},
+    "numpy._core.multiarray": {"scalar", "_reconstruct"},
+    "collections": {"OrderedDict"},
+}
+
+LEGACY_EXTENSIONS = frozenset({".pkl", ".joblib", ".pickle"})
+
+
+# ---------------------------------------------------------------------------
+# Restricted unpickler
+# ---------------------------------------------------------------------------
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """An unpickler that only allows a vetted set of safe classes."""
+
+    def find_class(self, module: str, name: str) -> Any:
+        allowed = _ALLOWED_MODULES_CLASSES.get(module)
+        if allowed is not None and name in allowed:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Blocked: {module}.{name} is not in the migration allow-list"
+        )
+
+
+def _restricted_loads(data: bytes) -> Any:
+    """Deserialize bytes using the restricted unpickler."""
+    return _RestrictedUnpickler(io.BytesIO(data)).load()
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+def scan_legacy_files(roots: List[Path]) -> List[Path]:
+    """Find all ``.pkl`` / ``.joblib`` / ``.pickle`` files under *roots*."""
+    found: List[Path] = []
+    seen: set = set()
+    for root in roots:
+        resolved = root.resolve()
+        if resolved in seen or not resolved.exists() or not resolved.is_dir():
+            continue
+        seen.add(resolved)
+        for candidate in sorted(resolved.rglob("*")):
+            if candidate.is_file() and candidate.suffix.lower() in LEGACY_EXTENSIONS:
+                found.append(candidate)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Conversion helpers
+# ---------------------------------------------------------------------------
+
+def _convert_vector_index(pkl_path: Path) -> Optional[Path]:
+    """Convert a legacy VectorMemory pickle index to JSON."""
+    raw = pkl_path.read_bytes()
+    if len(raw) > MAX_PICKLE_BYTES:
+        logger.error("File too large (%d bytes), skipping: %s", len(raw), pkl_path)
+        return None
+
+    data = _restricted_loads(raw)
+    if not isinstance(data, dict):
+        logger.error("Unexpected pickle payload type %s in %s", type(data).__name__, pkl_path)
+        return None
+
+    documents: list = data.get("documents", [])
+    embeddings = data.get("embeddings")
+
+    out: Dict[str, Any] = {
+        "documents": documents,
+        "embeddings": None,
+        "embeddings_shape": None,
+        "embeddings_dtype": None,
+        "format_version": "2.0",
+        "migrated_from": str(pkl_path.name),
+    }
+
+    if embeddings is not None:
+        arr = np.asarray(embeddings, dtype=np.float32)
+        out["embeddings"] = base64.b64encode(arr.tobytes()).decode("ascii")
+        out["embeddings_shape"] = list(arr.shape)
+        out["embeddings_dtype"] = "float32"
+
+    json_path = pkl_path.with_suffix(".json")
+    json_path.write_text(json.dumps(out, ensure_ascii=False, indent=2), encoding="utf-8")
+    logger.info("Converted vector index: %s -> %s", pkl_path, json_path)
+    return json_path
+
+
+def _convert_generic_pickle(pkl_path: Path) -> Optional[Path]:
+    """Convert a generic pickle file to JSON (best-effort)."""
+    raw = pkl_path.read_bytes()
+    if len(raw) > MAX_PICKLE_BYTES:
+        logger.error("File too large (%d bytes), skipping: %s", len(raw), pkl_path)
+        return None
+
+    data = _restricted_loads(raw)
+
+    # Try to serialize to JSON — numpy arrays need special handling
+    def _default(obj: Any) -> Any:
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, (np.integer,)):
+            return int(obj)
+        if isinstance(obj, (np.floating,)):
+            return float(obj)
+        if isinstance(obj, bytes):
+            return base64.b64encode(obj).decode("ascii")
+        raise TypeError(f"Cannot serialize {type(obj).__name__}")
+
+    json_path = pkl_path.with_suffix(".json")
+    json_path.write_text(
+        json.dumps(data, default=_default, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    logger.info("Converted generic pickle: %s -> %s", pkl_path, json_path)
+    return json_path
+
+
+def migrate_file(pkl_path: Path, *, dry_run: bool = False) -> Optional[Path]:
+    """Migrate a single legacy pickle file to JSON.
+
+    Returns the output JSON path on success, or ``None`` on failure / dry-run.
+    """
+    if not pkl_path.is_file():
+        logger.warning("Not a file, skipping: %s", pkl_path)
+        return None
+
+    if pkl_path.suffix.lower() not in LEGACY_EXTENSIONS:
+        logger.warning("Not a legacy pickle file, skipping: %s", pkl_path)
+        return None
+
+    if dry_run:
+        logger.info("[DRY-RUN] Would convert: %s", pkl_path)
+        return None
+
+    try:
+        # Peek at the pickle to decide strategy
+        raw = pkl_path.read_bytes()
+        if len(raw) > MAX_PICKLE_BYTES:
+            logger.error("File too large (%d bytes > %d max), skipping: %s",
+                         len(raw), MAX_PICKLE_BYTES, pkl_path)
+            return None
+
+        data = _restricted_loads(raw)
+
+        # Heuristic: if it has "documents" and "embeddings" keys, treat as
+        # VectorMemory index.
+        if isinstance(data, dict) and "documents" in data:
+            return _convert_vector_index(pkl_path)
+        else:
+            return _convert_generic_pickle(pkl_path)
+
+    except pickle.UnpicklingError as exc:
+        logger.error("Restricted unpickle failed for %s: %s", pkl_path, exc)
+        return None
+    except Exception as exc:
+        logger.error("Migration failed for %s: %s", pkl_path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def _default_scan_dirs() -> List[Path]:
+    """Return the default directories to scan for legacy artifacts."""
+    repo_root = Path(__file__).resolve().parents[1]
+    dirs = [
+        repo_root / "core" / "models",
+    ]
+    import os
+    mem_dir = os.getenv("VERITAS_MEMORY_DIR", "").strip()
+    if mem_dir:
+        dirs.append(Path(mem_dir))
+    return dirs
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Migrate legacy pickle/joblib artifacts to safe JSON format.",
+    )
+    parser.add_argument(
+        "--scan-dir",
+        action="append",
+        type=Path,
+        default=None,
+        help="Directory to scan (can be repeated). Defaults to MemoryOS model dirs.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only list files that would be converted; do not write anything.",
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable debug logging.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    scan_dirs = args.scan_dir or _default_scan_dirs()
+    legacy_files = scan_legacy_files(scan_dirs)
+
+    if not legacy_files:
+        logger.info("No legacy pickle/joblib files found in %s", scan_dirs)
+        return 0
+
+    logger.info("Found %d legacy file(s) to migrate:", len(legacy_files))
+    for f in legacy_files:
+        logger.info("  %s", f)
+
+    converted = 0
+    failed = 0
+    for pkl_path in legacy_files:
+        result = migrate_file(pkl_path, dry_run=args.dry_run)
+        if args.dry_run:
+            continue
+        if result is not None:
+            converted += 1
+        else:
+            failed += 1
+
+    if args.dry_run:
+        logger.info("[DRY-RUN] %d file(s) would be converted.", len(legacy_files))
+    else:
+        logger.info("Migration complete: %d converted, %d failed.", converted, failed)
+        if converted > 0:
+            logger.info(
+                "Remove the original .pkl/.joblib files after verifying the JSON output."
+            )
+
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/veritas_os/tests/test_capability_flags.py
+++ b/veritas_os/tests/test_capability_flags.py
@@ -72,13 +72,11 @@ def test_fuji_tool_bridge_flag_blocks_call_tool(monkeypatch):
         assert "VERITAS_CAP_FUJI_TOOL_BRIDGE" in str(exc)
 
 
-def test_memory_joblib_flag_disables_loader(monkeypatch):
-    """Memory module disables joblib model loading via capability flag."""
-    monkeypatch.setenv("VERITAS_CAP_MEMORY_JOBLIB_MODEL", "0")
-
+def test_memory_joblib_removed(monkeypatch):
+    """Memory module no longer exposes joblib_load (pickle fully removed)."""
     _, memory_mod = _reload_config_and("veritas_os.core.memory")
 
-    assert memory_mod.joblib_load is None
+    assert not hasattr(memory_mod, "joblib_load")
 
 
 def test_fuji_yaml_flag_requires_pyyaml(monkeypatch):

--- a/veritas_os/tests/test_memory_vector.py
+++ b/veritas_os/tests/test_memory_vector.py
@@ -333,7 +333,7 @@ def test_legacy_pickle_detection_log_includes_migration_guidance(
         _new_vector_memory(index_path=idx_path, dim=4)
 
     assert "[SECURITY] Legacy vector index pickle detected" in caplog.text
-    assert memory.PICKLE_RUNTIME_BLOCK_DEADLINE in caplog.text
+    assert "permanently disabled" in caplog.text
     assert memory.PICKLE_MIGRATION_GUIDE_PATH in caplog.text
 
 

--- a/veritas_os/tests/test_pickle_removal.py
+++ b/veritas_os/tests/test_pickle_removal.py
@@ -1,0 +1,254 @@
+"""Tests verifying complete pickle removal from MemoryOS.
+
+Test requirements covered:
+1. Runtime never loads pickle files at startup
+2. Pickle files present on disk are NOT auto-loaded
+3. Only the migration CLI can convert legacy files
+4. After migration, the old format is rejected at runtime
+5. Safe JSON format read/write works correctly
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pickle
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from veritas_os.core import memory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyModel:
+    """Minimal embedding model for VectorMemory tests."""
+
+    def __init__(self, dim: int = 4):
+        self.dim = dim
+
+    def encode(self, texts: list) -> np.ndarray:
+        return np.ones((len(texts), self.dim), dtype=np.float32)
+
+
+def _make_vm(index_path: Path | None = None, dim: int = 4) -> memory.VectorMemory:
+    vm = memory.VectorMemory(index_path=index_path, embedding_dim=dim)
+    vm.model = _DummyModel(dim)
+    return vm
+
+
+def _write_pkl(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        pickle.dump(data, f)
+
+
+# ---------------------------------------------------------------------------
+# 1. Runtime never loads pickle at startup
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_does_not_load_pickle_on_startup(tmp_path: Path):
+    """VectorMemory.__init__ ignores .pkl files entirely."""
+    pkl_path = tmp_path / "index.pkl"
+    _write_pkl(pkl_path, {"documents": [{"id": "1", "text": "hello"}], "embeddings": None})
+
+    vm = _make_vm(index_path=pkl_path)
+    assert vm.documents == [], "Runtime must not auto-load .pkl files"
+
+
+# ---------------------------------------------------------------------------
+# 2. Pickle on disk is NOT auto-loaded even with env flag
+# ---------------------------------------------------------------------------
+
+
+def test_pickle_not_loaded_even_with_env_flag(tmp_path: Path, monkeypatch):
+    """Even VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION=1 does not enable loading."""
+    monkeypatch.setenv("VERITAS_MEMORY_ALLOW_PICKLE_MIGRATION", "1")
+    pkl_path = tmp_path / "legacy.pkl"
+    _write_pkl(pkl_path, {"documents": [{"id": "1", "text": "test"}], "embeddings": None})
+
+    vm = _make_vm(index_path=pkl_path)
+    assert vm.documents == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Migration CLI is the only way to convert
+# ---------------------------------------------------------------------------
+
+
+def test_migration_cli_converts_pkl_to_json(tmp_path: Path):
+    """migrate_pickle CLI converts a .pkl file to .json."""
+    from veritas_os.scripts.migrate_pickle import migrate_file
+
+    pkl_path = tmp_path / "index.pkl"
+    docs = [{"id": "d1", "kind": "semantic", "text": "hello world", "tags": []}]
+    emb = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)
+    _write_pkl(pkl_path, {"documents": docs, "embeddings": emb})
+
+    result = migrate_file(pkl_path)
+    assert result is not None
+    assert result.suffix == ".json"
+    assert result.exists()
+
+    converted = json.loads(result.read_text(encoding="utf-8"))
+    assert converted["documents"] == docs
+    assert converted["format_version"] == "2.0"
+    assert converted["embeddings"] is not None  # base64 encoded
+
+
+def test_migration_cli_dry_run(tmp_path: Path):
+    """--dry-run does not write any files."""
+    from veritas_os.scripts.migrate_pickle import migrate_file
+
+    pkl_path = tmp_path / "index.pkl"
+    _write_pkl(pkl_path, {"documents": [], "embeddings": None})
+
+    result = migrate_file(pkl_path, dry_run=True)
+    assert result is None
+    json_path = pkl_path.with_suffix(".json")
+    assert not json_path.exists()
+
+
+def test_migration_cli_main_no_files(tmp_path: Path):
+    """CLI exits 0 when no legacy files are found."""
+    from veritas_os.scripts.migrate_pickle import main
+
+    rc = main(["--scan-dir", str(tmp_path)])
+    assert rc == 0
+
+
+def test_migration_cli_main_converts(tmp_path: Path):
+    """CLI converts found files and exits 0."""
+    from veritas_os.scripts.migrate_pickle import main
+
+    pkl_path = tmp_path / "data.pkl"
+    _write_pkl(pkl_path, {"documents": [], "embeddings": None})
+
+    rc = main(["--scan-dir", str(tmp_path)])
+    assert rc == 0
+    assert pkl_path.with_suffix(".json").exists()
+
+
+def test_migration_cli_rejects_unsafe_classes(tmp_path: Path):
+    """Migration CLI refuses to unpickle objects with dangerous classes."""
+    from veritas_os.scripts.migrate_pickle import migrate_file
+
+    # Create a pickle with os.system reference (dangerous)
+    import io as _io
+    pkl_path = tmp_path / "evil.pkl"
+    # Manually craft a pickle that references os.system
+    pkl_data = (
+        b"\x80\x04\x95\x1a\x00\x00\x00\x00\x00\x00\x00"
+        b"\x8c\x02os\x8c\x06system\x93"
+        b"\x8c\x08echo bad\x85R."
+    )
+    pkl_path.write_bytes(pkl_data)
+
+    result = migrate_file(pkl_path)
+    assert result is None, "Dangerous pickle classes must be rejected"
+
+
+# ---------------------------------------------------------------------------
+# 4. After migration, old format is rejected at runtime
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_rejects_pkl_after_migration(tmp_path: Path, caplog):
+    """After a .json exists, the runtime loads .json and warns on .pkl presence."""
+    # Create both .pkl and .json
+    pkl_path = tmp_path / "index.pkl"
+    json_path = tmp_path / "index.json"
+
+    _write_pkl(pkl_path, {"documents": [{"id": "1", "text": "old"}]})
+
+    # JSON (the migrated format)
+    json_data = {
+        "documents": [{"id": "1", "kind": "semantic", "text": "migrated", "tags": []}],
+        "embeddings": None,
+        "format_version": "2.0",
+    }
+    json_path.write_text(json.dumps(json_data), encoding="utf-8")
+
+    # VectorMemory should load .json and ignore .pkl
+    vm = _make_vm(index_path=json_path)
+    assert len(vm.documents) == 1
+    assert vm.documents[0]["text"] == "migrated"
+
+
+# ---------------------------------------------------------------------------
+# 5. Safe JSON format read/write works correctly
+# ---------------------------------------------------------------------------
+
+
+def test_json_roundtrip(tmp_path: Path):
+    """VectorMemory saves as JSON and can reload."""
+    idx_path = tmp_path / "test_index.json"
+    vm = _make_vm(index_path=idx_path)
+
+    vm.add(kind="test", text="Hello world", tags=["a"])
+    vm.add(kind="test", text="Goodbye world", tags=["b"])
+    vm._save_index()
+
+    assert idx_path.exists()
+    # Verify it's valid JSON
+    data = json.loads(idx_path.read_text(encoding="utf-8"))
+    assert data["format_version"] == "2.0"
+    assert len(data["documents"]) == 2
+
+    # Reload into new instance
+    vm2 = _make_vm(index_path=idx_path)
+    assert len(vm2.documents) == 2
+
+
+# ---------------------------------------------------------------------------
+# Additional defense tests
+# ---------------------------------------------------------------------------
+
+
+def test_joblib_load_symbol_removed():
+    """The joblib_load symbol is no longer exposed by the memory module."""
+    assert not hasattr(memory, "joblib_load")
+
+
+def test_pickle_runtime_block_deadline_removed():
+    """The PICKLE_RUNTIME_BLOCK_DEADLINE constant is removed (no sunset)."""
+    assert not hasattr(memory, "PICKLE_RUNTIME_BLOCK_DEADLINE")
+
+
+def test_runtime_guard_detects_pkl_files(tmp_path: Path, caplog):
+    """_warn_for_legacy_pickle_artifacts logs errors for .pkl/.joblib/.pickle files."""
+    root = tmp_path / "models"
+    root.mkdir()
+    (root / "old.pkl").write_bytes(b"x")
+    (root / "model.joblib").write_bytes(b"x")
+    (root / "data.pickle").write_bytes(b"x")
+
+    with caplog.at_level(logging.ERROR, logger="veritas_os.core.memory"):
+        memory._warn_for_legacy_pickle_artifacts([root])
+
+    assert "old.pkl" in caplog.text
+    assert "model.joblib" in caplog.text
+    assert "data.pickle" in caplog.text
+
+
+def test_migration_scan_finds_all_extensions(tmp_path: Path):
+    """scan_legacy_files finds .pkl, .joblib, and .pickle."""
+    from veritas_os.scripts.migrate_pickle import scan_legacy_files
+
+    (tmp_path / "a.pkl").write_bytes(b"x")
+    (tmp_path / "b.joblib").write_bytes(b"x")
+    (tmp_path / "c.pickle").write_bytes(b"x")
+    (tmp_path / "d.json").write_text("{}")
+
+    found = scan_legacy_files([tmp_path])
+    names = {f.name for f in found}
+    assert names == {"a.pkl", "b.joblib", "c.pickle"}
+    assert "d.json" not in names


### PR DESCRIPTION
Pickle deserialization poses arbitrary code execution (RCE) risk.
This change permanently removes all pickle/joblib loading paths from
the runtime and provides an explicit CLI for one-way migration of
legacy artifacts to safe JSON format.

Changes:
- Remove PICKLE_RUNTIME_BLOCK_DEADLINE (no sunset — permanent ban)
- Remove joblib_load shim from memory module
- Change enable_memory_joblib_model default to False
- Remove explicit joblib dependency (still available via scikit-learn)
- Add .pickle extension to detection in runtime guard and CI check
- Add migrate_pickle.py CLI with RestrictedUnpickler for safe conversion
- Add 13 tests covering all pickle removal requirements
- Update MEMORY_PICKLE_MIGRATION.md with CLI usage and procedures

https://claude.ai/code/session_015UqLzNtyDvtiEmaVPjfGv1