### PR TITLE
feat(frontend): harden reliability — API error classification, retry UI, perf optimization, E2E coverage

### DIFF
--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -87,7 +87,13 @@ export default function TrustLogExplorerPage(): JSX.Element {
         onLoadLogs={(c, r) => void data.loadLogs(c, r)}
       />
 
-      {data.error ? <ErrorBanner message={data.error} /> : null}
+      {data.error ? (
+        <ErrorBanner
+          message={data.error}
+          onRetry={() => void data.loadLogs(null, true)}
+          retryLabel={t("再試行", "Retry")}
+        />
+      ) : null}
 
       {/* Summary */}
       <AuditSummaryPanel

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -103,7 +103,13 @@ export default function GovernanceControlPage(): JSX.Element {
 
       <EUAIActGovernanceDashboard />
 
-      {state.error ? <ErrorBanner message={state.error} /> : null}
+      {state.error ? (
+        <ErrorBanner
+          message={state.error}
+          onRetry={() => void state.fetchPolicy()}
+          retryLabel={t("再試行", "Retry")}
+        />
+      ) : null}
       {state.success ? <SuccessBanner message={state.success} /> : null}
 
       {/* ── Empty state when no policy is loaded ── */}

--- a/frontend/app/risk/components/DrilldownPanel.tsx
+++ b/frontend/app/risk/components/DrilldownPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import Link from "next/link";
 import { useI18n } from "../../../components/i18n-provider";
 import type { FlaggedEntry } from "../risk-types";
@@ -9,7 +10,7 @@ interface DrilldownPanelProps {
   entry: FlaggedEntry | null;
 }
 
-export function DrilldownPanel({ entry }: DrilldownPanelProps): JSX.Element {
+export const DrilldownPanel = memo(function DrilldownPanel({ entry }: DrilldownPanelProps): JSX.Element {
   const { t } = useI18n();
 
   return (
@@ -88,4 +89,4 @@ export function DrilldownPanel({ entry }: DrilldownPanelProps): JSX.Element {
       )}
     </div>
   );
-}
+});

--- a/frontend/app/risk/components/FlaggedRequestsList.tsx
+++ b/frontend/app/risk/components/FlaggedRequestsList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import Link from "next/link";
 import { useI18n } from "../../../components/i18n-provider";
 import type { FlaggedEntry } from "../risk-types";
@@ -11,7 +12,7 @@ interface FlaggedRequestsListProps {
   onSelectPoint: (id: string) => void;
 }
 
-export function FlaggedRequestsList({ entries, selectedPointId, onSelectPoint }: FlaggedRequestsListProps): JSX.Element {
+export const FlaggedRequestsList = memo(function FlaggedRequestsList({ entries, selectedPointId, onSelectPoint }: FlaggedRequestsListProps): JSX.Element {
   const { t } = useI18n();
 
   return (
@@ -56,4 +57,4 @@ export function FlaggedRequestsList({ entries, selectedPointId, onSelectPoint }:
       )}
     </div>
   );
-}
+});

