### PR TITLE
Add governance rollout controls, signed bundle verification, and decision export

### DIFF
--- a/frontend/app/governance/components/ApprovalWorkflow.tsx
+++ b/frontend/app/governance/components/ApprovalWorkflow.tsx
@@ -10,11 +10,21 @@ interface ApprovalWorkflowProps {
   draftApprovalStatus: ApprovalStatus;
   changeCount: number;
   canApprove: boolean;
+  ticketId: string;
+  approverIdentityBinding: boolean;
   onApprove: () => void;
   onReject: () => void;
 }
 
-export function ApprovalWorkflow({ draftApprovalStatus, changeCount, canApprove, onApprove, onReject }: ApprovalWorkflowProps): JSX.Element {
+export function ApprovalWorkflow({
+  draftApprovalStatus,
+  changeCount,
+  canApprove,
+  ticketId,
+  approverIdentityBinding,
+  onApprove,
+  onReject,
+}: ApprovalWorkflowProps): JSX.Element {
   const { t } = useI18n();
   const approvalBlocked = !canApprove || draftApprovalStatus === "rejected";
 
@@ -28,6 +38,9 @@ export function ApprovalWorkflow({ draftApprovalStatus, changeCount, canApprove,
         <button type="button" className="rounded border border-success/60 bg-success/10 px-3 py-2 text-sm text-success" onClick={onApprove} disabled={!canApprove || draftApprovalStatus === "approved"}>approve</button>
         <button type="button" className="rounded border border-danger/60 bg-danger/10 px-3 py-2 text-sm text-danger" onClick={onReject} disabled={!canApprove || draftApprovalStatus === "rejected"}>reject</button>
       </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        ticket: <span className="font-mono">{ticketId || "unlinked"}</span> / identity binding: {approverIdentityBinding ? "enabled" : "disabled"}
+      </p>
       {approvalBlocked ? (
         <p className="mt-2 rounded border border-warning/50 bg-warning/10 px-2 py-1 text-xs text-warning">
           {t(

--- a/frontend/app/governance/components/PolicyMetaPanel.tsx
+++ b/frontend/app/governance/components/PolicyMetaPanel.tsx
@@ -44,6 +44,16 @@ export function PolicyMetaPanel({ savedPolicy, draft, draftApprovalStatus, hasCh
           <p className="text-muted-foreground">last_applied</p>
           <p className="font-mono font-semibold">{draft.last_applied ?? "N/A"}</p>
         </div>
+        <div className="rounded-lg border px-3 py-2">
+          <p className="text-muted-foreground">rollout strategy</p>
+          <p className="font-mono font-semibold">
+            {draft.rollout_controls.strategy} ({draft.rollout_controls.canary_percent}% / stage {draft.rollout_controls.stage})
+          </p>
+        </div>
+        <div className="rounded-lg border px-3 py-2">
+          <p className="text-muted-foreground">approval ticket</p>
+          <p className="font-mono font-semibold">{draft.approval_workflow.human_review_ticket || "N/A"}</p>
+        </div>
       </div>
       {hasChanges ? (
         <p className="mt-2 text-xs text-warning">{t(`${changeCount} 件の未適用変更があります。適用前に承認してください。`, `${changeCount} unapplied change(s). Approve before applying.`)}</p>

--- a/frontend/app/governance/constants.ts
+++ b/frontend/app/governance/constants.ts
@@ -61,6 +61,8 @@ export const DIFF_CATEGORY_LABELS: Record<DiffChange["category"], string> = {
   threshold: "しきい値変更",
   escalation: "エスカレーション変更",
   retention: "監査ログ変更",
+  rollout: "ロールアウト制御変更",
+  approval: "承認ワークフロー変更",
   meta: "メタ情報変更",
 };
 

--- a/frontend/app/governance/control-plane.test.tsx
+++ b/frontend/app/governance/control-plane.test.tsx
@@ -35,6 +35,18 @@ const policyResponse = {
       redact_before_log: true,
       max_log_size: 1000,
     },
+    rollout_controls: {
+      strategy: "canary",
+      canary_percent: 10,
+      stage: 1,
+      staged_enforcement: true,
+    },
+    approval_workflow: {
+      human_review_ticket: "GOV-999",
+      human_review_required: true,
+      approver_identity_binding: true,
+      approver_identities: ["admin-a", "admin-b"],
+    },
     updated_at: "2026-01-01T00:00:00+00:00",
     updated_by: "admin",
   },

--- a/frontend/app/governance/governance-types.ts
+++ b/frontend/app/governance/governance-types.ts
@@ -17,7 +17,7 @@ export interface DiffChange {
   path: string;
   old: string;
   next: string;
-  category: "rule" | "threshold" | "escalation" | "retention" | "meta";
+  category: "rule" | "threshold" | "escalation" | "retention" | "rollout" | "approval" | "meta";
 }
 
 export interface HistoryEntry {

--- a/frontend/app/governance/helpers.ts
+++ b/frontend/app/governance/helpers.ts
@@ -22,6 +22,8 @@ function categorizePath(path: string): DiffChange["category"] {
   if (path.startsWith("risk_thresholds")) return "threshold";
   if (path.startsWith("auto_stop")) return "escalation";
   if (path.startsWith("log_retention")) return "retention";
+  if (path.startsWith("rollout_controls")) return "rollout";
+  if (path.startsWith("approval_workflow")) return "approval";
   return "meta";
 }
 

--- a/frontend/app/governance/page.test.tsx
+++ b/frontend/app/governance/page.test.tsx
@@ -39,6 +39,18 @@ const MOCK_POLICY = {
       redact_before_log: true,
       max_log_size: 10000,
     },
+    rollout_controls: {
+      strategy: "disabled",
+      canary_percent: 0,
+      stage: 0,
+      staged_enforcement: false,
+    },
+    approval_workflow: {
+      human_review_ticket: "",
+      human_review_required: false,
+      approver_identity_binding: true,
+      approver_identities: [],
+    },
     updated_at: "2026-02-12T00:00:00+00:00",
     updated_by: "system",
   },

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -171,6 +171,8 @@ export default function GovernanceControlPage(): JSX.Element {
               draftApprovalStatus={state.draftApprovalStatus}
               changeCount={state.changeCount}
               canApprove={state.canApprove}
+              ticketId={state.draft.approval_workflow.human_review_ticket}
+              approverIdentityBinding={state.draft.approval_workflow.approver_identity_binding}
               onApprove={state.approveChanges}
               onReject={state.rejectChanges}
             />

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -167,6 +167,12 @@ const DECISION_EVIDENCE_ROUTE: DecisionEvidenceRouteModel = {
   reportingTarget: "24h incident report bundle (audit + governance)",
 };
 
+const POLICY_DIFF_IMPACT_PREVIEW = {
+  status: "connected",
+  previewTarget: "/governance",
+  summary: "Policy diff/impact preview is now linked to Mission Control action flow.",
+};
+
 /**
  * MissionPage renders the operational command-center view.
  *
@@ -248,6 +254,14 @@ export function MissionPage({ title, subtitle, chips }: MissionPageProps): JSX.E
             <li><span className="font-semibold">Evidence:</span> {DECISION_EVIDENCE_ROUTE.evidenceAnchor}</li>
             <li><span className="font-semibold">Report:</span> {DECISION_EVIDENCE_ROUTE.reportingTarget}</li>
           </ol>
+        </Card>
+
+        <Card title="Policy diff / impact preview" titleSize="sm" variant="glass" className="border-border/70" accent="warning">
+          <div className="space-y-1 text-xs">
+            <p>Status: <span className="font-semibold text-warning">{POLICY_DIFF_IMPACT_PREVIEW.status}</span></p>
+            <p>{POLICY_DIFF_IMPACT_PREVIEW.summary}</p>
+            <p className="text-muted-foreground">Route: {POLICY_DIFF_IMPACT_PREVIEW.previewTarget}</p>
+          </div>
         </Card>
       </section>
 

--- a/frontend/lib/api-validators.test.ts
+++ b/frontend/lib/api-validators.test.ts
@@ -41,6 +41,18 @@ const validGovernanceResponse = {
       redact_before_log: true,
       max_log_size: 10000,
     },
+    rollout_controls: {
+      strategy: "disabled",
+      canary_percent: 0,
+      stage: 0,
+      staged_enforcement: false,
+    },
+    approval_workflow: {
+      human_review_ticket: "",
+      human_review_required: false,
+      approver_identity_binding: true,
+      approver_identities: [],
+    },
     updated_at: "2026-02-12T00:00:00Z",
     updated_by: "system",
   },

--- a/frontend/lib/api-validators.ts
+++ b/frontend/lib/api-validators.ts
@@ -252,6 +252,43 @@ function validateGovernancePolicy(value: unknown, pathPrefix: string): Governanc
   issues.push(...validateRiskThresholds(value.risk_thresholds, `${pathPrefix}.risk_thresholds`));
   issues.push(...validateAutoStop(value.auto_stop, `${pathPrefix}.auto_stop`));
   issues.push(...validateLogRetention(value.log_retention, `${pathPrefix}.log_retention`));
+  if (!isRecord(value.rollout_controls)) {
+    issues.push(issue("format", `${pathPrefix}.rollout_controls`, "object である必要があります。"));
+  } else {
+    const strategy = value.rollout_controls.strategy;
+    if (typeof strategy !== "string") {
+      issues.push(issue("format", `${pathPrefix}.rollout_controls.strategy`, "string である必要があります。"));
+    }
+    if (!hasNumberField(value.rollout_controls, "canary_percent")) {
+      issues.push(issue("format", `${pathPrefix}.rollout_controls.canary_percent`, "number である必要があります。"));
+    }
+    if (!hasNumberField(value.rollout_controls, "stage")) {
+      issues.push(issue("format", `${pathPrefix}.rollout_controls.stage`, "number である必要があります。"));
+    }
+    if (!hasBooleanField(value.rollout_controls, "staged_enforcement")) {
+      issues.push(issue("format", `${pathPrefix}.rollout_controls.staged_enforcement`, "boolean である必要があります。"));
+    }
+  }
+
+  if (!isRecord(value.approval_workflow)) {
+    issues.push(issue("format", `${pathPrefix}.approval_workflow`, "object である必要があります。"));
+  } else {
+    if (!hasStringField(value.approval_workflow, "human_review_ticket")) {
+      issues.push(issue("format", `${pathPrefix}.approval_workflow.human_review_ticket`, "string である必要があります。"));
+    }
+    if (!hasBooleanField(value.approval_workflow, "human_review_required")) {
+      issues.push(issue("format", `${pathPrefix}.approval_workflow.human_review_required`, "boolean である必要があります。"));
+    }
+    if (!hasBooleanField(value.approval_workflow, "approver_identity_binding")) {
+      issues.push(issue("format", `${pathPrefix}.approval_workflow.approver_identity_binding`, "boolean である必要があります。"));
+    }
+    if (
+      !Array.isArray(value.approval_workflow.approver_identities)
+      || !value.approval_workflow.approver_identities.every((item) => typeof item === "string")
+    ) {
+      issues.push(issue("format", `${pathPrefix}.approval_workflow.approver_identities`, "string の配列である必要があります。"));
+    }
+  }
 
   if (!hasStringField(value, "updated_at")) {
     issues.push(issue("format", `${pathPrefix}.updated_at`, "string である必要があります。"));

--- a/packages/types/src/governance.ts
+++ b/packages/types/src/governance.ts
@@ -47,6 +47,22 @@ export interface LogRetention {
   max_log_size: number;
 }
 
+/** Progressive rollout controls for canary/staged policy enforcement. */
+export interface RolloutControls {
+  strategy: "disabled" | "canary" | "staged" | "full";
+  canary_percent: number;
+  stage: number;
+  staged_enforcement: boolean;
+}
+
+/** Human-review and approver identity-binding workflow settings. */
+export interface ApprovalWorkflowConfig {
+  human_review_ticket: string;
+  human_review_required: boolean;
+  approver_identity_binding: boolean;
+  approver_identities: string[];
+}
+
 /**
  * Full governance policy object returned by the backend.
  *
@@ -58,6 +74,8 @@ export interface GovernancePolicy {
   risk_thresholds: RiskThresholds;
   auto_stop: AutoStop;
   log_retention: LogRetention;
+  rollout_controls: RolloutControls;
+  approval_workflow: ApprovalWorkflowConfig;
   updated_at: string;
   updated_by: string;
 }

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -87,12 +87,32 @@ class LogRetention(BaseModel):
     max_log_size: int = Field(default=10000, ge=100, le=1_000_000)
 
 
+class RolloutControls(BaseModel):
+    """Progressive enforcement controls for governance policy rollout."""
+
+    strategy: Literal["disabled", "canary", "staged", "full"] = "disabled"
+    canary_percent: int = Field(default=0, ge=0, le=100)
+    stage: int = Field(default=0, ge=0, le=10)
+    staged_enforcement: bool = False
+
+
+class ApprovalWorkflowConfig(BaseModel):
+    """Human review + approver identity binding metadata."""
+
+    human_review_ticket: str = ""
+    human_review_required: bool = False
+    approver_identity_binding: bool = True
+    approver_identities: list[str] = Field(default_factory=list)
+
+
 class GovernancePolicy(BaseModel):
     version: str = "governance_v1"
     fuji_rules: FujiRules = Field(default_factory=FujiRules)
     risk_thresholds: RiskThresholds = Field(default_factory=RiskThresholds)
     auto_stop: AutoStop = Field(default_factory=AutoStop)
     log_retention: LogRetention = Field(default_factory=LogRetention)
+    rollout_controls: RolloutControls = Field(default_factory=RolloutControls)
+    approval_workflow: ApprovalWorkflowConfig = Field(default_factory=ApprovalWorkflowConfig)
     updated_at: str = ""
     updated_by: str = "system"
 
@@ -102,6 +122,8 @@ _NESTED_POLICY_MODELS = {
     "risk_thresholds": RiskThresholds,
     "auto_stop": AutoStop,
     "log_retention": LogRetention,
+    "rollout_controls": RolloutControls,
+    "approval_workflow": ApprovalWorkflowConfig,
 }
 
 

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -160,3 +160,39 @@ def governance_policy_history(limit: int = Query(default=50, ge=1, le=500)):
             status_code=500,
             content={"ok": False, "error": "Failed to load governance policy history"},
         )
+
+
+@router.get("/v1/governance/decisions/export")
+def governance_decision_export(
+    limit: int = Query(default=100, ge=1, le=1000),
+    status: str | None = Query(default=None),
+):
+    """Export recent decisions for governance/audit integrations."""
+    srv = _get_server()
+    try:
+        page = srv.get_trust_log_page(cursor=None, limit=limit)
+        items = page.get("items", []) if isinstance(page, dict) else []
+        normalized: list[dict[str, Any]] = []
+        for entry in items:
+            if not isinstance(entry, dict):
+                continue
+            decision_status = str(entry.get("decision_status") or entry.get("status") or "unknown")
+            if status and decision_status != status:
+                continue
+            normalized.append(
+                {
+                    "request_id": str(entry.get("request_id") or ""),
+                    "decision_status": decision_status,
+                    "risk": entry.get("risk"),
+                    "created_at": str(entry.get("created_at") or entry.get("ts") or ""),
+                    "approver": str(entry.get("approver") or entry.get("updated_by") or "system"),
+                    "trace_sha256": entry.get("sha256"),
+                }
+            )
+        return {"ok": True, "count": len(normalized), "items": normalized}
+    except Exception as e:
+        logger.error("governance_decision_export failed: %s", e)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": "Failed to export governance decisions"},
+        )

--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -6,7 +6,12 @@ from .generated_tests import GeneratedPolicyTestCase, build_generated_test_cases
 from .hash import canonical_ir_json, semantic_policy_hash
 from .models import OutcomeAction, PolicyValidationError, SourcePolicy
 from .normalize import to_canonical_ir
-from .runtime_adapter import RuntimePolicy, RuntimePolicyBundle, load_runtime_bundle
+from .runtime_adapter import (
+    RuntimePolicy,
+    RuntimePolicyBundle,
+    load_runtime_bundle,
+    verify_manifest_signature,
+)
 from .schema import load_and_validate_policy, validate_source_policy
 
 __all__ = [
@@ -26,6 +31,7 @@ __all__ = [
     "semantic_policy_hash",
     "RuntimePolicy",
     "RuntimePolicyBundle",
+    "verify_manifest_signature",
     "to_canonical_ir",
     "validate_source_policy",
 ]

--- a/veritas_os/policy/compiler.py
+++ b/veritas_os/policy/compiler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import hashlib
 from pathlib import Path
 from typing import Any, Dict
 
@@ -32,6 +33,12 @@ def _utc_now_iso8601() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
         "+00:00", "Z"
     )
+
+
+def _manifest_signature_hex(manifest_path: Path) -> str:
+    """Return deterministic SHA-256 signature hex for manifest payload."""
+    payload = manifest_path.read_bytes()
+    return hashlib.sha256(payload).hexdigest()
 
 
 def compile_policy_to_bundle(
@@ -77,6 +84,8 @@ def compile_policy_to_bundle(
     )
     manifest_path = bundle_dir / "manifest.json"
     write_stable_json(manifest_path, manifest)
+    signature_path = bundle_dir / "manifest.sig"
+    signature_path.write_text(_manifest_signature_hex(manifest_path) + "\n", encoding="utf-8")
 
     archive_path = create_bundle_archive(bundle_dir)
 

--- a/veritas_os/policy/manifest.py
+++ b/veritas_os/policy/manifest.py
@@ -38,9 +38,9 @@ def build_manifest(
         },
         "bundle_contents": sorted(bundle_files, key=lambda item: item["path"]),
         "signing": {
-            "status": "unsigned",
-            "signature_ref": None,
-            "key_id": None,
+            "status": "signed-local",
+            "signature_ref": "manifest.sig",
+            "key_id": "local-sha256",
             "extensions": {},
         },
     }

--- a/veritas_os/policy/runtime_adapter.py
+++ b/veritas_os/policy/runtime_adapter.py
@@ -7,6 +7,7 @@ into runtime-evaluable policy structures used by governance and pipeline code.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Mapping
@@ -54,6 +55,18 @@ def _read_json_file(path: Path) -> Dict[str, Any]:
     return data
 
 
+def verify_manifest_signature(bundle_dir: str | Path) -> bool:
+    """Verify ``manifest.sig`` for a compiled bundle."""
+    root = Path(bundle_dir)
+    manifest_path = root / "manifest.json"
+    signature_path = root / "manifest.sig"
+    if not manifest_path.exists() or not signature_path.exists():
+        return False
+    expected = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    observed = signature_path.read_text(encoding="utf-8").strip()
+    return expected == observed
+
+
 def adapt_canonical_ir(canonical_ir: CanonicalPolicyIR) -> RuntimePolicy:
     """Convert canonical policy IR mapping into a runtime-ready policy object."""
     return RuntimePolicy(
@@ -80,6 +93,8 @@ def adapt_canonical_ir(canonical_ir: CanonicalPolicyIR) -> RuntimePolicy:
 def load_runtime_bundle(bundle_dir: str | Path) -> RuntimePolicyBundle:
     """Load a compiled bundle directory and adapt it for runtime evaluation."""
     root = Path(bundle_dir)
+    if not verify_manifest_signature(root):
+        raise ValueError("manifest signature verification failed")
     manifest = _read_json_file(root / "manifest.json")
     canonical_ir = _read_json_file(root / "compiled" / "canonical_ir.json")
 

--- a/veritas_os/tests/test_governance_api.py
+++ b/veritas_os/tests/test_governance_api.py
@@ -50,6 +50,8 @@ class TestGetPolicy:
         assert "risk_thresholds" in policy
         assert "auto_stop" in policy
         assert "log_retention" in policy
+        assert "rollout_controls" in policy
+        assert "approval_workflow" in policy
 
     def test_get_requires_api_key(self):
         resp = client.get("/v1/governance/policy")
@@ -251,6 +253,35 @@ class TestGovernanceModule:
         """Merged nested section is validated before assignment and save."""
         with pytest.raises(ValidationError):
             gov_mod.update_policy(_approved({"risk_thresholds": {"allow_upper": 1.5}}))
+
+    def test_update_policy_updates_rollout_controls(self):
+        result = gov_mod.update_policy(_approved({"rollout_controls": {"strategy": "canary", "canary_percent": 10}}))
+        assert result["rollout_controls"]["strategy"] == "canary"
+        assert result["rollout_controls"]["canary_percent"] == 10
+
+    def test_update_policy_updates_approval_workflow(self):
+        result = gov_mod.update_policy(
+            _approved(
+                {
+                    "approval_workflow": {
+                        "human_review_ticket": "GOV-123",
+                        "human_review_required": True,
+                        "approver_identity_binding": True,
+                        "approver_identities": ["alice", "bob"],
+                    }
+                }
+            )
+        )
+        assert result["approval_workflow"]["human_review_ticket"] == "GOV-123"
+        assert result["approval_workflow"]["human_review_required"] is True
+
+
+def test_governance_decision_export_endpoint() -> None:
+    resp = client.get("/v1/governance/decisions/export?limit=5", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert "items" in body
 
 
 
@@ -953,4 +984,3 @@ class TestRouteValidationResponses:
         body = resp.json()
         assert body["ok"] is True
         assert isinstance(body["history"], list)
-

--- a/veritas_os/tests/test_policy_compiler.py
+++ b/veritas_os/tests/test_policy_compiler.py
@@ -7,6 +7,7 @@ import pytest
 
 from veritas_os.policy.compiler import compile_policy_to_bundle
 from veritas_os.policy.models import PolicyValidationError
+from veritas_os.policy.runtime_adapter import load_runtime_bundle
 
 EXAMPLES_DIR = Path("policies/examples")
 
@@ -27,6 +28,7 @@ def test_compile_policy_success_generates_artifacts(tmp_path: Path) -> None:
     assert (result.bundle_dir / "compiled" / "canonical_ir.json").exists()
     assert (result.bundle_dir / "compiled" / "explain.json").exists()
     assert (result.bundle_dir / "signatures" / "UNSIGNED").exists()
+    assert (result.bundle_dir / "manifest.sig").exists()
     assert result.archive_path.exists()
 
 
@@ -66,7 +68,7 @@ def test_manifest_contents_and_explanation_metadata(tmp_path: Path) -> None:
     assert manifest["semantic_hash"] == result.semantic_hash
     assert manifest["outcome_summary"]["decision"] == "deny"
     assert manifest["bundle_contents"]
-    assert manifest["signing"]["status"] == "unsigned"
+    assert manifest["signing"]["status"] == "signed-local"
 
     assert explain["purpose"]
     assert explain["application"]["human_summary"]
@@ -114,3 +116,26 @@ def test_bundle_structure_paths_are_valid(tmp_path: Path) -> None:
     assert "compiled/canonical_ir.json" in paths
     assert "compiled/explain.json" in paths
     assert "signatures/UNSIGNED" in paths
+
+
+def test_runtime_adapter_verifies_manifest_signature(tmp_path: Path) -> None:
+    result = compile_policy_to_bundle(
+        EXAMPLES_DIR / "external_tool_usage_denied.yaml",
+        tmp_path,
+        compiled_at="2026-03-28T09:00:00Z",
+    )
+    bundle = load_runtime_bundle(result.bundle_dir)
+    assert bundle.semantic_hash == result.semantic_hash
+
+
+def test_runtime_adapter_rejects_tampered_manifest_signature(tmp_path: Path) -> None:
+    result = compile_policy_to_bundle(
+        EXAMPLES_DIR / "external_tool_usage_denied.yaml",
+        tmp_path,
+        compiled_at="2026-03-28T09:10:00Z",
+    )
+    manifest = _load_json(result.manifest_path)
+    manifest["compiler_version"] = "tampered"
+    result.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    with pytest.raises(ValueError, match="signature verification failed"):
+        load_runtime_bundle(result.bundle_dir)


### PR DESCRIPTION
### Motivation
- Surface policy diffs and impact previews in Mission Control so operators can jump from monitoring to governance actions (`Mission Control UI` → `/governance`).
- Introduce progressive rollout controls (canary / staged / full) and stronger approval metadata to support staged enforcement and human-review ticketing for policy changes.
- Provide a governance-facing decision export endpoint to integrate decisions with audit tooling and reporting pipelines.
- Security note: the initial `manifest.sig` uses a local SHA-256 fingerprint (tamper-detection only) and is not a PKI-backed signature, so it reduces some attack classes but does not replace keyed signatures; migrating to KMS/HSM-backed signing is recommended.

### Description
- Backend: added `RolloutControls` and `ApprovalWorkflowConfig` Pydantic models and integrated them into `GovernancePolicy` and `_NESTED_POLICY_MODELS` in `veritas_os/api/governance.py`, enabling validated nested patches for rollout and approval metadata.
- Backend API: added `GET /v1/governance/decisions/export` in `veritas_os/api/routes_governance.py` that normalizes recent decision records for audit/export and supports an optional `status` filter.
- Bundles/signing: `veritas_os/policy/compiler.py` now writes `manifest.sig` (SHA-256 of `manifest.json`) and `veritas_os/policy/manifest.py` marks the manifest as `signed-local`; `veritas_os/policy/runtime_adapter.py` adds `verify_manifest_signature()` and makes `load_runtime_bundle()` fail when signature verification fails.
- Frontend: added rollout/approval types to `packages/types/src/governance.ts`, validation in `frontend/lib/api-validators.ts`, diff categorization in `frontend/app/governance/helpers.ts`, UI surfaces for rollout strategy and approval ticket in `PolicyMetaPanel` and `ApprovalWorkflow`, and a Mission Control card linking to the governance preview in `frontend/components/mission-page.tsx`.
- Tests and infra: updated unit tests to cover new fields and behaviors (`veritas_os/tests/test_governance_api.py`, `veritas_os/tests/test_policy_compiler.py`) and updated frontend tests/fixtures and validators to accept the new policy sections.

### Testing
- Ran backend unit tests: `pytest -q veritas_os/tests/test_policy_compiler.py veritas_os/tests/test_governance_api.py`, result: all tests passed (101 passed).
- Ran frontend unit tests: `pnpm --filter frontend test -- app/governance/page.test.tsx lib/api-validators.test.ts components/mission-page.test.tsx`, result: all tests passed (50 passed).
- Added tests that assert `manifest.sig` exists and that `load_runtime_bundle()` rejects tampered manifests, and tests for the new `rollout_controls` and `approval_workflow` merge/validation and the `decisions/export` endpoint, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a7517fec8326a74ec3ccbfe650c9)