### PR TITLE
ci: split Trivy reporting from enforcement gate

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -54,6 +54,16 @@ jobs:
           scanners: vuln
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Enforce Trivy gate (actionable criticals only)
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ steps.image.outputs.name }}:${{ github.sha }}
+          format: table
+          scanners: vuln
+          severity: CRITICAL
+          ignore-unfixed: true
           exit-code: '1'
 
       - name: Upload Trivy scan results to GitHub Security


### PR DESCRIPTION
### Motivation
- The existing Trivy step blocked GHCR image publication on all `CRITICAL` and `HIGH` findings which produced noisy, non-actionable failures for releases. 
- The change aims to keep broad vulnerability visibility while restricting blocking behavior to actionable critical vulnerabilities that have available fixes. 
- This narrows the enforcement surface but accepts that `HIGH` findings will not block publishes, so teams should track and remediate HIGH issues via policy or SLOs. 

### Description
- Set the SARIF-producing Trivy scan step to be non-blocking by changing `exit-code` to `0` and keeping `format: sarif` and `ignore-unfixed: true` in `.github/workflows/publish-ghcr.yml`. 
- Add a new dedicated Trivy enforcement step that scans only `CRITICAL` severity with `ignore-unfixed: true` and `exit-code: '1'`, using `format: table` so only actionable criticals block the workflow. 
- Preserve the SARIF upload to GitHub Security and leave the image push step unchanged. 

### Testing
- Validated the modified workflow file by loading it with `yaml.safe_load()` (PyYAML) and the parse succeeded. 
- No CI run was executed as part of this change; CI behavior should be observed on the next workflow run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c23605cdd88326bd1572094e7e4bc7)