### PR TITLE
docs: add large file review for technical debt candidates

### DIFF
--- a/LARGE_FILE_REVIEW.md
+++ b/LARGE_FILE_REVIEW.md
@@ -1,0 +1,324 @@
+# Large File Review: Technical Debt Candidates
+
+**Date:** 2026-03-15
+**Scope:** Source files exceeding 1,000 lines that should be split to prevent technical debt
+
+---
+
+## Executive Summary
+
+| Priority | File | Lines | Recommended Splits |
+|----------|------|------:|:------------------:|
+| CRITICAL | `veritas_os/api/server.py` | 3,536 | 13 modules |
+| CRITICAL | `veritas_os/core/memory.py` | 2,130 | 12 modules |
+| HIGH | `veritas_os/core/eu_ai_act_compliance_module.py` | 2,036 | 6 modules |
+| HIGH | `veritas_os/core/fuji.py` | 1,680 | 5 modules |
+| HIGH | `veritas_os/core/planner.py` | 1,407 | 5 modules |
+| HIGH | `frontend/app/audit/page.tsx` | 1,322 | 5 components |
+| HIGH | `veritas_os/tools/web_search.py` | 1,306 | 5 modules |
+| MEDIUM | `veritas_os/core/pipeline.py` | 1,223 | 4 modules |
+| MEDIUM | `veritas_os/core/world.py` | 1,084 | TBD |
+| MEDIUM | `veritas_os/core/kernel.py` | 1,076 | TBD |
+| MEDIUM | `veritas_os/api/schemas.py` | 1,039 | TBD |
+
+---
+
+## 1. `veritas_os/api/server.py` (3,536 lines) — CRITICAL
+
+### Current State
+
+8 classes, 76 top-level functions, 43 API endpoints, 6 middleware components packed into a single file.
+
+### Identified Responsibility Groups
+
+| Group | Approx Lines | Description |
+|-------|-------------:|-------------|
+| Authentication & Authorization | 700+ | API key validation, HMAC verification, AuthSecurityStore (Protocol + InMemory + Redis), auth failure tracking |
+| Middleware & Request Processing | 400+ | Trace ID, response time, rate limit headers, body size limiting, security headers, in-flight tracking |
+| Trust Log & Auditing | 400+ | Trust log file I/O, verification, export, PROV document generation, statistics |
+| Core Decision APIs | 500+ | `/v1/decide`, `/v1/replay`, `/v1/fuji/validate`, error handling, payload coercion |
+| Governance & Policy | 350+ | Policy CRUD, value drift, alerts, RBAC/ABAC, four-eyes approval |
+| Rate Limiting & Nonce | 300+ | Rate bucket tracking, nonce replay prevention, scheduled cleanup |
+| Compliance & Reporting | 250+ | EU AI Act reports, deployment readiness, compliance config |
+| Real-time Streaming | 200+ | SSE event hub, `/v1/events`, WebSocket `/v1/ws/trustlog` |
+| Memory Store APIs | 200+ | `/v1/memory/put`, `/v1/memory/search`, `/v1/memory/get`, `/v1/memory/erase` |
+| System Control | 150+ | Emergency halt/resume, LLM pool cleanup, graceful shutdown |
+| Initialization & Lazy Loading | 150+ | LazyState, startup validation, config/pipeline/FUJI lazy imports |
+| Utilities & Helpers | 250+ | Error formatting, redaction, ID generation, JSON operations |
+
+### Recommended Split
+
+```
+api/
+├── server.py              # (~200 lines) FastAPI app init, lifespan, health endpoints, route registration
+├── auth.py                # (~700 lines) API key, HMAC, AuthSecurityStore, auth failure tracking
+├── rate_limiting.py       # (~300 lines) Rate bucket, nonce replay prevention, scheduled cleanup
+├── middleware.py           # (~400 lines) Trace ID, response time, security headers, body size
+├── routes/
+│   ├── decision.py        # (~500 lines) /v1/decide, /v1/replay, /v1/fuji/validate
+│   ├── memory.py          # (~200 lines) /v1/memory/*
+│   ├── trust.py           # (~400 lines) /v1/trust/*, /v1/trustlog/*
+│   ├── governance.py      # (~350 lines) /v1/governance/*
+│   ├── compliance.py      # (~250 lines) /v1/compliance/*, /v1/report/*
+│   ├── system.py          # (~150 lines) /v1/system/*
+│   └── streaming.py       # (~200 lines) /v1/events, /v1/ws/trustlog
+├── config.py              # (~200 lines) CORS, lazy loading, startup validation
+└── utils.py               # (~250 lines) Error formatting, redaction, ID generation, JSON ops
+```
+
+### Key Risks If Not Split
+
+- Merge conflicts: 43 endpoints in one file makes parallel development difficult
+- Test isolation: Cannot unit-test auth logic without importing all routes
+- Cognitive load: 3,500+ lines exceeds reasonable comprehension limits
+- Deployment: Any change to any endpoint requires reviewing the entire file
+
+---
+
+## 2. `veritas_os/core/memory.py` (2,130 lines) — CRITICAL
+
+### Current State
+
+3 classes (`VectorMemory`, `MemoryStore`, `_LazyMemoryStore`) plus 30+ module-level functions mixing vector search, KVS persistence, file locking, GDPR compliance, LLM-based distillation, and global state management.
+
+### Identified Responsibility Groups
+
+| Group | Approx Lines | Description |
+|-------|-------------:|-------------|
+| VectorMemory (embeddings) | 415 | Sentence-transformer embeddings, cosine similarity, JSON persistence with Base64 numpy |
+| MemoryStore (KVS core) | 683 | JSON-based key-value store, file locking, in-memory TTL cache, lifecycle metadata |
+| GDPR / Compliance | 100+ | User erasure with audit trail, cascade deletion for semantic lineage, legal hold |
+| Memory Distillation | 200 | Episodic-to-semantic summarization via LLM, prompt engineering |
+| Search Orchestration | 150 | Dual-mode search (vector -> KVS fallback), deduplication, user filtering |
+| Evidence Formatting | 80 | Evidence conversion for `/v1/decide` |
+| Model Loading | 80 | ONNX model loading, external model compatibility |
+| Global State / Lazy Init | 100 | `_LazyMemoryStore`, global `MEM`, `MEM_VEC`, once-only guards |
+| File I/O & Locking | 70 | `locked_memory()` context manager, POSIX fcntl / Windows fallback |
+| Module-level API Wrappers | 140 | `add()`, `put()`, `get()`, `search()`, `recent()`, etc. |
+
+### Recommended Split
+
+```
+memory/
+├── __init__.py            # (~100 lines) Public API exports, module-level wrappers
+├── vector.py              # (~250 lines) VectorMemory class (embeddings, search)
+├── store.py               # (~300 lines) MemoryStore KVS core
+├── lifecycle.py           # (~100 lines) Retention, expiration, legal hold
+├── compliance.py          # (~100 lines) User erasure, cascade delete, audit trail
+├── distillation.py        # (~150 lines) Episodic-to-semantic LLM summarization
+├── search.py              # (~150 lines) Search orchestration (vector -> KVS fallback)
+├── evidence.py            # (~50 lines)  Evidence formatting for /v1/decide
+├── storage.py             # (~150 lines) File I/O, locking, JSON serialization
+├── models.py              # (~80 lines)  Model loading, external compatibility
+└── config.py              # (~40 lines)  Environment variable configuration
+```
+
+### Key Risks If Not Split
+
+- Thread-safety: 5 independent locks scattered across file make reasoning about concurrency difficult
+- Compliance coupling: GDPR logic embedded in KVS makes compliance auditing harder
+- Two storage backends (vector + KVS) with no clear boundary
+
+---
+
+## 3. `veritas_os/core/eu_ai_act_compliance_module.py` (2,036 lines) — HIGH
+
+### Current State
+
+5 classes and 21 top-level functions implementing EU AI Act compliance across Articles 5, 9, 10, 12, 13, 14, 15, and 50.
+
+### Identified Responsibility Groups
+
+| Group | Article(s) | Approx Lines | Description |
+|-------|-----------|-------------:|-------------|
+| Prohibited Practices Detection | Art. 5 | 360 | Pattern normalization, n-gram similarity, multi-language matching |
+| Risk Classification | Art. 9 | 30 | Annex III high-risk domain classification |
+| Human Oversight | Art. 14 | 210 | `HumanReviewQueue` (SLA tracking, webhook), `SystemHaltController` |
+| Documentation & Transparency | Art. 12, 13 | 300 | Tamper-evident trust logs, third-party notifications, log retention |
+| Content Watermarking | Art. 50 | 80 | C2PA-compatible watermark metadata |
+| Compliance Pipeline | Multiple | 140 | `eu_compliance_pipeline()` decorator for `/v1/decide` |
+| Deployment Validation | Art. 6, 10, 15 | 500+ | PII safety, synthetic data, audit readiness, legal approval, CE marking, data quality |
+| Degraded Mode | Art. 15 | 50 | Safe response when LLM unavailable |
+
+### Recommended Split
+
+```
+compliance/
+├── __init__.py                # Re-exports, backward compatibility
+├── prohibited_practices.py    # (~360 lines) Art. 5: pattern detection, n-gram, normalization
+├── human_oversight.py         # (~210 lines) Art. 14: HumanReviewQueue, SystemHaltController
+├── transparency.py            # (~300 lines) Art. 12/13: trust logs, notifications, watermarking
+├── deployment_validation.py   # (~500 lines) Art. 6/10/15: PII, data quality, CE marking, legal
+├── pipeline.py                # (~140 lines) Compliance pipeline decorator
+└── config.py                  # (~50 lines)  EUComplianceConfig, retention config
+```
+
+---
+
+## 4. `veritas_os/core/fuji.py` (1,680 lines) — HIGH
+
+### Current State
+
+1 dataclass (`SafetyHeadResult`) and 30+ functions implementing the FUJI safety gate: policy engine, LLM safety evaluation, prompt injection detection, and multi-stage decision logic.
+
+### Identified Responsibility Groups
+
+| Group | Approx Lines | Description |
+|-------|-------------:|-------------|
+| Policy Engine | 430 | YAML loading, hot-reload, runtime pattern compilation, policy application |
+| Safety Head Evaluation | 200 | LLM-based safety scoring, fallback heuristics, penalty application |
+| Prompt Injection Detection | 100 | Injection detection, text normalization, scoring |
+| Core Decision Logic | 350 | `fuji_core_decide()` — multi-stage safety, evidence checks, risk aggregation |
+| Output Interfaces | 300 | `fuji_gate()`, `validate_action()`, `posthoc_check()`, `evaluate()` |
+| Utilities & Trust Log | 200 | Text normalization, redaction, FUJI code selection, trust events |
+
+### Recommended Split
+
+```
+fuji/
+├── __init__.py          # Re-exports
+├── policy.py            # (~430 lines) Policy loading, hot-reload, pattern compilation
+├── safety_head.py       # (~200 lines) LLM safety evaluation, fallback heuristics
+├── injection.py         # (~100 lines) Prompt injection detection & scoring
+├── core.py              # (~350 lines) fuji_core_decide(), risk aggregation
+└── gate.py              # (~300 lines) fuji_gate(), validate_action(), evaluate()
+```
+
+### Key Risk
+
+- `fuji_core_decide()` concentrates safety head + policy + injection + deterministic rules in deeply nested logic — highest single-function complexity in the codebase
+
+---
+
+## 5. `veritas_os/core/planner.py` (1,407 lines) — HIGH
+
+### Identified Responsibility Groups
+
+| Group | Approx Lines | Description |
+|-------|-------------:|-------------|
+| JSON Parsing & Extraction | 680+ | Input sanitization, safe JSON rescue with retry, multi-strategy extraction |
+| Planning Decision Logic | 190 | Simple Q&A detection, step1 detection, immediate planning |
+| LLM Prompt Engineering | 130 | System/user prompt construction |
+| Fallback & Recovery | 80 | Ultra-safe fallback plans, VERITAS stage inference |
+| Hybrid Planning | 180 | World Model + LLM integration, memory snippet retrieval |
+| Code Task Generation | 140 | Benchmark-based code task generation |
+
+### Recommended Split
+
+```
+planner/
+├── __init__.py          # Re-exports, generate_plan() backward compat
+├── json_parsing.py      # (~680 lines) JSON extraction, rescue, retry
+├── detection.py         # (~190 lines) Simple QA detection, step1 detection
+├── prompts.py           # (~130 lines) System/user prompt construction
+├── fallback.py          # (~80 lines)  Fallback plans, VERITAS stage inference
+└── hybrid.py            # (~320 lines) World+LLM planning, code task generation
+```
+
+### Notable Concern
+
+- JSON parsing accounts for ~48% of the file — a clear candidate for extraction
+
+---
+
+## 6. `frontend/app/audit/page.tsx` (1,322 lines) — HIGH
+
+### Current State
+
+Single React component (`TrustLogExplorerPage`) containing all state, hooks, handlers, and JSX for the entire audit page.
+
+### Recommended Split
+
+```
+frontend/app/audit/
+├── page.tsx                  # (~100 lines) Main page, composition of sub-components
+├── constants.ts              # (~60 lines)  Status colors, page limits
+├── hooks/
+│   └── useAuditData.ts       # (~200 lines) Data fetching, filtering, sorting, memos
+├── handlers/
+│   └── useAuditActions.ts    # (~250 lines) Verify, export, report, search handlers
+└── components/
+    ├── SearchPanel.tsx        # (~150 lines) Request ID search, cross-search
+    ├── TimelineList.tsx       # (~250 lines) Trust log explorer list
+    ├── DetailPanel.tsx        # (~200 lines) Summary, Metadata, Hash tabs
+    └── ExportPanel.tsx        # (~150 lines) Date range, format, download
+```
+
+---
+
+## 7. `veritas_os/tools/web_search.py` (1,306 lines) — HIGH
+
+### Identified Responsibility Groups
+
+| Group | Approx Lines | Description |
+|-------|-------------:|-------------|
+| SSRF & DNS Rebinding Defense | 160 | Hostname canonicalization, private host detection, DNS resolution, rebinding guard |
+| Config & Credentials | 100 | Environment vars, API key resolution, allowlist parsing |
+| Query Enhancement & Filtering | 100 | AGI detection, VERITAS anchor, query boosting, result blocking |
+| Toxicity & Content Safety | 60 | Toxic result detection, Base64 payload inspection |
+| HTTP & Retry Logic | 80 | Exponential backoff, retry status detection |
+| Main Orchestrator | 400+ | `web_search()` entry point, result normalization |
+| Safe Parameter Parsing | 90 | `_safe_int()`, `_safe_float()`, bounds validation |
+
+### Recommended Split
+
+```
+tools/
+├── web_search.py              # (~400 lines) Main orchestrator, result normalization
+├── web_search_security.py     # (~160 lines) SSRF/DNS rebinding defense
+├── web_search_config.py       # (~100 lines) Credentials, allowlist, safe parsing
+├── web_search_filtering.py    # (~100 lines) AGI detection, query boosting, blocking
+└── web_search_safety.py       # (~60 lines)  Toxicity detection, Base64 inspection
+```
+
+---
+
+## 8. `veritas_os/core/pipeline.py` (1,223 lines) — MEDIUM
+
+### Identified Responsibility Groups
+
+| Group | Approx Lines | Description |
+|-------|-------------:|-------------|
+| Initialization & Imports | 100 | Module checks, persona loading, warning setup |
+| Utilities & Helpers | 120 | Type conversions, value clipping, request param extraction |
+| Persistence & Storage | 180 | Path resolution, decision loading, dataset/trust log fallbacks |
+| Policy & Gate Logic | 100 | Gate prediction, value stats, alternative deduplication |
+| Main Orchestration | 200+ | `run_decide_pipeline()` — delegates to stage modules |
+
+### Recommended Split
+
+```
+pipeline/
+├── __init__.py           # Re-exports
+├── pipeline.py           # (~200 lines) Main run_decide_pipeline() orchestrator
+├── persistence.py        # (~180 lines) Path resolution, decision loading, fallbacks
+├── helpers.py            # (~120 lines) Type conversions, clipping, params
+└── gate.py               # (~100 lines) Gate prediction, value stats, dedup
+```
+
+---
+
+## Test Files Requiring Attention
+
+Several test files also exceed reasonable size and should be organized:
+
+| File | Lines | Note |
+|------|------:|------|
+| `tests/test_api_server_extra.py` | 1,886 | Should mirror server.py split |
+| `tests/test_coverage_boost.py` | 1,380 | Consider splitting by feature |
+| `tests/test_kernel_core_extra.py` | 1,217 | Split by kernel responsibility |
+| `tests/test_api_pipeline.py` | 1,128 | Split by pipeline stage |
+| `packages/types/src/index.test.ts` | 1,590 | Split by type domain |
+
+---
+
+## Recommended Execution Order
+
+1. **`api/server.py`** — Highest line count, most diverse responsibilities, blocking parallel development
+2. **`core/memory.py`** — Critical infrastructure with scattered concurrency concerns
+3. **`core/fuji.py`** — Safety-critical code benefits most from isolated testing
+4. **`core/eu_ai_act_compliance_module.py`** — Regulatory code should be clearly separated
+5. **`frontend/app/audit/page.tsx`** — Standard React componentization
+6. **`tools/web_search.py`** — Security-critical SSRF logic should be isolated
+7. **`core/planner.py`** — JSON parsing dominates; straightforward extraction
+8. **`core/pipeline.py`** — Already partially delegating to sub-modules

