### PR TITLE
Add continuation runtime phase-1 tests, eval harness, and architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,29 @@ VERITAS OS wraps an LLM (e.g. OpenAI GPT-4.1-mini) with a **reproducible, fail-c
 - The project is **not** positioned as an alpha prototype anymore; it already contains substantial operational and audit infrastructure.
 - You should still expect active iteration in policy packs, deployment defaults, and environment-specific integrations.
 
+### Continuation Runtime (Phase-1: Observe/Shadow)
+
+VERITAS now includes a **chain-level continuation observation layer** that runs beside (not inside) the existing step-level decision infrastructure. This is **not** enforcement — it is observation only.
+
+| Aspect | Status |
+|---|---|
+| Mode | Observe / shadow only — no enforcement, no refusal gating |
+| FUJI | Unchanged — remains the final safety/policy gate for each step |
+| `gate.decision_status` | Unchanged — no new values, no reinterpretation |
+| Feature flag off | Zero change to response, logs, UI, or behavior |
+| Purpose | Detect when a chain's continuation standing weakens (narrowed, degraded, escalated, halted, revoked) even though individual steps pass |
+
+Key concepts:
+- **Snapshot** (state): minimal governable facts — support basis, scope, burden, headroom, law version
+- **Receipt** (audit witness): how revalidation was conducted, divergence flags, reason codes, receipt chain linkage
+- The snapshot is not a receipt. The receipt is not a state store. They are separate responsibilities.
+- Revalidation runs **before** step-level merit evaluation (pre-merit placement)
+- `should_refuse_before_effect` is advisory only in phase-1
+
+Enable with: `VERITAS_CAP_CONTINUATION_RUNTIME=1` (default: off)
+
+See: `docs/architecture/continuation_runtime_adr.md`, `docs/architecture/continuation_runtime_architecture_note.md`
+
 ## Why VERITAS?
 
 Most "agent frameworks" optimize autonomy and tool use.

--- a/docs/architecture/continuation_runtime_architecture_note.md
+++ b/docs/architecture/continuation_runtime_architecture_note.md
@@ -1,0 +1,146 @@
+# Architecture Note: Continuation Runtime (Phase-1)
+
+**Status**: Phase-1 (observe/shadow only)
+**Date**: 2026-03-28
+
+---
+
+## One-Page Summary
+
+### Before: Decision-Centric Model
+
+VERITAS OS evaluates each `/v1/decide` call as an independent step.
+FUJI gates each step on content safety and policy. Once a step passes,
+there is no mechanism to track whether the *chain* of steps retains the
+right to continue.
+
+```
+Step N  →  FUJI gate  →  allow/deny  →  done
+Step N+1 →  FUJI gate  →  allow/deny  →  done    (no chain awareness)
+```
+
+**Gap**: A chain can accumulate risk, lose its justification, or exceed
+its scope across steps — and no layer notices.
+
+### After: Decision + Governed Continuation Substrate
+
+The Continuation Runtime adds a **chain-level observation layer** that
+runs beside (not inside) the existing step-level infrastructure.
+
+```
+Step N  →  [Continuation Revalidation]  →  FUJI gate  →  allow/deny
+           ↓ snapshot (state)
+           ↓ receipt (audit witness)
+```
+
+FUJI is unchanged. `gate.decision_status` is unchanged. The Continuation
+Runtime observes and records whether the chain's continuation standing
+is maintained, narrowed, escalated, halted, or revoked.
+
+---
+
+## Why Lineage
+
+A `ContinuationClaimLineage` is a **live object** created at chain entry
+and updated at each step. It is not a permit — it is the structured
+record of an ongoing claim that must be continuously justified.
+
+Without lineage, there is no persistent identity for a chain's
+continuation standing. Each step would need to re-derive context from
+scratch, losing the ability to detect progressive weakening.
+
+## Why Snapshot
+
+A `ClaimStateSnapshot` captures the **minimal governable facts** at a
+point in time: support basis, scope, burden, headroom, law version, and
+revocation conditions.
+
+Snapshots are replaced at each revalidation. Only the current snapshot
+is authoritative for runtime logic. This prevents stale state from
+accumulating and keeps the snapshot schema small and fixed.
+
+**Separation rule**: Snapshots do not carry revalidation_status,
+divergence_flag, or preceding_decision_continuity. Those belong to
+receipts.
+
+## Why Receipt
+
+A `ContinuationReceipt` is the **audit witness** emitted per
+revalidation pass. It records how the claim was examined, what was found,
+and what the runtime would have recommended.
+
+Receipts are append-only and form a chain-level audit trail. They carry
+digests, reason codes, divergence flags, and linkage to parent receipts.
+
+**Separation rule**: Receipts do not carry support_basis, burden_state,
+or headroom_state. Those belong to snapshots. Receipts are for audit,
+replay, and divergence analysis — not for runtime state.
+
+## Why Pre-Merit Revalidation
+
+Continuation revalidation runs **before** FUJI's step-level evaluation
+(between pipeline stages 5b and 6a). This preserves the principle that
+continuation standing is checked before new work is assessed — not
+derived from the result of that work.
+
+If revalidation ran after FUJI, local step success could mask chain-level
+problems. Pre-merit placement ensures the runtime can detect "locally
+correct but chain-level problematic" situations.
+
+## Why Burden / Headroom
+
+**Burden** tracks evidentiary obligations the chain must sustain across
+steps. It is part of the support basis — not a separate metric bolted on.
+
+**Headroom** is the runtime interpretation of burden: how much margin
+remains before thresholds are breached. When headroom collapses (reaches
+threshold_suspension), the claim is halted.
+
+Without burden/headroom, there is no way to detect gradual evidentiary
+erosion across steps — only sudden, total support loss.
+
+## Why Refusal-Before-Effect is Deferred
+
+Phase-1 is observe/shadow only. The `should_refuse_before_effect` field
+is advisory: it records what the runtime *would* recommend, but does not
+block execution.
+
+Enforcement is deferred to later phases because:
+
+1. Shadow data must first demonstrate consistent, explainable assessments
+   under production traffic.
+2. Snapshot/receipt separation must hold under real-world conditions.
+3. Divergence patterns must be understood before acting on them.
+4. Explicit architectural review is required before advancing.
+
+---
+
+## What is NOT Solved
+
+- Enforcement (refusal gating) — deferred to phase-3
+- Advisory mode (logged recommendations) — deferred to phase-2
+- Integration with external authority/policy stores — phase-1 uses heuristics
+- Cross-chain continuation awareness — out of scope
+- Production-grade burden accumulation logic — phase-1 is conservative
+
+## Key Invariants
+
+| Invariant | Guarantee |
+|---|---|
+| FUJI unchanged | No modification to FUJI's public contract or internal logic |
+| gate.decision_status unchanged | No new values, no reinterpretation |
+| Feature flag off = zero change | No response mutation, no computation, no log output |
+| Snapshot ≠ Receipt | Separate schemas, separate responsibilities |
+| Revocation is terminal | Once revoked, always revoked |
+| Pre-merit placement | Revalidation runs before FUJI evaluation |
+| Law version recorded | Every snapshot and receipt records applicable law_version |
+
+---
+
+## References
+
+- `continuation_runtime_adr.md` — Architecture decision record (detailed)
+- `continuation_runtime_glossary.md` — Term definitions
+- `continuation_runtime_rollout.md` — Phased rollout plan
+- `spec/continuation_runtime_overview.md` — Conceptual overview
+- `core_responsibility_boundaries.md` — Module boundaries

--- a/frontend/features/console/components/continuation-status-card.test.tsx
+++ b/frontend/features/console/components/continuation-status-card.test.tsx
@@ -114,7 +114,8 @@ describe("ContinuationStatusCard", () => {
         })}
       />,
     );
