### PR TITLE
Implement RBAC system with admin/operator/auditor roles

### DIFF
--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -17,6 +17,7 @@ from fastapi import Header, HTTPException, Query, Request, Security, WebSocket
 from fastapi.security.api_key import APIKeyHeader
 
 from veritas_os.api.utils import _errstr, redact
+from veritas_os.api.rbac import Permission, Role, ROLE_PERMISSIONS
 
 logger = logging.getLogger(__name__)
 
@@ -466,6 +467,120 @@ def _get_expected_api_key() -> str:
     return key
 
 
+# ==============================
+# Multi-key RBAC resolution
+# ==============================
+
+import json as _json
+from typing import List
+
+
+def _parse_api_keys_config() -> List[dict]:
+    """Parse VERITAS_API_KEYS JSON env var into a list of {key, role} dicts.
+
+    Returns an empty list when the env var is unset or empty.
+    Raises ValueError on malformed JSON or invalid role values.
+    """
+    raw = (os.getenv("VERITAS_API_KEYS") or "").strip()
+    if not raw:
+        return []
+    try:
+        entries = _json.loads(raw)
+    except _json.JSONDecodeError as exc:
+        raise ValueError(f"VERITAS_API_KEYS is not valid JSON: {exc}") from exc
+    if not isinstance(entries, list):
+        raise ValueError("VERITAS_API_KEYS must be a JSON array")
+    valid_roles = {r.value for r in Role}
+    result: List[dict] = []
+    for entry in entries:
+        if not isinstance(entry, dict) or "key" not in entry or "role" not in entry:
+            raise ValueError("Each VERITAS_API_KEYS entry must have 'key' and 'role' fields")
+        role_str = str(entry["role"]).strip().lower()
+        if role_str not in valid_roles:
+            raise ValueError(f"Invalid role '{entry['role']}' in VERITAS_API_KEYS; valid roles: {sorted(valid_roles)}")
+        key_str = str(entry["key"]).strip()
+        if not key_str:
+            raise ValueError("Empty key in VERITAS_API_KEYS entry")
+        result.append({"key": key_str, "role": role_str})
+    return result
+
+
+def resolve_role_for_key(api_key: str) -> Role:
+    """Resolve the Role for an authenticated API key.
+
+    Priority:
+    1. VERITAS_API_KEYS (JSON, multi-key) — exact match → role from config
+    2. VERITAS_API_KEY (single legacy key) — match → admin
+    3. No match → raises ValueError
+    """
+    api_key = (api_key or "").strip()
+    if not api_key:
+        raise ValueError("empty api key")
+
+    # Check multi-key config first
+    try:
+        multi_keys = _parse_api_keys_config()
+    except ValueError:
+        multi_keys = []
+
+    for entry in multi_keys:
+        if secrets.compare_digest(api_key, entry["key"]):
+            return Role(entry["role"])
+
+    # Backward compat: single VERITAS_API_KEY → admin
+    expected = _get_expected_api_key()
+    if expected and secrets.compare_digest(api_key, expected):
+        return Role.admin
+
+    raise ValueError("api key does not match any configured key")
+
+
+def _resolve_role_from_request(
+    x_api_key: str | None,
+) -> Role:
+    """Resolve role from the request API key, defaulting to admin for legacy keys."""
+    key = (x_api_key or "").strip()
+    if not key:
+        return Role.admin  # Will be caught by require_api_key first
+    try:
+        return resolve_role_for_key(key)
+    except ValueError:
+        return Role.admin  # Fallback; auth check already validated the key
+
+
+def require_permission(permission: Permission):
+    """FastAPI dependency factory that enforces a specific RBAC permission.
+
+    Usage::
+
+        @router.get("/v1/some/endpoint",
+                     dependencies=[Depends(require_permission(Permission.decide))])
+        def some_endpoint(): ...
+    """
+    def _check(
+        request: Request = None,  # type: ignore[assignment]
+        x_api_key: str | None = Security(api_key_scheme),
+    ):
+        role = _resolve_role_from_request(x_api_key)
+        allowed = ROLE_PERMISSIONS.get(role, frozenset())
+        if permission not in allowed:
+            _record_auth_reject_reason("insufficient_permission")
+            logger.warning(
+                "RBAC denied: role=%s permission=%s",
+                role.value,
+                permission.value,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail=f"Role '{role.value}' does not have '{permission.value}' permission",
+            )
+        # Attach role to request state for downstream use (e.g. TrustLog extras)
+        if request is not None:
+            request.state.rbac_role = role.value  # type: ignore[attr-defined]
+        return True
+    return _check
+
+
 def _get_trusted_proxies() -> frozenset:
     """Return the set of trusted proxy IPs from VERITAS_TRUSTED_PROXIES env var."""
     raw = os.getenv("VERITAS_TRUSTED_PROXIES", "").strip()
