### PR TITLE
Add replay dependency-version evidence for stronger auditability

### DIFF
--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -139,6 +139,7 @@
 - ✅ #5 対応: TrustLog の WORM ミラーに hard-fail モード（`VERITAS_TRUSTLOG_WORM_HARD_FAIL=1`）を追加。
 - ✅ #6 対応: `/v1/governance/policy` 更新時に **4-eyes 承認（2名・重複不可署名）** を必須化。デフォルト有効で `VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES=0` の場合のみ無効化。加えて承認失敗時の API 応答は固定文言へ統一し、例外詳細の外部露出を抑止。
 - ✅ #7 対応: `/v1/fuji/validate` にガバナンス境界ガードを追加し、`VERITAS_ENABLE_DIRECT_FUJI_API=1` を明示設定しない限り `403` で拒否（標準経路 `/v1/decide` 利用を強制）。
+- ✅ #9 対応: Replay スナップショットに `external_dependency_versions`（Python実行環境・主要依存パッケージ版本）を記録し、Replay レポート `meta` へ証跡を出力するよう改善。
 
 ## 17. Final Verdict
 - **B. serious engineering foundation**

--- a/veritas_os/core/pipeline_persist.py
+++ b/veritas_os/core/pipeline_persist.py
@@ -15,9 +15,11 @@ Handles:
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata
 import json
 import logging
 import os
+import platform
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -27,6 +29,28 @@ from .utils import utc_now, utc_now_iso_z, redact_payload
 from .pipeline_helpers import _warn
 
 logger = logging.getLogger(__name__)
+
+
+def _collect_external_dependency_evidence() -> Dict[str, Any]:
+    """Collect runtime dependency versions used for replay audit evidence."""
+    package_names = (
+        "openai",
+        "anthropic",
+        "httpx",
+        "pydantic",
+    )
+    packages: Dict[str, str] = {}
+    for package_name in package_names:
+        try:
+            packages[package_name] = importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError:
+            packages[package_name] = "not_installed"
+
+    return {
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "packages": packages,
+    }
 
 
 def _stable_checksum(payload: Any) -> str:
@@ -508,6 +532,7 @@ def build_replay_snapshot(
             "web_search": bool(should_run_web and not ctx.mock_external_apis),
             "web_search_mocked": bool(should_run_web and ctx.mock_external_apis),
         },
