### PR TITLE
docs: add capability-profile runbook section and CI checker

### DIFF
--- a/docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md
+++ b/docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md
@@ -125,6 +125,35 @@
 - production / shared staging / preview: **禁止**。残置は認証保護低下のセキュリティ事故につながる。
 - local / isolated test: 明示的な検証時のみ一時許容。終了後は必ず削除する。
 
+
+## 6.3 capability profile / strict mode 推奨
+
+### production 推奨設定
+- `VERITAS_CAP_FUJI_TRUST_LOG=1`: FUJI 判定の TrustLog 監査証跡を維持する。production では常時有効を推奨。
+- `VERITAS_CAP_EMIT_MANIFEST=1`: startup 時に capability manifest を出力し、optional dependency の欠落や capability drift を観測可能にする。
+- `VERITAS_CAP_MEMORY_POSIX_FILE_LOCK=1`（POSIX 環境）: Memory store のファイル更新競合を抑制するため有効を維持する。
+- `VERITAS_CAP_FUJI_TOOL_BRIDGE=1` は、FUJI が外部 safety tool を使う運用でのみ有効化する。無効化する場合は capability manifest と運用手順で明示する。
+
+### local / test でのみ許容する設定
+- `VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS=0`: 依存未導入環境で fallback 検証を行うときのみ許容。本番推奨構成では embedding 差分による挙動差を避けるため、使用有無を固定する。
+- `VERITAS_CAP_FUJI_TOOL_BRIDGE=0`: ローカル単体試験やオフライン検証では許容できるが、shared 環境では FUJI capability 差分として扱う。
+- `VERITAS_AUTH_ALLOW_FAIL_OPEN=true`: 認証 fail-open の危険フラグであり、isolated local/test の一時検証以外では禁止する。
+
+### strict mode を推奨する箇所
+- `VERITAS_CAP_FUJI_YAML_POLICY=1`: production で YAML policy を正規運用する場合は明示有効化し、依存（PyYAML）欠落を fail-fast させる。
+- `VERITAS_FUJI_STRICT_POLICY_LOAD=1`: policy file の欠損・破損時に permissive fallback へ流さず、deny policy へ倒す strict load を推奨する。
+- `VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS=1`: ベクトル検索品質を production で固定したい場合は明示有効化し、依存欠落を設定不整合として表面化させる。
+
+### fallback / degraded の観測方法
+- startup log の `[CapabilityManifest] component=... manifest=... disabled=...` を確認し、想定外に disabled になった capability がないかを監視する。
+- FUJI policy fallback は `FUJI policy fallback triggered:` warning と strict mode 時の error で検知する。
+- Memory sentence-transformers fallback は `[CONFIG_MISMATCH] sentence-transformers is unavailable...` warning で検知する。
+- auth fail-open は §6.2 の startup warning / fail-fast / deployment check を併用し、shared 環境に残置しない。
+
+### セキュリティ注意
+- optional dependency fallback は可用性向上に役立つ一方、shared 環境では capability drift により安全性・監査性・検索品質の非決定性を生む。
+- 特に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` と permissive policy fallback の併用は、防御低下の複合リスクになるため避ける。
+
 ## 7. セキュリティ上の警告
 - `trace_id` は監査相関用であり、認可判定には使用しない。
 - 外部入力の `trace_id` は形式検証を行い、ヘッダ/ログインジェクションを防止する。

--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -175,10 +175,12 @@ fail-open は非本番でも認証保護を弱めるため、
 - **Priority 3 / 指示 3-2**: `veritas_os/api/routes_memory.py` の broad exception を、通常の validation / backend / storage / policy 失敗だけを structured response に落とす限定例外タプルへ段階的に縮小した。これにより `KeyboardInterrupt` / `SystemExit` 相当の `BaseException` を握りつぶさず、既存の `ok / status / errors[] / error_code` 契約は維持した。`veritas_os/tests/test_api_server_extra.py` に回帰テストを追加した。
 - **Priority 1 / 指示 1-2**: `veritas_os/core/memory.py` 内の compatibility-heavy な `MemoryStore` lifecycle 正規化 / expiry 判定を `veritas_os/core/memory_store_helpers.py` へ抽出し、`_install_memory_store_compat_hooks()` は互換フック配線のみに寄せた。これにより MemoryOS の互換層分岐を helper 側へ逃がしつつ、既存 `MemoryStore._normalize_lifecycle` / `_is_record_expired` 契約は維持した。`veritas_os/tests/test_memory_store_core.py` に helper 経由の回帰テストを追加した。
 - **Follow-up fix**: Priority 1 / 指示 1-2 の helper 抽出後、`veritas_os/core/memory.py` の `VectorMemory.add()` が引き続き `datetime.now(timezone.utc)` を参照するため、lint で検知された `datetime` import 抜けを復旧した。責務や public contract の変更はない。
+- **Priority 4 / 指示 4-1**: `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に capability profile / strict mode 推奨セクションを追加し、FUJI / MemoryOS の production 推奨設定、local/test 限定設定、strict mode 推奨箇所、fallback 観測方法を明文化した。optional dependency による capability drift を startup log と warning で追跡できるよう、`[CapabilityManifest]` と各 fallback warning の確認ポイントも追記した。
+- **Priority 4 / 指示 4-1 の回帰防止**: `scripts/quality/check_capability_profile_doc.py` を追加し、runbook に上記 capability profile 必須トークンが残っているかを CI 向けに検査できるようにした。対応する回帰テストも追加した。
 
 ### 今回あえて実施しなかった改善
 - **Priority 1 / 指示 1-2 以降** の helper 分離や、Memory API 以外の広域例外縮小は、既存 public contract・責務境界・回帰範囲への影響が相対的に大きいため、今回の最小差分では未着手とした。
