### PR TITLE
Handle invalid architecture doc encoding in boundary checker

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319_reassessment.md
+++ b/docs/reviews/precision_code_review_ja_20260319_reassessment.md
@@ -258,6 +258,29 @@ doc alignment error が発生しうる** 状態でした。
 レビューで重視された「正規拡張ポイントの明確化」を
 不要な CI ノイズなしで維持しやすくするものです。
 
+## 2026-03-20 追加改善（architecture 文書の不正エンコーディングを構造化エラー化）
+
+再評価文書の観点で boundary checker の文書読込経路をさらに確認したところ、
+`docs/architecture/core_responsibility_boundaries.md` が存在していても
+**UTF-8 以外で壊れて保存された場合は `UnicodeDecodeError` がそのまま伝播し、
+CI から機械可読な失敗理由を拾いにくい** 状態が残っていました。
+
+これは責務境界や public contract の問題ではなく、文書依存の運用パスにおける
+observability の不足です。無駄な中核変更を避けるため、今回は boundary checker の
+文書デコード失敗だけを最小差分で構造化しました。
+
+- `scripts/architecture/check_responsibility_boundaries.py` にて
+  architecture 文書の UTF-8 デコード失敗を `DocExtractionError` として扱い、
+  `doc_alignment_error` / `source_module=documentation` で一貫して返すよう修正
+- 併せてその他の `OSError` も構造化メッセージへ変換し、
+  traceback 依存なしで CI から失敗理由を取得できるよう改善
+- `veritas_os/tests/test_responsibility_boundary_checker.py` に
+  invalid UTF-8 文書の回帰テストを追加し、将来の退行を防止
+
+この改善も Planner / Kernel / FUJI / MemoryOS の責務境界や public contract を一切変えず、
+レビューで重視された「正規拡張ポイントの明確化」を支える
+CI/運用監視の信頼性だけを高めるものです。
+
 ## 最終結論
 
 このコードベースは、監査性・安全性・再現性を強く意識して作られた高品質な基盤です。

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -421,7 +421,7 @@ def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
 def _read_doc_extension_points(
     doc_path: Path,
 ) -> tuple[dict[str, tuple[str, ...]], DocExtractionError | None]:
-    """Read doc extension points while converting I/O failures to structured errors."""
+    """Read doc extension points while converting doc access failures to errors."""
     try:
         return extract_doc_extension_points(doc_path), None
     except FileNotFoundError:
@@ -436,6 +436,20 @@ def _read_doc_extension_points(
             message=(
                 "Unable to read architecture boundary document: "
                 f"permission denied for {doc_path}"
+            )
+        )
+    except UnicodeDecodeError:
+        return {}, DocExtractionError(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"invalid UTF-8 at {doc_path}"
+            )
+        )
+    except OSError as exc:
+        return {}, DocExtractionError(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"os error for {doc_path}: {exc.strerror or str(exc)}"
             )
         )
 

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -253,6 +253,26 @@ def test_collect_doc_alignment_issues_classifies_missing_doc_file(
     ]
 
 
+def test_collect_doc_alignment_issues_classifies_invalid_utf8_doc(
+    tmp_path: Path,
+) -> None:
+    """Invalid UTF-8 docs should become structured alignment errors."""
+    doc_path = tmp_path / "core_responsibility_boundaries.md"
+    doc_path.write_bytes(bytes.fromhex("fffe00") + b"bad utf8")
+
+    issues = collect_doc_alignment_issues(doc_path)
+
+    assert issues == [
+        DocAlignmentIssue(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"invalid UTF-8 at {doc_path}"
+            ),
+            source_module="documentation",
+        )
+    ]
+
+
 def test_build_machine_report_counts_by_code(tmp_path: Path) -> None:
     """Machine report should summarize issue counts for CI parsers."""
     issues = [


### PR DESCRIPTION
### Motivation
- The boundary checker could raise raw tracebacks when the architecture document was unreadable or encoded with invalid bytes, making CI/monitoring unable to classify doc-drift failures; the intent is to emit machine-readable `doc_alignment_error` results without changing core module responsibilities.

### Description
- Add structured decoding/error handling to `_read_doc_extension_points()` in `scripts/architecture/check_responsibility_boundaries.py` to catch `UnicodeDecodeError` and generic `OSError` and return `DocExtractionError` with clear messages.
- Add regression test `test_collect_doc_alignment_issues_classifies_invalid_utf8_doc` to `veritas_os/tests/test_responsibility_boundary_checker.py` that writes an invalid-UTF8 file and asserts a structured `DocAlignmentIssue` is returned.
- Record the change in `docs/reviews/precision_code_review_ja_20260319_reassessment.md` to document the intent and scope of this minimal fix.
- No public contracts or core Planner/Kernel/FUJI/MemoryOS responsibilities were changed.

### Testing
- Ran `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py`, which passed (22 passed). 
- Ran `python scripts/architecture/check_responsibility_boundaries.py --report-format json` to validate machine report output, which completed and returned a passed status with expected summary counts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcc974fe5083269ae54466a1b34457)