### PR TITLE
Harden MemoryOS allowlist validation against relative paths

### DIFF
--- a/docs/reviews/full_code_review_20260327.md
+++ b/docs/reviews/full_code_review_20260327.md
@@ -107,6 +107,15 @@
      - allowlist が実質無制限になる構成を CI/レビュー段階で遮断。
      - 「allowlist を設定しているが制約が効いていない」誤設定を予防。
 
+7. **allowlist の相対パス指定を拒否して設定ドリフトを予防**
+   - `scripts/security/check_memory_dir_allowlist.py` に
+     `VERITAS_MEMORY_DIR_ALLOWLIST` が相対パスを含む場合の失敗判定を追加。
+   - `veritas_os/tests/test_check_memory_dir_allowlist.py` に
+     相対 allowlist を拒否する回帰テストを追加。
+   - セキュリティ意図:
+     - 実行カレントディレクトリ依存で allowlist 解釈が変わる構成を遮断。
+     - CI と実運用のパス解決差による見逃しリスクを低減。
+
 ### セキュリティ警告（継続）
 - strict mode は `CI=true` でも既定有効になったが、ローカル/手動実行では
   既定で有効化されない。必要なジョブでは引き続き
@@ -115,3 +124,5 @@
 - `VERITAS_MEMORY_DIR_ALLOWLIST=/` は検査で拒否されるが、`/var` や `/tmp` など
   広すぎる上位ディレクトリは依然として運用判断に依存する。環境ごとに専用サブディレクトリ
   （例: `/var/lib/veritas/memory`）へさらに絞り込むこと。
+- `VERITAS_MEMORY_DIR_ALLOWLIST` に相対パスを使うと検査は失敗する。必ず絶対パスで明示し、
+  実行場所に依存しない設定に統一すること。

--- a/scripts/security/check_memory_dir_allowlist.py
+++ b/scripts/security/check_memory_dir_allowlist.py
@@ -47,6 +47,18 @@ def _normalize_allowlist(raw_allowlist: str) -> list[Path]:
     ]
 
 
+def _find_non_absolute_allowlist_entries(raw_allowlist: str) -> list[str]:
+    """Return raw allowlist entries that are not absolute filesystem paths."""
+    non_absolute_entries: list[str] = []
+    for raw_prefix in raw_allowlist.split(","):
+        normalized = raw_prefix.strip()
+        if not normalized:
+            continue
+        if not Path(normalized).expanduser().is_absolute():
+            non_absolute_entries.append(normalized)
+    return non_absolute_entries
+
+
 def _find_overbroad_allowlist_prefixes(allow_prefixes: list[Path]) -> list[Path]:
     """Return allowlist prefixes that are too broad for secure operation.
 
@@ -95,6 +107,20 @@ def validate_memory_dir_configuration(
         findings.append(
             "[SECURITY] VERITAS_MEMORY_DIR_ALLOWLIST must be set when "
             "VERITAS_MEMORY_DIR is configured in production."
+        )
+        return False, findings
+
+    non_absolute_allowlist_entries = _find_non_absolute_allowlist_entries(
+        raw_allowlist
+    )
+    if non_absolute_allowlist_entries:
+        findings.append(
+            "[SECURITY] VERITAS_MEMORY_DIR_ALLOWLIST must contain absolute "
+            "paths in production deployments."
+        )
+        findings.append(
+            "- non_absolute_allowlist_entries: "
+            + ", ".join(non_absolute_allowlist_entries)
         )
         return False, findings
 

--- a/veritas_os/tests/test_check_memory_dir_allowlist.py
+++ b/veritas_os/tests/test_check_memory_dir_allowlist.py
@@ -82,6 +82,21 @@ def test_validate_rejects_filesystem_root_allowlist_in_production(
     assert any("overbroad_allowlist:" in line for line in findings)
 
 
+def test_validate_rejects_non_absolute_allowlist_in_production(tmp_path: Path) -> None:
+    """Production allowlist entries must be absolute paths to avoid drift."""
+    ok, findings = checker.validate_memory_dir_configuration(
+        {
+            "VERITAS_ENV": "production",
+            "VERITAS_MEMORY_DIR": str(tmp_path / "memory"),
+            "VERITAS_MEMORY_DIR_ALLOWLIST": "relative/path",
+        }
+    )
+
+    assert ok is False
+    assert any("must contain absolute paths" in line for line in findings)
+    assert any("non_absolute_allowlist_entries:" in line for line in findings)
+
+
 def test_main_returns_non_zero_for_invalid_configuration(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
### Motivation
- Prevent configuration drift where `VERITAS_MEMORY_DIR_ALLOWLIST` uses relative paths that resolve differently between CI and runtime and can weaken MemoryOS containment guarantees.

### Description
- Add `_find_non_absolute_allowlist_entries` and reject production configurations where `VERITAS_MEMORY_DIR_ALLOWLIST` contains non-absolute paths in `scripts/security/check_memory_dir_allowlist.py`.
- Add a regression test `test_validate_rejects_non_absolute_allowlist_in_production` in `veritas_os/tests/test_check_memory_dir_allowlist.py` and update `docs/reviews/full_code_review_20260327.md` to document the change and operational guidance.

### Testing
- Ran `pytest -q veritas_os/tests/test_check_memory_dir_allowlist.py` and all tests passed (`10 passed`).
- Ran `ruff check scripts/security/check_memory_dir_allowlist.py veritas_os/tests/test_check_memory_dir_allowlist.py` and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c629516738832683a7eb32c05511c3)