### PR TITLE
Delegate FUJI policy loaders to shared fuji_policy helpers

### DIFF
--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -166,6 +166,7 @@ fail-open は非本番でも認証保護を弱めるため、
 ## 実施記録（2026-03-20）
 
 ### 今回完了した改善
+- **Priority 1 / 指示 1-2 追加（今回）**: `veritas_os/core/fuji.py` に残っていた YAML policy fallback / load の compatibility-heavy な重複実装を、共有 helper である `veritas_os/core/fuji_policy.py` へ委譲する形に整理した。`fuji.py` 側には `_sync_fuji_policy_runtime()` を追加し、`_load_policy()` / `_load_policy_from_str()` / `_fallback_policy()` が shared policy helper を経由しても既存の capability alias と public contract を維持するようにした。`veritas_os/tests/test_fuji_core.py` に委譲経路の回帰テストを追加した。
 - **Priority 3 / 指示 3-1**: `veritas_os/api/routes_memory.py` の Memory API 失敗応答に additive な `error_code` 分類 (`validation_failure` / `backend_unavailable` / `security_policy_rejection` / `serialization_storage_failure` / `unknown_failure`) を追加し、既存の `ok / status / errors[]` 契約を維持したまま監査・運用トリアージしやすくした。`memory_put` の stage-level error と `memory_search` / `memory_get` / `memory_erase` の失敗応答で利用できる。
 - **Priority 1 / 指示 1-1**: `pipeline.py` / `kernel.py` / `fuji.py` / `memory.py` の module docstring を更新し、public contract・推奨拡張ポイント・compatibility layer の扱いを明示した。
 - **Priority 1 / 指示 1-1 の回帰防止**: `scripts/architecture/check_responsibility_boundaries.py` を拡張し、上記 4 モジュールの docstring に required marker と推奨拡張ポイントが残っているかを CI 向けに検査できるようにした。対応する回帰テストも追加した。

--- a/veritas_os/core/fuji.py
+++ b/veritas_os/core/fuji.py
@@ -223,97 +223,42 @@ def _detect_prompt_injection(text: str) -> Dict[str, Any]:
     return _detect_prompt_injection_impl(text)
 
 
+def _sync_fuji_policy_runtime() -> None:
+    """Keep shared policy helpers aligned with fuji.py capability aliases."""
+    _fuji_policy.yaml = yaml
+    _fuji_policy.capability_cfg = capability_cfg
+
+
 def _fallback_policy(
     *,
     path: Path | None,
     reason: str,
     exc: Exception | None = None,
 ) -> Dict[str, Any]:
-    """Return fallback policy while preserving fuji.py logging semantics."""
-    path_label = str(path) if path is not None else "<none>"
-    strict_mode = _strict_policy_load_enabled()
-
-    if exc is None:
-        _logger.warning(
-            "FUJI policy fallback triggered: reason=%s path=%s strict=%s",
-            reason,
-            path_label,
-            strict_mode,
-        )
-    else:
-        _logger.warning(
-            "FUJI policy fallback triggered: reason=%s path=%s exc_type=%s strict=%s",
-            reason,
-            path_label,
-            type(exc).__name__,
-            strict_mode,
-            exc_info=True,
-        )
-
-    if strict_mode:
-        _logger.error(
-            "FUJI strict policy-load mode active. Deny policy is enforced due to policy load failure. "
-            "path=%s reason=%s",
-            path_label,
-            reason,
-        )
-        return dict(_STRICT_DENY_POLICY)
-
-    return dict(_DEFAULT_POLICY)
+    """Delegate fallback-policy handling to fuji_policy helpers."""
+    _sync_fuji_policy_runtime()
+    return _fuji_policy._fallback_policy(path=path, reason=reason, exc=exc)
 
 
 
 def _load_policy(path: Path | None) -> Dict[str, Any]:
-    """Backward-compatible FUJI policy loader with local logger semantics."""
-    if not capability_cfg.enable_fuji_yaml_policy or yaml is None:
-        return dict(_DEFAULT_POLICY)
-
-    if path is None or not path.exists():
-        return _fallback_policy(path=path, reason="missing_policy_file")
-
-    yaml_error = getattr(yaml, "YAMLError", None)
-    yaml_errors = (yaml_error,) if isinstance(yaml_error, type) else ()
-    handled_errors = (TypeError, ValueError, OSError) + yaml_errors
-
-    try:
-        with path.open("r", encoding="utf-8") as file_obj:
-            data = yaml.safe_load(file_obj) or {}
-    except handled_errors as exc:
-        return _fallback_policy(path=path, reason="yaml_load_error", exc=exc)
-
-    if "version" not in data:
-        data["version"] = f"fuji_file_{path.name}"
-
-    return data
+    """Backward-compatible FUJI policy loader via the shared policy module."""
+    _sync_fuji_policy_runtime()
+    return _fuji_policy._load_policy(path)
 
 
 
 def _load_policy_from_str(content: str, path: Path) -> Dict[str, Any]:
-    """Parse FUJI policy content while preserving legacy error behavior."""
-    if not capability_cfg.enable_fuji_yaml_policy or yaml is None:
-        return dict(_DEFAULT_POLICY)
-
-    yaml_error = getattr(yaml, "YAMLError", None)
-    yaml_errors = (yaml_error,) if isinstance(yaml_error, type) else ()
-    handled_errors = (TypeError, ValueError) + yaml_errors
-
-    try:
-        data = yaml.safe_load(content) or {}
-    except handled_errors as exc:
-        return _fallback_policy(path=path, reason="yaml_parse_error", exc=exc)
-
-    if "version" not in data:
-        data["version"] = f"fuji_file_{path.name}"
-
-    return data
+    """Parse FUJI policy content via the shared policy module."""
+    _sync_fuji_policy_runtime()
+    return _fuji_policy._load_policy_from_str(content, path)
 
 
 
 def reload_policy() -> Dict[str, Any]:
     """Reload the shared FUJI policy state and keep module aliases synchronized."""
     global POLICY, _POLICY_MTIME
-    _fuji_policy.yaml = yaml
-    _fuji_policy.capability_cfg = capability_cfg
+    _sync_fuji_policy_runtime()
     POLICY = _fuji_policy.reload_policy()
     _POLICY_MTIME = getattr(_fuji_policy, "_POLICY_MTIME", _POLICY_MTIME)
     return POLICY

--- a/veritas_os/tests/test_fuji_core.py
+++ b/veritas_os/tests/test_fuji_core.py
@@ -184,6 +184,57 @@ def test_load_policy_strict_mode_enforces_deny_policy(tmp_path, monkeypatch, cap
     assert "strict policy-load mode active" in caplog.text.lower()
 
 
+def test_load_policy_delegates_to_shared_fuji_policy(monkeypatch, tmp_path):
+    """fuji.py の互換入口は shared policy helper を経由する。"""
+    policy_file = tmp_path / "fuji.yaml"
+    policy_file.write_text("version: delegated", encoding="utf-8")
+    expected = {"version": "delegated"}
+    observed = {}
+
+    def _fake_load_policy(path):
+        observed["path"] = path
+        observed["yaml"] = fuji._fuji_policy.yaml
+        observed["capability"] = fuji._fuji_policy.capability_cfg
+        return expected
+
+    monkeypatch.setattr(fuji._fuji_policy, "_load_policy", _fake_load_policy)
+
+    result = fuji._load_policy(policy_file)  # type: ignore[attr-defined]
+
+    assert result == expected
+    assert observed["path"] == policy_file
+    assert observed["yaml"] is fuji.yaml
+    assert observed["capability"] is fuji.capability_cfg
+
+
+def test_load_policy_from_str_delegates_to_shared_fuji_policy(monkeypatch):
+    """文字列ロードも shared policy helper に委譲し、runtime alias を同期する。"""
+    expected = {"version": "from_shared_helper"}
+    observed = {}
+
+    def _fake_load_policy_from_str(content, path):
+        observed["content"] = content
+        observed["path"] = path
+        observed["yaml"] = fuji._fuji_policy.yaml
+        observed["capability"] = fuji._fuji_policy.capability_cfg
+        return expected
+
+    monkeypatch.setattr(
+        fuji._fuji_policy,
+        "_load_policy_from_str",
+        _fake_load_policy_from_str,
+    )
+    path = Path("/tmp/fuji_policy.yaml")
+
+    result = fuji._load_policy_from_str("version: delegated", path)  # type: ignore[attr-defined]
+
+    assert result == expected
+    assert observed["content"] == "version: delegated"
+    assert observed["path"] == path
+    assert observed["yaml"] is fuji.yaml
+    assert observed["capability"] is fuji.capability_cfg
+
+
 # ---------------------------------------------------------
 # fallback_safety_head
 # ---------------------------------------------------------
@@ -737,5 +788,4 @@ def test_evaluate_with_string_query(monkeypatch):
     assert called["context"]["stakes"] == 0.1
     assert called["evidence"] == []
     assert called["alternatives"] == []
-
 


### PR DESCRIPTION
### Motivation
- Reduce duplicated compatibility logic in `fuji.py` by centralizing YAML policy fallback/load behavior in the shared `fuji_policy.py` helper while keeping the FUJI public contract and capability aliases unchanged.
- Keep `fuji.py` focused on compatibility aliasing and gate coordination so new policy-loading logic lives in one place and core module complexity does not increase.
- Ensure runtime aliases (`yaml` and `capability_cfg`) remain synchronized before delegation so existing behavior and observability are preserved.

### Description
- Add `_sync_fuji_policy_runtime()` to `veritas_os/core/fuji.py` and update `'_fallback_policy'`, `'_load_policy'`, `'_load_policy_from_str'`, and `reload_policy` to delegate to the corresponding helpers in `veritas_os/core/fuji_policy.py` after syncing runtime aliases. 
- Add regression tests in `veritas_os/tests/test_fuji_core.py` verifying that `fuji._load_policy()` and `fuji._load_policy_from_str()` delegate to the shared helper and that `yaml` / `capability_cfg` aliases are synchronized before delegation. 
- Update `docs/reviews/improvement_instructions_ja_20260320.md` to record this Priority 1 minimal refactor as part of the improvement log. 

### Testing
- Ran `pytest -q veritas_os/tests/test_fuji_core.py -q`, and the test suite completed successfully. 
- Ran `python -m compileall veritas_os/core/fuji.py veritas_os/tests/test_fuji_core.py`, and compilation completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd25ce407c83269714a5e12078574e)