### PR TITLE
Refactor MemoryStore compatibility helpers

### DIFF
--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -174,6 +174,7 @@ fail-open は非本番でも認証保護を弱めるため、
 - **Priority 2 / 指示 2-2 の検知強化**: `scripts/quality/check_deployment_env_defaults.py` を強化し、`export VERITAS_AUTH_ALLOW_FAIL_OPEN = "true"` のような空白・引用符・大文字小文字ゆらぎ付きの危険設定も検知できるようにした。対応する回帰テストを追加した。
 - **Priority 3 / 指示 3-2**: `veritas_os/api/routes_memory.py` の broad exception を、通常の validation / backend / storage / policy 失敗だけを structured response に落とす限定例外タプルへ段階的に縮小した。これにより `KeyboardInterrupt` / `SystemExit` 相当の `BaseException` を握りつぶさず、既存の `ok / status / errors[] / error_code` 契約は維持した。`veritas_os/tests/test_api_server_extra.py` に回帰テストを追加した。
 - **Priority 1 / 指示 1-2**: `veritas_os/core/memory.py` 内の compatibility-heavy な `MemoryStore` lifecycle 正規化 / expiry 判定を `veritas_os/core/memory_store_helpers.py` へ抽出し、`_install_memory_store_compat_hooks()` は互換フック配線のみに寄せた。これにより MemoryOS の互換層分岐を helper 側へ逃がしつつ、既存 `MemoryStore._normalize_lifecycle` / `_is_record_expired` 契約は維持した。`veritas_os/tests/test_memory_store_core.py` に helper 経由の回帰テストを追加した。
+- **Follow-up fix**: Priority 1 / 指示 1-2 の helper 抽出後、`veritas_os/core/memory.py` の `VectorMemory.add()` が引き続き `datetime.now(timezone.utc)` を参照するため、lint で検知された `datetime` import 抜けを復旧した。責務や public contract の変更はない。
 
 ### 今回あえて実施しなかった改善
 - **Priority 1 / 指示 1-2 以降** の helper 分離や、Memory API 以外の広域例外縮小は、既存 public contract・責務境界・回帰範囲への影響が相対的に大きいため、今回の最小差分では未着手とした。

