### PR TITLE
frontend: add CSP Report-Only endpoint default and safety warnings

### DIFF
--- a/REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md
+++ b/REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md
@@ -176,4 +176,21 @@
 
 - **セキュリティ警告（継続）**
   - 本改善は「可視化と運用統制」の強化であり、実装上の脆弱性を直接緩和するものではない。
-  - query `api_key` や CSP 互換モードの例外運用が残る場合、必ず期限付きで追跡し、解除完了までリスク受容を明示すること。
+- query `api_key` や CSP 互換モードの例外運用が残る場合、必ず期限付きで追跡し、解除完了までリスク受容を明示すること。
+
+### 2026-03-30 追加追記（CSP Report-Only 違反収集のコード内既定化）
+
+- **実施した改善**
+  - frontend middleware の `Content-Security-Policy-Report-Only` に `report-uri` を追加し、違反収集先をコード上で既定化。
+  - 既定値は同一オリジンの `/api/veritas/csp-report` とし、`VERITAS_CSP_REPORT_ONLY_ENDPOINT` で明示上書き可能にした。
+  - `VERITAS_CSP_REPORT_ONLY_ENDPOINT` が同一オリジン相対パス（`/` 始まり）でない場合にセキュリティ警告ログを出すガードを追加し、外部 collector への誤送信リスクを可視化。
+
+- **追加テスト**
+  - Report-Only CSP に既定 `report-uri /api/veritas/csp-report` が含まれることを単体テストで検証。
+  - `VERITAS_CSP_REPORT_ONLY_ENDPOINT` 指定時に `report-uri` が上書きされることを単体テストで検証。
+  - report endpoint 警告ヘルパーが「未指定/相対パスは警告なし、絶対URLは警告あり」を返すことを単体テストで検証。
+  - 絶対URL指定時に middleware がセキュリティ警告を出力することを単体テストで検証。
+
+- **セキュリティ警告（更新）**
+  - CSP 違反レポートは URL 断片やユーザー操作由来の情報を含み得るため、`VERITAS_CSP_REPORT_ONLY_ENDPOINT` の外部送信先設定はデータ取扱い承認を前提にすること。
+  - 既定の同一オリジン収集先（`/api/veritas/csp-report`）を維持し、外部 collector は期限付き・目的限定で運用すること。

--- a/frontend/middleware.test.ts
+++ b/frontend/middleware.test.ts
@@ -5,6 +5,8 @@ import {
   buildCspReportOnly,
   generateNonce,
   middleware,
+  resolveCspReportOnlyEndpoint,
+  shouldWarnInsecureCspReportOnlyEndpoint,
   shouldEnforceNonceCsp,
   shouldWarnInsecureProductionCspConfig,
 } from "./middleware";
