### PR TITLE
Add top-level status to /health responses

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -119,6 +119,7 @@ health / audit への明示的な露出が望ましい。
 - [x] Memory corruption / load failure を health / audit に反映する
   - 2026-03-21 対応済み。`veritas_os/memory/store.py` に非致命な読み込み障害を記録する health telemetry を追加し、boot rebuild / targeted payload load での JSON decode error・I/O error・サイズ超過・truncation を `health_snapshot()` で取得できるようにした。
   - `veritas_os/api/routes_system.py` の `/health` / `/v1/health` は、MemoryStore が degraded telemetry を持つ場合に `checks.memory="degraded"` と `memory_health` を返すよう変更した。これにより empty-state へフォールバックしても運用監視から破損兆候を検知できる。
+  - 2026-03-21 追記。health 応答に top-level の `status` (`ok` / `degraded` / `unavailable`) を追加し、Memory の非致命障害と依存欠落をレスポンスだけで判別できるようにした。`ok` の既存ブール契約は維持しつつ、監視側が `checks` の深掘りなしで degradation を扱える。
   - `veritas_os/tests/test_memory_store.py` と `veritas_os/tests/test_api_backend_improvements.py` に回帰テストを追加した。
 
 ### P2

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -77,6 +77,7 @@ def root() -> Dict[str, Any]:
 @public_router.get("/health")
 @public_router.get("/v1/health")
 def health() -> Dict[str, Any]:
+    """Return lightweight health information with explicit degraded status."""
     srv = _get_server()
     try:
         pipeline_ok = srv.get_decision_pipeline() is not None
@@ -86,16 +87,24 @@ def health() -> Dict[str, Any]:
         if memory_ok and hasattr(memory_store, "health_snapshot"):
             memory_health = memory_store.health_snapshot()
 
+        pipeline_status = "ok" if pipeline_ok else "unavailable"
         memory_status = "ok" if memory_ok else "unavailable"
         if memory_health and memory_health.get("status") == "degraded":
             memory_status = "degraded"
 
-        all_ok = pipeline_ok and memory_status == "ok"
+        health_status = "ok"
+        if pipeline_status == "unavailable" or memory_status == "unavailable":
+            health_status = "unavailable"
+        elif memory_status == "degraded":
+            health_status = "degraded"
+
+        all_ok = health_status == "ok"
         result: Dict[str, Any] = {
             "ok": all_ok,
+            "status": health_status,
             "uptime": int(time.time() - srv.START_TS),
             "checks": {
-                "pipeline": "ok" if pipeline_ok else "unavailable",
+                "pipeline": pipeline_status,
                 "memory": memory_status,
             },
         }

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -104,6 +104,8 @@ class TestEnhancedHealth:
         assert r.status_code == 200
         data = r.json()
         assert "uptime" in data
+        assert "status" in data
+        assert data["status"] in ("ok", "degraded", "unavailable")
         assert "checks" in data
         checks = data["checks"]
         assert "pipeline" in checks
@@ -134,6 +136,7 @@ class TestEnhancedHealth:
         assert r.status_code == 200
         data = r.json()
         assert data["ok"] is False
+        assert data["status"] == "degraded"
         assert data["checks"]["memory"] == "degraded"
         assert data["memory_health"]["last_error"]["detail"] == "JSONDecodeError"
 
@@ -147,6 +150,17 @@ class TestEnhancedHealth:
         )
         r = client.get("/health")
         data = r.json()
+        assert data["checks"]["pipeline"] == "unavailable"
+
+    def test_health_status_is_unavailable_when_pipeline_is_missing(self, monkeypatch):
+        """Top-level health status should distinguish unavailable dependencies."""
+        monkeypatch.setattr(server, "get_decision_pipeline", lambda: None)
+
+        r = client.get("/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is False
+        assert data["status"] == "unavailable"
         assert data["checks"]["pipeline"] == "unavailable"
 
 


### PR DESCRIPTION
### Motivation
- Improve observability so monitoring can quickly distinguish overall service `status` (`ok` / `degraded` / `unavailable`) without parsing nested `checks` fields. 
- Surface MemoryStore non-fatal load issues and missing dependencies more clearly while preserving the existing boolean `ok` contract. 
- Make the smallest scoped change focused on health visibility per the code review guidance and record the modification in the review document.

### Description
- Add a docstring and a top-level `status` field to the `/health` and `/v1/health` handlers in `veritas_os/api/routes_system.py` with logic that computes `status` from pipeline and memory checks. 
- Preserve the existing `ok` boolean while mapping dependency states to `status` values `ok`, `degraded`, or `unavailable`. 
- Update `veritas_os/tests/test_api_backend_improvements.py` to assert the presence and correct values of the new `status` field and add a test covering the pipeline-missing (`unavailable`) case. 
- Append a brief note about the change to `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` explaining the addition of the top-level `status` for monitoring ergonomics.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_backend_improvements.py` and the test file passed (`12 passed`). 
- Ran `python -m compileall veritas_os/api/routes_system.py` to ensure the module compiles successfully and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec31ec1d08326871d256406537412)