--- a/LARGE_FILE_REVIEW.md
+++ b/LARGE_FILE_REVIEW.md
@@ -1,324 +1,324 @@
-# Large File Review: Technical Debt Candidates
+# 巨大ファイルレビュー: 技術負債候補
 
-**Date:** 2026-03-15
-**Scope:** Source files exceeding 1,000 lines that should be split to prevent technical debt
-
----
-
-## Executive Summary
-
-| Priority | File | Lines | Recommended Splits |
-|----------|------|------:|:------------------:|
-| CRITICAL | `veritas_os/api/server.py` | 3,536 | 13 modules |
-| CRITICAL | `veritas_os/core/memory.py` | 2,130 | 12 modules |
-| HIGH | `veritas_os/core/eu_ai_act_compliance_module.py` | 2,036 | 6 modules |
-| HIGH | `veritas_os/core/fuji.py` | 1,680 | 5 modules |
-| HIGH | `veritas_os/core/planner.py` | 1,407 | 5 modules |
-| HIGH | `frontend/app/audit/page.tsx` | 1,322 | 5 components |
-| HIGH | `veritas_os/tools/web_search.py` | 1,306 | 5 modules |
-| MEDIUM | `veritas_os/core/pipeline.py` | 1,223 | 4 modules |
-| MEDIUM | `veritas_os/core/world.py` | 1,084 | TBD |
-| MEDIUM | `veritas_os/core/kernel.py` | 1,076 | TBD |
-| MEDIUM | `veritas_os/api/schemas.py` | 1,039 | TBD |
+**日付:** 2026-03-15
+**対象:** 技術負債を防ぐために分割すべき1,000行超のソースファイル
 
 ---
 
