### PR TITLE
fix: patch OpenSSL CVE, tighten lint rules, improve error observability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# セキュリティパッチ適用（ベースイメージの既知CVE修正）
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 # ビルドステージからインストール済みパッケージのみコピー（ビルドツール類を除外）
 COPY --from=builder /build/deps /app/deps
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -21,8 +21,6 @@ ignore = [
     "F401",   # imported but unused (re-exports)
     "W291",   # trailing whitespace
     "W293",   # whitespace before ':'
-    "F841",   # local variable assigned but never used
     "B007",   # loop control variable not used (common in pattern iteration)
     "B009",   # getattr with constant value (used deliberately after dynamic imports)
-    "B904",   # raise without from inside except (existing code pattern)
 ]

--- a/veritas_os/core/debate.py
+++ b/veritas_os/core/debate.py
@@ -554,8 +554,8 @@ def _safe_json_extract_like(raw: str) -> Dict[str, Any]:
                         else:
                             try:
                                 objs.append(json.loads(s))
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                logger.debug("DebateOS: skipping unparseable JSON object: %s", e)
                         buf_start = None
                         if len(objs) >= max_objects:
                             break

--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -857,8 +857,8 @@ async def decide(
     try:
         latency_ms = int((time.time() - start_ts) * 1000)
         extras["metrics"]["latency_ms"] = latency_ms
-    except (TypeError, ValueError, OverflowError):
-        pass
+    except (TypeError, ValueError, OverflowError) as e:
+        logger.debug("latency_ms calculation failed: %s", e)
 
     if degraded_subsystems:
         extras["degraded_subsystems"] = sorted(set(degraded_subsystems))

--- a/veritas_os/core/memory.py
+++ b/veritas_os/core/memory.py
@@ -411,7 +411,7 @@ def locked_memory(path: Path, timeout: float = 5.0):
                         lockfile, e,
                     )
                 if time.time() - start > timeout:
-                    raise TimeoutError(f"failed to acquire lock for {path}")
+                    raise TimeoutError(f"failed to acquire lock for {path}") from None
                 time.sleep(backoff)
                 backoff = min(backoff * 2.0, 0.32)
         try:

--- a/veritas_os/core/memory_storage.py
+++ b/veritas_os/core/memory_storage.py
@@ -105,7 +105,7 @@ def locked_memory(path: Path, timeout: float = 5.0) -> Any:
             except BlockingIOError:
                 if time.time() - start > timeout:
                     fh.close()
-                    raise TimeoutError(f"failed to acquire lock for {path}")
+                    raise TimeoutError(f"failed to acquire lock for {path}") from None
                 time.sleep(0.02)
         try:
             yield
@@ -143,7 +143,7 @@ def locked_memory(path: Path, timeout: float = 5.0) -> Any:
                         e,
                     )
                 if time.time() - start > timeout:
-                    raise TimeoutError(f"failed to acquire lock for {path}")
+                    raise TimeoutError(f"failed to acquire lock for {path}") from None
                 time.sleep(backoff)
                 backoff = min(backoff * 2.0, 0.32)
         try:

--- a/veritas_os/core/utils.py
+++ b/veritas_os/core/utils.py
@@ -335,7 +335,7 @@ def _redact_text(text: str) -> str:
         try:
             return _mask_pii_impl(text)
         except Exception:
-            pass
+            logger.warning("sanitize.mask_pii failed; falling back to basic regex")
     text = re.sub(r"\b[\w\.-]+@[\w\.-]+\.\w+\b", "[redacted@email]", text)
     text = re.sub(
         r"\b\d{2,4}[-・\s]?\d{2,4}[-・\s]?\d{3,4}\b",

--- a/veritas_os/replay/replay_engine.py
+++ b/veritas_os/replay/replay_engine.py
@@ -305,7 +305,6 @@ def _audit_summary(
     mode_label = "strict" if strict else "standard"
     verdict = "MATCH" if match else "MISMATCH"
 
-    divergence = diff.get("divergence_level", DIVERGENCE_NONE)
     if match:
         return f"Replay {decision_id} ({mode_label}): {verdict} — no divergence detected."
 

--- a/veritas_os/tools/llm_safety.py
+++ b/veritas_os/tools/llm_safety.py
@@ -262,7 +262,6 @@ def heuristic_analyze(text: str) -> Dict[str, Any]:
     - カテゴリ別リスク設定
     """
     scan_variants = _build_safety_scan_variants(text)
-    t = scan_variants[0]
     categories: List[str] = []
     risk = 0.05
     reasons: List[str] = []


### PR DESCRIPTION
## Summary

- **Dockerfile**: `apt-get upgrade` in runtime stage to patch OpenSSL CVE-2025-15467 — fixes failing Trivy gate in `publish-ghcr.yml`
- **ruff.toml**: Remove F841 (unused variables) and B904 (raise without from) from ignore list, enforcing stricter lint going forward
- **Code fixes**: Fix all existing F841/B904 violations and replace silent `except: pass` with proper logging

## Changes (9 files)

| File | Change |
|---|---|
| `Dockerfile` | Add `apt-get upgrade` to patch base image CVEs |
| `ruff.toml` | Remove F841, B904 from ignore list |
| `veritas_os/replay/replay_engine.py` | Remove unused `divergence` variable |
| `veritas_os/tools/llm_safety.py` | Remove unused `t` variable |
| `veritas_os/core/memory.py` | `raise TimeoutError(...) from None` |
| `veritas_os/core/memory_storage.py` | `raise TimeoutError(...) from None` (×2) |
| `veritas_os/core/kernel.py` | Log latency calculation failure instead of silencing |
| `veritas_os/core/debate.py` | Log JSON parse failure instead of silencing |
| `veritas_os/core/utils.py` | Log `mask_pii` failure instead of silencing |

## Test plan

- [x] `ruff check veritas_os/` passes with tightened rules
- [x] All 4965 tests pass (0 failures, 6 skipped)
- [ ] Trivy gate should pass with patched OpenSSL in Docker image

https://claude.ai/code/session_01QVGpMoFuGcTkKrPx93icjV