### PR TITLE
Harden MemoryStore cache isolation and fail-closed search boundaries

### DIFF
--- a/docs/COVERAGE_REPORT.md
+++ b/docs/COVERAGE_REPORT.md
@@ -117,6 +117,44 @@
 これに合わせ、`core/fuji_policy.py` と `core/fuji_policy_rollout.py` で
 fail-closed 明確化のための小規模構造改善を実施（未知アクション時 deny、rollout 評価例外時 deny）。
 
+## 追補 (2026-03-26): MemoryOS core の再測定・改善更新
+
+`core/memory_store.py` の信頼性改善に合わせ、MemoryOS のコアモジュールを対象に
+focused coverage を再測定した。
+
+- 実行テスト:
+  - `test_memory_store_hardening.py`
+  - `test_memory_store_core.py`
+  - `test_memory_store.py`
+  - `test_memory_store_io_strategy.py`
+  - `test_memory_lifecycle.py`
+  - `test_memory_storage.py`
+  - `test_memory_compliance.py`
+- 結果: **228 passed**
+
+> 計測方式の注意: この環境では `pytest-cov` が未導入のため、標準ライブラリ
+> `trace` の `--count --missing` を使用して line coverage を算出した。
+> そのため、CI の branch coverage 指標とは直接比較できない。
+
+### Focused coverage (trace, line-only)
+
+| モジュール | Executed | Missed | Line Coverage |
+|-----------|----------|--------|---------------|
+| `core/memory_store.py` | 366 | 5 | **98.7%** |
+| `core/memory_storage.py` | 94 | 3 | **96.9%** |
+| `core/memory_lifecycle.py` | 102 | 4 | **96.2%** |
+| `core/memory_compliance.py` | 95 | 0 | **100.0%** |
+
+### 今回の改善ポイント（memory_store）
+
+- `_load_all(copy=True)` の deep copy 化で、呼び出し側のネスト更新による
+  キャッシュ汚染を防止。
+- `list_all`/`search` の `user_id` 判定を `is not None` に統一し、
+  `user_id=""` での境界漏れを防止。
+- `search(k, min_sim)` の境界を fail-closed 化（負値/型不正）。
+- `put_episode` で KVS 保存失敗時に vector 同期を抑止し、部分成功による
+  不整合を回避。
+
 ## 制約・注意点
 
 1. **フルスイート実行**: `not slow` マーク付きテストのみ実行 (CI 相当)。slow テストは除外されている。

--- a/veritas_os/core/memory_lifecycle.py
+++ b/veritas_os/core/memory_lifecycle.py
@@ -31,7 +31,10 @@ def parse_expires_at(expires_at: Any) -> Optional[str]:
         return None
 
     if isinstance(expires_at, (int, float)):
-        dt = datetime.fromtimestamp(float(expires_at), tz=timezone.utc)
+        try:
+            dt = datetime.fromtimestamp(float(expires_at), tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
         return dt.isoformat()
 
     if isinstance(expires_at, str):

--- a/veritas_os/core/memory_store.py
+++ b/veritas_os/core/memory_store.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from datetime import datetime, timezone
+from copy import deepcopy
 import json
 import os
 import time
@@ -112,7 +113,7 @@ class MemoryStore:
                 ):
                     data = self._cache_data
                     if copy:
-                        return [dict(r) for r in data]
+                        return deepcopy(data)
                     return data
 
         if not self.path.exists():
@@ -141,7 +142,7 @@ class MemoryStore:
             self._cache_loaded_at = time.time()
 
         if copy:
-            return [dict(r) for r in data]
+            return deepcopy(data)
         return data
 
     def _save_all(self, data: List[Dict[str, Any]]) -> bool:
@@ -215,7 +216,7 @@ class MemoryStore:
         """全レコードをリスト"""
         data = self._load_all(copy=True)
         filtered_data = [r for r in data if not self._is_record_expired(r)]
-        if user_id:
+        if user_id is not None:
             return [r for r in filtered_data if r.get("user_id") == user_id]
         return filtered_data
 
@@ -226,7 +227,10 @@ class MemoryStore:
             return None
 
         if isinstance(expires_at, (int, float)):
