### PR TITLE
kernel: extract intent heuristics to helper (keep decide stable)

### DIFF
--- a/veritas_os/core/kernel.py
+++ b/veritas_os/core/kernel.py
@@ -26,7 +26,6 @@ Compatibility guidance:
 from __future__ import annotations
 
 import logging
-import re
 import subprocess as _subprocess
 import time
 import uuid
@@ -115,6 +114,10 @@ from .kernel_qa import (
     handle_knowledge_qa as _handle_knowledge_qa,
     SIMPLE_QA_PATTERNS,
     AGI_BLOCK_KEYWORDS,
+)
+from .kernel_intent import (
+    detect_intent as _detect_intent_impl,
+    gen_options_by_intent as _gen_options_by_intent_impl,
 )
 
 reason_core: ReasonCapability | None = (
@@ -224,51 +227,21 @@ def _safe_load_persona() -> Dict[str, Any]:
 
 
 # ============================================================
-# Intent 検出（事前コンパイル済み正規表現）
+# Intent ヒューリスティック（helper module へ分離）
+# - kernel.py: 決定エンジン本体の責務（選択・ゲート・理由生成）
+# - kernel_intent.py: 非コア寄りの intent 判定と候補テンプレート生成
+# - pipeline.py: 入力準備と副作用オーケストレーション
 # ============================================================
-
-INTENT_PATTERNS = {
-    "weather": re.compile(r"(天気|気温|降水|雨|晴れ|weather|forecast)", re.I),
-    "health": re.compile(r"(疲れ|だる|体調|休む|回復|睡眠|寝|サウナ)", re.I),
-    "learn": re.compile(r"(とは|仕組み|なぜ|how|why|教えて|違い|比較)", re.I),
-    "plan": re.compile(r"(計画|進め|やるべき|todo|最小ステップ|スケジュール|plan)", re.I),
-}
-
-INTENT_OPTION_TEMPLATES = {
-    "weather": [
-        "天気アプリ/サイトで明日の予報を確認する",
-        "降水確率が高い時間にリマインドを設定する",
-        "傘・レインウェア・防水靴を準備する",
-    ],
-    "health": [
-        "今日は休息し回復を最優先にする",
-        "15分の軽い散歩で血流を上げる",
-        "短時間サウナ＋十分な水分補給を行う",
-    ],
-    "learn": [
-        "一次情報（公式/論文）を調べる",
-        "要点を3行に要約する",
-        "学んだことを1つだけ行動に落とす",
-    ],
-    "plan": [
-        "最小ステップで前進する",
-        "情報収集を優先する",
-        "今日は休息し回復に充てる",
-    ],
-}
 
 
 def _detect_intent(q: str) -> str:
-    q = (q or "").strip().lower()
-    for name, pattern in INTENT_PATTERNS.items():
-        if pattern.search(q):
-            return name
-    return "plan"
+    """Backward-compatible wrapper for intent detection heuristics."""
+    return _detect_intent_impl(q)
 
 
 def _gen_options_by_intent(intent: str) -> List[OptionDict]:
-    templates = INTENT_OPTION_TEMPLATES.get(intent, INTENT_OPTION_TEMPLATES["plan"])
-    return [_mk_option(title) for title in templates]
+    """Backward-compatible wrapper for intent option templates."""
+    return _gen_options_by_intent_impl(intent)
 
 
 # ============================================================

--- a/veritas_os/core/kernel_intent.py
+++ b/veritas_os/core/kernel_intent.py
@@ -1,0 +1,73 @@
+# veritas_os/core/kernel_intent.py
+# -*- coding: utf-8 -*-
+"""Intent heuristics helper for the kernel decision flow.
+
+Ownership boundary:
+- This module owns lightweight, non-core heuristics such as intent detection
+  and hardcoded fallback option templates.
+- ``kernel.py`` remains the core decision engine and consumes these helpers
+  via compatibility wrappers.
+- ``pipeline.py`` remains the orchestration layer and must not depend on
+  heuristics from this module directly.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from typing import List
+
+from .types import OptionDict
+
+INTENT_PATTERNS = {
+    "weather": re.compile(r"(天気|気温|降水|雨|晴れ|weather|forecast)", re.I),
+    "health": re.compile(r"(疲れ|だる|体調|休む|回復|睡眠|寝|サウナ)", re.I),
+    "learn": re.compile(r"(とは|仕組み|なぜ|how|why|教えて|違い|比較)", re.I),
+    "plan": re.compile(r"(計画|進め|やるべき|todo|最小ステップ|スケジュール|plan)", re.I),
+}
+
+INTENT_OPTION_TEMPLATES = {
+    "weather": [
+        "天気アプリ/サイトで明日の予報を確認する",
+        "降水確率が高い時間にリマインドを設定する",
+        "傘・レインウェア・防水靴を準備する",
+    ],
+    "health": [
+        "今日は休息し回復を最優先にする",
+        "15分の軽い散歩で血流を上げる",
+        "短時間サウナ＋十分な水分補給を行う",
+    ],
+    "learn": [
+        "一次情報（公式/論文）を調べる",
+        "要点を3行に要約する",
+        "学んだことを1つだけ行動に落とす",
+    ],
+    "plan": [
+        "最小ステップで前進する",
+        "情報収集を優先する",
+        "今日は休息し回復に充てる",
+    ],
+}
+
+
+def _mk_option(title: str, description: str = "") -> OptionDict:
+    return OptionDict(
+        id=uuid.uuid4().hex,
+        title=title,
+        description=description,
+        score=1.0,
+    )
+
+
+def detect_intent(query: str) -> str:
+    """Detect coarse intent for fallback alternative generation."""
+    normalized = (query or "").strip().lower()
+    for name, pattern in INTENT_PATTERNS.items():
+        if pattern.search(normalized):
+            return name
+    return "plan"
+
+
+def gen_options_by_intent(intent: str) -> List[OptionDict]:
+    """Generate fallback alternatives from a small intent template map."""
+    templates = INTENT_OPTION_TEMPLATES.get(intent, INTENT_OPTION_TEMPLATES["plan"])
+    return [_mk_option(title) for title in templates]

--- a/veritas_os/core/kernel_qa.py
+++ b/veritas_os/core/kernel_qa.py
@@ -5,6 +5,7 @@ VERITAS Kernel - QA処理モジュール
 
 Simple QA と Knowledge QA の検出・ハンドリングを担当。
 責任分界: QA系の早期リターン処理に特化。
+kernel.py は decision 本体、pipeline.py はオーケストレーションを担当。
 
 主要関数:
 - detect_simple_qa: 時刻/曜日/日付などの単純QAを検出

--- a/veritas_os/core/kernel_stages.py
+++ b/veritas_os/core/kernel_stages.py
@@ -4,6 +4,11 @@
 kernel.decide() から責務を分離したステージモジュール
 
 各ステージは独立してテスト可能で、設定値はconfig.pyから取得します。
+
+責務境界:
+- kernel.py は最終的な意思決定エンジンを保持
+- この helper はステージ単位の補助計算を保持
+- pipeline.py は実行順制御と副作用オーケストレーションを保持
 """
 from __future__ import annotations
 

--- a/veritas_os/tests/test_kernel_core.py
+++ b/veritas_os/tests/test_kernel_core.py
@@ -113,6 +113,25 @@ def test_detect_intent_basic():
     assert kernel._detect_intent("今日やるべきことを整理したい") == "plan"
 
 
+def test_intent_wrappers_delegate_to_helper(monkeypatch):
+    """kernel の互換ラッパが helper 実装へ委譲することを確認。"""
+
+    monkeypatch.setattr(kernel, "_detect_intent_impl", lambda q: "learn")
+    assert kernel._detect_intent("任意の質問") == "learn"
+
+    called = {"intent": None}
+
+    def _fake_gen_options(intent):
+        called["intent"] = intent
+        return [{"id": "x", "title": "T", "description": "", "score": 1.0}]
+
+    monkeypatch.setattr(kernel, "_gen_options_by_intent_impl", _fake_gen_options)
+    opts = kernel._gen_options_by_intent("weather")
+
+    assert called["intent"] == "weather"
+    assert opts[0]["title"] == "T"
+
+
 def test_gen_options_by_intent_and_filter_weather():
     # weather intent のデフォルトオプション
     opts = kernel._gen_options_by_intent("weather")


### PR DESCRIPTION
### Motivation

- kernel.py の責務混在を小さくし、意思決定エンジン本体（`decide()`）をより明確にするために、非コア寄りのヒューリスティックを分離しました。 
- 影響範囲を最小に保ちつつ ownership を整理する限定的なクリーンアップを目的としています。

### Description

- `INTENT_PATTERNS`、`INTENT_OPTION_TEMPLATES` とそれに伴う意図検出/テンプレ生成ロジックを `veritas_os/core/kernel_intent.py` に移設しました。 
- `veritas_os/core/kernel.py` には後方互換のラッパ関数 ` _detect_intent()` と `_gen_options_by_intent()` を残して helper 実装へ委譲する形としました。 
- `kernel_stages.py` と `kernel_qa.py` のヘッダに責務境界を明示する docstring コメントを追加し、ownership（kernel: decision core / helper: stage/heuristics / pipeline: orchestration）を明確化しました。 
- focused テストを追加してラッパが helper に委譲することを検証するテストを `veritas_os/tests/test_kernel_core.py` に追加しました（既存の intent/option テストはそのまま）。

### Testing

- 実行したテスト: `pytest -q veritas_os/tests/test_kernel_core.py -q` が成功しファイル内のテストはすべて通過しました。 
- 変更は限定的で `decide()` のシグネチャや主要フローは変更していないため回帰リスクは低いと見ています。 
- 互換性リスク: 外部で `INTENT_*` 等の内部定数を `kernel` から直接参照している非公開利用があると影響する可能性があるため注意が必要です（関数ラッパは維持しています）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ed27c8048326844623837a4486af)