### PR TITLE
Add stage-1 Policy-as-Code schema, canonical IR, and semantic hashing

### DIFF
--- a/docs/policy_as_code.md
+++ b/docs/policy_as_code.md
@@ -1,0 +1,74 @@
+# Policy-as-Code (Stage 1)
+
+## 目的
+
+本ドキュメントは、VERITAS の Policy-as-Code 第1段階として導入した
+**source policy schema / validation / canonical IR / semantic hash** の最小実装を説明します。
+
+## Source Policy Format
+
+- Authoring 形式: YAML または JSON
+- スキーマバージョン: `schema_version: "1.0"`
+- 必須項目:
+  - `policy_id`
+  - `version`
+  - `title`
+  - `description`
+  - `scope` (`domains` / `routes` / `actors`)
+  - `outcome` (`decision` / `reason`)
+- 任意項目:
+  - `conditions`
+  - `requirements`
+  - `constraints`
+  - `obligations`
+  - `test_vectors`
+
+許可される `outcome.decision` は次の列挙のみです。
+
+- `allow`
+- `deny`
+- `halt`
+- `escalate`
+- `require_human_review`
+
+## Validation Flow
+
+1. `veritas_os.policy.schema.load_and_validate_policy` がファイル拡張子を検証します。
+2. YAML/JSON をロードし、マッピング形式であることを検証します。
+3. `SourcePolicy` (Pydantic strict model) で以下を検証します。
+   - 必須フィールド
+   - 列挙値 (`outcome`, 演算子)
+   - ネスト構造 (`scope`, `requirements`, `outcome`)
+   - `minimum_approval_count` と `required_reviewers` の整合性
+4. エラー時は `PolicyValidationError` を返します。
+
+## Canonical IR の役割
+
+`veritas_os.policy.normalize.to_canonical_ir` は、監査と差分比較のための安定化処理を提供します。
+
+- リスト値を重複排除 + ソート
+- 条件/制約を deterministic order に整列
+- test vector も安定ソート
+- 不要な見た目差分（記述順序）を除去
+
+この Canonical IR を `veritas_os.policy.hash.semantic_policy_hash` に入力して、
+見た目に依存しない semantic hash (SHA-256) を生成します。
+
+## Example Policies
+
+- `policies/examples/high_risk_route_requires_human_review.yaml`
+- `policies/examples/external_tool_usage_denied.yaml`
+- `policies/examples/missing_mandatory_evidence_halt.yaml`
+
+## この Task で未実装
+
+- FUJI runtime への本格統合
+- Policy compiler (`Policy -> ValueCore/FUJI rules`) 本体
+- generated tests の自動生成
+- bundle signing / distribution
+- UI 差分可視化
+
+## セキュリティ上の注意
+
+- 本段階の semantic hash は **整合性検証の基礎** であり、署名・鍵管理は未導入です。
+- そのため、本番供給チェーンでは将来タスクとして署名検証を追加してください。

--- a/policies/examples/external_tool_usage_denied.yaml
+++ b/policies/examples/external_tool_usage_denied.yaml
@@ -1,0 +1,38 @@
+schema_version: "1.0"
+policy_id: "policy.external_tool_usage.denied"
+version: "2026.03.28"
+title: "Deny external tool usage under restricted conditions"
+description: "Disallow external tool invocation when tenant data classification is restricted."
+scope:
+  domains: ["tooling", "security"]
+  routes: ["/api/tools", "/api/decide"]
+  actors: ["kernel", "tool_adapter"]
+conditions:
+  - field: "tool.external"
+    operator: "eq"
+    value: true
+  - field: "data.classification"
+    operator: "in"
+    value: ["restricted", "secret"]
+requirements:
+  required_evidence: ["data_classification_label"]
+  required_reviewers: ["security_officer"]
+  minimum_approval_count: 1
+constraints:
+  - field: "tool.name"
+    operator: "not_in"
+    value: ["internal_search", "approved_registry"]
+outcome:
+  decision: "deny"
+  reason: "External tools are prohibited for restricted data handling contexts."
+obligations:
+  - "emit_security_alert"
+  - "record_denial_reason"
+test_vectors:
+  - name: "external tool denied for restricted data"
+    input:
+      tool:
+        external: true
+      data:
+        classification: "restricted"
+    expected_outcome: "deny"

