### PR TITLE
Harden deployment fail-open env checks

### DIFF
--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -108,6 +108,8 @@ health / audit への明示的な露出が望ましい。
 ### P0
 
 - [x] production で sanitize import failure を fail-closed にする
+  - 2026-03-23 追記。`scripts/quality/check_deployment_env_defaults.py` を更新し、operator-facing template に `VERITAS_AUTH_STORE_FAILURE_MODE=open` が残っている場合も CI/レビュー時に検知できるようにした。既存の `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` 検知と合わせて、startup では警告や fail-closed になる危険フラグが deployment template 側に温存される経路を最小差分で塞いだ。
+  - `veritas_os/tests/test_deployment_env_defaults.py` に、引用符・`export` 付きの `VERITAS_AUTH_STORE_FAILURE_MODE=OPEN` を forbidden assignment として捕捉する回帰テストを追加した。
   - 2026-03-21 対応済み。`veritas_os/api/startup_health.py` の `check_runtime_feature_health()` を更新し、`sanitize` モジュール未ロード時は non-production では警告、production (`VERITAS_ENV=production` / `prod`) では `RuntimeError` を送出して API 起動を停止するよう変更した。これにより PII masking 欠落状態での fail-open 起動を防止する。
   - `veritas_os/tests/test_api_startup_health.py` に、non-production 警告動作を維持しつつ production では fail-closed になる回帰テストを追加した。
   - 2026-03-22 追記。`veritas_os/api/routes_system.py` の `/health` / `/v1/health` に `runtime_features` を追加し、`sanitize` / `atomic_io` の欠落を `degraded` として返すようにした。起動自体は継続する non-production でも、監視側が安全機能の欠落をレスポンスだけで検知できる。

--- a/scripts/quality/check_deployment_env_defaults.py
+++ b/scripts/quality/check_deployment_env_defaults.py
@@ -34,7 +34,10 @@ RULES = (
             "NEXT_PUBLIC_API_BASE_URL",
             "NEXT_PUBLIC_VERITAS_API_BASE_URL",
         ),
-        forbidden_env_assignments=(("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),),
+        forbidden_env_assignments=(
+            ("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),
+            ("VERITAS_AUTH_STORE_FAILURE_MODE", "open"),
+        ),
     ),
     TemplateRule(
         relative_path="setup.sh",
@@ -46,7 +49,10 @@ RULES = (
             "NEXT_PUBLIC_API_BASE_URL",
             "NEXT_PUBLIC_VERITAS_API_BASE_URL",
         ),
-        forbidden_env_assignments=(("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),),
+        forbidden_env_assignments=(
+            ("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),
+            ("VERITAS_AUTH_STORE_FAILURE_MODE", "open"),
+        ),
     ),
 )
 
@@ -134,7 +140,8 @@ def main() -> int:
         print(f"- {violation}")
     print(
         "\nUse server-only VERITAS_* variables in operator-facing templates and "
-        "never ship fail-open auth flags in default configuration."
+        "never ship fail-open auth flags or open auth-store failure modes in "
+        "default configuration."
     )
     return 1
 

--- a/veritas_os/tests/test_deployment_env_defaults.py
+++ b/veritas_os/tests/test_deployment_env_defaults.py
@@ -55,6 +55,38 @@ def test_validate_rule_flags_fail_open_with_export_spacing(tmp_path: Path) -> No
     ]
 
 
+def test_validate_rule_flags_auth_store_open_mode(tmp_path: Path) -> None:
+    """Open auth-store failure mode must be rejected in deployment templates."""
+    template = tmp_path / ".env.example"
+    template.write_text(
+        """
+        VERITAS_API_BASE_URL=http://localhost:8000
+        VERITAS_ENV=production
+        export VERITAS_AUTH_STORE_FAILURE_MODE = "OPEN"
+        """,
+        encoding="utf-8",
+    )
+    rule = deployment_defaults.TemplateRule(
+        relative_path=str(template.relative_to(tmp_path)),
+        required_tokens=("VERITAS_API_BASE_URL", "VERITAS_ENV=production"),
+        forbidden_env_assignments=(
+            ("VERITAS_AUTH_STORE_FAILURE_MODE", "open"),
+        ),
+    )
+
+    original_root = deployment_defaults.REPO_ROOT
+    deployment_defaults.REPO_ROOT = tmp_path
+    try:
+        violations = deployment_defaults._validate_rule(rule)
+    finally:
+        deployment_defaults.REPO_ROOT = original_root
+
+    assert violations == [
+        ".env.example: forbidden env assignment "
+        "VERITAS_AUTH_STORE_FAILURE_MODE=open"
+    ]
+
+
 def test_validate_rule_passes_without_forbidden_defaults(tmp_path: Path) -> None:
     """Safe templates should continue to pass the smoke check."""
     template = tmp_path / ".env.example"
@@ -69,7 +101,10 @@ def test_validate_rule_passes_without_forbidden_defaults(tmp_path: Path) -> None
         relative_path=str(template.relative_to(tmp_path)),
         required_tokens=("VERITAS_API_BASE_URL", "VERITAS_ENV=production"),
         forbidden_tokens=("NEXT_PUBLIC_VERITAS_API_BASE_URL",),
-        forbidden_env_assignments=(("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),),
+        forbidden_env_assignments=(
+            ("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),
+            ("VERITAS_AUTH_STORE_FAILURE_MODE", "open"),
+        ),
     )
 
     original_root = deployment_defaults.REPO_ROOT


### PR DESCRIPTION
### Motivation
- Prevent operator-facing templates from shipping dangerous auth fail-open flags by detecting `VERITAS_AUTH_STORE_FAILURE_MODE=open` in addition to the existing `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` checks. 
- Implement the minimal, low-risk change needed to close a detection gap in deployment templates without touching runtime behavior. 
- Record the targeted improvement in the review document so the change is visible in the project’s audit trail.

### Description
- Extend `scripts/quality/check_deployment_env_defaults.py` to forbid `VERITAS_AUTH_STORE_FAILURE_MODE=open` in operator-facing templates. 
- Update the smoke-check message to mention both fail-open auth flags and open auth-store failure modes. 
- Add a regression test `veritas_os/tests/test_deployment_env_defaults.py::test_validate_rule_flags_auth_store_open_mode` that catches quoted/exported/case variants like `export VERITAS_AUTH_STORE_FAILURE_MODE = "OPEN"`. 
- Append a short note to `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` documenting the minimal fix and its intent.

### Testing
- Ran `pytest -q veritas_os/tests/test_deployment_env_defaults.py` and the test suite passed (`4 passed`).
- Executed `python scripts/quality/check_deployment_env_defaults.py` and the smoke check returned success (`Deployment env templates passed smoke checks.`).
- All automated checks executed for this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a005964483268c58e1ece1e14b21)