### PR TITLE
refactor(frontend): split monolithic pages into composable sub-components

### DIFF
--- a/frontend/app/audit/components/AuditSummaryPanel.tsx
+++ b/frontend/app/audit/components/AuditSummaryPanel.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import { StatCard } from "../../../components/ui";
+import { STATUS_BG } from "../constants";
+
+interface AuditSummaryData {
+  total: number;
+  verified: number;
+  broken: number;
+  missing: number;
+  orphan: number;
+  replayLinked: number;
+  policyVersions: Record<string, number>;
+}
+
+interface AuditSummaryPanelProps {
+  summary: AuditSummaryData;
+  hasItems: boolean;
+}
+
+export function AuditSummaryPanel({ summary, hasItems }: AuditSummaryPanelProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <Card title="Audit Summary" titleSize="sm" variant="elevated">
+      {!hasItems ? (
+        <p className="text-xs text-muted-foreground">
+          {t(
+            "ログを読み込むと、ここに全体の監査サマリーが表示されます。",
+            "Load logs to see the overall audit summary here.",
+          )}
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {/* Status bar */}
+          <div className="grid grid-cols-2 gap-2 md:grid-cols-3 lg:grid-cols-6">
+            <StatCard label={t("全エントリ", "Total")} value={summary.total} />
+            <StatCard label="Verified" value={summary.verified} variant="success" className={STATUS_BG.verified} />
+            <StatCard label="Broken" value={summary.broken} variant="danger" className={STATUS_BG.broken} />
+            <StatCard label="Missing" value={summary.missing} variant="warning" className={STATUS_BG.missing} />
+            <StatCard label="Orphan" value={summary.orphan} variant="info" className={STATUS_BG.orphan} />
+            <StatCard label={t("リプレイ連携", "Replay Linked")} value={summary.replayLinked} />
+          </div>
+
+          {/* Policy version distribution */}
+          {Object.keys(summary.policyVersions).length > 0 && (
+            <div>
+              <p className="mb-1 text-xs font-semibold">
+                {t("ポリシーバージョン分布", "Policy Version Distribution")}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(summary.policyVersions).map(([version, count]) => (
+                  <span key={version} className="rounded border border-border px-2 py-0.5 font-mono text-2xs">
+                    {version}: {count}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Integrity bar */}
+          {summary.total > 0 && (
+            <div>
+              <div className="flex h-2 overflow-hidden rounded-full">
+                {summary.verified > 0 && (
+                  <div className="bg-success" style={{ width: `${(summary.verified / summary.total) * 100}%` }} />
+                )}
+                {summary.broken > 0 && (
+                  <div className="bg-danger" style={{ width: `${(summary.broken / summary.total) * 100}%` }} />
+                )}
+                {summary.missing > 0 && (
+                  <div className="bg-warning" style={{ width: `${(summary.missing / summary.total) * 100}%` }} />
+                )}
+                {summary.orphan > 0 && (
+                  <div className="bg-info" style={{ width: `${(summary.orphan / summary.total) * 100}%` }} />
+                )}
+              </div>
+              <p className="mt-1 text-2xs text-muted-foreground">
+                {t("チェーン整合率", "Chain integrity")}:{" "}
+                {Math.round((summary.verified / summary.total) * 100)}%
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/app/audit/components/AuditTimeline.tsx
+++ b/frontend/app/audit/components/AuditTimeline.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import { classifyChain, getString, type DetailTab } from "../audit-types";
+import { STATUS_COLORS, STATUS_DOT } from "../constants";
+import type { TrustLogItem } from "../../../lib/api-validators";
+
+interface AuditTimelineProps {
+  filteredItems: TrustLogItem[];
+  stageFilter: string;
+  stageOptions: string[];
+  selected: TrustLogItem | null;
+  onStageFilterChange: (value: string) => void;
+  onSelect: (item: TrustLogItem) => void;
+  onDetailTabChange: (tab: DetailTab) => void;
+}
+
+export function AuditTimeline({
+  filteredItems,
+  stageFilter,
+  stageOptions,
+  selected,
+  onStageFilterChange,
+  onSelect,
+  onDetailTabChange,
+}: AuditTimelineProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <Card title="Timeline" titleSize="md" variant="elevated">
+      <div className="mb-2 flex items-center gap-2">
+        <label htmlFor="stage-filter" className="text-xs">Stage</label>
+        <select
+          id="stage-filter"
+          value={stageFilter}
+          onChange={(e) => onStageFilterChange(e.target.value)}
+          className="rounded border border-border px-2 py-1 text-xs"
+        >
+          {stageOptions.map((stage) => (
+            <option key={stage} value={stage}>{stage}</option>
+          ))}
+        </select>
+        <span className="ml-auto text-xs">
+          {t("表示件数", "Visible")}: {filteredItems.length}
+        </span>
+      </div>
+
+      {filteredItems.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {t(
+            "監査対象が未読込です。request_id/decision_id・ハッシュ整合・リプレイ関連をここで確認できます。",
+            "No logs loaded yet. This timeline verifies request/decision IDs, hash chain, and replay linkage.",
+          )}
+        </p>
+      ) : null}
+
+      {/* Column header */}
+      {filteredItems.length > 0 && (
+        <div className="mb-1 grid grid-cols-2 gap-1 px-3 text-2xs font-semibold text-muted-foreground md:grid-cols-7">
+          <span>{t("重要度", "Severity")}</span>
+          <span>Stage</span>
+          <span>{t("タイムスタンプ", "Timestamp")}</span>
+          <span>request_id</span>
+          <span>decision_id</span>
+          <span>{t("チェーン", "Chain")}</span>
+          <span>Replay</span>
+        </div>
+      )}
+
+      <ol className="space-y-1">
+        {filteredItems.map((item, index) => {
+          const chain = classifyChain(item, filteredItems[index + 1] ?? null);
+          const isSelected = selected === item;
+          const timelineKey = [
+            item.request_id ?? "unknown",
+            String(item.decision_id ?? "no-decision"),
+            item.created_at ?? "no-timestamp",
+            item.sha256 ?? "no-sha",
+            item.sha256_prev ?? "no-prev-sha",
+          ].join("-");
+          return (
+            <li key={timelineKey}>
+              <button
+                type="button"
+                onClick={() => {
+                  onSelect(item);
+                  onDetailTabChange("summary");
+                }}
+                className={`w-full rounded border px-3 py-2 text-left text-xs transition-colors ${
+                  isSelected
+                    ? "border-primary/50 bg-primary/5"
+                    : "border-border hover:bg-muted/30"
+                }`}
+              >
+                <div className="grid grid-cols-2 gap-1 md:grid-cols-7">
+                  <span className="font-medium">{getString(item, "severity")}</span>
+                  <span>{getString(item, "stage")}</span>
+                  <span className="font-mono text-2xs">{item.created_at ?? "-"}</span>
+                  <span className="truncate font-mono text-2xs">{item.request_id ?? "-"}</span>
+                  <span className="truncate font-mono text-2xs">{String(item.decision_id ?? "-")}</span>
+                  <span className="flex items-center gap-1">
+                    <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT[chain.status]}`} />
+                    <span className={STATUS_COLORS[chain.status]}>{chain.status}</span>
+                  </span>
+                  <span className="text-2xs">
+                    {typeof item.replay_id === "string" ? "linked" : "-"}
+                  </span>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </Card>
+  );
+}

--- a/frontend/app/audit/components/ExportPanel.tsx
+++ b/frontend/app/audit/components/ExportPanel.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import type { ExportFormat, RedactionMode, RegulatoryReport } from "../audit-types";
+import { computeAuditSummary } from "../audit-types";
+import type { TrustLogItem } from "../../../lib/api-validators";
+
+interface ExportPanelProps {
+  sortedItems: TrustLogItem[];
+  reportStartDate: string;
+  reportEndDate: string;
+  redactionMode: RedactionMode;
+  exportFormat: ExportFormat;
+  confirmPiiRisk: boolean;
+  reportError: string | null;
+  latestReport: RegulatoryReport | null;
+  exportTargetCount: number;
+  onReportStartDateChange: (v: string) => void;
+  onReportEndDateChange: (v: string) => void;
+  onRedactionModeChange: (v: RedactionMode) => void;
+  onExportFormatChange: (v: ExportFormat) => void;
+  onConfirmPiiRiskChange: (v: boolean) => void;
+  onReportError: (v: string | null) => void;
+  onLatestReport: (v: RegulatoryReport | null) => void;
+}
+
+export function ExportPanel({
+  sortedItems,
+  reportStartDate,
+  reportEndDate,
+  redactionMode,
+  exportFormat,
+  confirmPiiRisk,
+  reportError,
+  latestReport,
+  exportTargetCount,
+  onReportStartDateChange,
+  onReportEndDateChange,
+  onRedactionModeChange,
+  onExportFormatChange,
+  onConfirmPiiRiskChange,
+  onReportError,
+  onLatestReport,
+}: ExportPanelProps): JSX.Element {
+  const { t } = useI18n();
+
+  const createRegulatoryReport = (): RegulatoryReport | null => {
+    onReportError(null);
+    if (!confirmPiiRisk) {
+      onReportError(t("PII/metadata warning を確認してください。", "Please acknowledge the PII/metadata warning."));
+      return null;
+    }
+    if (!reportStartDate || !reportEndDate) {
+      onReportError(t("期間を指定してください。", "Please select both start and end dates."));
+      return null;
+    }
+    const start = new Date(`${reportStartDate}T00:00:00.000Z`).getTime();
+    const end = new Date(`${reportEndDate}T23:59:59.999Z`).getTime();
+    const periodItems = sortedItems.filter((item) => {
+      const stamp = new Date(item.created_at ?? "").getTime();
+      return Number.isFinite(stamp) && stamp >= start && stamp <= end;
+    });
+    if (periodItems.length === 0) {
+      onReportError(t("指定期間にデータがありません。", "No logs found for the selected period."));
+      return null;
+    }
+
+    const summary = computeAuditSummary(periodItems);
+    const report: RegulatoryReport = {
+      generatedAt: new Date().toISOString(),
+      totalEntries: summary.total,
+      verified: summary.verified,
+      broken: summary.broken,
+      missing: summary.missing,
+      orphan: summary.orphan,
+      mismatchLinks: summary.broken,
+      brokenCount: summary.broken,
+      redactionMode,
+      policyVersions: summary.policyVersions,
+    };
+    onLatestReport(report);
+    return report;
+  };
+
+  const downloadJsonReport = (): void => {
+    const report = createRegulatoryReport();
+    if (!report) return;
+    const reportBlob = new Blob([JSON.stringify(report, null, 2)], { type: "application/json" });
+    const objectUrl = URL.createObjectURL(reportBlob);
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = `audit-report-${reportStartDate}-${reportEndDate}.json`;
+    anchor.click();
+    URL.revokeObjectURL(objectUrl);
+  };
+
+  const generatePdfReport = (): void => {
+    const report = createRegulatoryReport();
+    if (!report) return;
+    const printWindow = window.open("", "_blank", "noopener,noreferrer,width=900,height=700");
+    if (!printWindow) {
+      onReportError(t("PDFウィンドウを開けませんでした。", "Failed to open PDF print window."));
+      return;
+    }
+    const doc = printWindow.document;
+    const title = doc.createElement("h1");
+    title.textContent = "Regulatory Report Generator";
+    const warning = doc.createElement("p");
+    warning.textContent = "Security note: Report may include PII and sensitive metadata.";
+    const redactNote = doc.createElement("p");
+    redactNote.textContent = `Redaction mode: ${report.redactionMode}`;
+    doc.body.appendChild(title);
+    doc.body.appendChild(warning);
+    doc.body.appendChild(redactNote);
+    doc.body.appendChild(doc.createTextNode(JSON.stringify(report, null, 2)));
+    doc.close();
+    printWindow.focus();
+    printWindow.print();
+  };
+
+  const handleExport = (): void => {
+    if (exportFormat === "pdf") {
+      generatePdfReport();
+    } else {
+      downloadJsonReport();
+    }
+  };
+
+  const REDACTION_OPTIONS = [
+    { value: "full" as const, label: t("完全出力", "Full"), desc: t("すべてのフィールドを含む", "Includes all fields") },
+    { value: "redacted" as const, label: t("墨消し", "Redacted"), desc: t("PII関連フィールドを除外", "PII fields removed") },
+    { value: "metadata-only" as const, label: t("メタデータのみ", "Metadata only"), desc: t("監査メタデータのみ", "Audit metadata only") },
+  ] as const;
+
+  return (
+    <Card
+      title={t("第三者監査用エクスポート", "Regulatory Report Generator")}
+      titleSize="md"
+      variant="elevated"
+      accent="warning"
+    >
+      <div className="space-y-4 text-sm">
+        {/* Period selection */}
+        <div>
+          <p className="mb-1 text-xs font-semibold">{t("対象期間", "Export Period")}</p>
+          <div className="grid gap-3 md:grid-cols-2">
+            <input
+              aria-label={t("監査レポート開始日", "Audit report start date")}
+              type="date"
+              value={reportStartDate}
+              onChange={(e) => onReportStartDateChange(e.target.value)}
+              className="rounded border border-border px-3 py-2"
+            />
+            <input
+              aria-label={t("監査レポート終了日", "Audit report end date")}
+              type="date"
+              value={reportEndDate}
+              onChange={(e) => onReportEndDateChange(e.target.value)}
+              className="rounded border border-border px-3 py-2"
+            />
+          </div>
+          {reportStartDate && reportEndDate && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("エクスポート対象", "Export target")}: {exportTargetCount} {t("件", "entries")}
+            </p>
+          )}
+        </div>
+
+        {/* Redaction mode */}
+        <fieldset className="space-y-1">
+          <legend className="text-xs font-semibold">{t("墨消しモード", "Redaction Mode")}</legend>
+          <div className="flex gap-3 text-xs">
+            {REDACTION_OPTIONS.map((opt) => (
+              <label key={opt.value} className="flex items-start gap-1.5">
+                <input
+                  aria-label={opt.label}
+                  type="radio"
+                  name="redaction"
+                  value={opt.value}
+                  checked={redactionMode === opt.value}
+                  onChange={() => onRedactionModeChange(opt.value)}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-medium">{opt.label}</span>
+                  <br />
+                  <span className="text-xs text-muted-foreground">{opt.desc}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        {/* Format selection */}
+        <fieldset className="space-y-1">
+          <legend className="text-xs font-semibold">{t("出力形式", "Export Format")}</legend>
+          <div className="flex gap-4 text-xs">
+            <label className="flex items-start gap-1.5">
+              <input aria-label="JSON" type="radio" name="exportFormat" value="json" checked={exportFormat === "json"} onChange={() => onExportFormatChange("json")} className="mt-0.5" />
+              <span>
+                <span className="font-medium">JSON</span><br />
+                <span className="text-xs text-muted-foreground">{t("機械可読形式。APIやスクリプトでの処理に最適", "Machine-readable. Best for API and script processing")}</span>
+              </span>
+            </label>
+            <label className="flex items-start gap-1.5">
+              <input aria-label="PDF" type="radio" name="exportFormat" value="pdf" checked={exportFormat === "pdf"} onChange={() => onExportFormatChange("pdf")} className="mt-0.5" />
+              <span>
+                <span className="font-medium">PDF</span><br />
+                <span className="text-xs text-muted-foreground">{t("印刷用。第三者監査提出に適した形式", "Printable. Suitable for third-party audit submission")}</span>
+              </span>
+            </label>
+          </div>
+        </fieldset>
+
+        {/* PII acknowledgement */}
+        <div className="rounded border border-warning/30 bg-warning/5 p-3">
+          <label className="flex items-start gap-2 text-xs">
+            <input
+              aria-label={t("PII/metadata warningの確認", "Acknowledge PII/metadata warning")}
+              type="checkbox"
+              checked={confirmPiiRisk}
+              onChange={(e) => onConfirmPiiRiskChange(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              {t(
+                "PII/metadata warning を理解し、社内ポリシーに従って取り扱います。",
+                "I acknowledge PII/metadata warning and will handle exports under policy.",
+              )}
+            </span>
+          </label>
+          <p className="mt-2 text-2xs text-warning">
+            {t(
+              "セキュリティ警告: エクスポートにはPII（個人識別情報）や監査メタデータが含まれる可能性があります。社内の情報セキュリティポリシーに従い、安全に取り扱ってください。",
+              "Security warning: Exports may include PII (personally identifiable information) and audit metadata. Handle according to your organization's information security policy.",
+            )}
+          </p>
+        </div>
+
+        {/* Export button */}
+        <button type="button" className="rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm" onClick={handleExport}>
+          {exportFormat === "json" ? t("JSON生成", "Generate JSON") : t("PDF生成", "Generate PDF")}
+        </button>
+
+        {reportError ? <p className="text-xs text-warning">{reportError}</p> : null}
+        {latestReport ? (
+          <div className="rounded border border-border p-2 text-xs">
+            <p>
+              entries: {latestReport.totalEntries} / verified: {latestReport.verified} / broken: {latestReport.broken} /
+              missing: {latestReport.missing} / orphan: {latestReport.orphan} / mismatches: {latestReport.mismatchLinks}
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/app/audit/components/VerificationPanel.tsx
+++ b/frontend/app/audit/components/VerificationPanel.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import { STATUS_DOT } from "../constants";
+import type { TrustLogItem } from "../../../lib/api-validators";
+
+interface VerificationPanelProps {
+  decisionIds: string[];
+  selectedDecisionId: string;
+  selectedDecisionEntry: TrustLogItem | null;
+  verificationMessage: string | null;
+  onSelectedDecisionIdChange: (id: string) => void;
+  onVerify: () => void;
+}
+
+export function VerificationPanel({
+  decisionIds,
+  selectedDecisionId,
+  selectedDecisionEntry,
+  verificationMessage,
+  onSelectedDecisionIdChange,
+  onVerify,
+}: VerificationPanelProps): JSX.Element {
+  const { t } = useI18n();
+
+  const handleVerify = (): void => {
+    if (!selectedDecisionEntry) {
+      onVerify();
+      return;
+    }
+    onVerify();
+  };
+
+  return (
+    <Card
+      title={t("TrustLog インタラクティブ検証", "TrustLog Interactive Verification")}
+      titleSize="md"
+      variant="elevated"
+      accent="success"
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <select
+            aria-label={t("検証対象の意思決定ID", "Decision ID for verification")}
+            className="rounded border border-border px-2 py-1 text-xs"
+            value={selectedDecisionId}
+            onChange={(e) => onSelectedDecisionIdChange(e.target.value)}
+          >
+            <option value="">{t("意思決定IDを選択", "Select a decision ID")}</option>
+            {decisionIds.map((id) => (
+              <option key={id} value={id}>{id}</option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="rounded border border-primary/40 bg-primary/10 px-3 py-1.5 text-xs"
+            onClick={handleVerify}
+          >
+            {t("ハッシュチェーン検証", "Verify hash chain")}
+          </button>
+        </div>
+        {verificationMessage ? (
+          <p className="text-xs">{verificationMessage}</p>
+        ) : null}
+        <div className="flex flex-wrap gap-2 text-2xs">
+          {(["verified", "broken", "missing", "orphan"] as const).map((status) => (
+            <span key={status} className="flex items-center gap-1">
+              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT[status]}`} />
+              {status}
+            </span>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -2,17 +2,15 @@
 
 import { Card } from "@veritas/design-system";
 import { useI18n } from "../../components/i18n-provider";
-import {
-  classifyChain,
-  computeAuditSummary,
-  getString,
-  type SearchField,
-} from "./audit-types";
-import { STATUS_BG, STATUS_COLORS, STATUS_DOT } from "./constants";
+import { ErrorBanner } from "../../components/ui";
+import { classifyChain } from "./audit-types";
 import { useAuditData } from "./hooks/useAuditData";
 import { SearchPanel } from "./components/SearchPanel";
 import { DetailPanel } from "./components/DetailPanel";
-import type { ExportFormat, RedactionMode, RegulatoryReport } from "./audit-types";
+import { AuditSummaryPanel } from "./components/AuditSummaryPanel";
+import { AuditTimeline } from "./components/AuditTimeline";
+import { VerificationPanel } from "./components/VerificationPanel";
+import { ExportPanel } from "./components/ExportPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
@@ -21,115 +19,6 @@ import type { ExportFormat, RedactionMode, RegulatoryReport } from "./audit-type
 export default function TrustLogExplorerPage(): JSX.Element {
   const { t } = useI18n();
   const data = useAuditData();
-
-  /* -- export actions (kept inline since they use multiple state setters) -- */
-
-  const createRegulatoryReport = (): RegulatoryReport | null => {
-    data.setReportError(null);
-    if (!data.confirmPiiRisk) {
-      data.setReportError(
-        t(
-          "PII/metadata warning を確認してください。",
-          "Please acknowledge the PII/metadata warning.",
-        ),
-      );
-      return null;
-    }
-    if (!data.reportStartDate || !data.reportEndDate) {
-      data.setReportError(
-        t("期間を指定してください。", "Please select both start and end dates."),
-      );
-      return null;
-    }
-    const start = new Date(`${data.reportStartDate}T00:00:00.000Z`).getTime();
-    const end = new Date(`${data.reportEndDate}T23:59:59.999Z`).getTime();
-    const periodItems = data.sortedItems.filter((item) => {
-      const stamp = new Date(item.created_at ?? "").getTime();
-      return Number.isFinite(stamp) && stamp >= start && stamp <= end;
-    });
-    if (periodItems.length === 0) {
-      data.setReportError(
-        t(
-          "指定期間にデータがありません。",
-          "No logs found for the selected period.",
-        ),
-      );
-      return null;
-    }
-
-    const summary = computeAuditSummary(periodItems);
-
-    const report: RegulatoryReport = {
-      generatedAt: new Date().toISOString(),
-      totalEntries: summary.total,
-      verified: summary.verified,
-      broken: summary.broken,
-      missing: summary.missing,
-      orphan: summary.orphan,
-      mismatchLinks: summary.broken,
-      brokenCount: summary.broken,
-      redactionMode: data.redactionMode,
-      policyVersions: summary.policyVersions,
-    };
-    data.setLatestReport(report);
-    return report;
-  };
-
-  const downloadJsonReport = (): void => {
-    const report = createRegulatoryReport();
-    if (!report) return;
-    const reportBlob = new Blob([JSON.stringify(report, null, 2)], {
-      type: "application/json",
-    });
-    const objectUrl = URL.createObjectURL(reportBlob);
-    const anchor = document.createElement("a");
-    anchor.href = objectUrl;
-    anchor.download = `audit-report-${data.reportStartDate}-${data.reportEndDate}.json`;
-    anchor.click();
-    URL.revokeObjectURL(objectUrl);
-  };
-
-  const generatePdfReport = (): void => {
-    const report = createRegulatoryReport();
-    if (!report) return;
-    const printWindow = window.open(
-      "",
-      "_blank",
-      "noopener,noreferrer,width=900,height=700",
-    );
-    if (!printWindow) {
-      data.setReportError(
-        t(
-          "PDFウィンドウを開けませんでした。",
-          "Failed to open PDF print window.",
-        ),
-      );
-      return;
-    }
-    const doc = printWindow.document;
-    const title = doc.createElement("h1");
-    title.textContent = "Regulatory Report Generator";
-    const warning = doc.createElement("p");
-    warning.textContent =
-      "Security note: Report may include PII and sensitive metadata.";
-    const redactNote = doc.createElement("p");
-    redactNote.textContent = `Redaction mode: ${report.redactionMode}`;
-    doc.body.appendChild(title);
-    doc.body.appendChild(warning);
-    doc.body.appendChild(redactNote);
-    doc.body.appendChild(doc.createTextNode(JSON.stringify(report, null, 2)));
-    doc.close();
-    printWindow.focus();
-    printWindow.print();
-  };
-
-  const handleExport = (): void => {
-    if (data.exportFormat === "pdf") {
-      generatePdfReport();
-    } else {
-      downloadJsonReport();
-    }
-  };
 
   const verifySelectedDecision = (): void => {
     if (!data.selectedDecisionEntry) {
@@ -154,7 +43,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
 
   return (
     <div className="space-y-6">
-      {/* Empty-state hero / page purpose */}
+      {/* Page header */}
       <Card
         title="TrustLog Explorer"
         description={t(
@@ -183,7 +72,7 @@ export default function TrustLogExplorerPage(): JSX.Element {
         </div>
       </Card>
 
-      {/* Search: Connection + request_id + cross-search */}
+      {/* Search */}
       <SearchPanel
         requestId={data.requestId}
         onRequestIdChange={data.setRequestId}
@@ -198,250 +87,26 @@ export default function TrustLogExplorerPage(): JSX.Element {
         onLoadLogs={(c, r) => void data.loadLogs(c, r)}
       />
 
-      {data.error ? (
-        <p className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
-          {data.error}
-        </p>
-      ) : null}
+      {data.error ? <ErrorBanner message={data.error} /> : null}
 
-      {/* Enhanced Audit Summary */}
-      <Card title="Audit Summary" titleSize="sm" variant="elevated">
-        {data.filteredItems.length === 0 ? (
-          <p className="text-xs text-muted-foreground">
-            {t(
-              "ログを読み込むと、ここに全体の監査サマリーが表示されます。",
-              "Load logs to see the overall audit summary here.",
-            )}
-          </p>
-        ) : (
-          <div className="space-y-3">
-            {/* Status bar */}
-            <div className="grid grid-cols-2 gap-2 md:grid-cols-3 lg:grid-cols-6">
-              <div className="rounded border border-border px-3 py-2 text-center">
-                <p className="text-lg font-semibold">{data.auditSummary.total}</p>
-                <p className="text-2xs text-muted-foreground">
-                  {t("全エントリ", "Total")}
-                </p>
-              </div>
-              <div
-                className={`rounded border px-3 py-2 text-center ${STATUS_BG.verified}`}
-              >
-                <p className="text-lg font-semibold text-success">
-                  {data.auditSummary.verified}
-                </p>
-                <p className="text-2xs text-muted-foreground">Verified</p>
-              </div>
-              <div
-                className={`rounded border px-3 py-2 text-center ${STATUS_BG.broken}`}
-              >
-                <p className="text-lg font-semibold text-danger">
-                  {data.auditSummary.broken}
-                </p>
-                <p className="text-2xs text-muted-foreground">Broken</p>
-              </div>
-              <div
-                className={`rounded border px-3 py-2 text-center ${STATUS_BG.missing}`}
-              >
-                <p className="text-lg font-semibold text-warning">
-                  {data.auditSummary.missing}
-                </p>
-                <p className="text-2xs text-muted-foreground">Missing</p>
-              </div>
-              <div
-                className={`rounded border px-3 py-2 text-center ${STATUS_BG.orphan}`}
-              >
-                <p className="text-lg font-semibold text-info">
-                  {data.auditSummary.orphan}
-                </p>
-                <p className="text-2xs text-muted-foreground">Orphan</p>
-              </div>
-              <div className="rounded border border-border px-3 py-2 text-center">
-                <p className="text-lg font-semibold">
-                  {data.auditSummary.replayLinked}
-                </p>
-                <p className="text-2xs text-muted-foreground">
-                  {t("リプレイ連携", "Replay Linked")}
-                </p>
-              </div>
-            </div>
+      {/* Summary */}
+      <AuditSummaryPanel
+        summary={data.auditSummary}
+        hasItems={data.filteredItems.length > 0}
+      />
 
-            {/* Policy version distribution */}
-            {Object.keys(data.auditSummary.policyVersions).length > 0 && (
-              <div>
-                <p className="mb-1 text-xs font-semibold">
-                  {t("ポリシーバージョン分布", "Policy Version Distribution")}
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  {Object.entries(data.auditSummary.policyVersions).map(
-                    ([version, count]) => (
-                      <span
-                        key={version}
-                        className="rounded border border-border px-2 py-0.5 font-mono text-2xs"
-                      >
-                        {version}: {count}
-                      </span>
-                    ),
-                  )}
-                </div>
-              </div>
-            )}
+      {/* Timeline */}
+      <AuditTimeline
+        filteredItems={data.filteredItems}
+        stageFilter={data.stageFilter}
+        stageOptions={data.stageOptions}
+        selected={data.selected}
+        onStageFilterChange={data.setStageFilter}
+        onSelect={data.setSelected}
+        onDetailTabChange={data.setDetailTab}
+      />
 
-            {/* Integrity bar */}
-            {data.auditSummary.total > 0 && (
-              <div>
-                <div className="flex h-2 overflow-hidden rounded-full">
-                  {data.auditSummary.verified > 0 && (
-                    <div
-                      className="bg-success"
-                      style={{
-                        width: `${(data.auditSummary.verified / data.auditSummary.total) * 100}%`,
-                      }}
-                    />
-                  )}
-                  {data.auditSummary.broken > 0 && (
-                    <div
-                      className="bg-danger"
-                      style={{
-                        width: `${(data.auditSummary.broken / data.auditSummary.total) * 100}%`,
-                      }}
-                    />
-                  )}
-                  {data.auditSummary.missing > 0 && (
-                    <div
-                      className="bg-warning"
-                      style={{
-                        width: `${(data.auditSummary.missing / data.auditSummary.total) * 100}%`,
-                      }}
-                    />
-                  )}
-                  {data.auditSummary.orphan > 0 && (
-                    <div
-                      className="bg-info"
-                      style={{
-                        width: `${(data.auditSummary.orphan / data.auditSummary.total) * 100}%`,
-                      }}
-                    />
-                  )}
-                </div>
-                <p className="mt-1 text-2xs text-muted-foreground">
-                  {t("チェーン整合率", "Chain integrity")}:{" "}
-                  {Math.round(
-                    (data.auditSummary.verified / data.auditSummary.total) * 100,
-                  )}
-                  %
-                </p>
-              </div>
-            )}
-          </div>
-        )}
-      </Card>
-
-      {/* Enhanced Timeline */}
-      <Card title="Timeline" titleSize="md" variant="elevated">
-        <div className="mb-2 flex items-center gap-2">
-          <label htmlFor="stage-filter" className="text-xs">
-            Stage
-          </label>
-          <select
-            id="stage-filter"
-            value={data.stageFilter}
-            onChange={(e) => data.setStageFilter(e.target.value)}
-            className="rounded border border-border px-2 py-1 text-xs"
-          >
-            {data.stageOptions.map((stage) => (
-              <option key={stage} value={stage}>
-                {stage}
-              </option>
-            ))}
-          </select>
-          <span className="ml-auto text-xs">
-            {t("表示件数", "Visible")}: {data.filteredItems.length}
-          </span>
-        </div>
-        {data.filteredItems.length === 0 ? (
-          <p className="text-xs text-muted-foreground">
-            {t(
-              "監査対象が未読込です。request_id/decision_id・ハッシュ整合・リプレイ関連をここで確認できます。",
-              "No logs loaded yet. This timeline verifies request/decision IDs, hash chain, and replay linkage.",
-            )}
-          </p>
-        ) : null}
-
-        {/* Column header */}
-        {data.filteredItems.length > 0 && (
-          <div className="mb-1 grid grid-cols-2 gap-1 px-3 text-2xs font-semibold text-muted-foreground md:grid-cols-7">
-            <span>{t("重要度", "Severity")}</span>
-            <span>Stage</span>
-            <span>{t("タイムスタンプ", "Timestamp")}</span>
-            <span>request_id</span>
-            <span>decision_id</span>
-            <span>{t("チェーン", "Chain")}</span>
-            <span>Replay</span>
-          </div>
-        )}
-
-        <ol className="space-y-1">
-          {data.filteredItems.map((item, index) => {
-            const chain = classifyChain(
-              item,
-              data.filteredItems[index + 1] ?? null,
-            );
-            const isSelected = data.selected === item;
-            const timelineKey = [
-              item.request_id ?? "unknown",
-              String(item.decision_id ?? "no-decision"),
-              item.created_at ?? "no-timestamp",
-              item.sha256 ?? "no-sha",
-              item.sha256_prev ?? "no-prev-sha",
-            ].join("-");
-            return (
-              <li key={timelineKey}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    data.setSelected(item);
-                    data.setDetailTab("summary");
-                  }}
-                  className={`w-full rounded border px-3 py-2 text-left text-xs transition-colors ${
-                    isSelected
-                      ? "border-primary/50 bg-primary/5"
-                      : "border-border hover:bg-muted/30"
-                  }`}
-                >
-                  <div className="grid grid-cols-2 gap-1 md:grid-cols-7">
-                    <span className="font-medium">
-                      {getString(item, "severity")}
-                    </span>
-                    <span>{getString(item, "stage")}</span>
-                    <span className="font-mono text-2xs">
-                      {item.created_at ?? "-"}
-                    </span>
-                    <span className="truncate font-mono text-2xs">
-                      {item.request_id ?? "-"}
-                    </span>
-                    <span className="truncate font-mono text-2xs">
-                      {String(item.decision_id ?? "-")}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <span
-                        className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT[chain.status]}`}
-                      />
-                      <span className={STATUS_COLORS[chain.status]}>
-                        {chain.status}
-                      </span>
-                    </span>
-                    <span className="text-2xs">
-                      {typeof item.replay_id === "string" ? "linked" : "-"}
-                    </span>
-                  </div>
-                </button>
-              </li>
-            );
-          })}
-        </ol>
-      </Card>
-
-      {/* Selected Audit detail with tabs */}
+      {/* Detail */}
       <DetailPanel
         selected={data.selected}
         selectedChain={data.selectedChain}
@@ -451,266 +116,35 @@ export default function TrustLogExplorerPage(): JSX.Element {
         onDetailTabChange={data.setDetailTab}
       />
 
-      {/* Hash Chain Verification */}
-      <Card
-        title={t(
-          "TrustLog インタラクティブ検証",
-          "TrustLog Interactive Verification",
-        )}
-        titleSize="md"
-        variant="elevated"
-        accent="success"
-      >
-        <div className="space-y-3">
-          <div className="flex items-center gap-2">
-            <select
-              aria-label={t(
-                "検証対象の意思決定ID",
-                "Decision ID for verification",
-              )}
-              className="rounded border border-border px-2 py-1 text-xs"
-              value={data.selectedDecisionId}
-              onChange={(e) => data.setSelectedDecisionId(e.target.value)}
-            >
-              <option value="">
-                {t("意思決定IDを選択", "Select a decision ID")}
-              </option>
-              {data.decisionIds.map((id) => (
-                <option key={id} value={id}>
-                  {id}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              className="rounded border border-primary/40 bg-primary/10 px-3 py-1.5 text-xs"
-              onClick={verifySelectedDecision}
-            >
-              {t("ハッシュチェーン検証", "Verify hash chain")}
-            </button>
-          </div>
-          {data.verificationMessage ? (
-            <p className="text-xs">{data.verificationMessage}</p>
-          ) : null}
-          <div className="flex flex-wrap gap-2 text-2xs">
-            <span className="flex items-center gap-1">
-              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT.verified}`} />
-              verified
-            </span>
-            <span className="flex items-center gap-1">
-              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT.broken}`} />
-              broken
-            </span>
-            <span className="flex items-center gap-1">
-              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT.missing}`} />
-              missing
-            </span>
-            <span className="flex items-center gap-1">
-              <span className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT.orphan}`} />
-              orphan
-            </span>
-          </div>
-        </div>
-      </Card>
+      {/* Verification */}
+      <VerificationPanel
+        decisionIds={data.decisionIds}
+        selectedDecisionId={data.selectedDecisionId}
+        selectedDecisionEntry={data.selectedDecisionEntry}
+        verificationMessage={data.verificationMessage}
+        onSelectedDecisionIdChange={data.setSelectedDecisionId}
+        onVerify={verifySelectedDecision}
+      />
 
       {/* Export */}
-      <Card
-        title={t(
-          "第三者監査用エクスポート",
-          "Regulatory Report Generator",
-        )}
-        titleSize="md"
-        variant="elevated"
-        accent="warning"
-      >
-        <div className="space-y-4 text-sm">
-          {/* Period selection */}
-          <div>
-            <p className="mb-1 text-xs font-semibold">
-              {t("対象期間", "Export Period")}
-            </p>
-            <div className="grid gap-3 md:grid-cols-2">
-              <input
-                aria-label={t("監査レポート開始日", "Audit report start date")}
-                type="date"
-                value={data.reportStartDate}
-                onChange={(e) => data.setReportStartDate(e.target.value)}
-                className="rounded border border-border px-3 py-2"
-              />
-              <input
-                aria-label={t("監査レポート終了日", "Audit report end date")}
-                type="date"
-                value={data.reportEndDate}
-                onChange={(e) => data.setReportEndDate(e.target.value)}
-                className="rounded border border-border px-3 py-2"
-              />
-            </div>
-            {data.reportStartDate && data.reportEndDate && (
-              <p className="mt-1 text-xs text-muted-foreground">
-                {t("エクスポート対象", "Export target")}: {data.exportTargetCount}{" "}
-                {t("件", "entries")}
-              </p>
-            )}
-          </div>
-
-          {/* Redaction mode */}
-          <fieldset className="space-y-1">
-            <legend className="text-xs font-semibold">
-              {t("墨消しモード", "Redaction Mode")}
-            </legend>
-            <div className="flex gap-3 text-xs">
-              {(
-                [
-                  {
-                    value: "full" as const,
-                    label: t("完全出力", "Full"),
-                    desc: t(
-                      "すべてのフィールドを含む",
-                      "Includes all fields",
-                    ),
-                  },
-                  {
-                    value: "redacted" as const,
-                    label: t("墨消し", "Redacted"),
-                    desc: t(
-                      "PII関連フィールドを除外",
-                      "PII fields removed",
-                    ),
-                  },
-                  {
-                    value: "metadata-only" as const,
-                    label: t("メタデータのみ", "Metadata only"),
-                    desc: t(
-                      "監査メタデータのみ",
-                      "Audit metadata only",
-                    ),
-                  },
-                ] as const
-              ).map((opt) => (
-                <label key={opt.value} className="flex items-start gap-1.5">
-                  <input
-                    aria-label={opt.label}
-                    type="radio"
-                    name="redaction"
-                    value={opt.value}
-                    checked={data.redactionMode === opt.value}
-                    onChange={() => data.setRedactionMode(opt.value)}
-                    className="mt-0.5"
-                  />
-                  <span>
-                    <span className="font-medium">{opt.label}</span>
-                    <br />
-                    <span className="text-xs text-muted-foreground">
-                      {opt.desc}
-                    </span>
-                  </span>
-                </label>
-              ))}
-            </div>
-          </fieldset>
-
-          {/* Format selection */}
-          <fieldset className="space-y-1">
-            <legend className="text-xs font-semibold">
-              {t("出力形式", "Export Format")}
-            </legend>
-            <div className="flex gap-4 text-xs">
-              <label className="flex items-start gap-1.5">
-                <input
-                  aria-label="JSON"
-                  type="radio"
-                  name="exportFormat"
-                  value="json"
-                  checked={data.exportFormat === "json"}
-                  onChange={() => data.setExportFormat("json")}
-                  className="mt-0.5"
-                />
-                <span>
-                  <span className="font-medium">JSON</span>
-                  <br />
-                  <span className="text-xs text-muted-foreground">
-                    {t(
-                      "機械可読形式。APIやスクリプトでの処理に最適",
-                      "Machine-readable. Best for API and script processing",
-                    )}
-                  </span>
-                </span>
-              </label>
-              <label className="flex items-start gap-1.5">
-                <input
-                  aria-label="PDF"
-                  type="radio"
-                  name="exportFormat"
-                  value="pdf"
-                  checked={data.exportFormat === "pdf"}
-                  onChange={() => data.setExportFormat("pdf")}
-                  className="mt-0.5"
-                />
-                <span>
-                  <span className="font-medium">PDF</span>
-                  <br />
-                  <span className="text-xs text-muted-foreground">
-                    {t(
-                      "印刷用。第三者監査提出に適した形式",
-                      "Printable. Suitable for third-party audit submission",
-                    )}
-                  </span>
-                </span>
-              </label>
-            </div>
-          </fieldset>
-
-          {/* PII acknowledgement */}
-          <div className="rounded border border-warning/30 bg-warning/5 p-3">
-            <label className="flex items-start gap-2 text-xs">
-              <input
-                aria-label={t("PII/metadata warningの確認", "Acknowledge PII/metadata warning")}
-                type="checkbox"
-                checked={data.confirmPiiRisk}
-                onChange={(e) => data.setConfirmPiiRisk(e.target.checked)}
-                className="mt-0.5"
-              />
-              <span>
-                {t(
-                  "PII/metadata warning を理解し、社内ポリシーに従って取り扱います。",
-                  "I acknowledge PII/metadata warning and will handle exports under policy.",
-                )}
-              </span>
-            </label>
-            <p className="mt-2 text-2xs text-warning">
-              {t(
-                "セキュリティ警告: エクスポートにはPII（個人識別情報）や監査メタデータが含まれる可能性があります。社内の情報セキュリティポリシーに従い、安全に取り扱ってください。",
-                "Security warning: Exports may include PII (personally identifiable information) and audit metadata. Handle according to your organization's information security policy.",
-              )}
-            </p>
-          </div>
-
-          {/* Export button */}
-          <button
-            type="button"
-            className="rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm"
-            onClick={handleExport}
-          >
-            {data.exportFormat === "json"
-              ? t("JSON生成", "Generate JSON")
-              : t("PDF生成", "Generate PDF")}
-          </button>
-
-          {data.reportError ? (
-            <p className="text-xs text-warning">{data.reportError}</p>
-          ) : null}
-          {data.latestReport ? (
-            <div className="rounded border border-border p-2 text-xs">
-              <p>
-                entries: {data.latestReport.totalEntries} / verified:{" "}
-                {data.latestReport.verified} / broken: {data.latestReport.broken} /
-                missing: {data.latestReport.missing} / orphan:{" "}
-                {data.latestReport.orphan} / mismatches: {data.latestReport.mismatchLinks}
-              </p>
-            </div>
-          ) : null}
-        </div>
-      </Card>
+      <ExportPanel
+        sortedItems={data.sortedItems}
+        reportStartDate={data.reportStartDate}
+        reportEndDate={data.reportEndDate}
+        redactionMode={data.redactionMode}
+        exportFormat={data.exportFormat}
+        confirmPiiRisk={data.confirmPiiRisk}
+        reportError={data.reportError}
+        latestReport={data.latestReport}
+        exportTargetCount={data.exportTargetCount}
+        onReportStartDateChange={data.setReportStartDate}
+        onReportEndDateChange={data.setReportEndDate}
+        onRedactionModeChange={data.setRedactionMode}
+        onExportFormatChange={data.setExportFormat}
+        onConfirmPiiRiskChange={data.setConfirmPiiRisk}
+        onReportError={data.setReportError}
+        onLatestReport={data.setLatestReport}
+      />
     </div>
   );
 }

--- a/frontend/app/governance/components/ApplyFlow.tsx
+++ b/frontend/app/governance/components/ApplyFlow.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import type { ApprovalStatus, PolicyActionMode } from "../governance-types";
+
+interface ApplyFlowProps {
+  hasChanges: boolean;
+  saving: boolean;
+  canApply: boolean;
+  canOperate: boolean;
+  draftApprovalStatus: ApprovalStatus;
+  onApply: (mode: PolicyActionMode) => void;
+  onRollback: () => void;
+}
+
+export function ApplyFlow({ hasChanges, saving, canApply, canOperate, draftApprovalStatus, onApply, onRollback }: ApplyFlowProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <Card title="Apply Flow" titleSize="md" variant="elevated">
+      <div className="flex flex-wrap gap-2">
+        <button type="button" className="rounded border px-3 py-2 text-sm" onClick={() => onApply("apply")} disabled={!hasChanges || saving || !canApply}>{t("適用", "apply")}</button>
+        <button type="button" className="rounded border px-3 py-2 text-sm" onClick={() => onApply("dry-run")} disabled={!hasChanges || saving || !canOperate}>{t("ドライラン", "dry-run")}</button>
+        <button type="button" className="rounded border px-3 py-2 text-sm" onClick={() => onApply("shadow")} disabled={saving || !canOperate}>{t("シャドウモード", "shadow mode")}</button>
+        <button type="button" className="rounded border px-3 py-2 text-sm" onClick={onRollback} disabled={saving || !hasChanges || !canApply}>{t("ロールバック", "rollback")}</button>
+      </div>
+      {!canApply ? <p className="mt-2 text-xs text-warning">{t("RBAC: apply/rollback は admin のみ実行可能です。", "RBAC: apply/rollback requires admin role.")}</p> : null}
+      {hasChanges && draftApprovalStatus !== "approved" ? <p className="mt-2 text-xs text-info">{t("apply するには先に承認が必要です。dry-run / shadow は承認前でも実行できます。", "Approval is required before apply. dry-run / shadow can be executed before approval.")}</p> : null}
+    </Card>
+  );
+}

--- a/frontend/app/governance/components/ApprovalWorkflow.tsx
+++ b/frontend/app/governance/components/ApprovalWorkflow.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import { StatusBadge } from "../../../components/ui";
+import type { ApprovalStatus } from "../governance-types";
+import { APPROVAL_STATUS_ACCENT } from "../constants";
+
+interface ApprovalWorkflowProps {
+  draftApprovalStatus: ApprovalStatus;
+  changeCount: number;
+  canApprove: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+export function ApprovalWorkflow({ draftApprovalStatus, changeCount, canApprove, onApprove, onReject }: ApprovalWorkflowProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <Card title="Approval Workflow" titleSize="md" variant="elevated" accent="warning">
+      <div className="flex items-center gap-3 mb-3">
+        <StatusBadge label={draftApprovalStatus} variant={APPROVAL_STATUS_ACCENT[draftApprovalStatus]} />
+        <span className="text-xs text-muted-foreground">{t(`${changeCount} 件の変更が承認待ちです`, `${changeCount} change(s) awaiting approval`)}</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button type="button" className="rounded border border-success/60 bg-success/10 px-3 py-2 text-sm text-success" onClick={onApprove} disabled={!canApprove || draftApprovalStatus === "approved"}>approve</button>
+        <button type="button" className="rounded border border-danger/60 bg-danger/10 px-3 py-2 text-sm text-danger" onClick={onReject} disabled={!canApprove || draftApprovalStatus === "rejected"}>reject</button>
+      </div>
+      {!canApprove ? <p className="mt-2 text-xs text-warning">{t("RBAC: approve/reject は admin のみ実行可能です。", "RBAC: approve/reject requires admin role.")}</p> : null}
+    </Card>
+  );
+}

--- a/frontend/app/governance/components/ChangeHistory.tsx
+++ b/frontend/app/governance/components/ChangeHistory.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import type { HistoryEntry } from "../governance-types";
+
+interface ChangeHistoryProps {
+  entries: HistoryEntry[];
+}
+
+const ACTION_STYLE: Record<string, string> = {
+  apply: "bg-success/20 text-success",
+  rollback: "bg-warning/20 text-warning",
+  approve: "bg-success/20 text-success",
+  reject: "bg-danger/20 text-danger",
+};
+
+export function ChangeHistory({ entries }: ChangeHistoryProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <Card title="Change History" titleSize="md" variant="elevated">
+      <ul className="space-y-1 text-xs">
+        {entries.length === 0 ? (
+          <li className="text-muted-foreground">{t("ポリシー操作後に変更履歴が表示されます。", "Change history will appear after policy operations.")}</li>
+        ) : entries.map((entry) => (
+          <li key={entry.id} className="rounded border px-2 py-1">
+            <span className={`inline-flex items-center rounded px-1 py-0.5 text-[10px] font-semibold mr-1 ${ACTION_STYLE[entry.action] ?? "bg-muted text-muted-foreground"}`}>{entry.action}</span>
+            <span className="text-muted-foreground">{entry.actor}</span> / {entry.summary} / <span className="font-mono">{entry.at}</span>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/frontend/app/governance/components/DiffPreview.tsx
+++ b/frontend/app/governance/components/DiffPreview.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useI18n } from "../../../components/i18n-provider";
+import type { DiffChange, GovernancePolicyUI } from "../governance-types";
+import { DIFF_CATEGORY_LABELS } from "../constants";
+import { collectChanges } from "../helpers";
+
+interface DiffPreviewProps {
+  before: GovernancePolicyUI | null;
+  after: GovernancePolicyUI | null;
+}
+
+export function DiffPreview({ before, after }: DiffPreviewProps): JSX.Element {
+  const { t } = useI18n();
+  const rows = before && after
+    ? collectChanges(
+      "",
+      before as unknown as Record<string, unknown>,
+      after as unknown as Record<string, unknown>,
+    )
+    : [];
+  if (rows.length === 0) return <p className="text-xs text-muted-foreground">{t("変更はありません。", "No changes.")}</p>;
+
+  const grouped = rows.reduce<Record<string, DiffChange[]>>((acc, row) => {
+    const cat = row.category;
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push(row);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">{t(`${rows.length} 件の変更を検出`, `${rows.length} change(s) detected`)}</p>
+      {(Object.keys(grouped) as DiffChange["category"][]).map((cat) => (
+        <div key={cat}>
+          <p className="mb-1 text-xs font-semibold text-muted-foreground">{DIFF_CATEGORY_LABELS[cat]}</p>
+          <div className="space-y-1">
+            {grouped[cat].map((row) => (
+              <div key={row.path} className="rounded-md border px-3 py-1 text-xs">
+                <p className="font-semibold">{row.path}</p>
+                <div className="flex gap-2">
+                  <span className="text-red-400 line-through">{row.old}</span>
+                  <span className="text-green-400">{row.next}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/governance/components/FujiRulesEditor.tsx
+++ b/frontend/app/governance/components/FujiRulesEditor.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import type { FujiRules } from "@veritas/types";
+import { useI18n } from "../../../components/i18n-provider";
+import type { GovernancePolicyUI } from "../governance-types";
+import { FUJI_LABELS } from "../constants";
+import { ToggleRow } from "./ToggleRow";
+
+interface FujiRulesEditorProps {
+  draft: GovernancePolicyUI;
+  isViewer: boolean;
+  onUpdate: (updater: (prev: GovernancePolicyUI) => GovernancePolicyUI) => void;
+}
+
+export function FujiRulesEditor({ draft, isViewer, onUpdate }: FujiRulesEditorProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <Card title="FUJI rules / thresholds / escalation" titleSize="md" variant="elevated">
+      <div className="grid gap-2 md:grid-cols-2">
+        {(Object.keys(FUJI_LABELS) as (keyof FujiRules)[]).map((key) => (
+          <ToggleRow key={key} label={FUJI_LABELS[key]} checked={draft.fuji_rules[key]} disabled={isViewer} onChange={(v) => onUpdate((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, [key]: v } }))} />
+        ))}
+      </div>
+
+      <div className="mt-4">
+        <p className="text-xs font-semibold mb-2">Risk Thresholds</p>
+        <div className="grid gap-2 md:grid-cols-2">
+          {(["allow_upper", "warn_upper", "human_review_upper", "deny_upper"] as const).map((field) => (
+            <label key={field} className="text-xs">
+              {field}{" "}
+              <span className="font-mono text-muted-foreground">({draft.risk_thresholds[field].toFixed(2)})</span>
+              <input
+                aria-label={field}
+                aria-valuetext={`${(draft.risk_thresholds[field] * 100).toFixed(0)}%`}
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={draft.risk_thresholds[field]}
+                disabled={isViewer}
+                onChange={(e) => onUpdate((prev) => ({ ...prev, risk_thresholds: { ...prev.risk_thresholds, [field]: Number(e.target.value) } }))}
+                className="w-full"
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <p className="text-xs font-semibold mb-2">Auto-Stop / Escalation</p>
+        <div className="grid gap-2 md:grid-cols-2">
+          <ToggleRow label="Auto-Stop Enabled" checked={draft.auto_stop.enabled} disabled={isViewer} onChange={(v) => onUpdate((prev) => ({ ...prev, auto_stop: { ...prev.auto_stop, enabled: v } }))} />
+          <label className="text-xs">
+            max_risk_score{" "}
+            <span className="font-mono text-muted-foreground">({draft.auto_stop.max_risk_score.toFixed(2)})</span>
+            <input
+              aria-label="max_risk_score"
+              aria-valuetext={`${(draft.auto_stop.max_risk_score * 100).toFixed(0)}%`}
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={draft.auto_stop.max_risk_score}
+              disabled={isViewer}
+              onChange={(e) => onUpdate((prev) => ({ ...prev, auto_stop: { ...prev.auto_stop, max_risk_score: Number(e.target.value) } }))}
+              className="w-full"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <p className="text-xs font-semibold mb-2">Log Retention / Audit</p>
+        <div className="grid gap-2 md:grid-cols-2">
+          <label className="text-xs">
+            retention_days{" "}
+            <span className="font-mono text-muted-foreground">({draft.log_retention.retention_days})</span>
+            <input
+              aria-label="retention_days"
+              aria-valuetext={`${draft.log_retention.retention_days} ${t("日", "days")}`}
+              type="range"
+              min={1}
+              max={365}
+              step={1}
+              value={draft.log_retention.retention_days}
+              disabled={isViewer}
+              onChange={(e) => onUpdate((prev) => ({ ...prev, log_retention: { ...prev.log_retention, retention_days: Number(e.target.value) } }))}
+              className="w-full"
+            />
+          </label>
+          <ToggleRow label="Redact Before Log" checked={draft.log_retention.redact_before_log} disabled={isViewer} onChange={(v) => onUpdate((prev) => ({ ...prev, log_retention: { ...prev.log_retention, redact_before_log: v } }))} />
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/app/governance/components/PolicyMetaPanel.tsx
+++ b/frontend/app/governance/components/PolicyMetaPanel.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import { StatusBadge } from "../../../components/ui";
+import type { ApprovalStatus, GovernancePolicyUI } from "../governance-types";
+import { APPROVAL_STATUS_ACCENT } from "../constants";
+
+interface PolicyMetaPanelProps {
+  savedPolicy: GovernancePolicyUI | null;
+  draft: GovernancePolicyUI;
+  draftApprovalStatus: ApprovalStatus;
+  hasChanges: boolean;
+  changeCount: number;
+}
+
+export function PolicyMetaPanel({ savedPolicy, draft, draftApprovalStatus, hasChanges, changeCount }: PolicyMetaPanelProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <Card title="Policy Meta" titleSize="md" variant="elevated" accent={APPROVAL_STATUS_ACCENT[draftApprovalStatus]}>
+      <div className="grid gap-3 text-xs md:grid-cols-2 lg:grid-cols-3">
+        <div className="rounded-lg border px-3 py-2">
+          <p className="text-muted-foreground">Current Version</p>
+          <p className="font-mono font-semibold">{savedPolicy?.version ?? "N/A"}</p>
+        </div>
+        <div className="rounded-lg border px-3 py-2">
+          <p className="text-muted-foreground">Draft Version</p>
+          <p className="font-mono font-semibold">{draft.draft_version ?? "N/A"}</p>
+        </div>
+        <div className="rounded-lg border px-3 py-2">
+          <p className="text-muted-foreground">Approval Status</p>
+          <StatusBadge label={draftApprovalStatus} variant={APPROVAL_STATUS_ACCENT[draftApprovalStatus]} />
+        </div>
+        <div className="rounded-lg border px-3 py-2">
+          <p className="text-muted-foreground">updated_by</p>
+          <p className="font-mono font-semibold">{draft.updated_by}</p>
+        </div>
+        <div className="rounded-lg border px-3 py-2">
+          <p className="text-muted-foreground">effective_at</p>
+          <p className="font-mono font-semibold">{draft.effective_at ?? "N/A"}</p>
+        </div>
+        <div className="rounded-lg border px-3 py-2">
+          <p className="text-muted-foreground">last_applied</p>
+          <p className="font-mono font-semibold">{draft.last_applied ?? "N/A"}</p>
+        </div>
+      </div>
+      {hasChanges ? (
+        <p className="mt-2 text-xs text-warning">{t(`${changeCount} 件の未適用変更があります。適用前に承認してください。`, `${changeCount} unapplied change(s). Approve before applying.`)}</p>
+      ) : null}
+    </Card>
+  );
+}

--- a/frontend/app/governance/components/RiskImpactGauge.tsx
+++ b/frontend/app/governance/components/RiskImpactGauge.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+const RISK_BAND_BG: Record<string, string> = {
+  danger: "bg-danger",
+  warning: "bg-warning",
+  success: "bg-success",
+};
+
+const RISK_BAND_TEXT: Record<string, string> = {
+  danger: "text-danger",
+  warning: "text-warning",
+  success: "text-success",
+};
+
+function riskBand(value: number): string {
+  if (value > 75) return "danger";
+  if (value > 50) return "warning";
+  return "success";
+}
+
+interface RiskImpactGaugeProps {
+  current: number;
+  pending: number;
+  drift: number;
+}
+
+export function RiskImpactGauge({ current, pending, drift }: RiskImpactGaugeProps): JSX.Element {
+  const band = riskBand(current);
+  const pendingBand = riskBand(pending);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-3">
+        <span className="text-xs font-semibold w-28">Current Policy</span>
+        <div className="flex-1 rounded-full bg-muted h-2.5 overflow-hidden">
+          <div className={`h-full rounded-full transition-all ${RISK_BAND_BG[band]}`} style={{ width: `${current}%` }} />
+        </div>
+        <span className={`text-xs font-mono font-semibold ${RISK_BAND_TEXT[band]}`}>{current}%</span>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="text-xs font-semibold w-28">Pending Impact</span>
+        <div className="flex-1 rounded-full bg-muted h-2.5 overflow-hidden">
+          <div className={`h-full rounded-full transition-all ${RISK_BAND_BG[pendingBand]}`} style={{ width: `${pending}%` }} />
+        </div>
+        <span className={`text-xs font-mono font-semibold ${RISK_BAND_TEXT[pendingBand]}`}>{pending}%</span>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="text-xs font-semibold w-28">Recent Drift</span>
+        <span className={`text-xs font-mono font-semibold ${drift > 5 ? "text-warning" : "text-success"}`}>
+          {drift > 0 ? `+${drift}%` : `${drift}%`} from baseline
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/governance/components/ToggleRow.tsx
+++ b/frontend/app/governance/components/ToggleRow.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+interface ToggleRowProps {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+}
+
+export function ToggleRow({ label, checked, onChange, disabled }: ToggleRowProps): JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border px-3.5 py-2.5 text-sm">
+      <span>{label}</span>
+      <button
+        type="button"
+        role="switch"
+        aria-label={label}
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={["relative inline-flex h-5 w-10 items-center rounded-full transition-colors", checked ? "bg-primary" : "bg-muted", disabled ? "opacity-50 cursor-not-allowed" : ""].join(" ")}
+      >
+        <span className={["inline-block h-4 w-4 rounded-full bg-white transition-transform", checked ? "translate-x-5" : "translate-x-0.5"].join(" ")} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/governance/components/TrustLogStream.tsx
+++ b/frontend/app/governance/components/TrustLogStream.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Card } from "@veritas/design-system";
+import { useI18n } from "../../../components/i18n-provider";
+import type { TrustLogEntry } from "../governance-types";
+
+interface TrustLogStreamProps {
+  entries: TrustLogEntry[];
+}
+
+const SEVERITY_STYLE: Record<TrustLogEntry["severity"], string> = {
+  warning: "bg-warning/20 text-warning",
+  policy: "bg-info/20 text-info",
+  info: "bg-muted text-muted-foreground",
+};
+
+export function TrustLogStream({ entries }: TrustLogStreamProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <Card title="TrustLog Stream" titleSize="md" variant="elevated">
+      <ul className="space-y-1 text-xs">
+        {entries.length === 0 ? (
+          <li className="text-muted-foreground">{t("ポリシー読み込み後にストリームイベントが表示されます。", "Stream events will appear after loading a policy.")}</li>
+        ) : entries.map((entry) => (
+          <li key={entry.id} className={`rounded border px-2 py-1 ${entry.severity === "policy" ? "border-info/40 bg-info/5" : ""}`}>
+            <span className="font-mono">{entry.at}</span>{" "}
+            <span className={`inline-flex items-center rounded px-1 py-0.5 text-[10px] font-semibold ${SEVERITY_STYLE[entry.severity]}`}>{entry.severity}</span>{" "}
+            {entry.message}
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/frontend/app/governance/constants.ts
+++ b/frontend/app/governance/constants.ts
@@ -1,0 +1,72 @@
+import type { FujiRules } from "@veritas/types";
+import type { ApprovalStatus, DiffChange, GovernanceMode, UserRole } from "./governance-types";
+
+export const FUJI_LABELS: Record<keyof FujiRules, string> = {
+  pii_check: "PII Check",
+  self_harm_block: "Self-Harm Block",
+  illicit_block: "Illicit Block",
+  violence_review: "Violence Review",
+  minors_review: "Minors Review",
+  keyword_hard_block: "Keyword Hard Block",
+  keyword_soft_flag: "Keyword Soft Flag",
+  llm_safety_head: "LLM Safety Head",
+};
+
+export const MODE_EXPLANATIONS: Record<GovernanceMode, { summary: string; details: string[]; affects: string[] }> = {
+  standard: {
+    summary: "通常運用モード",
+    details: [
+      "通常運用: 既存しきい値とエスカレーションを使用します。",
+      "FUJIルール違反時は既存フローのままレビューへ。",
+    ],
+    affects: [
+      "risk_thresholds: デフォルト値を使用",
+      "audit_level: standard",
+      "human_review: しきい値超過時のみ",
+      "escalation: 通常ルート",
+    ],
+  },
+  eu_ai_act: {
+    summary: "EU AI Act 準拠モード",
+    details: [
+      "EU AI Act mode: explainability と audit retention を優先します。",
+      "高リスク判定時に人間レビュー経路を強制し、監査ログ粒度を上げます。",
+    ],
+    affects: [
+      "risk_thresholds: 低め(厳格)に自動調整",
+      "audit_level: full → 全フィールド記録",
+      "human_review: 高リスク判定で強制",
+      "escalation: Art.14(4) 停止権限を付与",
+    ],
+  },
+};
+
+export const ROLE_CAPABILITIES: Record<UserRole, { label: string; permissions: string[] }> = {
+  viewer: {
+    label: "Viewer（閲覧専用）",
+    permissions: ["ポリシー閲覧", "Diff プレビュー", "TrustLog 閲覧", "変更履歴の参照"],
+  },
+  operator: {
+    label: "Operator（運用）",
+    permissions: ["ポリシー閲覧", "dry-run 実行", "shadow validation", "承認リクエスト送信"],
+  },
+  admin: {
+    label: "Admin（管理者）",
+    permissions: ["全操作権限", "ポリシー適用", "ロールバック", "承認 / 却下", "モード変更"],
+  },
+};
+
+export const DIFF_CATEGORY_LABELS: Record<DiffChange["category"], string> = {
+  rule: "ルール変更",
+  threshold: "しきい値変更",
+  escalation: "エスカレーション変更",
+  retention: "監査ログ変更",
+  meta: "メタ情報変更",
+};
+
+export const APPROVAL_STATUS_ACCENT: Record<ApprovalStatus, "success" | "warning" | "danger" | "info"> = {
+  approved: "success",
+  pending: "warning",
+  rejected: "danger",
+  draft: "info",
+};

--- a/frontend/app/governance/governance-types.ts
+++ b/frontend/app/governance/governance-types.ts
@@ -1,0 +1,36 @@
+import type { GovernancePolicy } from "@veritas/types";
+
+export type UserRole = "viewer" | "operator" | "admin";
+export type PolicyActionMode = "apply" | "dry-run" | "shadow";
+export type GovernanceMode = "standard" | "eu_ai_act";
+export type ApprovalStatus = "approved" | "pending" | "rejected" | "draft";
+
+/** UI-specific extension of the API GovernancePolicy with local workflow fields. */
+export interface GovernancePolicyUI extends GovernancePolicy {
+  draft_version?: string;
+  effective_at?: string;
+  last_applied?: string;
+  approval_status: ApprovalStatus;
+}
+
+export interface DiffChange {
+  path: string;
+  old: string;
+  next: string;
+  category: "rule" | "threshold" | "escalation" | "retention" | "meta";
+}
+
+export interface HistoryEntry {
+  id: string;
+  action: string;
+  actor: UserRole;
+  at: string;
+  summary: string;
+}
+
+export interface TrustLogEntry {
+  id: string;
+  at: string;
+  message: string;
+  severity: "info" | "warning" | "policy";
+}

--- a/frontend/app/governance/helpers.ts
+++ b/frontend/app/governance/helpers.ts
@@ -1,0 +1,48 @@
+import type { DiffChange } from "./governance-types";
+
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
+  }
+
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  return keysA.length === keysB.length && keysA.every((key) => deepEqual(objA[key], objB[key]));
+}
+
+function categorizePath(path: string): DiffChange["category"] {
+  if (path.startsWith("fuji_rules")) return "rule";
+  if (path.startsWith("risk_thresholds")) return "threshold";
+  if (path.startsWith("auto_stop")) return "escalation";
+  if (path.startsWith("log_retention")) return "retention";
+  return "meta";
+}
+
+export function collectChanges(prefix: string, a: Record<string, unknown>, b: Record<string, unknown>): DiffChange[] {
+  const changes: DiffChange[] = [];
+  for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+    const av = a[key];
+    const bv = b[key];
+    if (deepEqual(av, bv)) continue;
+    if (typeof av === "object" && av !== null && typeof bv === "object" && bv !== null) {
+      changes.push(...collectChanges(`${prefix}.${key}`, av as Record<string, unknown>, bv as Record<string, unknown>));
+      continue;
+    }
+    const fullPath = `${prefix}.${key}`.replace(/^\./, "");
+    changes.push({ path: fullPath, old: JSON.stringify(av), next: JSON.stringify(bv), category: categorizePath(fullPath) });
+  }
+  return changes;
+}
+
+export function bumpDraftVersion(version: string): string {
+  const match = version.match(/^(.+\.)(\d+)$/);
+  if (!match) return `${version}-draft.1`;
+  return `${match[1]}${Number(match[2]) + 1}-draft`;
+}

--- a/frontend/app/governance/hooks/useGovernanceState.ts
+++ b/frontend/app/governance/hooks/useGovernanceState.ts
@@ -1,0 +1,218 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useI18n } from "../../../components/i18n-provider";
+import { veritasFetch } from "../../../lib/api-client";
+import { validateGovernancePolicyResponse } from "../../../lib/api-validators";
+import type {
+  ApprovalStatus,
+  GovernancePolicyUI,
+  GovernanceMode,
+  HistoryEntry,
+  PolicyActionMode,
+  TrustLogEntry,
+  UserRole,
+} from "../governance-types";
+import { bumpDraftVersion, collectChanges, deepEqual } from "../helpers";
+
+export function useGovernanceState() {
+  const { t } = useI18n();
+  const [savedPolicy, setSavedPolicy] = useState<GovernancePolicyUI | null>(null);
+  const [draft, setDraft] = useState<GovernancePolicyUI | null>(null);
+  const [selectedRole, setSelectedRole] = useState<UserRole>("admin");
+  const [governanceMode, setGovernanceMode] = useState<GovernanceMode>("standard");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [trustLog, setTrustLog] = useState<TrustLogEntry[]>([]);
+
+  const hasChanges = useMemo(() => savedPolicy !== null && draft !== null && !deepEqual(savedPolicy, draft), [savedPolicy, draft]);
+  const canApply = selectedRole === "admin";
+  const canOperate = selectedRole === "admin" || selectedRole === "operator";
+  const canApprove = selectedRole === "admin";
+
+  const changeCount = useMemo(() => {
+    if (!savedPolicy || !draft) return 0;
+    return collectChanges("", savedPolicy as unknown as Record<string, unknown>, draft as unknown as Record<string, unknown>).length;
+  }, [savedPolicy, draft]);
+
+  const appendLog = useCallback((message: string, severity: "info" | "warning" | "policy" = "info") => {
+    setTrustLog((prev) => [{ id: crypto.randomUUID(), at: new Date().toISOString(), message, severity }, ...prev].slice(0, 12));
+  }, []);
+
+  const appendHistory = useCallback((action: string, summary: string) => {
+    setHistory((prev) => [
+      { id: crypto.randomUUID(), action, actor: selectedRole, at: new Date().toISOString(), summary },
+      ...prev,
+    ].slice(0, 20));
+  }, [selectedRole]);
+
+  const updateDraft = useCallback((updater: (prev: GovernancePolicyUI) => GovernancePolicyUI) => {
+    setDraft((prev) => {
+      if (!prev) return prev;
+      const next = updater(prev);
+      return { ...next, approval_status: "pending" as ApprovalStatus };
+    });
+  }, []);
+
+  const fetchPolicy = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await veritasFetch("/api/veritas/v1/governance/policy");
+      if (!res.ok) {
+        setError(t(`HTTP ${res.status}: ポリシー取得に失敗しました。`, `HTTP ${res.status}: Failed to fetch policy.`));
+        return;
+      }
+      const validation = validateGovernancePolicyResponse(await res.json());
+      if (!validation.ok) {
+        setError(t("レスポンスの検証に失敗しました。フォーマット不整合の可能性があります。", "Response validation failed. Possible format mismatch."));
+        return;
+      }
+      const normalized = {
+        ...validation.data.policy,
+        effective_at: validation.data.policy.updated_at,
+        last_applied: validation.data.policy.updated_at,
+        approval_status: "approved" as ApprovalStatus,
+        draft_version: bumpDraftVersion(validation.data.policy.version),
+      } as GovernancePolicyUI;
+      setSavedPolicy(normalized);
+      setDraft(structuredClone(normalized));
+      appendHistory("load", `version ${normalized.version} loaded`);
+      appendLog(`policy version ${normalized.version} loaded`, "policy");
+    } catch {
+      setError(t("ネットワークエラー: バックエンドへ接続できません。", "Network error: cannot connect to backend."));
+    } finally {
+      setLoading(false);
+    }
+  }, [appendHistory, appendLog, t]);
+
+  const applyPolicy = useCallback(async (mode: PolicyActionMode) => {
+    if (!draft) return;
+    if (!window.confirm(t(`${mode} を実行します。変更を確定しますか？`, `Execute ${mode}. Confirm changes?`))) return;
+
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    if (mode === "dry-run") {
+      appendHistory("dry-run", "no persistent write");
+      appendLog("dry-run completed without apply", "info");
+      setSuccess(t("Dry-run を完了しました。適用はされていません。", "Dry-run completed. No changes applied."));
+      setSaving(false);
+      return;
+    }
+
+    if (mode === "shadow") {
+      appendHistory("shadow", "shadow validation stream enabled");
+      appendLog("shadow mode enabled; outputs are validated only", "warning");
+      setSuccess(t("Shadow mode を有効化しました。判定のみ実施します。", "Shadow mode enabled. Validation only."));
+      setSaving(false);
+      return;
+    }
+
+    try {
+      const res = await veritasFetch("/api/veritas/v1/governance/policy", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(draft),
+      });
+      if (!res.ok) {
+        setError(t(`HTTP ${res.status}: ポリシー更新に失敗しました。`, `HTTP ${res.status}: Failed to update policy.`));
+        return;
+      }
+      const validation = validateGovernancePolicyResponse(await res.json());
+      if (!validation.ok) {
+        setError(t("適用レスポンスの検証に失敗しました。TrustLog を確認してください。", "Apply response validation failed. Check TrustLog."));
+        return;
+      }
+      const nextPolicy = {
+        ...validation.data.policy,
+        effective_at: new Date().toISOString(),
+        last_applied: new Date().toISOString(),
+        approval_status: "approved" as ApprovalStatus,
+        draft_version: bumpDraftVersion(validation.data.policy.version),
+      } as GovernancePolicyUI;
+      setSavedPolicy(nextPolicy);
+      setDraft(structuredClone(nextPolicy));
+      appendHistory("apply", `version ${nextPolicy.version} applied`);
+      appendLog(`applied version ${nextPolicy.version}`, "policy");
+      setSuccess(t("ポリシーを適用しました。", "Policy applied successfully."));
+    } catch {
+      setError(t("適用処理に失敗しました。通信・権限・整合性を確認してください。", "Apply failed. Check connectivity, permissions, and consistency."));
+    } finally {
+      setSaving(false);
+    }
+  }, [appendHistory, appendLog, draft, t]);
+
+  const rollback = useCallback(() => {
+    if (!savedPolicy) return;
+    if (!window.confirm(t("現在の適用済みポリシーへロールバックしますか？", "Rollback to the currently applied policy?"))) return;
+    setDraft(structuredClone(savedPolicy));
+    appendHistory("rollback", `rolled back to version ${savedPolicy.version}`);
+    appendLog(`rollback preview to ${savedPolicy.version}`, "warning");
+    setSuccess(t("ドラフトを適用済みポリシーへ戻しました。", "Draft reverted to the applied policy."));
+  }, [appendHistory, appendLog, savedPolicy, t]);
+
+  const approveChanges = useCallback(() => {
+    if (!draft || !hasChanges) return;
+    if (!window.confirm(t("ドラフト変更を承認しますか？", "Approve draft changes?"))) return;
+    setDraft((prev) => prev ? { ...prev, approval_status: "approved" } : prev);
+    appendHistory("approve", `draft changes approved by ${selectedRole}`);
+    appendLog(`draft approved by ${selectedRole}`, "policy");
+    setSuccess(t("ドラフトを承認しました。apply で本番適用できます。", "Draft approved. Apply to push to production."));
+  }, [draft, hasChanges, appendHistory, appendLog, selectedRole, t]);
+
+  const rejectChanges = useCallback(() => {
+    if (!draft || !hasChanges) return;
+    if (!window.confirm(t("ドラフト変更を却下しますか？", "Reject draft changes?"))) return;
+    setDraft((prev) => prev ? { ...prev, approval_status: "rejected" } : prev);
+    appendHistory("reject", `draft changes rejected by ${selectedRole}`);
+    appendLog(`draft rejected by ${selectedRole}`, "warning");
+    setSuccess(t("ドラフトを却下しました。", "Draft rejected."));
+  }, [draft, hasChanges, appendHistory, appendLog, selectedRole, t]);
+
+  const currentRisk = savedPolicy ? Math.round(((savedPolicy.risk_thresholds.deny_upper + savedPolicy.auto_stop.max_risk_score) / 2) * 100) : 0;
+  const pendingRisk = draft ? Math.round(((draft.risk_thresholds.deny_upper + draft.auto_stop.max_risk_score) / 2) * 100) : 0;
+  const riskGauge = draft ? pendingRisk : currentRisk;
+  const riskDrift = pendingRisk - currentRisk;
+
+  const draftApprovalStatus: ApprovalStatus = useMemo(() => {
+    if (!draft) return "draft";
+    if (!hasChanges) return draft.approval_status;
+    return "pending";
+  }, [draft, hasChanges]);
+
+  return {
+    savedPolicy,
+    draft,
+    selectedRole,
+    setSelectedRole,
+    governanceMode,
+    setGovernanceMode,
+    loading,
+    saving,
+    error,
+    success,
+    history,
+    trustLog,
+    hasChanges,
+    canApply,
+    canOperate,
+    canApprove,
+    changeCount,
+    updateDraft,
+    fetchPolicy,
+    applyPolicy,
+    rollback,
+    approveChanges,
+    rejectChanges,
+    currentRisk,
+    pendingRisk,
+    riskGauge,
+    riskDrift,
+    draftApprovalStatus,
+  };
+}

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -1,290 +1,20 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
 import { Card } from "@veritas/design-system";
-import type { AutoStop, FujiRules, GovernancePolicy, LogRetention, RiskThresholds } from "@veritas/types";
 import { useI18n } from "../../components/i18n-provider";
-import { veritasFetch } from "../../lib/api-client";
-import { validateGovernancePolicyResponse } from "../../lib/api-validators";
+import { EmptyState, ErrorBanner, SuccessBanner } from "../../components/ui";
 import { EUAIActGovernanceDashboard } from "../../features/console/components/eu-ai-act-governance-dashboard";
-
-/* ------------------------------------------------------------------ */
-/*  Types                                                              */
-/* ------------------------------------------------------------------ */
-
-type UserRole = "viewer" | "operator" | "admin";
-type PolicyActionMode = "apply" | "dry-run" | "shadow";
-type GovernanceMode = "standard" | "eu_ai_act";
-type ApprovalStatus = "approved" | "pending" | "rejected" | "draft";
-
-/** UI-specific extension of the API GovernancePolicy with local workflow fields. */
-interface GovernancePolicyUI extends GovernancePolicy {
-  draft_version?: string;
-  effective_at?: string;
-  last_applied?: string;
-  approval_status: ApprovalStatus;
-}
-
-interface DiffChange {
-  path: string;
-  old: string;
-  next: string;
-  category: "rule" | "threshold" | "escalation" | "retention" | "meta";
-}
-
-interface HistoryEntry {
-  id: string;
-  action: string;
-  actor: UserRole;
-  at: string;
-  summary: string;
-}
-
-interface TrustLogEntry {
-  id: string;
-  at: string;
-  message: string;
-  severity: "info" | "warning" | "policy";
-}
-
-/* ------------------------------------------------------------------ */
-/*  Constants                                                          */
-/* ------------------------------------------------------------------ */
-
-const FUJI_LABELS: Record<keyof FujiRules, string> = {
-  pii_check: "PII Check",
-  self_harm_block: "Self-Harm Block",
-  illicit_block: "Illicit Block",
-  violence_review: "Violence Review",
-  minors_review: "Minors Review",
-  keyword_hard_block: "Keyword Hard Block",
-  keyword_soft_flag: "Keyword Soft Flag",
-  llm_safety_head: "LLM Safety Head",
-};
-
-const MODE_EXPLANATIONS: Record<GovernanceMode, { summary: string; details: string[]; affects: string[] }> = {
-  standard: {
-    summary: "通常運用モード",
-    details: [
-      "通常運用: 既存しきい値とエスカレーションを使用します。",
-      "FUJIルール違反時は既存フローのままレビューへ。",
-    ],
-    affects: [
-      "risk_thresholds: デフォルト値を使用",
-      "audit_level: standard",
-      "human_review: しきい値超過時のみ",
-      "escalation: 通常ルート",
-    ],
-  },
-  eu_ai_act: {
-    summary: "EU AI Act 準拠モード",
-    details: [
-      "EU AI Act mode: explainability と audit retention を優先します。",
-      "高リスク判定時に人間レビュー経路を強制し、監査ログ粒度を上げます。",
-    ],
-    affects: [
-      "risk_thresholds: 低め(厳格)に自動調整",
-      "audit_level: full → 全フィールド記録",
-      "human_review: 高リスク判定で強制",
-      "escalation: Art.14(4) 停止権限を付与",
-    ],
-  },
-};
-
-const ROLE_CAPABILITIES: Record<UserRole, { label: string; permissions: string[] }> = {
-  viewer: {
-    label: "Viewer（閲覧専用）",
-    permissions: ["ポリシー閲覧", "Diff プレビュー", "TrustLog 閲覧", "変更履歴の参照"],
-  },
-  operator: {
-    label: "Operator（運用）",
-    permissions: ["ポリシー閲覧", "dry-run 実行", "shadow validation", "承認リクエスト送信"],
-  },
-  admin: {
-    label: "Admin（管理者）",
-    permissions: ["全操作権限", "ポリシー適用", "ロールバック", "承認 / 却下", "モード変更"],
-  },
-};
-
-const DIFF_CATEGORY_LABELS: Record<DiffChange["category"], string> = {
-  rule: "ルール変更",
-  threshold: "しきい値変更",
-  escalation: "エスカレーション変更",
-  retention: "監査ログ変更",
-  meta: "メタ情報変更",
-};
-
-/* ------------------------------------------------------------------ */
-/*  Pure helpers                                                       */
-/* ------------------------------------------------------------------ */
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== typeof b || a === null || b === null) return false;
-  if (typeof a !== "object") return false;
-  if (Array.isArray(a) !== Array.isArray(b)) return false;
-
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
-  }
-
-  const objA = a as Record<string, unknown>;
-  const objB = b as Record<string, unknown>;
-  const keysA = Object.keys(objA);
-  const keysB = Object.keys(objB);
-  return keysA.length === keysB.length && keysA.every((key) => deepEqual(objA[key], objB[key]));
-}
-
-function categorizePath(path: string): DiffChange["category"] {
-  if (path.startsWith("fuji_rules")) return "rule";
-  if (path.startsWith("risk_thresholds")) return "threshold";
-  if (path.startsWith("auto_stop")) return "escalation";
-  if (path.startsWith("log_retention")) return "retention";
-  return "meta";
-}
-
-function collectChanges(prefix: string, a: Record<string, unknown>, b: Record<string, unknown>): DiffChange[] {
-  const changes: DiffChange[] = [];
-  for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
-    const av = a[key];
-    const bv = b[key];
-    if (deepEqual(av, bv)) continue;
-    if (typeof av === "object" && av !== null && typeof bv === "object" && bv !== null) {
-      changes.push(...collectChanges(`${prefix}.${key}`, av as Record<string, unknown>, bv as Record<string, unknown>));
-      continue;
-    }
-    const fullPath = `${prefix}.${key}`.replace(/^\./, "");
-    changes.push({ path: fullPath, old: JSON.stringify(av), next: JSON.stringify(bv), category: categorizePath(fullPath) });
-  }
-  return changes;
-}
-
-function bumpDraftVersion(version: string): string {
-  const match = version.match(/^(.+\.)(\d+)$/);
-  if (!match) return `${version}-draft.1`;
-  return `${match[1]}${Number(match[2]) + 1}-draft`;
-}
-
-/* ------------------------------------------------------------------ */
-/*  Sub-components                                                     */
-/* ------------------------------------------------------------------ */
-
-function StatusBadge({ status }: { status: ApprovalStatus }): JSX.Element {
-  const styles: Record<ApprovalStatus, string> = {
-    approved: "bg-success/20 text-success border-success/40",
-    pending: "bg-warning/20 text-warning border-warning/40",
-    rejected: "bg-danger/20 text-danger border-danger/40",
-    draft: "bg-info/20 text-info border-info/40",
-  };
-  return <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${styles[status]}`}>{status}</span>;
-}
-
-function ToggleRow({ label, checked, onChange, disabled }: { label: string; checked: boolean; onChange: (v: boolean) => void; disabled?: boolean }): JSX.Element {
-  return (
-    <div className="flex items-center justify-between gap-3 rounded-lg border px-3.5 py-2.5 text-sm">
-      <span>{label}</span>
-      <button
-        type="button"
-        role="switch"
-        aria-label={label}
-        aria-checked={checked}
-        disabled={disabled}
-        onClick={() => onChange(!checked)}
-        className={["relative inline-flex h-5 w-10 items-center rounded-full transition-colors", checked ? "bg-primary" : "bg-muted", disabled ? "opacity-50 cursor-not-allowed" : ""].join(" ")}
-      >
-        <span className={["inline-block h-4 w-4 rounded-full bg-white transition-transform", checked ? "translate-x-5" : "translate-x-0.5"].join(" ")} />
-      </button>
-    </div>
-  );
-}
-
-function DiffPreview({ before, after }: { before: GovernancePolicyUI | null; after: GovernancePolicyUI | null }): JSX.Element {
-  const { t } = useI18n();
-  const rows = before && after
-    ? collectChanges(
-      "",
-      before as unknown as Record<string, unknown>,
-      after as unknown as Record<string, unknown>,
-    )
-    : [];
-  if (rows.length === 0) return <p className="text-xs text-muted-foreground">{t("変更はありません。", "No changes.")}</p>;
-
-  const grouped = rows.reduce<Record<string, DiffChange[]>>((acc, row) => {
-    const cat = row.category;
-    if (!acc[cat]) acc[cat] = [];
-    acc[cat].push(row);
-    return acc;
-  }, {});
-
-  return (
-    <div className="space-y-3">
-      <p className="text-xs text-muted-foreground">{t(`${rows.length} 件の変更を検出`, `${rows.length} change(s) detected`)}</p>
-      {(Object.keys(grouped) as DiffChange["category"][]).map((cat) => (
-        <div key={cat}>
-          <p className="mb-1 text-xs font-semibold text-muted-foreground">{DIFF_CATEGORY_LABELS[cat]}</p>
-          <div className="space-y-1">
-            {grouped[cat].map((row) => (
-              <div key={row.path} className="rounded-md border px-3 py-1 text-xs">
-                <p className="font-semibold">{row.path}</p>
-                <div className="flex gap-2">
-                  <span className="text-red-400 line-through">{row.old}</span>
-                  <span className="text-green-400">{row.next}</span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-const RISK_BAND_BG: Record<string, string> = {
-  danger: "bg-danger",
-  warning: "bg-warning",
-  success: "bg-success",
-};
-
-const RISK_BAND_TEXT: Record<string, string> = {
-  danger: "text-danger",
-  warning: "text-warning",
-  success: "text-success",
-};
-
-function riskBand(value: number): string {
-  if (value > 75) return "danger";
-  if (value > 50) return "warning";
-  return "success";
-}
-
-function RiskImpactGauge({ current, pending, drift }: { current: number; pending: number; drift: number }): JSX.Element {
-  const band = riskBand(current);
-  const pendingBand = riskBand(pending);
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-3">
-        <span className="text-xs font-semibold w-28">Current Policy</span>
-        <div className="flex-1 rounded-full bg-muted h-2.5 overflow-hidden">
-          <div className={`h-full rounded-full transition-all ${RISK_BAND_BG[band]}`} style={{ width: `${current}%` }} />
-        </div>
-        <span className={`text-xs font-mono font-semibold ${RISK_BAND_TEXT[band]}`}>{current}%</span>
-      </div>
-      <div className="flex items-center gap-3">
-        <span className="text-xs font-semibold w-28">Pending Impact</span>
-        <div className="flex-1 rounded-full bg-muted h-2.5 overflow-hidden">
-          <div className={`h-full rounded-full transition-all ${RISK_BAND_BG[pendingBand]}`} style={{ width: `${pending}%` }} />
-        </div>
-        <span className={`text-xs font-mono font-semibold ${RISK_BAND_TEXT[pendingBand]}`}>{pending}%</span>
-      </div>
-      <div className="flex items-center gap-3">
-        <span className="text-xs font-semibold w-28">Recent Drift</span>
-        <span className={`text-xs font-mono font-semibold ${drift > 5 ? "text-warning" : "text-success"}`}>
-          {drift > 0 ? `+${drift}%` : `${drift}%`} from baseline
-        </span>
-      </div>
-    </div>
-  );
-}
+import type { GovernanceMode, UserRole } from "./governance-types";
+import { MODE_EXPLANATIONS, ROLE_CAPABILITIES } from "./constants";
+import { useGovernanceState } from "./hooks/useGovernanceState";
+import { PolicyMetaPanel } from "./components/PolicyMetaPanel";
+import { FujiRulesEditor } from "./components/FujiRulesEditor";
+import { DiffPreview } from "./components/DiffPreview";
+import { RiskImpactGauge } from "./components/RiskImpactGauge";
+import { ApprovalWorkflow } from "./components/ApprovalWorkflow";
+import { ApplyFlow } from "./components/ApplyFlow";
+import { TrustLogStream } from "./components/TrustLogStream";
+import { ChangeHistory } from "./components/ChangeHistory";
 
 /* ------------------------------------------------------------------ */
 /*  Main page component                                                */
@@ -292,201 +22,66 @@ function RiskImpactGauge({ current, pending, drift }: { current: number; pending
 
 export default function GovernanceControlPage(): JSX.Element {
   const { t } = useI18n();
-  const [savedPolicy, setSavedPolicy] = useState<GovernancePolicyUI | null>(null);
-  const [draft, setDraft] = useState<GovernancePolicyUI | null>(null);
-  const [selectedRole, setSelectedRole] = useState<UserRole>("admin");
-  const [governanceMode, setGovernanceMode] = useState<GovernanceMode>("standard");
-  const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
-  const [history, setHistory] = useState<HistoryEntry[]>([]);
-  const [trustLog, setTrustLog] = useState<TrustLogEntry[]>([]);
-
-  const hasChanges = useMemo(() => savedPolicy !== null && draft !== null && !deepEqual(savedPolicy, draft), [savedPolicy, draft]);
-  const canApply = selectedRole === "admin";
-  const canOperate = selectedRole === "admin" || selectedRole === "operator";
-  const canApprove = selectedRole === "admin";
-
-  const changeCount = useMemo(() => {
-    if (!savedPolicy || !draft) return 0;
-    return collectChanges("", savedPolicy as unknown as Record<string, unknown>, draft as unknown as Record<string, unknown>).length;
-  }, [savedPolicy, draft]);
-
-  const appendLog = useCallback((message: string, severity: "info" | "warning" | "policy" = "info") => {
-    setTrustLog((prev) => [{ id: crypto.randomUUID(), at: new Date().toISOString(), message, severity }, ...prev].slice(0, 12));
-  }, []);
-
-  const appendHistory = useCallback((action: string, summary: string) => {
-    setHistory((prev) => [
-      { id: crypto.randomUUID(), action, actor: selectedRole, at: new Date().toISOString(), summary },
-      ...prev,
-    ].slice(0, 20));
-  }, [selectedRole]);
-
-  const updateDraft = useCallback((updater: (prev: GovernancePolicyUI) => GovernancePolicyUI) => {
-    setDraft((prev) => {
-      if (!prev) return prev;
-      const next = updater(prev);
-      return { ...next, approval_status: "pending" as ApprovalStatus };
-    });
-  }, []);
-
-  const fetchPolicy = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await veritasFetch("/api/veritas/v1/governance/policy");
-      if (!res.ok) {
-        setError(t(`HTTP ${res.status}: ポリシー取得に失敗しました。`, `HTTP ${res.status}: Failed to fetch policy.`));
-        return;
-      }
-      const validation = validateGovernancePolicyResponse(await res.json());
-      if (!validation.ok) {
-        setError(t("レスポンスの検証に失敗しました。フォーマット不整合の可能性があります。", "Response validation failed. Possible format mismatch."));
-        return;
-      }
-      const normalized = {
-        ...validation.data.policy,
-        effective_at: validation.data.policy.updated_at,
-        last_applied: validation.data.policy.updated_at,
-        approval_status: "approved" as ApprovalStatus,
-        draft_version: bumpDraftVersion(validation.data.policy.version),
-      } as GovernancePolicyUI;
-      setSavedPolicy(normalized);
-      setDraft(structuredClone(normalized));
-      appendHistory("load", `version ${normalized.version} loaded`);
-      appendLog(`policy version ${normalized.version} loaded`, "policy");
-    } catch {
-      setError(t("ネットワークエラー: バックエンドへ接続できません。", "Network error: cannot connect to backend."));
-    } finally {
-      setLoading(false);
-    }
-  }, [appendHistory, appendLog, t]);
-
-  const applyPolicy = useCallback(async (mode: PolicyActionMode) => {
-    if (!draft) return;
-    if (!window.confirm(t(`${mode} を実行します。変更を確定しますか？`, `Execute ${mode}. Confirm changes?`))) return;
-
-    setSaving(true);
-    setError(null);
-    setSuccess(null);
-
-    if (mode === "dry-run") {
-      appendHistory("dry-run", "no persistent write");
-      appendLog("dry-run completed without apply", "info");
-      setSuccess(t("Dry-run を完了しました。適用はされていません。", "Dry-run completed. No changes applied."));
-      setSaving(false);
-      return;
-    }
-
-    if (mode === "shadow") {
-      appendHistory("shadow", "shadow validation stream enabled");
-      appendLog("shadow mode enabled; outputs are validated only", "warning");
-      setSuccess(t("Shadow mode を有効化しました。判定のみ実施します。", "Shadow mode enabled. Validation only."));
-      setSaving(false);
-      return;
-    }
-
-    try {
-      const res = await veritasFetch("/api/veritas/v1/governance/policy", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(draft),
-      });
-      if (!res.ok) {
-        setError(t(`HTTP ${res.status}: ポリシー更新に失敗しました。`, `HTTP ${res.status}: Failed to update policy.`));
-        return;
-      }
-      const validation = validateGovernancePolicyResponse(await res.json());
-      if (!validation.ok) {
-        setError(t("適用レスポンスの検証に失敗しました。TrustLog を確認してください。", "Apply response validation failed. Check TrustLog."));
-        return;
-      }
-      const nextPolicy = {
-        ...validation.data.policy,
-        effective_at: new Date().toISOString(),
-        last_applied: new Date().toISOString(),
-        approval_status: "approved" as ApprovalStatus,
-        draft_version: bumpDraftVersion(validation.data.policy.version),
-      } as GovernancePolicyUI;
-      setSavedPolicy(nextPolicy);
-      setDraft(structuredClone(nextPolicy));
-      appendHistory("apply", `version ${nextPolicy.version} applied`);
-      appendLog(`applied version ${nextPolicy.version}`, "policy");
-      setSuccess(t("ポリシーを適用しました。", "Policy applied successfully."));
-    } catch {
-      setError(t("適用処理に失敗しました。通信・権限・整合性を確認してください。", "Apply failed. Check connectivity, permissions, and consistency."));
-    } finally {
-      setSaving(false);
-    }
-  }, [appendHistory, appendLog, draft, t]);
-
-  const rollback = useCallback(() => {
-    if (!savedPolicy) return;
-    if (!window.confirm(t("現在の適用済みポリシーへロールバックしますか？", "Rollback to the currently applied policy?"))) return;
-    setDraft(structuredClone(savedPolicy));
-    appendHistory("rollback", `rolled back to version ${savedPolicy.version}`);
-    appendLog(`rollback preview to ${savedPolicy.version}`, "warning");
-    setSuccess(t("ドラフトを適用済みポリシーへ戻しました。", "Draft reverted to the applied policy."));
-  }, [appendHistory, appendLog, savedPolicy, t]);
-
-  const approveChanges = useCallback(() => {
-    if (!draft || !hasChanges) return;
-    if (!window.confirm(t("ドラフト変更を承認しますか？", "Approve draft changes?"))) return;
-    setDraft((prev) => prev ? { ...prev, approval_status: "approved" } : prev);
-    appendHistory("approve", `draft changes approved by ${selectedRole}`);
-    appendLog(`draft approved by ${selectedRole}`, "policy");
-    setSuccess(t("ドラフトを承認しました。apply で本番適用できます。", "Draft approved. Apply to push to production."));
-  }, [draft, hasChanges, appendHistory, appendLog, selectedRole, t]);
-
-  const rejectChanges = useCallback(() => {
-    if (!draft || !hasChanges) return;
-    if (!window.confirm(t("ドラフト変更を却下しますか？", "Reject draft changes?"))) return;
-    setDraft((prev) => prev ? { ...prev, approval_status: "rejected" } : prev);
-    appendHistory("reject", `draft changes rejected by ${selectedRole}`);
-    appendLog(`draft rejected by ${selectedRole}`, "warning");
-    setSuccess(t("ドラフトを却下しました。", "Draft rejected."));
-  }, [draft, hasChanges, appendHistory, appendLog, selectedRole, t]);
-
-  const currentRisk = savedPolicy ? Math.round(((savedPolicy.risk_thresholds.deny_upper + savedPolicy.auto_stop.max_risk_score) / 2) * 100) : 0;
-  const pendingRisk = draft ? Math.round(((draft.risk_thresholds.deny_upper + draft.auto_stop.max_risk_score) / 2) * 100) : 0;
-  const riskGauge = draft ? pendingRisk : currentRisk;
-  const riskDrift = pendingRisk - currentRisk;
-
-  const draftApprovalStatus: ApprovalStatus = useMemo(() => {
-    if (!draft) return "draft";
-    if (!hasChanges) return draft.approval_status;
-    return "pending";
-  }, [draft, hasChanges]);
+  const state = useGovernanceState();
 
   return (
     <div className="space-y-6">
       {/* ── Header: Governance Control Plane ── */}
-      <Card title="Governance Control" description={t("Rule control / versioning / diff / approval / rollback / shadow validation を統合管理します。", "Integrated management of rule control, versioning, diff, approval, rollback, and shadow validation.")} titleSize="lg" variant="glass" accent="primary" className="border-primary/15">
+      <Card
+        title="Governance Control"
+        description={t(
+          "Rule control / versioning / diff / approval / rollback / shadow validation を統合管理します。",
+          "Integrated management of rule control, versioning, diff, approval, rollback, and shadow validation.",
+        )}
+        titleSize="lg"
+        variant="glass"
+        accent="primary"
+        className="border-primary/15"
+      >
         <div className="grid gap-3 md:grid-cols-4">
-          <label className="text-xs">Role
-            <select aria-label="role" value={selectedRole} onChange={(e) => setSelectedRole(e.target.value as UserRole)} className="mt-1 w-full rounded border px-2 py-1">
+          <label className="text-xs">
+            Role
+            <select
+              aria-label="role"
+              value={state.selectedRole}
+              onChange={(e) => state.setSelectedRole(e.target.value as UserRole)}
+              className="mt-1 w-full rounded border px-2 py-1"
+            >
               <option value="viewer">viewer</option>
               <option value="operator">operator</option>
               <option value="admin">admin</option>
             </select>
           </label>
-          <label className="text-xs">Mode
-            <select aria-label="mode" value={governanceMode} onChange={(e) => setGovernanceMode(e.target.value as GovernanceMode)} className="mt-1 w-full rounded border px-2 py-1">
+          <label className="text-xs">
+            Mode
+            <select
+              aria-label="mode"
+              value={state.governanceMode}
+              onChange={(e) => state.setGovernanceMode(e.target.value as GovernanceMode)}
+              className="mt-1 w-full rounded border px-2 py-1"
+            >
               <option value="standard">Standard</option>
               <option value="eu_ai_act">EU AI Act</option>
             </select>
           </label>
-          <button type="button" onClick={() => void fetchPolicy()} className="rounded border px-3 py-2 text-sm" disabled={loading}>{loading ? t("読み込み中...", "Loading...") : t("ポリシーを読み込む", "Load policy")}</button>
-          <div className="rounded border px-3 py-2 text-xs">Risk gauge: <span className="font-mono">{riskGauge}%</span></div>
+          <button
+            type="button"
+            onClick={() => void state.fetchPolicy()}
+            className="rounded border px-3 py-2 text-sm"
+            disabled={state.loading}
+          >
+            {state.loading ? t("読み込み中...", "Loading...") : t("ポリシーを読み込む", "Load policy")}
+          </button>
+          <div className="rounded border px-3 py-2 text-xs">
+            Risk gauge: <span className="font-mono">{state.riskGauge}%</span>
+          </div>
         </div>
 
         {/* ── Role capability matrix ── */}
         <div className="mt-3 rounded-lg border bg-surface/50 px-3 py-2">
-          <p className="text-xs font-semibold mb-1">{ROLE_CAPABILITIES[selectedRole].label}</p>
+          <p className="text-xs font-semibold mb-1">{ROLE_CAPABILITIES[state.selectedRole].label}</p>
           <div className="flex flex-wrap gap-1.5">
-            {ROLE_CAPABILITIES[selectedRole].permissions.map((perm) => (
+            {ROLE_CAPABILITIES[state.selectedRole].permissions.map((perm) => (
               <span key={perm} className="inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] text-muted-foreground">{perm}</span>
             ))}
           </div>
@@ -494,12 +89,12 @@ export default function GovernanceControlPage(): JSX.Element {
 
         {/* ── Mode explanation ── */}
         <div className="mt-3 rounded-lg border bg-surface/50 px-3 py-2">
-          <p className="text-xs font-semibold mb-1">{MODE_EXPLANATIONS[governanceMode].summary}</p>
+          <p className="text-xs font-semibold mb-1">{MODE_EXPLANATIONS[state.governanceMode].summary}</p>
           <ul className="list-disc pl-5 text-xs text-muted-foreground">
-            {MODE_EXPLANATIONS[governanceMode].details.map((entry) => <li key={entry}>{entry}</li>)}
+            {MODE_EXPLANATIONS[state.governanceMode].details.map((entry) => <li key={entry}>{entry}</li>)}
           </ul>
           <div className="mt-2 grid gap-1 md:grid-cols-2">
-            {MODE_EXPLANATIONS[governanceMode].affects.map((effect) => (
+            {MODE_EXPLANATIONS[state.governanceMode].affects.map((effect) => (
               <span key={effect} className="rounded border px-2 py-0.5 text-[10px] font-mono text-muted-foreground">{effect}</span>
             ))}
           </div>
@@ -508,161 +103,73 @@ export default function GovernanceControlPage(): JSX.Element {
 
       <EUAIActGovernanceDashboard />
 
-      {error ? <div role="alert" className="rounded border border-danger/40 px-3 py-2 text-sm text-danger">{error}</div> : null}
-      {success ? <div role="status" className="rounded border border-success/40 px-3 py-2 text-sm text-success">{success}</div> : null}
+      {state.error ? <ErrorBanner message={state.error} /> : null}
+      {state.success ? <SuccessBanner message={state.success} /> : null}
 
       {/* ── Empty state when no policy is loaded ── */}
-      {!draft ? (
+      {!state.draft ? (
         <Card title="Policy Status" titleSize="md" variant="elevated">
-          <div className="flex flex-col items-center gap-3 py-8 text-center">
-            <div className="rounded-full border-2 border-dashed border-muted p-4">
+          <EmptyState
+            title={t("ポリシー未読み込み", "No policy loaded")}
+            description={t(
+              "「ポリシーを読み込む」ボタンでバックエンドから現在の統制ポリシーを取得してください。",
+              "Click \"Load policy\" to fetch the current governance policy from the backend.",
+            )}
+            icon={
               <svg className="h-8 w-8 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
               </svg>
-            </div>
-            <div>
-              <p className="text-sm font-semibold">{t("ポリシー未読み込み", "No policy loaded")}</p>
-              <p className="text-xs text-muted-foreground mt-1">{t("「ポリシーを読み込む」ボタンでバックエンドから現在の統制ポリシーを取得してください。", "Click \"Load policy\" to fetch the current governance policy from the backend.")}</p>
-            </div>
-          </div>
+            }
+          />
         </Card>
       ) : null}
 
-      {draft ? (
+      {state.draft ? (
         <>
-          {/* ── Policy Header with approval status ── */}
-          <Card title="Policy Meta" titleSize="md" variant="elevated" accent={draftApprovalStatus === "approved" ? "success" : draftApprovalStatus === "pending" ? "warning" : draftApprovalStatus === "rejected" ? "danger" : "info"}>
-            <div className="grid gap-3 text-xs md:grid-cols-2 lg:grid-cols-3">
-              <div className="rounded-lg border px-3 py-2">
-                <p className="text-muted-foreground">Current Version</p>
-                <p className="font-mono font-semibold">{savedPolicy?.version ?? "N/A"}</p>
-              </div>
-              <div className="rounded-lg border px-3 py-2">
-                <p className="text-muted-foreground">Draft Version</p>
-                <p className="font-mono font-semibold">{draft.draft_version ?? "N/A"}</p>
-              </div>
-              <div className="rounded-lg border px-3 py-2">
-                <p className="text-muted-foreground">Approval Status</p>
-                <StatusBadge status={draftApprovalStatus} />
-              </div>
-              <div className="rounded-lg border px-3 py-2">
-                <p className="text-muted-foreground">updated_by</p>
-                <p className="font-mono font-semibold">{draft.updated_by}</p>
-              </div>
-              <div className="rounded-lg border px-3 py-2">
-                <p className="text-muted-foreground">effective_at</p>
-                <p className="font-mono font-semibold">{draft.effective_at ?? "N/A"}</p>
-              </div>
-              <div className="rounded-lg border px-3 py-2">
-                <p className="text-muted-foreground">last_applied</p>
-                <p className="font-mono font-semibold">{draft.last_applied ?? "N/A"}</p>
-              </div>
-            </div>
-            {hasChanges ? (
-              <p className="mt-2 text-xs text-warning">{t(`${changeCount} 件の未適用変更があります。適用前に承認してください。`, `${changeCount} unapplied change(s). Approve before applying.`)}</p>
-            ) : null}
+          <PolicyMetaPanel
+            savedPolicy={state.savedPolicy}
+            draft={state.draft}
+            draftApprovalStatus={state.draftApprovalStatus}
+            hasChanges={state.hasChanges}
+            changeCount={state.changeCount}
+          />
+
+          <FujiRulesEditor
+            draft={state.draft}
+            isViewer={state.selectedRole === "viewer"}
+            onUpdate={state.updateDraft}
+          />
+
+          <Card title="Current vs Draft Diff" titleSize="md" variant="elevated">
+            <DiffPreview before={state.savedPolicy} after={state.draft} />
           </Card>
 
-          {/* ── FUJI rules / thresholds / escalation ── */}
-          <Card title="FUJI rules / thresholds / escalation" titleSize="md" variant="elevated">
-            <div className="grid gap-2 md:grid-cols-2">
-              {(Object.keys(FUJI_LABELS) as (keyof FujiRules)[]).map((key) => (
-                <ToggleRow key={key} label={FUJI_LABELS[key]} checked={draft.fuji_rules[key]} disabled={selectedRole === "viewer"} onChange={(v) => updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, [key]: v } }))} />
-              ))}
-            </div>
-
-            <div className="mt-4">
-              <p className="text-xs font-semibold mb-2">Risk Thresholds</p>
-              <div className="grid gap-2 md:grid-cols-2">
-                <label className="text-xs">allow_upper <span className="font-mono text-muted-foreground">({draft.risk_thresholds.allow_upper.toFixed(2)})</span><input aria-label="allow_upper" aria-valuetext={`${(draft.risk_thresholds.allow_upper * 100).toFixed(0)}%`} type="range" min={0} max={1} step={0.05} value={draft.risk_thresholds.allow_upper} disabled={selectedRole === "viewer"} onChange={(e) => updateDraft((prev) => ({ ...prev, risk_thresholds: { ...prev.risk_thresholds, allow_upper: Number(e.target.value) } }))} className="w-full" /></label>
-                <label className="text-xs">warn_upper <span className="font-mono text-muted-foreground">({draft.risk_thresholds.warn_upper.toFixed(2)})</span><input aria-label="warn_upper" aria-valuetext={`${(draft.risk_thresholds.warn_upper * 100).toFixed(0)}%`} type="range" min={0} max={1} step={0.05} value={draft.risk_thresholds.warn_upper} disabled={selectedRole === "viewer"} onChange={(e) => updateDraft((prev) => ({ ...prev, risk_thresholds: { ...prev.risk_thresholds, warn_upper: Number(e.target.value) } }))} className="w-full" /></label>
-                <label className="text-xs">human_review_upper <span className="font-mono text-muted-foreground">({draft.risk_thresholds.human_review_upper.toFixed(2)})</span><input aria-label="human_review_upper" aria-valuetext={`${(draft.risk_thresholds.human_review_upper * 100).toFixed(0)}%`} type="range" min={0} max={1} step={0.05} value={draft.risk_thresholds.human_review_upper} disabled={selectedRole === "viewer"} onChange={(e) => updateDraft((prev) => ({ ...prev, risk_thresholds: { ...prev.risk_thresholds, human_review_upper: Number(e.target.value) } }))} className="w-full" /></label>
-                <label className="text-xs">deny_upper <span className="font-mono text-muted-foreground">({draft.risk_thresholds.deny_upper.toFixed(2)})</span><input aria-label="deny_upper" aria-valuetext={`${(draft.risk_thresholds.deny_upper * 100).toFixed(0)}%`} type="range" min={0} max={1} step={0.05} value={draft.risk_thresholds.deny_upper} disabled={selectedRole === "viewer"} onChange={(e) => updateDraft((prev) => ({ ...prev, risk_thresholds: { ...prev.risk_thresholds, deny_upper: Number(e.target.value) } }))} className="w-full" /></label>
-              </div>
-            </div>
-
-            <div className="mt-4">
-              <p className="text-xs font-semibold mb-2">Auto-Stop / Escalation</p>
-              <div className="grid gap-2 md:grid-cols-2">
-                <ToggleRow label="Auto-Stop Enabled" checked={draft.auto_stop.enabled} disabled={selectedRole === "viewer"} onChange={(v) => updateDraft((prev) => ({ ...prev, auto_stop: { ...prev.auto_stop, enabled: v } }))} />
-                <label className="text-xs">max_risk_score <span className="font-mono text-muted-foreground">({draft.auto_stop.max_risk_score.toFixed(2)})</span><input aria-label="max_risk_score" aria-valuetext={`${(draft.auto_stop.max_risk_score * 100).toFixed(0)}%`} type="range" min={0} max={1} step={0.05} value={draft.auto_stop.max_risk_score} disabled={selectedRole === "viewer"} onChange={(e) => updateDraft((prev) => ({ ...prev, auto_stop: { ...prev.auto_stop, max_risk_score: Number(e.target.value) } }))} className="w-full" /></label>
-              </div>
-            </div>
-
-            <div className="mt-4">
-              <p className="text-xs font-semibold mb-2">Log Retention / Audit</p>
-              <div className="grid gap-2 md:grid-cols-2">
-                <label className="text-xs">retention_days <span className="font-mono text-muted-foreground">({draft.log_retention.retention_days})</span><input aria-label="retention_days" aria-valuetext={`${draft.log_retention.retention_days} ${t("日", "days")}`} type="range" min={1} max={365} step={1} value={draft.log_retention.retention_days} disabled={selectedRole === "viewer"} onChange={(e) => updateDraft((prev) => ({ ...prev, log_retention: { ...prev.log_retention, retention_days: Number(e.target.value) } }))} className="w-full" /></label>
-                <ToggleRow label="Redact Before Log" checked={draft.log_retention.redact_before_log} disabled={selectedRole === "viewer"} onChange={(v) => updateDraft((prev) => ({ ...prev, log_retention: { ...prev.log_retention, redact_before_log: v } }))} />
-              </div>
-            </div>
+          <Card title="Risk Impact Analysis" titleSize="md" variant="elevated" accent={state.riskDrift > 5 ? "warning" : state.riskDrift < -5 ? "success" : undefined}>
+            <RiskImpactGauge current={state.currentRisk} pending={state.pendingRisk} drift={state.riskDrift} />
           </Card>
 
-          {/* ── Current vs Draft Diff ── */}
-          <Card title="Current vs Draft Diff" titleSize="md" variant="elevated"><DiffPreview before={savedPolicy} after={draft} /></Card>
-
-          {/* ── Risk Impact ── */}
-          <Card title="Risk Impact Analysis" titleSize="md" variant="elevated" accent={riskDrift > 5 ? "warning" : riskDrift < -5 ? "success" : undefined}>
-            <RiskImpactGauge current={currentRisk} pending={pendingRisk} drift={riskDrift} />
-          </Card>
-
-          {/* ── Approval Workflow ── */}
-          {hasChanges ? (
-            <Card title="Approval Workflow" titleSize="md" variant="elevated" accent="warning">
-              <div className="flex items-center gap-3 mb-3">
-                <StatusBadge status={draftApprovalStatus} />
-                <span className="text-xs text-muted-foreground">{t(`${changeCount} 件の変更が承認待ちです`, `${changeCount} change(s) awaiting approval`)}</span>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <button type="button" className="rounded border border-success/60 bg-success/10 px-3 py-2 text-sm text-success" onClick={approveChanges} disabled={!canApprove || draftApprovalStatus === "approved"}>approve</button>
-                <button type="button" className="rounded border border-danger/60 bg-danger/10 px-3 py-2 text-sm text-danger" onClick={rejectChanges} disabled={!canApprove || draftApprovalStatus === "rejected"}>reject</button>
-              </div>
-              {!canApprove ? <p className="mt-2 text-xs text-warning">{t("RBAC: approve/reject は admin のみ実行可能です。", "RBAC: approve/reject requires admin role.")}</p> : null}
-            </Card>
+          {state.hasChanges ? (
+            <ApprovalWorkflow
+              draftApprovalStatus={state.draftApprovalStatus}
+              changeCount={state.changeCount}
+              canApprove={state.canApprove}
+              onApprove={state.approveChanges}
+              onReject={state.rejectChanges}
+            />
           ) : null}
 
-          {/* ── Apply Flow ── */}
-          <Card title="Apply Flow" titleSize="md" variant="elevated">
-            <div className="flex flex-wrap gap-2">
-              <button type="button" className="rounded border px-3 py-2 text-sm" onClick={() => void applyPolicy("apply")} disabled={!hasChanges || saving || !canApply}>{t("適用", "apply")}</button>
-              <button type="button" className="rounded border px-3 py-2 text-sm" onClick={() => void applyPolicy("dry-run")} disabled={!hasChanges || saving || !canOperate}>{t("ドライラン", "dry-run")}</button>
-              <button type="button" className="rounded border px-3 py-2 text-sm" onClick={() => void applyPolicy("shadow")} disabled={saving || !canOperate}>{t("シャドウモード", "shadow mode")}</button>
-              <button type="button" className="rounded border px-3 py-2 text-sm" onClick={rollback} disabled={saving || !hasChanges || !canApply}>{t("ロールバック", "rollback")}</button>
-            </div>
-            {!canApply ? <p className="mt-2 text-xs text-warning">{t("RBAC: apply/rollback は admin のみ実行可能です。", "RBAC: apply/rollback requires admin role.")}</p> : null}
-            {hasChanges && draftApprovalStatus !== "approved" ? <p className="mt-2 text-xs text-info">{t("apply するには先に承認が必要です。dry-run / shadow は承認前でも実行できます。", "Approval is required before apply. dry-run / shadow can be executed before approval.")}</p> : null}
-          </Card>
+          <ApplyFlow
+            hasChanges={state.hasChanges}
+            saving={state.saving}
+            canApply={state.canApply}
+            canOperate={state.canOperate}
+            draftApprovalStatus={state.draftApprovalStatus}
+            onApply={(mode) => void state.applyPolicy(mode)}
+            onRollback={state.rollback}
+          />
 
-          {/* ── TrustLog Stream ── */}
-          <Card title="TrustLog Stream" titleSize="md" variant="elevated">
-            <ul className="space-y-1 text-xs">
-              {trustLog.length === 0 ? <li className="text-muted-foreground">{t("ポリシー読み込み後にストリームイベントが表示されます。", "Stream events will appear after loading a policy.")}</li> : trustLog.map((entry) => (
-                <li key={entry.id} className={`rounded border px-2 py-1 ${entry.severity === "policy" ? "border-info/40 bg-info/5" : ""}`}>
-                  <span className="font-mono">{entry.at}</span>{" "}
-                  <span className={`inline-flex items-center rounded px-1 py-0.5 text-[10px] font-semibold ${entry.severity === "warning" ? "bg-warning/20 text-warning" : entry.severity === "policy" ? "bg-info/20 text-info" : "bg-muted text-muted-foreground"}`}>{entry.severity}</span>{" "}
-                  {entry.message}
-                </li>
-              ))}
-            </ul>
-          </Card>
-
-          {/* ── Change History ── */}
-          <Card title="Change History" titleSize="md" variant="elevated">
-            <ul className="space-y-1 text-xs">
-              {history.length === 0 ? <li className="text-muted-foreground">{t("ポリシー操作後に変更履歴が表示されます。", "Change history will appear after policy operations.")}</li> : history.map((entry) => (
-                <li key={entry.id} className="rounded border px-2 py-1">
-                  <span className={`inline-flex items-center rounded px-1 py-0.5 text-[10px] font-semibold mr-1 ${
-                    entry.action === "apply" ? "bg-success/20 text-success" :
-                    entry.action === "rollback" ? "bg-warning/20 text-warning" :
-                    entry.action === "approve" ? "bg-success/20 text-success" :
-                    entry.action === "reject" ? "bg-danger/20 text-danger" :
-                    "bg-muted text-muted-foreground"
-                  }`}>{entry.action}</span>
-                  <span className="text-muted-foreground">{entry.actor}</span> / {entry.summary} / <span className="font-mono">{entry.at}</span>
-                </li>
-              ))}
-            </ul>
-          </Card>
+          <TrustLogStream entries={state.trustLog} />
+          <ChangeHistory entries={state.history} />
         </>
       ) : null}
     </div>

--- a/frontend/app/risk/components/DrilldownPanel.tsx
+++ b/frontend/app/risk/components/DrilldownPanel.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import { useI18n } from "../../../components/i18n-provider";
+import type { FlaggedEntry } from "../risk-types";
+import { SEVERITY_CLASSES, STATUS_LABELS } from "../constants";
+
+interface DrilldownPanelProps {
+  entry: FlaggedEntry | null;
+}
+
+export function DrilldownPanel({ entry }: DrilldownPanelProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs" data-testid="drilldown-panel">
+      <p className="font-semibold">Drilldown panel</p>
+      {entry ? (
+        <div className="mt-2 grid gap-3 md:grid-cols-2">
+          <div className="space-y-2">
+            <div>
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Request ID / Seed</p>
+              <p className="font-mono text-[11px]">{entry.point.id}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <p className="text-[10px] font-semibold uppercase text-muted-foreground">Uncertainty</p>
+                <p className="font-mono font-semibold">{entry.point.uncertainty.toFixed(3)}</p>
+              </div>
+              <div>
+                <p className="text-[10px] font-semibold uppercase text-muted-foreground">Risk score</p>
+                <p className="font-mono font-semibold">{entry.point.risk.toFixed(3)}</p>
+              </div>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Severity / Status</p>
+              <div className="mt-0.5 flex items-center gap-2">
+                <span className={`rounded-full border px-1.5 py-0.5 text-[9px] font-semibold uppercase ${SEVERITY_CLASSES[entry.severity]}`}>
+                  {entry.severity}
+                </span>
+                <span className="rounded bg-muted/40 px-1 py-0.5 text-[9px]">{STATUS_LABELS[entry.status]}</span>
+              </div>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <div>
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Related policy hits</p>
+              {entry.relatedPolicyHits.length > 0 ? (
+                <ul className="mt-0.5 space-y-0.5">
+                  {entry.relatedPolicyHits.map((hit) => (
+                    <li key={hit} className="rounded bg-warning/10 px-1.5 py-0.5 text-[10px]">⚡ {hit}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-muted-foreground">No policy hits</p>
+              )}
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Stage anomalies</p>
+              {entry.stageAnomalies.length > 0 ? (
+                <ul className="mt-0.5 space-y-0.5">
+                  {entry.stageAnomalies.map((anomaly) => (
+                    <li key={anomaly} className="rounded bg-danger/10 px-1.5 py-0.5 text-[10px]">⚠ {anomaly}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-muted-foreground">No anomalies detected</p>
+              )}
+            </div>
+          </div>
+          <div className="md:col-span-2 flex flex-wrap gap-1 border-t border-border/30 pt-2">
+            <Link href={`/console?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
+              <span aria-hidden>⚡</span> Open in Decision
+            </Link>
+            <Link href={`/audit?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
+              <span aria-hidden>📋</span> Open in TrustLog
+            </Link>
+            <Link href="/governance" className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
+              <span aria-hidden>🛡</span> Adjust in Governance
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-2 rounded-lg border border-border/30 bg-muted/10 px-3 py-4 text-center text-muted-foreground" data-testid="empty-drilldown">
+          <p className="text-sm font-medium">{t("監視対象", "Monitoring target")}</p>
+          <p className="mt-1 text-[11px]">{t("ポイントを選択するとドリルダウン情報が表示されます。リアルタイムでリスク監視を継続中です。", "Select a point to view drilldown details. Real-time risk monitoring continues.")}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/risk/components/FlaggedRequestsList.tsx
+++ b/frontend/app/risk/components/FlaggedRequestsList.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import { useI18n } from "../../../components/i18n-provider";
+import type { FlaggedEntry } from "../risk-types";
+import { SEVERITY_CLASSES, STATUS_LABELS } from "../constants";
+
+interface FlaggedRequestsListProps {
+  entries: FlaggedEntry[];
+  selectedPointId: string | null;
+  onSelectPoint: (id: string) => void;
+}
+
+export function FlaggedRequestsList({ entries, selectedPointId, onSelectPoint }: FlaggedRequestsListProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs">
+      <p className="mb-2 font-semibold">Flagged requests</p>
+      {entries.length === 0 ? (
+        <div className="rounded-lg border border-border/30 bg-muted/10 px-3 py-4 text-center text-muted-foreground" data-testid="empty-flagged">
+          <p className="text-sm font-medium">{t("監視中", "Monitoring active")}</p>
+          <p className="mt-1 text-[11px]">{t("現在フラグされたリクエストはありません。リアルタイムで監視を継続しています。", "No flagged requests in this window. Real-time monitoring continues.")}</p>
+        </div>
+      ) : (
+        <ul className="max-h-64 space-y-2 overflow-auto pr-1">
+          {entries.map((entry) => (
+            <li key={entry.point.id}>
+              <button
+                type="button"
+                onClick={() => onSelectPoint(entry.point.id)}
+                className={`w-full rounded border px-2 py-1.5 text-left hover:bg-muted/30 ${selectedPointId === entry.point.id ? "ring-1 ring-primary/50 bg-muted/20" : "border-border/40"}`}
+              >
+                <div className="flex items-center justify-between">
+                  <p className="font-mono text-[10px]">{entry.point.id}</p>
+                  <div className="flex items-center gap-1">
+                    <span className={`rounded-full border px-1.5 py-0.5 text-[9px] font-semibold uppercase ${SEVERITY_CLASSES[entry.severity]}`}>
+                      {entry.severity}
+                    </span>
+                    <span className="rounded bg-muted/40 px-1 py-0.5 text-[9px]">{STATUS_LABELS[entry.status]}</span>
+                  </div>
+                </div>
+                <p className="mt-0.5 text-muted-foreground">risk {entry.point.risk.toFixed(2)} / uncertainty {entry.point.uncertainty.toFixed(2)}</p>
+                <div className="mt-1 flex gap-1">
+                  <Link href={`/console?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/50 px-1.5 py-0.5 text-[9px] hover:bg-muted/40" onClick={(event) => event.stopPropagation()}>
+                    Open in Decision
+                  </Link>
+                  <Link href={`/audit?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/50 px-1.5 py-0.5 text-[9px] hover:bg-muted/40" onClick={(event) => event.stopPropagation()}>
+                    Open in TrustLog
+                  </Link>
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/risk/components/InsightCards.tsx
+++ b/frontend/app/risk/components/InsightCards.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+
+interface InsightCardsProps {
+  clusterRatio: number;
+  clusterCount: number;
+  filteredPointsCount: number;
+  unsafeBurst: boolean;
+  latestHighRisk: number;
+  uncertainCount: number;
+}
+
+
+export function InsightCards({ clusterRatio, clusterCount, filteredPointsCount, unsafeBurst, latestHighRisk, uncertainCount }: InsightCardsProps): JSX.Element {
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      <div className={`rounded-lg border p-3 text-xs ${clusterRatio >= 0.05 ? "border-warning/40 bg-warning/5" : "border-border/50 bg-background/60"}`}>
+        <p className="font-semibold">Policy drift</p>
+        <p className="mt-1 text-muted-foreground">
+          <span className="font-medium text-foreground">Why it matters:</span> Rising high-risk ratio ({(clusterRatio * 100).toFixed(1)}%) suggests policy thresholds may no longer match current traffic patterns.
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          <span className="font-medium text-foreground">Impact scope:</span> {clusterCount} critical requests in current window across {filteredPointsCount} total points.
+        </p>
+        <Link href="/governance" className="mt-2 inline-block rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40">
+          Review thresholds in Governance →
+        </Link>
+      </div>
+      <div className={`rounded-lg border p-3 text-xs ${unsafeBurst ? "border-danger/40 bg-danger/5" : "border-border/50 bg-background/60"}`}>
+        <p className="font-semibold">Unsafe burst</p>
+        <p className="mt-1 text-muted-foreground">
+          <span className="font-medium text-foreground">Why it matters:</span> {unsafeBurst ? "Active burst detected — ≥6 critical events in the latest 3h window may indicate prompt injection or rollout regression." : "No active burst. Critical event concentration is within normal bounds."}
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          <span className="font-medium text-foreground">Impact scope:</span> {latestHighRisk} critical events in latest 3h bucket.
+        </p>
+        <Link href="/console" className="mt-2 inline-block rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40">
+          Investigate in Decision →
+        </Link>
+      </div>
+      <div className={`rounded-lg border p-3 text-xs ${uncertainCount >= 10 ? "border-info/40 bg-info/5" : "border-border/50 bg-background/60"}`}>
+        <p className="font-semibold">Unstable output cluster</p>
+        <p className="mt-1 text-muted-foreground">
+          <span className="font-medium text-foreground">Why it matters:</span> High-uncertainty clusters ({uncertainCount} points) can precede trust degradation and model drift.
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          <span className="font-medium text-foreground">Impact scope:</span> May affect retrieval quality and output consistency for end users.
+        </p>
+        <Link href="/audit" className="mt-2 inline-block rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40">
+          Check stability in TrustLog →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/risk/components/RiskScatterPlot.tsx
+++ b/frontend/app/risk/components/RiskScatterPlot.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { RiskPoint } from "../risk-types";
+import { getCluster, pointFill } from "../data-helpers";
+
+interface RiskScatterPlotProps {
+  filteredPoints: RiskPoint[];
+  selectedPointId: string | null;
+  hoveredPointId: string | null;
+  hoveredPoint: RiskPoint | null;
+  onSelectPoint: (id: string) => void;
+  onHoverPoint: (id: string | null) => void;
+}
+
+export function RiskScatterPlot({
+  filteredPoints,
+  selectedPointId,
+  hoveredPointId,
+  hoveredPoint,
+  onSelectPoint,
+  onHoverPoint,
+}: RiskScatterPlotProps): JSX.Element {
+  return (
+    <div className="rounded-xl border border-border/50 bg-muted/10 p-5">
+      <div className="relative mx-auto h-[380px] w-full max-w-5xl">
+        <svg viewBox="0 0 100 100" className="h-full w-full" aria-label="Scatter plot of request uncertainty and risk from the last 24 hours" role="img">
+          <defs>
+            <linearGradient id="riskGradient" x1="0" y1="100" x2="100" y2="0">
+              <stop offset="0%" stopColor="hsl(var(--ds-color-primary) / 0.12)" />
+              <stop offset="50%" stopColor="hsl(var(--ds-color-warning) / 0.18)" />
+              <stop offset="100%" stopColor="hsl(var(--ds-color-danger) / 0.25)" />
+            </linearGradient>
+          </defs>
+          <rect x="0" y="0" width="100" height="100" fill="url(#riskGradient)" rx="2" />
+
+          <text x="50" y="99" textAnchor="middle" fontSize="2.5" fill="hsl(var(--ds-color-muted-foreground))">Uncertainty →</text>
+          <text x="1.5" y="50" textAnchor="middle" fontSize="2.5" fill="hsl(var(--ds-color-muted-foreground))" transform="rotate(-90,1.5,50)">Risk →</text>
+
+          {[20, 40, 60, 80].map((line) => (
+            <g key={line}>
+              <line x1={line} y1={0} x2={line} y2={100} stroke="hsl(var(--ds-color-border) / 0.5)" strokeWidth="0.25" />
+              <line x1={0} y1={line} x2={100} y2={line} stroke="hsl(var(--ds-color-border) / 0.5)" strokeWidth="0.25" />
+            </g>
+          ))}
+
+          <rect x="82" y="0" width="18" height="18" fill="hsl(var(--destructive) / 0.08)" rx="1" />
+          <text x="91" y="10" textAnchor="middle" fontSize="2" fill="hsl(var(--destructive) / 0.5)">CRITICAL</text>
+
+          {filteredPoints.map((point) => {
+            const x = point.uncertainty * 100;
+            const y = (1 - point.risk) * 100;
+            const cluster = getCluster(point);
+            const isSelected = selectedPointId === point.id;
+            const isHovered = hoveredPointId === point.id;
+            const fill = pointFill(cluster);
+            return (
+              <g key={point.id}>
+                {isSelected && (
+                  <circle cx={x} cy={y} r="2.8" fill="none" stroke={fill} strokeWidth="0.4" opacity="0.6" />
+                )}
+                <circle
+                  cx={x}
+                  cy={y}
+                  r={isSelected ? 1.6 : isHovered ? 1.4 : 1.1}
+                  fill={fill}
+                  opacity={cluster === "critical" ? 0.95 : cluster === "risky" ? 0.85 : 0.72}
+                  className="cursor-pointer"
+                  tabIndex={0}
+                  role="button"
+                  aria-label={`${cluster} point: Risk ${point.risk.toFixed(2)}, Uncertainty ${point.uncertainty.toFixed(2)}`}
+                  onClick={() => onSelectPoint(point.id)}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelectPoint(point.id); } }}
+                  onMouseEnter={() => onHoverPoint(point.id)}
+                  onMouseLeave={() => onHoverPoint(null)}
+                  onFocus={() => onHoverPoint(point.id)}
+                  onBlur={() => onHoverPoint(null)}
+                >
+                  <title>{`ID: ${point.id}\nRisk: ${point.risk.toFixed(2)} | Uncertainty: ${point.uncertainty.toFixed(2)}\nCluster: ${cluster}`}</title>
+                </circle>
+              </g>
+            );
+          })}
+        </svg>
+
+        {hoveredPoint && (
+          <div className="pointer-events-none absolute left-4 top-4 z-10 max-w-xs rounded-lg border border-border/60 bg-background/95 px-3 py-2 text-xs shadow-lg" data-testid="hover-summary">
+            <p className="font-mono text-[10px] text-muted-foreground">{hoveredPoint.id}</p>
+            <p className="mt-0.5"><span className="text-muted-foreground">Risk:</span> <span className="font-semibold">{hoveredPoint.risk.toFixed(2)}</span> · <span className="text-muted-foreground">Uncertainty:</span> <span className="font-semibold">{hoveredPoint.uncertainty.toFixed(2)}</span></p>
+            <p className="mt-0.5 text-muted-foreground">Cluster: <span className="font-semibold">{getCluster(hoveredPoint)}</span></p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/risk/components/TrendChart.tsx
+++ b/frontend/app/risk/components/TrendChart.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { TrendBucket } from "../risk-types";
+import { bucketMeaning } from "../data-helpers";
+
+interface TrendChartProps {
+  trend: TrendBucket[];
+  spikeDetected: boolean;
+  unsafeBurst: boolean;
+  onSelectCluster: (cluster: "all" | "critical") => void;
+}
+
+export function TrendChart({ trend, spikeDetected, unsafeBurst, onSelectCluster }: TrendChartProps): JSX.Element {
+  return (
+    <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs">
+      <p className="mb-2 font-semibold">Trend / Spike / Burst</p>
+      <div className="flex items-end gap-2" aria-label="trend chart">
+        {trend.map((bucket) => {
+          const isLatest = bucket.label === trend[7]?.label;
+          return (
+            <button
+              type="button"
+              key={bucket.label}
+              className={`flex flex-1 flex-col items-center gap-1 rounded px-0.5 py-0.5 ${isLatest ? "ring-1 ring-primary/40" : ""}`}
+              title={bucketMeaning(bucket)}
+              onClick={() => onSelectCluster(bucket.highRisk > 0 ? "critical" : "all")}
+            >
+              <div className="flex w-full flex-col items-center">
+                {bucket.highRisk > 0 && (
+                  <span className="w-full rounded-t bg-danger/40" style={{ height: `${Math.max(4, bucket.highRisk * 4)}px` }} />
+                )}
+                <span className="w-full rounded bg-primary/20" style={{ height: `${Math.max(8, bucket.total * 2)}px` }} />
+              </div>
+              <span className="text-[10px] text-muted-foreground">{bucket.label}</span>
+              {bucket.highRisk > 0 && <span className="text-[9px] font-semibold text-danger">{bucket.highRisk}</span>}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-2 space-y-1 text-muted-foreground">
+        <p>{spikeDetected ? "⚠ Spike detected — latest bucket shows 1.8× above average." : "No significant spike."}</p>
+        <p>{unsafeBurst ? "🔴 Unsafe burst active — ≥6 critical events in latest window." : "Burst within normal band."}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/risk/components/WhyFlaggedPanel.tsx
+++ b/frontend/app/risk/components/WhyFlaggedPanel.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useI18n } from "../../../components/i18n-provider";
+import type { FlaggedEntry } from "../risk-types";
+
+interface WhyFlaggedPanelProps {
+  entry: FlaggedEntry | null;
+}
+
+export function WhyFlaggedPanel({ entry }: WhyFlaggedPanelProps): JSX.Element {
+  const { t } = useI18n();
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs" data-testid="why-flagged">
+      <p className="font-semibold">Why flagged</p>
+      {entry ? (
+        <div className="mt-2 space-y-3">
+          <p className="font-mono text-[10px] text-muted-foreground">{entry.point.id}</p>
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-lg border border-border/40 px-2 py-1.5">
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Policy confidence</p>
+              <p className={`font-mono font-semibold ${entry.reason.policyConfidence < 0.3 ? "text-danger" : entry.reason.policyConfidence < 0.6 ? "text-warning" : "text-success"}`}>
+                {(entry.reason.policyConfidence * 100).toFixed(0)}%
+              </p>
+            </div>
+            <div className="rounded-lg border border-border/40 px-2 py-1.5">
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Unstable output</p>
+              <p className={`font-semibold ${entry.reason.unstableOutputSignal ? "text-danger" : "text-success"}`}>
+                {entry.reason.unstableOutputSignal ? "Detected" : "Stable"}
+              </p>
+            </div>
+            <div className="rounded-lg border border-border/40 px-2 py-1.5">
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Retrieval anomaly</p>
+              <p className={`font-semibold ${entry.reason.retrievalAnomaly ? "text-warning" : "text-success"}`}>
+                {entry.reason.retrievalAnomaly ? "Anomaly" : "Normal"}
+              </p>
+            </div>
+            <div className="rounded-lg border border-border/40 px-2 py-1.5">
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Cluster</p>
+              <p className="font-semibold">{entry.cluster}</p>
+            </div>
+          </div>
+          <div className="rounded-lg border border-border/40 bg-muted/5 px-2 py-1.5">
+            <p className="text-[10px] font-semibold uppercase text-muted-foreground">Analysis</p>
+            <p className="mt-0.5 text-muted-foreground">{entry.reason.summary}</p>
+          </div>
+          <div className="rounded-lg border border-primary/30 bg-primary/5 px-2 py-1.5">
+            <p className="text-[10px] font-semibold uppercase text-muted-foreground">Suggested next action</p>
+            <p className="mt-0.5">{entry.reason.suggestedAction}</p>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-2 rounded-lg border border-border/30 bg-muted/10 px-3 py-4 text-center text-muted-foreground" data-testid="empty-why-flagged">
+          <p className="text-sm font-medium">{t("監視中", "Monitoring active")}</p>
+          <p className="mt-1 text-[11px]">{t("フラグされたリクエストがないため、構造化理由は表示されません。", "No flagged requests — structured reasoning will appear when a request is selected.")}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/risk/constants.ts
+++ b/frontend/app/risk/constants.ts
@@ -1,0 +1,24 @@
+import type { RequestStatus, Severity } from "./risk-types";
+
+export const STREAM_WINDOW_MS = 24 * 60 * 60 * 1000;
+export const ALERT_CLUSTER_THRESHOLD = 0.82;
+export const STREAM_TICK_MS = 2_000;
+export const MAX_POINTS = 480;
+export const RISK_CONFIDENCE_WEIGHT = 0.9;
+export const UNCERTAINTY_CONFIDENCE_WEIGHT = 0.15;
+export const UNSAFE_BURST_THRESHOLD = 6;
+export const ELEVATED_RISK_THRESHOLD = 3;
+
+export const SEVERITY_CLASSES: Record<Severity, string> = {
+  critical: "bg-danger/15 text-danger border-danger/30",
+  high: "bg-warning/15 text-warning border-warning/30",
+  medium: "bg-info/15 text-info border-info/30",
+  low: "bg-muted/20 text-muted-foreground border-border/40",
+};
+
+export const STATUS_LABELS: Record<RequestStatus, string> = {
+  active: "Active",
+  mitigated: "Mitigated",
+  investigating: "Investigating",
+  new: "New",
+};

--- a/frontend/app/risk/data-helpers.ts
+++ b/frontend/app/risk/data-helpers.ts
@@ -1,0 +1,160 @@
+import type { ClusterKind, FlaggedEntry, FlagReason, RiskPoint, Severity, RequestStatus, TrendBucket } from "./risk-types";
+import {
+  ALERT_CLUSTER_THRESHOLD,
+  RISK_CONFIDENCE_WEIGHT,
+  STREAM_WINDOW_MS,
+  UNCERTAINTY_CONFIDENCE_WEIGHT,
+  UNSAFE_BURST_THRESHOLD,
+  ELEVATED_RISK_THRESHOLD,
+} from "./constants";
+
+/**
+ * NOTE: This page uses synthetic telemetry until a per-request risk API is available.
+ * It is safe for UI/interaction validation only, and must not be used as evidence for
+ * production incident response or compliance reporting.
+ */
+export function createInitialPoints(now: number): RiskPoint[] {
+  return Array.from({ length: 160 }, (_, index) => {
+    const wave = (Math.sin(index * 0.42) + 1) / 2;
+    const uncertainty = Math.min(1, Math.max(0.03, wave * 0.88 + (index % 5) * 0.02));
+    const risk = Math.min(1, Math.max(0.04, ((Math.cos(index * 0.31) + 1) / 2) * 0.9));
+
+    return {
+      id: `seed-${index}`,
+      uncertainty,
+      risk,
+      timestamp: now - (index / 160) * STREAM_WINDOW_MS,
+    };
+  });
+}
+
+export function createStreamPoint(now: number): RiskPoint {
+  const id = `${now}-${Math.random().toString(36).slice(2, 8)}`;
+  const uncertainty = Math.random();
+  const baseRisk = uncertainty * 0.65 + Math.random() * 0.35;
+  const spike = Math.random() > 0.93 ? 0.15 : 0;
+
+  return {
+    id,
+    uncertainty,
+    risk: Math.min(1, baseRisk + spike),
+    timestamp: now,
+  };
+}
+
+export function getCluster(point: RiskPoint): ClusterKind {
+  if (point.uncertainty >= ALERT_CLUSTER_THRESHOLD && point.risk >= ALERT_CLUSTER_THRESHOLD) {
+    return "critical";
+  }
+  if (point.risk >= ALERT_CLUSTER_THRESHOLD) {
+    return "risky";
+  }
+  if (point.uncertainty >= ALERT_CLUSTER_THRESHOLD) {
+    return "uncertain";
+  }
+  return "stable";
+}
+
+export function deriveSeverity(point: RiskPoint): Severity {
+  const combined = point.risk * 0.6 + point.uncertainty * 0.4;
+  if (combined >= 0.85) return "critical";
+  if (combined >= 0.7) return "high";
+  if (combined >= 0.5) return "medium";
+  return "low";
+}
+
+export function deriveStatus(point: RiskPoint): RequestStatus {
+  if (point.id.startsWith("seed-")) {
+    const idx = Number(point.id.replace("seed-", ""));
+    if (idx % 7 === 0) return "mitigated";
+    if (idx % 5 === 0) return "investigating";
+  }
+  return "new";
+}
+
+export function buildFlagReason(point: RiskPoint): FlagReason {
+  const cluster = getCluster(point);
+  const policyConfidence = Math.max(0, 1 - point.risk * RISK_CONFIDENCE_WEIGHT - point.uncertainty * UNCERTAINTY_CONFIDENCE_WEIGHT);
+  const unstableOutputSignal = point.uncertainty >= 0.75;
+  const retrievalAnomaly = point.risk >= 0.7 && point.uncertainty >= 0.6;
+
+  let summary: string;
+  let suggestedAction: string;
+
+  if (cluster === "critical") {
+    summary = "High uncertainty combined with high risk score. Policy confidence is low and output stability cannot be guaranteed.";
+    suggestedAction = "Escalate to Decision Console for immediate review; verify trust chain in TrustLog.";
+  } else if (cluster === "risky") {
+    summary = "Risk score exceeds threshold. Policy violation likelihood is elevated despite moderate uncertainty.";
+    suggestedAction = "Check Decision Console for policy hit details; review Governance thresholds.";
+  } else if (cluster === "uncertain") {
+    summary = "Uncertainty is high. Model behavior may drift or produce unstable outputs.";
+    suggestedAction = "Monitor in TrustLog for output consistency; consider tightening retrieval quality checks.";
+  } else {
+    summary = "Within expected safety envelope.";
+    suggestedAction = "No immediate action required.";
+  }
+
+  return { policyConfidence, unstableOutputSignal, retrievalAnomaly, summary, suggestedAction };
+}
+
+function deriveRelatedPolicyHits(point: RiskPoint): string[] {
+  const hits: string[] = [];
+  if (point.risk >= 0.82) hits.push("content-safety-v2");
+  if (point.uncertainty >= 0.82) hits.push("output-stability-check");
+  if (point.risk >= 0.7 && point.uncertainty >= 0.6) hits.push("retrieval-quality-gate");
+  if (point.risk >= 0.9) hits.push("prompt-injection-shield");
+  return hits;
+}
+
+function deriveStageAnomalies(point: RiskPoint): string[] {
+  const anomalies: string[] = [];
+  if (point.uncertainty >= 0.75) anomalies.push("LLM output variance high");
+  if (point.risk >= 0.8) anomalies.push("Safety gate triggered");
+  if (point.risk >= 0.7 && point.uncertainty >= 0.6) anomalies.push("Retrieval confidence low");
+  if (point.risk >= 0.9) anomalies.push("Post-processing filter activated");
+  return anomalies;
+}
+
+export function enrichFlaggedEntry(point: RiskPoint): FlaggedEntry {
+  return {
+    point,
+    cluster: getCluster(point),
+    severity: deriveSeverity(point),
+    status: deriveStatus(point),
+    reason: buildFlagReason(point),
+    relatedPolicyHits: deriveRelatedPolicyHits(point),
+    stageAnomalies: deriveStageAnomalies(point),
+  };
+}
+
+export function buildTrendBuckets(points: RiskPoint[], now: number): TrendBucket[] {
+  const bucketMs = 3 * 60 * 60 * 1000;
+  return Array.from({ length: 8 }, (_, index) => {
+    const start = now - (8 - index) * bucketMs;
+    const end = start + bucketMs;
+    const segment = points.filter((point) => point.timestamp >= start && point.timestamp < end);
+    const highRisk = segment.filter((point) => getCluster(point) === "critical").length;
+
+    return {
+      label: `${index * 3}-${(index + 1) * 3}h`,
+      total: segment.length,
+      highRisk,
+    };
+  });
+}
+
+export function bucketMeaning(bucket: TrendBucket): string {
+  if (bucket.highRisk >= UNSAFE_BURST_THRESHOLD) return "Unsafe burst — critical concentration detected";
+  if (bucket.highRisk >= ELEVATED_RISK_THRESHOLD) return "Elevated risk — multiple critical events";
+  if (bucket.highRisk > 0) return "Low-level risk events present";
+  if (bucket.total === 0) return "No activity in this window";
+  return "Normal operation";
+}
+
+export function pointFill(cluster: ClusterKind): string {
+  if (cluster === "critical") return "hsl(var(--destructive))";
+  if (cluster === "risky") return "hsl(var(--ds-color-warning))";
+  if (cluster === "uncertain") return "hsl(var(--ds-color-info))";
+  return "hsl(var(--primary) / 0.82)";
+}

--- a/frontend/app/risk/hooks/useRiskStream.ts
+++ b/frontend/app/risk/hooks/useRiskStream.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { RiskPoint } from "../risk-types";
+import {
+  buildTrendBuckets,
+  createInitialPoints,
+  createStreamPoint,
+  enrichFlaggedEntry,
+  getCluster,
+} from "../data-helpers";
+import {
+  ELEVATED_RISK_THRESHOLD,
+  MAX_POINTS,
+  STREAM_TICK_MS,
+  STREAM_WINDOW_MS,
+  UNSAFE_BURST_THRESHOLD,
+} from "../constants";
+
+export function useRiskStream() {
+  const [points, setPoints] = useState<RiskPoint[]>([]);
+  const [now, setNow] = useState<number>(0);
+  const [timeWindowHours, setTimeWindowHours] = useState<number>(24);
+  const [selectedCluster, setSelectedCluster] = useState<"all" | "critical" | "risky" | "uncertain">("all");
+  const [selectedPointId, setSelectedPointId] = useState<string | null>(null);
+  const [hoveredPointId, setHoveredPointId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const initial = Date.now();
+    setNow(initial);
+    setPoints(createInitialPoints(initial));
+  }, []);
+
+  const tickCallback = useCallback(() => {
+    const tick = Date.now();
+    setNow(tick);
+    setPoints((previous) => {
+      return [...previous, createStreamPoint(tick)]
+        .filter((point) => tick - point.timestamp <= STREAM_WINDOW_MS)
+        .slice(-MAX_POINTS);
+    });
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setInterval(tickCallback, STREAM_TICK_MS);
+    return () => { window.clearInterval(timer); };
+  }, [tickCallback]);
+
+  const visiblePoints = useMemo(() => {
+    return points.filter((point) => now - point.timestamp <= timeWindowHours * 60 * 60 * 1000);
+  }, [points, now, timeWindowHours]);
+
+  const filteredPoints = useMemo(() => {
+    if (selectedCluster === "all") return visiblePoints;
+    return visiblePoints.filter((point) => getCluster(point) === selectedCluster);
+  }, [visiblePoints, selectedCluster]);
+
+  const clusterStats = useMemo(() => {
+    const highRiskPoints = visiblePoints.filter((point) => getCluster(point) === "critical");
+    const ratio = visiblePoints.length === 0 ? 0 : highRiskPoints.length / visiblePoints.length;
+    return { ratio, count: highRiskPoints.length, alert: highRiskPoints.length >= 15 || ratio >= 0.08 };
+  }, [visiblePoints]);
+
+  const trend = useMemo(() => buildTrendBuckets(visiblePoints, now), [visiblePoints, now]);
+  const previousHighRisk = trend.slice(0, 7).reduce((sum, bucket) => sum + bucket.highRisk, 0) / 7;
+  const latestHighRisk = trend[7]?.highRisk ?? 0;
+  const spikeDetected = latestHighRisk >= previousHighRisk * 1.8 && latestHighRisk >= ELEVATED_RISK_THRESHOLD;
+  const unsafeBurst = latestHighRisk >= UNSAFE_BURST_THRESHOLD;
+
+  const flaggedEntries = useMemo(() => {
+    return visiblePoints
+      .filter((point) => getCluster(point) !== "stable")
+      .sort((left, right) => right.risk + right.uncertainty - (left.risk + left.uncertainty))
+      .slice(0, 20)
+      .map(enrichFlaggedEntry);
+  }, [visiblePoints]);
+
+  const selectedEntry = flaggedEntries.find((entry) => entry.point.id === selectedPointId) ?? flaggedEntries[0] ?? null;
+  const hoveredPoint = hoveredPointId ? visiblePoints.find((point) => point.id === hoveredPointId) ?? null : null;
+
+  return {
+    now,
+    visiblePoints,
+    filteredPoints,
+    clusterStats,
+    trend,
+    latestHighRisk,
+    spikeDetected,
+    unsafeBurst,
+    flaggedEntries,
+    selectedEntry,
+    hoveredPoint,
+    timeWindowHours,
+    setTimeWindowHours,
+    selectedCluster,
+    setSelectedCluster,
+    selectedPointId,
+    setSelectedPointId,
+    hoveredPointId,
+    setHoveredPointId,
+  };
+}

--- a/frontend/app/risk/page.tsx
+++ b/frontend/app/risk/page.tsx
@@ -3,234 +3,14 @@
 import Link from "next/link";
 import { Card } from "@veritas/design-system";
 import { useI18n } from "../../components/i18n-provider";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-/* ------------------------------------------------------------------ */
-/*  Types                                                              */
-/* ------------------------------------------------------------------ */
-
-type ClusterKind = "critical" | "risky" | "uncertain" | "stable";
-type Severity = "critical" | "high" | "medium" | "low";
-type RequestStatus = "active" | "mitigated" | "investigating" | "new";
-
-interface RiskPoint {
-  id: string;
-  uncertainty: number;
-  risk: number;
-  timestamp: number;
-}
-
-interface TrendBucket {
-  label: string;
-  total: number;
-  highRisk: number;
-}
-
-/** Structured reason for flagging a request. */
-interface FlagReason {
-  policyConfidence: number;
-  unstableOutputSignal: boolean;
-  retrievalAnomaly: boolean;
-  summary: string;
-  suggestedAction: string;
-}
-
-/** Enriched view of a flagged request used in drilldown and lists. */
-interface FlaggedEntry {
-  point: RiskPoint;
-  cluster: ClusterKind;
-  severity: Severity;
-  status: RequestStatus;
-  reason: FlagReason;
-  relatedPolicyHits: string[];
-  stageAnomalies: string[];
-}
-
-/* ------------------------------------------------------------------ */
-/*  Constants                                                          */
-/* ------------------------------------------------------------------ */
-
-const STREAM_WINDOW_MS = 24 * 60 * 60 * 1000;
-const ALERT_CLUSTER_THRESHOLD = 0.82;
-const STREAM_TICK_MS = 2_000;
-const MAX_POINTS = 480;
-const RISK_CONFIDENCE_WEIGHT = 0.9;
-const UNCERTAINTY_CONFIDENCE_WEIGHT = 0.15;
-const UNSAFE_BURST_THRESHOLD = 6;
-const ELEVATED_RISK_THRESHOLD = 3;
-
-const SEVERITY_CLASSES: Record<Severity, string> = {
-  critical: "bg-danger/15 text-danger border-danger/30",
-  high: "bg-warning/15 text-warning border-warning/30",
-  medium: "bg-info/15 text-info border-info/30",
-  low: "bg-muted/20 text-muted-foreground border-border/40",
-};
-
-const STATUS_LABELS: Record<RequestStatus, string> = {
-  active: "Active",
-  mitigated: "Mitigated",
-  investigating: "Investigating",
-  new: "New",
-};
-
-/* ------------------------------------------------------------------ */
-/*  Data helpers                                                       */
-/* ------------------------------------------------------------------ */
-
-/**
- * NOTE: This page uses synthetic telemetry until a per-request risk API is available.
- * It is safe for UI/interaction validation only, and must not be used as evidence for
- * production incident response or compliance reporting.
- */
-function createInitialPoints(now: number): RiskPoint[] {
-  return Array.from({ length: 160 }, (_, index) => {
-    const wave = (Math.sin(index * 0.42) + 1) / 2;
-    const uncertainty = Math.min(1, Math.max(0.03, wave * 0.88 + (index % 5) * 0.02));
-    const risk = Math.min(1, Math.max(0.04, ((Math.cos(index * 0.31) + 1) / 2) * 0.9));
-
-    return {
-      id: `seed-${index}`,
-      uncertainty,
-      risk,
-      timestamp: now - (index / 160) * STREAM_WINDOW_MS,
-    };
-  });
-}
-
-function createStreamPoint(now: number): RiskPoint {
-  const id = `${now}-${Math.random().toString(36).slice(2, 8)}`;
-  const uncertainty = Math.random();
-  const baseRisk = uncertainty * 0.65 + Math.random() * 0.35;
-  const spike = Math.random() > 0.93 ? 0.15 : 0;
-
-  return {
-    id,
-    uncertainty,
-    risk: Math.min(1, baseRisk + spike),
-    timestamp: now,
-  };
-}
-
-function getCluster(point: RiskPoint): ClusterKind {
-  if (point.uncertainty >= ALERT_CLUSTER_THRESHOLD && point.risk >= ALERT_CLUSTER_THRESHOLD) {
-    return "critical";
-  }
-  if (point.risk >= ALERT_CLUSTER_THRESHOLD) {
-    return "risky";
-  }
-  if (point.uncertainty >= ALERT_CLUSTER_THRESHOLD) {
-    return "uncertain";
-  }
-  return "stable";
-}
-
-function deriveSeverity(point: RiskPoint): Severity {
-  const combined = point.risk * 0.6 + point.uncertainty * 0.4;
-  if (combined >= 0.85) return "critical";
-  if (combined >= 0.7) return "high";
-  if (combined >= 0.5) return "medium";
-  return "low";
-}
-
-function deriveStatus(point: RiskPoint): RequestStatus {
-  if (point.id.startsWith("seed-")) {
-    const idx = Number(point.id.replace("seed-", ""));
-    if (idx % 7 === 0) return "mitigated";
-    if (idx % 5 === 0) return "investigating";
-  }
-  return "new";
-}
-
-function buildFlagReason(point: RiskPoint): FlagReason {
-  const cluster = getCluster(point);
-  const policyConfidence = Math.max(0, 1 - point.risk * RISK_CONFIDENCE_WEIGHT - point.uncertainty * UNCERTAINTY_CONFIDENCE_WEIGHT);
-  const unstableOutputSignal = point.uncertainty >= 0.75;
-  const retrievalAnomaly = point.risk >= 0.7 && point.uncertainty >= 0.6;
-
-  let summary: string;
-  let suggestedAction: string;
-
-  if (cluster === "critical") {
-    summary = "High uncertainty combined with high risk score. Policy confidence is low and output stability cannot be guaranteed.";
-    suggestedAction = "Escalate to Decision Console for immediate review; verify trust chain in TrustLog.";
-  } else if (cluster === "risky") {
-    summary = "Risk score exceeds threshold. Policy violation likelihood is elevated despite moderate uncertainty.";
-    suggestedAction = "Check Decision Console for policy hit details; review Governance thresholds.";
-  } else if (cluster === "uncertain") {
-    summary = "Uncertainty is high. Model behavior may drift or produce unstable outputs.";
-    suggestedAction = "Monitor in TrustLog for output consistency; consider tightening retrieval quality checks.";
-  } else {
-    summary = "Within expected safety envelope.";
-    suggestedAction = "No immediate action required.";
-  }
-
-  return { policyConfidence, unstableOutputSignal, retrievalAnomaly, summary, suggestedAction };
-}
-
-function deriveRelatedPolicyHits(point: RiskPoint): string[] {
-  const hits: string[] = [];
-  if (point.risk >= 0.82) hits.push("content-safety-v2");
-  if (point.uncertainty >= 0.82) hits.push("output-stability-check");
-  if (point.risk >= 0.7 && point.uncertainty >= 0.6) hits.push("retrieval-quality-gate");
-  if (point.risk >= 0.9) hits.push("prompt-injection-shield");
-  return hits;
-}
-
-function deriveStageAnomalies(point: RiskPoint): string[] {
-  const anomalies: string[] = [];
-  if (point.uncertainty >= 0.75) anomalies.push("LLM output variance high");
-  if (point.risk >= 0.8) anomalies.push("Safety gate triggered");
-  if (point.risk >= 0.7 && point.uncertainty >= 0.6) anomalies.push("Retrieval confidence low");
-  if (point.risk >= 0.9) anomalies.push("Post-processing filter activated");
-  return anomalies;
-}
-
-function enrichFlaggedEntry(point: RiskPoint): FlaggedEntry {
-  return {
-    point,
-    cluster: getCluster(point),
-    severity: deriveSeverity(point),
-    status: deriveStatus(point),
-    reason: buildFlagReason(point),
-    relatedPolicyHits: deriveRelatedPolicyHits(point),
-    stageAnomalies: deriveStageAnomalies(point),
-  };
-}
-
-function buildTrendBuckets(points: RiskPoint[], now: number): TrendBucket[] {
-  const bucketMs = 3 * 60 * 60 * 1000;
-  return Array.from({ length: 8 }, (_, index) => {
-    const start = now - (8 - index) * bucketMs;
-    const end = start + bucketMs;
-    const segment = points.filter((point) => point.timestamp >= start && point.timestamp < end);
-    const highRisk = segment.filter((point) => getCluster(point) === "critical").length;
-
-    return {
-      label: `${index * 3}-${(index + 1) * 3}h`,
-      total: segment.length,
-      highRisk,
-    };
-  });
-}
-
-function bucketMeaning(bucket: TrendBucket): string {
-  if (bucket.highRisk >= UNSAFE_BURST_THRESHOLD) return "Unsafe burst — critical concentration detected";
-  if (bucket.highRisk >= ELEVATED_RISK_THRESHOLD) return "Elevated risk — multiple critical events";
-  if (bucket.highRisk > 0) return "Low-level risk events present";
-  if (bucket.total === 0) return "No activity in this window";
-  return "Normal operation";
-}
-
-/* ------------------------------------------------------------------ */
-/*  Scatter plot fill helpers                                          */
-/* ------------------------------------------------------------------ */
-
-function pointFill(cluster: ClusterKind): string {
-  if (cluster === "critical") return "hsl(var(--destructive))";
-  if (cluster === "risky") return "hsl(var(--ds-color-warning))";
-  if (cluster === "uncertain") return "hsl(var(--ds-color-info))";
-  return "hsl(var(--primary) / 0.82)";
-}
+import { getCluster } from "./data-helpers";
+import { useRiskStream } from "./hooks/useRiskStream";
+import { RiskScatterPlot } from "./components/RiskScatterPlot";
+import { InsightCards } from "./components/InsightCards";
+import { TrendChart } from "./components/TrendChart";
+import { FlaggedRequestsList } from "./components/FlaggedRequestsList";
+import { DrilldownPanel } from "./components/DrilldownPanel";
+import { WhyFlaggedPanel } from "./components/WhyFlaggedPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Page component                                                     */
@@ -238,78 +18,9 @@ function pointFill(cluster: ClusterKind): string {
 
 export default function RiskIntelligencePage(): JSX.Element {
   const { t, language } = useI18n();
-  const [points, setPoints] = useState<RiskPoint[]>([]);
-  const [now, setNow] = useState<number>(0);
+  const stream = useRiskStream();
 
-  useEffect(() => {
-    const initial = Date.now();
-    setNow(initial);
-    setPoints(createInitialPoints(initial));
-  }, []);
-  const [timeWindowHours, setTimeWindowHours] = useState<number>(24);
-  const [selectedCluster, setSelectedCluster] = useState<"all" | "critical" | "risky" | "uncertain">("all");
-  const [selectedPointId, setSelectedPointId] = useState<string | null>(null);
-  const [hoveredPointId, setHoveredPointId] = useState<string | null>(null);
-
-  const tickCallback = useCallback(() => {
-    const tick = Date.now();
-    setNow(tick);
-    setPoints((previous) => {
-      return [...previous, createStreamPoint(tick)]
-        .filter((point) => tick - point.timestamp <= STREAM_WINDOW_MS)
-        .slice(-MAX_POINTS);
-    });
-  }, []);
-
-  useEffect(() => {
-    const timer = window.setInterval(tickCallback, STREAM_TICK_MS);
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [tickCallback]);
-
-  /* ---------- derived data ---------- */
-
-  const visiblePoints = useMemo(() => {
-    return points.filter((point) => now - point.timestamp <= timeWindowHours * 60 * 60 * 1000);
-  }, [points, now, timeWindowHours]);
-
-  const filteredPoints = useMemo(() => {
-    if (selectedCluster === "all") {
-      return visiblePoints;
-    }
-    return visiblePoints.filter((point) => getCluster(point) === selectedCluster);
-  }, [visiblePoints, selectedCluster]);
-
-  const clusterStats = useMemo(() => {
-    const highRiskPoints = visiblePoints.filter((point) => getCluster(point) === "critical");
-    const ratio = visiblePoints.length === 0 ? 0 : highRiskPoints.length / visiblePoints.length;
-    return {
-      ratio,
-      count: highRiskPoints.length,
-      alert: highRiskPoints.length >= 15 || ratio >= 0.08,
-    };
-  }, [visiblePoints]);
-
-  const trend = useMemo(() => buildTrendBuckets(visiblePoints, now), [visiblePoints, now]);
-  const previousHighRisk = trend.slice(0, 7).reduce((sum, bucket) => sum + bucket.highRisk, 0) / 7;
-  const latestHighRisk = trend[7]?.highRisk ?? 0;
-  const spikeDetected = latestHighRisk >= previousHighRisk * 1.8 && latestHighRisk >= ELEVATED_RISK_THRESHOLD;
-  const unsafeBurst = latestHighRisk >= UNSAFE_BURST_THRESHOLD;
-
-  const flaggedEntries = useMemo(() => {
-    return visiblePoints
-      .filter((point) => getCluster(point) !== "stable")
-      .sort((left, right) => right.risk + right.uncertainty - (left.risk + left.uncertainty))
-      .slice(0, 20)
-      .map(enrichFlaggedEntry);
-  }, [visiblePoints]);
-
-  const selectedEntry = flaggedEntries.find((entry) => entry.point.id === selectedPointId) ?? flaggedEntries[0] ?? null;
-
-  const hoveredPoint = hoveredPointId ? visiblePoints.find((point) => point.id === hoveredPointId) ?? null : null;
-
-  /* ---------- render ---------- */
+  const uncertainCount = stream.visiblePoints.filter((p) => getCluster(p) === "uncertain").length;
 
   return (
     <div className="space-y-6">
@@ -337,35 +48,35 @@ export default function RiskIntelligencePage(): JSX.Element {
       {/* ── Heatmap section ── */}
       <Card title="Real-time Risk Heatmap" titleSize="md" variant="elevated">
         <div className="space-y-5">
-          {/* status metrics */}
+          {/* Status metrics */}
           <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
             <div className="rounded-lg border border-border/50 bg-background/60 px-3 py-2.5 text-xs">
               <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t("ステータス", "Status")}</p>
-              <p className={`mt-0.5 font-semibold ${clusterStats.alert ? "text-danger" : "text-success"}`}>
-                {clusterStats.alert ? "Cluster Alert" : "Normal"}
+              <p className={`mt-0.5 font-semibold ${stream.clusterStats.alert ? "text-danger" : "text-success"}`}>
+                {stream.clusterStats.alert ? "Cluster Alert" : "Normal"}
               </p>
             </div>
             <div className="rounded-lg border border-border/50 bg-background/60 px-3 py-2.5 text-xs">
               <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t("高リスク", "High-risk")}</p>
-              <p className="mt-0.5 font-mono font-semibold text-foreground">{clusterStats.count} / {visiblePoints.length}</p>
+              <p className="mt-0.5 font-mono font-semibold text-foreground">{stream.clusterStats.count} / {stream.visiblePoints.length}</p>
             </div>
             <div className="rounded-lg border border-border/50 bg-background/60 px-3 py-2.5 text-xs">
               <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t("クラスタ率", "Cluster rate")}</p>
-              <p className="mt-0.5 font-mono font-semibold text-foreground">{(clusterStats.ratio * 100).toFixed(1)}%</p>
+              <p className="mt-0.5 font-mono font-semibold text-foreground">{(stream.clusterStats.ratio * 100).toFixed(1)}%</p>
             </div>
             <div className="rounded-lg border border-border/50 bg-background/60 px-3 py-2.5 text-xs">
               <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{t("最終更新", "Updated")}</p>
               <p className="mt-0.5 font-mono text-[11px] font-semibold text-foreground" aria-live="polite">
-                {new Date(now).toLocaleTimeString(language === "ja" ? "ja-JP" : "en-US", { hour12: false })}
+                {new Date(stream.now).toLocaleTimeString(language === "ja" ? "ja-JP" : "en-US", { hour12: false })}
               </p>
             </div>
           </div>
 
-          {/* filter controls */}
+          {/* Filter controls */}
           <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border/50 bg-background/60 px-3 py-2.5 text-xs">
             <label className="space-y-1">
               <span className="text-muted-foreground">Time window</span>
-              <select className="block rounded border border-border bg-background px-2 py-1" value={timeWindowHours} onChange={(event) => setTimeWindowHours(Number(event.target.value))}>
+              <select className="block rounded border border-border bg-background px-2 py-1" value={stream.timeWindowHours} onChange={(event) => stream.setTimeWindowHours(Number(event.target.value))}>
                 <option value={1}>1h</option>
                 <option value={6}>6h</option>
                 <option value={12}>12h</option>
@@ -374,7 +85,7 @@ export default function RiskIntelligencePage(): JSX.Element {
             </label>
             <label className="space-y-1">
               <span className="text-muted-foreground">Cluster drilldown</span>
-              <select className="block rounded border border-border bg-background px-2 py-1" value={selectedCluster} onChange={(event) => setSelectedCluster(event.target.value as "all" | "critical" | "risky" | "uncertain")}>
+              <select className="block rounded border border-border bg-background px-2 py-1" value={stream.selectedCluster} onChange={(event) => stream.setSelectedCluster(event.target.value as "all" | "critical" | "risky" | "uncertain")}>
                 <option value="all">all points</option>
                 <option value="critical">critical cluster</option>
                 <option value="risky">high risk only</option>
@@ -383,321 +94,44 @@ export default function RiskIntelligencePage(): JSX.Element {
             </label>
           </div>
 
-          {/* scatter plot with enhanced interactivity */}
-          <div className="rounded-xl border border-border/50 bg-muted/10 p-5">
-            <div className="relative mx-auto h-[380px] w-full max-w-5xl">
-              <svg viewBox="0 0 100 100" className="h-full w-full" aria-label="Scatter plot of request uncertainty and risk from the last 24 hours" role="img">
-                <defs>
-                  <linearGradient id="riskGradient" x1="0" y1="100" x2="100" y2="0">
-                    <stop offset="0%" stopColor="hsl(var(--ds-color-primary) / 0.12)" />
-                    <stop offset="50%" stopColor="hsl(var(--ds-color-warning) / 0.18)" />
-                    <stop offset="100%" stopColor="hsl(var(--ds-color-danger) / 0.25)" />
-                  </linearGradient>
-                </defs>
-                <rect x="0" y="0" width="100" height="100" fill="url(#riskGradient)" rx="2" />
+          {/* Scatter plot */}
+          <RiskScatterPlot
+            filteredPoints={stream.filteredPoints}
+            selectedPointId={stream.selectedPointId}
+            hoveredPointId={stream.hoveredPointId}
+            hoveredPoint={stream.hoveredPoint}
+            onSelectPoint={stream.setSelectedPointId}
+            onHoverPoint={stream.setHoveredPointId}
+          />
 
-                {/* axis labels */}
-                <text x="50" y="99" textAnchor="middle" fontSize="2.5" fill="hsl(var(--ds-color-muted-foreground))">Uncertainty →</text>
-                <text x="1.5" y="50" textAnchor="middle" fontSize="2.5" fill="hsl(var(--ds-color-muted-foreground))" transform="rotate(-90,1.5,50)">Risk →</text>
+          {/* Insight cards */}
+          <InsightCards
+            clusterRatio={stream.clusterStats.ratio}
+            clusterCount={stream.clusterStats.count}
+            filteredPointsCount={stream.filteredPoints.length}
+            unsafeBurst={stream.unsafeBurst}
+            latestHighRisk={stream.latestHighRisk}
+            uncertainCount={uncertainCount}
+          />
 
-                {/* grid lines */}
-                {[20, 40, 60, 80].map((line) => (
-                  <g key={line}>
-                    <line x1={line} y1={0} x2={line} y2={100} stroke="hsl(var(--ds-color-border) / 0.5)" strokeWidth="0.25" />
-                    <line x1={0} y1={line} x2={100} y2={line} stroke="hsl(var(--ds-color-border) / 0.5)" strokeWidth="0.25" />
-                  </g>
-                ))}
-
-                {/* danger zone indicator */}
-                <rect x="82" y="0" width="18" height="18" fill="hsl(var(--destructive) / 0.08)" rx="1" />
-                <text x="91" y="10" textAnchor="middle" fontSize="2" fill="hsl(var(--destructive) / 0.5)">CRITICAL</text>
-
-                {/* data points */}
-                {filteredPoints.map((point) => {
-                  const x = point.uncertainty * 100;
-                  const y = (1 - point.risk) * 100;
-                  const cluster = getCluster(point);
-                  const isSelected = selectedPointId === point.id;
-                  const isHovered = hoveredPointId === point.id;
-                  const fill = pointFill(cluster);
-                  return (
-                    <g key={point.id}>
-                      {isSelected && (
-                        <circle cx={x} cy={y} r="2.8" fill="none" stroke={fill} strokeWidth="0.4" opacity="0.6" />
-                      )}
-                      <circle
-                        cx={x}
-                        cy={y}
-                        r={isSelected ? 1.6 : isHovered ? 1.4 : 1.1}
-                        fill={fill}
-                        opacity={cluster === "critical" ? 0.95 : cluster === "risky" ? 0.85 : 0.72}
-                        className="cursor-pointer"
-                        tabIndex={0}
-                        role="button"
-                        aria-label={`${cluster} point: Risk ${point.risk.toFixed(2)}, Uncertainty ${point.uncertainty.toFixed(2)}`}
-                        onClick={() => setSelectedPointId(point.id)}
-                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedPointId(point.id); } }}
-                        onMouseEnter={() => setHoveredPointId(point.id)}
-                        onMouseLeave={() => setHoveredPointId(null)}
-                        onFocus={() => setHoveredPointId(point.id)}
-                        onBlur={() => setHoveredPointId(null)}
-                      >
-                        <title>{`ID: ${point.id}\nRisk: ${point.risk.toFixed(2)} | Uncertainty: ${point.uncertainty.toFixed(2)}\nCluster: ${cluster}`}</title>
-                      </circle>
-                    </g>
-                  );
-                })}
-              </svg>
-
-              {/* Hover summary tooltip */}
-              {hoveredPoint && (
-                <div className="pointer-events-none absolute left-4 top-4 z-10 max-w-xs rounded-lg border border-border/60 bg-background/95 px-3 py-2 text-xs shadow-lg" data-testid="hover-summary">
-                  <p className="font-mono text-[10px] text-muted-foreground">{hoveredPoint.id}</p>
-                  <p className="mt-0.5"><span className="text-muted-foreground">Risk:</span> <span className="font-semibold">{hoveredPoint.risk.toFixed(2)}</span> · <span className="text-muted-foreground">Uncertainty:</span> <span className="font-semibold">{hoveredPoint.uncertainty.toFixed(2)}</span></p>
-                  <p className="mt-0.5 text-muted-foreground">Cluster: <span className="font-semibold">{getCluster(hoveredPoint)}</span></p>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* ── Insight cards: Policy drift / Unsafe burst / Unstable cluster ── */}
-          <div className="grid gap-3 md:grid-cols-3">
-            <div className={`rounded-lg border p-3 text-xs ${clusterStats.ratio >= 0.05 ? "border-warning/40 bg-warning/5" : "border-border/50 bg-background/60"}`}>
-              <p className="font-semibold">Policy drift</p>
-              <p className="mt-1 text-muted-foreground">
-                <span className="font-medium text-foreground">Why it matters:</span> Rising high-risk ratio ({(clusterStats.ratio * 100).toFixed(1)}%) suggests policy thresholds may no longer match current traffic patterns.
-              </p>
-              <p className="mt-1 text-muted-foreground">
-                <span className="font-medium text-foreground">Impact scope:</span> {clusterStats.count} critical requests in current window across {filteredPoints.length} total points.
-              </p>
-              <Link href="/governance" className="mt-2 inline-block rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40">
-                Review thresholds in Governance →
-              </Link>
-            </div>
-            <div className={`rounded-lg border p-3 text-xs ${unsafeBurst ? "border-danger/40 bg-danger/5" : "border-border/50 bg-background/60"}`}>
-              <p className="font-semibold">Unsafe burst</p>
-              <p className="mt-1 text-muted-foreground">
-                <span className="font-medium text-foreground">Why it matters:</span> {unsafeBurst ? "Active burst detected — ≥6 critical events in the latest 3h window may indicate prompt injection or rollout regression." : "No active burst. Critical event concentration is within normal bounds."}
-              </p>
-              <p className="mt-1 text-muted-foreground">
-                <span className="font-medium text-foreground">Impact scope:</span> {latestHighRisk} critical events in latest 3h bucket.
-              </p>
-              <Link href="/console" className="mt-2 inline-block rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40">
-                Investigate in Decision →
-              </Link>
-            </div>
-            <div className={`rounded-lg border p-3 text-xs ${visiblePoints.filter((p) => getCluster(p) === "uncertain").length >= 10 ? "border-info/40 bg-info/5" : "border-border/50 bg-background/60"}`}>
-              <p className="font-semibold">Unstable output cluster</p>
-              <p className="mt-1 text-muted-foreground">
-                <span className="font-medium text-foreground">Why it matters:</span> High-uncertainty clusters ({visiblePoints.filter((p) => getCluster(p) === "uncertain").length} points) can precede trust degradation and model drift.
-              </p>
-              <p className="mt-1 text-muted-foreground">
-                <span className="font-medium text-foreground">Impact scope:</span> May affect retrieval quality and output consistency for end users.
-              </p>
-              <Link href="/audit" className="mt-2 inline-block rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40">
-                Check stability in TrustLog →
-              </Link>
-            </div>
-          </div>
-
-          {/* ── Trend / Spike / Burst + Flagged requests ── */}
+          {/* Trend + Flagged requests */}
           <div className="grid gap-4 lg:grid-cols-2">
-            <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs">
-              <p className="mb-2 font-semibold">Trend / Spike / Burst</p>
-              <div className="flex items-end gap-2" aria-label="trend chart">
-                {trend.map((bucket) => {
-                  const isLatest = bucket.label === trend[7]?.label;
-                  return (
-                    <button
-                      type="button"
-                      key={bucket.label}
-                      className={`flex flex-1 flex-col items-center gap-1 rounded px-0.5 py-0.5 ${isLatest ? "ring-1 ring-primary/40" : ""}`}
-                      title={bucketMeaning(bucket)}
-                      onClick={() => setSelectedCluster(bucket.highRisk > 0 ? "critical" : "all")}
-                    >
-                      <div className="flex w-full flex-col items-center">
-                        {bucket.highRisk > 0 && (
-                          <span className="w-full rounded-t bg-danger/40" style={{ height: `${Math.max(4, bucket.highRisk * 4)}px` }} />
-                        )}
-                        <span className="w-full rounded bg-primary/20" style={{ height: `${Math.max(8, bucket.total * 2)}px` }} />
-                      </div>
-                      <span className="text-[10px] text-muted-foreground">{bucket.label}</span>
-                      {bucket.highRisk > 0 && <span className="text-[9px] font-semibold text-danger">{bucket.highRisk}</span>}
-                    </button>
-                  );
-                })}
-              </div>
-              <div className="mt-2 space-y-1 text-muted-foreground">
-                <p>{spikeDetected ? "⚠ Spike detected — latest bucket shows 1.8× above average." : "No significant spike."}</p>
-                <p>{unsafeBurst ? "🔴 Unsafe burst active — ≥6 critical events in latest window." : "Burst within normal band."}</p>
-              </div>
-            </div>
-
-            {/* ── Flagged requests (enhanced) ── */}
-            <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs">
-              <p className="mb-2 font-semibold">Flagged requests</p>
-              {flaggedEntries.length === 0 ? (
-                <div className="rounded-lg border border-border/30 bg-muted/10 px-3 py-4 text-center text-muted-foreground" data-testid="empty-flagged">
-                  <p className="text-sm font-medium">{t("監視中", "Monitoring active")}</p>
-                  <p className="mt-1 text-[11px]">{t("現在フラグされたリクエストはありません。リアルタイムで監視を継続しています。", "No flagged requests in this window. Real-time monitoring continues.")}</p>
-                </div>
-              ) : (
-                <ul className="max-h-64 space-y-2 overflow-auto pr-1">
-                  {flaggedEntries.map((entry) => (
-                    <li key={entry.point.id}>
-                      <button
-                        type="button"
-                        onClick={() => setSelectedPointId(entry.point.id)}
-                        className={`w-full rounded border px-2 py-1.5 text-left hover:bg-muted/30 ${selectedPointId === entry.point.id ? "ring-1 ring-primary/50 bg-muted/20" : "border-border/40"}`}
-                      >
-                        <div className="flex items-center justify-between">
-                          <p className="font-mono text-[10px]">{entry.point.id}</p>
-                          <div className="flex items-center gap-1">
-                            <span className={`rounded-full border px-1.5 py-0.5 text-[9px] font-semibold uppercase ${SEVERITY_CLASSES[entry.severity]}`}>
-                              {entry.severity}
-                            </span>
-                            <span className="rounded bg-muted/40 px-1 py-0.5 text-[9px]">{STATUS_LABELS[entry.status]}</span>
-                          </div>
-                        </div>
-                        <p className="mt-0.5 text-muted-foreground">risk {entry.point.risk.toFixed(2)} / uncertainty {entry.point.uncertainty.toFixed(2)}</p>
-                        <div className="mt-1 flex gap-1">
-                          <Link href={`/console?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/50 px-1.5 py-0.5 text-[9px] hover:bg-muted/40" onClick={(event) => event.stopPropagation()}>
-                            Open in Decision
-                          </Link>
-                          <Link href={`/audit?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/50 px-1.5 py-0.5 text-[9px] hover:bg-muted/40" onClick={(event) => event.stopPropagation()}>
-                            Open in TrustLog
-                          </Link>
-                        </div>
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+            <TrendChart
+              trend={stream.trend}
+              spikeDetected={stream.spikeDetected}
+              unsafeBurst={stream.unsafeBurst}
+              onSelectCluster={stream.setSelectedCluster}
+            />
+            <FlaggedRequestsList
+              entries={stream.flaggedEntries}
+              selectedPointId={stream.selectedPointId}
+              onSelectPoint={stream.setSelectedPointId}
+            />
           </div>
 
-          {/* ── Drilldown panel ── */}
-          <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs" data-testid="drilldown-panel">
-            <p className="font-semibold">Drilldown panel</p>
-            {selectedEntry ? (
-              <div className="mt-2 grid gap-3 md:grid-cols-2">
-                <div className="space-y-2">
-                  <div>
-                    <p className="text-[10px] font-semibold uppercase text-muted-foreground">Request ID / Seed</p>
-                    <p className="font-mono text-[11px]">{selectedEntry.point.id}</p>
-                  </div>
-                  <div className="grid grid-cols-2 gap-2">
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase text-muted-foreground">Uncertainty</p>
-                      <p className="font-mono font-semibold">{selectedEntry.point.uncertainty.toFixed(3)}</p>
-                    </div>
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase text-muted-foreground">Risk score</p>
-                      <p className="font-mono font-semibold">{selectedEntry.point.risk.toFixed(3)}</p>
-                    </div>
-                  </div>
-                  <div>
-                    <p className="text-[10px] font-semibold uppercase text-muted-foreground">Severity / Status</p>
-                    <div className="mt-0.5 flex items-center gap-2">
-                      <span className={`rounded-full border px-1.5 py-0.5 text-[9px] font-semibold uppercase ${SEVERITY_CLASSES[selectedEntry.severity]}`}>
-                        {selectedEntry.severity}
-                      </span>
-                      <span className="rounded bg-muted/40 px-1 py-0.5 text-[9px]">{STATUS_LABELS[selectedEntry.status]}</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <div>
-                    <p className="text-[10px] font-semibold uppercase text-muted-foreground">Related policy hits</p>
-                    {selectedEntry.relatedPolicyHits.length > 0 ? (
-                      <ul className="mt-0.5 space-y-0.5">
-                        {selectedEntry.relatedPolicyHits.map((hit) => (
-                          <li key={hit} className="rounded bg-warning/10 px-1.5 py-0.5 text-[10px]">⚡ {hit}</li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="text-muted-foreground">No policy hits</p>
-                    )}
-                  </div>
-                  <div>
-                    <p className="text-[10px] font-semibold uppercase text-muted-foreground">Stage anomalies</p>
-                    {selectedEntry.stageAnomalies.length > 0 ? (
-                      <ul className="mt-0.5 space-y-0.5">
-                        {selectedEntry.stageAnomalies.map((anomaly) => (
-                          <li key={anomaly} className="rounded bg-danger/10 px-1.5 py-0.5 text-[10px]">⚠ {anomaly}</li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="text-muted-foreground">No anomalies detected</p>
-                    )}
-                  </div>
-                </div>
-                <div className="md:col-span-2 flex flex-wrap gap-1 border-t border-border/30 pt-2">
-                  <Link href={`/console?request_id=${encodeURIComponent(selectedEntry.point.id)}`} className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
-                    <span aria-hidden>⚡</span> Open in Decision
-                  </Link>
-                  <Link href={`/audit?request_id=${encodeURIComponent(selectedEntry.point.id)}`} className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
-                    <span aria-hidden>📋</span> Open in TrustLog
-                  </Link>
-                  <Link href="/governance" className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
-                    <span aria-hidden>🛡</span> Adjust in Governance
-                  </Link>
-                </div>
-              </div>
-            ) : (
-              <div className="mt-2 rounded-lg border border-border/30 bg-muted/10 px-3 py-4 text-center text-muted-foreground" data-testid="empty-drilldown">
-                <p className="text-sm font-medium">{t("監視対象", "Monitoring target")}</p>
-                <p className="mt-1 text-[11px]">{t("ポイントを選択するとドリルダウン情報が表示されます。リアルタイムでリスク監視を継続中です。", "Select a point to view drilldown details. Real-time risk monitoring continues.")}</p>
-              </div>
-            )}
-          </div>
-
-          {/* ── Structured why-flagged ── */}
-          <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs" data-testid="why-flagged">
-            <p className="font-semibold">Why flagged</p>
-            {selectedEntry ? (
-              <div className="mt-2 space-y-3">
-                <p className="font-mono text-[10px] text-muted-foreground">{selectedEntry.point.id}</p>
-                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-                  <div className="rounded-lg border border-border/40 px-2 py-1.5">
-                    <p className="text-[10px] font-semibold uppercase text-muted-foreground">Policy confidence</p>
-                    <p className={`font-mono font-semibold ${selectedEntry.reason.policyConfidence < 0.3 ? "text-danger" : selectedEntry.reason.policyConfidence < 0.6 ? "text-warning" : "text-success"}`}>
-                      {(selectedEntry.reason.policyConfidence * 100).toFixed(0)}%
-                    </p>
-                  </div>
-                  <div className="rounded-lg border border-border/40 px-2 py-1.5">
-                    <p className="text-[10px] font-semibold uppercase text-muted-foreground">Unstable output</p>
-                    <p className={`font-semibold ${selectedEntry.reason.unstableOutputSignal ? "text-danger" : "text-success"}`}>
-                      {selectedEntry.reason.unstableOutputSignal ? "Detected" : "Stable"}
-                    </p>
-                  </div>
-                  <div className="rounded-lg border border-border/40 px-2 py-1.5">
-                    <p className="text-[10px] font-semibold uppercase text-muted-foreground">Retrieval anomaly</p>
-                    <p className={`font-semibold ${selectedEntry.reason.retrievalAnomaly ? "text-warning" : "text-success"}`}>
-                      {selectedEntry.reason.retrievalAnomaly ? "Anomaly" : "Normal"}
-                    </p>
-                  </div>
-                  <div className="rounded-lg border border-border/40 px-2 py-1.5">
-                    <p className="text-[10px] font-semibold uppercase text-muted-foreground">Cluster</p>
-                    <p className="font-semibold">{selectedEntry.cluster}</p>
-                  </div>
-                </div>
-                <div className="rounded-lg border border-border/40 bg-muted/5 px-2 py-1.5">
-                  <p className="text-[10px] font-semibold uppercase text-muted-foreground">Analysis</p>
-                  <p className="mt-0.5 text-muted-foreground">{selectedEntry.reason.summary}</p>
-                </div>
-                <div className="rounded-lg border border-primary/30 bg-primary/5 px-2 py-1.5">
-                  <p className="text-[10px] font-semibold uppercase text-muted-foreground">Suggested next action</p>
-                  <p className="mt-0.5">{selectedEntry.reason.suggestedAction}</p>
-                </div>
-              </div>
-            ) : (
-              <div className="mt-2 rounded-lg border border-border/30 bg-muted/10 px-3 py-4 text-center text-muted-foreground" data-testid="empty-why-flagged">
-                <p className="text-sm font-medium">{t("監視中", "Monitoring active")}</p>
-                <p className="mt-1 text-[11px]">{t("フラグされたリクエストがないため、構造化理由は表示されません。", "No flagged requests — structured reasoning will appear when a request is selected.")}</p>
-              </div>
-            )}
-          </div>
+          {/* Drilldown + Why flagged */}
+          <DrilldownPanel entry={stream.selectedEntry} />
+          <WhyFlaggedPanel entry={stream.selectedEntry} />
         </div>
       </Card>
     </div>

--- a/frontend/app/risk/risk-types.ts
+++ b/frontend/app/risk/risk-types.ts
@@ -1,0 +1,34 @@
+export type ClusterKind = "critical" | "risky" | "uncertain" | "stable";
+export type Severity = "critical" | "high" | "medium" | "low";
+export type RequestStatus = "active" | "mitigated" | "investigating" | "new";
+
+export interface RiskPoint {
+  id: string;
+  uncertainty: number;
+  risk: number;
+  timestamp: number;
+}
+
+export interface TrendBucket {
+  label: string;
+  total: number;
+  highRisk: number;
+}
+
+export interface FlagReason {
+  policyConfidence: number;
+  unstableOutputSignal: boolean;
+  retrievalAnomaly: boolean;
+  summary: string;
+  suggestedAction: string;
+}
+
+export interface FlaggedEntry {
+  point: RiskPoint;
+  cluster: ClusterKind;
+  severity: Severity;
+  status: RequestStatus;
+  reason: FlagReason;
+  relatedPolicyHits: string[];
+  stageAnomalies: string[];
+}

--- a/frontend/components/ui/empty-state.tsx
+++ b/frontend/components/ui/empty-state.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  icon?: JSX.Element;
+  action?: JSX.Element;
+  className?: string;
+}
+
+export function EmptyState({ title, description, icon, action, className }: EmptyStateProps): JSX.Element {
+  return (
+    <div className={`flex flex-col items-center gap-3 py-8 text-center${className ? ` ${className}` : ""}`}>
+      {icon ? (
+        <div className="rounded-full border-2 border-dashed border-muted p-4">
+          {icon}
+        </div>
+      ) : null}
+      <div>
+        <p className="text-sm font-semibold">{title}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      </div>
+      {action ?? null}
+    </div>
+  );
+}

--- a/frontend/components/ui/error-banner.tsx
+++ b/frontend/components/ui/error-banner.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+interface ErrorBannerProps {
+  message: string;
+  variant?: "danger" | "warning";
+  className?: string;
+}
+
+export function ErrorBanner({ message, variant = "danger", className }: ErrorBannerProps): JSX.Element {
+  const styles = variant === "danger"
+    ? "border-danger/30 bg-danger/10 text-danger"
+    : "border-warning/30 bg-warning/10 text-warning";
+
+  return (
+    <div
+      role="alert"
+      className={`rounded-lg border px-3 py-2 text-sm ${styles}${className ? ` ${className}` : ""}`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -1,0 +1,6 @@
+export { StatusBadge } from "./status-badge";
+export { StatCard } from "./stat-card";
+export { EmptyState } from "./empty-state";
+export { ErrorBanner } from "./error-banner";
+export { SuccessBanner } from "./success-banner";
+export { SectionHeader } from "./section-header";

--- a/frontend/components/ui/section-header.tsx
+++ b/frontend/components/ui/section-header.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+interface SectionHeaderProps {
+  title: string;
+  description?: string;
+  trailing?: JSX.Element;
+  className?: string;
+}
+
+export function SectionHeader({ title, description, trailing, className }: SectionHeaderProps): JSX.Element {
+  return (
+    <div className={`flex items-start justify-between gap-3${className ? ` ${className}` : ""}`}>
+      <div className="min-w-0">
+        <p className="text-xs font-semibold">{title}</p>
+        {description ? (
+          <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      {trailing ?? null}
+    </div>
+  );
+}

--- a/frontend/components/ui/stat-card.tsx
+++ b/frontend/components/ui/stat-card.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  variant?: "default" | "success" | "danger" | "warning" | "info";
+  className?: string;
+}
+
+const VALUE_STYLES: Record<NonNullable<StatCardProps["variant"]>, string> = {
+  default: "text-foreground",
+  success: "text-success",
+  danger: "text-danger",
+  warning: "text-warning",
+  info: "text-info",
+};
+
+export function StatCard({ label, value, variant = "default", className }: StatCardProps): JSX.Element {
+  return (
+    <div className={`rounded border border-border px-3 py-2 text-center${className ? ` ${className}` : ""}`}>
+      <p className={`text-lg font-semibold ${VALUE_STYLES[variant]}`}>{value}</p>
+      <p className="text-2xs text-muted-foreground">{label}</p>
+    </div>
+  );
+}

--- a/frontend/components/ui/status-badge.tsx
+++ b/frontend/components/ui/status-badge.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+type BadgeVariant = "success" | "warning" | "danger" | "info" | "muted";
+
+const VARIANT_STYLES: Record<BadgeVariant, string> = {
+  success: "bg-success/20 text-success border-success/40",
+  warning: "bg-warning/20 text-warning border-warning/40",
+  danger: "bg-danger/20 text-danger border-danger/40",
+  info: "bg-info/20 text-info border-info/40",
+  muted: "bg-muted/20 text-muted-foreground border-border/40",
+};
+
+interface StatusBadgeProps {
+  label: string;
+  variant: BadgeVariant;
+  className?: string;
+}
+
+export function StatusBadge({ label, variant, className }: StatusBadgeProps): JSX.Element {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${VARIANT_STYLES[variant]}${className ? ` ${className}` : ""}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/components/ui/success-banner.tsx
+++ b/frontend/components/ui/success-banner.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+interface SuccessBannerProps {
+  message: string;
+  className?: string;
+}
+
+export function SuccessBanner({ message, className }: SuccessBannerProps): JSX.Element {
+  return (
+    <div
+      role="status"
+      className={`rounded-lg border border-success/40 px-3 py-2 text-sm text-success${className ? ` ${className}` : ""}`}
+    >
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
Report
1. Changed Files (37 files)
New shared UI components (7 files):
	∙	components/ui/status-badge.tsx - Reusable status badge with variant support
	∙	components/ui/stat-card.tsx - Metric display card with colored variants
	∙	components/ui/empty-state.tsx - Consistent empty state with icon/action slots
	∙	components/ui/error-banner.tsx - Error alert with danger/warning variants
	∙	components/ui/success-banner.tsx - Success notification banner
	∙	components/ui/section-header.tsx - Section title with optional trailing element
	∙	components/ui/index.ts - Barrel export
Governance split (13 files):
	∙	governance/governance-types.ts - Types extracted from page
	∙	governance/constants.ts - Constants (FUJI labels, mode explanations, role capabilities)
	∙	governance/helpers.ts - Pure functions (deepEqual, collectChanges, bumpDraftVersion)
	∙	governance/hooks/useGovernanceState.ts - All state management & API logic
	∙	governance/components/ToggleRow.tsx, DiffPreview.tsx, RiskImpactGauge.tsx, PolicyMetaPanel.tsx, FujiRulesEditor.tsx, ApprovalWorkflow.tsx, ApplyFlow.tsx, TrustLogStream.tsx, ChangeHistory.tsx
	∙	governance/page.tsx - 670→130 lines, pure composition
Audit split (4 new + 1 modified):
	∙	audit/components/AuditSummaryPanel.tsx - Summary stats with integrity bar
	∙	audit/components/AuditTimeline.tsx - Timeline list with chain status
	∙	audit/components/VerificationPanel.tsx - Hash chain verification UI
	∙	audit/components/ExportPanel.tsx - Report generation with redaction/format options
	∙	audit/page.tsx - 716→130 lines, pure composition
Risk split (10 files):
	∙	risk/risk-types.ts - All type definitions
	∙	risk/constants.ts - Thresholds and style constants
	∙	risk/data-helpers.ts - All synthetic data generation & analytics functions
	∙	risk/hooks/useRiskStream.ts - Stream state & derived data
	∙	risk/components/RiskScatterPlot.tsx, InsightCards.tsx, TrendChart.tsx, FlaggedRequestsList.tsx, DrilldownPanel.tsx, WhyFlaggedPanel.tsx
	∙	risk/page.tsx - 705→130 lines, pure composition
2. What Was Improved
	∙	Monolithic pages decomposed: Each 670-716 line page reduced to ~130 lines of pure composition
	∙	State management extracted: useGovernanceState and useRiskStream hooks isolate business logic from UI
	∙	Types/constants/helpers separated: Pure functions and type definitions are now independently testable
	∙	Shared UI primitives: 6 reusable components extracted from repeated patterns across pages
	∙	Consistent error/success/empty states: Using ErrorBanner, SuccessBanner, EmptyState across pages
3. UX / Maintainability / Performance / Accessibility Effects
	∙	UX: No visual changes — behavior is 100% preserved. Foundation now allows incremental UI improvements per-component
	∙	Maintainability: Each component has a single responsibility and clear prop interface. Changes to e.g. the approval workflow don’t touch unrelated governance UI
	∙	Performance: Smaller components enable more granular React re-renders. Hooks separate from UI allow future React.memo optimization
	∙	Accessibility: All existing ARIA labels, roles, keyboard handlers, and i18n preserved without degradation
	∙	Type safety: All prop interfaces are explicit, no any introduced
4. High-Value Next Steps
	1.	Add component-level tests for each extracted sub-component (currently tested through page-level tests)
	2.	MissionPage / Dashboard (/): Enhance with live health metrics and better information hierarchy
	3.	Console (/console): Already well-decomposed; improve result panel tab UX
	4.	Responsive/mobile: The grid layouts need breakpoint testing for tablet/mobile
	5.	Skeleton loading states: Add shimmer placeholders for data fetch transitions
	6.	Design system consolidation: Move ToggleRow, StatusBadge, StatCard candidates to @veritas/design-system
5. Commands & Results
![image](https://github.com/user-attachments/assets/e3367191-183c-4536-932b-6a3dff30f615)
![image](https://github.com/user-attachments/assets/5b1e7ed4-aa7e-4a9c-809f-5aa7005ba481)