### PR TITLE
Add CI guardrail to detect 'unknown' replay pipeline versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,11 @@ jobs:
       - name: subprocess shell usage check
         run: python scripts/security/check_subprocess_shell_usage.py
 
+      - name: replay pipeline-version unknown-rate check
+        run: |
+          python scripts/quality/check_replay_pipeline_version_unknown_rate.py \
+            --max-unknown-rate 0.0
+
       - name: Bandit security scan
         run: |
           bandit -r veritas_os/core veritas_os/api veritas_os/tools \

--- a/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
@@ -62,3 +62,10 @@
   既存のセキュリティゲートと同列で継続監視する運用に強化。
 - 回帰防止として `veritas_os/tests/test_check_subprocess_shell_usage.py` を追加し、
   検知・非検知・許可マーカー・除外ディレクトリの挙動を単体テストで固定化。
+- 追加改善（Low-1運用監視の自動化）: `scripts/quality/check_replay_pipeline_version_unknown_rate.py`
+  を追加し、`replay_*.json` の `meta.pipeline_version == "unknown"` 比率を閾値監視できるようにした。
+  閾値超過時は非0終了し、監査トレーサビリティ低下をセキュリティ警告として明示する。
+- CI (`.github/workflows/main.yml`) の lint ジョブへ同チェッカーを追加し、
+  `--max-unknown-rate 0.0` で継続的に `unknown` 混入を検出する運用に強化。
+- 回帰防止として `veritas_os/tests/test_check_replay_pipeline_version_unknown_rate.py` を追加し、
+  比率計算・閾値判定・欠損ディレクトリ・不正閾値・不正JSONスキップ挙動を単体テストで固定化。

