### PR TITLE
Add subprocess security guardrail checker to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,9 @@ jobs:
       - name: httpx raw upload deprecation check
         run: python scripts/security/check_httpx_raw_upload_usage.py
 
+      - name: subprocess shell usage check
+        run: python scripts/security/check_subprocess_shell_usage.py
+
       - name: Bandit security scan
         run: |
           bandit -r veritas_os/core veritas_os/api veritas_os/tools \

--- a/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
@@ -56,4 +56,9 @@
 - 追加改善（CI安定化）: `VERITAS_PIPELINE_VERSION` が常時注入されるCI環境で
   `test_replay_engine` が環境依存で失敗しないよう、該当テストで環境変数を明示的に解除して
   判定条件を固定化。
-
+- 追加改善（Low-2対応）: `scripts/security/check_subprocess_shell_usage.py` を追加し、
+  `subprocess` の `shell=True` 利用と文字列コマンド実行を静的検知するガードレールを実装。
+- CI (`.github/workflows/main.yml`) の lint ジョブへ同チェッカー実行を追加し、
+  既存のセキュリティゲートと同列で継続監視する運用に強化。
+- 回帰防止として `veritas_os/tests/test_check_subprocess_shell_usage.py` を追加し、
+  検知・非検知・許可マーカー・除外ディレクトリの挙動を単体テストで固定化。

