### PR TITLE
Enforce external secret manager integration in startup config

### DIFF
--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -143,6 +143,7 @@
 - ✅ #9 対応: Replay スナップショットに `external_dependency_versions`（Python実行環境・主要依存パッケージ版本）を記録し、Replay レポート `meta` へ証跡を出力するよう改善。
 - ✅ #10 対応: Safety判定のキャリブレーション自動レポート生成スクリプト `scripts/quality/generate_safety_calibration_report.py` を追加。JSONL評価データから Brier score / ECE / バケット別乖離を JSON+Markdown で出力し、入力不足時は `SECURITY WARNING` で失敗する fail-closed 監視を実装。
 - ✅ #11 対応: STRIDE/LINDDUN ベースの脅威モデル文書 `docs/reviews/THREAT_MODEL_STRIDE_LINDDUN_20260314.md` を追加し、資産・境界・脅威・優先対策・運用ルールを明文化。
+- ✅ #12 対応: Secret 管理を Vault/KMS 前提に統合するため、`VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER=1` 時は `VERITAS_SECRET_PROVIDER`（`vault` / `aws_secrets_manager` / `gcp_secret_manager` / `azure_key_vault` / `kms`）と `VERITAS_API_SECRET_REF` を必須化し、未設定・不正値・ランタイム注入失敗時は起動検証で fail-closed（`ValueError`）となるよう強化。
 
 ## 17. Final Verdict
 - **B. serious engineering foundation**

--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -78,6 +78,11 @@ def _parse_bool(env_key: str, default: bool = False) -> bool:
     return default
 
 
+def _parse_str(env_key: str, default: str = "") -> str:
+    """環境変数から文字列を取得し、前後空白を除去して返す。"""
+    return (os.getenv(env_key, default) or "").strip()
+
+
 # =============================================================================
 # スコアリング設定（kernel.py から外部化）
 # =============================================================================
@@ -304,6 +309,12 @@ class VeritasConfig:
             "",
         )
     )
+    secret_provider: str = field(
+        default_factory=lambda: _parse_str("VERITAS_SECRET_PROVIDER", "")
+    )
+    api_secret_ref: str = field(
+        default_factory=lambda: _parse_str("VERITAS_API_SECRET_REF", "")
+    )
     api_header: str = "X-API-Key"
     api_key: str = ""  # alias
 
@@ -397,6 +408,47 @@ class VeritasConfig:
             "Refusing to start without a configured API secret."
         )
 
+    def validate_secret_manager_integration(self) -> None:
+        """Validate secret manager integration when strict mode is enabled.
+
+        Strict mode is controlled by ``VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER``.
+        When enabled, the deployment must provide both:
+        - ``VERITAS_SECRET_PROVIDER``: the provider identifier
+        - ``VERITAS_API_SECRET_REF``: external secret reference name/path
+
+        Raises:
+            ValueError: When strict mode is on and required metadata is missing.
+        """
+        if not _parse_bool("VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER", False):
+            return
+
+        allowed_providers = {
+            "vault",
+            "aws_secrets_manager",
+            "gcp_secret_manager",
+            "azure_key_vault",
+            "kms",
+        }
+        provider = self.secret_provider.strip().lower()
+        if provider not in allowed_providers:
+            raise ValueError(
+                "VERITAS_SECRET_PROVIDER must be one of "
+                f"{sorted(allowed_providers)} when "
+                "VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER=1."
+            )
+
+        if not self.api_secret_ref:
+            raise ValueError(
+                "VERITAS_API_SECRET_REF must be set when "
+                "VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER=1."
+            )
+
+        if not self.api_secret_configured:
+            raise ValueError(
+                "VERITAS_API_SECRET must be injected at runtime from the configured "
+                "external secret manager."
+            )
+
     @staticmethod
     def should_enforce_api_secret_validation() -> bool:
         """Return whether startup should fail on missing API secret.
@@ -472,6 +524,8 @@ def validate_startup_config() -> None:
     """
     if cfg.should_enforce_api_secret_validation():
         cfg.validate_api_secret_non_empty()
+
+    cfg.validate_secret_manager_integration()
 
 
 # サブ設定インスタンス（各モジュールからインポート可能）

