### PR TITLE
Harden pipeline policy numeric sanitization

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319.md
+++ b/docs/reviews/precision_code_review_ja_20260319.md
@@ -1,0 +1,45 @@
+# VERITAS OS Precision Code Review フォローアップ（2026-03-19）
+
+## 前提
+
+- 指定された `docs/reviews/precision_code_review_ja_20260319.md` は作業開始時点で未存在だった。
+- そのため、既存の最新レビュー群（特に `docs/reviews/technical_dd_review_ja_20260315.md` と `docs/reviews/CODE_REVIEW_CONSISTENCY_2026_03_15_JP.md`）を起点に、**高優先度かつ未解消で、責務境界を越えない項目だけ**を再確認した。
+
+## 優先度判断
+
+今回の再点検では、既存レビュー中の Critical / High の多くが既に解消済みだった。未解消かつ実害が大きい候補として、以下を最優先と判断した。
+
+1. **NaN / Inf による gate 数値汚染**
+   - `pipeline_policy` は FUJI risk / EMA / Debate risk delta を受け取り、最終 gate 判定に反映する。
+   - `NaN` が混入すると比較・clamp が壊れ、安全判定や学習量が不安定になる。
+   - Planner / Kernel / Fuji / MemoryOS の責務越境なしで、`pipeline_policy` 内に局所修正できる。
+
+## 実施した改善
+
+### P1: `pipeline_policy` の非有限数 fail-closed 化
+
+- `_coerce_finite_probability()` を追加し、`NaN` / `Inf` / 型不正値を `0.0〜1.0` の有限値へ正規化するようにした。
+- FUJI precheck の `risk` 表示用値を同ヘルパーへ統一した。
+- `stage_value_core()` で:
+  - `value_ema` の `NaN` を安全既定値 `0.5` へ補正。
+  - `fuji_dict["risk"]` の `NaN` / `Inf` を **fail-closed で `1.0`** として扱うよう修正。
+  - `effective_risk` も再度有限値検証してから利用するよう修正。
+- `stage_gate_decision()` で:
+  - Debate 由来の `risk_delta` が `NaN` / `Inf` の場合は無効化。
+  - マージ後 `risk` / `effective_risk` も有限値検証を通すよう修正。
+
+## 無駄な改善をしなかった理由
+
+- 暗号化バイパスや TrustLog 強制など、既存レビューで挙がっていたより重い問題は、現コードでは既に fail-closed 実装済みだったため再改修していない。
+- `pipeline.py` や `fuji.py` 全域への広範な例外整理は、今回の未解消 P1 論点より効果が薄く、変更面積も大きいため見送った。
+- 責務境界維持のため、Planner / Kernel / Fuji / MemoryOS には横断的修正を入れていない。
+
+## テスト
+
+- `stage_value_core()` に対し、`ema="nan"` と `risk="nan"` が入っても `value_ema=0.5`、`effective_risk` が fail-closed 側へ倒れる回帰テストを追加。
+- `stage_gate_decision()` に対し、Debate の `risk_delta="nan"` が無視され、既存 risk を汚染しないことを確認する回帰テストを追加。
+
+## セキュリティ警告
+
+- **警告**: この修正は「非有限数の混入」に対する fail-closed 強化であり、入力値そのものの真正性を保証するものではない。
+- 外部入力や replay データを受け取る経路では、引き続きソース検証・署名検証・監査ログ確認を併用すべき。

--- a/veritas_os/core/pipeline_policy.py
+++ b/veritas_os/core/pipeline_policy.py
@@ -12,6 +12,7 @@ Handles:
 from __future__ import annotations
 
 import logging
+import math
 import os
 import time
 from typing import Any