-- **Priority 4 capability profile** は有用だが、まず中核モジュールの入口明示と degraded / fail-open runbook のほうが優先度が高いため後続タスクへ残す。
+- **Priority 4 capability profile** の基礎文書化と CI チェックは今回完了したが、将来的な profile 細分化（環境別 manifest 例や dependency matrix の詳細表）は、既存運用に必要な最小差分を超えるため未着手とした。
 
 ### セキュリティ警告
 - `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` は local / isolated test 限定の危険フラグであり、shared staging / preview / production へ残置すると auth store 障害時の防御低下を招く。

--- a/scripts/quality/check_capability_profile_doc.py
+++ b/scripts/quality/check_capability_profile_doc.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Validate capability-profile runbook guidance required for operations.
+
+The runbook documents the production-recommended capability profile for
+optional integrations so operators can detect capability drift before it
+turns into a security or observability incident.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+RUNBOOK_PATH = REPO_ROOT / "docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md"
+REQUIRED_TOKENS = (
+    "## 6.3 capability profile / strict mode 推奨",
+    "### production 推奨設定",
+    "VERITAS_CAP_FUJI_TRUST_LOG=1",
+    "VERITAS_CAP_EMIT_MANIFEST=1",
+    "### local / test でのみ許容する設定",
+    "VERITAS_AUTH_ALLOW_FAIL_OPEN=true",
+    "### strict mode を推奨する箇所",
+    "VERITAS_CAP_FUJI_YAML_POLICY=1",
+    "VERITAS_FUJI_STRICT_POLICY_LOAD=1",
+    "### fallback / degraded の観測方法",
+    "[CapabilityManifest]",
+)
+
+
+def collect_missing_tokens(content: str) -> list[str]:
+    """Return required capability-profile markers missing from the runbook."""
+    return [token for token in REQUIRED_TOKENS if token not in content]
+
+
+def main() -> int:
+    """Validate the runbook keeps capability-profile guidance complete."""
+    if not RUNBOOK_PATH.exists():
+        print(f"Missing runbook: {RUNBOOK_PATH}")
+        return 1
+
+    content = RUNBOOK_PATH.read_text(encoding="utf-8")
+    missing_tokens = collect_missing_tokens(content)
+    if not missing_tokens:
+        print("Capability profile runbook guidance passed checks.")
+        return 0
+
+    print("[DOCS] Capability profile runbook guidance is incomplete:")
+    for token in missing_tokens:
+        print(f"- missing token: {token}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/veritas_os/tests/test_check_capability_profile_doc.py
+++ b/veritas_os/tests/test_check_capability_profile_doc.py
@@ -1,0 +1,25 @@
+"""Tests for scripts.quality.check_capability_profile_doc."""
+
+from __future__ import annotations
+
+from scripts.quality import check_capability_profile_doc as checker
+
+
+def test_collect_missing_tokens_reports_missing_required_markers() -> None:
+    """Checker should list missing capability-profile markers."""
+    missing = checker.collect_missing_tokens(
+        "## 6.3 capability profile / strict mode 推奨\n"
+    )
+
+    assert "### production 推奨設定" in missing
+    assert "VERITAS_CAP_FUJI_TRUST_LOG=1" in missing
+    assert "[CapabilityManifest]" in missing
+
+
+def test_main_returns_success_for_current_runbook(capsys) -> None:
+    """Repository runbook should satisfy the capability-profile doc check."""
+    exit_code = checker.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Capability profile runbook guidance passed checks." in output


### PR DESCRIPTION
### Motivation
- Complete the remaining Priority 4 improvement by documenting a production-recommended capability profile and strict-mode guidance so operators can detect capability drift without changing core module responsibilities.
- Prevent accidental drift of optional capability settings (which can weaken safety/observability) by adding a small CI-facing guard rather than broad behavioral changes.

### Description
- Add a `6.3 capability profile / strict mode 推奨` section to `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` documenting production-recommended flags, local/test-only allowances, strict-mode recommendations, fallback observability points, and a security note about `VERITAS_AUTH_ALLOW_FAIL_OPEN=true`.
- Add a lightweight checker `scripts/quality/check_capability_profile_doc.py` that validates required capability-profile markers are present in the runbook for CI.
- Add regression tests `veritas_os/tests/test_check_capability_profile_doc.py` that assert the checker finds missing tokens and that the repository runbook currently passes the check.
- Update `docs/reviews/improvement_instructions_ja_20260320.md` to record the completed Priority 4 task and clarify remaining scope.

### Testing
- Ran `pytest -q veritas_os/tests/test_check_capability_profile_doc.py veritas_os/tests/test_check_deployment_env_defaults.py` and all tests passed (6 passed).
- Ran the checker directly with `python scripts/quality/check_capability_profile_doc.py` which printed a success message and exited with code 0.
- Compiled the checker with `python -m compileall scripts/quality/check_capability_profile_doc.py` to ensure syntax correctness and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1a3752ac83268c21db40e219b29b)