### PR TITLE
Harden production startup on atomic I/O failures

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -122,6 +122,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/tests/test_api_backend_improvements.py` に、metrics 応答へ memory/runtime の degradation が露出する回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/auth.py` の `_create_auth_security_store()` を更新し、`VERITAS_AUTH_SECURITY_STORE=redis` を要求した production (`VERITAS_ENV=production` / `prod`) では、`VERITAS_AUTH_REDIS_URL` 未設定や Redis 初期化失敗時に `RuntimeError` を送出して fail-closed で起動停止するようにした。これにより distributed-safe な auth store を要求した本番構成が silent に in-memory へ degrade する経路を閉じた。
   - `veritas_os/tests/test_auth_core.py` に、non-production では従来どおり warning + fallback を維持しつつ、production では missing URL / Redis 初期化失敗を fail-closed にする回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/startup_health.py` の `check_runtime_feature_health()` を更新し、`atomic_io` モジュール未ロード時も production (`VERITAS_ENV=production` / `prod`) では `RuntimeError` を送出して API 起動を停止するよう変更した。これにより trust-log / shadow-log が direct file I/O に silently degrade したまま本番稼働する経路を閉じ、監査ログの crash-safe 性を fail-closed で守る。
+  - `veritas_os/tests/test_api_startup_health.py` に、non-production では従来どおり warning を維持しつつ production では fail-closed になる回帰テストを追加した。
 
 ### P1
 

--- a/veritas_os/api/startup_health.py
+++ b/veritas_os/api/startup_health.py
@@ -120,8 +120,8 @@ def check_runtime_feature_health(
       local recovery work can continue.
     - Missing sanitize support is fatal in production because running without
       PII masking can leak sensitive data into logs.
-    - Missing atomic I/O remains warning-only because it affects reliability
-      rather than confidentiality/integrity of request handling.
+    - Missing atomic I/O is also fatal in production because trust-log writes
+      lose crash-safe guarantees and audit durability degrades silently.
     """
     if not has_sanitize:
         message = (
@@ -133,8 +133,12 @@ def check_runtime_feature_health(
             raise RuntimeError(f"{message} Refusing startup in production.")
         logger.warning("%s", message)
     if not has_atomic_io:
-        logger.warning(
-            "[RELIABILITY] Atomic I/O is DISABLED (atomic_io module failed to load). "
-            "Trust log writes are less crash-safe (using direct file I/O). "
-            "Fix the import error and restart to restore full protection."
+        message = (
+            "[SECURITY] Atomic I/O is DISABLED (atomic_io module failed to load). "
+            "Trust-log and shadow-log writes are no longer crash-safe, so audit "
+            "durability is degraded. Fix the import error and restart to restore "
+            "full protection."
         )
+        if should_fail_fast_startup():
+            raise RuntimeError(f"{message} Refusing startup in production.")
+        logger.warning("%s", message)

--- a/veritas_os/tests/test_api_startup_health.py
+++ b/veritas_os/tests/test_api_startup_health.py
@@ -170,3 +170,31 @@ def test_check_runtime_feature_health_rejects_missing_sanitize_in_production(
             has_sanitize=False,
             has_atomic_io=True,
         )
+
+
+def test_check_runtime_feature_health_logs_atomic_io_warning_non_production(
+    caplog,
+):
+    """Non-production should still surface atomic I/O degradation as a warning."""
+    with caplog.at_level(logging.WARNING):
+        startup_health.check_runtime_feature_health(
+            logger=logging.getLogger("test.startup_health"),
+            has_sanitize=True,
+            has_atomic_io=False,
+        )
+
+    assert "Atomic I/O is DISABLED" in caplog.text
+
+
+def test_check_runtime_feature_health_rejects_missing_atomic_io_in_production(
+    monkeypatch,
+):
+    """Production must fail closed when crash-safe audit writes are unavailable."""
+    monkeypatch.setenv("VERITAS_ENV", "production")
+
+    with pytest.raises(RuntimeError, match="Atomic I/O is DISABLED"):
+        startup_health.check_runtime_feature_health(
+            logger=logging.getLogger("test.startup_health"),
+            has_sanitize=True,
+            has_atomic_io=False,
+        )


### PR DESCRIPTION
### Motivation
- Close a remaining production fail-open path where missing `atomic_io` lets trust-log/shadow-log fall back to direct I/O, silently degrading audit durability.
- Keep the change minimal and limited to API startup hardening without changing Planner / Kernel / FUJI / MemoryOS responsibilities.

### Description
- Update `check_runtime_feature_health()` in `veritas_os/api/startup_health.py` to treat missing `atomic_io` as fatal in production (`VERITAS_ENV=production` / `prod`), raising `RuntimeError` instead of only logging a warning.
- Preserve non-production behavior by emitting a warning when `atomic_io` is unavailable outside production.
- Add regression tests in `veritas_os/tests/test_api_startup_health.py` covering non-production warning and production fail-closed behavior for missing `atomic_io`.
- Record the change in `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to reflect the improvement in the prior review summary.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_startup_health.py` and observed all tests pass (14 passed).
- The changes are limited to startup health handling, test coverage, and documentation; no other automated test suites were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bffa4352f083268b147ee42e99ca06)