### PR TITLE
Fix Trivy action version in publish-ghcr workflow

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ steps.image.outputs.name }}:${{ github.sha }}
           format: sarif


### PR DESCRIPTION
### Motivation
- Replace the invalid `aquasecurity/trivy-action@0.28.0` reference with `aquasecurity/trivy-action@0.35.0` in `.github/workflows/publish-ghcr.yml` to prevent immediate action-resolution failure; this is a minimal fix and for stronger supply-chain safety consider pinning to a full commit SHA.

### Description
- Change a single workflow step in `.github/workflows/publish-ghcr.yml` from `uses: aquasecurity/trivy-action@0.28.0` to `uses: aquasecurity/trivy-action@0.35.0` and leave the GHCR publish and SARIF upload flow otherwise unchanged.

### Testing
- Performed a Python YAML parse/assertion that verified the `uses` value is `aquasecurity/trivy-action@0.35.0`, inspected the `git diff` to confirm the one-line change, and committed the patch successfully; all automated checks ran and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcf2e2c86883269b3b1dbf4b6e20f5)