### PR TITLE
Tolerate reordered boundary extension points

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319_reassessment.md
+++ b/docs/reviews/precision_code_review_ja_20260319_reassessment.md
@@ -236,6 +236,28 @@ doc alignment error が発生しうる** 状態でした。
 レビューで継続課題とされた「拡張境界の見えにくさ」を支える
 文書整合性チェックの信頼性だけを上げるものです。
 
+## 2026-03-20 追加改善（箇条書き順序差分への耐性強化）
+
+上記までの整合性検証を再確認したところ、boundary checker の
+`find_doc_alignment_issues()` は Preferred extension points の**並び順まで
+厳密一致**で比較しており、**意味が同じ箇条書きの順序入れ替えだけでも
+doc alignment error が発生しうる** 状態でした。
+
+これは責務境界や public contract の問題ではなく、
+文書ガイダンスの意味差分と cosmetic diff を過剰に同一視してしまう
+運用ノイズの問題です。そこで今回は checker の整合性比較だけを最小修正しました。
+
+- `scripts/architecture/check_responsibility_boundaries.py` の
+  extension point 整合性比較を順序非依存にし、
+  箇条書きの並び替えだけでは drift 扱いしないように改善
+- `veritas_os/tests/test_responsibility_boundary_checker.py` に
+  全モジュールで順序だけを入れ替えた Markdown を与える回帰テストを追加し、
+  今後の文書整理で CI が誤検知しないことを固定
+
+この改善も Planner / Kernel / FUJI / MemoryOS の責務境界を変えず、
+レビューで重視された「正規拡張ポイントの明確化」を
+不要な CI ノイズなしで維持しやすくするものです。
+
 ## 最終結論
 
 このコードベースは、監査性・安全性・再現性を強く意識して作られた高品質な基盤です。

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -402,6 +402,13 @@ def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
     return extracted
 
 
+def _normalize_extension_points_for_alignment(
+    extension_points: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Normalize extension-point lists for order-insensitive doc alignment."""
+    return tuple(sorted(extension_points))
+
+
 def find_doc_alignment_issues(doc_path: Path) -> list[str]:
     """Return human-readable mismatches between docs and checker guidance."""
     documented_points = extract_doc_extension_points(doc_path)
@@ -414,7 +421,9 @@ def find_doc_alignment_issues(doc_path: Path) -> list[str]:
                 f"Missing preferred extension point section for '{module_name}' in {doc_path}"
             )
             continue
-        if expected_points != configured_points:
+        if _normalize_extension_points_for_alignment(
+            expected_points
+        ) != _normalize_extension_points_for_alignment(configured_points):
             mismatches.append(
                 "Preferred extension points out of sync for "
                 f"'{module_name}': doc={list(expected_points)} "

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -389,6 +389,49 @@ def test_find_doc_alignment_issues_returns_empty_for_current_doc() -> None:
     assert issues == []
 
 
+def test_find_doc_alignment_issues_ignores_bullet_order_only(tmp_path: Path) -> None:
+    """Pure bullet reordering should not count as doc/checker drift."""
+    doc_path = tmp_path / "core_responsibility_boundaries.md"
+    doc_path.write_text(
+        """
+# Core Responsibility Boundaries
+
+### Planner (`veritas_os.core.planner`)
+**Preferred extension points**:
+- `veritas_os.core.strategy`
+- `veritas_os.core.planner_json`
+- `veritas_os.core.planner_normalization`
+
+### Kernel (`veritas_os.core.kernel`)
+**Preferred extension points**:
+- `veritas_os.core.pipeline_contracts`
+- `veritas_os.core.kernel_qa`
+- `veritas_os.core.kernel_stages`
+
+### FUJI (`veritas_os.core.fuji`)
+**Preferred extension points**:
+- `veritas_os.core.fuji_safety_head`
+- `veritas_os.core.fuji_helpers`
+- `veritas_os.core.fuji_policy_rollout`
+- `veritas_os.core.fuji_policy`
+
+### MemoryOS (`veritas_os.core.memory`)
+**Preferred extension points**:
+- `veritas_os.core.memory_security`
+- `veritas_os.core.memory_lifecycle`
+- `veritas_os.core.memory_summary_helpers`
+- `veritas_os.core.memory_search_helpers`
+- `veritas_os.core.memory_helpers`
+- `veritas_os.core.memory_store`
+""".strip(),
+        encoding="utf-8",
+    )
+
+    issues = find_doc_alignment_issues(doc_path)
+
+    assert issues == []
+
+
 def test_check_boundaries_includes_doc_alignment_issues(tmp_path: Path) -> None:
     """Text-mode checker should fail when the architecture doc drifts."""
     _write_module(tmp_path / "planner.py", "# planner module\n")


### PR DESCRIPTION
### Motivation
- Reduce CI noise caused by cosmetic reordering of `Preferred extension points` in the architecture doc without changing any core module responsibilities. 
- Implement a minimal, low-risk fix that preserves existing public contracts while avoiding false-positive doc alignment errors.

### Description
- Make `find_doc_alignment_issues()` order-insensitive by adding `_normalize_extension_points_for_alignment()` and comparing sorted extension-point lists in `scripts/architecture/check_responsibility_boundaries.py`.
- Add regression test `test_find_doc_alignment_issues_ignores_bullet_order_only` to `veritas_os/tests/test_responsibility_boundary_checker.py` to ensure reordering of bullets is not treated as drift.
- Update `docs/reviews/precision_code_review_ja_20260319_reassessment.md` to record the 2026-03-20 minimal improvement for bullet-order tolerance.

### Testing
- Ran `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py` and all tests passed (`17 passed`).
- Ran `python scripts/architecture/check_responsibility_boundaries.py --core-dir veritas_os/core --doc-path docs/architecture/core_responsibility_boundaries.md` and the checker completed successfully (`Responsibility boundary check passed.`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcadae6b2083268bb62c820018e281)