### PR TITLE
Validate VERITAS API key for benchmark runner and add unit tests

### DIFF
--- a/veritas_os/scripts/run_benchmarks_enhanced.py
+++ b/veritas_os/scripts/run_benchmarks_enhanced.py
@@ -45,6 +45,26 @@ BENCH_DIR = REPO_ROOT / "benchmarks"
 LOG_ROOT  = REPO_ROOT / "scripts" / "logs" / "benchmarks"
 LOG_ROOT.mkdir(parents=True, exist_ok=True)
 
+_API_KEY_PLACEHOLDER = "YOUR_API_KEY_HERE"
+
+
+def _resolve_api_key(raw_api_key: Optional[str] = None) -> str:
+    """Return a validated API key for benchmark requests.
+
+    Security policy:
+    - Empty keys are rejected.
+    - Placeholder values are rejected to prevent accidental unauthenticated
+      benchmark runs.
+    """
+    candidate = API_KEY if raw_api_key is None else raw_api_key
+    normalized = (candidate or "").strip()
+    if not normalized or normalized == _API_KEY_PLACEHOLDER:
+        raise ValueError(
+            "VERITAS_API_KEY is not configured. "
+            "Set a valid non-placeholder API key before running benchmarks."
+        )
+    return normalized
+
 
 def run_one_bench(
     path: Path,
@@ -99,7 +119,7 @@ def run_one_bench(
     url = f"{BASE_URL}/v1/decide"
     headers = {
         "Content-Type": "application/json",
-        "X-API-Key": API_KEY,
+        "X-API-Key": _resolve_api_key(),
     }
 
     logger.info(f"Running: {bench_id} ({name})")
@@ -318,6 +338,12 @@ def main():
     )
     
     args = parser.parse_args()
+
+    try:
+        _resolve_api_key()
+    except ValueError as exc:
+        logger.error(str(exc))
+        return 1
     
     # ログレベル調整
     if args.verbose:

--- a/veritas_os/tests/test_run_benchmarks_enhanced.py
+++ b/veritas_os/tests/test_run_benchmarks_enhanced.py
@@ -1,0 +1,31 @@
+"""Tests for veritas_os.scripts.run_benchmarks_enhanced security behavior."""
+
+from __future__ import annotations
+
+from veritas_os.scripts import run_benchmarks_enhanced as module
+
+
+def test_resolve_api_key_rejects_empty_value() -> None:
+    """Empty API key must fail fast."""
+    try:
+        module._resolve_api_key("")
+    except ValueError as exc:
+        assert "VERITAS_API_KEY is not configured" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected ValueError for empty API key")
+
+
+def test_resolve_api_key_rejects_placeholder_value() -> None:
+    """Placeholder API key must fail fast."""
+    try:
+        module._resolve_api_key(module._API_KEY_PLACEHOLDER)
+    except ValueError as exc:
+        assert "VERITAS_API_KEY is not configured" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected ValueError for placeholder API key")
+
+
+def test_resolve_api_key_accepts_real_value() -> None:
+    """Non-empty non-placeholder key should pass validation."""
+    actual = module._resolve_api_key("real-key-123")
+    assert actual == "real-key-123"


### PR DESCRIPTION
### Motivation

- Prevent accidental unauthenticated benchmark runs by rejecting empty or placeholder API keys before any HTTP requests are made.

### Description

- Introduce `_API_KEY_PLACEHOLDER` and implement `_resolve_api_key()` to validate and normalize API keys and raise `ValueError` for empty or placeholder values.
- Replace direct use of `API_KEY` in request headers with a call to `_resolve_api_key()` in `run_one_bench()` so requests always use a validated key.
- Add an early validation check in `main()` that logs an error and returns `1` when the API key is not configured instead of proceeding.
- Add unit tests in `veritas_os/tests/test_run_benchmarks_enhanced.py` covering empty, placeholder, and valid API key cases for `_resolve_api_key()`.

### Testing

- Ran `pytest veritas_os/tests/test_run_benchmarks_enhanced.py` and the three new tests passed.
- Ran the test suite with modified module imports and observed no regressions related to the new validation logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9491d94bc8326ae8cf781e1e1d543)