### PR TITLE
Harden deployment env fail-open checks

### DIFF
--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -170,6 +170,7 @@ fail-open は非本番でも認証保護を弱めるため、
 - **Priority 1 / 指示 1-1 の回帰防止**: `scripts/architecture/check_responsibility_boundaries.py` を拡張し、上記 4 モジュールの docstring に required marker と推奨拡張ポイントが残っているかを CI 向けに検査できるようにした。対応する回帰テストも追加した。
 - **Priority 2 / 指示 2-1**: `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に TrustLog degraded 状態 (`trust_json_status=unreadable|invalid|too_large`) の運用 runbook を追加した。
 - **Priority 2 / 指示 2-2**: 同 runbook に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` の startup warning / fail-fast / CI・deployment check / 環境別ポリシーを追記した。
+- **Priority 2 / 指示 2-2 の検知強化**: `scripts/quality/check_deployment_env_defaults.py` を強化し、`export VERITAS_AUTH_ALLOW_FAIL_OPEN = "true"` のような空白・引用符・大文字小文字ゆらぎ付きの危険設定も検知できるようにした。対応する回帰テストを追加した。
 
 ### 今回あえて実施しなかった改善
 - **Priority 1 / 指示 1-2 以降** の helper 分離や例外契約拡張は、既存 public contract・責務境界・回帰範囲への影響が相対的に大きいため、今回の最小差分では未着手とした。

--- a/scripts/quality/check_deployment_env_defaults.py
+++ b/scripts/quality/check_deployment_env_defaults.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pathlib
 import sys
 from dataclasses import dataclass
+from typing import Iterable
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
@@ -22,6 +23,7 @@ class TemplateRule:
     relative_path: str
     required_tokens: tuple[str, ...] = ()
     forbidden_tokens: tuple[str, ...] = ()
