### PR TITLE
Add continuation runtime core data model (phase-1 observe/shadow)

### DIFF
--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -294,6 +294,9 @@ class CapabilityConfig:
             "VERITAS_CAP_MEMORY_SENTENCE_TRANSFORMERS", False
         )
     )
+    enable_continuation_runtime: bool = field(
+        default_factory=lambda: _parse_bool("VERITAS_CAP_CONTINUATION_RUNTIME", False)
+    )
     emit_manifest_on_import: bool = field(
         default_factory=lambda: _parse_bool("VERITAS_CAP_EMIT_MANIFEST", True)
     )

--- a/veritas_os/core/continuation_runtime/__init__.py
+++ b/veritas_os/core/continuation_runtime/__init__.py
@@ -1,0 +1,55 @@
+# veritas_os/core/continuation_runtime/__init__.py
+# -*- coding: utf-8 -*-
+"""
+Continuation Runtime — Core Data Model (Phase-1: observe/shadow only)
+
+Chain-level continuation observation substrate that runs *beside* the
+existing step-level decision infrastructure.  This module defines the
+four core structures:
+
+- ContinuationClaimLineage : live object representing a chain's standing
+- ClaimStateSnapshot       : minimal governable state at a point in time
+- ContinuationReceipt      : audit witness emitted per revalidation
+- ContinuationLawPack      : versioned rule set governing revalidation
+
+Phase-1 contract:
+  - Feature flag off → zero side effects, zero imports beyond this module
+  - No enforcement; snapshots and receipts are observation artifacts only
+  - FUJI is unmodified; gate.decision_status is unmodified
+"""
+from __future__ import annotations
+
+from .reason_codes import ReasonCode
+from .lineage import ContinuationClaimLineage, ClaimStatus
+from .snapshot import (
+    ClaimStateSnapshot,
+    SupportBasis,
+    Scope,
+    BurdenState,
+    HeadroomState,
+    RevocationCondition,
+)
+from .receipt import ContinuationReceipt, RevalidationStatus, RevalidationOutcome
+from .lawpack import ContinuationLawPack, EvaluationMode
+
+__all__ = [
+    # lineage
+    "ContinuationClaimLineage",
+    "ClaimStatus",
+    # snapshot
+    "ClaimStateSnapshot",
+    "SupportBasis",
+    "Scope",
+    "BurdenState",
+    "HeadroomState",
+    "RevocationCondition",
+    # receipt
+    "ContinuationReceipt",
+    "RevalidationStatus",
+    "RevalidationOutcome",
+    # lawpack
+    "ContinuationLawPack",
+    "EvaluationMode",
+    # reason codes
+    "ReasonCode",
+]

