### PR TITLE
test(frontend): stabilize live-event and global-error tests to eliminate warnings

### DIFF
--- a/frontend/app/global-error.test.tsx
+++ b/frontend/app/global-error.test.tsx
@@ -1,20 +1,32 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import GlobalFatalErrorPage from "./global-error";
 
+function renderGlobalFatalErrorPage(error: Error, reset: () => void) {
+  document.documentElement.innerHTML = "";
+
+  return render(
+    <GlobalFatalErrorPage
+      error={error}
+      reset={reset}
+    />,
+    {
+      baseElement: document.documentElement,
+      container: document.documentElement,
+    },
+  );
+}
+
 describe("GlobalFatalErrorPage", () => {
   it("renders fatal fallback UI and calls reset on reload", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const reset = vi.fn();
+    const rendered = renderGlobalFatalErrorPage(new Error("fatal"), reset);
 
-    render(
-      <GlobalFatalErrorPage
-        error={new Error("fatal")}
-        reset={reset}
-      />
-    );
-
-    expect(screen.getByText("重大な問題が発生しました")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "再読み込み" }));
+    expect(rendered.getByText("重大な問題が発生しました")).toBeTruthy();
+    fireEvent.click(rendered.getByRole("button", { name: "再読み込み" }));
     expect(reset).toHaveBeenCalledTimes(1);
   });
 
@@ -24,12 +36,7 @@ describe("GlobalFatalErrorPage", () => {
       .mockImplementation(() => undefined);
     const error = new Error("fatal route failure");
 
-    render(
-      <GlobalFatalErrorPage
-        error={error}
-        reset={vi.fn()}
-      />
-    );
+    renderGlobalFatalErrorPage(error, vi.fn());
 
     expect(consoleErrorSpy).toHaveBeenCalledWith("Unhandled fatal app error:", error);
   });

--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -14,6 +14,14 @@ function createReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
   });
 }
 
+function createPersistentReadableStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start() {
+      // Keep the stream open so reconnection side effects do not race tests.
+    },
+  });
+}
+
 describe("LiveEventStream", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -22,13 +30,15 @@ describe("LiveEventStream", () => {
   });
 
   it("renders seeded operations events with required fields", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, body: createReadableStream([]) }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, body: createPersistentReadableStream() }));
 
     render(
       <I18nProvider>
         <LiveEventStream />
       </I18nProvider>,
     );
+
+    await screen.findByText(/Connected|接続済み/);
 
     expect(screen.getByText("Live Event Feed")).toBeInTheDocument();
     expect(screen.getByText("FUJI reject")).toBeInTheDocument();
@@ -40,13 +50,15 @@ describe("LiveEventStream", () => {
   });
 
   it("supports acknowledge mute and pin controls", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, body: createReadableStream([]) }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, body: createPersistentReadableStream() }));
 
     render(
       <I18nProvider>
         <LiveEventStream />
       </I18nProvider>,
     );
+
+    await screen.findByText(/Connected|接続済み/);
 
     const ackButton = screen.getAllByRole("button", { name: "acknowledge" })[0];
     fireEvent.click(ackButton);


### PR DESCRIPTION
### Motivation
- Resolve high-priority frontend test warnings reported in the code review: React `act(...)` update warnings and `validateDOMNesting` (`<html>` in `<div>`) warnings while keeping changes limited to test code and not touching component responsibilities.

### Description
- Replace immediately-closed mock SSE stream with a `createPersistentReadableStream` helper and stub `fetch` to return it so reconnection/state update races no longer trigger `act(...)` warnings in `LiveEventStream` tests.
- Wait for the connection status to be reflected by adding `await screen.findByText(/Connected|接続済み/)` before asserting UI state to ensure asynchronous state updates settle.
- Introduce `renderGlobalFatalErrorPage` helper that renders the fatal error page into `document.documentElement` to avoid invalid DOM nesting during tests and spy `console.error` in tests to suppress expected noisy logs while preserving the assertion that the error was logged.
- Changes are limited to test files and do not modify runtime behavior or responsibility boundaries; note that spying on `console.error` can mask logs and should be used carefully to avoid hiding meaningful error signals.

### Testing
- Ran the focused frontend tests with `pnpm --dir frontend test -- components/live-event-stream.test.tsx app/global-error.test.tsx` and all test files passed; total: 2 test files, 5 tests, 5 passed.
- The modified tests were exercised iteratively to observe elimination of the `act(...)` and `validateDOMNesting` warnings and to confirm the expected UI interactions (ack/pin/mute and reload behavior) remain correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b514a63e708326ba85b5c4b20122ae)