### PR TITLE
refactor: extract JSON parsing and SSRF security into separate modules

### DIFF
--- a/LARGE_FILE_REVIEW.md
+++ b/LARGE_FILE_REVIEW.md
@@ -319,6 +319,62 @@ pipeline/
 3. **`core/fuji.py`** — 安全性に関わるコードは分離テストの恩恵が最大
 4. **`core/eu_ai_act_compliance_module.py`** — 規制関連コードは明確に分離すべき
 5. **`frontend/app/audit/page.tsx`** — 標準的なReactコンポーネント分割
-6. **`tools/web_search.py`** — セキュリティ上重要なSSRFロジックを分離すべき
-7. **`core/planner.py`** — JSON解析が支配的; 直接的な抽出が可能
+6. ~~**`tools/web_search.py`** — セキュリティ上重要なSSRFロジックを分離すべき~~ **完了**
+7. ~~**`core/planner.py`** — JSON解析が支配的; 直接的な抽出が可能~~ **完了**
 8. **`core/pipeline.py`** — 既にサブモジュールへの部分的委譲あり
+
+---
+
+## 実施済み改善 (2026-03-15)
+
+### 7. `core/planner.py` — JSON解析モジュール分離
+
+**変更内容:** JSON解析・救出ロジック（~274行）を `core/planner_json.py` に抽出
+
+| 項目 | 変更前 | 変更後 |
+|------|-------:|-------:|
+| `planner.py` | 1,407行 | 1,133行 |
+| `planner_json.py` | — | 304行 |
+
+**抽出した関数:**
+- `_truncate_json_extract_input()` — BOM/NUL除去、サイズ制限
+- `_safe_parse()` — dict/list/str 統一パーサ（fenced JSON対応）
+- `_safe_json_extract_core()` — LLM出力からのJSON救出エンジン（4段階フォールバック）
+- `_safe_json_extract()` — 後方互換ラッパー
+- 関連定数: `_MAX_JSON_EXTRACT_CHARS`, `_MAX_JSON_DECODE_ATTEMPTS` 等
+
+**後方互換性:** `planner.py` が `planner_json` から全シンボルを再インポートするため、既存のインポートパスは変更不要。
+
+---
+
+### 6. `tools/web_search.py` — SSRFセキュリティモジュール分離
+
+**変更内容:** SSRF/DNS rebinding防御ロジック（~214行）を `tools/web_search_security.py` に抽出
+
+| 項目 | 変更前 | 変更後 |
+|------|-------:|-------:|
+| `web_search.py` | 1,306行 | 1,120行 |
+| `web_search_security.py` | — | 294行 |
+
+**抽出した関数:**
+- `_sanitize_websearch_url()` — HTTPS強制、埋め込み資格情報禁止
+- `_extract_hostname()` / `_canonicalize_hostname()` — ホスト名正規化
+- `_is_obviously_private_or_local_host()` — 文字列ベースのプライベートホスト検出
+- `_resolve_host_infos()` — LRUキャッシュ付きDNS解決
+- `_is_private_or_local_host()` — DNS解決ベースのSSRF検出
+- `_resolve_public_ips_uncached()` — リクエスト時DNS解決（rebindingガード用）
+- `_extract_public_ips_for_url()` / `_validate_rebinding_guard()` — DNS rebinding防御
+- `_is_hostname_exact_or_subdomain()` — サブドメイン判定
+
+**後方互換性:** テストが `web_search_mod` 経由で monkeypatch するパターンに対応するため、`_is_allowed_websearch_url()` と `_validate_rebinding_guard()` は `web_search.py` にローカルラッパーとして維持。全107テスト（test_web_search.py: 45, test_web_search_extra.py: 62）パス。
+
+---
+
+### 改善効果サマリ
+
+| メトリクス | 変更前 | 変更後 | 削減率 |
+|-----------|-------:|-------:|-------:|
+| `planner.py` 行数 | 1,407 | 1,133 | -19.5% |
+| `web_search.py` 行数 | 1,306 | 1,120 | -14.2% |
+| セキュリティコード分離 | 未分離 | 独立モジュール | — |
+| JSON解析分離 | 未分離 | 独立モジュール | — |

--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -13,51 +13,21 @@ from . import world as world_model
 from . import memory as mem
 from . import code_planner  # ★ 追加
 from .planner_normalization import normalize_float, normalize_int
+from .planner_json import (  # ★ JSON解析ロジックを分離
+    _truncate_json_extract_input,
+    _safe_parse,
+    _safe_json_extract_core,
+    _safe_json_extract,
+    _MAX_JSON_EXTRACT_CHARS,
+    _MAX_JSON_DECODE_ATTEMPTS,
+    _MAX_STEPS_OBJECT_EXTRACT_ATTEMPTS,
+    _MAX_FENCED_BLOCK_SCAN_ATTEMPTS,
+)
 
 logger = logging.getLogger(__name__)
 
 _FALLBACK_SAFE_ERRORS = (ValueError, TypeError, KeyError, AttributeError)
 _MEMORY_LOOKUP_ERRORS = (AttributeError, TypeError, ValueError, OSError)
