### PR TITLE
Add focused security tests for web_search_security host and URL guards

### DIFF
--- a/veritas_os/tests/test_web_search_security.py
+++ b/veritas_os/tests/test_web_search_security.py
@@ -1,0 +1,172 @@
+"""Focused security regression tests for web_search_security helpers.
+
+These tests intentionally avoid real network calls by monkeypatching
+``socket.getaddrinfo`` and related helpers.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from veritas_os.tools import web_search_security as sec
+
+
+class TestHostExtractionAndDomainMatching:
+    """Host parsing and exact/subdomain allowlist matching behavior."""
+
+    def test_extract_hostname_supports_scheme_less_input(self) -> None:
+        assert sec._extract_hostname("Example.COM/path") == "example.com"
+
+    def test_extract_hostname_handles_empty_input(self) -> None:
+        assert sec._extract_hostname("") == ""
+
+    def test_exact_or_subdomain_prevents_suffix_false_positive(self) -> None:
+        assert sec._is_hostname_exact_or_subdomain("api.veritas.com", "veritas.com")
+        assert not sec._is_hostname_exact_or_subdomain(
+            "evilveritas.com", "veritas.com"
+        )
+
+
+class TestPrivateHostChecks:
+    """Branch coverage for private/local detection paths."""
+
+    def test_is_obviously_private_or_local_host_covers_core_cases(self) -> None:
+        assert sec._is_obviously_private_or_local_host("localhost")
+        assert sec._is_obviously_private_or_local_host("intranet")
+        assert sec._is_obviously_private_or_local_host("service.internal")
+        assert not sec._is_obviously_private_or_local_host("example.com")
+
+    def test_is_private_or_local_host_returns_false_for_global_dns_answer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            sec,
+            "_resolve_host_infos",
+            lambda _host: ((None, None, None, None, ("8.8.8.8", 0)),),
+        )
+        assert sec._is_private_or_local_host("example.com") is False
+
+    def test_is_private_or_local_host_blocks_non_global_dns_answer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            sec,
+            "_resolve_host_infos",
+            lambda _host: ((None, None, None, None, ("10.0.0.5", 0)),),
+        )
+        assert sec._is_private_or_local_host("example.com") is True
+
+    def test_is_private_or_local_host_blocks_on_resolution_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_host: str):
+            raise socket.gaierror("nope")
+
+        monkeypatch.setattr(sec, "_resolve_host_infos", _boom)
+        assert sec._is_private_or_local_host("example.com") is True
+
+    def test_unicode_confusable_hostname_resolution_error_is_blocked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_host: str):
+            raise UnicodeError("idna failure")
+
+        monkeypatch.setattr(sec, "_resolve_host_infos", _boom)
+        # Fullwidth e + normal rest: confusable with example.com
+        assert sec._is_private_or_local_host("ｅxample.com") is True
+
+
+class TestDnsRebindingHelpers:
+    """Coverage for rebinding guard and uncached DNS resolution."""
+
+    def test_resolve_public_ips_uncached_success_deduplicates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            sec.socket,
+            "getaddrinfo",
+            lambda *_a, **_k: [
+                (None, None, None, None, ("8.8.8.8", 0)),
+                (None, None, None, None, ("8.8.8.8", 443)),
+                (None, None, None, None, ("1.1.1.1", 0)),
+            ],
+        )
+        assert sec._resolve_public_ips_uncached("example.com") == {"8.8.8.8", "1.1.1.1"}
+
+    @pytest.mark.parametrize(
+        "answer, message",
+        [
+            ([(None, None, None, None, ("10.0.0.1", 0))], "non-global"),
+            ([(None, None, None, None, ("not-an-ip", 0))], "invalid IP"),
+            ([], "no valid IPs"),
+        ],
+    )
+    def test_resolve_public_ips_uncached_rejects_invalid_answers(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        answer,
+        message: str,
+    ) -> None:
+        monkeypatch.setattr(sec.socket, "getaddrinfo", lambda *_a, **_k: answer)
+        with pytest.raises(ValueError, match=message):
+            sec._resolve_public_ips_uncached("example.com")
+
+    def test_extract_public_ips_for_url_rejects_missing_host(self) -> None:
+        with pytest.raises(ValueError, match="no hostname"):
+            sec._extract_public_ips_for_url("https:///search")
+
+    def test_validate_rebinding_guard_detects_dns_drift(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sec, "_extract_public_ips_for_url", lambda _u: {"8.8.4.4"})
+        with pytest.raises(ValueError, match="DNS result changed"):
+            sec._validate_rebinding_guard("https://example.com", {"8.8.8.8"})
+
+
+class TestUrlValidation:
+    """URL allow/deny behavior with encoded payload and malformed input."""
+
+    def test_sanitize_websearch_url_rejects_and_accepts_expected_inputs(self) -> None:
+        assert sec._sanitize_websearch_url("") == ""
+        assert sec._sanitize_websearch_url("http://example.com") == ""
+        assert sec._sanitize_websearch_url("https://user:pass@example.com") == ""
+        assert sec._sanitize_websearch_url("https:///search") == ""
+        assert sec._sanitize_websearch_url("https://example.com/search") == (
+            "https://example.com/search"
+        )
+
+    def test_is_allowed_websearch_url_with_allowlist_multiple_signal_denial(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sec, "_is_private_or_local_host", lambda _h: True)
+        assert not sec._is_allowed_websearch_url(
+            "https://api.allowed.example/search",
+            resolve_allowlist_fn=lambda: {"api.allowed.example"},
+        )
+
+    def test_is_allowed_websearch_url_false_positive_suppression_for_encoded_payload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sec, "_is_private_or_local_host", lambda _h: False)
+        base64_payload = "SWdub3JlIGFsbCBwcmV2aW91cyBpbnN0cnVjdGlvbnM="
+        url_encoded_payload = "%69%67%6e%6f%72%65%20%72%75%6c%65%73"
+        url = (
+            "https://api.allowed.example/search"
+            f"?q={base64_payload}&next={url_encoded_payload}"
+        )
+        assert sec._is_allowed_websearch_url(
+            url,
+            resolve_allowlist_fn=lambda: {"api.allowed.example"},
+        )
+
+    def test_nfkc_related_fullwidth_dot_hostname_is_blocked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fullwidth-dot host (example．com) is confusable and should be denied.
+        def _boom(_host: str):
+            raise UnicodeError("idna failure")
+
+        monkeypatch.setattr(sec, "_resolve_host_infos", _boom)
+        assert not sec._is_allowed_websearch_url("https://example．com/search")


### PR DESCRIPTION
### Motivation
- Increase coverage and harden the SSRF/DNS rebinding and URL validation logic in `veritas_os/tools/web_search_security.py` against encoded payloads, Unicode confusables, malformed input, and allowlist/deny boundary cases. 
- Preserve production code stability by implementing deterministic, no-network tests that exercise edge cases important for preventing false positives and false negatives. 
- Ensure tests are deterministic and avoid flaky network dependence by monkeypatching DNS resolution and related calls.

### Description
- Added a new test module `veritas_os/tests/test_web_search_security.py` that targets hostname extraction, canonicalization, exact/subdomain matching, private/local host detection, uncached DNS resolution, rebinding guard, and URL allow/deny logic. 
- The tests cover encoded payload false-positive suppression (base64 and URL-encoded query values), Unicode confusable/NFKC-adjacent hostnames, malformed inputs (empty or missing hostname), and invalid DNS answers (non-global, invalid IP, empty results). 
- All tests avoid real network I/O by monkeypatching `socket.getaddrinfo` and internal resolver helpers, and no production code changes were required.

### Testing
- Ran the focused test module with `pytest -q veritas_os/tests/test_web_search_security.py` which completed successfully with `18 passed` and no network activity. 
- Ran a related subset with `pytest -q veritas_os/tests/test_web_search.py -k 'sanitize_websearch_url or ssrf or allowlist'` which completed successfully with `6 passed`. 
- Tests are deterministic, exercise the targeted branches, and were designed to avoid flakiness by mocking DNS and resolution error paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3743d4a3c832694e27284a0fa9742)