### PR TITLE
Harden direct FUJI API controls and surface security posture in health/status

### DIFF
--- a/docs/system_review_2026-03-26.md
+++ b/docs/system_review_2026-03-26.md
@@ -71,3 +71,42 @@
 - `veritas_os/api/routes_decide.py`
 - `veritas_os/logging/encryption.py`
 - `veritas_os/tools/web_search.py`
+
+---
+
+## 追記（改善実施ログ / 2026-03-26）
+
+以下の改善を実装し、責務境界（Planner / Kernel / FUJI / MemoryOS）を越えない
+API運用層の安全性向上として反映しました。
+
+### 1) 本番環境で Direct FUJI API を強制無効化
+- 対応:
+  - `VERITAS_ENABLE_DIRECT_FUJI_API=true` が設定されていても、
+    `VERITAS_ENV=prod|production` では実行時に `False` として扱うガードを追加。
+  - 起動時セキュリティ検証で、production で当該フラグが有効なら fail-fast で起動拒否。
+- 目的:
+  - `/v1/decide` パイプラインを経由しない直接利用の誤運用を防止し、
+    本番の統合制御（監査・運用ポリシー）を維持する。
+
+### 2) `/health` と `/status` にセキュリティ姿勢スナップショットを追加
+- 対応:
+  - `security_posture.direct_fuji_api_enabled`
+  - `security_posture.encryption`（暗号化有効状態・アルゴリズム等）
+  を返すよう拡張。
+- 目的:
+  - 「今どの安全機構が有効か」を即時確認可能にし、
+    運用Runbook/監視ダッシュボードでの誤認を減らす。
+
+### 3) テスト追加・更新
+- 追加:
+  - production で direct FUJI API が強制無効化されることの単体テスト。
+  - 起動時セキュリティ検証で direct FUJI API を
+    - non-production: 警告
+    - production: 例外
+    として扱うテスト。
+  - `/health` が `security_posture` を含むことの確認テスト。
+
+## 追加セキュリティ警告
+- **[HIGH] Direct FUJI API の本番有効化は重大リスク**  
+  本改善で fail-fast + 実行時ガードを実装済みですが、設定管理（IaC / Secret Manager）
+  でも `VERITAS_ENABLE_DIRECT_FUJI_API` を production で配布しない統制を継続してください。

--- a/docs/system_review_2026-03-26.md
+++ b/docs/system_review_2026-03-26.md
@@ -110,3 +110,13 @@ API運用層の安全性向上として反映しました。
 - **[HIGH] Direct FUJI API の本番有効化は重大リスク**  
   本改善で fail-fast + 実行時ガードを実装済みですが、設定管理（IaC / Secret Manager）
   でも `VERITAS_ENABLE_DIRECT_FUJI_API` を production で配布しない統制を継続してください。
+
+### 追記（E2E品質改善 / 2026-03-26）
+- `frontend/e2e/governance-flow.spec.ts` の待機条件に含まれていた `/version/i` が、
+  画面ヘッダー文言（versioning）に誤マッチして早期通過することで、実際のロード完了前に
+  `viewer role keeps apply action blocked` テストが判定へ進む不安定要因を確認。
+- 対策として、`waitForPolicyLoadOutcome` ヘルパーを導入し、
+  - apply ボタン可視化（ロード成功）
+  - エラーバナー可視化（ロード失敗）
+  のどちらかを待つ deterministic な待機へ変更。
+- これにより flake を抑制し、RBAC（viewer の apply 禁止）検証の意図を維持。

