### PR TITLE
Remove stale httpx DeprecationWarning from test allowlist and update review log

### DIFF
--- a/config/test_warning_allowlist.json
+++ b/config/test_warning_allowlist.json
@@ -1,12 +1,6 @@
 {
   "entries": [
     {
-      "rule": "ignore:\"content=<...>\" is deprecated\\. Use 'data=<...>' instead:DeprecationWarning:httpx\\..*",
-      "expires_on": "2026-09-30",
-      "owner": "platform-backend",
-      "reason": "httpx upstream deprecation migration window"
-    },
-    {
       "rule": "ignore:invalid escape sequence.*:SyntaxWarning:sentence_transformers\\..*",
       "expires_on": "2026-09-30",
       "owner": "ml-platform",

--- a/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
+++ b/docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md
@@ -69,3 +69,8 @@
   `--max-unknown-rate 0.0` で継続的に `unknown` 混入を検出する運用に強化。
 - 回帰防止として `veritas_os/tests/test_check_replay_pipeline_version_unknown_rate.py` を追加し、
   比率計算・閾値判定・欠損ディレクトリ・不正閾値・不正JSONスキップ挙動を単体テストで固定化。
+
+- 追加改善（優先アクション継続）: `scripts/quality/check_warning_allowlist.py` の実行結果に合わせ、
+  `config/test_warning_allowlist.json` から未使用の `httpx` DeprecationWarning 例外ルールを削除。
+  `pyproject.toml` の `filterwarnings` と allowlist の整合性を回復し、
+  stale 例外の温存による警告ガバナンス形骸化リスクを低減。


### PR DESCRIPTION
### Motivation
- `scripts/quality/check_warning_allowlist.py` failed due to a stale `httpx` DeprecationWarning rule present in `config/test_warning_allowlist.json`, so the allowlist must be aligned with `pyproject.toml` to restore warning-governance consistency.
- Security note: this change does not introduce runtime vulnerabilities but reduces the operational risk that important warnings become hidden by stale allowlist entries.

### Description
- Remove the unused `httpx` DeprecationWarning entry from `config/test_warning_allowlist.json` so the allowlist matches `pyproject.toml`'s `filterwarnings`.
- Append a short note to `docs/review/CODE_REVIEW_FULL_2026_03_14_JP.md` documenting the cleanup action and reasoning.

### Testing
- Ran `python scripts/quality/check_warning_allowlist.py` and it exited with success (policy check passed).
- Ran `pytest -q veritas_os/tests/test_warning_allowlist_policy.py` and all tests passed (3 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50f719f10832686d4a4bc74c53e63)