### PR TITLE
Improve frontend/BFF/OpenAPI drift detection for direct `fetch` and variable URL patterns

### DIFF
--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -112,3 +112,17 @@
 セキュリティ補足:
 - 本改善は「未許可経路の BFF 露出」を防ぐ監視強化であり、BFF 境界を緩める変更は含まない。
 - なお provenance 経路（`/v1/trust/{request_id}/prov`）を今後 BFF 公開する場合は、引き続き最小権限・最小レスポンス原則を必須とする。
+
+### 7.1 2026-03-30 追加改善（この依頼で実施）
+
+上記の自動突合チェックに対し、実運用で使われる `fetch(...)` の抽出漏れを最小範囲で補強した。
+
+- `scripts/quality/check_frontend_api_contract_consistency.py`
+  - `veritasFetch` / `EventSource` に加えて、`fetch("/api/veritas/v1/...")` の直接呼び出しを抽出対象に追加。
+  - `const streamUrl = "/api/veritas/v1/events"` のような **定数経由の URL 参照** を `fetch(streamUrl)` / `veritasFetch(streamUrl)` / `EventSource(streamUrl)` で解決できるよう改善。
+- `veritas_os/tests/test_frontend_api_contract_consistency.py`
+  - 直接 `fetch` と定数経由 URL の両方を検証するテストを追加し、回帰を防止。
+
+セキュリティ補足:
+- 本変更は検出精度の向上のみであり、BFF の許可境界や認可ロジック自体は変更していない。
+- したがって、権限昇格・経路露出の新規リスクは増やしていない（監視の見落としリスクを低減）。

--- a/scripts/quality/check_frontend_api_contract_consistency.py
+++ b/scripts/quality/check_frontend_api_contract_consistency.py
@@ -31,8 +31,21 @@ VERITAS_FETCH_CALL_PATTERN = re.compile(
     r"veritasFetch\(\s*([\"'`])(?P<path>/api/veritas/v1/[^\"'`]+)\1(?P<tail>[^\)]*)\)",
     re.DOTALL,
 )
