### PR TITLE
Harden SSE/WebSocket query API key auth to fail-closed in production

### DIFF
--- a/REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md
+++ b/REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md
@@ -81,3 +81,18 @@
 - `dashboard_server.py` の権限設定失敗ログで、資格情報ファイルパス（`...password...`）を含む可変値を出力しないよう修正。
 - 監査上必要な事象（権限設定失敗）は維持しつつ、ログ上の機微情報露出リスクを低減。
 - 単体テストで「警告ログにパス文字列が含まれないこと」を検証。
+
+### 2026-03-30 追加追記（SSE/WS query API key の本番 fail-closed 強化）
+
+- **実施した改善**
+  - `VERITAS_ALLOW_*_QUERY_API_KEY` と `VERITAS_ACK_*_QUERY_API_KEY_RISK` の2フラグが同時に有効でも、`VERITAS_ENV=prod|production` または `NODE_ENV=production` では **query API key 認証を無効化** するよう変更。
+  - SSE (`/v1/events`) / WebSocket (`/v1/ws/trustlog`) ともに、production runtime ではヘッダ認証（`X-API-Key`）のみ許可する fail-closed 動作へ統一。
+  - 本番で query 有効化フラグが誤設定された場合、セキュリティ警告ログを出力して設定無効化を明示。
+
+- **追加テスト**
+  - SSE: production runtime では dual opt-in フラグ有効時でも query `api_key` を拒否することを単体テストで検証。
+  - WebSocket: production runtime では dual opt-in フラグ有効時でも query `api_key` を拒否することを単体テストで検証。
+
+- **セキュリティ警告（更新）**
+  - 開発/検証環境では query API key 許可フラグを有効化すると、引き続き URL 経由の機密情報露出リスクがある。
+  - 本番環境では fail-closed 化により誤設定耐性を高めたが、運用上は引き続き `X-API-Key` ヘッダ運用を標準とし、query 経路は移行用途に限定すること。

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -47,9 +47,9 @@ Variables prefixed with `VERITAS_` are project-specific.
 | `VERITAS_AUTH_REDIS_URL` | `""` | Redis connection URL when using redis backend |
 | `VERITAS_AUTH_STORE_FAILURE_MODE` | `closed` | `closed` (deny on error) or `open` (allow on error) — **never** use `open` in production |
 | `VERITAS_AUTH_ALLOW_FAIL_OPEN` | `false` | Explicit opt-in to allow fail-open (test environments only) |
-| `VERITAS_ALLOW_SSE_QUERY_API_KEY` | `false` | Permit API key in SSE query parameters (⚠️ security risk) |
+| `VERITAS_ALLOW_SSE_QUERY_API_KEY` | `false` | Permit API key in SSE query parameters (⚠️ security risk, ignored in production profiles) |
 | `VERITAS_ACK_SSE_QUERY_API_KEY_RISK` | `false` | Acknowledgment of SSE query API key risk |
-| `VERITAS_ALLOW_WS_QUERY_API_KEY` | `false` | Permit API key in WebSocket query parameters (⚠️ security risk) |
+| `VERITAS_ALLOW_WS_QUERY_API_KEY` | `false` | Permit API key in WebSocket query parameters (⚠️ security risk, ignored in production profiles) |
 | `VERITAS_ACK_WS_QUERY_API_KEY_RISK` | `false` | Acknowledgment of WebSocket query API key risk |
 | `VERITAS_TRUSTED_PROXIES` | `""` | Comma-separated trusted proxy IPs for X-Forwarded-For handling |
 

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -757,7 +757,24 @@ def require_api_key_header_or_query(
 
 
 def _allow_sse_query_api_key() -> bool:
-    """Return True only when dual opt-in flags enable SSE query auth."""
+    """Return True only when dual opt-in flags enable SSE query auth.
+
+    Security note:
+        Query-string credentials are blocked in production profiles even when
+        migration flags are set. This keeps production authentication
+        fail-closed and limits accidental credential leakage via URLs.
+    """
+    if _is_production_runtime():
+        if _is_query_api_key_flag_requested(
+            allow_key="VERITAS_ALLOW_SSE_QUERY_API_KEY",
+            ack_key="VERITAS_ACK_SSE_QUERY_API_KEY_RISK",
+        ):
+            logger.warning(
+                "[security-warning] SSE query api_key flags were ignored in production runtime. "
+                "Use X-API-Key header authentication.",
+            )
+        return False
+
     allow_raw = (os.getenv("VERITAS_ALLOW_SSE_QUERY_API_KEY") or "").strip().lower()
     allow_query_auth = allow_raw in {"1", "true", "yes", "on"}
     if not allow_query_auth:
@@ -800,7 +817,24 @@ def _authenticate_websocket_api_key(websocket: WebSocket) -> bool:
 
 
 def _allow_ws_query_api_key() -> bool:
-    """Return True only when dual opt-in flags allow WebSocket query auth."""
+    """Return True only when dual opt-in flags allow WebSocket query auth.
+
+    Security note:
+        Query-string credentials are blocked in production profiles even when
+        migration flags are set. This keeps production authentication
+        fail-closed and limits accidental credential leakage via URLs.
+    """
+    if _is_production_runtime():
+        if _is_query_api_key_flag_requested(
+            allow_key="VERITAS_ALLOW_WS_QUERY_API_KEY",
+            ack_key="VERITAS_ACK_WS_QUERY_API_KEY_RISK",
+        ):
+            logger.warning(
+                "[security-warning] WebSocket query api_key flags were ignored in production runtime. "
+                "Use X-API-Key header authentication.",
+            )
+        return False
+
     allow_raw = (os.getenv("VERITAS_ALLOW_WS_QUERY_API_KEY") or "").strip().lower()
     allow_query_auth = allow_raw in {"1", "true", "yes", "on"}
     if not allow_query_auth:
@@ -817,6 +851,21 @@ def _allow_ws_query_api_key() -> bool:
         return False
 
     return True
+
+
+def _is_production_runtime() -> bool:
+    """Return True when environment indicates a production runtime profile."""
+    profile = (os.getenv("VERITAS_ENV") or "").strip().lower()
+    node_env = (os.getenv("NODE_ENV") or "").strip().lower()
+    return profile in {"prod", "production"} or node_env == "production"
+
+
+def _is_query_api_key_flag_requested(*, allow_key: str, ack_key: str) -> bool:
+    """Return True when both query-auth opt-in flags are explicitly enabled."""
+    truthy_values = {"1", "true", "yes", "on"}
+    allow_raw = (os.getenv(allow_key) or "").strip().lower()
+    ack_raw = (os.getenv(ack_key) or "").strip().lower()
+    return allow_raw in truthy_values and ack_raw in truthy_values
 
 
 # ---- HMAC signature / replay (optional) ----

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -1810,6 +1810,20 @@ def test_events_accepts_query_api_key_only_when_dual_flags_enabled(monkeypatch):
     ) is True
 
 
