### PR TITLE
Harden startup security by rejecting auth fail-open in staging

### DIFF
--- a/docs/reviews/system_improvement_review_ja_20260327.md
+++ b/docs/reviews/system_improvement_review_ja_20260327.md
@@ -1,0 +1,24 @@
+# VERITAS システム改善レビュー（2026-03-27）
+
+## 実施サマリー
+- 対象: `veritas_os/api/startup_health.py` と関連テスト
+- 目的: 共有ステージング環境での auth fail-open 誤設定を、警告止まりではなく fail-closed で遮断
+- 境界確認: Planner / Kernel / FUJI / MemoryOS の責務には未介入（API 起動時の設定検証のみ変更）
+
+## 改善内容
+1. `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` または `VERITAS_AUTH_STORE_FAILURE_MODE=open` が指定された場合:
+   - `VERITAS_ENV=prod|production` は従来通り起動拒否
+   - **`VERITAS_ENV=stg|staging` も新たに起動拒否**
+2. docstring のセキュリティ方針を更新し、staging を「保護対象の pre-production」と明示
+3. 回帰防止テストを追加
+   - `staging` + `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` で `RuntimeError`
+   - `stg` + `VERITAS_AUTH_STORE_FAILURE_MODE=open` で `RuntimeError`
+
+## セキュリティ警告（運用者向け）
+- **[HIGH] 認証ストア fail-open は、nonce / rate-limit / auth failure 制御を弱めます。**
+- 本変更後、staging でも fail-open は許可されません。IaC/環境変数配布の段階で該当フラグを除外してください。
+
+## 期待効果
+- 共有検証環境で「本番に近いセキュリティ前提」を維持
+- 設定ドリフト時に警告見落としで進行するリスクを削減
+- fail-closed 運用姿勢の一貫性向上

--- a/veritas_os/api/startup_health.py
+++ b/veritas_os/api/startup_health.py
@@ -58,8 +58,9 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
     - `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` must never be present in production.
     - `VERITAS_AUTH_STORE_FAILURE_MODE=open` must also be surfaced explicitly so
       operators can see the effective fail-open request during startup.
-    - Auth fail-open is only supported for local/test-style profiles and must
-      not remain enabled in shared staging environments.
+    - Auth fail-open is only supported for local/test-style profiles. Shared
+      staging profiles (`stg`/`staging`) are treated as protected pre-production
+      environments and must fail closed when fail-open is requested.
     - `NEXT_PUBLIC_VERITAS_API_BASE_URL` must never be present in production
       because it can leak internal routing details and triggers BFF fail-closed.
     - `VERITAS_ENABLE_DIRECT_FUJI_API=true` must never be present in production
@@ -100,6 +101,11 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
         )
         if is_production:
             raise RuntimeError(f"{message} Refusing startup in production.")
+        if profile in {"stg", "staging"}:
+            raise RuntimeError(
+                f"{message} Refusing startup for protected staging profile "
+                f"VERITAS_ENV={profile}."
+            )
         logger.warning("%s", message)
         if profile not in {"dev", "development", "local", "test"}:
             logger.warning(

--- a/veritas_os/tests/test_api_startup_health.py
+++ b/veritas_os/tests/test_api_startup_health.py
@@ -84,20 +84,30 @@ def test_validate_startup_security_flags_warns_non_production_requested_open_mod
     assert "VERITAS_AUTH_STORE_FAILURE_MODE=open is enabled" in caplog.text
 
 
-def test_validate_startup_security_flags_warns_fail_open_unsupported_profile(
+def test_validate_startup_security_flags_rejects_fail_open_in_staging(
     monkeypatch,
-    caplog,
 ):
-    """Shared non-production profiles should warn that fail-open is unsupported."""
+    """Staging must fail closed when auth fail-open flags are requested."""
     monkeypatch.setenv("VERITAS_ENV", "staging")
     monkeypatch.setenv("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true")
 
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(RuntimeError, match="VERITAS_ENV=staging"):
         startup_health.validate_startup_security_flags(
             logger=logging.getLogger("test.startup_health")
         )
 
-    assert "will be ignored by auth store fallback logic" in caplog.text
+
+def test_validate_startup_security_flags_rejects_open_mode_in_staging(
+    monkeypatch,
+):
+    """Staging must reject open auth-store fallback mode requests."""
+    monkeypatch.setenv("VERITAS_ENV", "stg")
+    monkeypatch.setenv("VERITAS_AUTH_STORE_FAILURE_MODE", "open")
+
+    with pytest.raises(RuntimeError, match="VERITAS_ENV=stg"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
 
 
 def test_validate_startup_security_flags_warns_fail_open_when_profile_unset(


### PR DESCRIPTION
### Motivation
- Shared staging environments should preserve production-like auth security guarantees and must not silently allow auth-store fail-open settings. 
- Current behavior only warned for staging, which permits risky misconfiguration drift during startup; this change enforces fail-closed for protected pre-production profiles. 
- The change must remain within API startup validation and not alter Planner / Kernel / FUJI / MemoryOS responsibilities.

### Description
- Strengthen `validate_startup_security_flags` so that when `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` or `VERITAS_AUTH_STORE_FAILURE_MODE=open` is requested, the function raises a `RuntimeError` for `VERITAS_ENV` values `stg` and `staging` in addition to existing `prod|production` checks, and update the function docstring to reflect staging as protected pre-production. 
- Add regression tests in `veritas_os/tests/test_api_startup_health.py` that assert `RuntimeError` is raised for `VERITAS_ENV=staging` with `VERITAS_AUTH_ALLOW_FAIL_OPEN=true` and for `VERITAS_ENV=stg` with `VERITAS_AUTH_STORE_FAILURE_MODE=open`. 
- Add a Japanese system improvement review document `docs/reviews/system_improvement_review_ja_20260327.md` summarizing the rationale, scope, and operational guidance.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_startup_health.py` and all tests passed (`19 passed`).
- Changes are limited to startup validation, associated tests, and docs; no tests were modified outside `test_api_startup_health.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5fda004448326925312f24cba6da5)