### PR TITLE
fix: resolve 3 HIGH security issues from code review

### DIFF
--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -11,19 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  fork-pr-permission-notice:
-    name: Fork PR permission notice
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Explain skip reason
-        run: |
-          echo "::warning::Security Gates jobs that require repository checkout are skipped for fork PRs due to GitHub token permission restrictions."
-          echo "::warning::Security risk: skipping these checks lowers enforcement for untrusted forks; run full gates after maintainers branch the changes."
-
   dependency-audit:
     name: Dependency audit (Python + Node)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -73,7 +62,6 @@ jobs:
 
   secret-scan:
     name: Secret scan (gitleaks)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -91,7 +79,6 @@ jobs:
 
   next-public-secret-guard:
     name: Guard NEXT_PUBLIC secret-like variables
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/docs/code-review-2026-03-24.md
+++ b/docs/code-review-2026-03-24.md
@@ -247,14 +247,14 @@
 
 | # | 問題 | ステータス | 対応内容 |
 |---|------|-----------|---------|
-| 1 | DNS Rebinding TOCTOU | 未対応 | IPピンニングの実装が必要（アーキテクチャ変更） |
-| 2 | ReDoS防止が不十分 | 未対応 | 入力長上限 `_MAX_PII_INPUT_LENGTH` は設定済み。チャンク処理は要検討 |
+| 1 | DNS Rebinding TOCTOU | **修正済み** | `web_search_security.py`: `_pin_dns_context()` を追加し、urllib3のDNS解決をプリフライトIPにピンニング。`web_search.py`: リクエスト実行時にコンテキストマネージャで適用し、検証〜接続間のTOCTOUギャップを解消 |
+| 2 | ReDoS防止が不十分 | **修正済み** | `sanitize.py`: `_MAX_PII_INPUT_LENGTH` を1,000,000から100,000に引き下げ。チャンク処理は既存実装済み（128文字オーバーラップ付きセグメント分割） |
 | 3 | Slack Webhook URLのホスト検証 | **対策済み** | `hooks.slack-gov.com` が `allowed_hosts` に追加済み |
 | 4 | 暗号化アルゴリズムのマーキング不足 | **修正済み** | `encryption.py`: 暗号文に `ENC:aesgcm:` / `ENC:hmac-ctr:` タグを付与。復号時にタグで自動ディスパッチ。レガシー（タグなし）トークンとの後方互換性も維持 |
 | 5 | サブプロセスの外部タイムアウト制御なし | **対策済み** | `alert_doctor.py`: `subprocess.check_output()` に `timeout` パラメータ設定済み + `TimeoutExpired` ハンドリング済み |
-| 6 | fork PRでセキュリティゲートがスキップ | 未対応 | GitHub Actions のトークン権限制限による構造的制約 |
+| 6 | fork PRでセキュリティゲートがスキップ | **修正済み** | `security-gates.yml`: fork PRを除外する `if` 条件を全ジョブから削除。`dependency-audit`・`secret-scan`・`next-public-secret-guard` はいずれも `contents: read` 権限のみで動作するため、fork PRでも実行可能 |
 | 7 | Trivyスキャンで HIGH脆弱性をサイレント通過 | **対策済み** | `publish-ghcr.yml`: 2段構成（SARIF出力用 `exit-code: '0'` + CRITICAL強制ゲート `exit-code: '1'`） |
 | 8 | Dockerイメージタグがローリング | **修正済み** | `Dockerfile`: `python:3.11.12-slim` に固定 / `docker-compose.yml`: `node:20.19.0-bookworm` に固定 |
 | 9 | セキュリティツールのバージョン未固定 | **修正済み** | `main.yml`: `ruff==0.11.4`, `bandit==1.9.4`, `pip-audit==2.8.0` / `security-gates.yml`: `pip-audit==2.8.0` に固定 |
-| 10 | openapi.yaml additionalProperties | 未対応 | 35箇所以上の変更が必要（スキーマ互換性の確認が先） |
+| 10 | openapi.yaml additionalProperties | 未対応 | 35箇所以上の変更が必要（スキーマ互換性の確認が先。可変構造スキーマが多く一律変更はAPIブレイキングチェンジのリスク大） |
 | 11 | localStorage例外処理なし | **修正済み** | `i18n-provider.tsx`: `try/catch` 追加 + `storage` イベントリスナーによるマルチタブ同期 |

--- a/veritas_os/core/sanitize.py
+++ b/veritas_os/core/sanitize.py
@@ -42,7 +42,8 @@ _logger = logging.getLogger(__name__)
 # Luhnチェック時の入力文字列長上限（DoS対策）
 _MAX_CARD_INPUT_LENGTH = 256
 # PII検査対象の入力長上限（ReDoS/CPU DoS対策）
