### PR TITLE
Improve boundary checker doc drift reporting

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319_reassessment.md
+++ b/docs/reviews/precision_code_review_ja_20260319_reassessment.md
@@ -268,3 +268,28 @@ doc alignment error が発生しうる** 状態でした。
 
 > 思想と安全設計は非常に強く、API レベルの高優先度懸念はかなり改善済み。
 > これからの主戦場は、構造的複雑度の制御である。
+
+## 2026-03-20 追加改善（doc drift の機械可読性を強化）
+
+再評価文書を踏まえて boundary checker の運用経路を再確認したところ、
+`doc_alignment_error` は CI の JSON レポートに出力されるものの、
+`source_module` が一律 `documentation` になっており、**どの責務境界のガイダンスが
+ずれたのかを機械的に特定しにくい** 状態が残っていました。
+
+これは中核責務の再設計ではなく observability の不足であり、
+無駄なモジュール分割を避けるため今回は boundary checker の
+構造化エラー生成だけを最小改善しました。
+
+- `scripts/architecture/check_responsibility_boundaries.py` に
+  `DocAlignmentIssue` と `collect_doc_alignment_issues()` を追加し、
+  doc drift を module 単位で構造化して扱うよう改善
+- `collect_boundary_issues()` が `doc_alignment_error` を
+  `planner` / `kernel` / `fuji` / `memory` の実モジュール名付きで返すよう修正し、
+  JSON machine report でも対象境界を直接追跡可能に変更
+- `veritas_os/tests/test_responsibility_boundary_checker.py` に
+  module context が保持されることの回帰テストを追加し、
+  今後の CI 解析で対象責務が失われないことを固定
+
+この改善も Planner / Kernel / FUJI / MemoryOS の責務境界や public contract を変えず、
+レビューで継続課題とされた「正規拡張ポイントの明確化」を
+運用・監視側から扱いやすくするための最小差分です。

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -43,6 +43,14 @@ class BoundaryIssue:
     forbidden_module: str | None = None
 
 
+@dataclass(frozen=True)
+class DocAlignmentIssue:
+    """Structured mismatch between the checker config and architecture docs."""
+
+    source_module: str
+    message: str
+
+
 DEFAULT_DOC_PATH = Path("docs/architecture/core_responsibility_boundaries.md")
 
 
@@ -181,13 +189,13 @@ def collect_boundary_issues(
 ) -> list[BoundaryIssue]:
     """Collect machine-classifiable boundary checker issues."""
     issues: list[BoundaryIssue] = []
-    for message in find_doc_alignment_issues(doc_path):
+    for issue in collect_doc_alignment_issues(doc_path):
         issues.append(
             BoundaryIssue(
                 code="doc_alignment_error",
-                message=message,
+                message=issue.message,
                 path=doc_path,
-                source_module="documentation",
+                source_module=issue.source_module,
             )
         )
     for rule in rules:
