### PR TITLE
fix(frontend): migrate lint script to ESLint CLI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --ignore-pattern next-env.d.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "e2e": "playwright test",


### PR DESCRIPTION
### Motivation
- The `next lint` command is deprecated and will be removed in Next.js 16, which caused CI lint gates to fail; the change moves the frontend lint step to the ESLint CLI and ignores the generated `next-env.d.ts` triple-slash reference to avoid spurious lint errors.

### Description
- Update `frontend/package.json` `scripts.lint` to use `eslint . --ext .js,.jsx,.ts,.tsx --ignore-pattern next-env.d.ts` instead of `next lint` so CI remains compatible with future Next.js upgrades.

### Testing
- Ran `cd frontend && pnpm lint` which now exits successfully with warnings but no errors, and ran `cd frontend && pnpm typecheck` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2e6be3648326883989c36a741c73)