-## 1. `veritas_os/api/server.py` (3,536 lines) — CRITICAL
+## エグゼクティブサマリ
 
-### Current State
+| 優先度 | ファイル | 行数 | 推奨分割数 |
+|--------|------|------:|:----------:|
+| 最重要 | `veritas_os/api/server.py` | 3,536 | 13モジュール |
+| 最重要 | `veritas_os/core/memory.py` | 2,130 | 12モジュール |
+| 高 | `veritas_os/core/eu_ai_act_compliance_module.py` | 2,036 | 6モジュール |
+| 高 | `veritas_os/core/fuji.py` | 1,680 | 5モジュール |
+| 高 | `veritas_os/core/planner.py` | 1,407 | 5モジュール |
+| 高 | `frontend/app/audit/page.tsx` | 1,322 | 5コンポーネント |
+| 高 | `veritas_os/tools/web_search.py` | 1,306 | 5モジュール |
+| 中 | `veritas_os/core/pipeline.py` | 1,223 | 4モジュール |
+| 中 | `veritas_os/core/world.py` | 1,084 | 未定 |
+| 中 | `veritas_os/core/kernel.py` | 1,076 | 未定 |
+| 中 | `veritas_os/api/schemas.py` | 1,039 | 未定 |
 
-8 classes, 76 top-level functions, 43 API endpoints, 6 middleware components packed into a single file.
+---
 
