### PR TITLE
Harden production auth store startup

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -118,6 +118,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/tests/test_api_backend_improvements.py` に、metrics 応答へ auth store degradation が露出する回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/v1/metrics` に `memory_status` / `memory_health` / `runtime_features` を追加し、Memory 破損フォールバックや `sanitize` / `atomic_io` 欠落を health endpoint 以外の定期メトリクス収集からも追跡できるようにした。これにより empty-state へ倒れた非致命障害や安全機能の欠落が、監査・監視パイプライン上で見落とされにくくなる。
   - `veritas_os/tests/test_api_backend_improvements.py` に、metrics 応答へ memory/runtime の degradation が露出する回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/auth.py` の `_create_auth_security_store()` を更新し、`VERITAS_AUTH_SECURITY_STORE=redis` を要求した production (`VERITAS_ENV=production` / `prod`) では、`VERITAS_AUTH_REDIS_URL` 未設定や Redis 初期化失敗時に `RuntimeError` を送出して fail-closed で起動停止するようにした。これにより distributed-safe な auth store を要求した本番構成が silent に in-memory へ degrade する経路を閉じた。
+  - `veritas_os/tests/test_auth_core.py` に、non-production では従来どおり warning + fallback を維持しつつ、production では missing URL / Redis 初期化失敗を fail-closed にする回帰テストを追加した。
 
 ### P1
 

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -193,14 +193,34 @@ class RedisAuthSecurityStore:
 
 
 def _create_auth_security_store() -> AuthSecurityStore:
-    """Create auth security store from environment configuration."""
+    """Create auth security store from environment configuration.
+
+    Security policy:
+        When operators explicitly request Redis-backed auth security storage in
+        production, initialization must fail closed if Redis is misconfigured
+        or unavailable. Silently downgrading to the in-memory store would
+        weaken replay/rate-limit guarantees in multi-worker deployments.
+    """
     mode = (os.getenv("VERITAS_AUTH_SECURITY_STORE") or "memory").strip().lower()
     if mode != "redis":
         return InMemoryAuthSecurityStore()
 
+    def _raise_or_warn(detail: str) -> None:
+        """Enforce fail-closed auth-store startup in production deployments."""
+        from veritas_os.api.startup_health import should_fail_fast_startup
+
+        message = (
+            f"{detail} "
+            "Auth security store cannot fall back to in-memory in production "
+            "when VERITAS_AUTH_SECURITY_STORE=redis is required."
+        )
+        if should_fail_fast_startup():
+            raise RuntimeError(message)
+        logger.warning("%s", message)
+
     redis_url = (os.getenv("VERITAS_AUTH_REDIS_URL") or "").strip()
     if not redis_url:
-        logger.warning(
+        _raise_or_warn(
             "VERITAS_AUTH_SECURITY_STORE=redis but VERITAS_AUTH_REDIS_URL is missing; "
             "falling back to in-memory auth store (not distributed-safe)."
         )
@@ -213,10 +233,9 @@ def _create_auth_security_store() -> AuthSecurityStore:
         logger.info("Auth security store initialized in redis mode")
         return RedisAuthSecurityStore(client)
     except Exception as exc:
-        logger.warning(
+        _raise_or_warn(
             "Failed to initialize redis auth store (%s); falling back to in-memory "
-            "auth store (not distributed-safe).",
-            _errstr(exc),
+            "auth store (not distributed-safe)." % _errstr(exc)
         )
         return InMemoryAuthSecurityStore()
 

--- a/veritas_os/tests/test_auth_core.py
+++ b/veritas_os/tests/test_auth_core.py
@@ -9,6 +9,7 @@ import pytest
 
 from veritas_os.api.auth import (
     InMemoryAuthSecurityStore,
+    _create_auth_security_store,
     _auth_store_failure_mode,
     _warn_auth_store_fail_open_once,
     _check_and_register_nonce,
@@ -223,6 +224,56 @@ class TestAuthStoreFailureMode:
             clear=True,
         ):
             assert _auth_store_failure_mode() == "closed"
+
+
+class TestCreateAuthSecurityStore:
+    def test_redis_mode_warns_and_falls_back_outside_production(self, caplog):
+        """Non-production Redis auth-store failures may degrade with warning."""
+        caplog.set_level("WARNING")
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VERITAS_ENV": "local",
+                "VERITAS_AUTH_SECURITY_STORE": "redis",
+            },
+            clear=True,
+        ):
+            store = _create_auth_security_store()
+
+        assert isinstance(store, InMemoryAuthSecurityStore)
+        assert "VERITAS_AUTH_REDIS_URL is missing" in caplog.text
+
+    def test_redis_mode_rejects_missing_url_in_production(self):
+        """Production must fail closed when Redis auth-store config is incomplete."""
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VERITAS_ENV": "production",
+                "VERITAS_AUTH_SECURITY_STORE": "redis",
+            },
+            clear=True,
+        ):
+            with pytest.raises(RuntimeError, match="VERITAS_AUTH_REDIS_URL is missing"):
+                _create_auth_security_store()
+
+    def test_redis_mode_rejects_runtime_init_failure_in_production(self):
+        """Production must fail closed when Redis auth-store initialization fails."""
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VERITAS_ENV": "production",
+                "VERITAS_AUTH_SECURITY_STORE": "redis",
+                "VERITAS_AUTH_REDIS_URL": "redis://example.test:6379/0",
+            },
+            clear=True,
+        ):
+            with mock.patch(
+                "veritas_os.api.auth.importlib.import_module",
+                side_effect=RuntimeError("redis unavailable"),
+            ):
+                with pytest.raises(RuntimeError, match="redis unavailable"):
+                    _create_auth_security_store()
 
 
 class TestEnvIntSafe:


### PR DESCRIPTION
### Motivation
- Prevent silent security degradation where a production deployment that requires a Redis-backed auth store falls back to the in-memory store, which weakens nonce/rate-limit guarantees in multi-worker environments.

### Description
- Update `veritas_os/api/auth.py` in `_create_auth_security_store()` to enforce fail-closed behavior when `VERITAS_AUTH_SECURITY_STORE=redis` is requested in production; missing `VERITAS_AUTH_REDIS_URL` or Redis initialization failures now raise a `RuntimeError` in production and emit a warning + fallback only in non-production.
- Add regression tests in `veritas_os/tests/test_auth_core.py` and document the change in `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to record the fix and preserve the previous non-production fallback behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_auth_core.py veritas_os/tests/test_api_startup_health.py` and all tests passed (test suite output: 50 passed).
- New tests verify that non-production still warns and falls back to in-memory, while production raises `RuntimeError` on missing URL or Redis init failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf654ede448326bcf2d3c3a96e4041)