@@ -511,14 +626,44 @@ def _enforce_auth_failure_rate_limit(client_ip: str) -> None:
         raise HTTPException(status_code=429, detail="Too many auth failures")
 
 
+def _is_valid_api_key(candidate: str) -> bool:
+    """Check if *candidate* matches any configured API key (multi or single)."""
+    candidate = candidate.strip()
+    if not candidate:
+        return False
+
+    # Check multi-key config
+    try:
+        multi_keys = _parse_api_keys_config()
+        for entry in multi_keys:
+            if secrets.compare_digest(candidate, entry["key"]):
+                return True
+    except ValueError:
+        pass
+
+    # Fallback to single-key
+    expected = (_get_expected_api_key() or "").strip()
+    if expected and secrets.compare_digest(candidate, expected):
+        return True
+
+    return False
+
+
 def require_api_key(
     request: Request = None,  # type: ignore[assignment]
     x_api_key: Optional[str] = Security(api_key_scheme),
     x_forwarded_for: Optional[str] = Header(default=None, alias="X-Forwarded-For"),
 ):
     """テスト契約: サーバ側の API Key が未設定なら 500, ヘッダが無い/不一致なら 401"""
+    # Check if any key is configured (multi or single)
+    has_multi = False
+    try:
+        has_multi = bool(_parse_api_keys_config())
+    except ValueError:
+        pass
     expected = (_get_expected_api_key() or "").strip()
-    if not expected:
+
+    if not expected and not has_multi:
         _record_auth_reject_reason("api_key_server_unconfigured")
         raise HTTPException(status_code=500, detail="Server API key not configured")
 