-### Identified Responsibility Groups
+## 1. `veritas_os/api/server.py` (3,536行) — 最重要
 
-| Group | Approx Lines | Description |
-|-------|-------------:|-------------|
-| Authentication & Authorization | 700+ | API key validation, HMAC verification, AuthSecurityStore (Protocol + InMemory + Redis), auth failure tracking |
-| Middleware & Request Processing | 400+ | Trace ID, response time, rate limit headers, body size limiting, security headers, in-flight tracking |
-| Trust Log & Auditing | 400+ | Trust log file I/O, verification, export, PROV document generation, statistics |
-| Core Decision APIs | 500+ | `/v1/decide`, `/v1/replay`, `/v1/fuji/validate`, error handling, payload coercion |
-| Governance & Policy | 350+ | Policy CRUD, value drift, alerts, RBAC/ABAC, four-eyes approval |
-| Rate Limiting & Nonce | 300+ | Rate bucket tracking, nonce replay prevention, scheduled cleanup |
-| Compliance & Reporting | 250+ | EU AI Act reports, deployment readiness, compliance config |
-| Real-time Streaming | 200+ | SSE event hub, `/v1/events`, WebSocket `/v1/ws/trustlog` |
-| Memory Store APIs | 200+ | `/v1/memory/put`, `/v1/memory/search`, `/v1/memory/get`, `/v1/memory/erase` |
-| System Control | 150+ | Emergency halt/resume, LLM pool cleanup, graceful shutdown |
-| Initialization & Lazy Loading | 150+ | LazyState, startup validation, config/pipeline/FUJI lazy imports |
-| Utilities & Helpers | 250+ | Error formatting, redaction, ID generation, JSON operations |
+### 現状
 
-### Recommended Split
+8クラス、76個のトップレベル関数、43個のAPIエンドポイント、6個のミドルウェアが1ファイルに集約されている。
+
+### 特定された責務グループ
+
+| グループ | 概算行数 | 説明 |
+|---------|--------:|------|
+| 認証・認可 | 700+ | APIキー検証、HMAC検証、AuthSecurityStore（Protocol + InMemory + Redis）、認証失敗追跡 |
+| ミドルウェア・リクエスト処理 | 400+ | トレースID、レスポンスタイム、レート制限ヘッダ、ボディサイズ制限、セキュリティヘッダ、インフライト追跡 |
+| トラストログ・監査 | 400+ | トラストログファイルI/O、検証、エクスポート、PROVドキュメント生成、統計 |
+| コア意思決定API | 500+ | `/v1/decide`、`/v1/replay`、`/v1/fuji/validate`、エラーハンドリング、ペイロード変換 |
+| ガバナンス・ポリシー | 350+ | ポリシーCRUD、価値ドリフト、アラート、RBAC/ABAC、四眼承認 |
+| レート制限・ノンス管理 | 300+ | レートバケット追跡、ノンスリプレイ防止、スケジュールクリーンアップ |
+| コンプライアンス・レポート | 250+ | EU AI Actレポート、デプロイ準備状況、コンプライアンス設定 |
+| リアルタイムストリーミング | 200+ | SSEイベントハブ、`/v1/events`、WebSocket `/v1/ws/trustlog` |
+| メモリストアAPI | 200+ | `/v1/memory/put`、`/v1/memory/search`、`/v1/memory/get`、`/v1/memory/erase` |
+| システム制御 | 150+ | 緊急停止/再開、LLMプールクリーンアップ、グレースフルシャットダウン |
+| 初期化・遅延ロード | 150+ | LazyState、起動時バリデーション、config/pipeline/FUJIの遅延インポート |
+| ユーティリティ・ヘルパー | 250+ | エラーフォーマット、マスキング、ID生成、JSON操作 |
+
+### 推奨分割構成
 
 ```
 api/
-├── server.py              # (~200 lines) FastAPI app init, lifespan, health endpoints, route registration
-├── auth.py                # (~700 lines) API key, HMAC, AuthSecurityStore, auth failure tracking
-├── rate_limiting.py       # (~300 lines) Rate bucket, nonce replay prevention, scheduled cleanup
-├── middleware.py           # (~400 lines) Trace ID, response time, security headers, body size
+├── server.py              # (~200行) FastAPIアプリ初期化、ライフスパン、ヘルスエンドポイント、ルート登録
+├── auth.py                # (~700行) APIキー、HMAC、AuthSecurityStore、認証失敗追跡
+├── rate_limiting.py       # (~300行) レートバケット、ノンスリプレイ防止、スケジュールクリーンアップ
+├── middleware.py           # (~400行) トレースID、レスポンスタイム、セキュリティヘッダ、ボディサイズ制限
 ├── routes/
-│   ├── decision.py        # (~500 lines) /v1/decide, /v1/replay, /v1/fuji/validate
-│   ├── memory.py          # (~200 lines) /v1/memory/*
-│   ├── trust.py           # (~400 lines) /v1/trust/*, /v1/trustlog/*
-│   ├── governance.py      # (~350 lines) /v1/governance/*
-│   ├── compliance.py      # (~250 lines) /v1/compliance/*, /v1/report/*
-│   ├── system.py          # (~150 lines) /v1/system/*
-│   └── streaming.py       # (~200 lines) /v1/events, /v1/ws/trustlog
-├── config.py              # (~200 lines) CORS, lazy loading, startup validation
-└── utils.py               # (~250 lines) Error formatting, redaction, ID generation, JSON ops
+│   ├── decision.py        # (~500行) /v1/decide, /v1/replay, /v1/fuji/validate
+│   ├── memory.py          # (~200行) /v1/memory/*
+│   ├── trust.py           # (~400行) /v1/trust/*, /v1/trustlog/*
+│   ├── governance.py      # (~350行) /v1/governance/*
+│   ├── compliance.py      # (~250行) /v1/compliance/*, /v1/report/*
+│   ├── system.py          # (~150行) /v1/system/*
+│   └── streaming.py       # (~200行) /v1/events, /v1/ws/trustlog
+├── config.py              # (~200行) CORS、遅延ロード、起動時バリデーション
+└── utils.py               # (~250行) エラーフォーマット、マスキング、ID生成、JSON操作
 ```
 
-### Key Risks If Not Split
+### 分割しない場合のリスク
 