-            dt = datetime.fromtimestamp(float(expires_at), tz=timezone.utc)
+            try:
+                dt = datetime.fromtimestamp(float(expires_at), tz=timezone.utc)
+            except (OverflowError, OSError, ValueError):
+                return None
             return dt.isoformat()
 
         if isinstance(expires_at, str):
@@ -419,12 +423,26 @@ class MemoryStore:
         if not query:
             return {}
 
+        try:
+            limit = max(0, int(k))
+        except (TypeError, ValueError):
+            limit = 0
+
+        if limit == 0:
+            return {}
+
+        try:
+            min_similarity = float(min_sim)
+        except (TypeError, ValueError):
+            # fail-closed: invalid threshold should not broaden matches.
+            min_similarity = 1.1
+
         data = self._load_all(copy=True)
         episodic: List[Dict[str, Any]] = []
-        target_user = user_id
+        target_user = user_id if user_id is not None else None
 
         for r in data:
-            if target_user and r.get("user_id") != target_user:
+            if target_user is not None and r.get("user_id") != target_user:
                 continue
 
             val = r.get("value") or {}
@@ -436,7 +454,7 @@ class MemoryStore:
                 continue
 
             score = self._simple_score(query, text)
-            if score < min_sim:
+            if score < min_similarity:
                 continue
 
             tags = val.get("tags") or []
@@ -465,7 +483,7 @@ class MemoryStore:
             return {}
 
         logger.debug("[MemoryOS][KVS] episodic hits=%d", len(episodic))