--- a/policies/examples/high_risk_route_requires_human_review.yaml
+++ b/policies/examples/high_risk_route_requires_human_review.yaml
@@ -1,0 +1,35 @@
+schema_version: "1.0"
+policy_id: "policy.high_risk_route.human_review"
+version: "2026.03.28"
+title: "High-risk route requires human review"
+description: "High-risk routes must be routed to human review with explicit evidence and approvers."
+scope:
+  domains: ["governance", "decisioning"]
+  routes: ["/api/decide", "/api/routes_decide"]
+  actors: ["planner", "kernel"]
+conditions:
+  - field: "risk.level"
+    operator: "in"
+    value: ["high", "critical"]
+requirements:
+  required_evidence: ["risk_assessment", "impact_assessment"]
+  required_reviewers: ["governance_officer", "safety_reviewer"]
+  minimum_approval_count: 2
+constraints:
+  - field: "runtime.auto_execute"
+    operator: "eq"
+    value: false
+outcome:
+  decision: "require_human_review"
+  reason: "High-risk routes must be reviewed by authorized humans before execution."
+obligations:
+  - "record_trust_log"
+  - "attach_review_ticket"
+  - "notify_governance_channel"
+test_vectors:
+  - name: "high-risk route blocked for auto execution"
+    input:
+      route: "/api/decide"
+      risk:
+        level: "critical"
+    expected_outcome: "require_human_review"

--- a/policies/examples/missing_mandatory_evidence_halt.yaml
+++ b/policies/examples/missing_mandatory_evidence_halt.yaml
@@ -1,0 +1,35 @@
+schema_version: "1.0"
+policy_id: "policy.mandatory_evidence.halt"
+version: "2026.03.28"
+title: "Missing mandatory evidence causes halt"
+description: "Critical decisions must halt when mandatory evidence is missing from the request context."
+scope:
+  domains: ["governance", "audit"]
+  routes: ["/api/decide"]
+  actors: ["planner", "kernel", "fuji"]
+conditions:
+  - field: "decision.criticality"
+    operator: "in"
+    value: ["high", "critical"]
+requirements:
+  required_evidence: ["source_citation", "impact_assessment", "approval_ticket"]
+  required_reviewers: ["audit_reviewer", "governance_officer"]
+  minimum_approval_count: 1
+constraints:
+  - field: "evidence.missing_count"
+    operator: "gt"
+    value: 0
+outcome:
+  decision: "halt"
+  reason: "Execution must halt until all mandatory evidence artifacts are present."
+obligations:
+  - "open_evidence_gap_incident"
+  - "record_halt_event"
+test_vectors:
+  - name: "missing evidence halts critical decision"
+    input:
+      decision:
+        criticality: "critical"
+      evidence:
+        missing_count: 2
+    expected_outcome: "halt"

--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -1,0 +1,17 @@
+"""Policy-as-Code public interfaces for schema validation and canonicalization."""
+
+from .hash import canonical_ir_json, semantic_policy_hash
+from .models import OutcomeAction, PolicyValidationError, SourcePolicy
+from .normalize import to_canonical_ir
+from .schema import load_and_validate_policy, validate_source_policy
+
+__all__ = [
+    "OutcomeAction",
+    "PolicyValidationError",
+    "SourcePolicy",
+    "canonical_ir_json",
+    "load_and_validate_policy",
+    "semantic_policy_hash",
+    "to_canonical_ir",
+    "validate_source_policy",
+]

