### PR TITLE
Policy Compiler v0.1 — compile source policy → canonical IR → manifest + bundle

### DIFF
--- a/docs/policy_as_code.md
+++ b/docs/policy_as_code.md
@@ -1,9 +1,14 @@
-# Policy-as-Code (Stage 1)
+# Policy-as-Code (Stage 2 / Compiler v0.1)
 
 ## 目的
 
-本ドキュメントは、VERITAS の Policy-as-Code 第1段階として導入した
-**source policy schema / validation / canonical IR / semantic hash** の最小実装を説明します。
+本ドキュメントは、VERITAS Policy-as-Code の Stage 2 として導入した
+**source policy → canonical IR → compiled bundle artifacts** の実装を説明します。
+
+Stage 1 の schema validation / canonicalization / semantic hash を土台に、
+Stage 2 では **Policy Compiler v0.1** を追加しました。
+
+---
 
 ## Source Policy Format
 
@@ -17,11 +22,14 @@
   - `scope` (`domains` / `routes` / `actors`)
   - `outcome` (`decision` / `reason`)
 - 任意項目:
+  - `effective_date` (ISO 日付文字列)
   - `conditions`
   - `requirements`
   - `constraints`
   - `obligations`
   - `test_vectors`
+  - `source_refs`
+  - `metadata`
 
 許可される `outcome.decision` は次の列挙のみです。
 
@@ -31,44 +39,142 @@
 - `escalate`
 - `require_human_review`
 
-## Validation Flow
+---
 
-1. `veritas_os.policy.schema.load_and_validate_policy` がファイル拡張子を検証します。
-2. YAML/JSON をロードし、マッピング形式であることを検証します。
-3. `SourcePolicy` (Pydantic strict model) で以下を検証します。
-   - 必須フィールド
-   - 列挙値 (`outcome`, 演算子)
-   - ネスト構造 (`scope`, `requirements`, `outcome`)
-   - `minimum_approval_count` と `required_reviewers` の整合性
-4. エラー時は `PolicyValidationError` を返します。
+## Compiler Entrypoint
 
-## Canonical IR の役割
+CLI:
 
-`veritas_os.policy.normalize.to_canonical_ir` は、監査と差分比較のための安定化処理を提供します。
+```bash
+python -m veritas_os.scripts.compile_policy \
+  policies/examples/high_risk_route_requires_human_review.yaml \
+  --output-dir artifacts/policy_compiler
+```
 
-- リスト値を重複排除 + ソート
-- 条件/制約を deterministic order に整列
-- test vector も安定ソート
-- 不要な見た目差分（記述順序）を除去
+deterministic manifest を明示したい場合:
 
-この Canonical IR を `veritas_os.policy.hash.semantic_policy_hash` に入力して、
-見た目に依存しない semantic hash (SHA-256) を生成します。
+```bash
+python -m veritas_os.scripts.compile_policy \
+  policies/examples/high_risk_route_requires_human_review.yaml \
+  --output-dir artifacts/policy_compiler \
+  --compiled-at 2026-03-28T00:00:00Z
+```
 
-## Example Policies
+Python API:
 
-- `policies/examples/high_risk_route_requires_human_review.yaml`
-- `policies/examples/external_tool_usage_denied.yaml`
-- `policies/examples/missing_mandatory_evidence_halt.yaml`
+- `veritas_os.policy.compile_policy_to_bundle(...)`
 
-## この Task で未実装
+---
 
