### PR TITLE
Expose auth-store degradation in /health

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -112,6 +112,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/tests/test_api_startup_health.py` に、non-production 警告動作を維持しつつ production では fail-closed になる回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/health` / `/v1/health` に `runtime_features` を追加し、`sanitize` / `atomic_io` の欠落を `degraded` として返すようにした。起動自体は継続する non-production でも、監視側が安全機能の欠落をレスポンスだけで検知できる。
   - `veritas_os/tests/test_api_backend_improvements.py` に、runtime feature の degradation が health 応答へ露出する回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/auth.py` に `auth_store_health_snapshot()` を追加し、`veritas_os/api/routes_system.py` の `/health` / `/v1/health` で `checks.auth_store` と `auth_store` 詳細を返すようにした。これにより `VERITAS_AUTH_SECURITY_STORE=redis` を要求しながら in-memory にフォールバックしている状態や、non-production の fail-open 設定を health 監視だけで検知できる。
+  - `veritas_os/tests/test_api_backend_improvements.py` に、auth store の degraded 状態が health 応答へ露出する回帰テストを追加した。
 
 ### P1
 

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -291,6 +291,44 @@ def _warn_auth_store_fail_open_once() -> None:
     )
 
 
+def auth_store_health_snapshot() -> Dict[str, Any]:
+    """Return auth store runtime health for monitoring and audit visibility.
+
+    The snapshot intentionally exposes posture rather than secrets so `/health`
+    can reveal when a distributed deployment silently fell back to the
+    in-memory store, or when non-production testing is running in fail-open
+    mode. This helps operators detect degraded security before an outage turns
+    into an auth control gap.
+    """
+    requested_mode = (
+        (os.getenv("VERITAS_AUTH_SECURITY_STORE") or "memory").strip().lower()
+        or "memory"
+    )
+    failure_mode = _auth_store_failure_mode()
+    effective_store = _get_effective_auth_store()
+    effective_mode = "redis" if isinstance(effective_store, RedisAuthSecurityStore) else "memory"
+
+    status = "ok"
+    reasons = []
+
+    if requested_mode == "redis" and effective_mode != "redis":
+        status = "degraded"
+        reasons.append("redis_store_unavailable")
+
+    if failure_mode == "open":
+        status = "degraded"
+        reasons.append("fail_open_enabled")
+
+    return {
+        "status": status,
+        "requested_mode": requested_mode,
+        "effective_mode": effective_mode,
+        "failure_mode": failure_mode,
+        "distributed_safe": effective_mode == "redis",
+        "reasons": reasons,
+    }
+
+
 def _auth_store_register_nonce(nonce: str, ttl_sec: float) -> bool:
     """Register nonce with explicit fail-open/fail-closed fallback policy."""
     try:

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -52,6 +52,16 @@ def _runtime_feature_checks(srv: Any) -> Dict[str, str]:
     }
 
 
+def _auth_store_health(srv: Any) -> Dict[str, Any]:
+    """Return auth-store runtime health details for system health responses."""
+    snapshot = srv.auth_store_health_snapshot()
+    status = snapshot.get("status", "ok")
+    return {
+        "status": status if status in {"ok", "degraded"} else "degraded",
+        "details": snapshot,
+    }
+
+
 # ------------------------------------------------------------------
 # Pydantic models
 # ------------------------------------------------------------------
@@ -100,6 +110,7 @@ def health() -> Dict[str, Any]:
         pipeline_status = "ok" if pipeline_ok else "unavailable"
         memory_status = "ok" if memory_ok else "unavailable"
         runtime_features = _runtime_feature_checks(srv)
+        auth_store = _auth_store_health(srv)
         if memory_health and memory_health.get("status") == "degraded":
             memory_status = "degraded"
 
@@ -109,6 +120,7 @@ def health() -> Dict[str, Any]:
         elif (
             memory_status == "degraded"
             or "degraded" in runtime_features.values()
+            or auth_store["status"] == "degraded"
         ):
             health_status = "degraded"
 
@@ -120,8 +132,10 @@ def health() -> Dict[str, Any]:
             "checks": {
                 "pipeline": pipeline_status,
                 "memory": memory_status,
+                "auth_store": auth_store["status"],
             },
             "runtime_features": runtime_features,
+            "auth_store": auth_store["details"],
         }
         if memory_health:
             result["memory_health"] = memory_health

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -465,6 +465,7 @@ from veritas_os.api.auth import (  # noqa: E402,F401
     _auth_fail_lock,
     _cleanup_auth_fail_bucket_unsafe,
     _auth_store_failure_mode,
+    auth_store_health_snapshot,
     _auth_store_register_nonce,
     _auth_store_increment_auth_failure,
     _auth_store_increment_rate_limit,

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -110,12 +110,15 @@ class TestEnhancedHealth:
         checks = data["checks"]
         assert "pipeline" in checks
         assert "memory" in checks
+        assert "auth_store" in checks
         assert "runtime_features" in data
+        assert "auth_store" in data
         assert "sanitize" in data["runtime_features"]
         assert "atomic_io" in data["runtime_features"]
         # Values should be either "ok", "degraded", or "unavailable"
         assert checks["pipeline"] in ("ok", "unavailable")
         assert checks["memory"] in ("ok", "degraded", "unavailable")
+        assert checks["auth_store"] in ("ok", "degraded")
         assert data["runtime_features"]["sanitize"] in ("ok", "degraded")
         assert data["runtime_features"]["atomic_io"] in ("ok", "degraded")
 
@@ -181,6 +184,31 @@ class TestEnhancedHealth:
         assert data["status"] == "degraded"
         assert data["runtime_features"]["sanitize"] == "degraded"
         assert data["runtime_features"]["atomic_io"] == "degraded"
+
+    def test_health_shows_auth_store_degradation(self, monkeypatch):
+        """Health endpoint should expose auth-store security degradation."""
+        monkeypatch.setattr(
+            server,
+            "auth_store_health_snapshot",
+            lambda: {
+                "status": "degraded",
+                "requested_mode": "redis",
+                "effective_mode": "memory",
+                "failure_mode": "closed",
+                "distributed_safe": False,
+                "reasons": ["redis_store_unavailable"],
+            },
+        )
+
+        r = client.get("/health")
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is False
+        assert data["status"] == "degraded"
+        assert data["checks"]["auth_store"] == "degraded"
+        assert data["auth_store"]["requested_mode"] == "redis"
+        assert data["auth_store"]["effective_mode"] == "memory"
 
 
 # -------------------------------------------------


### PR DESCRIPTION
### Motivation

- The code review noted auth-store fallbacks and fail-open settings can silently weaken security, so operators need visibility into auth-store posture via health endpoints.

### Description

- Added `auth_store_health_snapshot()` in `veritas_os/api/auth.py` to report `requested_mode`, `effective_mode`, `failure_mode`, `distributed_safe`, `status`, and `reasons` without leaking secrets.
- Re-exported `auth_store_health_snapshot` from `veritas_os/api/server.py` for backward-compatible access by the server module.
- Extended `/health` and `/v1/health` in `veritas_os/api/routes_system.py` to include `checks.auth_store` and a detailed top-level `auth_store` field and to consider auth-store degradation when computing overall `status`.
- Added a regression test `test_health_shows_auth_store_degradation` in `veritas_os/tests/test_api_backend_improvements.py` and updated the code review document `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to record the change.

### Testing

- Ran the focused test-suite with `pytest -q veritas_os/tests/test_api_backend_improvements.py veritas_os/tests/test_api_startup_health.py` which completed successfully (all tests passed: 26 passed).
- Performed bytecode validation with `python -m compileall veritas_os/api/auth.py veritas_os/api/routes_system.py veritas_os/api/server.py` which succeeded.
- No other automated tests were modified or run as part of this change.

Security warning: if `auth_store_health_snapshot` reports `requested_mode="redis"` but `effective_mode="memory"` or `failure_mode="open"`, this indicates the auth protections (nonce/rate-limit/auth-failure tracking) may be degraded and should be treated as an alerting condition by monitoring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf571b6f6c832689955ff99b3862a2)