### PR TITLE
Clarify /v1/decide response layers while preserving compatibility

### DIFF
--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -336,8 +336,12 @@ export interface ContinuationOutput {
 }
 
 export interface DecideResponse extends DecideResponseMeta {
+  /* ------------------------------------------------------------------ */
+  /* Core decision contract fields                                      */
+  /* ------------------------------------------------------------------ */
   chosen: Record<string, unknown>;
   alternatives: DecisionAlternative[];
+  /** Backward-compatible alias of alternatives for legacy clients. */
   options: DecisionAlternative[];
   decision_status: DecisionStatus;
   rejection_reason: string | null;
@@ -361,6 +365,9 @@ export interface DecideResponse extends DecideResponseMeta {
    */
   debate: Array<DebateView | Record<string, unknown>>;
 
+  /* ------------------------------------------------------------------ */
+  /* Audit / debug / internal fields                                   */
+  /* ------------------------------------------------------------------ */
   extras: Record<string, unknown>;
   reason: unknown;
   rsi_note: Record<string, unknown> | null;

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -557,6 +557,11 @@ class DecideResponse(BaseModel):
     - evidence / critique / debate / alternatives が dict / str / BaseModel 混在でも落ちない
     - list_type エラーの根絶（dict/tuple/set/generator も安全に list 化）
     - alternatives/options のミラー互換
+
+    Response layers (for readability, payload shape stays flat):
+    1) Core decision contract fields
+    2) Audit / debug / internal fields
+    3) Backward-compatible legacy fields
     """
     model_config = ConfigDict(extra="allow")
 
@@ -568,7 +573,7 @@ class DecideResponse(BaseModel):
     chosen: Dict[str, Any] = Field(default_factory=dict)
 
     alternatives: List[Alt] = Field(default_factory=list, max_length=MAX_LIST_ITEMS)
-    # 互換のために残す（通常は alternatives と同じ）
+    # 互換/レガシー用途のエイリアス（通常は alternatives と同じ）
     options: List[Alt] = Field(default_factory=list, max_length=MAX_LIST_ITEMS)
 
     values: Optional[ValuesOut] = None
@@ -606,11 +611,11 @@ class DecideResponse(BaseModel):
         ),
     )
 
-    # MemoryOS メタ
+    # Audit / debug / internal: MemoryOS メタ
     memory_citations: List[Any] = Field(default_factory=list, max_length=MAX_LIST_ITEMS)
     memory_used_count: int = 0
 
-    # PlannerOS / ReasonOS
+    # Audit / debug / internal: PlannerOS / ReasonOS
     plan: Optional[Dict[str, Any]] = None
     planner: Optional[Dict[str, Any]] = None
     reason: Optional[Any] = None

--- a/veritas_os/core/pipeline.py
+++ b/veritas_os/core/pipeline.py
@@ -772,6 +772,9 @@ async def run_decide_pipeline(
 
     # =================================================================
     # Stage 7: Response assembly  (-> pipeline_response)
+    # - core decision contract
+    # - audit/debug/internal envelope
+    # - backward-compatible aliases
     # =================================================================
     plan = ctx.plan
     res = assemble_response(ctx, load_persona_fn=load_persona, plan=plan)

--- a/veritas_os/core/pipeline_response.py
+++ b/veritas_os/core/pipeline_response.py
@@ -23,28 +23,64 @@ from .pipeline_helpers import _warn
 
 logger = logging.getLogger(__name__)
 
+# Top-level /v1/decide response groups.
+# These constants document the payload layering without changing runtime behavior.
+CORE_DECISION_FIELDS = (
+    "ok",
+    "error",
+    "request_id",
+    "query",
+    "chosen",
+    "alternatives",
+    "evidence",
+    "critique",
+    "debate",
+    "telos_score",
+    "fuji",
+    "gate",
+    "values",
+    "persona",
+    "version",
+    "decision_status",
+    "rejection_reason",
+)
 
-def assemble_response(
+AUDIT_DEBUG_INTERNAL_FIELDS = (
+    "extras",
+    "plan",
+    "planner",
+    "trust_log",
+    "memory_citations",
+    "memory_used_count",
+)
+
+BACKWARD_COMPAT_FIELDS = (
+    "options",
+)
+
+
+def _build_response_layers(
     ctx: PipelineContext,
     *,
     load_persona_fn: Any,
     plan: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Build the DecideResponse‑compatible dict from pipeline context."""
