### PR TITLE
Add pre-merit continuation revalidation shadow runtime (Task 3)

### DIFF
--- a/tests/test_continuation_revalidator.py
+++ b/tests/test_continuation_revalidator.py
@@ -1,0 +1,581 @@
+# tests/test_continuation_revalidator.py
+# -*- coding: utf-8 -*-
+"""
+Tests for ContinuationRevalidator — phase-1 shadow revalidation engine.
+
+Verifies:
+  - Snapshot / receipt pair emission and coherence
+  - Status determination (conservative logic)
+  - Divergence detection
+  - Flag off → zero side effects
+  - Lineage mutable pointer updates
+  - state/receipt separation
+"""
+from __future__ import annotations
+
+import os
+import pytest
+
+
+# =====================================================================
+# Revalidator unit tests
+# =====================================================================
+
+
+class TestContinuationRevalidator:
+    """Core revalidator logic tests."""
+
+    def _make_revalidator(self):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            ContinuationRevalidator,
+        )
+        return ContinuationRevalidator()
+
+    def _make_lineage(self, **kwargs):
+        from veritas_os.core.continuation_runtime.lineage import (
+            ContinuationClaimLineage,
+        )
+        defaults = {"chain_id": "test-chain", "origin_ref": "step:0"}
+        defaults.update(kwargs)
+        return ContinuationClaimLineage(**defaults)
+
+    def _make_condition(self, **kwargs):
+        from veritas_os.core.continuation_runtime.revalidator import PresentCondition
+        defaults = {
+            "chain_id": "test-chain",
+            "step_index": 1,
+            "query": "What is the weather?",
+            "context": {},
+        }
+        defaults.update(kwargs)
+        return PresentCondition(**defaults)
+
+    def test_basic_revalidation_returns_snapshot_and_receipt(self):
+        """Revalidation always returns both snapshot and receipt."""
+        from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
+        from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert isinstance(snapshot, ClaimStateSnapshot)
+        assert isinstance(receipt, ContinuationReceipt)
+
+    def test_snapshot_receipt_share_snapshot_id(self):
+        """Snapshot and receipt must reference the same snapshot_id."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert receipt.snapshot_id == snapshot.snapshot_id
+
+    def test_snapshot_receipt_share_lineage_id(self):
+        """Both reference the same claim_lineage_id."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.claim_lineage_id == lineage.claim_lineage_id
+        assert receipt.claim_lineage_id == lineage.claim_lineage_id
+
+    def test_live_status_yields_renewed(self):
+        """Default conditions → LIVE / RENEWED, no divergence."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.claim_status == ClaimStatus.LIVE
+        assert receipt.revalidation_status == RevalidationStatus.RENEWED
+        assert receipt.divergence_flag is False
+        assert receipt.should_refuse_before_effect is False
+
+    def test_lineage_updated_after_revalidation(self):
+        """Lineage mutable pointers are updated after revalidation."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert lineage.latest_snapshot_id == snapshot.snapshot_id
+        assert lineage.current_claim_status == snapshot.claim_status
+
+    def test_revoked_is_terminal(self):
+        """Once revoked, stays revoked regardless of new conditions."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        lineage.current_claim_status = ClaimStatus.REVOKED
+        lineage.is_revoked = True
+
+        condition = self._make_condition()
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.claim_status == ClaimStatus.REVOKED
+        assert receipt.divergence_flag is True
+        assert receipt.should_refuse_before_effect is True
+
+    def test_support_basis_lost_yields_revoked(self):
+        """No authority AND no policy → REVOKED."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition(
+            chain_id="",
+            context={"authorization": "", "policy_ref": ""},
+        )
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.claim_status == ClaimStatus.REVOKED
+        assert receipt.divergence_flag is True
+        assert receipt.should_refuse_before_effect is True
+
+    def test_scope_restriction_yields_narrowed(self):
+        """Restricted action classes present → NARROWED."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition(
+            context={"restricted_actions": ["execute"]},
+        )
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.claim_status == ClaimStatus.NARROWED
+        assert receipt.divergence_flag is True
+
+    def test_escalation_required_yields_escalated(self):
+        """escalation_required in scope → ESCALATED."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition(
+            context={"escalation_required": True},
+        )
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.claim_status == ClaimStatus.ESCALATED
+
+    def test_burden_threshold_exceeded_yields_degraded(self):
+        """Burden below threshold → DEGRADED."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition(
+            context={
+                "required_evidence": ["ev1", "ev2", "ev3"],
+                "satisfied_evidence": ["ev1"],
+                "burden_threshold": 1.0,
+            },
+        )
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.claim_status == ClaimStatus.DEGRADED
+
+    def test_snapshot_has_law_version(self):
+        """Snapshot records which law_version was applied."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.law_version != ""
+        assert snapshot.law_version == "v0.1.0-shadow"
+
+    def test_receipt_has_law_version_id(self):
+        """Receipt records law_version_id."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert receipt.law_version_id == "v0.1.0-shadow"
+
+    def test_snapshot_has_scope(self):
+        """Snapshot scope is explicit, not implicit."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.scope is not None
+        assert isinstance(snapshot.scope.allowed_action_classes, list)
+
+    def test_snapshot_has_burden_state(self):
+        """Snapshot carries burden_state (not optional)."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.burden_state is not None
+        assert hasattr(snapshot.burden_state, "threshold")
+
+    def test_snapshot_has_support_basis(self):
+        """Snapshot carries structured support_basis (not empty)."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        sb = snapshot.support_basis
+        # At minimum, authority or policy should be present for LIVE
+        assert sb.authority or sb.policy
+
+    def test_receipt_has_digests(self):
+        """Receipt carries digest summaries for audit."""
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert receipt.support_basis_digest is not None
+        assert receipt.scope_digest is not None
+        assert receipt.burden_headroom_digest is not None
+
+    def test_snapshot_serialization_roundtrip(self):
+        """Snapshot survives to_dict → from_dict."""
+        from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        snapshot, _ = rv.revalidate(lineage, condition)
+
+        d = snapshot.to_dict()
+        restored = ClaimStateSnapshot.from_dict(d)
+
+        assert restored.snapshot_id == snapshot.snapshot_id
+        assert restored.claim_status == snapshot.claim_status
+        assert restored.law_version == snapshot.law_version
+
+    def test_receipt_serialization_roundtrip(self):
+        """Receipt survives to_dict → from_dict."""
+        from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition()
+
+        _, receipt = rv.revalidate(lineage, condition)
+
+        d = receipt.to_dict()
+        restored = ContinuationReceipt.from_dict(d)
+
+        assert restored.receipt_id == receipt.receipt_id
+        assert restored.revalidation_status == receipt.revalidation_status
+        assert restored.divergence_flag == receipt.divergence_flag
+
+    def test_coherence_violation_raises(self):
+        """Coherence guard detects snapshot/receipt mismatch."""
+        from veritas_os.core.continuation_runtime.revalidator import (
+            ContinuationRevalidator,
+        )
+        from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
+        from veritas_os.core.continuation_runtime.receipt import (
+            ContinuationReceipt,
+            RevalidationStatus,
+        )
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        snap = ClaimStateSnapshot(
+            claim_status=ClaimStatus.REVOKED,
+            snapshot_id="snap-1",
+        )
+        rcpt = ContinuationReceipt(
+            snapshot_id="snap-1",
+            revalidation_status=RevalidationStatus.RENEWED,  # contradicts!
+        )
+
+        with pytest.raises(ValueError, match="Coherence violation"):
+            ContinuationRevalidator._assert_coherence(snap, rcpt)
+
+    def test_divergence_observable_when_claim_weakened(self):
+        """Divergence flag is True when claim_status != LIVE."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        rv = self._make_revalidator()
+        lineage = self._make_lineage()
+        condition = self._make_condition(
+            context={"restricted_actions": ["execute"]},
+        )
+
+        snapshot, receipt = rv.revalidate(lineage, condition)
+
+        assert snapshot.claim_status != ClaimStatus.LIVE
+        assert receipt.divergence_flag is True
+
+
+# =====================================================================
+# Convenience function tests
+# =====================================================================
+
+
+class TestRunContinuationRevalidationShadow:
+    """Tests for the pipeline integration helper function."""
+
+    def test_returns_three_objects(self):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+        from veritas_os.core.continuation_runtime.lineage import (
+            ContinuationClaimLineage,
+        )
+        from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
+        from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
+
+        lineage, snapshot, receipt = run_continuation_revalidation_shadow(
+            chain_id="test-chain",
+            step_index=0,
+            query="test",
+            context={},
+        )
+
+        assert isinstance(lineage, ContinuationClaimLineage)
+        assert isinstance(snapshot, ClaimStateSnapshot)
+        assert isinstance(receipt, ContinuationReceipt)
+
+    def test_creates_lineage_when_none_provided(self):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+
+        lineage, _, _ = run_continuation_revalidation_shadow(
+            chain_id="auto-chain",
+            step_index=0,
+            query="test",
+            context={},
+        )
+
+        assert lineage.chain_id == "auto-chain"
+        assert lineage.latest_snapshot_id is not None
+
+
+# =====================================================================
+# Output structure verification (against task requirements)
+# =====================================================================
+
+
+class TestOutputStructure:
+    """Verify that output structures meet task requirements."""
+
+    def _run_revalidation(self, **ctx_kwargs):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+        defaults = {
+            "chain_id": "struct-test",
+            "step_index": 1,
+            "query": "test query",
+            "context": {},
+        }
+        defaults.update(ctx_kwargs)
+        _, snapshot, receipt = run_continuation_revalidation_shadow(**defaults)
+        return snapshot.to_dict(), receipt.to_dict()
+
+    def test_state_side_required_fields(self):
+        """State side must contain all required fields."""
+        snap_d, _ = self._run_revalidation()
+
+        assert "claim_lineage_id" in snap_d
+        assert "snapshot_id" in snap_d
+        assert "claim_status" in snap_d
+        assert "support_basis" in snap_d
+        assert "scope" in snap_d
+        assert "burden_state" in snap_d
+        assert "headroom_state" in snap_d
+        assert "law_version" in snap_d
+
+    def test_receipt_side_required_fields(self):
+        """Receipt side must contain all required fields."""
+        _, rcpt_d = self._run_revalidation()
+
+        assert "receipt_id" in rcpt_d
+        assert "revalidation_status" in rcpt_d
+        assert "revalidation_outcome" in rcpt_d
+        assert "revalidation_reason_codes" in rcpt_d
+        assert "prior_decision_continuity_ref" in rcpt_d
+        assert "parent_receipt_ref" in rcpt_d
+        assert "should_refuse_before_effect" in rcpt_d
+        assert "divergence_flag" in rcpt_d
+
+    def test_state_and_receipt_are_separate(self):
+        """Snapshot and receipt are separate dicts, not merged."""
+        snap_d, rcpt_d = self._run_revalidation()
+
+        # Receipt fields must NOT appear in snapshot
+        assert "revalidation_status" not in snap_d
+        assert "divergence_flag" not in snap_d
+        assert "should_refuse_before_effect" not in snap_d
+
+        # State-specific fields must NOT appear in receipt
+        assert "support_basis" not in rcpt_d
+        assert "burden_state" not in rcpt_d
+        assert "headroom_state" not in rcpt_d
+
+    def test_continuation_is_not_bool_or_enum_only(self):
+        """Continuation must be a rich structure, not a bool/enum."""
+        snap_d, rcpt_d = self._run_revalidation()
+
+        # Both must be dicts with multiple fields
+        assert isinstance(snap_d, dict) and len(snap_d) > 5
+        assert isinstance(rcpt_d, dict) and len(rcpt_d) > 5
+
+    def test_law_version_present(self):
+        """law_version must be non-empty."""
+        snap_d, rcpt_d = self._run_revalidation()
+
+        assert snap_d["law_version"] != ""
+        assert rcpt_d["law_version_id"] != ""
+
+
+# =====================================================================
+# Feature flag off — zero side effects
+# =====================================================================
+
+
+class TestFeatureFlagOff:
+    """Verify that flag off → zero computation in PipelineContext."""
+
+    def test_pipeline_context_defaults_none(self):
+        """PipelineContext continuation fields default to None."""
+        from veritas_os.core.pipeline_types import PipelineContext
+
+        ctx = PipelineContext()
+
+        assert ctx.continuation_snapshot is None
+        assert ctx.continuation_receipt is None
+
+    def test_flag_off_default(self):
+        """VERITAS_CAP_CONTINUATION_RUNTIME defaults to False."""
+        # Ensure env var is not set
+        env_val = os.environ.pop("VERITAS_CAP_CONTINUATION_RUNTIME", None)
+        try:
+            from veritas_os.core.config import _parse_bool
+            assert _parse_bool("VERITAS_CAP_CONTINUATION_RUNTIME", False) is False
+        finally:
+            if env_val is not None:
+                os.environ["VERITAS_CAP_CONTINUATION_RUNTIME"] = env_val
+
+    def test_response_omits_continuation_when_flag_off(self):
+        """assemble_response omits 'continuation' key when ctx has no snapshot."""
+        from veritas_os.core.pipeline_types import PipelineContext
+        from veritas_os.core.pipeline_response import assemble_response
+
+        ctx = PipelineContext(
+            request_id="test-req",
+            query="test",
+            response_extras={"metrics": {}, "memory_citations": [], "memory_used_count": 0},
+        )
+
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "test"},
+            plan={"steps": [], "raw": None, "source": "fallback"},
+        )
+
+        assert "continuation" not in res
+
+    def test_response_includes_continuation_when_present(self):
+        """assemble_response includes 'continuation' when snapshot/receipt set."""
+        from veritas_os.core.pipeline_types import PipelineContext
+        from veritas_os.core.pipeline_response import assemble_response
+
+        ctx = PipelineContext(
+            request_id="test-req",
+            query="test",
+            response_extras={"metrics": {}, "memory_citations": [], "memory_used_count": 0},
+            continuation_snapshot={"snapshot_id": "s1", "claim_status": "live"},
+            continuation_receipt={"receipt_id": "r1", "divergence_flag": False},
+        )
+
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "test"},
+            plan={"steps": [], "raw": None, "source": "fallback"},
+        )
+
+        assert "continuation" in res
+        assert res["continuation"]["state"]["snapshot_id"] == "s1"
+        assert res["continuation"]["receipt"]["receipt_id"] == "r1"
+
+
+# =====================================================================
+# Divergence observation tests
+# =====================================================================
+
+
+class TestDivergenceObservation:
+    """Verify that divergence between local step pass and claim weakened
+    is observable in the output."""
+
+    def test_local_allow_with_continuation_degraded(self):
+        """Local step allows, but continuation is degraded → divergence visible."""
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+
+        _, snapshot, receipt = run_continuation_revalidation_shadow(
+            chain_id="div-test",
+            step_index=2,
+            query="normal query",
+            context={
+                "required_evidence": ["ev1", "ev2", "ev3"],
+                "satisfied_evidence": ["ev1"],
+                "burden_threshold": 1.0,
+            },
+            prior_decision_status="allow",  # local step passed
+        )
+
+        # Continuation is degraded while local step was allow
+        assert snapshot.to_dict()["claim_status"] == "degraded"
+        assert receipt.divergence_flag is True
+        assert receipt.prior_decision_continuity_ref == "allow"
+        # Advisory only — should_refuse is False for degraded
+        assert receipt.should_refuse_before_effect is False
+
+    def test_local_allow_with_continuation_revoked(self):
+        """Local step allows, but continuation is revoked → divergence + advisory refuse."""
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+
+        _, snapshot, receipt = run_continuation_revalidation_shadow(
+            chain_id="",  # no chain_id → no authority
+            step_index=3,
+            query="test",
+            context={"authorization": "", "policy_ref": ""},
+            prior_decision_status="allow",
+        )
+
+        assert snapshot.to_dict()["claim_status"] == "revoked"
+        assert receipt.divergence_flag is True
+        assert receipt.should_refuse_before_effect is True
+        assert receipt.prior_decision_continuity_ref == "allow"

--- a/veritas_os/core/continuation_runtime/__init__.py
+++ b/veritas_os/core/continuation_runtime/__init__.py
@@ -31,6 +31,11 @@ from .snapshot import (
 )
 from .receipt import ContinuationReceipt, RevalidationStatus, RevalidationOutcome
 from .lawpack import ContinuationLawPack, EvaluationMode
+from .revalidator import (
+    ContinuationRevalidator,
+    PresentCondition,
+    run_continuation_revalidation_shadow,
+)
 
 __all__ = [
     # lineage
@@ -52,4 +57,8 @@ __all__ = [
     "EvaluationMode",
     # reason codes
     "ReasonCode",
+    # revalidator
+    "ContinuationRevalidator",
+    "PresentCondition",
+    "run_continuation_revalidation_shadow",
 ]

--- a/veritas_os/core/continuation_runtime/revalidator.py
+++ b/veritas_os/core/continuation_runtime/revalidator.py
@@ -1,0 +1,583 @@
+# veritas_os/core/continuation_runtime/revalidator.py
+# -*- coding: utf-8 -*-
+"""
+ContinuationRevalidator — pre-merit chain-level revalidation engine.
+
+Phase-1 contract:
+  - Shadow / observe only; no enforcement, no refusal gating.
+  - Runs *before* step-level merit evaluation (FUJI / gate).
+  - Emits a (snapshot, receipt) pair per revalidation pass.
+  - ``should_refuse_before_effect`` is advisory only.
+  - snapshot and receipt are tightly coupled (emitted together,
+    share snapshot_id) but remain separate objects.
+
+The revalidator is NOT part of FUJI.  It lives beside FUJI as an
+independent chain-level observation substrate.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from .lineage import ContinuationClaimLineage, ClaimStatus
+from .snapshot import (
+    ClaimStateSnapshot,
+    SupportBasis,
+    Scope,
+    BurdenState,
+    HeadroomState,
+    RevocationCondition,
+)
+from .receipt import ContinuationReceipt, RevalidationStatus, RevalidationOutcome
+from .lawpack import ContinuationLawPack, EvaluationMode
+from .reason_codes import ReasonCode
+
+logger = logging.getLogger(__name__)
+
+
+# =====================================================================
+# Present-condition input (collected from pipeline context)
+# =====================================================================
+
+
+@dataclass
+class PresentCondition:
+    """Observable conditions at the point of revalidation.
+
+    Collected from the pipeline context *before* step-level evaluation.
+    This is the revalidator's input — not a snapshot (output).
+    """
+
+    chain_id: str = ""
+    step_index: int = 0
+    query: str = ""
+    context: Dict[str, Any] = field(default_factory=dict)
+    prior_decision_status: Optional[str] = None
+    prior_receipt_id: Optional[str] = None
+
+
+# =====================================================================
+# Default law pack (phase-1: shadow, conservative)
+# =====================================================================
+
+_DEFAULT_LAW_PACK = ContinuationLawPack(
+    law_version_id="v0.1.0-shadow",
+    policy_family="continuation_baseline",
+    invariant_family="structural_v1",
+    corridor_family="default",
+    rule_refs=[
+        "support_basis_present",
+        "scope_within_bounds",
+        "burden_below_threshold",
+        "headroom_positive",
+    ],
+    evaluation_mode=EvaluationMode.SHADOW,
+)
+
+
+def _default_law_pack() -> ContinuationLawPack:
+    """Return the default phase-1 law pack (shadow mode)."""
+    return _DEFAULT_LAW_PACK
+
+
+# =====================================================================
+# ContinuationRevalidator
+# =====================================================================
+
+
+class ContinuationRevalidator:
+    """Pre-merit chain-level revalidation engine.
+
+    Usage::
+
+        revalidator = ContinuationRevalidator()
+        snapshot, receipt = revalidator.revalidate(
+            lineage=lineage,
+            condition=present_condition,
+        )
+
+    The revalidator:
+      1. Loads / initialises the lineage (or accepts one).
+      2. Collects present conditions.
+      3. Resolves the applicable law pack.
+      4. Evaluates continuation standing (conservative).
+      5. Builds a new snapshot (state) and receipt (audit witness).
+      6. Updates the lineage's mutable pointers.
+
+    It does NOT enforce; it observes and records.
+    """
+
+    def __init__(
+        self,
+        law_pack: Optional[ContinuationLawPack] = None,
+    ) -> None:
+        self._law_pack = law_pack or _default_law_pack()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def revalidate(
+        self,
+        lineage: ContinuationClaimLineage,
+        condition: PresentCondition,
+        *,
+        prior_snapshot: Optional[ClaimStateSnapshot] = None,
+        prior_receipt: Optional[ContinuationReceipt] = None,
+    ) -> Tuple[ClaimStateSnapshot, ContinuationReceipt]:
+        """Run a single revalidation pass.
+
+        Returns ``(snapshot, receipt)`` — always both, always consistent.
+        """
+        # 1. Collect present conditions into a candidate support basis
+        support_basis = self._collect_support_basis(condition)
+
+        # 2. Build candidate scope
+        scope = self._collect_scope(condition)
+
+        # 3. Evaluate burden / headroom from context
+        burden_state = self._evaluate_burden(condition, prior_snapshot)
+        headroom_state = self._evaluate_headroom(burden_state)
+
+        # 4. Check revocation conditions
+        revocation_conditions = self._check_revocation_conditions(
+            condition, support_basis, prior_snapshot
+        )
+
+        # 5. Determine claim status and reason codes
+        claim_status, reason_codes = self._determine_status(
+            support_basis=support_basis,
+            scope=scope,
+            burden_state=burden_state,
+            headroom_state=headroom_state,
+            revocation_conditions=revocation_conditions,
+            prior_status=lineage.current_claim_status,
+        )
+
+        # 6. Build snapshot
+        snapshot = ClaimStateSnapshot(
+            claim_lineage_id=lineage.claim_lineage_id,
+            prior_snapshot_id=(
+                prior_snapshot.snapshot_id if prior_snapshot else lineage.latest_snapshot_id
+            ),
+            support_basis=support_basis,
+            scope=scope,
+            burden_state=burden_state,
+            headroom_state=headroom_state,
+            law_version=self._law_pack.law_version_id,
+            revocation_conditions=revocation_conditions,
+            claim_status=claim_status,
+        )
+
+        # 7. Map claim status to revalidation status/outcome
+        reval_status = self._map_revalidation_status(claim_status)
+        reval_outcome = self._map_revalidation_outcome(claim_status)
+
+        # 8. Determine divergence and advisory refusal
+        should_refuse = claim_status in (
+            ClaimStatus.HALTED,
+            ClaimStatus.REVOKED,
+        )
+        divergence = claim_status != ClaimStatus.LIVE
+
+        # 9. Build receipt
+        receipt = ContinuationReceipt(
+            claim_lineage_id=lineage.claim_lineage_id,
+            snapshot_id=snapshot.snapshot_id,
+            law_version_id=self._law_pack.law_version_id,
+            revalidation_status=reval_status,
+            revalidation_outcome=reval_outcome,
+            revalidation_reason_codes=reason_codes,
+            prior_decision_continuity_ref=condition.prior_decision_status,
+            parent_receipt_ref=(
+                prior_receipt.receipt_id if prior_receipt else condition.prior_receipt_id
+            ),
+            divergence_flag=divergence,
+            should_refuse_before_effect=should_refuse,
+            support_basis_digest=self._digest_support_basis(support_basis),
+            scope_digest=self._digest_scope(scope),
+            burden_headroom_digest=self._digest_burden_headroom(
+                burden_state, headroom_state
+            ),
+        )
+
+        # 10. Coherence guard: snapshot and receipt must agree on status
+        #     (prevents runtime claiming standing while receipt shows loss)
+        self._assert_coherence(snapshot, receipt)
+
+        # 11. Update lineage mutable pointers
+        lineage.latest_snapshot_id = snapshot.snapshot_id
+        lineage.current_claim_status = claim_status
+        if claim_status == ClaimStatus.REVOKED:
+            lineage.is_revoked = True
+            from .lineage import _utcnow
+            lineage.revoked_at = _utcnow()
+
+        return snapshot, receipt
+
+    # ------------------------------------------------------------------
+    # Condition collectors
+    # ------------------------------------------------------------------
+
+    def _collect_support_basis(self, condition: PresentCondition) -> SupportBasis:
+        """Build support basis from present conditions.
+
+        Phase-1 uses simple heuristics; production will integrate with
+        actual authority/policy/evidence stores.
+        """
+        ctx = condition.context or {}
+
+        # Authority: check if there's an explicit authorization
+        authority = ctx.get("authorization", "")
+        if not authority and condition.chain_id:
+            authority = f"chain:{condition.chain_id}"
+
+        # Policy: check for policy reference
+        policy = ctx.get("policy_ref", "default")
+
+        # Evidence: summarize available evidence
+        evidence_count = len(ctx.get("evidence", []))
+        evidence = f"evidence_count:{evidence_count}" if evidence_count else ""
+
+        # Dependency: external dependencies still available
+        dependency = ctx.get("dependency_status", "")
+
+        # Environment: runtime conditions
+        environment = ctx.get("environment_status", "nominal")
+
+        return SupportBasis(
+            authority=authority,
+            policy=policy,
+            evidence=evidence,
+            dependency=dependency,
+            environment=environment,
+        )
+
+    def _collect_scope(self, condition: PresentCondition) -> Scope:
+        """Build scope from present conditions."""
+        ctx = condition.context or {}
+        return Scope(
+            allowed_action_classes=ctx.get("allowed_actions", ["query", "decide"]),
+            restricted_action_classes=ctx.get("restricted_actions", []),
+            escalation_required=ctx.get("escalation_required", False),
+        )
+
+    def _evaluate_burden(
+        self,
+        condition: PresentCondition,
+        prior_snapshot: Optional[ClaimStateSnapshot],
+    ) -> BurdenState:
+        """Evaluate current burden state.
+
+        Burden accumulates across steps; each step may satisfy or
+        increase evidentiary requirements.
+        """
+        ctx = condition.context or {}
+
+        # Carry forward from prior snapshot if available
+        if prior_snapshot is not None:
+            prior_burden = prior_snapshot.burden_state
+            required = list(prior_burden.required_evidence)
+            satisfied = list(prior_burden.satisfied_evidence)
+            threshold = prior_burden.threshold
+            current_level = prior_burden.current_level
+        else:
+            required = ctx.get("required_evidence", [])
+            satisfied = ctx.get("satisfied_evidence", [])
+            threshold = ctx.get("burden_threshold", 1.0)
+            current_level = ctx.get("burden_current_level", 1.0)
+
+        # Check for newly satisfied evidence
+        new_evidence = ctx.get("new_evidence", [])
+        for ev in new_evidence:
+            if ev in required and ev not in satisfied:
+                satisfied.append(ev)
+
+        # Recalculate current level
+        if required:
+            current_level = len(satisfied) / len(required)
+        else:
+            current_level = 1.0
+
+        return BurdenState(
+            required_evidence=required,
+            satisfied_evidence=satisfied,
+            threshold=threshold,
+            current_level=current_level,
+        )
+
+    def _evaluate_headroom(self, burden_state: BurdenState) -> HeadroomState:
+        """Derive headroom from burden state.
+
+        Headroom = how much margin remains before burden thresholds
+        are breached.
+        """
+        remaining = burden_state.current_level
+        return HeadroomState(
+            remaining=remaining,
+            threshold_escalation=0.3,
+            threshold_suspension=0.0,
+        )
+
+    def _check_revocation_conditions(
+        self,
+        condition: PresentCondition,
+        support_basis: SupportBasis,
+        prior_snapshot: Optional[ClaimStateSnapshot],
+    ) -> List[RevocationCondition]:
+        """Check pre-declared revocation conditions."""
+        conditions: List[RevocationCondition] = []
+
+        # Condition: support basis must have authority
+        conditions.append(
+            RevocationCondition(
+                condition_id="authority_present",
+                description="Chain must have an authority reference",
+                is_met=not bool(support_basis.authority),
+            )
+        )
+
+        # Condition: policy must be present
+        conditions.append(
+            RevocationCondition(
+                condition_id="policy_present",
+                description="Policy reference must exist",
+                is_met=not bool(support_basis.policy),
+            )
+        )
+
+        return conditions
+
+    # ------------------------------------------------------------------
+    # Status determination (conservative)
+    # ------------------------------------------------------------------
+
+    def _determine_status(
+        self,
+        *,
+        support_basis: SupportBasis,
+        scope: Scope,
+        burden_state: BurdenState,
+        headroom_state: HeadroomState,
+        revocation_conditions: List[RevocationCondition],
+        prior_status: ClaimStatus,
+    ) -> Tuple[ClaimStatus, List[ReasonCode]]:
+        """Determine claim status from evaluated conditions.
+
+        Phase-1 is conservative: only degrades, never upgrades.
+        Once revoked, stays revoked.
+        """
+        reason_codes: List[ReasonCode] = []
+
+        # Revoked is terminal
+        if prior_status == ClaimStatus.REVOKED:
+            return ClaimStatus.REVOKED, [ReasonCode.CLAIM_REVOKED]
+
+        # Halted is terminal within a session
+        if prior_status == ClaimStatus.HALTED:
+            return ClaimStatus.HALTED, [ReasonCode.CLAIM_HALTED]
+
+        # Check revocation conditions
+        met_revocations = [rc for rc in revocation_conditions if rc.is_met]
+        if met_revocations:
+            # Both authority AND policy lost → revoked
+            authority_lost = any(
+                rc.condition_id == "authority_present" for rc in met_revocations
+            )
+            policy_lost = any(
+                rc.condition_id == "policy_present" for rc in met_revocations
+            )
+            if authority_lost and policy_lost:
+                reason_codes.append(ReasonCode.SUPPORT_LOST_APPROVAL)
+                reason_codes.append(ReasonCode.SUPPORT_LOST_POLICY_SCOPE)
+                return ClaimStatus.REVOKED, reason_codes
+
+        # Support basis lost (no authority and no policy)
+        if not support_basis.authority and not support_basis.policy:
+            reason_codes.append(ReasonCode.SUPPORT_LOST_APPROVAL)
+            return ClaimStatus.REVOKED, reason_codes
+
+        # Headroom collapsed
+        if headroom_state.remaining <= headroom_state.threshold_suspension:
+            reason_codes.append(ReasonCode.HEADROOM_COLLAPSED)
+            return ClaimStatus.HALTED, reason_codes
+
+        # Headroom near escalation
+        if headroom_state.remaining <= headroom_state.threshold_escalation:
+            reason_codes.append(ReasonCode.HEADROOM_COLLAPSED)
+            return ClaimStatus.ESCALATED, reason_codes
+
+        # Scope mismatch: escalation required
+        if scope.escalation_required:
+            reason_codes.append(ReasonCode.ACTION_CLASS_NOT_ALLOWED)
+            return ClaimStatus.ESCALATED, reason_codes
+
+        # Burden threshold exceeded
+        if burden_state.current_level < burden_state.threshold:
+            reason_codes.append(ReasonCode.BURDEN_THRESHOLD_EXCEEDED)
+            return ClaimStatus.DEGRADED, reason_codes
+
+        # Scope narrowing: restricted actions present
+        if scope.restricted_action_classes:
+            reason_codes.append(ReasonCode.ACTION_CLASS_NOT_ALLOWED)
+            return ClaimStatus.NARROWED, reason_codes
+
+        # All clear — maintain or renew
+        return ClaimStatus.LIVE, reason_codes
+
+    # ------------------------------------------------------------------
+    # Status mapping (ClaimStatus → RevalidationStatus / Outcome)
+    # ------------------------------------------------------------------
+
+    _STATUS_MAP: Dict[ClaimStatus, RevalidationStatus] = {
+        ClaimStatus.LIVE: RevalidationStatus.RENEWED,
+        ClaimStatus.NARROWED: RevalidationStatus.NARROWED,
+        ClaimStatus.DEGRADED: RevalidationStatus.DEGRADED,
+        ClaimStatus.ESCALATED: RevalidationStatus.ESCALATED,
+        ClaimStatus.HALTED: RevalidationStatus.HALTED,
+        ClaimStatus.REVOKED: RevalidationStatus.REVOKED,
+    }
+
+    _OUTCOME_MAP: Dict[ClaimStatus, RevalidationOutcome] = {
+        ClaimStatus.LIVE: RevalidationOutcome.RENEWED,
+        ClaimStatus.NARROWED: RevalidationOutcome.NARROWED,
+        ClaimStatus.DEGRADED: RevalidationOutcome.DEGRADED,
+        ClaimStatus.ESCALATED: RevalidationOutcome.ESCALATED,
+        ClaimStatus.HALTED: RevalidationOutcome.HALTED,
+        ClaimStatus.REVOKED: RevalidationOutcome.REVOKED,
+    }
+
+    def _map_revalidation_status(self, status: ClaimStatus) -> RevalidationStatus:
+        return self._STATUS_MAP.get(status, RevalidationStatus.FAILED)
+
+    def _map_revalidation_outcome(self, status: ClaimStatus) -> RevalidationOutcome:
+        return self._OUTCOME_MAP.get(status, RevalidationOutcome.FAILED)
+
+    # ------------------------------------------------------------------
+    # Digest helpers (for receipt audit fields)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _digest_support_basis(sb: SupportBasis) -> str:
+        raw = json.dumps(sb.to_dict(), sort_keys=True)
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _digest_scope(scope: Scope) -> str:
+        raw = json.dumps(scope.to_dict(), sort_keys=True)
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _digest_burden_headroom(
+        burden: BurdenState, headroom: HeadroomState
+    ) -> str:
+        raw = json.dumps(
+            {"burden": burden.to_dict(), "headroom": headroom.to_dict()},
+            sort_keys=True,
+        )
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+    # ------------------------------------------------------------------
+    # Coherence guard
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _assert_coherence(
+        snapshot: ClaimStateSnapshot,
+        receipt: ContinuationReceipt,
+    ) -> None:
+        """Ensure snapshot and receipt do not contradict each other.
+
+        Prevents: runtime claims standing while receipt shows lawful
+        continuity loss (strong-coupling requirement).
+        """
+        # snapshot.claim_status == REVOKED ↔ receipt shows REVOKED
+        if snapshot.claim_status == ClaimStatus.REVOKED:
+            if receipt.revalidation_status != RevalidationStatus.REVOKED:
+                raise ValueError(
+                    "Coherence violation: snapshot is REVOKED but "
+                    f"receipt status is {receipt.revalidation_status}"
+                )
+        if receipt.revalidation_status == RevalidationStatus.REVOKED:
+            if snapshot.claim_status != ClaimStatus.REVOKED:
+                raise ValueError(
+                    "Coherence violation: receipt is REVOKED but "
+                    f"snapshot status is {snapshot.claim_status}"
+                )
+
+        # snapshot.claim_status == HALTED ↔ receipt shows HALTED
+        if snapshot.claim_status == ClaimStatus.HALTED:
+            if receipt.revalidation_status != RevalidationStatus.HALTED:
+                raise ValueError(
+                    "Coherence violation: snapshot is HALTED but "
+                    f"receipt status is {receipt.revalidation_status}"
+                )
+        if receipt.revalidation_status == RevalidationStatus.HALTED:
+            if snapshot.claim_status != ClaimStatus.HALTED:
+                raise ValueError(
+                    "Coherence violation: receipt is HALTED but "
+                    f"snapshot status is {snapshot.claim_status}"
+                )
+
+        # Shared snapshot_id
+        if receipt.snapshot_id != snapshot.snapshot_id:
+            raise ValueError(
+                "Coherence violation: receipt.snapshot_id != snapshot.snapshot_id"
+            )
+
+
+# =====================================================================
+# Pipeline integration helper
+# =====================================================================
+
+
+def run_continuation_revalidation_shadow(
+    *,
+    chain_id: str,
+    step_index: int,
+    query: str,
+    context: Dict[str, Any],
+    prior_decision_status: Optional[str] = None,
+    prior_receipt_id: Optional[str] = None,
+    lineage: Optional[ContinuationClaimLineage] = None,
+    prior_snapshot: Optional[ClaimStateSnapshot] = None,
+    prior_receipt: Optional[ContinuationReceipt] = None,
+) -> Tuple[
+    ContinuationClaimLineage,
+    ClaimStateSnapshot,
+    ContinuationReceipt,
+]:
+    """Convenience function for pipeline integration.
+
+    Creates a lineage if none exists, runs revalidation, returns all
+    three objects.  This is the single entry-point used by the pipeline
+    sidecar stage.
+    """
+    if lineage is None:
+        lineage = ContinuationClaimLineage(
+            chain_id=chain_id,
+            origin_ref=f"step:{step_index}",
+            initial_law_version=_DEFAULT_LAW_PACK.law_version_id,
+        )
+
+    condition = PresentCondition(
+        chain_id=chain_id,
+        step_index=step_index,
+        query=query,
+        context=context,
+        prior_decision_status=prior_decision_status,
+        prior_receipt_id=prior_receipt_id,
+    )
+
+    revalidator = ContinuationRevalidator()
+    snapshot, receipt = revalidator.revalidate(
+        lineage=lineage,
+        condition=condition,
+        prior_snapshot=prior_snapshot,
+        prior_receipt=prior_receipt,
+    )
+
+    return lineage, snapshot, receipt

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -706,6 +706,38 @@ async def run_decide_pipeline(
     )
 
     # =================================================================
