### PR TITLE
Add observability package (OpenTelemetry/Prometheus) with metrics, middleware, and instrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,14 @@ system = [
   "trio==0.26.2",
   "starlette==0.49.1",
 ]
+observability = [
+  "opentelemetry-api>=1.20",
+  "opentelemetry-sdk>=1.20",
+  "opentelemetry-exporter-otlp>=1.20",
+  "prometheus-client>=0.20",
+]
 full = [
-  "veritas-os[ml,reports,anthropic,system]",
+  "veritas-os[ml,reports,anthropic,system,observability]",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,10 @@ system = [
   "starlette==0.49.1",
 ]
 observability = [
-  "opentelemetry-api>=1.20",
-  "opentelemetry-sdk>=1.20",
-  "opentelemetry-exporter-otlp>=1.20",
-  "prometheus-client>=0.20",
+  "opentelemetry-api==1.20.0",
+  "opentelemetry-sdk==1.20.0",
+  "opentelemetry-exporter-otlp==1.20.0",
+  "prometheus-client==0.20.0",
 ]
 full = [
   "veritas-os[ml,reports,anthropic,system,observability]",

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -21,6 +21,12 @@ from veritas_os.api.rbac import Permission, Role, ROLE_PERMISSIONS
 
 logger = logging.getLogger(__name__)
 
+try:
+    from veritas_os.observability.metrics import record_auth_rejection
+except Exception:  # pragma: no cover - optional observability dependency
+    def record_auth_rejection(reason: str) -> None:
+        return None
+
 
 # ==============================
 # Auth failure tracking / metrics
@@ -34,6 +40,7 @@ def _record_auth_reject_reason(reason_code: str) -> None:
     """Track reject reason counters for operational audit metrics."""
     with _AUTH_REJECT_REASON_LOCK:
         _AUTH_REJECT_REASON_METRICS[reason_code] = _AUTH_REJECT_REASON_METRICS.get(reason_code, 0) + 1
+    record_auth_rejection(reason_code)
 
 
 def _snapshot_auth_reject_reason_metrics() -> Dict[str, int]:

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -9,6 +9,7 @@ stops, and response coercion/validation lives in
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, Request
@@ -34,6 +35,15 @@ from veritas_os.api import decide_service as _svc
 
 logger = logging.getLogger(__name__)
 
+try:
+    from veritas_os.observability.metrics import record_decide, set_telos_score
+except Exception:  # pragma: no cover - optional observability dependency
+    def record_decide(status: Any, mode: Any, intent: Any, duration_seconds: float | None = None) -> None:
+        return None
+
+    def set_telos_score(user_id: Any, score: Any) -> None:
+        return None
+
 router = APIRouter()
 
 # Rejection status set, shared across handlers.
@@ -54,6 +64,21 @@ def _get_server():
 
 @router.post("/v1/decide", response_model=DecideResponse, dependencies=[Depends(require_permission(Permission.decide))])
 async def decide(req: DecideRequest, request: Request):
+    started_at = time.perf_counter()
+    mode = "fast" if bool(getattr(req, "fast_mode", False)) else "normal"
+    intent = "unknown"
+    req_context = getattr(req, "context", None)
+    if isinstance(req_context, dict):
+        intent = req_context.get("intent") or intent
+
+    def _record(status: str) -> None:
+        record_decide(
+            status=status,
+            mode=mode,
+            intent=intent,
+            duration_seconds=time.perf_counter() - started_at,
+        )
+
     srv = _get_server()
     p = srv.get_decision_pipeline()
     if p is None:
@@ -62,6 +87,7 @@ async def decide(req: DecideRequest, request: Request):
             srv._publish_event("decide.completed", {"ok": False, "error": DECIDE_GENERIC_ERROR})
         except Exception:
             logger.debug("event publish failed on pipeline unavailable (best-effort)", exc_info=True)
+        _record("unavailable")
         return _svc.error_response(503, error=DECIDE_GENERIC_ERROR)
 
     try:
@@ -76,6 +102,7 @@ async def decide(req: DecideRequest, request: Request):
             )
         except Exception:
             logger.debug("event publish failed on pipeline error (best-effort)", exc_info=True)
+        _record("error")
         return _svc.error_response(503, error=DECIDE_GENERIC_ERROR, failure_category=failure_category)
 
     if isinstance(payload, dict):
@@ -89,6 +116,7 @@ async def decide(req: DecideRequest, request: Request):
 
     coerced, stop_response = _svc.apply_compliance_stop(coerced, srv._publish_event)
     if stop_response is not None:
+        _record("compliance_stop")
         return stop_response
 
     try:
@@ -101,6 +129,17 @@ async def decide(req: DecideRequest, request: Request):
         )
     except Exception:
         logger.debug("post-pipeline event publish failed (best-effort)", exc_info=True)
