### PR TITLE
Improve replay version traceability with CI-injected pipeline version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  VERITAS_PIPELINE_VERSION: "${{ github.sha }}"
+
 # ============================================================
 # Lint & Security (fast-fail — テストより先に回す)
 # ============================================================

--- a/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
@@ -45,3 +45,12 @@
 ## 結論
 - 現行コードベースは、今回実施した責務境界・セキュリティ・Lint・関連テストの観点で健全。
 - 次フェーズは、運用監視（`unknown` 版情報率）と `subprocess` ガードレールの継続が妥当。
+
+## 対応状況（2026-03-14 追記）
+- High優先度の追加改善として、`replay_engine` のパイプライン版情報取得に
+  `VERITAS_PIPELINE_VERSION` 環境変数オーバーライドを追加。
+  Gitメタデータが取得できない実行環境でも、CI注入値で `unknown` を回避可能。
+- CI (`.github/workflows/main.yml`) に `VERITAS_PIPELINE_VERSION: ${{ github.sha }}` を追加し、
+  監査トレーサビリティを強化。
+- 回帰防止として `veritas_os/tests/test_replay_engine.py` に環境変数優先の単体テストを追加。
+

--- a/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
@@ -53,4 +53,7 @@
 - CI (`.github/workflows/main.yml`) に `VERITAS_PIPELINE_VERSION: ${{ github.sha }}` を追加し、
   監査トレーサビリティを強化。
 - 回帰防止として `veritas_os/tests/test_replay_engine.py` に環境変数優先の単体テストを追加。
+- 追加改善（CI安定化）: `VERITAS_PIPELINE_VERSION` が常時注入されるCI環境で
+  `test_replay_engine` が環境依存で失敗しないよう、該当テストで環境変数を明示的に解除して
+  判定条件を固定化。
 

--- a/veritas_os/replay/replay_engine.py
+++ b/veritas_os/replay/replay_engine.py
@@ -49,7 +49,15 @@ def _pipeline_version() -> str:
     Security note:
         We intentionally do not swallow arbitrary exceptions here so that
         unexpected runtime errors are surfaced during diagnostics.
+
+    Operational note:
+        CI can inject ``VERITAS_PIPELINE_VERSION`` to avoid ``unknown`` when
+        Git metadata is unavailable in runtime environments.
     """
+    injected_version = (os.getenv("VERITAS_PIPELINE_VERSION") or "").strip()
+    if injected_version:
+        return injected_version
+
     try:
         out = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"],

--- a/veritas_os/tests/test_replay_engine.py
+++ b/veritas_os/tests/test_replay_engine.py
@@ -18,6 +18,19 @@ def test_pipeline_version_returns_unknown_on_expected_subprocess_failures(monkey
     assert replay_engine._pipeline_version() == "unknown"
 
 
+
+
+def test_pipeline_version_prefers_env_override(monkeypatch) -> None:
+    """Environment override should be used before git command lookup."""
+    monkeypatch.setenv("VERITAS_PIPELINE_VERSION", "ci-sha-123")
+
+    def _raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("should_not_run")
+
+    monkeypatch.setattr(replay_engine.subprocess, "check_output", _raise_runtime_error)
+
+    assert replay_engine._pipeline_version() == "ci-sha-123"
+
 def test_pipeline_version_does_not_swallow_unexpected_errors(monkeypatch) -> None:
     def _raise_runtime_error(*_args, **_kwargs):
         raise RuntimeError("boom")

--- a/veritas_os/tests/test_replay_engine.py
+++ b/veritas_os/tests/test_replay_engine.py
@@ -10,6 +10,7 @@ from veritas_os.replay import replay_engine
 
 
 def test_pipeline_version_returns_unknown_on_expected_subprocess_failures(monkeypatch) -> None:
+    monkeypatch.delenv("VERITAS_PIPELINE_VERSION", raising=False)
     def _raise_called_process_error(*_args, **_kwargs):
         raise subprocess.CalledProcessError(1, ["git"])
 
@@ -32,6 +33,7 @@ def test_pipeline_version_prefers_env_override(monkeypatch) -> None:
     assert replay_engine._pipeline_version() == "ci-sha-123"
 
 def test_pipeline_version_does_not_swallow_unexpected_errors(monkeypatch) -> None:
+    monkeypatch.delenv("VERITAS_PIPELINE_VERSION", raising=False)
     def _raise_runtime_error(*_args, **_kwargs):
         raise RuntimeError("boom")
 


### PR DESCRIPTION
### Motivation
- Address Low-1 from the review by avoiding `unknown` pipeline versions when Git metadata is unavailable in runtime environments.
- Provide a CI-friendly mechanism so audit/traceability can be restored even when the runtime lacks `.git` data.
- Keep changes limited to replay metadata resolution and CI wiring without crossing Planner/Kernel/Fuji/MemoryOS boundaries.

### Description
- Add environment override support in `veritas_os/replay/replay_engine.py` so `_pipeline_version()` returns `VERITAS_PIPELINE_VERSION` when set and documents this in the function docstring.
- Inject `VERITAS_PIPELINE_VERSION: ${{ github.sha }}` into the CI workflow by updating `.github/workflows/main.yml` to ensure CI provides a stable SHA.
- Add unit test `test_pipeline_version_prefers_env_override` in `veritas_os/tests/test_replay_engine.py` to verify the environment variable takes precedence over invoking `git`.
- Append an "対応状況" entry to `docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md` noting the implemented remediation.

### Testing
- Ran `ruff check veritas_os/replay/replay_engine.py veritas_os/tests/test_replay_engine.py scripts/security/check_httpx_raw_upload_usage.py` and it passed.
- Ran `pytest -q veritas_os/tests/test_replay_engine.py` and all tests passed (`5 passed`).
- Ran `python scripts/architecture/check_responsibility_boundaries.py --report-format json` and it returned a passing report.
- Ran `python scripts/security/check_httpx_raw_upload_usage.py` and it reported no deprecated usage.

Security note: No new high-risk vulnerabilities were introduced, but `subprocess` usage remains an attack surface and existing guidance (`shell=True` prohibition and careful argument handling) should be maintained.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ed80e8148326af17bf9ae41d4635)