+    # Stage 5.9: Continuation revalidation (shadow / sidecar)
+    # =================================================================
+    # Runs *before* step-level merit evaluation (FUJI / gate).
+    # Feature flag off → zero computation, zero side effects.
+    try:
+        from .config import capability_cfg as _cap_cfg
+        if _cap_cfg.enable_continuation_runtime:
+            from .continuation_runtime.revalidator import (
+                run_continuation_revalidation_shadow as _run_cont_reval,
+            )
+            _cont_lineage, _cont_snap, _cont_rcpt = _run_cont_reval(
+                chain_id=ctx.body.get("chain_id", ctx.request_id),
+                step_index=ctx.body.get("step_index", 0),
+                query=ctx.query,
+                context=ctx.context,
+                prior_decision_status=ctx.decision_status,
+            )
+            ctx.continuation_snapshot = _cont_snap.to_dict()
+            ctx.continuation_receipt = _cont_rcpt.to_dict()
+            logger.debug(
+                "[continuation] shadow revalidation: status=%s divergence=%s",
+                _cont_snap.claim_status.value,
+                _cont_rcpt.divergence_flag,
+            )
+    except Exception as _cont_err:
+        _stage_failures.append(f"continuation_shadow:{type(_cont_err).__name__}")
+        logger.warning(
+            "[pipeline] continuation shadow revalidation failed (best-effort): %s",
+            _cont_err,
+        )
+
+    # =================================================================
     # Stage 6: Policy (FUJI + ValueCore + Gate)  (-> pipeline_policy)
     # =================================================================
     stage_fuji_precheck(ctx)