@@ -49,6 +51,16 @@ describe("middleware CSP", () => {
     expect(csp).toContain("default-src 'self'");
     expect(scriptDirective).toContain("'nonce-sample-nonce'");
     expect(scriptDirective).not.toContain("'unsafe-inline'");
+    expect(csp).toContain("report-uri /api/veritas/csp-report");
+  });
+
+  it("uses configured report-only endpoint when explicitly provided", () => {
+    vi.stubEnv("VERITAS_CSP_REPORT_ONLY_ENDPOINT", "/security/csp-report");
+
+    expect(resolveCspReportOnlyEndpoint()).toBe("/security/csp-report");
+    expect(buildCspReportOnly("sample-nonce")).toContain(
+      "report-uri /security/csp-report",
+    );
   });
 
   it("defaults nonce enforcement flag to false in non-production profile", () => {
@@ -106,6 +118,22 @@ describe("middleware CSP", () => {
     expect(shouldWarnInsecureProductionCspConfig()).toBe(true);
   });
 
+  it("warn helper returns false for unset report-only endpoint override", () => {
+    expect(shouldWarnInsecureCspReportOnlyEndpoint()).toBe(false);
+  });
+
+  it("warn helper returns false for same-origin report-only endpoint override", () => {
+    vi.stubEnv("VERITAS_CSP_REPORT_ONLY_ENDPOINT", "/security/csp-report");
+
+    expect(shouldWarnInsecureCspReportOnlyEndpoint()).toBe(false);
+  });
+
+  it("warn helper returns true for cross-origin report-only endpoint override", () => {
+    vi.stubEnv("VERITAS_CSP_REPORT_ONLY_ENDPOINT", "https://collector.example/csp");
+
+    expect(shouldWarnInsecureCspReportOnlyEndpoint()).toBe(true);
+  });
+
   it("sets CSP headers and forwards nonce to the Next.js request", () => {
     const response = middleware({ headers: new Headers() } as never);
     const csp = response.headers.get("Content-Security-Policy") ?? "";
@@ -152,5 +180,16 @@ describe("middleware CSP", () => {
     middleware({ headers: new Headers() } as never);
 
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits warning when report-only endpoint is cross-origin", () => {
+    vi.stubEnv("VERITAS_CSP_REPORT_ONLY_ENDPOINT", "https://collector.example/csp");
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    middleware({ headers: new Headers() } as never);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 const NONCE_BYTES = 16;
 const ENFORCE_NONCE_ENV = "VERITAS_CSP_ENFORCE_NONCE";
 const ALLOW_UNSAFE_INLINE_COMPAT_ENV = "VERITAS_CSP_ALLOW_UNSAFE_INLINE_COMPAT";
+const REPORT_ONLY_ENDPOINT_ENV = "VERITAS_CSP_REPORT_ONLY_ENDPOINT";
 
 /**
  * Generates a CSP nonce for the current response.
@@ -67,6 +68,21 @@ export function shouldWarnInsecureProductionCspConfig(): boolean {
 }
 
 /**
+ * Returns whether report-only CSP endpoint config is security-risky.
+ *
+ * Warns when:
+ * - `VERITAS_CSP_REPORT_ONLY_ENDPOINT` is configured, and
+ * - the configured endpoint is not a same-origin relative path.
+ */
+export function shouldWarnInsecureCspReportOnlyEndpoint(): boolean {
+  const configuredEndpoint = (process.env[REPORT_ONLY_ENDPOINT_ENV] ?? "").trim();
+  if (!configuredEndpoint) {
+    return false;
+  }
+  return !configuredEndpoint.startsWith("/");
+}
+
+/**
  * Builds an enforced CSP policy string.
  *
  * Compatibility mode keeps `unsafe-inline` for scripts to avoid blocking
@@ -98,6 +114,8 @@ export function buildCspEnforced(nonce: string, enforceNonce: boolean): string {
  * Builds a strict report-only CSP policy string bound to a nonce.
  */
 export function buildCspReportOnly(nonce: string): string {
+  const reportOnlyEndpoint = resolveCspReportOnlyEndpoint();
+
   return [
     "default-src 'self'",
     "base-uri 'self'",
@@ -109,9 +127,28 @@ export function buildCspReportOnly(nonce: string): string {
     "font-src 'self' data:",
     "connect-src 'self'",
     "form-action 'self'",
+    `report-uri ${reportOnlyEndpoint}`,
     "upgrade-insecure-requests",
     "block-all-mixed-content",
   ].join("; ");
+}
+
+/**
+ * Resolves the CSP report-only collection endpoint.
+ *
+ * Security behavior:
+ * - Defaults to same-origin `/api/veritas/csp-report` to keep violation reports
+ *   within the BFF boundary.
+ * - Allows explicit override through `VERITAS_CSP_REPORT_ONLY_ENDPOINT`.
+ * - Falls back to the safe default when the override is empty.
+ */
+export function resolveCspReportOnlyEndpoint(): string {
+  const configuredEndpoint = process.env[REPORT_ONLY_ENDPOINT_ENV] ?? "";
+  const normalizedEndpoint = configuredEndpoint.trim();
+  if (normalizedEndpoint) {
+    return normalizedEndpoint;
+  }
+  return "/api/veritas/csp-report";
 }
 
 /**
@@ -142,6 +179,13 @@ export function middleware(request: NextRequest): NextResponse {
       "[security-warning] CSP strict nonce rollout is not fully enforced for this production runtime. " +
         "Unset VERITAS_CSP_ALLOW_UNSAFE_INLINE_COMPAT and set VERITAS_ENV=production " +
         "(or VERITAS_CSP_ENFORCE_NONCE=true) after compatibility validation.",
+    );
+  }
+  if (shouldWarnInsecureCspReportOnlyEndpoint()) {
+    console.warn(
+      "[security-warning] VERITAS_CSP_REPORT_ONLY_ENDPOINT is not a same-origin relative path. " +
+        "External CSP report collectors may leak URL metadata and should be used only with explicit " +
+        "data handling approval.",
     );
   }
 


### PR DESCRIPTION
### Motivation
- Codify a safe default for CSP violation collection to avoid ad-hoc external collectors and accidental leakage of URL/metadata.  
- Provide an opt-in override while surfacing misconfiguration risk when an external (non-same-origin) collector is configured.  
- Improve observability and safe rollout of CSP migration by making the report-only sink explicit in-code and covered by tests.

### Description
- Added `VERITAS_CSP_REPORT_ONLY_ENDPOINT` support and a resolver helper `resolveCspReportOnlyEndpoint()` with a same-origin default of `/api/veritas/csp-report`.  
- Included `report-uri <endpoint>` in `buildCspReportOnly()` and added `shouldWarnInsecureCspReportOnlyEndpoint()` plus a runtime `console.warn` in `middleware()` when the override is a non-relative (cross-origin) URL.  
- Added unit tests in `frontend/middleware.test.ts` to verify the default `report-uri`, override behavior, the warning helper logic, and that the middleware emits a warning for cross-origin endpoints, and appended the change summary and test notes to `REVIEW_CURRENT_IMPROVEMENTS_2026-03-30.md`.

### Testing
- Ran unit tests with `pnpm --filter frontend test -- middleware.test.ts` and all tests passed (`middleware.test.ts` — 20 tests passed).  
- Ran linter with `pnpm --filter frontend lint`, which completed successfully (exit code 0) with unrelated pre-existing warnings.  
- Confirmed the new tests exercise default and override behaviors and that middleware emits the expected warning when configured with a cross-origin `VERITAS_CSP_REPORT_ONLY_ENDPOINT`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca31de6dfc8326b6178145a697168c)