### PR TITLE
Extract planner helpers into veritas_os/core/planner_helpers.py (backward-compatible)

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -123,7 +123,9 @@ health / audit への明示的な露出が望ましい。
 
 ### P2
 
-- `planner.py` / `kernel.py` の互換ロジックを helper/stage へさらに移送する
+- [x] `planner.py` / `kernel.py` の互換ロジックを helper/stage へさらに移送する
+  - 2026-03-21 対応。`veritas_os/core/planner.py` 先頭に集中していた inventory 判定・step 正規化・simple QA 判定を `veritas_os/core/planner_helpers.py` へ移送し、`planner.py` 側は既存の `_wants_inventory_step` / `_normalize_step` / `_normalize_steps_list` / `_is_simple_qa` を helper alias として再公開する形に整理した。これにより Planner 本体の責務は plan 生成フローに寄り、既存呼び出し互換も維持した。
+  - `veritas_os/tests/test_planner.py` に helper alias の互換性テストを追加し、既存 API の挙動が変わっていないことを固定した。
 
 ### P3
 

--- a/veritas_os/core/planner.py
+++ b/veritas_os/core/planner.py
@@ -13,6 +13,13 @@ from . import world as world_model
 from . import memory as mem
 from . import code_planner  # ★ 追加
 from .planner_normalization import normalize_float, normalize_int