-        return {"episodic": episodic[:k]}
+        return {"episodic": episodic[:limit]}
 
     def put_episode(
         self,
@@ -495,7 +513,10 @@ class MemoryStore:
         key = f"episode_{int(time.time())}"
 
         # KVS
-        self.put(user_id, key, record)
+        saved = self.put(user_id, key, record)
+        if not saved:
+            logger.error("[MemoryOS] put_episode persist failed: key=%s", key)
+            return key
 
         # ベクトルインデックスにも追加
         if _get_mem_vec_fn is not None:

--- a/veritas_os/core/memory_store_helpers.py
+++ b/veritas_os/core/memory_store_helpers.py
@@ -145,14 +145,33 @@ def build_kvs_search_hits(
     min_sim: float = 0.0,
     user_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Build normalized fallback KVS search hits from raw store records."""
+    """Build normalized fallback KVS search hits from raw store records.
+
+    Fail-safe guards:
+    - Invalid ``k`` values produce no hits.
+    - Invalid ``min_sim`` values are treated as strict threshold (fail-closed).
+    - ``user_id`` filtering is applied when explicitly provided, including
+      empty-string identifiers.
+    """
     normalized_query = (query or "").strip()
     if not normalized_query:
         return []
 
+    try:
+        limit = max(0, int(k))
+    except (TypeError, ValueError):
+        limit = 0
+    if limit == 0:
+        return []
+
+    try:
+        min_similarity = float(min_sim)
+    except (TypeError, ValueError):
+        min_similarity = 1.1
+
     hits: List[Dict[str, Any]] = []
     for record in records:
-        if user_id and record.get("user_id") != user_id:
+        if user_id is not None and record.get("user_id") != user_id:
             continue
 
         value = record.get("value") or {}
@@ -164,7 +183,7 @@ def build_kvs_search_hits(
             continue
 
         score = simple_score(normalized_query, text)
-        if score < min_sim:
+        if score < min_similarity:
             continue
 
         kind = value.get("kind", "episodic")
@@ -187,7 +206,7 @@ def build_kvs_search_hits(
         )
 
     hits.sort(key=lambda hit: hit.get("score", 0.0), reverse=True)
-    return hits[:k]
+    return hits[:limit]
 
 
 def erase_user_records(

--- a/veritas_os/tests/test_memory_lifecycle.py
+++ b/veritas_os/tests/test_memory_lifecycle.py
@@ -32,6 +32,11 @@ def test_parse_expires_at_blank_or_unsupported_returns_none() -> None:
     assert parse_expires_at({"expires_at": "2024-01-01"}) is None
 
 
+def test_parse_expires_at_out_of_range_numeric_returns_none() -> None:
+    """Out-of-range numeric timestamps should fail closed."""
+    assert parse_expires_at(float("inf")) is None
+
+
 def test_normalize_lifecycle_defaults_retention_and_hold() -> None:
     """Lifecycle defaults should be attached to memory-style documents."""
     result = normalize_lifecycle(

--- a/veritas_os/tests/test_memory_store_hardening.py
+++ b/veritas_os/tests/test_memory_store_hardening.py
@@ -97,6 +97,17 @@ class TestLoadAllCacheBehavior:
         assert len(data) == 1
         assert data[0]["value"] == "v1"
 
+    def test_load_all_copy_true_returns_deepcopy(
+        self, store: MemoryStore
+    ) -> None:
+        """copy=True should not allow nested mutation to leak into cache."""
+        store.put("u1", "k1", {"text": "v1", "meta": {"nested": {"x": 1}}})
+        loaded = store._load_all(copy=True)
+        loaded[0]["value"]["meta"]["nested"]["x"] = 999
+
+        original = store.get("u1", "k1")
+        assert original["meta"]["nested"]["x"] == 1
+
 
 # ---------------------------------------------------------------------------
 # _load_all — error handling
@@ -155,6 +166,9 @@ class TestParseExpiresAtEdgeCases:
     def test_float_timestamp(self) -> None:
         result = MemoryStore._parse_expires_at(1700000000.5)
         assert result is not None and "2023" in result
+
+    def test_out_of_range_timestamp_returns_none(self) -> None:
+        assert MemoryStore._parse_expires_at(float("inf")) is None
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +303,15 @@ class TestSearchBranches:
         ids = [h["meta"]["user_id"] for h in result["episodic"]]
         assert all(uid == "u1" for uid in ids)
 
+    def test_search_empty_user_id_is_not_bypass(self, store: MemoryStore) -> None:
+        """Empty-string user_id should match only empty user records."""
+        store.put("u1", "k1", {"text": "shared term", "kind": "episodic"})
+        store.put("", "k2", {"text": "shared term", "kind": "episodic"})
+        result = store.search("shared", user_id="")
+        hits = result.get("episodic", [])
+        assert len(hits) == 1
+        assert hits[0]["meta"]["user_id"] == ""
+
     def test_search_kind_filtering(self, store: MemoryStore) -> None:
         """kinds filter only returns matching kinds.
 
@@ -316,6 +339,14 @@ class TestSearchBranches:
             store.put("u1", f"k{i}", {"text": "common term", "kind": "episodic"})
         result = store.search("common", k=2)
         assert len(result.get("episodic", [])) <= 2
+
+    def test_search_negative_k_returns_empty(self, store: MemoryStore) -> None:
+        store.put("u1", "k1", {"text": "common term", "kind": "episodic"})
+        assert store.search("common", k=-1) == {}
+
+    def test_search_invalid_min_sim_fails_closed(self, store: MemoryStore) -> None:
+        store.put("u1", "k1", {"text": "common term", "kind": "episodic"})
+        assert store.search("common", min_sim="bad-value") == {}
 
     def test_search_whitespace_query(self, store: MemoryStore) -> None:
         """Whitespace-only query should return empty dict."""
@@ -394,6 +425,17 @@ class TestRecentEdgeCases:
     def test_recent_empty_user(self, store: MemoryStore) -> None:
         results = store.recent("nonexistent_user")
         assert results == []
+
+
+class TestListAllUserBoundary:
+    def test_list_all_empty_user_id_does_not_return_other_users(
+        self, store: MemoryStore
+    ) -> None:
+        store.put("u1", "k1", "v1")
+        store.put("", "k2", "v2")
+        results = store.list_all(user_id="")
+        assert len(results) == 1
+        assert results[0]["user_id"] == ""
 
 
 # ---------------------------------------------------------------------------
@@ -507,6 +549,21 @@ class TestPutEpisodeBranches:
         record = store.get("episodic", key)
         assert record is not None
         assert record["text"] == "no user"
+
+    def test_put_episode_skips_vector_when_put_fails(
+        self, store: MemoryStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import inspect
+
+        sig = inspect.signature(type(store).put_episode)
+        if "_get_mem_vec_fn" not in sig.parameters:
+            pytest.skip("put_episode has been replaced by compat layer")
+
+        vec = mock.Mock()
+        monkeypatch.setattr(store, "put", lambda *_args, **_kwargs: False)
+        key = store.put_episode("x", _get_mem_vec_fn=lambda: vec)
+        assert key.startswith("episode_")
+        vec.add.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/veritas_os/tests/test_memory_store_helpers.py
+++ b/veritas_os/tests/test_memory_store_helpers.py
@@ -82,3 +82,44 @@ def test_build_kvs_search_hits_applies_user_kind_and_similarity_filters() -> Non
             },
         }
     ]
