### PR TITLE
Add search and pinned prioritization to LiveEventStream

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { I18nProvider } from "./i18n-provider";
@@ -67,10 +67,36 @@ describe("LiveEventStream", () => {
     const pinButton = screen.getAllByRole("button", { name: "pin" })[0];
     fireEvent.click(pinButton);
     expect(screen.getByRole("button", { name: "pinned" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "pinned" })).toHaveAttribute("aria-pressed", "true");
 
     const muteButton = screen.getAllByRole("button", { name: "mute" })[0];
     fireEvent.click(muteButton);
     expect(screen.queryByText("FUJI reject")).not.toBeInTheDocument();
+  });
+
+  it("filters events by search query and keeps pinned event at top", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, body: createPersistentReadableStream() }));
+
+    render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
+
+    await screen.findByText(/Connected|接続済み/);
+
+    const search = screen.getByRole("searchbox", { name: /Search events|イベント検索/ });
+    fireEvent.change(search, { target: { value: "sign-off" } });
+    expect(screen.queryByText("FUJI reject")).not.toBeInTheDocument();
+    expect(screen.getByText("policy update pending")).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "" } });
+    const policyCard = screen.getByText("policy update pending").closest("div.rounded-lg");
+    expect(policyCard).not.toBeNull();
+    fireEvent.click(within(policyCard as HTMLElement).getByRole("button", { name: "pin" }));
+
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", "/governance");
   });
 
   it("appends valid SSE events and keeps clickable route", async () => {

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -167,6 +167,7 @@ export function LiveEventStream(): JSX.Element {
   const [connected, setConnected] = useState(false);
   const [authRecoveryAt, setAuthRecoveryAt] = useState<number | null>(null);
   const [activeFilter, setActiveFilter] = useState<EventFilter>("all");
+  const [searchQuery, setSearchQuery] = useState("");
   const [ackedIds, setAckedIds] = useState<Set<string>>(new Set());
   const [mutedIds, setMutedIds] = useState<Set<string>>(new Set());
   const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set());
@@ -267,11 +268,33 @@ export function LiveEventStream(): JSX.Element {
 
   const filteredEvents = useMemo(() => {
     const withoutMuted = events.filter((event) => !mutedIds.has(event.id));
-    if (activeFilter === "all") {
-      return withoutMuted;
-    }
-    return withoutMuted.filter((event) => event.severity === activeFilter);
-  }, [activeFilter, events, mutedIds]);
+    const severityFiltered = activeFilter === "all"
+      ? withoutMuted
+      : withoutMuted.filter((event) => event.severity === activeFilter);
+
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    const queryFiltered = normalizedQuery.length === 0
+      ? severityFiltered
+      : severityFiltered.filter((event) => {
+        const searchableText = [
+          EVENT_TYPE_LABEL[event.type],
+          event.summary,
+          event.request_id,
+          event.decision_id,
+          event.owner,
+        ].join(" ").toLowerCase();
+        return searchableText.includes(normalizedQuery);
+      });
+
+    return [...queryFiltered].sort((left, right) => {
+      const leftPinned = pinnedIds.has(left.id);
+      const rightPinned = pinnedIds.has(right.id);
+      if (leftPinned === rightPinned) {
+        return 0;
+      }
+      return leftPinned ? -1 : 1;
+    });
+  }, [activeFilter, events, mutedIds, pinnedIds, searchQuery]);
 
   const toggle = (setState: Dispatch<SetStateAction<Set<string>>>, id: string): void => {
     setState((current) => {
@@ -307,6 +330,19 @@ export function LiveEventStream(): JSX.Element {
             </button>
           ))}
         </div>
+      </div>
+      <div className="mb-3">
+        <label className="sr-only" htmlFor="event-search-input">
+          {t("イベント検索", "Search events")}
+        </label>
+        <input
+          id="event-search-input"
+          type="search"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder={t("イベントを検索...", "Search events...")}
+          className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
       </div>
 
       {authRecoveryAt !== null ? (
@@ -366,6 +402,7 @@ export function LiveEventStream(): JSX.Element {
                   <button
                     type="button"
                     onClick={() => toggle(setAckedIds, event.id)}
+                    aria-pressed={isAcked}
                     className="rounded border border-border px-2 py-1"
                   >
                     {isAcked ? "acknowledged" : "acknowledge"}
@@ -380,6 +417,7 @@ export function LiveEventStream(): JSX.Element {
                   <button
                     type="button"
                     onClick={() => toggle(setPinnedIds, event.id)}
+                    aria-pressed={isPinned}
                     className="rounded border border-border px-2 py-1"
                   >
                     {isPinned ? "pinned" : "pin"}


### PR DESCRIPTION
### Motivation
- Improve operator ability to find and surface relevant live events quickly by adding a search box and better ordering for important events.
- Make toggle controls more accessible by exposing pressed state so assistive tech can report acknowledge/pin state.
- Keep behavior localized to the frontend live-event feed without changing responsibility boundaries or external auth flows.

### Description
- Added a `searchQuery` state and an input (`type="search"`) to `LiveEventStream` to allow searching across event type label, summary, `request_id`, `decision_id`, and owner with i18n placeholders and label. (file: `frontend/components/live-event-stream.tsx`)
- Updated event filtering to combine severity filter + search query and to stable-sort results so pinned events are moved to the top while preserving relative order otherwise. (file: `frontend/components/live-event-stream.tsx`)
- Exposed `aria-pressed` on acknowledge and pin controls so their pressed state is accessible to assistive technologies. (file: `frontend/components/live-event-stream.tsx`)
- Extended `live-event-stream` tests to cover search filtering, pinned prioritization, and `aria-pressed` behavior, and added test helpers for interacting with the card-level pin button. (file: `frontend/components/live-event-stream.test.tsx`)
- No backend/API contract changes or new external network flows were introduced.

### Testing
- Ran unit tests with `pnpm --filter frontend test -- live-event-stream.test.tsx`, which completed successfully with all tests passing (`4 passed`).
- Ran linter with `pnpm --filter frontend lint`, which exited with 0 errors and repository pre-existing warnings (10 warnings) unchanged.
- Updated/added tests exercise: search filtering behavior, pinned ordering, button pressed state, and SSE append/linking; all assertions in the changed test file passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95c792eb483269fb30e6a0256eaf4)