--- a/veritas_os/core/continuation_runtime/lawpack.py
+++ b/veritas_os/core/continuation_runtime/lawpack.py
@@ -1,0 +1,63 @@
+# veritas_os/core/continuation_runtime/lawpack.py
+# -*- coding: utf-8 -*-
+"""
+ContinuationLawPack — versioned, immutable rule set for revalidation.
+
+Law packs define the conditions under which continuation standing is
+maintained, narrowed, or lost.  They are NOT policies in the FUJI sense
+(content safety); they govern the structural validity of continuation.
+
+Each law pack is versioned and immutable once published.  Snapshots
+record which law_version was applied so that replay can deterministically
+reproduce the revalidation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class EvaluationMode(str, Enum):
+    """How the law pack's rules are combined during revalidation."""
+
+    SHADOW = "shadow"
+    ADVISORY = "advisory"
+    ENFORCE = "enforce"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass
+class ContinuationLawPack:
+    """Versioned rule set governing continuation revalidation.
+
+    Immutable once published.  ``law_version_id`` is the primary
+    reference used by snapshots and receipts.
+    """
+
+    law_version_id: str = ""
+    policy_family: str = ""
+    invariant_family: str = ""
+    corridor_family: str = ""
+    rule_refs: List[str] = field(default_factory=list)
+    evaluation_mode: EvaluationMode = EvaluationMode.SHADOW
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable dict representation."""
+        d = asdict(self)
+        d["evaluation_mode"] = self.evaluation_mode.value
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ContinuationLawPack":
+        """Reconstruct from a dict (e.g. deserialized JSON)."""
+        data = dict(data)  # shallow copy
+        if "evaluation_mode" in data and isinstance(data["evaluation_mode"], str):
+            data["evaluation_mode"] = EvaluationMode(data["evaluation_mode"])
+        return cls(**data)

--- a/veritas_os/core/continuation_runtime/lineage.py
+++ b/veritas_os/core/continuation_runtime/lineage.py
@@ -1,0 +1,79 @@
+# veritas_os/core/continuation_runtime/lineage.py
+# -*- coding: utf-8 -*-
+"""
+ContinuationClaimLineage — the live chain-level continuation object.
+
+A lineage is created at chain entry and updated at each revalidation.
+It is not a permit — it is the structured record of an ongoing claim
+that must be continuously justified.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+
+class ClaimStatus(str, Enum):
+    """Current standing of a continuation claim."""
+
+    LIVE = "live"
+    NARROWED = "narrowed"
+    DEGRADED = "degraded"
+    ESCALATED = "escalated"
+    HALTED = "halted"
+    REVOKED = "revoked"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class ContinuationClaimLineage:
+    """Live object representing a chain's continuation standing.
+
+    Created once at chain entry.  ``latest_snapshot_id`` and
+    ``current_claim_status`` are updated after each revalidation pass.
+    """
+
+    # identity
+    claim_lineage_id: str = field(default_factory=lambda: uuid4().hex)
+    chain_id: str = ""
+    origin_ref: str = ""
+
+    # provenance
+    created_at: str = field(default_factory=_utcnow)
+    initial_law_version: str = ""
+    initial_support_basis_ref: str = ""
+
+    # mutable pointers (updated by revalidation)
+    latest_snapshot_id: Optional[str] = None
+    current_claim_status: ClaimStatus = ClaimStatus.LIVE
+
+    # revocation
+    is_revoked: bool = False
+    revoked_at: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable dict representation."""
+        d = asdict(self)
+        d["current_claim_status"] = self.current_claim_status.value
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ContinuationClaimLineage":
+        """Reconstruct from a dict (e.g. deserialized JSON)."""
+        data = dict(data)  # shallow copy
+        if "current_claim_status" in data:
+            data["current_claim_status"] = ClaimStatus(data["current_claim_status"])
+        return cls(**data)

--- a/veritas_os/core/continuation_runtime/reason_codes.py
+++ b/veritas_os/core/continuation_runtime/reason_codes.py
@@ -1,0 +1,28 @@
+# veritas_os/core/continuation_runtime/reason_codes.py
+# -*- coding: utf-8 -*-
+"""
+Reason codes for continuation revalidation outcomes.
+
+Each code identifies a specific condition that caused standing to change.
+Codes are carried in ContinuationReceipt.revalidation_reason_codes.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ReasonCode(str, Enum):
+    """Machine-readable reason codes for revalidation outcomes."""
+
+    SUPPORT_LOST_POLICY_SCOPE = "SUPPORT_LOST_POLICY_SCOPE"
+    SUPPORT_LOST_WORLD_STATE = "SUPPORT_LOST_WORLD_STATE"
+    SUPPORT_LOST_APPROVAL = "SUPPORT_LOST_APPROVAL"
+    BURDEN_THRESHOLD_EXCEEDED = "BURDEN_THRESHOLD_EXCEEDED"
+    HEADROOM_COLLAPSED = "HEADROOM_COLLAPSED"
+    REVALIDATION_FAILED = "REVALIDATION_FAILED"
+    ACTION_CLASS_NOT_ALLOWED = "ACTION_CLASS_NOT_ALLOWED"
+    CLAIM_HALTED = "CLAIM_HALTED"
+    CLAIM_REVOKED = "CLAIM_REVOKED"
+
+    def __str__(self) -> str:
+        return self.value

