### PR TITLE
Implement roadmap #16–#20: risk-weighted coverage, OpenAPI checks, PROV export, governance RBAC/ABAC, realtime alerts

### DIFF
--- a/docs/reviews/technical_dd_review_ja_20260314.md
+++ b/docs/reviews/technical_dd_review_ja_20260314.md
@@ -148,6 +148,12 @@
 - ✅ #14 対応: 分散ロック/認証ストア一貫性の **chaos テスト** を追加（`veritas_os/tests/test_auth_store_consistency_chaos.py`）。共有 Redis 相当バックエンドを模擬し、ワーカー跨ぎ nonce 再利用拒否・分散レート制限の整合性・障害時 fail-open/fail-closed ポリシーを検証。
 - ✅ #15 対応: Safety regression suite（敵対プロンプト）を拡充し、`llm_safety` の難読化攻撃（leet/記号分割）検知テストを追加。`k1ll` や `h a c k` のような入力でも決定論ヒューリスティックで `illicit` 判定となることを検証。
 
+- ✅ #16 対応: `veritas_os/tools/coverage_map_pipeline.py` に `--risk-weights` を追加し、オーナー単位の未カバレッジ行を重み付けした `risk_weighted_missing_ratio` を算出可能に改善（機能リスク重み付きカバレッジ指標）。
+- ✅ #17 対応: OpenAPI と実装差分の検証を強化し、`veritas_os/tests/test_openapi_spec.py` で **実ランタイムの重要経路**（governance/trustlog/prov）と `openapi.yaml` の整合性を自動検証するよう改善。
+- ✅ #18 対応: Decision trace の W3C PROV 輸出 API `GET /v1/trust/{request_id}/prov` を追加。監査ツール連携向けに PROV-JSON 形式（entity/activity/agent/wasGeneratedBy）を返却。
+- ✅ #19 対応: API 層に governance 管理系向け RBAC/ABAC ガード `require_governance_access` を追加。`X-Role` によるロール制御と `VERITAS_GOVERNANCE_TENANT_ID` による tenant 属性制約を実装。
+- ✅ #20 対応: 重要設定（`fuji_rules`/`risk_thresholds`/`auto_stop`）変更時に `governance.alert` SSE イベントを発火するリアルタイムアラートを追加し、運用検知を強化。
+
 ## 17. Final Verdict
 - **B. serious engineering foundation**
 - 研究プロトタイプを超える実装密度はあるが、production-grade governance infrastructure を名乗るには fail-closed / 外部不変監査 / 組織的承認制御が未充足。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1199,6 +1199,25 @@ paths:
                 type: object
                 additionalProperties: true
 
+
+  /v1/trust/{request_id}/prov:
+    get:
+      summary: Decision trace export as W3C PROV JSON
+      parameters:
+        - in: path
+          name: request_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: PROV export payload
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+
   /v1/events:
     get:
       summary: SSE event stream
@@ -1225,6 +1244,17 @@ paths:
   /v1/governance/value-drift:
     get:
       summary: Value drift metrics
+      parameters:
+        - in: header
+          name: X-Role
+          required: false
+          schema:
+            type: string
+        - in: header
+          name: X-Tenant-Id
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: Value drift data
@@ -1237,6 +1267,17 @@ paths:
   /v1/governance/policy:
     get:
       summary: Governance policy read
+      parameters:
+        - in: header
+          name: X-Role
+          required: false
+          schema:
+            type: string
+        - in: header
+          name: X-Tenant-Id
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: Governance policy
@@ -1246,6 +1287,17 @@ paths:
                 $ref: '#/components/schemas/GovernancePolicyResponse'
     put:
       summary: Governance policy update
+      parameters:
+        - in: header
+          name: X-Role
+          required: false
+          schema:
+            type: string
+        - in: header
+          name: X-Tenant-Id
+          required: false
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -1263,6 +1315,17 @@ paths:
   /v1/governance/policy/history:
     get:
       summary: Governance policy change history