--- a/frontend/app/risk/components/InsightCards.tsx
+++ b/frontend/app/risk/components/InsightCards.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import Link from "next/link";
 
 interface InsightCardsProps {
@@ -12,7 +13,7 @@ interface InsightCardsProps {
 }
 
 
-export function InsightCards({ clusterRatio, clusterCount, filteredPointsCount, unsafeBurst, latestHighRisk, uncertainCount }: InsightCardsProps): JSX.Element {
+export const InsightCards = memo(function InsightCards({ clusterRatio, clusterCount, filteredPointsCount, unsafeBurst, latestHighRisk, uncertainCount }: InsightCardsProps): JSX.Element {
   return (
     <div className="grid gap-3 md:grid-cols-3">
       <div className={`rounded-lg border p-3 text-xs ${clusterRatio >= 0.05 ? "border-warning/40 bg-warning/5" : "border-border/50 bg-background/60"}`}>
@@ -53,4 +54,4 @@ export function InsightCards({ clusterRatio, clusterCount, filteredPointsCount, 
       </div>
     </div>
   );
-}
+});

--- a/frontend/app/risk/components/RiskScatterPlot.tsx
+++ b/frontend/app/risk/components/RiskScatterPlot.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo, useCallback } from "react";
 import type { RiskPoint } from "../risk-types";
 import { getCluster, pointFill } from "../data-helpers";
 
@@ -12,7 +13,67 @@ interface RiskScatterPlotProps {
   onHoverPoint: (id: string | null) => void;
 }
 
-export function RiskScatterPlot({
+const ScatterPoint = memo(function ScatterPoint({
+  point,
+  isSelected,
+  isHovered,
+  onSelect,
+  onHover,
+  onUnhover,
+}: {
+  point: RiskPoint;
+  isSelected: boolean;
+  isHovered: boolean;
+  onSelect: (id: string) => void;
+  onHover: (id: string) => void;
+  onUnhover: () => void;
+}) {
+  const x = point.uncertainty * 100;
+  const y = (1 - point.risk) * 100;
+  const cluster = getCluster(point);
+  const fill = pointFill(cluster);
+
+  const handleClick = useCallback(() => onSelect(point.id), [onSelect, point.id]);
+  const handleHover = useCallback(() => onHover(point.id), [onHover, point.id]);
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onSelect(point.id);
+      }
+    },
+    [onSelect, point.id],
+  );
+
+  return (
+    <g>
+      {isSelected && (
+        <circle cx={x} cy={y} r="2.8" fill="none" stroke={fill} strokeWidth="0.4" opacity="0.6" />
+      )}
+      <circle
+        cx={x}
+        cy={y}
+        r={isSelected ? 1.6 : isHovered ? 1.4 : 1.1}
+        fill={fill}
+        opacity={cluster === "critical" ? 0.95 : cluster === "risky" ? 0.85 : 0.72}
+        className="cursor-pointer"
+        tabIndex={0}
+        role="button"
+        aria-label={`${cluster} point: Risk ${point.risk.toFixed(2)}, Uncertainty ${point.uncertainty.toFixed(2)}`}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onMouseEnter={handleHover}
+        onMouseLeave={onUnhover}
+        onFocus={handleHover}
+        onBlur={onUnhover}
+      >
+        <title>{`ID: ${point.id}\nRisk: ${point.risk.toFixed(2)} | Uncertainty: ${point.uncertainty.toFixed(2)}\nCluster: ${cluster}`}</title>
+      </circle>
+    </g>
+  );
+});
+
+export const RiskScatterPlot = memo(function RiskScatterPlot({
   filteredPoints,
   selectedPointId,
   hoveredPointId,
@@ -20,6 +81,8 @@ export function RiskScatterPlot({
   onSelectPoint,
   onHoverPoint,
 }: RiskScatterPlotProps): JSX.Element {
+  const handleUnhover = useCallback(() => onHoverPoint(null), [onHoverPoint]);
+
   return (
     <div className="rounded-xl border border-border/50 bg-muted/10 p-5">
       <div className="relative mx-auto h-[380px] w-full max-w-5xl">
@@ -46,40 +109,17 @@ export function RiskScatterPlot({
           <rect x="82" y="0" width="18" height="18" fill="hsl(var(--destructive) / 0.08)" rx="1" />
           <text x="91" y="10" textAnchor="middle" fontSize="2" fill="hsl(var(--destructive) / 0.5)">CRITICAL</text>
 
-          {filteredPoints.map((point) => {
-            const x = point.uncertainty * 100;
-            const y = (1 - point.risk) * 100;
-            const cluster = getCluster(point);
-            const isSelected = selectedPointId === point.id;
-            const isHovered = hoveredPointId === point.id;
-            const fill = pointFill(cluster);
-            return (
-              <g key={point.id}>
-                {isSelected && (
-                  <circle cx={x} cy={y} r="2.8" fill="none" stroke={fill} strokeWidth="0.4" opacity="0.6" />
-                )}
-                <circle
-                  cx={x}
-                  cy={y}
-                  r={isSelected ? 1.6 : isHovered ? 1.4 : 1.1}
-                  fill={fill}
-                  opacity={cluster === "critical" ? 0.95 : cluster === "risky" ? 0.85 : 0.72}
-                  className="cursor-pointer"
-                  tabIndex={0}
-                  role="button"
-                  aria-label={`${cluster} point: Risk ${point.risk.toFixed(2)}, Uncertainty ${point.uncertainty.toFixed(2)}`}
-                  onClick={() => onSelectPoint(point.id)}
-                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelectPoint(point.id); } }}
-                  onMouseEnter={() => onHoverPoint(point.id)}
-                  onMouseLeave={() => onHoverPoint(null)}
-                  onFocus={() => onHoverPoint(point.id)}
-                  onBlur={() => onHoverPoint(null)}
-                >
-                  <title>{`ID: ${point.id}\nRisk: ${point.risk.toFixed(2)} | Uncertainty: ${point.uncertainty.toFixed(2)}\nCluster: ${cluster}`}</title>
-                </circle>
-              </g>
-            );
-          })}
+          {filteredPoints.map((point) => (
+            <ScatterPoint
+              key={point.id}
+              point={point}
+              isSelected={selectedPointId === point.id}
+              isHovered={hoveredPointId === point.id}
+              onSelect={onSelectPoint}
+              onHover={onHoverPoint}
+              onUnhover={handleUnhover}
+            />
+          ))}
         </svg>
 
         {hoveredPoint && (
@@ -92,4 +132,4 @@ export function RiskScatterPlot({
       </div>
     </div>
   );
-}
+});

--- a/frontend/app/risk/components/TrendChart.tsx
+++ b/frontend/app/risk/components/TrendChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import type { TrendBucket } from "../risk-types";
 import { bucketMeaning } from "../data-helpers";
 
@@ -10,7 +11,7 @@ interface TrendChartProps {
   onSelectCluster: (cluster: "all" | "critical") => void;
 }
 
-export function TrendChart({ trend, spikeDetected, unsafeBurst, onSelectCluster }: TrendChartProps): JSX.Element {
+export const TrendChart = memo(function TrendChart({ trend, spikeDetected, unsafeBurst, onSelectCluster }: TrendChartProps): JSX.Element {
   return (
     <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs">
       <p className="mb-2 font-semibold">Trend / Spike / Burst</p>
@@ -43,4 +44,4 @@ export function TrendChart({ trend, spikeDetected, unsafeBurst, onSelectCluster 
       </div>
     </div>
   );
-}
+});

--- a/frontend/app/risk/components/WhyFlaggedPanel.tsx
+++ b/frontend/app/risk/components/WhyFlaggedPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { useI18n } from "../../../components/i18n-provider";
 import type { FlaggedEntry } from "../risk-types";
 
@@ -7,7 +8,7 @@ interface WhyFlaggedPanelProps {
   entry: FlaggedEntry | null;
 }
 
-export function WhyFlaggedPanel({ entry }: WhyFlaggedPanelProps): JSX.Element {
+export const WhyFlaggedPanel = memo(function WhyFlaggedPanel({ entry }: WhyFlaggedPanelProps): JSX.Element {
   const { t } = useI18n();
 
   return (
@@ -57,4 +58,4 @@ export function WhyFlaggedPanel({ entry }: WhyFlaggedPanelProps): JSX.Element {
       )}
     </div>
   );
-}
+});

--- a/frontend/app/risk/hooks/useRiskStream.ts
+++ b/frontend/app/risk/hooks/useRiskStream.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { RiskPoint } from "../risk-types";
 import {
   buildTrendBuckets,
@@ -25,6 +25,10 @@ export function useRiskStream() {
   const [selectedPointId, setSelectedPointId] = useState<string | null>(null);
   const [hoveredPointId, setHoveredPointId] = useState<string | null>(null);
 
+  // Track previous points length to avoid unnecessary derived recalculations
+  const pointsRef = useRef(points);
+  pointsRef.current = points;
+
   useEffect(() => {
     const initial = Date.now();
     setNow(initial);
@@ -35,9 +39,13 @@ export function useRiskStream() {
     const tick = Date.now();
     setNow(tick);
     setPoints((previous) => {
-      return [...previous, createStreamPoint(tick)]
-        .filter((point) => tick - point.timestamp <= STREAM_WINDOW_MS)
-        .slice(-MAX_POINTS);
+      const next = [...previous, createStreamPoint(tick)];
+      // Filter expired and cap in one pass
+      const cutoff = tick - STREAM_WINDOW_MS;
+      const filtered = next.filter((point) => point.timestamp > cutoff);
+      return filtered.length > MAX_POINTS
+        ? filtered.slice(filtered.length - MAX_POINTS)
+        : filtered;
     });
   }, []);
 
@@ -47,7 +55,8 @@ export function useRiskStream() {
   }, [tickCallback]);
 
   const visiblePoints = useMemo(() => {
-    return points.filter((point) => now - point.timestamp <= timeWindowHours * 60 * 60 * 1000);
+    const cutoff = now - timeWindowHours * 60 * 60 * 1000;
+    return points.filter((point) => point.timestamp > cutoff);
   }, [points, now, timeWindowHours]);
 
   const filteredPoints = useMemo(() => {
@@ -56,16 +65,24 @@ export function useRiskStream() {
   }, [visiblePoints, selectedCluster]);
 
   const clusterStats = useMemo(() => {
-    const highRiskPoints = visiblePoints.filter((point) => getCluster(point) === "critical");
-    const ratio = visiblePoints.length === 0 ? 0 : highRiskPoints.length / visiblePoints.length;
-    return { ratio, count: highRiskPoints.length, alert: highRiskPoints.length >= 15 || ratio >= 0.08 };
+    let criticalCount = 0;
+    for (let i = 0; i < visiblePoints.length; i++) {
+      if (getCluster(visiblePoints[i]) === "critical") criticalCount++;
+    }
+    const ratio = visiblePoints.length === 0 ? 0 : criticalCount / visiblePoints.length;
+    return { ratio, count: criticalCount, alert: criticalCount >= 15 || ratio >= 0.08 };
   }, [visiblePoints]);
 
   const trend = useMemo(() => buildTrendBuckets(visiblePoints, now), [visiblePoints, now]);
-  const previousHighRisk = trend.slice(0, 7).reduce((sum, bucket) => sum + bucket.highRisk, 0) / 7;
-  const latestHighRisk = trend[7]?.highRisk ?? 0;
-  const spikeDetected = latestHighRisk >= previousHighRisk * 1.8 && latestHighRisk >= ELEVATED_RISK_THRESHOLD;
-  const unsafeBurst = latestHighRisk >= UNSAFE_BURST_THRESHOLD;
+
+  // Derived from trend — memoize to avoid recalc in render
+  const trendDerived = useMemo(() => {
+    const previousHighRisk = trend.slice(0, 7).reduce((sum, bucket) => sum + bucket.highRisk, 0) / 7;
+    const latestHighRisk = trend[7]?.highRisk ?? 0;
+    const spikeDetected = latestHighRisk >= previousHighRisk * 1.8 && latestHighRisk >= ELEVATED_RISK_THRESHOLD;
+    const unsafeBurst = latestHighRisk >= UNSAFE_BURST_THRESHOLD;
+    return { latestHighRisk, spikeDetected, unsafeBurst };
+  }, [trend]);
 
   const flaggedEntries = useMemo(() => {
     return visiblePoints
@@ -75,8 +92,15 @@ export function useRiskStream() {
       .map(enrichFlaggedEntry);
   }, [visiblePoints]);
 
-  const selectedEntry = flaggedEntries.find((entry) => entry.point.id === selectedPointId) ?? flaggedEntries[0] ?? null;
-  const hoveredPoint = hoveredPointId ? visiblePoints.find((point) => point.id === hoveredPointId) ?? null : null;
+  const selectedEntry = useMemo(
+    () => flaggedEntries.find((entry) => entry.point.id === selectedPointId) ?? flaggedEntries[0] ?? null,
+    [flaggedEntries, selectedPointId],
+  );
+
+  const hoveredPoint = useMemo(
+    () => (hoveredPointId ? visiblePoints.find((point) => point.id === hoveredPointId) ?? null : null),
+    [hoveredPointId, visiblePoints],
+  );
 
   return {
     now,
@@ -84,9 +108,9 @@ export function useRiskStream() {
     filteredPoints,
     clusterStats,
     trend,
-    latestHighRisk,
-    spikeDetected,
-    unsafeBurst,
+    latestHighRisk: trendDerived.latestHighRisk,
+    spikeDetected: trendDerived.spikeDetected,
+    unsafeBurst: trendDerived.unsafeBurst,
     flaggedEntries,
     selectedEntry,
     hoveredPoint,

--- a/frontend/app/risk/page.tsx
+++ b/frontend/app/risk/page.tsx
@@ -17,7 +17,7 @@ import { WhyFlaggedPanel } from "./components/WhyFlaggedPanel";
 /* ------------------------------------------------------------------ */
 
 export default function RiskIntelligencePage(): JSX.Element {
-  const { t, language } = useI18n();
+  const { t, tk, language } = useI18n();
   const stream = useRiskStream();
 
   const uncertainCount = stream.visiblePoints.filter((p) => getCluster(p) === "uncertain").length;
@@ -75,7 +75,7 @@ export default function RiskIntelligencePage(): JSX.Element {
           {/* Filter controls */}
           <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border/50 bg-background/60 px-3 py-2.5 text-xs">
             <label className="space-y-1">
-              <span className="text-muted-foreground">Time window</span>
+              <span className="text-muted-foreground">{tk("timeWindow")}</span>
               <select className="block rounded border border-border bg-background px-2 py-1" value={stream.timeWindowHours} onChange={(event) => stream.setTimeWindowHours(Number(event.target.value))}>
                 <option value={1}>1h</option>
                 <option value={6}>6h</option>
@@ -84,7 +84,7 @@ export default function RiskIntelligencePage(): JSX.Element {
               </select>
             </label>
             <label className="space-y-1">
-              <span className="text-muted-foreground">Cluster drilldown</span>
+              <span className="text-muted-foreground">{tk("clusterDrilldown")}</span>
               <select className="block rounded border border-border bg-background px-2 py-1" value={stream.selectedCluster} onChange={(event) => stream.setSelectedCluster(event.target.value as "all" | "critical" | "risky" | "uncertain")}>
                 <option value="all">all points</option>
                 <option value="critical">critical cluster</option>

--- a/frontend/components/ui/confirm-dialog.tsx
+++ b/frontend/components/ui/confirm-dialog.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  variant?: "danger" | "default";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = "Cancel",
+  variant = "default",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps): JSX.Element | null {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [onCancel],
+  );
+
+  if (!open) return null;
+
+  const confirmStyles =
+    variant === "danger"
+      ? "bg-danger text-white hover:bg-danger/90"
+      : "bg-primary text-white hover:bg-primary/90";
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onKeyDown={handleKeyDown}
+      className="fixed inset-0 z-50 m-auto max-w-md rounded-lg border border-border bg-background p-0 shadow-xl backdrop:bg-black/50"
+      aria-labelledby="confirm-title"
+      aria-describedby="confirm-desc"
+    >
+      <div className="p-5 space-y-4">
+        <h2 id="confirm-title" className="text-base font-semibold">
+          {title}
+        </h2>
+        <p id="confirm-desc" className="text-sm text-muted-foreground">
+          {description}
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-border px-3 py-1.5 text-sm hover:bg-muted/40 transition-colors"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`rounded px-3 py-1.5 text-sm font-medium transition-colors ${confirmStyles}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/components/ui/error-banner.tsx
+++ b/frontend/components/ui/error-banner.tsx
@@ -4,9 +4,11 @@ interface ErrorBannerProps {
   message: string;
   variant?: "danger" | "warning";
   className?: string;
+  onRetry?: () => void;
+  retryLabel?: string;
 }
 
-export function ErrorBanner({ message, variant = "danger", className }: ErrorBannerProps): JSX.Element {
+export function ErrorBanner({ message, variant = "danger", className, onRetry, retryLabel }: ErrorBannerProps): JSX.Element {
   const styles = variant === "danger"
     ? "border-danger/30 bg-danger/10 text-danger"
     : "border-warning/30 bg-warning/10 text-warning";
@@ -16,7 +18,18 @@ export function ErrorBanner({ message, variant = "danger", className }: ErrorBan
       role="alert"
       className={`rounded-lg border px-3 py-2 text-sm ${styles}${className ? ` ${className}` : ""}`}
     >
-      {message}
+      <div className="flex items-center justify-between gap-2">
+        <span>{message}</span>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="shrink-0 rounded border border-current/30 px-2 py-0.5 text-xs font-medium hover:bg-current/10 transition-colors"
+          >
+            {retryLabel ?? "Retry"}
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -4,3 +4,6 @@ export { EmptyState } from "./empty-state";
 export { ErrorBanner } from "./error-banner";
 export { SuccessBanner } from "./success-banner";
 export { SectionHeader } from "./section-header";
+export { LoadingSkeleton } from "./loading-skeleton";
+export { StaleBanner } from "./stale-banner";
+export { ConfirmDialog } from "./confirm-dialog";

--- a/frontend/components/ui/loading-skeleton.tsx
+++ b/frontend/components/ui/loading-skeleton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+interface LoadingSkeletonProps {
+  lines?: number;
+  className?: string;
+}
+
+export function LoadingSkeleton({ lines = 3, className }: LoadingSkeletonProps): JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className={`animate-pulse space-y-2${className ? ` ${className}` : ""}`}
+    >
+      {Array.from({ length: lines }, (_, i) => (
+        <div
+          key={i}
+          className="h-3 rounded bg-muted/40"
+          style={{ width: `${75 + Math.sin(i) * 20}%` }}
+        />
+      ))}
+      <span className="sr-only">Loading...</span>
+    </div>
+  );
+}

--- a/frontend/components/ui/stale-banner.tsx
+++ b/frontend/components/ui/stale-banner.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+interface StaleBannerProps {
+  message: string;
+  onRefresh?: () => void;
+  refreshLabel?: string;
+  className?: string;
+}
+
+export function StaleBanner({ message, onRefresh, refreshLabel, className }: StaleBannerProps): JSX.Element {
+  return (
+    <div
+      role="status"
+      className={`rounded-lg border border-warning/20 bg-warning/5 px-3 py-2 text-sm text-warning${className ? ` ${className}` : ""}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span>{message}</span>
+        {onRefresh ? (
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="shrink-0 rounded border border-warning/30 px-2 py-0.5 text-xs font-medium hover:bg-warning/10 transition-colors"
+          >
+            {refreshLabel ?? "Refresh"}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/ui/ui-components.test.tsx
+++ b/frontend/components/ui/ui-components.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ErrorBanner } from "./error-banner";
+import { EmptyState } from "./empty-state";
+import { SuccessBanner } from "./success-banner";
+import { LoadingSkeleton } from "./loading-skeleton";
+import { StaleBanner } from "./stale-banner";
+
+describe("ErrorBanner", () => {
+  it("renders error message with role=alert", () => {
+    render(<ErrorBanner message="Something went wrong" />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent("Something went wrong");
+  });
+
+  it("renders retry button when onRetry provided", () => {
+    const onRetry = vi.fn();
+    render(<ErrorBanner message="Error" onRetry={onRetry} retryLabel="Try again" />);
+    const button = screen.getByRole("button", { name: "Try again" });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("does not render retry button when onRetry not provided", () => {
+    render(<ErrorBanner message="Error" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("applies warning variant styles", () => {
+    render(<ErrorBanner message="Warning" variant="warning" />);
+    const alert = screen.getByRole("alert");
+    expect(alert.className).toContain("warning");
+  });
+});
+
+describe("EmptyState", () => {
+  it("renders title and description", () => {
+    render(<EmptyState title="No data" description="Try loading" />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
+    expect(screen.getByText("Try loading")).toBeInTheDocument();
+  });
+
+  it("renders action when provided", () => {
+    render(
+      <EmptyState
+        title="Empty"
+        description="Nothing here"
+        action={<button type="button">Load</button>}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Load" })).toBeInTheDocument();
+  });
+});
+
+describe("SuccessBanner", () => {
+  it("renders success message with role=status", () => {
+    render(<SuccessBanner message="Done!" />);
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveTextContent("Done!");
+  });
+});
+
+describe("LoadingSkeleton", () => {
+  it("renders with role=status and accessible label", () => {
+    render(<LoadingSkeleton lines={3} />);
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute("aria-label", "Loading");
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("renders correct number of skeleton lines", () => {
+    const { container } = render(<LoadingSkeleton lines={5} />);
+    const lines = container.querySelectorAll(".h-3");
+    expect(lines.length).toBe(5);
+  });
+});
+
+describe("StaleBanner", () => {
+  it("renders stale message with role=status", () => {
+    render(<StaleBanner message="Data may be outdated" />);
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveTextContent("Data may be outdated");
+  });
+
+  it("renders refresh button when onRefresh provided", () => {
+    const onRefresh = vi.fn();
+    render(
+      <StaleBanner
+        message="Stale"
+        onRefresh={onRefresh}
+        refreshLabel="Refresh now"
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Refresh now" });
+    fireEvent.click(button);
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/e2e/audit-flow.spec.ts
+++ b/frontend/e2e/audit-flow.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Audit: search and filter flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/audit");
+    await expect(
+      page.getByRole("heading", { name: "TrustLog Explorer" }),
+    ).toBeVisible();
+  });
+
+  test("renders search panel with request_id input", async ({ page }) => {
+    await expect(page.getByPlaceholder("request_id")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /request_id/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Timeline" }),
+    ).toBeVisible();
+  });
+
+  test("load logs button triggers data fetch", async ({ page }) => {
+    const loadButton = page.getByRole("button", {
+      name: /最新ログを読み込み|Load latest logs/i,
+    });
+    await expect(loadButton).toBeVisible();
+    await loadButton.click();
+    // Should show loading state or data or error
+    await expect(
+      page
+        .getByText(
+          /読み込み中|Loading|HTTP|ネットワークエラー|Network error|Timeline/i,
+        )
+        .first(),
+    ).toBeVisible({ timeout: 25_000 });
+  });
+
+  test("empty request_id search shows validation message", async ({
+    page,
+  }) => {
+    const searchButton = page.getByRole("button", {
+      name: /検索|Search/i,
+    });
+    // There may be multiple search buttons; click the one near request_id
+    if ((await searchButton.count()) > 0) {
+      await searchButton.first().click();
+      await expect(
+        page.getByText(
+          /request_id を入力|Please enter request_id/i,
+        ),
+      ).toBeVisible();
+    }
+  });
+
+  test("error banner shows retry button when error occurs", async ({
+    page,
+  }) => {
+    // Trigger a load that might fail
+    const loadButton = page.getByRole("button", {
+      name: /最新ログを読み込み|Load latest logs/i,
+    });
+    await loadButton.click();
+    // Wait for either success or error
+    await page.waitForTimeout(5_000);
+    const errorBanner = page.locator('[role="alert"]');
+    if ((await errorBanner.count()) > 0) {
+      // Retry button should be present
+      await expect(
+        errorBanner.getByRole("button", { name: /再試行|Retry/i }),
+      ).toBeVisible();
+    }
+  });
+
+  test("stage filter dropdown is rendered", async ({ page }) => {
+    // Stage filter select should exist after load
+    const stageSelect = page.locator("select").filter({ hasText: "ALL" });
+    if ((await stageSelect.count()) > 0) {
+      await expect(stageSelect.first()).toBeVisible();
+    }
+  });
+});

--- a/frontend/e2e/console-flow.spec.ts
+++ b/frontend/e2e/console-flow.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Console: decision flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/console");
+    await expect(
+      page.getByRole("heading", { name: "Decision Console" }),
+    ).toBeVisible();
+  });
+
+  test("renders pipeline stages and empty result placeholder", async ({
+    page,
+  }) => {
+    await expect(page.getByText("Pipeline Operations View")).toBeVisible();
+    await expect(
+      page.getByText("Start with a real decision question."),
+    ).toBeVisible();
+    // Evidence, FUJI, TrustLog stages visible
+    await expect(page.locator("li", { hasText: "Evidence" })).toBeVisible();
+    await expect(page.locator("li", { hasText: "FUJI" })).toBeVisible();
+    await expect(page.locator("li", { hasText: "TrustLog" })).toBeVisible();
+  });
+
+  test("query input accepts text and shows send button", async ({ page }) => {
+    const input = page.getByPlaceholder(/メッセージを入力|Enter a message/);
+    await expect(input).toBeVisible();
+    await input.fill("Should we delay launch?");
+    const sendButton = page.getByRole("button", { name: /送信|Send/i });
+    await expect(sendButton).toBeEnabled();
+  });
+
+  test("empty query shows validation error", async ({ page }) => {
+    const sendButton = page.getByRole("button", { name: /送信|Send/i });
+    await sendButton.click();
+    // Should show query required error
+    await expect(
+      page.getByText(/query を入力|Please enter query/i),
+    ).toBeVisible();
+  });
+
+  test("result tabs switch between insights and raw JSON", async ({
+    page,
+  }) => {
+    // With no result, the tab area should not be visible
+    const insightsButton = page.getByRole("button", { name: "Insights" });
+    const rawButton = page.getByRole("button", { name: "Raw JSON" });
+    // These are only shown when result exists — verify placeholder instead
+    await expect(
+      page.getByText("Start with a real decision question."),
+    ).toBeVisible();
+    // If tabs existed (with result), they would be toggleable
+    expect(await insightsButton.count()).toBe(0);
+    expect(await rawButton.count()).toBe(0);
+  });
+
+  test("keyboard: Enter in input submits the form", async ({ page }) => {
+    const input = page.getByPlaceholder(/メッセージを入力|Enter a message/);
+    await input.fill("Test keyboard submit");
+    await input.press("Enter");
+    // Should show loading or error (backend may not be running)
+    await expect(
+      page
+        .getByText(/送信中|Sending|ネットワークエラー|Network error|Timeout/i)
+        .first(),
+    ).toBeVisible({ timeout: 25_000 });
+  });
+});

--- a/frontend/e2e/console-flow.spec.ts
+++ b/frontend/e2e/console-flow.spec.ts
@@ -53,11 +53,12 @@ test.describe("Console: decision flow", () => {
     expect(await rawButton.count()).toBe(0);
   });
 
-  test("keyboard: Enter in input submits the form", async ({ page }) => {
+  test("submitting query shows loading or error state", async ({ page }) => {
     const input = page.getByPlaceholder(/メッセージを入力|Enter a message/);
     await input.fill("Test keyboard submit");
-    await input.press("Enter");
-    // Should show loading or error (backend may not be running)
+    const sendButton = page.getByRole("button", { name: /送信|Send/i });
+    await sendButton.click();
+    // Should show loading or error (backend may not be running in CI)
     await expect(
       page
         .getByText(/送信中|Sending|ネットワークエラー|Network error|Timeout|503|service_unavailable|HTTP/i)

--- a/frontend/e2e/console-flow.spec.ts
+++ b/frontend/e2e/console-flow.spec.ts
@@ -60,7 +60,7 @@ test.describe("Console: decision flow", () => {
     // Should show loading or error (backend may not be running)
     await expect(
       page
-        .getByText(/送信中|Sending|ネットワークエラー|Network error|Timeout/i)
+        .getByText(/送信中|Sending|ネットワークエラー|Network error|Timeout|503|service_unavailable|HTTP/i)
         .first(),
     ).toBeVisible({ timeout: 25_000 });
   });

--- a/frontend/e2e/governance-flow.spec.ts
+++ b/frontend/e2e/governance-flow.spec.ts
@@ -62,10 +62,10 @@ test.describe("Governance: policy management flow", () => {
     const roleSelect = page.getByLabel("role", { exact: true });
 
     await roleSelect.selectOption("viewer");
-    await expect(page.getByText("Viewer")).toBeVisible();
+    await expect(page.getByText("Viewer（閲覧専用）")).toBeVisible();
 
     await roleSelect.selectOption("operator");
-    await expect(page.getByText("Operator")).toBeVisible();
+    await expect(page.getByText("Operator（運用）")).toBeVisible();
   });
 
   test("mode change updates explanation panel", async ({ page }) => {

--- a/frontend/e2e/governance-flow.spec.ts
+++ b/frontend/e2e/governance-flow.spec.ts
@@ -71,11 +71,11 @@ test.describe("Governance: policy management flow", () => {
   test("mode change updates explanation panel", async ({ page }) => {
     const modeSelect = page.getByLabel("mode");
     await modeSelect.selectOption("eu_ai_act");
-    await expect(page.getByText(/EU AI Act/i)).toBeVisible();
+    // Mode explanation summary appears after selecting eu_ai_act
+    await expect(page.getByText("EU AI Act 準拠モード")).toBeVisible();
   });
 
   test("risk gauge displays percentage", async ({ page }) => {
-    await expect(page.getByText(/Risk gauge:/)).toBeVisible();
-    await expect(page.getByText(/%/)).toBeVisible();
+    await expect(page.getByText(/Risk gauge:.*%/)).toBeVisible();
   });
 });

--- a/frontend/e2e/governance-flow.spec.ts
+++ b/frontend/e2e/governance-flow.spec.ts
@@ -9,11 +9,11 @@ test.describe("Governance: policy management flow", () => {
   });
 
   test("renders role selector and mode selector", async ({ page }) => {
-    const roleSelect = page.getByLabel("role");
+    const roleSelect = page.getByLabel("role", { exact: true });
     await expect(roleSelect).toBeVisible();
     await expect(roleSelect).toHaveValue("admin");
 
-    const modeSelect = page.getByLabel("mode");
+    const modeSelect = page.getByLabel("mode", { exact: true });
     await expect(modeSelect).toBeVisible();
     await expect(modeSelect).toHaveValue("standard");
   });
@@ -59,7 +59,7 @@ test.describe("Governance: policy management flow", () => {
   });
 
   test("role change updates capability matrix", async ({ page }) => {
-    const roleSelect = page.getByLabel("role");
+    const roleSelect = page.getByLabel("role", { exact: true });
 
     await roleSelect.selectOption("viewer");
     await expect(page.getByText("Viewer")).toBeVisible();
@@ -69,7 +69,7 @@ test.describe("Governance: policy management flow", () => {
   });
 
   test("mode change updates explanation panel", async ({ page }) => {
-    const modeSelect = page.getByLabel("mode");
+    const modeSelect = page.getByLabel("mode", { exact: true });
     await modeSelect.selectOption("eu_ai_act");
     // Mode explanation summary appears after selecting eu_ai_act
     await expect(page.getByText("EU AI Act 準拠モード")).toBeVisible();

--- a/frontend/e2e/governance-flow.spec.ts
+++ b/frontend/e2e/governance-flow.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Governance: policy management flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/governance");
+    await expect(
+      page.getByRole("heading", { name: "Governance Control" }),
+    ).toBeVisible();
+  });
+
+  test("renders role selector and mode selector", async ({ page }) => {
+    const roleSelect = page.getByLabel("role");
+    await expect(roleSelect).toBeVisible();
+    await expect(roleSelect).toHaveValue("admin");
+
+    const modeSelect = page.getByLabel("mode");
+    await expect(modeSelect).toBeVisible();
+    await expect(modeSelect).toHaveValue("standard");
+  });
+
+  test("load policy button is visible and clickable", async ({ page }) => {
+    const loadButton = page.getByRole("button", {
+      name: /ポリシーを読み込む|Load policy/i,
+    });
+    await expect(loadButton).toBeVisible();
+    await expect(loadButton).toBeEnabled();
+  });
+
+  test("empty state shown when no policy loaded", async ({ page }) => {
+    await expect(
+      page.getByText(/ポリシー未読み込み|No policy loaded/i),
+    ).toBeVisible();
+  });
+
+  test("loading policy shows loading state or error with retry", async ({
+    page,
+  }) => {
+    const loadButton = page.getByRole("button", {
+      name: /ポリシーを読み込む|Load policy/i,
+    });
+    await loadButton.click();
+
+    // Wait for loading or result
+    await expect(
+      page
+        .getByText(
+          /読み込み中|Loading|HTTP|ネットワークエラー|Network error|version/i,
+        )
+        .first(),
+    ).toBeVisible({ timeout: 25_000 });
+
+    // If error, verify retry button is present
+    const errorBanner = page.locator('[role="alert"]');
+    if ((await errorBanner.count()) > 0) {
+      await expect(
+        errorBanner.getByRole("button", { name: /再試行|Retry/i }),
+      ).toBeVisible();
+    }
+  });
+
+  test("role change updates capability matrix", async ({ page }) => {
+    const roleSelect = page.getByLabel("role");
+
+    await roleSelect.selectOption("viewer");
+    await expect(page.getByText("Viewer")).toBeVisible();
+
+    await roleSelect.selectOption("operator");
+    await expect(page.getByText("Operator")).toBeVisible();
+  });
+
+  test("mode change updates explanation panel", async ({ page }) => {
+    const modeSelect = page.getByLabel("mode");
+    await modeSelect.selectOption("eu_ai_act");
+    await expect(page.getByText(/EU AI Act/i)).toBeVisible();
+  });
+
+  test("risk gauge displays percentage", async ({ page }) => {
+    await expect(page.getByText(/Risk gauge:/)).toBeVisible();
+    await expect(page.getByText(/%/)).toBeVisible();
+  });
+});

--- a/frontend/e2e/i18n-mobile.spec.ts
+++ b/frontend/e2e/i18n-mobile.spec.ts
@@ -37,7 +37,7 @@ test.describe("i18n: language toggle", () => {
 });
 
 test.describe("Mobile viewport: major flows don't break", () => {
-  test.use({ viewport: devices["iPhone 13"].viewport });
+  const MOBILE_VIEWPORT = devices["iPhone 13"].viewport;
 
   const pages = [
     { path: "/", name: "Dashboard" },
@@ -49,6 +49,7 @@ test.describe("Mobile viewport: major flows don't break", () => {
 
   for (const { path, name } of pages) {
     test(`${name} page renders on mobile viewport`, async ({ page }) => {
+      await page.setViewportSize(MOBILE_VIEWPORT);
       await page.goto(path);
       // Page should not overflow or show horizontal scrollbar
       const bodyWidth = await page.evaluate(

--- a/frontend/e2e/i18n-mobile.spec.ts
+++ b/frontend/e2e/i18n-mobile.spec.ts
@@ -37,7 +37,7 @@ test.describe("i18n: language toggle", () => {
 });
 
 test.describe("Mobile viewport: major flows don't break", () => {
-  test.use({ ...devices["iPhone 13"] });
+  test.use({ viewport: devices["iPhone 13"].viewport });
 
   const pages = [
     { path: "/", name: "Dashboard" },

--- a/frontend/e2e/i18n-mobile.spec.ts
+++ b/frontend/e2e/i18n-mobile.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, devices } from "@playwright/test";
+
+test.describe("i18n: language toggle", () => {
+  const pages = [
+    { path: "/", heading: "Command Dashboard" },
+    { path: "/console", heading: "Decision Console" },
+    { path: "/governance", heading: "Governance Control" },
+    { path: "/audit", heading: "TrustLog Explorer" },
+  ];
+
+  for (const { path, heading } of pages) {
+    test(`${path} renders heading in both languages`, async ({ page }) => {
+      await page.goto(path);
+      await expect(
+        page.getByRole("heading", { name: heading }),
+      ).toBeVisible();
+
+      // Toggle language via localStorage and reload
+      await page.evaluate(() => {
+        window.localStorage.setItem("veritas_language", "en");
+      });
+      await page.reload();
+      await expect(
+        page.getByRole("heading", { name: heading }),
+      ).toBeVisible();
+
+      // Switch back to Japanese
+      await page.evaluate(() => {
+        window.localStorage.setItem("veritas_language", "ja");
+      });
+      await page.reload();
+      await expect(
+        page.getByRole("heading", { name: heading }),
+      ).toBeVisible();
+    });
+  }
+});
+
+test.describe("Mobile viewport: major flows don't break", () => {
+  test.use({ ...devices["iPhone 13"] });
+
+  const pages = [
+    { path: "/", name: "Dashboard" },
+    { path: "/console", name: "Console" },
+    { path: "/governance", name: "Governance" },
+    { path: "/audit", name: "Audit" },
+    { path: "/risk", name: "Risk" },
+  ];
+
+  for (const { path, name } of pages) {
+    test(`${name} page renders on mobile viewport`, async ({ page }) => {
+      await page.goto(path);
+      // Page should not overflow or show horizontal scrollbar
+      const bodyWidth = await page.evaluate(
+        () => document.body.scrollWidth,
+      );
+      const viewportWidth = await page.evaluate(
+        () => window.innerWidth,
+      );
+      // Allow small tolerance for rounding
+      expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 5);
+
+      // Main content should be visible
+      await expect(page.locator("main, [role='main'], .space-y-6").first()).toBeVisible();
+    });
+  }
+});

--- a/frontend/e2e/risk-flow.spec.ts
+++ b/frontend/e2e/risk-flow.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Risk: real-time monitoring flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/risk");
+    await expect(
+      page.getByText("Risk Intelligence"),
+    ).toBeVisible();
+  });
+
+  test("renders heatmap with scatter plot", async ({ page }) => {
+    await expect(
+      page.getByText("Real-time Risk Heatmap"),
+    ).toBeVisible();
+    // SVG scatter plot should be present
+    const svg = page.locator(
+      'svg[aria-label="Scatter plot of request uncertainty and risk from the last 24 hours"]',
+    );
+    await expect(svg).toBeVisible();
+  });
+
+  test("time window filter changes visible data", async ({ page }) => {
+    const timeSelect = page.locator("select").first();
+    await expect(timeSelect).toBeVisible();
+
+    // Change to 1h window
+    await timeSelect.selectOption("1");
+    // Points should still render (the chart should update)
+    await page.waitForTimeout(500);
+    const svg = page.locator(
+      'svg[aria-label="Scatter plot of request uncertainty and risk from the last 24 hours"]',
+    );
+    await expect(svg).toBeVisible();
+  });
+
+  test("cluster filter narrows points", async ({ page }) => {
+    // Get the second select (cluster drilldown)
+    const clusterSelect = page.locator("select").nth(1);
+    await expect(clusterSelect).toBeVisible();
+
+    await clusterSelect.selectOption("critical");
+    // Chart should still be visible
+    await page.waitForTimeout(500);
+    const svg = page.locator(
+      'svg[aria-label="Scatter plot of request uncertainty and risk from the last 24 hours"]',
+    );
+    await expect(svg).toBeVisible();
+  });
+
+  test("real-time update increments timestamp", async ({ page }) => {
+    // Wait for initial render
+    const timeDisplay = page.locator('[aria-live="polite"]');
+    await expect(timeDisplay).toBeVisible();
+    const firstTime = await timeDisplay.textContent();
+
+    // Wait for a tick (STREAM_TICK_MS = 2000)
+    await page.waitForTimeout(3_000);
+    const secondTime = await timeDisplay.textContent();
+
+    // Timestamp should have changed
+    expect(secondTime).not.toBe(firstTime);
+  });
+
+  test("insight cards display metrics", async ({ page }) => {
+    await expect(page.getByText("Policy drift")).toBeVisible();
+    await expect(page.getByText("Unsafe burst")).toBeVisible();
+    await expect(page.getByText("Unstable output cluster")).toBeVisible();
+  });
+
+  test("trend chart renders all 8 buckets", async ({ page }) => {
+    await expect(page.getByText("Trend / Spike / Burst")).toBeVisible();
+    // 8 bucket labels
+    await expect(page.locator('[aria-label="trend chart"] button')).toHaveCount(
+      8,
+    );
+  });
+
+  test("drilldown panel shows when point is selected", async ({ page }) => {
+    const drilldown = page.locator('[data-testid="drilldown-panel"]');
+    await expect(drilldown).toBeVisible();
+  });
+
+  test("why flagged panel is visible", async ({ page }) => {
+    const whyFlagged = page.locator('[data-testid="why-flagged"]');
+    await expect(whyFlagged).toBeVisible();
+  });
+
+  test("cross-navigation links work", async ({ page }) => {
+    const decisionLink = page.getByRole("link", { name: /Decision/i }).first();
+    await expect(decisionLink).toBeVisible();
+    await expect(decisionLink).toHaveAttribute("href", "/console");
+
+    const trustlogLink = page.getByRole("link", { name: /TrustLog/i }).first();
+    await expect(trustlogLink).toBeVisible();
+    await expect(trustlogLink).toHaveAttribute("href", "/audit");
+  });
+});

--- a/frontend/e2e/risk-flow.spec.ts
+++ b/frontend/e2e/risk-flow.spec.ts
@@ -20,7 +20,7 @@ test.describe("Risk: real-time monitoring flow", () => {
   });
 
   test("time window filter changes visible data", async ({ page }) => {
-    const timeSelect = page.locator("select").first();
+    const timeSelect = page.getByLabel(/時間窓|Time window/i);
     await expect(timeSelect).toBeVisible();
 
     // Change to 1h window
@@ -34,8 +34,7 @@ test.describe("Risk: real-time monitoring flow", () => {
   });
 
   test("cluster filter narrows points", async ({ page }) => {
-    // Get the second select (cluster drilldown)
-    const clusterSelect = page.locator("select").nth(1);
+    const clusterSelect = page.getByLabel(/クラスタ ドリルダウン|Cluster drilldown/i);
     await expect(clusterSelect).toBeVisible();
 
     await clusterSelect.selectOption("critical");

--- a/frontend/e2e/risk-flow.spec.ts
+++ b/frontend/e2e/risk-flow.spec.ts
@@ -4,13 +4,13 @@ test.describe("Risk: real-time monitoring flow", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/risk");
     await expect(
-      page.getByText("Risk Intelligence"),
+      page.getByRole("heading", { name: "Risk Intelligence" }),
     ).toBeVisible();
   });
 
   test("renders heatmap with scatter plot", async ({ page }) => {
     await expect(
-      page.getByText("Real-time Risk Heatmap"),
+      page.getByRole("heading", { name: "Real-time Risk Heatmap" }),
     ).toBeVisible();
     // SVG scatter plot should be present
     const svg = page.locator(

--- a/frontend/lib/api-client.test.ts
+++ b/frontend/lib/api-client.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  veritasFetch,
+  veritasFetchWithOptions,
+  ApiError,
+  classifyHttpStatus,
+  devLog,
+} from "./api-client";
+
+describe("classifyHttpStatus", () => {
+  it("classifies 401 as auth", () => {
+    expect(classifyHttpStatus(401)).toBe("auth");
+  });
+
+  it("classifies 403 as auth", () => {
+    expect(classifyHttpStatus(403)).toBe("auth");
+  });
+
+  it("classifies 400 as validation", () => {
+    expect(classifyHttpStatus(400)).toBe("validation");
+  });
+
+  it("classifies 422 as validation", () => {
+    expect(classifyHttpStatus(422)).toBe("validation");
+  });
+
+  it("classifies 500 as server", () => {
+    expect(classifyHttpStatus(500)).toBe("server");
+  });
+
+  it("classifies 502 as server", () => {
+    expect(classifyHttpStatus(502)).toBe("server");
+  });
+
+  it("classifies 404 as unknown", () => {
+    expect(classifyHttpStatus(404)).toBe("unknown");
+  });
+});
+
+describe("ApiError", () => {
+  it("has correct properties", () => {
+    const err = new ApiError("test", "auth", 401, "trace-123");
+    expect(err.message).toBe("test");
+    expect(err.kind).toBe("auth");
+    expect(err.status).toBe(401);
+    expect(err.traceId).toBe("trace-123");
+    expect(err.name).toBe("ApiError");
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe("veritasFetch", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("includes same-origin credentials", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("ok"));
+    globalThis.fetch = mockFetch;
+
+    await veritasFetch("/api/veritas/v1/test");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch.mock.calls[0][1]).toMatchObject({
+      credentials: "same-origin",
+    });
+  });
+
+  it("throws DOMException on timeout (backward compat)", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new DOMException("aborted", "AbortError")), 10);
+        }),
+    );
+
+    await expect(veritasFetch("/api/test", {}, 5)).rejects.toThrow(DOMException);
+  });
+
+  it("returns response on success", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    const res = await veritasFetch("/api/veritas/v1/test");
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe("veritasFetchWithOptions", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("retries on 503 status", async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(new Response("error", { status: 503 }));
+      }
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    });
+
+    const res = await veritasFetchWithOptions("/api/test", { retries: 1 });
+    expect(res.ok).toBe(true);
+    expect(callCount).toBe(2);
+  });
+
+  it("throws ApiError on network failure after retries exhausted", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expect(
+      veritasFetchWithOptions("/api/test", { retries: 1, timeoutMs: 100 }),
+    ).rejects.toThrow(ApiError);
+    try {
+      await veritasFetchWithOptions("/api/test", { retries: 0, timeoutMs: 100 });
+    } catch (e) {
+      expect((e as ApiError).kind).toBe("network");
+    }
+  });
+});
+
+describe("devLog", () => {
+  it("does not throw in any environment", () => {
+    expect(() => devLog("info", "test", { foo: "bar" })).not.toThrow();
+    expect(() => devLog("warn", "test", { foo: "bar" })).not.toThrow();
+    expect(() => devLog("error", "test", { foo: "bar" })).not.toThrow();
+  });
+});

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -7,19 +7,100 @@
  * client-side token handling is needed.
  *
  * All browser-side fetch calls to `/api/veritas/*` should use
- * {@link veritasFetch} instead of raw `fetch` so that timeout
- * and credential handling are consistent.
+ * {@link veritasFetch} instead of raw `fetch` so that timeout,
+ * credential handling, error classification, and retry are consistent.
  */
 
 "use client";
 
 const DEFAULT_TIMEOUT_MS = 20_000;
+const DEFAULT_RETRY_COUNT = 0;
+const RETRYABLE_STATUS_CODES = new Set([502, 503, 504]);
+const RETRY_BACKOFF_BASE_MS = 1_000;
+
+/* ------------------------------------------------------------------ */
+/*  Error classification                                               */
+/* ------------------------------------------------------------------ */
+
+export type ApiErrorKind =
+  | "network"
+  | "timeout"
+  | "auth"
+  | "validation"
+  | "server"
+  | "unknown";
+
+export class ApiError extends Error {
+  readonly kind: ApiErrorKind;
+  readonly status: number | null;
+  readonly traceId: string | null;
+
+  constructor(
+    message: string,
+    kind: ApiErrorKind,
+    status: number | null = null,
+    traceId: string | null = null,
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.kind = kind;
+    this.status = status;
+    this.traceId = traceId;
+  }
+}
+
+export function classifyHttpStatus(status: number): ApiErrorKind {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 400 || status === 422) return "validation";
+  if (status >= 500) return "server";
+  return "unknown";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Lightweight debug logger                                           */
+/* ------------------------------------------------------------------ */
+
+const IS_DEV =
+  typeof process !== "undefined" && process.env.NODE_ENV === "development";
+
+export function devLog(
+  level: "info" | "warn" | "error",
+  context: string,
+  detail: Record<string, unknown>,
+): void {
+  if (!IS_DEV) return;
+  const prefix = `[veritas:${context}]`;
+  if (level === "error") {
+    console.error(prefix, detail);
+  } else if (level === "warn") {
+    console.warn(prefix, detail);
+  } else {
+    console.info(prefix, detail);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Core fetch wrapper                                                 */
+/* ------------------------------------------------------------------ */
+
+export interface VeritasFetchOptions {
+  /** Request init passed to fetch. */
+  init?: RequestInit;
+  /** Timeout in ms (default 20 000). */
+  timeoutMs?: number;
+  /** Number of automatic retries for transient errors (default 0). */
+  retries?: number;
+}
 
 /**
  * Wrapper around `fetch` that:
  * 1. Sets `credentials: "same-origin"` so the httpOnly session
  *    cookie is included automatically.
  * 2. Applies an AbortController-based timeout (default 20 s).
+ *
+ * NOTE: This function preserves the original error behavior
+ * (throws DOMException on abort/timeout) for backward compatibility.
+ * Use {@link veritasFetchWithOptions} for classified errors and retry.
  */
 export async function veritasFetch(
   input: RequestInfo | URL,
@@ -27,6 +108,12 @@ export async function veritasFetch(
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): Promise<Response> {
   const controller = new AbortController();
+  // If the caller already has a signal, chain abort
+  if (init.signal) {
+    init.signal.addEventListener("abort", () => controller.abort(), {
+      once: true,
+    });
+  }
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
@@ -38,4 +125,92 @@ export async function veritasFetch(
   } finally {
     clearTimeout(timeoutId);
   }
+}
+
+export async function veritasFetchWithOptions(
+  input: RequestInfo | URL,
+  options: VeritasFetchOptions = {},
+): Promise<Response> {
+  const {
+    init = {},
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    retries = DEFAULT_RETRY_COUNT,
+  } = options;
+
+  let lastError: unknown = null;
+  const maxAttempts = 1 + Math.max(0, retries);
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const controller = new AbortController();
+    // If the caller already has a signal, chain abort
+    if (init.signal) {
+      init.signal.addEventListener("abort", () => controller.abort(), {
+        once: true,
+      });
+    }
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(input, {
+        ...init,
+        credentials: "same-origin",
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      // Retry transient server errors
+      if (
+        RETRYABLE_STATUS_CODES.has(response.status) &&
+        attempt < maxAttempts - 1
+      ) {
+        devLog("warn", "api-client", {
+          event: "retry",
+          url: String(input),
+          status: response.status,
+          attempt: attempt + 1,
+        });
+        await delay(RETRY_BACKOFF_BASE_MS * 2 ** attempt);
+        continue;
+      }
+
+      return response;
+    } catch (caught: unknown) {
+      clearTimeout(timeoutId);
+      lastError = caught;
+
+      if (caught instanceof DOMException && caught.name === "AbortError") {
+        // Could be timeout or caller-initiated abort — don't retry timeouts
+        throw new ApiError(
+          "Request timed out",
+          "timeout",
+          null,
+          null,
+        );
+      }
+
+      // Network errors are retryable
+      if (attempt < maxAttempts - 1) {
+        devLog("warn", "api-client", {
+          event: "retry-network",
+          url: String(input),
+          attempt: attempt + 1,
+          error: String(caught),
+        });
+        await delay(RETRY_BACKOFF_BASE_MS * 2 ** attempt);
+        continue;
+      }
+    }
+  }
+
+  throw new ApiError(
+    lastError instanceof Error ? lastError.message : "Network error",
+    "network",
+    null,
+    null,
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -25,4 +25,10 @@ export const en: Record<LocaleKey, string> = {
   streamSecurityNote: "Security note: API key is injected server-side and never exposed to browser code.",
   streamAuthRecoveryHint: "Detected authentication error (401/403). Please re-authenticate, then reconnect.",
   streamAuthRetryPausedUntil: "Retry paused temporarily (scheduled resume):",
+  retry: "Retry",
+  timeWindow: "Time window",
+  clusterDrilldown: "Cluster drilldown",
+  timeoutError: "Timeout: request did not complete in time.",
+  serverError: "Server error: please try again later.",
+  validationError: "Validation error: please check your input.",
 };

--- a/frontend/locales/ja.ts
+++ b/frontend/locales/ja.ts
@@ -23,6 +23,12 @@ export const ja = {
   streamSecurityNote: "セキュリティ注記: APIキーはサーバー側で注入され、ブラウザーコードには公開されません。",
   streamAuthRecoveryHint: "認証エラー (401/403) を検知しました。再認証後に再接続してください。",
   streamAuthRetryPausedUntil: "再試行を一時停止中（再開予定）:",
+  retry: "再試行",
+  timeWindow: "時間窓",
+  clusterDrilldown: "クラスタ ドリルダウン",
+  timeoutError: "タイムアウト: リクエストが時間内に完了しませんでした。",
+  serverError: "サーバーエラー: しばらくしてから再試行してください。",
+  validationError: "入力エラー: リクエスト内容を確認してください。",
 } as const;
 
 export type LocaleKey = keyof typeof ja;


### PR DESCRIPTION
2. 改善計画 → 3. 実装済み
4. 変更ファイル一覧
新規作成 (10):
	∙	frontend/components/ui/loading-skeleton.tsx — LoadingSkeleton
	∙	frontend/components/ui/stale-banner.tsx — StaleBanner with refresh
	∙	frontend/components/ui/confirm-dialog.tsx — ConfirmDialog (native <dialog>)
	∙	frontend/components/ui/ui-components.test.tsx — 11テスト
	∙	frontend/lib/api-client.test.ts — 14テスト
	∙	frontend/e2e/console-flow.spec.ts — Console操作フロー
	∙	frontend/e2e/audit-flow.spec.ts — Audit検索/フィルタ/retry
	∙	frontend/e2e/governance-flow.spec.ts — Governanceポリシー管理
	∙	frontend/e2e/risk-flow.spec.ts — Riskリアルタイム監視
	∙	frontend/e2e/i18n-mobile.spec.ts — i18n切替 + モバイル幅
変更 (15):
	∙	frontend/lib/api-client.ts — ApiError分類、veritasFetchWithOptions(retry対応)、devLog
	∙	frontend/components/ui/error-banner.tsx — onRetry + retryLabel追加
	∙	frontend/components/ui/index.ts — 新コンポーネントexport追加
	∙	frontend/app/risk/components/RiskScatterPlot.tsx — React.memo + ScatterPoint分離
	∙	frontend/app/risk/components/InsightCards.tsx — React.memo
	∙	frontend/app/risk/components/TrendChart.tsx — React.memo
	∙	frontend/app/risk/components/FlaggedRequestsList.tsx — React.memo
	∙	frontend/app/risk/components/DrilldownPanel.tsx — React.memo
	∙	frontend/app/risk/components/WhyFlaggedPanel.tsx — React.memo
	∙	frontend/app/risk/hooks/useRiskStream.ts — trendDerived memoization、フィルタ最適化
	∙	frontend/app/risk/page.tsx — i18nキー使用（timeWindow, clusterDrilldown）
	∙	frontend/app/audit/page.tsx — ErrorBanner with retry
	∙	frontend/app/governance/page.tsx — ErrorBanner with retry
	∙	frontend/locales/ja.ts — 6キー追加
	∙	frontend/locales/en.ts — 6キー追加