### PR TITLE
Add safety calibration report generator (Roadmap #10)

### DIFF
--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -141,6 +141,7 @@
 - ✅ #7 対応: `/v1/fuji/validate` にガバナンス境界ガードを追加し、`VERITAS_ENABLE_DIRECT_FUJI_API=1` を明示設定しない限り `403` で拒否（標準経路 `/v1/decide` 利用を強制）。
 - ✅ #8 対応: TrustLog チェーンハッシュを外部連携可能な Transparency log へアンカーする仕組みを追加（`VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH`）。必須化は `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED=1` で fail-closed 運用可能。
 - ✅ #9 対応: Replay スナップショットに `external_dependency_versions`（Python実行環境・主要依存パッケージ版本）を記録し、Replay レポート `meta` へ証跡を出力するよう改善。
+- ✅ #10 対応: Safety判定のキャリブレーション自動レポート生成スクリプト `scripts/quality/generate_safety_calibration_report.py` を追加。JSONL評価データから Brier score / ECE / バケット別乖離を JSON+Markdown で出力し、入力不足時は `SECURITY WARNING` で失敗する fail-closed 監視を実装。
 
 ## 17. Final Verdict
 - **B. serious engineering foundation**

--- a/scripts/quality/generate_safety_calibration_report.py
+++ b/scripts/quality/generate_safety_calibration_report.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Generate a safety-model calibration report from labeled decision records.
+
+The report is intended to operationalize roadmap item #10 by producing
+machine-readable and human-readable calibration evidence:
+- Brier score
+- Expected calibration error (ECE)
+- Per-bucket confidence vs. empirical unsafe rate
+
+Input format:
+- JSONL file where each line is a JSON object.
+- Predicted risk can be provided by one of:
+  - ``predicted_risk``
+  - ``risk``
+  - ``fuji.risk``
+- Ground truth unsafe label can be provided by one of:
+  - ``actual_unsafe`` (bool/int/"true"/"false")
+  - ``label`` ("unsafe"/"safe")
+
+Security note:
+- This tool does not perform PII masking; avoid feeding raw sensitive payloads.
+  Use redacted datasets to reduce compliance risk.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CalibrationBin:
+    """One calibration bucket summary."""
+
+    index: int
+    sample_count: int
+    avg_predicted_risk: float
+    empirical_unsafe_rate: float
+    absolute_gap: float
+
+
+@dataclass(frozen=True)
+class CalibrationReport:
+    """Top-level calibration metrics for safety predictions."""
+
+    generated_at: str
+    source_path: str
+    total_samples: int
+    positive_rate: float
+    brier_score: float
+    expected_calibration_error: float
+    bins: list[CalibrationBin]
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate safety calibration report from labeled JSONL records.",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to JSONL file with predicted risk and actual labels.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("audit") / "reports" / "safety_calibration_report.json",
+        help="Output path for machine-readable JSON report.",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("audit") / "reports" / "safety_calibration_report.md",
+        help="Output path for Markdown summary report.",
+    )
+    parser.add_argument(
+        "--bins",
+        type=int,
+        default=10,
+        help="Number of equally spaced bins for ECE calculation.",
+    )
+    return parser.parse_args(argv)
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if result < 0.0 or result > 1.0:
+        return None
+    return result
+
+
+def _to_label(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int) and value in (0, 1):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "unsafe", "positive"}:
+            return 1
+        if lowered in {"0", "false", "safe", "negative"}:
+            return 0
+    return None
+
+
+def _extract_predicted_risk(record: dict[str, Any]) -> float | None:
+    direct = _safe_float(record.get("predicted_risk"))
+    if direct is not None:
+        return direct
+
+    fallback = _safe_float(record.get("risk"))
+    if fallback is not None:
+        return fallback
+
+    fuji = record.get("fuji")
+    if isinstance(fuji, dict):
+        return _safe_float(fuji.get("risk"))
+    return None
+
+
+def _extract_actual_label(record: dict[str, Any]) -> int | None:
+    label = _to_label(record.get("actual_unsafe"))
+    if label is not None:
+        return label
+
+    return _to_label(record.get("label"))
+
+
+def _load_samples(path: Path) -> list[tuple[float, int]]:
+    samples: list[tuple[float, int]] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+
+        risk = _extract_predicted_risk(payload)
+        label = _extract_actual_label(payload)
+        if risk is None or label is None:
+            continue
+        samples.append((risk, label))
+    return samples
+
+
+def _compute_brier_score(samples: list[tuple[float, int]]) -> float:
+    if not samples:
+        return 0.0
+    return sum((pred - label) ** 2 for pred, label in samples) / len(samples)
+
+
+def _compute_bins(samples: list[tuple[float, int]], n_bins: int) -> list[CalibrationBin]:
+    buckets: list[list[tuple[float, int]]] = [[] for _ in range(n_bins)]
+    for pred, label in samples:
+        idx = min(int(pred * n_bins), n_bins - 1)
+        buckets[idx].append((pred, label))
+
+    results: list[CalibrationBin] = []
+    for idx, bucket in enumerate(buckets):
+        if not bucket:
+            continue
+        count = len(bucket)
+        avg_pred = sum(pred for pred, _ in bucket) / count
+        emp_rate = sum(label for _, label in bucket) / count
+        gap = abs(avg_pred - emp_rate)
+        results.append(
+            CalibrationBin(
+                index=idx,
+                sample_count=count,
+                avg_predicted_risk=avg_pred,
+                empirical_unsafe_rate=emp_rate,
+                absolute_gap=gap,
+            )
+        )
+    return results
+
+
+def _compute_ece(bins: list[CalibrationBin], total_count: int) -> float:
+    if total_count <= 0:
+        return 0.0
+    return sum((item.sample_count / total_count) * item.absolute_gap for item in bins)
+
+
+def _build_report(samples: list[tuple[float, int]], source_path: Path, n_bins: int) -> CalibrationReport:
+    total = len(samples)
+    bins = _compute_bins(samples, n_bins=n_bins)
+    positives = sum(label for _, label in samples)
+    positive_rate = (positives / total) if total else 0.0
+    return CalibrationReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        source_path=str(source_path),
+        total_samples=total,
+        positive_rate=positive_rate,
+        brier_score=_compute_brier_score(samples),
+        expected_calibration_error=_compute_ece(bins, total_count=total),
+        bins=bins,
+    )
+
+
+def _write_json_report(report: CalibrationReport, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = asdict(report)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _write_markdown_report(report: CalibrationReport, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Safety Calibration Report",
+        "",
+        f"- Generated at: `{report.generated_at}`",
+        f"- Source: `{report.source_path}`",
+        f"- Total samples: **{report.total_samples}**",
+        f"- Positive (unsafe) rate: **{report.positive_rate:.3f}**",
+        f"- Brier score: **{report.brier_score:.4f}**",
+        (
+            "- Expected calibration error (ECE): "
+            f"**{report.expected_calibration_error:.4f}**"
+        ),
+        "",
+        "## Bucket Details",
+        "",
+        "| Bin | Samples | Avg predicted risk | Empirical unsafe rate | Gap |",
+        "|---:|---:|---:|---:|---:|",
+    ]
+
+    for item in report.bins:
+        lines.append(
+            "| "
+            f"{item.index} | {item.sample_count} | {item.avg_predicted_risk:.3f} "
+            f"| {item.empirical_unsafe_rate:.3f} | {item.absolute_gap:.3f} |"
+        )
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _validate_args(parsed: argparse.Namespace) -> None:
+    if parsed.bins <= 1:
+        raise ValueError("--bins must be greater than 1")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parsed = _parse_args(argv or sys.argv[1:])
+
+    try:
+        _validate_args(parsed)
+    except ValueError as exc:
+        print(f"ERROR: {exc}")
+        return 2
+
+    input_path = parsed.input.resolve(strict=False)
+    if not input_path.exists():
+        print(f"ERROR: input file does not exist: {input_path}")
+        return 2
+
+    samples = _load_samples(input_path)
+    if not samples:
+        print(
+            "SECURITY WARNING: no valid labeled samples were loaded. "
+            "Calibration is not measurable; safety drift may go undetected."
+        )
+        return 1
+
+    report = _build_report(samples, source_path=input_path, n_bins=parsed.bins)
+    _write_json_report(report, parsed.output_json)
+    _write_markdown_report(report, parsed.output_md)
+
+    print(
+        "Generated safety calibration report: "
+        f"samples={report.total_samples}, "
+        f"brier={report.brier_score:.4f}, "
+        f"ece={report.expected_calibration_error:.4f}"
+    )
+    print(f"JSON: {parsed.output_json}")
+    print(f"MD: {parsed.output_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_generate_safety_calibration_report.py
+++ b/veritas_os/tests/test_generate_safety_calibration_report.py
@@ -1,0 +1,104 @@
+"""Tests for scripts.quality.generate_safety_calibration_report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.quality import generate_safety_calibration_report as report
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    """Write newline-delimited JSON fixtures."""
+    lines = [json.dumps(item, ensure_ascii=False) for item in records]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_load_samples_accepts_multiple_supported_shapes(tmp_path: Path) -> None:
+    """Loader should parse supported risk and label field variants."""
+    input_path = tmp_path / "samples.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {"predicted_risk": 0.9, "actual_unsafe": True},
+            {"risk": 0.2, "label": "safe"},
+            {"fuji": {"risk": 0.7}, "actual_unsafe": 1},
+            {"predicted_risk": 1.2, "actual_unsafe": True},
+            {"predicted_risk": 0.5, "label": "unknown"},
+        ],
+    )
+
+    samples = report._load_samples(input_path)
+
+    assert samples == [(0.9, 1), (0.2, 0), (0.7, 1)]
+
+
+def test_main_generates_json_and_markdown_reports(tmp_path: Path, capsys) -> None:
+    """Main should produce both report formats for valid samples."""
+    input_path = tmp_path / "samples.jsonl"
+    output_json = tmp_path / "out" / "calibration.json"
+    output_md = tmp_path / "out" / "calibration.md"
+    _write_jsonl(
+        input_path,
+        [
+            {"predicted_risk": 0.8, "actual_unsafe": 1},
+            {"predicted_risk": 0.2, "actual_unsafe": 0},
+            {"predicted_risk": 0.6, "actual_unsafe": 1},
+            {"predicted_risk": 0.3, "actual_unsafe": 0},
+        ],
+    )
+
+    code = report.main(
+        [
+            "--input",
+            str(input_path),
+            "--output-json",
+            str(output_json),
+            "--output-md",
+            str(output_md),
+            "--bins",
+            "5",
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "Generated safety calibration report" in output
+    assert output_json.exists()
+    assert output_md.exists()
+
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["total_samples"] == 4
+    assert payload["brier_score"] >= 0.0
+    assert payload["expected_calibration_error"] >= 0.0
+
+    markdown = output_md.read_text(encoding="utf-8")
+    assert "# Safety Calibration Report" in markdown
+    assert "| Bin | Samples |" in markdown
+
+
+def test_main_returns_security_warning_for_empty_valid_samples(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """No valid records should return non-zero with security warning."""
+    input_path = tmp_path / "empty.jsonl"
+    _write_jsonl(input_path, [{"predicted_risk": "bad", "actual_unsafe": "x"}])
+
+    code = report.main(["--input", str(input_path)])
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert "SECURITY WARNING" in output
+
+
+def test_main_rejects_invalid_bins_argument(tmp_path: Path, capsys) -> None:
+    """Invalid bin count should fail with argument error."""
+    input_path = tmp_path / "samples.jsonl"
+    _write_jsonl(input_path, [{"predicted_risk": 0.5, "actual_unsafe": 1}])
+
+    code = report.main(["--input", str(input_path), "--bins", "1"])
+    output = capsys.readouterr().out
+
+    assert code == 2
+    assert "must be greater than 1" in output


### PR DESCRIPTION
### Motivation
- Implement Improvement Roadmap item #10 to provide automated calibration evidence (Brier score, ECE, per-bin gaps) for safety judgement models to detect calibration drift. 
- Provide a fail-closed operational guard so pipelines/CI do not silently pass when labeled data is missing or invalid. 
- Offer a lightweight CLI tool that can be used by ops/reviewers to produce machine-readable and human-readable calibration artifacts for audits. 

### Description
- Added a CLI script `scripts/quality/generate_safety_calibration_report.py` that reads a JSONL of labeled decision records and emits a JSON report and a Markdown summary with Brier score, Expected Calibration Error (ECE), and per-bin calibration gaps. 
- The script accepts multiple input field shapes (`predicted_risk`, `risk`, `fuji.risk` for predictions and `actual_unsafe`/`label` for ground truth), supports configurable bin counts via `--bins`, and includes a top-level docstring with a PII/security caution. 
- Added unit tests in `veritas_os/tests/test_generate_safety_calibration_report.py` covering loader shape variants, report file generation, CLI argument validation, and the fail-closed behavior when no valid samples exist. 
- Updated `docs/reviews/technical_dd_review_ja_20260314.md` to mark Improvement Roadmap `#10` as addressed. 

### Testing
- Ran the new unit test module with `pytest -q veritas_os/tests/test_generate_safety_calibration_report.py` and all tests passed (`4 passed`). 
- Executed the CLI for a missing input case (`python scripts/quality/generate_safety_calibration_report.py --input /tmp/nonexistent.jsonl`) to verify error handling, which returned the expected error message. 
- No other automated tests were modified; the added tests validate the new functionality and argument/error paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56c112b7c8326b0c98645e174007e)