### PR TITLE
Add Japanese reassessment report for Precision Code Review (2026-03-19)

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319_reassessment.md
+++ b/docs/reviews/precision_code_review_ja_20260319_reassessment.md
@@ -1,0 +1,127 @@
+# VERITAS OS 再評価レビュー
+
+作成日: 2026-03-19
+対象文書: `docs/reviews/precision_code_review_ja_20260319.md`
+
+## 要約
+
+`precision_code_review_ja_20260319.md` を全文再読し、関連実装とテストを照合した結果、
+文書前半で High として挙げられている懸念のうち、
+TrustLog / Memory API / auth fail-open に関する項目は、
+同一文書の後半に記載された 2026-03-19 改善で概ね解消済みであることを確認しました。
+
+一方で、`kernel.py` / `pipeline.py` / `fuji.py` / `memory.py` などの
+中核モジュールに複雑度が集中しているという指摘は、
+現時点でも有効です。
+
+**再評価の結論**:
+
+- 完成度: 高い
+- 整合性: 高い
+- 一貫性: 高い
+- コード品質: 高いが、中核モジュールの複雑度集中が継続課題
+- セキュリティ: 強いが、fail-open 設定の運用統制は継続必須
+
+## 再評価結果
+
+### 1. 文書前半の High 指摘の扱い
+
+#### H1. 中核モジュールへの複雑度集中
+これは現在も有効です。
+今回確認した改善は主に API 安全性・観測性・設定防御に関するものであり、
+中核アーキテクチャそのものの分割や責務再整理を完了させたものではありません。
+
+#### H2. API 層の broad exception と observability 不足
+この点は、現状では「過去の主要懸念」寄りです。
+以下の改善がすでに反映されていました。
+
+- TrustLog aggregate JSON の状態を `missing / ok / invalid / unreadable / too_large` で区別
+- unreadable な aggregate JSON を append 時に上書きしない
+- Memory API が `status: ok | partial_failure | failed` と `errors[]` を返す
+- auth fail-open を explicit local/test profile に限定
+- `/v1/metrics` で TrustLog aggregate の状態を露出
+
+したがって、文書前半の問題提起自体は妥当ですが、
+**現在の実装評価としては「すでに大きく改善済み」** と整理するのが正確です。
+
+### 2. 現在の最重要課題
+
+現時点で最も重い論点は、次の一点です。
+
+- `pipeline.py` / `kernel.py` / `fuji.py` / `memory.py` に集中した構造的複雑度
+
+これは単なる行数の多さではなく、以下の実務リスクにつながります。
+
+- 変更影響範囲の読解コスト上昇
+- backward compatibility layer と正規経路の判別難化
+- monkeypatch 前提テストの増加
+- Planner / Kernel / Fuji / MemoryOS の責務境界の将来的侵食
+
+## 実装照合メモ
+
+### TrustLog
+
+`veritas_os/api/trust_log_io.py` では、`TrustLogLoadResult` と
+`load_logs_json_result()` が導入されており、aggregate JSON の異常状態を
+空配列へ丸めずに扱えるようになっています。
+また append 処理では、aggregate JSON が unreadable な場合に
+`trust_log.json` の再保存をスキップし、JSONL 側のみ維持します。
+
+### Memory API
+
+`veritas_os/api/routes_memory.py` の `memory_put()` は、
+legacy 保存と vector 保存を分離して評価し、
+部分成功を `partial_failure` として返します。
+これにより「成功に見える部分失敗」はかなり緩和されています。
+
+### auth fail-open
+
+`veritas_os/api/auth.py` では、`VERITAS_AUTH_STORE_FAILURE_MODE=open` を使うには
+`VERITAS_AUTH_ALLOW_FAIL_OPEN=true` に加えて、
+`VERITAS_ENV=dev|development|local|test` が必要です。
+`VERITAS_ENV` 未設定や staging などでは `closed` に戻されます。
+
+さらに `veritas_os/api/startup_health.py` では、
+unsupported profile で `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` が残っている場合に
+警告が出るようになっています。
+
+### metrics observability
+
+`veritas_os/api/routes_system.py` の `/v1/metrics` は、
+`trust_json_status` と `trust_json_error` を返します。
+これにより、TrustLog aggregate JSON の破損や unreadable 状態を
+運用から検知しやすくなっています。
+
+## セキュリティ警告
+
+1. `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` は、非本番でも認証保護を弱めます。
+   shared staging / preview では原則として残さないでください。
+2. TrustLog aggregate JSON が unreadable の場合、
+   いまの実装は「壊れた上書き」を防ぐだけで、根本原因を自動修復するものではありません。
+   warning を検知したら速やかに復旧が必要です。
+3. Memory API は改善済みですが、例外種別の細分化余地は残っています。
+   監査要件がさらに厳しくなる場合は、段階別に例外契約を明確化する価値があります。
+
+## 推奨アクション
+
+### Priority 1
+
+- 中核モジュールの public contract と internal helper の境界をさらに明文化する
+- backward compatibility export と正規拡張ポイントを architecture docs に固定する
+- 新規コントリビュータ向けに「正規経路」と「互換レイヤ」を区別した案内を追加する
+
+### Priority 2
+
+- TrustLog degraded 状態の運用手順を runbook 化する
+- fail-open 警告を shared 環境で CI / startup policy によりさらに検知しやすくする
+
+## 最終結論
+
+このコードベースは、監査性・安全性・再現性を強く意識して作られた高品質な基盤です。
+ただし、今後の品質向上効果が最も大きいのは、機能追加ではなく
+**中核モジュールの複雑度削減と拡張境界の明確化**です。
+
+つまり、今回の再評価を一言でまとめると次の通りです。
+
+> 思想と安全設計は非常に強く、API レベルの高優先度懸念はかなり改善済み。
+> これからの主戦場は、構造的複雑度の制御である。


### PR DESCRIPTION
### Motivation

- Add a reassessment document that re-reads `docs/reviews/precision_code_review_ja_20260319.md` and verifies implementation and test alignments observed on 2026-03-19. 
- Record which High-priority issues were resolved (TrustLog, Memory API, auth fail-open, metrics) and which structural risks remain (complexity concentrated in core modules). 
- Provide actionable recommendations and operational security warnings based on the implementation audit.

### Description

- Add `docs/reviews/precision_code_review_ja_20260319_reassessment.md` containing a summary, detailed findings, implementation alignment notes, security warnings, and prioritized recommendations. 
- Document confirms TrustLog aggregate JSON now distinguishes `missing / ok / invalid / unreadable / too_large` and avoids overwriting unreadable aggregates, and that append behavior preserves JSONL. 
- Document confirms Memory API returns `status: ok | partial_failure | failed` with `errors[]`, and that `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` now requires `VERITAS_ENV=dev|development|local|test` to enable fail-open. 
- Highlight remaining concern about structural complexity concentrated in `pipeline.py`, `kernel.py`, `fuji.py`, and `memory.py`, and recommend clarifying public contracts and compatibility layers.

### Testing

- No automated tests were required for this documentation-only change and none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbe24bdec48326903707ff29229b04)