### PR TITLE
frontend: localize chat message list aria-label

### DIFF
--- a/frontend/app/console/page.test.tsx
+++ b/frontend/app/console/page.test.tsx
@@ -63,7 +63,7 @@ describe("DecisionConsolePage", () => {
       expect(screen.getByText("Rejected reasons")).toBeInTheDocument();
       expect(screen.getByText("Cost-Benefit Analytics")).toBeInTheDocument();
       expect(screen.getByText("Total Token Cost")).toBeInTheDocument();
-      expect(screen.getByRole("list", { name: "chat messages" })).toBeInTheDocument();
+      expect(screen.getByRole("list", { name: "チャットメッセージ一覧" })).toBeInTheDocument();
       expect(screen.getByText("ユーザー")).toBeInTheDocument();
       expect(screen.getByText("アシスタント")).toBeInTheDocument();
     });

--- a/frontend/features/console/components/chat-panel.test.tsx
+++ b/frontend/features/console/components/chat-panel.test.tsx
@@ -3,7 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChatPanel } from "./chat-panel";
 
 const t = (_ja: string, en: string) => en;
-const tk = (key: string) => key;
+const translations: Record<string, string> = {
+  chatMessagesAriaLabel: "Chat messages",
+  messageLabel: "messageLabel",
+  noMessagesYet: "noMessagesYet",
+  send: "send",
+  sending: "sending",
+};
+const tk = (key: string) => translations[key] ?? key;
 
 function renderPanel(overrides: Partial<Parameters<typeof ChatPanel>[0]> = {}) {
   const defaults = {
@@ -39,7 +46,7 @@ describe("ChatPanel", () => {
     });
     expect(screen.getByText("Hello")).toBeInTheDocument();
     expect(screen.getByText("Hi there")).toBeInTheDocument();
-    expect(screen.getByRole("list", { name: "chat messages" })).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Chat messages" })).toBeInTheDocument();
   });
 
   it("strips HTML tags from message content for XSS protection", () => {

--- a/frontend/features/console/components/chat-panel.tsx
+++ b/frontend/features/console/components/chat-panel.tsx
@@ -40,7 +40,7 @@ export function ChatPanel({
       <div className="mb-4 rounded-md border border-border bg-background/60 p-3">
         <p className="mb-2 text-xs font-medium text-muted-foreground">{tk("chatHistory")}</p>
         {chatMessages.length > 0 ? (
-          <ul className="space-y-2" aria-label="chat messages">
+          <ul className="space-y-2" aria-label={tk("chatMessagesAriaLabel")}>
             {chatMessages.map((message) => (
               <li
                 key={message.id}

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -11,6 +11,7 @@ export const en: Record<LocaleKey, string> = {
   schemaMismatch: "Schema mismatch: response is not an object.",
   networkError: "Network error: cannot reach backend.",
   chatHistory: "Chat history",
+  chatMessagesAriaLabel: "Chat messages",
   noMessagesYet: "No messages yet.",
   chatRoleUser: "User",
   chatRoleAssistant: "Assistant",

--- a/frontend/locales/ja.ts
+++ b/frontend/locales/ja.ts
@@ -9,6 +9,7 @@ export const ja = {
   schemaMismatch: "schema不一致: レスポンスがオブジェクトではありません。",
   networkError: "ネットワークエラー: バックエンドへ接続できません。",
   chatHistory: "チャット履歴",
+  chatMessagesAriaLabel: "チャットメッセージ一覧",
   noMessagesYet: "まだメッセージはありません。",
   chatRoleUser: "ユーザー",
   chatRoleAssistant: "アシスタント",


### PR DESCRIPTION
### Motivation
- Improve i18n consistency by removing a hard-coded English `aria-label` in the chat list and making it translatable via the existing locale helpers.
- Make the chat list accessible and localized for both Japanese and English locales by providing an explicitly named locale key instead of an inline string.
- Keep user-facing strings out of component markup to make future localization and automated checks easier.
- Note: this change does not modify CSP or XSS protections; the repository still requires CSP hardening (e.g. removing `unsafe-inline`) as noted in the frontend review.

### Description
- Replaced the hard-coded `aria-label=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95543ef408326b52372e9437f38f5)