### PR TITLE
Add continuation runtime design boundary documents (ADR, glossary, rollout, overview)

### DIFF
--- a/docs/architecture/continuation_runtime_adr.md
+++ b/docs/architecture/continuation_runtime_adr.md
@@ -1,0 +1,222 @@
+# ADR: Continuation Runtime — Architecture Decision Record
+
+**Status**: Proposed (Phase-1 design boundary)
+**Date**: 2026-03-28
+**Author**: Principal Engineer (automated)
+**Scope**: Chain-level continuation observation substrate for VERITAS OS
+
+---
+
+## Context
+
+VERITAS OS currently operates with a **step-level decision infrastructure**: each
+call to `/v1/decide` is independently evaluated by the pipeline, gated by FUJI,
+and persisted to the TrustLog. There is no first-class concept of whether a
+chain of decisions — a sequence of steps toward a goal — retains the right to
+continue executing.
+
+This gap means that:
+
+- A chain can accumulate risk across steps without any mechanism noticing the
+  aggregate trajectory.
+- There is no place to record *why* a chain is still permitted to continue,
+  separate from *why* a single step passed the gate.
+- Revocation of continuation rights requires ad-hoc intervention rather than
+  structured adjudication.
+
+The Continuation Runtime addresses this by introducing a **chain-level
+continuation observation and adjudication layer** that runs alongside — not
+inside — the existing step-level infrastructure.
+
+---
+
+## Decision
+
+### 1. Continuation Runtime is an independent responsibility beside FUJI
+
+The Continuation Runtime is **not** part of FUJI. It does not modify, wrap, or
+extend FUJI's evaluation logic. FUJI remains the final safety and policy gate
+for each individual step. The Continuation Runtime operates on a different axis:
+whether the *chain as a whole* retains continuation standing.
+
+**Rationale**: FUJI's responsibility boundary is well-defined (safety and policy
+evaluation for actions and content — see `core_responsibility_boundaries.md`).
+Embedding chain-level continuation logic inside FUJI would blur this boundary,
+complicate FUJI's fail-closed guarantees, and make it harder to review safety
+behavior in isolation.
+
+### 2. FUJI remains the final safety/policy gate — unchanged
+
+FUJI's public contract (`evaluate()`, `validate_action()`, `reload_policy()`)
+and its internal status semantics (`allow`, `allow_with_warning`,
+`needs_human_review`, `deny`) are not modified. The Continuation Runtime does
+not override, veto, or reinterpret FUJI decisions.
+
+### 3. Continuation Runtime owns chain-level continuation observation and adjudication
+
+The Continuation Runtime is responsible for:
+
+- Maintaining a `ContinuationClaimLineage` — a live object representing a
+  chain's continuation standing across steps.
+- Running **revalidation** before each step's merit evaluation, producing a
+  `ClaimStateSnapshot`.
+- Emitting a `ContinuationReceipt` after revalidation that records how the
+  standing was examined, maintained, narrowed, escalated, suspended, or lost.
+- Evaluating continuation against a `ContinuationLawPack` (versioned law set).
+
+It is **not** responsible for:
+
+- Deciding whether an individual step's content is safe (FUJI's job).
+- Generating per-step permits (see Non-Goals).
+- Enforcing refusal (phase-1 is observe/shadow only).
+
+### 4. Phase-1 is observe/shadow only
+
+In phase-1, the Continuation Runtime:
+
+- **Observes**: Runs revalidation logic and produces snapshots and receipts.
+- **Shadows**: Records what it *would* recommend (continue / narrow / escalate /
+  suspend / revoke) without affecting execution.
+- **Does not enforce**: The pipeline proceeds exactly as it does today regardless
+  of the Continuation Runtime's assessment.
+
+This means that with the continuation runtime feature flag off, there is **zero
+change** to response payloads, log output, UI behavior, or execution semantics.
+
+### 5. `gate.decision_status` is not modified
+
+`gate.decision_status` (the `DecisionStatus` enum: `allow`, `modify`, `block`,
+`abstain`, `rejected`) represents the outcome of FUJI's step-level safety gate.
+The Continuation Runtime does not add new values, reinterpret existing values, or
+condition its behavior on `decision_status` in ways that would change its
+meaning.
+
+**Rationale**: `decision_status` is consumed by the API layer, frontend, replay
+engine, and audit tooling. Changing its semantics would cascade across the entire
+system. The Continuation Runtime introduces its own state vocabulary
+(`ClaimStateSnapshot`) that is orthogonal to `decision_status`.
+
+### 6. Snapshot and Receipt have separated responsibilities
+
+| Concern | Snapshot (`ClaimStateSnapshot`) | Receipt (`ContinuationReceipt`) |
+|---|---|---|
+| Purpose | Minimal governable state of the claim at a point in time | Evidence of how revalidation was conducted and what was found |
+| Content | standing, scope, burden_state, headroom, law_version | revalidation_status, basis_examined, divergences, preceding_decision_continuity, timestamps, auditor-facing detail |
+| Lifecycle | Replaced each revalidation; only current snapshot is authoritative | Appended; forms an audit trail across steps |
+| Size | Small and fixed-schema | Grows with evidence complexity |
+| Consumed by | Runtime logic (next revalidation, shadow recommendations) | Audit, replay, compliance review |
+
+The snapshot is not a receipt. The receipt is not a state store. Revalidation
+status belongs to the receipt side (it describes what happened during
+revalidation, not the resulting standing). Preceding decision continuity belongs
+to the receipt/audit side (it describes the relationship between consecutive
+steps, which is evidence, not current state).
+
+### 7. Pipeline insertion point design
+
+The Continuation Runtime revalidation runs **before** FUJI's step-level
+evaluation. In the current 8-stage pipeline:
+
+```
+... Stage 5b (Critique) →
+  [Continuation Revalidation]  ← new, pre-merit
+  Stage 6a (FUJI Pre-check) →
+  Stage 6b (ValueCore) →
+  Stage 6c (Gate Decision) →
+...
+```
+
+**Candidate insertion**: Between stage 5b and stage 6a, as a sidecar operation
+that reads pipeline context but writes only to its own state (snapshot + receipt).
+It does not modify `PipelineContext` fields that FUJI or the gate consume.
+
+In phase-1 (observe/shadow), this insertion is a no-op for pipeline flow: it
+produces artifacts but does not alter `ctx.fuji_dict`, `ctx.decision_status`, or
+any other pipeline state.
+
+**Alternative considered**: Post-gate insertion (after stage 6c). Rejected
+because revalidation must happen *before* merit evaluation to preserve the
+principle that continuation standing is checked before new work is assessed — not
+derived from the result of that work.
+
+---
+
+## Non-Goals
+
+1. **FUJI as continuation engine**: FUJI evaluates steps; the Continuation
+   Runtime evaluates chains. These are distinct responsibilities.
+2. **Per-step permits**: Continuation claims are not permits. A claim represents
+   ongoing standing that is revalidated, not a fresh authorization issued per
+   step.
+3. **Reverse-engineering continuation from step results**: Local step success
+   does not prove continuation lawfulness. Continuation standing must be
+   evaluated on its own terms (law pack, burden, scope) before step merit is
+   known.
+4. **Burden as a separate metric**: Burden is part of the support basis within
+   the continuation claim, not an independent metric bolted onto the pipeline.
+5. **Phase-1 enforcement**: No refusal, blocking, or behavioral modification in
+   phase-1. The runtime observes and records only.
+6. **New routes or product areas**: No new API endpoints, no new UI pages. Shadow
+   data is internal or exposed via existing extension points (e.g., response
+   extras, audit artifacts).
+7. **Large-scale refactoring**: The runtime is added as a sidecar. Existing
+   modules are not restructured.
+
+---
+
+## Stop Conditions
+
+Implementation must halt and report (without code changes) if any of:
+
+- Existing responsibility boundaries (Planner / Kernel / FUJI / MemoryOS) cannot
+  be read clearly enough to guarantee non-interference.
+- Implementation requires modifying FUJI's public contract or internal logic.
+- `gate.decision_status` semantics must change.
+- No viable pre-merit insertion point exists in the pipeline without modifying
+  existing stage signatures.
+- Feature-flag-off invariance cannot be guaranteed.
+- The continuation claim must degenerate into a per-step permit to function.
+- Existing tests break in ways that require widespread modification.
+
+---
+
+## Rollout Strategy
+
+See `continuation_runtime_rollout.md` for detailed phasing. Summary:
+
+| Phase | Mode | Enforcement | Scope |
+|---|---|---|---|
+| 1 | observe / shadow | None | Internal artifacts only |
+| 2 | advise | Logged recommendations; no blocking | Shadow + advisory signals |
+| 3 | enforce | Continuation-based gating | Full integration |
+
+Phase boundaries are gated by:
+
+- Divergence data from shadow mode demonstrating the runtime produces
+  consistent, explainable assessments.
+- Confirmation that snapshot/receipt separation holds under production traffic
+  patterns.
+- Explicit architectural review before advancing.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Continuation logic leaks into FUJI | Strict module boundary; continuation runtime is a separate package/module; CI boundary check |
+| Shadow mode adds latency | Revalidation is designed to be lightweight; phase-1 monitors latency overhead |
+| Snapshot schema grows unbounded | Fixed-schema constraint; additional data goes to receipt |
+| Receipt replaces snapshot as de facto state | Architectural rule enforced in review: runtime logic reads snapshot, not receipt |
+| Feature flag off still costs something | Flag check is the first operation; short-circuit before any allocation |
+
+---
+
+## References
+
+- `docs/architecture/core_responsibility_boundaries.md` — Module boundaries
+- `docs/self_healing_loop.md` — Existing retry/continuation pattern (step-scoped)
+- `docs/replay_audit.md` — Replay and divergence detection infrastructure
+- `docs/architecture/continuation_runtime_glossary.md` — Term definitions
+- `docs/architecture/continuation_runtime_rollout.md` — Phased rollout plan
+- `spec/continuation_runtime_overview.md` — Conceptual overview