--- a/frontend/e2e/governance-flow.spec.ts
+++ b/frontend/e2e/governance-flow.spec.ts
@@ -1,4 +1,22 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+async function waitForPolicyLoadOutcome(
+  page: Page,
+): Promise<"loaded" | "error"> {
+  const applyButton = page.getByRole("button", { name: /適用|Apply/i }).first();
+  const errorBanner = page.locator('[role="alert"]').first();
+
+  const outcome = await Promise.race([
+    applyButton.waitFor({ state: "visible", timeout: 25_000 }).then(
+      () => "loaded" as const,
+    ),
+    errorBanner.waitFor({ state: "visible", timeout: 25_000 }).then(
+      () => "error" as const,
+    ),
+  ]);
+
+  return outcome;
+}
 
 test.describe("Governance: policy management flow", () => {
   test.beforeEach(async ({ page }) => {
@@ -40,18 +58,11 @@ test.describe("Governance: policy management flow", () => {
     });
     await loadButton.click();
 
-    // Wait for loading or result
-    await expect(
-      page
-        .getByText(
-          /読み込み中|Loading|HTTP|ネットワークエラー|Network error|version/i,
-        )
-        .first(),
-    ).toBeVisible({ timeout: 25_000 });
+    const outcome = await waitForPolicyLoadOutcome(page);
 
     // If error, verify retry button is present
     const errorBanner = page.locator('[role="alert"]');
-    if ((await errorBanner.count()) > 0) {
+    if (outcome === "error" || (await errorBanner.count()) > 0) {
       await expect(
         errorBanner.getByRole("button", { name: /再試行|Retry/i }),
       ).toBeVisible();
@@ -84,14 +95,10 @@ test.describe("Governance: policy management flow", () => {
       name: /ポリシーを読み込む|Load policy/i,
     });
     await loadButton.click();
-    await expect(
-      page
-        .getByText(/読み込み中|Loading|HTTP|ネットワークエラー|Network error|version/i)
-        .first(),
-    ).toBeVisible({ timeout: 25_000 });
+    const outcome = await waitForPolicyLoadOutcome(page);
 
     const applyButton = page.getByRole("button", { name: /適用|Apply/i });
-    if ((await applyButton.count()) > 0) {
+    if (outcome === "loaded" && (await applyButton.count()) > 0) {
       await page.getByLabel("role", { exact: true }).selectOption("viewer");
       await expect(applyButton).toBeDisabled();
       await expect(page.getByText(/RBAC: apply\/rollback/)).toBeVisible();

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -16,10 +16,12 @@ from fastapi import APIRouter, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
+from veritas_os.api.utils import _is_direct_fuji_api_enabled
 from veritas_os.api.pipeline_orchestrator import (
     get_runtime_config,
     update_runtime_config,
 )
+from veritas_os.logging.encryption import get_encryption_status
 # Note: report/compliance functions accessed via _get_server() to support
 # test monkeypatching on the server module.
 
@@ -77,6 +79,15 @@ def _trust_log_health(srv: Any) -> Dict[str, Any]:
     if error:
         details["error"] = error
     return {"status": status, "details": details}
+
+
+def _security_posture_snapshot() -> Dict[str, Any]:
+    """Return security-sensitive runtime toggles for operations visibility."""
+    encryption_status = get_encryption_status()
+    return {
+        "direct_fuji_api_enabled": _is_direct_fuji_api_enabled(),
+        "encryption": encryption_status,
+    }
 
 
 def _derive_alert_policy(
@@ -261,6 +272,7 @@ def health() -> Dict[str, Any]:
             "alert_policy": _derive_alert_policy(checks, runtime_features),
             "auth_store": auth_store["details"],
             "trust_log": trust_log["details"],
+            "security_posture": _security_posture_snapshot(),
         }
         if memory_health:
             result["memory_health"] = memory_health
@@ -322,6 +334,7 @@ def _system_status_snapshot(srv: Any) -> Dict[str, Any]:
         "alert_policy": _derive_alert_policy(checks, runtime_features),
         "auth_store": auth_store["details"],
         "trust_log": trust_log["details"],
+        "security_posture": _security_posture_snapshot(),
     }
     if memory_health:
         result["memory_health"] = memory_health

--- a/veritas_os/api/startup_health.py
+++ b/veritas_os/api/startup_health.py
@@ -62,6 +62,9 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
       not remain enabled in shared staging environments.
     - `NEXT_PUBLIC_VERITAS_API_BASE_URL` must never be present in production
       because it can leak internal routing details and triggers BFF fail-closed.
+    - `VERITAS_ENABLE_DIRECT_FUJI_API=true` must never be present in production
+      because it bypasses `/v1/decide` pipeline controls and expands attack
+      surface to direct FUJI policy probing.
     - `NODE_ENV=production` without `VERITAS_ENV=production` must emit a warning
       because frontend strict CSP defaults will not activate automatically.
     """
@@ -73,6 +76,7 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
         (os.getenv("VERITAS_AUTH_STORE_FAILURE_MODE") or "closed").strip().lower()
     )
     auth_fail_open_requested = auth_store_failure_mode == "open"
+    direct_fuji_enabled = _is_truthy_env("VERITAS_ENABLE_DIRECT_FUJI_API")
     public_api_base_url = (os.getenv("NEXT_PUBLIC_VERITAS_API_BASE_URL") or "").strip()
 
     if is_node_production and not is_production:
@@ -115,6 +119,16 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
             raise RuntimeError(
                 f"{message} Refusing startup in production."
             )
+        logger.warning("%s", message)
+
+    if direct_fuji_enabled:
+        message = (
+            "[SECURITY] VERITAS_ENABLE_DIRECT_FUJI_API=true is enabled. "
+            "Direct FUJI endpoints bypass `/v1/decide` orchestration controls, "
+            "so this flag must remain disabled in production."
+        )
+        if is_production:
+            raise RuntimeError(f"{message} Refusing startup in production.")
         logger.warning("%s", message)
 
 

--- a/veritas_os/api/utils.py
+++ b/veritas_os/api/utils.py
@@ -208,12 +208,29 @@ def _is_debug_mode() -> bool:
 
 
 def _is_direct_fuji_api_enabled() -> bool:
-    """Return whether direct FUJI API access is explicitly allowed."""
+    """Return whether direct FUJI API access is explicitly allowed.
+
+    Security guard:
+    Production profiles always force this feature off even when the flag is
+    set, because direct FUJI access bypasses `/v1/decide` pipeline controls.
+    """
     import os
+
     flag = os.getenv("VERITAS_ENABLE_DIRECT_FUJI_API", "")
     normalized_flag = flag.strip().lower()
     truthy_values = {"1", "true", "yes", "on"}
-    return normalized_flag in truthy_values
+    if normalized_flag not in truthy_values:
+        return False
+
+    profile = (os.getenv("VERITAS_ENV") or "").strip().lower()
+    if profile in {"prod", "production"}:
+        logger.warning(
+            "[security-warning] VERITAS_ENABLE_DIRECT_FUJI_API was ignored in "
+            "VERITAS_ENV=%s. Direct FUJI API is blocked in production.",
+            profile,
+        )
+        return False
+    return True
 
 
 def _parse_risk_from_trust_entry(entry: Dict[str, Any]) -> float | None:

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -127,6 +127,10 @@ class TestEnhancedHealth:
         assert "alert_policy" in data
         assert data["alert_policy"]["highest_priority"] in ("none", "P0", "P1")
         assert isinstance(data["alert_policy"]["alerts"], list)
+        assert "security_posture" in data
+        assert "direct_fuji_api_enabled" in data["security_posture"]
+        assert "encryption" in data["security_posture"]
+        assert "algorithm" in data["security_posture"]["encryption"]
 
     def test_health_exposes_memory_degradation_details(self, monkeypatch):
         """Non-fatal MemoryStore load issues should surface in /health."""

--- a/veritas_os/tests/test_api_startup_health.py
+++ b/veritas_os/tests/test_api_startup_health.py
@@ -175,6 +175,35 @@ def test_validate_startup_security_flags_warns_node_env_production_without_verit
     assert "NODE_ENV=production is set without VERITAS_ENV=production" in caplog.text
 
 
+def test_validate_startup_security_flags_warns_direct_fuji_non_production(
+    monkeypatch,
+    caplog,
+):
+    """Direct FUJI flag must raise a warning even in non-production."""
+    monkeypatch.setenv("VERITAS_ENV", "local")
+    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "true")
+
+    with caplog.at_level(logging.WARNING):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+    assert "VERITAS_ENABLE_DIRECT_FUJI_API=true is enabled" in caplog.text
+
+
+def test_validate_startup_security_flags_rejects_direct_fuji_in_production(
+    monkeypatch,
+):
+    """Production must reject direct FUJI API mode to preserve pipeline controls."""
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "true")
+
+    with pytest.raises(RuntimeError, match="VERITAS_ENABLE_DIRECT_FUJI_API=true"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
 def test_check_runtime_feature_health_logs_security_warning(caplog):
     """Security warning must be emitted when sanitization is unavailable."""
     with caplog.at_level(logging.WARNING):

--- a/veritas_os/tests/test_api_utils.py
+++ b/veritas_os/tests/test_api_utils.py
@@ -180,6 +180,16 @@ class TestIsDirectFujiApiEnabled:
         with mock.patch.dict(os.environ, {"VERITAS_ENABLE_DIRECT_FUJI_API": "1"}):
             assert _is_direct_fuji_api_enabled() is True
 
+    def test_forced_off_in_production(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "VERITAS_ENABLE_DIRECT_FUJI_API": "1",
+                "VERITAS_ENV": "production",
+            },
+        ):
+            assert _is_direct_fuji_api_enabled() is False
+
 
 class TestParseRiskFromTrustEntry:
     def test_direct_risk(self):


### PR DESCRIPTION
### Motivation
- Close a high-risk misconfiguration where `VERITAS_ENABLE_DIRECT_FUJI_API` could expose direct FUJI endpoints in production and bypass `/v1/decide` orchestration controls. 
- Improve operator visibility of runtime security posture (encryption / direct-FUJI flag) in health/status endpoints to reduce operational misinterpretation. 
- Make the fixes within the API/operations layer without touching Planner / Kernel / FUJI / MemoryOS responsibilities.

### Description
- Added a production safety guard in `_is_direct_fuji_api_enabled()` so `VERITAS_ENABLE_DIRECT_FUJI_API` is ignored/treated as disabled when `VERITAS_ENV` is `prod|production`, with a security-warning log in that case (`veritas_os/api/utils.py`).
- Extended startup validation `validate_startup_security_flags()` to warn for non-production and fail-fast (raise) for production when `VERITAS_ENABLE_DIRECT_FUJI_API=true` is present (`veritas_os/api/startup_health.py`).
- Exposed a `security_posture` snapshot from `/health` and `/status` that includes `direct_fuji_api_enabled` and the encryption backend/status via `get_encryption_status()` (`veritas_os/api/routes_system.py`).
- Updated/added unit tests to cover the new behavior and health payload fields (`veritas_os/tests/test_api_utils.py`, `veritas_os/tests/test_api_startup_health.py`, `veritas_os/tests/test_api_backend_improvements.py`).
- Appended `docs/system_review_2026-03-26.md` with the implementation log, test coverage summary, and an updated HIGH-severity security warning.

### Testing
- Ran targeted pytest: `pytest -q veritas_os/tests/test_api_utils.py::TestIsDirectFujiApiEnabled veritas_os/tests/test_api_startup_health.py::test_validate_startup_security_flags_warns_direct_fuji_non_production veritas_os/tests/test_api_startup_health.py::test_validate_startup_security_flags_rejects_direct_fuji_in_production veritas_os/tests/test_api_backend_improvements.py::TestEnhancedHealth::test_health_includes_checks`, result: `6 passed`.
- Compiled modified modules with `python -m compileall veritas_os/api/startup_health.py veritas_os/api/utils.py veritas_os/api/routes_system.py` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4bd0f5eec8326b80178abba60ad57)