--- a/veritas_os/policy/hash.py
+++ b/veritas_os/policy/hash.py
@@ -1,0 +1,24 @@
+"""Semantic hashing based on canonical policy IR."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from .ir import CanonicalPolicyIR
+
+
+def canonical_ir_json(canonical_ir: CanonicalPolicyIR) -> str:
+    """Serialize canonical IR into stable JSON bytes representation."""
+    return json.dumps(
+        canonical_ir,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def semantic_policy_hash(canonical_ir: CanonicalPolicyIR) -> str:
+    """Compute SHA-256 semantic hash from canonical policy IR."""
+    payload = canonical_ir_json(canonical_ir).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()

--- a/veritas_os/policy/ir.py
+++ b/veritas_os/policy/ir.py
@@ -1,0 +1,30 @@
+"""Canonical Policy IR types used for deterministic audit and hashing."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, TypedDict
+
+
+class CanonicalExpression(TypedDict):
+    """Normalized expression tuple serialized as a stable mapping."""
+
+    field: str
+    operator: str
+    value: Any
+
+
+class CanonicalPolicyIR(TypedDict):
+    """Canonical and deterministic policy representation."""
+
+    schema_version: str
+    policy_id: str
+    version: str
+    title: str
+    description: str
+    scope: Dict[str, List[str]]
+    conditions: List[CanonicalExpression]
+    requirements: Dict[str, Any]
+    constraints: List[CanonicalExpression]
+    outcome: Dict[str, str]
+    obligations: List[str]
+    test_vectors: List[Dict[str, Any]]