-    res = {
+) -> Dict[str, Dict[str, Any]]:
+    """Build grouped payload layers for readability and maintenance.
+
+    Layering is documentation-oriented: callers still receive one flat dict.
+    """
+    core = {
         "ok": True,
         "error": None,
         "request_id": ctx.request_id,
         "query": ctx.query,
         "chosen": ctx.chosen,
         "alternatives": ctx.alternatives,
-        "options": list(ctx.alternatives),
         "evidence": ctx.evidence,
         "critique": ctx.critique,
         "debate": ctx.debate,
         "telos_score": float(ctx.telos),
         "fuji": ctx.fuji_dict,
-        "extras": ctx.response_extras,
         "gate": {
             "risk": float(ctx.effective_risk),
             "telos_score": float(ctx.telos),
@@ -57,12 +93,41 @@ def assemble_response(
         "version": os.getenv("VERITAS_API_VERSION", "veritas-api 1.x"),
         "decision_status": ctx.decision_status,
         "rejection_reason": ctx.rejection_reason,
+    }
+
+    audit_debug_internal = {
+        "extras": ctx.response_extras,
         "memory_citations": ctx.response_extras.get("memory_citations", []),
         "memory_used_count": ctx.response_extras.get("memory_used_count", 0),
         "plan": plan,
         "planner": ctx.response_extras.get("planner", {"steps": [], "raw": None, "source": "fallback"}),
         "trust_log": ctx.raw.get("trust_log") if isinstance(ctx.raw, dict) else None,
     }
+
+    backward_compat = {
+        # Legacy alias kept for historical clients; mirrors alternatives.
+        "options": list(ctx.alternatives),
+    }
+    return {
+        "core": core,
+        "audit_debug_internal": audit_debug_internal,
+        "backward_compat": backward_compat,
+    }
+
+
+def assemble_response(
+    ctx: PipelineContext,
+    *,
+    load_persona_fn: Any,
+    plan: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build the DecideResponse‑compatible dict from pipeline context."""
+    layers = _build_response_layers(ctx, load_persona_fn=load_persona_fn, plan=plan)
+    # Flattened payload keeps pre-existing top-level contract/shape for clients.
+    res: Dict[str, Any] = {}
+    res.update(layers["core"])
+    res.update(layers["audit_debug_internal"])
+    res.update(layers["backward_compat"])
 
     # Continuation runtime shadow output (flag on only; omitted entirely when off)
     if ctx.continuation_snapshot is not None and ctx.continuation_receipt is not None:

--- a/veritas_os/tests/test_pipeline_stages.py
+++ b/veritas_os/tests/test_pipeline_stages.py
@@ -290,6 +290,34 @@ class TestAssembleResponse:
         assert res["rejection_reason"] == "blocked"
         assert res["trust_log"] == [{"stage": "gate"}]
 
+    def test_assembly_declares_layered_top_level_contract_keys(self) -> None:
+        from veritas_os.core.pipeline_response import (
+            assemble_response,
+            CORE_DECISION_FIELDS,
+            AUDIT_DEBUG_INTERNAL_FIELDS,
+            BACKWARD_COMPAT_FIELDS,
+        )
+
+        ctx = PipelineContext(
+            query="layer-check",
+            request_id="req-layer",
+            chosen={"title": "A"},
+            alternatives=[{"title": "A"}],
+            decision_status="allow",
+            response_extras={"memory_citations": [{"id": "m1"}], "memory_used_count": 1},
+        )
+        res = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {"name": "layered"},
+            plan={"steps": ["s1"]},
+        )
+
+        for key in CORE_DECISION_FIELDS + AUDIT_DEBUG_INTERNAL_FIELDS + BACKWARD_COMPAT_FIELDS:
+            assert key in res
+
+        # Compatibility alias contract: legacy "options" mirrors "alternatives".
+        assert res["options"] == res["alternatives"]
+
 
 class TestCoerceToDecideResponse:
     """DecideResponse coercion stage."""


### PR DESCRIPTION
### Motivation
- Make the top-level `/v1/decide` payload easier to understand by explicitly documenting three response layers (core decision, audit/debug/internal, backward-compat) without changing runtime shape. 
- Preserve all existing top-level fields and frontend expectations while making the assembly code and shared types more self-documenting. 
- Keep the change minimal and low-risk: only add an internal builder, grouping constants, comments, and a focused test to lock in behavior.

### Description
- Added layer constants `CORE_DECISION_FIELDS`, `AUDIT_DEBUG_INTERNAL_FIELDS`, and `BACKWARD_COMPAT_FIELDS` and a small `_build_response_layers(...)` helper to `veritas_os/core/pipeline_response.py`, and refactored `assemble_response` to build via these layers then flatten back to the same top-level dict. 
- Left final payload shape unchanged; `options` continues to mirror `alternatives` as a backward-compatible alias. 
- Improved docstring/comment clarity in `veritas_os/api/schemas.py` and added grouped comments in `packages/types/src/decision.ts` to indicate which fields belong to which layer. 
- Added a short orchestration comment in `veritas_os/core/pipeline.py` to document response-layer intent at the callsite. 
- Added a focused test in `veritas_os/tests/test_pipeline_stages.py` that asserts layered keys are present in the assembled response and that `options == alternatives` remains true.

Changed files: `veritas_os/core/pipeline_response.py`, `veritas_os/api/schemas.py`, `veritas_os/core/pipeline.py`, `packages/types/src/decision.ts`, `veritas_os/tests/test_pipeline_stages.py`.

### Testing
- Ran the focused backend tests: `pytest -q veritas_os/tests/test_pipeline_stages.py -k layered_top_level_contract_keys` and `pytest -q veritas_os/tests/test_pipeline_stages.py -k "TestAssembleResponse"`, both succeeded (the assemble-related tests reported as passed). 
- Ran the Type package tests: `pnpm --filter @veritas/types test`, which passed (`57 passed`). 
- No top-level payload fields were removed and the added unit test validates the preserved compatibility behavior; overall risk is low.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e6aeabe08326a005fca9ea4d6924)