### PR TITLE
Harden MemoryOS allowlist validation to reject filesystem-root ('/') entries

### DIFF
--- a/docs/reviews/full_code_review_20260327.md
+++ b/docs/reviews/full_code_review_20260327.md
@@ -97,8 +97,21 @@
      `CI=true` かつ production 設定未指定時は `checker.main([])` が失敗するテストを追加。
    - これにより、将来 strict 判定ロジックが緩んだ場合の退行を自動検知可能。
 
+6. **allowlist の過剰許可（`/`）を検知して失敗化**
+   - `scripts/security/check_memory_dir_allowlist.py` に
+     `VERITAS_MEMORY_DIR_ALLOWLIST=/`（filesystem root）を過剰許可として
+     明示的に reject する検証を追加。
+   - `veritas_os/tests/test_check_memory_dir_allowlist.py` に
+     root allowlist を拒否する回帰テストを追加。
+   - セキュリティ意図:
+     - allowlist が実質無制限になる構成を CI/レビュー段階で遮断。
+     - 「allowlist を設定しているが制約が効いていない」誤設定を予防。
+
 ### セキュリティ警告（継続）
 - strict mode は `CI=true` でも既定有効になったが、ローカル/手動実行では
   既定で有効化されない。必要なジョブでは引き続き
   `VERITAS_MEMORY_DIR_CHECK_REQUIRE_PRODUCTION=1` を明示し、実行条件の意図を固定すること。
 - 実運用では、`VERITAS_MEMORY_DIR_ALLOWLIST` を最小権限のディレクトリ範囲に限定し、過剰に広い許可（例: `/tmp` 全体）を避けること。
+- `VERITAS_MEMORY_DIR_ALLOWLIST=/` は検査で拒否されるが、`/var` や `/tmp` など
+  広すぎる上位ディレクトリは依然として運用判断に依存する。環境ごとに専用サブディレクトリ
+  （例: `/var/lib/veritas/memory`）へさらに絞り込むこと。

--- a/scripts/security/check_memory_dir_allowlist.py
+++ b/scripts/security/check_memory_dir_allowlist.py
@@ -47,6 +47,16 @@ def _normalize_allowlist(raw_allowlist: str) -> list[Path]:
     ]
 
 
+def _find_overbroad_allowlist_prefixes(allow_prefixes: list[Path]) -> list[Path]:
+    """Return allowlist prefixes that are too broad for secure operation.
+
+    Security rationale:
+        Allowing the filesystem root (`/`) effectively disables containment and
+        defeats the purpose of MemoryOS directory restrictions.
+    """
+    return [prefix for prefix in allow_prefixes if prefix.parent == prefix]
+
+
 def validate_memory_dir_configuration(
     env: dict[str, str] | None = None,
 ) -> tuple[bool, list[str]]:
@@ -85,6 +95,19 @@ def validate_memory_dir_configuration(
         findings.append(
             "[SECURITY] VERITAS_MEMORY_DIR_ALLOWLIST must be set when "
             "VERITAS_MEMORY_DIR is configured in production."
+        )
+        return False, findings
+
+    overbroad_prefixes = _find_overbroad_allowlist_prefixes(allow_prefixes)
+    if overbroad_prefixes:
+        findings.append(
+            "[SECURITY] VERITAS_MEMORY_DIR_ALLOWLIST contains an overbroad "
+            "filesystem-root entry. Use a dedicated minimal directory prefix "
+            "instead of '/'."
+        )
+        findings.append(
+            "- overbroad_allowlist: "
+            + ", ".join(str(prefix) for prefix in overbroad_prefixes)
         )
         return False, findings
 

--- a/veritas_os/tests/test_check_memory_dir_allowlist.py
+++ b/veritas_os/tests/test_check_memory_dir_allowlist.py
@@ -65,6 +65,23 @@ def test_validate_accepts_allowlisted_production_dir(tmp_path: Path) -> None:
     assert findings == []
 
 
+def test_validate_rejects_filesystem_root_allowlist_in_production(
+    tmp_path: Path,
+) -> None:
+    """Production deployments must not use filesystem-root allowlist entries."""
+    ok, findings = checker.validate_memory_dir_configuration(
+        {
+            "VERITAS_ENV": "production",
+            "VERITAS_MEMORY_DIR": str(tmp_path / "memory"),
+            "VERITAS_MEMORY_DIR_ALLOWLIST": "/",
+        }
+    )
+
+    assert ok is False
+    assert any("filesystem-root entry" in line for line in findings)
+    assert any("overbroad_allowlist:" in line for line in findings)
+
+
 def test_main_returns_non_zero_for_invalid_configuration(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
### Motivation
- Production 環境で `VERITAS_MEMORY_DIR_ALLOWLIST` に filesystem root (`/`) を含めると allowlist が実質無制限になり、MemoryOS の意図した制約が失われるため自動検査で検出・失敗させて誤設定を防止する。 

### Description
- `scripts/security/check_memory_dir_allowlist.py` に `_find_overbroad_allowlist_prefixes` を追加し、allowlist に filesystem-root 相当の過剰許可エントリを検出するロジックを導入した。 
- production 検証中に過剰許可（`/`）が見つかった場合はセキュリティ所見を出力して失敗するよう `validate_memory_dir_configuration` を拡張した。 
- `veritas_os/tests/test_check_memory_dir_allowlist.py` に `test_validate_rejects_filesystem_root_allowlist_in_production` を追加して root allowlist を拒否する回帰テストを導入した。 
- `docs/reviews/full_code_review_20260327.md` に今回の改善記録と運用上の注意点を追記した。 

### Testing
- Lint を実行して `ruff check scripts/security/check_memory_dir_allowlist.py veritas_os/tests/test_check_memory_dir_allowlist.py` は成功した。 
- 単体テストを `pytest -q veritas_os/tests/test_check_memory_dir_allowlist.py` で実行し `9 passed` で成功した。 
- CLI を `python scripts/security/check_memory_dir_allowlist.py` で実行し、非 production 設定下でスキップ動作を確認した（exit 0）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c621d520a08326a1af29a22f6e04d2)