### PR TITLE
起動時の auth fail-open 検出を強化

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -124,6 +124,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/tests/test_auth_core.py` に、non-production では従来どおり warning + fallback を維持しつつ、production では missing URL / Redis 初期化失敗を fail-closed にする回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/startup_health.py` の `check_runtime_feature_health()` を更新し、`atomic_io` モジュール未ロード時も production (`VERITAS_ENV=production` / `prod`) では `RuntimeError` を送出して API 起動を停止するよう変更した。これにより trust-log / shadow-log が direct file I/O に silently degrade したまま本番稼働する経路を閉じ、監査ログの crash-safe 性を fail-closed で守る。
   - `veritas_os/tests/test_api_startup_health.py` に、non-production では従来どおり warning を維持しつつ production では fail-closed になる回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/startup_health.py` の startup flag validation を更新し、実際に auth fail-open を要求する `VERITAS_AUTH_STORE_FAILURE_MODE=open` も `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` と同様に明示警告・production fail-closed の対象にした。これにより、起動前チェックが実ランタイム設定とずれて fail-open 要求を見落とす経路を閉じた。
+  - `veritas_os/tests/test_api_startup_health.py` に、`VERITAS_AUTH_STORE_FAILURE_MODE=open` の non-production 警告と production fail-closed を固定する回帰テストを追加した。
 
 ### P1
 

--- a/veritas_os/api/startup_health.py
+++ b/veritas_os/api/startup_health.py
@@ -56,6 +56,8 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
 
     Security policy:
     - `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` must never be present in production.
+    - `VERITAS_AUTH_STORE_FAILURE_MODE=open` must also be surfaced explicitly so
+      operators can see the effective fail-open request during startup.
     - Auth fail-open is only supported for local/test-style profiles and must
       not remain enabled in shared staging environments.
     - `NEXT_PUBLIC_VERITAS_API_BASE_URL` must never be present in production
@@ -67,6 +69,10 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
     is_node_production = _is_node_env_production()
     profile = (os.getenv("VERITAS_ENV") or "").strip().lower()
     auth_fail_open_enabled = _is_truthy_env("VERITAS_AUTH_ALLOW_FAIL_OPEN")
+    auth_store_failure_mode = (
+        (os.getenv("VERITAS_AUTH_STORE_FAILURE_MODE") or "closed").strip().lower()
+    )
+    auth_fail_open_requested = auth_store_failure_mode == "open"
     public_api_base_url = (os.getenv("NEXT_PUBLIC_VERITAS_API_BASE_URL") or "").strip()
 
     if is_node_production and not is_production:
@@ -76,21 +82,26 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
             "deployments must explicitly set VERITAS_ENV=production before release."
         )
 
-    if auth_fail_open_enabled:
+    if auth_fail_open_enabled or auth_fail_open_requested:
+        configured_flags = []
+        if auth_fail_open_enabled:
+            configured_flags.append("VERITAS_AUTH_ALLOW_FAIL_OPEN=true")
+        if auth_fail_open_requested:
+            configured_flags.append("VERITAS_AUTH_STORE_FAILURE_MODE=open")
+        configured_flags_text = " + ".join(configured_flags)
         message = (
-            "[SECURITY] VERITAS_AUTH_ALLOW_FAIL_OPEN=true is enabled. "
+            f"[SECURITY] {configured_flags_text} is enabled. "
             "This weakens auth-store failure protections and must stay limited "
             "to controlled non-production testing."
         )
         if is_production:
-            raise RuntimeError(
-                f"{message} Refusing startup in production."
-            )
+            raise RuntimeError(f"{message} Refusing startup in production.")
         logger.warning("%s", message)
         if profile not in {"dev", "development", "local", "test"}:
             logger.warning(
-                "[SECURITY] VERITAS_AUTH_ALLOW_FAIL_OPEN=true is unsupported for "
+                "[SECURITY] Auth fail-open request (%s) is unsupported for "
                 "VERITAS_ENV=%s and will be ignored by auth store fallback logic.",
+                configured_flags_text,
                 profile or "unset",
             )
 

--- a/veritas_os/tests/test_api_startup_health.py
+++ b/veritas_os/tests/test_api_startup_health.py
@@ -68,6 +68,22 @@ def test_validate_startup_security_flags_warns_non_production_fail_open(
     assert "VERITAS_AUTH_ALLOW_FAIL_OPEN=true is enabled" in caplog.text
 
 
+def test_validate_startup_security_flags_warns_non_production_requested_open_mode(
+    monkeypatch,
+    caplog,
+):
+    """Requesting open auth-store fallback should also emit a security warning."""
+    monkeypatch.setenv("VERITAS_ENV", "local")
+    monkeypatch.setenv("VERITAS_AUTH_STORE_FAILURE_MODE", "open")
+
+    with caplog.at_level(logging.WARNING):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+    assert "VERITAS_AUTH_STORE_FAILURE_MODE=open is enabled" in caplog.text
+
+
 def test_validate_startup_security_flags_warns_fail_open_unsupported_profile(
     monkeypatch,
     caplog,
@@ -109,6 +125,19 @@ def test_validate_startup_security_flags_rejects_production_fail_open(
     monkeypatch.setenv("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true")
 
     with pytest.raises(RuntimeError, match="VERITAS_AUTH_ALLOW_FAIL_OPEN=true"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_validate_startup_security_flags_rejects_production_open_failure_mode(
+    monkeypatch,
+):
+    """Production must fail fast when auth-store fallback is requested open."""
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_AUTH_STORE_FAILURE_MODE", "open")
+
+    with pytest.raises(RuntimeError, match="VERITAS_AUTH_STORE_FAILURE_MODE=open"):
         startup_health.validate_startup_security_flags(
             logger=logging.getLogger("test.startup_health")
         )


### PR DESCRIPTION
### Motivation
- 起動時のセキュリティ検証で実ランタイムの fail-open 要求が見落とされる経路を閉じるため、`VERITAS_AUTH_STORE_FAILURE_MODE=open` を既存の `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` と同様に明示検知するようにする。 
- production では fail-closed にして、認証ストアの fail-open 要求で安全性が低下したまま起動することを防止する。 

### Description
- `validate_startup_security_flags()` を更新して `VERITAS_AUTH_STORE_FAILURE_MODE` を読み取り、`open` の場合は `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` と同様に非本番では警告、本番では `RuntimeError` を送出するようにした（`veritas_os/api/startup_health.py`）。
- 複数フラグが設定された場合に人間読み取りしやすい `configured_flags_text` を組み立てて警告メッセージ/例外メッセージに含めるようにした（`veritas_os/api/startup_health.py`）。
- `VERITAS_AUTH_STORE_FAILURE_MODE=open` の非本番警告と本番での起動拒否を固定する回帰テストを追加した（`veritas_os/tests/test_api_startup_health.py`）。
- 変更内容をレビュー文書に追記して経緯を記録した（`docs/reviews/CODE_REVIEW_2026_03_21_JP.md`）。

### Testing
- 実行した自動化テストは `pytest -q veritas_os/tests/test_api_startup_health.py` で、結果は `16 passed` で全て成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c000c7b4b883268c891c0b50da7e20)