### PR TITLE
Guard core module extension-point docstrings and add CI docstring checks

### DIFF
--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -167,6 +167,7 @@ fail-open は非本番でも認証保護を弱めるため、
 
 ### 今回完了した改善
 - **Priority 1 / 指示 1-1**: `pipeline.py` / `kernel.py` / `fuji.py` / `memory.py` の module docstring を更新し、public contract・推奨拡張ポイント・compatibility layer の扱いを明示した。
+- **Priority 1 / 指示 1-1 の回帰防止**: `scripts/architecture/check_responsibility_boundaries.py` を拡張し、上記 4 モジュールの docstring に required marker と推奨拡張ポイントが残っているかを CI 向けに検査できるようにした。対応する回帰テストも追加した。
 - **Priority 2 / 指示 2-1**: `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に TrustLog degraded 状態 (`trust_json_status=unreadable|invalid|too_large`) の運用 runbook を追加した。
 - **Priority 2 / 指示 2-2**: 同 runbook に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` の startup warning / fail-fast / CI・deployment check / 環境別ポリシーを追記した。
 

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -49,6 +49,7 @@ class DocAlignmentIssue:
 
     source_module: str
     message: str
+    path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -136,6 +137,30 @@ DOC_SECTION_TO_MODULE: dict[str, str] = {
     "FUJI": "fuji",
     "MemoryOS": "memory",
 }
+MODULE_DOCSTRING_REQUIRED_MARKERS: tuple[str, ...] = (
+    "Public contract:",
+    "Preferred extension points:",
+    "Compatibility guidance:",
+)
+DOCSTRING_GUARD_MODULES: tuple[str, ...] = (
+    "pipeline",
+    "kernel",
+    "fuji",
+    "memory",
+)
+MODULE_DOCSTRING_EXTENSION_POINTS: dict[str, tuple[str, ...]] = {
+    "pipeline": (
+        "veritas_os.core.pipeline_inputs",
+        "veritas_os.core.pipeline_execute",
+        "veritas_os.core.pipeline_policy",
+        "veritas_os.core.pipeline_response",
+        "veritas_os.core.pipeline_persist",
+        "veritas_os.core.pipeline_replay",
+    ),
+    "kernel": RECOMMENDED_EXTENSION_POINTS["kernel"],
+    "fuji": RECOMMENDED_EXTENSION_POINTS["fuji"],
+    "memory": RECOMMENDED_EXTENSION_POINTS["memory"],
+}
 
 
 def _normalize_module_name(module_name: str) -> str:
@@ -189,6 +214,64 @@ def _parse_imported_names(path: Path) -> set[str]:
     return _collect_imported_names(tree)
 
 
+def _load_module_docstring(path: Path) -> str:
+    """Return the module docstring for a Python source file."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    return ast.get_docstring(tree, clean=False) or ""
+
+
+def collect_module_docstring_issues(
+    core_dir: Path,
+    modules: Iterable[str] = DOCSTRING_GUARD_MODULES,
+) -> list[DocAlignmentIssue]:
+    """Validate core module docstrings keep boundary guidance visible."""
+    issues: list[DocAlignmentIssue] = []
+    for module_name in modules:
+        path = core_dir / f"{module_name}.py"
+        try:
+            docstring = _load_module_docstring(path)
+        except FileNotFoundError:
+            continue
+
+        missing_markers = [
+            marker for marker in MODULE_DOCSTRING_REQUIRED_MARKERS
+            if marker not in docstring
+        ]
+        if missing_markers:
+            issues.append(
+                DocAlignmentIssue(
+                    source_module=module_name,
+                    message=(
+                        f"Module docstring guidance missing for '{module_name}': "
+                        f"{missing_markers}"
+                    ),
+                    path=path,
+                )
+            )
+
+        recommended_points = MODULE_DOCSTRING_EXTENSION_POINTS.get(module_name, ())
+        missing_points = [
+            point for point in recommended_points
+            if f"``{point.rsplit('.', maxsplit=1)[-1]}.py``" not in docstring
+            and f"``{point.rsplit('.', maxsplit=1)[-1]}``" not in docstring
+            and point not in docstring
+        ]
+        if missing_points:
+            issues.append(
+                DocAlignmentIssue(
+                    source_module=module_name,
+                    message=(
+                        "Module docstring extension points out of sync for "
+                        f"'{module_name}': missing={missing_points}"
+                    ),
+                    path=path,
+                )
+            )
+
+    return issues
+
+
 def collect_boundary_issues(
     core_dir: Path,
     rules: Iterable[BoundaryRule] = DEFAULT_RULES,
@@ -201,7 +284,16 @@ def collect_boundary_issues(
             BoundaryIssue(
                 code="doc_alignment_error",
                 message=issue.message,
-                path=doc_path,
+                path=issue.path or doc_path,
+                source_module=issue.source_module,
+            )
+        )
+    for issue in collect_module_docstring_issues(core_dir):
+        issues.append(
+            BoundaryIssue(
+                code="doc_alignment_error",
+                message=issue.message,
+                path=issue.path or core_dir / f"{issue.source_module}.py",
                 source_module=issue.source_module,
             )
         )

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -1,7 +1,5 @@
 # veritas_os/core/pipeline.py
 # -*- coding: utf-8 -*-
-from __future__ import annotations
-
 """
 VERITAS Decision Pipeline – Orchestrator (core/pipeline.py)
 
