### PR TITLE
Add storage abstraction layer, file-backed adapters, DI factory and Postgres stubs

### DIFF
--- a/veritas_os/api/dependency_resolver.py
+++ b/veritas_os/api/dependency_resolver.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any, Callable, Optional, Tuple
 
+from fastapi import Request
+
+from veritas_os.storage.base import MemoryStore, TrustLogStore
+
 
 class SupportsLazyState:
     """Protocol-like structural type for lazy import cache state."""
@@ -196,3 +200,19 @@ def resolve_memory_store(
             state.obj = None
             logger.warning("memory store import failed: %s", state.err)
             return None, current_memory_store
+
+
+def get_trust_log_store(request: Request) -> TrustLogStore:
+    """Resolve TrustLogStore instance from FastAPI app state."""
+    store = getattr(request.app.state, "trust_log_store", None)
+    if store is None:
+        raise RuntimeError("trust_log_store is not initialized in app.state")
+    return store
+
+
+def get_memory_store(request: Request) -> MemoryStore:
+    """Resolve MemoryStore instance from FastAPI app state."""
+    store = getattr(request.app.state, "memory_store", None)
+    if store is None:
+        raise RuntimeError("memory_store is not initialized in app.state")
+    return store

--- a/veritas_os/api/lifespan.py
+++ b/veritas_os/api/lifespan.py
@@ -7,6 +7,8 @@ import time
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Callable
 
+from veritas_os.storage.factory import create_memory_store, create_trust_log_store
+
 
 @asynccontextmanager
 async def run_lifespan(
@@ -27,7 +29,6 @@ async def run_lifespan(
     This helper keeps server bootstrap concerns out of ``server.py`` while
     preserving behavior and backward compatibility.
     """
-    del app
     import veritas_os.api.middleware as middleware
     import veritas_os.api.server as server
 
@@ -35,6 +36,11 @@ async def run_lifespan(
     middleware._inflight_count = 0
     server._shutting_down = False
     server._inflight_count = 0
+
+
+    # Storage DI: initialize backend instances once per application lifecycle.
+    app.state.trust_log_store = create_trust_log_store()
+    app.state.memory_store = create_memory_store()
 
     startup_validation()
     runtime_health_check()

--- a/veritas_os/storage/__init__.py
+++ b/veritas_os/storage/__init__.py
@@ -1,0 +1,18 @@
+"""Storage interfaces and backend factories."""
+
+from veritas_os.storage.base import MemoryStore, TrustLogStore
+from veritas_os.storage.factory import create_memory_store, create_trust_log_store
+from veritas_os.storage.json_kv import JsonMemoryStore
+from veritas_os.storage.jsonl import JsonlTrustLogStore
+from veritas_os.storage.postgresql import PostgresMemoryStore, PostgresTrustLogStore
+
+__all__ = [
+    "MemoryStore",
+    "TrustLogStore",
+    "JsonMemoryStore",
+    "JsonlTrustLogStore",
+    "PostgresMemoryStore",
+    "PostgresTrustLogStore",
+    "create_memory_store",
+    "create_trust_log_store",
+]

--- a/veritas_os/storage/base.py
+++ b/veritas_os/storage/base.py
@@ -1,0 +1,53 @@
+"""Storage protocol interfaces for TrustLog and MemoryOS backends."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, List, Optional, Protocol
+
+
+class TrustLogStore(Protocol):
+    """TrustLog 永続化の抽象インターフェース。"""
+
+    async def append(self, entry: Dict[str, Any]) -> str:
+        """エントリを追記し、割り当てられた ID を返す。"""
+
+    async def get_by_id(self, request_id: str) -> Optional[Dict[str, Any]]:
+        """request_id でエントリを取得する。"""
+
+    async def iter_entries(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """エントリをページングで逐次取得する。"""
+
+    async def get_last_hash(self) -> Optional[str]:
+        """ハッシュチェーンの最新ハッシュを返す。"""
+
+
+class MemoryStore(Protocol):
+    """MemoryOS 永続化の抽象インターフェース。"""
+
+    async def put(self, key: str, value: Dict[str, Any], *, user_id: str) -> None:
+        """キーへ値を保存する。"""
+
+    async def get(self, key: str) -> Optional[Dict[str, Any]]:
+        """キーから値を取得する。"""
+
+    async def search(
+        self,
+        query: str,
+        *,
+        user_id: str,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """ユーザー単位で値を検索する。"""
+
+    async def delete(self, key: str, *, user_id: str) -> bool:
+        """キーを削除する。"""
+
+    async def list_all(self, *, user_id: str) -> List[Dict[str, Any]]:
+        """ユーザー単位ですべての値を返す。"""
+
+    async def erase_user_data(self, user_id: str) -> int:
+        """ユーザーの保存データを全消去し、削除件数を返す。"""

--- a/veritas_os/storage/factory.py
+++ b/veritas_os/storage/factory.py
@@ -1,0 +1,31 @@
+"""Storage backend factory for Dependency Injection."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from veritas_os.storage.base import MemoryStore, TrustLogStore
+from veritas_os.storage.json_kv import JsonMemoryStore
+from veritas_os.storage.jsonl import JsonlTrustLogStore
+from veritas_os.storage.postgresql import PostgresMemoryStore, PostgresTrustLogStore
+
+
+def create_trust_log_store() -> TrustLogStore:
+    """Create TrustLog store from backend environment configuration."""
+    backend = os.getenv("VERITAS_TRUSTLOG_BACKEND", "jsonl").strip().lower()
+    if backend == "postgresql":
+        return PostgresTrustLogStore()
+    return JsonlTrustLogStore()
+
+
+def create_memory_store() -> MemoryStore:
+    """Create MemoryOS store from backend environment configuration."""
+    backend = os.getenv("VERITAS_MEMORY_BACKEND", "json").strip().lower()
+    if backend == "postgresql":
+        return PostgresMemoryStore()
+
+    memory_path = Path(
+        os.getenv("VERITAS_MEMORY_PATH", "./runtime/memory/memory_store.json")
+    )
+    return JsonMemoryStore(memory_path)

--- a/veritas_os/storage/json_kv.py
+++ b/veritas_os/storage/json_kv.py
@@ -1,0 +1,66 @@
+"""JSON key-value based MemoryOS backend implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from veritas_os.core.memory.memory_store import MemoryStore as LegacyMemoryStore
+
+
+class JsonMemoryStore:
+    """MemoryOS store adapter backed by the existing JSON file implementation."""
+
+    def __init__(self, path: Path):
+        self._store = LegacyMemoryStore.load(path)
+
+    async def put(self, key: str, value: Dict[str, Any], *, user_id: str) -> None:
+        self._store.put(user_id=user_id, key=key, value=value)
+
+    async def get(self, key: str) -> Optional[Dict[str, Any]]:
+        records = self._store.list_all()
+        for record in records:
+            if record.get("key") == key:
+                stored = record.get("value")
+                return stored if isinstance(stored, dict) else None
+        return None
+
+    async def search(
+        self,
+        query: str,
+        *,
+        user_id: str,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        result = self._store.search(query=query, k=limit, user_id=user_id)
+        if isinstance(result, dict):
+            return list(result.get("episodic") or [])
+        if isinstance(result, list):
+            return result
+        return []
+
+    async def delete(self, key: str, *, user_id: str) -> bool:
+        records = self._store._load_all(copy=True, use_cache=False)
+        kept = [
+            record for record in records
+            if not (
+                record.get("user_id") == user_id
+                and record.get("key") == key
+            )
+        ]
+        if len(kept) == len(records):
+            return False
+        return bool(self._store._save_all(kept))
+
+    async def list_all(self, *, user_id: str) -> List[Dict[str, Any]]:
+        return self._store.list_all(user_id=user_id)
+
+    async def erase_user_data(self, user_id: str) -> int:
+        report = self._store.erase_user(
+            user_id=user_id,
+            reason="api.erase_user_data",
+            actor="storage.json_kv",
+        )
+        if isinstance(report, dict):
+            return int(report.get("deleted", 0))
+        return 0

--- a/veritas_os/storage/jsonl.py
+++ b/veritas_os/storage/jsonl.py
@@ -1,0 +1,39 @@
+"""JSONL-based TrustLog backend implementation."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, Optional
+
+from veritas_os.logging import trust_log
+
+
+class JsonlTrustLogStore:
+    """File-backed TrustLog store based on existing trust_log module logic.
+
+    Hash-chain and encryption behavior remain encapsulated in the underlying
+    TrustLog implementation to preserve existing security guarantees.
+    """
+
+    async def append(self, entry: Dict[str, Any]) -> str:
+        saved = trust_log.append_trust_log(entry)
+        request_id = str(saved.get("request_id") or saved.get("sha256") or "")
+        return request_id
+
+    async def get_by_id(self, request_id: str) -> Optional[Dict[str, Any]]:
+        return trust_log.get_trust_log_entry(request_id)
+
+    async def iter_entries(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        if limit <= 0:
+            return
+
+        items = trust_log.load_trust_log(limit=None)
+        selected = items[offset:offset + limit]
+        for entry in selected:
+            yield entry
+
+    async def get_last_hash(self) -> Optional[str]:
+        return trust_log.get_last_hash()

--- a/veritas_os/storage/postgresql.py
+++ b/veritas_os/storage/postgresql.py
@@ -1,0 +1,61 @@
+"""Planned PostgreSQL backends (stub for v2.1)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+
+class _PostgresBase:
+    """Shared PostgreSQL backend base for future implementation."""
+
+    def __init__(self) -> None:
+        self.database_url = os.getenv("VERITAS_DATABASE_URL", "")
+
+
+class PostgresTrustLogStore(_PostgresBase):
+    """PostgreSQL TrustLog backend (planned)."""
+
+    async def append(self, entry: Dict[str, Any]) -> str:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+    async def get_by_id(self, request_id: str) -> Optional[Dict[str, Any]]:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+    async def iter_entries(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+    async def get_last_hash(self) -> Optional[str]:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+
+class PostgresMemoryStore(_PostgresBase):
+    """PostgreSQL MemoryOS backend (planned)."""
+
+    async def put(self, key: str, value: Dict[str, Any], *, user_id: str) -> None:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+    async def get(self, key: str) -> Optional[Dict[str, Any]]:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+    async def search(
+        self,
+        query: str,
+        *,
+        user_id: str,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+    async def delete(self, key: str, *, user_id: str) -> bool:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+    async def list_all(self, *, user_id: str) -> List[Dict[str, Any]]:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")
+
+    async def erase_user_data(self, user_id: str) -> int:
+        raise NotImplementedError("PostgreSQL backend is planned for v2.1")

--- a/veritas_os/tests/test_storage_base.py
+++ b/veritas_os/tests/test_storage_base.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+from veritas_os.storage.base import MemoryStore, TrustLogStore
+from veritas_os.storage.json_kv import JsonMemoryStore
+from veritas_os.storage.jsonl import JsonlTrustLogStore
+
+
+def test_jsonl_store_conforms_trustlog_protocol() -> None:
+    store: TrustLogStore = JsonlTrustLogStore()
+    assert hasattr(store, "append")
+    assert hasattr(store, "get_by_id")
+    assert hasattr(store, "iter_entries")
+    assert hasattr(store, "get_last_hash")
+
+
+def test_json_memory_store_conforms_memory_protocol(tmp_path) -> None:
+    store: MemoryStore = JsonMemoryStore(tmp_path / "memory.json")
+    assert hasattr(store, "put")
+    assert hasattr(store, "get")
+    assert hasattr(store, "search")
+    assert hasattr(store, "delete")
+    assert hasattr(store, "list_all")
+    assert hasattr(store, "erase_user_data")
+
+
+def test_json_memory_store_basic_async_ops(tmp_path) -> None:
+    async def _run() -> Dict[str, Any]:
+        store = JsonMemoryStore(tmp_path / "memory.json")
+        await store.put("k1", {"text": "hello world"}, user_id="u1")
+        loaded = await store.get("k1")
+        hits = await store.search("hello", user_id="u1", limit=5)
+        return {
+            "loaded": loaded,
+            "hits": hits,
+        }
+
+    result = asyncio.run(_run())
+    assert result["loaded"] is not None
+    assert result["loaded"].get("text") == "hello world"
+    assert len(result["hits"]) == 1

--- a/veritas_os/tests/test_storage_factory.py
+++ b/veritas_os/tests/test_storage_factory.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from veritas_os.storage.factory import create_memory_store, create_trust_log_store
+from veritas_os.storage.json_kv import JsonMemoryStore
+from veritas_os.storage.jsonl import JsonlTrustLogStore
+from veritas_os.storage.postgresql import PostgresMemoryStore, PostgresTrustLogStore
+
+
+def test_factory_defaults_to_json_backends(monkeypatch):
+    monkeypatch.delenv("VERITAS_TRUSTLOG_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_MEMORY_BACKEND", raising=False)
+
+    trust_store = create_trust_log_store()
+    memory_store = create_memory_store()
+
+    assert isinstance(trust_store, JsonlTrustLogStore)
+    assert isinstance(memory_store, JsonMemoryStore)
+
+
+def test_factory_selects_postgresql_backends(monkeypatch):
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_MEMORY_BACKEND", "postgresql")
+
+    trust_store = create_trust_log_store()
+    memory_store = create_memory_store()
+
+    assert isinstance(trust_store, PostgresTrustLogStore)
+    assert isinstance(memory_store, PostgresMemoryStore)

--- a/veritas_os/tests/test_storage_jsonl.py
+++ b/veritas_os/tests/test_storage_jsonl.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+
+from veritas_os.storage.jsonl import JsonlTrustLogStore
+
+
+def test_jsonl_trust_log_store_append_and_get(monkeypatch, tmp_path) -> None:
+    from veritas_os.logging import trust_log
+    from veritas_os.logging.encryption import generate_key
+
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    monkeypatch.setattr(trust_log, "LOG_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSON", tmp_path / "trust_log.json", raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSONL", tmp_path / "trust_log.jsonl", raising=False)
+
+    def _open_for_append():
+        trust_log.LOG_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        return open(trust_log.LOG_JSONL, "a", encoding="utf-8")
+
+    monkeypatch.setattr(trust_log, "open_trust_log_for_append", _open_for_append)
+
+    store = JsonlTrustLogStore()
+
+    async def _run() -> tuple[str, dict | None]:
+        entry_id = await store.append({"request_id": "req-1", "action": "allow"})
+        loaded = await store.get_by_id("req-1")
+        return entry_id, loaded
+
+    entry_id, loaded = asyncio.run(_run())
+    assert entry_id == "req-1"
+    assert loaded is not None
+    assert loaded.get("action") == "allow"
+
+
+def test_jsonl_trust_log_store_iter_entries(monkeypatch, tmp_path) -> None:
+    from veritas_os.logging import trust_log
+    from veritas_os.logging.encryption import generate_key
+
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    monkeypatch.setattr(trust_log, "LOG_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSON", tmp_path / "trust_log.json", raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSONL", tmp_path / "trust_log.jsonl", raising=False)
+
+    def _open_for_append():
+        trust_log.LOG_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        return open(trust_log.LOG_JSONL, "a", encoding="utf-8")
+
+    monkeypatch.setattr(trust_log, "open_trust_log_for_append", _open_for_append)
+
+    store = JsonlTrustLogStore()
+
+    async def _run() -> list[dict]:
+        await store.append({"request_id": "req-a", "seq": 1})
+        await store.append({"request_id": "req-b", "seq": 2})
+        rows = []
+        async for entry in store.iter_entries(limit=1, offset=0):
+            rows.append(entry)
+        return rows
+
+    rows = asyncio.run(_run())
+    assert len(rows) == 1
+    assert rows[0].get("request_id") == "req-b"


### PR DESCRIPTION
### Motivation
- Introduce an abstract storage layer to decouple TrustLog and MemoryOS persistence from concrete file-backed implementations. 
- Provide a DI-friendly factory so the runtime can select backends via environment variables while preserving existing file-based behavior by default. 
- Add PostgreSQL backend stubs to plan for v2.1 without changing runtime semantics today. 
- Security: note that the JSON KVS adapter currently calls some LegacyMemoryStore internals for delete/erase operations which may need public API hardening in a follow-up to avoid future fragility.

### Description
- Added new package `veritas_os/storage` with Protocol interfaces in `storage/base.py` for `TrustLogStore` and `MemoryStore` to define the abstract contracts. 
- Implemented file-backed adapters: `JsonlTrustLogStore` in `storage/jsonl.py` that delegates to the existing `veritas_os.logging.trust_log`, and `JsonMemoryStore` in `storage/json_kv.py` that adapts the existing `veritas_os.core.memory.memory_store`. 
- Added `storage/factory.py` to create store instances based on `VERITAS_TRUSTLOG_BACKEND` (`jsonl|postgresql`) and `VERITAS_MEMORY_BACKEND` (`json|postgresql`), defaulting to the legacy file-backed backends. 
- Added `storage/postgresql.py` with `PostgresTrustLogStore` and `PostgresMemoryStore` classes whose methods raise `NotImplementedError("PostgreSQL backend is planned for v2.1")` and read `VERITAS_DATABASE_URL` for future use. 
- Wired DI: `veritas_os/api/lifespan.py` initializes `app.state.trust_log_store` and `app.state.memory_store` on startup, and `veritas_os/api/dependency_resolver.py` exposes `get_trust_log_store` / `get_memory_store` helpers to resolve stores from `Request.app.state`. 
- Added tests exercising the new layer and adapters: `tests/test_storage_base.py`, `tests/test_storage_jsonl.py`, and `tests/test_storage_factory.py` and made minimal, focused adjustments to tests to reflect adapter behavior. 

### Testing
- Ran `pytest -q veritas_os/tests/test_storage_base.py veritas_os/tests/test_storage_jsonl.py veritas_os/tests/test_storage_factory.py veritas_os/tests/test_api_dependency_resolver.py` and all tests passed (`11 passed`). 
- Ran a production-like TrustLog check `pytest -q veritas_os/tests/test_production_trustlog.py::TestTrustLogWriteReadVerify::test_single_append_and_read veritas_os/tests/test_api_dependency_resolver.py` and it passed (`5 passed`). 
- Unit tests added to cover Protocol conformance, Jsonl trust-log append/iterate/get behavior, and factory backend selection (all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90aa53ae48326972f3313d28b5a34)