### PR TITLE
Harden memory dir prod alias handling

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -130,6 +130,7 @@ health / audit への明示的な露出が望ましい。
   - 2026-03-21 対応済み。`veritas_os/memory/store.py` に非致命な読み込み障害を記録する health telemetry を追加し、boot rebuild / targeted payload load での JSON decode error・I/O error・サイズ超過・truncation を `health_snapshot()` で取得できるようにした。
   - `veritas_os/api/routes_system.py` の `/health` / `/v1/health` は、MemoryStore が degraded telemetry を持つ場合に `checks.memory="degraded"` と `memory_health` を返すよう変更した。これにより empty-state へフォールバックしても運用監視から破損兆候を検知できる。
   - 2026-03-21 追記。health 応答に top-level の `status` (`ok` / `degraded` / `unavailable`) を追加し、Memory の非致命障害と依存欠落をレスポンスだけで判別できるようにした。`ok` の既存ブール契約は維持しつつ、監視側が `checks` の深掘りなしで degradation を扱える。
+  - 2026-03-22 追記。`veritas_os/memory/store.py` の production 判定を `VERITAS_ENV=production` だけでなく `prod` も含むよう修正し、`VERITAS_MEMORY_DIR_ALLOWLIST` の強制が `prod` 別名では抜け落ちる経路を閉じた。これにより Memory ディレクトリの fail-closed 制約が、他の startup hardening と同じ production alias 契約で一貫する。
   - `veritas_os/tests/test_memory_store.py` と `veritas_os/tests/test_api_backend_improvements.py` に回帰テストを追加した。
 
 ### P2

--- a/veritas_os/memory/store.py
+++ b/veritas_os/memory/store.py
@@ -33,7 +33,7 @@ def _resolve_memory_dir() -> Path:
     default_path = _default_memory_dir()
     env_memory_dir = os.getenv("VERITAS_MEMORY_DIR", "").strip()
     profile = (os.getenv("VERITAS_ENV", "") or "").strip().lower()
-    is_production = profile == "production"
+    is_production = profile in {"prod", "production"}
 
     if not env_memory_dir:
         resolved_default = default_path.resolve(strict=False)

--- a/veritas_os/tests/test_memory_store.py
+++ b/veritas_os/tests/test_memory_store.py
@@ -496,6 +496,30 @@ def test_resolve_memory_dir_accepts_allowlisted_path_in_production(
     assert str(allowed_dir.resolve(strict=False)) in caplog.text
 
 
+def test_resolve_memory_dir_rejects_non_allowlisted_path_in_prod_alias(
+    memory_env,
+    monkeypatch,
+    caplog,
+    tmp_path,
+):
+    """`VERITAS_ENV=prod` でも production と同じ allowlist 制約を適用する。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    default_dir = tmp_path / "default-memory"
+    allowed_root = tmp_path / "allowed"
+    denied_dir = tmp_path / "denied" / "memory"
+    monkeypatch.setattr(store, "_default_memory_dir", lambda: default_dir)
+    monkeypatch.setenv("VERITAS_ENV", "prod")
+    monkeypatch.setenv("VERITAS_MEMORY_DIR", str(denied_dir))
+    monkeypatch.setenv("VERITAS_MEMORY_DIR_ALLOWLIST", str(allowed_root))
+
+    caplog.set_level("WARNING")
+    resolved = store._resolve_memory_dir()
+
+    assert resolved == default_dir
+    assert "rejected in production" in caplog.text
+
+
 def test_resolve_memory_dir_rejects_relative_path(memory_env, monkeypatch, caplog, tmp_path):
     """相対パスの VERITAS_MEMORY_DIR は安全上の理由で拒否する。"""
     store, files, index_paths, FakeIndex, FakeEmbedder = memory_env


### PR DESCRIPTION
### Motivation
- Close a security gap where `VERITAS_ENV=prod` was not treated as production, which could allow `VERITAS_MEMORY_DIR_ALLOWLIST` checks to be bypassed and accept unsafe memory directory paths.

### Description
- Make `veritas_os/memory/store.py` treat `VERITAS_ENV` values in `{"prod", "production"}` as production, add a regression test `test_resolve_memory_dir_rejects_non_allowlisted_path_in_prod_alias` in `veritas_os/tests/test_memory_store.py`, and record the change in `docs/reviews/CODE_REVIEW_2026_03_21_JP.md`.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_store.py -k 'resolve_memory_dir'` which completed successfully (`6 passed, 15 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf6937f88883268627df4d26070fdb)