### PR TITLE
Require 4-eyes approval for governance policy updates

### DIFF
--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -137,7 +137,8 @@
 - ✅ #3 対応: Replay スナップショットに `retrieval_snapshot_checksum` を追加し、再実行時に整合性検証を実施。
 - ✅ #4 対応: Replay 実行時に `model_version` の一致検証を追加（`VERITAS_REPLAY_ENFORCE_MODEL_VERSION=1` で有効）。
 - ✅ #5 対応: TrustLog の WORM ミラーに hard-fail モード（`VERITAS_TRUSTLOG_WORM_HARD_FAIL=1`）を追加。
-- ⚠️ #6, #7 は本変更では未着手（組織承認フローおよび API 境界ガードは別PRで実施予定）。
+- ✅ #6 対応: `/v1/governance/policy` 更新時に **4-eyes 承認（2名・重複不可署名）** を必須化。デフォルト有効で `VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES=0` の場合のみ無効化。
+- ⚠️ #7 は本変更では未着手（Pipeline 外 API に対する追加ガードは別PRで実施予定）。
 
 ## 17. Final Verdict
 - **B. serious engineering foundation**

--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -137,7 +137,7 @@
 - ✅ #3 対応: Replay スナップショットに `retrieval_snapshot_checksum` を追加し、再実行時に整合性検証を実施。
 - ✅ #4 対応: Replay 実行時に `model_version` の一致検証を追加（`VERITAS_REPLAY_ENFORCE_MODEL_VERSION=1` で有効）。
 - ✅ #5 対応: TrustLog の WORM ミラーに hard-fail モード（`VERITAS_TRUSTLOG_WORM_HARD_FAIL=1`）を追加。
-- ✅ #6 対応: `/v1/governance/policy` 更新時に **4-eyes 承認（2名・重複不可署名）** を必須化。デフォルト有効で `VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES=0` の場合のみ無効化。
+- ✅ #6 対応: `/v1/governance/policy` 更新時に **4-eyes 承認（2名・重複不可署名）** を必須化。デフォルト有効で `VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES=0` の場合のみ無効化。加えて承認失敗時の API 応答は固定文言へ統一し、例外詳細の外部露出を抑止。
 - ⚠️ #7 は本変更では未着手（Pipeline 外 API に対する追加ガードは別PRで実施予定）。
 
 ## 17. Final Verdict

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 from collections import deque
 from copy import deepcopy
@@ -332,6 +333,46 @@ def update_policy(patch: Dict[str, Any]) -> Dict[str, Any]:
     _notify_policy_update(result)
 
     return result
+
+
+def enforce_four_eyes_approval(payload: Dict[str, Any]) -> None:
+    """Enforce 4-eyes approval for governance policy updates.
+
+    This control is enabled by default and can be disabled explicitly for
+    development with ``VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES=0``.
+
+    Required payload shape:
+
+    - ``approvals``: list of exactly two objects
+    - each object must include non-empty ``reviewer`` and ``signature``
+    - reviewers and signatures must be distinct
+    """
+    enforce = os.getenv("VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES", "1").strip().lower()
+    if enforce in {"0", "false", "no", "off"}:
+        return
+
+    approvals = payload.get("approvals")
+    if not isinstance(approvals, list) or len(approvals) != 2:
+        raise PermissionError("governance update requires exactly two approvals")
+
+    reviewers: set[str] = set()
+    signatures: set[str] = set()
+    for approval in approvals:
+        if not isinstance(approval, dict):
+            raise PermissionError("approval entries must be objects")
+
+        reviewer = str(approval.get("reviewer", "")).strip()
+        signature = str(approval.get("signature", "")).strip()
+        if not reviewer or not signature:
+            raise PermissionError("approval entries require reviewer and signature")
+
+        reviewers.add(reviewer)
+        signatures.add(signature)
+
+    if len(reviewers) != 2:
+        raise PermissionError("approvals must be from two distinct reviewers")
+    if len(signatures) != 2:
+        raise PermissionError("approvals must include two distinct signatures")
 
 
 def get_policy_history(limit: int = 50) -> List[Dict[str, Any]]:

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -54,7 +54,13 @@ from veritas_os.api.schemas import (
     MemorySearchRequest,
     TrustFeedbackRequest,
 )