-- FUJI runtime への本格統合
-- Policy compiler (`Policy -> ValueCore/FUJI rules`) 本体
-- generated tests の自動生成
-- bundle signing / distribution
-- UI 差分可視化
+## 生成される Artifact
+
+出力ディレクトリ:
+
+```text
+{output_dir}/{policy_id}/{version}/bundle/
+├── compiled/
+│   ├── canonical_ir.json
+│   └── explain.json
+├── signatures/
+│   └── UNSIGNED
+└── manifest.json
+```
+
+加えて同階層に配布用アーカイブを生成:
+
+```text
+{output_dir}/{policy_id}/{version}/bundle.tar.gz
+```
+
+### canonical_ir.json
+
+- 凍結済み Canonical IR
+- semantic hash の source of truth
+- deterministic JSON 形式
+
+### explain.json
+
+UI / audit export 向けの説明素材。
+
+- policy purpose
+- application scope summary
+- outcome summary
+- obligations summary
+- requirements summary
+
+### manifest.json
+
+最低限以下を含みます。
+
+- `policy_id`
+- `version`
+- `semantic_hash`
+- `compiler_version`
+- `compiled_at`
+- `effective_date`
+- `source_files`
+- `schema_version` (manifest schema)
+- `outcome_summary`
+- `bundle_contents`
+- `signing` (future extension)
+
+---
+
+## Deterministic Output の方針
+
+- Canonical IR は list/order/辞書キーを正規化して deterministic serialize します。
+- `semantic_hash` は canonical IR のみを入力に SHA-256 で計算します。
+- `compiled_at` は manifest 監査情報であり、semantic hash の対象外です。
+- 生成 JSON は stable formatting (`sort_keys=True`, fixed indent) で出力します。
+
+> 同一 source かつ同一 `--compiled-at` を与えた場合、manifest / compiled artifacts は一致します。
+
+---
+
+## Bundle Format v0.1 と将来署名拡張
+
+v0.1 では署名本体は未実装ですが、bundle 構造に以下の拡張点を用意しています。
+
+- `signatures/UNSIGNED` マーカー
+- `manifest.signing`
+  - `status`
+  - `signature_ref`
+  - `key_id`
+  - `extensions`
+
+将来 Task で、以下を段階的に追加できます。
+
+1. `signatures/manifest.sig` の実装
+2. `manifest.signing.signature_ref` の実リンク化
+3. transparency log / trust log 連携
+4. rollout / rollback policy pack metadata の追加
+
+---
+
+## Validation / Compile Flow
+
+1. `load_and_validate_policy` で source policy を strict validation。
+2. `to_canonical_ir` で Canonical IR に正規化。
+3. `semantic_policy_hash` を計算。
+4. `explain.json` と `manifest.json` を生成。
+5. bundle directory + `bundle.tar.gz` を生成。
+
+---
+
+## テスト観点
+
+- valid policy compile success
+- invalid policy compile failure
+- manifest の必須項目整合
+- explanation metadata 出力確認
+- semantic hash stability
+- deterministic output（固定 `compiled_at`）
+- bundle structure validity
+
+---
 
 ## セキュリティ上の注意
 
-- 本段階の semantic hash は **整合性検証の基礎** であり、署名・鍵管理は未導入です。
-- そのため、本番供給チェーンでは将来タスクとして署名検証を追加してください。
+- semantic hash は改ざん検知の基礎だが、**真正性保証は署名導入後**に成立します。
+- `signing.status=unsigned` の bundle は、配布時に信頼境界を跨ぐ用途へそのまま使わないでください。
+- source policy の `metadata` / `source_refs` は監査補助情報であり、機密データの生埋め込みは避けてください。

--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -1,5 +1,6 @@
 """Policy-as-Code public interfaces for schema validation and canonicalization."""
 
+from .compiler import COMPILER_VERSION, CompileResult, compile_policy_to_bundle
 from .hash import canonical_ir_json, semantic_policy_hash
 from .models import OutcomeAction, PolicyValidationError, SourcePolicy
 from .normalize import to_canonical_ir
