### PR TITLE
Expose trust log degradation in health endpoint

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -114,6 +114,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/tests/test_api_backend_improvements.py` に、runtime feature の degradation が health 応答へ露出する回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/auth.py` に `auth_store_health_snapshot()` を追加し、`veritas_os/api/routes_system.py` の `/health` / `/v1/health` で `checks.auth_store` と `auth_store` 詳細を返すようにした。これにより `VERITAS_AUTH_SECURITY_STORE=redis` を要求しながら in-memory にフォールバックしている状態や、non-production の fail-open 設定を health 監視だけで検知できる。
   - `veritas_os/tests/test_api_backend_improvements.py` に、auth store の degraded 状態が health 応答へ露出する回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/health` / `/v1/health` に `checks.trust_log` と `trust_log` 詳細を追加し、aggregate `trust_log.json` が `invalid` / `unreadable` / `too_large` へ劣化した状態を health 監視から直接検知できるようにした。これにより audit trail の degraded 状態が `/v1/metrics` だけでなく軽量 health poll でも観測可能になり、silent degradation を避けやすくなる。
+  - `veritas_os/tests/test_api_backend_improvements.py` に、trust log の degraded 状態が health 応答へ露出する回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/v1/metrics` に `auth_store_effective_mode` / `auth_store_status` / `auth_store_reasons` を追加し、health poll だけでなく監査・運用メトリクス収集側でも auth store の degrade を追跡できるようにした。これにより redis 要求時の in-memory フォールバックや fail-open 設定が、定期メトリクス収集からも把握できる。
   - `veritas_os/tests/test_api_backend_improvements.py` に、metrics 応答へ auth store degradation が露出する回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/v1/metrics` に `memory_status` / `memory_health` / `runtime_features` を追加し、Memory 破損フォールバックや `sanitize` / `atomic_io` 欠落を health endpoint 以外の定期メトリクス収集からも追跡できるようにした。これにより empty-state へ倒れた非致命障害や安全機能の欠落が、監査・監視パイプライン上で見落とされにくくなる。

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -61,6 +61,24 @@ def _auth_store_health(srv: Any) -> Dict[str, Any]:
     }
 
 
+def _trust_log_health(srv: Any) -> Dict[str, Any]:
+    """Return trust-log aggregate JSON health for audit visibility."""
+    trust_log_runtime = getattr(srv, "_trust_log_runtime", None)
+    if trust_log_runtime is None:
+        return {"status": "unknown", "details": {"status": "unknown"}}
+
+    _, log_json, _ = srv._effective_log_paths()
+    trust_log_runtime.effective_log_paths = srv._effective_log_paths
+    load_result = trust_log_runtime.load_logs_json_result(log_json)
+    raw_status = getattr(load_result, "status", "unknown")
+    status = "ok" if raw_status in {"ok", "missing"} else "degraded"
+    details: Dict[str, Any] = {"status": raw_status}
+    error = getattr(load_result, "error", None)
+    if error:
+        details["error"] = error
+    return {"status": status, "details": details}
+
+
 # ------------------------------------------------------------------
 # Pydantic models
 # ------------------------------------------------------------------
@@ -110,6 +128,7 @@ def health() -> Dict[str, Any]:
         memory_status = "ok" if memory_ok else "unavailable"
         runtime_features = _runtime_feature_checks(srv)
         auth_store = _auth_store_health(srv)
+        trust_log = _trust_log_health(srv)
         if memory_health and memory_health.get("status") == "degraded":
             memory_status = "degraded"
 
@@ -120,6 +139,7 @@ def health() -> Dict[str, Any]:
             memory_status == "degraded"
             or "degraded" in runtime_features.values()
             or auth_store["status"] == "degraded"
+            or trust_log["status"] == "degraded"
         ):
             health_status = "degraded"
 
@@ -132,9 +152,11 @@ def health() -> Dict[str, Any]:
                 "pipeline": pipeline_status,
                 "memory": memory_status,
                 "auth_store": auth_store["status"],
+                "trust_log": trust_log["status"],
             },
             "runtime_features": runtime_features,
             "auth_store": auth_store["details"],
+            "trust_log": trust_log["details"],
         }
         if memory_health:
             result["memory_health"] = memory_health

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -111,14 +111,17 @@ class TestEnhancedHealth:
         assert "pipeline" in checks
         assert "memory" in checks
         assert "auth_store" in checks
+        assert "trust_log" in checks
         assert "runtime_features" in data
         assert "auth_store" in data
+        assert "trust_log" in data
         assert "sanitize" in data["runtime_features"]
         assert "atomic_io" in data["runtime_features"]
         # Values should be either "ok", "degraded", or "unavailable"
         assert checks["pipeline"] in ("ok", "unavailable")
         assert checks["memory"] in ("ok", "degraded", "unavailable")
         assert checks["auth_store"] in ("ok", "degraded")
+        assert checks["trust_log"] in ("ok", "degraded", "unknown")
         assert data["runtime_features"]["sanitize"] in ("ok", "degraded")
         assert data["runtime_features"]["atomic_io"] in ("ok", "degraded")
 
@@ -211,6 +214,33 @@ class TestEnhancedHealth:
         assert data["checks"]["auth_store"] == "degraded"
         assert data["auth_store"]["requested_mode"] == "redis"
         assert data["auth_store"]["effective_mode"] == "memory"
+
+    def test_health_shows_trust_log_degradation(self, monkeypatch):
+        """Health endpoint should expose degraded trust-log aggregate state."""
+
+        class FakeTrustLogRuntime:
+            def __init__(self):
+                self.effective_log_paths = None
+
+            @staticmethod
+            def load_logs_json_result(_path):
+                class Result:
+                    status = "invalid"
+                    error = "aggregate log payload is not a list"
+
+                return Result()
+
+        monkeypatch.setattr(server, "_trust_log_runtime", FakeTrustLogRuntime())
+
+        r = client.get("/health")
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is False
+        assert data["status"] == "degraded"
+        assert data["checks"]["trust_log"] == "degraded"
+        assert data["trust_log"]["status"] == "invalid"
+        assert "error" in data["trust_log"]
 
 
 # -------------------------------------------------


### PR DESCRIPTION
### Motivation
- Ensure audit-trail degraded states for the trust-log aggregate JSON are visible from lightweight health polls so silent degradation of trust logs is detectable by monitoring. 
- Align the runtime health surface with prior review guidance to avoid hiding `invalid`/`unreadable`/`too_large` trust-log states behind heavier metrics endpoints.

### Description
- Add `_trust_log_health()` in `veritas_os/api/routes_system.py` which queries the server `TrustLogRuntime` via `load_logs_json_result()` and returns a stabilized `status` and `details` payload. 
- Integrate trust-log posture into `health()` so `checks.trust_log` and `trust_log` details are returned and the top-level `status` can become `degraded` when the aggregate log is degraded. 
- Add regression test `test_health_shows_trust_log_degradation` to `veritas_os/tests/test_api_backend_improvements.py` to assert degraded trust-log visibility and response shape. 
- Update `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to record the implemented follow-up for review traceability.

### Testing
- Ran the focused test suite with `pytest -q veritas_os/tests/test_api_backend_improvements.py` and all tests passed. 
- Test run result: `17 passed in 4.77s`, confirming the new health exposure and existing health/metrics tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd72620a483268554a20ea84dd072)