--- a/veritas_os/policy/models.py
+++ b/veritas_os/policy/models.py
@@ -1,0 +1,185 @@
+"""Strict source policy schema for Policy-as-Code authoring."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+SCHEMA_VERSION = "1.0"
+
+
+class PolicyValidationError(ValueError):
+    """Raised when a source policy fails strict validation."""
+
+
+class OutcomeAction(str, Enum):
+    """Allowed policy outcomes for governance decisions."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    HALT = "halt"
+    ESCALATE = "escalate"
+    REQUIRE_HUMAN_REVIEW = "require_human_review"
+
+
+class Expression(BaseModel):
+    """A simple condition or constraint expression."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    field: str = Field(min_length=1, max_length=120)
+    operator: Literal[
+        "eq",
+        "neq",
+        "in",
+        "not_in",
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+        "contains",
+        "regex",
+    ]
+    value: Any
+
+    @field_validator("field")
+    @classmethod
+    def _normalize_field(cls, value: str) -> str:
+        return value.strip()
+
+
+class PolicyScope(BaseModel):
+    """Scope selectors describing where this policy applies."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    domains: List[str] = Field(min_length=1)
+    routes: List[str] = Field(min_length=1)
+    actors: List[str] = Field(min_length=1)
+
+    @field_validator("domains", "routes", "actors", mode="before")
+    @classmethod
+    def _ensure_list(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return [value]
+        return value
+
+    @field_validator("domains", "routes", "actors")
+    @classmethod
+    def _strip_and_validate_items(cls, values: List[str]) -> List[str]:
+        cleaned = [item.strip() for item in values if item and item.strip()]
+        if not cleaned:
+            raise ValueError("scope list must include at least one value")
+        return cleaned
+
+
+class PolicyRequirements(BaseModel):
+    """Evidence and approval requirements enforced by a policy."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required_evidence: List[str] = Field(default_factory=list)
+    required_reviewers: List[str] = Field(default_factory=list)
+    minimum_approval_count: int = Field(default=0, ge=0, le=20)
+
+    @field_validator("required_evidence", "required_reviewers", mode="before")
+    @classmethod
+    def _ensure_list(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return value
+
+    @field_validator("required_evidence", "required_reviewers")
+    @classmethod
+    def _normalize_items(cls, values: List[str]) -> List[str]:
+        return [item.strip() for item in values if item and item.strip()]
+
+    @model_validator(mode="after")
+    def _approval_consistency(self) -> "PolicyRequirements":
+        if self.minimum_approval_count > len(set(self.required_reviewers)):
+            raise ValueError(
+                "minimum_approval_count cannot exceed number of "
+                "required_reviewers"
+            )
+        return self
+
+
+class PolicyOutcome(BaseModel):
+    """Policy decision outcome with optional rationale metadata."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    decision: OutcomeAction
+    reason: str = Field(default="", max_length=2000)
+
+    @field_validator("reason")
+    @classmethod
+    def _normalize_reason(cls, value: str) -> str:
+        return value.strip()
+
+
+class PolicyExample(BaseModel):
+    """Test vector that documents expected policy behavior."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(min_length=1, max_length=200)
+    input: Dict[str, Any] = Field(default_factory=dict)
+    expected_outcome: OutcomeAction
+
+    @field_validator("name")
+    @classmethod
+    def _normalize_name(cls, value: str) -> str:
+        return value.strip()
+
+
+class SourcePolicy(BaseModel):
+    """Human-authored source policy schema."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: str = Field(default=SCHEMA_VERSION)
+    policy_id: str = Field(min_length=3, max_length=120)
+    version: str = Field(min_length=1, max_length=50)
+    title: str = Field(min_length=1, max_length=200)
+    description: str = Field(min_length=1, max_length=4000)
+    scope: PolicyScope
+    conditions: List[Expression] = Field(default_factory=list)
+    requirements: PolicyRequirements = Field(default_factory=PolicyRequirements)
+    constraints: List[Expression] = Field(default_factory=list)
+    outcome: PolicyOutcome
+    obligations: List[str] = Field(default_factory=list)
+    test_vectors: List[PolicyExample] = Field(default_factory=list)
+
+    @field_validator("policy_id", "version", "title", "description")
+    @classmethod
+    def _normalize_string_fields(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("obligations", mode="before")
+    @classmethod
+    def _ensure_obligations_list(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return value
+
+    @field_validator("obligations")
+    @classmethod
+    def _normalize_obligations(cls, values: List[str]) -> List[str]:
+        return [item.strip() for item in values if item and item.strip()]
+
+    @model_validator(mode="after")
+    def _validate_schema_version(self) -> "SourcePolicy":
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported schema_version={self.schema_version}; "
+                f"expected {SCHEMA_VERSION}"
+            )
+        return self

--- a/veritas_os/policy/normalize.py
+++ b/veritas_os/policy/normalize.py
@@ -1,0 +1,80 @@
+"""Normalization routines that convert source policies into Canonical IR."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List
+
+from .ir import CanonicalExpression, CanonicalPolicyIR
+from .models import SourcePolicy
+
+
+def _dedupe_sorted(values: Iterable[str]) -> List[str]:
+    return sorted({value.strip() for value in values if value and value.strip()})
+
+
+def _normalize_expression(expr: Dict[str, Any]) -> CanonicalExpression:
+    normalized_value = expr["value"]
+    if isinstance(normalized_value, dict):
+        normalized_value = {
+            key: normalized_value[key]
+            for key in sorted(normalized_value.keys())
+        }
+    return {
+        "field": expr["field"].strip(),
+        "operator": expr["operator"],
+        "value": normalized_value,
+    }
+
+
+def _normalize_expression_list(values: List[Dict[str, Any]]) -> List[CanonicalExpression]:
+    expressions = [_normalize_expression(value) for value in values]
+    expressions.sort(
+        key=lambda item: (
+            item["field"],
+            item["operator"],
+            json.dumps(item["value"], sort_keys=True, separators=(",", ":")),
+        )
+    )
+    return expressions
+
+
+def to_canonical_ir(policy: SourcePolicy) -> CanonicalPolicyIR:
+    """Normalize a validated `SourcePolicy` into deterministic canonical IR."""
+    policy_dict = policy.model_dump(mode="python")
+    requirements = policy_dict["requirements"]
+
+    test_vectors = sorted(
+        policy_dict["test_vectors"],
+        key=lambda item: (
+            item["name"],
+            json.dumps(item["input"], sort_keys=True, separators=(",", ":")),
+            item["expected_outcome"],
+        ),
+    )
+
+    return {
+        "schema_version": policy_dict["schema_version"],
+        "policy_id": policy_dict["policy_id"],
+        "version": policy_dict["version"],
+        "title": policy_dict["title"],
+        "description": policy_dict["description"],
+        "scope": {
+            "domains": _dedupe_sorted(policy_dict["scope"]["domains"]),
+            "routes": _dedupe_sorted(policy_dict["scope"]["routes"]),
+            "actors": _dedupe_sorted(policy_dict["scope"]["actors"]),
+        },
+        "conditions": _normalize_expression_list(policy_dict["conditions"]),
+        "requirements": {
+            "required_evidence": _dedupe_sorted(requirements["required_evidence"]),
+            "required_reviewers": _dedupe_sorted(requirements["required_reviewers"]),
+            "minimum_approval_count": requirements["minimum_approval_count"],
+        },
+        "constraints": _normalize_expression_list(policy_dict["constraints"]),
+        "outcome": {
+            "decision": policy_dict["outcome"]["decision"],
+            "reason": policy_dict["outcome"]["reason"],
+        },
+        "obligations": _dedupe_sorted(policy_dict["obligations"]),
+        "test_vectors": test_vectors,
+    }

--- a/veritas_os/policy/schema.py
+++ b/veritas_os/policy/schema.py
@@ -1,0 +1,48 @@
+"""Policy loader and strict validation entrypoints."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+from pydantic import ValidationError
+
+from .models import PolicyValidationError, SourcePolicy
+
+
+SUPPORTED_EXTENSIONS = {".yaml", ".yml", ".json"}
+
+
+def _load_source_file(path: Path) -> Dict[str, Any]:
+    suffix = path.suffix.lower()
+    if suffix not in SUPPORTED_EXTENSIONS:
+        raise PolicyValidationError(
+            f"unsupported policy file extension '{path.suffix}'"
+        )
+
+    raw = path.read_text(encoding="utf-8")
+    if suffix in {".yaml", ".yml"}:
+        loaded = yaml.safe_load(raw)
+    else:
+        loaded = json.loads(raw)
+
+    if not isinstance(loaded, dict):
+        raise PolicyValidationError("policy source must decode to a mapping object")
+    return loaded
+
+
+def validate_source_policy(data: Dict[str, Any]) -> SourcePolicy:
+    """Validate raw source policy mapping into strict typed model."""
+    try:
+        return SourcePolicy.model_validate(data)
+    except ValidationError as exc:
+        raise PolicyValidationError(f"invalid policy: {exc}") from exc
+
+
+def load_and_validate_policy(path: str | Path) -> SourcePolicy:
+    """Load a policy from YAML/JSON and validate against strict schema."""
+    policy_path = Path(path)
+    source = _load_source_file(policy_path)
+    return validate_source_policy(source)

--- a/veritas_os/tests/test_policy_canonical_ir.py
+++ b/veritas_os/tests/test_policy_canonical_ir.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from veritas_os.policy.hash import semantic_policy_hash
+from veritas_os.policy.normalize import to_canonical_ir
+from veritas_os.policy.schema import load_and_validate_policy, validate_source_policy
+from veritas_os.policy.models import PolicyValidationError
+
+
+EXAMPLES_DIR = Path("policies/examples")
+
+
+def test_valid_example_policy_parses_successfully() -> None:
+    policy = load_and_validate_policy(
+        EXAMPLES_DIR / "high_risk_route_requires_human_review.yaml"
+    )
+
+    assert policy.policy_id == "policy.high_risk_route.human_review"
+    assert policy.outcome.decision.value == "require_human_review"
+
+
+@pytest.mark.parametrize(
+    "example_name",
+    [
+        "high_risk_route_requires_human_review.yaml",
+        "external_tool_usage_denied.yaml",
+        "missing_mandatory_evidence_halt.yaml",
+    ],
+)
+def test_all_example_policies_validate(example_name: str) -> None:
+    policy = load_and_validate_policy(EXAMPLES_DIR / example_name)
+
+    assert policy.schema_version == "1.0"
+
+
+def test_invalid_policy_fails_with_useful_error() -> None:
+    invalid = {
+        "schema_version": "1.0",
+        "policy_id": "policy.invalid.enum",
+        "version": "1",
+        "title": "Invalid enum policy",
+        "description": "Should fail because outcome enum is invalid.",
+        "scope": {
+            "domains": ["governance"],
+            "routes": ["/api/decide"],
+            "actors": ["kernel"],
+        },
+        "outcome": {
+            "decision": "block_all",
+            "reason": "invalid",
+        },
+    }
+
+    with pytest.raises(PolicyValidationError, match="invalid policy"):
+        validate_source_policy(invalid)
+
+
+def test_required_nested_structures_are_enforced() -> None:
+    missing_scope = {
+        "schema_version": "1.0",
+        "policy_id": "policy.invalid.missing_scope",
+        "version": "1",
+        "title": "Missing scope",
+        "description": "This policy should fail.",
+        "outcome": {
+            "decision": "deny",
+            "reason": "invalid",
+        },
+    }
+
+    with pytest.raises(PolicyValidationError, match="scope"):
+        validate_source_policy(missing_scope)
+
+
+def test_normalization_is_deterministic_for_equivalent_policies() -> None:
+    policy_a = validate_source_policy(
+        {
+            "schema_version": "1.0",
+            "policy_id": "policy.same.meaning",
+            "version": "1",
+            "title": "Same semantics",
+            "description": "Ordering differences should normalize.",
+            "scope": {
+                "domains": ["security", "governance"],
+                "routes": ["/api/decide", "/api/tools"],
+                "actors": ["kernel", "planner"],
+            },
+            "conditions": [
+                {"field": "risk.level", "operator": "in", "value": ["high", "critical"]},
+                {"field": "tool.external", "operator": "eq", "value": True},
+            ],
+            "requirements": {
+                "required_evidence": ["impact_assessment", "risk_assessment"],
+                "required_reviewers": ["security_officer", "governance_officer"],
+                "minimum_approval_count": 1,
+            },
+            "constraints": [
+                {"field": "runtime.auto_execute", "operator": "eq", "value": False},
+            ],
+            "outcome": {"decision": "escalate", "reason": "Escalate."},
+            "obligations": ["record_trust_log", "notify_governance_channel"],
+        }
+    )
+    policy_b = validate_source_policy(
+        {
+            "schema_version": "1.0",
+            "policy_id": "policy.same.meaning",
+            "version": "1",
+            "title": "Same semantics",
+            "description": "Ordering differences should normalize.",
+            "scope": {
+                "domains": ["governance", "security", "governance"],
+                "routes": ["/api/tools", "/api/decide"],
+                "actors": ["planner", "kernel", "planner"],
+            },
+            "conditions": [
+                {"field": "tool.external", "operator": "eq", "value": True},
+                {"field": "risk.level", "operator": "in", "value": ["high", "critical"]},
+            ],
+            "requirements": {
+                "required_evidence": ["risk_assessment", "impact_assessment", "risk_assessment"],
+                "required_reviewers": ["governance_officer", "security_officer"],
+                "minimum_approval_count": 1,
+            },
+            "constraints": [
+                {"field": "runtime.auto_execute", "operator": "eq", "value": False},
+            ],
+            "outcome": {"decision": "escalate", "reason": "Escalate."},
+            "obligations": ["notify_governance_channel", "record_trust_log"],
+        }
+    )
+
+    assert to_canonical_ir(policy_a) == to_canonical_ir(policy_b)
+
+
+def test_semantic_hash_is_stable_for_equivalent_policies() -> None:
+    policy_a = load_and_validate_policy(
+        EXAMPLES_DIR / "external_tool_usage_denied.yaml"
+    )
+    policy_b = validate_source_policy(
+        {
+            "schema_version": "1.0",
+            "policy_id": "policy.external_tool_usage.denied",
+            "version": "2026.03.28",
+            "title": "Deny external tool usage under restricted conditions",
+            "description": (
+                "Disallow external tool invocation when tenant data "
+                "classification is restricted."
+            ),
+            "scope": {
+                "domains": ["security", "tooling"],
+                "routes": ["/api/decide", "/api/tools"],
+                "actors": ["tool_adapter", "kernel"],
+            },
+            "conditions": [
+                {"field": "data.classification", "operator": "in", "value": ["restricted", "secret"]},
+                {"field": "tool.external", "operator": "eq", "value": True},
+            ],
+            "requirements": {
+                "required_evidence": ["data_classification_label"],
+                "required_reviewers": ["security_officer"],
+                "minimum_approval_count": 1,
+            },
+            "constraints": [
+                {
+                    "field": "tool.name",
+                    "operator": "not_in",
+                    "value": ["internal_search", "approved_registry"],
+                }
+            ],
+            "outcome": {
+                "decision": "deny",
+                "reason": "External tools are prohibited for restricted data handling contexts.",
+            },
+            "obligations": ["record_denial_reason", "emit_security_alert"],
+            "test_vectors": [
+                {
+                    "name": "external tool denied for restricted data",
+                    "input": {
+                        "tool": {"external": True},
+                        "data": {"classification": "restricted"},
+                    },
+                    "expected_outcome": "deny",
+                }
+            ],
+        }
+    )
+
+    hash_a = semantic_policy_hash(to_canonical_ir(policy_a))
+    hash_b = semantic_policy_hash(to_canonical_ir(policy_b))
+
+    assert hash_a == hash_b


### PR DESCRIPTION
### Motivation
- Introduce a first-stage Policy-as-Code foundation to enable auditable, machine-validated governance policies and stable fingerprints for policies.
- Ensure human-authored policies can be strictly validated so invalid or malformed policies fail fast with clear errors.
- Provide a deterministic canonical IR and semantic hash so semantically-equivalent policies produce the same representation and fingerprint for auditing and replay.
- Ship a small set of example policies and tests to bootstrap compiler/runtime integration in a later task.

### Description
- Add a new `veritas_os.policy` package exposing `load_and_validate_policy`, `validate_source_policy`, `to_canonical_ir`, and `semantic_policy_hash` along with `OutcomeAction` and `PolicyValidationError` types (files: `models.py`, `schema.py`, `normalize.py`, `ir.py`, `hash.py`, `__init__.py`).
- Implement a strict Pydantic `SourcePolicy` schema (`schema_version = "1.0"`) with nested models for `scope`, `requirements`, `outcome`, `conditions`, `constraints`, `test_vectors`, and enforced enums for outcomes and expression operators. 
- Implement deterministic normalization rules in `to_canonical_ir` including dedupe+sort for lists, stable ordering for expressions and test-vectors, and normalized expression serialization for stable canonical IR. 
- Implement `canonical_ir_json` + `semantic_policy_hash` producing a stable JSON serialization and SHA-256 fingerprint derived from the canonical IR, and add file-extension and mapping checks when loading YAML/JSON source files. 
- Add three example policies under `policies/examples/` and a focused test module `veritas_os/tests/test_policy_canonical_ir.py`, and add `docs/policy_as_code.md` documenting format, validation flow, IR role, and known non-goals.

### Testing
- Ran `pytest -q veritas_os/tests/test_policy_canonical_ir.py`, which executed the validation, normalization, and hashing tests and completed successfully with `8 passed`.
- Ran `python -m compileall -q veritas_os/policy` to ensure modules compile cleanly, which succeeded.
- Tests include parsing of valid examples, rejection of invalid policies with helpful errors, deterministic normalization equivalence checks, and semantic hash stability checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c829d9a6c08326a8a93682fc9ad4d2)