### PR TITLE
Add improvement theme classification to responsibility boundary reports

### DIFF
--- a/REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md
+++ b/REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md
@@ -127,3 +127,21 @@
 - **セキュリティ警告（継続）**
   - `NODE_ENV=production` 警告状態を放置すると、`script-src 'unsafe-inline'` 互換モードが残る可能性があり、XSS リスクが高止まりする。
   - 本番判定は必ず `VERITAS_ENV=production` を明示し、段階移行完了後は `VERITAS_CSP_ALLOW_UNSAFE_INLINE_COMPAT` を未設定に固定すること。
+
+### 2026-03-30 追加追記（責務境界チェックの改善テーマ自動マッピング）
+
+- **実施した改善**
+  - `scripts/architecture/check_responsibility_boundaries.py` の JSON レポートに `improvement_theme` を追加し、責務境界違反を PR 単位で扱いやすいテーマへ自動分類するようにした。
+  - 分類ルール:
+    - `boundary_violation` は原則 `architecture`。
+    - ただし `fuji` / `memory` の責務境界違反は安全性影響を重視して `security` に昇格。
+    - `permission_denied` は `security`、`doc_alignment_error` / `input_invalid` は `operations`。
+  - これにより、既存の責務境界 CI 結果を「セキュリティ・運用・アーキテクチャ」テーマに接続しやすくした。
+
+- **追加テスト**
+  - machine report に `improvement_theme` が出力されることを検証。
+  - `fuji` / `memory` の責務境界違反が `security` に分類されることを単体テストで検証。
+
+- **セキュリティ警告（継続）**
+  - 本改善は triage 導線の強化であり、実際の責務境界違反を無害化するものではない。
+  - `fuji` / `memory` の違反検知時は、従来どおりリリースブロック相当で扱い、根本修正を優先すること。

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -43,6 +43,23 @@ class BoundaryIssue:
     forbidden_module: str | None = None
 
 
+THEME_BY_ISSUE_CODE: dict[str, str] = {
+    "boundary_violation": "architecture",
+    "doc_alignment_error": "operations",
+    "input_invalid": "operations",
+    "permission_denied": "security",
+}
+
+
+def classify_issue_theme(issue: BoundaryIssue) -> str:
+    """Classify boundary issues into improvement themes for PR-level triage."""
+    if issue.code == "boundary_violation":
+        if issue.source_module in {"fuji", "memory"}:
+            return "security"
+        return "architecture"
+    return THEME_BY_ISSUE_CODE.get(issue.code, "operations")
+
+
 @dataclass(frozen=True)
 class DocAlignmentIssue:
     """Structured mismatch between the checker config and architecture docs."""
@@ -473,6 +490,7 @@ def build_machine_report(issues: Iterable[BoundaryIssue]) -> str:
                 "forbidden_module": issue.forbidden_module,
                 "path": str(issue.path),
                 "message": issue.message,
+                "improvement_theme": classify_issue_theme(issue),
                 "allowed_dependencies": list(
                     ALLOWED_DEPENDENCY_GUIDE.get(issue.source_module, ())
                 ),

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -14,6 +14,7 @@ from scripts.architecture.check_responsibility_boundaries import (
     build_machine_report,
     build_remediation_guide,
     check_boundaries,
+    classify_issue_theme,
     collect_boundary_issues,
     collect_doc_alignment_issues,
     collect_module_docstring_issues,
@@ -541,6 +542,8 @@ def test_build_machine_report_counts_by_code(tmp_path: Path) -> None:
     assert report["summary"]["permission_denied"] == 1
     assert report["summary"]["input_invalid"] == 0
     assert report["summary"]["doc_alignment_error"] == 0
+    assert report["issues"][0]["improvement_theme"] == "architecture"
+    assert report["issues"][1]["improvement_theme"] == "security"
     assert report["issues"][0]["allowed_dependencies"] == [
         "veritas_os.core.memory",
         "veritas_os.core.world",
@@ -949,3 +952,24 @@ def test_check_boundaries_includes_doc_alignment_issues(tmp_path: Path) -> None:
     issues = check_boundaries(core_dir=tmp_path, doc_path=doc_path)
 
     assert any("Preferred extension points out of sync" in issue for issue in issues)
+
+
+def test_classify_issue_theme_promotes_fuji_and_memory_violations_to_security() -> None:
+    """Fuji/Memory boundary breaks should map to security triage theme."""
+    fuji_issue = BoundaryIssue(
+        code="boundary_violation",
+        message="violation",
+        path=Path("veritas_os/core/fuji.py"),
+        source_module="fuji",
+        forbidden_module="kernel",
+    )
+    memory_issue = BoundaryIssue(
+        code="boundary_violation",
+        message="violation",
+        path=Path("veritas_os/core/memory.py"),
+        source_module="memory",
+        forbidden_module="planner",
+    )
+
+    assert classify_issue_theme(fuji_issue) == "security"
+    assert classify_issue_theme(memory_issue) == "security"


### PR DESCRIPTION
### Motivation

- Make CI responsibility-boundary findings easier to triage by mapping issues to PR-level improvement themes such as `architecture`, `security`, and `operations`. 
- Emphasize higher-risk violations originating from `fuji` and `memory` by surfacing them as `security` issues for prioritization. 
- Record the change in the project improvement log to keep operational guidance and tests in sync.

### Description

- Added `THEME_BY_ISSUE_CODE` and `classify_issue_theme()` in `scripts/architecture/check_responsibility_boundaries.py` to classify `BoundaryIssue` objects into improvement themes. 
- Added `improvement_theme` to the machine JSON report emitted by `build_machine_report()` so CI consumers can map findings to triage categories. 
- Updated unit tests in `veritas_os/tests/test_responsibility_boundary_checker.py` to validate `improvement_theme` presence and that `fuji`/`memory` boundary violations are classified as `security`. 
- Appended an entry to `REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md` describing the change, tests added, and the continued security guidance.

### Testing

- Ran `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py` and all tests passed (`30 passed`). 
- New tests assert `improvement_theme` appears in the machine report and that `fuji`/`memory` violations map to `security` (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca266205888326a109b5429aa18791)