@@ -9,7 +10,10 @@ __all__ = [
     "OutcomeAction",
     "PolicyValidationError",
     "SourcePolicy",
+    "COMPILER_VERSION",
+    "CompileResult",
     "canonical_ir_json",
+    "compile_policy_to_bundle",
     "load_and_validate_policy",
     "semantic_policy_hash",
     "to_canonical_ir",

--- a/veritas_os/policy/bundle.py
+++ b/veritas_os/policy/bundle.py
@@ -1,0 +1,44 @@
+"""Bundle layout and archive helpers for policy compiler artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import tarfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def compute_file_sha256(path: Path) -> str:
+    """Compute SHA-256 checksum for a generated artifact file."""
+    hasher = hashlib.sha256()
+    hasher.update(path.read_bytes())
+    return hasher.hexdigest()
+
+
+def collect_bundle_files(bundle_dir: Path) -> List[Dict[str, Any]]:
+    """Collect bundle file metadata excluding generated archive files."""
+    files: List[Dict[str, Any]] = []
+    for file_path in sorted(bundle_dir.rglob("*")):
+        if not file_path.is_file():
+            continue
+        rel = file_path.relative_to(bundle_dir).as_posix()
+        if rel.endswith(".tar.gz"):
+            continue
+        files.append(
+            {
+                "path": rel,
+                "sha256": compute_file_sha256(file_path),
+                "size": file_path.stat().st_size,
+            }
+        )
+    return files
+
+
+def create_bundle_archive(bundle_dir: Path) -> Path:
+    """Create deterministic tar.gz archive for distribution."""
+    archive_path = bundle_dir.with_suffix(".tar.gz")
+    with tarfile.open(archive_path, mode="w:gz") as tar:
+        for entry in sorted(bundle_dir.rglob("*")):
+            rel = entry.relative_to(bundle_dir.parent)
+            tar.add(entry, arcname=rel.as_posix(), recursive=False)
+    return archive_path

--- a/veritas_os/policy/compiler.py
+++ b/veritas_os/policy/compiler.py
@@ -1,0 +1,88 @@
+"""Policy compiler for canonical IR + manifest + bundle artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from .bundle import collect_bundle_files, create_bundle_archive
+from .emit import write_stable_json
+from .explain import build_explanation_metadata
+from .hash import semantic_policy_hash
+from .manifest import build_manifest
+from .normalize import to_canonical_ir
+from .schema import load_and_validate_policy
+
+COMPILER_VERSION = "0.1.0"
+
+
+@dataclass(frozen=True)
+class CompileResult:
+    """Compiled bundle output summary."""
+
+    bundle_dir: Path
+    archive_path: Path
+    semantic_hash: str
+    manifest_path: Path
+
+
+def _utc_now_iso8601() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def compile_policy_to_bundle(
+    source_policy_path: str | Path,
+    output_dir: str | Path,
+    *,
+    compiled_at: str | None = None,
+    compiler_version: str = COMPILER_VERSION,
+) -> CompileResult:
+    """Compile a source policy into deterministic bundle artifacts."""
+    source_path = Path(source_policy_path)
+    out_dir = Path(output_dir)
+
+    policy = load_and_validate_policy(source_path)
+    canonical_ir = to_canonical_ir(policy)
+    semantic_hash = semantic_policy_hash(canonical_ir)
+
+    policy_dir = out_dir / canonical_ir["policy_id"] / canonical_ir["version"]
+    bundle_dir = policy_dir / "bundle"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    canonical_path = bundle_dir / "compiled" / "canonical_ir.json"
+    explain_path = bundle_dir / "compiled" / "explain.json"
+    unsigned_path = bundle_dir / "signatures" / "UNSIGNED"
+
+    write_stable_json(canonical_path, canonical_ir)
+    explanation_metadata: Dict[str, Any] = build_explanation_metadata(canonical_ir)
+    write_stable_json(explain_path, explanation_metadata)
+    unsigned_path.parent.mkdir(parents=True, exist_ok=True)
+    unsigned_path.write_text(
+        "signature pending for future signing workflow\n",
+        encoding="utf-8",
+    )
+
+    bundle_files = collect_bundle_files(bundle_dir)
+    manifest = build_manifest(
+        canonical_ir,
+        semantic_hash=semantic_hash,
+        compiler_version=compiler_version,
+        compiled_at=compiled_at or _utc_now_iso8601(),
+        source_files=[source_path.as_posix()],
+        bundle_files=bundle_files,
+    )
+    manifest_path = bundle_dir / "manifest.json"
+    write_stable_json(manifest_path, manifest)
+
+    archive_path = create_bundle_archive(bundle_dir)
+
+    return CompileResult(
+        bundle_dir=bundle_dir,
+        archive_path=archive_path,
+        semantic_hash=semantic_hash,
+        manifest_path=manifest_path,
+    )

--- a/veritas_os/policy/emit.py
+++ b/veritas_os/policy/emit.py
@@ -1,0 +1,23 @@
+"""Stable JSON emit utilities for compiled policy artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def stable_json_dumps(payload: Any) -> str:
+    """Serialize payload with deterministic formatting for reproducible output."""
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2,
+    ) + "\n"
+
+
+def write_stable_json(path: Path, payload: Any) -> None:
+    """Write JSON in a deterministic layout and create parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(stable_json_dumps(payload), encoding="utf-8")

--- a/veritas_os/policy/explain.py
+++ b/veritas_os/policy/explain.py
@@ -1,0 +1,52 @@
+"""Human-readable explanation metadata for compiled policy artifacts."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .ir import CanonicalPolicyIR
+
+
+def build_explanation_metadata(canonical_ir: CanonicalPolicyIR) -> Dict[str, Any]:
+    """Build explanation metadata for UI and audit export consumers."""
+    outcome = canonical_ir["outcome"]
+    requirements = canonical_ir["requirements"]
+    decision = outcome["decision"]
+
+    return {
+        "policy_id": canonical_ir["policy_id"],
+        "title": canonical_ir["title"],
+        "purpose": canonical_ir["description"],
+        "application": {
+            "scope": canonical_ir["scope"],
+            "condition_count": len(canonical_ir["conditions"]),
+            "constraint_count": len(canonical_ir["constraints"]),
+            "human_summary": (
+                f"Apply to domains={', '.join(canonical_ir['scope']['domains'])}; "
+                f"routes={', '.join(canonical_ir['scope']['routes'])}; "
+                f"actors={', '.join(canonical_ir['scope']['actors'])}."
+            ),
+        },
+        "outcome": {
+            "decision": decision,
+            "reason": outcome["reason"],
+            "human_summary": f"If policy matches, outcome is '{decision}'.",
+        },
+        "obligations": {
+            "items": canonical_ir["obligations"],
+            "human_summary": (
+                "No obligations are defined."
+                if not canonical_ir["obligations"]
+                else (
+                    "Required obligations: "
+                    + ", ".join(canonical_ir["obligations"])
+                    + "."
+                )
+            ),
+        },
+        "requirements": {
+            "required_evidence": requirements["required_evidence"],
+            "required_reviewers": requirements["required_reviewers"],
+            "minimum_approval_count": requirements["minimum_approval_count"],
+        },
+    }

--- a/veritas_os/policy/ir.py
+++ b/veritas_os/policy/ir.py
@@ -21,6 +21,7 @@ class CanonicalPolicyIR(TypedDict):
     version: str
     title: str
     description: str
+    effective_date: str | None
     scope: Dict[str, List[str]]
     conditions: List[CanonicalExpression]
     requirements: Dict[str, Any]
@@ -28,3 +29,5 @@ class CanonicalPolicyIR(TypedDict):
     outcome: Dict[str, str]
     obligations: List[str]
     test_vectors: List[Dict[str, Any]]
+    source_refs: List[str]
+    metadata: Dict[str, Any]

--- a/veritas_os/policy/manifest.py
+++ b/veritas_os/policy/manifest.py
@@ -1,0 +1,46 @@
+"""Manifest builder for compiled policy bundles."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .ir import CanonicalPolicyIR
+
+MANIFEST_SCHEMA_VERSION = "0.1"
+
+
+def build_manifest(
+    canonical_ir: CanonicalPolicyIR,
+    *,
+    semantic_hash: str,
+    compiler_version: str,
+    compiled_at: str,
+    source_files: List[str],
+    bundle_files: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build manifest metadata for bundle distribution and audit workflows."""
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "policy_id": canonical_ir["policy_id"],
+        "version": canonical_ir["version"],
+        "semantic_hash": semantic_hash,
+        "compiler_version": compiler_version,
+        "compiled_at": compiled_at,
+        "effective_date": canonical_ir["effective_date"],
+        "source_files": sorted(source_files),
+        "source_refs": canonical_ir["source_refs"],
+        "outcome_summary": {
+            "decision": canonical_ir["outcome"]["decision"],
+            "reason": canonical_ir["outcome"]["reason"],
+            "obligation_count": len(canonical_ir["obligations"]),
+            "condition_count": len(canonical_ir["conditions"]),
+            "constraint_count": len(canonical_ir["constraints"]),
+        },
+        "bundle_contents": sorted(bundle_files, key=lambda item: item["path"]),
+        "signing": {
+            "status": "unsigned",
+            "signature_ref": None,
+            "key_id": None,
+            "extensions": {},
+        },
+    }

--- a/veritas_os/policy/models.py
+++ b/veritas_os/policy/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from enum import Enum
 from typing import Any, Dict, List, Literal
 
@@ -148,6 +149,7 @@ class SourcePolicy(BaseModel):
     version: str = Field(min_length=1, max_length=50)
     title: str = Field(min_length=1, max_length=200)
     description: str = Field(min_length=1, max_length=4000)
+    effective_date: str | None = Field(default=None)
     scope: PolicyScope
     conditions: List[Expression] = Field(default_factory=list)
     requirements: PolicyRequirements = Field(default_factory=PolicyRequirements)
@@ -155,6 +157,8 @@ class SourcePolicy(BaseModel):
     outcome: PolicyOutcome
     obligations: List[str] = Field(default_factory=list)
     test_vectors: List[PolicyExample] = Field(default_factory=list)
+    source_refs: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("policy_id", "version", "title", "description")
     @classmethod
@@ -168,6 +172,36 @@ class SourcePolicy(BaseModel):
             return []
         if isinstance(value, str):
             return [value]
+        return value
+
+    @field_validator("source_refs", mode="before")
+    @classmethod
+    def _ensure_source_refs_list(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return value
+
+    @field_validator("source_refs")
+    @classmethod
+    def _normalize_source_refs(cls, values: List[str]) -> List[str]:
+        return [item.strip() for item in values if item and item.strip()]
+
+    @field_validator("effective_date")
+    @classmethod
+    def _validate_effective_date(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        date.fromisoformat(normalized)
+        return normalized
+
+    @field_validator("metadata")
+    @classmethod
+    def _ensure_metadata_mapping(cls, value: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ValueError("metadata must be an object")
         return value
 
     @field_validator("obligations")

--- a/veritas_os/policy/normalize.py
+++ b/veritas_os/policy/normalize.py
@@ -39,6 +39,17 @@ def _normalize_expression_list(values: List[Dict[str, Any]]) -> List[CanonicalEx
     return expressions
 
 
+def _normalize_json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _normalize_json_value(value[key])
+            for key in sorted(value.keys())
+        }
+    if isinstance(value, list):
+        return [_normalize_json_value(item) for item in value]
+    return value
+
+
 def to_canonical_ir(policy: SourcePolicy) -> CanonicalPolicyIR:
     """Normalize a validated `SourcePolicy` into deterministic canonical IR."""
     policy_dict = policy.model_dump(mode="python")
@@ -59,6 +70,7 @@ def to_canonical_ir(policy: SourcePolicy) -> CanonicalPolicyIR:
         "version": policy_dict["version"],
         "title": policy_dict["title"],
         "description": policy_dict["description"],
+        "effective_date": policy_dict["effective_date"],
         "scope": {
             "domains": _dedupe_sorted(policy_dict["scope"]["domains"]),
             "routes": _dedupe_sorted(policy_dict["scope"]["routes"]),
@@ -77,4 +89,6 @@ def to_canonical_ir(policy: SourcePolicy) -> CanonicalPolicyIR:
         },
         "obligations": _dedupe_sorted(policy_dict["obligations"]),
         "test_vectors": test_vectors,
+        "source_refs": _dedupe_sorted(policy_dict["source_refs"]),
+        "metadata": _normalize_json_value(policy_dict["metadata"]),
     }

--- a/veritas_os/scripts/compile_policy.py
+++ b/veritas_os/scripts/compile_policy.py
@@ -1,0 +1,51 @@
+"""CLI entrypoint for VERITAS Policy Compiler v0.1."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from veritas_os.policy.compiler import compile_policy_to_bundle
+from veritas_os.policy.models import PolicyValidationError
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Compile VERITAS source policy")
+    parser.add_argument("source", help="Path to source policy YAML/JSON")
+    parser.add_argument(
+        "--output-dir",
+        default="artifacts/policy_compiler",
+        help="Output directory for compiled bundle artifacts",
+    )
+    parser.add_argument(
+        "--compiled-at",
+        default=None,
+        help="Optional ISO-8601 UTC timestamp for deterministic manifests",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        result = compile_policy_to_bundle(
+            source_policy_path=Path(args.source),
+            output_dir=Path(args.output_dir),
+            compiled_at=args.compiled_at,
+        )
+    except PolicyValidationError as exc:
+        print(f"policy compile failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"bundle_dir={result.bundle_dir}")
+    print(f"manifest={result.manifest_path}")
+    print(f"archive={result.archive_path}")
+    print(f"semantic_hash={result.semantic_hash}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_policy_compiler.py
+++ b/veritas_os/tests/test_policy_compiler.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from veritas_os.policy.compiler import compile_policy_to_bundle
+from veritas_os.policy.models import PolicyValidationError
+
+EXAMPLES_DIR = Path("policies/examples")
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_compile_policy_success_generates_artifacts(tmp_path: Path) -> None:
+    result = compile_policy_to_bundle(
+        EXAMPLES_DIR / "high_risk_route_requires_human_review.yaml",
+        tmp_path,
+        compiled_at="2026-03-28T00:00:00Z",
+    )
+
+    assert result.bundle_dir.exists()
+    assert result.manifest_path.exists()
+    assert (result.bundle_dir / "compiled" / "canonical_ir.json").exists()
+    assert (result.bundle_dir / "compiled" / "explain.json").exists()
+    assert (result.bundle_dir / "signatures" / "UNSIGNED").exists()
+    assert result.archive_path.exists()
+
+
+def test_compile_policy_failure_for_invalid_source(tmp_path: Path) -> None:
+    invalid_file = tmp_path / "invalid.yaml"
+    invalid_file.write_text(
+        """
+        schema_version: "1.0"
+        policy_id: "policy.invalid"
+        version: "1"
+        title: "broken"
+        description: "missing scope and invalid outcome"
+        outcome:
+          decision: "block_all"
+          reason: "invalid"
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PolicyValidationError):
+        compile_policy_to_bundle(invalid_file, tmp_path)
+
+
+def test_manifest_contents_and_explanation_metadata(tmp_path: Path) -> None:
+    result = compile_policy_to_bundle(
+        EXAMPLES_DIR / "external_tool_usage_denied.yaml",
+        tmp_path,
+        compiled_at="2026-03-28T01:02:03Z",
+    )
+
+    manifest = _load_json(result.manifest_path)
+    explain = _load_json(result.bundle_dir / "compiled" / "explain.json")
+
+    assert manifest["policy_id"] == "policy.external_tool_usage.denied"
+    assert manifest["compiled_at"] == "2026-03-28T01:02:03Z"
+    assert manifest["schema_version"] == "0.1"
+    assert manifest["semantic_hash"] == result.semantic_hash
+    assert manifest["outcome_summary"]["decision"] == "deny"
+    assert manifest["bundle_contents"]
+    assert manifest["signing"]["status"] == "unsigned"
+
+    assert explain["purpose"]
+    assert explain["application"]["human_summary"]
+    assert explain["outcome"]["human_summary"]
+
+
+def test_semantic_hash_stability_and_deterministic_outputs(tmp_path: Path) -> None:
+    fixed_compiled_at = "2026-03-28T04:00:00Z"
+    left = compile_policy_to_bundle(
+        EXAMPLES_DIR / "missing_mandatory_evidence_halt.yaml",
+        tmp_path / "left",
+        compiled_at=fixed_compiled_at,
+    )
+    right = compile_policy_to_bundle(
+        EXAMPLES_DIR / "missing_mandatory_evidence_halt.yaml",
+        tmp_path / "right",
+        compiled_at=fixed_compiled_at,
+    )
+
+    assert left.semantic_hash == right.semantic_hash
+
+    left_manifest = _load_json(left.manifest_path)
+    right_manifest = _load_json(right.manifest_path)
+    left_canonical = _load_json(left.bundle_dir / "compiled" / "canonical_ir.json")
+    right_canonical = _load_json(right.bundle_dir / "compiled" / "canonical_ir.json")
+
+    # output-root path only is non-deterministic because each test run directory differs
+    left_manifest["source_files"] = ["<redacted-source>"]
+    right_manifest["source_files"] = ["<redacted-source>"]
+
+    assert left_manifest == right_manifest
+    assert left_canonical == right_canonical
+
+
+def test_bundle_structure_paths_are_valid(tmp_path: Path) -> None:
+    result = compile_policy_to_bundle(
+        EXAMPLES_DIR / "external_tool_usage_denied.yaml",
+        tmp_path,
+        compiled_at="2026-03-28T08:00:00Z",
+    )
+    manifest = _load_json(result.manifest_path)
+
+    paths = [entry["path"] for entry in manifest["bundle_contents"]]
+
+    assert "compiled/canonical_ir.json" in paths
+    assert "compiled/explain.json" in paths
+    assert "signatures/UNSIGNED" in paths


### PR DESCRIPTION
### Motivation
- Implement Stage-2 Policy-as-Code: produce compiled artifacts from validated source policies for auditable distribution and future signing. 
- Preserve source provenance and operational metadata (`effective_date`, `source_refs`, `metadata`) in the canonical IR so compiled bundles are auditable. 
- Ensure deterministic outputs and clear extension points for future cryptographic signing and rollout workflows.

### Description
- Add a modular compiler pipeline with `veritas_os.policy.compiler` and helpers `emit`, `explain`, `manifest`, and `bundle` that produce deterministic JSON artifacts and a tarball archive (files added: `veritas_os/policy/{compiler.py,emit.py,explain.py,manifest.py,bundle.py}`).
- Extend the source schema and canonical IR to carry `effective_date`, `source_refs`, and free-form `metadata` and normalize them in `to_canonical_ir` (`veritas_os/policy/models.py`, `veritas_os/policy/ir.py`, `veritas_os/policy/normalize.py`).
- Provide deterministic, stable JSON emission with `write_stable_json` and compute a semantic SHA-256 over the canonical IR via `semantic_policy_hash`; manifest includes `semantic_hash`, `compiler_version`, `compiled_at`, `bundle_contents`, and a `signing` extension block (`veritas_os/policy/emit.py`, `veritas_os/policy/manifest.py`, `veritas_os/policy/hash.py`).
- Add a CLI entrypoint and Python API: `python -m veritas_os.scripts.compile_policy` and `veritas_os.policy.compile_policy_to_bundle(...)`, and include a `signatures/UNSIGNED` marker to reserve signing extension points (`veritas_os/scripts/compile_policy.py`, `veritas_os/policy/__init__.py`).

### Testing
- Ran unit tests: `pytest -q veritas_os/tests/test_policy_canonical_ir.py veritas_os/tests/test_policy_compiler.py` and all tests passed (`13 passed`).
- Executed the CLI example `python -m veritas_os.scripts.compile_policy policies/examples/high_risk_route_requires_human_review.yaml --output-dir /tmp/veritas_policy_artifacts --compiled-at 2026-03-28T00:00:00Z` which produced the bundle, manifest and semantic hash successfully.
- Added `veritas_os/tests/test_policy_compiler.py` covering compile success/failure, manifest correctness, explanation metadata presence, semantic hash stability, deterministic output (with fixed `compiled_at`), and bundle structure checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c86381c8308326b70436640f091c9a)