### PR TITLE
Detect duplicate architecture boundary sections

### DIFF
--- a/docs/reviews/precision_code_review_ja_20260319_reassessment.md
+++ b/docs/reviews/precision_code_review_ja_20260319_reassessment.md
@@ -363,3 +363,26 @@ CI/運用監視の信頼性だけを高めるものです。
 この改善も Planner / Kernel / FUJI / MemoryOS の public contract や責務境界を変えず、
 レビューで継続課題とされた「正規拡張ポイントの明確化」を
 不要な CI ノイズなしで維持しやすくするものです。
+
+## 2026-03-20 追加改善（architecture 文書の重複節を drift として検知）
+
+再評価文書に沿って boundary checker の運用上の盲点を再確認したところ、
+`docs/architecture/core_responsibility_boundaries.md` に同じ責務境界の節が
+重複して追加された場合、**後勝ちや黙殺ではなく「曖昧なガイダンス」そのものを
+CI で止めるべきなのに、従来は明示的に検知していませんでした。**
+
+これは中核責務の見直しではなく、正規拡張ポイント文書の監査性不足です。
+無駄な構造変更を避けるため、今回は boundary checker の文書整合性検証だけを
+最小差分で改善しました。
+
+- `scripts/architecture/check_responsibility_boundaries.py` に
+  architecture 文書の重複節を抽出する処理を追加し、
+  同一モジュールの Preferred extension points 節が複数ある場合は
+  `doc_alignment_error` として module 単位で失敗させるよう修正
+- `veritas_os/tests/test_responsibility_boundary_checker.py` に
+  duplicate Planner 節の回帰テストを追加し、
+  今後の文書編集で曖昧な拡張ガイダンスが見逃されないことを固定
+
+この改善も Planner / Kernel / FUJI / MemoryOS の public contract や責務境界を変えず、
+レビューで継続課題とされた「正規拡張ポイントの明確化」を
+曖昧な文書状態のまま通さないための最小差分です。

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -379,6 +379,14 @@ def build_machine_report(issues: Iterable[BoundaryIssue]) -> str:
 def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
     """Extract preferred extension points from the architecture document."""
     document = doc_path.read_text(encoding="utf-8")
+    extracted, _ = _extract_doc_extension_points_from_text(document)
+    return extracted
+
+
+def _extract_doc_extension_points_from_text(
+    document: str,
+) -> tuple[dict[str, tuple[str, ...]], tuple[str, ...]]:
+    """Extract doc extension points and duplicate module sections from text."""
     section_pattern = re.compile(
         r"### (?P<section>[^\n]+?) \(`veritas_os\.core\.[^`]+`\)\n"
         r"(?P<body>.*?)(?=\n### |\Z)",
@@ -386,6 +394,7 @@ def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
     )
     marker = "**Preferred extension points**:"
     extracted: dict[str, tuple[str, ...]] = {}
+    duplicate_sections: list[str] = []
 
     for match in section_pattern.finditer(document):
         section_name = match.group("section").strip()
@@ -413,45 +422,12 @@ def extract_doc_extension_points(doc_path: Path) -> dict[str, tuple[str, ...]]:
                 continue
             if bullet_collection_started:
                 break
+        if module_name in extracted:
+            duplicate_sections.append(module_name)
+            continue
         extracted[module_name] = tuple(bullet_lines)
 
-    return extracted
-
-
-def _read_doc_extension_points(
-    doc_path: Path,
-) -> tuple[dict[str, tuple[str, ...]], DocExtractionError | None]:
-    """Read doc extension points while converting doc access failures to errors."""
-    try:
-        return extract_doc_extension_points(doc_path), None
-    except FileNotFoundError:
-        return {}, DocExtractionError(
-            message=(
-                "Unable to read architecture boundary document: "
-                f"file not found at {doc_path}"
-            )
-        )
-    except PermissionError:
-        return {}, DocExtractionError(
-            message=(
-                "Unable to read architecture boundary document: "
-                f"permission denied for {doc_path}"
-            )
-        )
-    except UnicodeDecodeError:
-        return {}, DocExtractionError(
-            message=(
-                "Unable to read architecture boundary document: "
-                f"invalid UTF-8 at {doc_path}"
-            )
-        )
-    except OSError as exc:
-        return {}, DocExtractionError(
-            message=(
-                "Unable to read architecture boundary document: "
-                f"os error for {doc_path}: {exc.strerror or str(exc)}"
-            )
-        )
+    return extracted, tuple(duplicate_sections)
 
 
 def _normalize_extension_points_for_alignment(
@@ -463,7 +439,50 @@ def _normalize_extension_points_for_alignment(
 
 def collect_doc_alignment_issues(doc_path: Path) -> list[DocAlignmentIssue]:
     """Return structured mismatches between docs and checker guidance."""
-    documented_points, extraction_error = _read_doc_extension_points(doc_path)
+    try:
+        document = doc_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        extraction_error = DocExtractionError(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"file not found at {doc_path}"
+            )
+        )
+        documented_points = {}
+        duplicate_sections: tuple[str, ...] = ()
+    except PermissionError:
+        extraction_error = DocExtractionError(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"permission denied for {doc_path}"
+            )
+        )
+        documented_points = {}
+        duplicate_sections = ()
+    except UnicodeDecodeError:
+        extraction_error = DocExtractionError(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"invalid UTF-8 at {doc_path}"
+            )
+        )
+        documented_points = {}
+        duplicate_sections = ()
+    except OSError as exc:
+        extraction_error = DocExtractionError(
+            message=(
+                "Unable to read architecture boundary document: "
+                f"os error for {doc_path}: {exc.strerror or str(exc)}"
+            )
+        )
+        documented_points = {}
+        duplicate_sections = ()
+    else:
+        documented_points, duplicate_sections = _extract_doc_extension_points_from_text(
+            document
+        )
+        extraction_error = None
+
     mismatches: list[DocAlignmentIssue] = []
     if extraction_error is not None:
         mismatches.append(
@@ -473,6 +492,17 @@ def collect_doc_alignment_issues(doc_path: Path) -> list[DocAlignmentIssue]:
             )
         )
         return mismatches