@@ -527,7 +672,7 @@ def require_api_key(
         _record_auth_reject_reason("api_key_missing")
         _enforce_auth_failure_rate_limit(client_ip)
         raise HTTPException(status_code=401, detail="Missing API key")
-    if not secrets.compare_digest(x_api_key.strip(), expected):
+    if not _is_valid_api_key(x_api_key):
         _record_auth_reject_reason("api_key_invalid")
         _enforce_auth_failure_rate_limit(client_ip)
         raise HTTPException(status_code=401, detail="Invalid API key")
@@ -567,8 +712,13 @@ def require_api_key_header_or_query(
     x_forwarded_for: Optional[str] = Header(default=None, alias="X-Forwarded-For"),
 ):
     """Authenticate SSE requests with header-first policy."""
+    has_multi = False
+    try:
+        has_multi = bool(_parse_api_keys_config())
+    except ValueError:
+        pass
     expected = (_get_expected_api_key() or "").strip()
-    if not expected:
+    if not expected and not has_multi:
         _record_auth_reject_reason("api_key_server_unconfigured")
         raise HTTPException(status_code=500, detail="Server API key not configured")
 
@@ -592,7 +742,7 @@ def require_api_key_header_or_query(
         _record_auth_reject_reason("api_key_missing")
         _enforce_auth_failure_rate_limit(client_ip)
         raise HTTPException(status_code=401, detail="Missing API key")
-    if not secrets.compare_digest(candidate, expected):
+    if not _is_valid_api_key(candidate):
         _record_auth_reject_reason("api_key_invalid")
         _enforce_auth_failure_rate_limit(client_ip)
         raise HTTPException(status_code=401, detail="Invalid API key")
@@ -627,7 +777,7 @@ def _authenticate_websocket_api_key(websocket: WebSocket) -> bool:
 
     header_candidate = (websocket.headers.get("X-API-Key") or "").strip()
     if header_candidate:
-        return secrets.compare_digest(header_candidate, expected)
+        return _is_valid_api_key(header_candidate)
 
     query_candidate = (websocket.query_params.get("api_key") or "").strip()
     if not query_candidate:
@@ -639,7 +789,7 @@ def _authenticate_websocket_api_key(websocket: WebSocket) -> bool:
         "WebSocket auth accepted query api_key due to VERITAS_ALLOW_WS_QUERY_API_KEY=1. "
         "This mode increases credential exposure risk.",
     )
-    return secrets.compare_digest(query_candidate, expected)
+    return _is_valid_api_key(query_candidate)
 
 
 def _allow_ws_query_api_key() -> bool:

--- a/veritas_os/api/rbac.py
+++ b/veritas_os/api/rbac.py
@@ -1,0 +1,61 @@
+# veritas_os/api/rbac.py
+"""Role-Based Access Control (RBAC) definitions for VERITAS API.
+
+Defines roles, permissions, and their mappings. The authorization logic
+(resolving keys to roles and enforcing permissions) lives in auth.py.
+"""
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, Set
+
+
+class Role(str, enum.Enum):
+    """API consumer roles."""
+
+    admin = "admin"
+    operator = "operator"
+    auditor = "auditor"
+
+
+class Permission(str, enum.Enum):
+    """Fine-grained API permissions."""
+
+    decide = "decide"
+    memory_read = "memory_read"
+    memory_write = "memory_write"
+    trust_log_read = "trust_log_read"
+    governance_read = "governance_read"
+    governance_write = "governance_write"
+    config_write = "config_write"
+    compliance_read = "compliance_read"
+
+
+ROLE_PERMISSIONS: Dict[Role, FrozenSet[Permission]] = {
+    Role.admin: frozenset(Permission),
+    Role.operator: frozenset({
+        Permission.decide,
+        Permission.memory_read,
+        Permission.memory_write,
+        Permission.trust_log_read,
+    }),
+    Role.auditor: frozenset({
+        Permission.trust_log_read,
+        Permission.governance_read,
+        Permission.compliance_read,
+    }),
+}
+
+
+@dataclass(frozen=True)
+class RBACPolicy:
+    """Immutable snapshot of role-to-permission mappings."""
+
+    mapping: Dict[Role, FrozenSet[Permission]] = field(
+        default_factory=lambda: dict(ROLE_PERMISSIONS)
+    )
+
+    def has_permission(self, role: Role, permission: Permission) -> bool:
+        """Return True when *role* grants *permission*."""
+        return permission in self.mapping.get(role, frozenset())

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
+from veritas_os.api.auth import require_permission
+from veritas_os.api.rbac import Permission
 from veritas_os.api.schemas import DecideRequest, DecideResponse, FujiDecision
 from veritas_os.api.pipeline_orchestrator import resolve_dynamic_steps
 from veritas_os.api.utils import (
@@ -50,7 +52,7 @@ def _get_server():
 # /v1/decide
 # ------------------------------------------------------------------
 
-@router.post("/v1/decide", response_model=DecideResponse)
+@router.post("/v1/decide", response_model=DecideResponse, dependencies=[Depends(require_permission(Permission.decide))])
 async def decide(req: DecideRequest, request: Request):
     srv = _get_server()
     p = srv.get_decision_pipeline()
@@ -224,7 +226,7 @@ def _call_fuji(fc: Any, action: str, context: dict) -> dict:
     raise RuntimeError("fuji_core has neither validate_action nor validate")
 
 
-@router.post("/v1/fuji/validate", response_model=FujiDecision)
+@router.post("/v1/fuji/validate", response_model=FujiDecision, dependencies=[Depends(require_permission(Permission.decide))])
 def fuji_validate(payload: dict):
     srv = _get_server()
     if not _is_direct_fuji_api_enabled():

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -6,8 +6,11 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
+
+from veritas_os.api.auth import require_permission
+from veritas_os.api.rbac import Permission
 
 # Governance functions accessed via _get_server() for test monkeypatching compat
 
@@ -83,7 +86,7 @@ def _emit_governance_change_alert(previous: Dict[str, Any], updated: Dict[str, A
 # Endpoints
 # ------------------------------------------------------------------
 
-@router.get("/v1/governance/value-drift")
+@router.get("/v1/governance/value-drift", dependencies=[Depends(require_permission(Permission.governance_read))])
 def governance_value_drift(telos_baseline: float = Query(default=0.5, ge=0.0, le=1.0)):
     """Return ValueCore drift metrics against a Telos baseline."""
     srv = _get_server()
@@ -98,7 +101,7 @@ def governance_value_drift(telos_baseline: float = Query(default=0.5, ge=0.0, le
         )
 
 
-@router.get("/v1/governance/policy")
+@router.get("/v1/governance/policy", dependencies=[Depends(require_permission(Permission.governance_read))])
 def governance_get():
     """Return the current governance policy."""
     srv = _get_server()
@@ -113,7 +116,7 @@ def governance_get():
         )
 
 
-@router.put("/v1/governance/policy")
+@router.put("/v1/governance/policy", dependencies=[Depends(require_permission(Permission.governance_write))])
 def governance_put(body: dict):
     """Update the governance policy (partial merge)."""
     srv = _get_server()
@@ -147,7 +150,7 @@ def governance_put(body: dict):
         )
 
 
-@router.get("/v1/governance/policy/history")
+@router.get("/v1/governance/policy/history", dependencies=[Depends(require_permission(Permission.governance_read))])
 def governance_policy_history(limit: int = Query(default=50, ge=1, le=500)):
     """Return recent governance policy change history (newest first)."""
     srv = _get_server()
@@ -162,7 +165,7 @@ def governance_policy_history(limit: int = Query(default=50, ge=1, le=500)):
         )
 
 
-@router.get("/v1/governance/decisions/export")
+@router.get("/v1/governance/decisions/export", dependencies=[Depends(require_permission(Permission.governance_read))])
 def governance_decision_export(
     limit: int = Query(default=100, ge=1, le=1000),
     status: str | None = Query(default=None),

--- a/veritas_os/api/routes_memory.py
+++ b/veritas_os/api/routes_memory.py
@@ -8,8 +8,10 @@ from datetime import datetime, timezone
 from json import JSONDecodeError
 from typing import Any, Dict, Optional, Tuple
 
-from fastapi import APIRouter, Header, Response
+from fastapi import APIRouter, Depends, Header, Response
 
+from veritas_os.api.auth import require_permission
+from veritas_os.api.rbac import Permission
 from veritas_os.api.schemas import (
     MemoryEraseRequest,
     MemoryGetRequest,
@@ -161,7 +163,7 @@ def _validate_memory_kinds(kinds: Any) -> Tuple[Optional[list[str]], Optional[st
 # Endpoints
 # ------------------------------------------------------------------
 
-@router.post("/v1/memory/put")
+@router.post("/v1/memory/put", dependencies=[Depends(require_permission(Permission.memory_write))])
 def memory_put(body: MemoryPutRequest, response: Response = None, x_api_key: Optional[str] = Header(default=None, alias="X-API-Key")) -> Dict[str, Any]:
     """Store memory data and surface stage-level partial failures explicitly."""
     srv = _get_server()
@@ -286,7 +288,7 @@ def memory_put(body: MemoryPutRequest, response: Response = None, x_api_key: Opt
     return response
 
 
-@router.post("/v1/memory/search")
+@router.post("/v1/memory/search", dependencies=[Depends(require_permission(Permission.memory_read))])
 def memory_search(payload: MemorySearchRequest, response: Response = None, x_api_key: Optional[str] = Header(default=None, alias="X-API-Key")) -> Dict[str, Any]:
     srv = _get_server()
     store = srv.get_memory_store()
@@ -358,7 +360,7 @@ def memory_search(payload: MemorySearchRequest, response: Response = None, x_api
         }
 
 
-@router.post("/v1/memory/get")
+@router.post("/v1/memory/get", dependencies=[Depends(require_permission(Permission.memory_read))])
 def memory_get(body: MemoryGetRequest, response: Response = None, x_api_key: Optional[str] = Header(default=None, alias="X-API-Key")) -> Dict[str, Any]:
     srv = _get_server()
     store = srv.get_memory_store()
@@ -387,7 +389,7 @@ def memory_get(body: MemoryGetRequest, response: Response = None, x_api_key: Opt
         }
 
 
-@router.post("/v1/memory/erase")
+@router.post("/v1/memory/erase", dependencies=[Depends(require_permission(Permission.memory_write))])
 def memory_erase(body: MemoryEraseRequest, response: Response = None, x_api_key: Optional[str] = Header(default=None, alias="X-API-Key")) -> Dict[str, Any]:
     """Erase a tenant's memories with legal-hold protection and audit log."""
     srv = _get_server()

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -12,10 +12,12 @@ import time
 from pathlib import Path
 from typing import Any, Dict
 
-from fastapi import APIRouter, Query, Request, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
+from veritas_os.api.auth import require_permission
+from veritas_os.api.rbac import Permission
 from veritas_os.api.utils import _is_direct_fuji_api_enabled
 from veritas_os.api.pipeline_orchestrator import (
     get_runtime_config,
@@ -378,7 +380,7 @@ def _collect_recent_decide_files(shadow_dir: Path, limit: int) -> tuple[list[Pat
     return newest, total_count
 
 
-@router.get("/v1/metrics")
+@router.get("/v1/metrics", dependencies=[Depends(require_permission(Permission.compliance_read))])
 def metrics(decide_file_limit: int = Query(default=500, ge=1, le=5000)):
     """Return operational metrics with degraded security/memory posture."""
     srv = _get_server()
@@ -531,13 +533,13 @@ async def trustlog_ws(websocket: WebSocket):
 # Compliance config
 # ------------------------------------------------------------------
 
-@router.get("/v1/compliance/config")
+@router.get("/v1/compliance/config", dependencies=[Depends(require_permission(Permission.compliance_read))])
 def compliance_get_config() -> Dict[str, Any]:
     """Return runtime compliance config for UI toggle."""
     return {"ok": True, "config": get_runtime_config()}
 
 
-@router.put("/v1/compliance/config")
+@router.put("/v1/compliance/config", dependencies=[Depends(require_permission(Permission.config_write))])
 def compliance_put_config(body: ComplianceConfigBody) -> Dict[str, Any]:
     """Update runtime compliance config."""
     srv = _get_server()
@@ -553,7 +555,7 @@ def compliance_put_config(body: ComplianceConfigBody) -> Dict[str, Any]:
 # Reports
 # ------------------------------------------------------------------
 
-@router.get("/v1/report/eu_ai_act/{decision_id}")
+@router.get("/v1/report/eu_ai_act/{decision_id}", dependencies=[Depends(require_permission(Permission.governance_read))])
 def report_eu_ai_act(decision_id: str):
     """Generate an enterprise-ready EU AI Act compliance report."""
     srv = _get_server()
@@ -570,7 +572,7 @@ def report_eu_ai_act(decision_id: str):
         )
 
 
-@router.get("/v1/report/governance")
+@router.get("/v1/report/governance", dependencies=[Depends(require_permission(Permission.governance_read))])
 def report_governance(from_: str = Query(alias="from"), to: str = Query(alias="to")):
     """Generate internal governance report for the requested date range."""
     srv = _get_server()
@@ -597,7 +599,7 @@ def report_governance(from_: str = Query(alias="from"), to: str = Query(alias="t
 # System halt / resume (Art. 14(4))
 # ------------------------------------------------------------------
 
-@router.post("/v1/system/halt")
+@router.post("/v1/system/halt", dependencies=[Depends(require_permission(Permission.config_write))])
 def system_halt(body: SystemHaltRequest):
     """Halt the AI decision system (Art. 14(4) emergency stop)."""
     srv = _get_server()
@@ -614,7 +616,7 @@ def system_halt(body: SystemHaltRequest):
         )
 
 
-@router.post("/v1/system/resume")
+@router.post("/v1/system/resume", dependencies=[Depends(require_permission(Permission.config_write))])
 def system_resume(body: SystemResumeRequest):
     """Resume the AI decision system after a halt (Art. 14(4))."""
     srv = _get_server()
@@ -631,7 +633,7 @@ def system_resume(body: SystemResumeRequest):
         )
 
 
-@router.get("/v1/system/halt-status")
+@router.get("/v1/system/halt-status", dependencies=[Depends(require_permission(Permission.compliance_read))])
 def system_halt_status():
     """Return the current halt status of the AI decision system."""
     srv = _get_server()
@@ -646,7 +648,7 @@ def system_halt_status():
         )
 
 
-@router.get("/v1/compliance/deployment-readiness")
+@router.get("/v1/compliance/deployment-readiness", dependencies=[Depends(require_permission(Permission.compliance_read))])
 def compliance_deployment_readiness():
     """Check deployment readiness for EU AI Act compliance (P1-5)."""
     srv = _get_server()

--- a/veritas_os/api/routes_trust.py
+++ b/veritas_os/api/routes_trust.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
+from veritas_os.api.auth import require_permission
+from veritas_os.api.rbac import Permission
 from veritas_os.api.schemas import TrustFeedbackRequest
 
 logger = logging.getLogger(__name__)
@@ -53,14 +55,14 @@ def _prov_actor_for_entry(entry: Dict[str, Any]) -> str:
 # Trust Log read endpoints
 # ------------------------------------------------------------------
 
-@router.get("/v1/trust/logs")
+@router.get("/v1/trust/logs", dependencies=[Depends(require_permission(Permission.trust_log_read))])
 def trust_logs(cursor: Optional[str] = None, limit: int = 50):
     """TrustLog をページング取得する。"""
     srv = _get_server()
     return srv.get_trust_log_page(cursor=cursor, limit=limit)
 
 
-@router.get("/v1/trust/stats")
+@router.get("/v1/trust/stats", dependencies=[Depends(require_permission(Permission.trust_log_read))])
 def trust_log_stats():
     """Return TrustLog append success/failure counters for operational monitoring."""
     try:
@@ -75,7 +77,7 @@ def trust_log_stats():
         )
 
 
-@router.get("/v1/trust/{request_id}/prov")
+@router.get("/v1/trust/{request_id}/prov", dependencies=[Depends(require_permission(Permission.trust_log_read))])
 def trust_prov_export(request_id: str) -> Dict[str, Any]:
     """Export one decision trace as W3C PROV JSON for external audit tooling."""
     srv = _get_server()
@@ -103,7 +105,7 @@ def trust_prov_export(request_id: str) -> Dict[str, Any]:
         )
 
 
-@router.get("/v1/trust/{request_id}")
+@router.get("/v1/trust/{request_id}", dependencies=[Depends(require_permission(Permission.trust_log_read))])
 def trust_log_by_request(request_id: str):
     """request_id 単位で TrustLog を取得する。"""
     srv = _get_server()
@@ -114,7 +116,7 @@ def trust_log_by_request(request_id: str):
 # Trust Feedback
 # ------------------------------------------------------------------
 
-@router.post("/v1/trust/feedback")
+@router.post("/v1/trust/feedback", dependencies=[Depends(require_permission(Permission.trust_log_read))])
 def trust_feedback(body: TrustFeedbackRequest):
     """人間からのフィードバックを trust_log に記録する簡易API。"""
     srv = _get_server()
@@ -155,7 +157,7 @@ def trust_feedback(body: TrustFeedbackRequest):
 # TrustLog verify / export
 # ------------------------------------------------------------------
 
-@router.get("/v1/trustlog/verify")
+@router.get("/v1/trustlog/verify", dependencies=[Depends(require_permission(Permission.trust_log_read))])
 def trustlog_verify() -> Dict[str, Any]:
     """Verify signed append-only TrustLog integrity and signatures."""
     srv = _get_server()
@@ -169,7 +171,7 @@ def trustlog_verify() -> Dict[str, Any]:
         )
 
 
-@router.get("/v1/trustlog/export")
+@router.get("/v1/trustlog/export", dependencies=[Depends(require_permission(Permission.trust_log_read))])
 def trustlog_export() -> Dict[str, Any]:
     """Export signed append-only TrustLog entries for external audit."""
     srv = _get_server()

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -493,6 +493,17 @@ from veritas_os.api.auth import (  # noqa: E402,F401
     _check_and_register_nonce,
     verify_signature,
     _check_multiworker_auth_store,
+    _parse_api_keys_config,
+    _is_valid_api_key,
+    resolve_role_for_key,
+    _resolve_role_from_request,
+    require_permission,
+)
+from veritas_os.api.rbac import (  # noqa: E402,F401
+    Role,
+    Permission,
+    ROLE_PERMISSIONS,
+    RBACPolicy,
 )
 
 # Keep _log_api_key_source_once in server.py so tests that patch server.logger work

--- a/veritas_os/tests/test_rbac.py
+++ b/veritas_os/tests/test_rbac.py
@@ -1,0 +1,345 @@
+# veritas_os/tests/test_rbac.py
+"""Tests for RBAC: role definitions, permission resolution, and endpoint guards."""
+from __future__ import annotations
+
+import json
+import os
+from unittest import mock
+
+import pytest
+
+from veritas_os.api.rbac import Permission, Role, ROLE_PERMISSIONS, RBACPolicy
+from veritas_os.api.auth import (
+    _parse_api_keys_config,
+    resolve_role_for_key,
+    _resolve_role_from_request,
+    require_permission,
+    _record_auth_reject_reason,
+    _snapshot_auth_reject_reason_metrics,
+)
+
+
+# ==============================
+# rbac.py — Role & Permission definitions
+# ==============================
+
+class TestRoleEnum:
+    def test_all_roles_defined(self):
+        assert set(Role) == {Role.admin, Role.operator, Role.auditor}
+
+    def test_role_values(self):
+        assert Role.admin.value == "admin"
+        assert Role.operator.value == "operator"
+        assert Role.auditor.value == "auditor"
+
+
+class TestPermissionEnum:
+    def test_all_permissions_defined(self):
+        expected = {
+            "decide", "memory_read", "memory_write",
+            "trust_log_read", "governance_read", "governance_write",
+            "config_write", "compliance_read",
+        }
+        assert {p.value for p in Permission} == expected
+
+
+class TestRolePermissions:
+    def test_admin_has_all_permissions(self):
+        assert ROLE_PERMISSIONS[Role.admin] == frozenset(Permission)
+
+    def test_operator_permissions(self):
+        expected = {
+            Permission.decide,
+            Permission.memory_read,
+            Permission.memory_write,
+            Permission.trust_log_read,
+        }
+        assert ROLE_PERMISSIONS[Role.operator] == frozenset(expected)
+
+    def test_operator_cannot_write_governance(self):
+        assert Permission.governance_write not in ROLE_PERMISSIONS[Role.operator]
+        assert Permission.config_write not in ROLE_PERMISSIONS[Role.operator]
+
+    def test_auditor_permissions(self):
+        expected = {
+            Permission.trust_log_read,
+            Permission.governance_read,
+            Permission.compliance_read,
+        }
+        assert ROLE_PERMISSIONS[Role.auditor] == frozenset(expected)
+
+    def test_auditor_cannot_decide(self):
+        assert Permission.decide not in ROLE_PERMISSIONS[Role.auditor]
+
+    def test_auditor_cannot_write(self):
+        assert Permission.memory_write not in ROLE_PERMISSIONS[Role.auditor]
+        assert Permission.governance_write not in ROLE_PERMISSIONS[Role.auditor]
+        assert Permission.config_write not in ROLE_PERMISSIONS[Role.auditor]
+
+
+class TestRBACPolicy:
+    def test_default_policy_admin(self):
+        policy = RBACPolicy()
+        assert policy.has_permission(Role.admin, Permission.config_write) is True
+
+    def test_default_policy_auditor_denied(self):
+        policy = RBACPolicy()
+        assert policy.has_permission(Role.auditor, Permission.decide) is False
+
+    def test_custom_policy(self):
+        custom = RBACPolicy(mapping={
+            Role.admin: frozenset({Permission.decide}),
+            Role.operator: frozenset(),
+            Role.auditor: frozenset(),
+        })
+        assert custom.has_permission(Role.admin, Permission.decide) is True
+        assert custom.has_permission(Role.admin, Permission.config_write) is False
+
+
+# ==============================
+# auth.py — Multi-key parsing
+# ==============================
+
+class TestParseApiKeysConfig:
+    def test_empty_env(self):
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": ""}, clear=False):
+            assert _parse_api_keys_config() == []
+
+    def test_unset_env(self):
+        env = {k: v for k, v in os.environ.items() if k != "VERITAS_API_KEYS"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            assert _parse_api_keys_config() == []
+
+    def test_valid_json(self):
+        keys_json = json.dumps([
+            {"key": "sk-admin-xxx", "role": "admin"},
+            {"key": "sk-op-yyy", "role": "operator"},
+        ])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            result = _parse_api_keys_config()
+            assert len(result) == 2
+            assert result[0]["role"] == "admin"
+            assert result[1]["role"] == "operator"
+
+    def test_invalid_json_raises(self):
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": "not-json"}, clear=False):
+            with pytest.raises(ValueError, match="not valid JSON"):
+                _parse_api_keys_config()
+
+    def test_not_a_list_raises(self):
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": '{"key":"x"}'}, clear=False):
+            with pytest.raises(ValueError, match="must be a JSON array"):
+                _parse_api_keys_config()
+
+    def test_invalid_role_raises(self):
+        keys_json = json.dumps([{"key": "sk-xxx", "role": "superuser"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            with pytest.raises(ValueError, match="Invalid role"):
+                _parse_api_keys_config()
+
+    def test_missing_key_field_raises(self):
+        keys_json = json.dumps([{"role": "admin"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            with pytest.raises(ValueError, match="must have 'key' and 'role'"):
+                _parse_api_keys_config()
+
+    def test_empty_key_raises(self):
+        keys_json = json.dumps([{"key": "", "role": "admin"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            with pytest.raises(ValueError, match="Empty key"):
+                _parse_api_keys_config()
+
+
+# ==============================
+# auth.py — Role resolution
+# ==============================
+
+class TestResolveRoleForKey:
+    def test_multi_key_admin(self):
+        keys_json = json.dumps([
+            {"key": "sk-admin-abc", "role": "admin"},
+            {"key": "sk-op-def", "role": "operator"},
+        ])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            assert resolve_role_for_key("sk-admin-abc") == Role.admin
+
+    def test_multi_key_operator(self):
+        keys_json = json.dumps([
+            {"key": "sk-admin-abc", "role": "admin"},
+            {"key": "sk-op-def", "role": "operator"},
+        ])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            assert resolve_role_for_key("sk-op-def") == Role.operator
+
+    def test_multi_key_auditor(self):
+        keys_json = json.dumps([{"key": "sk-audit-ghi", "role": "auditor"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            assert resolve_role_for_key("sk-audit-ghi") == Role.auditor
+
+    def test_legacy_single_key_becomes_admin(self):
+        """Backward compat: VERITAS_API_KEY-only config resolves to admin."""
+        env = {k: v for k, v in os.environ.items() if k != "VERITAS_API_KEYS"}
+        env["VERITAS_API_KEY"] = "legacy-key-123"
+        with mock.patch.dict(os.environ, env, clear=True):
+            assert resolve_role_for_key("legacy-key-123") == Role.admin
+
+    def test_unknown_key_raises(self):
+        env = {k: v for k, v in os.environ.items() if k != "VERITAS_API_KEYS"}
+        env["VERITAS_API_KEY"] = "real-key"
+        with mock.patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="does not match"):
+                resolve_role_for_key("wrong-key")
+
+    def test_empty_key_raises(self):
+        with pytest.raises(ValueError, match="empty api key"):
+            resolve_role_for_key("")
+
+
+# ==============================
+# auth.py — require_permission dependency
+# ==============================
+
+class TestRequirePermission:
+    """Test the require_permission factory returns a callable that checks RBAC."""
+
+    def _make_request_stub(self, api_key: str):
+        """Create a minimal request-like object for testing."""
+
+        class _State:
+            rbac_role = None
+
+        class _Req:
+            state = _State()
+
+        return _Req()
+
+    def test_admin_allowed_decide(self):
+        keys_json = json.dumps([{"key": "sk-admin", "role": "admin"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            checker = require_permission(Permission.decide)
+            req = self._make_request_stub("sk-admin")
+            result = checker(request=req, x_api_key="sk-admin")
+            assert result is True
+            assert req.state.rbac_role == "admin"
+
+    def test_operator_allowed_decide(self):
+        keys_json = json.dumps([{"key": "sk-op", "role": "operator"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            checker = require_permission(Permission.decide)
+            req = self._make_request_stub("sk-op")
+            result = checker(request=req, x_api_key="sk-op")
+            assert result is True
+
+    def test_auditor_denied_decide(self):
+        from fastapi import HTTPException
+
+        keys_json = json.dumps([{"key": "sk-audit", "role": "auditor"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            checker = require_permission(Permission.decide)
+            req = self._make_request_stub("sk-audit")
+            with pytest.raises(HTTPException) as exc_info:
+                checker(request=req, x_api_key="sk-audit")
+            assert exc_info.value.status_code == 403
+            assert "permission" in exc_info.value.detail.lower()
+
+    def test_auditor_allowed_trust_log_read(self):
+        keys_json = json.dumps([{"key": "sk-audit", "role": "auditor"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            checker = require_permission(Permission.trust_log_read)
+            req = self._make_request_stub("sk-audit")
+            result = checker(request=req, x_api_key="sk-audit")
+            assert result is True
+
+    def test_auditor_denied_governance_write(self):
+        from fastapi import HTTPException
+
+        keys_json = json.dumps([{"key": "sk-audit", "role": "auditor"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            checker = require_permission(Permission.governance_write)
+            req = self._make_request_stub("sk-audit")
+            with pytest.raises(HTTPException) as exc_info:
+                checker(request=req, x_api_key="sk-audit")
+            assert exc_info.value.status_code == 403
+
+    def test_operator_denied_config_write(self):
+        from fastapi import HTTPException
+
+        keys_json = json.dumps([{"key": "sk-op", "role": "operator"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            checker = require_permission(Permission.config_write)
+            req = self._make_request_stub("sk-op")
+            with pytest.raises(HTTPException) as exc_info:
+                checker(request=req, x_api_key="sk-op")
+            assert exc_info.value.status_code == 403
+
+    def test_insufficient_permission_records_metric(self):
+        from fastapi import HTTPException
+
+        keys_json = json.dumps([{"key": "sk-audit", "role": "auditor"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            checker = require_permission(Permission.decide)
+            req = self._make_request_stub("sk-audit")
+            with pytest.raises(HTTPException):
+                checker(request=req, x_api_key="sk-audit")
+            snap = _snapshot_auth_reject_reason_metrics()
+            assert snap.get("insufficient_permission", 0) >= 1
+
+
+# ==============================
+# Backward compatibility
+# ==============================
+
+class TestBackwardCompat:
+    """VERITAS_API_KEY (single key) still works as admin."""
+
+    def test_single_key_resolves_admin(self):
+        env = {k: v for k, v in os.environ.items() if k != "VERITAS_API_KEYS"}
+        env["VERITAS_API_KEY"] = "compat-key-456"
+        with mock.patch.dict(os.environ, env, clear=True):
+            assert resolve_role_for_key("compat-key-456") == Role.admin
+
+    def test_single_key_passes_permission_check(self):
+        env = {k: v for k, v in os.environ.items() if k != "VERITAS_API_KEYS"}
+        env["VERITAS_API_KEY"] = "compat-key-456"
+        with mock.patch.dict(os.environ, env, clear=True):
+            checker = require_permission(Permission.config_write)
+
+            class _State:
+                rbac_role = None
+
+            class _Req:
+                state = _State()
+
+            req = _Req()
+            result = checker(request=req, x_api_key="compat-key-456")
+            assert result is True
+            assert req.state.rbac_role == "admin"
+
+
+# ==============================
+# Error handling edge cases
+# ==============================
+
+class TestErrorHandling:
+    def test_malformed_json_env_gracefully_handled_in_role_resolution(self):
+        """When VERITAS_API_KEYS is malformed, resolve_role_for_key falls back to single key."""
+        env = dict(os.environ)
+        env["VERITAS_API_KEYS"] = "{bad json"
+        env["VERITAS_API_KEY"] = "fallback-key"
+        with mock.patch.dict(os.environ, env, clear=True):
+            # Should fall back to single-key match
+            assert resolve_role_for_key("fallback-key") == Role.admin
+
+    def test_malformed_json_env_still_rejects_wrong_key(self):
+        env = dict(os.environ)
+        env["VERITAS_API_KEYS"] = "{bad json"
+        env["VERITAS_API_KEY"] = "fallback-key"
+        with mock.patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="does not match"):
+                resolve_role_for_key("wrong-key")
+
+    def test_parse_api_keys_non_dict_entry_raises(self):
+        keys_json = json.dumps(["not-a-dict"])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            with pytest.raises(ValueError, match="must have 'key' and 'role'"):
+                _parse_api_keys_config()


### PR DESCRIPTION
Add role-based access control to the VERITAS API:
- New rbac.py: Role and Permission enums, ROLE_PERMISSIONS mapping, RBACPolicy dataclass
- Extended auth.py: multi-key support via VERITAS_API_KEYS JSON env var,
  role resolution per key, require_permission() FastAPI dependency,
  backward-compatible single VERITAS_API_KEY → admin fallback
- All route endpoints now enforce fine-grained permissions:
  admin=full, operator=decide+memory+trust_log, auditor=read-only logs/governance/compliance
- Permission denial returns HTTP 403 and records "insufficient_permission" metric
- Comprehensive test suite (38 tests): role/permission mapping, multi-key parsing,
  backward compat, error handling for invalid JSON/roles

https://claude.ai/code/session_01JcT9qyETHS8DpDmhiviQuF