@@ -27,6 +28,28 @@ from .pipeline_helpers import _lazy_import, _apply_value_boost, _warn
 from .pipeline_evidence import _norm_evidence_item
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_finite_probability(
+    value: Any,
+    *,
+    default: float,
+    fail_closed: bool = False,
+) -> float:
+    """Normalize probability-like values to a finite ``[0.0, 1.0]`` float.
+
+    This prevents ``NaN`` / ``Inf`` values from silently bypassing gate logic.
+    When ``fail_closed`` is true, non-finite inputs are treated as maximum risk.
+    """
+    try:
+        numeric = float(value)
+    except (ValueError, TypeError):
+        numeric = default
+
+    if not math.isfinite(numeric):
+        numeric = 1.0 if fail_closed else default
+
+    return max(0.0, min(1.0, numeric))
 
 
 def _build_fail_closed_fuji_precheck(reason: str) -> dict[str, Any]:
@@ -81,14 +104,11 @@ def stage_fuji_precheck(ctx: PipelineContext) -> None:
     }
 
     fuji_status = ctx.fuji_dict.get("status", "allow")
-    try:
-        import math as _math
-        risk_val = float(ctx.fuji_dict.get("risk", 0.0))
-        if not _math.isfinite(risk_val):
-            risk_val = 1.0  # fail-closed: NaN/Inf は最大リスクとして扱う
-        risk_val = max(0.0, min(1.0, risk_val))
-    except (ValueError, TypeError):
-        risk_val = 0.0
+    risk_val = _coerce_finite_probability(
+        ctx.fuji_dict.get("risk", 0.0),
+        default=0.0,
+        fail_closed=True,
+    )
     reasons_list = ctx.fuji_dict.get("reasons", []) or []
     viols = ctx.fuji_dict.get("violations", []) or []
 