-_MAX_PII_INPUT_LENGTH = 1_000_000
+# 100k: 複雑な日本語PII正規表現との組み合わせで計算量爆発を防止
+_MAX_PII_INPUT_LENGTH = 100_000
 # 1回の検出で保持する一致数上限（メモリ消費抑止）
 _MAX_PII_MATCHES = 10_000
 

--- a/veritas_os/tools/web_search.py
+++ b/veritas_os/tools/web_search.py
@@ -67,6 +67,7 @@ from .web_search_security import (
     _extract_public_ips_for_url,
     _clear_private_host_cache,
     _is_hostname_exact_or_subdomain,
+    _pin_dns_context,
 )
 
 WEBSEARCH_URL: str = os.getenv("VERITAS_WEBSEARCH_URL", "").strip()
@@ -317,14 +318,23 @@ def _post_with_retry(
             if expected_ips is not None:
                 _validate_rebinding_guard(url, expected_ips)
 
-            response = requests.post(
-                url,
-                headers=headers,
-                json=payload,
-                timeout=timeout,
-                allow_redirects=False,
-                proxies=request_proxies,
-            )
+            # IP pinning: force urllib3 to connect to the preflight-resolved
+            # IP, closing the TOCTOU window between validation and connect.
+            _ctx = _pin_dns_context(url, expected_ips) if expected_ips else None
+            if _ctx is not None:
+                _ctx.__enter__()
+            try:
+                response = requests.post(
+                    url,
+                    headers=headers,
+                    json=payload,
+                    timeout=timeout,
+                    allow_redirects=False,
+                    proxies=request_proxies,
+                )
+            finally:
+                if _ctx is not None:
+                    _ctx.__exit__(None, None, None)
             status_code = getattr(response, "status_code", None)
             if status_code is not None and _should_retry_status(status_code):
                 if attempt < WEBSEARCH_MAX_RETRIES:

--- a/veritas_os/tools/web_search_security.py
+++ b/veritas_os/tools/web_search_security.py
@@ -201,6 +201,44 @@ def _validate_rebinding_guard(url: str, expected_ips: set[str]) -> None:
         raise ValueError("websearch endpoint DNS result changed during request")
 
 
+def _pin_dns_context(url: str, pinned_ips: set[str]):
+    """Context manager that pins urllib3 DNS resolution to pre-resolved IPs.
+
+    Eliminates the TOCTOU gap between DNS validation and the actual HTTP
+    request by overriding ``urllib3.util.connection.create_connection`` so
+    that the target hostname always resolves to one of the preflight IPs.
+
+    Usage::
+
+        with _pin_dns_context(url, resolved_ips):
+            requests.post(url, ...)
+    """
+    import contextlib
+    import urllib3.util.connection as _urllib3_conn
+
+    parsed = urlparse((url or "").strip())
+    target_host = _canonicalize_hostname(parsed.hostname or "")
+    pinned_ip = sorted(pinned_ips)[0]
+
+    @contextlib.contextmanager
+    def _pin():
+        original = _urllib3_conn.create_connection
+
+        def _pinned(address, *args, **kwargs):  # type: ignore[no-untyped-def]
+            host, port = address
+            if _canonicalize_hostname(host) == target_host:
+                return original((pinned_ip, port), *args, **kwargs)
+            return original(address, *args, **kwargs)
+
+        _urllib3_conn.create_connection = _pinned  # type: ignore[assignment]
+        try:
+            yield
+        finally:
+            _urllib3_conn.create_connection = original
+
+    return _pin()
+
+
 def _clear_private_host_cache() -> None:
     """Clear DNS lookup cache used by SSRF host checks."""
     _resolve_host_infos.cache_clear()


### PR DESCRIPTION
HIGH-1: DNS Rebinding TOCTOU - Add IP pinning via _pin_dns_context()
that overrides urllib3 DNS resolution during requests, closing the
TOCTOU gap between DNS validation and HTTP connect.

HIGH-2: ReDoS mitigation - Reduce _MAX_PII_INPUT_LENGTH from 1M to
100K chars. Chunked processing with 128-char overlap was already
implemented for inputs exceeding the limit.

HIGH-6: Fork PR security gates - Remove fork-PR skip conditions from
dependency-audit, secret-scan, and next-public-secret-guard jobs.
All three require only contents:read permission and work with fork
PR's read-only GITHUB_TOKEN.

https://claude.ai/code/session_01S7crCAKjWXfHuP6XHbqdo2