### PR TITLE
ci: narrow Trivy gate to actionable image vulnerabilities

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -51,7 +51,9 @@ jobs:
           image-ref: ${{ steps.image.outputs.name }}:${{ github.sha }}
           format: sarif
           output: trivy-results.sarif
+          scanners: vuln
           severity: CRITICAL,HIGH
+          ignore-unfixed: true
           exit-code: '1'
 
       - name: Upload Trivy scan results to GitHub Security


### PR DESCRIPTION
### Motivation
- The GHCR publish workflow was producing Trivy results that are often non-actionable (unfixed upstream CVEs and scanner noise) and caused unnecessary build failures.
- The goal is to keep security visibility while preventing the workflow from blocking on vulnerabilities the repo cannot remediate.

### Description
- Modified the Trivy step in `.github/workflows/publish-ghcr.yml` to add `scanners: vuln` to limit the scan to vulnerability findings.
- Added `ignore-unfixed: true` so unfixed upstream vulnerabilities do not fail the workflow while retaining `exit-code: '1'` to fail on fixable CRITICAL/HIGH issues.
- Kept SARIF upload to GitHub Security via the existing `upload-sarif` step so findings remain visible for triage.

### Testing
- Ran `git diff --check` and it succeeded.
- Verified the working tree shows only `.github/workflows/publish-ghcr.yml` was changed using `git status --short`.
- Workflow linting with `actionlint` was not executed because `actionlint` was not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c218c6a334832682843791d567ced3)