### PR TITLE
BFF: Read VERITAS_API_KEY at request time and add regression tests

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -111,7 +111,9 @@ health / audit への明示的な露出が望ましい。
 
 ### P1
 
-- BFF の `VERITAS_API_KEY` を request 時に取得する形へ変更し、緊急ローテーションを即時反映できるようにする
+- [x] BFF の `VERITAS_API_KEY` を request 時に取得する形へ変更し、緊急ローテーションを即時反映できるようにする
+  - 2026-03-21 対応済み。`frontend/app/api/veritas/[...path]/route.ts` で module import 時の固定読み込みを廃止し、各 request ごとに `process.env.VERITAS_API_KEY` を再評価するよう変更した。これにより BFF 再起動なしでもキー更新が次リクエストから反映される。
+  - `frontend/app/api/veritas/[...path]/route.test.ts` に、未設定時の 503 応答と、連続 2 リクエストで異なる API キーが upstream に送られる回帰テストを追加した。
 - Memory corruption / load failure を health / audit に反映する
 
 ### P2

--- a/frontend/app/api/veritas/[...path]/route.test.ts
+++ b/frontend/app/api/veritas/[...path]/route.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -7,6 +8,7 @@ import {
   parseAuthTokensConfig,
 } from "./route-auth";
 import { getBodySizeBytes } from "./body-size";
+import { GET } from "./route";
 import { resolveTraceId } from "./trace-id";
 import {
   resetApiBaseUrlWarningStateForTest,
@@ -178,5 +180,61 @@ describe("resolveTraceId", () => {
     expect(traceId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
     );
+  });
+});
+
+
+describe("veritas bff route runtime api key resolution", () => {
+  it("returns 503 when VERITAS_API_KEY is missing at request time", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      headers: { authorization: "Bearer token-admin" },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "server_misconfigured",
+      detail: "VERITAS_API_KEY is not configured on server.",
+    });
+  });
+
+  it("uses the latest VERITAS_API_KEY for each request", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.stubEnv("VERITAS_API_KEY", "first-key");
+    const firstRequest = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      headers: { authorization: "Bearer token-admin" },
+    });
+    await GET(firstRequest, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    vi.stubEnv("VERITAS_API_KEY", "rotated-key");
+    const secondRequest = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      headers: { authorization: "Bearer token-admin" },
+    });
+    await GET(secondRequest, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect((fetchMock.mock.calls[0]?.[1]?.headers as Headers).get("X-API-Key")).toBe("first-key");
+    expect((fetchMock.mock.calls[1]?.[1]?.headers as Headers).get("X-API-Key")).toBe("rotated-key");
   });
 });

--- a/frontend/app/api/veritas/[...path]/route.ts
+++ b/frontend/app/api/veritas/[...path]/route.ts
@@ -10,10 +10,12 @@ import { resolveTraceId, TRACE_ID_HEADER_NAME } from "./trace-id";
 
 import { resolveApiBaseUrl } from "./route-config";
 
-const API_KEY = process.env.VERITAS_API_KEY ?? "";
-
 /** Max request body size for proxied requests (1MB). */
 const MAX_PROXY_BODY_BYTES = 1 * 1024 * 1024;
+
+function resolveApiKey(): string {
+  return (process.env.VERITAS_API_KEY ?? "").trim();
+}
 
 function buildTargetUrl(
   apiBaseUrl: string,
@@ -80,7 +82,9 @@ async function handleProxy(request: NextRequest, pathSegments: string[]): Promis
     );
   }
 
-  if (!API_KEY.trim()) {
+  const apiKey = resolveApiKey();
+
+  if (!apiKey) {
     return NextResponse.json(
       {
         error: "server_misconfigured",
@@ -98,7 +102,7 @@ async function handleProxy(request: NextRequest, pathSegments: string[]): Promis
 
   const targetUrl = buildTargetUrl(apiBaseUrl, pathSegments, request.nextUrl.searchParams);
   const upstreamHeaders = new Headers();
-  upstreamHeaders.set("X-API-Key", API_KEY.trim());
+  upstreamHeaders.set("X-API-Key", apiKey);
   upstreamHeaders.set(TRACE_ID_HEADER_NAME, traceId);
   upstreamHeaders.set("X-Request-Id", traceId);
 


### PR DESCRIPTION
### Motivation

- Fix the security/ops issue where the BFF route read `VERITAS_API_KEY` once at module import time so key rotations did not take effect until restart.
- Apply the minimal, focused improvement requested in the review without expanding responsibilities beyond the BFF route.

### Description

- Change `frontend/app/api/veritas/[...path]/route.ts` to evaluate `process.env.VERITAS_API_KEY` per request via a new `resolveApiKey()` helper instead of caching at module import time. This ensures rotated keys are used by subsequent requests without a restart.
- Update the upstream header setting to use the runtime `apiKey` value for `X-API-Key` in the proxied request flow.
- Add regression tests in `frontend/app/api/veritas/[...path]/route.test.ts` that assert a 503 when `VERITAS_API_KEY` is missing at request time and that two consecutive requests see different `X-API-Key` values when the env var is rotated.
- Update `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to mark the P1 item as completed and document the change and added tests.

### Testing

- Ran the focused frontend test file with Vitest: `pnpm --dir frontend vitest run app/api/veritas/[...path]/route.test.ts`, all tests passed (21 tests).
- Ran ESLint on the changed files and resolved prior warnings; lint shows no blocking errors for the modified files.
- The new tests verify both fail-closed behavior when the API key is absent and that runtime key rotation is reflected per request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beae213a648326b64545d1bea27c0f)