### PR TITLE
Tighten Memory API failure error codes

### DIFF
--- a/docs/reviews/improvement_instructions_ja_20260320.md
+++ b/docs/reviews/improvement_instructions_ja_20260320.md
@@ -166,6 +166,7 @@ fail-open は非本番でも認証保護を弱めるため、
 ## 実施記録（2026-03-20）
 
 ### 今回完了した改善
+- **Priority 3 / 指示 3-1 追加（今回）**: `veritas_os/api/routes_memory.py` の Memory API 失敗分類を、完全失敗だけでなく「memory store unavailable」および `kinds` バリデーション失敗にも一貫して付与するよう補強した。`memory_put` / `memory_search` / `memory_get` / `memory_erase` の backend unavailable は additive な `error_code="backend_unavailable"` を返し、`memory_search` の不正 `kinds` は `error_code="validation_failure"` を返す。これにより既存の public contract を壊さず、運用 triage と監査の粒度を高めた。`veritas_os/tests/test_api_server_extra.py` に回帰テストを追加した。
 - **Priority 1 / 指示 1-2 追加（今回）**: `veritas_os/core/fuji.py` に残っていた YAML policy fallback / load の compatibility-heavy な重複実装を、共有 helper である `veritas_os/core/fuji_policy.py` へ委譲する形に整理した。`fuji.py` 側には `_sync_fuji_policy_runtime()` を追加し、`_load_policy()` / `_load_policy_from_str()` / `_fallback_policy()` が shared policy helper を経由しても既存の capability alias と public contract を維持するようにした。`veritas_os/tests/test_fuji_core.py` に委譲経路の回帰テストを追加した。
 - **Priority 3 / 指示 3-1**: `veritas_os/api/routes_memory.py` の Memory API 失敗応答に additive な `error_code` 分類 (`validation_failure` / `backend_unavailable` / `security_policy_rejection` / `serialization_storage_failure` / `unknown_failure`) を追加し、既存の `ok / status / errors[]` 契約を維持したまま監査・運用トリアージしやすくした。`memory_put` の stage-level error と `memory_search` / `memory_get` / `memory_erase` の失敗応答で利用できる。
 - **Priority 1 / 指示 1-1**: `pipeline.py` / `kernel.py` / `fuji.py` / `memory.py` の module docstring を更新し、public contract・推奨拡張ポイント・compatibility layer の扱いを明示した。