+
+    fuji = coerced.get("fuji") if isinstance(coerced, dict) else {}
+    status = "allow"
+    if isinstance(fuji, dict):
+        status = str(fuji.get("decision_status") or fuji.get("status") or status)
+
+    user_id = getattr(getattr(request, "state", None), "user_id", None)
+    if user_id is None and isinstance(req_context, dict):
+        user_id = req_context.get("user_id")
+    set_telos_score(user_id=user_id or "anonymous", score=coerced.get("telos_score"))
+    _record(status)
 
     return _svc.validate_and_respond(
         DecideResponse, coerced,

--- a/veritas_os/api/routes_memory.py
+++ b/veritas_os/api/routes_memory.py
@@ -22,6 +22,18 @@ from veritas_os.api.constants import VALID_MEMORY_KINDS
 
 logger = logging.getLogger(__name__)
 
+try:
+    from veritas_os.observability.metrics import (
+        record_memory_operation,
+        set_memory_store_entries,
+    )
+except Exception:  # pragma: no cover - optional observability dependency
+    def record_memory_operation(operation: str, kind: str) -> None:
+        return None
+
+    def set_memory_store_entries(user_id: str, entries: Any) -> None:
+        return None
+
 router = APIRouter()
 
 
@@ -74,6 +86,29 @@ def _get_server():
     """Late import to avoid circular dependency at module load time."""
     from veritas_os.api import server as srv
     return srv
+
+
+def _observe_memory_store_entries(store: Any, user_id: str) -> None:
+    """Best-effort gauge update for user memory entry count."""
+    if not user_id:
+        return
+    try:
+        if hasattr(store, "count"):
+            count = store.count(user_id=user_id)
+            set_memory_store_entries(user_id=user_id, entries=count)
+            return
+        if hasattr(store, "search"):
+            hits = _store_search(
+                store,
+                query="",
+                k=10000,
+                kinds=None,
+                min_sim=0.0,
+                user_id=user_id,
+            )
+            set_memory_store_entries(user_id=user_id, entries=len(hits or []))
+    except MEMORY_ROUTE_EXCEPTIONS:
+        return
 
 
 # ------------------------------------------------------------------
@@ -189,6 +224,7 @@ def memory_put(body: MemoryPutRequest, response: Response = None, x_api_key: Opt
         }
 
     key = body.key or f"memory_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    record_memory_operation("put", body.kind or "semantic")
     value = body.value or {}
 
     text = body.text.strip()
@@ -278,6 +314,7 @@ def memory_put(body: MemoryPutRequest, response: Response = None, x_api_key: Opt
             "legal_hold": legal_hold,
         },
     }
+    _observe_memory_store_entries(store, user_id)
     if errors:
         response["errors"] = errors
         if not ok:
@@ -310,6 +347,12 @@ def memory_search(payload: MemorySearchRequest, response: Response = None, x_api
         k = payload.k
         min_sim = payload.min_sim
         user_id = srv._resolve_memory_user_id(payload.user_id, x_api_key)
+        metric_kind = "semantic"
+        if isinstance(kinds, list) and kinds:
+            metric_kind = str(kinds[0] or "semantic")
+        elif isinstance(kinds, str) and kinds.strip():
+            metric_kind = kinds
+        record_memory_operation("search", metric_kind)
 
         validated_kinds, kinds_error = _validate_memory_kinds(kinds)
         if kinds_error:
@@ -347,6 +390,7 @@ def memory_search(payload: MemorySearchRequest, response: Response = None, x_api
                     norm_hits.append(h)
                 continue
 
+        _observe_memory_store_entries(store, user_id)
         return {"ok": True, "hits": norm_hits, "count": len(norm_hits)}
 
     except MEMORY_ROUTE_EXCEPTIONS as e:
@@ -376,8 +420,10 @@ def memory_get(body: MemoryGetRequest, response: Response = None, x_api_key: Opt
 
     try:
         uid = srv._resolve_memory_user_id(body.user_id, x_api_key)
+        record_memory_operation("get", "semantic")
         key = body.key
         value = _store_get(store, uid, key)
+        _observe_memory_store_entries(store, uid)
         return {"ok": True, "value": value}
     except MEMORY_ROUTE_EXCEPTIONS as e:
         logger.error("memory_get failed: %s", e)

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -104,6 +104,16 @@ from veritas_os.api.log_path_resolver import (
     effective_shadow_dir,
 )
 from veritas_os.api.trust_log_runtime import TrustLogRuntime
+
+try:
+    from veritas_os.observability.middleware import observe_request_metrics
+    from veritas_os.observability.exporters import configure_metrics_exporter
+except Exception:  # pragma: no cover - optional observability dependency
+    observe_request_metrics = None  # type: ignore
+
+    def configure_metrics_exporter(app: Any, auth_dependency: Optional[Any] = None) -> str:
+        return "none"
+
 from veritas_os.api.dependency_resolver import (
     LazyState,
     resolve_cfg,
@@ -631,7 +641,10 @@ app.middleware("http")(add_rate_limit_headers)
 app.middleware("http")(track_inflight_requests)
 app.middleware("http")(limit_body_size)
 app.middleware("http")(add_security_headers)
+if observe_request_metrics is not None:
+    app.middleware("http")(observe_request_metrics)
 
+configure_metrics_exporter(app, auth_dependency=require_api_key)
 
 # ==============================
 # 422 error handler

--- a/veritas_os/core/fuji/__init__.py
+++ b/veritas_os/core/fuji/__init__.py
@@ -110,6 +110,18 @@ from ..config import capability_cfg, emit_capability_manifest
 from veritas_os.logging.trust_log import append_trust_event as _append_trust_event
 from veritas_os.tools import call_tool as _call_tool
 
+try:
+    from veritas_os.observability.metrics import (
+        record_fuji_decision,
+        record_fuji_violations,
+    )
+except Exception:  # pragma: no cover - optional observability dependency
+    def record_fuji_decision(decision_status: Any) -> None:
+        return None
+
+    def record_fuji_violations(violation_types: Sequence[Any] | None) -> None:
+        return None
+
 _FUJI_YAML_EXPLICITLY_ENABLED = os.getenv("VERITAS_CAP_FUJI_YAML_POLICY") in {
     "1",
     "true",
@@ -930,6 +942,9 @@ def fuji_gate(
             code=code,
             trust_log_id=_resolve_trust_log_id(ctx),
         )
+
+    record_fuji_decision(decision_status)
+    record_fuji_violations(violations)
 
     return {
         "status": status,                    # 内部状態

--- a/veritas_os/core/llm_client.py
+++ b/veritas_os/core/llm_client.py
@@ -58,6 +58,12 @@ import httpx
 from veritas_os.core import affect as affect_core
 from veritas_os.core.utils import _redact_text
 
+try:
+    from veritas_os.observability.metrics import observe_llm_call_duration
+except Exception:  # pragma: no cover - optional observability dependency
+    def observe_llm_call_duration(provider: str, duration_seconds: float) -> None:
+        return None
+
 log = logging.getLogger(__name__)
 
 
@@ -961,7 +967,12 @@ def chat_completion(
     This compatibility alias exists so internal modules can consistently call
     one function name (`chat_completion`) even if implementation details evolve.
     """
-    return chat(system_prompt=system_prompt, user_prompt=user_prompt, **kwargs)
+    provider = str(kwargs.get("provider") or LLM_PROVIDER)
+    started_at = time.perf_counter()
+    try:
+        return chat(system_prompt=system_prompt, user_prompt=user_prompt, **kwargs)
+    finally:
+        observe_llm_call_duration(provider=provider, duration_seconds=time.perf_counter() - started_at)
 
 
 __all__ = [

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -69,6 +69,19 @@ from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+
+try:
+    from veritas_os.observability.metrics import (
+        observe_pipeline_stage_duration,
+        set_degraded_subsystems,
+    )
+except Exception:  # pragma: no cover - optional observability dependency
+    def observe_pipeline_stage_duration(stage: str, duration_seconds: float) -> None:
+        return None
+
+    def set_degraded_subsystems(count: Any) -> None:
+        return None
+
 from ..utils import (  # noqa: F401 – _redact_text/redact_payload re-exported for backward compat
     _redact_text,
     redact_payload,
@@ -708,12 +721,14 @@ async def run_decide_pipeline(
     # =================================================================
     # Stage 1: Input normalization  (-> pipeline_inputs)
     # =================================================================
+    _stage_started_at = time.perf_counter()
     ctx = normalize_pipeline_inputs(
         req,
         request,
         _get_request_params=_get_request_params,
         _to_dict_fn=to_dict,
     )
+    observe_pipeline_stage_duration("input_norm", time.perf_counter() - _stage_started_at)
 
     # =================================================================
     # Stage 2: MemoryOS retrieval  (-> pipeline_retrieval)
@@ -751,12 +766,14 @@ async def run_decide_pipeline(
     # =================================================================
     # Stage 4: Core decision + self-healing  (-> pipeline_execute)
     # =================================================================
+    _stage_started_at = time.perf_counter()
     await stage_core_execute(
         ctx,
         call_core_decide_fn=call_core_decide,
         append_trust_log_fn=append_trust_log,
         veritas_core=veritas_core,
     )
+    observe_pipeline_stage_duration("kernel_execute", time.perf_counter() - _stage_started_at)
 
     # =================================================================
     # Stage 4b: Absorb raw results  (-> pipeline_decide_stages)
@@ -837,9 +854,11 @@ async def run_decide_pipeline(
     # =================================================================
     # Stage 6: Policy (FUJI + ValueCore + Gate)  (-> pipeline_policy)
     # =================================================================
+    _stage_started_at = time.perf_counter()
     stage_fuji_precheck(ctx)
     stage_value_core(ctx, _load_valstats=_load_valstats, _clip01=_clip01)
     stage_gate_decision(ctx)
+    observe_pipeline_stage_duration("fuji_gate", time.perf_counter() - _stage_started_at)
 
     # =================================================================
     # Stage 6b: Value learning EMA  (-> pipeline_decide_stages)
@@ -877,12 +896,14 @@ async def run_decide_pipeline(
     # Stage 8: Post-decision persistence phase  (-> pipeline_persist)
     # - best-effort side effects and artifact generation only
     # =================================================================
+    _stage_started_at = time.perf_counter()
     _run_post_decision_persistence_phase(
         ctx,
         payload,
         effective_get_memory_store=effective_get_memory_store,
         stage_failures=_stage_failures,
     )
+    observe_pipeline_stage_duration("persist", time.perf_counter() - _stage_started_at)
 
     # =================================================================
     # Observability: record pipeline health summary
@@ -895,6 +916,7 @@ async def run_decide_pipeline(
             metrics["pipeline_total_ms"] = total_ms
             if _stage_failures:
                 metrics["degraded_stages"] = _stage_failures
+    set_degraded_subsystems(len(_stage_failures))
     if _stage_failures:
         logger.info(
             "[pipeline] completed with degraded stages (%d ms): %s",

--- a/veritas_os/observability/__init__.py
+++ b/veritas_os/observability/__init__.py
@@ -1,0 +1,5 @@
+"""VERITAS OS observability integration package."""
+
+from veritas_os.observability.exporters import configure_metrics_exporter
+
+__all__ = ["configure_metrics_exporter"]

--- a/veritas_os/observability/exporters.py
+++ b/veritas_os/observability/exporters.py
@@ -1,0 +1,92 @@
+"""Metrics exporter bootstrap for Prometheus and OTLP."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+from fastapi import Depends
+from fastapi.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+
+_METRICS_ROUTE_INSTALLED = False
+
+
+def _exporter_mode() -> str:
+    return (os.getenv("VERITAS_METRICS_EXPORTER") or "none").strip().lower()
+
+
+def _metrics_auth_required() -> bool:
+    raw = (os.getenv("VERITAS_METRICS_AUTH") or "0").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _build_prometheus_endpoint():
+    try:
+        from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+    except Exception:
+        CONTENT_TYPE_LATEST = "application/json"
+
+        def endpoint() -> Response:
+            return JSONResponse(
+                status_code=503,
+                content={"ok": False, "error": "prometheus_client is not installed"},
+            )
+
+        return endpoint
+
+    def endpoint() -> Response:
+        return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    return endpoint
+
+
+def _install_prometheus_endpoint(app: Any, auth_dependency: Optional[Any]) -> None:
+    global _METRICS_ROUTE_INSTALLED
+    if _METRICS_ROUTE_INSTALLED:
+        return
+
+    endpoint = _build_prometheus_endpoint()
+    dependencies = []
+    if _metrics_auth_required() and auth_dependency is not None:
+        dependencies = [Depends(auth_dependency)]
+    app.add_api_route("/metrics", endpoint, methods=["GET"], include_in_schema=False, dependencies=dependencies)
+    _METRICS_ROUTE_INSTALLED = True
+
+
+def _configure_otlp_exporter() -> bool:
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry import metrics
+    except Exception as exc:
+        logger.warning("OTLP exporter requested but OpenTelemetry deps are unavailable: %s", exc)
+        return False
+
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    reader = PeriodicExportingMetricReader(OTLPMetricExporter(endpoint=endpoint))
+    provider = MeterProvider(metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+    return True
+
+
+def configure_metrics_exporter(app: Any, auth_dependency: Optional[Any] = None) -> str:
+    """Configure runtime metric export mode and endpoints.
+
+    Modes:
+      - none (default): collect metrics only.
+      - prometheus: expose ``/metrics`` endpoint.
+      - otlp: configure OpenTelemetry OTLP exporter.
+    """
+    mode = _exporter_mode()
+    if mode == "prometheus":
+        _install_prometheus_endpoint(app, auth_dependency=auth_dependency)
+    elif mode == "otlp":
+        _configure_otlp_exporter()
+    elif mode != "none":
+        logger.warning("Unknown VERITAS_METRICS_EXPORTER=%s; falling back to none", mode)
+        mode = "none"
+    return mode

--- a/veritas_os/observability/metrics.py
+++ b/veritas_os/observability/metrics.py
@@ -1,0 +1,209 @@
+"""Observability metric definitions and safe recording helpers.
+
+This module exposes a stable helper API used by core/api modules.
+When ``prometheus_client`` is unavailable, all helpers degrade to no-op,
+keeping runtime compatibility for environments without observability extras.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class _NoOpMetric:
+    """No-op metric object compatible with Counter/Histogram/Gauge usage."""
+
+    def labels(self, **_: Any) -> "_NoOpMetric":
+        return self
+
+    def inc(self, _: float = 1.0) -> None:
+        return None
+
+    def observe(self, _: float) -> None:
+        return None
+
+    def set(self, _: float) -> None:
+        return None
+
+
+try:
+    from prometheus_client import Counter, Gauge, Histogram
+
+    _PROMETHEUS_AVAILABLE = True
+except Exception as exc:  # pragma: no cover - optional dependency path
+    Counter = Gauge = Histogram = None  # type: ignore
+    _PROMETHEUS_AVAILABLE = False
+    logger.debug("prometheus_client unavailable, using no-op metrics: %s", exc)
+
+
+def _counter(*args: Any, **kwargs: Any) -> Any:
+    if not _PROMETHEUS_AVAILABLE:
+        return _NoOpMetric()
+    return Counter(*args, **kwargs)
+
+
+def _histogram(*args: Any, **kwargs: Any) -> Any:
+    if not _PROMETHEUS_AVAILABLE:
+        return _NoOpMetric()
+    return Histogram(*args, **kwargs)
+
+
+def _gauge(*args: Any, **kwargs: Any) -> Any:
+    if not _PROMETHEUS_AVAILABLE:
+        return _NoOpMetric()
+    return Gauge(*args, **kwargs)
+
+
+VERITAS_DECIDE_TOTAL = _counter(
+    "veritas_decide_total",
+    "Total number of /v1/decide calls",
+    labelnames=("status", "mode", "intent"),
+)
+VERITAS_FUJI_DECISIONS_TOTAL = _counter(
+    "veritas_fuji_decisions_total",
+    "FUJI gate decisions by status",
+    labelnames=("decision_status",),
+)
+VERITAS_FUJI_VIOLATIONS_TOTAL = _counter(
+    "veritas_fuji_violations_total",
+    "FUJI violations by type",
+    labelnames=("violation_type",),
+)
+VERITAS_AUTH_REJECTIONS_TOTAL = _counter(
+    "veritas_auth_rejections_total",
+    "Authentication rejections by reason",
+    labelnames=("reason",),
+)
+VERITAS_MEMORY_OPERATIONS_TOTAL = _counter(
+    "veritas_memory_operations_total",
+    "Memory operations by operation and kind",
+    labelnames=("operation", "kind"),
+)
+
+VERITAS_DECIDE_DURATION_SECONDS = _histogram(
+    "veritas_decide_duration_seconds",
+    "Latency of /v1/decide",
+    labelnames=("mode",),
+)
+VERITAS_PIPELINE_STAGE_DURATION_SECONDS = _histogram(
+    "veritas_pipeline_stage_duration_seconds",
+    "Per-stage latency for decide pipeline",
+    labelnames=("stage",),
+)
+VERITAS_LLM_CALL_DURATION_SECONDS = _histogram(
+    "veritas_llm_call_duration_seconds",
+    "LLM provider call latency",
+    labelnames=("provider",),
+)
+
+VERITAS_TELOS_SCORE = _gauge(
+    "veritas_telos_score",
+    "Latest telos_score",
+    labelnames=("user_id",),
+)
+VERITAS_MEMORY_STORE_ENTRIES = _gauge(
+    "veritas_memory_store_entries",
+    "Memory store entry count per user",
+    labelnames=("user_id",),
+)
+VERITAS_DEGRADED_SUBSYSTEMS = _gauge(
+    "veritas_degraded_subsystems",
+    "Count of degraded subsystems",
+)
+
+VERITAS_HTTP_REQUEST_DURATION_SECONDS = _histogram(
+    "veritas_http_request_duration_seconds",
+    "HTTP request duration by method/path",
+    labelnames=("method", "path"),
+)
+VERITAS_HTTP_REQUESTS_TOTAL = _counter(
+    "veritas_http_requests_total",
+    "HTTP request count by method/path/status",
+    labelnames=("method", "path", "status_code"),
+)
+
+
+def _label(value: Any, fallback: str = "unknown") -> str:
+    text = str(value).strip() if value is not None else ""
+    return text or fallback
+
+
+def record_decide(status: Any, mode: Any, intent: Any, duration_seconds: Optional[float] = None) -> None:
+    """Record /v1/decide call count and latency."""
+    status_label = _label(status, "unknown")
+    mode_label = _label(mode, "normal")
+    intent_label = _label(intent, "unknown")
+    VERITAS_DECIDE_TOTAL.labels(
+        status=status_label,
+        mode=mode_label,
+        intent=intent_label,
+    ).inc()
+    if duration_seconds is not None:
+        VERITAS_DECIDE_DURATION_SECONDS.labels(mode=mode_label).observe(max(0.0, duration_seconds))
+
+
+def observe_pipeline_stage_duration(stage: str, duration_seconds: float) -> None:
+    VERITAS_PIPELINE_STAGE_DURATION_SECONDS.labels(stage=_label(stage)).observe(max(0.0, duration_seconds))
+
+
+def observe_llm_call_duration(provider: Any, duration_seconds: float) -> None:
+    VERITAS_LLM_CALL_DURATION_SECONDS.labels(provider=_label(provider)).observe(max(0.0, duration_seconds))
+
+
+def record_fuji_decision(decision_status: Any) -> None:
+    VERITAS_FUJI_DECISIONS_TOTAL.labels(decision_status=_label(decision_status)).inc()
+
+
+def record_fuji_violations(violation_types: Optional[Iterable[Any]]) -> None:
+    for violation in violation_types or []:
+        VERITAS_FUJI_VIOLATIONS_TOTAL.labels(violation_type=_label(violation)).inc()
+
+
+def record_auth_rejection(reason: Any) -> None:
+    VERITAS_AUTH_REJECTIONS_TOTAL.labels(reason=_label(reason)).inc()
+
+
+def record_memory_operation(operation: Any, kind: Any) -> None:
+    VERITAS_MEMORY_OPERATIONS_TOTAL.labels(
+        operation=_label(operation),
+        kind=_label(kind, "unknown"),
+    ).inc()
+
+
+def set_telos_score(user_id: Any, score: Any) -> None:
+    try:
+        VERITAS_TELOS_SCORE.labels(user_id=_label(user_id, "anonymous")).set(float(score))
+    except (TypeError, ValueError):
+        return
+
+
+def set_memory_store_entries(user_id: Any, entries: Any) -> None:
+    try:
+        VERITAS_MEMORY_STORE_ENTRIES.labels(user_id=_label(user_id, "anonymous")).set(float(entries))
+    except (TypeError, ValueError):
+        return
+
+
+def set_degraded_subsystems(count: Any) -> None:
+    try:
+        VERITAS_DEGRADED_SUBSYSTEMS.set(float(count))
+    except (TypeError, ValueError):
+        return
+
+
+def record_http_request(method: str, path: str, status_code: int, duration_seconds: float) -> None:
+    """Record generic HTTP request latency and status metrics."""
+    method_label = _label(method, "UNKNOWN")
+    path_label = _label(path, "unknown")
+    code_label = _label(status_code, "0")
+    VERITAS_HTTP_REQUEST_DURATION_SECONDS.labels(
+        method=method_label,
+        path=path_label,
+    ).observe(max(0.0, duration_seconds))
+    VERITAS_HTTP_REQUESTS_TOTAL.labels(
+        method=method_label,
+        path=path_label,
+        status_code=code_label,
+    ).inc()

--- a/veritas_os/observability/middleware.py
+++ b/veritas_os/observability/middleware.py
@@ -1,0 +1,39 @@
+"""Observability-only FastAPI middleware.
+
+The middleware records request duration and response status metrics only.
+It intentionally avoids modifying auth, headers, or request flow responsibilities
+already handled by :mod:`veritas_os.api.middleware`.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from fastapi import Request
+
+from veritas_os.observability.metrics import record_http_request
+
+
+def _resolve_route_path(request: Request) -> str:
+    route = request.scope.get("route")
+    if route is not None and hasattr(route, "path"):
+        return str(getattr(route, "path"))
+    return request.url.path
+
+
+async def observe_request_metrics(request: Request, call_next: Any):
+    """Record per-request latency and status code metrics."""
+    started_at = time.perf_counter()
+    status_code = 500
+    try:
+        response = await call_next(request)
+        status_code = int(getattr(response, "status_code", 500) or 500)
+        return response
+    finally:
+        elapsed = time.perf_counter() - started_at
+        record_http_request(
+            method=request.method,
+            path=_resolve_route_path(request),
+            status_code=status_code,
+            duration_seconds=elapsed,
+        )

--- a/veritas_os/requirements.txt
+++ b/veritas_os/requirements.txt
@@ -47,3 +47,9 @@ anthropic==0.34.2
 psutil==6.0.0
 trio==0.26.2
 starlette==0.49.1
+
+# --- Optional [observability]: OTel / Prometheus ---
+opentelemetry-api==1.20.0
+opentelemetry-sdk==1.20.0
+opentelemetry-exporter-otlp==1.20.0
+prometheus-client==0.20.0

--- a/veritas_os/tests/test_dependency_profiles.py
+++ b/veritas_os/tests/test_dependency_profiles.py
@@ -28,7 +28,14 @@ _REQUIREMENTS = _ROOT / "veritas_os" / "requirements.txt"
 
 # --- Expected extras groups ---------------------------------------------------
 
-EXPECTED_EXTRAS = {"ml", "reports", "anthropic", "system", "full"}
+EXPECTED_EXTRAS = {
+    "ml",
+    "reports",
+    "anthropic",
+    "system",
+    "observability",
+    "full",
+}
 
 EXPECTED_CORE = {
     "fastapi",
@@ -54,6 +61,10 @@ EXPECTED_OPTIONAL = {
     "psutil",
     "trio",
     "starlette",
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp",
+    "prometheus-client",
 }
 
 

--- a/veritas_os/tests/test_observability_metrics.py
+++ b/veritas_os/tests/test_observability_metrics.py
@@ -1,0 +1,75 @@
+"""Unit tests for observability metric recording helpers."""
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+
+class _MetricProbe:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def labels(self, **labels: Any) -> "_MetricProbe":
+        self.calls.append({"labels": labels})
+        return self
+
+    def inc(self, amount: float = 1.0) -> None:
+        self.calls.append({"inc": amount})
+
+    def observe(self, value: float) -> None:
+        self.calls.append({"observe": value})
+
+    def set(self, value: float) -> None:
+        self.calls.append({"set": value})
+
+
+def test_record_decide_and_gauge_helpers(monkeypatch):
+    metrics = importlib.import_module("veritas_os.observability.metrics")
+    decide_total = _MetricProbe()
+    decide_duration = _MetricProbe()
+    telos = _MetricProbe()
+    degraded = _MetricProbe()
+
+    monkeypatch.setattr(metrics, "VERITAS_DECIDE_TOTAL", decide_total)
+    monkeypatch.setattr(metrics, "VERITAS_DECIDE_DURATION_SECONDS", decide_duration)
+    monkeypatch.setattr(metrics, "VERITAS_TELOS_SCORE", telos)
+    monkeypatch.setattr(metrics, "VERITAS_DEGRADED_SUBSYSTEMS", degraded)
+
+    metrics.record_decide(status="allow", mode="fast", intent="qa", duration_seconds=0.25)
+    metrics.set_telos_score(user_id="u-1", score=0.87)
+    metrics.set_degraded_subsystems(2)
+
+    assert any(call.get("labels") == {"status": "allow", "mode": "fast", "intent": "qa"} for call in decide_total.calls)
+    assert any(call.get("observe") == 0.25 for call in decide_duration.calls)
+    assert any(call.get("labels") == {"user_id": "u-1"} for call in telos.calls)
+    assert any(call.get("set") == 2.0 for call in degraded.calls)
+
+
+def test_fuji_and_memory_metrics(monkeypatch):
+    metrics = importlib.import_module("veritas_os.observability.metrics")
+    fuji_decisions = _MetricProbe()
+    fuji_violations = _MetricProbe()
+    mem_ops = _MetricProbe()
+
+    monkeypatch.setattr(metrics, "VERITAS_FUJI_DECISIONS_TOTAL", fuji_decisions)
+    monkeypatch.setattr(metrics, "VERITAS_FUJI_VIOLATIONS_TOTAL", fuji_violations)
+    monkeypatch.setattr(metrics, "VERITAS_MEMORY_OPERATIONS_TOTAL", mem_ops)
+
+    metrics.record_fuji_decision("deny")
+    metrics.record_fuji_violations(["pii", "policy"])
+    metrics.record_memory_operation("search", "semantic")
+
+    assert any(call.get("labels") == {"decision_status": "deny"} for call in fuji_decisions.calls)
+    assert any(call.get("labels") == {"violation_type": "pii"} for call in fuji_violations.calls)
+    assert any(call.get("labels") == {"operation": "search", "kind": "semantic"} for call in mem_ops.calls)
+
+
+def test_noop_mode_without_prometheus_client(monkeypatch):
+    monkeypatch.setitem(sys.modules, "prometheus_client", None)
+    metrics = importlib.reload(importlib.import_module("veritas_os.observability.metrics"))
+
+    # Must not raise even when prometheus_client is missing.
+    metrics.record_decide(status="allow", mode="normal", intent="unknown", duration_seconds=0.01)
+    metrics.record_auth_rejection("api_key_invalid")
+    metrics.observe_pipeline_stage_duration("kernel_execute", 0.05)

--- a/veritas_os/tests/test_observability_middleware.py
+++ b/veritas_os/tests/test_observability_middleware.py
@@ -1,0 +1,63 @@
+"""Integration tests for observability middleware."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veritas_os.observability.middleware import observe_request_metrics
+
+
+def test_observe_request_metrics_records_status_and_path(monkeypatch):
+    captured: list[dict] = []
+
+    def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(
+        "veritas_os.observability.middleware.record_http_request",
+        _capture,
+    )
+
+    app = FastAPI()
+    app.middleware("http")(observe_request_metrics)
+
+    @app.get("/health")
+    async def health():
+        return {"ok": True}
+
+    client = TestClient(app)
+    res = client.get("/health")
+
+    assert res.status_code == 200
+    assert captured
+    assert captured[0]["method"] == "GET"
+    assert captured[0]["path"] == "/health"
+    assert captured[0]["status_code"] == 200
+    assert captured[0]["duration_seconds"] >= 0.0
+
+
+def test_observe_request_metrics_handles_exceptions(monkeypatch):
+    captured: list[dict] = []
+
+    def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(
+        "veritas_os.observability.middleware.record_http_request",
+        _capture,
+    )
+
+    app = FastAPI()
+    app.middleware("http")(observe_request_metrics)
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("boom")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    res = client.get("/boom")
+
+    assert res.status_code == 500
+    assert captured
+    assert captured[0]["path"] == "/boom"
+    assert captured[0]["status_code"] == 500


### PR DESCRIPTION
### Motivation
- Provide structured observability (OpenTelemetry / Prometheus) for VERITAS OS so runtime events and latencies can be scraped and correlated instead of relying on the manual `extras.metrics` dictionary.
- Keep the integration optional and backward-compatible: when observability extras are not installed the helpers degrade to no-op and default exporter mode is `none` to avoid changing existing behavior.
- Add minimal-responsibility FastAPI middleware for metric collection that does not conflict with existing `veritas_os/api/middleware.py` responsibilities.
- Security warning: several metrics use high-cardinality labels (per-`user_id` gauges and path-labelled HTTP metrics), which can expose sensitive metadata or cause cardinality explosion; operators must sanitize/limit labels, retention, or enable anonymization in production.

### Description
- Added a new package `veritas_os.observability` with `metrics.py` (metric definitions + no-op fallbacks), `middleware.py` (request timing/status middleware), `exporters.py` (bootstrap for `VERITAS_METRICS_EXPORTER=none|prometheus|otlp` and optional `/metrics` auth via `VERITAS_METRICS_AUTH`), and `__init__.py` that exports `configure_metrics_exporter`.
- Instrumented core code paths to call the helpers only when available (safe import + no-op fallback):
  - `/v1/decide` in `veritas_os/api/routes_decide.py`: record `veritas_decide_total`, `veritas_decide_duration_seconds`, and update `veritas_telos_score` gauge.
  - Pipeline in `veritas_os/core/pipeline/__init__.py`: observe per-stage durations (`input_norm`, `kernel_execute`, `fuji_gate`, `persist`), set `veritas_degraded_subsystems` gauge, and keep existing `extras.metrics` writes intact.
  - FUJI in `veritas_os/core/fuji/__init__.py`: increment FUJI decision and violation counters after evaluation.
  - LLM client in `veritas_os/core/llm_client.py`: record `veritas_llm_call_duration_seconds` around `chat_completion`.
  - Auth in `veritas_os/api/auth.py`: increment auth rejection counter when recording existing in-memory reject reasons.
  - Memory APIs in `veritas_os/api/routes_memory.py`: emit memory operation counters for `put/get/search` and best-effort user memory-entry gauge updates.
- Integrated middleware and exporter configuration into FastAPI server startup (`veritas_os/api/server.py`) so `observe_request_metrics` is registered when available and `/metrics` is exposed when `VERITAS_METRICS_EXPORTER=prometheus`.
- Added `observability` optional dependency group to `pyproject.toml` and included it in the `full` extra.
- Created unit and integration tests (`veritas_os/tests/test_observability_metrics.py`, `veritas_os/tests/test_observability_middleware.py`) and added docstrings per requirement.

### Testing
- Ran static compile checks: `python -m py_compile` on all modified runtime files — succeeded.
- Metrics and middleware tests: `pytest -q veritas_os/tests/test_observability_metrics.py veritas_os/tests/test_observability_middleware.py` — all tests passed (5 passed).
- Sanity regression: `pytest -q veritas_os/tests/test_auth_core.py` and `pytest -q veritas_os/tests/test_middleware_core.py` executed and passed to ensure no-op mode did not break existing behavior.
- Notes: the observability code paths use optional imports and no-op fallbacks so existing test suite and default runtime (VERITAS_METRICS_EXPORTER=none) remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90f5fcf70832690b6856294d36464)