### PR TITLE
Tighten Memory API exception boundaries

### DIFF
--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -172,9 +172,10 @@ fail-open は非本番でも認証保護を弱めるため、
 - **Priority 2 / 指示 2-1**: `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に TrustLog degraded 状態 (`trust_json_status=unreadable|invalid|too_large`) の運用 runbook を追加した。
 - **Priority 2 / 指示 2-2**: 同 runbook に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` の startup warning / fail-fast / CI・deployment check / 環境別ポリシーを追記した。
 - **Priority 2 / 指示 2-2 の検知強化**: `scripts/quality/check_deployment_env_defaults.py` を強化し、`export VERITAS_AUTH_ALLOW_FAIL_OPEN = "true"` のような空白・引用符・大文字小文字ゆらぎ付きの危険設定も検知できるようにした。対応する回帰テストを追加した。
+- **Priority 3 / 指示 3-2**: `veritas_os/api/routes_memory.py` の broad exception を、通常の validation / backend / storage / policy 失敗だけを structured response に落とす限定例外タプルへ段階的に縮小した。これにより `KeyboardInterrupt` / `SystemExit` 相当の `BaseException` を握りつぶさず、既存の `ok / status / errors[] / error_code` 契約は維持した。`veritas_os/tests/test_api_server_extra.py` に回帰テストを追加した。
 
 ### 今回あえて実施しなかった改善
-- **Priority 1 / 指示 1-2 以降** の helper 分離や例外契約拡張は、既存 public contract・責務境界・回帰範囲への影響が相対的に大きいため、今回の最小差分では未着手とした。
+- **Priority 1 / 指示 1-2 以降** の helper 分離や、Memory API 以外の広域例外縮小は、既存 public contract・責務境界・回帰範囲への影響が相対的に大きいため、今回の最小差分では未着手とした。
 - **Priority 4 capability profile** は有用だが、まず中核モジュールの入口明示と degraded / fail-open runbook のほうが優先度が高いため後続タスクへ残す。
 
 ### セキュリティ警告

