### PR TITLE
Harden MemoryOS allowlist validation by enabling strict mode in CI

### DIFF
--- a/docs/reviews/full_code_review_20260327.md
+++ b/docs/reviews/full_code_review_20260327.md
@@ -82,7 +82,23 @@
      - strict mode で検証スキップ時に失敗すること
      - strict mode で正しい production 設定時に成功すること
 
+4. **CI 環境で strict mode をデフォルト有効化（ドリフト耐性の強化）**
+   - `scripts/security/check_memory_dir_allowlist.py` の strict 判定を拡張し、
+     `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION` が未設定でも
+     `CI=true` の場合は strict mode を有効化するよう改善。
+   - 効果:
+     - workflow 変更時に strict 用 env の付与漏れがあっても、CI 実行自体で
+       「production 検証スキップ」を失敗として検知できる。
+     - 既存の明示フラグ (`VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION=1`) は
+       従来どおり優先され、互換性を維持。
+
+5. **CI strict 既定化の回帰テストを追加**
+   - `veritas_os/tests/test_check_memory_dir_allowlist.py` に
+     `CI=true` かつ production 設定未指定時は `checker.main([])` が失敗するテストを追加。
+   - これにより、将来 strict 判定ロジックが緩んだ場合の退行を自動検知可能。
+
 ### セキュリティ警告（継続）
-- strict mode は CI 側で有効化しないと機能しないため、将来 workflow が変更された際に
-  `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION=1` が欠落しないよう保守が必要。
+- strict mode は `CI=true` でも既定有効になったが、ローカル/手動実行では
+  既定で有効化されない。必要なジョブでは引き続き
+  `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION=1` を明示し、実行条件の意図を固定すること。
 - 実運用では、`VERITAS_MEMORY_DIR_ALLOWLIST` を最小権限のディレクトリ範囲に限定し、過剰に広い許可（例: `/tmp` 全体）を避けること。

--- a/scripts/security/check_memory_dir_allowlist.py
+++ b/scripts/security/check_memory_dir_allowlist.py
@@ -17,6 +17,7 @@ from typing import Sequence
 
 PRODUCTION_ALIASES = {"prod", "production"}
 STRICT_PRODUCTION_ENV = "VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION"
+CI_ENV = "CI"
 
 
 def _is_strict_production_required(environ: dict[str, str]) -> bool:
@@ -28,7 +29,13 @@ def _is_strict_production_required(environ: dict[str, str]) -> bool:
         production-profile validation in automated pipelines.
     """
     raw_value = (environ.get(STRICT_PRODUCTION_ENV, "") or "").strip().lower()
-    return raw_value in {"1", "true", "yes", "on"}
+    if raw_value in {"1", "true", "yes", "on"}:
+        return True
+
+    # In CI pipelines, treat strict validation as opt-out to avoid silently
+    # skipping production-profile checks when workflow env wiring drifts.
+    ci_value = (environ.get(CI_ENV, "") or "").strip().lower()
+    return ci_value in {"1", "true", "yes", "on"}
 
 
 def _normalize_allowlist(raw_allowlist: str) -> list[Path]:

--- a/veritas_os/tests/test_check_memory_dir_allowlist.py
+++ b/veritas_os/tests/test_check_memory_dir_allowlist.py
@@ -113,3 +113,20 @@ def test_main_strict_mode_passes_with_valid_production_configuration(
 
     assert exit_code == 0
     assert "MemoryOS production directory configuration is valid." in output
+
+
+def test_main_ci_env_enforces_strict_validation_when_skipped(
+    monkeypatch, capsys
+) -> None:
+    """CI environment must fail when production-profile validation is skipped."""
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION", raising=False)
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+    monkeypatch.delenv("VERITAS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("VERITAS_MEMORY_DIR_ALLOWLIST", raising=False)
+
+    exit_code = checker.main([])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Strict mode enabled" in output


### PR DESCRIPTION
### Motivation
- Prevent CI from silently skipping production MemoryOS allowlist validation when the explicit strict env (`VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION`) is accidentally omitted. 
- Make automated pipelines fail fast on missing production allowlist configuration to reduce release drift risk.

### Description
- Treat `CI=true` as enabling strict validation by default in `_is_strict_production_required` within `scripts/security/check_memory_dir_allowlist.py` so CI runs enforce production-check failure when skipped. 
- Add a regression test `test_main_ci_env_enforces_strict_validation_when_skipped` to `veritas_os/tests/test_check_memory_dir_allowlist.py` that ensures `checker.main([])` fails when `CI=true` and production settings are absent. 
- Update `docs/reviews/full_code_review_20260327.md` to record the CI-default strict behavior, its rationale, and an operational guidance note to still explicitly set `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION=1` where intended.

### Testing
- Ran `pytest -q veritas_os/tests/test_check_memory_dir_allowlist.py` and observed `8 passed`.
- Ran `ruff check scripts/security/check_memory_dir_allowlist.py veritas_os/tests/test_check_memory_dir_allowlist.py` and observed `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c61b889bfc8326a2abbb03e7ad4d27)