-- Merge conflicts: 43 endpoints in one file makes parallel development difficult
-- Test isolation: Cannot unit-test auth logic without importing all routes
-- Cognitive load: 3,500+ lines exceeds reasonable comprehension limits
-- Deployment: Any change to any endpoint requires reviewing the entire file
+- **マージコンフリクト**: 43エンドポイントが1ファイルにあるため、並行開発が困難
+- **テスト分離不可**: 認証ロジックを単体テストするのに全ルートのインポートが必要
+- **認知負荷**: 3,500行超は人間の合理的な理解限界を超えている
+- **デプロイ**: いずれかのエンドポイントの変更でもファイル全体のレビューが必要
 
 ---
 
-## 2. `veritas_os/core/memory.py` (2,130 lines) — CRITICAL
+## 2. `veritas_os/core/memory.py` (2,130行) — 最重要
 
-### Current State
+### 現状
 
-3 classes (`VectorMemory`, `MemoryStore`, `_LazyMemoryStore`) plus 30+ module-level functions mixing vector search, KVS persistence, file locking, GDPR compliance, LLM-based distillation, and global state management.
+3クラス（`VectorMemory`、`MemoryStore`、`_LazyMemoryStore`）と30以上のモジュールレベル関数が、ベクトル検索・KVS永続化・ファイルロック・GDPRコンプライアンス・LLMベース蒸留・グローバル状態管理を混在させている。
 
-### Identified Responsibility Groups
+### 特定された責務グループ
 
-| Group | Approx Lines | Description |
-|-------|-------------:|-------------|
-| VectorMemory (embeddings) | 415 | Sentence-transformer embeddings, cosine similarity, JSON persistence with Base64 numpy |
-| MemoryStore (KVS core) | 683 | JSON-based key-value store, file locking, in-memory TTL cache, lifecycle metadata |
-| GDPR / Compliance | 100+ | User erasure with audit trail, cascade deletion for semantic lineage, legal hold |
-| Memory Distillation | 200 | Episodic-to-semantic summarization via LLM, prompt engineering |
-| Search Orchestration | 150 | Dual-mode search (vector -> KVS fallback), deduplication, user filtering |
-| Evidence Formatting | 80 | Evidence conversion for `/v1/decide` |
-| Model Loading | 80 | ONNX model loading, external model compatibility |
-| Global State / Lazy Init | 100 | `_LazyMemoryStore`, global `MEM`, `MEM_VEC`, once-only guards |
-| File I/O & Locking | 70 | `locked_memory()` context manager, POSIX fcntl / Windows fallback |
-| Module-level API Wrappers | 140 | `add()`, `put()`, `get()`, `search()`, `recent()`, etc. |
+| グループ | 概算行数 | 説明 |
+|---------|--------:|------|
+| VectorMemory（埋め込み） | 415 | Sentence-transformer埋め込み、コサイン類似度、Base64 numpyによるJSON永続化 |
+| MemoryStore（KVSコア） | 683 | JSONベースキーバリューストア、ファイルロック、インメモリTTLキャッシュ、ライフサイクルメタデータ |
+| GDPR / コンプライアンス | 100+ | 監査証跡付きユーザー消去、セマンティック系統のカスケード削除、法的保持 |
+| メモリ蒸留 | 200 | LLMによるエピソード記憶からセマンティック記憶への要約、プロンプトエンジニアリング |
+| 検索オーケストレーション | 150 | デュアルモード検索（ベクトル → KVSフォールバック）、重複排除、ユーザーフィルタリング |
+| エビデンスフォーマット | 80 | `/v1/decide`向けエビデンス変換 |
+| モデルロード | 80 | ONNXモデルロード、外部モデル互換性 |
+| グローバル状態 / 遅延初期化 | 100 | `_LazyMemoryStore`、グローバル`MEM`、`MEM_VEC`、ワンスオンリーガード |
+| ファイルI/O・ロック | 70 | `locked_memory()`コンテキストマネージャ、POSIX fcntl / Windowsフォールバック |
+| モジュールレベルAPIラッパー | 140 | `add()`、`put()`、`get()`、`search()`、`recent()`等 |
 
-### Recommended Split
+### 推奨分割構成
 
 ```
 memory/
-├── __init__.py            # (~100 lines) Public API exports, module-level wrappers
-├── vector.py              # (~250 lines) VectorMemory class (embeddings, search)
-├── store.py               # (~300 lines) MemoryStore KVS core
-├── lifecycle.py           # (~100 lines) Retention, expiration, legal hold
-├── compliance.py          # (~100 lines) User erasure, cascade delete, audit trail
-├── distillation.py        # (~150 lines) Episodic-to-semantic LLM summarization
-├── search.py              # (~150 lines) Search orchestration (vector -> KVS fallback)
-├── evidence.py            # (~50 lines)  Evidence formatting for /v1/decide
-├── storage.py             # (~150 lines) File I/O, locking, JSON serialization
-├── models.py              # (~80 lines)  Model loading, external compatibility
-└── config.py              # (~40 lines)  Environment variable configuration
+├── __init__.py            # (~100行) 公開APIエクスポート、モジュールレベルラッパー
+├── vector.py              # (~250行) VectorMemoryクラス（埋め込み、検索）
+├── store.py               # (~300行) MemoryStore KVSコア
+├── lifecycle.py           # (~100行) 保持期間、有効期限、法的保持
+├── compliance.py          # (~100行) ユーザー消去、カスケード削除、監査証跡
+├── distillation.py        # (~150行) エピソード→セマンティックLLM要約
+├── search.py              # (~150行) 検索オーケストレーション（ベクトル → KVSフォールバック）
+├── evidence.py            # (~50行)  /v1/decide向けエビデンスフォーマット
+├── storage.py             # (~150行) ファイルI/O、ロック、JSONシリアライゼーション
+├── models.py              # (~80行)  モデルロード、外部互換性
+└── config.py              # (~40行)  環境変数設定
 ```
 
-### Key Risks If Not Split
+### 分割しない場合のリスク
 
-- Thread-safety: 5 independent locks scattered across file make reasoning about concurrency difficult
-- Compliance coupling: GDPR logic embedded in KVS makes compliance auditing harder
-- Two storage backends (vector + KVS) with no clear boundary
+- **スレッド安全性**: 5つの独立したロックがファイル全体に散在し、並行性の推論が困難
+- **コンプライアンス結合**: GDPRロジックがKVSに埋め込まれ、コンプライアンス監査が困難
+- **2つのストレージバックエンド**（ベクトル + KVS）に明確な境界がない
 
 ---
 
-## 3. `veritas_os/core/eu_ai_act_compliance_module.py` (2,036 lines) — HIGH
+## 3. `veritas_os/core/eu_ai_act_compliance_module.py` (2,036行) — 高
 
-### Current State
+### 現状
 
-5 classes and 21 top-level functions implementing EU AI Act compliance across Articles 5, 9, 10, 12, 13, 14, 15, and 50.
+5クラスと21個のトップレベル関数が、EU AI Act第5条、第9条、第10条、第12条、第13条、第14条、第15条、第50条のコンプライアンスを実装している。
 
