### PR TITLE
Fix Decision Console timeout misclassification and add execution lifecycle states

### DIFF
--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Card } from "@veritas/design-system";
 import { useI18n } from "../../components/i18n-provider";
 import { renderValue, toArray } from "../../features/console/analytics/utils";
@@ -32,7 +32,7 @@ export default function DecisionConsolePage(): JSX.Element {
   } = useConsoleState();
   const [activeResultTab, setActiveResultTab] = useState<"insights" | "raw">("insights");
 
-  const { loading, error, runDecision } = useDecide({
+  const { loading, error, executionStatus, latestEvent, notifySseActivity, runDecision } = useDecide({
     t,
     tk,
     query,
@@ -40,6 +40,30 @@ export default function DecisionConsolePage(): JSX.Element {
     setResult,
     setChatMessages,
   });
+
+  useEffect(() => {
+    if (typeof EventSource === "undefined") {
+      return () => undefined;
+    }
+    const stream = new EventSource("/api/veritas/v1/events");
+    stream.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as { type?: string; ts?: string; summary?: string };
+        const eventType = payload.type ?? "event";
+        const eventAt = payload.ts ?? new Date().toISOString();
+        const eventSummary = payload.summary ?? eventType;
+        notifySseActivity(`${eventType} @ ${eventAt} — ${eventSummary}`);
+      } catch {
+        // Ignore malformed event payloads.
+      }
+    };
+    stream.onerror = () => {
+      stream.close();
+    };
+    return () => {
+      stream.close();
+    };
+  }, [notifySseActivity]);
 
   const decisionId = String((result?.chosen as Record<string, unknown> | undefined)?.id ?? result?.request_id ?? "");
 
@@ -63,12 +87,19 @@ export default function DecisionConsolePage(): JSX.Element {
         chatMessages={chatMessages}
         query={query}
         loading={loading}
+        executionStatus={executionStatus}
         error={error}
         setQuery={setQuery}
         runDecision={runDecision}
       />
 
-      <PipelineVisualizer loading={loading} result={result} error={error} />
+      <PipelineVisualizer
+        loading={loading}
+        executionStatus={executionStatus}
+        latestEvent={latestEvent}
+        result={result}
+        error={error}
+      />
 
       <FujiGateStatusPanel result={result} />
 

--- a/frontend/features/console/api/useDecide.test.ts
+++ b/frontend/features/console/api/useDecide.test.ts
@@ -90,7 +90,7 @@ describe("useDecide", () => {
     const { result } = renderHook(() =>
       useDecide({
         t: (_ja, en) => en,
-        tk: () => "",
+        tk: (key) => key,
         query: "q",
         setQuery,
         setResult,
@@ -128,7 +128,7 @@ describe("useDecide", () => {
     const { result } = renderHook(() =>
       useDecide({
         t: (_ja, en) => en,
-        tk: () => "",
+        tk: (key) => key,
         query: "q",
         setQuery,
         setResult,
@@ -140,7 +140,7 @@ describe("useDecide", () => {
       await result.current.runDecision("question");
     });
 
-    expect(result.current.error).toBe("HTTP 500: Request failed. Please try again later.");
+    expect(result.current.error).toBe("serverError");
     expect(result.current.error).not.toContain("stack trace");
     expect(setResult).toHaveBeenCalledWith(null);
   });
@@ -165,7 +165,7 @@ describe("useDecide", () => {
     const { result } = renderHook(() =>
       useDecide({
         t: (_ja, en) => en,
-        tk: () => "",
+        tk: (key) => key,
         query: "q",
         setQuery,
         setResult,

--- a/frontend/features/console/api/useDecide.ts
+++ b/frontend/features/console/api/useDecide.ts
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type DecideResponse, isDecideResponse } from "@veritas/types";
-import { veritasFetch } from "../../../lib/api-client";
+import { ApiError, classifyHttpStatus, veritasFetchWithOptions } from "../../../lib/api-client";
 import { toAssistantMessage } from "../analytics/utils";
-import { type ChatMessage } from "../types";
+import { type ChatMessage, type ConsoleExecutionStatus } from "../types";
 import { type LocaleKey } from "../../../locales/ja";
 
 interface UseDecideParams {
@@ -17,11 +17,14 @@ interface UseDecideParams {
 interface UseDecideResult {
   loading: boolean;
   error: string | null;
+  executionStatus: ConsoleExecutionStatus;
+  latestEvent: string | null;
   setError: (error: string | null) => void;
+  notifySseActivity: (eventSummary: string) => void;
   runDecision: (nextQuery?: string) => Promise<void>;
 }
 
-const DECIDE_TIMEOUT_MS = 20_000;
+const DECIDE_TIMEOUT_MS = 45_000;
 
 /**
  * Encapsulates decide API communication and user-facing error handling.
@@ -39,6 +42,8 @@ export function useDecide({
 }: UseDecideParams): UseDecideResult {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [executionStatus, setExecutionStatus] = useState<ConsoleExecutionStatus>("idle");
+  const [latestEvent, setLatestEvent] = useState<string | null>(null);
   const activeControllerRef = useRef<AbortController | null>(null);
   const requestSequenceRef = useRef(0);
   const latestRequestIdRef = useRef(0);
@@ -51,13 +56,20 @@ export function useDecide({
     };
   }, []);
 
+  const notifySseActivity = useCallback((eventSummary: string): void => {
+    setLatestEvent(eventSummary);
+    setExecutionStatus((current) => (current === "submitting" || current === "streaming" ? "streaming" : current));
+  }, []);
+
   const runDecision = async (nextQuery?: string): Promise<void> => {
     const queryToUse = (nextQuery ?? query).trim();
     setQuery(queryToUse);
     setError(null);
+    setLatestEvent(null);
 
     if (!queryToUse) {
       setError(tk("queryRequired"));
+      setExecutionStatus("failed");
       return;
     }
 
@@ -70,20 +82,23 @@ export function useDecide({
     latestRequestIdRef.current = requestId;
     const isLatestRequest = (): boolean => latestRequestIdRef.current === requestId;
     setLoading(true);
+    setExecutionStatus("submitting");
 
     try {
-      const response = await veritasFetch(
+      const response = await veritasFetchWithOptions(
         "/api/veritas/v1/decide",
-        {
-          method: "POST",
-          signal: controller.signal,
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            query: queryToUse,
-            context: {},
-          }),
+        { 
+          init: {
+            method: "POST",
+            signal: controller.signal,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              query: queryToUse,
+              context: {},
+            }),
+          },
+          timeoutMs: DECIDE_TIMEOUT_MS,
         },
-        DECIDE_TIMEOUT_MS,
       );
 
       if (!isLatestRequest()) {
@@ -93,6 +108,7 @@ export function useDecide({
       if (response.status === 401) {
         const authError = tk("authError");
         setError(authError);
+        setExecutionStatus("failed");
         setChatMessages((prev) => [
           ...prev,
           {
@@ -108,6 +124,7 @@ export function useDecide({
       if (response.status === 503) {
         const unavailable = tk("serviceUnavailable");
         setError(unavailable);
+        setExecutionStatus("failed");
         setChatMessages((prev) => [
           ...prev,
           {
@@ -121,11 +138,19 @@ export function useDecide({
       }
 
       if (!response.ok) {
-        const nextError = t(
-          `HTTP ${response.status}: リクエストに失敗しました。時間をおいて再試行してください。`,
-          `HTTP ${response.status}: Request failed. Please try again later.`,
-        );
+        const errorKind = classifyHttpStatus(response.status);
+        const nextError = errorKind === "auth"
+          ? tk("authError")
+          : errorKind === "validation"
+            ? tk("validationError")
+            : errorKind === "server"
+              ? tk("serverError")
+              : t(
+                `HTTP ${response.status}: リクエストに失敗しました。時間をおいて再試行してください。`,
+                `HTTP ${response.status}: Request failed. Please try again later.`,
+              );
         setError(nextError);
+        setExecutionStatus("failed");
         setChatMessages((prev) => [...prev, { id: nextMessageId(), role: "assistant", content: nextError }]);
         setResult(null);
         return;
@@ -135,26 +160,38 @@ export function useDecide({
       if (!isDecideResponse(payload)) {
         const schemaError = tk("schemaMismatch");
         setError(schemaError);
+        setExecutionStatus("failed");
         setChatMessages((prev) => [...prev, { id: nextMessageId(), role: "assistant", content: schemaError }]);
         setResult(null);
         return;
       }
 
       setResult(payload);
+      setExecutionStatus("completed");
       setChatMessages((prev) => [
         ...prev,
         { id: nextMessageId(), role: "assistant", content: toAssistantMessage(payload, t) },
       ]);
     } catch (caught: unknown) {
-      if (caught instanceof DOMException && caught.name === "AbortError") {
+      if (caught instanceof ApiError && caught.kind === "cancelled") {
         if (isLatestRequest()) {
-          const timeoutError = t(
-            "タイムアウト: 意思決定リクエストが時間内に完了しませんでした。",
-            "Timeout: decision request did not complete in time.",
-          );
+          setExecutionStatus("idle");
+        }
+        return;
+      }
+      if (caught instanceof ApiError && caught.kind === "timeout") {
+        if (isLatestRequest()) {
+          const timeoutError = tk("timeoutError");
           setError(timeoutError);
+          setExecutionStatus("timeout");
           setChatMessages((prev) => [...prev, { id: nextMessageId(), role: "assistant", content: timeoutError }]);
           setResult(null);
+        }
+        return;
+      }
+      if (caught instanceof DOMException && caught.name === "AbortError") {
+        if (isLatestRequest()) {
+          setExecutionStatus("idle");
         }
         return;
       }
@@ -163,6 +200,7 @@ export function useDecide({
       }
       const networkError = tk("networkError");
       setError(networkError);
+      setExecutionStatus("failed");
       setChatMessages((prev) => [...prev, { id: nextMessageId(), role: "assistant", content: networkError }]);
       setResult(null);
     } finally {
@@ -172,5 +210,5 @@ export function useDecide({
     }
   };
 
-  return { loading, error, setError, runDecision };
+  return { loading, error, executionStatus, latestEvent, setError, notifySseActivity, runDecision };
 }

--- a/frontend/features/console/components/chat-panel.test.tsx
+++ b/frontend/features/console/components/chat-panel.test.tsx
@@ -12,6 +12,7 @@ function renderPanel(overrides: Partial<Parameters<typeof ChatPanel>[0]> = {}) {
     chatMessages: [],
     query: "",
     loading: false,
+    executionStatus: "idle",
     error: null,
     setQuery: vi.fn(),
     runDecision: vi.fn().mockResolvedValue(undefined),

--- a/frontend/features/console/components/chat-panel.tsx
+++ b/frontend/features/console/components/chat-panel.tsx
@@ -2,7 +2,7 @@ import { type LocaleKey } from "../../../locales/ja";
 import { sanitizeText } from "../../../lib/utils";
 import { Button, Card } from "@veritas/design-system";
 import { DANGER_PRESETS, isDangerPresetsEnabled } from "../constants";
-import { type ChatMessage } from "../types";
+import { type ChatMessage, type ConsoleExecutionStatus } from "../types";
 
 interface ChatPanelProps {
   t: (ja: string, en: string) => string;
@@ -10,6 +10,7 @@ interface ChatPanelProps {
   chatMessages: ChatMessage[];
   query: string;
   loading: boolean;
+  executionStatus: ConsoleExecutionStatus;
   error: string | null;
   setQuery: (value: string) => void;
   runDecision: (nextQuery?: string) => Promise<void>;
@@ -27,6 +28,7 @@ export function ChatPanel({
   chatMessages,
   query,
   loading,
+  executionStatus,
   error,
   setQuery,
   runDecision,
@@ -100,6 +102,12 @@ export function ChatPanel({
         <Button type="submit" disabled={loading}>
           {loading ? tk("sending") : tk("send")}
         </Button>
+
+        {executionStatus === "submitting" || executionStatus === "streaming" ? (
+          <p className="text-xs text-muted-foreground">
+            {executionStatus === "streaming" ? tk("streamingStatus") : tk("submittingStatus")}
+          </p>
+        ) : null}
 
         {error ? (
           <p role="alert" className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-300">

--- a/frontend/features/console/components/pipeline-visualizer.test.tsx
+++ b/frontend/features/console/components/pipeline-visualizer.test.tsx
@@ -15,7 +15,7 @@ describe("PipelineVisualizer", () => {
   });
 
   it("renders all pipeline stages and supports stage drilldown", () => {
-    render(<PipelineVisualizer loading={false} result={null} error={null} />);
+    render(<PipelineVisualizer loading={false} executionStatus="idle" latestEvent={null} result={null} error={null} />);
 
     expect(screen.getByText("Pipeline Operations View")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /1\. Input/i })).toBeInTheDocument();
@@ -33,7 +33,7 @@ describe("PipelineVisualizer", () => {
     vi.useFakeTimers();
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 
-    const { unmount } = render(<PipelineVisualizer loading result={null} error={null} />);
+    const { unmount } = render(<PipelineVisualizer loading executionStatus="submitting" latestEvent={null} result={null} error={null} />);
 
     act(() => {
       vi.advanceTimersByTime(1300);

--- a/frontend/features/console/components/pipeline-visualizer.tsx
+++ b/frontend/features/console/components/pipeline-visualizer.tsx
@@ -2,9 +2,12 @@ import { type DecideResponse } from "@veritas/types";
 import { useEffect, useMemo, useState } from "react";
 import { toPipelineStageViews } from "../adapters/decision-view";
 import { PIPELINE_STAGES } from "../constants";
+import { type ConsoleExecutionStatus } from "../types";
 
 interface PipelineVisualizerProps {
   loading: boolean;
+  executionStatus: ConsoleExecutionStatus;
+  latestEvent: string | null;
   result: DecideResponse | null;
   error: string | null;
 }
@@ -13,7 +16,13 @@ interface PipelineVisualizerProps {
  * Renders live decision pipeline cards and per-stage details.
  * While loading, cards progress sequentially so operators can track execution.
  */
-export function PipelineVisualizer({ loading, result, error }: PipelineVisualizerProps): JSX.Element {
+export function PipelineVisualizer({
+  loading,
+  executionStatus,
+  latestEvent,
+  result,
+  error,
+}: PipelineVisualizerProps): JSX.Element {
   const [activeIndex, setActiveIndex] = useState(0);
   const [selectedStage, setSelectedStage] = useState<(typeof PIPELINE_STAGES)[number]>(PIPELINE_STAGES[0]);
 
@@ -40,9 +49,11 @@ export function PipelineVisualizer({ loading, result, error }: PipelineVisualize
     <section aria-label="pipeline visualizer" className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold text-foreground">Pipeline Operations View</h2>
-        <span className="text-xs text-muted-foreground">
-          {loading ? "Live execution in progress" : "Latest execution snapshot"}
-        </span>
+        <div className="text-right text-xs text-muted-foreground">
+          <p>{loading ? "Live execution in progress" : "Latest execution snapshot"}</p>
+          <p className="uppercase tracking-wide">state: {executionStatus}</p>
+          {latestEvent ? <p className="max-w-[32rem] truncate">latest event: {latestEvent}</p> : null}
+        </div>
       </div>
       <ol className="grid gap-2 text-xs md:grid-cols-8">
         {cards.map((card, index) => {

--- a/frontend/features/console/types.ts
+++ b/frontend/features/console/types.ts
@@ -6,6 +6,14 @@ export interface ChatMessage {
   content: string;
 }
 
+export type ConsoleExecutionStatus =
+  | "idle"
+  | "submitting"
+  | "streaming"
+  | "completed"
+  | "failed"
+  | "timeout";
+
 export interface StepAnalytics {
   name: string;
   executed: boolean;

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -31,4 +31,6 @@ export const en: Record<LocaleKey, string> = {
   timeoutError: "Timeout: request did not complete in time.",
   serverError: "Server error: please try again later.",
   validationError: "Validation error: please check your input.",
+  submittingStatus: "Running… (submitting request)",
+  streamingStatus: "Running… (receiving events)",
 };

--- a/frontend/locales/ja.ts
+++ b/frontend/locales/ja.ts
@@ -29,6 +29,8 @@ export const ja = {
   timeoutError: "タイムアウト: リクエストが時間内に完了しませんでした。",
   serverError: "サーバーエラー: しばらくしてから再試行してください。",
   validationError: "入力エラー: リクエスト内容を確認してください。",
+  submittingStatus: "実行中…（リクエスト送信中）",
+  streamingStatus: "実行中…（イベント受信中）",
 } as const;
 
 export type LocaleKey = keyof typeof ja;


### PR DESCRIPTION
### Motivation
- The Decision Console occasionally showed a timeout even when backend `/v1/decide` returned 200 because the frontend used a 20s abort-based timeout and treated AbortError generically as a timeout, causing race conditions between POST and SSE updates.
- The goal is to ensure UI does not mark a backend-successful run as failed, keep SSE/BFF unchanged, and present clearer execution states to users.
- Also needed clearer error classification (auth/validation/server/timeout) and a streaming-friendly UX so pipeline snapshots reflect live SSE events while a POST is in-flight.

### Description
- Increased decide request timeout from `20_000` to `45_000` ms and switched `useDecide` to use `veritasFetchWithOptions` so timeouts, cancellations and HTTP errors are classified separately instead of relying on raw `AbortError`.
- Added a typed execution lifecycle `ConsoleExecutionStatus = "idle" | "submitting" | "streaming" | "completed" | "failed" | "timeout"` and wired state transitions in `useDecide` to reflect `submitting`, `streaming`, `completed`, `failed`, and `timeout` appropriately.
- Subscribed the Console page to the existing SSE endpoint (`/api/veritas/v1/events`) and propagate a `latestEvent` summary into the console state so the Pipeline header can show live event activity without modifying BFF/SSE server code.
- Improved error messages by classifying HTTP status via `classifyHttpStatus` and mapping to localized strings for `auth`, `validation`, and `server` errors; preserved distinct handling for `timeout` and `cancelled`.
- Minor UX updates: show `submitting` / `streaming` messages in the chat panel and display `executionStatus` + `latestEvent` in the Pipeline Operations header.
- Files changed (major):
  - `frontend/features/console/api/useDecide.ts` (timeout bump, fetchWithOptions, error classification, execution state)
  - `frontend/app/console/page.tsx` (SSE subscription + pass execution state to components)
  - `frontend/features/console/components/pipeline-visualizer.tsx` (show execution state and latest event)
  - `frontend/features/console/components/chat-panel.tsx` (show in-flight status)
  - `frontend/features/console/types.ts` (added `ConsoleExecutionStatus` type)
  - `frontend/locales/ja.ts`, `frontend/locales/en.ts` (new localized status strings)
  - Tests updated: `frontend/features/console/api/useDecide.test.ts`, `frontend/features/console/components/chat-panel.test.tsx`, `frontend/features/console/components/pipeline-visualizer.test.tsx`.
- Security note: SSE payloads are summarized and displayed; no use of `dangerouslySetInnerHTML` was introduced, but backend should avoid emitting sensitive plaintext in event `summary` to minimize exposure.

### Testing
- Ran unit tests for the modified console features: `pnpm test -- --run features/console/api/useDecide.test.ts features/console/components/chat-panel.test.tsx features/console/components/pipeline-visualizer.test.tsx app/console/page.test.tsx`, and all selected tests passed (17 tests passed).
- Performed TypeScript check: `pnpm typecheck` completed with no errors.
- Notes: an initial failing assertion in `useDecide` tests (due to changed i18n return values) was updated and the test suite was re-run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7b216385c83268b079aa96cee4acc)