### PR TITLE
Organize runtime artifact paths under runtime/<namespace> and add doctor auto log locations

### DIFF
--- a/veritas_os/core/config.py
+++ b/veritas_os/core/config.py
@@ -83,6 +83,35 @@ def _parse_str(env_key: str, default: str = "") -> str:
     return (os.getenv(env_key, default) or "").strip()
 
 
+def _resolve_runtime_namespace() -> str:
+    """Resolve runtime namespace (dev/test/demo/prod) from environment."""
+    explicit = _parse_str("VERITAS_RUNTIME_NAMESPACE")
+    if explicit:
+        return explicit.lower()
+
+    env_profile = _parse_str("VERITAS_ENV").lower()
+    mapping = {
+        "production": "prod",
+        "prod": "prod",
+        "staging": "dev",
+        "stage": "dev",
+        "development": "dev",
+        "dev": "dev",
+        "test": "test",
+        "testing": "test",
+        "demo": "demo",
+    }
+    return mapping.get(env_profile, "dev")
+
+
+def _resolve_runtime_root(repo_root: Path) -> Path:
+    """Resolve runtime root from environment or repository default."""
+    env_root = _parse_str("VERITAS_RUNTIME_ROOT")
+    if env_root:
+        return Path(env_root).expanduser()
+    return repo_root.parent / "runtime"
+
+
 # =============================================================================
 # スコアリング設定（kernel.py から外部化）
 # =============================================================================
@@ -370,12 +399,17 @@ class VeritasConfig:
 
     data_dir: Path | None = None
     log_dir: Path | None = None
+    runtime_root: Path | None = None
+    runtime_namespace: str = field(default_factory=_resolve_runtime_namespace)
+    runtime_dir: Path | None = None
     dataset_dir: Path | None = None
     memory_path: Path | None = None
     value_stats_path: Path | None = None
 
     trust_log_path: Path | None = None
     kv_path: Path | None = None
+    doctor_auto_log_path: Path | None = None
+    doctor_auto_err_path: Path | None = None
 
     # ==== Weights / meta ====
     telos_default_WT: float = 0.6
@@ -407,31 +441,39 @@ class VeritasConfig:
         if not self.api_key:
             self.api_key = self.api_key_str
 
-        # ベースは常に veritas_os
-        base = self.repo_root  # .../veritas_clean_test2/veritas_os
+        # runtime ルート / namespace / ディレクトリ
+        if self.runtime_root is None:
+            self.runtime_root = _resolve_runtime_root(self.repo_root)
+        if self.runtime_dir is None:
+            self.runtime_dir = self.runtime_root / self.runtime_namespace
 
         # --- PATH 決定 ---
         if self.log_dir is None:
-            self.log_dir = base / "scripts" / "logs"
+            self.log_dir = self.runtime_dir / "logs"
 
         if self.dataset_dir is None:
-            self.dataset_dir = base / "scripts" / "datasets"
+            self.dataset_dir = self.runtime_dir / "datasets"
 
         if self.data_dir is None:
-            # 互換用：data_dir も logs と同じ場所に寄せる
-            self.data_dir = self.log_dir
+            self.data_dir = self.runtime_dir / "data"
 
         if self.memory_path is None:
-            self.memory_path = self.log_dir / "memory.json"
+            self.memory_path = self.data_dir / "memory.json"
 
         if self.value_stats_path is None:
-            self.value_stats_path = self.log_dir / "value_stats.json"
+            self.value_stats_path = self.data_dir / "value_stats.json"
 
         if self.trust_log_path is None:
             self.trust_log_path = self.log_dir / "trust_log.json"
 
         if self.kv_path is None:
-            self.kv_path = self.log_dir / "kv.sqlite3"
+            self.kv_path = self.data_dir / "kv.sqlite3"
+
+        if self.doctor_auto_log_path is None:
+            self.doctor_auto_log_path = self.log_dir / "doctor" / "doctor_auto.log"
+
+        if self.doctor_auto_err_path is None:
+            self.doctor_auto_err_path = self.log_dir / "doctor" / "doctor_auto.err"
 
     def validate_api_secret_non_empty(self) -> None:
         """Validate that ``VERITAS_API_SECRET`` is configured securely.
@@ -517,6 +559,7 @@ class VeritasConfig:
                 self.dataset_dir.mkdir(parents=True, exist_ok=True)
                 self.data_dir.mkdir(parents=True, exist_ok=True)
                 self.kv_path.parent.mkdir(parents=True, exist_ok=True)
+                self.doctor_auto_log_path.parent.mkdir(parents=True, exist_ok=True)
                 self._dirs_ensured = True
             except OSError as e:
                 logging.getLogger(__name__).warning(

--- a/veritas_os/tests/test_config_coverage.py
+++ b/veritas_os/tests/test_config_coverage.py
@@ -175,6 +175,8 @@ def test_parse_str_trim(monkeypatch):
 def test_veritas_config_post_init_defaults():
     """All path fields get defaults when None."""
     cfg = VeritasConfig(api_secret="test_secret_value")
+    assert cfg.runtime_root is not None
+    assert cfg.runtime_dir is not None
     assert cfg.log_dir is not None
     assert cfg.dataset_dir is not None
     assert cfg.data_dir is not None
@@ -182,6 +184,8 @@ def test_veritas_config_post_init_defaults():
     assert cfg.value_stats_path is not None
     assert cfg.trust_log_path is not None
     assert cfg.kv_path is not None
+    assert cfg.doctor_auto_log_path is not None
+    assert cfg.doctor_auto_err_path is not None
 
 
 def test_veritas_config_api_key_alias():
@@ -345,12 +349,28 @@ def test_pipeline_config_defaults():
 
 
 # ============================================================
-# data_dir defaults to log_dir
+# data_dir defaults to runtime data directory (separate from logs)
 # ============================================================
 
-def test_data_dir_defaults_to_log_dir():
+def test_data_dir_defaults_to_runtime_data_dir():
     cfg = VeritasConfig(api_secret="test_secret_value")
-    assert cfg.data_dir == cfg.log_dir
+    assert cfg.runtime_dir is not None
+    assert cfg.data_dir == cfg.runtime_dir / "data"
+    assert cfg.log_dir == cfg.runtime_dir / "logs"
+
+
+def test_default_runtime_artifact_paths_are_grouped_under_runtime():
+    """Runtime artifacts should be written under runtime/<namespace> tree."""
+    cfg = VeritasConfig(api_secret="test_secret_value")
+    assert cfg.runtime_dir is not None
+    assert cfg.memory_path == cfg.runtime_dir / "data" / "memory.json"
+    assert cfg.trust_log_path == cfg.runtime_dir / "logs" / "trust_log.json"
+    assert cfg.doctor_auto_log_path == (
+        cfg.runtime_dir / "logs" / "doctor" / "doctor_auto.log"
+    )
+    assert cfg.doctor_auto_err_path == (
+        cfg.runtime_dir / "logs" / "doctor" / "doctor_auto.err"
+    )
 
 
 # ============================================================


### PR DESCRIPTION
### Motivation

- 現在のデフォルト出力先が `scripts/logs` に集中しており、状態ファイルとログが混在しているため、ランタイムごとの分離と整理を行う必要があった。 
- `memory.json` や `world_state.json.lock`、および自動診断（doctor）ログ出力先をランタイム名前空間ごとに整理し、開発/テスト/本番の分離を明確にするための変更。 
- 外部パス指定（`VERITAS_RUNTIME_ROOT` 等）による書き出し先変更は運用リスクを伴うため、その点を明示して注意喚起する必要があった。 

### Description

- `veritas_os/core/config.py` に `_resolve_runtime_namespace` と `_resolve_runtime_root` を追加して `runtime/<namespace>` ベースのパス解決を導入した。 
- `VeritasConfig` に `runtime_root`, `runtime_namespace`, `runtime_dir`, `doctor_auto_log_path`, `doctor_auto_err_path` のフィールドを追加し、デフォルトを `runtime/<ns>/data`（state）と `runtime/<ns>/logs`（logs）へ分離した。 
- `memory.json` / `value_stats.json` / `kv.sqlite3` などの状態データを `data` 側に配置し、ログは `logs` 側に配置するよう既定値を変更した。 
- `ensure_dirs()` で `logs/doctor` の親ディレクトリを作成するようにし、doctor 自動実行ログが書けることを保証する処理を追加した。 
- 関連のユニットテスト `veritas_os/tests/test_config_coverage.py` を更新して `runtime` 配下への集約と新しい doctor ログパスの期待値を検証するテストケースを追加した。 
- 変更されたファイル: `veritas_os/core/config.py`, `veritas_os/tests/test_config_coverage.py`。

セキュリティ注意: 設定変数 `VERITAS_RUNTIME_ROOT` を外部/任意のパスへ向けると、state/log を意図しない場所へ書き出すリスクがあるため、運用では信頼できる固定パスと適切なファイル権限を設定することを推奨します.

### Testing

- Ran `pytest -q veritas_os/tests/test_config_coverage.py` and all tests passed (`52 passed`).
- Existing coverage-focused assertions were updated and the modified test file verifies default path grouping and `ensure_dirs()` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d2c97cdc83268f2103fbb9abe045)