@@ -409,28 +417,44 @@ def _normalize_extension_points_for_alignment(
     return tuple(sorted(extension_points))
 
 
-def find_doc_alignment_issues(doc_path: Path) -> list[str]:
-    """Return human-readable mismatches between docs and checker guidance."""
+def collect_doc_alignment_issues(doc_path: Path) -> list[DocAlignmentIssue]:
+    """Return structured mismatches between docs and checker guidance."""
     documented_points = extract_doc_extension_points(doc_path)
-    mismatches: list[str] = []
+    mismatches: list[DocAlignmentIssue] = []
 
     for module_name, configured_points in RECOMMENDED_EXTENSION_POINTS.items():
         expected_points = documented_points.get(module_name)
         if expected_points is None:
             mismatches.append(
-                f"Missing preferred extension point section for '{module_name}' in {doc_path}"
+                DocAlignmentIssue(
+                    source_module=module_name,
+                    message=(
+                        "Missing preferred extension point section for "
+                        f"'{module_name}' in {doc_path}"
+                    ),
+                )
             )
             continue
         if _normalize_extension_points_for_alignment(
             expected_points
         ) != _normalize_extension_points_for_alignment(configured_points):
             mismatches.append(
-                "Preferred extension points out of sync for "
-                f"'{module_name}': doc={list(expected_points)} "
-                f"checker={list(configured_points)}"
+                DocAlignmentIssue(
+                    source_module=module_name,
+                    message=(
+                        "Preferred extension points out of sync for "
+                        f"'{module_name}': doc={list(expected_points)} "
+                        f"checker={list(configured_points)}"
+                    ),
+                )
             )
 
     return mismatches
+
+
+def find_doc_alignment_issues(doc_path: Path) -> list[str]:
+    """Return human-readable mismatches between docs and checker guidance."""
+    return [issue.message for issue in collect_doc_alignment_issues(doc_path)]
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -14,6 +14,7 @@ from scripts.architecture.check_responsibility_boundaries import (
     build_remediation_guide,
     check_boundaries,
     collect_boundary_issues,
+    collect_doc_alignment_issues,
     extract_doc_extension_points,
     find_doc_alignment_issues,
 )
@@ -136,6 +137,65 @@ def test_collect_boundary_issues_classifies_boundary_violation(tmp_path: Path) -
     assert issues[0].code == "boundary_violation"
     assert issues[0].source_module == "planner"
     assert issues[0].forbidden_module == "kernel"
+
+
+def test_collect_doc_alignment_issues_preserves_module_context(tmp_path: Path) -> None:
+    """Structured doc drift issues should keep the affected module name."""
+    doc_path = tmp_path / "core_responsibility_boundaries.md"
+    doc_path.write_text(
+        """
+# Core Responsibility Boundaries
+
+### Planner (`veritas_os.core.planner`)
+**Preferred extension points**:
+- veritas_os.core.planner_json
+
+### Kernel (`veritas_os.core.kernel`)
+**Preferred extension points**:
+- veritas_os.core.kernel_stages
+
+### FUJI (`veritas_os.core.fuji`)
+**Preferred extension points**:
+- veritas_os.core.fuji_policy
+
+### MemoryOS (`veritas_os.core.memory`)
+**Preferred extension points**:
+- veritas_os.core.memory_store
+""".strip(),
+        encoding="utf-8",
+    )
+
+    issues = collect_doc_alignment_issues(doc_path)
+
+    assert issues
+    assert issues[0].source_module == "planner"
+    assert "planner" in issues[0].message
+
+
+def test_build_machine_report_keeps_module_context_for_doc_alignment_error(
+    tmp_path: Path,
+) -> None:
+    """Machine report should expose doc drift under the affected module."""
+    issues = [
+        BoundaryIssue(
+            code="doc_alignment_error",
+            message="Preferred extension points out of sync for 'memory'",
+            path=tmp_path / "core_responsibility_boundaries.md",
+            source_module="memory",
+        ),
+    ]
+
+    report = json.loads(build_machine_report(issues))
+
+    assert report["issues"][0]["source_module"] == "memory"
+    assert report["issues"][0]["recommended_extension_points"] == [
+        "veritas_os.core.memory_store",
+        "veritas_os.core.memory_helpers",
+        "veritas_os.core.memory_search_helpers",
+        "veritas_os.core.memory_summary_helpers",
+        "veritas_os.core.memory_lifecycle",
+        "veritas_os.core.memory_security",
+    ]
 
 
 def test_collect_boundary_issues_detects_doc_alignment_error(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- The `doc_alignment_error` entries in the CI JSON report were emitted without module context (`source_module` was `documentation`), making it hard for automated consumers to identify which core boundary (Planner / Kernel / FUJI / MemoryOS) drifted; the goal was to improve observability without changing any core responsibilities or public contracts.

### Description
- Add a structured `DocAlignmentIssue` dataclass and a new `collect_doc_alignment_issues()` function to produce module-scoped doc drift information in `scripts/architecture/check_responsibility_boundaries.py`.
- Change `collect_boundary_issues()` to consume `DocAlignmentIssue` instances and emit `BoundaryIssue` entries with the real `source_module` (e.g. `planner`, `kernel`, `fuji`, `memory`).
- Keep `find_doc_alignment_issues()` as a backwards-compatible wrapper that returns human-readable messages from the structured collector, and update machine report generation to expose module-scoped context.
- Add regression tests in `veritas_os/tests/test_responsibility_boundary_checker.py` and record the change in `docs/reviews/precision_code_review_ja_20260319_reassessment.md`.

### Testing
- Ran `python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py` and all tests passed (`19 passed`).
- Ran the checker CLI `python scripts/architecture/check_responsibility_boundaries.py --core-dir veritas_os/core --doc-path docs/architecture/core_responsibility_boundaries.md --report-format json` and it produced a passing JSON report with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcb499b68c83269215c94fe8c8747c)