### PR TITLE
refactor: extract compat utilities from pipeline.py hot path

### DIFF
--- a/veritas_os/README.md
+++ b/veritas_os/README.md
@@ -246,10 +246,13 @@ Planner → Evidence → Critique → Debate → FUJI → World/Memory update
 
 #### `pipeline.py`
 
-Defines the stages and execution flow of the decision pipeline:
+Orchestrator for the `/v1/decide` decision pipeline:
 
-* Which OS modules are called and in what order
-* Which metrics are collected at which stage
+* `run_decide_pipeline()` is the single entry-point for `/v1/decide`
+* Delegates to responsibility-separated stage modules (`pipeline_inputs`,
+  `pipeline_execute`, `pipeline_policy`, `pipeline_response`, `pipeline_persist`)
+* Pure utility functions live in `pipeline_compat.py` (re-exported for backward compat)
+* Web search core logic lives in `pipeline_web_adapter.py`
 
 #### `planner.py` (PlannerOS)
 

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -17,10 +17,16 @@ Preferred extension points:
 - ``pipeline_persist`` and ``pipeline_replay`` for persistence / replay
 
 Compatibility guidance:
-- This file intentionally keeps compatibility imports and re-exports so older
-  call paths do not break immediately. Extend helpers first, and treat local
-  compatibility wrappers here as adapters rather than a place for new policy
-  branches or fallback-heavy logic.
+- Pure utility functions (to_dict, _norm_alt, get_request_params, etc.) have
+  been moved to ``pipeline_compat.py`` and are re-exported here for backward
+  compatibility.  All existing ``from veritas_os.core.pipeline import X``
+  paths continue to work.
+- Web search core logic has been moved to ``pipeline_web_adapter.safe_web_search``
+  with a dependency-injection pattern.  ``_safe_web_search`` here is a thin
+  wrapper that resolves the web_search function from module-level state,
+  preserving monkeypatch support.
+- Extend helpers first, and treat local compatibility wrappers here as
+  adapters rather than a place for new policy branches or fallback-heavy logic.
 
 This module is the *single entry-point* for the /v1/decide endpoint.
 ``run_decide_pipeline(req, request)`` orchestrates the full decision flow
@@ -33,6 +39,7 @@ by delegating to responsibility-separated stage modules:
   pipeline_persist  – audit, disk persist, memory, world-state, replay
   pipeline_replay   – deterministic replay & diff
   pipeline_types    – PipelineContext dataclass + constants
+  pipeline_compat   – backward-compat utility functions (to_dict, _norm_alt, etc.)
 
 ISSUE-4 / robustness goals:
 - Import must be resilient (optional components must not crash import).
@@ -54,23 +61,15 @@ Payload contracts restored (tests / server expectations):
 
 from __future__ import annotations
 
-import inspect
-import json
-import hashlib
+import inspect  # noqa: F401 – re-exported; tests access pipeline.inspect
 import logging
 import os
-import re
 import time