-
-# LLMの暴走出力によるJSON救出時の過剰CPU使用を抑えるための上限
-_MAX_JSON_EXTRACT_CHARS = 200_000
-_MAX_JSON_DECODE_ATTEMPTS = 512
-_MAX_STEPS_OBJECT_EXTRACT_ATTEMPTS = 512
-_MAX_FENCED_BLOCK_SCAN_ATTEMPTS = 128
-
-
-def _truncate_json_extract_input(raw: Any) -> str:
-    """Normalize and size-limit JSON extraction input.
-
-    The helper accepts arbitrary values because several planner call paths may
-    pass non-string payloads during fallback handling. It also removes a UTF-8
-    BOM and NUL bytes which frequently appear in streamed model output and can
-    break JSON parsing.
-    """
-    if raw is None:
-        return ""
-
-    if not isinstance(raw, str):
-        raw = str(raw)
-
-    cleaned = raw.strip()
-    if cleaned.startswith("\ufeff"):
-        cleaned = cleaned.lstrip("\ufeff")
-        logger.warning("planner JSON extraction removed leading BOM")
-
-    if "\x00" in cleaned:
-        cleaned = "".join(cleaned.split("\x00"))
-        logger.warning("planner JSON extraction removed NUL bytes")
-
-    if len(cleaned) <= _MAX_JSON_EXTRACT_CHARS:
-        return cleaned
-
-    logger.warning(
-        "planner JSON extraction input too large (%d chars); truncating to %d chars",
-        len(cleaned),
-        _MAX_JSON_EXTRACT_CHARS,
-    )
-    return cleaned[:_MAX_JSON_EXTRACT_CHARS]
 
 
 class StepDict(TypedDict, total=False):