--- a/scripts/security/check_subprocess_shell_usage.py
+++ b/scripts/security/check_subprocess_shell_usage.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Detect dangerous subprocess usage patterns.
+
+This checker enforces two guardrails:
+1. ``shell=True`` is always rejected.
+2. String commands are rejected unless a module-level allow comment exists.
+
+String commands are often coupled with shell parsing and increase command
+injection risk when future refactors accidentally involve user-controlled
+inputs. The preferred style is ``subprocess.run(["cmd", "arg"])``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCAN_ROOTS = (
+    REPO_ROOT / "veritas_os",
+    REPO_ROOT / "scripts",
+)
+SKIP_DIR_NAMES = {
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".venv",
+    "node_modules",
+}
+SKIP_PATH_PARTS = {"tests"}
+SUBPROCESS_CALL_NAMES = {"run", "check_call", "check_output", "Popen", "call"}
+ALLOW_STRING_COMMAND_MARKER = "allow-subprocess-string-command"
+
+
+@dataclass(frozen=True)
+class Violation:
+    """Represents one detected subprocess security violation."""
+
+    path: Path
+    line: int
+    message: str
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check Python source for risky subprocess usage "
+            "(shell=True, or string command arguments)."
+        )
+    )
+    parser.add_argument(
+        "--scan-root",
+        action="append",
+        default=[],
+        help="Optional directory/file to scan. Can be provided multiple times.",
+    )
+    return parser.parse_args(argv)
+
+
+def _iter_python_files(scan_roots: list[Path]) -> list[Path]:
+    """Return Python files under the provided roots, excluding cache/vendor dirs."""
+    files: list[Path] = []
+    for root in scan_roots:
+        resolved = root.resolve(strict=False)
+        if not resolved.exists():
+            continue
+        if resolved.is_file() and resolved.suffix == ".py":
+            files.append(resolved)
+            continue
+
+        for path in resolved.rglob("*.py"):
+            if any(part in SKIP_DIR_NAMES for part in path.parts):
+                continue
+            if any(part in SKIP_PATH_PARTS for part in path.parts):
+                continue
+            files.append(path)
+    return files
+
+
+def _is_subprocess_call(call: ast.Call) -> bool:
+    """Return True when AST call matches common subprocess execution APIs."""
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr in SUBPROCESS_CALL_NAMES
+    return False
+
+
+def _allows_string_command(source: str) -> bool:
+    """Return True when source explicitly documents string-command exception."""
+    return ALLOW_STRING_COMMAND_MARKER in source
+
+
+def _is_string_command_arg(node: ast.AST | None) -> bool:
+    """Return True when subprocess command argument is likely a string command."""
+    if node is None:
+        return False
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, str)
+    return isinstance(node, ast.JoinedStr)
+
+
+def _find_command_arg(call: ast.Call) -> ast.AST | None:
+    """Resolve the command argument from positional/keyword form."""
+    if call.args:
+        return call.args[0]
+
+    for keyword in call.keywords:
+        if keyword.arg in {"args", "cmd", "command"}:
+            return keyword.value
+    return None
+
+
+def _scan_file(path: Path) -> list[Violation]:
+    """Scan one Python file and return detected violations."""
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    allow_string = _allows_string_command(source)
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_subprocess_call(node):
+            continue
+
+        for keyword in node.keywords:
+            if keyword.arg == "shell" and isinstance(keyword.value, ast.Constant):
+                if keyword.value.value is True:
+                    violations.append(
+                        Violation(
+                            path=path,
+                            line=keyword.value.lineno,
+                            message="subprocess call with shell=True is forbidden",
+                        )
+                    )
+
+        command_arg = _find_command_arg(node)
+        if not allow_string and _is_string_command_arg(command_arg):
+            violations.append(
+                Violation(
+                    path=path,
+                    line=command_arg.lineno,
+                    message=(
+                        "subprocess string command detected; use argument list "
+                        "(or document exception with "
+                        f"'{ALLOW_STRING_COMMAND_MARKER}')"
+                    ),
+                )
+            )
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run scan and return shell exit code."""
+    parsed = _parse_args(argv or sys.argv[1:])
+    scan_roots = DEFAULT_SCAN_ROOTS + tuple(Path(p) for p in parsed.scan_root)
+
+    violations: list[Violation] = []
+    for file_path in _iter_python_files(list(scan_roots)):
+        violations.extend(_scan_file(file_path))
+
+    if not violations:
+        print("No risky subprocess usage detected.")
+        return 0
+
+    print("Risky subprocess usage detected:")
+    for item in sorted(violations, key=lambda it: (str(it.path), it.line, it.message)):
+        try:
+            relative = item.path.relative_to(REPO_ROOT)
+        except ValueError:
+            relative = item.path
+        print(f"- {relative}:{item.line}: {item.message}")
+
+    print(
+        "\nSecurity remediation: avoid shell=True, pass commands as lists, "
+        "and never concatenate external input into command strings."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_check_subprocess_shell_usage.py
+++ b/veritas_os/tests/test_check_subprocess_shell_usage.py
@@ -1,0 +1,123 @@
+"""Tests for scripts.security.check_subprocess_shell_usage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.security import check_subprocess_shell_usage as checker
+
+
+def test_scan_file_detects_shell_true_and_string_command(tmp_path: Path) -> None:
+    """Scanner should flag shell=True and direct string command usage."""
+    source = tmp_path / "bad.py"
+    source.write_text(
+        "\n".join(
+            [
+                "import subprocess",
+                "subprocess.run('echo hi', shell=True)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert len(violations) == 2
+    assert any("shell=True" in violation.message for violation in violations)
+    assert any("string command" in violation.message for violation in violations)
+
+
+def test_scan_file_allows_list_command_without_shell(tmp_path: Path) -> None:
+    """List-form command without shell=True should not be flagged."""
+    source = tmp_path / "good.py"
+    source.write_text(
+        "\n".join(
+            [
+                "import subprocess",
+                "subprocess.run(['echo', 'hi'], check=True)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert violations == []
+
+
+def test_scan_file_allows_string_command_with_explicit_marker(tmp_path: Path) -> None:
+    """Marker comment should permit documented string command exceptions."""
+    source = tmp_path / "allow.py"
+    source.write_text(
+        "\n".join(
+            [
+                "# allow-subprocess-string-command",
+                "import subprocess",
+                "subprocess.run('git rev-parse --short HEAD', check=True)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert violations == []
+
+
+def test_main_returns_non_zero_when_violation_found(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    """Command exits with 1 and prints remediation guidance on violations."""
+    source = tmp_path / "bad.py"
+    source.write_text(
+        "import subprocess\nsubprocess.run('echo hi', shell=True)\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(checker, "DEFAULT_SCAN_ROOTS", ())
+    exit_code = checker.main(["--scan-root", str(source)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Risky subprocess usage detected" in output
+    assert "Security remediation" in output
+
+
+def test_main_returns_zero_when_clean(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    """Command exits with 0 and prints success output on clean code."""
+    source = tmp_path / "good.py"
+    source.write_text(
+        "import subprocess\nsubprocess.run(['echo', 'hi'], check=True)\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(checker, "DEFAULT_SCAN_ROOTS", ())
+    exit_code = checker.main(["--scan-root", str(source)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "No risky subprocess usage detected" in output
+
+
+def test_iter_python_files_skips_tests_directory(tmp_path: Path) -> None:
+    """File iterator should skip test directories to reduce false positives."""
+    app_dir = tmp_path / "veritas_os"
+    tests_dir = app_dir / "tests"
+    app_dir.mkdir()
+    tests_dir.mkdir()
+
+    prod_file = app_dir / "runner.py"
+    test_file = tests_dir / "test_runner.py"
+    prod_file.write_text("print('ok')\n", encoding="utf-8")
+    test_file.write_text("print('test')\n", encoding="utf-8")
+
+    files = checker._iter_python_files([app_dir])
+
+    assert prod_file.resolve() in files
+    assert test_file.resolve() not in files


### PR DESCRIPTION
### Motivation
- Implement the Low-2 recommendation from the code review to continuously monitor risky `subprocess` usage (detect `shell=True` and string-form commands). 
- Reduce future command-injection risk by adding an automated static gate that enforces safe subprocess patterns and documents allowed exceptions. 
- Minimize false positives by excluding test directories from the scan to avoid flagging test-only fixtures. 
- Provide a clear, test-covered remediation path with docstrings and unit tests per the project guidance. 

### Description
- Added a new static checker `scripts/security/check_subprocess_shell_usage.py` that detects `subprocess(..., shell=True)` and string-command usages and supports an explicit module-level exemption marker `allow-subprocess-string-command`. 
- Added unit tests at `veritas_os/tests/test_check_subprocess_shell_usage.py` covering detection, safe list-form commands, explicit marker allowance, and test-directory exclusion. 
- Wired the checker into the CI lint job by adding an invocation in `.github/workflows/main.yml`. 
- Updated the review document `docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md` to record the Low-2 improvement and test/CI additions. 

### Testing
- Ran `ruff check scripts/security/check_subprocess_shell_usage.py veritas_os/tests/test_check_subprocess_shell_usage.py` and the linter passed. 
- Ran `pytest -q veritas_os/tests/test_check_subprocess_shell_usage.py veritas_os/tests/test_replay_engine.py veritas_os/tests/test_check_httpx_raw_upload_usage.py` and all tests passed (`15 passed`). 
- Executed `python scripts/security/check_subprocess_shell_usage.py` which completed and reported no risky subprocess usage in the current workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f99105b883269d4e1a7377a3d235)