--- a/scripts/quality/check_replay_pipeline_version_unknown_rate.py
+++ b/scripts/quality/check_replay_pipeline_version_unknown_rate.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Check unknown pipeline version rate in replay reports.
+
+This script enforces an operational guardrail recommended by the code review:
+monitor the rate of ``meta.pipeline_version == 'unknown'`` in replay reports.
+High unknown rates reduce audit traceability during incident response.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORTS_DIR = REPO_ROOT / "audit" / "replay_reports"
+UNKNOWN_VALUE = "unknown"
+
+
+@dataclass(frozen=True)
+class VersionRateResult:
+    """Computed replay version quality metrics."""
+
+    total_reports: int
+    unknown_reports: int
+
+    @property
+    def unknown_rate(self) -> float:
+        """Return unknown version ratio in [0, 1]."""
+        if self.total_reports <= 0:
+            return 0.0
+        return self.unknown_reports / self.total_reports
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check unknown pipeline version rate in replay reports and fail "
+            "when the rate exceeds a configured threshold."
+        )
+    )
+    parser.add_argument(
+        "--reports-dir",
+        type=Path,
+        default=DEFAULT_REPORTS_DIR,
+        help="Directory that stores replay_*.json reports.",
+    )
+    parser.add_argument(
+        "--max-unknown-rate",
+        type=float,
+        default=0.0,
+        help="Maximum allowed unknown ratio (0.0 - 1.0).",
+    )
+    return parser.parse_args(argv)
+
+
+def _extract_pipeline_version(payload: dict[str, object]) -> str:
+    """Extract normalized pipeline version from replay payload."""
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        return UNKNOWN_VALUE
+
+    version = meta.get("pipeline_version")
+    if isinstance(version, str) and version.strip():
+        return version.strip()
+    return UNKNOWN_VALUE
+
+
+def _load_json(path: Path) -> dict[str, object] | None:
+    """Load one replay report and return dict payload, or None on parse issues."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+    return raw
+
+
+def _compute_version_rate(reports_dir: Path) -> VersionRateResult:
+    """Compute unknown pipeline version rate for replay reports."""
+    total = 0
+    unknown = 0
+
+    for path in sorted(reports_dir.glob("replay_*.json")):
+        payload = _load_json(path)
+        if payload is None:
+            continue
+        total += 1
+        if _extract_pipeline_version(payload) == UNKNOWN_VALUE:
+            unknown += 1
+
+    return VersionRateResult(total_reports=total, unknown_reports=unknown)
+
+
+def _validate_rate_threshold(max_unknown_rate: float) -> None:
+    """Validate threshold range and raise ``ValueError`` when invalid."""
+    if 0.0 <= max_unknown_rate <= 1.0:
+        return
+    raise ValueError("--max-unknown-rate must be between 0.0 and 1.0")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run unknown-rate check and return process exit code."""
+    parsed = _parse_args(argv or sys.argv[1:])
+
+    try:
+        _validate_rate_threshold(parsed.max_unknown_rate)
+    except ValueError as exc:
+        print(f"ERROR: {exc}")
+        return 2
+
+    reports_dir = parsed.reports_dir.resolve(strict=False)
+    if not reports_dir.exists():
+        print(f"WARNING: replay reports directory does not exist: {reports_dir}")
+        return 0
+
+    result = _compute_version_rate(reports_dir)
+    if result.total_reports == 0:
+        print(f"WARNING: no replay reports found under {reports_dir}")
+        return 0
+
+    rate = result.unknown_rate
+    print(
+        "Replay pipeline version metrics: "
+        f"unknown={result.unknown_reports}/{result.total_reports} "
+        f"({rate:.2%})"
+    )
+
+    if rate > parsed.max_unknown_rate:
+        print(
+            "SECURITY WARNING: unknown pipeline version rate exceeded threshold; "
+            "audit traceability is degraded. Ensure CI injects "
+            "VERITAS_PIPELINE_VERSION and investigate missing Git metadata."
+        )
+        return 1
+
+    print("OK: unknown pipeline version rate is within threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_check_replay_pipeline_version_unknown_rate.py
+++ b/veritas_os/tests/test_check_replay_pipeline_version_unknown_rate.py
@@ -1,0 +1,109 @@
+"""Tests for scripts.quality.check_replay_pipeline_version_unknown_rate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.quality import check_replay_pipeline_version_unknown_rate as checker
+
+
+def _write_report(path: Path, pipeline_version: str | None) -> None:
+    """Write a replay report fixture with optional pipeline version."""
+    meta = {}
+    if pipeline_version is not None:
+        meta["pipeline_version"] = pipeline_version
+
+    payload = {
+        "decision_id": "dec-1",
+        "meta": meta,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_compute_version_rate_counts_unknown_and_known(tmp_path: Path) -> None:
+    """Rate calculation should count unknown and known reports correctly."""
+    _write_report(tmp_path / "replay_a.json", "abc123")
+    _write_report(tmp_path / "replay_b.json", "unknown")
+    _write_report(tmp_path / "replay_c.json", None)
+
+    result = checker._compute_version_rate(tmp_path)
+
+    assert result.total_reports == 3
+    assert result.unknown_reports == 2
+    assert result.unknown_rate == 2 / 3
+
+
+def test_main_returns_failure_when_rate_exceeds_threshold(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Main should fail and print security warning when threshold is exceeded."""
+    _write_report(tmp_path / "replay_a.json", "unknown")
+    _write_report(tmp_path / "replay_b.json", "abc123")
+
+    code = checker.main([
+        "--reports-dir",
+        str(tmp_path),
+        "--max-unknown-rate",
+        "0.2",
+    ])
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert "SECURITY WARNING" in output
+
+
+def test_main_returns_success_when_rate_is_within_threshold(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Main should return success when unknown rate is acceptable."""
+    _write_report(tmp_path / "replay_a.json", "abc123")
+    _write_report(tmp_path / "replay_b.json", "def456")
+
+    code = checker.main([
+        "--reports-dir",
+        str(tmp_path),
+        "--max-unknown-rate",
+        "0.1",
+    ])
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "OK: unknown pipeline version rate is within threshold." in output
+
+
+def test_main_returns_warning_when_directory_missing(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Missing report directory should not fail CI in cold-start environments."""
+    missing_dir = tmp_path / "missing"
+
+    code = checker.main(["--reports-dir", str(missing_dir)])
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "does not exist" in output
+
+
+def test_main_rejects_invalid_threshold(capsys) -> None:
+    """Invalid threshold should return argument error exit code."""
+    code = checker.main(["--max-unknown-rate", "1.5"])
+    output = capsys.readouterr().out
+
+    assert code == 2
+    assert "must be between 0.0 and 1.0" in output
+
+
+def test_compute_version_rate_skips_invalid_json(tmp_path: Path) -> None:
+    """Malformed JSON files should be ignored rather than crashing the checker."""
+    bad = tmp_path / "replay_bad.json"
+    bad.write_text("{not-json", encoding="utf-8")
+    _write_report(tmp_path / "replay_good.json", "unknown")
+
+    result = checker._compute_version_rate(tmp_path)
+
+    assert result.total_reports == 1
+    assert result.unknown_reports == 1


### PR DESCRIPTION
### Motivation
- The code review identified an operational gap where `replay` reports can carry `meta.pipeline_version == "unknown"`, reducing audit traceability; this PR adds an automated guardrail to detect and alert on that condition.
- Changes are scoped to tooling/quality checks and CI only and do not cross the responsibilities of Planner / Kernel / Fuji / MemoryOS.

### Description
- Add `scripts/quality/check_replay_pipeline_version_unknown_rate.py` which scans `audit/replay_reports/replay_*.json` and computes the ratio of reports where `meta.pipeline_version` is `"unknown"`, and exits non-zero with a `SECURITY WARNING` when the rate exceeds `--max-unknown-rate`.
- Add unit tests in `veritas_os/tests/test_check_replay_pipeline_version_unknown_rate.py` covering rate calculation, threshold behavior, missing directory handling, invalid threshold handling, and malformed JSON skipping.
- Run the new checker in the CI lint job by updating `.github/workflows/main.yml` to execute the script with `--max-unknown-rate 0.0`.
- Update `docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md` to record the completed Low-1 operational monitoring improvement.

### Testing
- Ran static checks with `python -m ruff check scripts/quality/check_replay_pipeline_version_unknown_rate.py veritas_os/tests/test_check_replay_pipeline_version_unknown_rate.py` and it passed.
- Executed unit tests with `pytest -q veritas_os/tests/test_check_replay_pipeline_version_unknown_rate.py veritas_os/tests/test_replay_engine.py veritas_os/tests/test_check_subprocess_shell_usage.py` and all tests passed (`17 passed`).
- Manually ran `python scripts/quality/check_replay_pipeline_version_unknown_rate.py --max-unknown-rate 0.0` in a dev workspace without `audit/replay_reports` and observed the expected warning about the missing reports directory (normal cold-start behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ff69ff6083269f1562936d860079)