--- a/veritas_os/core/pipeline_response.py
+++ b/veritas_os/core/pipeline_response.py
@@ -31,7 +31,7 @@ def assemble_response(
     plan: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Build the DecideResponse‑compatible dict from pipeline context."""
-    return {
+    res = {
         "ok": True,
         "error": None,
         "request_id": ctx.request_id,
@@ -63,6 +63,15 @@ def assemble_response(
         "planner": ctx.response_extras.get("planner", {"steps": [], "raw": None, "source": "fallback"}),
         "trust_log": ctx.raw.get("trust_log") if isinstance(ctx.raw, dict) else None,
     }
+
+    # Continuation runtime shadow output (flag on only; omitted entirely when off)
+    if ctx.continuation_snapshot is not None and ctx.continuation_receipt is not None:
+        res["continuation"] = {
+            "state": ctx.continuation_snapshot,
+            "receipt": ctx.continuation_receipt,
+        }
+
+    return res
 
 
 def coerce_to_decide_response(

--- a/veritas_os/core/pipeline_types.py
+++ b/veritas_os/core/pipeline_types.py
@@ -90,6 +90,10 @@ class PipelineContext:
     rejection_reason: Optional[str] = None
     modifications: List[Any] = field(default_factory=list)
 
+    # --- Continuation runtime (shadow / observe only) ---
+    continuation_snapshot: Optional[Dict[str, Any]] = None
+    continuation_receipt: Optional[Dict[str, Any]] = None
+
     # --- Stage flags ---
     _should_run_web: bool = False
 


### PR DESCRIPTION
Introduce ContinuationRevalidator as a sidecar observation engine that
runs chain-level revalidation *before* step-level FUJI/gate evaluation.
Phase-1: shadow/observe only — no enforcement, no refusal gating.

- New: continuation_runtime/revalidator.py (lineage loader, condition
  collector, law pack resolver, revalidation engine, snapshot/receipt
  builder, coherence guard)
- Pipeline: Stage 5.9 inserted before Stage 6 (Policy), guarded by
  VERITAS_CAP_CONTINUATION_RUNTIME feature flag (default off)
- Response: continuation.state + continuation.receipt emitted only
  when flag is on; omitted entirely when off
- PipelineContext: two Optional[Dict] fields added (None by default)
- Tests: 33 tests covering revalidator logic, output structure,
  flag-off invariance, divergence observation, coherence checks

Existing behavior is fully preserved when flag is off: zero imports,
zero computation, zero response changes, zero log additions.
FUJI responsibility unchanged. gate.decision_status unchanged.

https://claude.ai/code/session_01EsSvQ3ED5crkM5JcBmTzEQ