### PR TITLE
Refine Memory API failure classification (additive error_code for triage)

### DIFF
--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -166,6 +166,7 @@ fail-open は非本番でも認証保護を弱めるため、
 ## 実施記録（2026-03-20）
 
 ### 今回完了した改善
+- **Priority 3 / 指示 3-1**: `veritas_os/api/routes_memory.py` の Memory API 失敗応答に additive な `error_code` 分類 (`validation_failure` / `backend_unavailable` / `security_policy_rejection` / `serialization_storage_failure` / `unknown_failure`) を追加し、既存の `ok / status / errors[]` 契約を維持したまま監査・運用トリアージしやすくした。`memory_put` の stage-level error と `memory_search` / `memory_get` / `memory_erase` の失敗応答で利用できる。
 - **Priority 1 / 指示 1-1**: `pipeline.py` / `kernel.py` / `fuji.py` / `memory.py` の module docstring を更新し、public contract・推奨拡張ポイント・compatibility layer の扱いを明示した。
 - **Priority 1 / 指示 1-1 の回帰防止**: `scripts/architecture/check_responsibility_boundaries.py` を拡張し、上記 4 モジュールの docstring に required marker と推奨拡張ポイントが残っているかを CI 向けに検査できるようにした。対応する回帰テストも追加した。
 - **Priority 2 / 指示 2-1**: `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に TrustLog degraded 状態 (`trust_json_status=unreadable|invalid|too_large`) の運用 runbook を追加した。

--- a/veritas_os/api/routes_memory.py
+++ b/veritas_os/api/routes_memory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime, timezone
+from json import JSONDecodeError
 from typing import Any, Dict, Optional, Tuple
 
 from fastapi import APIRouter, Header
@@ -22,10 +23,32 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _classify_memory_failure(exc: Exception) -> str:
+    """Classify MemoryOS failures without changing the public response contract.
+
+    The returned code is additive metadata for operators and clients that need
+    finer auditability. Existing ``ok`` / ``status`` / ``errors[]`` fields remain
+    unchanged so callers can adopt the new codes incrementally.
+    """
+    if isinstance(exc, PermissionError):
+        return "security_policy_rejection"
+    if isinstance(exc, (ValueError, TypeError)):
+        return "validation_failure"
+    if isinstance(exc, (JSONDecodeError, OSError)):
+        return "serialization_storage_failure"
+    if isinstance(exc, (ConnectionError, TimeoutError, RuntimeError)):
+        return "backend_unavailable"
+    return "unknown_failure"
+
+
 def _build_memory_stage_error(stage: str, exc: Exception) -> Dict[str, str]:
     """Return a sanitized stage error payload for partial MemoryOS failures."""
     logger.warning("[MemoryOS][%s] Error: %s", stage, exc)
-    return {"stage": stage, "message": f"{stage} save failed"}
+    return {
+        "stage": stage,
+        "message": f"{stage} save failed",
+        "error_code": _classify_memory_failure(exc),
+    }
 
 
 def _get_server():
@@ -230,6 +253,9 @@ def memory_put(body: MemoryPutRequest, x_api_key: Optional[str] = Header(default
         response["errors"] = errors
         if not ok:
             response["error"] = "memory operation failed"
+            response["error_code"] = (
+                errors[0].get("error_code") if len(errors) == 1 else "partial_failure"
+            )
     return response
 
 
@@ -287,7 +313,13 @@ def memory_search(payload: MemorySearchRequest, x_api_key: Optional[str] = Heade
 
     except Exception as e:
         logger.error("[MemoryOS][search] Error: %s", e)
-        return {"ok": False, "error": "memory search failed", "hits": [], "count": 0}
+        return {
+            "ok": False,
+            "error": "memory search failed",
+            "error_code": _classify_memory_failure(e),
+            "hits": [],
+            "count": 0,
+        }
 
 
 @router.post("/v1/memory/get")
@@ -304,7 +336,12 @@ def memory_get(body: MemoryGetRequest, x_api_key: Optional[str] = Header(default
         return {"ok": True, "value": value}
     except Exception as e:
         logger.error("memory_get failed: %s", e)
-        return {"ok": False, "error": "memory retrieval failed", "value": None}
+        return {
+            "ok": False,
+            "error": "memory retrieval failed",
+            "error_code": _classify_memory_failure(e),
+            "value": None,
+        }
 
 
 @router.post("/v1/memory/erase")
@@ -331,4 +368,8 @@ def memory_erase(body: MemoryEraseRequest, x_api_key: Optional[str] = Header(def
         }
     except Exception as e:
         logger.error("memory_erase failed: %s", e)
-        return {"ok": False, "error": "memory erase failed"}
+        return {
+            "ok": False,
+            "error": "memory erase failed",
+            "error_code": _classify_memory_failure(e),
+        }

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -20,7 +20,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 import veritas_os.api.server as server
-from veritas_os.api.schemas import MemoryPutRequest
+from veritas_os.api.schemas import MemoryPutRequest, MemorySearchRequest
 
 
 client = TestClient(server.app)
@@ -1215,7 +1215,11 @@ def test_memory_put_reports_partial_failure_when_vector_save_fails(monkeypatch):
     assert res["legacy"]["saved"] is True
     assert res["vector"]["saved"] is False
     assert res["errors"] == [
-        {"stage": "vector", "message": "vector save failed"}
+        {
+            "stage": "vector",
+            "message": "vector save failed",
+            "error_code": "backend_unavailable",
+        }
     ]
 
 
@@ -1241,7 +1245,9 @@ def test_memory_put_reports_failed_when_all_save_paths_fail(monkeypatch):
     assert res["ok"] is False
     assert res["status"] == "failed"
     assert res["error"] == "memory operation failed"
+    assert res["error_code"] == "partial_failure"
     assert {item["stage"] for item in res["errors"]} == {"legacy", "vector"}
+    assert {item["error_code"] for item in res["errors"]} == {"backend_unavailable"}
 
 
 def test_memory_search_filters_by_user(monkeypatch):
@@ -1951,3 +1957,19 @@ def test_memory_put_accepts_string_value():
     )
     assert r.status_code == 200
     assert r.json()["ok"] is True
+
+
+def test_memory_search_exposes_error_code_for_validation_failures(monkeypatch):
+    """memory_search should publish additive error codes for failure triage."""
+
+    class InvalidSearchStore:
+        def search(self, **_kwargs):
+            raise ValueError("query shape invalid")
+
+    monkeypatch.setattr(server, "get_memory_store", lambda: InvalidSearchStore())
+
+    res = server.memory_search(MemorySearchRequest(user_id="u1", query="hello"))
+
+    assert res["ok"] is False
+    assert res["error"] == "memory search failed"
+    assert res["error_code"] == "validation_failure"

--- a/veritas_os/tests/test_coverage_boost.py
+++ b/veritas_os/tests/test_coverage_boost.py
@@ -609,7 +609,11 @@ class TestServerMemoryEndpoints:
         assert body["legacy"]["saved"] is False
         assert body["vector"]["saved"] is True
         assert body["errors"] == [
-            {"stage": "legacy", "message": "legacy save failed"}
+            {
+                "stage": "legacy",
+                "message": "legacy save failed",
+                "error_code": "backend_unavailable",
+            }
         ]
 
     def test_memory_search_store_unavailable(self, monkeypatch):


### PR DESCRIPTION
### Motivation
- Improve operational triage and auditability of MemoryOS failures by adding a small, additive failure classification without changing the existing `ok` / `status` / `errors[]` public contract.
- Maintain responsibility boundaries and minimize diff size by implementing the classification inside `veritas_os/api/routes_memory.py` and updating only the necessary tests and documentation.

### Description
- Add a `_classify_memory_failure(exc: Exception) -> str` helper to map common exception types to additive `error_code` values such as `validation_failure`, `backend_unavailable`, `security_policy_rejection`, `serialization_storage_failure`, and `unknown_failure`.
- Include an `error_code` field in stage-level errors returned by `memory_put` and surface a top-level `error_code` for `memory_search`, `memory_get`, and `memory_erase` failure responses while preserving existing fields.
- Update unit tests to assert the presence and values of `error_code` in `veritas_os/tests/test_api_server_extra.py` and `veritas_os/tests/test_coverage_boost.py` and add a test that verifies `validation_failure` is exposed for search validation errors.
- Record the change in `docs/reviews/improvement_instructions_ja_20260320.md` as the implemented Priority 3 item for traceability.

### Testing
- Ran `python -m pytest veritas_os/tests/test_api_server_extra.py -k 'memory_put_reports_partial_failure_when_vector_save_fails or memory_put_reports_failed_when_all_save_paths_fail or memory_search_exposes_error_code_for_validation_failures'` and all selected tests passed.
- Ran `python -m pytest veritas_os/tests/test_coverage_boost.py -k 'memory_put_reports_partial_failure_when_legacy_save_fails'` and the selected test passed.
- Ran `python -m compileall veritas_os/api/routes_memory.py` to ensure the module compiles and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd06e55a2c8326a88cd8dd275a83c9)