### PR TITLE
Harden WebSocket API key auth with header-first policy

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -1508,19 +1508,61 @@ def _allow_sse_query_api_key() -> bool:
 
 
 def _authenticate_websocket_api_key(websocket: WebSocket) -> bool:
-    """Authenticate WebSocket using query-string API key.
+    """Authenticate WebSocket API key with header-first policy.
 
-    Security warning:
-        Query API keys can leak via URL logs/history. Prefer short-lived keys and
-        TLS (wss://) in production.
+    Security:
+        - ``X-API-Key`` header is preferred because URL query parameters are
+          commonly captured by access logs, browser history, and monitoring
+          tooling.
+        - Query authentication is disabled by default. It can be enabled only
+          with dual opt-in flags during migration windows.
     """
     expected = (_get_expected_api_key() or "").strip()
     if not expected:
         return False
-    candidate = (websocket.query_params.get("api_key") or "").strip()
-    if not candidate:
+
+    header_candidate = (websocket.headers.get("X-API-Key") or "").strip()
+    if header_candidate:
+        return secrets.compare_digest(header_candidate, expected)
+
+    query_candidate = (websocket.query_params.get("api_key") or "").strip()
+    if not query_candidate:
         return False
-    return secrets.compare_digest(candidate, expected)
+    if not _allow_ws_query_api_key():
+        return False
+
+    logger.warning(
+        "WebSocket auth accepted query api_key due to VERITAS_ALLOW_WS_QUERY_API_KEY=1. "
+        "This mode increases credential exposure risk.",
+    )
+    return secrets.compare_digest(query_candidate, expected)
+
+
+def _allow_ws_query_api_key() -> bool:
+    """Return True only when dual opt-in flags allow WebSocket query auth.
+
+    Security note:
+        Query-string API keys can leak through logs and browser history.
+        To reduce accidental exposure, enabling this mode requires both
+        ``VERITAS_ALLOW_WS_QUERY_API_KEY`` and
+        ``VERITAS_ACK_WS_QUERY_API_KEY_RISK``.
+    """
+    allow_raw = (os.getenv("VERITAS_ALLOW_WS_QUERY_API_KEY") or "").strip().lower()
+    allow_query_auth = allow_raw in {"1", "true", "yes", "on"}
+    if not allow_query_auth:
+        return False
+
+    ack_raw = (os.getenv("VERITAS_ACK_WS_QUERY_API_KEY_RISK") or "").strip().lower()
+    acknowledged = ack_raw in {"1", "true", "yes", "on"}
+    if not acknowledged:
+        logger.warning(
+            "WebSocket query api_key enable flag ignored because "
+            "VERITAS_ACK_WS_QUERY_API_KEY_RISK is not set. "
+            "Set both flags only for temporary migration windows.",
+        )
+        return False
+
+    return True
 
 
 # ---- HMAC signature / replay (optional) ----

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -7,6 +7,7 @@ import os
 import time
 import hmac
 import hashlib
+from types import SimpleNamespace
 
 # ★ テスト用APIキーを設定（認証付きエンドポイントのテスト用）
 # server import 前に設定して、起動時の警告を抑制
@@ -1711,6 +1712,56 @@ def test_events_rejects_query_api_key_without_risk_ack(monkeypatch):
             api_key=_TEST_API_KEY,
         )
     assert exc.value.status_code == 401
+
+
+def test_websocket_auth_prefers_header_api_key(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+
+    ws = SimpleNamespace(
+        headers={"X-API-Key": _TEST_API_KEY},
+        query_params={},
+    )
+
+    assert server._authenticate_websocket_api_key(ws) is True
+
+
+def test_websocket_auth_rejects_query_api_key_by_default(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.delenv("VERITAS_ALLOW_WS_QUERY_API_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_ACK_WS_QUERY_API_KEY_RISK", raising=False)
+
+    ws = SimpleNamespace(
+        headers={},
+        query_params={"api_key": _TEST_API_KEY},
+    )
+
+    assert server._authenticate_websocket_api_key(ws) is False
+
+
+def test_websocket_auth_accepts_query_api_key_only_when_dual_flags_enabled(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_ALLOW_WS_QUERY_API_KEY", "1")
+    monkeypatch.setenv("VERITAS_ACK_WS_QUERY_API_KEY_RISK", "true")
+
+    ws = SimpleNamespace(
+        headers={},
+        query_params={"api_key": _TEST_API_KEY},
+    )
+
+    assert server._authenticate_websocket_api_key(ws) is True
+
+
+def test_websocket_auth_rejects_query_api_key_without_risk_ack(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_ALLOW_WS_QUERY_API_KEY", "1")
+    monkeypatch.delenv("VERITAS_ACK_WS_QUERY_API_KEY_RISK", raising=False)
+
+    ws = SimpleNamespace(
+        headers={},
+        query_params={"api_key": _TEST_API_KEY},
+    )
+
+    assert server._authenticate_websocket_api_key(ws) is False
 
 
 def test_decide_failure_publishes_sse_event(monkeypatch):


### PR DESCRIPTION
### Motivation
- Close a critical credential-exposure vector by removing default reliance on query-string `api_key` for WebSocket authentication and prefer header-based `X-API-Key` instead.
- Provide a controlled migration path for legacy clients while reducing accidental leaks to access logs, browser history, and monitoring tooling.
- Surface configuration mistakes via explicit warnings so operators are aware when risky modes are enabled.

### Description
- Change `_authenticate_websocket_api_key` to prefer `X-API-Key` header and only fall back to a query `api_key` when header is absent and a dual opt-in is enabled. 
- Add `_allow_ws_query_api_key()` helper that requires both `VERITAS_ALLOW_WS_QUERY_API_KEY` and `VERITAS_ACK_WS_QUERY_API_KEY_RISK` to enable query auth and emit warning logs otherwise.
- Add explanatory docstring and explicit warning logs when query-based WebSocket auth is accepted or misconfigured.
- Add unit tests to validate header-first behavior and the dual-flag gating and import `SimpleNamespace` used by tests.
- Files changed: `veritas_os/api/server.py`, `veritas_os/tests/test_api_server_extra.py`.

### Testing
- Ran targeted tests: `pytest -q veritas_os/tests/test_api_server_extra.py -k 'events_requires_api_key_header_only_by_default or events_accepts_query_api_key_only_when_dual_flags_enabled or events_rejects_query_api_key_without_risk_ack or websocket_auth'` and observed all selected tests passed (`7 passed, 77 deselected`).
- Linted modified files with `ruff check veritas_os/api/server.py veritas_os/tests/test_api_server_extra.py` and it returned no issues.
- Result: automated checks for the changed behavior succeeded.

Note: enabling query-string API key auth remains a security risk and should be used only for short migration windows; production deployments should prefer header auth + TLS + short-lived credentials.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51b2b91ec8326b01e454a30a7be4a)