### PR TITLE
test: strengthen compliance report engine degraded-path coverage

### DIFF
--- a/veritas_os/tests/test_compliance_report_engine.py
+++ b/veritas_os/tests/test_compliance_report_engine.py
@@ -164,3 +164,230 @@ def test_latest_replay_result_reraises_unexpected_json_error(
 
     with pytest.raises(RuntimeError, match="unexpected parser failure"):
         report_engine._latest_replay_result("dec-001")
+
+
+def _patch_report_environment(monkeypatch, tmp_path: Path):
+    """Patch report engine paths and integrity checks for stable tests."""
+    log_dir = tmp_path / "logs"
+    replay_dir = tmp_path / "replay"
+    report_dir = tmp_path / "reports"
+    key_dir = tmp_path / "keys"
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    replay_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(report_engine, "LOG_DIR", log_dir)
+    monkeypatch.setattr(report_engine, "REPLAY_REPORT_DIR", replay_dir)
+    monkeypatch.setattr(report_engine, "REPORT_DIR", report_dir)
+    monkeypatch.setattr(report_engine, "PRIVATE_KEY_PATH", key_dir / "private.key")
+    monkeypatch.setattr(report_engine, "PUBLIC_KEY_PATH", key_dir / "public.key")
+    monkeypatch.setattr(
+        report_engine,
+        "verify_trustlog_chain",
+        lambda: {"ok": True, "entries_checked": 2, "issues": []},
+    )
+    monkeypatch.setattr(
+        report_engine,
+        "verify_trust_log",
+        lambda: {"ok": True, "checked": 2, "broken": False, "broken_reason": None},
+    )
+    return log_dir, replay_dir, report_dir
+
+
+def test_generate_eu_ai_act_report_missing_replay_artifact(monkeypatch, tmp_path: Path):
+    log_dir, _, _ = _patch_report_environment(monkeypatch, tmp_path)
+    _write_decision(log_dir / "decide_no_replay.json", "dec-no-replay", risk=0.25)
+
+    result = report_engine.generate_eu_ai_act_report("dec-no-replay")
+
+    assert result["ok"] is True
+    assert result["replay_verification"] == {"available": False, "result": "missing"}
+
+
+def test_generate_eu_ai_act_report_handles_partial_trust_log(monkeypatch, tmp_path: Path):
+    log_dir, replay_dir, _ = _patch_report_environment(monkeypatch, tmp_path)
+    _write_decision(log_dir / "decide_partial_trust.json", "dec-partial", risk=0.45)
+    replay_dir.joinpath("replay_dec-partial_001.json").write_text(
+        json.dumps({"match": False, "diff": {"fuji": "changed"}, "replay_time_ms": 42}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        report_engine,
+        "verify_trustlog_chain",
+        lambda: {
+            "ok": False,
+            "entries_checked": 10,
+            "issues": ["missing_signature_entry"],
+        },
+    )
+    monkeypatch.setattr(
+        report_engine,
+        "verify_trust_log",
+        lambda: {
+            "ok": False,
+            "checked": 10,
+            "broken": True,
+            "broken_reason": "hash_mismatch",
+        },
+    )
+
+    result = report_engine.generate_eu_ai_act_report("dec-partial")
+
+    assert result["ok"] is True
+    assert result["signature_verification"]["ok"] is False
+    assert result["signature_verification"]["issues"] == ["missing_signature_entry"]
+    assert result["hash_chain_integrity"]["broken"] is True
+    assert result["replay_verification"]["match"] is False
+
+
+def test_build_decision_section_tolerates_missing_optional_fields():
+    rec = {"request_id": "req-minimal", "decision_status": "allow"}
+
+    section = report_engine._build_decision_section(rec)
+
+    assert section["decision_overview"]["decision_id"] == "req-minimal"
+    assert section["decision_overview"]["timestamp"] is None
+    assert section["risk_classification"]["risk_score"] == 0.0
+    assert section["risk_classification"]["risk_level"] == "low"
+    assert section["mitigation_actions"] == []
+
+
+@pytest.mark.parametrize(
+    ("risk_score", "expected_level"),
+    [
+        (0.0, "low"),
+        (0.3, "medium"),
+        (0.5, "high"),
+        (0.8, "critical"),
+    ],
+)
+def test_schema_normalization_risk_boundary_levels(risk_score: float, expected_level: str):
+    rec = {
+        "request_id": f"req-{expected_level}",
+        "gate": {"risk": risk_score},
+        "fuji": {},
+    }
+
+    section = report_engine._build_decision_section(rec)
+
+    assert section["risk_classification"]["risk_level"] == expected_level
+    assert isinstance(section["risk_classification"]["violations"], list)
+    assert isinstance(section["mitigation_actions"], list)
+
+
+def test_generate_internal_governance_report_omits_invalid_optional_records(
+    monkeypatch,
+    tmp_path: Path,
+):
+    log_dir, _, _ = _patch_report_environment(monkeypatch, tmp_path)
+
+    _write_decision(log_dir / "decide_valid_001.json", "dec-valid-1", risk=0.9)
+    _write_decision(log_dir / "decide_valid_002.json", "dec-valid-2", risk=0.1)
+
+    (log_dir / "decide_missing_ts.json").write_text(
+        json.dumps({"request_id": "dec-no-ts", "gate": {"risk": 0.7}}),
+        encoding="utf-8",
+    )
+    (log_dir / "decide_invalid_ts.json").write_text(
+        json.dumps(
+            {
+                "request_id": "dec-bad-ts",
+                "ts": "not-a-date",
+                "gate": {"risk": 0.7},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = report_engine.generate_internal_governance_report(
+        ("2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z")
+    )
+
+    assert result["ok"] is True
+    assert result["decision_count"] == 2
+    assert result["summary"]["high_risk_decisions"] == 1
+    assert result["summary"]["risk_ratio"] == 0.5
+
+
+def test_generate_internal_governance_report_empty_input(monkeypatch, tmp_path: Path):
+    _patch_report_environment(monkeypatch, tmp_path)
+
+    result = report_engine.generate_internal_governance_report(
+        ("2026-01-01T00:00:00Z", "2026-01-01T23:59:59Z")
+    )
+
+    assert result["ok"] is True
+    assert result["decision_count"] == 0
+    assert result["summary"]["risk_ratio"] == 0.0
+    assert result["summary"]["high_risk_decisions"] == 0
+    assert result["replay_verification"]["result"] == "missing"
+
+
+def test_generate_internal_governance_report_invalid_input_raises_value_error(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _patch_report_environment(monkeypatch, tmp_path)
+
+    with pytest.raises(ValueError):
+        report_engine.generate_internal_governance_report(("invalid", "2026-01-01"))
+
+
+def test_generate_eu_ai_act_report_not_found_has_fallback_narrative():
+    result = report_engine.generate_eu_ai_act_report("not-found")
+
+    assert result == {
+        "ok": False,
+        "error": "decision_not_found",
+        "decision_id": "not-found",
+    }
+
+
+def test_finalize_report_includes_export_artifacts_paths(monkeypatch, tmp_path: Path):
+    _, _, report_dir = _patch_report_environment(monkeypatch, tmp_path)
+
+    report = report_engine._finalize_report(
+        "eu_ai_act",
+        {"scope": "eu_ai_act", "summary": {"compliance_status": "pass"}},
+    ).report
+
+    json_path = Path(report["artifacts"]["json_path"])
+    pdf_path = Path(report["artifacts"]["pdf_path"])
+
+    assert json_path.exists()
+    assert pdf_path.exists()
+    assert json_path.parent == report_dir
+    assert pdf_path.parent == report_dir
+    assert json_path.suffix == ".json"
+    assert pdf_path.suffix == ".pdf"
+
+
+def test_risk_summary_report_compliance_readiness_summary(monkeypatch, tmp_path: Path):
+    log_dir, _, _ = _patch_report_environment(monkeypatch, tmp_path)
+    _write_decision(log_dir / "decide_low.json", "low", risk=0.1)
+    _write_decision(log_dir / "decide_medium.json", "medium", risk=0.4)
+    _write_decision(log_dir / "decide_high.json", "high", risk=0.7)
+
+    result = report_engine.generate_risk_summary_report()
+
+    assert result["ok"] is True
+    assert result["decision_count"] == 3
+    assert result["risk_distribution"] == {
+        "low": 1,
+        "medium": 1,
+        "high": 1,
+        "critical": 0,
+    }
+    assert result["summary"]["top_risk_level"] in {"low", "medium", "high"}
+
+
+def test_latest_replay_result_invalid_schema_returns_degraded_result(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _, replay_dir, _ = _patch_report_environment(monkeypatch, tmp_path)
+    replay_dir.joinpath("replay_dec-invalid_1.json").write_text("[]", encoding="utf-8")
+
+    result = report_engine._latest_replay_result("dec-invalid")
+
+    assert result == {"available": False, "result": "invalid"}


### PR DESCRIPTION
### Motivation
- Improve resilience and coverage of the compliance report engine around degraded and partial-data paths used for EU AI Act and internal governance reports.
- Validate that missing/invalid replay artifacts, partial trust-log verification, missing decision fields, and other optional data do not cause failures and that output schema remains stable.
- Keep production code unchanged and ensure tests avoid external dependencies by stubbing keys, persistence, and verification routines.

### Description
- Expanded `veritas_os/tests/test_compliance_report_engine.py` with a `_patch_report_environment` helper that monkeypatches paths and integrity-check functions for stable, isolated tests.
- Added tests for missing replay artifacts, partial trust-log outcomes, minimal decision records, risk-boundary normalization, governance-report behavior with invalid/missing timestamps, empty/invalid input handling, export artifact placement, risk-summary distribution, and invalid replay schema degraded results.
- All tests use local tmp paths and monkeypatches to avoid network or global state, and no production code was modified in this change.
- Security note: tests create ephemeral key files and persist report artifacts to temp directories; ensure production key generation and artifact storage are handled with proper permissions and secret management to avoid exposing private keys.

### Testing
- Ran `pytest -q veritas_os/tests/test_compliance_report_engine.py` which executed the new and existing tests.
- Result: `19 passed` with zero failures, and tests are deterministic and isolated using `monkeypatch` and `tmp_path`.
- No external services or network calls were used during tests, and the tests assert graceful degradation and schema consistency across exercised branches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c37821e25483269e336ba85a1a0166)