+from .planner_helpers import (
+    StepDict,
+    is_simple_qa as _is_simple_qa,
+    normalize_step as _normalize_step,
+    normalize_steps_list as _normalize_steps_list,
+    wants_inventory_step as _wants_inventory_step,
+)
 from .planner_json import (  # ★ JSON解析ロジックを分離
     _truncate_json_extract_input,
     _safe_parse,
@@ -30,18 +37,6 @@ _FALLBACK_SAFE_ERRORS = (ValueError, TypeError, KeyError, AttributeError)
 _MEMORY_LOOKUP_ERRORS = (AttributeError, TypeError, ValueError, OSError)
 
 
-class StepDict(TypedDict, total=False):
-    """Planner step definition for normalized step payloads."""
-
-    id: str
-    title: str
-    detail: str
-    why: str
-    eta_hours: float
-    risk: float
-    dependencies: List[str]
-
-
 class PlanDict(TypedDict, total=False):
     """Planner plan payload containing normalized steps and metadata."""
 
@@ -49,196 +44,6 @@ class PlanDict(TypedDict, total=False):
     raw: Dict[str, Any]
     meta: Dict[str, Any]
     source: str
-
-# ============================
-#  step1（棚卸し）意図判定
-# ============================
-
-def _wants_inventory_step(query: str, context: Dict[str, Any] | None = None) -> bool:
-    """
-    「棚卸し/現状整理/step1で進めて」など、inventory(step1)系を明示的に求めているか。
-    ここで True のときだけ step1 を“特別扱い”してよい前提にする。
-    """
-    _ = context or {}
-    q = (query or "").strip()
-    if not q:
-        return False
-    ql = q.lower()
-
-    # 明示の step 指定
-    if "step1" in ql or "step 1" in ql:
-        return True
-
-    # 棚卸し/現状整理
-    if "棚卸" in q or "棚おろし" in q:
-        return True
-    if ("現状" in q) and ("整理" in q or "把握" in q or "棚卸" in q):
-        return True
-
-    # 英語寄り
-    if "inventory" in ql:
-        return True
-
-    return False
-
-
-# ============================
-#  共通: step 正規化ヘルパ
-# ============================
-
-def _normalize_step(
-    step: StepDict,
-    default_eta_hours: float = 1.0,
-    default_risk: float = 0.1,
-) -> StepDict:
-    """
-    1つの step に対して、eta_hours / risk / dependencies を安全な値へ正規化する。
-
-    - eta_hours: 数値へ変換し、負値は 0.0 に丸める
-    - risk: 数値へ変換し、0.0〜1.0 の範囲へ丸める
-    - dependencies: list[str] に正規化
-
-    既存値がある場合も型不正な値は補正し、後続処理での型崩れを防ぐ。
-    """
-    s: StepDict = dict(step)
-
-    eta_candidate = s.get("eta_hours", default_eta_hours)
-    s["eta_hours"] = normalize_float(
-        eta_candidate,
-        field_name="eta_hours",
-        default_override=default_eta_hours,
-    )
-
-    risk_candidate = s.get("risk", default_risk)
-    s["risk"] = normalize_float(
-        risk_candidate,
-        field_name="risk",
-        default_override=default_risk,
-    )
-
-    deps = s.get("dependencies")
-    if not isinstance(deps, list):
-        s["dependencies"] = []
-    else:
-        s["dependencies"] = [str(d) for d in deps]
-
-    return s
-
-
-def _normalize_steps_list(
-    steps: List[StepDict] | None,
-    default_eta_hours: float = 1.0,
-    default_risk: float = 0.1,
-) -> List[StepDict]:
-    """
-    steps のリストに対して _normalize_step を一括適用。
-    None や不正要素が混ざっていても「まともな dict だけ」を採用する。
-    """
-    if not isinstance(steps, list):
-        return []
-
-    normalized: List[StepDict] = []
-    for st in steps:
-        if not isinstance(st, dict):
-            continue
-        normalized.append(
-            _normalize_step(
-                st,
-                default_eta_hours=default_eta_hours,
-                default_risk=default_risk,
-            )
-        )
-    return normalized
-
-
-# ============================
-#  simple QA 判定 & プラン
-# ============================
-
-def _is_simple_qa(query: str, context: Dict[str, Any] | None = None) -> bool:
-    """
-    「重いAGIプラン不要なシンプル質問」かどうかをざっくり判定する。
-    - kernel / pipeline 側の simple_qa モードと合わせて使うことを想定。
-    - ※ AGI / VERITAS 系の問いはここでは simple_qa に絶対しない。
-    """
-    ctx = context or {}
-
-    if ctx.get("mode") == "simple_qa" or ctx.get("simple_qa"):
-        return True
-
-    q = (query or "").strip()
-    if not q:
-        return False
-
-    q_lower = q.lower()
-
-    agi_block_keywords = [
-        "agi",
-        "ＡＧＩ",
-        "veritas",
-        "ヴェリタス",
-        "ベリタス",
-        "proto-agi",
-        "プロトagi",
-    ]
-    if any(k in q or k in q_lower for k in agi_block_keywords):
-        return False
-
-    is_short = len(q) <= 40
-    question_prefixes = (
-        "what",
-        "why",
-        "when",
-        "where",
-        "who",
-        "which",
-        "how",
-        "can ",
-        "could ",
-        "should ",
-        "is ",
-        "are ",
-        "do ",
-        "does ",
-        "did ",
-    )
-    question_endings = (
-        "か",
-        "かね",
-        "かな",
-        "でしょうか",
-        "教えて",
-        "を教えて",
-        "知りたい",
-    )
-    looks_question = (
-        ("?" in q)
-        or ("？" in q)
-        or q_lower.startswith(question_prefixes)
-        or q.endswith(question_endings)
-    )
-    has_plan_words = any(
-        k in q for k in ["どう進め", "進め方", "計画", "プラン", "ロードマップ", "タスク"]
-    ) or any(
-        k in q_lower
-        for k in [
-            "roadmap",
-            "plan",
-            "strategy",
-            "next step",
-            "next steps",
-            "implementation",
-            "implement",
-            "task",
-            "tasks",
-        ]
-    )
-
-    if is_short and looks_question and not has_plan_words:
-        return True
-
-    return False
-
 
 def _simple_qa_plan(
     query: str,

--- a/veritas_os/core/planner_helpers.py
+++ b/veritas_os/core/planner_helpers.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from typing import Dict, List, TypedDict
+
+from .planner_normalization import normalize_float
+
+
+class StepDict(TypedDict, total=False):
+    """Planner step definition for normalized step payloads."""
+
+    id: str
+    title: str
+    detail: str
+    why: str
+    eta_hours: float
+    risk: float
+    dependencies: List[str]
+
+
+def wants_inventory_step(
+    query: str, context: Dict[str, object] | None = None
+) -> bool:
+    """Return whether the query explicitly requests inventory-first planning."""
+    _ = context or {}
+    q = (query or "").strip()
+    if not q:
+        return False
+    ql = q.lower()
+
+    if "step1" in ql or "step 1" in ql:
+        return True
+    if "棚卸" in q or "棚おろし" in q:
+        return True
+    if ("現状" in q) and ("整理" in q or "把握" in q or "棚卸" in q):
+        return True
+    if "inventory" in ql:
+        return True
+    return False
+
+
+def normalize_step(
+    step: StepDict,
+    default_eta_hours: float = 1.0,
+    default_risk: float = 0.1,
+) -> StepDict:
+    """Normalize a planner step into safe scalar and dependency values."""
+    normalized_step: StepDict = dict(step)
+
+    eta_candidate = normalized_step.get("eta_hours", default_eta_hours)
+    normalized_step["eta_hours"] = normalize_float(
+        eta_candidate,
+        field_name="eta_hours",
+        default_override=default_eta_hours,
+    )
+
+    risk_candidate = normalized_step.get("risk", default_risk)
+    normalized_step["risk"] = normalize_float(
+        risk_candidate,
+        field_name="risk",
+        default_override=default_risk,
+    )
+
+    dependencies = normalized_step.get("dependencies")
+    if not isinstance(dependencies, list):
+        normalized_step["dependencies"] = []
+    else:
+        normalized_step["dependencies"] = [str(dep) for dep in dependencies]
+
+    return normalized_step
+
+
+def normalize_steps_list(
+    steps: List[StepDict] | None,
+    default_eta_hours: float = 1.0,
+    default_risk: float = 0.1,
+) -> List[StepDict]:
+    """Normalize a step list while dropping malformed non-dict elements."""
+    if not isinstance(steps, list):
+        return []
+
+    normalized_steps: List[StepDict] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        normalized_steps.append(
+            normalize_step(
+                step,
+                default_eta_hours=default_eta_hours,
+                default_risk=default_risk,
+            )
+        )
+    return normalized_steps
+
+
+def is_simple_qa(query: str, context: Dict[str, object] | None = None) -> bool:
+    """Return whether a query should bypass heavy planning as simple QA."""
+    ctx = context or {}
+
+    if ctx.get("mode") == "simple_qa" or ctx.get("simple_qa"):
+        return True
+
+    q = (query or "").strip()
+    if not q:
+        return False
+
+    q_lower = q.lower()
+    agi_block_keywords = [
+        "agi",
+        "ＡＧＩ",
+        "veritas",
+        "ヴェリタス",
+        "ベリタス",
+        "proto-agi",
+        "プロトagi",
+    ]
+    if any(keyword in q or keyword in q_lower for keyword in agi_block_keywords):
+        return False
+
+    question_prefixes = (
+        "what",
+        "why",
+        "when",
+        "where",
+        "who",
+        "which",
+        "how",
+        "can ",
+        "could ",
+        "should ",
+        "is ",
+        "are ",
+        "do ",
+        "does ",
+        "did ",
+    )
+    question_endings = (
+        "か",
+        "かね",
+        "かな",
+        "でしょうか",
+        "教えて",
+        "を教えて",
+        "知りたい",
+    )
+    looks_question = (
+        ("?" in q)
+        or ("？" in q)
+        or q_lower.startswith(question_prefixes)
+        or q.endswith(question_endings)
+    )
+    has_plan_words = any(
+        keyword in q
+        for keyword in [
+            "どう進め",
+            "進め方",
+            "計画",
+            "プラン",
+            "ロードマップ",
+            "タスク",
+        ]
+    ) or any(
+        keyword in q_lower
+        for keyword in [
+            "roadmap",
+            "plan",
+            "strategy",
+            "next step",
+            "next steps",
+            "implementation",
+            "implement",
+            "task",
+            "tasks",
+        ]
+    )
+
+    return len(q) <= 40 and looks_question and not has_plan_words

--- a/veritas_os/tests/test_planner.py
+++ b/veritas_os/tests/test_planner.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 import pytest
 
 from veritas_os.core import planner as planner_core
+from veritas_os.core import planner_helpers
 
 
 # -------------------------------
@@ -148,6 +149,22 @@ def test_simple_qa_plan_structure_and_stage():
         assert "eta_hours" in s
         assert "risk" in s
         assert isinstance(s["dependencies"], list)
+
+
+def test_planner_helper_aliases_preserve_behavior():
+    assert (
+        planner_core._wants_inventory_step("inventory check")
+        == planner_helpers.wants_inventory_step("inventory check")
+    )
+    assert planner_core._normalize_step({"id": "s1"}) == planner_helpers.normalize_step(
+        {"id": "s1"}
+    )
+    assert planner_core._normalize_steps_list([{"id": "s1"}]) == (
+        planner_helpers.normalize_steps_list([{"id": "s1"}])
+    )
+    assert planner_core._is_simple_qa("今日は何日ですか？", {}) == (
+        planner_helpers.is_simple_qa("今日は何日ですか？", {})
+    )
 
 
 # -------------------------------


### PR DESCRIPTION
### Motivation
- Reduce Planner core file size and move small, high-cohesion helpers (inventory detection, step normalization, simple-QA heuristics) out of the main planner flow to improve responsibility separation without changing public behavior. 
- Keep changes minimal and constrained to Planner responsibilities, avoiding modifications to Kernel/FUJI/MemoryOS.

### Description
- Added `veritas_os/core/planner_helpers.py` which contains extracted helpers: `wants_inventory_step`, `normalize_step`, `normalize_steps_list`, and `is_simple_qa`, plus a `StepDict` TypedDict and docstrings for each helper. 
- Updated `veritas_os/core/planner.py` to import and re-export the existing underscored helper names as aliases (`_wants_inventory_step`, `_normalize_step`, `_normalize_steps_list`, `_is_simple_qa`) so external callers remain compatible. 
- Added a regression test in `veritas_os/tests/test_planner.py` to assert parity between the old underscored helpers and the new helpers. 
- Updated the review document `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to record the applied P2 improvement. 
- Changes are limited to internal refactor only and follow existing responsibilities and style constraints (PEP8-compliant helpers and docstrings included).

### Testing
- Ran `pytest veritas_os/tests/test_planner.py veritas_os/tests/test_planner_coverage.py` and all tests passed (`139 passed`).
- Ran static compile check `python -m compileall veritas_os/core/planner.py veritas_os/core/planner_helpers.py` which succeeded.
- No new automated security tests were added; this is an internal refactor and no new external input paths or permissions were introduced, but practitioners should note the change surface (helper relocation) when auditing imports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bebf32ec288326aa21c88560b08d31)