+
+
+def test_build_kvs_search_hits_empty_user_id_is_filtered() -> None:
+    """Empty-string user IDs must be treated as explicit filter values."""
+    records = [
+        {"key": "a", "user_id": "u1", "ts": 1, "value": {"text": "hello"}},
+        {"key": "b", "user_id": "", "ts": 2, "value": {"text": "hello"}},
+    ]
+    hits = memory_store_helpers.build_kvs_search_hits(
+        records,
+        query="hello",
+        k=10,
+        user_id="",
+    )
+    assert [hit["id"] for hit in hits] == ["b"]
+
+
+def test_build_kvs_search_hits_invalid_min_sim_fails_closed() -> None:
+    """Malformed min_sim should not broaden matches."""
+    records = [
+        {"key": "a", "user_id": "u1", "ts": 1, "value": {"text": "hello"}},
+    ]
+    hits = memory_store_helpers.build_kvs_search_hits(
+        records,
+        query="hello",
+        k=10,
+        min_sim="bad",
+    )
+    assert hits == []
+
+
+def test_build_kvs_search_hits_non_positive_k_returns_empty() -> None:
+    """Non-positive k values should produce empty results."""
+    records = [
+        {"key": "a", "user_id": "u1", "ts": 1, "value": {"text": "hello"}},
+    ]
+    assert memory_store_helpers.build_kvs_search_hits(
+        records,
+        query="hello",
+        k=0,
+    ) == []


### PR DESCRIPTION
### Motivation
- MemoryStore の put/get/search/erase/put_episode 周りで発生しうる「silent corruption」「ユーザー境界の漏れ」「不正入力での不定動作」「部分成功による不整合」を最小限の修正で封じ、既存 public API を壊さずに信頼性を高めるため。 

### Description
- `veritas_os/core/memory_store.py` にて `_load_all(copy=True)` の戻り値を浅いコピーから `deepcopy` に変更してキャッシュ実体の破壊的書き換えを防止した。 
- `list_all` と `search` の `user_id` 判定を `is not None` に変更し、空文字列 `user_id=""` が「無条件フィルタ」になってしまう境界問題を修正した。 
- `_parse_expires_at` に数値タイムスタンプの例外ハンドリングを追加し、`inf` や範囲外値を安全に `None` 扱いにして fail-closed にした。 
- `search` において `k` を整数化して非正値で空結果を返す処理と、`min_sim` が不正な場合に閾値を高く設定してマッチを広げない（fail-closed）挙動を追加し、パラメータ境界を堅牢化した。 
- `put_episode` で KVS 保存が失敗した場合はベクトル同期処理へ進まずログを出すようにして、部分成功による不整合を回避した。 
- `veritas_os/tests/test_memory_store_hardening.py` に信頼性重視のテストを追加し、deep-copy 保証・out-of-range timestamp・user_id 空文字境界・`k`/`min_sim` の境界・`put_episode` の部分失敗耐性を仕様化した。 

### Testing
- 追加したテスト群を含めて `pytest -q veritas_os/tests/test_memory_store_hardening.py veritas_os/tests/test_memory_store_core.py` を実行し `155 passed` で成功した。 
- 互換性確認として `pytest -q veritas_os/tests/test_memory_store.py veritas_os/tests/test_memory_store_io_strategy.py` を実行し `26 passed` で成功した。 
- 変更によりカバレッジと fail-safe 動作（deepcopy によるキャッシュ保全・検索/境界の fail-closed 化・put_episode の一貫性）が自動テストで検証される状態になった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49ca77b848326b528d57bac62e7fd)