### PR TITLE
Expose runtime feature degradation in /health

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -110,6 +110,8 @@ health / audit への明示的な露出が望ましい。
 - [x] production で sanitize import failure を fail-closed にする
   - 2026-03-21 対応済み。`veritas_os/api/startup_health.py` の `check_runtime_feature_health()` を更新し、`sanitize` モジュール未ロード時は non-production では警告、production (`VERITAS_ENV=production` / `prod`) では `RuntimeError` を送出して API 起動を停止するよう変更した。これにより PII masking 欠落状態での fail-open 起動を防止する。
   - `veritas_os/tests/test_api_startup_health.py` に、non-production 警告動作を維持しつつ production では fail-closed になる回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/health` / `/v1/health` に `runtime_features` を追加し、`sanitize` / `atomic_io` の欠落を `degraded` として返すようにした。起動自体は継続する non-production でも、監視側が安全機能の欠落をレスポンスだけで検知できる。
+  - `veritas_os/tests/test_api_backend_improvements.py` に、runtime feature の degradation が health 応答へ露出する回帰テストを追加した。
 
 ### P1
 

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -42,6 +42,16 @@ def _get_server():
     return srv
 
 
+def _runtime_feature_checks(srv: Any) -> Dict[str, str]:
+    """Return runtime feature statuses for health visibility."""
+    sanitize_status = "ok" if getattr(srv, "_HAS_SANITIZE", False) else "degraded"
+    atomic_io_status = "ok" if getattr(srv, "_HAS_ATOMIC_IO", False) else "degraded"
+    return {
+        "sanitize": sanitize_status,
+        "atomic_io": atomic_io_status,
+    }
+
+
 # ------------------------------------------------------------------
 # Pydantic models
 # ------------------------------------------------------------------
@@ -89,13 +99,17 @@ def health() -> Dict[str, Any]:
 
         pipeline_status = "ok" if pipeline_ok else "unavailable"
         memory_status = "ok" if memory_ok else "unavailable"
+        runtime_features = _runtime_feature_checks(srv)
         if memory_health and memory_health.get("status") == "degraded":
             memory_status = "degraded"
 
         health_status = "ok"
         if pipeline_status == "unavailable" or memory_status == "unavailable":
             health_status = "unavailable"
-        elif memory_status == "degraded":
+        elif (
+            memory_status == "degraded"
+            or "degraded" in runtime_features.values()
+        ):
             health_status = "degraded"
 
         all_ok = health_status == "ok"
@@ -107,6 +121,7 @@ def health() -> Dict[str, Any]:
                 "pipeline": pipeline_status,
                 "memory": memory_status,
             },
+            "runtime_features": runtime_features,
         }
         if memory_health:
             result["memory_health"] = memory_health

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -110,9 +110,14 @@ class TestEnhancedHealth:
         checks = data["checks"]
         assert "pipeline" in checks
         assert "memory" in checks
+        assert "runtime_features" in data
+        assert "sanitize" in data["runtime_features"]
+        assert "atomic_io" in data["runtime_features"]
         # Values should be either "ok", "degraded", or "unavailable"
         assert checks["pipeline"] in ("ok", "unavailable")
         assert checks["memory"] in ("ok", "degraded", "unavailable")
+        assert data["runtime_features"]["sanitize"] in ("ok", "degraded")
+        assert data["runtime_features"]["atomic_io"] in ("ok", "degraded")
 
     def test_health_exposes_memory_degradation_details(self, monkeypatch):
         """Non-fatal MemoryStore load issues should surface in /health."""
@@ -162,6 +167,20 @@ class TestEnhancedHealth:
         assert data["ok"] is False
         assert data["status"] == "unavailable"
         assert data["checks"]["pipeline"] == "unavailable"
+
+    def test_health_runtime_features_show_sanitize_degradation(self, monkeypatch):
+        """Health endpoint should expose runtime security degradation."""
+        monkeypatch.setattr(server, "_HAS_SANITIZE", False)
+        monkeypatch.setattr(server, "_HAS_ATOMIC_IO", False)
+
+        r = client.get("/health")
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is False
+        assert data["status"] == "degraded"
+        assert data["runtime_features"]["sanitize"] == "degraded"
+        assert data["runtime_features"]["atomic_io"] == "degraded"
 
 
 # -------------------------------------------------


### PR DESCRIPTION
### Motivation
- 非本番環境で安全機能（PII masking / atomic I/O）が欠落しても API が fail-open 状態に見えにくい点を改善するため、監視経由で検知可能にすることを目的とした。

### Description
- `/health` と `/v1/health` に `runtime_features` フィールドを追加し、`sanitize` と `atomic_io` の状態を `ok`/`degraded` で返すようにした（`veritas_os/api/routes_system.py`）。
- runtime feature が `degraded` の場合は top-level の `status` を `degraded` に上げるロジックを追加した（health 判定に反映）。
- 回帰テストを追加・更新して `runtime_features` の存在と `sanitize`/`atomic_io` 欠落時の挙動を検証するテストを追加した（`veritas_os/tests/test_api_backend_improvements.py`）。
- 変更内容をレビュー文書 `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` に追記して実施日を記録した。 

### Testing
- 実行コマンド `pytest -q veritas_os/tests/test_api_backend_improvements.py veritas_os/tests/test_api_startup_health.py` を実行し、テストはすべて成功した（25 passed）。
- ヘルスエンドポイントの JSON 応答に `runtime_features` が含まれることと、`sanitize`/`atomic_io` が欠落した場合に `status: "degraded"` となることを自動テストで確認済み。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf460eece88326b561f9388f6391db)