### PR TITLE
Improve memory health issue classification

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -131,6 +131,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/api/routes_system.py` の `/health` / `/v1/health` は、MemoryStore が degraded telemetry を持つ場合に `checks.memory="degraded"` と `memory_health` を返すよう変更した。これにより empty-state へフォールバックしても運用監視から破損兆候を検知できる。
   - 2026-03-21 追記。health 応答に top-level の `status` (`ok` / `degraded` / `unavailable`) を追加し、Memory の非致命障害と依存欠落をレスポンスだけで判別できるようにした。`ok` の既存ブール契約は維持しつつ、監視側が `checks` の深掘りなしで degradation を扱える。
   - `veritas_os/tests/test_memory_store.py` と `veritas_os/tests/test_api_backend_improvements.py` に回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/memory/store.py` の health telemetry に `issue_code` / `issue_counts` を追加し、JSON 破損・ファイル消失・権限不備などの非致命な読み込み失敗を `file_missing` / `permission_denied` / `io_error` の安定コードで識別できるようにした。これにより、従来の `detail` 文字列だけでは曖昧だった「破損・消失・I/O 障害」の区別を監視側が機械的に扱える。
+  - `veritas_os/tests/test_memory_store.py` と `veritas_os/tests/test_api_backend_improvements.py` に、`issue_code` の露出と missing file 分類の回帰テストを追加した。
 
 ### P2
 

--- a/veritas_os/memory/store.py
+++ b/veritas_os/memory/store.py
@@ -14,6 +14,16 @@ from veritas_os.core.atomic_io import atomic_append_line
 
 logger = logging.getLogger(__name__)
 
+
+def _classify_load_exception(exc: OSError) -> str:
+    """Return a stable telemetry code for non-fatal filesystem errors."""
+    if isinstance(exc, FileNotFoundError):
+        return "file_missing"
+    if isinstance(exc, PermissionError):
+        return "permission_denied"
+    return "io_error"
+
+
 def _default_memory_dir() -> Path:
     """Return the project-local memory directory path."""
     base_dir = Path(__file__).resolve().parents[2]
@@ -155,22 +165,35 @@ class MemoryStore:
         }
         self._boot()
 
-    def _record_load_issue(self, stage: str, kind: str, detail: str) -> None:
+    def _record_load_issue(
+        self,
+        stage: str,
+        kind: str,
+        detail: str,
+        issue_code: Optional[str] = None,
+    ) -> None:
         """Record a non-fatal memory load issue for health/audit visibility."""
         issue_key = f"{stage}:{kind}"
+        normalized_issue_code = issue_code or detail
         issue = {
             "stage": stage,
             "kind": kind,
             "detail": detail,
+            "issue_code": normalized_issue_code,
             "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         }
         with self._health_lock:
             error_counts = dict(self._health_status.get("error_counts") or {})
+            issue_counts = dict(self._health_status.get("issue_counts") or {})
             error_counts[issue_key] = int(error_counts.get(issue_key, 0)) + 1
+            issue_counts[normalized_issue_code] = int(
+                issue_counts.get(normalized_issue_code, 0)
+            ) + 1
             self._health_status = {
                 "status": "degraded",
                 "last_error": issue,
                 "error_counts": error_counts,
+                "issue_counts": issue_counts,
             }
 
     def health_snapshot(self) -> Dict[str, Any]:
@@ -202,7 +225,12 @@ class MemoryStore:
                     self._record_load_issue("boot_rebuild", kind, "file_too_large")
                     continue
             except OSError as exc:
-                self._record_load_issue("boot_rebuild", kind, f"stat_failed:{exc}")
+                self._record_load_issue(
+                    "boot_rebuild",
+                    kind,
+                    f"stat_failed:{exc}",
+                    issue_code=_classify_load_exception(exc),
+                )
                 continue
 
             ids, texts = [], []
@@ -367,7 +395,12 @@ class MemoryStore:
                 self._record_load_issue("targeted_payload_load", kind, "file_too_large")
                 return found
         except OSError as exc:
-            self._record_load_issue("targeted_payload_load", kind, f"stat_failed:{exc}")
+            self._record_load_issue(
+                "targeted_payload_load",
+                kind,
+                f"stat_failed:{exc}",
+                issue_code=_classify_load_exception(exc),
+            )
             return found
 
         offset_map = self._offset_index.get(kind, {})
@@ -409,7 +442,12 @@ class MemoryStore:
                                 break
         except (OSError, IOError) as e:
             logger.warning("[MemoryStore] Failed targeted payload load from %s: %s", path, e)
-            self._record_load_issue("targeted_payload_load", kind, f"open_failed:{e}")
+            self._record_load_issue(
+                "targeted_payload_load",
+                kind,
+                f"open_failed:{e}",
+                issue_code=_classify_load_exception(e),
+            )
 
         return found
 

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -133,6 +133,7 @@ class TestEnhancedHealth:
                         "stage": "targeted_payload_load",
                         "kind": "episodic",
                         "detail": "JSONDecodeError",
+                        "issue_code": "JSONDecodeError",
                         "recorded_at": "2026-03-21T00:00:00Z",
                     },
                     "error_counts": {"targeted_payload_load:episodic": 2},
