### PR TITLE
Clarify core module contracts and add TrustLog degraded + fail-open runbook

### DIFF
--- a/docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md
+++ b/docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md
@@ -83,6 +83,48 @@
 - `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` は検証専用の危険フラグであり、production へ混入させない。backend startup は fail-fast するが、環境定義から除去しておくこと。
 - デプロイ担当者はリリース前に環境変数一覧をレビューし、不要な `NEXT_PUBLIC_*` と fail-open 系フラグが含まれていないことを確認する。
 
+## 6.1 TrustLog degraded 状態 runbook
+
+### `trust_json_status` の意味
+- `unreadable`: `trust_log.json` の読込時に例外が発生し、aggregate JSON を安全側で無視した状態。JSONL 追記は継続しても aggregate JSON 更新は停止される。
+- `invalid`: `trust_log.json` が list / `{"items": [...]}` 以外で、監査集計に使えない状態。
+- `too_large`: aggregate JSON が保護上限を超え、破壊的な再読込を避けるため更新を停止した状態。
+
+### 監査上の影響
+- いずれも **自動修復ではなく degraded 保護**。既存 aggregate JSON を黙って上書きしないことで監査証跡の破壊を防ぐ。
+- JSONL 側に新規追記が残る可能性はあるため、監査時は aggregate JSON と JSONL の乖離有無を確認する。
+
+### 初動確認手順
+1. `/health` や system status で `trust_json_status` を確認する。
+2. `trust_log.json` と `trust_log.jsonl` のサイズ・更新時刻・権限差分を確認する。
+3. backend log の warning `write trust_log.json skipped: aggregate log status=...` を確認し、`unreadable|invalid|too_large` のどれかを特定する。
+
+### 復旧手順
+1. `unreadable` の場合は権限・所有者・破損ファイルの有無を確認し、読める状態へ戻す。
+2. `invalid` の場合は JSON 構造を修復し、list もしくは `{"items": [...]}` へ正規化する。
+3. `too_large` の場合はバックアップ取得後に分割・アーカイブし、上限内サイズへ縮退する。
+4. 修復後に `trust_json_status=ok` へ戻ること、かつ append warning が止まることを確認する。
+
+### 再発防止の確認項目
+- aggregate JSON を手編集しない運用に統一する。
+- 監査ジョブで `trust_json_status != ok` を検知する。
+- 大容量化しやすい環境では rotate / archive 手順を定期化する。
+
+## 6.2 fail-open 設定の検知経路
+
+### startup warning / fail-fast の確認手順
+1. backend startup log で `[SECURITY] VERITAS_AUTH_ALLOW_FAIL_OPEN=true is enabled.` の warning を確認する。
+2. `VERITAS_ENV=prod|production` では startup が `RuntimeError` で fail-fast することを確認する。
+3. `VERITAS_ENV` が `dev|development|local|test` 以外の shared 環境では warning に加え、auth store fallback logic が `open` を無視して `closed` に戻すことを確認する。
+
+### CI / deployment check
+- `scripts/quality/check_deployment_env_defaults.py` の smoke check で、テンプレートに危険な public env や不足設定がないことを継続検証する。
+- 本番前レビューでは環境変数一覧に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` が残っていないことをチェックリスト化する。
+
+### 環境別ポリシー
+- production / shared staging / preview: **禁止**。残置は認証保護低下のセキュリティ事故につながる。
+- local / isolated test: 明示的な検証時のみ一時許容。終了後は必ず削除する。
+
 ## 7. セキュリティ上の警告
 - `trace_id` は監査相関用であり、認可判定には使用しない。
 - 外部入力の `trace_id` は形式検証を行い、ヘッダ/ログインジェクションを防止する。

--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -161,3 +161,18 @@ fail-open は非本番でも認証保護を弱めるため、
 - 中核本体に処理を足す前に helper / stage へ逃がす
 - セキュリティ上の degraded 状態は「黙って通す」のではなく観測可能に保つ
 - shared 環境で fail-open を許さない
+
+
+## 実施記録（2026-03-20）
+
+### 今回完了した改善
+- **Priority 1 / 指示 1-1**: `pipeline.py` / `kernel.py` / `fuji.py` / `memory.py` の module docstring を更新し、public contract・推奨拡張ポイント・compatibility layer の扱いを明示した。
+- **Priority 2 / 指示 2-1**: `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に TrustLog degraded 状態 (`trust_json_status=unreadable|invalid|too_large`) の運用 runbook を追加した。
+- **Priority 2 / 指示 2-2**: 同 runbook に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` の startup warning / fail-fast / CI・deployment check / 環境別ポリシーを追記した。
+
+### 今回あえて実施しなかった改善
+- **Priority 1 / 指示 1-2 以降** の helper 分離や例外契約拡張は、既存 public contract・責務境界・回帰範囲への影響が相対的に大きいため、今回の最小差分では未着手とした。
+- **Priority 4 capability profile** は有用だが、まず中核モジュールの入口明示と degraded / fail-open runbook のほうが優先度が高いため後続タスクへ残す。
+
+### セキュリティ警告
+- `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` は local / isolated test 限定の危険フラグであり、shared staging / preview / production へ残置すると auth store 障害時の防御低下を招く。

--- a/veritas_os/core/fuji.py
+++ b/veritas_os/core/fuji.py
@@ -3,6 +3,22 @@
 """
 FUJI Gate v2 (Safety Head × Policy Engine × TrustLog)
 
+Public contract:
+- ``fuji_gate()`` and the v1-compatible validation helpers provide the stable
+  policy/safety gate consumed by Kernel and API layers.
+- This module coordinates final gate decisions and audit-facing status only;
+  detailed policy loading and safety-head behavior belong in helper modules.
+
+Preferred extension points:
+- ``fuji_policy.py`` / ``fuji_policy_rollout.py`` for policy loading and rollout
+- ``fuji_helpers.py`` for normalization and compatibility helpers
+- ``fuji_safety_head.py`` for deterministic / LLM safety-head behavior
+
+Compatibility guidance:
+- This file still contains compatibility shims for older validation paths.
+  Preserve those adapters, but add new fallback, rollout, or safety logic to
+  the helper modules above so FUJI responsibility does not sprawl further.
+
 PoC仕様：
 - low_evidence のときは allow に倒さず、必ず「補う/止める」へ寄せる
   - 高リスク/高ステークス => deny

--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -3,10 +3,22 @@
 # -*- coding: utf-8 -*-
 """Core decision logic for VERITAS Kernel.
 
-This module keeps ``decide()`` backward compatible while limiting its
-responsibility to *decision computation* (alternative scoring, debate,
-FUJI gating, and rationale generation). Pipeline orchestration, side effects,
-and persistence are handled in ``core/pipeline.py``.
+Public contract:
+- ``decide()`` remains the backward-compatible kernel entry-point consumed by
+  pipeline orchestration and tests.
+- The module is responsible for decision computation only: alternative
+  scoring, debate, FUJI gating, and rationale generation.
+
+Preferred extension points:
+- ``kernel_stages.py`` for staged kernel flow changes
+- ``kernel_qa.py`` for QA / validation-specific helpers
+- ``pipeline_contracts.py`` for cross-module payload normalization contracts
+
+Compatibility guidance:
+- Backward-compatible wrappers live here so older call sites continue to work,
+  but new branching, fallback shaping, and adapter logic should be added to
+  helper modules first. Pipeline orchestration, side effects, and persistence
+  stay in ``core/pipeline.py``.
 """
 from __future__ import annotations
 

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -2,6 +2,24 @@
 """
 MemoryOS - 改善版
 
+Public contract:
+- ``MemoryStore`` と関連 API は、記憶の保存・検索・要約・ライフサイクル
+  制御を担う MemoryOS の互換入口です。
+- 本モジュールは MemoryOS の I/O と orchestration を保持し、Planner /
+  Kernel / FUJI の責務へ横滑りしません。
+
+Preferred extension points:
+- ``memory_helpers.py`` for normalization / compatibility helpers
+- ``memory_search_helpers.py`` for search payload shaping and fallback scoring
+- ``memory_summary_helpers.py`` for summary text formatting
+- ``memory_lifecycle.py`` / ``memory_security.py`` / ``memory_store.py`` for
+  lifecycle, security, and backend store details
+
+Compatibility guidance:
+- Optional dependency fallback と既存 private wrapper は後方互換のため残して
+  あります。新しい検索整形・summary 整形・fallback 分岐は helper 側へ追加し、
+  本体へ新規責務を直接積み増さないでください。
+
 主な改善点:
 1. 組み込みベクトル検索実装（sentence-transformers）
 2. インデックス管理の改善

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -5,6 +5,25 @@ from __future__ import annotations
 """
 VERITAS Decision Pipeline – Orchestrator (core/pipeline.py)
 
+Public contract:
+- ``run_decide_pipeline(req, request)`` is the stable entry-point used by
+  the API layer for ``/v1/decide``.
+- This module owns orchestration only; stage-specific shaping, gating, and
+  persistence should stay in the dedicated pipeline_* helper modules.
+
+Preferred extension points:
+- ``pipeline_inputs`` for request normalization
+- ``pipeline_execute`` for kernel execution / self-healing
+- ``pipeline_policy`` for FUJI / ValueCore policy steps
+- ``pipeline_response`` for response assembly
+- ``pipeline_persist`` and ``pipeline_replay`` for persistence / replay
+
+Compatibility guidance:
+- This file intentionally keeps compatibility imports and re-exports so older
+  call paths do not break immediately. Extend helpers first, and treat local
+  compatibility wrappers here as adapters rather than a place for new policy
+  branches or fallback-heavy logic.
+
 This module is the *single entry-point* for the /v1/decide endpoint.
 ``run_decide_pipeline(req, request)`` orchestrates the full decision flow
 by delegating to responsibility-separated stage modules:


### PR DESCRIPTION
### Motivation
- Reduce cognitive load in large core modules by clearly documenting each module's public contract and recommended extension points so new logic is directed to helper/stage modules. 
- Improve operational observability for TrustLog degraded states to avoid silent audit loss and to provide concrete runbook steps for operators. 
- Provide explicit detection and handling guidance for fail-open auth flags to prevent accidental security weakening in shared/production environments.

### Description
- Added explicit `Public contract`, `Preferred extension points`, and `Compatibility guidance` module docstrings to `veritas_os/core/pipeline.py`, `veritas_os/core/kernel.py`, `veritas_os/core/fuji.py`, and `veritas_os/core/memory.py` to steer extensions toward helper modules and preserve responsibility boundaries. 
- Extended `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` with a `TrustLog degraded` runbook that defines `trust_json_status` values (`unreadable`, `invalid`, `too_large`), audit impact, initial triage, recovery steps, and recurrence prevention. 
- Added `fail-open` detection and CI/deployment guidance to the runbook describing startup warnings, production fail-fast behavior, and environment policies for `VERITAS_AUTH_ALLOW_FAIL_OPEN`. 
- Appended an implementation record to `docs/reviews/improvement_instructions_ja_20260320.md` summarizing completed work and deferred items, and included a clear security warning about `VERITAS_AUTH_ALLOW_FAIL_OPEN=true`.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_startup_health.py veritas_os/tests/test_check_deployment_env_defaults.py`, and the tests passed (`15 passed`).
- Verified syntax/compilation with `python -m compileall` on the four modified core modules with no errors.
- No other automated tests were modified; changes were confined to docstrings and documentation runbook content and kept minimal to avoid altering public contracts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bceef8b140832685f16e20e10c1718)