### PR TITLE
Add TrustLog field-level data classification metadata (Roadmap #13)

### DIFF
--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -144,6 +144,7 @@
 - ✅ #10 対応: Safety判定のキャリブレーション自動レポート生成スクリプト `scripts/quality/generate_safety_calibration_report.py` を追加。JSONL評価データから Brier score / ECE / バケット別乖離を JSON+Markdown で出力し、入力不足時は `SECURITY WARNING` で失敗する fail-closed 監視を実装。
 - ✅ #11 対応: STRIDE/LINDDUN ベースの脅威モデル文書 `docs/reviews/THREAT_MODEL_STRIDE_LINDDUN_20260314.md` を追加し、資産・境界・脅威・優先対策・運用ルールを明文化。
 - ✅ #12 対応: Secret 管理を Vault/KMS 前提に統合するため、`VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER=1` 時は `VERITAS_SECRET_PROVIDER`（`vault` / `aws_secrets_manager` / `gcp_secret_manager` / `azure_key_vault` / `kms`）と `VERITAS_API_SECRET_REF` を必須化し、未設定・不正値・ランタイム注入失敗時は起動検証で fail-closed（`ValueError`）となるよう強化。
+- ✅ #13 対応: TrustLog エントリへ `_data_classification`（schema_version/contains_pii/contains_secret/fields）を追加し、`request_id` 等の識別子・PII・secret を項目単位で自動分類して監査証跡へ記録するよう改善。
 
 ## 17. Final Verdict
 - **B. serious engineering foundation**

--- a/veritas_os/logging/redact.py
+++ b/veritas_os/logging/redact.py
@@ -86,6 +86,27 @@ try:
 except (ImportError, AttributeError):
     _mask_pii = None  # type: ignore[assignment]
 
+try:
+    from veritas_os.core.sanitize import detect_pii as _detect_pii
+except (ImportError, AttributeError):
+    _detect_pii = None  # type: ignore[assignment]
+
+
+_CLASSIFICATION_FIELD = "_data_classification"
+_CLASS_PUBLIC = "public"
+_CLASS_IDENTIFIER = "identifier"
+_CLASS_PII = "pii"
+_CLASS_SECRET = "secret"
+
+_IDENTIFIER_FIELDS = frozenset({
+    "request_id",
+    "decision_id",
+    "user_id",
+    "session_id",
+    "tenant_id",
+    "trace_id",
+})
+
 
 def _redact_secrets(text: str) -> str:
     """Replace API keys, bearer tokens, and secret-like strings in *text*."""
@@ -106,6 +127,89 @@ def _redact_string(value: str) -> str:
     if _mask_pii is not None:
         result = _mask_pii(result)
     return result
+
+
+def _contains_secret(value: str) -> bool:
+    """Return True when *value* matches known secret/token patterns."""
+    return bool(
+        _RE_BEARER.search(value)
+        or _RE_API_KEY.search(value)
+        or _RE_SECRET_KV.search(value)
+        or _RE_SECRET_HEX.search(value)
+        or _RE_SECRET_B64.search(value)
+    )
+
+
+def _contains_pii(value: str) -> bool:
+    """Return True when PII markers are detected in *value*."""
+    if _detect_pii is None:
+        return False
+    try:
+        return len(_detect_pii(value)) > 0
+    except (ValueError, TypeError):
+        logger.warning("PII classification failed for trust-log field", exc_info=True)
+        return False
+
+
+def _classify_scalar(field_name: str, value: Any) -> str:
+    """Classify a scalar value for audit metadata."""
+    if field_name in _IDENTIFIER_FIELDS:
+        return _CLASS_IDENTIFIER
+    if not isinstance(value, str):
+        return _CLASS_PUBLIC
+    if _contains_secret(value):
+        return _CLASS_SECRET
+    if _contains_pii(value):
+        return _CLASS_PII
+    return _CLASS_PUBLIC
+
+
+def _collect_field_classification(
+    value: Any,
+    *,
+    path: str,
+    field_map: Dict[str, str],
+) -> None:
+    """Collect per-field classification labels recursively."""
+    if isinstance(value, dict):
+        for child_key, child_value in value.items():
+            child_path = f"{path}.{child_key}" if path else str(child_key)
+            _collect_field_classification(
+                child_value,
+                path=child_path,
+                field_map=field_map,
+            )
+        return
+
+    if isinstance(value, list):
+        for idx, item in enumerate(value):
+            child_path = f"{path}[{idx}]"
+            _collect_field_classification(
+                item,
+                path=child_path,
+                field_map=field_map,
+            )
+        return
+
+    field_name = path.split(".")[-1] if path else ""
+    field_map[path] = _classify_scalar(field_name, value)
+
+
+def _build_data_classification(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Build data-classification metadata for a TrustLog entry."""
+    field_map: Dict[str, str] = {}
+    for key, value in entry.items():
+        if key == _CLASSIFICATION_FIELD:
+            continue
+        _collect_field_classification(value, path=key, field_map=field_map)
+
+    labels = set(field_map.values())
+    return {
+        "schema_version": "1.0",
+        "fields": field_map,
+        "contains_pii": _CLASS_PII in labels,
+        "contains_secret": _CLASS_SECRET in labels,
+    }
 
 
 def _redact_value(value: Any) -> Any:
@@ -132,12 +236,14 @@ def redact_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         A **new** dict with sensitive values replaced by placeholders.
     """
+    classification = _build_data_classification(entry)
     result: Dict[str, Any] = {}
     for key, value in entry.items():
         if key in _STRUCTURAL_FIELDS:
             result[key] = value
         else:
             result[key] = _redact_value(value)
+    result[_CLASSIFICATION_FIELD] = classification
     return result
 
 

--- a/veritas_os/tests/test_secure_trustlog.py
+++ b/veritas_os/tests/test_secure_trustlog.py
@@ -110,6 +110,29 @@ class TestPIIRedaction:
         assert "sk-1234567890abcdef1234567890" not in safe["query"]
 
 
+    def test_data_classification_includes_pii_and_identifier(self):
+        """Classification metadata should tag identifier and PII fields."""
+        safe = redact_entry({
+            "request_id": "r100",
+            "query": "user@example.com",
+        })
+        classification = safe["_data_classification"]
+        assert classification["contains_pii"] is True
+        assert classification["contains_secret"] is False
+        assert classification["fields"]["request_id"] == "identifier"
+        assert classification["fields"]["query"] == "pii"
+
+    def test_data_classification_includes_secret(self):
+        """Classification metadata should tag secret-bearing fields."""
+        safe = redact_entry({
+            "request_id": "r101",
+            "config": "api_secret=TopSecret123456",
+        })
+        classification = safe["_data_classification"]
+        assert classification["contains_secret"] is True
+        assert classification["fields"]["config"] == "secret"
+
+
 # ---------------------------------------------------------------------------
 # 2. Stored file is NOT plaintext JSON
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Implement Improvement Roadmap item #13 to record per-field data classification in TrustLog entries for improved auditability and compliance. 
- Provide a lightweight, schema-versioned `_data_classification` metadata blob that flags `contains_pii` / `contains_secret` and a `fields` map of field-path → classification. 
- Preserve secure-by-default behavior by performing redaction before hashing/encryption while also surfacing classification metadata to help operators triage sensitive records. 
- Security warning: recording field paths can leak information if key names themselves contain sensitive data, so key naming conventions and access controls must be enforced. 

### Description
- Added field-level classification to TrustLog redaction output by extending `veritas_os/logging/redact.py` to build `_data_classification` with `schema_version`, `contains_pii`, `contains_secret`, and a `fields` map of field-paths to labels (`public`, `identifier`, `pii`, `secret`). 
- Integrated optional PII detection via `detect_pii` from `veritas_os.core.sanitize` with safe fallback when unavailable, and added secret-detection helpers to classify strings. 
- Classification is collected recursively for nested dicts/lists and the metadata is attached to the redacted entry in `redact_entry`. 
- Added unit tests in `veritas_os/tests/test_secure_trustlog.py` to verify PII/identifier/secret classification behavior and updated `docs/reviews/technical_dd_review_ja_20260314.md` to mark roadmap #13 as completed. 

### Testing
- Ran targeted tests with `pytest -q veritas_os/tests/test_secure_trustlog.py::TestPIIRedaction::test_data_classification_includes_pii_and_identifier veritas_os/tests/test_secure_trustlog.py::TestPIIRedaction::test_data_classification_includes_secret veritas_os/tests/test_secure_trustlog.py::TestPIIRedaction::test_redact_entry_standalone` which returned `3 passed`.
- Ran the full TrustLog secure tests with `pytest -q veritas_os/tests/test_secure_trustlog.py` which returned `23 passed`.
- All new tests passed locally and the redaction pipeline continues to redact values before hashing/encryption as part of the secure-by-default flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5785f6bd88326833ac28d0cba6cea)