-### Identified Responsibility Groups
+### 特定された責務グループ
 
-| Group | Article(s) | Approx Lines | Description |
-|-------|-----------|-------------:|-------------|
-| Prohibited Practices Detection | Art. 5 | 360 | Pattern normalization, n-gram similarity, multi-language matching |
-| Risk Classification | Art. 9 | 30 | Annex III high-risk domain classification |
-| Human Oversight | Art. 14 | 210 | `HumanReviewQueue` (SLA tracking, webhook), `SystemHaltController` |
-| Documentation & Transparency | Art. 12, 13 | 300 | Tamper-evident trust logs, third-party notifications, log retention |
-| Content Watermarking | Art. 50 | 80 | C2PA-compatible watermark metadata |
-| Compliance Pipeline | Multiple | 140 | `eu_compliance_pipeline()` decorator for `/v1/decide` |
-| Deployment Validation | Art. 6, 10, 15 | 500+ | PII safety, synthetic data, audit readiness, legal approval, CE marking, data quality |
-| Degraded Mode | Art. 15 | 50 | Safe response when LLM unavailable |
+| グループ | 対応条項 | 概算行数 | 説明 |
+|---------|---------|--------:|------|
+| 禁止行為検出 | 第5条 | 360 | パターン正規化、n-gram類似度、多言語マッチング |
+| リスク分類 | 第9条 | 30 | 附属書IIIハイリスクドメイン分類 |
+| 人的監視 | 第14条 | 210 | `HumanReviewQueue`（SLA追跡、Webhook）、`SystemHaltController` |
+| 文書化・透明性 | 第12条、第13条 | 300 | 改ざん防止トラストログ、第三者通知、ログ保持 |
+| コンテンツ透かし | 第50条 | 80 | C2PA互換の透かしメタデータ |
+| コンプライアンスパイプライン | 複数 | 140 | `/v1/decide`向け`eu_compliance_pipeline()`デコレータ |
+| デプロイバリデーション | 第6条、第10条、第15条 | 500+ | PII安全性、合成データ、監査準備、法的承認、CEマーキング、データ品質 |
+| 劣化モード | 第15条 | 50 | LLM利用不可時の安全な応答 |
 
-### Recommended Split
+### 推奨分割構成
 
 ```
 compliance/
-├── __init__.py                # Re-exports, backward compatibility
-├── prohibited_practices.py    # (~360 lines) Art. 5: pattern detection, n-gram, normalization
-├── human_oversight.py         # (~210 lines) Art. 14: HumanReviewQueue, SystemHaltController
-├── transparency.py            # (~300 lines) Art. 12/13: trust logs, notifications, watermarking
-├── deployment_validation.py   # (~500 lines) Art. 6/10/15: PII, data quality, CE marking, legal
-├── pipeline.py                # (~140 lines) Compliance pipeline decorator
-└── config.py                  # (~50 lines)  EUComplianceConfig, retention config
+├── __init__.py                # 再エクスポート、後方互換性
+├── prohibited_practices.py    # (~360行) 第5条: パターン検出、n-gram、正規化
+├── human_oversight.py         # (~210行) 第14条: HumanReviewQueue、SystemHaltController
+├── transparency.py            # (~300行) 第12/13条: トラストログ、通知、透かし
+├── deployment_validation.py   # (~500行) 第6/10/15条: PII、データ品質、CEマーキング、法的承認
+├── pipeline.py                # (~140行) コンプライアンスパイプラインデコレータ
+└── config.py                  # (~50行)  EUComplianceConfig、保持期間設定
 ```
 
 ---
 
-## 4. `veritas_os/core/fuji.py` (1,680 lines) — HIGH
+## 4. `veritas_os/core/fuji.py` (1,680行) — 高
 
-### Current State
+### 現状
 
-1 dataclass (`SafetyHeadResult`) and 30+ functions implementing the FUJI safety gate: policy engine, LLM safety evaluation, prompt injection detection, and multi-stage decision logic.
+1データクラス（`SafetyHeadResult`）と30以上の関数が、FUJIセーフティゲート（ポリシーエンジン、LLM安全性評価、プロンプトインジェクション検出、多段階意思決定ロジック）を実装している。
 
-### Identified Responsibility Groups
+### 特定された責務グループ
 
-| Group | Approx Lines | Description |
-|-------|-------------:|-------------|
-| Policy Engine | 430 | YAML loading, hot-reload, runtime pattern compilation, policy application |
-| Safety Head Evaluation | 200 | LLM-based safety scoring, fallback heuristics, penalty application |
-| Prompt Injection Detection | 100 | Injection detection, text normalization, scoring |
-| Core Decision Logic | 350 | `fuji_core_decide()` — multi-stage safety, evidence checks, risk aggregation |
-| Output Interfaces | 300 | `fuji_gate()`, `validate_action()`, `posthoc_check()`, `evaluate()` |
-| Utilities & Trust Log | 200 | Text normalization, redaction, FUJI code selection, trust events |
+| グループ | 概算行数 | 説明 |
+|---------|--------:|------|
+| ポリシーエンジン | 430 | YAMLロード、ホットリロード、ランタイムパターンコンパイル、ポリシー適用 |
+| セーフティヘッド評価 | 200 | LLMベース安全性スコアリング、フォールバックヒューリスティクス、ペナルティ適用 |
+| プロンプトインジェクション検出 | 100 | インジェクション検出、テキスト正規化、スコアリング |
+| コア意思決定ロジック | 350 | `fuji_core_decide()` — 多段階安全性評価、エビデンス確認、リスク集約 |
+| 出力インターフェース | 300 | `fuji_gate()`、`validate_action()`、`posthoc_check()`、`evaluate()` |
+| ユーティリティ・トラストログ | 200 | テキスト正規化、マスキング、FUJIコード選択、トラストイベント |
 
-### Recommended Split
+### 推奨分割構成
 
 ```
 fuji/
-├── __init__.py          # Re-exports
-├── policy.py            # (~430 lines) Policy loading, hot-reload, pattern compilation
-├── safety_head.py       # (~200 lines) LLM safety evaluation, fallback heuristics
-├── injection.py         # (~100 lines) Prompt injection detection & scoring
-├── core.py              # (~350 lines) fuji_core_decide(), risk aggregation
-└── gate.py              # (~300 lines) fuji_gate(), validate_action(), evaluate()
+├── __init__.py          # 再エクスポート
+├── policy.py            # (~430行) ポリシーロード、ホットリロード、パターンコンパイル
+├── safety_head.py       # (~200行) LLM安全性評価、フォールバックヒューリスティクス
+├── injection.py         # (~100行) プロンプトインジェクション検出・スコアリング
+├── core.py              # (~350行) fuji_core_decide()、リスク集約
+└── gate.py              # (~300行) fuji_gate()、validate_action()、evaluate()
 ```
 