+    forbidden_env_assignments: tuple[tuple[str, str], ...] = ()
 
 
 RULES = (
@@ -31,8 +33,8 @@ RULES = (
         forbidden_tokens=(
             "NEXT_PUBLIC_API_BASE_URL",
             "NEXT_PUBLIC_VERITAS_API_BASE_URL",
-            "VERITAS_AUTH_ALLOW_FAIL_OPEN=true",
         ),
+        forbidden_env_assignments=(("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),),
     ),
     TemplateRule(
         relative_path="setup.sh",
@@ -43,10 +45,47 @@ RULES = (
         forbidden_tokens=(
             "NEXT_PUBLIC_API_BASE_URL",
             "NEXT_PUBLIC_VERITAS_API_BASE_URL",
-            "VERITAS_AUTH_ALLOW_FAIL_OPEN=true",
         ),
+        forbidden_env_assignments=(("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),),
     ),
 )
+
+
+def _iter_env_assignments(content: str) -> Iterable[tuple[str, str]]:
+    """Yield normalized ``KEY=value`` pairs from shell-style env templates.
+
+    The parser intentionally ignores comments and optional ``export`` prefixes so
+    deployment checks catch dangerous defaults even when spacing or casing varies.
+    """
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        yield key.strip(), value.strip().strip("'\"")
+
+
+def _collect_forbidden_assignment_violations(
+    *,
+    rule: TemplateRule,
+    assignments: Iterable[tuple[str, str]],
+) -> list[str]:
+    """Return violations for forbidden env assignments in a template."""
+    normalized_assignments = {
+        key.strip(): value.strip().lower() for key, value in assignments
+    }
+    violations: list[str] = []
+    for key, value in rule.forbidden_env_assignments:
+        current_value = normalized_assignments.get(key)
+        if current_value == value.strip().lower():
+            violations.append(
+                f"{rule.relative_path}: forbidden env assignment {key}={value}"
+            )
+    return violations
 
 
 def _validate_rule(rule: TemplateRule) -> list[str]:
@@ -69,6 +108,13 @@ def _validate_rule(rule: TemplateRule) -> list[str]:
             violations.append(
                 f"{rule.relative_path}: forbidden token present {token!r}"
             )
+
+    violations.extend(
+        _collect_forbidden_assignment_violations(
+            rule=rule,
+            assignments=_iter_env_assignments(content),
+        )
+    )
 
     return violations
 

--- a/veritas_os/tests/test_deployment_env_defaults.py
+++ b/veritas_os/tests/test_deployment_env_defaults.py
@@ -1,0 +1,82 @@
+"""Tests for deployment environment template smoke checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.quality import check_deployment_env_defaults as deployment_defaults
+
+
+def test_iter_env_assignments_normalizes_export_and_quotes() -> None:
+    """Shell-style env syntax should still be parsed into normalized pairs."""
+    content = """
+    # comment
+    export VERITAS_AUTH_ALLOW_FAIL_OPEN = 'TRUE'
+    VERITAS_ENV=production
+    """
+
+    assignments = list(deployment_defaults._iter_env_assignments(content))
+
+    assert assignments == [
+        ("VERITAS_AUTH_ALLOW_FAIL_OPEN", "TRUE"),
+        ("VERITAS_ENV", "production"),
+    ]
+
+
+def test_validate_rule_flags_fail_open_with_export_spacing(tmp_path: Path) -> None:
+    """Fail-open defaults must be caught even when template formatting varies."""
+    template = tmp_path / "setup.sh"
+    template.write_text(
+        """
+        export VERITAS_API_BASE_URL=http://localhost:8000
+        VERITAS_ENV=production
+        export VERITAS_AUTH_ALLOW_FAIL_OPEN = \"TrUe\"
+        """,
+        encoding="utf-8",
+    )
+    rule = deployment_defaults.TemplateRule(
+        relative_path=str(template.relative_to(tmp_path)),
+        required_tokens=(
+            "VERITAS_API_BASE_URL=http://localhost:8000",
+            "VERITAS_ENV=production",
+        ),
+        forbidden_env_assignments=(("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),),
+    )
+
+    original_root = deployment_defaults.REPO_ROOT
+    deployment_defaults.REPO_ROOT = tmp_path
+    try:
+        violations = deployment_defaults._validate_rule(rule)
+    finally:
+        deployment_defaults.REPO_ROOT = original_root
+
+    assert violations == [
+        "setup.sh: forbidden env assignment VERITAS_AUTH_ALLOW_FAIL_OPEN=true"
+    ]
+
+
+def test_validate_rule_passes_without_forbidden_defaults(tmp_path: Path) -> None:
+    """Safe templates should continue to pass the smoke check."""
+    template = tmp_path / ".env.example"
+    template.write_text(
+        """
+        VERITAS_API_BASE_URL=http://localhost:8000
+        VERITAS_ENV=production
+        """,
+        encoding="utf-8",
+    )
+    rule = deployment_defaults.TemplateRule(
+        relative_path=str(template.relative_to(tmp_path)),
+        required_tokens=("VERITAS_API_BASE_URL", "VERITAS_ENV=production"),
+        forbidden_tokens=("NEXT_PUBLIC_VERITAS_API_BASE_URL",),
+        forbidden_env_assignments=(("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),),
+    )
+
+    original_root = deployment_defaults.REPO_ROOT
+    deployment_defaults.REPO_ROOT = tmp_path
+    try:
+        violations = deployment_defaults._validate_rule(rule)
+    finally:
+        deployment_defaults.REPO_ROOT = original_root
+
+    assert violations == []


### PR DESCRIPTION
### Motivation

- Prevent accidental shipping of `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` in shared environments by detecting it even when templates use `export`, extra whitespace, quotes, or mixed-case values.
- Apply a minimal, responsibility-boundary-preserving fix that improves CI/deployment smoke checks without changing core runtime contracts.

### Description

- Enhance `scripts/quality/check_deployment_env_defaults.py` to parse shell-style `KEY=value` assignments via a new `_iter_env_assignments` helper and detect forbidden env assignments via `forbidden_env_assignments` in `TemplateRule`.
- Add `_collect_forbidden_assignment_violations` to report forbidden env defaults such as `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` regardless of spacing/quotes/casing.
- Add regression tests in `veritas_os/tests/test_deployment_env_defaults.py` covering parsing of `export`/quotes/spacing and the detection of the forbidden fail-open assignment, plus a passing safe-template case.
- Update `docs/reviews/improvement_instructions_ja_20260320.md` to record this Priority 2 / 指示 2-2 detection hardening.

### Testing

- Ran the deployment smoke-check unit tests with `python -m pytest veritas_os/tests/test_deployment_env_defaults.py -q`, which passed (`3 passed`).
- Ran broader unit test set with `python -m pytest veritas_os/tests/test_api_startup_health.py veritas_os/tests/test_responsibility_boundary_checker.py veritas_os/tests/test_deployment_env_defaults.py -q`, which passed (`42 passed`).
- Executed the static checks `python scripts/architecture/check_responsibility_boundaries.py` and `python scripts/quality/check_deployment_env_defaults.py`, both of which completed successfully and reported no violations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd02cca35c8326a21ebb8b043e3c78)