### PR TITLE
Add CI security guard for unsafe dynamic execution patterns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,9 @@ jobs:
       - name: subprocess shell usage check
         run: python scripts/security/check_subprocess_shell_usage.py
 
+      - name: unsafe dynamic execution/deserialization check
+        run: python scripts/security/check_unsafe_dynamic_execution_usage.py
+
       - name: replay pipeline-version unknown-rate check
         run: |
           python scripts/quality/check_replay_pipeline_version_unknown_rate.py \

--- a/docs/reviews/full_code_review_20260327.md
+++ b/docs/reviews/full_code_review_20260327.md
@@ -126,3 +126,15 @@
   （例: `/var/lib/veritas/memory`）へさらに絞り込むこと。
 - `VERITAS_MEMORY_DIR_ALLOWLIST` に相対パスを使うと検査は失敗する。必ず絶対パスで明示し、
   実行場所に依存しない設定に統一すること。
+
+8. **危険APIパターン検知をスクリプト化して CI 常設化**
+   - `scripts/security/check_unsafe_dynamic_execution_usage.py` を追加し、
+     `eval(...)` / `exec(...)` / `pickle.loads(...)` / `yaml.load(...)` を
+     AST ベースで検出して失敗化するよう改善。
+   - `.github/workflows/main.yml` の lint ジョブに
+     `unsafe dynamic execution/deserialization check` ステップを追加。
+   - `veritas_os/tests/test_check_unsafe_dynamic_execution_usage.py` に
+     検知・非検知・CLI 終了コード・テストディレクトリ除外の回帰テストを追加。
+   - セキュリティ意図:
+     - これまで `rg` に依存していた危険 API の検出を再現可能な CI ガードレールへ昇格。
+     - レビュー手順の運用漏れ（手動実行忘れ）を抑止。