--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -173,6 +173,7 @@ fail-open は非本番でも認証保護を弱めるため、
 - **Priority 2 / 指示 2-2**: 同 runbook に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` の startup warning / fail-fast / CI・deployment check / 環境別ポリシーを追記した。
 - **Priority 2 / 指示 2-2 の検知強化**: `scripts/quality/check_deployment_env_defaults.py` を強化し、`export VERITAS_AUTH_ALLOW_FAIL_OPEN = "true"` のような空白・引用符・大文字小文字ゆらぎ付きの危険設定も検知できるようにした。対応する回帰テストを追加した。
 - **Priority 3 / 指示 3-2**: `veritas_os/api/routes_memory.py` の broad exception を、通常の validation / backend / storage / policy 失敗だけを structured response に落とす限定例外タプルへ段階的に縮小した。これにより `KeyboardInterrupt` / `SystemExit` 相当の `BaseException` を握りつぶさず、既存の `ok / status / errors[] / error_code` 契約は維持した。`veritas_os/tests/test_api_server_extra.py` に回帰テストを追加した。
+- **Priority 1 / 指示 1-2**: `veritas_os/core/memory.py` 内の compatibility-heavy な `MemoryStore` lifecycle 正規化 / expiry 判定を `veritas_os/core/memory_store_helpers.py` へ抽出し、`_install_memory_store_compat_hooks()` は互換フック配線のみに寄せた。これにより MemoryOS の互換層分岐を helper 側へ逃がしつつ、既存 `MemoryStore._normalize_lifecycle` / `_is_record_expired` 契約は維持した。`veritas_os/tests/test_memory_store_core.py` に helper 経由の回帰テストを追加した。
 
 ### 今回あえて実施しなかった改善
 - **Priority 1 / 指示 1-2 以降** の helper 分離や、Memory API 以外の広域例外縮小は、既存 public contract・責務境界・回帰範囲への影響が相対的に大きいため、今回の最小差分では未着手とした。

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
-from datetime import datetime, timezone
+from datetime import timezone
 from uuid import uuid4
 import json
 import os
@@ -78,6 +78,8 @@ from .memory_search_helpers import (
 from .memory_store_helpers import (
     build_kvs_search_hits,
     filter_recent_records,
+    is_record_expired_compat as _is_record_expired_compat_impl,
+    normalize_document_lifecycle as _normalize_document_lifecycle_impl,
     simple_score as _simple_score_impl,
 )
 from .memory_summary_helpers import build_planner_summary
@@ -837,66 +839,22 @@ def _install_memory_store_compat_hooks() -> None:
         return parse_expires_at(expires_at)
 
     def _normalize_lifecycle_compat(value: Any) -> Any:
-        if not isinstance(value, dict):
-            return value
-
-        lifecycle_target_keys = {"text", "kind", "tags", "meta"}
-        if not any(key in value for key in lifecycle_target_keys):
-            return value
-
-        normalized = dict(value)
-        meta = dict(normalized.get("meta") or {})
-
-        retention_class = str(
-            meta.get("retention_class") or DEFAULT_RETENTION_CLASS
-        ).strip().lower()
-        if retention_class not in ALLOWED_RETENTION_CLASSES:
-            retention_class = DEFAULT_RETENTION_CLASS
-
-        raw_hold = meta.get("legal_hold", False)
-        if isinstance(raw_hold, str):
-            legal_hold = raw_hold.strip().lower() in ("true", "1", "yes")
-        else:
-            legal_hold = bool(raw_hold)
-        normalized_expires_at = MemoryStore._parse_expires_at(meta.get("expires_at"))
-
-        meta["retention_class"] = retention_class
-        meta["legal_hold"] = legal_hold
-        meta["expires_at"] = normalized_expires_at
-        normalized["meta"] = meta
-        return normalized
+        return _normalize_document_lifecycle_impl(
+            value,
+            default_retention_class=DEFAULT_RETENTION_CLASS,
+            allowed_retention_classes=ALLOWED_RETENTION_CLASSES,
+            parse_expires_at=MemoryStore._parse_expires_at,
+        )
 
     def _is_record_expired_compat(
         record: Dict[str, Any],
         now_ts: Optional[float] = None,
     ) -> bool:
-        value = record.get("value") or {}
-        if not isinstance(value, dict):
-            return False
-
-        meta = value.get("meta") or {}
-        if not isinstance(meta, dict):
-            return False
-
-        raw_hold = meta.get("legal_hold", False)
-        if isinstance(raw_hold, str):
-            hold = raw_hold.strip().lower() in ("true", "1", "yes")
-        else:
-            hold = bool(raw_hold)
-        if hold:
-            return False
-
-        expires_at = MemoryStore._parse_expires_at(meta.get("expires_at"))
-        if not expires_at:
-            return False
-
-        try:
-            expire_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
-        except ValueError:
-            return False
-
-        now = now_ts if now_ts is not None else time.time()
-        return expire_dt.timestamp() <= float(now)
+        return _is_record_expired_compat_impl(
+            record,
+            parse_expires_at=MemoryStore._parse_expires_at,
+            now_ts=now_ts,
+        )
 
     def _erase_user_compat(
         self: MemoryStore,

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
-from datetime import timezone
+from datetime import datetime, timezone
 from uuid import uuid4
 import json
 import os

--- a/veritas_os/core/memory_store_helpers.py
+++ b/veritas_os/core/memory_store_helpers.py
@@ -6,7 +6,86 @@ selection and scoring logic into a focused module.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from datetime import datetime
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+
+def normalize_document_lifecycle(
+    value: Any,
+    *,
+    default_retention_class: str,
+    allowed_retention_classes: set[str],
+    parse_expires_at: Callable[[Any], Optional[str]],
+) -> Any:
+    """Normalize lifecycle metadata for MemoryStore-compatible documents.
+
+    The helper is intentionally side-effect free so ``memory.py`` can reuse it
+    from compatibility hooks without growing new branching logic inline.
+    """
+    if not isinstance(value, dict):
+        return value
+
+    lifecycle_target_keys = {"text", "kind", "tags", "meta"}
+    if not any(key in value for key in lifecycle_target_keys):
+        return value
+
+    normalized = dict(value)
+    meta = dict(normalized.get("meta") or {})
+
+    retention_class = str(
+        meta.get("retention_class") or default_retention_class
+    ).strip().lower()
+    if retention_class not in allowed_retention_classes:
+        retention_class = default_retention_class
+
+    raw_hold = meta.get("legal_hold", False)
+    if isinstance(raw_hold, str):
+        legal_hold = raw_hold.strip().lower() in ("true", "1", "yes")
+    else:
+        legal_hold = bool(raw_hold)
+
+    meta["retention_class"] = retention_class
+    meta["legal_hold"] = legal_hold
+    meta["expires_at"] = parse_expires_at(meta.get("expires_at"))
+    normalized["meta"] = meta
+    return normalized
+
+
+def is_record_expired_compat(
+    record: Dict[str, Any],
+    *,
+    parse_expires_at: Callable[[Any], Optional[str]],
+    now_ts: Optional[float] = None,
+) -> bool:
+    """Return whether a MemoryStore record is expired for compat wrappers."""
+    value = record.get("value") or {}
+    if not isinstance(value, dict):
+        return False
+
+    meta = value.get("meta") or {}
+    if not isinstance(meta, dict):
+        return False
+
+    raw_hold = meta.get("legal_hold", False)
+    if isinstance(raw_hold, str):
+        hold = raw_hold.strip().lower() in ("true", "1", "yes")
+    else:
+        hold = bool(raw_hold)
+    if hold:
+        return False
+
+    expires_at = parse_expires_at(meta.get("expires_at"))
+    if not expires_at:
+        return False
+
+    try:
+        expire_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+
+    now = now_ts if now_ts is not None else time.time()
+    return expire_dt.timestamp() <= float(now)
 
 
 def extract_record_text(record: Dict[str, Any]) -> str:

--- a/veritas_os/tests/test_memory_store_core.py
+++ b/veritas_os/tests/test_memory_store_core.py
@@ -14,6 +14,10 @@ from veritas_os.core.memory_store import (
     DEFAULT_RETENTION_CLASS,
     ALLOWED_RETENTION_CLASSES,
 )
+from veritas_os.core.memory_store_helpers import (
+    is_record_expired_compat,
+    normalize_document_lifecycle,
+)
 
 
 @pytest.fixture
@@ -171,6 +175,33 @@ class TestIsRecordExpired:
         assert MemoryStore._is_record_expired({"value": "string"}) is False
 
 
+class TestMemoryStoreCompatHelpers:
+    def test_normalize_document_lifecycle_keeps_contract(self):
+        payload = {
+            "text": "hello",
+            "meta": {"retention_class": "LONG", "legal_hold": "yes"},
+        }
+
+        result = normalize_document_lifecycle(
+            payload,
+            default_retention_class=DEFAULT_RETENTION_CLASS,
+            allowed_retention_classes={"short", "medium", "long"},
+            parse_expires_at=MemoryStore._parse_expires_at,
+        )
+
+        assert result["meta"]["retention_class"] == "long"
+        assert result["meta"]["legal_hold"] is True
+
+    def test_is_record_expired_compat_handles_expired_record(self):
+        past = time.time() - 86400
+        record = {"value": {"meta": {"expires_at": past}}}
+
+        assert is_record_expired_compat(
+            record,
+            parse_expires_at=MemoryStore._parse_expires_at,
+        ) is True
+
+
 class TestSearch:
     def test_basic_search(self, store):
         store.put("u1", "k1", {"text": "hello world", "kind": "episodic"})
@@ -186,7 +217,6 @@ class TestSearch:
         result = store.search("zzzznotfound", min_sim=0.5)
         assert result == {} or len(result.get("episodic", [])) == 0
 
-
 class TestSimpleScore:
     def test_exact_substring(self, store):
         score = store._simple_score("hello", "hello world")
@@ -198,7 +228,6 @@ class TestSimpleScore:
 
     def test_empty(self, store):
         assert store._simple_score("", "hello") == 0.0
-
 
 class TestRecent:
     def test_recent(self, store):
@@ -213,7 +242,6 @@ class TestRecent:
         results = store.recent("u1", contains="apple")
         assert len(results) == 1
 
-
 class TestEraseUser:
     def test_erase(self, store):
         store.put("u1", "k1", "v1")
@@ -222,12 +250,10 @@ class TestEraseUser:
         assert report["deleted_count"] >= 1
         assert store.get("u1", "k1") is None
 
-
 class TestPutEpisode:
     def test_basic_episode(self, store):
         key = store.put_episode("test episode text", tags=["test"])
         assert key.startswith("episode_")
-
 
 class TestSummarizeForPlanner:
     def test_no_matches(self, store):
@@ -239,11 +265,9 @@ class TestSummarizeForPlanner:
         result = store.summarize_for_planner("u1", "VERITAS")
         assert "VERITAS" in result
 
-
 class TestAppendHistory:
     def test_append(self, store):
         assert store.append_history("u1", {"event": "test"}) is True
-
 
 class TestAddUsage:
     def test_add(self, store):


### PR DESCRIPTION
### Motivation
- Reduce complexity in the MemoryOS core by moving compatibility-heavy lifecycle normalization and expiry logic out of `veritas_os/core/memory.py` and into a focused helper module. 
- Preserve existing public contracts for `MemoryStore` while making extension points and compatibility wiring clearer and easier to review. 

### Description
- Extracted lifecycle normalization and expiry helpers into `veritas_os/core/memory_store_helpers.py` as `normalize_document_lifecycle` and `is_record_expired_compat`, keeping them side-effect free and documented. 
- Updated `veritas_os/core/memory.py` to import and call the new helper implementations from its `_install_memory_store_compat_hooks()` so the compatibility hook wiring remains in the core and new branching stays in the helper. 
- Added regression tests in `veritas_os/tests/test_memory_store_core.py` to validate the helper behavior and ensure the `MemoryStore` contracts remain intact. 
- Recorded the implemented Priority 1/1-2 improvement in `docs/reviews/improvement_instructions_ja_20260320.md`. 

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_store_core.py` and all tests passed (46 passed). 
- Executed `python scripts/architecture/check_responsibility_boundaries.py` and the responsibility boundary check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd13f6f2948326a3741e9773848516)