--- a/docs/architecture/continuation_runtime_glossary.md
+++ b/docs/architecture/continuation_runtime_glossary.md
@@ -1,0 +1,272 @@
+# Continuation Runtime — Glossary
+
+**Status**: Proposed (Phase-1 design boundary)
+**Date**: 2026-03-28
+
+This glossary defines terms used across the Continuation Runtime design
+documents. Definitions are intentionally precise to prevent semantic drift
+between phases.
+
+---
+
+## Core Structures
+
+### ContinuationClaimLineage
+
+A **live object** representing a chain's continuation standing across its
+lifetime. It is created when a chain is initiated (entry) and updated at each
+step via revalidation. It is not a token or permit — it is the structured record
+of an ongoing claim that must be continuously justified.
+
+A lineage tracks: who claimed, under what law, with what scope, and what the
+current burden state is. It is the identity of the continuation across steps.
+
+### ClaimStateSnapshot
+
+The **minimal governable state** of a `ContinuationClaimLineage` at a specific
+point in time — specifically, after a revalidation pass. A snapshot contains only
+the facts needed for the next revalidation and for shadow-mode recommendations:
+
+- `standing`: Current continuation standing (e.g., active, narrowed, suspended,
+  revoked).
+- `scope`: Explicit boundary of what the chain is permitted to continue doing.
+- `burden_state`: Current state of the evidentiary burden the chain must sustain.
+- `headroom`: Remaining capacity before automatic escalation or suspension
+  triggers.
+- `law_version`: Version identifier of the `ContinuationLawPack` under which
+  this snapshot was produced.
+
+A snapshot is **replaced** at each revalidation. Only the current snapshot is
+authoritative for runtime logic. Prior snapshots are accessible only through
+receipts.
+
+### ContinuationReceipt
+
+An **evidence artifact** produced by each revalidation pass, recording how the
+claim's standing was examined and what was found. Receipts are **append-only** —
+they accumulate across steps to form a chain-level audit trail.
+
+A receipt records:
+
+- `revalidation_status`: What happened during revalidation (passed, narrowed,
+  escalated, suspended, revoked) — this is a description of the revalidation
+  event, not the resulting standing.
+- `basis_examined`: Which elements of the support basis were checked.
+- `divergences_observed`: Any differences between expected and observed
+  continuation conditions.
+- `preceding_decision_continuity`: How this step's context relates to the prior
+  step's decision — this is evidence about continuity, belonging to the audit
+  trail.
+- `shadow_recommendation`: What the runtime would have recommended if enforcement
+  were active (phase-1 only).
+- `timestamps`: When revalidation started and completed.
+- `law_version`: The law pack version used for this revalidation.
+
+A receipt is **not** a state store. Runtime logic reads the snapshot for current
+state; it reads receipts only for audit, replay, and divergence analysis.
+
+### ContinuationLawPack
+
+A **versioned, immutable set of rules** that govern continuation revalidation.
+Each law pack has a version identifier. When a snapshot is produced, it records
+which law pack version was applied.
+
+Law packs define:
+
+- Conditions under which standing is maintained, narrowed, or lost.
+- Burden requirements and escalation thresholds.
+- Headroom calculation rules.
+- Scope validation criteria.
+
+Law packs are not policies in the FUJI sense (they do not evaluate content
+safety). They govern the structural validity of continuation itself.
+
+---
+
+## Support Basis and Burden
+
+### Support Basis
+
+The **set of justifications** that sustain a continuation claim's standing. A
+support basis is not a single score — it is a structured collection of grounds
+(e.g., original authorization, accumulated compliance record, scope consistency,
+burden satisfaction).
+
+Burden is a **component within** the support basis, not a separate metric.
+
+### Burden State
+
+The **current evidentiary obligation** that a continuation claim must satisfy to
+maintain its standing. Burden state tracks:
+
+- What evidence is required.
+- Whether that evidence has been provided.
+- How close the burden is to being unsatisfied (which would trigger narrowing or
+  escalation).
+
+Burden state is carried in the `ClaimStateSnapshot` because it is essential for
+the next revalidation decision.
+
+### Headroom
+
+The **remaining capacity** before a continuation claim triggers automatic
+escalation, narrowing, or suspension. Headroom is a derived quantity computed
+during revalidation based on burden state, scope usage, and law pack thresholds.
+
+Headroom is carried in the snapshot because it is needed for shadow-mode
+recommendations and future revalidation logic.
+
+---
+
+## Revalidation Lifecycle
+
+### Revalidation
+
+The process of **re-examining** a continuation claim's standing before a new step
+is evaluated on its merits. Revalidation:
+
+1. Reads the current `ClaimStateSnapshot`.
+2. Evaluates the claim against the current `ContinuationLawPack`.
+3. Produces a new `ClaimStateSnapshot` (replacing the old one).
+4. Emits a `ContinuationReceipt` (appended to the audit trail).
+
+Revalidation runs **before** FUJI pre-check — before the step's content is
+evaluated for safety. This ordering is deliberate: continuation standing is a
+precondition, not a consequence.
+
+### Revocation
+
+The **terminal loss** of continuation standing. Once revoked, a claim cannot be
+reinstated within the same lineage. A new chain would require a new entry with
+its own claim.
+
+Revocation is recorded in both the final snapshot (`standing: revoked`) and the
+corresponding receipt (with the reason and evidence).
+
+### Refusal-Before-Effect
+
+The principle that a chain should be stopped **before** it produces effects that
+would need to be undone, rather than after. In the continuation model, this means
+revalidation (which can lead to suspension or revocation) happens before step
+execution, not after.
+
+In phase-1 (observe/shadow), refusal-before-effect is not enforced — it is only
+observed and logged as a shadow recommendation.
+
+---
+
+## Step vs Chain Concepts
+
+### Local Step Validity
+
+Whether an individual step passes FUJI's safety and policy evaluation. This is
+the existing VERITAS responsibility — `gate.decision_status` reflects this.
+Local step validity says nothing about whether the chain as a whole should
+continue.
+
+### Chain-Level Continuation Rights
+
+Whether a chain retains the standing to continue executing additional steps.
+This is the Continuation Runtime's responsibility. Chain-level rights depend on
+the claim lineage, law pack, burden state, and scope — not on any single step's
+local validity.
+
+A step can be locally valid but the chain's continuation standing can be
+narrowed, suspended, or revoked. Conversely, a chain with active continuation
+standing still requires each step to pass FUJI independently.
+
+---
+
+## Operating Modes
+
+### Observe Mode (Phase-1)
+
+The Continuation Runtime runs revalidation, produces snapshots and receipts, and
+records shadow recommendations — but does **not** affect pipeline execution. No
+blocking, no modification, no signaling to FUJI or the gate. The runtime is
+invisible to the pipeline's decision path.
+
+### Advise Mode (Phase-2, future)
+
+The Continuation Runtime produces advisory signals that are visible in logs,
+audit artifacts, and potentially response extras — but does **not** block or
+modify execution. Operators can see what the runtime recommends.
+
+### Enforce Mode (Phase-3, future)
+
+The Continuation Runtime's assessments are integrated into the pipeline's
+execution path. Suspension or revocation of continuation standing can prevent
+step execution. This mode requires extensive validation from observe and advise
+phases.
+
+---
+
+## Architectural Boundaries
+
+### State vs Receipt Boundary
+
+**State** (snapshot) is the minimal, current, actionable representation of the
+claim. **Receipt** is the historical, evidential record of how state was derived.
+
+The boundary rule: runtime logic that decides what to do next reads the
+**snapshot**. Logic that explains what happened and why reads **receipts**.
+
+Violations of this boundary (e.g., the runtime reading receipts to determine
+current standing, or snapshots accumulating audit-level detail) are architectural
+defects.
+
+### Revalidation Status
+
+Revalidation status (what happened during a revalidation pass) belongs to the
+**receipt** side, not the snapshot side. The snapshot records the *result*
+(updated standing, burden, headroom). The receipt records the *process*
+(what was checked, what was found, what diverged).
+
+### Preceding Decision Continuity
+
+The relationship between consecutive steps' decisions (e.g., "step N's decision
+was consistent with step N-1's") is **evidence about continuity**. It belongs to
+the receipt / audit trail, not to the snapshot. The snapshot does not need to
+carry the history of prior decisions — only the current standing that results
+from considering that history.
+
+---
+
+## Replay and Audit
+
+### Lawful Replay
+
+A replay is **lawful** if it can reproduce the continuation revalidation
+sequence using the same law pack versions and input conditions, and arrive at the
+same snapshot states and receipt contents. Lawful replay requires that:
+
+- Law pack versions are immutable and retrievable.
+- Snapshots are deterministically derived from inputs + law pack.
+- Receipts record sufficient detail to verify the revalidation process.
+
+This aligns with VERITAS's existing replay infrastructure
+(`docs/replay_audit.md`), extending it to cover chain-level continuation
+artifacts.
+
+### Continuity Grounding
+
+The property that a continuation claim's standing is **traceable** back to its
+original entry authorization through an unbroken chain of revalidation receipts.
+If any receipt in the chain is missing or inconsistent, continuity grounding is
+lost, which is an audit finding.
+
+---
+
+## Entry vs Continuation
+
+### Entry
+
+The initiation of a new chain. Entry requires establishing a fresh
+`ContinuationClaimLineage` with an initial scope, burden, and law pack version.
+Entry is a distinct event from continuation — it is not "the first continuation."
+
+### Continuation
+
+The ongoing exercise of an existing claim across subsequent steps. Each
+continuation requires successful revalidation. Continuation is not automatic —
+it must be actively sustained through burden satisfaction and scope compliance.