+      parameters:
+        - in: header
+          name: X-Role
+          required: false
+          schema:
+            type: string
+        - in: header
+          name: X-Tenant-Id
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: Policy change history

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -65,6 +65,7 @@ from veritas_os.compliance.report_engine import (
     generate_eu_ai_act_report,
     generate_internal_governance_report,
 )
+from veritas_os.reporting.exporters import build_w3c_prov_document
 from veritas_os.replay.replay_engine import run_replay
 from veritas_os.api.constants import (
     DECISION_ALLOW,
@@ -3189,11 +3190,127 @@ def trustlog_export() -> Dict[str, Any]:
         )
 
 
+@app.get("/v1/trust/{request_id}/prov", dependencies=[Depends(require_api_key), Depends(enforce_rate_limit)])
+def trust_prov_export(request_id: str) -> Dict[str, Any]:
+    """Export one decision trace as W3C PROV JSON for external audit tooling."""
+    try:
+        entries = get_trust_logs_by_request(request_id)
+        if not entries:
+            return JSONResponse(
+                status_code=404,
+                content={"ok": False, "error": "trust trace not found"},
+            )
+
+        latest = entries[-1]
+        prov = build_w3c_prov_document(
+            request_id=request_id,
+            decision_status=str(latest.get("decision_status") or latest.get("status") or "unknown"),
+            risk=_parse_risk_from_trust_entry(latest),
+            timestamp=str(latest.get("ts") or latest.get("timestamp") or utc_now_iso_z()),
+            actor=_prov_actor_for_entry(latest),
+        )
+        return {"ok": True, "request_id": request_id, "prov": prov}
+    except Exception as e:
+        logger.error("trust_prov_export failed: %s", e)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": "Failed to export PROV trace"},
+        )
+
+
+
+def _governance_rbac_enabled() -> bool:
+    """Return True when governance RBAC/ABAC guard is enabled."""
+    return (os.getenv("VERITAS_GOVERNANCE_ENFORCE_RBAC", "1").strip().lower()
+            not in {"0", "false", "no", "off"})
+
+
+def _resolve_governance_allowed_roles() -> set[str]:
+    """Resolve allowed governance roles from env or safe defaults."""
+    raw = (os.getenv("VERITAS_GOVERNANCE_ALLOWED_ROLES") or "admin,compliance_owner").strip()
+    roles = {item.strip().lower() for item in raw.split(",") if item.strip()}
+    return roles or {"admin", "compliance_owner"}
+
+
+def require_governance_access(
+    x_role: Optional[str] = Header(default=None, alias="X-Role"),
+    x_tenant_id: Optional[str] = Header(default=None, alias="X-Tenant-Id"),
+) -> bool:
+    """Enforce governance RBAC/ABAC constraints for admin endpoints.
+
+    Security warning:
+        If ``VERITAS_GOVERNANCE_ENFORCE_RBAC=0`` this guard is disabled and
+        governance APIs rely only on API-key authentication.
+    """
+    if not _governance_rbac_enabled():
+        logger.warning(
+            "SECURITY WARNING: governance RBAC/ABAC is disabled by "
+            "VERITAS_GOVERNANCE_ENFORCE_RBAC=0"
+        )
+        return True
+
+    role = (x_role or "").strip().lower()
+    if role not in _resolve_governance_allowed_roles():
+        raise HTTPException(status_code=403, detail="Insufficient governance role")
+
+    expected_tenant = (os.getenv("VERITAS_GOVERNANCE_TENANT_ID") or "").strip()
+    if expected_tenant and (x_tenant_id or "").strip() != expected_tenant:
+        raise HTTPException(status_code=403, detail="Tenant scope mismatch")
+
+    return True
+
+
+def _emit_governance_change_alert(previous: Dict[str, Any], updated: Dict[str, Any]) -> None:
+    """Emit a realtime alert event when high-impact governance settings change."""
+    critical_keys = ("fuji_rules", "risk_thresholds", "auto_stop")
+    changed = [key for key in critical_keys if previous.get(key) != updated.get(key)]
+    if not changed:
+        return
+
+    _publish_event(
+        "governance.alert",
+        {
+            "severity": "high",
+            "changed_fields": changed,
+            "updated_by": updated.get("updated_by", "api"),
+        },
+    )
+
+
+def _parse_risk_from_trust_entry(entry: Dict[str, Any]) -> float | None:
+    """Extract risk score from trust-log payload in a backward compatible way."""
+    if not isinstance(entry, dict):
+        return None
+
+    candidates = (
+        entry.get("risk"),
+        (entry.get("gate") or {}).get("risk") if isinstance(entry.get("gate"), dict) else None,
+        (entry.get("fuji") or {}).get("risk") if isinstance(entry.get("fuji"), dict) else None,
+    )
+    for item in candidates:
+        try:
+            if item is None:
+                continue
+            return float(item)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _prov_actor_for_entry(entry: Dict[str, Any]) -> str:
+    """Resolve PROV agent label from trust entry metadata."""
+    for key in ("updated_by", "actor", "user_id", "request_user_id"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "veritas_api"
+
+
 # ==============================
 # Governance Policy API
 # ==============================
 
-@app.get("/v1/governance/value-drift", dependencies=[Depends(require_api_key)])
+@app.get("/v1/governance/value-drift", dependencies=[Depends(require_api_key), Depends(require_governance_access)])
 def governance_value_drift(telos_baseline: float = Query(default=0.5, ge=0.0, le=1.0)):
     """Return ValueCore drift metrics against a Telos baseline."""
     try:
@@ -3207,7 +3324,7 @@ def governance_value_drift(telos_baseline: float = Query(default=0.5, ge=0.0, le
         )
 
 
-@app.get("/v1/governance/policy", dependencies=[Depends(require_api_key)])
+@app.get("/v1/governance/policy", dependencies=[Depends(require_api_key), Depends(require_governance_access)])
 def governance_get():
     """Return the current governance policy."""
     try:
@@ -3221,16 +3338,18 @@ def governance_get():
         )
 
 
-@app.put("/v1/governance/policy", dependencies=[Depends(require_api_key)])
+@app.put("/v1/governance/policy", dependencies=[Depends(require_api_key), Depends(require_governance_access)])
 def governance_put(body: dict):
     """Update the governance policy (partial merge)."""
     try:
         enforce_four_eyes_approval(body)
+        previous = get_policy()
         updated = update_policy(body)
         _publish_event(
             "governance.updated",
             {"updated_by": updated.get("updated_by", "api")},
         )
+        _emit_governance_change_alert(previous=previous, updated=updated)
         return {"ok": True, "policy": updated}
     except PermissionError as e:
         logger.warning("governance_put rejected: %s", e)
@@ -3246,7 +3365,7 @@ def governance_put(body: dict):
         )
 
 
