### PR TITLE
Resolve static URL alias chains in frontend API contract checker

### DIFF
--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -126,3 +126,17 @@
 セキュリティ補足:
 - 本変更は検出精度の向上のみであり、BFF の許可境界や認可ロジック自体は変更していない。
 - したがって、権限昇格・経路露出の新規リスクは増やしていない（監視の見落としリスクを低減）。
+
+### 7.2 2026-03-30 追加改善（最小差分）
+
+無駄な機能追加を避け、既存チェックの抽出精度に限定して最小改善を実施。
+
+- `scripts/quality/check_frontend_api_contract_consistency.py`
+  - `const apiUrl = baseUrl; const endpoint = apiUrl;` のような **URL 定数エイリアス連鎖** を解決し、`fetch(endpoint)` でも `/api/veritas/v1/*` 経路を抽出できるよう改善。
+  - 実装は 1 ファイル内の静的代入のみを対象とし、責務境界（Planner / Kernel / Fuji / MemoryOS）を跨ぐ変更は行っていない。
+- `veritas_os/tests/test_frontend_api_contract_consistency.py`
+  - URL 定数の one-hop / chained alias を経由した `fetch` 呼び出しを検証するテストを追加。
+
+セキュリティ補足:
+- 本改善は「検査の見落とし低減」のみを目的とし、BFF の許可行列・認可判定・公開 API の挙動自体は不変。
+- そのため新規の経路露出は発生しないが、将来 alias が動的生成に拡大した場合は静的解析の限界を越えるため、過信せず実行時監査を併用すること。

--- a/scripts/quality/check_frontend_api_contract_consistency.py
+++ b/scripts/quality/check_frontend_api_contract_consistency.py
@@ -47,6 +47,10 @@ PATH_VARIABLE_PATTERN = re.compile(
     r"(?:const|let|var)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
     r"([\"'`])(?P<path>/api/veritas/v1/[^\"'`]+)\2"
 )
+PATH_ALIAS_PATTERN = re.compile(
+    r"(?:const|let|var)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"(?P<ref>[A-Za-z_][A-Za-z0-9_]*)\s*;"
+)
 METHOD_PATTERN = re.compile(r'method\s*:\s*[\"\'](?P<method>GET|POST|PUT|PATCH|DELETE)[\"\']')
 ROUTE_POLICY_PATTERN = re.compile(
     r'pathPattern:\s*/\^(?P<pattern>.+?)\$/\s*,\s*method:\s*"(?P<method>[A-Z]+)"',
@@ -97,6 +101,19 @@ def collect_frontend_usages() -> list[FrontendRouteUsage]:
                 match.group("name"): match.group("path")
                 for match in PATH_VARIABLE_PATTERN.finditer(content)
             }
+            alias_variables = {
+                match.group("name"): match.group("ref")
+                for match in PATH_ALIAS_PATTERN.finditer(content)
+            }
+            for _ in range(len(alias_variables)):
+                updated = False
+                for alias, ref in alias_variables.items():
+                    resolved = path_variables.get(ref)
+                    if resolved and path_variables.get(alias) != resolved:
+                        path_variables[alias] = resolved
+                        updated = True
+                if not updated:
+                    break
 
             for match in VERITAS_FETCH_CALL_PATTERN.finditer(content):
                 method_match = METHOD_PATTERN.search(match.group("tail"))

--- a/veritas_os/tests/test_frontend_api_contract_consistency.py
+++ b/veritas_os/tests/test_frontend_api_contract_consistency.py
@@ -86,3 +86,34 @@ def test_collect_frontend_usages_extracts_fetch_and_variable_path(tmp_path: path
     assert ("GET", "/api/veritas/v1/events") in found
     assert ("GET", "/api/veritas/v1/metrics") in found
     assert ("GET", "/api/veritas/v1/trust/logs") in found
+
+
+def test_collect_frontend_usages_resolves_variable_aliases(tmp_path: pathlib.Path) -> None:
+    """Collector should resolve one-hop and chained aliases for API path constants."""
+    frontend_root = tmp_path / "frontend"
+    source_file = frontend_root / "app" / "alias.ts"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        textwrap.dedent(
+            """
+            const baseUrl = "/api/veritas/v1/compliance/config";
+            const apiUrl = baseUrl;
+            const endpoint = apiUrl;
+
+            async function load() {
+              await fetch(endpoint, { method: "GET" });
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    original_frontend_root = checker.FRONTEND_ROOT
+    checker.FRONTEND_ROOT = frontend_root
+    try:
+        usages = checker.collect_frontend_usages()
+    finally:
+        checker.FRONTEND_ROOT = original_frontend_root
+
+    found = {(usage.method, usage.raw_path) for usage in usages}
+    assert ("GET", "/api/veritas/v1/compliance/config") in found


### PR DESCRIPTION
### Motivation
- The frontend/OpenAPI/BFF consistency checker missed usages where frontend code referenced `/api/veritas/v1/*` via constant aliases, producing false negatives.  
- The change is intentionally minimal to avoid adding features beyond the review scope and to keep responsibilities inside the existing quality scripts.  
- Maintain security posture by improving detection only and not altering BFF allowlists or authorization logic.

### Description
- Added a `PATH_ALIAS_PATTERN` and an iterative alias-resolution pass in `scripts/quality/check_frontend_api_contract_consistency.py` to resolve one-hop and chained static variable aliases that point to `/api/veritas/v1/*` constants.  
- The collector still only handles static, same-file assignments (no runtime or cross-file resolution) to respect responsibility boundaries.  
- Added `test_collect_frontend_usages_resolves_variable_aliases` to `veritas_os/tests/test_frontend_api_contract_consistency.py` and appended a brief note (section 7.2) to `docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md` describing the minimal-scope improvement and security caveat.

### Testing
- Ran `pytest -q veritas_os/tests/test_frontend_api_contract_consistency.py` and all tests passed (`5 passed`).  
- Ran `python scripts/quality/check_frontend_api_contract_consistency.py` and the consistency check completed successfully with no drift detected.  
- The change is covered by the new unit test and the runtime consistency script was validated locally; no failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca4feb03f483269535e843a85f4aad)