--- a/veritas_os/api/routes_memory.py
+++ b/veritas_os/api/routes_memory.py
@@ -23,6 +23,23 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# Route handlers intentionally catch only expected operational failures so
+# process-level BaseException signals (for example KeyboardInterrupt/SystemExit)
+# still propagate. The public response contract stays unchanged.
+MEMORY_ROUTE_EXCEPTIONS = (
+    AttributeError,
+    ConnectionError,
+    JSONDecodeError,
+    KeyError,
+    OSError,
+    PermissionError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+)
+
+
 def _classify_memory_failure(exc: Exception) -> str:
     """Classify MemoryOS failures without changing the public response contract.
 
@@ -155,7 +172,7 @@ def memory_put(body: MemoryPutRequest, x_api_key: Optional[str] = Header(default
 
     try:
         user_id = srv._resolve_memory_user_id(body.user_id, x_api_key)
-    except Exception as exc:
+    except MEMORY_ROUTE_EXCEPTIONS as exc:
         logger.error("[MemoryOS][resolve_user] Error: %s", exc)
         return {"ok": False, "error": "memory operation failed"}
 
@@ -178,7 +195,7 @@ def memory_put(body: MemoryPutRequest, x_api_key: Optional[str] = Header(default
         try:
             _store_put(store, user_id, key, value)
             legacy_saved = True
-        except Exception as exc:
+        except MEMORY_ROUTE_EXCEPTIONS as exc:
             errors.append(_build_memory_stage_error("legacy", exc))
 
     kind = body.kind
@@ -228,7 +245,7 @@ def memory_put(body: MemoryPutRequest, x_api_key: Optional[str] = Header(default
                     {"text": text_clean, "tags": tags, "meta": meta_for_store},
                 )
                 new_id = episode_key
-        except Exception as exc:
+        except MEMORY_ROUTE_EXCEPTIONS as exc:
             errors.append(_build_memory_stage_error("vector", exc))
 
     ok = legacy_saved or bool(new_id) or (not value and not text)
@@ -311,7 +328,7 @@ def memory_search(payload: MemorySearchRequest, x_api_key: Optional[str] = Heade
 
         return {"ok": True, "hits": norm_hits, "count": len(norm_hits)}
 
-    except Exception as e:
+    except MEMORY_ROUTE_EXCEPTIONS as e:
         logger.error("[MemoryOS][search] Error: %s", e)
         return {
             "ok": False,
@@ -334,7 +351,7 @@ def memory_get(body: MemoryGetRequest, x_api_key: Optional[str] = Header(default
         key = body.key
         value = _store_get(store, uid, key)
         return {"ok": True, "value": value}
-    except Exception as e:
+    except MEMORY_ROUTE_EXCEPTIONS as e:
         logger.error("memory_get failed: %s", e)
         return {
             "ok": False,
@@ -366,7 +383,7 @@ def memory_erase(body: MemoryEraseRequest, x_api_key: Optional[str] = Header(def
             "ok": False,
             "error": "erase operation unsupported by active memory backend",
         }
-    except Exception as e:
+    except MEMORY_ROUTE_EXCEPTIONS as e:
         logger.error("memory_erase failed: %s", e)
         return {
             "ok": False,

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -1973,3 +1973,41 @@ def test_memory_search_exposes_error_code_for_validation_failures(monkeypatch):
     assert res["ok"] is False
     assert res["error"] == "memory search failed"
     assert res["error_code"] == "validation_failure"
+
+
+def test_memory_search_does_not_swallow_base_exceptions(monkeypatch):
+    """memory_search must not mask process-level exceptions."""
+
+    class SearchAbort(BaseException):
+        """Sentinel used to verify BaseException propagation."""
+
+    class ExplodingStore:
+        def search(self, **_kwargs):
+            raise SearchAbort("stop search")
+
+    monkeypatch.setattr(server, "get_memory_store", lambda: ExplodingStore())
+
+    with pytest.raises(SearchAbort, match="stop search"):
+        server.memory_search(MemorySearchRequest(user_id="u1", query="hello"))
+
+
+def test_memory_put_does_not_swallow_base_exceptions(monkeypatch):
+    """memory_put should preserve BaseException semantics during backend writes."""
+
+    class WriteAbort(BaseException):
+        """Sentinel used to verify BaseException propagation."""
+
+    class ExplodingStore:
+        def put(self, *args, **kwargs):
+            raise WriteAbort("stop write")
+
+    monkeypatch.setattr(server, "get_memory_store", lambda: ExplodingStore())
+
+    with pytest.raises(WriteAbort, match="stop write"):
+        server.memory_put(
+            MemoryPutRequest(
+                user_id="u1",
+                key="k1",
+                value={"foo": "bar"},
+            )
+        )


### PR DESCRIPTION
### Motivation
- Avoid masking process-level control exceptions (`KeyboardInterrupt` / `SystemExit`) at the Memory API layer while keeping the existing public response contract intact. 
- Make a minimal, low-risk improvement that increases observability of failures without changing public semantics or crossing core responsibility boundaries. 

### Description
- Added `MEMORY_ROUTE_EXCEPTIONS` tuple and replaced broad `except Exception` handlers with `except MEMORY_ROUTE_EXCEPTIONS` in `veritas_os/api/routes_memory.py`, so only expected operational failures are converted to structured responses. 
- Preserved the `ok / status / errors[] / error_code` response contract and added explanatory comments clarifying why `BaseException` is not caught. 
- Added regression tests to `veritas_os/tests/test_api_server_extra.py` that verify `memory_search`/`memory_put` still surface additive `error_code` values and that `BaseException`-derived signals are not swallowed. 
- Updated `docs/reviews/improvement_instructions_ja_20260320.md` to record this work as the completed Priority 3-2 item. 

### Testing
- Ran the focused test subset with `pytest -q veritas_os/tests/test_api_server_extra.py -k 'memory_search_does_not_swallow_base_exceptions or memory_put_does_not_swallow_base_exceptions or memory_search_exposes_error_code_for_validation_failures or memory_put_reports_partial_failure_when_vector_save_fails or memory_put_reports_failed_when_all_save_paths_fail'`, which passed (`5 passed, 84 deselected`). 
- Verified syntax by running `python -m py_compile veritas_os/api/routes_memory.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd0f0587ec83268c5461e9611d3cc9)