-@app.get("/v1/governance/policy/history", dependencies=[Depends(require_api_key)])
+@app.get("/v1/governance/policy/history", dependencies=[Depends(require_api_key), Depends(require_governance_access)])
 def governance_policy_history(limit: int = Query(default=50, ge=1, le=500)):
     """Return recent governance policy change history (newest first).
 

--- a/veritas_os/reporting/exporters.py
+++ b/veritas_os/reporting/exporters.py
@@ -9,6 +9,68 @@ from typing import Any, Dict
 from veritas_os.core.atomic_io import atomic_write_json
 
 
+def build_w3c_prov_document(
+    *,
+    request_id: str,
+    decision_status: str,
+    risk: float | None,
+    timestamp: str,
+    actor: str,
+    source: str = "veritas_os.pipeline",
+) -> Dict[str, Any]:
+    """Build a compact W3C PROV JSON document for one decision trace.
+
+    The output follows PROV-JSON style keys so audit systems can ingest the
+    decision lineage without binding to internal VERITAS schemas.
+    """
+    risk_value = 0.0 if risk is None else max(0.0, min(1.0, float(risk)))
+    activity_id = f"activity:decision:{request_id}"
+    entity_id = f"entity:decision:{request_id}"
+    agent_id = f"agent:{actor or 'unknown'}"
+
+    return {
+        "prefix": {
+            "prov": "http://www.w3.org/ns/prov#",
+            "veritas": "https://veritas-os.example/ns#",
+        },
+        "entity": {
+            entity_id: {
+                "prov:type": "veritas:Decision",
+                "veritas:request_id": request_id,
+                "veritas:decision_status": decision_status,
+                "veritas:risk": risk_value,
+                "prov:generatedAtTime": timestamp,
+                "veritas:source": source,
+            }
+        },
+        "activity": {
+            activity_id: {
+                "prov:type": "veritas:DecisionEvaluation",
+                "prov:startedAtTime": timestamp,
+                "prov:endedAtTime": timestamp,
+            }
+        },
+        "agent": {
+            agent_id: {
+                "prov:type": "prov:SoftwareAgent",
+                "prov:label": actor,
+            }
+        },
+        "wasGeneratedBy": {
+            f"wgb:{request_id}": {
+                "prov:entity": entity_id,
+                "prov:activity": activity_id,
+            }
+        },
+        "wasAssociatedWith": {
+            f"waw:{request_id}": {
+                "prov:activity": activity_id,
+                "prov:agent": agent_id,
+            }
+        },
+    }
+
+
 def _escape_pdf_text(value: str) -> str:
     """Escape PDF text operators for literal text rendering."""
     return (

--- a/veritas_os/tests/test_coverage_map_extra.py
+++ b/veritas_os/tests/test_coverage_map_extra.py
@@ -421,3 +421,24 @@ class TestOwnerFunction:
     def test_owner_empty_defs(self):
         """Test owner with empty defs."""
         assert m.owner([], 5) == "<module-level>"
+
+class TestRiskWeightedCoverage:
+    """Tests for risk-weighted coverage helpers."""
+
+    def test_parse_risk_weights_valid_file(self, tmp_path) -> None:
+        """Risk weight parser should clamp values to [0, 1]."""
+        weights = tmp_path / "weights.json"
+        weights.write_text('{"A": 0.2, "B": 2.0, "C": -1.0}', encoding="utf-8")
+
+        parsed = m._parse_risk_weights(["--risk-weights", str(weights)])
+        assert parsed["A"] == 0.2
+        assert parsed["B"] == 1.0
+        assert parsed["C"] == 0.0
+
+    def test_compute_weighted_gap(self) -> None:
+        """Weighted gap should use owner weights and default to 0.5."""
+        by_owner = {"A": [1, 2], "B": [10]}
+        weights = {"A": 1.0}
+        got = m._compute_weighted_gap(by_owner=by_owner, risk_weights=weights)
+        # ((2 * 1.0) + (1 * 0.5)) / 3
+        assert round(got, 4) == round(2.5 / 3.0, 4)

--- a/veritas_os/tests/test_governance_api.py
+++ b/veritas_os/tests/test_governance_api.py
@@ -14,7 +14,7 @@ from veritas_os.api import governance as gov_mod
 from veritas_os.api import server as srv
 
 client = TestClient(srv.app)
-HEADERS = {"X-API-Key": "test-governance-key"}
+HEADERS = {"X-API-Key": "test-governance-key", "X-Role": "admin"}
 
 
 def _approved(payload: dict | None = None) -> dict:
@@ -344,3 +344,22 @@ class TestFujiValidateErrorPaths:
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] == "error"
+
+
+
+def test_get_rejects_without_governance_role() -> None:
+    """Governance API should reject requests without RBAC role header."""
+    resp = client.get("/v1/governance/policy", headers={"X-API-Key": "test-governance-key"})
+    assert resp.status_code == 403
+
+
+def test_put_rejects_tenant_mismatch(monkeypatch) -> None:
+    """Governance API should enforce tenant ABAC when configured."""
+    monkeypatch.setenv("VERITAS_GOVERNANCE_TENANT_ID", "tenant-a")
+    headers = {"X-API-Key": "test-governance-key", "X-Role": "admin", "X-Tenant-Id": "tenant-b"}
+    resp = client.put(
+        "/v1/governance/policy",
+        headers=headers,
+        json=_approved({"fuji_rules": {"pii_check": False}}),
+    )
+    assert resp.status_code == 403

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import yaml
 
+from veritas_os.api import server as srv
+
 
 def _load_openapi_spec() -> dict:
     """Load and parse the repository OpenAPI YAML document."""
@@ -43,3 +45,21 @@ def test_health_endpoint_has_no_auth_requirement() -> None:
     operation = spec["paths"]["/health"]["get"]
 
     assert operation.get("security") == []
+
+
+def test_openapi_includes_runtime_audit_and_governance_routes() -> None:
+    """OpenAPI should include critical runtime routes used for governance/audit."""
+    spec = _load_openapi_spec()
+    paths = spec.get("paths", {})
+    runtime_paths = {route.path for route in srv.app.routes}
+
+    critical = {
+        "/v1/governance/policy",
+        "/v1/governance/policy/history",
+        "/v1/trustlog/verify",
+        "/v1/trust/{request_id}/prov",
+    }
+
+    for path in critical:
+        assert path in runtime_paths
+        assert path in paths

--- a/veritas_os/tests/test_prov_export.py
+++ b/veritas_os/tests/test_prov_export.py
@@ -1,0 +1,53 @@
+"""Tests for W3C PROV decision-trace export endpoint."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from veritas_os.api import server
+
+
+client = TestClient(server.app)
+
+
+def test_prov_export_success(monkeypatch) -> None:
+    """Endpoint should return PROV payload for an existing trust trace."""
+    monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+    monkeypatch.setattr(
+        server,
+        "get_trust_logs_by_request",
+        lambda _rid: [
+            {
+                "request_id": "req-1",
+                "decision_status": "allow",
+                "risk": 0.2,
+                "ts": "2026-03-14T00:00:00Z",
+                "actor": "api",
+            }
+        ],
+    )
+
+    resp = client.get(
+        "/v1/trust/req-1/prov",
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert "prov" in body
+    assert "entity" in body["prov"]
+
+
+def test_prov_export_not_found(monkeypatch) -> None:
+    """Endpoint should return 404 when trust trace is missing."""
+    monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+    monkeypatch.setattr(server, "get_trust_logs_by_request", lambda _rid: [])
+
+    resp = client.get(
+        "/v1/trust/missing/prov",
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["ok"] is False

--- a/veritas_os/tools/coverage_map_pipeline.py
+++ b/veritas_os/tools/coverage_map_pipeline.py
@@ -277,6 +277,62 @@ def _parse_target_suffix(argv: List[str]) -> str:
     return target_suffix
 
 
+
+
+def _parse_risk_weights(argv: List[str]) -> Dict[str, float]:
+    """Parse optional risk weight JSON file.
+
+    The file should map owner names to weights in ``[0.0, 1.0]``.
+    Unknown/invalid entries are ignored for fail-safe operation.
+    """
+    if "--risk-weights" not in argv:
+        return {}
+
+    try:
+        idx = argv.index("--risk-weights")
+        path = Path(argv[idx + 1].strip())
+    except (ValueError, IndexError, AttributeError):
+        _eprint("[coverage_map_pipeline] invalid --risk-weights usage")
+        return {}
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as err:
+        _eprint(f"[coverage_map_pipeline] failed to parse risk weights: {repr(err)[:120]}")
+        return {}
+
+    if not isinstance(payload, dict):
+        return {}
+
+    out: Dict[str, float] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            continue
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            continue
+        out[key] = max(0.0, min(1.0, v))
+    return out
+
+
+def _compute_weighted_gap(by_owner: Dict[str, List[int]], risk_weights: Dict[str, float]) -> float:
+    """Compute risk-weighted uncovered-line ratio from owner-level missing lines."""
+    if not by_owner:
+        return 0.0
+
+    weighted_missing = 0.0
+    weighted_total = 0.0
+    for owner_name, lines in by_owner.items():
+        line_count = float(len(set(lines)))
+        weight = float(risk_weights.get(owner_name, 0.5))
+        weighted_missing += line_count * weight
+        weighted_total += line_count
+
+    if weighted_total <= 0.0:
+        return 0.0
+    return weighted_missing / weighted_total
+
 # =========================================================
 # Main
 # =========================================================
@@ -290,6 +346,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     """
     argv = argv or sys.argv[1:]
     target_suffix = _parse_target_suffix(argv)
+    risk_weights = _parse_risk_weights(argv)
 
     cov = load_cov()
     if not cov:
@@ -363,6 +420,10 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(f"- {name}: {len(uniq)} lines  [{_preview_ints(uniq)}]")
     else:
         print("[top owners] (none)")
+
+    if risk_weights:
+        weighted_gap = _compute_weighted_gap(by_owner=by_owner, risk_weights=risk_weights)
+        print(f"\n[pipeline] risk_weighted_missing_ratio={weighted_gap:.3f}")
 
     # Missing exit arcs
     exits = _exit_arcs(missing_branches)


### PR DESCRIPTION
### Motivation
- Complete Improvement Roadmap items #16–#20 to improve coverage signal quality, audit interoperability, and governance controls.
- Provide a W3C PROV export and OpenAPI/runtime alignment so decision traces can be ingested by external audit tooling and the spec matches runtime routes.
- Harden governance management with API-layer RBAC/ABAC and realtime alerts while explicitly warning that disabling RBAC via `VERITAS_GOVERNANCE_ENFORCE_RBAC=0` reduces protection.

### Description
- Added risk-weighted coverage support to `veritas_os/tools/coverage_map_pipeline.py` including `--risk-weights`, `_parse_risk_weights`, `_compute_weighted_gap`, and printed `risk_weighted_missing_ratio` for owner-weighted coverage analysis.
- Implemented `build_w3c_prov_document` in `veritas_os/reporting/exporters.py` and a new API endpoint `GET /v1/trust/{request_id}/prov` in `veritas_os/api/server.py` to export decision traces as compact PROV-JSON.
- Added governance access guard `require_governance_access` (checks `X-Role` and optional `X-Tenant-Id` against env-configured policies), wired it into governance endpoints, and emit a `governance.alert` SSE event when critical policy fields (`fuji_rules`, `risk_thresholds`, `auto_stop`) change; updated `openapi.yaml` to reflect the new endpoint and governance headers.
- Updated and added unit tests and docs: modified `veritas_os/tests/test_coverage_map_extra.py`, `veritas_os/tests/test_openapi_spec.py`, `veritas_os/tests/test_governance_api.py`, added `veritas_os/tests/test_prov_export.py`, and recorded completions in `docs/reviews/technical_dd_review_ja_20260314.md`.

### Testing
- Ran targeted unit tests including the new and updated tests with `pytest`, and observed all tests passing locally (final run: `75 passed`).
- Performed static compilation checks with `python -m py_compile` for `veritas_os/api/server.py`, `veritas_os/reporting/exporters.py`, and `veritas_os/tools/coverage_map_pipeline.py`, which completed without errors.
- Added unit tests that validate risk-weight parsing and weighted-gap computation, OpenAPI↔runtime route presence, governance RBAC/tenant rejection cases, and PROV export success/not-found scenarios, all of which passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b65f6c234c8326b64fb0fa4ebb6523)