+        "external_dependency_versions": _collect_external_dependency_evidence(),
         "stage_outputs": {
             "planner": ctx.response_extras.get("planner"),
             "retrieval": ctx.retrieved,

--- a/veritas_os/replay/replay_engine.py
+++ b/veritas_os/replay/replay_engine.py
@@ -117,6 +117,25 @@ def _stable_checksum(payload: Any) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _normalize_external_dependency_evidence(value: Any) -> Dict[str, Any]:
+    """Return a sanitized dependency evidence map for replay reporting."""
+    if not isinstance(value, dict):
+        return {}
+
+    packages = value.get("packages") if isinstance(value.get("packages"), dict) else {}
+    normalized_packages = {
+        str(name): str(version)
+        for name, version in packages.items()
+    }
+
+    normalized = {
+        "python_version": str(value.get("python_version") or ""),
+        "platform": str(value.get("platform") or ""),
+        "packages": normalized_packages,
+    }
+    return normalized
+
+
 def _sort_evidence(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     def _key(item: Dict[str, Any]) -> str:
         return str(
@@ -238,6 +257,10 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
         if str(expected_retrieval_checksum) != actual_retrieval_checksum:
             raise ValueError("replay_retrieval_snapshot_checksum_mismatch")
 
+    replay_dependency_evidence = _normalize_external_dependency_evidence(
+        replay_meta.get("external_dependency_versions")
+    )
+
     req_body = replay_meta.get("request_body") if isinstance(replay_meta.get("request_body"), dict) else {}
     req_body = dict(req_body)
 
@@ -282,6 +305,7 @@ async def run_replay(decision_id: str, strict: bool | None = None) -> ReplayResu
             "created_at": _iso_now(),
             "pipeline_version": _pipeline_version(),
             "notes": "strict mode reuses deterministic replay snapshot and disables external tools.",
+            "external_dependency_versions": replay_dependency_evidence,
         },
     }
 

--- a/veritas_os/tests/test_pipeline_stages.py
+++ b/veritas_os/tests/test_pipeline_stages.py
@@ -344,3 +344,28 @@ class TestFinalizeEvidence:
         finalize_evidence(payload, web_evidence=web_ev, evidence_max=50)
         sources = [e.get("source") for e in payload["evidence"]]
         assert "web" in sources
+
+
+def test_build_replay_snapshot_includes_external_dependency_versions() -> None:
+    from veritas_os.core.pipeline_persist import build_replay_snapshot
+    from veritas_os.core.pipeline_types import PipelineContext
+
+    ctx = PipelineContext(
+        request_id="req-1",
+        query="q",
+        body={"temperature": 0},
+        context={},
+    )
+    ctx.retrieved = []
+    ctx.response_extras = {"web_search": None}
+    ctx.seed = 123
+
+    payload = {"meta": {}, "evidence": []}
+    build_replay_snapshot(ctx, payload, should_run_web=False)
+
+    replay = payload.get("deterministic_replay")
+    assert isinstance(replay, dict)
+    deps = replay.get("external_dependency_versions")
+    assert isinstance(deps, dict)
+    assert isinstance(deps.get("packages"), dict)
+    assert "python_version" in deps

--- a/veritas_os/tests/test_replay_engine.py
+++ b/veritas_os/tests/test_replay_engine.py
@@ -97,6 +97,11 @@ async def test_run_replay_writes_expected_diff_schema(monkeypatch, tmp_path: Pat
         "request_id": "dec-200",
         "query": "hello",
         "deterministic_replay": {
+            "external_dependency_versions": {
+                "python_version": "3.12.0",
+                "platform": "linux-x",
+                "packages": {"openai": "1.0.0"},
+            },
             "request_body": {"query": "hello", "context": {}},
             "final_output": {
                 "decision": {"output": "allow", "answer": "ok"},
@@ -131,6 +136,7 @@ async def test_run_replay_writes_expected_diff_schema(monkeypatch, tmp_path: Pat
     assert payload["decision_id"] == "dec-200"
     assert "meta" in payload
     assert "pipeline_version" in payload["meta"]
+    assert payload["meta"]["external_dependency_versions"]["packages"]["openai"] == "1.0.0"
 
 
 @pytest.mark.asyncio
@@ -186,3 +192,15 @@ async def test_run_replay_rejects_retrieval_checksum_mismatch(monkeypatch, tmp_p
 
     with pytest.raises(ValueError, match="replay_retrieval_snapshot_checksum_mismatch"):
         await replay_engine.run_replay("dec-301", strict=True)
+
+
+def test_normalize_external_dependency_evidence_handles_invalid_shape() -> None:
+    normalized = replay_engine._normalize_external_dependency_evidence(["bad"])
+    assert normalized == {}
+
+    normalized2 = replay_engine._normalize_external_dependency_evidence(
+        {"python_version": 3.12, "platform": None, "packages": {"openai": 1}}
+    )
+    assert normalized2["python_version"] == "3.12"
+    assert normalized2["platform"] == ""
+    assert normalized2["packages"]["openai"] == "1"


### PR DESCRIPTION
### Motivation
- Improve replay auditability by recording the execution environment and key dependency versions so Replay reports can better detect non-determinism caused by runtime differences. 
- Implement Improvement Roadmap item (#9) to increase reproducibility verification without changing Planner/Kernel/FUJI/MemoryOS responsibilities. 

### Description
- Added `_collect_external_dependency_evidence()` to `veritas_os/core/pipeline_persist.py` and attached `external_dependency_versions` (Python runtime, platform, and selected package versions: `openai`, `anthropic`, `httpx`, `pydantic`) to the deterministic replay snapshot. 
- Added `_normalize_external_dependency_evidence()` to `veritas_os/replay/replay_engine.py` and propagate the normalized dependency evidence into replay report `meta.external_dependency_versions`. 
- Updated review document `docs/reviews/technical_dd_review_ja_20260314.md` to mark #9 as addressed. 
- Added unit tests to validate snapshot inclusion and normalization: `veritas_os/tests/test_pipeline_stages.py` and `veritas_os/tests/test_replay_engine.py`. 

### Testing
- Ran `pytest -q veritas_os/tests/test_replay_engine.py veritas_os/tests/test_pipeline_stages.py -q` and the test suite passed successfully. 
- New tests verify that `deterministic_replay.external_dependency_versions` is produced and that replay reports include the normalized evidence, and that the normalizer tolerates malformed input. 

Security note: `external_dependency_versions` contains environment fingerprints (Python version, platform, package versions); avoid leaking reports publicly or sanitize fields before external sharing to reduce information-exposure risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b564c839ec8326aa9a5b58199dcaed)