--- a/veritas_os/api/routes_memory.py
+++ b/veritas_os/api/routes_memory.py
@@ -168,13 +168,21 @@ def memory_put(body: MemoryPutRequest, x_api_key: Optional[str] = Header(default
     store = srv.get_memory_store()
     if store is None:
         logger.warning("memory_put: memory store unavailable: %s", srv._memory_store_state.err)
-        return {"ok": False, "error": "memory store unavailable"}
+        return {
+            "ok": False,
+            "error": "memory store unavailable",
+            "error_code": "backend_unavailable",
+        }
 
     try:
         user_id = srv._resolve_memory_user_id(body.user_id, x_api_key)
     except MEMORY_ROUTE_EXCEPTIONS as exc:
         logger.error("[MemoryOS][resolve_user] Error: %s", exc)
-        return {"ok": False, "error": "memory operation failed"}
+        return {
+            "ok": False,
+            "error": "memory operation failed",
+            "error_code": _classify_memory_failure(exc),
+        }
 
     key = body.key or f"memory_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
     value = body.value or {}
@@ -282,7 +290,13 @@ def memory_search(payload: MemorySearchRequest, x_api_key: Optional[str] = Heade
     store = srv.get_memory_store()
     if store is None:
         logger.warning("memory_search: memory store unavailable: %s", srv._memory_store_state.err)
-        return {"ok": False, "error": "memory store unavailable", "hits": [], "count": 0}
+        return {
+            "ok": False,
+            "error": "memory store unavailable",
+            "error_code": "backend_unavailable",
+            "hits": [],
+            "count": 0,
+        }
 
     try:
         q = payload.query
@@ -296,6 +310,7 @@ def memory_search(payload: MemorySearchRequest, x_api_key: Optional[str] = Heade
             return {
                 "ok": False,
                 "error": kinds_error,
+                "error_code": "validation_failure",
                 "hits": [],
                 "count": 0,
             }
@@ -344,7 +359,12 @@ def memory_get(body: MemoryGetRequest, x_api_key: Optional[str] = Header(default
     srv = _get_server()
     store = srv.get_memory_store()
     if store is None:
-        return {"ok": False, "error": "memory store unavailable", "value": None}
+        return {
+            "ok": False,
+            "error": "memory store unavailable",
+            "error_code": "backend_unavailable",
+            "value": None,
+        }
 
     try:
         uid = srv._resolve_memory_user_id(body.user_id, x_api_key)
@@ -367,7 +387,11 @@ def memory_erase(body: MemoryEraseRequest, x_api_key: Optional[str] = Header(def
     srv = _get_server()
     store = srv.get_memory_store()
     if store is None:
-        return {"ok": False, "error": "memory store unavailable"}
+        return {
+            "ok": False,
+            "error": "memory store unavailable",
+            "error_code": "backend_unavailable",
+        }
 
     try:
         user_id = srv._resolve_memory_user_id(body.user_id, x_api_key)
@@ -382,6 +406,7 @@ def memory_erase(body: MemoryEraseRequest, x_api_key: Optional[str] = Header(def
         return {
             "ok": False,
             "error": "erase operation unsupported by active memory backend",
+            "error_code": "backend_unavailable",
         }
     except MEMORY_ROUTE_EXCEPTIONS as e:
         logger.error("memory_erase failed: %s", e)

--- a/veritas_os/tests/test_api_server_extra.py
+++ b/veritas_os/tests/test_api_server_extra.py
@@ -20,7 +20,11 @@ from fastapi.testclient import TestClient
 import pytest
 
 import veritas_os.api.server as server
-from veritas_os.api.schemas import MemoryPutRequest, MemorySearchRequest
+from veritas_os.api.schemas import (
+    MemoryGetRequest,
+    MemoryPutRequest,
+    MemorySearchRequest,
+)
 
 
 client = TestClient(server.app)
@@ -1973,6 +1977,47 @@ def test_memory_search_exposes_error_code_for_validation_failures(monkeypatch):
     assert res["ok"] is False
     assert res["error"] == "memory search failed"
     assert res["error_code"] == "validation_failure"
+
+
+def test_memory_search_invalid_kinds_returns_validation_error_code() -> None:
+    """Invalid kind filters should expose the same additive validation code."""
+
+    res = server.memory_search(
+        MemorySearchRequest(user_id="u1", query="hello", kinds=["semantic", "bad"])
+    )
+
+    assert res["ok"] is False
+    assert res["error"] == "invalid kinds: ['bad']"
+    assert res["error_code"] == "validation_failure"
+
+
+def test_memory_put_unavailable_store_returns_backend_error_code(monkeypatch):
+    """Unavailable memory backends should remain observable to operators."""
+
+    class DummyState:
+        err = "offline"
+
+    monkeypatch.setattr(server, "_memory_store_state", DummyState())
+    monkeypatch.setattr(server, "get_memory_store", lambda: None)
+
+    res = server.memory_put(MemoryPutRequest(user_id="u1", text="hello"))
+
+    assert res["ok"] is False
+    assert res["error"] == "memory store unavailable"
+    assert res["error_code"] == "backend_unavailable"
+
+
+def test_memory_get_unavailable_store_returns_backend_error_code(monkeypatch):
+    """memory_get should classify store-unavailable failures consistently."""
+
+    monkeypatch.setattr(server, "get_memory_store", lambda: None)
+
+    res = server.memory_get(MemoryGetRequest(user_id="u1", key="k1"))
+
+    assert res["ok"] is False
+    assert res["error"] == "memory store unavailable"
+    assert res["error_code"] == "backend_unavailable"
+    assert res["value"] is None
 
 
 def test_memory_search_does_not_swallow_base_exceptions(monkeypatch):


### PR DESCRIPTION
### Motivation
- Improve observability and triage of degraded MemoryOS behavior by making failure classification consistently available for store-unavailable and input-validation failures while preserving existing public response contracts.

### Description
- Return additive `error_code="backend_unavailable"` when the memory backend is absent in `memory_put`, `memory_search`, `memory_get`, and `memory_erase` in `veritas_os/api/routes_memory.py`.
- Return `error_code="validation_failure"` for invalid `kinds` in `memory_search` and include classified `error_code` for user-resolution exceptions via `_classify_memory_failure` without changing existing `ok`/`status`/`errors[]` semantics.
- Add regression tests in `veritas_os/tests/test_api_server_extra.py` covering invalid `kinds` and store-unavailable cases, and update `docs/reviews/improvement_instructions_ja_20260320.md` to record the change.

### Testing
- Ran the targeted tests with `pytest -q veritas_os/tests/test_api_server_extra.py -k "memory_search_invalid_kinds_returns_validation_error_code or memory_put_unavailable_store_returns_backend_error_code or memory_get_unavailable_store_returns_backend_error_code or memory_search_exposes_error_code_for_validation_failures or memory_put_reports_partial_failure_when_vector_save_fails or memory_put_reports_failed_when_all_save_paths_fail"` and observed `6 passed, 86 deselected`.
- All added/modified tests passed on the final run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd28a469948326943327aeef912cf6)