### PR TITLE
Handle boundary doc read failures gracefully

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319_reassessment.md
+++ b/docs/reviews/precision_code_review_ja_20260319_reassessment.md
@@ -293,3 +293,28 @@ doc alignment error が発生しうる** 状態でした。
 この改善も Planner / Kernel / FUJI / MemoryOS の責務境界や public contract を変えず、
 レビューで継続課題とされた「正規拡張ポイントの明確化」を
 運用・監視側から扱いやすくするための最小差分です。
+
+## 2026-03-20 追加改善（アーキテクチャ文書の欠落を構造化エラー化）
+
+再評価文書の観点で boundary checker の失敗経路を再確認したところ、
+Preferred extension points の整合性比較は強化されていた一方で、
+`docs/architecture/core_responsibility_boundaries.md` 自体が欠落または unreadable な場合は
+**checker が例外で終了し、CI から機械可読な失敗理由を拾いにくい** 状態が残っていました。
+
+これは Planner / Kernel / FUJI / MemoryOS の責務見直しではなく、
+文書依存の運用パスにおける observability の不足です。
+無駄な構造変更を避けるため、今回は boundary checker の
+文書読込エラーだけを最小差分で構造化しました。
+
+- `scripts/architecture/check_responsibility_boundaries.py` に
+  文書読込失敗を `DocExtractionError` として受ける補助関数を追加
+- architecture 文書が欠落・権限不足でも、
+  `doc_alignment_error` / `source_module=documentation` として
+  一貫した失敗要因を返すよう修正
+- `veritas_os/tests/test_responsibility_boundary_checker.py` に
+  文書欠落時の回帰テストを追加し、
+  doc alignment の失敗が traceback ではなく構造化エラーで観測されることを固定
+
+この改善も責務境界や public contract を一切変えず、
+レビューで重視された「正規拡張ポイントの明確化」を支える
+CI/運用監視の信頼性だけを高めるものです。

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -51,6 +51,13 @@ class DocAlignmentIssue:
     message: str
 
 
+@dataclass(frozen=True)
+class DocExtractionError:
+    """Structured error raised while reading extension points from docs."""
+
+    message: str
+
+
 DEFAULT_DOC_PATH = Path("docs/architecture/core_responsibility_boundaries.md")
 
 
@@ -410,6 +417,28 @@ def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
     return extracted
 
 
+def _read_doc_extension_points(
+    doc_path: Path,
+) -> tuple[dict[str, tuple[str, ...]], DocExtractionError | None]:
+    """Read doc extension points while converting I/O failures to structured errors."""
+    try:
+        return extract_doc_extension_points(doc_path), None
+    except FileNotFoundError:
+        return {}, DocExtractionError(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"file not found at {doc_path}"
+            )
+        )
+    except PermissionError:
+        return {}, DocExtractionError(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"permission denied for {doc_path}"
+            )
+        )
+
+
 def _normalize_extension_points_for_alignment(
     extension_points: tuple[str, ...],
 ) -> tuple[str, ...]:
@@ -419,8 +448,16 @@ def _normalize_extension_points_for_alignment(
 
 def collect_doc_alignment_issues(doc_path: Path) -> list[DocAlignmentIssue]:
     """Return structured mismatches between docs and checker guidance."""
-    documented_points = extract_doc_extension_points(doc_path)
+    documented_points, extraction_error = _read_doc_extension_points(doc_path)
     mismatches: list[DocAlignmentIssue] = []
+    if extraction_error is not None:
+        mismatches.append(
+            DocAlignmentIssue(
+                source_module="documentation",
+                message=extraction_error.message,
+            )
+        )
+        return mismatches
 
     for module_name, configured_points in RECOMMENDED_EXTENSION_POINTS.items():
         expected_points = documented_points.get(module_name)

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -9,6 +9,7 @@ from scripts.architecture.check_responsibility_boundaries import (
     REMEDIATION_LINK,
     BoundaryIssue,
     BoundaryRule,
+    DocAlignmentIssue,
     ViolationDetail,
     build_machine_report,
     build_remediation_guide,
@@ -231,6 +232,25 @@ def test_collect_boundary_issues_detects_doc_alignment_error(tmp_path: Path) -> 
     issues = collect_boundary_issues(core_dir=tmp_path, doc_path=doc_path)
 
     assert any(issue.code == "doc_alignment_error" for issue in issues)
+
+
+def test_collect_doc_alignment_issues_classifies_missing_doc_file(
+    tmp_path: Path,
+) -> None:
+    """Missing architecture docs should surface as structured doc errors."""
+    doc_path = tmp_path / "missing_boundaries.md"
+
+    issues = collect_doc_alignment_issues(doc_path)
+
+    assert issues == [
+        DocAlignmentIssue(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"file not found at {doc_path}"
+            ),
+            source_module="documentation",
+        )
+    ]
 
 
 def test_build_machine_report_counts_by_code(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- The boundary checker crashed or produced uncaught exceptions when the architecture document `docs/architecture/core_responsibility_boundaries.md` was missing or unreadable, which made CI/automation unable to observe doc-alignment failures as structured errors. 
- The intent is a minimal operational improvement to surface document read failures as machine-readable `doc_alignment_error` issues without changing Planner/Kernel/FUJI/MemoryOS responsibilities or public contracts.

### Description
- Add `DocExtractionError` dataclass and helper `_read_doc_extension_points()` that converts I/O failures when reading the architecture doc into structured errors instead of raising exceptions. 
- Change `collect_doc_alignment_issues()` to use `_read_doc_extension_points()` and to emit a `DocAlignmentIssue` with `source_module="documentation"` when the doc cannot be read. 
- Add a regression test `test_collect_doc_alignment_issues_classifies_missing_doc_file` in `veritas_os/tests/test_responsibility_boundary_checker.py` to verify missing/unreadable docs surface as structured errors. 
- Update `docs/reviews/precision_code_review_ja_20260319_reassessment.md` to record the minimal corrective action and rationale.

### Testing
- Ran `pytest veritas_os/tests/test_responsibility_boundary_checker.py` and all tests passed (`20 passed`).
- Ran the checker CLI with `python scripts/architecture/check_responsibility_boundaries.py --report-format json` and it produced a valid JSON machine report (`status: passed`), confirming the report generation path remains functional.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcbbe5a1c88326a2a1dfd5987cfe03)