### PR TITLE
test: strengthen memory_storage I/O guardrail coverage

### DIFF
--- a/veritas_os/tests/test_memory_storage.py
+++ b/veritas_os/tests/test_memory_storage.py
@@ -1,78 +1,277 @@
-# tests for veritas_os/core/memory_storage.py
-"""Tests for file I/O, locking, and pickle security guards."""
+"""Tests for ``veritas_os.core.memory_storage``."""
+
 from __future__ import annotations
 
-import os
-import tempfile
 from pathlib import Path
 
 import pytest
 
-from veritas_os.core.memory_storage import (
-    locked_memory,
-    _warn_for_legacy_pickle_artifacts,
-    _emit_legacy_pickle_runtime_blocked,
-)
+import veritas_os.core.memory_storage as memory_storage
 
 
-class TestLockedMemory:
-    def test_basic_lock_unlock(self, tmp_path):
-        p = tmp_path / "test.json"
-        p.write_text("[]")
-        with locked_memory(p):
-            # Can read/write while holding lock
-            assert p.exists()
+class TestLockedMemoryPosix:
+    def test_basic_lock_unlock(self, tmp_path: Path) -> None:
+        target = tmp_path / "memory.json"
+        target.write_text("[]", encoding="utf-8")
 
-    def test_creates_parent_dirs(self, tmp_path):
-        p = tmp_path / "sub" / "dir" / "test.json"
-        with locked_memory(p):
+        with memory_storage.locked_memory(target):
+            assert target.exists()
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "dir" / "memory.json"
+
+        with memory_storage.locked_memory(target):
             pass
-        assert p.parent.exists()
 
-    def test_lock_timeout(self, tmp_path):
-        """Verify TimeoutError when lock is held by another entity."""
-        p = tmp_path / "test.json"
-        p.write_text("[]")
-        lockfile = p.with_suffix(p.suffix + ".lock")
+        assert target.parent.exists()
 
-        # Simulate held lock (Windows/non-POSIX path)
-        if os.name == "nt" or not hasattr(os, "O_EXCL"):
-            pytest.skip("POSIX lock test only")
+    @pytest.mark.skipif(
+        memory_storage.fcntl is None or memory_storage.IS_WIN,
+        reason="POSIX flock branch only",
+    )
+    def test_unlock_failure_logs_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        target = tmp_path / "memory.json"
 
