### PR TITLE
Enforce governance guard for /v1/fuji/validate (opt-in)

### DIFF
--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -138,7 +138,7 @@
 - ✅ #4 対応: Replay 実行時に `model_version` の一致検証を追加（`VERITAS_REPLAY_ENFORCE_MODEL_VERSION=1` で有効）。
 - ✅ #5 対応: TrustLog の WORM ミラーに hard-fail モード（`VERITAS_TRUSTLOG_WORM_HARD_FAIL=1`）を追加。
 - ✅ #6 対応: `/v1/governance/policy` 更新時に **4-eyes 承認（2名・重複不可署名）** を必須化。デフォルト有効で `VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES=0` の場合のみ無効化。加えて承認失敗時の API 応答は固定文言へ統一し、例外詳細の外部露出を抑止。
-- ⚠️ #7 は本変更では未着手（Pipeline 外 API に対する追加ガードは別PRで実施予定）。
+- ✅ #7 対応: `/v1/fuji/validate` にガバナンス境界ガードを追加し、`VERITAS_ENABLE_DIRECT_FUJI_API=1` を明示設定しない限り `403` で拒否（標準経路 `/v1/decide` 利用を強制）。
 
 ## 17. Final Verdict
 - **B. serious engineering foundation**

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -2099,6 +2099,20 @@ def _is_debug_mode() -> bool:
     return normalized_flag in debug_truthy_values
 
 
+def _is_direct_fuji_api_enabled() -> bool:
+    """Return whether direct FUJI API access is explicitly allowed.
+
+    Security note:
+        `/v1/fuji/validate` can bypass the standard `/v1/decide` governance
+        pipeline. This endpoint therefore defaults to disabled and must be
+        explicitly enabled with `VERITAS_ENABLE_DIRECT_FUJI_API=1`.
+    """
+    flag = os.getenv("VERITAS_ENABLE_DIRECT_FUJI_API", "")
+    normalized_flag = flag.strip().lower()
+    truthy_values = {"1", "true", "yes", "on"}
+    return normalized_flag in truthy_values
+
+
 @app.get("/")
 def root() -> Dict[str, Any]:
     return {"ok": True, "service": "veritas-api", "server_time": utc_now_iso_z()}
@@ -2544,6 +2558,17 @@ def _call_fuji(fc: Any, action: str, context: dict) -> dict:
     dependencies=[Depends(require_api_key), Depends(enforce_rate_limit)],
 )
 def fuji_validate(payload: dict):
+    if not _is_direct_fuji_api_enabled():
+        return JSONResponse(
+            status_code=403,
+            content={
+                "detail": (
+                    "direct_fuji_api_disabled: use /v1/decide pipeline or set "
+                    "VERITAS_ENABLE_DIRECT_FUJI_API=1"
+                )
+            },
+        )
+
     fc = get_fuji_core()
     if fc is None:
         logger.warning("fuji_validate: fuji_core unavailable: %s", _fuji_state.err)

--- a/veritas_os/tests/test_api_extra.py
+++ b/veritas_os/tests/test_api_extra.py
@@ -356,6 +356,8 @@ class TestFUJIValidation:
         """
         安全なアクションがallowされることを確認
         """
+        monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "1")
+
         def fake_validate_action(action, context):
             """モック：安全なアクションを返す"""
             assert action == "safe_operation"
@@ -392,6 +394,8 @@ class TestFUJIValidation:
         """
         危険なアクションがrejectedされることを確認
         """
+        monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "1")
+
         def fake_validate_action(action, context):
             """モック：危険なアクションを返す"""
             return {
@@ -420,6 +424,19 @@ class TestFUJIValidation:
         
         assert data["status"] == "rejected"
         assert len(data["violations"]) > 0
+
+    def test_fuji_validate_blocked_without_direct_api_opt_in(self, client, monkeypatch):
+        """Pipeline bypass endpoint is blocked by default for governance safety."""
+        monkeypatch.delenv("VERITAS_ENABLE_DIRECT_FUJI_API", raising=False)
+
+        response = client.post(
+            "/v1/fuji/validate",
+            headers={"X-API-Key": "test-key"},
+            json={"action": "safe_operation", "context": {}},
+        )
+
+        assert response.status_code == 403
+        assert "direct_fuji_api_disabled" in response.json()["detail"]
 
 
 # =========================

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -918,6 +918,8 @@ def test_fuji_validate_uses_validate_action(monkeypatch):
     """
     fuji_core.validate_action がある場合、その経路が使われる
     """
+    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "1")
+
     calls = []
 
     class DummyFuji:
@@ -946,6 +948,8 @@ def test_fuji_validate_falls_back_to_validate(monkeypatch):
     validate_action が無く validate だけある場合、validate 経由になる
     """
 
+    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "1")
+
     class DummyFuji:
         @staticmethod
         def validate(action, context):
@@ -968,6 +972,8 @@ def test_fuji_validate_no_impl_raises_500(monkeypatch):
     """
     validate_action も validate も無い場合は 500 を返す
     """
+
+    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "1")
 
     class DummyFuji:
         pass

--- a/veritas_os/tests/test_governance_api.py
+++ b/veritas_os/tests/test_governance_api.py
@@ -318,6 +318,7 @@ class TestGovernanceServerErrors:
 class TestFujiValidateErrorPaths:
     def test_runtime_error_returns_error_structure(self, monkeypatch):
         """Non-impl RuntimeError in fuji_validate → 200 with error."""
+        monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "1")
         fake = type("F", (), {"validate_action": None, "validate": None})()
         monkeypatch.setattr(srv, "get_fuji_core", lambda: fake)
         monkeypatch.setattr(
@@ -332,6 +333,7 @@ class TestFujiValidateErrorPaths:
 
     def test_general_exception_returns_error_structure(self, monkeypatch):
         """General exception in fuji_validate → 200 with error."""
+        monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "1")
         fake = type("F", (), {"validate_action": None, "validate": None})()
         monkeypatch.setattr(srv, "get_fuji_core", lambda: fake)
         monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Roadmap item #7 identified a bypass risk where `/v1/fuji/validate` could be used outside the governance `run_decide_pipeline`, so the endpoint must default to fail-closed to preserve governance boundaries. 
- The change aims to force use of the canonical `/v1/decide` pipeline by default and require explicit operator opt-in for direct FUJI validation access.

### Description
- Added `_is_direct_fuji_api_enabled()` and an early opt-in check in the `fuji_validate` handler so `/v1/fuji/validate` returns `403` unless `VERITAS_ENABLE_DIRECT_FUJI_API=1` is set. 
- Kept error hygiene: internal errors remain hidden in normal mode and existing size truncation for `action` is preserved. 
- Updated tests in `veritas_os/tests/test_api_extra.py` to set `VERITAS_ENABLE_DIRECT_FUJI_API=1` for allowed cases and added `test_fuji_validate_blocked_without_direct_api_opt_in` to assert default `403`. 
- Updated `docs/reviews/technical_dd_review_ja_20260314.md` to mark roadmap item #7 as completed.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_extra.py -k fuji_validate` and obtained `3 passed` (the FUJI validation tests). 
- The modified test suite exercised both the opt-in allowed flow and the default-blocked behavior and passed.
- Note: this is a governance / operational change and will block existing direct callers until `VERITAS_ENABLE_DIRECT_FUJI_API` is intentionally enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55a0104e0832680aa864f8c8d32d7)