--- a/docs/architecture/continuation_runtime_rollout.md
+++ b/docs/architecture/continuation_runtime_rollout.md
@@ -1,0 +1,184 @@
+# Continuation Runtime — Rollout Plan
+
+**Status**: Proposed (Phase-1 design boundary)
+**Date**: 2026-03-28
+
+---
+
+## Overview
+
+The Continuation Runtime is introduced in three strictly separated phases. Each
+phase has explicit entry criteria, exit criteria, and a verification protocol.
+No phase advances without architectural review.
+
+The guiding principle is **incremental confidence**: each phase must demonstrate
+that the runtime produces correct, explainable results before the next phase
+adds any coupling to the execution path.
+
+---
+
+## Phase-1: Observe / Shadow
+
+### Goal
+
+Demonstrate that the Continuation Runtime can run revalidation beside the
+existing pipeline, produce consistent snapshots and receipts, and generate
+meaningful divergence data — without affecting any existing behavior.
+
+### Mode
+
+- Feature flag: `VERITAS_CAP_CONTINUATION_RUNTIME` (default: `false`)
+- When `false`: zero code paths executed, zero allocations, zero log entries,
+  zero response changes. The system behaves exactly as it does today.
+- When `true`: revalidation runs as a sidecar between stage 5b (Critique) and
+  stage 6a (FUJI Pre-check). Results are written to internal shadow artifacts
+  only.
+
+### Scope
+
+- `ContinuationClaimLineage` creation and lifecycle management.
+- `ClaimStateSnapshot` production via revalidation.
+- `ContinuationReceipt` emission and storage.
+- `ContinuationLawPack` loading and version tracking.
+- Shadow recommendation generation (continue / narrow / escalate / suspend /
+  revoke) — logged but not acted upon.
+- Divergence detection: comparison between shadow recommendations and actual
+  pipeline outcomes.
+
+### What Phase-1 does NOT do
+
+- Modify `PipelineContext` fields consumed by FUJI or the gate.
+- Change `gate.decision_status` values or semantics.
+- Add new API routes or response fields visible to clients.
+- Add new UI components or dashboard pages.
+- Enforce any continuation-based blocking or modification.
+- Alter self-healing loop behavior.
+
+### Entry Criteria
+
+- ADR, glossary, and overview documents are reviewed and accepted.
+- Responsibility boundaries between FUJI and Continuation Runtime are
+  documented and understood by the team.
+- Feature flag mechanism is confirmed to provide complete isolation.
+
+### Exit Criteria (Phase-1 Success)
+
+Phase-1 is considered successful when all of the following are demonstrated:
+
+1. **Shadow consistency**: Revalidation produces deterministic snapshots given
+   the same inputs and law pack version (verified via replay).
+2. **Receipt completeness**: Every revalidation produces a receipt with
+   sufficient detail for audit reconstruction.
+3. **Divergence observability**: Cases where shadow recommendations differ from
+   actual pipeline outcomes are detectable and explainable.
+4. **Zero interference**: With flag on, all existing tests pass without
+   modification. With flag off, the system is bytewise identical in behavior.
+5. **Latency budget**: Shadow revalidation adds less than 5ms p99 to pipeline
+   latency (configurable threshold).
+6. **Snapshot/receipt separation holds**: No instance where runtime logic reads
+   receipts for state, or snapshots carry audit-level detail.
+
+### Verification Protocol
+
+- Run full existing test suite with flag off → all pass, no new output.
+- Run full existing test suite with flag on → all pass, original outputs
+  identical, shadow artifacts produced as side-effects.
+- Replay selected decisions with flag on → shadow artifacts are reproducible.
+- Review shadow divergence log for false positives and unexplained assessments.
+
+---
+
+## Phase-2: Advise (Future)
+
+### Goal
+
+Make continuation assessments visible to operators without affecting execution.
+
+### Mode
+
+- Feature flag: `VERITAS_CAP_CONTINUATION_ADVISE` (default: `false`,
+  requires `VERITAS_CAP_CONTINUATION_RUNTIME` = `true`)
+- Continuation assessments appear in response extras, audit logs, and
+  potentially operator-facing UI elements (read-only indicators).
+
+### Scope
+
+- Advisory signals in response extras (e.g., `continuation.shadow_recommendation`).
+- Operator-visible warnings when continuation standing is narrowed or at risk.
+- Audit log entries that link continuation receipts to TrustLog events.
+- No blocking, no modification of `decision_status`, no pipeline flow changes.
+
+### Entry Criteria
+
+- Phase-1 exit criteria fully met.
+- Divergence data reviewed and deemed consistent.
+- Architectural review approves advise-mode coupling points.
+
+### Exit Criteria
+
+- Operators can interpret continuation signals correctly (validated via review).
+- Advisory signals do not cause confusion with existing gate signals.
+- No operator workflow depends on advise signals for correctness (they are
+  informational only).
+
+---
+
+## Phase-3: Enforce (Future)
+
+### Goal
+
+Integrate continuation standing into the pipeline's execution path so that
+suspension or revocation of continuation can prevent step execution.
+
+### Mode
+
+- Feature flag: `VERITAS_CAP_CONTINUATION_ENFORCE` (default: `false`,
+  requires both prior flags = `true`)
+- Continuation standing affects pipeline flow: suspended or revoked claims
+  prevent step execution before FUJI evaluation.
+
+### Scope
+
+- Pre-merit blocking: if continuation standing is `suspended` or `revoked`,
+  the step is not submitted to FUJI or the kernel.
+- Integration with self-healing loop: continuation-based rejections may trigger
+  healing or human review.
+- New `decision_status` considerations (if any) to be designed in phase-3
+  planning — not pre-committed here.
+
+### Entry Criteria
+
+- Phase-2 exit criteria fully met.
+- Sufficient advise-mode data demonstrates enforcement would be safe and
+  predictable.
+- Explicit architectural review and stakeholder approval.
+
+### Exit Criteria
+
+- Enforcement produces outcomes consistent with advise-mode predictions.
+- No regression in safety or correctness compared to pre-continuation baseline.
+- Rollback to advise or observe mode is instantaneous via flag toggle.
+
+---
+
+## Rollback Strategy
+
+At any phase, setting the feature flag to `false` immediately disables all
+Continuation Runtime behavior. The system reverts to pre-continuation behavior
+with no residual effects. This is the primary safety mechanism.
+
+Shadow artifacts (snapshots, receipts) produced during observe/advise phases
+persist in storage but are not consumed by any pipeline logic when flags are off.
+
+---
+
+## Phase Boundary Rules
+
+1. **No forward references in implementation**: Phase-1 code must not contain
+   hooks, stubs, or abstractions designed for phase-2 or phase-3 unless they
+   are strictly necessary for phase-1 functionality.
+2. **No phase mixing**: A single deployment runs exactly one phase. There is no
+   "partial enforce" or "advise for some chains, enforce for others" within a
+   single deployment.
+3. **Each phase is independently revertible**: Advancing to phase-2 does not
+   make phase-1-only operation impossible.