+
+    for module_name in duplicate_sections:
+        mismatches.append(
+            DocAlignmentIssue(
+                source_module=module_name,
+                message=(
+                    "Duplicate preferred extension point section found for "
+                    f"'{module_name}' in {doc_path}"
+                ),
+            )
+        )
 
     for module_name, configured_points in RECOMMENDED_EXTENSION_POINTS.items():
         expected_points = documented_points.get(module_name)

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -507,6 +507,61 @@ def test_extract_doc_extension_points_accepts_asterisk_bullets(
     )
 
 
+def test_collect_doc_alignment_issues_detects_duplicate_module_sections(
+    tmp_path: Path,
+) -> None:
+    """Duplicate module sections should surface as structured doc drift."""
+    doc_path = tmp_path / "core_responsibility_boundaries.md"
+    doc_path.write_text(
+        """
+# Core Responsibility Boundaries
+
+### Planner (`veritas_os.core.planner`)
+**Preferred extension points**:
+- `veritas_os.core.planner_normalization`
+- `veritas_os.core.planner_json`
+- `veritas_os.core.strategy`
+
+### Planner (`veritas_os.core.planner`)
+**Preferred extension points**:
+- `veritas_os.core.planner_normalization`
+- `veritas_os.core.planner_json`
+- `veritas_os.core.strategy`
+
+### Kernel (`veritas_os.core.kernel`)
+**Preferred extension points**:
+- `veritas_os.core.kernel_stages`
+- `veritas_os.core.kernel_qa`
+- `veritas_os.core.pipeline_contracts`
+
+### FUJI (`veritas_os.core.fuji`)
+**Preferred extension points**:
+- `veritas_os.core.fuji_policy`
+- `veritas_os.core.fuji_policy_rollout`
+- `veritas_os.core.fuji_helpers`
+- `veritas_os.core.fuji_safety_head`
+
+### MemoryOS (`veritas_os.core.memory`)
+**Preferred extension points**:
+- `veritas_os.core.memory_store`
+- `veritas_os.core.memory_helpers`
+- `veritas_os.core.memory_search_helpers`
+- `veritas_os.core.memory_summary_helpers`
+- `veritas_os.core.memory_lifecycle`
+- `veritas_os.core.memory_security`
+""".strip(),
+        encoding="utf-8",
+    )
+
+    issues = collect_doc_alignment_issues(doc_path)
+
+    assert any(
+        issue.source_module == "planner"
+        and "Duplicate preferred extension point section" in issue.message
+        for issue in issues
+    )
+
+
 def test_find_doc_alignment_issues_returns_empty_for_current_doc() -> None:
     """Checker guidance should stay aligned with the architecture source of truth."""
     issues = find_doc_alignment_issues(


### PR DESCRIPTION
### Motivation
- The boundary checker could silently accept duplicate `Preferred extension points` sections in `docs/architecture/core_responsibility_boundaries.md`, producing ambiguous guidance that CI might allow through; this change prevents that class of doc drift without touching core module responsibilities. 
- Improve machine-readable observability so CI and automation can identify which module's doc guidance is ambiguous. 
- This is a minimal operational fix that does not change Planner/Kernel/FUJI/MemoryOS contracts or runtime behavior, but reduces risk that ambiguous docs lead to incorrect placement of security-sensitive logic.

### Description
- Add `_extract_doc_extension_points_from_text()` and make `extract_doc_extension_points()` use it to also detect duplicate module sections (returns duplicate module names). 
- Modify `collect_doc_alignment_issues()` to surface duplicate preferred-extension sections as `DocAlignmentIssue` entries with module context and a clear message. 
- Add `test_collect_doc_alignment_issues_detects_duplicate_module_sections()` to `veritas_os/tests/test_responsibility_boundary_checker.py` to lock in the behavior. 
- Update `docs/reviews/precision_code_review_ja_20260319_reassessment.md` to document this 2026-03-20 follow-up improvement and its intent (detect ambiguous/duplicate sections rather than silently preferring one).

### Testing
- Ran the unit test suite for the checker with `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py` and all tests passed (`23 passed`).
- Ran the checker CLI with `python scripts/architecture/check_responsibility_boundaries.py --report-format json` and observed a machine-readable success report for the current repo state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcd12fe8f48326a9ff322676b17d5e)