@@ -53,6 +51,8 @@ Payload contracts restored (tests / server expectations):
 - web_search payload normalized (ok/results)
 - decision saved into MemoryOS with key prefix "decision_"
 """
+
+from __future__ import annotations
 
 import inspect
 import json

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -16,6 +16,7 @@ from scripts.architecture.check_responsibility_boundaries import (
     check_boundaries,
     collect_boundary_issues,
     collect_doc_alignment_issues,
+    collect_module_docstring_issues,
     extract_doc_extension_points,
     find_doc_alignment_issues,
 )
@@ -26,12 +27,81 @@ def _write_module(path: Path, source: str) -> None:
     path.write_text(source, encoding="utf-8")
 
 
+def _write_guarded_core_docstrings(tmp_path: Path) -> None:
+    """Create minimal valid docstrings for guarded core modules."""
+    _write_module(
+        tmp_path / "pipeline.py",
+        '''"""Public contract:
+- stable entry point
+
+Preferred extension points:
+- ``pipeline_inputs.py``
+- ``pipeline_execute.py``
+- ``pipeline_policy.py``
+- ``pipeline_response.py``
+- ``pipeline_persist.py``
+- ``pipeline_replay.py``
+
+Compatibility guidance:
+- keep wrappers here
+"""
+''',
+    )
+    _write_module(
+        tmp_path / "kernel.py",
+        '''"""Public contract:
+- stable entry point
+
+Preferred extension points:
+- ``kernel_stages.py``
+- ``kernel_qa.py``
+- ``pipeline_contracts.py``
+
+Compatibility guidance:
+- keep wrappers here
+"""
+''',
+    )
+    _write_module(
+        tmp_path / "fuji.py",
+        '''"""Public contract:
+- stable entry point
+
+Preferred extension points:
+- ``fuji_policy.py``
+- ``fuji_policy_rollout.py``
+- ``fuji_helpers.py``
+- ``fuji_safety_head.py``
+
+Compatibility guidance:
+- keep wrappers here
+"""
+''',
+    )
+    _write_module(
+        tmp_path / "memory.py",
+        '''"""Public contract:
+- stable entry point
+
+Preferred extension points:
+- ``memory_store.py``
+- ``memory_helpers.py``
+- ``memory_search_helpers.py``
+- ``memory_summary_helpers.py``
+- ``memory_lifecycle.py``
+- ``memory_security.py``
+
+Compatibility guidance:
+- keep wrappers here
+"""
+''',
+    )
+
+
 def test_check_boundaries_reports_forbidden_import(tmp_path: Path) -> None:
     """Checker should report violations when forbidden imports exist."""
+    _write_guarded_core_docstrings(tmp_path)
     _write_module(tmp_path / "planner.py", "import veritas_os.core.kernel\n")
-    _write_module(tmp_path / "kernel.py", "# kernel module\n")
-    _write_module(tmp_path / "fuji.py", "# fuji module\n")
-    _write_module(tmp_path / "memory.py", "# memory module\n")
 
     issues = check_boundaries(core_dir=tmp_path)
 
@@ -42,10 +112,22 @@ def test_check_boundaries_reports_forbidden_import(tmp_path: Path) -> None:
 
 def test_check_boundaries_accepts_valid_dependency_directions(tmp_path: Path) -> None:
     """Checker should pass when no forbidden cross-module imports are present."""
+    _write_guarded_core_docstrings(tmp_path)
     _write_module(tmp_path / "planner.py", "from veritas_os.core.memory import summarize_for_planner\n")
-    _write_module(tmp_path / "kernel.py", "from veritas_os.core.planner import plan_for_veritas_agi\n")
-    _write_module(tmp_path / "fuji.py", "from veritas_os.core.fuji_codes import FujiAction\n")
-    _write_module(tmp_path / "memory.py", "import json\n")
+    _write_module(
+        tmp_path / "kernel.py",
+        (tmp_path / "kernel.py").read_text(encoding="utf-8")
+        + "\nfrom veritas_os.core.planner import plan_for_veritas_agi\n",
+    )
+    _write_module(
+        tmp_path / "fuji.py",
+        (tmp_path / "fuji.py").read_text(encoding="utf-8")
+        + "\nfrom veritas_os.core.fuji_codes import FujiAction\n",
+    )
+    _write_module(
+        tmp_path / "memory.py",
+        (tmp_path / "memory.py").read_text(encoding="utf-8") + "\nimport json\n",
+    )
 
     issues = check_boundaries(core_dir=tmp_path)
 
@@ -54,10 +136,13 @@ def test_check_boundaries_accepts_valid_dependency_directions(tmp_path: Path) ->
 
 def test_check_boundaries_supports_custom_rules(tmp_path: Path) -> None:
     """Checker should evaluate custom rules provided by callers."""
-    _write_module(tmp_path / "kernel.py", "from veritas_os.core.memory import add\n")
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(
+        tmp_path / "kernel.py",
+        (tmp_path / "kernel.py").read_text(encoding="utf-8")
+        + "\nfrom veritas_os.core.memory import add\n",
+    )
     _write_module(tmp_path / "planner.py", "# planner module\n")
-    _write_module(tmp_path / "fuji.py", "# fuji module\n")
-    _write_module(tmp_path / "memory.py", "# memory module\n")
 
     issues = check_boundaries(
         core_dir=tmp_path,
@@ -76,10 +161,8 @@ def test_check_boundaries_supports_custom_rules(tmp_path: Path) -> None:
 
 def test_check_boundaries_detects_from_core_import_pattern(tmp_path: Path) -> None:
     """Checker should catch `from veritas_os.core import <forbidden>` imports."""
+    _write_guarded_core_docstrings(tmp_path)
     _write_module(tmp_path / "planner.py", "from veritas_os.core import kernel\n")
-    _write_module(tmp_path / "kernel.py", "# kernel module\n")
-    _write_module(tmp_path / "fuji.py", "# fuji module\n")
-    _write_module(tmp_path / "memory.py", "# memory module\n")
 
     issues = check_boundaries(core_dir=tmp_path)
 
@@ -127,10 +210,8 @@ def test_collect_boundary_issues_classifies_missing_module(tmp_path: Path) -> No
 
 def test_collect_boundary_issues_classifies_boundary_violation(tmp_path: Path) -> None:
     """Forbidden import should be classified as boundary_violation."""
+    _write_guarded_core_docstrings(tmp_path)
     _write_module(tmp_path / "planner.py", "import veritas_os.core.kernel\n")
-    _write_module(tmp_path / "kernel.py", "# kernel module\n")
-    _write_module(tmp_path / "fuji.py", "# fuji module\n")
-    _write_module(tmp_path / "memory.py", "# memory module\n")
 
     issues = collect_boundary_issues(core_dir=tmp_path)
 
@@ -271,6 +352,148 @@ def test_collect_doc_alignment_issues_classifies_invalid_utf8_doc(
             source_module="documentation",
         )
     ]
+
+
+def test_collect_module_docstring_issues_accepts_guidance_complete_modules(
+    tmp_path: Path,
+) -> None:
+    """Module docstring guidance should pass when markers and helpers are present."""
+    module_docstring = '''"""Public contract:
+- stable entry point
+
+Preferred extension points:
+- ``kernel_stages.py``
+- ``kernel_qa.py``
+- ``pipeline_contracts.py``
+
+Compatibility guidance:
+- keep wrappers here
+"""
+'''
+    _write_module(tmp_path / "kernel.py", module_docstring)
+
+    issues = collect_module_docstring_issues(tmp_path, modules=("kernel",))
+
+    assert issues == []
+
+
+def test_collect_module_docstring_issues_reports_missing_markers_and_helpers(
+    tmp_path: Path,
+) -> None:
+    """Module docstring drift should be surfaced as structured issues."""
+    _write_module(
+        tmp_path / "memory.py",
+        '''"""Public contract:
+- stable entry point
+"""
+''',
+    )
+
+    issues = collect_module_docstring_issues(tmp_path, modules=("memory",))
+
+    assert len(issues) == 2
+    assert "Module docstring guidance missing" in issues[0].message
+    assert "Module docstring extension points out of sync" in issues[1].message
+
+
+def test_collect_boundary_issues_includes_module_docstring_drift(
+    tmp_path: Path,
+) -> None:
+    """Boundary issue collection should expose module docstring regressions."""
+    _write_module(
+        tmp_path / "pipeline.py",
+        '''"""Public contract:
+- stable entry point
+"""
+''',
+    )
+    _write_module(
+        tmp_path / "kernel.py",
+        '''"""Public contract:
+- stable entry point
+
+Preferred extension points:
+- ``kernel_stages.py``
+- ``kernel_qa.py``
+- ``pipeline_contracts.py``
+
+Compatibility guidance:
+- keep wrappers here
+"""
+''',
+    )
+    _write_module(
+        tmp_path / "fuji.py",
+        '''"""Public contract:
+- stable entry point
+
+Preferred extension points:
+- ``fuji_policy.py``
+- ``fuji_policy_rollout.py``
+- ``fuji_helpers.py``
+- ``fuji_safety_head.py``
+
+Compatibility guidance:
+- keep wrappers here
+"""
+''',
+    )
+    _write_module(
+        tmp_path / "memory.py",
+        '''"""Public contract:
+- stable entry point
+
+Preferred extension points:
+- ``memory_store.py``
+- ``memory_helpers.py``
+- ``memory_search_helpers.py``
+- ``memory_summary_helpers.py``
+- ``memory_lifecycle.py``
+- ``memory_security.py``
+
+Compatibility guidance:
+- keep wrappers here
+"""
+''',
+    )
+    doc_path = tmp_path / "core_responsibility_boundaries.md"
+    doc_path.write_text(
+        """
+# Core Responsibility Boundaries
+
+### Kernel (`veritas_os.core.kernel`)
+**Preferred extension points**:
+- veritas_os.core.kernel_stages
+- veritas_os.core.kernel_qa
+- veritas_os.core.pipeline_contracts
+
+### FUJI (`veritas_os.core.fuji`)
+**Preferred extension points**:
+- veritas_os.core.fuji_policy
+- veritas_os.core.fuji_policy_rollout
+- veritas_os.core.fuji_helpers
+- veritas_os.core.fuji_safety_head
+
+### MemoryOS (`veritas_os.core.memory`)
+**Preferred extension points**:
+- veritas_os.core.memory_store
+- veritas_os.core.memory_helpers
+- veritas_os.core.memory_search_helpers
+- veritas_os.core.memory_summary_helpers
+- veritas_os.core.memory_lifecycle
+- veritas_os.core.memory_security
+""".strip(),
+        encoding="utf-8",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path, doc_path=doc_path)
+
+    assert any(
+        issue.code == "doc_alignment_error"
+        and issue.source_module == "pipeline"
+        and "Module docstring guidance missing" in issue.message
+        for issue in issues
+    )
 
 
 def test_build_machine_report_counts_by_code(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent silent regression of responsibility-boundary guidance by ensuring core modules (`pipeline`, `kernel`, `fuji`, `memory`) keep explicit docstring markers and recommended extension-points. 
- Implement a minimal, in-scope CI-level guard to satisfy the `improvement_instructions_ja_20260320.md` requirement to make extension points and compatibility guidance observable and testable without changing runtime responsibilities.

### Description
- Extend `scripts/architecture/check_responsibility_boundaries.py` to validate module docstrings by adding `MODULE_DOCSTRING_REQUIRED_MARKERS`, `DOCSTRING_GUARD_MODULES`, `MODULE_DOCSTRING_EXTENSION_POINTS`, the helper `_load_module_docstring()`, and `collect_module_docstring_issues()` and integrate these checks into `collect_boundary_issues()` so docstring drift produces machine-readable `doc_alignment_error` issues. 
- Add `path` metadata to `DocAlignmentIssue` so reports can point to the exact module file. 
- Move the pipeline guidance into the actual top-of-file module docstring in `veritas_os/core/pipeline.py` so the checker can detect the presence of required markers. 
- Add regression tests and fixtures in `veritas_os/tests/test_responsibility_boundary_checker.py` to cover the new docstring guard behavior and its integration with `collect_boundary_issues()`. 
- Record the regression-prevention change in `docs/reviews/improvement_instructions_ja_20260320.md` to document the improvement performed.

### Testing
- Ran `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py` and all tests passed (`28 passed in 0.26s`).
- Ran the checker directly with `python scripts/architecture/check_responsibility_boundaries.py --report-format json` to validate CI output formatting and it returned a passed JSON report when run against the repository state. 
- No runtime behavior or public contracts were changed and the change is limited to static checks, tests, docs, and a docstring placement edit to make the guidance machine-detectable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcfe65fc18832682d7b8e070aebb5b)