### PR TITLE
Add MemoryStore health telemetry

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -114,7 +114,10 @@ health / audit への明示的な露出が望ましい。
 - [x] BFF の `VERITAS_API_KEY` を request 時に取得する形へ変更し、緊急ローテーションを即時反映できるようにする
   - 2026-03-21 対応済み。`frontend/app/api/veritas/[...path]/route.ts` で module import 時の固定読み込みを廃止し、各 request ごとに `process.env.VERITAS_API_KEY` を再評価するよう変更した。これにより BFF 再起動なしでもキー更新が次リクエストから反映される。
   - `frontend/app/api/veritas/[...path]/route.test.ts` に、未設定時の 503 応答と、連続 2 リクエストで異なる API キーが upstream に送られる回帰テストを追加した。
-- Memory corruption / load failure を health / audit に反映する
+- [x] Memory corruption / load failure を health / audit に反映する
+  - 2026-03-21 対応済み。`veritas_os/memory/store.py` に非致命な読み込み障害を記録する health telemetry を追加し、boot rebuild / targeted payload load での JSON decode error・I/O error・サイズ超過・truncation を `health_snapshot()` で取得できるようにした。
+  - `veritas_os/api/routes_system.py` の `/health` / `/v1/health` は、MemoryStore が degraded telemetry を持つ場合に `checks.memory="degraded"` と `memory_health` を返すよう変更した。これにより empty-state へフォールバックしても運用監視から破損兆候を検知できる。
+  - `veritas_os/tests/test_memory_store.py` と `veritas_os/tests/test_api_backend_improvements.py` に回帰テストを追加した。
 
 ### P2
 

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -80,16 +80,27 @@ def health() -> Dict[str, Any]:
     srv = _get_server()
     try:
         pipeline_ok = srv.get_decision_pipeline() is not None
-        memory_ok = srv.get_memory_store() is not None
-        all_ok = pipeline_ok and memory_ok
+        memory_store = srv.get_memory_store()
+        memory_ok = memory_store is not None
+        memory_health = None
+        if memory_ok and hasattr(memory_store, "health_snapshot"):
+            memory_health = memory_store.health_snapshot()
+
+        memory_status = "ok" if memory_ok else "unavailable"
+        if memory_health and memory_health.get("status") == "degraded":
+            memory_status = "degraded"
+
+        all_ok = pipeline_ok and memory_status == "ok"
         result: Dict[str, Any] = {
             "ok": all_ok,
             "uptime": int(time.time() - srv.START_TS),
             "checks": {
                 "pipeline": "ok" if pipeline_ok else "unavailable",
-                "memory": "ok" if memory_ok else "unavailable",
+                "memory": memory_status,
             },
         }
+        if memory_health:
+            result["memory_health"] = memory_health
         return result
     except Exception as e:
         logger.error("[Health] check failed: %s", e)

--- a/veritas_os/memory/store.py
+++ b/veritas_os/memory/store.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from copy import deepcopy
 import json
 import logging
 import math
@@ -131,6 +132,12 @@ class MemoryStore:
 
     def __init__(self, dim: int = 384) -> None:
         self._lock = threading.RLock()  # リエントラントロック
+        self._health_lock = threading.Lock()
+        self._health_status: Dict[str, Any] = {
+            "status": "ok",
+            "last_error": None,
+            "error_counts": {},
+        }
         self.emb = HashEmbedder(dim=dim)
         # 段階キャッシュ（kind -> id -> payload）
         self._payload_cache: Dict[str, Dict[str, Dict[str, Any]]] = {
@@ -147,6 +154,29 @@ class MemoryStore:
             for k in FILES.keys()
         }
         self._boot()