-    expect(screen.getByText("YES")).toBeInTheDocument();
+    const yesElements = screen.getAllByText("YES");
+    expect(yesElements.length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows reason codes when present", () => {

--- a/frontend/features/console/components/continuation-status-card.test.tsx
+++ b/frontend/features/console/components/continuation-status-card.test.tsx
@@ -69,9 +69,11 @@ describe("ContinuationStatusCard", () => {
     expect(screen.getByText("v0.1.0-shadow")).toBeInTheDocument();
   });
 
-  it("renders revalidation status", () => {
+  it("renders revalidation status and outcome", () => {
     render(<ContinuationStatusCard result={makeResult()} />);
-    expect(screen.getByText("renewed")).toBeInTheDocument();
+    // Both revalidation_status and revalidation_outcome render "renewed"
+    const renewedElements = screen.getAllByText("renewed");
+    expect(renewedElements.length).toBeGreaterThanOrEqual(1);
   });
 
   it("does not show divergence banner when not diverged", () => {

--- a/frontend/features/console/components/continuation-status-card.test.tsx
+++ b/frontend/features/console/components/continuation-status-card.test.tsx
@@ -78,9 +78,8 @@ describe("ContinuationStatusCard", () => {
 
   it("does not show divergence banner when not diverged", () => {
     render(<ContinuationStatusCard result={makeResult()} />);
-    expect(
-      screen.queryByText(/chain continuation is weakened/i),
-    ).not.toBeInTheDocument();
+    // Japanese default: "弱化" is part of the divergence banner text
+    expect(screen.queryByText(/弱化/)).not.toBeInTheDocument();
   });
 
   it("shows divergence banner when diverged", () => {
@@ -96,9 +95,8 @@ describe("ContinuationStatusCard", () => {
         })}
       />,
     );
-    expect(
-      screen.getByText(/chain continuation is weakened/i),
-    ).toBeInTheDocument();
+    // Default locale is "ja" — t() returns first (Japanese) argument
+    expect(screen.getByText(/弱化/)).toBeInTheDocument();
     expect(screen.getByText("DEGRADED")).toBeInTheDocument();
   });
 

--- a/frontend/features/console/components/continuation-status-card.test.tsx
+++ b/frontend/features/console/components/continuation-status-card.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ContinuationStatusCard } from "./continuation-status-card";
+
+/**
+ * Minimal rendering tests for ContinuationStatusCard (phase-1).
+ *
+ * Verifies:
+ *   - Returns null when no continuation data
+ *   - Renders claim status when data present
+ *   - Renders divergence banner when diverged
+ *   - Does not render divergence banner when not diverged
+ *   - Shows law version
+ *   - Shows revalidation status / outcome
+ *   - Shows should-refuse indicator
+ */
+
+function makeResult(overrides: Record<string, unknown> = {}) {
+  return {
+    continuation: {
+      state: {
+        claim_lineage_id: "lin-1",
+        snapshot_id: "s-1",
+        claim_status: "live",
+        law_version: "v0.1.0-shadow",
+        support_basis: { authority: "chain:x", policy: "default" },
+        burden_state: { threshold: 1.0, current_level: 1.0 },
+        headroom_state: { remaining: 1.0 },
+        scope: { allowed_action_classes: ["query"] },
+        ...(overrides.state as Record<string, unknown> ?? {}),
+      },
+      receipt: {
+        receipt_id: "r-1",
+        revalidation_status: "renewed",
+        revalidation_outcome: "renewed",
+        should_refuse_before_effect: false,
+        divergence_flag: false,
+        reason_codes: [],
+        ...(overrides.receipt as Record<string, unknown> ?? {}),
+      },
+    },
+  } as never;
+}
+
+describe("ContinuationStatusCard", () => {
+  it("returns null when result has no continuation data", () => {
+    const { container } = render(
+      <ContinuationStatusCard result={{} as never} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when continuation.state is missing", () => {
+    const { container } = render(
+      <ContinuationStatusCard
+        result={{ continuation: { receipt: {} } } as never}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders claim status when data is present", () => {
+    render(<ContinuationStatusCard result={makeResult()} />);
+    expect(screen.getByText("LIVE")).toBeInTheDocument();
+  });
+
+  it("renders law version", () => {
+    render(<ContinuationStatusCard result={makeResult()} />);
+    expect(screen.getByText("v0.1.0-shadow")).toBeInTheDocument();
+  });
+
+  it("renders revalidation status", () => {
+    render(<ContinuationStatusCard result={makeResult()} />);
+    expect(screen.getByText("renewed")).toBeInTheDocument();
+  });
+
+  it("does not show divergence banner when not diverged", () => {
+    render(<ContinuationStatusCard result={makeResult()} />);
+    expect(
+      screen.queryByText(/chain continuation is weakened/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows divergence banner when diverged", () => {
+    render(
+      <ContinuationStatusCard
+        result={makeResult({
+          state: { claim_status: "degraded" },
+          receipt: {
+            revalidation_status: "degraded",
+            revalidation_outcome: "degraded",
+            divergence_flag: true,
+          },
+        })}
+      />,
+    );
+    expect(
+      screen.getByText(/chain continuation is weakened/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("DEGRADED")).toBeInTheDocument();
+  });
+
+  it("shows should-refuse YES when set", () => {
+    render(
+      <ContinuationStatusCard
+        result={makeResult({
+          state: { claim_status: "revoked" },
+          receipt: {
+            revalidation_status: "revoked",
+            revalidation_outcome: "revoked",
+            divergence_flag: true,
+            should_refuse_before_effect: true,
+          },
+        })}
+      />,
+    );
+    expect(screen.getByText("YES")).toBeInTheDocument();
+  });
+
+  it("shows reason codes when present", () => {
+    render(
+      <ContinuationStatusCard
+        result={makeResult({
+          state: { claim_status: "narrowed" },
+          receipt: {
+            revalidation_status: "narrowed",
+            divergence_flag: true,
+            reason_codes: ["ACTION_CLASS_NOT_ALLOWED"],
+          },
+        })}
+      />,
+    );
+    expect(
+      screen.getByText("ACTION_CLASS_NOT_ALLOWED"),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/test_continuation_eval_harness.py
+++ b/tests/test_continuation_eval_harness.py
@@ -1,0 +1,327 @@
+# tests/test_continuation_eval_harness.py
+# -*- coding: utf-8 -*-
+"""
+Minimal evaluation harness for Continuation Runtime phase-1.
+
+Runs a battery of scenarios and computes key metrics:
+  - divergence_detection_rate
+  - false_alarm_rate
+  - support_loss_capture_rate
+  - burden_headroom_drift_usefulness
+  - replay_explanatory_usefulness
+  - state_receipt_separation_clarity
+
+This is not a pytest-only file — the harness can also be run standalone
+for reporting.  But it is structured as pytest tests so CI picks it up.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Any, Tuple
+
+import pytest
+
+from veritas_os.core.continuation_runtime.revalidator import (
+    run_continuation_revalidation_shadow,
+    ContinuationRevalidator,
+    PresentCondition,
+)
+from veritas_os.core.continuation_runtime.lineage import (
+    ContinuationClaimLineage,
+    ClaimStatus,
+)
+from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
+from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
+
+
+# =====================================================================
+# Scenario definitions
+# =====================================================================
+
+
+@dataclass
+class EvalScenario:
+    """A single evaluation scenario."""
+
+    name: str
+    chain_id: str = "eval-chain"
+    context: Dict[str, Any] = field(default_factory=dict)
+    prior_decision_status: str = "allow"
+    expected_divergence: bool = False
+    expected_status: str = "live"
+    is_support_loss: bool = False
+    has_burden_drift: bool = False
+
+
+_SCENARIOS: List[EvalScenario] = [
+    # Normal — no divergence
+    EvalScenario(
+        name="normal_live",
+        context={},
+        expected_divergence=False,
+        expected_status="live",
+    ),
+    # True positive: support lost
+    EvalScenario(
+        name="support_lost_revoked",
+        chain_id="",
+        context={"authorization": "", "policy_ref": ""},
+        expected_divergence=True,
+        expected_status="revoked",
+        is_support_loss=True,
+    ),
+    # True positive: burden degraded
+    EvalScenario(
+        name="burden_degraded",
+        context={
+            "required_evidence": ["e1", "e2", "e3"],
+            "satisfied_evidence": ["e1"],
+        },
+        expected_divergence=True,
+        expected_status="degraded",
+        has_burden_drift=True,
+    ),
+    # True positive: headroom halted
+    EvalScenario(
+        name="headroom_halted",
+        context={
+            "required_evidence": ["e1", "e2"],
+            "satisfied_evidence": [],
+            "burden_current_level": 0.0,
+        },
+        expected_divergence=True,
+        expected_status="halted",
+        has_burden_drift=True,
+    ),
+    # True positive: scope narrowed
+    EvalScenario(
+        name="scope_narrowed",
+        context={"restricted_actions": ["execute"]},
+        expected_divergence=True,
+        expected_status="narrowed",
+    ),
+    # True positive: escalation required
+    EvalScenario(
+        name="escalation_required",
+        context={"escalation_required": True},
+        expected_divergence=True,
+        expected_status="escalated",
+    ),
+    # Normal — explicit good conditions
+    EvalScenario(
+        name="explicit_good_conditions",
+        context={
+            "authorization": "admin",
+            "policy_ref": "default",
+            "environment_status": "nominal",
+        },
+        expected_divergence=False,
+        expected_status="live",
+    ),
+    # Burden partial but not breached
+    EvalScenario(
+        name="burden_partial_not_breached",
+        context={
+            "required_evidence": ["e1", "e2"],
+            "satisfied_evidence": ["e1", "e2"],
+        },
+        expected_divergence=False,
+        expected_status="live",
+    ),
+]
+
+
+def _run_scenario(scenario: EvalScenario) -> Tuple[ClaimStateSnapshot, ContinuationReceipt]:
+    """Run a single scenario and return (snapshot, receipt)."""
+    _, snap, rcpt = run_continuation_revalidation_shadow(
+        chain_id=scenario.chain_id,
+        step_index=1,
+        query=f"eval: {scenario.name}",
+        context=scenario.context,
+        prior_decision_status=scenario.prior_decision_status,
+    )
+    return snap, rcpt
+
+
+# =====================================================================
+# Metric computation
+# =====================================================================
+
+
+@dataclass
+class EvalMetrics:
+    """Evaluation metrics for the continuation runtime."""
+
+    total_scenarios: int = 0
+    divergence_true_positive: int = 0
+    divergence_false_positive: int = 0
+    divergence_true_negative: int = 0
+    divergence_false_negative: int = 0
+    support_loss_detected: int = 0
+    support_loss_total: int = 0
+    burden_drift_detected: int = 0
+    burden_drift_total: int = 0
+    state_receipt_separated: int = 0
+    replay_explainable: int = 0
+
+    @property
+    def divergence_detection_rate(self) -> float:
+        tp = self.divergence_true_positive
+        fn = self.divergence_false_negative
+        return tp / (tp + fn) if (tp + fn) > 0 else 0.0
+
+    @property
+    def false_alarm_rate(self) -> float:
+        fp = self.divergence_false_positive
+        tn = self.divergence_true_negative
+        return fp / (fp + tn) if (fp + tn) > 0 else 0.0
+
+    @property
+    def support_loss_capture_rate(self) -> float:
+        return (
+            self.support_loss_detected / self.support_loss_total
+            if self.support_loss_total > 0
+            else 0.0
+        )
+
+    @property
+    def burden_headroom_drift_usefulness(self) -> float:
+        return (
+            self.burden_drift_detected / self.burden_drift_total
+            if self.burden_drift_total > 0
+            else 0.0
+        )
+
+    @property
+    def replay_explanatory_usefulness(self) -> float:
+        return (
+            self.replay_explainable / self.total_scenarios
+            if self.total_scenarios > 0
+            else 0.0
+        )
+
+    @property
+    def state_receipt_separation_clarity(self) -> float:
+        return (
+            self.state_receipt_separated / self.total_scenarios
+            if self.total_scenarios > 0
+            else 0.0
+        )
+
+
+def _compute_metrics() -> EvalMetrics:
+    """Run all scenarios and compute metrics."""
+    metrics = EvalMetrics()
+
+    for scenario in _SCENARIOS:
+        snap, rcpt = _run_scenario(scenario)
+        metrics.total_scenarios += 1
+
+        actual_divergence = rcpt.divergence_flag
+        expected_divergence = scenario.expected_divergence
+
+        if expected_divergence and actual_divergence:
+            metrics.divergence_true_positive += 1
+        elif not expected_divergence and not actual_divergence:
+            metrics.divergence_true_negative += 1
+        elif not expected_divergence and actual_divergence:
+            metrics.divergence_false_positive += 1
+        elif expected_divergence and not actual_divergence:
+            metrics.divergence_false_negative += 1
+
+        # Support loss detection
+        if scenario.is_support_loss:
+            metrics.support_loss_total += 1
+            if snap.claim_status == ClaimStatus.REVOKED:
+                metrics.support_loss_detected += 1
+
+        # Burden/headroom drift
+        if scenario.has_burden_drift:
+            metrics.burden_drift_total += 1
+            if snap.claim_status in (ClaimStatus.DEGRADED, ClaimStatus.HALTED):
+                metrics.burden_drift_detected += 1
+
+        # State/receipt separation check
+        snap_d = snap.to_dict()
+        rcpt_d = rcpt.to_dict()
+        receipt_only_fields = {"revalidation_status", "divergence_flag", "should_refuse_before_effect"}
+        state_only_fields = {"support_basis", "burden_state", "headroom_state"}
+        if (
+            not receipt_only_fields.intersection(snap_d.keys())
+            and not state_only_fields.intersection(rcpt_d.keys())
+        ):
+            metrics.state_receipt_separated += 1
+
+        # Replay explainability: receipt has digests and reason codes
+        if (
+            rcpt.support_basis_digest is not None
+            and rcpt.scope_digest is not None
+            and rcpt.burden_headroom_digest is not None
+            and rcpt.law_version_id
+        ):
+            metrics.replay_explainable += 1
+
+    return metrics
+
+
+# =====================================================================
+# Pytest tests wrapping the harness
+# =====================================================================
+
+
+class TestEvalHarness:
+    """Evaluation harness as pytest tests."""
+
+    def test_divergence_detection_rate_is_perfect(self):
+        """All known divergence scenarios must be detected."""
+        metrics = _compute_metrics()
+        assert metrics.divergence_detection_rate == 1.0
+
+    def test_false_alarm_rate_is_zero(self):
+        """No false alarms on non-divergent scenarios."""
+        metrics = _compute_metrics()
+        assert metrics.false_alarm_rate == 0.0
+
+    def test_support_loss_capture_rate_is_perfect(self):
+        """All support-loss scenarios captured."""
+        metrics = _compute_metrics()
+        assert metrics.support_loss_capture_rate == 1.0
+
+    def test_burden_headroom_drift_usefulness_is_perfect(self):
+        """All burden/headroom drift scenarios detected."""
+        metrics = _compute_metrics()
+        assert metrics.burden_headroom_drift_usefulness == 1.0
+
+    def test_replay_explanatory_usefulness_is_perfect(self):
+        """All receipts have sufficient data for replay explanation."""
+        metrics = _compute_metrics()
+        assert metrics.replay_explanatory_usefulness == 1.0
+
+    def test_state_receipt_separation_clarity_is_perfect(self):
+        """State and receipt never contaminate each other."""
+        metrics = _compute_metrics()
+        assert metrics.state_receipt_separation_clarity == 1.0
+
+    def test_scenario_count_minimum(self):
+        """Harness has at least 8 scenarios."""
+        metrics = _compute_metrics()
+        assert metrics.total_scenarios >= 8
+
+    def test_metrics_printable_report(self):
+        """Metrics can be rendered as a human-readable report."""
+        metrics = _compute_metrics()
+        report = {
+            "total_scenarios": metrics.total_scenarios,
+            "divergence_detection_rate": metrics.divergence_detection_rate,
+            "false_alarm_rate": metrics.false_alarm_rate,
+            "support_loss_capture_rate": metrics.support_loss_capture_rate,
+            "burden_headroom_drift_usefulness": metrics.burden_headroom_drift_usefulness,
+            "replay_explanatory_usefulness": metrics.replay_explanatory_usefulness,
+            "state_receipt_separation_clarity": metrics.state_receipt_separation_clarity,
+        }
+        # All values must be numeric and within [0, 1]
+        for key, val in report.items():
+            if key == "total_scenarios":
+                assert isinstance(val, int) and val > 0
+            else:
+                assert 0.0 <= val <= 1.0, f"{key} out of range: {val}"

--- a/tests/test_continuation_golden.py
+++ b/tests/test_continuation_golden.py
@@ -1,0 +1,407 @@
+# tests/test_continuation_golden.py
+# -*- coding: utf-8 -*-
+"""
+Golden scenario tests for Continuation Runtime phase-1.
+
+These are the most important test cases: situations where the local step
+passes (or would pass) but the continuation runtime detects chain-level
+problems invisible to step-level evaluation.
+
+Priority: divergence > normal flow.
+
+Golden scenarios:
+  1. Local correct, support lost
+  2. Local correct, burden/headroom collapse
+  3. Local correct, scope narrowing needed
+  4. Local correct, escalation needed
+  5. Local correct, halted
+  6. Local correct, revoked
+  7. Local correct, receipt chain shows continuity weakening
+"""
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.core.continuation_runtime.revalidator import (
+    ContinuationRevalidator,
+    PresentCondition,
+    run_continuation_revalidation_shadow,
+)
+from veritas_os.core.continuation_runtime.lineage import (
+    ContinuationClaimLineage,
+    ClaimStatus,
+)
+from veritas_os.core.continuation_runtime.receipt import (
+    RevalidationStatus,
+    RevalidationOutcome,
+)
+from veritas_os.core.continuation_runtime.reason_codes import ReasonCode
+
+
+def _run_golden(context, *, chain_id="golden-chain", prior_decision_status="allow"):
+    """Run a single-step golden scenario: local step 'allow', continuation may diverge."""
+    lineage, snap, rcpt = run_continuation_revalidation_shadow(
+        chain_id=chain_id,
+        step_index=1,
+        query="golden scenario query",
+        context=context,
+        prior_decision_status=prior_decision_status,
+    )
+    return lineage, snap, rcpt
+
+
+# =====================================================================
+# Golden 1: Local correct, support lost
+# =====================================================================
+
+
+class TestGolden1SupportLost:
+    """The local step would be allowed, but the chain's support basis
+    has evaporated — authority and policy are gone."""
+
+    def test_claim_revoked_despite_local_allow(self):
+        _, snap, rcpt = _run_golden(
+            {"authorization": "", "policy_ref": ""},
+            chain_id="",  # no chain_id → no authority fallback
+        )
+
+        assert snap.claim_status == ClaimStatus.REVOKED
+        assert rcpt.prior_decision_continuity_ref == "allow"
+        assert rcpt.divergence_flag is True
+        assert rcpt.should_refuse_before_effect is True
+
+    def test_reason_codes_indicate_support_loss(self):
+        _, _, rcpt = _run_golden(
+            {"authorization": "", "policy_ref": ""},
+            chain_id="",
+        )
+
+        assert any(
+            rc in (ReasonCode.SUPPORT_LOST_APPROVAL, ReasonCode.SUPPORT_LOST_POLICY_SCOPE)
+            for rc in rcpt.revalidation_reason_codes
+        )
+
+    def test_support_basis_empty_in_snapshot(self):
+        _, snap, _ = _run_golden(
+            {"authorization": "", "policy_ref": ""},
+            chain_id="",
+        )
+
+        # Both authority and policy should be empty/absent
+        assert snap.support_basis.authority == ""
+        assert snap.support_basis.policy == ""
+
+
+# =====================================================================
+# Golden 2: Local correct, burden/headroom collapse
+# =====================================================================
+
+
+class TestGolden2BurdenHeadroomCollapse:
+    """The local step would be allowed, but evidentiary burden is unmet
+    and headroom has collapsed to zero."""
+
+    def test_halted_due_to_headroom_collapse(self):
+        _, snap, rcpt = _run_golden({
+            "required_evidence": ["e1", "e2", "e3", "e4", "e5"],
+            "satisfied_evidence": [],
+            "burden_current_level": 0.0,
+        })
+
+        assert snap.claim_status == ClaimStatus.HALTED
+        assert rcpt.divergence_flag is True
+        assert rcpt.should_refuse_before_effect is True
+
+    def test_burden_state_reflects_unmet_evidence(self):
+        _, snap, _ = _run_golden({
+            "required_evidence": ["e1", "e2", "e3"],
+            "satisfied_evidence": [],
+            "burden_current_level": 0.0,
+        })
+
+        assert snap.burden_state.current_level == 0.0
+        assert len(snap.burden_state.required_evidence) == 3
+        assert len(snap.burden_state.satisfied_evidence) == 0
+
+    def test_headroom_zero_in_snapshot(self):
+        _, snap, _ = _run_golden({
+            "required_evidence": ["e1", "e2"],
+            "satisfied_evidence": [],
+            "burden_current_level": 0.0,
+        })
+
+        assert snap.headroom_state.remaining == 0.0
+
+    def test_reason_code_headroom_collapsed(self):
+        _, _, rcpt = _run_golden({
+            "required_evidence": ["e1", "e2"],
+            "satisfied_evidence": [],
+            "burden_current_level": 0.0,
+        })
+
+        assert ReasonCode.HEADROOM_COLLAPSED in rcpt.revalidation_reason_codes
+
+
+# =====================================================================
+# Golden 3: Local correct, scope narrowing needed
+# =====================================================================
+
+
+class TestGolden3ScopeNarrowing:
+    """The local step is fine, but the chain's scope has been restricted."""
+
+    def test_narrowed_due_to_restricted_actions(self):
+        _, snap, rcpt = _run_golden({
+            "restricted_actions": ["execute", "deploy"],
+        })
+
+        assert snap.claim_status == ClaimStatus.NARROWED
+        assert rcpt.divergence_flag is True
+        assert rcpt.should_refuse_before_effect is False  # narrowed, not halted
+
+    def test_scope_reflects_restrictions(self):
+        _, snap, _ = _run_golden({
+            "restricted_actions": ["execute", "deploy"],
+        })
+
+        assert "execute" in snap.scope.restricted_action_classes
+        assert "deploy" in snap.scope.restricted_action_classes
+
+    def test_reason_code_action_class(self):
+        _, _, rcpt = _run_golden({
+            "restricted_actions": ["execute"],
+        })
+
+        assert ReasonCode.ACTION_CLASS_NOT_ALLOWED in rcpt.revalidation_reason_codes
+
+
+# =====================================================================
+# Golden 4: Local correct, escalation needed
+# =====================================================================
+
+
+class TestGolden4EscalationNeeded:
+    """The local step is fine, but escalation is required."""
+
+    def test_escalated_despite_local_allow(self):
+        _, snap, rcpt = _run_golden({
+            "escalation_required": True,
+        })
+
+        assert snap.claim_status == ClaimStatus.ESCALATED
+        assert rcpt.divergence_flag is True
+
+    def test_scope_escalation_flag(self):
+        _, snap, _ = _run_golden({
+            "escalation_required": True,
+        })
+
+        assert snap.scope.escalation_required is True
+
+
+# =====================================================================
+# Golden 5: Local correct, halted
+# =====================================================================
+
+
+class TestGolden5Halted:
+    """The local step passes, but headroom is at threshold_suspension."""
+
+    def test_halted_with_zero_headroom(self):
+        _, snap, rcpt = _run_golden({
+            "required_evidence": ["e1", "e2", "e3"],
+            "satisfied_evidence": [],
+            "burden_current_level": 0.0,
+        })
+
+        assert snap.claim_status == ClaimStatus.HALTED
+        assert rcpt.revalidation_status == RevalidationStatus.HALTED
+        assert rcpt.revalidation_outcome == RevalidationOutcome.HALTED
+        assert rcpt.should_refuse_before_effect is True
+
+    def test_halted_receipt_has_audit_digests(self):
+        _, _, rcpt = _run_golden({
+            "required_evidence": ["e1", "e2"],
+            "satisfied_evidence": [],
+            "burden_current_level": 0.0,
+        })
+
+        assert rcpt.support_basis_digest is not None
+        assert rcpt.scope_digest is not None
+        assert rcpt.burden_headroom_digest is not None
+
+
+# =====================================================================
+# Golden 6: Local correct, revoked
+# =====================================================================
+
+
+class TestGolden6Revoked:
+    """Local step passes, but continuation is fully revoked."""
+
+    def test_revoked_with_full_support_loss(self):
+        lineage, snap, rcpt = _run_golden(
+            {"authorization": "", "policy_ref": ""},
+            chain_id="",
+        )
+
+        assert snap.claim_status == ClaimStatus.REVOKED
+        assert rcpt.revalidation_status == RevalidationStatus.REVOKED
+        assert rcpt.revalidation_outcome == RevalidationOutcome.REVOKED
+        assert rcpt.should_refuse_before_effect is True
+        assert lineage.is_revoked is True
+
+    def test_revoked_lineage_has_timestamp(self):
+        lineage, _, _ = _run_golden(
+            {"authorization": "", "policy_ref": ""},
+            chain_id="",
+        )
+
+        assert lineage.revoked_at is not None
+
+    def test_revoked_is_terminal_in_chain(self):
+        """After revocation, subsequent steps remain revoked."""
+        rv = ContinuationRevalidator()
+        lineage = ContinuationClaimLineage(chain_id="", origin_ref="step:0")
+
+        # Step 0: revoke
+        cond0 = PresentCondition(
+            chain_id="",
+            step_index=0,
+            query="revoke",
+            context={"authorization": "", "policy_ref": ""},
+        )
+        snap0, rcpt0 = rv.revalidate(lineage, cond0)
+        assert snap0.claim_status == ClaimStatus.REVOKED
+
+        # Step 1: good conditions, but revoked is terminal
+        cond1 = PresentCondition(
+            chain_id="golden-chain",
+            step_index=1,
+            query="good step",
+            context={},
+        )
+        snap1, rcpt1 = rv.revalidate(lineage, cond1, prior_snapshot=snap0, prior_receipt=rcpt0)
+        assert snap1.claim_status == ClaimStatus.REVOKED
+        assert rcpt1.revalidation_status == RevalidationStatus.REVOKED
+
+
+# =====================================================================
+# Golden 7: Receipt chain shows continuity weakening
+# =====================================================================
+
+
+class TestGolden7ReceiptChainContinuityWeakening:
+    """A multi-step chain where local steps all pass but the receipt
+    chain reveals progressive continuation weakening."""
+
+    def _run_weakening_chain(self):
+        rv = ContinuationRevalidator()
+        lineage = ContinuationClaimLineage(chain_id="weaken-chain", origin_ref="step:0")
+        steps = [
+            # Step 0: LIVE (healthy)
+            PresentCondition(
+                chain_id="weaken-chain", step_index=0, query="step-0",
+                context={}, prior_decision_status="allow",
+            ),
+            # Step 1: NARROWED (scope restriction appears)
+            PresentCondition(
+                chain_id="weaken-chain", step_index=1, query="step-1",
+                context={"restricted_actions": ["execute"]},
+                prior_decision_status="allow",
+            ),
+            # Step 2: ESCALATED (escalation required)
+            PresentCondition(
+                chain_id="weaken-chain", step_index=2, query="step-2",
+                context={"escalation_required": True},
+                prior_decision_status="allow",
+            ),
+            # Step 3: REVOKED (support fully lost)
+            PresentCondition(
+                chain_id="", step_index=3, query="step-3",
+                context={"authorization": "", "policy_ref": ""},
+                prior_decision_status="allow",
+            ),
+        ]
+
+        results = []
+        prior_snap = None
+        prior_rcpt = None
+        for cond in steps:
+            snap, rcpt = rv.revalidate(
+                lineage, cond,
+                prior_snapshot=prior_snap,
+                prior_receipt=prior_rcpt,
+            )
+            results.append((snap, rcpt))
+            prior_snap = snap
+            prior_rcpt = rcpt
+
+        return lineage, results
+
+    def test_progressive_status_weakening(self):
+        _, results = self._run_weakening_chain()
+
+        statuses = [snap.claim_status for snap, _ in results]
+        assert statuses[0] == ClaimStatus.LIVE
+        assert statuses[1] == ClaimStatus.NARROWED
+        assert statuses[2] == ClaimStatus.ESCALATED
+        assert statuses[3] == ClaimStatus.REVOKED
+
+    def test_divergence_flags_track_weakening(self):
+        _, results = self._run_weakening_chain()
+
+        divergences = [rcpt.divergence_flag for _, rcpt in results]
+        assert divergences == [False, True, True, True]
+
+    def test_receipt_chain_is_linked(self):
+        _, results = self._run_weakening_chain()
+
+        for i in range(1, len(results)):
+            _, prev_rcpt = results[i - 1]
+            _, curr_rcpt = results[i]
+            assert curr_rcpt.parent_receipt_ref == prev_rcpt.receipt_id
+
+    def test_all_prior_decisions_were_allow(self):
+        """Every step had prior_decision_status='allow', proving
+        local step outcome did not influence continuation standing."""
+        _, results = self._run_weakening_chain()
+
+        for _, rcpt in results:
+            assert rcpt.prior_decision_continuity_ref == "allow"
+
+    def test_snapshot_replaced_at_each_step(self):
+        """Only latest snapshot is authoritative — each step creates new."""
+        lineage, results = self._run_weakening_chain()
+
+        snapshot_ids = [snap.snapshot_id for snap, _ in results]
+        assert len(set(snapshot_ids)) == len(results)  # all unique
+
+        # Lineage points to the last snapshot
+        assert lineage.latest_snapshot_id == results[-1][0].snapshot_id
+
+    def test_law_version_consistent_across_chain(self):
+        _, results = self._run_weakening_chain()
+
+        for snap, rcpt in results:
+            assert snap.law_version == "v0.1.0-shadow"
+            assert rcpt.law_version_id == "v0.1.0-shadow"
+
+    def test_audit_digests_present_in_every_receipt(self):
+        _, results = self._run_weakening_chain()
+
+        for _, rcpt in results:
+            assert rcpt.support_basis_digest is not None
+            assert rcpt.scope_digest is not None
+            assert rcpt.burden_headroom_digest is not None
+
+    def test_advisory_only_for_non_terminal_steps(self):
+        """Phase-1: should_refuse_before_effect is advisory only for
+        non-terminal statuses. HALTED/REVOKED set it True (advisory)."""
+        _, results = self._run_weakening_chain()
+
+        for snap, rcpt in results:
+            if snap.claim_status in (ClaimStatus.HALTED, ClaimStatus.REVOKED):
+                assert rcpt.should_refuse_before_effect is True
+            else:
+                assert rcpt.should_refuse_before_effect is False

--- a/tests/test_continuation_integration.py
+++ b/tests/test_continuation_integration.py
@@ -1,0 +1,362 @@
+# tests/test_continuation_integration.py
+# -*- coding: utf-8 -*-
+"""
+Integration tests for Continuation Runtime phase-1.
+
+Verifies:
+  - Feature flag off → zero side-effect, zero response mutation
+  - Feature flag on → continuation artifacts appended
+  - gate.decision_status unchanged regardless of continuation state
+  - FUJI output unchanged regardless of continuation state
+  - Continuation revalidation runs pre-merit (before FUJI)
+  - Snapshot and receipt are separate objects in response
+"""
+from __future__ import annotations
+
+import os
+import importlib
+import pytest
+
+
+# =====================================================================
+# Feature flag off — complete invariance
+# =====================================================================
+
+
+class TestFeatureFlagOffInvariance:
+    """When VERITAS_CAP_CONTINUATION_RUNTIME is off (default),
+    the continuation runtime must be fully inert."""
+
+    def test_flag_defaults_to_false(self):
+        """Default is off — no env var needed."""
+        from veritas_os.core.config import _parse_bool
+
+        assert _parse_bool("VERITAS_CAP_CONTINUATION_RUNTIME", False) is False
+
+    def test_pipeline_context_has_no_continuation_by_default(self):
+        """PipelineContext continuation fields are None when flag off."""
+        from veritas_os.core.pipeline_types import PipelineContext
+
+        ctx = PipelineContext()
+        assert ctx.continuation_snapshot is None
+        assert ctx.continuation_receipt is None
+
+    def test_response_omits_continuation_key_when_flag_off(self):
+        """assemble_response must not include 'continuation' when off."""
+        from veritas_os.core.pipeline_types import PipelineContext
+        from veritas_os.core.pipeline_response import assemble_response
+
+        ctx = PipelineContext(
+            request_id="flag-off-test",
+            query="test query",
+            response_extras={
+                "metrics": {},
+                "memory_citations": [],
+                "memory_used_count": 0,
+            },
+        )
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "test"},
+            plan={"steps": [], "raw": None, "source": "fallback"},
+        )
+
+        assert "continuation" not in res
+
+    def test_gate_decision_status_unchanged_when_flag_off(self):
+        """gate.decision_status is exactly what PipelineContext provides."""
+        from veritas_os.core.pipeline_types import PipelineContext
+        from veritas_os.core.pipeline_response import assemble_response
+
+        ctx = PipelineContext(
+            request_id="gate-test",
+            query="test",
+            decision_status="allow",
+            response_extras={
+                "metrics": {},
+                "memory_citations": [],
+                "memory_used_count": 0,
+            },
+        )
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "test"},
+            plan={"steps": [], "raw": None, "source": "fallback"},
+        )
+
+        assert res["gate"]["decision_status"] == "allow"
+        assert res["decision_status"] == "allow"
+
+
+# =====================================================================
+# Feature flag on — continuation artifacts present
+# =====================================================================
+
+
+class TestFeatureFlagOnAddsContinuation:
+    """When flag is on and continuation data is set on ctx,
+    response includes continuation with state/receipt separation."""
+
+    def _make_ctx_with_continuation(self, claim_status="live", divergence=False):
+        from veritas_os.core.pipeline_types import PipelineContext
+
+        return PipelineContext(
+            request_id="flag-on-test",
+            query="test",
+            decision_status="allow",
+            response_extras={
+                "metrics": {},
+                "memory_citations": [],
+                "memory_used_count": 0,
+            },
+            continuation_snapshot={
+                "snapshot_id": "s-1",
+                "claim_lineage_id": "lin-1",
+                "claim_status": claim_status,
+                "law_version": "v0.1.0-shadow",
+                "support_basis": {"authority": "chain:x", "policy": "default"},
+                "scope": {"allowed_action_classes": ["query"]},
+                "burden_state": {"threshold": 1.0, "current_level": 1.0},
+                "headroom_state": {"remaining": 1.0},
+            },
+            continuation_receipt={
+                "receipt_id": "r-1",
+                "revalidation_status": "renewed" if not divergence else "degraded",
+                "revalidation_outcome": "renewed" if not divergence else "degraded",
+                "divergence_flag": divergence,
+                "should_refuse_before_effect": False,
+                "revalidation_reason_codes": [],
+                "prior_decision_continuity_ref": None,
+            },
+        )
+
+    def test_response_includes_continuation_block(self):
+        from veritas_os.core.pipeline_response import assemble_response
+
+        ctx = self._make_ctx_with_continuation()
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "test"},
+            plan={"steps": [], "raw": None, "source": "fallback"},
+        )
+
+        assert "continuation" in res
+        assert "state" in res["continuation"]
+        assert "receipt" in res["continuation"]
+
+    def test_state_and_receipt_are_separate_in_response(self):
+        from veritas_os.core.pipeline_response import assemble_response
+
+        ctx = self._make_ctx_with_continuation()
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "test"},
+            plan={"steps": [], "raw": None, "source": "fallback"},
+        )
+
+        state = res["continuation"]["state"]
+        receipt = res["continuation"]["receipt"]
+
+        # State fields must NOT bleed into receipt
+        assert "support_basis" not in receipt
+        assert "burden_state" not in receipt
+
+        # Receipt fields must NOT bleed into state
+        assert "divergence_flag" not in state
+        assert "revalidation_status" not in state
+
+    def test_gate_decision_status_unchanged_when_flag_on(self):
+        """gate.decision_status must remain exactly as ctx provides,
+        regardless of continuation state."""
+        from veritas_os.core.pipeline_response import assemble_response
+
+        ctx = self._make_ctx_with_continuation(
+            claim_status="revoked", divergence=True
+        )
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "test"},
+            plan={"steps": [], "raw": None, "source": "fallback"},
+        )
+
+        # Even with continuation revoked, gate.decision_status is untouched
+        assert res["gate"]["decision_status"] == "allow"
+        assert res["decision_status"] == "allow"
+
+    def test_fuji_output_unchanged_when_continuation_present(self):
+        """FUJI dict is exactly what ctx provides, unmodified."""
+        from veritas_os.core.pipeline_types import PipelineContext
+        from veritas_os.core.pipeline_response import assemble_response
+
+        fuji_dict = {"status": "allow", "reasons": [], "violations": []}
+        ctx = PipelineContext(
+            request_id="fuji-test",
+            query="test",
+            fuji_dict=fuji_dict,
+            decision_status="allow",
+            response_extras={
+                "metrics": {},
+                "memory_citations": [],
+                "memory_used_count": 0,
+            },
+            continuation_snapshot={
+                "snapshot_id": "s-1",
+                "claim_status": "revoked",
+            },
+            continuation_receipt={
+                "receipt_id": "r-1",
+                "divergence_flag": True,
+            },
+        )
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "test"},
+            plan={"steps": [], "raw": None, "source": "fallback"},
+        )
+
+        assert res["fuji"] == fuji_dict
+
+
+# =====================================================================
+# Pre-merit revalidation evidence
+# =====================================================================
+
+
+class TestPreMeritRevalidation:
+    """Verify that continuation revalidation runs before step-level
+    merit evaluation and produces its own artifacts independently."""
+
+    def test_revalidation_produces_snapshot_before_any_decision(self):
+        """run_continuation_revalidation_shadow works without any
+        prior_decision_status — proving it doesn't need step outcome."""
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+
+        lineage, snap, rcpt = run_continuation_revalidation_shadow(
+            chain_id="pre-merit-test",
+            step_index=0,
+            query="first step",
+            context={},
+            prior_decision_status=None,  # no prior step
+        )
+
+        assert snap.snapshot_id
+        assert rcpt.receipt_id
+        assert rcpt.prior_decision_continuity_ref is None
+
+    def test_revalidation_does_not_read_or_modify_decision_status(self):
+        """Revalidation result is independent of prior_decision_status value."""
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+
+        # Same conditions, different prior_decision_status
+        _, snap_allow, _ = run_continuation_revalidation_shadow(
+            chain_id="c-1",
+            step_index=1,
+            query="test",
+            context={},
+            prior_decision_status="allow",
+        )
+        _, snap_block, _ = run_continuation_revalidation_shadow(
+            chain_id="c-1",
+            step_index=1,
+            query="test",
+            context={},
+            prior_decision_status="block",
+        )
+
+        # Continuation standing must be identical — it doesn't derive from step result
+        assert snap_allow.claim_status == snap_block.claim_status
+
+    def test_snapshot_receipt_pair_always_emitted(self):
+        """Every revalidation must produce both snapshot and receipt."""
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+        from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
+        from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
+
+        _, snap, rcpt = run_continuation_revalidation_shadow(
+            chain_id="pair-test",
+            step_index=0,
+            query="test",
+            context={},
+        )
+
+        assert isinstance(snap, ClaimStateSnapshot)
+        assert isinstance(rcpt, ContinuationReceipt)
+        assert rcpt.snapshot_id == snap.snapshot_id
+
+    def test_continuation_does_not_enforce(self):
+        """Phase-1: even when should_refuse_before_effect is True,
+        this is advisory only — no enforcement mechanism exists."""
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+
+        _, snap, rcpt = run_continuation_revalidation_shadow(
+            chain_id="",
+            step_index=0,
+            query="test",
+            context={"authorization": "", "policy_ref": ""},
+        )
+
+        # Advisory flag is set
+        assert rcpt.should_refuse_before_effect is True
+        # But no enforcement mechanism — the function simply returns
+        # (no exception, no side effect, no pipeline mutation)
+
+
+# =====================================================================
+# Continuation divergence is observable in structured output
+# =====================================================================
+
+
+class TestDivergenceObservability:
+    """Divergence between step pass and continuation weakening
+    must be observable in structured output."""
+
+    def test_divergence_flag_true_when_not_live(self):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        statuses_that_diverge = [
+            {"context": {"restricted_actions": ["x"]}, "expect": ClaimStatus.NARROWED},
+            {
+                "context": {
+                    "required_evidence": ["e1", "e2", "e3"],
+                    "satisfied_evidence": ["e1"],
+                },
+                "expect": ClaimStatus.DEGRADED,
+            },
+            {"context": {"escalation_required": True}, "expect": ClaimStatus.ESCALATED},
+        ]
+
+        for case in statuses_that_diverge:
+            _, snap, rcpt = run_continuation_revalidation_shadow(
+                chain_id="div-obs",
+                step_index=1,
+                query="test",
+                context=case["context"],
+                prior_decision_status="allow",
+            )
+            assert snap.claim_status == case["expect"], f"Expected {case['expect']}"
+            assert rcpt.divergence_flag is True
+
+    def test_divergence_flag_false_when_live(self):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+
+        _, snap, rcpt = run_continuation_revalidation_shadow(
+            chain_id="no-div",
+            step_index=1,
+            query="test",
+            context={},
+        )
+
+        assert rcpt.divergence_flag is False

--- a/tests/test_continuation_replay.py
+++ b/tests/test_continuation_replay.py
@@ -1,0 +1,311 @@
+# tests/test_continuation_replay.py
+# -*- coding: utf-8 -*-
+"""
+Replay tests for Continuation Runtime phase-1.
+
+Simulates multi-step chains and verifies:
+  - Receipt chain formation across steps
+  - Status transitions: narrowed, degraded, escalated, halted, revoked
+  - Receipt continuity grounding (parent_receipt_ref linkage)
+  - Snapshot replacement semantics (only latest is authoritative)
+  - Divergence tracking across chain steps
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _run_chain(steps, *, chain_id="replay-chain"):
+    """Run a multi-step chain and return list of (lineage, snapshot, receipt)."""
+    from veritas_os.core.continuation_runtime.revalidator import (
+        ContinuationRevalidator,
+        PresentCondition,
+    )
+    from veritas_os.core.continuation_runtime.lineage import ContinuationClaimLineage
+
+    rv = ContinuationRevalidator()
+    lineage = ContinuationClaimLineage(chain_id=chain_id, origin_ref="step:0")
+    results = []
+    prior_snapshot = None
+    prior_receipt = None
+
+    for i, step_ctx in enumerate(steps):
+        condition = PresentCondition(
+            chain_id=step_ctx.get("chain_id", chain_id),
+            step_index=i,
+            query=step_ctx.get("query", f"step-{i}"),
+            context=step_ctx.get("context", {}),
+            prior_decision_status=step_ctx.get("prior_decision_status"),
+            prior_receipt_id=prior_receipt.receipt_id if prior_receipt else None,
+        )
+        snapshot, receipt = rv.revalidate(
+            lineage=lineage,
+            condition=condition,
+            prior_snapshot=prior_snapshot,
+            prior_receipt=prior_receipt,
+        )
+        results.append((lineage, snapshot, receipt))
+        prior_snapshot = snapshot
+        prior_receipt = receipt
+
+    return results
+
+
+class TestReplayStepPassClaimNarrowed:
+    """Step passes but claim is narrowed due to scope restriction."""
+
+    def test_narrowed_transition(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        results = _run_chain([
+            {"context": {}},  # step 0: LIVE
+            {"context": {"restricted_actions": ["execute"]}},  # step 1: NARROWED
+        ])
+
+        _, snap0, rcpt0 = results[0]
+        _, snap1, rcpt1 = results[1]
+
+        assert snap0.claim_status == ClaimStatus.LIVE
+        assert snap1.claim_status == ClaimStatus.NARROWED
+        assert rcpt1.revalidation_status == RevalidationStatus.NARROWED
+        assert rcpt1.divergence_flag is True
+
+    def test_receipt_chain_linkage(self):
+        results = _run_chain([
+            {"context": {}},
+            {"context": {"restricted_actions": ["execute"]}},
+        ])
+
+        _, _, rcpt0 = results[0]
+        _, _, rcpt1 = results[1]
+
+        assert rcpt1.parent_receipt_ref == rcpt0.receipt_id
+
+
+class TestReplayStepPassClaimDegraded:
+    """Step passes but claim is degraded due to burden threshold."""
+
+    def test_degraded_transition(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        # Step 0 establishes burden; step 1 carries it forward unmet
+        results = _run_chain([
+            {
+                "context": {
+                    "required_evidence": ["e1", "e2", "e3"],
+                    "satisfied_evidence": ["e1"],
+                },
+            },  # step 0: DEGRADED (1/3 = 0.33, below threshold)
+            {
+                "context": {},  # no new_evidence → carries forward
+            },  # step 1: still DEGRADED
+        ])
+
+        _, snap0, _ = results[0]
+        _, snap1, rcpt1 = results[1]
+
+        assert snap0.claim_status == ClaimStatus.DEGRADED
+        assert snap1.claim_status == ClaimStatus.DEGRADED
+        assert rcpt1.divergence_flag is True
+
+    def test_burden_state_carried_forward(self):
+        results = _run_chain([
+            {
+                "context": {
+                    "required_evidence": ["e1", "e2", "e3"],
+                    "satisfied_evidence": ["e1"],
+                },
+            },
+            {
+                "context": {"new_evidence": ["e2"]},
+            },
+        ])
+
+        _, snap0, _ = results[0]
+        _, snap1, _ = results[1]
+
+        # Step 1 should carry forward burden and add new evidence
+        assert "e1" in snap1.burden_state.satisfied_evidence
+        assert "e2" in snap1.burden_state.satisfied_evidence
+
+
+class TestReplayStepPassClaimEscalated:
+    """Step passes but claim is escalated."""
+
+    def test_escalated_transition(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        results = _run_chain([
+            {"context": {}},
+            {"context": {"escalation_required": True}},
+        ])
+
+        _, snap1, rcpt1 = results[1]
+        assert snap1.claim_status == ClaimStatus.ESCALATED
+        assert rcpt1.divergence_flag is True
+
+
+class TestReplayStepPassClaimHalted:
+    """Step passes but claim is halted (headroom collapsed)."""
+
+    def test_halted_transition(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        # Step 0 establishes zero burden → HALTED
+        results = _run_chain([
+            {
+                "context": {
+                    "required_evidence": ["e1", "e2", "e3"],
+                    "satisfied_evidence": [],
+                    "burden_current_level": 0.0,
+                },
+            },  # step 0: HALTED (0/3 → headroom 0.0)
+            {"context": {}},  # step 1: still HALTED (terminal)
+        ])
+
+        _, snap0, rcpt0 = results[0]
+        _, snap1, rcpt1 = results[1]
+        assert snap0.claim_status == ClaimStatus.HALTED
+        assert snap1.claim_status == ClaimStatus.HALTED
+        assert rcpt0.should_refuse_before_effect is True
+
+    def test_halted_is_terminal(self):
+        """Once halted, remains halted even with good conditions."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        results = _run_chain([
+            {
+                "context": {
+                    "required_evidence": ["e1", "e2", "e3"],
+                    "satisfied_evidence": [],
+                    "burden_current_level": 0.0,
+                },
+            },
+            {"context": {}},  # good conditions, but halted is terminal
+        ])
+
+        _, snap1, _ = results[1]
+        assert snap1.claim_status == ClaimStatus.HALTED
+
+
+class TestReplayStepPassClaimRevoked:
+    """Step passes but claim is revoked (support fully lost)."""
+
+    def test_revoked_transition(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        # Use empty chain_id so authority fallback doesn't rescue support
+        results = _run_chain([
+            {"context": {}, "chain_id": "ok-chain"},  # step 0: LIVE
+            {
+                "context": {"authorization": "", "policy_ref": ""},
+                "chain_id": "",  # no chain_id → no authority
+                "query": "revoke-step",
+            },
+        ])
+
+        _, snap0, _ = results[0]
+        lineage, snap1, rcpt1 = results[1]
+        assert snap0.claim_status == ClaimStatus.LIVE
+        assert snap1.claim_status == ClaimStatus.REVOKED
+        assert rcpt1.should_refuse_before_effect is True
+        assert lineage.is_revoked is True
+
+    def test_revoked_is_terminal(self):
+        """Once revoked, stays revoked regardless of conditions."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        # Step 0 triggers revocation with empty chain_id
+        results = _run_chain([
+            {
+                "context": {"authorization": "", "policy_ref": ""},
+                "chain_id": "",
+            },
+            {"context": {}, "chain_id": "ok-chain"},  # good conditions, but revoked
+        ], chain_id="")
+
+        _, snap0, _ = results[0]
+        _, snap1, _ = results[1]
+        assert snap0.claim_status == ClaimStatus.REVOKED
+        assert snap1.claim_status == ClaimStatus.REVOKED
+
+
+class TestReplayReceiptChainContinuityGrounding:
+    """Receipt chain must demonstrate continuity grounding across steps."""
+
+    def test_receipt_chain_forms_linked_list(self):
+        results = _run_chain([
+            {"context": {}},
+            {"context": {}},
+            {"context": {"restricted_actions": ["execute"]}},
+            {"context": {"escalation_required": True}},
+        ])
+
+        for i in range(1, len(results)):
+            _, _, prev_rcpt = results[i - 1]
+            _, _, curr_rcpt = results[i]
+            assert curr_rcpt.parent_receipt_ref == prev_rcpt.receipt_id
+
+    def test_snapshot_id_advances_each_step(self):
+        results = _run_chain([
+            {"context": {}},
+            {"context": {}},
+            {"context": {}},
+        ])
+
+        snapshot_ids = [snap.snapshot_id for _, snap, _ in results]
+        assert len(set(snapshot_ids)) == 3  # all unique
+
+    def test_lineage_tracks_latest_snapshot(self):
+        results = _run_chain([
+            {"context": {}},
+            {"context": {}},
+            {"context": {}},
+        ])
+
+        lineage, last_snap, _ = results[-1]
+        assert lineage.latest_snapshot_id == last_snap.snapshot_id
+
+    def test_prior_decision_continuity_carried_in_receipt(self):
+        results = _run_chain([
+            {"context": {}, "prior_decision_status": "allow"},
+            {"context": {}, "prior_decision_status": "allow"},
+            {
+                "context": {"restricted_actions": ["x"]},
+                "prior_decision_status": "allow",
+            },
+        ])
+
+        for _, _, rcpt in results:
+            assert rcpt.prior_decision_continuity_ref == "allow"
+
+    def test_divergence_progressive_weakening(self):
+        """Chain shows progressive weakening visible in receipt chain."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        results = _run_chain([
+            {"context": {}},  # LIVE
+            {"context": {"restricted_actions": ["x"]}},  # NARROWED
+            {"context": {"escalation_required": True}},  # ESCALATED
+        ])
+
+        statuses = [snap.claim_status for _, snap, _ in results]
+        assert statuses[0] == ClaimStatus.LIVE
+        assert statuses[1] == ClaimStatus.NARROWED
+        assert statuses[2] == ClaimStatus.ESCALATED
+
+        # Divergence should be observable from step 1 onward
+        divergences = [rcpt.divergence_flag for _, _, rcpt in results]
+        assert divergences == [False, True, True]
+
+    def test_law_version_recorded_in_every_snapshot_and_receipt(self):
+        results = _run_chain([
+            {"context": {}},
+            {"context": {}},
+            {"context": {}},
+        ])
+
+        for _, snap, rcpt in results:
+            assert snap.law_version == "v0.1.0-shadow"
+            assert rcpt.law_version_id == "v0.1.0-shadow"

