### PR TITLE
Expose ignored auth fail-open requests in health/metrics

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -126,6 +126,8 @@ health / audit への明示的な露出が望ましい。
   - `veritas_os/tests/test_api_startup_health.py` に、non-production では従来どおり warning を維持しつつ production では fail-closed になる回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/startup_health.py` の startup flag validation を更新し、実際に auth fail-open を要求する `VERITAS_AUTH_STORE_FAILURE_MODE=open` も `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` と同様に明示警告・production fail-closed の対象にした。これにより、起動前チェックが実ランタイム設定とずれて fail-open 要求を見落とす経路を閉じた。
   - `veritas_os/tests/test_api_startup_health.py` に、`VERITAS_AUTH_STORE_FAILURE_MODE=open` の non-production 警告と production fail-closed を固定する回帰テストを追加した。
+  - 2026-03-22 追記。`veritas_os/api/auth.py` の `auth_store_health_snapshot()` に `requested_failure_mode` と `fail_open_request_ignored` 理由を追加し、`veritas_os/api/routes_system.py` の `/health` / `/v1/metrics` でも露出するようにした。これにより staging や `VERITAS_ENV` 未設定環境で `VERITAS_AUTH_STORE_FAILURE_MODE=open` が安全側で無効化されても、health/metrics 上は「正常」に見え続ける問題を避けられる。
+  - `veritas_os/tests/test_auth_core.py` と `veritas_os/tests/test_api_backend_improvements.py` に、ignored fail-open request が degraded として観測できる回帰テストを追加した。
 
 ### P1
 

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -317,11 +317,16 @@ def auth_store_health_snapshot() -> Dict[str, Any]:
     can reveal when a distributed deployment silently fell back to the
     in-memory store, or when non-production testing is running in fail-open
     mode. This helps operators detect degraded security before an outage turns
-    into an auth control gap.
+    into an auth control gap. It also surfaces ignored fail-open requests so
+    misconfigured staging/shared environments do not appear fully healthy.
     """
     requested_mode = (
         (os.getenv("VERITAS_AUTH_SECURITY_STORE") or "memory").strip().lower()
         or "memory"
+    )
+    requested_failure_mode = (
+        (os.getenv("VERITAS_AUTH_STORE_FAILURE_MODE") or "closed").strip().lower()
+        or "closed"
     )
     failure_mode = _auth_store_failure_mode()
     effective_store = _get_effective_auth_store()
@@ -334,6 +339,10 @@ def auth_store_health_snapshot() -> Dict[str, Any]:
         status = "degraded"
         reasons.append("redis_store_unavailable")
 
+    if requested_failure_mode == "open" and failure_mode != "open":
+        status = "degraded"
+        reasons.append("fail_open_request_ignored")
+
     if failure_mode == "open":
         status = "degraded"
         reasons.append("fail_open_enabled")
@@ -341,6 +350,7 @@ def auth_store_health_snapshot() -> Dict[str, Any]:
     return {
         "status": status,
         "requested_mode": requested_mode,
+        "requested_failure_mode": requested_failure_mode,
         "effective_mode": effective_mode,
         "failure_mode": failure_mode,
         "distributed_safe": effective_mode == "redis",

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -270,6 +270,10 @@ def metrics(decide_file_limit: int = Query(default=500, ge=1, le=5000)):
         "runtime_features": runtime_features,
         "auth_store_mode": auth_store["details"].get("requested_mode", "memory"),
         "auth_store_effective_mode": auth_store["details"].get("effective_mode", "memory"),
+        "auth_store_requested_failure_mode": auth_store["details"].get(
+            "requested_failure_mode",
+            "closed",
+        ),
         "auth_store_status": auth_store["status"],
         "auth_store_failure_mode": auth_store["details"].get(
             "failure_mode", srv._auth_store_failure_mode()

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -198,6 +198,7 @@ class TestEnhancedHealth:
             lambda: {
                 "status": "degraded",
                 "requested_mode": "redis",
+                "requested_failure_mode": "closed",
                 "effective_mode": "memory",
                 "failure_mode": "closed",
                 "distributed_safe": False,
@@ -214,6 +215,32 @@ class TestEnhancedHealth:
         assert data["checks"]["auth_store"] == "degraded"
         assert data["auth_store"]["requested_mode"] == "redis"
         assert data["auth_store"]["effective_mode"] == "memory"
+
+    def test_health_shows_ignored_fail_open_request(self, monkeypatch):
+        """Health endpoint should expose ignored fail-open requests."""
+        monkeypatch.setattr(
+            server,
+            "auth_store_health_snapshot",
+            lambda: {
+                "status": "degraded",
+                "requested_mode": "memory",
+                "requested_failure_mode": "open",
+                "effective_mode": "memory",
+                "failure_mode": "closed",
+                "distributed_safe": False,
+                "reasons": ["fail_open_request_ignored"],
+            },
+        )
+
+        r = client.get("/health")
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "degraded"
+        assert data["checks"]["auth_store"] == "degraded"
+        assert data["auth_store"]["requested_failure_mode"] == "open"
+        assert data["auth_store"]["failure_mode"] == "closed"
+        assert data["auth_store"]["reasons"] == ["fail_open_request_ignored"]
 
     def test_health_shows_trust_log_degradation(self, monkeypatch):
         """Health endpoint should expose degraded trust-log aggregate state."""
@@ -256,6 +283,7 @@ class TestEnhancedHealth:
             lambda: {
                 "status": "degraded",
                 "requested_mode": "redis",
+                "requested_failure_mode": "closed",
                 "effective_mode": "memory",
                 "failure_mode": "closed",
                 "distributed_safe": False,
@@ -269,9 +297,35 @@ class TestEnhancedHealth:
         data = r.json()
         assert data["auth_store_mode"] == "redis"
         assert data["auth_store_effective_mode"] == "memory"
+        assert data["auth_store_requested_failure_mode"] == "closed"
         assert data["auth_store_status"] == "degraded"
         assert data["auth_store_failure_mode"] == "closed"
         assert data["auth_store_reasons"] == ["redis_store_unavailable"]
+
+    def test_metrics_exposes_ignored_fail_open_request(self, monkeypatch):
+        """Metrics endpoint should expose ignored fail-open requests."""
+        monkeypatch.setattr(
+            server,
+            "auth_store_health_snapshot",
+            lambda: {
+                "status": "degraded",
+                "requested_mode": "memory",
+                "requested_failure_mode": "open",
+                "effective_mode": "memory",
+                "failure_mode": "closed",
+                "distributed_safe": False,
+                "reasons": ["fail_open_request_ignored"],
+            },
+        )
+
+        r = client.get("/v1/metrics", headers=_AUTH_HEADERS)
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["auth_store_status"] == "degraded"
+        assert data["auth_store_requested_failure_mode"] == "open"
+        assert data["auth_store_failure_mode"] == "closed"
+        assert data["auth_store_reasons"] == ["fail_open_request_ignored"]
 
     def test_metrics_exposes_memory_and_runtime_degradation(self, monkeypatch):
         """Metrics endpoint should expose degraded memory/runtime security posture."""

--- a/veritas_os/tests/test_auth_core.py
+++ b/veritas_os/tests/test_auth_core.py
@@ -12,6 +12,7 @@ from veritas_os.api.auth import (
     _create_auth_security_store,
     _auth_store_failure_mode,
     _warn_auth_store_fail_open_once,
+    auth_store_health_snapshot,
     _check_and_register_nonce,
     _cleanup_auth_fail_bucket_unsafe,
     _derive_api_user_id,
@@ -224,6 +225,29 @@ class TestAuthStoreFailureMode:
             clear=True,
         ):
             assert _auth_store_failure_mode() == "closed"
+
+
+class TestAuthStoreHealthSnapshot:
+    def setup_method(self):
+        _warn_auth_store_fail_open_once.cache_clear()
+
+    def test_health_snapshot_marks_ignored_fail_open_request_degraded(self):
+        """Ignored fail-open requests should stay visible in health telemetry."""
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VERITAS_ENV": "staging",
+                "VERITAS_AUTH_STORE_FAILURE_MODE": "open",
+                "VERITAS_AUTH_ALLOW_FAIL_OPEN": "true",
+            },
+            clear=True,
+        ):
+            snapshot = auth_store_health_snapshot()
+
+        assert snapshot["status"] == "degraded"
+        assert snapshot["requested_failure_mode"] == "open"
+        assert snapshot["failure_mode"] == "closed"
+        assert "fail_open_request_ignored" in snapshot["reasons"]
 
 
 class TestCreateAuthSecurityStore:


### PR DESCRIPTION
### Motivation
- 構成上で `VERITAS_AUTH_STORE_FAILURE_MODE=open` が実行時に安全側で無効化されても監視から見えず、運用上の誤設定が見逃される懸念を解消するための最小改良です。 
- 変更は auth 周りの観測性を向上させるだけで、Planner / Kernel / Fuji / MemoryOS の責務には影響を与えません。

### Description
- `auth_store_health_snapshot()` に `requested_failure_mode` を追加し、要求された fail-open 設定が無視された場合に `reasons` に `fail_open_request_ignored` を付与するようにしました。 
- `/health` と `/v1/metrics` の出力で `auth_store` 情報を拡張し、`requested_failure_mode` を `auth_store`/`auth_store_requested_failure_mode` として露出するようにしました。 
- 無視された fail-open 要求が degraded として観測されることを固定するため、`veritas_os/tests/test_auth_core.py` と `veritas_os/tests/test_api_backend_improvements.py` に回帰テストを追加しました。 
- ドキュメント `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` に今回の改善項目とテスト追加を追記しました。

### Testing
- 実行したテストは `pytest -q veritas_os/tests/test_auth_core.py -q` で、すべて成功しました。 
- 実行したテストは `pytest -q veritas_os/tests/test_api_backend_improvements.py -q` で、すべて成功しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08157212c832685f8f4c9a6117171)