-        # For POSIX with fcntl, test basic functionality
-        with locked_memory(p, timeout=1.0):
-            assert True  # Just verify it works
+        original_flock = memory_storage.fcntl.flock
+
+        def flaky_unlock(fd: int, operation: int) -> None:
+            if operation == memory_storage.fcntl.LOCK_UN:
+                raise OSError("unlock boom")
+            original_flock(fd, operation)
+
+        monkeypatch.setattr(memory_storage.fcntl, "flock", flaky_unlock)
+
+        with caplog.at_level("ERROR"):
+            with memory_storage.locked_memory(target):
+                pass
+
+        assert "unlock failed" in caplog.text
+
+
+class TestLockedMemoryFallback:
+    def test_fallback_acquires_and_cleans_lockfile(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "memory.json"
+        lock_path = target.with_suffix(".json.lock")
+        monkeypatch.setattr(memory_storage, "fcntl", None)
+
+        with memory_storage.locked_memory(target):
+            assert lock_path.exists()
+
+        assert not lock_path.exists()
+
+    def test_removes_stale_lockfile(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        target = tmp_path / "memory.json"
+        lock_path = target.with_suffix(".json.lock")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text("stale", encoding="utf-8")
+
+        monkeypatch.setattr(memory_storage, "fcntl", None)
+
+        now = 10_000.0
+
+        def fake_time() -> float:
+            return now
+
+        def fake_getmtime(_: str) -> float:
+            return now - 301.0
+
+        monkeypatch.setattr(memory_storage.time, "time", fake_time)
+        monkeypatch.setattr(memory_storage.os.path, "getmtime", fake_getmtime)
+
+        with caplog.at_level("WARNING"):
+            with memory_storage.locked_memory(target):
+                pass
+
+        assert "Removing stale lockfile" in caplog.text
+        assert not lock_path.exists()
+
+    def test_mtime_check_failure_debug_log(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        target = tmp_path / "memory.json"
+        lock_path = target.with_suffix(".json.lock")
+        lock_path.write_text("occupied", encoding="utf-8")
+
+        monkeypatch.setattr(memory_storage, "fcntl", None)
+
+        real_open = memory_storage.os.open
+
+        def fake_open(path: str, flags: int, mode: int = 0o777) -> int:
+            if path == str(lock_path):
+                raise FileExistsError
+            return real_open(path, flags, mode)
+
+        monkeypatch.setattr(memory_storage.os, "open", fake_open)
+        monkeypatch.setattr(
+            memory_storage.os.path,
+            "getmtime",
+            lambda _path: (_ for _ in ()).throw(OSError("mtime failed")),
+        )
+
+        clock = {"t": 0.0}
+
+        def fake_time() -> float:
+            clock["t"] += 0.3
+            return clock["t"]
+
+        monkeypatch.setattr(memory_storage.time, "time", fake_time)
+        monkeypatch.setattr(memory_storage.time, "sleep", lambda _: None)
+
+        with caplog.at_level("DEBUG"):
+            with pytest.raises(TimeoutError):
+                with memory_storage.locked_memory(target, timeout=0.5):
+                    pass
+
+        assert "mtime check failed" in caplog.text
+
+    def test_timeout_when_lock_never_released(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "memory.json"
+        lock_path = target.with_suffix(".json.lock")
+        lock_path.write_text("busy", encoding="utf-8")
+
+        monkeypatch.setattr(memory_storage, "fcntl", None)
+        monkeypatch.setattr(memory_storage.os.path, "getmtime", lambda _: 0.0)
+        monkeypatch.setattr(memory_storage.time, "sleep", lambda _: None)
+
+        times = iter([0.0, 0.3, 0.7])
+        monkeypatch.setattr(memory_storage.time, "time", lambda: next(times))
+
+        with pytest.raises(TimeoutError):
+            with memory_storage.locked_memory(target, timeout=0.5):
+                pass
+
+    def test_cleanup_failure_logs_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        target = tmp_path / "memory.json"
+        lock_path = target.with_suffix(".json.lock")
+        monkeypatch.setattr(memory_storage, "fcntl", None)
+
+        original_unlink = Path.unlink
+
+        def flaky_unlink(self: Path, missing_ok: bool = False) -> None:
+            if self == lock_path:
+                raise OSError("cleanup failed")
+            original_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", flaky_unlink)
+
+        with caplog.at_level("ERROR"):
+            with memory_storage.locked_memory(target):
+                pass
+
+        assert "lockfile cleanup failed" in caplog.text
 
 
 class TestLegacyPickleGuards:
-    def test_warn_for_pickle_artifacts(self, tmp_path):
-        # Create a fake pickle file
-        pkl = tmp_path / "index.pkl"
-        pkl.write_bytes(b"fake pickle data")
+    def test_warn_for_pickle_extensions_and_nested_paths(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        nested = tmp_path / "nested"
+        nested.mkdir(parents=True)
+        (nested / "a.pkl").write_bytes(b"pkl")
+        (nested / "b.joblib").write_bytes(b"joblib")
+        (nested / "c.pickle").write_bytes(b"pickle")
+        (nested / "ignore.json").write_text("{}", encoding="utf-8")
 
-        # Should log error but not raise
-        _warn_for_legacy_pickle_artifacts([tmp_path])
+        calls: list[tuple[Path, str]] = []
 
-    def test_warn_for_joblib_artifacts(self, tmp_path):
-        pkl = tmp_path / "model.joblib"
-        pkl.write_bytes(b"fake joblib data")
-        _warn_for_legacy_pickle_artifacts([tmp_path])
+        def fake_emit(path: Path, artifact_name: str) -> None:
+            calls.append((path, artifact_name))
 
-    def test_ignores_non_pickle_files(self, tmp_path):
-        json_file = tmp_path / "data.json"
-        json_file.write_text("{}")
-        # Should not log errors for json files
-        _warn_for_legacy_pickle_artifacts([tmp_path])
+        monkeypatch.setattr(
+            memory_storage,
+            "_emit_legacy_pickle_runtime_blocked",
+            fake_emit,
+        )
 
-    def test_handles_missing_root(self):
-        _warn_for_legacy_pickle_artifacts([Path("/nonexistent/path")])
+        memory_storage._warn_for_legacy_pickle_artifacts([tmp_path])
 
-    def test_deduplicates_roots(self, tmp_path):
-        pkl = tmp_path / "test.pkl"
-        pkl.write_bytes(b"data")
-        # Same root twice — should only scan once
-        _warn_for_legacy_pickle_artifacts([tmp_path, tmp_path])
+        assert sorted(path.name for path, _ in calls) == [
+            "a.pkl",
+            "b.joblib",
+            "c.pickle",
+        ]
+        assert all(name == "runtime artifact" for _, name in calls)
 
-    def test_emit_legacy_pickle_runtime_blocked(self):
-        # Just verify it doesn't raise
-        _emit_legacy_pickle_runtime_blocked(Path("/fake/path.pkl"), "test_artifact")
+    def test_deduplicates_equivalent_roots(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "artifact.pkl").write_bytes(b"data")
+        calls: list[Path] = []
+
+        monkeypatch.setattr(
+            memory_storage,
+            "_emit_legacy_pickle_runtime_blocked",
+            lambda path, artifact_name: calls.append(path),
+        )
+
+        relative = tmp_path / "."
+        memory_storage._warn_for_legacy_pickle_artifacts([tmp_path, relative])
+
+        assert len(calls) == 1
+
+    def test_ignores_missing_and_non_directory_roots(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        missing = tmp_path / "missing"
+        file_root = tmp_path / "not_dir"
+        file_root.write_text("x", encoding="utf-8")
+
+        called = False
+
+        def fake_emit(path: Path, artifact_name: str) -> None:
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(
+            memory_storage,
+            "_emit_legacy_pickle_runtime_blocked",
+            fake_emit,
+        )
+
+        memory_storage._warn_for_legacy_pickle_artifacts([missing, file_root])
+
+        assert called is False
+
+    def test_emit_legacy_pickle_runtime_blocked_logs_expected_message(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        path = Path("/tmp/legacy.pkl")
+
+        with caplog.at_level("ERROR"):
+            memory_storage._emit_legacy_pickle_runtime_blocked(path, "index")
+
+        assert "Runtime pickle/joblib loading is permanently disabled" in caplog.text
+        assert str(path) in caplog.text


### PR DESCRIPTION
### Motivation
- Improve branch coverage and harden file I/O/locking guardrails in `veritas_os/core/memory_storage.py` without changing production logic.
- Protect error paths related to lock file lifecycle, stale locks, mtime failures, cleanup failures, timeouts, and legacy pickle artifact detection.
- Use only temporary test paths and avoid touching any real runtime files.

### Description
- Rewrote and expanded tests in `veritas_os/tests/test_memory_storage.py` to exercise POSIX and fallback `.lock` branches of `locked_memory` and to assert logged errors/warnings for failure cases.
- Added tests for POSIX unlock error logging, fallback lockfile creation and cleanup, stale-lock removal, mtime-check failure handling, timeout when lock never releases, and cleanup failure logging.
- Expanded legacy-pickle guard tests to verify recursive scanning and extension filtering for `.pkl`, `.joblib`, and `.pickle`, plus deduplication of equivalent roots and ignoring missing/non-directory roots.
- No production code changes were made; this is a test-only change that targets fragile I/O branches and error-handling consistency.

### Testing
- Ran `pytest -q veritas_os/tests/test_memory_storage.py` which passed all tests in that module (`12 passed`).
- Ran `pytest -q veritas_os/tests/test_memory_storage.py veritas_os/tests/test_pickle_removal.py` which passed end-to-end for both modules (`25 passed`).
- Tests use `tmp_path` and extensive monkeypatching for time/os behavior to avoid flakiness and to avoid touching real files or requiring platform-specific state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c37aab0394832685cd2e965d956f37)