### PR TITLE
Harden Slack webhook notifications by disabling redirects

### DIFF
--- a/veritas_os/scripts/notify_slack.py
+++ b/veritas_os/scripts/notify_slack.py
@@ -4,6 +4,7 @@
 Security considerations:
 - HTTP request timeout is always set to prevent indefinite hangs.
 - Error logging never prints response body to avoid accidental data exposure.
+- Redirects are disabled to avoid forwarding payloads to non-Slack destinations.
 """
 
 import datetime
@@ -73,6 +74,7 @@ def send_slack_notification(webhook_url: str, message: str) -> int:
             webhook_url,
             json=payload,
             timeout=DEFAULT_TIMEOUT_SEC,
+            allow_redirects=False,
         )
     except requests.RequestException as exc:
         print(f"[Slack] 通知送信失敗: network_error={exc.__class__.__name__}")

--- a/veritas_os/tests/test_notify_slack.py
+++ b/veritas_os/tests/test_notify_slack.py
@@ -39,14 +39,15 @@ class NotifySlackTests(unittest.TestCase):
     """Behavioral tests for Slack notification script hardening."""
 
     def test_send_slack_uses_timeout(self):
-        """requests.post should always include a finite timeout value."""
+        """requests.post should include hardened request options."""
         module = load_module()
         observed = {}
 
-        def fake_post(url, json, timeout):
+        def fake_post(url, json, timeout, allow_redirects):
             observed["url"] = url
             observed["json"] = json
             observed["timeout"] = timeout
+            observed["allow_redirects"] = allow_redirects
             return _DummyResponse(200)
 
         with mock.patch.object(module.requests, "post", side_effect=fake_post):
@@ -58,6 +59,7 @@ class NotifySlackTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(observed["url"], "https://hooks.slack.com/services/a/b/c")
         self.assertEqual(observed["timeout"], module.DEFAULT_TIMEOUT_SEC)
+        self.assertFalse(observed["allow_redirects"])
         self.assertIn("hello", observed["json"]["text"])
 
     def test_send_slack_error_log_does_not_include_response_text(self):


### PR DESCRIPTION
### Motivation
- Following HTTP redirects from a validated Slack webhook could forward notification payloads to non-Slack destinations, creating an exfiltration/SSRF risk.  
- The change pins delivery to the verified Slack webhook host to reduce that attack surface.

### Description
- Disable HTTP redirect following by passing `allow_redirects=False` to `requests.post` in `veritas_os/scripts/notify_slack.py`.  
- Document the redirect-hardening intent in the module docstring.  
- Update `veritas_os/tests/test_notify_slack.py` to assert `allow_redirects=False` is passed when posting to Slack.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_notify_slack.py` and the suite passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63137f158832698734671d697c718)