+FETCH_CALL_PATTERN = re.compile(
+    r"fetch\(\s*([\"'`])(?P<path>/api/veritas/v1/[^\"'`]+)\1(?P<tail>[^\)]*)\)",
+    re.DOTALL,
+)
 EVENTSOURCE_CALL_PATTERN = re.compile(
     r"EventSource\(\s*([\"'`])(?P<path>/api/veritas/v1/[^\"'`]+)\1",
+)
+IDENTIFIER_CALL_PATTERN = re.compile(
+    r"(?P<fn>veritasFetch|fetch|EventSource)\(\s*(?P<var>[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?P<tail>[^\)]*)\)",
+    re.DOTALL,
+)
+PATH_VARIABLE_PATTERN = re.compile(
+    r"(?:const|let|var)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"([\"'`])(?P<path>/api/veritas/v1/[^\"'`]+)\2"
 )
 METHOD_PATTERN = re.compile(r'method\s*:\s*[\"\'](?P<method>GET|POST|PUT|PATCH|DELETE)[\"\']')
 ROUTE_POLICY_PATTERN = re.compile(
@@ -80,8 +93,23 @@ def collect_frontend_usages() -> list[FrontendRouteUsage]:
                 continue
 
             content = file_path.read_text(encoding="utf-8")
+            path_variables = {
+                match.group("name"): match.group("path")
+                for match in PATH_VARIABLE_PATTERN.finditer(content)
+            }
 
             for match in VERITAS_FETCH_CALL_PATTERN.finditer(content):
+                method_match = METHOD_PATTERN.search(match.group("tail"))
+                method = method_match.group("method") if method_match else "GET"
+                usages.append(
+                    FrontendRouteUsage(
+                        method=method,
+                        raw_path=match.group("path"),
+                        file_path=file_path,
+                    )
+                )
+
+            for match in FETCH_CALL_PATTERN.finditer(content):
                 method_match = METHOD_PATTERN.search(match.group("tail"))
                 method = method_match.group("method") if method_match else "GET"
                 usages.append(
@@ -97,6 +125,23 @@ def collect_frontend_usages() -> list[FrontendRouteUsage]:
                     FrontendRouteUsage(
                         method="GET",
                         raw_path=match.group("path"),
+                        file_path=file_path,
+                    )
+                )
+
+            for match in IDENTIFIER_CALL_PATTERN.finditer(content):
+                path = path_variables.get(match.group("var"))
+                if not path:
+                    continue
+                if match.group("fn") == "EventSource":
+                    method = "GET"
+                else:
+                    method_match = METHOD_PATTERN.search(match.group("tail"))
+                    method = method_match.group("method") if method_match else "GET"
+                usages.append(
+                    FrontendRouteUsage(
+                        method=method,
+                        raw_path=path,
                         file_path=file_path,
                     )
                 )
@@ -150,15 +195,13 @@ def load_openapi_route_matchers() -> list[RouteMatcher]:
 
     return matchers
 
-
-
-
 def _display_source_path(file_path: pathlib.Path) -> str:
     """Return repo-relative source path when possible, else keep original string."""
     try:
         return str(file_path.relative_to(REPO_ROOT))
     except ValueError:
         return str(file_path)
+
 
 def _matches_any(path: str, method: str, matchers: list[RouteMatcher]) -> bool:
     """Return True if any matcher supports the given method/path combination."""

--- a/veritas_os/tests/test_frontend_api_contract_consistency.py
+++ b/veritas_os/tests/test_frontend_api_contract_consistency.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import textwrap
 
 from scripts.quality import check_frontend_api_contract_consistency as checker
 
@@ -51,3 +52,37 @@ def test_validate_consistency_reports_missing_bff_and_openapi() -> None:
     assert len(errors) == 2
     assert "BFF allowlist missing GET /v1/trust/abc/prov" in errors[0]
     assert "OpenAPI path/method missing GET /v1/trust/abc/prov" in errors[1]
+
+
+def test_collect_frontend_usages_extracts_fetch_and_variable_path(tmp_path: pathlib.Path) -> None:
+    """Collector should detect fetch() calls with literal and variable paths."""
+    frontend_root = tmp_path / "frontend"
+    source_file = frontend_root / "app" / "sample.tsx"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        textwrap.dedent(
+            """
+            const streamUrl = "/api/veritas/v1/events";
+            const trustUrl = "/api/veritas/v1/trust/logs";
+
+            async function load() {
+              await fetch(streamUrl, { method: "GET" });
+              await fetch("/api/veritas/v1/metrics", { method: "GET" });
+              await veritasFetch(trustUrl);
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    original_frontend_root = checker.FRONTEND_ROOT
+    checker.FRONTEND_ROOT = frontend_root
+    try:
+        usages = checker.collect_frontend_usages()
+    finally:
+        checker.FRONTEND_ROOT = original_frontend_root
+
+    found = {(usage.method, usage.raw_path) for usage in usages}
+    assert ("GET", "/api/veritas/v1/events") in found
+    assert ("GET", "/api/veritas/v1/metrics") in found
+    assert ("GET", "/api/veritas/v1/trust/logs") in found


### PR DESCRIPTION
### Motivation
- The existing frontend/OpenAPI/BFF consistency checker missed some real usages when the frontend called `fetch(...)` directly or passed the URL via a local constant, creating blind spots in drift detection (address review item C). 
- The change aims to improve static-detection coverage only, avoiding any runtime or authorization surface changes and keeping responsibilities within the quality tooling scope.

### Description
- Enhanced `scripts/quality/check_frontend_api_contract_consistency.py` to detect direct `fetch("/api/veritas/v1/...")` calls and to resolve constant/variable URL assignments via added regexes (`FETCH_CALL_PATTERN`, `IDENTIFIER_CALL_PATTERN`, `PATH_VARIABLE_PATTERN`) and logic in `collect_frontend_usages()`.
- Added a unit test `veritas_os/tests/test_frontend_api_contract_consistency.py::test_collect_frontend_usages_extracts_fetch_and_variable_path` to cover direct `fetch` and variable-based URL usage patterns.
- Appended the review document `docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md` with a short note describing the focused improvement and its security impact.
- Code changes adhere to the repository standards (PEP8 style for Python) and only affect static analysis and tests.

### Testing
- Executed `python scripts/quality/check_frontend_api_contract_consistency.py`, which printed a success message: "Frontend/BFF/OpenAPI consistency checks passed." and exited normally.
- Ran unit tests with `pytest -q veritas_os/tests/test_frontend_api_contract_consistency.py`, which succeeded with `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca4a1c8fb08326b7f7b4bb50e341ba)