### PR TITLE
Harden boundary checker doc parsing

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319_reassessment.md
+++ b/docs/reviews/precision_code_review_ja_20260319_reassessment.md
@@ -215,6 +215,27 @@ doc alignment error が発生しうる** 状態でした。
 レビューで継続課題とされた「拡張境界の見えにくさ」を支える
 文書整合性チェックの信頼性だけを上げるものです。
 
+## 2026-03-20 追加改善（説明文入り Markdown への耐性強化）
+
+上記までの自動検証を再確認したところ、boundary checker の文書抽出は
+`**Preferred extension points**:` の直後に 1 行の説明文が入ると
+箇条書き抽出を打ち切ってしまい、**文書の意図が変わっていないのに
+軽微な説明追記だけで doc alignment error が発生しうる** 状態でした。
+
+これは責務境界の見直しではなく、整合性検証の過剰敏感さの問題であるため、
+今回は checker の文書パーサだけを最小修正しました。
+
+- `scripts/architecture/check_responsibility_boundaries.py` の
+  `extract_doc_extension_points()` を修正し、marker 直後の短い説明文を許容したうえで
+  Preferred extension points の箇条書きを抽出できるように改善
+- `veritas_os/tests/test_responsibility_boundary_checker.py` に
+  説明文入り Markdown を直接与える回帰テストを追加し、
+  今後の軽微な文書補足で CI が誤検知しないことを固定
+
+この改善も Planner / Kernel / FUJI / MemoryOS の public contract や責務境界を変えず、
+レビューで継続課題とされた「拡張境界の見えにくさ」を支える
+文書整合性チェックの信頼性だけを上げるものです。
+
 ## 最終結論
 
 このコードベースは、監査性・安全性・再現性を強く意識して作られた高品質な基盤です。

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -384,15 +384,19 @@ def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
             continue
 
         bullet_lines: list[str] = []
+        bullet_collection_started = False
         for line in remainder.splitlines():
             stripped_line = line.strip()
             if not stripped_line:
-                if bullet_lines:
+                if bullet_collection_started:
                     break
                 continue
-            if not stripped_line.startswith("- "):
+            if stripped_line.startswith("- "):
+                bullet_collection_started = True
+                bullet_lines.append(stripped_line[2:].strip().strip("`"))
+                continue
+            if bullet_collection_started:
                 break
-            bullet_lines.append(stripped_line[2:].strip().strip("`"))
         extracted[module_name] = tuple(bullet_lines)
 
     return extracted

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -352,6 +352,34 @@ def test_extract_doc_extension_points_tolerates_blank_line_after_marker(
     )
 
 
+def test_extract_doc_extension_points_tolerates_explanatory_text_before_bullets(
+    tmp_path: Path,
+) -> None:
+    """Doc parser should ignore short prose before the preferred bullet list."""
+    doc_path = tmp_path / "core_responsibility_boundaries.md"
+    doc_path.write_text(
+        """
+# Core Responsibility Boundaries
+
+### Planner (`veritas_os.core.planner`)
+**Preferred extension points**:
+These modules should absorb new planner shaping logic before planner.py.
+- `veritas_os.core.planner_normalization`
+- `veritas_os.core.planner_json`
+- `veritas_os.core.strategy`
+""".strip(),
+        encoding="utf-8",
+    )
+
+    points = extract_doc_extension_points(doc_path)
+
+    assert points["planner"] == (
+        "veritas_os.core.planner_normalization",
+        "veritas_os.core.planner_json",
+        "veritas_os.core.strategy",
+    )
+
+
 def test_find_doc_alignment_issues_returns_empty_for_current_doc() -> None:
     """Checker guidance should stay aligned with the architecture source of truth."""
     issues = find_doc_alignment_issues(


### PR DESCRIPTION
### Motivation
- The architecture doc parser could produce false-positive `doc_alignment_error` when a short explanatory line appeared between the `**Preferred extension points**:` marker and the following bullet list, so the checker was overly brittle to harmless Markdown changes. 
- Make a minimal, local fix that improves CI stability without changing any Planner / Kernel / FUJI / MemoryOS responsibilities or public API contracts. 
- Security note: this is a reliability improvement only and does not relax boundary enforcement, but the boundary checker should remain enabled in CI to preserve reviewability and auditability.

### Description
- Update `extract_doc_extension_points()` in `scripts/architecture/check_responsibility_boundaries.py` to tolerate a single short prose line before the bullet list and to correctly start collecting bullets when they appear. 
- Add a regression test `test_extract_doc_extension_points_tolerates_explanatory_text_before_bullets` to `veritas_os/tests/test_responsibility_boundary_checker.py` covering an explanatory sentence followed by bullets. 
- Append a short note to `docs/reviews/precision_code_review_ja_20260319_reassessment.md` documenting the targeted 2026-03-20 follow-up improvement and clarifying the minimal, non-invasive nature of the change. 

### Testing
- Ran `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py`, which passed (`16 passed`). 
- Ran `python scripts/architecture/check_responsibility_boundaries.py --core-dir veritas_os/core --doc-path docs/architecture/core_responsibility_boundaries.md`, which printed a successful check (`Responsibility boundary check passed.`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bca900c0f08326a83aeb59accbf91f)