### PR TITLE
Expose memory and runtime degradation in /v1/metrics

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -116,6 +116,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/tests/test_api_backend_improvements.py` に、auth store の degraded 状態が health 応答へ露出する回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/v1/metrics` に `auth_store_effective_mode` / `auth_store_status` / `auth_store_reasons` を追加し、health poll だけでなく監査・運用メトリクス収集側でも auth store の degrade を追跡できるようにした。これにより redis 要求時の in-memory フォールバックや fail-open 設定が、定期メトリクス収集からも把握できる。
   - `veritas_os/tests/test_api_backend_improvements.py` に、metrics 応答へ auth store degradation が露出する回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/v1/metrics` に `memory_status` / `memory_health` / `runtime_features` を追加し、Memory 破損フォールバックや `sanitize` / `atomic_io` 欠落を health endpoint 以外の定期メトリクス収集からも追跡できるようにした。これにより empty-state へ倒れた非致命障害や安全機能の欠落が、監査・監視パイプライン上で見落とされにくくなる。
+  - `veritas_os/tests/test_api_backend_improvements.py` に、metrics 応答へ memory/runtime の degradation が露出する回帰テストを追加した。
 
 ### P1
 

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -161,6 +161,7 @@ def status() -> Dict[str, Any]:
         "pipeline_ok": srv.get_decision_pipeline() is not None,
         "api_key_configured": bool(expected),
     }
+
     if srv._is_debug_mode():
         result["cfg_error"] = srv._cfg_state.err
         result["pipeline_error"] = srv._pipeline_state.err
@@ -192,6 +193,7 @@ def _collect_recent_decide_files(shadow_dir: Path, limit: int) -> tuple[list[Pat
 
 @router.get("/v1/metrics")
 def metrics(decide_file_limit: int = Query(default=500, ge=1, le=5000)):
+    """Return operational metrics with degraded security/memory posture."""
     srv = _get_server()
     shadow_dir = srv._effective_shadow_dir()
     _, log_json, log_jsonl = srv._effective_log_paths()
@@ -220,6 +222,17 @@ def metrics(decide_file_limit: int = Query(default=500, ge=1, le=5000)):
         logger.warning("read trust_log.jsonl failed: %s", srv._errstr(e))
 
     auth_store = _auth_store_health(srv)
+    runtime_features = _runtime_feature_checks(srv)
+    memory_store = srv.get_memory_store()
+    memory_health = None
+    memory_status = "unavailable"
+    if memory_store is not None:
+        memory_status = "ok"
+        if hasattr(memory_store, "health_snapshot"):
+            memory_health = memory_store.health_snapshot()
+            if memory_health.get("status") == "degraded":
+                memory_status = "degraded"
+
     result = {
         "decide_files": total_decide_files,
         "decide_files_returned": len(files),
@@ -231,6 +244,8 @@ def metrics(decide_file_limit: int = Query(default=500, ge=1, le=5000)):
         "last_decide_at": last_at,
         "server_time": srv.utc_now_iso_z(),
         "pipeline_ok": srv.get_decision_pipeline() is not None,
+        "memory_status": memory_status,
+        "runtime_features": runtime_features,
         "auth_store_mode": auth_store["details"].get("requested_mode", "memory"),
         "auth_store_effective_mode": auth_store["details"].get("effective_mode", "memory"),
         "auth_store_status": auth_store["status"],
@@ -240,6 +255,9 @@ def metrics(decide_file_limit: int = Query(default=500, ge=1, le=5000)):
         "auth_store_reasons": auth_store["details"].get("reasons", []),
         "auth_reject_reasons": srv._snapshot_auth_reject_reason_metrics(),
     }
+    if memory_health is not None:
+        result["memory_health"] = memory_health
+
     if srv._is_debug_mode():
         result["pipeline_error"] = srv._pipeline_state.err
         result["cfg_error"] = srv._cfg_state.err

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -241,6 +241,35 @@ class TestEnhancedHealth:
         assert data["auth_store_failure_mode"] == "closed"
         assert data["auth_store_reasons"] == ["redis_store_unavailable"]
 
+    def test_metrics_exposes_memory_and_runtime_degradation(self, monkeypatch):
+        """Metrics endpoint should expose degraded memory/runtime security posture."""
+
+        class FakeMemoryStore:
+            def health_snapshot(self):
+                return {
+                    "status": "degraded",
+                    "last_error": {
+                        "stage": "boot_rebuild",
+                        "kind": "semantic",
+                        "detail": "JSONDecodeError",
+                        "recorded_at": "2026-03-22T00:00:00Z",
+                    },
+                    "error_counts": {"boot_rebuild:semantic": 1},
+                }
+
+        monkeypatch.setattr(server, "get_memory_store", lambda: FakeMemoryStore())
+        monkeypatch.setattr(server, "_HAS_SANITIZE", False)
+        monkeypatch.setattr(server, "_HAS_ATOMIC_IO", False)
+
+        r = client.get("/v1/metrics", headers=_AUTH_HEADERS)
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["memory_status"] == "degraded"
+        assert data["memory_health"]["last_error"]["detail"] == "JSONDecodeError"
+        assert data["runtime_features"]["sanitize"] == "degraded"
+        assert data["runtime_features"]["atomic_io"] == "degraded"
+
 
 class TestGracefulShutdown:
     def test_shutdown_returns_503(self):


### PR DESCRIPTION
### Motivation
- Make MemoryStore non-fatal load issues and missing runtime security features (sanitize / atomic_io) visible to periodic metrics consumers so monitoring and audit pipelines can detect degraded security or memory posture outside of the /health endpoint. 
- Implement the smallest, focused change required by the code review recommendations to improve observability without changing failure modes or responsibilities.

### Description
- Add `memory_status`, `memory_health` and `runtime_features` to the `/v1/metrics` response in `veritas_os/api/routes_system.py` and include a short docstring for the metrics handler. 
- Compute `memory_status` by inspecting `srv.get_memory_store()` and calling `health_snapshot()` when available, marking degraded status when appropriate. 
- Add a regression test `test_metrics_exposes_memory_and_runtime_degradation` to `veritas_os/tests/test_api_backend_improvements.py` to verify metrics expose degraded memory/runtime information. 
- Update `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to record the change and rationale.

### Testing
- Ran `python -m pytest veritas_os/tests/test_api_backend_improvements.py` and observed all relevant tests pass (`16 passed`).
- Ran `python -m compileall veritas_os/api/routes_system.py veritas_os/tests/test_api_backend_improvements.py` to ensure modules compile without syntax errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf6001b04c832693362b3004cf3d1c)