@@ -148,7 +168,7 @@ def stage_value_core(
     # EMA
     try:
         vs = _load_valstats()
-        ctx.value_ema = float(vs.get("ema", 0.5))
+        ctx.value_ema = _coerce_finite_probability(vs.get("ema", 0.5), default=0.5)
     except (ValueError, TypeError):
         ctx.value_ema = 0.5
 
@@ -160,13 +180,16 @@ def stage_value_core(
     ctx.alternatives = _apply_value_boost(ctx.alternatives, boost)
 
     RISK_EMA_WEIGHT = float(os.getenv("VERITAS_RISK_EMA_WEIGHT", "0.15"))
-    try:
-        ctx.effective_risk = float(ctx.fuji_dict.get("risk", 0.0)) * (
-            1.0 - RISK_EMA_WEIGHT * ctx.value_ema
-        )
-    except (ValueError, TypeError):
-        ctx.effective_risk = 0.0
-    ctx.effective_risk = max(0.0, min(1.0, ctx.effective_risk))
+    base_risk = _coerce_finite_probability(
+        ctx.fuji_dict.get("risk", 0.0),
+        default=0.0,
+        fail_closed=True,
+    )
+    ctx.effective_risk = _coerce_finite_probability(
+        base_risk * (1.0 - RISK_EMA_WEIGHT * ctx.value_ema),
+        default=1.0,
+        fail_closed=True,
+    )
 
     TELOS_EMA_DELTA = float(os.getenv("VERITAS_TELOS_EMA_DELTA", "0.10"))
     ctx.telos_threshold = BASE_TELOS_THRESHOLD - TELOS_EMA_DELTA * (ctx.value_ema - 0.5) * 2.0
@@ -215,12 +238,25 @@ def stage_gate_decision(ctx: PipelineContext) -> None:
     # merge Debate risk_delta
     try:
         if isinstance(ctx.debate, list) and ctx.debate:
-            delta = float((ctx.debate[0] or {}).get("risk_delta", 0.0))
+            delta = _coerce_finite_probability(
+                (ctx.debate[0] or {}).get("risk_delta", 0.0),
+                default=0.0,
+            )
             if delta:
-                new_risk = max(0.0, min(1.0, float(ctx.fuji_dict.get("risk", 0.0)) + delta))
+                new_risk = _coerce_finite_probability(
+                    _coerce_finite_probability(
+                        ctx.fuji_dict.get("risk", 0.0),
+                        default=0.0,
+                        fail_closed=True,
+                    ) + delta,
+                    default=1.0,
+                    fail_closed=True,
+                )
                 ctx.fuji_dict["risk"] = new_risk
-                ctx.effective_risk = max(
-                    0.0, min(1.0, new_risk * (1.0 - RISK_EMA_WEIGHT * ctx.value_ema))
+                ctx.effective_risk = _coerce_finite_probability(
+                    new_risk * (1.0 - RISK_EMA_WEIGHT * ctx.value_ema),
+                    default=1.0,
+                    fail_closed=True,
                 )
     except (ValueError, TypeError) as e:
         _warn(f"[Debate→FUJI] merge failed: {e}")

--- a/veritas_os/tests/test_pipeline_stages.py
+++ b/veritas_os/tests/test_pipeline_stages.py
@@ -266,6 +266,50 @@ class TestStageGateDecision:
         assert "FUJI gate" in (ctx.rejection_reason or "")
 
 
+class TestStageValueCore:
+    """Value stage safety regressions."""
+
+    def test_non_finite_ema_and_risk_fail_closed(self) -> None:
+        from veritas_os.core.pipeline_policy import stage_value_core
+
+        ctx = PipelineContext(
+            query="test",
+            fuji_dict={"risk": "nan"},
+            telos=0.4,
+            input_alts=[{"score": 0.4}],
+            alternatives=[{"score": 0.6}],
+            response_extras={"metrics": {}},
+        )
+
+        stage_value_core(
+            ctx,
+            _load_valstats=lambda: {"ema": "nan"},
+            _clip01=lambda value: max(0.0, min(1.0, float(value))),
+        )
+
+        assert ctx.value_ema == 0.5
+        assert ctx.effective_risk >= 0.9
+        assert ctx.effective_risk <= 1.0
+
+    def test_non_finite_debate_risk_delta_is_ignored(self) -> None:
+        from veritas_os.core.pipeline_policy import stage_gate_decision
+
+        ctx = PipelineContext(
+            fuji_dict={"status": "allow", "risk": 0.2},
+            debate=[{"risk_delta": "nan"}],
+            effective_risk=0.2,
+            telos=0.9,
+            telos_threshold=0.2,
+            response_extras={"metrics": {"stage_latency": {"gate": 0}}},
+        )
+
+        stage_gate_decision(ctx)
+
+        assert ctx.fuji_dict["risk"] == 0.2
+        assert ctx.effective_risk == 0.2
+        assert ctx.decision_status == "allow"
+
+
 # =========================================================
 # pipeline_persist: persist_audit_log
 # =========================================================


### PR DESCRIPTION
### Motivation

- Prevent NaN/Inf/invalid numeric values from contaminating gate decisions (FUJI risk, EMA, Debate risk_delta) which can silently break clamping and lead to unsafe allow/deny outcomes. 
- Make a minimal, local change inside the pipeline policy stage without crossing Planner/Kernel/Fuji/MemoryOS responsibilities.

### Description

- Added helper `_coerce_finite_probability()` in `veritas_os/core/pipeline_policy.py` to normalize probability-like inputs to a finite float in `[0.0,1.0]` and optionally treat non-finite inputs as maximum risk (fail-closed). 
- Replaced direct `float(...)` uses with the helper in `stage_fuji_precheck`, `stage_value_core`, and `stage_gate_decision` so that FUJI `risk`, EMA values, and Debate `risk_delta` are validated and normalized, with fail-closed semantics for safety-critical paths. 
- Added targeted regression tests in `veritas_os/tests/test_pipeline_stages.py` covering `ema="nan"` and `risk="nan"` fail-closed behavior and ignored non-finite debate `risk_delta`. 
- Documented the focused follow-up in `docs/reviews/precision_code_review_ja_20260319.md` describing the priority, changes, and security caveat.

### Testing

- Ran `pytest -q veritas_os/tests/test_pipeline_stages.py` and the suite passed (all tests in that file succeeded). 
- Compiled the modified modules with `python -m compileall veritas_os/core/pipeline_policy.py veritas_os/tests/test_pipeline_stages.py` which succeeded.
- No other automated tests were modified; changes are local to `pipeline_policy` and accompanied by unit tests and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba9848e70832682630a0f8c5d5719)