### PR TITLE
Fix signed TrustLog race condition, durability gap, and audit traceability

### DIFF
--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -86,10 +86,16 @@ def _transparency_required_enabled() -> bool:
 
 
 def _append_line(path: Path, line: str) -> None:
-    """Append a line to ``path``, creating parent directories when required."""
+    """Append a line to ``path``, creating parent directories when required.
+
+    Uses ``fsync`` to ensure durability — matching the main TrustLog's
+    write-ahead guarantee so that signed entries survive process crashes.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as file:
         file.write(line)
+        file.flush()
+        os.fsync(file.fileno())
 
 
 def _mirror_to_worm(line: str) -> Dict[str, Any]:
@@ -273,6 +279,7 @@ _SUMMARY_ALLOWLIST: frozenset[str] = frozenset({
     "request_id",
     "created_at",
     "decision_id",
+    "context_user_id",
     # Hash-chain fields (set by append_trust_log before reaching here)
     "sha256",
     "sha256_prev",
@@ -402,8 +409,8 @@ def append_signed_decision(decision_payload: Dict[str, Any]) -> Dict[str, Any]:
             runtime errors (filesystem, serialization, or value issues).
     """
     try:
-        _ensure_signing_keys()
         with _lock:
+            _ensure_signing_keys()
             last_entry = _read_last_entry(SIGNED_TRUSTLOG_JSONL)
             previous_hash = _entry_chain_hash(last_entry) if last_entry else None
 

--- a/veritas_os/tests/test_trustlog_compaction.py
+++ b/veritas_os/tests/test_trustlog_compaction.py
@@ -308,6 +308,64 @@ class TestAppendSignedDecisionCompaction:
             assert "world_state" not in serialized
             assert "projects" not in serialized
 
+    def test_concurrent_signed_appends_no_corruption(self, signed_env):
+        """10 threads × 3 appends must not corrupt the signed TrustLog chain."""
+        import threading
+
+        errors: list = []
+        n_threads = 10
+        n_writes = 3
+
+        def worker(tid: int) -> None:
+            try:
+                for seq in range(n_writes):
+                    append_signed_decision(
+                        {"request_id": f"r-conc-{tid}-{seq}", "thread": tid}
+                    )
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=worker, args=(t,))
+            for t in range(n_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, f"Concurrent signed append errors: {errors}"
+
+        result = verify_trustlog_chain(path=signed_env["jsonl"])
+        assert result["ok"] is True
+        assert result["entries_checked"] == n_threads * n_writes
+
+        # Every line must be valid JSON
+        lines = signed_env["jsonl"].read_text(encoding="utf-8").splitlines()
+        assert len(lines) == n_threads * n_writes
+        for idx, line in enumerate(lines):
+            try:
+                json.loads(line)
+            except json.JSONDecodeError:
+                pytest.fail(f"Corrupt entry at line {idx} after concurrent writes")
+
+    def test_15_sequential_appends_chain_intact(self, signed_env):
+        """15 sequential appends must keep the hash chain and signatures intact."""
+        for i in range(15):
+            full = _make_bulky_payload(request_id=f"r-seq15-{i}")
+            entry = append_signed_decision(full)
+            assert verify_signature(entry) is True
+
+        result = verify_trustlog_chain(path=signed_env["jsonl"])
+        assert result["ok"] is True
+        assert result["entries_checked"] == 15
+        assert not result["issues"]
+
+        # Verify no world_state / projects leak in any line
+        raw = signed_env["jsonl"].read_text(encoding="utf-8")
+        assert "world_state" not in raw
+        assert '"projects"' not in raw
+
     def test_detect_tampering_still_works(self, signed_env):
         """Tampering detection must still work with compact payloads."""
         from veritas_os.audit.trustlog_signed import detect_tampering


### PR DESCRIPTION
Three critical issues found during strict implementation review:

1. TOCTOU race in _ensure_signing_keys: called outside _lock, allowing
   concurrent threads to each generate different keypairs. The second
   overwrites the first, invalidating all signatures from the first
   keypair. Moved inside the lock to atomize key creation + signing.

2. _append_line missing fsync: signed TrustLog writes were not durable
   on crash, unlike the main TrustLog which uses os.fsync. Added
   flush+fsync to match the durability guarantee.

3. _SUMMARY_ALLOWLIST missing context_user_id: the signed TrustLog
   summary dropped all user linkage, making per-user audit impossible.
   Added context_user_id to the allowlist.

New regression tests:
- 10 threads × 3 concurrent appends with chain+signature verification
- 15 sequential bulky appends verifying no world_state/projects leak

https://claude.ai/code/session_01SDUTtcnoZNNqEJfhh2wMrZ