### PR TITLE
Harden boundary checker doc parsing

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319_reassessment.md
+++ b/docs/reviews/precision_code_review_ja_20260319_reassessment.md
@@ -192,6 +192,29 @@ boundary checker の CLI / JSON レポートには未統合で、
 この対応はレビューで重視された「正規拡張ポイントの明確化」を維持するための
 運用改善であり、Planner / Kernel / FUJI / MemoryOS の責務分割そのものには触れていません。
 
+## 2026-03-20 追加改善（Markdown 整形差分への耐性強化）
+
+上記の運用改善を踏まえてさらに確認したところ、
+boundary checker の文書抽出は `**Preferred extension points**:` の直後に
+空行が入るだけでも箇条書きを読めなくなり、
+**文書の意味は変わっていないのに cosmetic な Markdown 整形だけで
+doc alignment error が発生しうる** 状態でした。
+
+これは責務境界そのものの問題ではなく、整合性検証の安定性の問題であるため、
+今回は checker の文書パーサだけを最小修正しました。
+
+- `scripts/architecture/check_responsibility_boundaries.py` の
+  `extract_doc_extension_points()` を修正し、
+  marker 直後の空行や行頭インデントを無視して
+  Preferred extension points の箇条書きを抽出できるように改善
+- `veritas_os/tests/test_responsibility_boundary_checker.py` に
+  空行入り Markdown を直接与える回帰テストを追加し、
+  今後の整形差分で CI が誤検知しないことを固定
+
+この改善も Planner / Kernel / FUJI / MemoryOS の public contract や責務境界を変えず、
+レビューで継続課題とされた「拡張境界の見えにくさ」を支える
+文書整合性チェックの信頼性だけを上げるものです。
+
 ## 最終結論
 
 このコードベースは、監査性・安全性・再現性を強く意識して作られた高品質な基盤です。

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -369,7 +369,7 @@ def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
         r"(?P<body>.*?)(?=\n### |\Z)",
         re.DOTALL,
     )
-    marker = "**Preferred extension points**:\n"
+    marker = "**Preferred extension points**:"
     extracted: dict[str, tuple[str, ...]] = {}
 
     for match in section_pattern.finditer(document):
@@ -385,9 +385,14 @@ def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
 
         bullet_lines: list[str] = []
         for line in remainder.splitlines():
-            if not line.startswith("- "):
+            stripped_line = line.strip()
+            if not stripped_line:
+                if bullet_lines:
+                    break
+                continue
+            if not stripped_line.startswith("- "):
                 break
-            bullet_lines.append(line[2:].strip().strip("`"))
+            bullet_lines.append(stripped_line[2:].strip().strip("`"))
         extracted[module_name] = tuple(bullet_lines)
 
     return extracted

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -264,6 +264,92 @@ def test_extract_doc_extension_points_reads_architecture_doc() -> None:
         "veritas_os.core.kernel_qa",
         "veritas_os.core.pipeline_contracts",
     )