@@ -147,6 +148,7 @@ class TestEnhancedHealth:
         assert data["status"] == "degraded"
         assert data["checks"]["memory"] == "degraded"
         assert data["memory_health"]["last_error"]["detail"] == "JSONDecodeError"
+        assert data["memory_health"]["last_error"]["issue_code"] == "JSONDecodeError"
 
     def test_health_ok_reflects_deps(self, monkeypatch):
         """ok field should reflect dependency availability."""

--- a/veritas_os/tests/test_memory_store.py
+++ b/veritas_os/tests/test_memory_store.py
@@ -581,6 +581,21 @@ def test_boot_records_health_when_json_is_corrupted(memory_env):
     assert health["error_counts"]["boot_rebuild:episodic"] >= 1
 
 
+def test_targeted_payload_load_records_missing_file_issue_code(memory_env):
+    """missing memory file は health telemetry で明示分類される。"""
+    store, files, index_paths, FakeIndex, FakeEmbedder = memory_env
+
+    ms = store.MemoryStore(dim=4)
+    loaded = ms._load_payloads_for_ids("episodic", ["missing-id"])
+
+    assert loaded == {}
+    health = ms.health_snapshot()
+    assert health["status"] == "degraded"
+    assert health["last_error"]["kind"] == "episodic"
+    assert health["last_error"]["issue_code"] == "file_missing"
+    assert health["issue_counts"]["file_missing"] >= 1
+
+
 def test_targeted_payload_load_records_health_on_decode_error(memory_env):
     """targeted payload load の decode error は health telemetry に残る。"""
     store, files, index_paths, FakeIndex, FakeEmbedder = memory_env


### PR DESCRIPTION
### Motivation
- Memory load failures (JSON decode, missing files, permission/I/O errors) were recorded only as free-text `detail`, making it hard for monitoring to distinguish file-missing vs corrupt vs generic I/O problems.
- Make a minimal, responsibility-bound improvement so monitoring/alerts can programmatically classify non-fatal memory load issues without changing Planner/Kernel/Fuji/MemoryOS boundaries.

### Description
- Add a stable classifier function `_classify_load_exception(exc: OSError)` that maps filesystem errors to `file_missing` / `permission_denied` / `io_error` and keep it internal to `veritas_os/memory/store.py`.
- Extend `MemoryStore._record_load_issue()` to accept an optional `issue_code` and to maintain `issue_counts` alongside `error_counts`, and include `issue_code` in the last error payload returned by `health_snapshot()`.
- Use the classifier when handling `stat`/`open` failures in `_boot()` and `_load_payloads_for_ids()` so these scenarios record a stable `issue_code` (no behavior change beyond telemetry).
- Add focused unit tests in `veritas_os/tests/test_memory_store.py` and update `veritas_os/tests/test_api_backend_improvements.py` to assert `issue_code` exposure and `issue_counts`, and update `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to document the change.

### Testing
- Ran `python -m pytest veritas_os/tests/test_memory_store.py -q` and `python -m pytest veritas_os/tests/test_api_backend_improvements.py -q` and confirmed all tests in these modules passed.
- The change is limited to telemetry fields and classification logic and kept within `veritas_os/memory/store.py`, so existing functional tests for memory behavior and API health continued to succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf901de0e083268fcb118b63b84d91)