--- a/veritas_os/tests/test_config_coverage.py
+++ b/veritas_os/tests/test_config_coverage.py
@@ -18,6 +18,7 @@ from veritas_os.core.config import (
     _parse_cors_origins,
     _parse_float,
     _parse_int,
+    _parse_str,
     ScoringConfig,
     FujiConfig,
     PipelineConfig,
@@ -150,6 +151,21 @@ def test_parse_bool_invalid_logs_warning(monkeypatch, caplog):
 
     assert _parse_bool("TEST_BOOL_KEY", True) is True
     assert "Invalid bool for TEST_BOOL_KEY" in caplog.text
+
+
+# ============================================================
+# _parse_str
+# ============================================================
+
+
+def test_parse_str_default(monkeypatch):
+    monkeypatch.delenv("TEST_STR_KEY", raising=False)
+    assert _parse_str("TEST_STR_KEY", "default") == "default"
+
+
+def test_parse_str_trim(monkeypatch):
+    monkeypatch.setenv("TEST_STR_KEY", "  value  ")
+    assert _parse_str("TEST_STR_KEY") == "value"
 
 
 # ============================================================
@@ -376,3 +392,51 @@ def test_should_enforce_api_secret_validation_disabled(monkeypatch):
     monkeypatch.setenv("VERITAS_ENFORCE_API_SECRET", "0")
     monkeypatch.setenv("VERITAS_ENFORCE_API_SECRET_IN_TESTS", "1")
     assert VeritasConfig.should_enforce_api_secret_validation() is False
+
+
+def test_validate_secret_manager_integration_disabled_by_default():
+    cfg = VeritasConfig(api_secret="real_secret_123")
+    cfg.validate_secret_manager_integration()
+
+
+def test_validate_secret_manager_integration_requires_valid_provider(monkeypatch):
+    monkeypatch.setenv("VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER", "1")
+    cfg = VeritasConfig(
+        api_secret="real_secret_123",
+        secret_provider="invalid_provider",
+        api_secret_ref="path/to/secret",
+    )
+    with pytest.raises(ValueError, match="VERITAS_SECRET_PROVIDER"):
+        cfg.validate_secret_manager_integration()
+
+
+def test_validate_secret_manager_integration_requires_secret_ref(monkeypatch):
+    monkeypatch.setenv("VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER", "1")
+    cfg = VeritasConfig(
+        api_secret="real_secret_123",
+        secret_provider="vault",
+        api_secret_ref="",
+    )
+    with pytest.raises(ValueError, match="VERITAS_API_SECRET_REF"):
+        cfg.validate_secret_manager_integration()
+
+
+def test_validate_secret_manager_integration_requires_runtime_secret(monkeypatch):
+    monkeypatch.setenv("VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER", "1")
+    cfg = VeritasConfig(
+        api_secret="",
+        secret_provider="vault",
+        api_secret_ref="secret/veritas/api",
+    )
+    with pytest.raises(ValueError, match="VERITAS_API_SECRET"):
+        cfg.validate_secret_manager_integration()
+
+
+def test_validate_secret_manager_integration_accepts_supported_provider(monkeypatch):
+    monkeypatch.setenv("VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER", "1")
+    cfg = VeritasConfig(
+        api_secret="real_secret_123",
+        secret_provider="aws_secrets_manager",
+        api_secret_ref="prod/veritas/api_secret",
+    )
+    cfg.validate_secret_manager_integration()


### PR DESCRIPTION
### Motivation
- Close Improvement Roadmap #12 by preventing fail-open secret misconfiguration and requiring external secret manager metadata when strict mode is enabled. 
- Ensure startup validation can fail-closed when operator config intends secret management via Vault/KMS to avoid running with missing or incorrect secrets.

### Description
- Added helper `_parse_str` to normalise environment string values and added `secret_provider` and `api_secret_ref` fields to `VeritasConfig` to expose `VERITAS_SECRET_PROVIDER` and `VERITAS_API_SECRET_REF` configuration. 
- Implemented `validate_secret_manager_integration()` which, when `VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER=1`, enforces a supported provider (`vault`, `aws_secrets_manager`, `gcp_secret_manager`, `azure_key_vault`, `kms`), requires `VERITAS_API_SECRET_REF`, and requires a runtime-injected `VERITAS_API_SECRET` (fail-closed on violations). 
- Wired the new validation into `validate_startup_config()` so it runs during server startup checks. 
- Added unit tests covering `_parse_str` and the new secret-manager validation failure and success cases, and updated the technical review document to mark Roadmap #12 as addressed.

### Testing
- Ran `pytest -q veritas_os/tests/test_config_coverage.py -k "parse_str or secret_manager_integration"` which returned `7 passed, 44 deselected`.
- Ran `pytest -q veritas_os/tests/test_config_coverage.py` which returned `51 passed`.
- All added tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5760d462c83269739eb0ffa7a80ca)