### PR TITLE
Harden TrustLog encryption parsing to fail-closed on malformed envelopes

### DIFF
--- a/veritas_os/logging/encryption.py
+++ b/veritas_os/logging/encryption.py
@@ -35,13 +35,14 @@ import logging
 import os
 import secrets
 import struct
-from typing import Optional
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
 _AES_BLOCK = 16
 _IV_SIZE = 16
 _HMAC_SIZE = 32
+_AESGCM_NONCE_SIZE = 12
 # Derive two independent 32-byte subkeys from the 32-byte master key
 # via HMAC-SHA256 so that both encryption and authentication use 256-bit keys.
 _HMAC_CTR_ENC_INFO = b"veritas-hmac-ctr-enc"
@@ -54,6 +55,7 @@ def _derive_hmac_ctr_keys(master: bytes) -> tuple[bytes, bytes]:
     hmac_key = hmac.new(master, _HMAC_CTR_MAC_INFO, hashlib.sha256).digest()
     return enc_key, hmac_key
 _STREAM_BLOCK = 32  # SHA-256 output size
+_LEGACY_DECRYPT_ENV = "VERITAS_ENCRYPTION_LEGACY_DECRYPT"
 
 
 class EncryptionKeyMissing(RuntimeError):
@@ -112,6 +114,58 @@ def is_encryption_enabled() -> bool:
     return _get_key_bytes() is not None
 
 