-import unicodedata
-from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
-from uuid import uuid4
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-from .utils import (
-    _safe_float,
-    _clip01 as _clip01_base,
+from .utils import (  # noqa: F401 – _redact_text/redact_payload re-exported for backward compat
     _redact_text,
     redact_payload,
     utc_now,
@@ -121,6 +120,7 @@ from .pipeline_memory_adapter import (
 from .pipeline_web_adapter import (
     _normalize_web_payload,
     _extract_web_results,
+    safe_web_search as _safe_web_search_impl,
 )
 from .pipeline_contracts import (
     _ensure_full_contract,
@@ -130,6 +130,17 @@ from .pipeline_contracts import (
 )
 from .pipeline_signature_adapter import (  # noqa: F401 – re-exported for backward compat
     call_core_decide,
+)
+from .pipeline_compat import (  # noqa: F401 – re-exported for backward compat
+    _to_bool,
+    _to_float_or,
+    _clip01,
+    to_dict,
+    _to_dict,
+    get_request_params,
+    _get_request_params,
+    _norm_alt,
+    _fallback_load_persona,
 )
 from .pipeline_persistence import (
     REPO_ROOT,
@@ -249,13 +260,7 @@ except (ImportError, ModuleNotFoundError):
 # ★ ただし、REQUIRED モジュールが None の場合は実行時にエラー
 # =========================================================
 
-def _to_bool(v: Any) -> bool:
-    """Convert value to bool (for env vars, config values, etc.).
-
-    Delegates to ``_to_bool_local`` from pipeline_helpers to eliminate
-    duplication while keeping the public name for backward compatibility.
-    """
-    return _to_bool_local(v)
+# _to_bool -> pipeline_compat.py に移動済み（上部 import で re-export 済み）
 
 
 def _warn(msg: str) -> None:
@@ -352,9 +357,7 @@ except (ImportError, ModuleNotFoundError) as e:  # pragma: no cover
     _warn(f"[WARN][pipeline] api.schemas import failed: {repr(e)}")
 
 
-def _fallback_load_persona() -> dict:
-    return {"name": "fallback", "mode": "minimal"}
-
+# _fallback_load_persona -> pipeline_compat.py に移動済み（上部 import で re-export 済み）
 
 load_persona: Any = _fallback_load_persona
 try:
@@ -372,77 +375,11 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover
 
 
 # =========================================================
-# util helpers
+# Utility functions -> pipeline_compat.py に移動済み
+# to_dict, _to_dict, get_request_params, _get_request_params,
+# _norm_alt, _clip01, _to_float_or, _to_bool, _fallback_load_persona
+# 上部 import で re-export 済み。既存の import path は維持される。
 # =========================================================
-
-def _to_float_or(v: Any, default: float) -> float:
-    """_safe_float のエイリアス（後方互換性のため維持）"""
-    return _safe_float(v, default)
-
-
-def to_dict(o: Any) -> Dict[str, Any]:
-    if isinstance(o, dict):
-        return o
-    if hasattr(o, "model_dump"):
-        try:
-            return o.model_dump(exclude_none=True)
-        except (TypeError, ValueError, RuntimeError):
-            logger.debug("_to_dict: model_dump() failed for %r", type(o).__name__, exc_info=True)
-    if hasattr(o, "dict"):
-        try:
-            return o.dict()
-        except (TypeError, ValueError, RuntimeError):
-            logger.debug("_to_dict: dict() failed for %r", type(o).__name__, exc_info=True)
-    try:
-        if hasattr(o, "__dict__"):
-            raw = o.__dict__
-            if isinstance(raw, dict):
-                # Filter out values that reference the original object to
-                # prevent circular references from breaking downstream
-                # JSON serialization.
-                return {
-                    k: v for k, v in raw.items()
-                    if v is not o
-                }
-            # __dict__ returned a non-dict (e.g. int) – fall through
-    except (TypeError, ValueError, AttributeError):
-        logger.debug("_to_dict: __dict__ fallback failed for %r", type(o).__name__, exc_info=True)
-    return {}
-
-
-# 後方互換エイリアス（テスト移行期間中に維持）
-_to_dict = to_dict
-
-# _redact_text / redact_payload は utils.py に統合済み（import 済み）
-
-
-def get_request_params(request: Any) -> Dict[str, Any]:
-    """
-    DummyRequest 互換:
-    - request.query_params (starlette)
-    - request.params (tests)
-    の両方を吸って dict 化する
-    """
-    out: Dict[str, Any] = {}
-    try:
-        qp = getattr(request, "query_params", None)
-        if qp is not None:
-            out.update(dict(qp))
-    except (TypeError, ValueError, AttributeError, KeyError, RuntimeError):
-        logger.debug("_get_request_params: query_params extraction failed", exc_info=True)
-    try:
-        pm = getattr(request, "params", None)
-        if pm is not None:
-            out.update(dict(pm))
-    except (TypeError, ValueError, AttributeError, KeyError, RuntimeError):
-        logger.debug("_get_request_params: params extraction failed", exc_info=True)
-    return out
-
-
-# 後方互換エイリアス（テスト移行期間中に維持）
-_get_request_params = get_request_params
-
-# _ensure_metrics_contract -> pipeline_contracts.py に移動済み（上部 import）
 
 
 def _get_memory_store() -> Optional[Any]:
@@ -450,55 +387,6 @@ def _get_memory_store() -> Optional[Any]:
     if mem is None:
         return None
     return _get_memory_store_impl(mem=mem)
-
-
-def _norm_alt(o: Any) -> Dict[str, Any]:
-    d = to_dict(o) or {}
-
-    # text/title/description の整形
-    text = d.get("text")
-    if isinstance(text, str):
-        text = text.strip()
-
-    title = d.get("title")
-    if not title and text:
-        title = text
-    d["title"] = str(title or "")
-
-    desc = d.get("description")
-    if not desc and text:
-        desc = text
-    d["description"] = str(desc or "")
-
-    # score 系
-    d["score"] = _to_float_or(d.get("score", 1.0), 1.0)
-    d["score_raw"] = _to_float_or(d.get("score_raw", d["score"]), d["score"])
-
-    # ★ id は「あるなら保持」、None/空/空白だけ新規発行
-    # ★ 制御文字・null バイト・Unicode制御文字（bidiオーバーライド等）を除去し、
-    #   長さを制限（downstream 安全性）
-    _id = d.get("id")
-    if _id is None or (isinstance(_id, str) and _id.strip() == ""):
-        d["id"] = uuid4().hex
-    else:
-        _id_str = str(_id)
-        # ASCII control chars + DEL
-        _id_str = re.sub(r"[\x00-\x1f\x7f]", "", _id_str)
-        # Filter out unsafe Unicode categories (bidi overrides, surrogates, etc.)
-        _id_str = "".join(
-            ch for ch in _id_str
-            if unicodedata.category(ch) not in _UNSAFE_UNICODE_CATEGORIES
-        )
-        if len(_id_str) > 256:
-            _id_str = _id_str[:256]
-        d["id"] = _id_str if _id_str.strip() else uuid4().hex
-
-    return d
-
-
-def _clip01(x: float) -> float:
-    """_clip01_base のラッパー（後方互換性のため維持）"""
-    return _clip01_base(x)
 
 
 # _safe_paths, EVIDENCE_MAX, _SAFE_FILENAME_RE -> pipeline_persistence.py に移動済み
@@ -633,68 +521,33 @@ except (ImportError, ModuleNotFoundError):
     pass  # optional dependency / env missing in CI or local
 
 
-async def _safe_web_search(query: str, *, max_results: int = 5) -> Optional[dict]:
-    """Returns web_search result dict or None (never raises).
-    Supports both sync/async web_search (tests often monkeypatch async).
+def _resolve_web_search_fn() -> Any:
+    """Resolve web_search callable at call time (monkeypatch-safe).
 
     Resolution order:
       1. module-level ``web_search`` (set by monkeypatch in tests)
       2. ``_tool_web_search`` (imported from tools.web_search)
-
-    ``max_results`` is sanitized to an integer in [1, 20] to avoid
-    accidentally passing unbounded values to external adapters.
     """
     import sys
-
-    query_text = str(query or "").strip()
-    if not query_text:
-        return None
-    if len(query_text) > 512:
-        query_text = query_text[:512]
-
-    # Block control characters and unsafe Unicode categories (bidi
-    # overrides, surrogates, etc.) to reduce risk of log injection /
-    # unsafe propagation into external adapters.  Consistent with the
-    # sanitization applied in ``_norm_alt`` for alternative IDs.
-    query_text = re.sub(r"[\x00-\x1f\x7f]", "", query_text)
-    query_text = "".join(
-        ch for ch in query_text
-        if unicodedata.category(ch) not in _UNSAFE_UNICODE_CATEGORIES
-    )
-    if not query_text:
-        return None
-
-    try:
-        max_results_int = int(max_results)
-    except (TypeError, ValueError):
-        max_results_int = 5
-    max_results_int = max(1, min(20, max_results_int))
-
     _this = sys.modules[__name__]
     fn = getattr(_this, "web_search", None)
-    if not callable(fn):
-        fn = getattr(_this, "_tool_web_search", None)
-    if not callable(fn):
-        return None
+    if callable(fn):
+        return fn
+    return getattr(_this, "_tool_web_search", None)
 
-    query_fingerprint = hashlib.sha256(
-        query_text.encode("utf-8", errors="ignore")
-    ).hexdigest()[:12]
 
-    try:
-        ws = fn(query_text, max_results=max_results_int)
-        if inspect.isawaitable(ws):
-            ws = await ws
-        return ws if isinstance(ws, dict) else None
-    except (RuntimeError, TypeError, ValueError, OSError, TimeoutError, ConnectionError) as exc:
-        logger.debug(
-            "_safe_web_search failed for query_redacted=%r query_sha256_12=%s: %s",
-            _redact_text(query_text),
-            query_fingerprint,
-            repr(exc),
-            exc_info=True,
-        )
-        return None
+async def _safe_web_search(query: str, *, max_results: int = 5) -> Optional[dict]:
+    """Returns web_search result dict or None (never raises).
+
+    Core logic is in ``pipeline_web_adapter.safe_web_search``.
+    This thin wrapper resolves the web_search function from module-level
+    state at call time, preserving monkeypatch support for tests.
+    """
+    return await _safe_web_search_impl(
+        query,
+        max_results=max_results,
+        web_search_resolver=_resolve_web_search_fn,
+    )
 
 
 # _normalize_web_payload -> pipeline_web_adapter.py に移動済み

--- a/veritas_os/core/pipeline_compat.py
+++ b/veritas_os/core/pipeline_compat.py
@@ -1,0 +1,205 @@
+# veritas_os/core/pipeline_compat.py
+# -*- coding: utf-8 -*-
+"""
+Pipeline 後方互換ユーティリティ層。
+
+pipeline.py の hot path から退避した純粋ユーティリティ関数群。
+これらは module-level mutable state に依存せず、テストの monkeypatch 対象
+でもないため、独立モジュールとして安全に切り出せる。
+
+pipeline.py は後方互換のためこれらを re-export する。
+``from veritas_os.core.pipeline import to_dict`` 等の既存 import は引き続き動作する。
+
+退避理由:
+- pipeline.py を orchestration coordinator に近づける
+- hot path の可読性向上（ユーティリティと orchestration の関心分離）
+"""
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+# Use the pipeline module's logger name so that tests capturing logs
+# from "veritas_os.core.pipeline" continue to work after this extraction.
+logger = logging.getLogger("veritas_os.core.pipeline")
+
+from .utils import _safe_float
+from .pipeline_helpers import _to_bool_local
+from .pipeline_persistence import _UNSAFE_UNICODE_CATEGORIES
+
+
+# =========================================================
+# 型変換ユーティリティ（後方互換エイリアス）
+# =========================================================
+
+def _to_bool(v: Any) -> bool:
+    """Convert value to bool (for env vars, config values, etc.).
+
+    Delegates to ``_to_bool_local`` from pipeline_helpers to eliminate
+    duplication while keeping the public name for backward compatibility.
+    """
+    return _to_bool_local(v)
+
+
+def _to_float_or(v: Any, default: float) -> float:
+    """_safe_float のエイリアス（後方互換性のため維持）"""
+    return _safe_float(v, default)
+
+
+def _clip01(x: float) -> float:
+    """Clip a float to [0, 1] range.
+
+    Backward-compat wrapper around ``utils._clip01``.
+    """
+    from .utils import _clip01 as _clip01_base
+    return _clip01_base(x)
+
+
+# =========================================================
+# dict 変換ユーティリティ
+# =========================================================
+
+def to_dict(o: Any) -> Dict[str, Any]:
+    """Convert an arbitrary object to a dict.
+
+    Tries model_dump() (Pydantic v2), dict() (Pydantic v1), then __dict__.
+    Filters out circular references (values that reference the original object).
+    Returns {} for unconvertible objects.
+    """
+    if isinstance(o, dict):
+        return o
+    if hasattr(o, "model_dump"):
+        try:
+            return o.model_dump(exclude_none=True)
+        except (TypeError, ValueError, RuntimeError):
+            logger.debug("to_dict: model_dump() failed for %r", type(o).__name__, exc_info=True)
+    if hasattr(o, "dict"):
+        try:
+            return o.dict()
+        except (TypeError, ValueError, RuntimeError):
+            logger.debug("to_dict: dict() failed for %r", type(o).__name__, exc_info=True)
+    try:
+        if hasattr(o, "__dict__"):
+            raw = o.__dict__
+            if isinstance(raw, dict):
+                return {
+                    k: v for k, v in raw.items()
+                    if v is not o
+                }
+    except (TypeError, ValueError, AttributeError):
+        logger.debug("to_dict: __dict__ fallback failed for %r", type(o).__name__, exc_info=True)
+    return {}
+
+
+# 後方互換エイリアス（テスト移行期間中に維持）
+_to_dict = to_dict
+
+
+# =========================================================
+# リクエストパラメータ抽出
+# =========================================================
+
+def get_request_params(request: Any) -> Dict[str, Any]:
+    """
+    DummyRequest 互換:
+    - request.query_params (starlette)
+    - request.params (tests)
+    の両方を吸って dict 化する
+    """
+    out: Dict[str, Any] = {}
+    try:
+        qp = getattr(request, "query_params", None)
+        if qp is not None:
+            out.update(dict(qp))
+    except (TypeError, ValueError, AttributeError, KeyError, RuntimeError):
+        logger.debug("get_request_params: query_params extraction failed", exc_info=True)
+    try:
+        pm = getattr(request, "params", None)
+        if pm is not None:
+            out.update(dict(pm))
+    except (TypeError, ValueError, AttributeError, KeyError, RuntimeError):
+        logger.debug("get_request_params: params extraction failed", exc_info=True)
+    return out
+
+
+# 後方互換エイリアス（テスト移行期間中に維持）
+_get_request_params = get_request_params
+
+
+# =========================================================
+# alternative 正規化
+# =========================================================
+
+def _norm_alt(o: Any) -> Dict[str, Any]:
+    """Normalize an alternative option dict.
+
+    Ensures required fields (title, description, score, id) are present
+    and sanitized. IDs are stripped of control characters and unsafe
+    Unicode categories.
+    """
+    d = to_dict(o) or {}
+
+    # text/title/description の整形
+    text = d.get("text")
+    if isinstance(text, str):
+        text = text.strip()
+
+    title = d.get("title")
+    if not title and text:
+        title = text
+    d["title"] = str(title or "")
+
+    desc = d.get("description")
+    if not desc and text:
+        desc = text
+    d["description"] = str(desc or "")
+
+    # score 系
+    d["score"] = _to_float_or(d.get("score", 1.0), 1.0)
+    d["score_raw"] = _to_float_or(d.get("score_raw", d["score"]), d["score"])
+
+    # ★ id は「あるなら保持」、None/空/空白だけ新規発行
+    # ★ 制御文字・null バイト・Unicode制御文字（bidiオーバーライド等）を除去し、
+    #   長さを制限（downstream 安全性）
+    _id = d.get("id")
+    if _id is None or (isinstance(_id, str) and _id.strip() == ""):
+        d["id"] = uuid4().hex
+    else:
+        _id_str = str(_id)
+        # ASCII control chars + DEL
+        _id_str = re.sub(r"[\x00-\x1f\x7f]", "", _id_str)
+        # Filter out unsafe Unicode categories (bidi overrides, surrogates, etc.)
+        _id_str = "".join(
+            ch for ch in _id_str
+            if unicodedata.category(ch) not in _UNSAFE_UNICODE_CATEGORIES
+        )
+        if len(_id_str) > 256:
+            _id_str = _id_str[:256]
+        d["id"] = _id_str if _id_str.strip() else uuid4().hex
+
+    return d
+
+
+# =========================================================
+# persona フォールバック
+# =========================================================
+
+def _fallback_load_persona() -> dict:
+    """Fallback persona loader when evolver module is unavailable."""
+    return {"name": "fallback", "mode": "minimal"}
+
+
+__all__ = [
+    "_to_bool",
+    "_to_float_or",
+    "_clip01",
+    "to_dict",
+    "_to_dict",
+    "get_request_params",
+    "_get_request_params",
+    "_norm_alt",
+    "_fallback_load_persona",
+]

--- a/veritas_os/core/pipeline_web_adapter.py
+++ b/veritas_os/core/pipeline_web_adapter.py
@@ -3,14 +3,31 @@
 """
 Pipeline Web検索アダプタ。
 
-_normalize_web_payload と _extract_web_results を提供する。
-_safe_web_search は globals() によるテストフック機構のため pipeline.py に残す。
+_normalize_web_payload / _extract_web_results / _safe_web_search を提供する。
+
+_safe_web_search は依存注入パターンを採用: 呼び出し元（pipeline.py）が
+web_search 関数を resolver callable として渡す。これにより、テストの
+monkeypatch (pipeline.web_search / pipeline._tool_web_search) が
+引き続き機能する。
 
 pipeline.py の module-level / nested 定義をここに移動した。
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+import hashlib
+import inspect
+import logging
+import re
+import unicodedata
+from typing import Any, Callable, Dict, List, Optional
+
+from .pipeline_persistence import _UNSAFE_UNICODE_CATEGORIES
+from .utils import _redact_text
+
+# Use the pipeline module's logger name for safe_web_search so that tests
+# capturing logs from "veritas_os.core.pipeline" continue to work.
+# _normalize_web_payload / _extract_web_results don't log, so this is safe.
+logger = logging.getLogger("veritas_os.core.pipeline")
 
 
 # =========================================================
@@ -104,7 +121,83 @@ def _extract_web_results(ws: Any) -> List[Any]:
     return []
 
 
+# =========================================================
+# safe web search (依存注入パターン)
+# =========================================================
+
+async def safe_web_search(
+    query: str,
+    *,
+    max_results: int = 5,
+    web_search_resolver: Optional[Callable[[], Optional[Callable]]] = None,
+) -> Optional[dict]:
+    """Execute web search safely, never raising exceptions.
+
+    Supports both sync and async web_search callables.
+
+    Args:
+        query: Search query string.
+        max_results: Max results (clamped to [1, 20]).
+        web_search_resolver: Callable that returns the actual web_search
+            function to use. This indirection allows the caller
+            (pipeline.py) to resolve the function at call time, preserving
+            monkeypatch support. If None or returns non-callable, returns None.
+
+    Returns:
+        Web search result dict, or None on failure.
+    """
+    query_text = str(query or "").strip()
+    if not query_text:
+        return None
+    if len(query_text) > 512:
+        query_text = query_text[:512]
+
+    # Block control characters and unsafe Unicode categories (bidi
+    # overrides, surrogates, etc.) to reduce risk of log injection /
+    # unsafe propagation into external adapters.
+    query_text = re.sub(r"[\x00-\x1f\x7f]", "", query_text)
+    query_text = "".join(
+        ch for ch in query_text
+        if unicodedata.category(ch) not in _UNSAFE_UNICODE_CATEGORIES
+    )
+    if not query_text:
+        return None
+
+    try:
+        max_results_int = int(max_results)
+    except (TypeError, ValueError):
+        max_results_int = 5
+    max_results_int = max(1, min(20, max_results_int))
+
+    # Resolve the actual web_search function via the caller-provided resolver
+    fn: Optional[Callable] = None
+    if callable(web_search_resolver):
+        fn = web_search_resolver()
+    if not callable(fn):
+        return None
+
+    query_fingerprint = hashlib.sha256(
+        query_text.encode("utf-8", errors="ignore")
+    ).hexdigest()[:12]
+
+    try:
+        ws = fn(query_text, max_results=max_results_int)
+        if inspect.isawaitable(ws):
+            ws = await ws
+        return ws if isinstance(ws, dict) else None
+    except (RuntimeError, TypeError, ValueError, OSError, TimeoutError, ConnectionError) as exc:
+        logger.debug(
+            "_safe_web_search failed for query_redacted=%r query_sha256_12=%s: %s",
+            _redact_text(query_text),
+            query_fingerprint,
+            repr(exc),
+            exc_info=True,
+        )
+        return None
+
+
 __all__ = [
     "_normalize_web_payload",
     "_extract_web_results",
+    "safe_web_search",
 ]

--- a/veritas_os/tests/test_pipeline_compat.py
+++ b/veritas_os/tests/test_pipeline_compat.py
@@ -1,0 +1,323 @@
+# veritas_os/tests/test_pipeline_compat.py
+# -*- coding: utf-8 -*-
+"""
+Tests for pipeline_compat.py – utility functions extracted from pipeline.py.
+
+Verifies that:
+1. Functions work identically to their original pipeline.py implementations.
+2. Backward-compat re-exports from pipeline.py still resolve correctly.
+3. Edge cases (None, empty, special chars) are handled safely.
+"""
+from __future__ import annotations
+
+import logging
+import pytest
+from unittest.mock import MagicMock
+
+
+# =========================================================
+# Direct imports from pipeline_compat
+# =========================================================
+
+class TestToDict:
+    """to_dict / _to_dict – generic object-to-dict conversion."""
+
+    def test_dict_passthrough(self):
+        from veritas_os.core.pipeline_compat import to_dict
+        d = {"a": 1}
+        assert to_dict(d) is d
+
+    def test_pydantic_v2_model_dump(self):
+        from veritas_os.core.pipeline_compat import to_dict
+        obj = MagicMock()
+        obj.model_dump.return_value = {"key": "val"}
+        assert to_dict(obj) == {"key": "val"}
+
+    def test_pydantic_v1_dict(self):
+        from veritas_os.core.pipeline_compat import to_dict
+        obj = MagicMock(spec=[])
+        obj.dict = MagicMock(return_value={"k": 1})
+        assert to_dict(obj) == {"k": 1}
+
+    def test_plain_object(self):
+        from veritas_os.core.pipeline_compat import to_dict
+
+        class Obj:
+            pass
+
+        o = Obj()
+        o.x = 10
+        o.y = "hello"
+        result = to_dict(o)
+        assert result.get("x") == 10
+        assert result.get("y") == "hello"
+
+    def test_circular_reference_filtered(self):
+        from veritas_os.core.pipeline_compat import to_dict
+
+        class Circ:
+            pass
+
+        obj = Circ()
+        obj.self_ref = obj
+        obj.name = "test"
+        result = to_dict(obj)
+        assert "name" in result
+        assert "self_ref" not in result
+
+    def test_none_returns_empty(self):
+        from veritas_os.core.pipeline_compat import to_dict
+        assert to_dict(None) == {}
+
+    def test_int_returns_empty(self):
+        from veritas_os.core.pipeline_compat import to_dict
+        assert to_dict(42) == {}
+
+    def test_backward_compat_alias(self):
+        from veritas_os.core.pipeline_compat import _to_dict, to_dict
+        assert _to_dict is to_dict
+
+
+class TestGetRequestParams:
+    """get_request_params / _get_request_params."""
+
+    def test_starlette_query_params(self):
+        from veritas_os.core.pipeline_compat import get_request_params
+
+        class Req:
+            query_params = {"fast": "true", "verbose": "1"}
+            params = None
+
+        result = get_request_params(Req())
+        assert result["fast"] == "true"
+
+    def test_dummy_params(self):
+        from veritas_os.core.pipeline_compat import get_request_params
+
+        class Req:
+            query_params = None
+            params = {"mode": "debug"}
+
+        result = get_request_params(Req())
+        assert result["mode"] == "debug"
+
+    def test_both_merged(self):
+        from veritas_os.core.pipeline_compat import get_request_params
+
+        class Req:
+            query_params = {"a": "1"}
+            params = {"b": "2"}
+
+        result = get_request_params(Req())
+        assert result == {"a": "1", "b": "2"}
+
+    def test_exception_safe(self):
+        from veritas_os.core.pipeline_compat import get_request_params
+
+        class BadReq:
+            query_params = None
+
+            def __getattribute__(self, name):
+                if name == "params":
+                    raise RuntimeError("boom")
+                return object.__getattribute__(self, name)
+
+        result = get_request_params(BadReq())
+        assert result == {}
+
+    def test_backward_compat_alias(self):
+        from veritas_os.core.pipeline_compat import _get_request_params, get_request_params
+        assert _get_request_params is get_request_params
+
+
+class TestNormAlt:
+    """_norm_alt – alternative normalization."""
+
+    def test_basic_dict(self):
+        from veritas_os.core.pipeline_compat import _norm_alt
+        result = _norm_alt({"text": "Hello", "score": 0.8})
+        assert result["title"] == "Hello"
+        assert result["description"] == "Hello"
+        assert result["score"] == 0.8
+        assert "id" in result
+
+    def test_id_preserved(self):
+        from veritas_os.core.pipeline_compat import _norm_alt
+        result = _norm_alt({"id": "abc123", "text": "X"})
+        assert result["id"] == "abc123"
+
+    def test_empty_id_generates_new(self):
+        from veritas_os.core.pipeline_compat import _norm_alt
+        result = _norm_alt({"id": "", "text": "X"})
+        assert len(result["id"]) == 32  # uuid4().hex
+
+    def test_none_id_generates_new(self):
+        from veritas_os.core.pipeline_compat import _norm_alt
+        result = _norm_alt({"text": "X"})
+        assert len(result["id"]) == 32
+
+    def test_control_chars_stripped_from_id(self):
+        from veritas_os.core.pipeline_compat import _norm_alt
+        result = _norm_alt({"id": "ab\x00cd\x1fef", "text": "X"})
+        assert result["id"] == "abcdef"
+
+    def test_id_length_capped(self):
+        from veritas_os.core.pipeline_compat import _norm_alt
+        long_id = "a" * 300
+        result = _norm_alt({"id": long_id, "text": "X"})
+        assert len(result["id"]) <= 256
+
+    def test_score_defaults(self):
+        from veritas_os.core.pipeline_compat import _norm_alt
+        result = _norm_alt({"text": "X"})
+        assert result["score"] == 1.0
+        assert result["score_raw"] == 1.0
+
+    def test_from_object(self):
+        from veritas_os.core.pipeline_compat import _norm_alt
+
+        class Alt:
+            pass
+
+        a = Alt()
+        a.text = "hi"
+        a.score = 0.5
+        result = _norm_alt(a)
+        assert result["title"] == "hi"
+        assert result["score"] == 0.5
+
+
+class TestToBool:
+    """_to_bool – bool conversion."""
+
+    def test_truthy(self):
+        from veritas_os.core.pipeline_compat import _to_bool
+        assert _to_bool("1") is True
+        assert _to_bool("true") is True
+        assert _to_bool("yes") is True
+        assert _to_bool(True) is True
+
+    def test_falsy(self):
+        from veritas_os.core.pipeline_compat import _to_bool
+        assert _to_bool("0") is False
+        assert _to_bool("false") is False
+        assert _to_bool("") is False
+        assert _to_bool(None) is False
+
+
+class TestToFloatOr:
+    """_to_float_or – float conversion with default."""
+
+    def test_valid(self):
+        from veritas_os.core.pipeline_compat import _to_float_or
+        assert _to_float_or("3.14", 0.0) == 3.14
+
+    def test_invalid(self):
+        from veritas_os.core.pipeline_compat import _to_float_or
+        assert _to_float_or("not_a_number", 42.0) == 42.0
+
+    def test_none(self):
+        from veritas_os.core.pipeline_compat import _to_float_or
+        assert _to_float_or(None, 1.0) == 1.0
+
+
+class TestClip01:
+    """_clip01 – clip float to [0, 1]."""
+
+    def test_in_range(self):
+        from veritas_os.core.pipeline_compat import _clip01
+        assert _clip01(0.5) == 0.5
+
+    def test_below(self):
+        from veritas_os.core.pipeline_compat import _clip01
+        assert _clip01(-0.5) == 0.0
+
+    def test_above(self):
+        from veritas_os.core.pipeline_compat import _clip01
+        assert _clip01(1.5) == 1.0
+
+
+class TestFallbackLoadPersona:
+    """_fallback_load_persona."""
+
+    def test_returns_fallback_dict(self):
+        from veritas_os.core.pipeline_compat import _fallback_load_persona
+        result = _fallback_load_persona()
+        assert result == {"name": "fallback", "mode": "minimal"}
+
+
+# =========================================================
+# Re-export verification: importing from pipeline.py still works
+# =========================================================
+
+class TestPipelineReExports:
+    """Verify that all moved functions are accessible from pipeline.py."""
+
+    def test_to_dict_reexport(self):
+        from veritas_os.core.pipeline import to_dict
+        assert callable(to_dict)
+        assert to_dict({"a": 1}) == {"a": 1}
+
+    def test_to_dict_alias_reexport(self):
+        from veritas_os.core.pipeline import _to_dict
+        assert callable(_to_dict)
+
+    def test_get_request_params_reexport(self):
+        from veritas_os.core.pipeline import get_request_params
+        assert callable(get_request_params)
+
+    def test_get_request_params_alias_reexport(self):
+        from veritas_os.core.pipeline import _get_request_params
+        assert callable(_get_request_params)
+
+    def test_norm_alt_reexport(self):
+        from veritas_os.core.pipeline import _norm_alt
+        result = _norm_alt({"text": "test"})
+        assert result["title"] == "test"
+
+    def test_to_bool_reexport(self):
+        from veritas_os.core.pipeline import _to_bool
+        assert _to_bool("1") is True
+
+    def test_clip01_reexport(self):
+        from veritas_os.core.pipeline import _clip01
+        assert _clip01(0.5) == 0.5
+
+    def test_fallback_load_persona_reexport(self):
+        from veritas_os.core.pipeline import _fallback_load_persona
+        assert _fallback_load_persona()["name"] == "fallback"
+
+
+# =========================================================
+# Logger integration: compat functions log to pipeline logger
+# =========================================================
+
+class TestCompatLogging:
+    """Functions in pipeline_compat log to veritas_os.core.pipeline logger."""
+
+    def test_get_request_params_logs_to_pipeline_logger(self, caplog):
+        from veritas_os.core.pipeline_compat import get_request_params
+
+        class BadReq:
+            query_params = None
+            def __getattribute__(self, name):
+                if name == "params":
+                    raise RuntimeError("test error")
+                return object.__getattribute__(self, name)
+
+        with caplog.at_level(logging.DEBUG, logger="veritas_os.core.pipeline"):
+            get_request_params(BadReq())
+
+        assert any("params extraction failed" in r.message for r in caplog.records)
+
+    def test_to_dict_logs_to_pipeline_logger(self, caplog):
+        from veritas_os.core.pipeline_compat import to_dict
+
+        class BadObj:
+            def model_dump(self, **kw):
+                raise RuntimeError("boom")
+
+        with caplog.at_level(logging.DEBUG, logger="veritas_os.core.pipeline"):
+            to_dict(BadObj())
+
+        assert any("model_dump() failed" in r.message for r in caplog.records)

--- a/veritas_os/tests/test_pipeline_web_search.py
+++ b/veritas_os/tests/test_pipeline_web_search.py
@@ -1,0 +1,223 @@
+# veritas_os/tests/test_pipeline_web_search.py
+# -*- coding: utf-8 -*-
+"""
+Tests for safe_web_search extracted to pipeline_web_adapter.py.
+
+Verifies:
+1. Core logic (sanitization, resolver pattern, error handling)
+2. Backward-compat wrapper in pipeline.py (_safe_web_search)
+3. Monkeypatch support through resolver pattern
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import pytest
+
+
+# =========================================================
+# safe_web_search (pipeline_web_adapter)
+# =========================================================
+
+class TestSafeWebSearchCore:
+    """Tests for pipeline_web_adapter.safe_web_search."""
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_none(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+        assert await safe_web_search("") is None
+        assert await safe_web_search("   ") is None
+
+    @pytest.mark.asyncio
+    async def test_no_resolver_returns_none(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+        assert await safe_web_search("test query") is None
+
+    @pytest.mark.asyncio
+    async def test_resolver_returns_none_fn(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+        result = await safe_web_search(
+            "test", web_search_resolver=lambda: None
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_sync_search_fn(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+
+        def mock_search(q, max_results=5):
+            return {"ok": True, "results": [{"title": q}]}
+
+        result = await safe_web_search(
+            "hello", web_search_resolver=lambda: mock_search
+        )
+        assert result["ok"] is True
+        assert result["results"][0]["title"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_async_search_fn(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+
+        async def mock_search(q, max_results=5):
+            return {"ok": True, "results": []}
+
+        result = await safe_web_search(
+            "hello", web_search_resolver=lambda: mock_search
+        )
+        assert result == {"ok": True, "results": []}
+
+    @pytest.mark.asyncio
+    async def test_max_results_clamped(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+
+        captured = {}
+
+        def mock_search(q, max_results=5):
+            captured["max_results"] = max_results
+            return {"ok": True, "results": []}
+
+        await safe_web_search(
+            "test", max_results=100, web_search_resolver=lambda: mock_search
+        )
+        assert captured["max_results"] == 20
+
+        await safe_web_search(
+            "test", max_results=-5, web_search_resolver=lambda: mock_search
+        )
+        assert captured["max_results"] == 1
+
+    @pytest.mark.asyncio
+    async def test_query_truncated_at_512(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+
+        captured = {}
+
+        def mock_search(q, max_results=5):
+            captured["q"] = q
+            return {"ok": True, "results": []}
+
+        long_q = "a" * 1000
+        await safe_web_search(
+            long_q, web_search_resolver=lambda: mock_search
+        )
+        assert len(captured["q"]) <= 512
+
+    @pytest.mark.asyncio
+    async def test_control_chars_stripped(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+
+        captured = {}
+
+        def mock_search(q, max_results=5):
+            captured["q"] = q
+            return {"ok": True, "results": []}
+
+        await safe_web_search(
+            "hello\x00world\x1f!", web_search_resolver=lambda: mock_search
+        )
+        assert "\x00" not in captured["q"]
+        assert "\x1f" not in captured["q"]
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_none(self, caplog):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+
+        def bad_search(q, max_results=5):
+            raise RuntimeError("network error")
+
+        with caplog.at_level(logging.DEBUG, logger="veritas_os.core.pipeline"):
+            result = await safe_web_search(
+                "test", web_search_resolver=lambda: bad_search
+            )
+
+        assert result is None
+        assert any("_safe_web_search failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_non_dict_result_returns_none(self):
+        from veritas_os.core.pipeline_web_adapter import safe_web_search
+
+        def mock_search(q, max_results=5):
+            return "not a dict"
+
+        result = await safe_web_search(
+            "test", web_search_resolver=lambda: mock_search
+        )
+        assert result is None
+
+
+# =========================================================
+# _safe_web_search wrapper (pipeline.py)
+# =========================================================
+
+class TestSafeWebSearchWrapper:
+    """Tests for pipeline._safe_web_search backward-compat wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_monkeypatch_web_search(self, monkeypatch):
+        """Monkeypatching pipeline.web_search still works."""
+        import veritas_os.core.pipeline as pipeline_mod
+
+        def mock_ws(q, max_results=5):
+            return {"ok": True, "results": [{"q": q}]}
+
+        monkeypatch.setattr(pipeline_mod, "web_search", mock_ws, raising=False)
+        result = await pipeline_mod._safe_web_search("hello")
+        assert result is not None
+        assert result["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_monkeypatch_tool_web_search(self, monkeypatch):
+        """Monkeypatching pipeline._tool_web_search still works."""
+        import veritas_os.core.pipeline as pipeline_mod
+
+        monkeypatch.setattr(pipeline_mod, "web_search", None, raising=False)
+
+        def mock_ws(q, max_results=5):
+            return {"ok": True, "results": []}
+
+        monkeypatch.setattr(pipeline_mod, "_tool_web_search", mock_ws)
+        result = await pipeline_mod._safe_web_search("test")
+        assert result == {"ok": True, "results": []}
+
+    @pytest.mark.asyncio
+    async def test_no_web_search_returns_none(self, monkeypatch):
+        """When no web_search function is available, returns None."""
+        import veritas_os.core.pipeline as pipeline_mod
+        monkeypatch.setattr(pipeline_mod, "web_search", None, raising=False)
+        monkeypatch.setattr(pipeline_mod, "_tool_web_search", None)
+        result = await pipeline_mod._safe_web_search("test")
+        assert result is None
+
+
+# =========================================================
+# _resolve_web_search_fn (pipeline.py)
+# =========================================================
+
+class TestResolveWebSearchFn:
+    """Tests for the resolver function in pipeline.py."""
+
+    def test_prefers_web_search_over_tool(self, monkeypatch):
+        import veritas_os.core.pipeline as pipeline_mod
+
+        def ws1(q, **kw):
+            return "ws1"
+
+        def ws2(q, **kw):
+            return "ws2"
+
+        monkeypatch.setattr(pipeline_mod, "web_search", ws1, raising=False)
+        monkeypatch.setattr(pipeline_mod, "_tool_web_search", ws2)
+        fn = pipeline_mod._resolve_web_search_fn()
+        assert fn is ws1
+
+    def test_falls_back_to_tool_web_search(self, monkeypatch):
+        import veritas_os.core.pipeline as pipeline_mod
+
+        def ws2(q, **kw):
+            return "ws2"
+
+        monkeypatch.setattr(pipeline_mod, "web_search", None, raising=False)
+        monkeypatch.setattr(pipeline_mod, "_tool_web_search", ws2)
+        fn = pipeline_mod._resolve_web_search_fn()
+        assert fn is ws2


### PR DESCRIPTION
## Summary

- Extract pure utility functions (`to_dict`, `_norm_alt`, `get_request_params`, `_to_bool`, `_clip01`, etc.) from `pipeline.py` to new `pipeline_compat.py`
- Move web search core logic (`_safe_web_search`) to `pipeline_web_adapter.py` with dependency-injection pattern
- `pipeline.py` re-exports all moved names — **zero breaking changes** to existing import paths

**pipeline.py: 929 → 780 lines (-16%)**. The `run_decide_pipeline()` orchestration is now free of interleaved utility definitions.

## What was moved

| Destination | Functions | Lines |
|---|---|---|
| `pipeline_compat.py` | `to_dict`, `_to_dict`, `get_request_params`, `_get_request_params`, `_norm_alt`, `_to_bool`, `_clip01`, `_to_float_or`, `_fallback_load_persona` | ~130 |
| `pipeline_web_adapter.py` | `safe_web_search` (core logic of `_safe_web_search`) | ~65 |

## Compatibility

- All `from veritas_os.core.pipeline import X` paths continue to work (re-exports)
- All monkeypatch targets (`pipeline.mem`, `pipeline.veritas_core`, `pipeline.web_search`, etc.) remain on `pipeline.py`
- Logger names preserved (`veritas_os.core.pipeline`) so test log assertions are unaffected
- `_safe_web_search` wrapper in pipeline.py resolves web_search function at call time via `_resolve_web_search_fn()`

## Test plan

- [x] 648 existing pipeline tests pass with zero regressions
- [x] 55 new tests added (`test_pipeline_compat.py`, `test_pipeline_web_search.py`)
- [x] 703 total tests pass
- [x] Monkeypatch-based tests verified (replay, integration, coverage)

https://claude.ai/code/session_01V5EYafhPjC2vCkcF7WQKkr