-from veritas_os.api.governance import get_policy, get_policy_history, get_value_drift, update_policy
+from veritas_os.api.governance import (
+    enforce_four_eyes_approval,
+    get_policy,
+    get_policy_history,
+    get_value_drift,
+    update_policy,
+)
 from veritas_os.compliance.report_engine import (
     generate_eu_ai_act_report,
     generate_internal_governance_report,
@@ -3194,12 +3200,19 @@ def governance_get():
 def governance_put(body: dict):
     """Update the governance policy (partial merge)."""
     try:
+        enforce_four_eyes_approval(body)
         updated = update_policy(body)
         _publish_event(
             "governance.updated",
             {"updated_by": updated.get("updated_by", "api")},
         )
         return {"ok": True, "policy": updated}
+    except PermissionError as e:
+        logger.warning("governance_put rejected: %s", e)
+        return JSONResponse(
+            status_code=403,
+            content={"ok": False, "error": str(e)},
+        )
     except Exception as e:
         logger.error("governance_put failed: %s", e)
         return JSONResponse(

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -3211,7 +3211,7 @@ def governance_put(body: dict):
         logger.warning("governance_put rejected: %s", e)
         return JSONResponse(
             status_code=403,
-            content={"ok": False, "error": str(e)},
+            content={"ok": False, "error": "governance approval validation failed"},
         )
     except Exception as e:
         logger.error("governance_put failed: %s", e)

--- a/veritas_os/tests/test_governance_api.py
+++ b/veritas_os/tests/test_governance_api.py
@@ -141,6 +141,25 @@ class TestPutPolicy:
         )
         assert resp.status_code == 403
         assert resp.json()["ok"] is False
+
+    def test_put_does_not_expose_permission_error_detail(self, monkeypatch):
+        """Permission errors are sanitized before returning to API clients."""
+
+        def sensitive_error(_body):
+            raise PermissionError("secret stack trace details")
+
+        monkeypatch.setattr(srv, "enforce_four_eyes_approval", sensitive_error)
+        resp = client.put(
+            "/v1/governance/policy",
+            headers=HEADERS,
+            json={"fuji_rules": {"pii_check": False}},
+        )
+        assert resp.status_code == 403
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["error"] == "governance approval validation failed"
+        assert "secret" not in json.dumps(body)
+
     def test_put_requires_api_key(self):
         resp = client.put("/v1/governance/policy", json={})
         assert resp.status_code in (401, 500)

--- a/veritas_os/tests/test_governance_api.py
+++ b/veritas_os/tests/test_governance_api.py
@@ -17,6 +17,16 @@ client = TestClient(srv.app)
 HEADERS = {"X-API-Key": "test-governance-key"}
 
 
+def _approved(payload: dict | None = None) -> dict:
+    """Attach a valid 4-eyes approval block to a governance payload."""
+    base = payload.copy() if payload else {}
+    base["approvals"] = [
+        {"reviewer": "alice", "signature": "sig-alice"},
+        {"reviewer": "bob", "signature": "sig-bob"},
+    ]
+    return base
+
+
 @pytest.fixture(autouse=True)
 def _temp_policy(tmp_path: Path, monkeypatch):
     """Use a temporary governance.json for every test."""
@@ -58,7 +68,7 @@ class TestPutPolicy:
         resp = client.put(
             "/v1/governance/policy",
             headers=HEADERS,
-            json={"fuji_rules": {"pii_check": False}},
+            json=_approved({"fuji_rules": {"pii_check": False}}),
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -71,7 +81,7 @@ class TestPutPolicy:
         resp = client.put(
             "/v1/governance/policy",
             headers=HEADERS,
-            json={"risk_thresholds": {"allow_upper": 0.50}},
+            json=_approved({"risk_thresholds": {"allow_upper": 0.50}}),
         )
         assert resp.status_code == 200
         assert resp.json()["policy"]["risk_thresholds"]["allow_upper"] == 0.50
@@ -80,7 +90,7 @@ class TestPutPolicy:
         resp = client.put(
             "/v1/governance/policy",
             headers=HEADERS,
-            json={"auto_stop": {"enabled": False, "max_risk_score": 0.70}},
+            json=_approved({"auto_stop": {"enabled": False, "max_risk_score": 0.70}}),
         )
         body = resp.json()
         assert body["policy"]["auto_stop"]["enabled"] is False
@@ -90,7 +100,7 @@ class TestPutPolicy:
         resp = client.put(
             "/v1/governance/policy",
             headers=HEADERS,
-            json={"log_retention": {"retention_days": 180, "audit_level": "summary"}},
+            json=_approved({"log_retention": {"retention_days": 180, "audit_level": "summary"}}),
         )
         body = resp.json()
         assert body["policy"]["log_retention"]["retention_days"] == 180
@@ -100,12 +110,37 @@ class TestPutPolicy:
         resp = client.put(
             "/v1/governance/policy",
             headers=HEADERS,
-            json={"fuji_rules": {"pii_check": True}},
+            json=_approved({"fuji_rules": {"pii_check": True}}),
         )
         body = resp.json()
         assert body["policy"]["updated_at"] != ""
         assert body["policy"]["updated_by"] == "api"
 
+
+
+    def test_put_rejects_without_four_eyes_approval(self):
+        resp = client.put(
+            "/v1/governance/policy",
+            headers=HEADERS,
+            json={"fuji_rules": {"pii_check": False}},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["ok"] is False
+
+    def test_put_rejects_duplicate_reviewer_in_approvals(self):
+        resp = client.put(
+            "/v1/governance/policy",
+            headers=HEADERS,
+            json={
+                "fuji_rules": {"pii_check": False},
+                "approvals": [
+                    {"reviewer": "alice", "signature": "sig-a"},
+                    {"reviewer": "alice", "signature": "sig-b"},
+                ],
+            },
+        )
+        assert resp.status_code == 403
+        assert resp.json()["ok"] is False
     def test_put_requires_api_key(self):
         resp = client.put("/v1/governance/policy", json={})
         assert resp.status_code in (401, 500)
@@ -114,7 +149,7 @@ class TestPutPolicy:
         client.put(
             "/v1/governance/policy",
             headers=HEADERS,
-            json={"risk_thresholds": {"warn_upper": 0.55}},
+            json=_approved({"risk_thresholds": {"warn_upper": 0.55}}),
         )
         resp = client.get("/v1/governance/policy", headers=HEADERS)
         assert resp.json()["policy"]["risk_thresholds"]["warn_upper"] == 0.55
@@ -127,7 +162,7 @@ class TestGovernanceModule:
         assert "fuji_rules" in result
 
     def test_update_policy_merges(self):
-        result = gov_mod.update_policy({"fuji_rules": {"pii_check": False}})
+        result = gov_mod.update_policy(_approved({"fuji_rules": {"pii_check": False}}))
         assert result["fuji_rules"]["pii_check"] is False
         assert result["fuji_rules"]["self_harm_block"] is True
 
@@ -159,7 +194,7 @@ class TestGovernanceModule:
         p = tmp_path / "gov.json"
         p.write_text(json.dumps({"fuji_rules": "broken", "version": "v0"}))
         with patch.object(gov_mod, "_DEFAULT_POLICY_PATH", p):
-            result = gov_mod.update_policy({"fuji_rules": {"pii_check": False}})
+            result = gov_mod.update_policy(_approved({"fuji_rules": {"pii_check": False}}))
         assert result["fuji_rules"]["pii_check"] is False
 
     def test_get_value_drift_with_no_data(self, tmp_path):
@@ -185,18 +220,18 @@ class TestGovernanceModule:
         p = tmp_path / "gov.json"
         p.write_text(json.dumps(gov_mod.GovernancePolicy().model_dump()))
         with patch.object(gov_mod, "_DEFAULT_POLICY_PATH", p):
-            result = gov_mod.update_policy({"version": "custom_v9"})
+            result = gov_mod.update_policy(_approved({"version": "custom_v9"}))
         assert result["version"] == "custom_v9"
 
     def test_update_policy_rejects_non_object_nested_patch(self):
         """Nested governance sections must be provided as objects."""
         with pytest.raises(ValueError, match="fuji_rules must be an object"):
-            gov_mod.update_policy({"fuji_rules": True})
+            gov_mod.update_policy(_approved({"fuji_rules": True}))
 
     def test_update_policy_validates_merged_nested_patch(self):
         """Merged nested section is validated before assignment and save."""
         with pytest.raises(ValidationError):
-            gov_mod.update_policy({"risk_thresholds": {"allow_upper": 1.5}})
+            gov_mod.update_policy(_approved({"risk_thresholds": {"allow_upper": 1.5}}))
 
 
 
@@ -250,7 +285,7 @@ class TestGovernanceServerErrors:
         resp = client.put(
             "/v1/governance/policy",
             headers=HEADERS,
-            json={"fuji_rules": {}},
+            json=_approved({"fuji_rules": {}}),
         )
         assert resp.status_code == 500
         body = resp.json()


### PR DESCRIPTION
### Motivation
- Implement Improvement Roadmap item #6 to strengthen governance by requiring dual authorization on policy updates. 
- Prevent unilateral policy tampering at the API boundary while keeping a dev-friendly opt-out.

### Description
- Add `enforce_four_eyes_approval(payload: Dict[str, Any])` to `veritas_os/api/governance.py`, which requires an `approvals` list of exactly two distinct objects each containing non-empty `reviewer` and `signature`, and is opt-out via `VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES=0`.
- Wire the approval check into the API boundary by calling `enforce_four_eyes_approval()` at the start of the `/v1/governance/policy` PUT handler in `veritas_os/api/server.py` and return `403` on approval failures while preserving existing `500` error behavior for other failures.
- Update `veritas_os/tests/test_governance_api.py` to attach valid approval blocks to successful PUT cases and add tests for rejection when approvals are missing or duplicate reviewers/signatures are provided.
- Update `docs/reviews/technical_dd_review_ja_20260314.md` to mark roadmap item #6 as implemented and note that #7 remains for a separate PR.

### Testing
- Ran style checks: `python -m ruff check veritas_os/api/governance.py veritas_os/api/server.py veritas_os/tests/test_governance_api.py` and all checks passed.
- Ran unit tests for governance API: `python -m pytest -q veritas_os/tests/test_governance_api.py` and `29 passed`.
- Note: the approval check currently validates structure and uniqueness only; cryptographic signature verification and identity binding were not implemented in this change and should be added in a follow-up for stronger non-repudiation and anti-spoofing guarantees.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b54c3a8a308326ae2cad3b9a56e2c6)