--- a/veritas_os/core/continuation_runtime/receipt.py
+++ b/veritas_os/core/continuation_runtime/receipt.py
@@ -1,0 +1,135 @@
+# veritas_os/core/continuation_runtime/receipt.py
+# -*- coding: utf-8 -*-
+"""
+ContinuationReceipt — audit witness emitted per revalidation pass.
+
+A receipt records *how* the claim's standing was examined, what was
+found, and what the runtime would have recommended.  Receipts are
+append-only and form a chain-level audit trail.
+
+The receipt is NOT a state store — runtime logic reads the snapshot for
+current state; receipts are for audit, replay, and divergence analysis.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from .reason_codes import ReasonCode
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class RevalidationStatus(str, Enum):
+    """What happened during revalidation (receipt-side, not snapshot-side)."""
+
+    RENEWED = "renewed"
+    NARROWED = "narrowed"
+    DEGRADED = "degraded"
+    ESCALATED = "escalated"
+    HALTED = "halted"
+    REVOKED = "revoked"
+    FAILED = "failed"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class RevalidationOutcome(str, Enum):
+    """High-level outcome of the revalidation pass."""
+
+    RENEWED = "renewed"
+    NARROWED = "narrowed"
+    DEGRADED = "degraded"
+    ESCALATED = "escalated"
+    HALTED = "halted"
+    REVOKED = "revoked"
+    FAILED = "failed"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass
+class ContinuationReceipt:
+    """Audit witness emitted after each revalidation pass.
+
+    Contains everything an auditor, replay engine, or divergence
+    analyzer needs to understand what happened during revalidation.
+    """
+
+    # identity
+    receipt_id: str = field(default_factory=lambda: uuid4().hex)
+    claim_lineage_id: str = ""
+    snapshot_id: str = ""
+    receipt_timestamp: str = field(default_factory=_utcnow)
+    law_version_id: str = ""
+
+    # revalidation outcome (receipt-side responsibility)
+    revalidation_status: RevalidationStatus = RevalidationStatus.RENEWED
+    revalidation_outcome: RevalidationOutcome = RevalidationOutcome.RENEWED
+    revalidation_reason_codes: List[ReasonCode] = field(default_factory=list)
+
+    # linkage to preceding decisions and receipts
+    prior_decision_continuity_ref: Optional[str] = None
+    parent_receipt_ref: Optional[str] = None
+    receipt_hash_or_attestation: Optional[str] = None
+    replay_linkage_ref: Optional[str] = None
+
+    # step-level observation (receipt holds this, NOT snapshot)
+    local_step_result: Optional[str] = None
+    divergence_flag: bool = False
+    should_refuse_before_effect: bool = False
+
+    # digest summaries for audit (derived from snapshot at emission time)
+    support_basis_digest: Optional[str] = None
+    scope_digest: Optional[str] = None
+    burden_headroom_digest: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable dict representation."""
+        d: Dict[str, Any] = {
+            "receipt_id": self.receipt_id,
+            "claim_lineage_id": self.claim_lineage_id,
+            "snapshot_id": self.snapshot_id,
+            "receipt_timestamp": self.receipt_timestamp,
+            "law_version_id": self.law_version_id,
+            "revalidation_status": self.revalidation_status.value,
+            "revalidation_outcome": self.revalidation_outcome.value,
+            "revalidation_reason_codes": [rc.value for rc in self.revalidation_reason_codes],
+            "prior_decision_continuity_ref": self.prior_decision_continuity_ref,
+            "parent_receipt_ref": self.parent_receipt_ref,
+            "receipt_hash_or_attestation": self.receipt_hash_or_attestation,
+            "replay_linkage_ref": self.replay_linkage_ref,
+            "local_step_result": self.local_step_result,
+            "divergence_flag": self.divergence_flag,
+            "should_refuse_before_effect": self.should_refuse_before_effect,
+            "support_basis_digest": self.support_basis_digest,
+            "scope_digest": self.scope_digest,
+            "burden_headroom_digest": self.burden_headroom_digest,
+        }
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ContinuationReceipt":
+        """Reconstruct from a dict (e.g. deserialized JSON)."""
+        data = dict(data)  # shallow copy
+        if "revalidation_status" in data and isinstance(data["revalidation_status"], str):
+            data["revalidation_status"] = RevalidationStatus(data["revalidation_status"])
+        if "revalidation_outcome" in data and isinstance(data["revalidation_outcome"], str):
+            data["revalidation_outcome"] = RevalidationOutcome(data["revalidation_outcome"])
+        if "revalidation_reason_codes" in data and isinstance(data["revalidation_reason_codes"], list):
+            data["revalidation_reason_codes"] = [
+                ReasonCode(rc) if isinstance(rc, str) else rc
+                for rc in data["revalidation_reason_codes"]
+            ]
+        return cls(**data)