@@ -469,254 +439,10 @@ def _build_user_prompt(
 
 
 # ============================
-#  JSON Parse（救出強化 + テスト互換）
+#  JSON Parse — planner_json.py に分離済み
+#  (_safe_parse, _safe_json_extract_core, _safe_json_extract,
+#   _truncate_json_extract_input は上部 import で再エクスポート)
 # ============================
-
-_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
-
-def _safe_parse(raw: Any) -> Dict[str, Any]:
-    """
-    テスト互換用（debate と同系）。
-    - dict -> dict
-    - list -> {"steps": list}
-    - str  -> fenced除去 + JSON救出
-    - その他 -> str化して救出
-    戻りは必ず {"steps": [...]} を含む dict。
-    """
-    if raw is None:
-        return {"steps": []}
-
-    if isinstance(raw, dict):
-        d = dict(raw)
-        # steps が list でなければ空に寄せる
-        if not isinstance(d.get("steps"), list):
-            if isinstance(d.get("steps"), dict):
-                d["steps"] = [d["steps"]]  # 変なモデル出力救済
-            else:
-                d.setdefault("steps", [])
-        return d
-
-    if isinstance(raw, list):
-        return {"steps": raw}
-
-    if not isinstance(raw, str):
-        raw = str(raw)
-
-    s = _truncate_json_extract_input(raw)
-    if not s:
-        return {"steps": []}
-
-    fallback_parsed: Optional[Dict[str, Any]] = None
-    fenced_attempts = 0
-    for fence_match in _FENCE_RE.finditer(s):
-        if fenced_attempts >= _MAX_FENCED_BLOCK_SCAN_ATTEMPTS:
-            logger.warning(
-                "planner fenced JSON scan limit reached (%d blocks)",
-                _MAX_FENCED_BLOCK_SCAN_ATTEMPTS,
-            )
-            break
-
-        fenced_attempts += 1
-        fenced = fence_match.group(1).strip()
-        parsed = _safe_json_extract_core(fenced)
-        if parsed.get("steps"):
-            return parsed
-        if fallback_parsed is None:
-            fallback_parsed = parsed
-
-    if fallback_parsed is not None:
-        return fallback_parsed
-
-    return _safe_json_extract_core(s)
-
-
-def _safe_json_extract_core(raw: str) -> Dict[str, Any]:
-    """
-    LLM の出力から JSON を安全に取り出す（救出エンジン）。
-    ※ _safe_parse が外側の互換層。
-    大きすぎる入力は先頭のみを使って解析し、DoSリスクを低減する。
-    """
-    if not raw:
-        return {"steps": []}
-
-    cleaned = _truncate_json_extract_input(raw)
-
-    # ``` の先頭/末尾だけ来た時も対策
-    if cleaned.startswith("```"):
-        first_newline = cleaned.find("\n")
-        if first_newline != -1:
-            cleaned = cleaned[first_newline + 1 :]
-        if cleaned.endswith("```"):
-            cleaned = cleaned[:-3].strip()
-
-    def _wrap_if_needed(obj: Any) -> Dict[str, Any]:
-        if isinstance(obj, list):
-            return {"steps": obj}
-        if isinstance(obj, dict):
-            if isinstance(obj.get("steps"), list):
-                return obj
-            # stepsが無い/壊れてる場合も必ず安定化
-            obj.setdefault("steps", [])
-            if isinstance(obj.get("steps"), dict):
-                obj["steps"] = [obj["steps"]]
-            elif not isinstance(obj.get("steps"), list):
-                obj["steps"] = []
-            return obj
-        return {"steps": []}
-
-    def _iter_decoded_json_values(text: str):
-        """Yield JSON values decoded from free-form text.
-
-        The probe count is bounded to avoid excessive CPU usage when malformed
-        text contains a very large number of ``{"`` / ``[`` characters.
-        Candidates that cannot possibly close are skipped before decoding
-        attempts.
-        """
-        decoder = json.JSONDecoder()
-        attempts = 0
-        last_obj_close = text.rfind("}")
-        last_list_close = text.rfind("]")
-
-        for i, ch in enumerate(text):
-            if ch not in "[{":
-                continue
-
-            if attempts >= _MAX_JSON_DECODE_ATTEMPTS:
-                logger.warning(
-                    "planner JSON decoder probe limit reached (%d attempts)",
-                    _MAX_JSON_DECODE_ATTEMPTS,
-                )
-                return None
-
-            attempts += 1
-
-            if ch == "{" and i > last_obj_close:
-                continue
-            if ch == "[" and i > last_list_close:
-                continue
-
-            try:
-                obj, _ = decoder.raw_decode(text, idx=i)
-                yield obj
-            except json.JSONDecodeError:
-                continue
-
-    # 1) そのまま
-    try:
-        obj = json.loads(cleaned)
-        return _wrap_if_needed(obj)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        logger.debug("planner JSON parse attempt 1 (raw) failed")
-
-    # 1.5) 先頭ノイズ付きの JSON を raw_decode で救済
-    fallback_from_raw_decode: Optional[Dict[str, Any]] = None
-    for obj in _iter_decoded_json_values(cleaned):
-        if isinstance(obj, list):
-            return _wrap_if_needed(obj)
-
-        if isinstance(obj, dict) and "steps" in obj:
-            return _wrap_if_needed(obj)
-
-        if isinstance(obj, dict) and fallback_from_raw_decode is None:
-            fallback_from_raw_decode = _wrap_if_needed(obj)
-
-    if fallback_from_raw_decode and cleaned.lstrip().startswith("{"):
-        return fallback_from_raw_decode
-
-    # 2) {} 抜き出し（旧来互換の救済）
-    try:
-        start = cleaned.index("{")
-        end = cleaned.rindex("}") + 1
-        snippet = cleaned[start:end]
-        obj = json.loads(snippet)
-        return _wrap_if_needed(obj)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        logger.debug("planner JSON parse attempt 2 (brace extraction) failed")
-
-    # 3) 末尾削り
-    max_len = len(cleaned)
-    attempts = 0
-    max_attempts = 500
-
-    for cut in range(max_len, 1, -1):
-        if attempts >= max_attempts:
-            break
-        ch = cleaned[cut - 1]
-        if ch not in ("}", "]"):
-            continue
-        attempts += 1
-        candidate = cleaned[:cut]
-        try:
-            obj = json.loads(candidate)
-            return _wrap_if_needed(obj)
-        except (TypeError, ValueError, json.JSONDecodeError):
-            continue
-
-    # 4) "steps":[{...},{...}] から dict だけ拾う（最後の保険）
-    #    NOTE: 以前の手書きパーサよりも、JSONDecoder を使って保守性を向上。
-    def _extract_step_objects(text: str) -> List[Dict[str, Any]]:
-        """Extract dict objects from a ``"steps"`` JSON-like array.
-
-        This parser is intentionally tolerant to partially broken LLM output.
-        It scans forward from ``"steps": [`` and decodes each object candidate
-        with ``json.JSONDecoder().raw_decode``. The decode attempt count is
-        bounded to reduce CPU abuse risk from malformed inputs.
-        """
-        idx = text.find('"steps"')
-        if idx == -1:
-            return []
-        idx = text.find("[", idx)
-        if idx == -1:
-            return []
-
-        objs: List[Dict[str, Any]] = []
-        decoder = json.JSONDecoder()
-        attempts = 0
-        i = idx + 1
-        n = len(text)
-
-        while i < n:
-            if attempts >= _MAX_STEPS_OBJECT_EXTRACT_ATTEMPTS:
-                logger.warning(
-                    "planner step object extraction attempt limit reached (%d)",
-                    _MAX_STEPS_OBJECT_EXTRACT_ATTEMPTS,
-                )
-                break
-
-            ch = text[i]
-            if ch == "]":
-                break
-
-            if ch != "{":
-                i += 1
-                continue
-
-            attempts += 1
-            try:
-                obj, end = decoder.raw_decode(text, idx=i)
-            except json.JSONDecodeError:
-                i += 1
-                continue
-
-            if isinstance(obj, dict):
-                objs.append(obj)
-            i = end
-
-        return objs
-
-    step_objs = _extract_step_objects(cleaned)
-    if step_objs:
-        return {"steps": step_objs}
-
-    return {"steps": []}
-
-
-def _safe_json_extract(raw: str) -> Dict[str, Any]:
-    """
-    互換のため残す（既存コード/テストが参照する可能性）。
-    実体は _safe_parse → _safe_json_extract_core。
-    """
-    return _safe_parse(raw)
 
 
 # ============================

--- a/veritas_os/core/planner_json.py
+++ b/veritas_os/core/planner_json.py
@@ -1,0 +1,304 @@
+"""JSON parsing and extraction for Planner payloads.
+
+This module centralizes the robust JSON extraction logic used by
+``veritas_os.core.planner`` to recover structured plan data from
+potentially malformed or noisy LLM output.
+
+Extracted from ``planner.py`` to reduce file size and improve testability.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# LLMの暴走出力によるJSON救出時の過剰CPU使用を抑えるための上限
+_MAX_JSON_EXTRACT_CHARS = 200_000
+_MAX_JSON_DECODE_ATTEMPTS = 512
+_MAX_STEPS_OBJECT_EXTRACT_ATTEMPTS = 512
+_MAX_FENCED_BLOCK_SCAN_ATTEMPTS = 128
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+
+
+def _truncate_json_extract_input(raw: Any) -> str:
+    """Normalize and size-limit JSON extraction input.
+
+    The helper accepts arbitrary values because several planner call paths may
+    pass non-string payloads during fallback handling. It also removes a UTF-8
+    BOM and NUL bytes which frequently appear in streamed model output and can
+    break JSON parsing.
+    """
+    if raw is None:
+        return ""
+
+    if not isinstance(raw, str):
+        raw = str(raw)
+
+    cleaned = raw.strip()
+    if cleaned.startswith("\ufeff"):
+        cleaned = cleaned.lstrip("\ufeff")
+        logger.warning("planner JSON extraction removed leading BOM")
+
+    if "\x00" in cleaned:
+        cleaned = "".join(cleaned.split("\x00"))
+        logger.warning("planner JSON extraction removed NUL bytes")
+
+    if len(cleaned) <= _MAX_JSON_EXTRACT_CHARS:
+        return cleaned
+
+    logger.warning(
+        "planner JSON extraction input too large (%d chars); truncating to %d chars",
+        len(cleaned),
+        _MAX_JSON_EXTRACT_CHARS,
+    )
+    return cleaned[:_MAX_JSON_EXTRACT_CHARS]
+
+
+def _safe_json_extract_core(raw: str) -> Dict[str, Any]:
+    """
+    LLM の出力から JSON を安全に取り出す（救出エンジン）。
+    ※ _safe_parse が外側の互換層。
+    大きすぎる入力は先頭のみを使って解析し、DoSリスクを低減する。
+    """
+    if not raw:
+        return {"steps": []}
+
+    cleaned = _truncate_json_extract_input(raw)
+
+    # ``` の先頭/末尾だけ来た時も対策
+    if cleaned.startswith("```"):
+        first_newline = cleaned.find("\n")
+        if first_newline != -1:
+            cleaned = cleaned[first_newline + 1 :]
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3].strip()
+
+    def _wrap_if_needed(obj: Any) -> Dict[str, Any]:
+        if isinstance(obj, list):
+            return {"steps": obj}
+        if isinstance(obj, dict):
+            if isinstance(obj.get("steps"), list):
+                return obj
+            # stepsが無い/壊れてる場合も必ず安定化
+            obj.setdefault("steps", [])
+            if isinstance(obj.get("steps"), dict):
+                obj["steps"] = [obj["steps"]]
+            elif not isinstance(obj.get("steps"), list):
+                obj["steps"] = []
+            return obj
+        return {"steps": []}
+
+    def _iter_decoded_json_values(text: str):
+        """Yield JSON values decoded from free-form text.
+
+        The probe count is bounded to avoid excessive CPU usage when malformed
+        text contains a very large number of ``{"`` / ``[`` characters.
+        Candidates that cannot possibly close are skipped before decoding
+        attempts.
+        """
+        decoder = json.JSONDecoder()
+        attempts = 0
+        last_obj_close = text.rfind("}")
+        last_list_close = text.rfind("]")
+
+        for i, ch in enumerate(text):
+            if ch not in "[{":
+                continue
+
+            if attempts >= _MAX_JSON_DECODE_ATTEMPTS:
+                logger.warning(
+                    "planner JSON decoder probe limit reached (%d attempts)",
+                    _MAX_JSON_DECODE_ATTEMPTS,
+                )
+                return None
+
+            attempts += 1
+
+            if ch == "{" and i > last_obj_close:
+                continue
+            if ch == "[" and i > last_list_close:
+                continue
+
+            try:
+                obj, _ = decoder.raw_decode(text, idx=i)
+                yield obj
+            except json.JSONDecodeError:
+                continue
+
+    # 1) そのまま
+    try:
+        obj = json.loads(cleaned)
+        return _wrap_if_needed(obj)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        logger.debug("planner JSON parse attempt 1 (raw) failed")
+
+    # 1.5) 先頭ノイズ付きの JSON を raw_decode で救済
+    fallback_from_raw_decode: Optional[Dict[str, Any]] = None
+    for obj in _iter_decoded_json_values(cleaned):
+        if isinstance(obj, list):
+            return _wrap_if_needed(obj)
+
+        if isinstance(obj, dict) and "steps" in obj:
+            return _wrap_if_needed(obj)
+
+        if isinstance(obj, dict) and fallback_from_raw_decode is None:
+            fallback_from_raw_decode = _wrap_if_needed(obj)
+
+    if fallback_from_raw_decode and cleaned.lstrip().startswith("{"):
+        return fallback_from_raw_decode
+
+    # 2) {} 抜き出し（旧来互換の救済）
+    try:
+        start = cleaned.index("{")
+        end = cleaned.rindex("}") + 1
+        snippet = cleaned[start:end]
+        obj = json.loads(snippet)
+        return _wrap_if_needed(obj)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        logger.debug("planner JSON parse attempt 2 (brace extraction) failed")
+
+    # 3) 末尾削り
+    max_len = len(cleaned)
+    attempts = 0
+    max_attempts = 500
+
+    for cut in range(max_len, 1, -1):
+        if attempts >= max_attempts:
+            break
+        ch = cleaned[cut - 1]
+        if ch not in ("}", "]"):
+            continue
+        attempts += 1
+        candidate = cleaned[:cut]
+        try:
+            obj = json.loads(candidate)
+            return _wrap_if_needed(obj)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+
+    # 4) "steps":[{...},{...}] から dict だけ拾う（最後の保険）
+    #    NOTE: 以前の手書きパーサよりも、JSONDecoder を使って保守性を向上。
+    def _extract_step_objects(text: str) -> List[Dict[str, Any]]:
+        """Extract dict objects from a ``"steps"`` JSON-like array.
+
+        This parser is intentionally tolerant to partially broken LLM output.
+        It scans forward from ``"steps": [`` and decodes each object candidate
+        with ``json.JSONDecoder().raw_decode``. The decode attempt count is
+        bounded to reduce CPU abuse risk from malformed inputs.
+        """
+        idx = text.find('"steps"')
+        if idx == -1:
+            return []
+        idx = text.find("[", idx)
+        if idx == -1:
+            return []
+
+        objs: List[Dict[str, Any]] = []
+        decoder = json.JSONDecoder()
+        attempts = 0
+        i = idx + 1
+        n = len(text)
+
+        while i < n:
+            if attempts >= _MAX_STEPS_OBJECT_EXTRACT_ATTEMPTS:
+                logger.warning(
+                    "planner step object extraction attempt limit reached (%d)",
+                    _MAX_STEPS_OBJECT_EXTRACT_ATTEMPTS,
+                )
+                break
+
+            ch = text[i]
+            if ch == "]":
+                break
+
+            if ch != "{":
+                i += 1
+                continue
+
+            attempts += 1
+            try:
+                obj, end = decoder.raw_decode(text, idx=i)
+            except json.JSONDecodeError:
+                i += 1
+                continue
+
+            if isinstance(obj, dict):
+                objs.append(obj)
+            i = end
+
+        return objs
+
+    step_objs = _extract_step_objects(cleaned)
+    if step_objs:
+        return {"steps": step_objs}
+
+    return {"steps": []}
+
+
+def _safe_parse(raw: Any) -> Dict[str, Any]:
+    """
+    テスト互換用（debate と同系）。
+    - dict -> dict
+    - list -> {"steps": list}
+    - str  -> fenced除去 + JSON救出
+    - その他 -> str化して救出
+    戻りは必ず {"steps": [...]} を含む dict。
+    """
+    if raw is None:
+        return {"steps": []}
+
+    if isinstance(raw, dict):
+        d = dict(raw)
+        # steps が list でなければ空に寄せる
+        if not isinstance(d.get("steps"), list):
+            if isinstance(d.get("steps"), dict):
+                d["steps"] = [d["steps"]]  # 変なモデル出力救済
+            else:
+                d.setdefault("steps", [])
+        return d
+
+    if isinstance(raw, list):
+        return {"steps": raw}
+
+    if not isinstance(raw, str):
+        raw = str(raw)
+
+    s = _truncate_json_extract_input(raw)
+    if not s:
+        return {"steps": []}
+
+    fallback_parsed: Optional[Dict[str, Any]] = None
+    fenced_attempts = 0
+    for fence_match in _FENCE_RE.finditer(s):
+        if fenced_attempts >= _MAX_FENCED_BLOCK_SCAN_ATTEMPTS:
+            logger.warning(
+                "planner fenced JSON scan limit reached (%d blocks)",
+                _MAX_FENCED_BLOCK_SCAN_ATTEMPTS,
+            )
+            break
+
+        fenced_attempts += 1
+        fenced = fence_match.group(1).strip()
+        parsed = _safe_json_extract_core(fenced)
+        if parsed.get("steps"):
+            return parsed
+        if fallback_parsed is None:
+            fallback_parsed = parsed
+
+    if fallback_parsed is not None:
+        return fallback_parsed
+
+    return _safe_json_extract_core(s)
+
+
+def _safe_json_extract(raw: str) -> Dict[str, Any]:
+    """
+    互換のため残す（既存コード/テストが参照する可能性）。
+    実体は _safe_parse → _safe_json_extract_core。
+    """
+    return _safe_parse(raw)

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -46,57 +46,31 @@ import math
 import os
 import random  # nosec B311 - jitter for retry backoff, not security-sensitive
 import re
+import socket  # kept for test monkeypatch compatibility (web_search_mod.socket)
 import time
 import base64
 import unicodedata
-import ipaddress
-import socket
-from functools import lru_cache
 from typing import Any, Dict, List, Optional
 from urllib.parse import unquote, urlparse
 
 import requests
 
+# ★ SSRF/DNS セキュリティロジックを web_search_security.py に分離
+from .web_search_security import (
+    _sanitize_websearch_url,
+    _extract_hostname,
+    _canonicalize_hostname,
+    _is_obviously_private_or_local_host,
+    _resolve_host_infos,
+    _is_private_or_local_host,
+    _resolve_public_ips_uncached,
+    _extract_public_ips_for_url,
+    _clear_private_host_cache,
+    _is_hostname_exact_or_subdomain,
+)
+
 WEBSEARCH_URL: str = os.getenv("VERITAS_WEBSEARCH_URL", "").strip()
 WEBSEARCH_KEY: str = os.getenv("VERITAS_WEBSEARCH_KEY", "").strip()
-
-
-def _sanitize_websearch_url(url: str) -> str:
-    """Validate env-derived web search URL and enforce HTTPS-only endpoints.
-
-    Security note:
-        Runtime env overrides are useful for incident response, but they must
-        still respect scheme restrictions to avoid accidental use of
-        non-network schemes (e.g. ``file://``).
-    """
-    candidate = (url or "").strip()
-    if not candidate:
-        return ""
-
-    parsed = urlparse(candidate)
-    if parsed.scheme != "https":
-        logging.getLogger(__name__).warning(
-            "VERITAS_WEBSEARCH_URL must use https (got scheme=%r); URL will be ignored",
-            parsed.scheme,
-        )
-        return ""
-
-    # URL 埋め込み資格情報は漏えい・誤設定の原因になり得るため禁止。
-    if parsed.username or parsed.password:
-        logging.getLogger(__name__).warning(
-            "VERITAS_WEBSEARCH_URL must not include embedded credentials; URL will be ignored"
-        )
-        return ""
-
-    # 明示的なホスト名がないURLは requests 側で曖昧解釈される恐れがあるため拒否。
-    if not parsed.hostname:
-        logging.getLogger(__name__).warning(
-            "VERITAS_WEBSEARCH_URL must include a hostname; URL will be ignored"
-        )
-        return ""
-
-    return candidate
-
 
 # ★ SSRF対策: WEBSEARCH_URL のスキームを検証
 WEBSEARCH_URL = _sanitize_websearch_url(WEBSEARCH_URL)
@@ -387,177 +361,34 @@ def _post_with_retry(
             raise
 
 
-def _extract_hostname(url: str) -> str:
-    """URLからホスト名を抽出する（スキームなしURLも対応）。"""
-    if not url:
-        return ""
-    candidate = url.strip()
-    parsed = urlparse(candidate)
-    host = parsed.hostname
-    if not host and "://" not in candidate:
-        parsed = urlparse(f"http://{candidate}")
-        host = parsed.hostname
-    return (host or "").lower().rstrip(".")
-
-
-def _canonicalize_hostname(hostname: str) -> str:
-    """Normalize hostnames for policy checks and allowlist matching.
-
-    DNS hostnames may be represented with a trailing dot (absolute form),
-    such as ``example.com.``. Treating these as distinct strings can bypass
-    exact-match checks and create inconsistent SSRF protections.
-
-    Args:
-        hostname: Raw hostname string.
-
-    Returns:
-        Canonicalized lowercase hostname without surrounding whitespace
-        or a trailing dot.
-    """
-    return (hostname or "").strip().lower().rstrip(".")
-
-
-def _is_obviously_private_or_local_host(hostname: str) -> bool:
-    """文字列情報だけで private/local と判断できるホストを検出する。"""
-    host = _canonicalize_hostname(hostname)
-    if not host:
-        return True
-
-    if host in {"localhost", "localhost.localdomain"}:
-        return True
-
-    # Single-label host names and local/internal pseudo-TLDs are typically
-    # internal-only and should not be used for outbound web search endpoints.
-    if "." not in host:
-        return True
-
-    if host.endswith((".local", ".internal", ".localhost", ".localdomain")):
-        return True
-
-    try:
-        ip = ipaddress.ip_address(host)
-        return not ip.is_global
-    except ValueError:
-        pass
-
-    return False
-
-
-@lru_cache(maxsize=256)
-def _resolve_host_infos(host: str) -> tuple[tuple[Any, ...], ...]:
-    """Resolve host addresses with LRU caching for successful lookups only.
-
-    The function intentionally propagates resolution errors so failed lookups
-    are not cached. This avoids long-lived false positives when DNS fails
-    transiently in CI/sandbox environments.
-    """
-    return tuple(socket.getaddrinfo(host, None))
-
-
-def _is_private_or_local_host(hostname: str) -> bool:
-    """ホストが localhost / private / loopback / link-local かを判定する。
-
-    DNS 解決の成功結果だけを LRU キャッシュし、失敗はキャッシュしない。
-    これにより一時的な名前解決障害での過剰ブロックを緩和する。
-    """
-    host = _canonicalize_hostname(hostname)
-    if _is_obviously_private_or_local_host(host):
-        return True
-
-    try:
-        infos = _resolve_host_infos(host)
-    except (socket.gaierror, OSError, UnicodeError):
-        # DNS解決不能や不正なホスト名（IDNA変換エラー等）は
-        # 誤設定かローカル向け名の可能性が高いため、保守的にブロックする。
-        return True
-
-    for info in infos:
-        ip_text = info[4][0]
-        try:
-            ip = ipaddress.ip_address(ip_text)
-        except ValueError:
-            continue
-        if not ip.is_global:
-            return True
-    return False
-
-
-def _resolve_public_ips_uncached(hostname: str) -> set[str]:
-    """Resolve hostname without cache and require globally routable IPs.
-
-    This request-time lookup narrows DNS rebinding / TOCTOU windows between
-    endpoint validation and the outbound web-search request.
-
-    Args:
-        hostname: Endpoint hostname to resolve.
-
-    Returns:
-        Set of resolved global IP literals.
-
-    Raises:
-        ValueError: Hostname is empty, invalid, unresolvable, or non-global.
-    """
-    host = _canonicalize_hostname(hostname)
-    if _is_obviously_private_or_local_host(host):
-        raise ValueError("host is private or local")
-
-    try:
-        infos = socket.getaddrinfo(host, None)
-    except (socket.gaierror, OSError, UnicodeError) as exc:
-        raise ValueError("host is not resolvable") from exc
-
-    resolved_ips: set[str] = set()
-    for info in infos:
-        ip_text = info[4][0]
-        try:
-            ip = ipaddress.ip_address(ip_text)
-        except ValueError as exc:
-            raise ValueError("host resolved to invalid IP") from exc
-        if not ip.is_global:
-            raise ValueError("host resolved to non-global IP")
-        resolved_ips.add(str(ip))
-
-    if not resolved_ips:
-        raise ValueError("host resolved to no valid IPs")
-
-    return resolved_ips
-
-
-def _extract_public_ips_for_url(url: str) -> set[str]:
-    """Extract URL host and resolve it to global IPs without cache."""
-    parsed = urlparse((url or "").strip())
-    host = _canonicalize_hostname(parsed.hostname or "")
-    if not host:
-        raise ValueError("url has no hostname")
-    return _resolve_public_ips_uncached(host)
+# ---------------------------------------------------------------------------
+# SSRF / DNS security — web_search_security.py に分離済み
+# (_extract_hostname, _canonicalize_hostname, _is_private_or_local_host 等は上部 import)
+# 以下のラッパーはテストの monkeypatch 互換性のためモジュールローカルに維持
+# ---------------------------------------------------------------------------
 
 
 def _validate_rebinding_guard(url: str, expected_ips: set[str]) -> None:
-    """Ensure request-time DNS answers match preflight-resolved IPs."""
+    """Ensure request-time DNS answers match preflight-resolved IPs.
+
+    Kept as a local function so tests can monkeypatch
+    ``_extract_public_ips_for_url`` on this module.
+    """
     current_ips = _extract_public_ips_for_url(url)
     if current_ips != expected_ips:
         raise ValueError("websearch endpoint DNS result changed during request")
 
 
-def _clear_private_host_cache() -> None:
-    """Clear DNS lookup cache used by SSRF host checks."""
-    _resolve_host_infos.cache_clear()
-
-
-_is_private_or_local_host.cache_clear = _clear_private_host_cache
-
-
 def _is_allowed_websearch_url(url: str) -> bool:
     """WEBSEARCH endpoint のスキーム・ホスト安全性を検証する。
 
-    Security note:
-        API key を平文送信しないため、HTTPS のみ許可する。
+    Uses module-level ``_is_private_or_local_host`` so tests can
+    monkeypatch it on this module for SSRF bypass.
     """
     parsed = urlparse((url or "").strip())
     if parsed.scheme != "https":
         return False
 
-    # URL 埋め込み資格情報の利用を禁止し、誤設定や漏えいリスクを低減する。
     if parsed.username or parsed.password:
         return False
 
@@ -566,9 +397,6 @@ def _is_allowed_websearch_url(url: str) -> bool:
     if host_allowlist:
         if host not in host_allowlist:
             return False
-        # Allowlisted hosts must also resolve to public IPs.
-        # This prevents DNS rebinding/misconfiguration from tunneling
-        # requests into private networks.
         return not _is_private_or_local_host(host)
 
     if _is_private_or_local_host(host):
@@ -709,21 +537,7 @@ def _is_blocked_result(title: str, snippet: str, url: str) -> bool:
     return False
 
 
-def _is_hostname_exact_or_subdomain(hostname: str, domain: str) -> bool:
-    """Return True when hostname is the same domain or a child subdomain.
-
-    This helper prevents suffix-matching mistakes such as treating
-    ``evilveritas.com`` as ``veritas.com``. Only exact matches or dot-bounded
-    subdomains (e.g., ``www.veritas.com``) are accepted.
-    """
-    normalized_host = _canonicalize_hostname(hostname)
-    normalized_domain = _canonicalize_hostname(domain)
-    if not normalized_host or not normalized_domain:
-        return False
-    return (
-        normalized_host == normalized_domain
-        or normalized_host.endswith(f".{normalized_domain}")
-    )
+# _is_hostname_exact_or_subdomain は web_search_security.py から import 済み
 
 
 def _sanitize_max_results(max_results: Any, *, default: int = 5) -> int:

--- a/veritas_os/tools/web_search_security.py
+++ b/veritas_os/tools/web_search_security.py
@@ -1,0 +1,294 @@
+"""SSRF / DNS rebinding protection for Web Search adapter.
+
+This module centralizes all host-validation, private-IP detection,
+and DNS rebinding guard logic used by ``veritas_os.tools.web_search``.
+
+Extracted from ``web_search.py`` to isolate security-critical code
+for easier review and independent testing.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from functools import lru_cache
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Hostname helpers
+# ---------------------------------------------------------------------------
+
+def _extract_hostname(url: str) -> str:
+    """URLからホスト名を抽出する（スキームなしURLも対応）。"""
+    if not url:
+        return ""
+    candidate = url.strip()
+    parsed = urlparse(candidate)
+    host = parsed.hostname
+    if not host and "://" not in candidate:
+        parsed = urlparse(f"http://{candidate}")
+        host = parsed.hostname
+    return (host or "").lower().rstrip(".")
+
+
+def _canonicalize_hostname(hostname: str) -> str:
+    """Normalize hostnames for policy checks and allowlist matching.
+
+    DNS hostnames may be represented with a trailing dot (absolute form),
+    such as ``example.com.``. Treating these as distinct strings can bypass
+    exact-match checks and create inconsistent SSRF protections.
+
+    Args:
+        hostname: Raw hostname string.
+
+    Returns:
+        Canonicalized lowercase hostname without surrounding whitespace
+        or a trailing dot.
+    """
+    return (hostname or "").strip().lower().rstrip(".")
+
+
+def _is_hostname_exact_or_subdomain(hostname: str, domain: str) -> bool:
+    """Return True when hostname is the same domain or a child subdomain.
+
+    This helper prevents suffix-matching mistakes such as treating
+    ``evilveritas.com`` as ``veritas.com``. Only exact matches or dot-bounded
+    subdomains (e.g., ``www.veritas.com``) are accepted.
+    """
+    normalized_host = _canonicalize_hostname(hostname)
+    normalized_domain = _canonicalize_hostname(domain)
+    if not normalized_host or not normalized_domain:
+        return False
+    return (
+        normalized_host == normalized_domain
+        or normalized_host.endswith(f".{normalized_domain}")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private / local host detection
+# ---------------------------------------------------------------------------
+
+def _is_obviously_private_or_local_host(hostname: str) -> bool:
+    """文字列情報だけで private/local と判断できるホストを検出する。"""
+    host = _canonicalize_hostname(hostname)
+    if not host:
+        return True
+
+    if host in {"localhost", "localhost.localdomain"}:
+        return True
+
+    # Single-label host names and local/internal pseudo-TLDs are typically
+    # internal-only and should not be used for outbound web search endpoints.
+    if "." not in host:
+        return True
+
+    if host.endswith((".local", ".internal", ".localhost", ".localdomain")):
+        return True
+
+    try:
+        ip = ipaddress.ip_address(host)
+        return not ip.is_global
+    except ValueError:
+        pass
+
+    return False
+
+
+@lru_cache(maxsize=256)
+def _resolve_host_infos(host: str) -> tuple[tuple[Any, ...], ...]:
+    """Resolve host addresses with LRU caching for successful lookups only.
+
+    The function intentionally propagates resolution errors so failed lookups
+    are not cached. This avoids long-lived false positives when DNS fails
+    transiently in CI/sandbox environments.
+    """
+    return tuple(socket.getaddrinfo(host, None))
+
+
+def _is_private_or_local_host(hostname: str) -> bool:
+    """ホストが localhost / private / loopback / link-local かを判定する。
+
+    DNS 解決の成功結果だけを LRU キャッシュし、失敗はキャッシュしない。
+    これにより一時的な名前解決障害での過剰ブロックを緩和する。
+    """
+    host = _canonicalize_hostname(hostname)
+    if _is_obviously_private_or_local_host(host):
+        return True
+
+    try:
+        infos = _resolve_host_infos(host)
+    except (socket.gaierror, OSError, UnicodeError):
+        # DNS解決不能や不正なホスト名（IDNA変換エラー等）は
+        # 誤設定かローカル向け名の可能性が高いため、保守的にブロックする。
+        return True
+
+    for info in infos:
+        ip_text = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_text)
+        except ValueError:
+            continue
+        if not ip.is_global:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# DNS rebinding guard
+# ---------------------------------------------------------------------------
+
+def _resolve_public_ips_uncached(hostname: str) -> set[str]:
+    """Resolve hostname without cache and require globally routable IPs.
+
+    This request-time lookup narrows DNS rebinding / TOCTOU windows between
+    endpoint validation and the outbound web-search request.
+
+    Args:
+        hostname: Endpoint hostname to resolve.
+
+    Returns:
+        Set of resolved global IP literals.
+
+    Raises:
+        ValueError: Hostname is empty, invalid, unresolvable, or non-global.
+    """
+    host = _canonicalize_hostname(hostname)
+    if _is_obviously_private_or_local_host(host):
+        raise ValueError("host is private or local")
+
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except (socket.gaierror, OSError, UnicodeError) as exc:
+        raise ValueError("host is not resolvable") from exc
+
+    resolved_ips: set[str] = set()
+    for info in infos:
+        ip_text = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_text)
+        except ValueError as exc:
+            raise ValueError("host resolved to invalid IP") from exc
+        if not ip.is_global:
+            raise ValueError("host resolved to non-global IP")
+        resolved_ips.add(str(ip))
+
+    if not resolved_ips:
+        raise ValueError("host resolved to no valid IPs")
+
+    return resolved_ips
+
+
+def _extract_public_ips_for_url(url: str) -> set[str]:
+    """Extract URL host and resolve it to global IPs without cache."""
+    parsed = urlparse((url or "").strip())
+    host = _canonicalize_hostname(parsed.hostname or "")
+    if not host:
+        raise ValueError("url has no hostname")
+    return _resolve_public_ips_uncached(host)
+
+
+def _validate_rebinding_guard(url: str, expected_ips: set[str]) -> None:
+    """Ensure request-time DNS answers match preflight-resolved IPs."""
+    current_ips = _extract_public_ips_for_url(url)
+    if current_ips != expected_ips:
+        raise ValueError("websearch endpoint DNS result changed during request")
+
+
+def _clear_private_host_cache() -> None:
+    """Clear DNS lookup cache used by SSRF host checks."""
+    _resolve_host_infos.cache_clear()
+
+
+# Attach cache_clear for monkeypatch compatibility
+_is_private_or_local_host.cache_clear = _clear_private_host_cache  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# URL validation
+# ---------------------------------------------------------------------------
+
+def _sanitize_websearch_url(url: str) -> str:
+    """Validate env-derived web search URL and enforce HTTPS-only endpoints.
+
+    Security note:
+        Runtime env overrides are useful for incident response, but they must
+        still respect scheme restrictions to avoid accidental use of
+        non-network schemes (e.g. ``file://``).
+    """
+    candidate = (url or "").strip()
+    if not candidate:
+        return ""
+
+    parsed = urlparse(candidate)
+    if parsed.scheme != "https":
+        logging.getLogger(__name__).warning(
+            "VERITAS_WEBSEARCH_URL must use https (got scheme=%r); URL will be ignored",
+            parsed.scheme,
+        )
+        return ""
+
+    # URL 埋め込み資格情報は漏えい・誤設定の原因になり得るため禁止。
+    if parsed.username or parsed.password:
+        logging.getLogger(__name__).warning(
+            "VERITAS_WEBSEARCH_URL must not include embedded credentials; URL will be ignored"
+        )
+        return ""
+
+    # 明示的なホスト名がないURLは requests 側で曖昧解釈される恐れがあるため拒否。
+    if not parsed.hostname:
+        logging.getLogger(__name__).warning(
+            "VERITAS_WEBSEARCH_URL must include a hostname; URL will be ignored"
+        )
+        return ""
+
+    return candidate
+
+
+def _is_allowed_websearch_url(
+    url: str,
+    *,
+    resolve_allowlist_fn=None,
+) -> bool:
+    """WEBSEARCH endpoint のスキーム・ホスト安全性を検証する。
+
+    Security note:
+        API key を平文送信しないため、HTTPS のみ許可する。
+
+    Args:
+        url: Target URL to validate.
+        resolve_allowlist_fn: Callable returning current host allowlist set.
+            If None, an empty set is used (no allowlist restriction).
+    """
+    parsed = urlparse((url or "").strip())
+    if parsed.scheme != "https":
+        return False
+
+    # URL 埋め込み資格情報の利用を禁止し、誤設定や漏えいリスクを低減する。
+    if parsed.username or parsed.password:
+        return False
+
+    host = _canonicalize_hostname(parsed.hostname or "")
+    if resolve_allowlist_fn is not None:
+        host_allowlist = resolve_allowlist_fn()
+    else:
+        host_allowlist: set[str] = set()
+
+    if host_allowlist:
+        if host not in host_allowlist:
+            return False
+        # Allowlisted hosts must also resolve to public IPs.
+        # This prevents DNS rebinding/misconfiguration from tunneling
+        # requests into private networks.
+        return not _is_private_or_local_host(host)
+
+    if _is_private_or_local_host(host):
+        return False
+
+    return True


### PR DESCRIPTION
- Extract planner JSON parsing/rescue logic (~274 lines) into
  core/planner_json.py for independent testing and reduced cognitive load
- Extract SSRF/DNS rebinding security functions (~214 lines) into
  tools/web_search_security.py to isolate security-critical code
- planner.py: 1,407 → 1,133 lines (-19.5%)
- web_search.py: 1,306 → 1,120 lines (-14.2%)
- All 107 web_search tests pass with full backward compatibility
- Update LARGE_FILE_REVIEW.md with completed improvements

https://claude.ai/code/session_01Ah43q2QeJYzuavMeNMnQNn