+    assert points["fuji"] == (
+        "veritas_os.core.fuji_policy",
+        "veritas_os.core.fuji_policy_rollout",
+        "veritas_os.core.fuji_helpers",
+        "veritas_os.core.fuji_safety_head",
+    )
+    assert points["memory"] == (
+        "veritas_os.core.memory_store",
+        "veritas_os.core.memory_helpers",
+        "veritas_os.core.memory_search_helpers",
+        "veritas_os.core.memory_summary_helpers",
+        "veritas_os.core.memory_lifecycle",
+        "veritas_os.core.memory_security",
+    )
+
+
+def test_extract_doc_extension_points_tolerates_blank_line_after_marker(
+    tmp_path: Path,
+) -> None:
+    """Doc parser should ignore cosmetic blank lines before bullet lists."""
+    doc_path = tmp_path / "core_responsibility_boundaries.md"
+    doc_path.write_text(
+        """
+# Core Responsibility Boundaries
+
+### Planner (`veritas_os.core.planner`)
+**Preferred extension points**:
+
+- `veritas_os.core.planner_normalization`
+- `veritas_os.core.planner_json`
+- `veritas_os.core.strategy`
+
+### Kernel (`veritas_os.core.kernel`)
+**Preferred extension points**:
+
+- `veritas_os.core.kernel_stages`
+- `veritas_os.core.kernel_qa`
+- `veritas_os.core.pipeline_contracts`
+
+### FUJI (`veritas_os.core.fuji`)
+**Preferred extension points**:
+
+- `veritas_os.core.fuji_policy`
+- `veritas_os.core.fuji_policy_rollout`
+- `veritas_os.core.fuji_helpers`
+- `veritas_os.core.fuji_safety_head`
+
+### MemoryOS (`veritas_os.core.memory`)
+**Preferred extension points**:
+
+- `veritas_os.core.memory_store`
+- `veritas_os.core.memory_helpers`
+- `veritas_os.core.memory_search_helpers`
+- `veritas_os.core.memory_summary_helpers`
+- `veritas_os.core.memory_lifecycle`
+- `veritas_os.core.memory_security`
+""".strip(),
+        encoding="utf-8",
+    )
+
+    points = extract_doc_extension_points(doc_path)
+
+    assert points["planner"] == (
+        "veritas_os.core.planner_normalization",
+        "veritas_os.core.planner_json",
+        "veritas_os.core.strategy",
+    )
+    assert points["kernel"] == (
+        "veritas_os.core.kernel_stages",
+        "veritas_os.core.kernel_qa",
+        "veritas_os.core.pipeline_contracts",
+    )
+    assert points["fuji"] == (
+        "veritas_os.core.fuji_policy",
+        "veritas_os.core.fuji_policy_rollout",
+        "veritas_os.core.fuji_helpers",
+        "veritas_os.core.fuji_safety_head",
+    )
+    assert points["memory"] == (
+        "veritas_os.core.memory_store",
+        "veritas_os.core.memory_helpers",
+        "veritas_os.core.memory_search_helpers",
+        "veritas_os.core.memory_summary_helpers",
+        "veritas_os.core.memory_lifecycle",
+        "veritas_os.core.memory_security",
+    )
 
 
 def test_find_doc_alignment_issues_returns_empty_for_current_doc() -> None:


### PR DESCRIPTION
### Motivation
- The boundary checker could report spurious `doc_alignment_error` when a cosmetic Markdown blank line or indentation appeared immediately after the `**Preferred extension points**:` marker, so make the parser more tolerant without changing any core module responsibilities.
- This is an operational stability improvement to avoid CI false-positives and does not change public contracts or move responsibilities across Planner / Kernel / FUJI / MemoryOS.
- There is no new security surface introduced by this change; it only hardens documentation parsing and test coverage.

### Description
- Relax `extract_doc_extension_points()` in `scripts/architecture/check_responsibility_boundaries.py` to tolerate blank lines and indentation after the `**Preferred extension points**:` marker and to strip leading/trailing whitespace when parsing bullet items. The parser now continues past cosmetic blank lines and stops correctly once bullets end. (`extract_doc_extension_points`) 
- Add a regression test `test_extract_doc_extension_points_tolerates_blank_line_after_marker` and complete assertions for FUJI/Memory extension points in `veritas_os/tests/test_responsibility_boundary_checker.py` to lock the parsing behavior. 
- Update `docs/reviews/precision_code_review_ja_20260319_reassessment.md` to document the change and rationale so the review record reflects the minimal parser hardening.

### Testing
- Ran `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py`, all tests passed (`15 passed`).
- Ran `python scripts/architecture/check_responsibility_boundaries.py --report-format json` to validate output formatting and alignment checks, which returned a passing JSON report.
- Changes are limited to parser/test/docs files and adhere to the project constraint of not modifying core module responsibilities.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc9723442083269d7e6b4e5a4af3e8)