### PR TITLE
Expose auth-store degradation in /v1/metrics

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -114,6 +114,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/tests/test_api_backend_improvements.py` に、runtime feature の degradation が health 応答へ露出する回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/auth.py` に `auth_store_health_snapshot()` を追加し、`veritas_os/api/routes_system.py` の `/health` / `/v1/health` で `checks.auth_store` と `auth_store` 詳細を返すようにした。これにより `VERITAS_AUTH_SECURITY_STORE=redis` を要求しながら in-memory にフォールバックしている状態や、non-production の fail-open 設定を health 監視だけで検知できる。
   - `veritas_os/tests/test_api_backend_improvements.py` に、auth store の degraded 状態が health 応答へ露出する回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/v1/metrics` に `auth_store_effective_mode` / `auth_store_status` / `auth_store_reasons` を追加し、health poll だけでなく監査・運用メトリクス収集側でも auth store の degrade を追跡できるようにした。これにより redis 要求時の in-memory フォールバックや fail-open 設定が、定期メトリクス収集からも把握できる。
+  - `veritas_os/tests/test_api_backend_improvements.py` に、metrics 応答へ auth store degradation が露出する回帰テストを追加した。
 
 ### P1
 

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -7,7 +7,6 @@ import asyncio
 import heapq
 import json
 import logging
-import os
 import queue
 import time
 from pathlib import Path
@@ -220,6 +219,7 @@ def metrics(decide_file_limit: int = Query(default=500, ge=1, le=5000)):
     except Exception as e:
         logger.warning("read trust_log.jsonl failed: %s", srv._errstr(e))
 
+    auth_store = _auth_store_health(srv)
     result = {
         "decide_files": total_decide_files,
         "decide_files_returned": len(files),
@@ -231,8 +231,13 @@ def metrics(decide_file_limit: int = Query(default=500, ge=1, le=5000)):
         "last_decide_at": last_at,
         "server_time": srv.utc_now_iso_z(),
         "pipeline_ok": srv.get_decision_pipeline() is not None,
-        "auth_store_mode": (os.getenv("VERITAS_AUTH_SECURITY_STORE") or "memory").strip().lower() or "memory",
-        "auth_store_failure_mode": srv._auth_store_failure_mode(),
+        "auth_store_mode": auth_store["details"].get("requested_mode", "memory"),
+        "auth_store_effective_mode": auth_store["details"].get("effective_mode", "memory"),
+        "auth_store_status": auth_store["status"],
+        "auth_store_failure_mode": auth_store["details"].get(
+            "failure_mode", srv._auth_store_failure_mode()
+        ),
+        "auth_store_reasons": auth_store["details"].get("reasons", []),
         "auth_reject_reasons": srv._snapshot_auth_reject_reason_metrics(),
     }
     if srv._is_debug_mode():

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -216,6 +216,32 @@ class TestEnhancedHealth:
 # -------------------------------------------------
 
 
+    def test_metrics_exposes_auth_store_degradation(self, monkeypatch):
+        """Metrics endpoint should expose auth-store posture for audit visibility."""
+        monkeypatch.setattr(
+            server,
+            "auth_store_health_snapshot",
+            lambda: {
+                "status": "degraded",
+                "requested_mode": "redis",
+                "effective_mode": "memory",
+                "failure_mode": "closed",
+                "distributed_safe": False,
+                "reasons": ["redis_store_unavailable"],
+            },
+        )
+
+        r = client.get("/v1/metrics", headers=_AUTH_HEADERS)
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["auth_store_mode"] == "redis"
+        assert data["auth_store_effective_mode"] == "memory"
+        assert data["auth_store_status"] == "degraded"
+        assert data["auth_store_failure_mode"] == "closed"
+        assert data["auth_store_reasons"] == ["redis_store_unavailable"]
+
+
 class TestGracefulShutdown:
     def test_shutdown_returns_503(self):
         """When shutting down, requests should get 503 with Retry-After."""


### PR DESCRIPTION
### Motivation
- 監査・運用の可視性を強化するため、health ポーリングだけでなく定期メトリクス収集側でも auth-store の劣化（redis→memory フォールバックや fail-open 設定）を検知できるようにすることを目的としました。 
- 変更は最小限に限定し `Planner / Kernel / FUJI / MemoryOS` の責務を越えないようにしています。 
- この変更は可視化の追加であり動作ポリシー（fail-open/closed）を変えるものではないため、運用側での対応が引き続き必要である点を警告します。

### Description
- `veritas_os/api/routes_system.py` の `metrics()` に `auth_store = _auth_store_health(srv)` を導入し、レスポンスに `auth_store_mode`（requested）、`auth_store_effective_mode`、`auth_store_status`、`auth_store_failure_mode`、`auth_store_reasons` を追加しました。 
- メトリクス中の既存 `auth_reject_reasons` は維持しつつ auth-store の姿勢を明示的に露出するようにしました。 
- 回帰テストとして `veritas_os/tests/test_api_backend_improvements.py` に `test_metrics_exposes_auth_store_degradation` を追加しました。 
- 対応内容を `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` に追記してレビュー記録を更新しました。

### Testing
- `pytest veritas_os/tests/test_api_backend_improvements.py -q` を実行しテストはすべて成功して `15 passed` でした。 
- `python -m compileall veritas_os/api/routes_system.py` を実行してコンパイルチェックは成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf5d27a16c832691abfc10354a3568)