### PR TITLE
frontend: 分離 - APIクライアントの abort を timeout と user-cancel に分類

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -127,7 +127,9 @@ health / audit への明示的な露出が望ましい。
 
 ### P3
 
-- フロント API client の abort 原因判定を改善し、timeout と user cancel を分離する
+- [x] フロント API client の abort 原因判定を改善し、timeout と user cancel を分離する
+  - 2026-03-21 対応済み。`frontend/lib/api-client.ts` の `veritasFetchWithOptions()` で timeout 起因の abort と caller 起因の abort を分離し、`ApiError.kind` に `cancelled` を追加した。これにより UI は timeout と明示的な user cancel を別扱いできる。
+  - `frontend/lib/api-client.test.ts` に timeout / caller abort の回帰テストを追加した。
 
 ---
 

--- a/frontend/lib/api-client.test.ts
+++ b/frontend/lib/api-client.test.ts
@@ -125,6 +125,41 @@ describe("veritasFetchWithOptions", () => {
       expect((e as ApiError).kind).toBe("network");
     }
   });
+
+  it("classifies timeout aborts as timeout errors", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_, init?: RequestInit) =>
+        new Promise((_, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+
+    await expect(
+      veritasFetchWithOptions("/api/test", { timeoutMs: 5 }),
+    ).rejects.toMatchObject({ kind: "timeout" });
+  });
+
+  it("classifies caller aborts as cancelled errors", async () => {
+    const controller = new AbortController();
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_, init?: RequestInit) =>
+        new Promise((_, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+
+    const pending = veritasFetchWithOptions("/api/test", {
+      init: { signal: controller.signal },
+      timeoutMs: 100,
+    });
+    controller.abort("user-cancelled");
+
+    await expect(pending).rejects.toMatchObject({ kind: "cancelled" });
+  });
 });
 
 describe("devLog", () => {

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -25,6 +25,7 @@ const RETRY_BACKOFF_BASE_MS = 1_000;
 export type ApiErrorKind =
   | "network"
   | "timeout"
+  | "cancelled"
   | "auth"
   | "validation"
   | "server"
@@ -142,13 +143,19 @@ export async function veritasFetchWithOptions(
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const controller = new AbortController();
+    let timedOut = false;
     // If the caller already has a signal, chain abort
     if (init.signal) {
-      init.signal.addEventListener("abort", () => controller.abort(), {
-        once: true,
-      });
+      init.signal.addEventListener(
+        "abort",
+        () => controller.abort(init.signal?.reason),
+        { once: true },
+      );
     }
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new DOMException("Request timed out", "TimeoutError"));
+    }, timeoutMs);
 
     try {
       const response = await fetch(input, {
@@ -180,13 +187,12 @@ export async function veritasFetchWithOptions(
       lastError = caught;
 
       if (caught instanceof DOMException && caught.name === "AbortError") {
-        // Could be timeout or caller-initiated abort — don't retry timeouts
-        throw new ApiError(
-          "Request timed out",
-          "timeout",
-          null,
-          null,
-        );
+        if (timedOut) {
+          throw new ApiError("Request timed out", "timeout", null, null);
+        }
+        if (init.signal?.aborted) {
+          throw new ApiError("Request was cancelled", "cancelled", null, null);
+        }
       }
 
       // Network errors are retryable


### PR DESCRIPTION
### Motivation
- フロント API client の abort 原因判定が曖昧で UI が timeout と明示的なユーザーキャンセルを区別できなかったため、最小限の改修で二者を分離する。

### Description
- `frontend/lib/api-client.ts` の `veritasFetchWithOptions()` にて、タイムアウト起因の abort と呼び出し元シグナル起因の abort を判別するロジックを追加し、`ApiErrorKind` に `cancelled` を追加した。  
- タイムアウトは `DOMException("Request timed out", "TimeoutError")` を使って内部フラグ `timedOut` を設定し判別する実装にした。  
- 呼び出し元の `AbortSignal` をチェーンして `init.signal?.reason` を渡すように変更した。  
- `frontend/lib/api-client.test.ts` にタイムアウト起因と caller abort 起因それぞれを検証する回帰テストを追加した。  
- `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` を更新し、本件（P3）の対応済み記載を追加した。 

### Testing
- `pnpm --filter frontend test -- --run lib/api-client.test.ts` を実行し、テストファイル `lib/api-client.test.ts` の 16 件のテストがすべて成功した（全件パス）。
- `pnpm --filter frontend exec tsc --noEmit` を実行し型チェックに成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bebc9d489c83269e24ebac77228c43)