--- a/tests/test_continuation_revalidator.py
+++ b/tests/test_continuation_revalidator.py
@@ -579,3 +579,497 @@ class TestDivergenceObservation:
         assert receipt.divergence_flag is True
         assert receipt.should_refuse_before_effect is True
         assert receipt.prior_decision_continuity_ref == "allow"
+
+
+# =====================================================================
+# Data model unit tests (Task 5 — snapshot/receipt boundary hardening)
+# =====================================================================
+
+
+class TestContinuationClaimLineageCreation:
+    """ContinuationClaimLineage creation and invariants."""
+
+    def test_creation_defaults(self):
+        from veritas_os.core.continuation_runtime.lineage import (
+            ContinuationClaimLineage,
+            ClaimStatus,
+        )
+
+        lineage = ContinuationClaimLineage()
+        assert lineage.claim_lineage_id  # non-empty uuid
+        assert lineage.current_claim_status == ClaimStatus.LIVE
+        assert lineage.is_revoked is False
+        assert lineage.revoked_at is None
+        assert lineage.latest_snapshot_id is None
+
+    def test_creation_with_chain_id(self):
+        from veritas_os.core.continuation_runtime.lineage import ContinuationClaimLineage
+
+        lineage = ContinuationClaimLineage(chain_id="c-1", origin_ref="step:0")
+        assert lineage.chain_id == "c-1"
+        assert lineage.origin_ref == "step:0"
+
+    def test_serialization_roundtrip(self):
+        from veritas_os.core.continuation_runtime.lineage import (
+            ContinuationClaimLineage,
+            ClaimStatus,
+        )
+
+        lineage = ContinuationClaimLineage(
+            chain_id="c-rt",
+            current_claim_status=ClaimStatus.NARROWED,
+        )
+        d = lineage.to_dict()
+        restored = ContinuationClaimLineage.from_dict(d)
+
+        assert restored.claim_lineage_id == lineage.claim_lineage_id
+        assert restored.current_claim_status == ClaimStatus.NARROWED
+        assert restored.chain_id == "c-rt"
+
+    def test_claim_status_enum_values(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        expected = {"live", "narrowed", "degraded", "escalated", "halted", "revoked"}
+        actual = {s.value for s in ClaimStatus}
+        assert actual == expected
+
+
+class TestClaimStateSnapshotCreation:
+    """ClaimStateSnapshot creation and structural invariants."""
+
+    def test_creation_defaults(self):
+        from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        snap = ClaimStateSnapshot()
+        assert snap.snapshot_id  # non-empty
+        assert snap.claim_status == ClaimStatus.LIVE
+        assert snap.support_basis is not None
+        assert snap.scope is not None
+        assert snap.burden_state is not None
+        assert snap.headroom_state is not None
+        assert snap.law_version == ""
+
+    def test_snapshot_does_not_contain_receipt_fields(self):
+        """Snapshot must NOT carry revalidation_status, divergence, etc."""
+        from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
+
+        snap = ClaimStateSnapshot()
+        d = snap.to_dict()
+        # These belong to receipt, not snapshot
+        assert "revalidation_status" not in d
+        assert "revalidation_outcome" not in d
+        assert "divergence_flag" not in d
+        assert "should_refuse_before_effect" not in d
+        assert "local_step_result" not in d
+        assert "prior_decision_continuity_ref" not in d
+        assert "parent_receipt_ref" not in d
+        assert "receipt_hash_or_attestation" not in d
+
+    def test_support_basis_sub_structure(self):
+        from veritas_os.core.continuation_runtime.snapshot import SupportBasis
+
+        sb = SupportBasis(authority="chain:x", policy="default", evidence="ev:2")
+        d = sb.to_dict()
+        restored = SupportBasis.from_dict(d)
+        assert restored.authority == "chain:x"
+        assert restored.policy == "default"
+
+    def test_scope_sub_structure(self):
+        from veritas_os.core.continuation_runtime.snapshot import Scope
+
+        scope = Scope(
+            allowed_action_classes=["query"],
+            restricted_action_classes=["execute"],
+            escalation_required=True,
+        )
+        d = scope.to_dict()
+        restored = Scope.from_dict(d)
+        assert restored.escalation_required is True
+        assert "execute" in restored.restricted_action_classes
+
+    def test_burden_state_sub_structure(self):
+        from veritas_os.core.continuation_runtime.snapshot import BurdenState
+
+        bs = BurdenState(
+            required_evidence=["e1", "e2"],
+            satisfied_evidence=["e1"],
+            threshold=1.0,
+            current_level=0.5,
+        )
+        d = bs.to_dict()
+        restored = BurdenState.from_dict(d)
+        assert restored.current_level == 0.5
+        assert len(restored.required_evidence) == 2
+
+    def test_headroom_state_sub_structure(self):
+        from veritas_os.core.continuation_runtime.snapshot import HeadroomState
+
+        hs = HeadroomState(remaining=0.7, threshold_escalation=0.3, threshold_suspension=0.0)
+        d = hs.to_dict()
+        restored = HeadroomState.from_dict(d)
+        assert restored.remaining == 0.7
+
+    def test_revocation_condition_sub_structure(self):
+        from veritas_os.core.continuation_runtime.snapshot import RevocationCondition
+
+        rc = RevocationCondition(
+            condition_id="auth", description="Must have auth", is_met=True
+        )
+        d = rc.to_dict()
+        restored = RevocationCondition.from_dict(d)
+        assert restored.is_met is True
+
+    def test_full_serialization_roundtrip(self):
+        from veritas_os.core.continuation_runtime.snapshot import (
+            ClaimStateSnapshot,
+            SupportBasis,
+            Scope,
+            BurdenState,
+            HeadroomState,
+            RevocationCondition,
+        )
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+
+        snap = ClaimStateSnapshot(
+            claim_lineage_id="lin-1",
+            support_basis=SupportBasis(authority="a", policy="p"),
+            scope=Scope(allowed_action_classes=["query"]),
+            burden_state=BurdenState(required_evidence=["e1"], current_level=0.5),
+            headroom_state=HeadroomState(remaining=0.5),
+            law_version="v0.1.0-shadow",
+            revocation_conditions=[
+                RevocationCondition(condition_id="rc1", is_met=False)
+            ],
+            claim_status=ClaimStatus.DEGRADED,
+        )
+        d = snap.to_dict()
+        restored = ClaimStateSnapshot.from_dict(d)
+
+        assert restored.claim_lineage_id == "lin-1"
+        assert restored.claim_status == ClaimStatus.DEGRADED
+        assert restored.law_version == "v0.1.0-shadow"
+        assert len(restored.revocation_conditions) == 1
+
+
+class TestContinuationReceiptGeneration:
+    """ContinuationReceipt generation and structural invariants."""
+
+    def test_creation_defaults(self):
+        from veritas_os.core.continuation_runtime.receipt import (
+            ContinuationReceipt,
+            RevalidationStatus,
+            RevalidationOutcome,
+        )
+
+        rcpt = ContinuationReceipt()
+        assert rcpt.receipt_id  # non-empty
+        assert rcpt.revalidation_status == RevalidationStatus.RENEWED
+        assert rcpt.revalidation_outcome == RevalidationOutcome.RENEWED
+        assert rcpt.divergence_flag is False
+        assert rcpt.should_refuse_before_effect is False
+
+    def test_receipt_does_not_contain_state_fields(self):
+        """Receipt must NOT carry support_basis, burden_state, etc."""
+        from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
+
+        rcpt = ContinuationReceipt()
+        d = rcpt.to_dict()
+        assert "support_basis" not in d
+        assert "burden_state" not in d
+        assert "headroom_state" not in d
+        assert "scope" not in d
+        assert "revocation_conditions" not in d
+
+    def test_revalidation_status_on_receipt_side(self):
+        """revalidation_status belongs to receipt, not snapshot."""
+        from veritas_os.core.continuation_runtime.receipt import (
+            ContinuationReceipt,
+            RevalidationStatus,
+        )
+
+        rcpt = ContinuationReceipt(
+            revalidation_status=RevalidationStatus.DEGRADED,
+        )
+        assert rcpt.revalidation_status == RevalidationStatus.DEGRADED
+
+    def test_revalidation_outcome_on_receipt_side(self):
+        """revalidation_outcome belongs to receipt, not snapshot."""
+        from veritas_os.core.continuation_runtime.receipt import (
+            ContinuationReceipt,
+            RevalidationOutcome,
+        )
+
+        rcpt = ContinuationReceipt(
+            revalidation_outcome=RevalidationOutcome.ESCALATED,
+        )
+        assert rcpt.revalidation_outcome == RevalidationOutcome.ESCALATED
+
+    def test_prior_decision_continuity_on_receipt_side(self):
+        """prior_decision_continuity_ref belongs to receipt, not snapshot."""
+        from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
+
+        rcpt = ContinuationReceipt(
+            prior_decision_continuity_ref="allow",
+        )
+        assert rcpt.prior_decision_continuity_ref == "allow"
+
+    def test_receipt_serialization_roundtrip_with_reason_codes(self):
+        from veritas_os.core.continuation_runtime.receipt import (
+            ContinuationReceipt,
+            RevalidationStatus,
+            RevalidationOutcome,
+        )
+        from veritas_os.core.continuation_runtime.reason_codes import ReasonCode
+
+        rcpt = ContinuationReceipt(
+            revalidation_status=RevalidationStatus.REVOKED,
+            revalidation_outcome=RevalidationOutcome.REVOKED,
+            revalidation_reason_codes=[
+                ReasonCode.SUPPORT_LOST_APPROVAL,
+                ReasonCode.SUPPORT_LOST_POLICY_SCOPE,
+            ],
+            prior_decision_continuity_ref="allow",
+            divergence_flag=True,
+            should_refuse_before_effect=True,
+        )
+        d = rcpt.to_dict()
+        restored = ContinuationReceipt.from_dict(d)
+
+        assert restored.revalidation_status == RevalidationStatus.REVOKED
+        assert len(restored.revalidation_reason_codes) == 2
+        assert ReasonCode.SUPPORT_LOST_APPROVAL in restored.revalidation_reason_codes
+        assert restored.divergence_flag is True
+
+    def test_receipt_revalidation_status_enum_values(self):
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        expected = {"renewed", "narrowed", "degraded", "escalated", "halted", "revoked", "failed"}
+        actual = {s.value for s in RevalidationStatus}
+        assert actual == expected
+
+
+class TestContinuationLawPackResolution:
+    """ContinuationLawPack resolution and invariants."""
+
+    def test_default_law_pack(self):
+        from veritas_os.core.continuation_runtime.lawpack import (
+            ContinuationLawPack,
+            EvaluationMode,
+        )
+        from veritas_os.core.continuation_runtime.revalidator import _default_law_pack
+
+        pack = _default_law_pack()
+        assert pack.law_version_id == "v0.1.0-shadow"
+        assert pack.evaluation_mode == EvaluationMode.SHADOW
+        assert len(pack.rule_refs) > 0
+
+    def test_law_pack_serialization_roundtrip(self):
+        from veritas_os.core.continuation_runtime.lawpack import (
+            ContinuationLawPack,
+            EvaluationMode,
+        )
+
+        pack = ContinuationLawPack(
+            law_version_id="v1.0.0",
+            policy_family="test",
+            evaluation_mode=EvaluationMode.ADVISORY,
+            rule_refs=["rule_a", "rule_b"],
+        )
+        d = pack.to_dict()
+        restored = ContinuationLawPack.from_dict(d)
+        assert restored.law_version_id == "v1.0.0"
+        assert restored.evaluation_mode == EvaluationMode.ADVISORY
+        assert len(restored.rule_refs) == 2
+
+    def test_evaluation_mode_enum_values(self):
+        from veritas_os.core.continuation_runtime.lawpack import EvaluationMode
+
+        expected = {"shadow", "advisory", "enforce"}
+        actual = {m.value for m in EvaluationMode}
+        assert actual == expected
+
+    def test_law_pack_rule_refs_non_empty_in_default(self):
+        from veritas_os.core.continuation_runtime.revalidator import _default_law_pack
+
+        pack = _default_law_pack()
+        assert "support_basis_present" in pack.rule_refs
+        assert "scope_within_bounds" in pack.rule_refs
+        assert "burden_below_threshold" in pack.rule_refs
+        assert "headroom_positive" in pack.rule_refs
+
+
+class TestReasonCodeMapping:
+    """Reason code mapping and coverage."""
+
+    def test_all_reason_codes_exist(self):
+        from veritas_os.core.continuation_runtime.reason_codes import ReasonCode
+
+        expected = {
+            "SUPPORT_LOST_POLICY_SCOPE",
+            "SUPPORT_LOST_WORLD_STATE",
+            "SUPPORT_LOST_APPROVAL",
+            "BURDEN_THRESHOLD_EXCEEDED",
+            "HEADROOM_COLLAPSED",
+            "REVALIDATION_FAILED",
+            "ACTION_CLASS_NOT_ALLOWED",
+            "CLAIM_HALTED",
+            "CLAIM_REVOKED",
+        }
+        actual = {rc.value for rc in ReasonCode}
+        assert actual == expected
+
+    def test_revoked_yields_support_lost_reason(self):
+        """Revocation due to support loss carries correct reason code."""
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+        from veritas_os.core.continuation_runtime.reason_codes import ReasonCode
+
+        _, _, receipt = run_continuation_revalidation_shadow(
+            chain_id="",
+            step_index=0,
+            query="test",
+            context={"authorization": "", "policy_ref": ""},
+        )
+
+        assert any(
+            rc in (ReasonCode.SUPPORT_LOST_APPROVAL, ReasonCode.SUPPORT_LOST_POLICY_SCOPE)
+            for rc in receipt.revalidation_reason_codes
+        )
+
+    def test_burden_exceeded_yields_correct_reason(self):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+        from veritas_os.core.continuation_runtime.reason_codes import ReasonCode
+
+        _, _, receipt = run_continuation_revalidation_shadow(
+            chain_id="c-1",
+            step_index=1,
+            query="test",
+            context={
+                "required_evidence": ["e1", "e2", "e3"],
+                "satisfied_evidence": ["e1"],
+            },
+        )
+
+        assert ReasonCode.BURDEN_THRESHOLD_EXCEEDED in receipt.revalidation_reason_codes
+
+    def test_escalation_yields_action_class_not_allowed(self):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+        from veritas_os.core.continuation_runtime.reason_codes import ReasonCode
+
+        _, _, receipt = run_continuation_revalidation_shadow(
+            chain_id="c-1",
+            step_index=1,
+            query="test",
+            context={"escalation_required": True},
+        )
+
+        assert ReasonCode.ACTION_CLASS_NOT_ALLOWED in receipt.revalidation_reason_codes
+
+    def test_narrowed_yields_action_class_not_allowed(self):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+        from veritas_os.core.continuation_runtime.reason_codes import ReasonCode
+
+        _, _, receipt = run_continuation_revalidation_shadow(
+            chain_id="c-1",
+            step_index=1,
+            query="test",
+            context={"restricted_actions": ["execute"]},
+        )
+
+        assert ReasonCode.ACTION_CLASS_NOT_ALLOWED in receipt.revalidation_reason_codes
+
+
+class TestClaimStatusConsistency:
+    """Verify claim_status consistency between snapshot, receipt, and lineage."""
+
+    def _run(self, **ctx):
+        from veritas_os.core.continuation_runtime.revalidator import (
+            run_continuation_revalidation_shadow,
+        )
+
+        defaults = {"chain_id": "cons-test", "step_index": 1, "query": "q", "context": {}}
+        defaults.update(ctx)
+        return run_continuation_revalidation_shadow(**defaults)
+
+    def test_live_consistency(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        lineage, snap, rcpt = self._run()
+        assert snap.claim_status == ClaimStatus.LIVE
+        assert rcpt.revalidation_status == RevalidationStatus.RENEWED
+        assert lineage.current_claim_status == ClaimStatus.LIVE
+
+    def test_narrowed_consistency(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        lineage, snap, rcpt = self._run(
+            context={"restricted_actions": ["execute"]},
+        )
+        assert snap.claim_status == ClaimStatus.NARROWED
+        assert rcpt.revalidation_status == RevalidationStatus.NARROWED
+        assert lineage.current_claim_status == ClaimStatus.NARROWED
+
+    def test_degraded_consistency(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        lineage, snap, rcpt = self._run(
+            context={
+                "required_evidence": ["e1", "e2", "e3"],
+                "satisfied_evidence": ["e1"],
+            },
+        )
+        assert snap.claim_status == ClaimStatus.DEGRADED
+        assert rcpt.revalidation_status == RevalidationStatus.DEGRADED
+        assert lineage.current_claim_status == ClaimStatus.DEGRADED
+
+    def test_escalated_consistency(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        lineage, snap, rcpt = self._run(
+            context={"escalation_required": True},
+        )
+        assert snap.claim_status == ClaimStatus.ESCALATED
+        assert rcpt.revalidation_status == RevalidationStatus.ESCALATED
+        assert lineage.current_claim_status == ClaimStatus.ESCALATED
+
+    def test_revoked_consistency(self):
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        lineage, snap, rcpt = self._run(
+            chain_id="",
+            context={"authorization": "", "policy_ref": ""},
+        )
+        assert snap.claim_status == ClaimStatus.REVOKED
+        assert rcpt.revalidation_status == RevalidationStatus.REVOKED
+        assert lineage.current_claim_status == ClaimStatus.REVOKED
+        assert lineage.is_revoked is True
+        assert lineage.revoked_at is not None
+
+    def test_halted_consistency(self):
+        """Headroom collapsed → HALTED."""
+        from veritas_os.core.continuation_runtime.lineage import ClaimStatus
+        from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
+
+        lineage, snap, rcpt = self._run(
+            context={
+                "required_evidence": ["e1", "e2", "e3"],
+                "satisfied_evidence": [],
+                "burden_current_level": 0.0,
+            },
+        )
+        assert snap.claim_status == ClaimStatus.HALTED
+        assert rcpt.revalidation_status == RevalidationStatus.HALTED
+        assert lineage.current_claim_status == ClaimStatus.HALTED


### PR DESCRIPTION
Hardens the continuation runtime with 129 tests across 5 backend test
files and 1 frontend test file, fixing snapshot/receipt boundary
separation, divergence detection, and replay chain continuity grounding.

Backend tests:
- Unit: lineage/snapshot/receipt creation, serialization roundtrips,
  reason code mapping, claim_status consistency across all 6 states,
  state/receipt field separation, law pack resolution
- Integration: feature flag off invariance (response, gate, FUJI),
  flag on adds continuation, pre-merit revalidation evidence,
  divergence observability
- Replay: multi-step chains for narrowed/degraded/escalated/halted/
  revoked transitions, receipt chain linkage, burden carry-forward,
  snapshot replacement, progressive weakening
- Golden: 7 scenarios prioritizing "local pass + chain weakened":
  support lost, burden/headroom collapse, scope narrowing, escalation,
  halted, revoked, receipt chain continuity weakening
- Eval harness: divergence detection rate, false alarm rate,
  support-loss capture, burden drift usefulness, replay explanatory
  usefulness, state/receipt separation clarity — all at 1.0/0.0

Frontend: ContinuationStatusCard rendering tests (null safety,
claim status display, divergence banner, reason codes)

Docs: 1-page architecture note (old vs new model, why lineage/
snapshot/receipt/pre-merit/burden, what is NOT solved)

README: minimal continuation runtime section (observe/shadow mode,
no enforcement, FUJI unchanged)

https://claude.ai/code/session_01F1mS3NKY4t6knzRZGm8rR2