### PR TITLE
Harden auth fail-open runbook checks

### DIFF
--- a/docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md
+++ b/docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md
@@ -138,6 +138,7 @@
 - `VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS=0`: 依存未導入環境で fallback 検証を行うときのみ許容。本番推奨構成では embedding 差分による挙動差を避けるため、使用有無を固定する。
 - `VERITAS_CAP_FUJI_TOOL_BRIDGE=0`: ローカル単体試験やオフライン検証では許容できるが、shared 環境では FUJI capability 差分として扱う。
 - `VERITAS_AUTH_ALLOW_FAIL_OPEN=true`: 認証 fail-open の危険フラグであり、isolated local/test の一時検証以外では禁止する。
+- `VERITAS_AUTH_STORE_FAILURE_MODE=open`: auth store 障害時に fail-open を要求する危険設定であり、`VERITAS_AUTH_ALLOW_FAIL_OPEN=true` と同様に isolated local/test の一時検証以外では禁止する。
 
 ### strict mode を推奨する箇所
 - `VERITAS_CAP_FUJI_YAML_POLICY=1`: production で YAML policy を正規運用する場合は明示有効化し、依存（PyYAML）欠落を fail-fast させる。
@@ -148,11 +149,11 @@
 - startup log の `[CapabilityManifest] component=... manifest=... disabled=...` を確認し、想定外に disabled になった capability がないかを監視する。
 - FUJI policy fallback は `FUJI policy fallback triggered:` warning と strict mode 時の error で検知する。
 - Memory sentence-transformers fallback は `[CONFIG_MISMATCH] sentence-transformers is unavailable...` warning で検知する。
-- auth fail-open は §6.2 の startup warning / fail-fast / deployment check を併用し、shared 環境に残置しない。
+- auth fail-open は §6.2 の startup warning / fail-fast / deployment check を併用し、`VERITAS_AUTH_ALLOW_FAIL_OPEN=true` と `VERITAS_AUTH_STORE_FAILURE_MODE=open` の両方を shared 環境に残置しない。
 
 ### セキュリティ注意
 - optional dependency fallback は可用性向上に役立つ一方、shared 環境では capability drift により安全性・監査性・検索品質の非決定性を生む。
-- 特に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` と permissive policy fallback の併用は、防御低下の複合リスクになるため避ける。
+- 特に `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` / `VERITAS_AUTH_STORE_FAILURE_MODE=open` と permissive policy fallback の併用は、防御低下の複合リスクになるため避ける。
 
 ## 7. セキュリティ上の警告
 - `trace_id` は監査相関用であり、認可判定には使用しない。

--- a/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
+++ b/docs/reviews/CODE_REVIEW_2026_03_21_JP.md
@@ -108,6 +108,8 @@ health / audit への明示的な露出が望ましい。
 ### P0
 
 - [x] production で sanitize import failure を fail-closed にする
+  - 2026-03-23 追記。`scripts/quality/check_capability_profile_doc.py` を更新し、運用 runbook (`docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md`) にも `VERITAS_AUTH_STORE_FAILURE_MODE=open` の危険性と禁止方針が明記されていることを CI で固定した。これにより deployment template だけでなく operator-facing capability profile 文書側でも auth fail-open 要求の見落としを防げる。
+  - `veritas_os/tests/test_check_capability_profile_doc.py` に、runbook checker が `VERITAS_AUTH_STORE_FAILURE_MODE=open` 欠落を検知する回帰テストを追加した。
   - 2026-03-23 追記。`scripts/quality/check_deployment_env_defaults.py` を更新し、operator-facing template に `VERITAS_AUTH_STORE_FAILURE_MODE=open` が残っている場合も CI/レビュー時に検知できるようにした。既存の `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` 検知と合わせて、startup では警告や fail-closed になる危険フラグが deployment template 側に温存される経路を最小差分で塞いだ。
   - `veritas_os/tests/test_deployment_env_defaults.py` に、引用符・`export` 付きの `VERITAS_AUTH_STORE_FAILURE_MODE=OPEN` を forbidden assignment として捕捉する回帰テストを追加した。
   - 2026-03-21 対応済み。`veritas_os/api/startup_health.py` の `check_runtime_feature_health()` を更新し、`sanitize` モジュール未ロード時は non-production では警告、production (`VERITAS_ENV=production` / `prod`) では `RuntimeError` を送出して API 起動を停止するよう変更した。これにより PII masking 欠落状態での fail-open 起動を防止する。

--- a/scripts/quality/check_capability_profile_doc.py
+++ b/scripts/quality/check_capability_profile_doc.py
@@ -20,6 +20,7 @@ REQUIRED_TOKENS = (
     "VERITAS_CAP_EMIT_MANIFEST=1",
     "### local / test でのみ許容する設定",
     "VERITAS_AUTH_ALLOW_FAIL_OPEN=true",
+    "VERITAS_AUTH_STORE_FAILURE_MODE=open",
     "### strict mode を推奨する箇所",
     "VERITAS_CAP_FUJI_YAML_POLICY=1",
     "VERITAS_FUJI_STRICT_POLICY_LOAD=1",

--- a/veritas_os/tests/test_check_capability_profile_doc.py
+++ b/veritas_os/tests/test_check_capability_profile_doc.py
@@ -13,6 +13,7 @@ def test_collect_missing_tokens_reports_missing_required_markers() -> None:
 
     assert "### production 推奨設定" in missing
     assert "VERITAS_CAP_FUJI_TRUST_LOG=1" in missing
+    assert "VERITAS_AUTH_STORE_FAILURE_MODE=open" in missing
     assert "[CapabilityManifest]" in missing
 
 


### PR DESCRIPTION
### Motivation
- Close an operational/CI gap so the operator-facing runbook explicitly documents and forbids the auth fail-open request `VERITAS_AUTH_STORE_FAILURE_MODE=open`. 
- Make a minimal, low-risk change that enforces the review recommendation to avoid fail-open auth settings in shared/production environments. 

### Description
- Add `VERITAS_AUTH_STORE_FAILURE_MODE=open` to the required tokens in `scripts/quality/check_capability_profile_doc.py` so the runbook checker fails if guidance is missing. 
- Update `docs/operations/ENTERPRISE_SLO_SLI_RUNBOOK_JP.md` to document the danger and prohibition of `VERITAS_AUTH_STORE_FAILURE_MODE=open` alongside `VERITAS_AUTH_ALLOW_FAIL_OPEN=true`. 
- Add an assertion to `veritas_os/tests/test_check_capability_profile_doc.py` to prevent regressions for the new required token. 
- Record the change in `docs/reviews/CODE_REVIEW_2026_03_21_JP.md` to indicate the review action was applied. 

### Testing
- Ran `pytest -q veritas_os/tests/test_check_capability_profile_doc.py` and the test suite passed (`2 passed`). 
- Executed `python scripts/quality/check_capability_profile_doc.py` and it printed `Capability profile runbook guidance passed checks.` indicating the runbook now satisfies the checker. 
- All automated checks described above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a35515b08326ba8d40c6deb541dd)