--- a/spec/continuation_runtime_overview.md
+++ b/spec/continuation_runtime_overview.md
@@ -1,0 +1,282 @@
+# Continuation Runtime — Conceptual Overview
+
+**Status**: Proposed (Phase-1 design boundary)
+**Date**: 2026-03-28
+
+---
+
+## From Step-Level Decisions to Governed Continuation
+
+### The Old Model: Step-Level Decision Infrastructure
+
+VERITAS OS today provides a **step-level decision infrastructure**. Each call to
+the decision pipeline is evaluated independently:
+
+1. Input is normalized.
+2. Evidence is retrieved.
+3. The kernel produces a decision.
+4. FUJI evaluates safety and policy.
+5. The gate emits `decision_status` (allow / modify / rejected).
+6. The result is persisted to the TrustLog.
+
+This model is sound for individual steps. FUJI's fail-closed gate, the
+hash-chained TrustLog, and the replay engine provide strong guarantees that each
+step is evaluated, recorded, and reproducible.
+
+But the model has no concept of **chains** — sequences of steps that together
+pursue a goal. When an agent executes step 1, then step 2, then step 3, each
+step passes through the pipeline independently. There is no mechanism to ask:
+"Given everything this chain has done so far, does it retain the right to
+continue?"
+
+### The New Model: Decision Infrastructure + Governed Continuation Substrate
+
+The Continuation Runtime adds a **chain-level continuation observation and
+adjudication layer** that runs beside the existing step-level infrastructure.
+The existing infrastructure is not replaced or modified — it gains a companion.
+
+```
+Step-Level (existing, unchanged):
+  Input → Kernel → FUJI → Gate → TrustLog
+  Each step independently evaluated.
+
+Chain-Level (new, additive):
+  ClaimLineage → Revalidation → Snapshot + Receipt
+  Each step's continuation standing evaluated before merit.
+```
+
+The two layers are complementary:
+
+- **Step-level** answers: "Is this specific action safe and policy-compliant?"
+- **Chain-level** answers: "Does this chain retain the standing to continue?"
+
+Both must be satisfied. A chain with active continuation standing still requires
+each step to independently pass FUJI. A step that passes FUJI does not
+automatically sustain the chain's continuation standing.
+
+---
+
+## Entry vs Continuation
+
+**Entry** is the initiation of a new chain. It establishes:
+
+- A fresh `ContinuationClaimLineage`.
+- An initial scope (what the chain is authorized to do).
+- An initial burden (what the chain must sustain to keep its standing).
+- A law pack version (which rules govern revalidation).
+
+**Continuation** is the ongoing exercise of an existing claim. At each
+subsequent step, the claim is **revalidated** — not re-authorized. The
+distinction matters:
+
+- Re-authorization would mean each step is treated as a new entry, discarding
+  chain history. This is the per-step permit model, and it is insufficient (see
+  below).
+- Revalidation means the existing claim is examined in light of accumulated
+  evidence, updated burden, and scope compliance. History is preserved and
+  matters.
+
+---
+
+## Why Per-Step Permits Are Insufficient
+
+A per-step permit model would evaluate each step's continuation right in
+isolation, based only on that step's properties. This fails because:
+
+1. **Accumulated risk is invisible**: A chain that gradually escalates across
+   steps would have each step independently permitted, even though the aggregate
+   trajectory is problematic.
+
+2. **Scope drift is undetectable**: If a chain's actions gradually shift away
+   from its original authorization, per-step permits cannot detect this because
+   they have no concept of original scope.
+
+3. **Burden cannot be tracked**: A per-step model has no memory of what evidence
+   was required and whether it was provided. Each step starts fresh.
+
+4. **Revocation has no meaning**: You cannot revoke a permit that is issued anew
+   each time. Per-step permits make chain-level governance impossible.
+
+5. **Audit trails are disconnected**: Without a lineage connecting steps, audit
+   must reconstruct chain relationships post-hoc rather than having them as
+   first-class structures.
+
+The continuation claim model addresses all of these by maintaining a live
+lineage across steps with explicit scope, burden, and revalidation.
+
+---
+
+## Snapshot: Light. Receipt: Thick.
+
+### Why the Snapshot Must Be Light
+
+The `ClaimStateSnapshot` is the input to the next revalidation. It is read on
+every step in the chain's critical path. It must contain exactly the facts
+needed to make the next revalidation decision — no more.
+
+If the snapshot grows to include audit detail, historical evidence, or
+explanatory text, it becomes:
+
+- Expensive to read and write on every step.
+- Tempting to use as a state store for audit queries (violating separation).
+- Difficult to version and migrate (because it mixes concerns).
+
+Snapshot fields: `standing`, `scope`, `burden_state`, `headroom`,
+`law_version`. Each is a direct input to revalidation logic.
+
+### Why the Receipt Must Be Thick
+
+The `ContinuationReceipt` is the audit artifact. It is written once per
+revalidation and read later — by auditors, replay engines, compliance reviewers,
+and divergence analyzers. It must contain enough detail to answer:
+
+- What was checked during revalidation?
+- What evidence was examined?
+- What divergences were observed?
+- What was the relationship to the preceding step's decision?
+- What would the runtime have recommended (in shadow mode)?
+
+Receipts are append-only. Their cost is amortized over time and they are not on
+the critical path of revalidation logic.
+
+### The Separation Rule
+
+Runtime logic (revalidation, shadow recommendations) reads **snapshots**.
+Audit logic (replay, compliance, divergence analysis) reads **receipts**.
+
+If runtime logic needs something from a receipt, that data should be promoted
+to the snapshot schema (with care, since it increases snapshot weight). If audit
+logic only needs current state, it reads the latest receipt's snapshot reference.
+The two never collapse into one structure.
+
+---
+
+## Why Pre-Merit Revalidation
+
+Revalidation runs **before** FUJI pre-check — before the step's content is
+evaluated for safety or policy compliance. This ordering is not arbitrary:
+
+1. **Continuation standing is a precondition, not a consequence**: A chain's
+   right to continue is determined by its accumulated history, scope compliance,
+   and burden satisfaction — not by whether the next step happens to be safe.
+   Evaluating merit first and then checking continuation would reverse the
+   logical dependency.
+
+2. **Prevents retroactive justification**: If revalidation ran after merit
+   evaluation, a passing step could be used to argue that the chain should
+   continue — even if the chain's accumulated trajectory warrants suspension.
+   Pre-merit ordering prevents local step success from being used to justify
+   chain-level continuation.
+
+3. **Refusal-before-effect**: If a chain's continuation standing is lost, the
+   chain should be stopped before the next step produces effects, not after.
+   Pre-merit revalidation is the structural enabler of this principle (enforced
+   in phase-3, observed in phase-1).
+
+4. **Clean separation of concerns**: FUJI evaluates "is this step safe?" The
+   Continuation Runtime evaluates "should this chain still be running?" Running
+   continuation first keeps FUJI's input unchanged — FUJI never needs to know
+   about continuation standing, and continuation never needs to know about step
+   content.
+
+---
+
+## Why Phase-1 Is Shadow-Only
+
+Phase-1 operates in observe/shadow mode for three reasons:
+
+1. **Calibration before consequence**: The Continuation Runtime is a new
+   assessment layer. Its judgments need to be validated against real production
+   traffic before they carry enforcement weight. Shadow mode produces the data
+   needed to evaluate whether the runtime's assessments are consistent,
+   explainable, and aligned with human judgment.
+
+2. **Protecting existing value**: VERITAS OS has a working, audited,
+   fail-closed step-level infrastructure. Introducing enforcement from a new,
+   unvalidated layer risks degrading the system's reliability. Shadow mode
+   guarantees that existing behavior is preserved while the new layer proves
+   itself.
+
+3. **Divergence as the primary signal**: The most valuable output of phase-1 is
+   **divergence data** — cases where the Continuation Runtime's shadow
+   recommendation differs from the actual pipeline outcome. These cases reveal
+   whether continuation-level observation adds genuine insight or merely
+   replicates what step-level gating already catches. Without shadow mode,
+   there is no way to measure this before enforcement changes behavior.
+
+---
+
+## Phase-1 Success Criteria
+
+Phase-1 is considered successful when:
+
+1. **Deterministic shadows**: Given the same inputs and law pack, revalidation
+   produces the same snapshots and receipts. Verified via the existing replay
+   infrastructure.
+
+2. **Receipt sufficiency**: An auditor can reconstruct the full revalidation
+   history of a chain from its receipts alone, without access to runtime state.
+
+3. **Divergence observability**: Cases where shadow recommendations differ from
+   actual outcomes are automatically detected, logged, and available for review.
+
+4. **Zero interference**: All existing tests pass with the feature flag both on
+   and off. Response payloads, log formats, UI behavior, and execution
+   semantics are identical to the pre-continuation baseline when the flag is on.
+
+5. **Latency within budget**: Shadow revalidation does not materially increase
+   pipeline latency (target: < 5ms p99 overhead).
+
+6. **Architectural boundaries hold**: Snapshot/receipt separation is maintained.
+   FUJI is unmodified. No new routes or product areas are introduced.
+
+Phase-1 success does **not** require:
+
+- Proof that continuation-level observation catches problems step-level gating
+  misses (that is what the divergence data is for — phase-1 collects it,
+  phase-2 planning interprets it).
+- A complete law pack covering all possible continuation scenarios (phase-1 law
+  packs may be minimal and evolve).
+- UI integration of any kind.
+
+---
+
+## What This Is Not
+
+The Continuation Runtime is **not**:
+
+- **A better FUJI**: It does not replace, improve, or compete with FUJI. FUJI
+  evaluates steps; the Continuation Runtime evaluates chains. Different axis,
+  different responsibility.
+- **A solved problem**: Phase-1 is explicitly exploratory. The runtime's value
+  proposition is hypothesized, not proven. Shadow data will determine whether
+  chain-level observation adds genuine governance capability.
+- **A rejection of the current design**: The existing step-level infrastructure
+  is the foundation. The Continuation Runtime extends it — it does not critique
+  or replace it.
+- **An abstraction layer**: It is a concrete runtime with specific data
+  structures (lineage, snapshot, receipt, law pack) and a specific insertion
+  point (pre-merit, between critique and FUJI pre-check). It is not a framework
+  or plugin system.
+
+---
+
+## Seam Between Step-Level and Chain-Level
+
+The seam between the two layers is narrow and well-defined:
+
+| Aspect | Step-Level (existing) | Chain-Level (new) |
+|---|---|---|
+| Unit of evaluation | Single pipeline invocation | Chain of invocations |
+| Primary gate | FUJI (`decision_status`) | Continuation Runtime (`standing`) |
+| State carrier | `PipelineContext` | `ContinuationClaimLineage` |
+| Point-in-time record | Gate decision in TrustLog | `ClaimStateSnapshot` |
+| Audit trail | TrustLog entries | `ContinuationReceipt` chain |
+| Evaluation timing | During pipeline execution | Before pipeline merit evaluation |
+| Phase-1 effect on pipeline | Defines pipeline outcome | None (shadow only) |
+
+The seam is **read-only from chain to step**: the Continuation Runtime may read
+pipeline context (e.g., chain identifier, step sequence number) but does not
+write to any `PipelineContext` field that step-level logic consumes. In phase-1,
+this is absolute. In future phases, any coupling across this seam requires
+explicit architectural review.


### PR DESCRIPTION
Establish architecture boundaries for chain-level continuation runtime
before any logic implementation. Fixes responsibility separation between
FUJI (step-level safety gate) and the new continuation runtime (chain-level
observation/adjudication), defines snapshot/receipt split, pipeline insertion
point, phased rollout strategy, and phase-1 success criteria.

No code changes. No existing behavior affected.

https://claude.ai/code/session_01NUaQsjRjKTpQqmbbLNTeLb