+def test_events_rejects_query_api_key_in_production_even_with_dual_flags(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "1")
+    monkeypatch.setenv("VERITAS_ACK_SSE_QUERY_API_KEY_RISK", "true")
+    monkeypatch.setenv("VERITAS_ENV", "production")
+
+    with pytest.raises(HTTPException) as exc:
+        server.require_api_key_header_or_query(
+            x_api_key=None,
+            api_key=_TEST_API_KEY,
+        )
+    assert exc.value.status_code == 401
+
+
 def test_events_rejects_query_api_key_without_risk_ack(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
     monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "1")
@@ -1858,6 +1872,22 @@ def test_websocket_auth_accepts_query_api_key_only_when_dual_flags_enabled(monke
     )
 
     assert server._authenticate_websocket_api_key(ws) is True
+
+
+def test_websocket_auth_rejects_query_api_key_in_production_even_with_dual_flags(
+    monkeypatch,
+):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_ALLOW_WS_QUERY_API_KEY", "1")
+    monkeypatch.setenv("VERITAS_ACK_WS_QUERY_API_KEY_RISK", "true")
+    monkeypatch.setenv("NODE_ENV", "production")
+
+    ws = SimpleNamespace(
+        headers={},
+        query_params={"api_key": _TEST_API_KEY},
+    )
+
+    assert server._authenticate_websocket_api_key(ws) is False
 
 
 def test_websocket_auth_rejects_query_api_key_without_risk_ack(monkeypatch):


### PR DESCRIPTION
### Motivation

- Prevent accidental credential leakage by disallowing `api_key` in URL query parameters for SSE and WebSocket in production runtime profiles. 
- Ensure production deployments are fail-closed even if migration opt-in flags are mis-set, and surface clear warnings when such flags are present in production. 

### Description

- In `veritas_os/api/auth.py` added `_is_production_runtime()` and `_is_query_api_key_flag_requested()` and modified `_allow_sse_query_api_key()` and `_allow_ws_query_api_key()` to return `False` in production and emit security-warning logs when dual opt-in flags are present. 
- Kept existing dual-flag opt-in behavior for non-production environments so migration/testing flexibility remains. 
- Added unit tests in `veritas_os/tests/unit/test_server_api.py` to assert that query `api_key` is rejected in production even when both opt-in flags are set. 
- Updated documentation in `docs/env-reference.md` and the improvement tracker `REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md` to note that query API key flags are ignored in production profiles. 

### Testing

- Ran targeted tests: `pytest -q veritas_os/tests/unit/test_server_api.py -k "production_even_with_dual_flags or accepts_query_api_key_only_when_dual_flags_enabled or websocket_auth_accepts_query_api_key_only_when_dual_flags_enabled"` with result `4 passed, 302 deselected`. 
- Ran `ruff check veritas_os/api/auth.py veritas_os/tests/unit/test_server_api.py`, which reported pre-existing lint/style issues in `veritas_os/tests/unit/test_server_api.py` unrelated to this change; the new logic was kept concise and documented. 
- Unit tests added verify SSE and WebSocket behavior in production and non-production contexts and passed as shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca0eda01ec8326b37f00c6d62bff4a)