+
+    def _record_load_issue(self, stage: str, kind: str, detail: str) -> None:
+        """Record a non-fatal memory load issue for health/audit visibility."""
+        issue_key = f"{stage}:{kind}"
+        issue = {
+            "stage": stage,
+            "kind": kind,
+            "detail": detail,
+            "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        with self._health_lock:
+            error_counts = dict(self._health_status.get("error_counts") or {})
+            error_counts[issue_key] = int(error_counts.get(issue_key, 0)) + 1
+            self._health_status = {
+                "status": "degraded",
+                "last_error": issue,
+                "error_counts": error_counts,
+            }
+
+    def health_snapshot(self) -> Dict[str, Any]:
+        """Return an immutable snapshot of MemoryStore health telemetry."""
+        with self._health_lock:
+            return deepcopy(self._health_status)
 
     def _boot(self) -> None:
         """
@@ -169,8 +199,10 @@ class MemoryStore:
                 if file_size > MAX_JSONL_FILE_SIZE:
                     logger.warning("[MemoryStore] %s too large for boot rebuild (%d bytes), skipping",
                                    kind, file_size)
+                    self._record_load_issue("boot_rebuild", kind, "file_too_large")
                     continue
-            except OSError:
+            except OSError as exc:
+                self._record_load_issue("boot_rebuild", kind, f"stat_failed:{exc}")
                 continue
 
             ids, texts = [], []
@@ -192,8 +224,9 @@ class MemoryStore:
                             or j.get("summary")
                             or j.get("snippet", "")
                         )
-                    except (json.JSONDecodeError, KeyError, TypeError):
+                    except (json.JSONDecodeError, KeyError, TypeError) as exc:
                         # 不正なJSONまたは必須フィールド欠損をスキップ
+                        self._record_load_issue("boot_rebuild", kind, type(exc).__name__)
                         continue
                     # ★ OOM対策: ブート時の再構築もアイテム数上限を適用
                     if len(ids) >= MAX_SEARCH_ITEMS:
@@ -201,6 +234,7 @@ class MemoryStore:
                             "[MemoryStore] %s hit MAX_SEARCH_ITEMS (%d) during boot, truncating",
                             kind, MAX_SEARCH_ITEMS,
                         )
+                        self._record_load_issue("boot_rebuild", kind, "max_search_items_truncated")
                         break
 
             self._cache_complete[kind] = len(ids) < MAX_SEARCH_ITEMS
@@ -210,6 +244,7 @@ class MemoryStore:
                 idx.add(vecs, ids)  # ★ ここで追加すると .npz 保存まで自動で行われる
             else:
                 logger.warning("[MemoryStore] No valid items found in %s for kind=%s", path, kind)
+                self._record_load_issue("boot_rebuild", kind, "no_valid_items")
 
     def put(self, kind: str, item: Dict[str, Any]) -> str:
         """
@@ -329,8 +364,10 @@ class MemoryStore:
             if file_size > MAX_JSONL_FILE_SIZE:
                 logger.warning("[MemoryStore] %s too large for targeted payload load (%d bytes)",
                                kind, file_size)
+                self._record_load_issue("targeted_payload_load", kind, "file_too_large")
                 return found
-        except OSError:
+        except OSError as exc:
+            self._record_load_issue("targeted_payload_load", kind, f"stat_failed:{exc}")
             return found
 
         offset_map = self._offset_index.get(kind, {})
@@ -351,7 +388,8 @@ class MemoryStore:
                         else:
                             # オフセット不整合（ファイルローテーション等）→ リニアスキャンにフォールバック
                             ids_without_offset.append(item_id)
-                    except (json.JSONDecodeError, OSError):
+                    except (json.JSONDecodeError, OSError) as exc:
+                        self._record_load_issue("targeted_payload_load", kind, type(exc).__name__)
                         ids_without_offset.append(item_id)  # フォールバック対象に追加
 
                 # オフセット未登録分のみ線形スキャン
@@ -362,6 +400,7 @@ class MemoryStore:
                         try:
                             item = json.loads(line)
                         except json.JSONDecodeError:
+                            self._record_load_issue("targeted_payload_load", kind, "JSONDecodeError")
                             continue
                         _id = item.get("id")
                         if _id in wanted:
@@ -370,6 +409,7 @@ class MemoryStore:
                                 break
         except (OSError, IOError) as e:
             logger.warning("[MemoryStore] Failed targeted payload load from %s: %s", path, e)
+            self._record_load_issue("targeted_payload_load", kind, f"open_failed:{e}")
 
         return found
 

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -108,9 +108,34 @@ class TestEnhancedHealth:
         checks = data["checks"]
         assert "pipeline" in checks
         assert "memory" in checks
-        # Values should be either "ok" or "unavailable"
+        # Values should be either "ok", "degraded", or "unavailable"
         assert checks["pipeline"] in ("ok", "unavailable")
-        assert checks["memory"] in ("ok", "unavailable")
+        assert checks["memory"] in ("ok", "degraded", "unavailable")
+
+    def test_health_exposes_memory_degradation_details(self, monkeypatch):
+        """Non-fatal MemoryStore load issues should surface in /health."""
+
+        class FakeMemoryStore:
+            def health_snapshot(self):
+                return {
+                    "status": "degraded",
+                    "last_error": {
+                        "stage": "targeted_payload_load",
+                        "kind": "episodic",
+                        "detail": "JSONDecodeError",
+                        "recorded_at": "2026-03-21T00:00:00Z",
+                    },
+                    "error_counts": {"targeted_payload_load:episodic": 2},
+                }
+
+        monkeypatch.setattr(server, "get_memory_store", lambda: FakeMemoryStore())
+
+        r = client.get("/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is False
+        assert data["checks"]["memory"] == "degraded"
+        assert data["memory_health"]["last_error"]["detail"] == "JSONDecodeError"
 
     def test_health_ok_reflects_deps(self, monkeypatch):
         """ok field should reflect dependency availability."""

--- a/veritas_os/tests/test_memory_store.py
+++ b/veritas_os/tests/test_memory_store.py
@@ -561,3 +561,44 @@ def test_put_episode_delegates_to_put(memory_env, monkeypatch):
     assert it["meta"] == {"foo": "bar"}
     # ts は put_episode 側で埋められている
     assert isinstance(it["ts"], (int, float))
+
+
+def test_boot_records_health_when_json_is_corrupted(memory_env):
+    """_boot は破損 JSON を health telemetry に記録する。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    files["episodic"].write_text(
+        '{"id":"ok","text":"valid","tags":[],"meta":{},"ts":1}\n{"id":\n',
+        encoding="utf-8",
+    )
+
+    ms = store.MemoryStore(dim=4)
+
+    health = ms.health_snapshot()
+    assert health["status"] == "degraded"
+    assert health["last_error"]["stage"] == "boot_rebuild"
+    assert health["last_error"]["kind"] == "episodic"
+    assert health["error_counts"]["boot_rebuild:episodic"] >= 1
+
+
+def test_targeted_payload_load_records_health_on_decode_error(memory_env):
+    """targeted payload load の decode error は health telemetry に残る。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    files["episodic"].write_text(
+        '{"id":"broken","text":"value","tags":[],"meta":{},"ts":1}\n',
+        encoding="utf-8",
+    )
+
+    ms = store.MemoryStore(dim=4)
+    ms._offset_index["episodic"]["broken"] = 0
+    files["episodic"].write_text("not-json\n", encoding="utf-8")
+
+    loaded = ms._load_payloads_for_ids("episodic", ["broken"])
+
+    assert loaded == {}
+    health = ms.health_snapshot()
+    assert health["status"] == "degraded"
+    assert health["last_error"]["stage"] == "targeted_payload_load"
+    assert health["last_error"]["kind"] == "episodic"
+    assert health["error_counts"]["targeted_payload_load:episodic"] >= 1


### PR DESCRIPTION
### Motivation
- Improve operational visibility for non-fatal Memory load failures so silent degradation is detectable without changing MemoryOS/Planner/Kernel/FUJI responsibilities. 
- Record boot-time rebuild and targeted payload load issues (JSON decode, I/O, size, truncation) so monitoring can act earlier.

### Description
- Add MemoryStore health telemetry state and locks with `health_snapshot()` and `_record_load_issue()` in `veritas_os/memory/store.py` to record non-fatal load problems. 
- Instrument `MemoryStore._boot()` and `_load_payloads_for_ids()` to record `boot_rebuild` and `targeted_payload_load` issues on JSON decode, stat/open failures, file-size truncation, and empty-rebuild cases. 
- Update `veritas_os/api/routes_system.py` `/health` and `/v1/health` to surface a `checks.memory` value of `degraded` and include `memory_health` when `MemoryStore` reports degraded telemetry. 
- Add regression tests in `veritas_os/tests/test_memory_store.py` and `veritas_os/tests/test_api_backend_improvements.py`, and mark the review note in `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` as completed for this item.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_store.py veritas_os/tests/test_api_backend_improvements.py` and the suite passed (`31 passed`).
- Changes were committed as part of the PR and unit tests were the only automated checks executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb1263d388326b5407c8c7988ab5b)