### PR TITLE
Add frontend/backend consistency review document (2026-03-30)

### DIFF
--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -1,0 +1,99 @@
+# フロントエンド / バックエンド整合性 精密レビュー（2026-03-30）
+
+## 1. 対象と観点
+
+- 対象: `frontend/` の BFF 経由 API 利用、`veritas_os/api` の実ランタイムルート、`openapi.yaml` の公開契約。
+- 観点:
+  1. フロントエンド呼び出し経路と BFF 許可行列の整合。
+  2. BFF 許可行列と FastAPI 実装ルートの整合。
+  3. FastAPI 実装ルートと OpenAPI 契約の整合。
+  4. セキュリティ上の不整合・運用上の警戒点。
+- 制約確認: Planner / Kernel / Fuji / MemoryOS の責務境界を跨ぐ実装変更は行わず、レビューのみ実施。
+
+## 2. レビュー手法（実施コマンド）
+
+- `python` で `frontend` から `/api/veritas/v1/*` 呼び出し箇所を抽出。
+- `python` で `veritas_os.api.server.app.routes` から実ルートを抽出。
+- `python` で `openapi.yaml` の `paths` を突合。
+- 既存回帰テスト `veritas_os/tests/test_openapi_spec.py` を実行。
+
+## 3. 整合性判定サマリ
+
+### 3.1 フロントエンド呼び出し経路
+
+主要な UI 側 API 利用は以下で確認:
+
+- `/api/veritas/v1/decide`
+- `/api/veritas/v1/events`
+- `/api/veritas/v1/compliance/config`
+- `/api/veritas/v1/governance/policy`
+- `/api/veritas/v1/trust/logs`
+- `/api/veritas/v1/trust/{request_id}`（動的）
+
+結論: 現在の主要画面（Console / Governance / Audit）で利用している経路は、BFF の許可行列と矛盾しない。
+
+### 3.2 BFF 許可行列 vs バックエンド実装
+
+- `route-auth.ts` の `ROUTE_POLICIES` は、`/v1/decide`, `/v1/events`, `/v1/governance/policy`, `/v1/trust/*`, `/v1/compliance/config` などの UI 主要経路をカバー。
+- FastAPI 実装側も同系統ルートを提供しており、経路名レベルで重大なズレは見当たらない。
+
+結論: **フロントで使う API の到達可能性は概ね整合**。
+
+### 3.3 OpenAPI 契約 vs 実装
+
+`test_openapi_spec.py` が担保している critical route（governance/trust/prov）の整合は維持されている。
+
+- `/v1/governance/policy`
+- `/v1/governance/policy/history`
+- `/v1/trustlog/verify`
+- `/v1/trust/{request_id}/prov`
+
+結論: **公開契約（OpenAPI）と実装の最重要経路は整合**。
+
+## 4. 精密レビューでの重要指摘
+
+## 指摘A（中）: provenance 経路の BFF 非公開ギャップ
+
+- バックエンドには `/v1/trust/{request_id}/prov` が実装・OpenAPI 定義されている一方、BFF 許可行列には同経路がない。
+- そのため、ブラウザ UI から provenance を直接取得する設計へ拡張する場合、現状のままでは到達不可。
+
+推奨:
+
+- Audit UI で provenance 詳細を扱う計画がある場合のみ、BFF に **限定公開（viewer 以上）** を追加検討。
+- 追加時は request_id の検証とレスポンス最小化を併せて実施。
+
+## 指摘B（中）: EventSource 運用依存（認証）
+
+- `/v1/events` は `EventSource` 利用で取得しており、ブラウザ仕様上カスタムヘッダを乗せない。
+- 現設計は `httpOnly` cookie 前提で妥当だが、同一オリジン/クッキー運用の逸脱時に接続失敗しやすい。
+
+推奨:
+
+- 本番運用 Runbook へ「`__veritas_bff` cookie 前提」の明文化を固定化。
+- 401/403 の際は UI 側で再接続ループを抑制する観測を継続。
+
+## 指摘C（低）: OpenAPI 回帰の検証範囲
+
+- 既存テストは critical paths を堅く押さえているが、フロントが常用する全経路の網羅チェックまでは実施していない。
+
+推奨:
+
+- 将来的に `frontend` 使用経路（静的抽出）と OpenAPI/BFF を自動突合する軽量チェック追加を検討。
+
+## 5. セキュリティ警告（必読）
+
+1. **BFF に provenance 経路を追加する場合は過剰露出リスク**に注意。
+   - 監査情報は内部メタデータを含む可能性があるため、role と出力項目を最小権限で設計すること。
+2. **SSE (`/v1/events`) は cookie 認証依存**のため、Cookie 設定不備があると認可失敗や監視欠落につながる。
+3. **BFF 非公開エンドポイント（`/v1/replay/*`, `/v1/decision/replay/*`, `/v1/ws/trustlog`）を UI から迂回呼び出ししないこと。**
+   - 署名・鍵管理・内部用途前提の境界を崩すと重大なセキュリティ事故につながる。
+
+## 6. 総合評価
+
+- 判定: **整合性は高い（High）**
+- 理由:
+  - 現行 UI の主要 API は BFF / FastAPI / OpenAPI の3層で一致。
+  - 認証境界は BFF allowlist で明示され、危険経路は意図的に除外されている。
+- 継続課題:
+  - provenance の UI 展開計画がある場合の BFF 公開方針を明文化。
+  - OpenAPI 契約検証を「critical path 以外」に段階拡張。


### PR DESCRIPTION
### Motivation

- Provide a precise cross-check of frontend BFF usage, backend runtime routes, and the public `openapi.yaml` contract to detect UI reachability and security gaps. 
- Surface actionable discrepancies and operational risks (notably a BFF non-exposure of the provenance route and SSE authentication assumptions) without changing runtime responsibilities. 
- Keep the change documentation-only to avoid touching Planner / Kernel / Fuji / MemoryOS responsibilities.

### Description

- Add a new review document `docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md` containing scope, methods, findings, security warnings, and recommendations. 
- The review describes the static extraction and cross-check technique used (frontend literal scan, `veritas_os.api.server.app.routes` inspection, and `openapi.yaml` path comparison). 
- Key findings called out include the BFF omission of `/v1/trust/{request_id}/prov`, the SSE (`/v1/events`) cookie-auth dependency, and a recommendation to expand OpenAPI regression coverage for frontend-used routes. 
- No application code or responsibility-boundary changes were made; this is documentation only.

### Testing

- Ran the automated OpenAPI regression test `pytest -q veritas_os/tests/test_openapi_spec.py`, which completed successfully with `4 passed`.
- Static validation scripts used during the review confirmed frontend literals and runtime routes were consistent with the documented findings (manual validation, not part of CI tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca3f31adf88326b506c6603b9223b9)