+def _decode_urlsafe_b64(payload: str) -> bytes:
+    """Decode URL-safe base64 with strict validation."""
+    if not payload:
+        raise ValueError("empty ciphertext payload")
+    try:
+        return base64.b64decode(
+            payload.encode("ascii"),
+            altchars=b"-_",
+            validate=True,
+        )
+    except (ValueError, TypeError, UnicodeEncodeError) as exc:
+        raise ValueError("invalid base64 payload") from exc
+
+
+def _legacy_decrypt_enabled() -> bool:
+    """Return whether legacy ``ENC:<payload>`` token decryption is allowed."""
+    raw = (os.environ.get(_LEGACY_DECRYPT_ENV) or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _split_encrypted_token(token: str) -> Tuple[str, str]:
+    """Parse ``ENC:<algorithm>:<base64>`` with explicit fail-closed checks.
+
+    Legacy ``ENC:<base64>`` tokens are rejected by default and can be enabled
+    only via ``VERITAS_ENCRYPTION_LEGACY_DECRYPT=1`` during migration.
+    """
+    if not token.startswith("ENC:"):
+        raise ValueError("missing ENC prefix")
+    after_prefix = token[4:]
+    if not after_prefix:
+        raise ValueError("missing encrypted envelope")
+
+    first_sep = after_prefix.find(":")
+    if first_sep == -1:
+        if _legacy_decrypt_enabled():
+            logger.warning(
+                "Legacy ENC payload accepted due to %s=1; migrate to ENC:<algorithm>:<payload>",
+                _LEGACY_DECRYPT_ENV,
+            )
+            algorithm = "aesgcm" if _USE_REAL_AES else "hmac-ctr"
+            return algorithm, after_prefix
+        raise ValueError("legacy encrypted envelope not accepted")
+
+    algorithm = after_prefix[:first_sep]
+    payload = after_prefix[first_sep + 1:]
+    if algorithm not in {"aesgcm", "hmac-ctr"}:
+        raise ValueError("unsupported encryption algorithm marker")
+    if not payload:
+        raise ValueError("missing encrypted payload")
+    return algorithm, payload
+
+
 # ---------------------------------------------------------------------------
 # Pure-Python HMAC-CTR stream cipher
 # ---------------------------------------------------------------------------
@@ -166,9 +220,9 @@ def decrypt(ciphertext: str) -> str:
     """Decrypt an ``ENC:``-prefixed ciphertext string.
 
     Algorithm dispatch uses the tag between ``ENC:`` and the payload
-    (e.g. ``ENC:aesgcm:<b64>``).  Legacy tokens without an algorithm tag
-    are dispatched based on the currently available backend for backward
-    compatibility.
+    (e.g. ``ENC:aesgcm:<b64>``). Legacy tokens without an algorithm tag are
+    rejected by default and can be enabled only for migrations via
+    ``VERITAS_ENCRYPTION_LEGACY_DECRYPT=1``.
 
     Returns the original string unchanged if it does not start with ``ENC:``.
     Raises :class:`EncryptionKeyMissing` when the key is required but absent.
@@ -182,22 +236,15 @@ def decrypt(ciphertext: str) -> str:
             "Cannot decrypt: VERITAS_ENCRYPTION_KEY not set"
         )
 
-    after_prefix = ciphertext[4:]  # strip "ENC:"
-
     try:
-        if after_prefix.startswith("aesgcm:"):
-            return _decrypt_aesgcm_raw(after_prefix[7:], key)
-        if after_prefix.startswith("hmac-ctr:"):
-            return _decrypt_hmac_ctr_raw(after_prefix[9:], key)
-
-        # Legacy tokens without algorithm tag — dispatch by available backend.
-        if _USE_REAL_AES:
-            return _decrypt_aesgcm(ciphertext, key)
-        return _decrypt_hmac_ctr(ciphertext, key)
+        algorithm, payload = _split_encrypted_token(ciphertext)
+        if algorithm == "aesgcm":
+            return _decrypt_aesgcm_raw(payload, key)
+        if algorithm == "hmac-ctr":
+            return _decrypt_hmac_ctr_raw(payload, key)
+        raise ValueError("unsupported encryption algorithm marker")
     except (ValueError, TypeError, KeyError) as exc:
-        raise DecryptionError(
-            f"Decryption failed for malformed ciphertext: {exc}"
-        ) from exc
+        raise DecryptionError(f"Decryption failed: {exc}") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -228,7 +275,7 @@ def _decrypt_hmac_ctr_raw(b64_payload: str, key: bytes) -> str:
     """Decrypt base64-encoded HMAC-CTR ciphertext (no ENC: prefix)."""
     enc_key, hmac_key = _derive_hmac_ctr_keys(key)
 
-    raw = base64.urlsafe_b64decode(b64_payload)
+    raw = _decode_urlsafe_b64(b64_payload)
     if len(raw) < _HMAC_SIZE + _IV_SIZE + 1:
         raise ValueError("ciphertext too short")
 
@@ -271,11 +318,11 @@ def _encrypt_aesgcm(plaintext: str, key: bytes) -> str:
 
 def _decrypt_aesgcm_raw(b64_payload: str, key: bytes) -> str:
     """Decrypt base64-encoded AES-GCM ciphertext (no ENC: prefix)."""
-    raw = base64.urlsafe_b64decode(b64_payload)
-    if len(raw) < 13:
+    raw = _decode_urlsafe_b64(b64_payload)
+    if len(raw) < _AESGCM_NONCE_SIZE + 1:
         raise ValueError("ciphertext too short for AES-GCM")
-    nonce = raw[:12]
-    ct = raw[12:]
+    nonce = raw[:_AESGCM_NONCE_SIZE]
+    ct = raw[_AESGCM_NONCE_SIZE:]
     aes = AESGCM(key)
     try:
         return aes.decrypt(nonce, ct, None).decode("utf-8")

--- a/veritas_os/tests/test_logging_encryption_hardening.py
+++ b/veritas_os/tests/test_logging_encryption_hardening.py
@@ -112,27 +112,49 @@ class TestEncryptDecryptFlow:
 
 
 class TestFallbackAndExceptionPath:
-    def test_unknown_algorithm_token_uses_legacy_dispatch_and_fails_closed(
+    def test_legacy_like_marker_without_separator_fails_closed(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         _set_valid_key(monkeypatch)
-        monkeypatch.setattr(encryption, "_USE_REAL_AES", False)
 
-        with pytest.raises(encryption.DecryptionError):
+        with pytest.raises(encryption.DecryptionError, match="legacy encrypted envelope not accepted"):
             encryption.decrypt("ENC:unknown-format")
 
-    def test_exception_from_legacy_backend_is_wrapped(
+    def test_missing_payload_fails_closed(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         _set_valid_key(monkeypatch)
+
+        with pytest.raises(encryption.DecryptionError, match="missing encrypted payload"):
+            encryption.decrypt("ENC:hmac-ctr:")
+
+    def test_legacy_format_rejected_by_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _set_valid_key(monkeypatch)
+
+        with pytest.raises(encryption.DecryptionError, match="legacy encrypted envelope not accepted"):
+            encryption.decrypt("ENC:Zm9v")
+
+    def test_legacy_format_can_be_explicitly_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _set_valid_key(monkeypatch, raw=b"A" * 32)
         monkeypatch.setattr(encryption, "_USE_REAL_AES", False)
+        token = encryption.encrypt("legacy-ok").replace("ENC:hmac-ctr:", "ENC:")
+        monkeypatch.setenv("VERITAS_ENCRYPTION_LEGACY_DECRYPT", "1")
 
-        def _raise_value_error(token: str, key: bytes) -> str:  # noqa: ARG001
-            raise ValueError("boom")
+        assert encryption.decrypt(token) == "legacy-ok"
 
-        monkeypatch.setattr(encryption, "_decrypt_hmac_ctr", _raise_value_error)
+    def test_base64_validation_error_is_wrapped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _set_valid_key(monkeypatch)
 
-        with pytest.raises(encryption.DecryptionError, match="malformed ciphertext"):
-            encryption.decrypt("ENC:anything")
+        with pytest.raises(encryption.DecryptionError, match="invalid base64 payload"):
+            encryption.decrypt("ENC:hmac-ctr:not_base64!!!")

--- a/veritas_os/tests/test_trustlog_adversarial.py
+++ b/veritas_os/tests/test_trustlog_adversarial.py
@@ -286,7 +286,6 @@ class TestSignatureInvalid:
         # Build a valid entry then tamper its signature
         payload = {"decision": "allow", "request_id": "sig-test"}
         payload_hash = sha256_of_canonical_json(payload)
-        sig = sign_payload_hash(payload_hash, priv_path)
 
         # Create a completely wrong signature (valid base64 of random bytes)
         wrong_sig = base64.urlsafe_b64encode(os.urandom(64)).decode("ascii")
@@ -309,7 +308,6 @@ class TestSignatureInvalid:
         assert any(i["reason"] == "signature_invalid" for i in result["issues"])
 
     def test_verify_signature_returns_false_for_missing_fields(self, tmp_path):
-        pub_path = tmp_path / "pub.key"
         # Missing key file
         assert verify_signature({"payload_hash": "h" * 64, "signature": "sig"}) is False
         # Missing required fields

--- a/veritas_os/tests/test_trustlog_adversarial.py
+++ b/veritas_os/tests/test_trustlog_adversarial.py
@@ -179,6 +179,23 @@ class TestCorruptedCiphertext:
         with pytest.raises(DecryptionError):
             decrypt(f"ENC:hmac-ctr:{short_b64}")
 
+    def test_mixed_old_new_format_rejected(self, monkeypatch):
+        _set_valid_key(monkeypatch, raw=b"F" * 32)
+        with pytest.raises(DecryptionError, match="invalid base64 payload"):
+            decrypt("ENC:hmac-ctr:legacy:payload")
+
+    def test_legacy_payload_requires_explicit_opt_in(self, monkeypatch):
+        _set_valid_key(monkeypatch, raw=b"Q" * 32)
+        monkeypatch.setattr(encryption, "_USE_REAL_AES", False)
+        modern = encrypt("legacy-migration")
+        legacy = modern.replace("ENC:hmac-ctr:", "ENC:")
+
+        with pytest.raises(DecryptionError, match="legacy encrypted envelope not accepted"):
+            decrypt(legacy)
+
+        monkeypatch.setenv("VERITAS_ENCRYPTION_LEGACY_DECRYPT", "true")
+        assert decrypt(legacy) == "legacy-migration"
+
 
 # ===========================================================================
 # 4. Truncated line handling


### PR DESCRIPTION
### Motivation
- Prevent ambiguous/legacy envelope parsing that can produce a "looks encrypted but is not safe" state and therefore enable a fail-closed policy for TrustLog at-rest encryption.  
- Reject malformed or mixed-format ciphertext deterministically (avoid silent acceptance of corrupt inputs).  
- Preserve existing public behavior for encryption writes (no plaintext fallback) while providing an explicit migration opt-in for legacy tokens.  

### Description
- Tightened envelope parsing in `veritas_os/logging/encryption.py` so `decrypt()` requires `ENC:<algorithm>:<payload>` and rejects legacy `ENC:<payload>` by default, with opt-in via `VERITAS_ENCRYPTION_LEGACY_DECRYPT=1`.  
- Added strict URL-safe base64 decoding helper (`_decode_urlsafe_b64`) with `validate=True` to reject invalid or mixed-format payloads and unified error messages wrapped as `DecryptionError`.  
- Factored envelope parsing into `_split_encrypted_token` and added small constants (`_AESGCM_NONCE_SIZE`, `_LEGACY_DECRYPT_ENV`) and explicit checks for missing payload, unsupported markers, and empty tokens.  
- Updated and added adversarial tests to cover legacy rejection/opt-in, missing payload, invalid base64, mixed old/new formats, and other malformed envelope cases in `veritas_os/tests/test_logging_encryption_hardening.py` and `veritas_os/tests/test_trustlog_adversarial.py`.  

### Testing
- Ran `pytest -q veritas_os/tests/test_logging_encryption_hardening.py veritas_os/tests/test_trustlog_adversarial.py -q` and all tests in those files passed.  
- Ran `pytest -q veritas_os/tests/test_secure_trustlog.py -q` and the suite passed.  
- Tests exercised missing-key, wrong-key, corrupted ciphertext, truncated payload, legacy-format opt-in, and invalid-base64 paths and validated fail-closed behavior (no plaintext fallback).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4a6a5df948326b497a5efe8c70ec7)