--- a/scripts/security/check_unsafe_dynamic_execution_usage.py
+++ b/scripts/security/check_unsafe_dynamic_execution_usage.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Detect unsafe dynamic execution and deserialization usage patterns.
+
+This checker rejects high-risk runtime primitives in production code:
+- ``eval(...)``
+- ``exec(...)``
+- ``pickle.loads(...)``
+- ``yaml.load(...)``
+
+Security rationale:
+    These APIs increase remote code execution risk when data provenance
+    assumptions drift over time. The project policy requires safer alternatives
+    (for example, ``yaml.safe_load``) and explicit review before any exception.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCAN_ROOTS = (
+    REPO_ROOT / "veritas_os",
+    REPO_ROOT / "scripts",
+)
+SKIP_DIR_NAMES = {
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".venv",
+    "node_modules",
+}
+SKIP_PATH_PARTS = {"tests"}
+
+
+@dataclass(frozen=True)
+class Violation:
+    """Represents one detected dynamic-execution security violation."""
+
+    path: Path
+    line: int
+    message: str
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check Python source for unsafe dynamic execution and "
+            "deserialization APIs (eval/exec/pickle.loads/yaml.load)."
+        )
+    )
+    parser.add_argument(
+        "--scan-root",
+        action="append",
+        default=[],
+        help="Optional directory/file to scan. Can be provided multiple times.",
+    )
+    return parser.parse_args(argv)
+
+
+def _iter_python_files(scan_roots: list[Path]) -> list[Path]:
+    """Return Python files under roots while skipping cache/vendor/test dirs."""
+    files: list[Path] = []
+    for root in scan_roots:
+        resolved = root.resolve(strict=False)
+        if not resolved.exists():
+            continue
+        if resolved.is_file() and resolved.suffix == ".py":
+            files.append(resolved)
+            continue
+
+        for path in resolved.rglob("*.py"):
+            if any(part in SKIP_DIR_NAMES for part in path.parts):
+                continue
+            if any(part in SKIP_PATH_PARTS for part in path.parts):
+                continue
+            files.append(path)
+    return files
+
+
+def _is_name_call(call: ast.Call, func_name: str) -> bool:
+    """Return True if ``call`` targets a plain name (e.g., eval(...))."""
+    return isinstance(call.func, ast.Name) and call.func.id == func_name
+
+
+def _is_attr_call(call: ast.Call, module_name: str, attr_name: str) -> bool:
+    """Return True if ``call`` targets a module attribute call."""
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == attr_name
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == module_name
+    )
+
+
+def _scan_file(path: Path) -> list[Violation]:
+    """Scan one Python file and return detected violations."""
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        if _is_name_call(node, "eval"):
+            violations.append(
+                Violation(
+                    path=path,
+                    line=node.lineno,
+                    message="eval(...) is forbidden due to code injection risk",
+                )
+            )
+        if _is_name_call(node, "exec"):
+            violations.append(
+                Violation(
+                    path=path,
+                    line=node.lineno,
+                    message="exec(...) is forbidden due to code injection risk",
+                )
+            )
+        if _is_attr_call(node, "pickle", "loads"):
+            violations.append(
+                Violation(
+                    path=path,
+                    line=node.lineno,
+                    message=(
+                        "pickle.loads(...) is forbidden for untrusted data; "
+                        "use a safe serialization format"
+                    ),
+                )
+            )
+        if _is_attr_call(node, "yaml", "load"):
+            violations.append(
+                Violation(
+                    path=path,
+                    line=node.lineno,
+                    message=(
+                        "yaml.load(...) is forbidden; use yaml.safe_load(...) "
+                        "with trusted schema validation"
+                    ),
+                )
+            )
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run scan and return shell exit code."""
+    parsed = _parse_args(argv or sys.argv[1:])
+    scan_roots = DEFAULT_SCAN_ROOTS + tuple(Path(p) for p in parsed.scan_root)
+
+    violations: list[Violation] = []
+    for file_path in _iter_python_files(list(scan_roots)):
+        violations.extend(_scan_file(file_path))
+
+    if not violations:
+        print("No unsafe dynamic execution/deserialization usage detected.")
+        return 0
+
+    print("Unsafe dynamic execution/deserialization usage detected:")
+    for item in sorted(violations, key=lambda it: (str(it.path), it.line, it.message)):
+        try:
+            relative = item.path.relative_to(REPO_ROOT)
+        except ValueError:
+            relative = item.path
+        print(f"- {relative}:{item.line}: {item.message}")
+
+    print(
+        "\nSecurity remediation: remove eval/exec, avoid pickle.loads on runtime "
+        "data, and replace yaml.load with yaml.safe_load plus schema checks."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_check_unsafe_dynamic_execution_usage.py
+++ b/veritas_os/tests/test_check_unsafe_dynamic_execution_usage.py
@@ -1,0 +1,105 @@
+"""Tests for scripts.security.check_unsafe_dynamic_execution_usage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.security import check_unsafe_dynamic_execution_usage as checker
+
+
+def test_scan_file_detects_forbidden_patterns(tmp_path: Path) -> None:
+    """Scanner should flag eval/exec/pickle.loads/yaml.load usage."""
+    source = tmp_path / "bad.py"
+    source.write_text(
+        "\n".join(
+            [
+                "import pickle",
+                "import yaml",
+                "eval('1 + 1')",
+                "exec('x = 1')",
+                "pickle.loads(data)",
+                "yaml.load(text)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert len(violations) == 4
+    assert any("eval(...)" in violation.message for violation in violations)
+    assert any("exec(...)" in violation.message for violation in violations)
+    assert any("pickle.loads(...)" in violation.message for violation in violations)
+    assert any("yaml.load(...)" in violation.message for violation in violations)
+
+
+def test_scan_file_allows_safe_alternatives(tmp_path: Path) -> None:
+    """Scanner should allow safe alternatives and non-forbidden names."""
+    source = tmp_path / "good.py"
+    source.write_text(
+        "\n".join(
+            [
+                "import yaml",
+                "data = yaml.safe_load(text)",
+                "result = literal_eval_like(value)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert violations == []
+
+
+def test_main_returns_non_zero_when_violation_found(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    """Command should fail and print remediation guidance on violations."""
+    source = tmp_path / "bad.py"
+    source.write_text("eval('1 + 1')\n", encoding="utf-8")
+
+    monkeypatch.setattr(checker, "DEFAULT_SCAN_ROOTS", ())
+    exit_code = checker.main(["--scan-root", str(source)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Unsafe dynamic execution/deserialization usage detected" in output
+    assert "Security remediation" in output
+
+
+def test_main_returns_zero_when_clean(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    """Command should succeed and print clean-status output."""
+    source = tmp_path / "good.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(checker, "DEFAULT_SCAN_ROOTS", ())
+    exit_code = checker.main(["--scan-root", str(source)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "No unsafe dynamic execution/deserialization usage detected" in output
+
+
+def test_iter_python_files_skips_tests_directory(tmp_path: Path) -> None:
+    """File iterator should skip test directories to reduce false positives."""
+    app_dir = tmp_path / "veritas_os"
+    tests_dir = app_dir / "tests"
+    app_dir.mkdir()
+    tests_dir.mkdir()
+
+    prod_file = app_dir / "runtime.py"
+    test_file = tests_dir / "test_runtime.py"
+    prod_file.write_text("print('ok')\n", encoding="utf-8")
+    test_file.write_text("print('test')\n", encoding="utf-8")
+
+    files = checker._iter_python_files([app_dir])
+
+    assert prod_file.resolve() in files
+    assert test_file.resolve() not in files


### PR DESCRIPTION
### Motivation
- Replace a partly manual `rg`-based dangerous-API check with an automated, reproducible CI guard to reduce operational omission risk. 
- Keep the change minimal and focused: block a small, high-risk set of runtime primitives (`eval`, `exec`, `pickle.loads`, `yaml.load`) without broad behavioral changes to core components.

### Description
- Add `scripts/security/check_unsafe_dynamic_execution_usage.py`, an AST-based scanner that flags `eval(...)`, `exec(...)`, `pickle.loads(...)`, and `yaml.load(...)` in production code paths and exits non-zero on findings. 
- Add regression tests in `veritas_os/tests/test_check_unsafe_dynamic_execution_usage.py` that cover detection, safe-alternative non-detection, CLI exit codes, and skipping of `tests` directories. 
- Integrate the new checker into the lint/security steps of CI by adding a `unsafe dynamic execution/deserialization check` step in `.github/workflows/main.yml`. 
- Document the change in `docs/reviews/full_code_review_20260327.md` under the improvements section.

### Testing
- Ran `ruff check scripts/security/check_unsafe_dynamic_execution_usage.py veritas_os/tests/test_check_unsafe_dynamic_execution_usage.py` and the checks passed. 
- Ran `pytest -q veritas_os/tests/test_check_unsafe_dynamic_execution_usage.py` and all tests passed (`5 passed`). 
- Executed `python scripts/security/check_unsafe_dynamic_execution_usage.py` against the repository and it returned clean output (`No unsafe dynamic execution/deserialization usage detected.`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6310827d88326959b07fd69d0ea23)