### PR TITLE
Add script to capture frontend snapshot (`scripts/take_frontend_snapshot.sh`)

### DIFF
--- a/scripts/take_frontend_snapshot.sh
+++ b/scripts/take_frontend_snapshot.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+OUTPUT_PATH="${1:-$ROOT_DIR/artifacts/frontend-snapshot.png}"
+URL="${2:-http://localhost:3000}"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[ERROR] pnpm が見つかりません。" >&2
+  exit 1
+fi
+
+echo "[SECURITY WARNING] 外部バイナリ取得を伴う可能性があります。"
+echo "[SECURITY WARNING] 信頼できるネットワーク/ミラーでのみ実行してください。"
+
+echo "[INFO] Next.js 開発サーバーを起動します: $URL"
+(
+  cd "$ROOT_DIR"
+  pnpm --filter frontend dev >/tmp/frontend-dev.log 2>&1
+) &
+DEV_PID=$!
+
+cleanup() {
+  if kill -0 "$DEV_PID" >/dev/null 2>&1; then
+    kill "$DEV_PID" >/dev/null 2>&1 || true
+    wait "$DEV_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Wait for the dev server
+for _ in $(seq 1 60); do
+  if curl -fsS "$URL" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -fsS "$URL" >/dev/null 2>&1; then
+  echo "[ERROR] 開発サーバーに接続できません。/tmp/frontend-dev.log を確認してください。" >&2
+  exit 1
+fi
+
+echo "[INFO] スクリーンショットを取得します: $OUTPUT_PATH"
+(
+  cd "$FRONTEND_DIR"
+  pnpm exec playwright screenshot --device="Desktop Chrome" "$URL" "$OUTPUT_PATH"
+)
+
+echo "[DONE] スナップショット作成完了: $OUTPUT_PATH"


### PR DESCRIPTION
### Motivation
- Provide a simple tool to start the Next.js frontend and produce a visual snapshot artifact for CI or local debugging.

### Description
- Added executable Bash script `scripts/take_frontend_snapshot.sh` that starts the frontend with `pnpm --filter frontend dev`, waits for the server to become available, and captures a screenshot using `pnpm exec playwright screenshot --device="Desktop Chrome"`.
- The script defaults the output to `artifacts/frontend-snapshot.png` and accepts optional `OUTPUT_PATH` and `URL` arguments.
- The script verifies `pnpm` is installed, writes the dev server log to `/tmp/frontend-dev.log`, emits a security warning, and installs a `trap`-based cleanup to stop the background dev server on exit.
- Informational and error messages in the script are written in Japanese to match local usage.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c931e9577c8326a78892f4bcbcfad6)