### PR TITLE
Add transparency anchor support for signed TrustLog

### DIFF
--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -139,6 +139,7 @@
 - ✅ #5 対応: TrustLog の WORM ミラーに hard-fail モード（`VERITAS_TRUSTLOG_WORM_HARD_FAIL=1`）を追加。
 - ✅ #6 対応: `/v1/governance/policy` 更新時に **4-eyes 承認（2名・重複不可署名）** を必須化。デフォルト有効で `VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES=0` の場合のみ無効化。加えて承認失敗時の API 応答は固定文言へ統一し、例外詳細の外部露出を抑止。
 - ✅ #7 対応: `/v1/fuji/validate` にガバナンス境界ガードを追加し、`VERITAS_ENABLE_DIRECT_FUJI_API=1` を明示設定しない限り `403` で拒否（標準経路 `/v1/decide` 利用を強制）。
+- ✅ #8 対応: TrustLog チェーンハッシュを外部連携可能な Transparency log へアンカーする仕組みを追加（`VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH`）。必須化は `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED=1` で fail-closed 運用可能。
 - ✅ #9 対応: Replay スナップショットに `external_dependency_versions`（Python実行環境・主要依存パッケージ版本）を記録し、Replay レポート `meta` へ証跡を出力するよう改善。
 
 ## 17. Final Verdict

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -57,6 +57,20 @@ def _worm_hard_fail_enabled() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
+def _transparency_log_path() -> Optional[Path]:
+    """Resolve optional transparency log destination for TrustLog anchors."""
+    anchor_path = os.getenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "").strip()
+    if not anchor_path:
+        return None
+    return Path(anchor_path)
+
+
+def _transparency_required_enabled() -> bool:
+    """Return whether transparency anchoring failures must abort writes."""
+    raw = (os.getenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED") or "0").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 def _append_line(path: Path, line: str) -> None:
     """Append a line to ``path``, creating parent directories when required."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -81,6 +95,39 @@ def _mirror_to_worm(line: str) -> Dict[str, Any]:
         }
 
     return {"configured": True, "ok": True, "path": str(path)}
+
+
+def _append_transparency_anchor(entry_hash: str) -> Dict[str, Any]:
+    """Best-effort append of the latest chain hash to a transparency log.
+
+    The transparency log can be a local spool file that is shipped to an
+    external append-only system by infrastructure.
+    """
+    path = _transparency_log_path()
+    if path is None:
+        return {"configured": False, "ok": False, "path": None}
+
+    payload = {
+        "timestamp": _utc_now_iso8601(),
+        "entry_hash": entry_hash,
+    }
+    line = json.dumps(payload, ensure_ascii=False) + "\n"
+    try:
+        _append_line(path, line)
+    except OSError as exc:
+        return {
+            "configured": True,
+            "ok": False,
+            "path": str(path),
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+
+    return {
+        "configured": True,
+        "ok": True,
+        "path": str(path),
+        "entry_hash": entry_hash,
+    }
 
 
 @dataclass
@@ -180,6 +227,15 @@ def append_signed_decision(decision_payload: Dict[str, Any]) -> Dict[str, Any]:
                 raise SignedTrustLogWriteError("worm_mirror_write_failed")
             entry["worm_mirror"] = mirror
 
+            transparency_anchor = _append_transparency_anchor(_entry_chain_hash(entry))
+            if (
+                _transparency_required_enabled()
+                and transparency_anchor.get("configured")
+                and not transparency_anchor.get("ok")
+            ):
+                raise SignedTrustLogWriteError("transparency_anchor_write_failed")
+            entry["transparency_anchor"] = transparency_anchor
+
         return entry
     except (
         OSError,
@@ -240,6 +296,17 @@ def verify_trustlog_chain(path: Optional[Path] = None) -> Dict[str, Any]:
             "entries": len(_read_all_entries(worm_path)) if worm_path.exists() else 0,
         })
 
+    transparency_path = _transparency_log_path()
+    transparency_status: Dict[str, Any] = {
+        "configured": transparency_path is not None,
+        "required": _transparency_required_enabled(),
+    }
+    if transparency_path is not None:
+        transparency_status.update({
+            "path": str(transparency_path),
+            "exists": transparency_path.exists(),
+        })
+
     key_meta: Dict[str, Any] = {"public_key_present": PUBLIC_KEY_PATH.exists()}
     if PUBLIC_KEY_PATH.exists():
         key_meta["fingerprint"] = public_key_fingerprint(PUBLIC_KEY_PATH)
@@ -249,6 +316,7 @@ def verify_trustlog_chain(path: Optional[Path] = None) -> Dict[str, Any]:
         "entries_checked": len(entries),
         "issues": [issue.__dict__ for issue in issues],
         "worm_mirror": worm_status,
+        "transparency_anchor": transparency_status,
         "key_management": key_meta,
     }
 

--- a/veritas_os/tests/test_trustlog_signed.py
+++ b/veritas_os/tests/test_trustlog_signed.py
@@ -65,3 +65,62 @@ def test_append_trust_log_continues_on_signed_log_runtime_error(monkeypatch, tmp
     # ★ JSONL は暗号化されているので iter_trust_log 経由で検証
     entries = list(trust_log.iter_trust_log(reverse=False))
     assert len(entries) == 1
+
+
+def test_append_signed_decision_adds_transparency_anchor(monkeypatch, tmp_path):
+    """Signed append records transparency anchor when configured."""
+    trustlog_path = tmp_path / "trustlog.jsonl"
+    anchor_path = tmp_path / "transparency.jsonl"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", trustlog_path)
+    monkeypatch.setattr(trustlog_signed, "_ensure_signing_keys", lambda: None)
+    monkeypatch.setattr(trustlog_signed, "_read_all_entries", lambda _path: [])
+    monkeypatch.setattr(
+        trustlog_signed,
+        "sha256_of_canonical_json",
+        lambda _payload: "h" * 64,
+    )
+    monkeypatch.setattr(trustlog_signed, "sign_payload_hash", lambda *_args, **_kwargs: "sig")
+    monkeypatch.setattr(trustlog_signed, "public_key_fingerprint", lambda _path: "fp")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", str(anchor_path))
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "req-transparency"})
+
+    assert entry["transparency_anchor"]["configured"] is True
+    assert entry["transparency_anchor"]["ok"] is True
+    assert entry["transparency_anchor"]["path"] == str(anchor_path)
+    assert anchor_path.exists()
+    lines = anchor_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["entry_hash"] == entry["transparency_anchor"]["entry_hash"]
+
+
+def test_append_signed_decision_raises_when_transparency_required(monkeypatch, tmp_path):
+    """Required transparency anchor mode fails closed on write errors."""
+    trustlog_path = tmp_path / "trustlog.jsonl"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", trustlog_path)
+    monkeypatch.setattr(trustlog_signed, "_ensure_signing_keys", lambda: None)
+    monkeypatch.setattr(trustlog_signed, "_read_all_entries", lambda _path: [])
+    monkeypatch.setattr(
+        trustlog_signed,
+        "sha256_of_canonical_json",
+        lambda _payload: "h" * 64,
+    )
+    monkeypatch.setattr(trustlog_signed, "sign_payload_hash", lambda *_args, **_kwargs: "sig")
+    monkeypatch.setattr(trustlog_signed, "public_key_fingerprint", lambda _path: "fp")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", str(tmp_path / "tp.jsonl"))
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
+
+    original_append_line = trustlog_signed._append_line
+
+    def _append_line_fail_for_anchor(path, line):
+        if str(path).endswith("tp.jsonl"):
+            raise OSError("anchor fs readonly")
+        original_append_line(path, line)
+
+    monkeypatch.setattr(trustlog_signed, "_append_line", _append_line_fail_for_anchor)
+
+    with pytest.raises(trustlog_signed.SignedTrustLogWriteError):
+        trustlog_signed.append_signed_decision({"request_id": "req-anchor-hard-fail"})


### PR DESCRIPTION
### Motivation
- Implement Improvement Roadmap #8 by adding an optional transparency-log anchoring mechanism so TrustLog chain hashes can be externally anchored to improve tamper-resistance.
- Note that transparency anchoring is best-effort by default and must be configured with immutable/append-only storage and `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED=1` for fail-closed behavior to preserve strict audit integrity.

### Description
- Added `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` resolution via `_transparency_log_path()` and a strict mode toggle `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` via `_transparency_required_enabled()` in `veritas_os/audit/trustlog_signed.py`.
- Implemented `_append_transparency_anchor()` and integrated transparency anchor writes into `append_signed_decision()` with fail-closed behavior when required, and attached `transparency_anchor` status to returned entries.
- Extended `verify_trustlog_chain()` to report transparency anchor configuration and status, and updated `docs/reviews/technical_dd_review_ja_20260314.md` to mark roadmap #8 as addressed.
- Added unit tests in `veritas_os/tests/test_trustlog_signed.py` for successful anchor append and for required-mode fail-closed behavior, and ensured changes adhere to PEP8.

### Testing
- Ran `pytest -q veritas_os/tests/test_trustlog_signed.py` and the test suite passed with `4 passed`.
- The changes are committed and include tests that exercise both best-effort and fail-closed transparency anchor modes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b568a8aea08326ba2c6b96a9f5b72f)