-### Key Risk
+### 主要リスク
 
-- `fuji_core_decide()` concentrates safety head + policy + injection + deterministic rules in deeply nested logic — highest single-function complexity in the codebase
+- `fuji_core_decide()`がセーフティヘッド + ポリシー + インジェクション + 決定論的ルールを深くネストされたロジックに集中 — コードベース中で最も高い単一関数複雑度
 
 ---
 
-## 5. `veritas_os/core/planner.py` (1,407 lines) — HIGH
+## 5. `veritas_os/core/planner.py` (1,407行) — 高
 
-### Identified Responsibility Groups
+### 特定された責務グループ
 
-| Group | Approx Lines | Description |
-|-------|-------------:|-------------|
-| JSON Parsing & Extraction | 680+ | Input sanitization, safe JSON rescue with retry, multi-strategy extraction |
-| Planning Decision Logic | 190 | Simple Q&A detection, step1 detection, immediate planning |
-| LLM Prompt Engineering | 130 | System/user prompt construction |
-| Fallback & Recovery | 80 | Ultra-safe fallback plans, VERITAS stage inference |
-| Hybrid Planning | 180 | World Model + LLM integration, memory snippet retrieval |
-| Code Task Generation | 140 | Benchmark-based code task generation |
+| グループ | 概算行数 | 説明 |
+|---------|--------:|------|
+| JSON解析・抽出 | 680+ | 入力サニタイズ、安全なJSONレスキューとリトライ、複数戦略による抽出 |
+| 計画判定ロジック | 190 | 単純Q&A検出、ステップ1検出、即時計画生成 |
+| LLMプロンプトエンジニアリング | 130 | システム/ユーザープロンプト構築 |
+| フォールバック・リカバリ | 80 | 超安全フォールバック計画、VERITASステージ推論 |
+| ハイブリッド計画 | 180 | ワールドモデル + LLM統合、メモリスニペット取得 |
+| コードタスク生成 | 140 | ベンチマークベースのコードタスク生成 |
 
-### Recommended Split
+### 推奨分割構成
 
 ```
 planner/
-├── __init__.py          # Re-exports, generate_plan() backward compat
-├── json_parsing.py      # (~680 lines) JSON extraction, rescue, retry
-├── detection.py         # (~190 lines) Simple QA detection, step1 detection
-├── prompts.py           # (~130 lines) System/user prompt construction
-├── fallback.py          # (~80 lines)  Fallback plans, VERITAS stage inference
-└── hybrid.py            # (~320 lines) World+LLM planning, code task generation
+├── __init__.py          # 再エクスポート、generate_plan()後方互換
+├── json_parsing.py      # (~680行) JSON抽出、レスキュー、リトライ
+├── detection.py         # (~190行) 単純QA検出、ステップ1検出
+├── prompts.py           # (~130行) システム/ユーザープロンプト構築
+├── fallback.py          # (~80行)  フォールバック計画、VERITASステージ推論
+└── hybrid.py            # (~320行) ワールド+LLM計画、コードタスク生成
 ```
 
-### Notable Concern
+### 注目すべき懸念点
 
-- JSON parsing accounts for ~48% of the file — a clear candidate for extraction
+- JSON解析がファイルの約48%を占有 — 明確な抽出候補
 
 ---
 
-## 6. `frontend/app/audit/page.tsx` (1,322 lines) — HIGH
+## 6. `frontend/app/audit/page.tsx` (1,322行) — 高
 
-### Current State
+### 現状
 
-Single React component (`TrustLogExplorerPage`) containing all state, hooks, handlers, and JSX for the entire audit page.
+単一のReactコンポーネント（`TrustLogExplorerPage`）に、全state、hooks、ハンドラ、JSXが集約されている。
 
-### Recommended Split
+### 推奨分割構成
 
 ```
 frontend/app/audit/
-├── page.tsx                  # (~100 lines) Main page, composition of sub-components
-├── constants.ts              # (~60 lines)  Status colors, page limits
+├── page.tsx                  # (~100行) メインページ、サブコンポーネントのコンポジション
+├── constants.ts              # (~60行)  ステータス色、ページ上限
 ├── hooks/
-│   └── useAuditData.ts       # (~200 lines) Data fetching, filtering, sorting, memos
+│   └── useAuditData.ts       # (~200行) データ取得、フィルタリング、ソート、メモ化
 ├── handlers/
-│   └── useAuditActions.ts    # (~250 lines) Verify, export, report, search handlers
+│   └── useAuditActions.ts    # (~250行) 検証、エクスポート、レポート、検索ハンドラ
 └── components/
-    ├── SearchPanel.tsx        # (~150 lines) Request ID search, cross-search
-    ├── TimelineList.tsx       # (~250 lines) Trust log explorer list
-    ├── DetailPanel.tsx        # (~200 lines) Summary, Metadata, Hash tabs
-    └── ExportPanel.tsx        # (~150 lines) Date range, format, download
+    ├── SearchPanel.tsx        # (~150行) リクエストID検索、横断検索
+    ├── TimelineList.tsx       # (~250行) トラストログエクスプローラーリスト
+    ├── DetailPanel.tsx        # (~200行) サマリ、メタデータ、ハッシュタブ
+    └── ExportPanel.tsx        # (~150行) 日付範囲、フォーマット選択、ダウンロード
 ```
 
 ---
 
-## 7. `veritas_os/tools/web_search.py` (1,306 lines) — HIGH
+## 7. `veritas_os/tools/web_search.py` (1,306行) — 高
 
-### Identified Responsibility Groups
+### 特定された責務グループ
 
-| Group | Approx Lines | Description |
-|-------|-------------:|-------------|
-| SSRF & DNS Rebinding Defense | 160 | Hostname canonicalization, private host detection, DNS resolution, rebinding guard |
-| Config & Credentials | 100 | Environment vars, API key resolution, allowlist parsing |
-| Query Enhancement & Filtering | 100 | AGI detection, VERITAS anchor, query boosting, result blocking |
-| Toxicity & Content Safety | 60 | Toxic result detection, Base64 payload inspection |
-| HTTP & Retry Logic | 80 | Exponential backoff, retry status detection |
-| Main Orchestrator | 400+ | `web_search()` entry point, result normalization |
-| Safe Parameter Parsing | 90 | `_safe_int()`, `_safe_float()`, bounds validation |
+| グループ | 概算行数 | 説明 |
+|---------|--------:|------|
+| SSRF・DNSリバインディング防御 | 160 | ホスト名正規化、プライベートホスト検出、DNS解決、リバインディングガード |
+| 設定・認証情報 | 100 | 環境変数、APIキー解決、許可リスト解析 |
+| クエリ強化・フィルタリング | 100 | AGI検出、VERITASアンカー、クエリブースト、結果ブロック |
+| 有害コンテンツ・安全性 | 60 | 有害結果検出、Base64ペイロード検査 |
+| HTTP・リトライロジック | 80 | 指数バックオフ、リトライステータス判定 |
+| メインオーケストレータ | 400+ | `web_search()`エントリポイント、結果正規化 |
+| 安全なパラメータ解析 | 90 | `_safe_int()`、`_safe_float()`、範囲バリデーション |
 
