### PR TITLE
Enforce MemoryOS allowlist validation under production profile in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,11 @@ jobs:
         run: python scripts/quality/check_frontend_docs_consistency.py
 
       - name: Memory directory allowlist check
+        env:
+          VERITAS_ENV: "production"
+          VERITAS_MEMORY_DIR: "/tmp/veritas_memory_ci/runtime"
+          VERITAS_MEMORY_DIR_ALLOWLIST: "/tmp/veritas_memory_ci"
+          VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION: "1"
         run: python scripts/security/check_memory_dir_allowlist.py
 
       - name: httpx raw upload deprecation check

--- a/docs/reviews/full_code_review_20260327.md
+++ b/docs/reviews/full_code_review_20260327.md
@@ -55,3 +55,34 @@
 ## 結論
 - 本実行で確認した範囲では、アーキテクチャ統制と基礎セキュリティ統制は良好であり、即時の重大ブロッカーは検出されなかった。
 - ただし、**MemoryOS allowlist の本番相当検証がスキップされた点は明確な警告事項**であり、環境を揃えた再検証が必要。
+
+---
+
+## 改善実施記録（2026-03-27 追記）
+
+### 実施内容
+1. **CI での MemoryOS allowlist 検査を本番プロファイル固定で実行**
+   - `.github/workflows/main.yml` の `Memory directory allowlist check` ステップに、以下を追加:
+     - `VERITAS_ENV=production`
+     - `VERITAS_MEMORY_DIR=/tmp/veritas_memory_ci/runtime`
+     - `VERITAS_MEMORY_DIR_ALLOWLIST=/tmp/veritas_memory_ci`
+     - `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION=1`
+   - これにより、CI 上で「non-production / 未設定のためスキップ」が発生しない運用へ改善。
+
+2. **allowlist チェックスクリプトに strict mode を追加**
+   - `scripts/security/check_memory_dir_allowlist.py` に
+     `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION` を導入。
+   - strict mode 有効時は、production 検証がスキップされる構成（`VERITAS_ENV` 非 production または `VERITAS_MEMORY_DIR` 未設定）を **明示的に失敗** させる。
+   - セキュリティ意図:
+     - チェックの「未実行」を見逃してリリースするリスクを低減。
+     - MemoryOS 設定ドリフトを CI で早期検知。
+
+3. **回帰テストを追加**
+   - `veritas_os/tests/test_check_memory_dir_allowlist.py` に以下を追加:
+     - strict mode で検証スキップ時に失敗すること
+     - strict mode で正しい production 設定時に成功すること
+
+### セキュリティ警告（継続）
+- strict mode は CI 側で有効化しないと機能しないため、将来 workflow が変更された際に
+  `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION=1` が欠落しないよう保守が必要。
+- 実運用では、`VERITAS_MEMORY_DIR_ALLOWLIST` を最小権限のディレクトリ範囲に限定し、過剰に広い許可（例: `/tmp` 全体）を避けること。

--- a/scripts/security/check_memory_dir_allowlist.py
+++ b/scripts/security/check_memory_dir_allowlist.py
@@ -16,12 +16,19 @@ from typing import Sequence
 
 
 PRODUCTION_ALIASES = {"prod", "production"}
+STRICT_PRODUCTION_ENV = "VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION"
 
 
-def _is_production_profile() -> bool:
-    """Return whether the current environment requests a production profile."""
-    profile = (os.getenv("VERITAS_ENV", "") or "").strip().lower()
-    return profile in PRODUCTION_ALIASES
+def _is_strict_production_required(environ: dict[str, str]) -> bool:
+    """Return whether CI must fail when production validation is skipped.
+
+    Security rationale:
+        CI skipping this check can hide drift where deployments stop validating
+        MemoryOS allowlist settings. This strict mode enforces explicit
+        production-profile validation in automated pipelines.
+    """
+    raw_value = (environ.get(STRICT_PRODUCTION_ENV, "") or "").strip().lower()
+    return raw_value in {"1", "true", "yes", "on"}
 
 
 def _normalize_allowlist(raw_allowlist: str) -> list[Path]:
@@ -99,9 +106,24 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Run the production memory-dir configuration check."""
     del argv  # reserved for future CLI options
 
-    ok, findings = validate_memory_dir_configuration()
+    environ = dict(os.environ)
+    ok, findings = validate_memory_dir_configuration(environ)
+    strict_required = _is_strict_production_required(environ)
+    production_profile = (environ.get("VERITAS_ENV", "") or "").strip().lower()
+    configured_dir = (environ.get("VERITAS_MEMORY_DIR", "") or "").strip()
+
+    if strict_required and (
+        production_profile not in PRODUCTION_ALIASES or not configured_dir
+    ):
+        print(
+            "[SECURITY] Strict mode enabled, but production MemoryOS allowlist "
+            "validation was skipped. Set VERITAS_ENV=production and provide "
+            "VERITAS_MEMORY_DIR plus VERITAS_MEMORY_DIR_ALLOWLIST."
+        )
+        return 1
+
     if ok:
-        if _is_production_profile() and os.getenv("VERITAS_MEMORY_DIR", "").strip():
+        if production_profile in PRODUCTION_ALIASES and configured_dir:
             print("MemoryOS production directory configuration is valid.")
         else:
             print(

--- a/veritas_os/tests/test_check_memory_dir_allowlist.py
+++ b/veritas_os/tests/test_check_memory_dir_allowlist.py
@@ -79,3 +79,37 @@ def test_main_returns_non_zero_for_invalid_configuration(
     assert exit_code == 1
     assert "[SECURITY]" in output
     assert "VERITAS_MEMORY_DIR" in output
+
+
+def test_main_strict_mode_fails_when_production_validation_is_skipped(
+    monkeypatch, capsys
+) -> None:
+    """Strict mode requires production-profile MemoryOS validation in CI."""
+    monkeypatch.setenv("VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION", "1")
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+    monkeypatch.delenv("VERITAS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("VERITAS_MEMORY_DIR_ALLOWLIST", raising=False)
+
+    exit_code = checker.main([])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Strict mode enabled" in output
+
+
+def test_main_strict_mode_passes_with_valid_production_configuration(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Strict mode passes when CI provides valid production allowlist config."""
+    allow_root = tmp_path / "allowed"
+    configured = allow_root / "memory"
+    monkeypatch.setenv("VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION", "1")
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_MEMORY_DIR", str(configured))
+    monkeypatch.setenv("VERITAS_MEMORY_DIR_ALLOWLIST", str(allow_root))
+
+    exit_code = checker.main([])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "MemoryOS production directory configuration is valid." in output


### PR DESCRIPTION
### Motivation
- The review found `check_memory_dir_allowlist.py` could be skipped in CI when `VERITAS_ENV` is non-production or `VERITAS_MEMORY_DIR` is unset, hiding configuration drift. 
- CI should fail fast when production-style MemoryOS allowlist validation is not actually exercised to reduce release risk.

### Description
- Add `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION` (constant `STRICT_PRODUCTION_ENV`) and helper `_is_strict_production_required` to `scripts/security/check_memory_dir_allowlist.py`. 
- Update `main()` to accept an `environ` snapshot, enforce strict mode and return non-zero when production validation is skipped under strict mode, and keep existing allowlist validation logic via `validate_memory_dir_configuration`. 
- Fix CI step in `.github/workflows/main.yml` to run the MemoryOS allowlist check with `VERITAS_ENV=production`, a test `VERITAS_MEMORY_DIR`, `VERITAS_MEMORY_DIR_ALLOWLIST`, and `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION=1`. 
- Add regression tests in `veritas_os/tests/test_check_memory_dir_allowlist.py` to cover strict-mode fail when skipped and strict-mode pass with valid production configuration, and update `docs/reviews/full_code_review_20260327.md` with the change log and cautions. 

### Testing
- Ran `pytest -q veritas_os/tests/test_check_memory_dir_allowlist.py` and all tests passed (`7 passed`).
- Ran `ruff check scripts/security/check_memory_dir_allowlist.py veritas_os/tests/test_check_memory_dir_allowlist.py` and linter checks passed (All checks passed!).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6139b13d08326b7f63d2dc5c38113)