--- a/veritas_os/core/continuation_runtime/snapshot.py
+++ b/veritas_os/core/continuation_runtime/snapshot.py
@@ -1,0 +1,213 @@
+# veritas_os/core/continuation_runtime/snapshot.py
+# -*- coding: utf-8 -*-
+"""
+ClaimStateSnapshot — minimal governable state of a continuation claim.
+
+A snapshot is the *input* to the next revalidation.  It contains exactly
+the facts needed to determine whether the claim's standing should be
+maintained, narrowed, escalated, or revoked — no more.
+
+Separation rule:
+  - revalidation_status   → receipt, NOT snapshot
+  - preceding_decision_continuity → receipt, NOT snapshot
+  - replay linkage        → receipt, NOT snapshot
+  - local_step_result     → receipt, NOT snapshot
+  - receipt hash          → receipt, NOT snapshot
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from .lineage import ClaimStatus
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# =====================================================================
+# Sub-structures carried in the snapshot
+# =====================================================================
+
+
+@dataclass
+class SupportBasis:
+    """Structured justification sustaining a continuation claim.
+
+    Not a flat bool or prose — a structured collection of grounds.
+    Burden lives here as a component of the support basis.
+    """
+
+    authority: str = ""
+    policy: str = ""
+    evidence: str = ""
+    dependency: str = ""
+    environment: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SupportBasis":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class Scope:
+    """Explicit boundary of what a chain is permitted to continue doing.
+
+    Never implicit — always declares allowed/restricted action classes.
+    """
+
+    allowed_action_classes: List[str] = field(default_factory=list)
+    restricted_action_classes: List[str] = field(default_factory=list)
+    escalation_required: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Scope":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class BurdenState:
+    """Current evidentiary obligation the claim must sustain.
+
+    Not an optional note — a structured runtime object.
+    """
+
+    required_evidence: List[str] = field(default_factory=list)
+    satisfied_evidence: List[str] = field(default_factory=list)
+    threshold: float = 1.0
+    current_level: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BurdenState":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class HeadroomState:
+    """Remaining capacity before automatic escalation/suspension.
+
+    Headroom is the runtime interpretation of burden — how much margin
+    remains before thresholds are breached.
+    """
+
+    remaining: float = 1.0
+    threshold_escalation: float = 0.3
+    threshold_suspension: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "HeadroomState":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class RevocationCondition:
+    """Pre-declared condition under which standing is revoked.
+
+    Declarative, not implicit — conditions are stated up front so that
+    revocation is traceable to a specific, pre-announced trigger.
+    """
+
+    condition_id: str = ""
+    description: str = ""
+    is_met: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RevocationCondition":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+# =====================================================================
+# ClaimStateSnapshot
+# =====================================================================
+
+
+@dataclass
+class ClaimStateSnapshot:
+    """Minimal governable state of a continuation claim at a point in time.
+
+    Replaced at each revalidation; only the current snapshot is
+    authoritative for runtime logic.
+    """
+
+    # identity & linkage
+    snapshot_id: str = field(default_factory=lambda: uuid4().hex)
+    claim_lineage_id: str = ""
+    prior_snapshot_id: Optional[str] = None
+    timestamp: str = field(default_factory=_utcnow)
+
+    # governable facts (core)
+    support_basis: SupportBasis = field(default_factory=SupportBasis)
+    scope: Scope = field(default_factory=Scope)
+    burden_state: BurdenState = field(default_factory=BurdenState)
+    headroom_state: HeadroomState = field(default_factory=HeadroomState)
+    law_version: str = ""
+    revocation_conditions: List[RevocationCondition] = field(default_factory=list)
+    claim_status: ClaimStatus = ClaimStatus.LIVE
+
+    # optional lightweight metadata (permitted but minimal)
+    state_digest: Optional[str] = None
+    effective_from: Optional[str] = None
+    effective_until: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable dict representation."""
+        d: Dict[str, Any] = {
+            "snapshot_id": self.snapshot_id,
+            "claim_lineage_id": self.claim_lineage_id,
+            "prior_snapshot_id": self.prior_snapshot_id,
+            "timestamp": self.timestamp,
+            "support_basis": self.support_basis.to_dict(),
+            "scope": self.scope.to_dict(),
+            "burden_state": self.burden_state.to_dict(),
+            "headroom_state": self.headroom_state.to_dict(),
+            "law_version": self.law_version,
+            "revocation_conditions": [rc.to_dict() for rc in self.revocation_conditions],
+            "claim_status": self.claim_status.value,
+            "state_digest": self.state_digest,
+            "effective_from": self.effective_from,
+            "effective_until": self.effective_until,
+        }
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ClaimStateSnapshot":
+        """Reconstruct from a dict (e.g. deserialized JSON)."""
+        data = dict(data)  # shallow copy
+        if "support_basis" in data and isinstance(data["support_basis"], dict):
+            data["support_basis"] = SupportBasis.from_dict(data["support_basis"])
+        if "scope" in data and isinstance(data["scope"], dict):
+            data["scope"] = Scope.from_dict(data["scope"])
+        if "burden_state" in data and isinstance(data["burden_state"], dict):
+            data["burden_state"] = BurdenState.from_dict(data["burden_state"])
+        if "headroom_state" in data and isinstance(data["headroom_state"], dict):
+            data["headroom_state"] = HeadroomState.from_dict(data["headroom_state"])
+        if "revocation_conditions" in data and isinstance(data["revocation_conditions"], list):
+            data["revocation_conditions"] = [
+                RevocationCondition.from_dict(rc) if isinstance(rc, dict) else rc
+                for rc in data["revocation_conditions"]
+            ]
+        if "claim_status" in data and isinstance(data["claim_status"], str):
+            data["claim_status"] = ClaimStatus(data["claim_status"])
+        return cls(**data)


### PR DESCRIPTION
Introduce chain-level continuation structures as an independent module
beside FUJI — no existing code modified except one feature flag addition.

New: ContinuationClaimLineage, ClaimStateSnapshot, ContinuationReceipt,
ContinuationLawPack, reason codes, and supporting sub-structures
(SupportBasis, Scope, BurdenState, HeadroomState, RevocationCondition).

Feature flag VERITAS_CAP_CONTINUATION_RUNTIME defaults to False.

https://claude.ai/code/session_01GnBx5swYHjqRqRLgLnm5rj