-### Recommended Split
+### 推奨分割構成
 
 ```
 tools/
-├── web_search.py              # (~400 lines) Main orchestrator, result normalization
-├── web_search_security.py     # (~160 lines) SSRF/DNS rebinding defense
-├── web_search_config.py       # (~100 lines) Credentials, allowlist, safe parsing
-├── web_search_filtering.py    # (~100 lines) AGI detection, query boosting, blocking
-└── web_search_safety.py       # (~60 lines)  Toxicity detection, Base64 inspection
+├── web_search.py              # (~400行) メインオーケストレータ、結果正規化
+├── web_search_security.py     # (~160行) SSRF/DNSリバインディング防御
+├── web_search_config.py       # (~100行) 認証情報、許可リスト、安全な解析
+├── web_search_filtering.py    # (~100行) AGI検出、クエリブースト、ブロック
+└── web_search_safety.py       # (~60行)  有害コンテンツ検出、Base64検査
 ```
 
 ---
 
-## 8. `veritas_os/core/pipeline.py` (1,223 lines) — MEDIUM
+## 8. `veritas_os/core/pipeline.py` (1,223行) — 中
 
-### Identified Responsibility Groups
+### 特定された責務グループ
 
-| Group | Approx Lines | Description |
-|-------|-------------:|-------------|
-| Initialization & Imports | 100 | Module checks, persona loading, warning setup |
-| Utilities & Helpers | 120 | Type conversions, value clipping, request param extraction |
-| Persistence & Storage | 180 | Path resolution, decision loading, dataset/trust log fallbacks |
-| Policy & Gate Logic | 100 | Gate prediction, value stats, alternative deduplication |
-| Main Orchestration | 200+ | `run_decide_pipeline()` — delegates to stage modules |
+| グループ | 概算行数 | 説明 |
+|---------|--------:|------|
+| 初期化・インポート | 100 | モジュールチェック、ペルソナロード、警告設定 |
+| ユーティリティ・ヘルパー | 120 | 型変換、値クリッピング、リクエストパラメータ抽出 |
+| 永続化・ストレージ | 180 | パス解決、意思決定ロード、データセット/トラストログフォールバック |
+| ポリシー・ゲートロジック | 100 | ゲート予測、バリュー統計、代替案重複排除 |
+| メインオーケストレーション | 200+ | `run_decide_pipeline()` — ステージモジュールへの委譲 |
 
-### Recommended Split
+### 推奨分割構成
 
 ```
 pipeline/
-├── __init__.py           # Re-exports
-├── pipeline.py           # (~200 lines) Main run_decide_pipeline() orchestrator
-├── persistence.py        # (~180 lines) Path resolution, decision loading, fallbacks
-├── helpers.py            # (~120 lines) Type conversions, clipping, params
-└── gate.py               # (~100 lines) Gate prediction, value stats, dedup
+├── __init__.py           # 再エクスポート
+├── pipeline.py           # (~200行) メインrun_decide_pipeline()オーケストレータ
+├── persistence.py        # (~180行) パス解決、意思決定ロード、フォールバック
+├── helpers.py            # (~120行) 型変換、クリッピング、パラメータ
+└── gate.py               # (~100行) ゲート予測、バリュー統計、重複排除
 ```
 
 ---
 
-## Test Files Requiring Attention
+## 要注意テストファイル
 
-Several test files also exceed reasonable size and should be organized:
+複数のテストファイルも適正なサイズを超えており、整理が必要:
 
-| File | Lines | Note |
-|------|------:|------|
-| `tests/test_api_server_extra.py` | 1,886 | Should mirror server.py split |
-| `tests/test_coverage_boost.py` | 1,380 | Consider splitting by feature |
-| `tests/test_kernel_core_extra.py` | 1,217 | Split by kernel responsibility |
-| `tests/test_api_pipeline.py` | 1,128 | Split by pipeline stage |
-| `packages/types/src/index.test.ts` | 1,590 | Split by type domain |
+| ファイル | 行数 | 備考 |
+|---------|-----:|------|
+| `tests/test_api_server_extra.py` | 1,886 | server.pyの分割に合わせるべき |
+| `tests/test_coverage_boost.py` | 1,380 | 機能別に分割を検討 |
+| `tests/test_kernel_core_extra.py` | 1,217 | カーネルの責務別に分割 |
+| `tests/test_api_pipeline.py` | 1,128 | パイプラインステージ別に分割 |
+| `packages/types/src/index.test.ts` | 1,590 | 型ドメイン別に分割 |
 
 ---
 
-## Recommended Execution Order
+## 推奨実行順序
 
-1. **`api/server.py`** — Highest line count, most diverse responsibilities, blocking parallel development
-2. **`core/memory.py`** — Critical infrastructure with scattered concurrency concerns
-3. **`core/fuji.py`** — Safety-critical code benefits most from isolated testing
-4. **`core/eu_ai_act_compliance_module.py`** — Regulatory code should be clearly separated
-5. **`frontend/app/audit/page.tsx`** — Standard React componentization
-6. **`tools/web_search.py`** — Security-critical SSRF logic should be isolated
-7. **`core/planner.py`** — JSON parsing dominates; straightforward extraction
-8. **`core/pipeline.py`** — Already partially delegating to sub-modules
+1. **`api/server.py`** — 最大行数、最も多様な責務、並行開発のボトルネック
+2. **`core/memory.py`** — 散在する並行性の懸念を持つ重要インフラ
+3. **`core/fuji.py`** — 安全性に関わるコードは分離テストの恩恵が最大
+4. **`core/eu_ai_act_compliance_module.py`** — 規制関連コードは明確に分離すべき
+5. **`frontend/app/audit/page.tsx`** — 標準的なReactコンポーネント分割
+6. **`tools/web_search.py`** — セキュリティ上重要なSSRFロジックを分離すべき
+7. **`core/planner.py`** — JSON解析が支配的; 直接的な抽出が可能
+8. **`core/pipeline.py`** — 既にサブモジュールへの部分的委譲あり


### PR DESCRIPTION
Review 11 files exceeding 1,000 lines with detailed splitting
recommendations to prevent future technical debt. Covers server.py
(3,536 lines), memory.py (2,130 lines), eu_ai_act_compliance_module.py,
fuji.py, planner.py, audit/page.tsx, web_search.py, and pipeline.py.

https://claude.ai/code/session_01HYFtjTb2DAvtUTNV1ntWSL