### PR TITLE
Refine MemoryStore compat helper routing

### DIFF
--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -175,12 +175,14 @@ fail-open は非本番でも認証保護を弱めるため、
 - **Priority 3 / 指示 3-2**: `veritas_os/api/routes_memory.py` の broad exception を、通常の validation / backend / storage / policy 失敗だけを structured response に落とす限定例外タプルへ段階的に縮小した。これにより `KeyboardInterrupt` / `SystemExit` 相当の `BaseException` を握りつぶさず、既存の `ok / status / errors[] / error_code` 契約は維持した。`veritas_os/tests/test_api_server_extra.py` に回帰テストを追加した。
 - **Priority 1 / 指示 1-2**: `veritas_os/core/memory.py` 内の compatibility-heavy な `MemoryStore` lifecycle 正規化 / expiry 判定を `veritas_os/core/memory_store_helpers.py` へ抽出し、`_install_memory_store_compat_hooks()` は互換フック配線のみに寄せた。これにより MemoryOS の互換層分岐を helper 側へ逃がしつつ、既存 `MemoryStore._normalize_lifecycle` / `_is_record_expired` 契約は維持した。`veritas_os/tests/test_memory_store_core.py` に helper 経由の回帰テストを追加した。
 - **Priority 1 / 指示 1-2 追加**: `veritas_os/core/memory.py` に残っていた `MemoryStore.erase_user()` / `recent()` / `search()` の compatibility-heavy な helper 選択分岐を `veritas_os/core/memory_store_helpers.py` の `erase_user_records()` / `recent_records_compat()` / `search_records_compat()` へ移し、`_install_memory_store_compat_hooks()` をさらに「互換フック配線」中心へ寄せた。既存の monkeypatch 互換点と `MemoryStore` public contract は維持し、`veritas_os/tests/test_memory_store_core.py` に patched helper 優先の回帰テストを追加した。
+- **Priority 1 / 指示 1-2 追加（今回）**: `veritas_os/core/memory.py` の `_install_memory_store_compat_hooks()` に残っていた `MemoryStore.put_episode()` / `summarize_for_planner()` の compatibility-heavy な inline 実装を、`veritas_os/core/memory_store_helpers.py` の `put_episode_record()` / `summarize_records_for_planner()` へ移した。これにより `memory.py` 側は互換フック配線に専念しつつ、既存 `MemoryStore` public contract と vector fallback warning は維持した。`veritas_os/tests/test_memory_store_core.py` に vector fallback warning と planner summary 契約の回帰テストを追加した。
 - **Follow-up fix**: Priority 1 / 指示 1-2 の helper 抽出後、`veritas_os/core/memory.py` の `VectorMemory.add()` が引き続き `datetime.now(timezone.utc)` を参照するため、lint で検知された `datetime` import 抜けを復旧した。責務や public contract の変更はない。
 - **Priority 4 / 指示 4-1**: `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` に capability profile / strict mode 推奨セクションを追加し、FUJI / MemoryOS の production 推奨設定、local/test 限定設定、strict mode 推奨箇所、fallback 観測方法を明文化した。optional dependency による capability drift を startup log と warning で追跡できるよう、`[CapabilityManifest]` と各 fallback warning の確認ポイントも追記した。
 - **Priority 4 / 指示 4-1 の回帰防止**: `scripts/quality/check_capability_profile_doc.py` を追加し、runbook に上記 capability profile 必須トークンが残っているかを CI 向けに検査できるようにした。対応する回帰テストも追加した。
 
 ### 今回あえて実施しなかった改善
 - **Priority 1 / 指示 1-2 以降** の helper 分離や、Memory API 以外の広域例外縮小は、既存 public contract・責務境界・回帰範囲への影響が相対的に大きいため、今回の最小差分では未着手とした。
+- `MemoryStore` 互換フックにはなお `legal_hold` / cascade delete / score 計算などの薄い adapter が残るが、現時点では pure helper 化の効果が小さく、責務境界や互換契約を崩さずに優先して削るべき複雑度ではないため未着手とした。
 - **Priority 4 capability profile** の基礎文書化と CI チェックは今回完了したが、将来的な profile 細分化（環境別 manifest 例や dependency matrix の詳細表）は、既存運用に必要な最小差分を超えるため未着手とした。
 
 ### セキュリティ警告

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -81,9 +81,11 @@ from .memory_store_helpers import (
     filter_recent_records,
     is_record_expired_compat as _is_record_expired_compat_impl,
     normalize_document_lifecycle as _normalize_document_lifecycle_impl,
+    put_episode_record,
     recent_records_compat,
     search_records_compat,
     simple_score as _simple_score_impl,
+    summarize_records_for_planner,
 )
 from .memory_summary_helpers import build_planner_summary
 from . import memory_store as _memory_store_module
@@ -942,29 +944,16 @@ def _install_memory_store_compat_hooks() -> None:
         meta: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> str:
-        record: Dict[str, Any] = {
-            "text": text,
-            "tags": tags or [],
-            "meta": meta or {},
-        }
-        for key, value in kwargs.items():
-            if key not in record:
-                record[key] = value
-        user_id = (record.get("meta") or {}).get("user_id", "episodic")
-        key = f"episode_{int(time.time())}"
-        self.put(user_id, key, record)
-        mem_vec = _get_mem_vec()
-        if mem_vec is not None:
-            try:
-                mem_vec.add(
-                    kind="episodic",
-                    text=text,
-                    tags=tags or [],
-                    meta=meta or {},
-                )
-            except Exception as exc:
-                logger.warning("[MemoryOS] put_episode MEM_VEC.add error: %s", exc)
-        return key
+        return put_episode_record(
+            store=self,
+            text=text,
+            tags=tags,
+            meta=meta,
+            mem_vec=_get_mem_vec(),
+            logger=logger,
+            time_module=time,
+            **kwargs,
+        )
 
     def _summarize_for_planner_compat(
         self: MemoryStore,
@@ -972,9 +961,13 @@ def _install_memory_store_compat_hooks() -> None:
         query: str,
         limit: int = 8,
     ) -> str:
-        result = self.search(query=query, k=limit, user_id=user_id)
-        episodic = result.get("episodic") or []
-        return build_planner_summary(episodic)
+        return summarize_records_for_planner(
+            store=self,
+            user_id=user_id,
+            query=query,
+            limit=limit,
+            build_summary=build_planner_summary,
+        )
 
     _memory_store_module.locked_memory = _compat_locked_memory
     _memory_store_module.erase_user_data = erase_user_data

--- a/veritas_os/core/memory_store_helpers.py
+++ b/veritas_os/core/memory_store_helpers.py
@@ -265,3 +265,60 @@ def search_records_compat(
     if not episodic:
         return {}
     return {"episodic": episodic}
+
+
+def put_episode_record(
+    *,
+    store: Any,
+    text: str,
+    tags: Optional[List[str]] = None,
+    meta: Optional[Dict[str, Any]] = None,
+    mem_vec: Any = None,
+    logger: Any = None,
+    time_module: Any = time,
+    **kwargs: Any,
+) -> str:
+    """Persist an episodic record while keeping optional vector fallback safe."""
+    record: Dict[str, Any] = {
+        "text": text,
+        "tags": tags or [],
+        "meta": meta or {},
+    }
+    for key, value in kwargs.items():
+        if key not in record:
+            record[key] = value
+
+    user_id = (record.get("meta") or {}).get("user_id", "episodic")
+    key = f"episode_{int(time_module.time())}"
+    store.put(user_id, key, record)
+
+    if mem_vec is not None:
+        try:
+            mem_vec.add(
+                kind="episodic",
+                text=text,
+                tags=tags or [],
+                meta=meta or {},
+            )
+        except Exception as exc:
+            if logger is not None:
+                logger.warning(
+                    "[MemoryOS] put_episode MEM_VEC.add error: %s",
+                    exc,
+                )
+
+    return key
+
+
+def summarize_records_for_planner(
+    *,
+    store: Any,
+    user_id: str,
+    query: str,
+    limit: int,
+    build_summary: Callable[[List[Dict[str, Any]]], str],
+) -> str:
+    """Build planner-facing text from MemoryStore search results."""
+    result = store.search(query=query, k=limit, user_id=user_id)
+    episodic = result.get("episodic") or []
+    return build_summary(episodic)

--- a/veritas_os/tests/test_memory_store_core.py
+++ b/veritas_os/tests/test_memory_store_core.py
@@ -18,8 +18,10 @@ from veritas_os.core.memory_store_helpers import (
     erase_user_records,
     is_record_expired_compat,
     normalize_document_lifecycle,
+    put_episode_record,
     recent_records_compat,
     search_records_compat,
+    summarize_records_for_planner,
 )
 
 
@@ -267,6 +269,37 @@ class TestMemoryStoreCompatHelpers:
             "episodic": [{"id": "patched", "text": "hello world", "score": 1.0}]
         }
         helper_module.build_kvs_search_hits.assert_called_once()
+
+    def test_put_episode_record_logs_vector_failure_without_breaking(self, store):
+        mem_vec = mock.Mock()
+        mem_vec.add.side_effect = RuntimeError("vector down")
+        logger = mock.Mock()
+
+        key = put_episode_record(
+            store=store,
+            text="episodic note",
+            tags=["ops"],
+            meta={"user_id": "u1"},
+            mem_vec=mem_vec,
+            logger=logger,
+        )
+
+        assert key.startswith("episode_")
+        assert store.get("u1", key)["text"] == "episodic note"
+        logger.warning.assert_called_once()
+
+    def test_summarize_records_for_planner_uses_search_contract(self, store):
+        store.put("u1", "k1", {"text": "planner context", "kind": "episodic"})
+
+        result = summarize_records_for_planner(
+            store=store,
+            user_id="u1",
+            query="planner",
+            limit=3,
+            build_summary=lambda items: f"items={len(items)}",
+        )
+
+        assert result == "items=1"
 
 
 class TestSearch:


### PR DESCRIPTION
### Motivation
- Reduce core MemoryOS module complexity by moving compatibility-heavy logic out of `memory.py` and into focused helper functions.
- Preserve existing `MemoryStore` public contract and vector fallback observability so degraded states remain detectable.
- Keep changes minimal and within responsibility boundaries to avoid touching Planner/Kernel/FUJI/MemoryOS contracts.

### Description
- Added `put_episode_record()` and `summarize_records_for_planner()` to `veritas_os/core/memory_store_helpers.py` with docstrings and safe vector-fallback handling. 
- Replaced inline compatibility implementations in `veritas_os/core/memory.py` (`MemoryStore.put_episode` and `MemoryStore.summarize_for_planner` adapters) to call the new helper functions and updated imports accordingly. 
- Added tests to `veritas_os/tests/test_memory_store_core.py` covering vector backend failure logging in `put_episode_record()` and planner-summary behavior via `summarize_records_for_planner()`. 
- Recorded the change and rationale in `docs/reviews/improvement_instructions_ja_20260320.md` under the Priority 1 improvements section.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_store_core.py` and the suite passed (all tests green). 
- Compiled modified modules with `python -m compileall veritas_os/core/memory.py veritas_os/core/memory_store_helpers.py veritas_os/tests/test_memory_store_core.py` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd2083dcf083269c6c49a6c7440e10)