### PR TITLE
フロントエンドのSSE認証リトライを安定化

### DIFF
--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -158,3 +158,16 @@
 セキュリティ補足:
 - 本変更は cookie 認証前提（`__veritas_bff`）を壊さず、未認証時の過剰な再試行を抑える安定化である。
 - BFF の許可行列・公開経路は変更していないため、API 露出面の増加はない。
+
+### 7.4 2026-03-31 追加改善（CI 回帰修正）
+
+`frontend` の品質ゲートで 1 件失敗していたため、最小差分でテストのモック順序を実運用の呼び出し順へ合わせた。
+
+- `frontend/app/governance/page.test.tsx`
+  - `EUAIActGovernanceDashboard` 初期化時の `compliance/config` 取得に加え、
+    `managed-sse` 導入で追加された `/api/veritas/v1/events` の事前プローブ呼び出しをモックに反映。
+  - その後に `governance/policy`（不正 payload）を返すようにし、
+    期待どおり「レスポンス検証エラー」を検証できるよう修正。
+
+セキュリティ補足:
+- 本修正はテストの整合性のみを対象としており、実行時の認可・公開 API・BFF 境界は変更していない。

--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -140,3 +140,21 @@
 セキュリティ補足:
 - 本改善は「検査の見落とし低減」のみを目的とし、BFF の許可行列・認可判定・公開 API の挙動自体は不変。
 - そのため新規の経路露出は発生しないが、将来 alias が動的生成に拡大した場合は静的解析の限界を越えるため、過信せず実行時監査を併用すること。
+
+### 7.3 2026-03-30 追加改善（最小・運用安定化）
+
+無駄な機能追加を避け、指摘B（`/v1/events` の認証運用依存）に限定して最小改善を実施。
+
+- `frontend/lib/managed-sse.ts` を追加。
+  - `fetch(..., credentials: "same-origin")` による事前疎通確認を行い、`401/403` の場合は **60秒の待機** を挟んで再試行する制御を共通化。
+  - `EventSource` のエラー時は指数バックオフで再接続し、無制御な再接続ループを抑制。
+- `frontend/app/console/page.tsx`
+  - 既存の直接 `EventSource` 接続を上記共通制御へ置換。
+- `frontend/features/console/components/eu-ai-act-governance-dashboard.tsx`
+  - 同様に直接 `EventSource` 接続を共通制御へ置換。
+- `frontend/lib/managed-sse.test.ts`
+  - `401` 時に待機してから再接続すること、`withCredentials: true` で接続することを検証するテストを追加。
+
+セキュリティ補足:
+- 本変更は cookie 認証前提（`__veritas_bff`）を壊さず、未認証時の過剰な再試行を抑える安定化である。
+- BFF の許可行列・公開経路は変更していないため、API 露出面の増加はない。

--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -17,6 +17,7 @@ import { StepExpansionPanel } from "../../features/console/components/step-expan
 import { ReplayDiffViewer } from "../../features/console/components/replay-diff-viewer";
 import { ContinuationStatusCard } from "../../features/console/components/continuation-status-card";
 import { useConsoleState } from "../../features/console/state/useConsoleState";
+import { startManagedEventStream } from "../../lib/managed-sse";
 
 export default function DecisionConsolePage(): JSX.Element {
   const { t, tk } = useI18n();
@@ -46,24 +47,20 @@ export default function DecisionConsolePage(): JSX.Element {
     if (typeof EventSource === "undefined") {
       return () => undefined;
     }
-    const stream = new EventSource("/api/veritas/v1/events");
-    stream.onmessage = (event) => {
-      try {
-        const payload = JSON.parse(event.data) as { type?: string; ts?: string; summary?: string };
-        const eventType = payload.type ?? "event";
-        const eventAt = payload.ts ?? new Date().toISOString();
-        const eventSummary = payload.summary ?? eventType;
-        notifySseActivity(`${eventType} @ ${eventAt} — ${eventSummary}`);
-      } catch {
-        // Ignore malformed event payloads.
-      }
-    };
-    stream.onerror = () => {
-      stream.close();
-    };
-    return () => {
-      stream.close();
-    };
+
+    return startManagedEventStream("/api/veritas/v1/events", {
+      onMessage: (event) => {
+        try {
+          const payload = JSON.parse(event.data) as { type?: string; ts?: string; summary?: string };
+          const eventType = payload.type ?? "event";
+          const eventAt = payload.ts ?? new Date().toISOString();
+          const eventSummary = payload.summary ?? eventType;
+          notifySseActivity(`${eventType} @ ${eventAt} — ${eventSummary}`);
+        } catch {
+          // Ignore malformed event payloads.
+        }
+      },
+    });
   }, [notifySseActivity]);
 
   const decisionId = String((result?.chosen as Record<string, unknown> | undefined)?.id ?? result?.request_id ?? "");

--- a/frontend/app/governance/page.test.tsx
+++ b/frontend/app/governance/page.test.tsx
@@ -225,7 +225,13 @@ describe("GovernanceControlPage", () => {
         status: 200,
         json: async () => ({ config: { eu_ai_act_mode: false, safety_threshold: 0.8 } }),
       } as Response)
-      // Second call: governance/policy triggered by button click
+      // Second call: managed SSE probe (/api/veritas/v1/events)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      } as Response)
+      // Third call: governance/policy triggered by button click
       .mockResolvedValueOnce({
         ok: true,
         status: 200,

--- a/frontend/features/console/components/eu-ai-act-governance-dashboard.tsx
+++ b/frontend/features/console/components/eu-ai-act-governance-dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { veritasFetch } from "../../../lib/api-client";
+import { startManagedEventStream } from "../../../lib/managed-sse";
 
 interface ComplianceConfig {
   eu_ai_act_mode: boolean;
@@ -69,7 +70,7 @@ export function EUAIActGovernanceDashboard(): JSX.Element {
     if (typeof EventSource === "undefined") {
       return () => undefined;
     }
-    const stream = new EventSource("/api/veritas/v1/events");
+
     const acceptedTypes = new Set([
       "trustlog.debate",
       "trustlog.critique",
@@ -77,32 +78,26 @@ export function EUAIActGovernanceDashboard(): JSX.Element {
       "compliance.pending_review",
     ]);
 
-    stream.onmessage = (event) => {
-      try {
-        const parsed = JSON.parse(event.data) as SSEEventPayload;
-        const type = String(parsed.type || "");
-        if (!acceptedTypes.has(type)) {
-          return;
+    return startManagedEventStream("/api/veritas/v1/events", {
+      onMessage: (event) => {
+        try {
+          const parsed = JSON.parse(event.data) as SSEEventPayload;
+          const type = String(parsed.type || "");
+          if (!acceptedTypes.has(type)) {
+            return;
+          }
+          const nextEntry: TrustLogEvent = {
+            id: typeof parsed.id === "number" ? parsed.id : undefined,
+            type,
+            ts: String(parsed.ts || new Date().toISOString()),
+            payload: parsed.payload ?? {},
+          };
+          setLogs((prev) => [nextEntry, ...prev].slice(0, 40));
+        } catch {
+          // ignore malformed event frames
         }
-        const nextEntry: TrustLogEvent = {
-          id: typeof parsed.id === "number" ? parsed.id : undefined,
-          type,
-          ts: String(parsed.ts || new Date().toISOString()),
-          payload: parsed.payload ?? {},
-        };
-        setLogs((prev) => [nextEntry, ...prev].slice(0, 40));
-      } catch {
-        // ignore malformed event frames
-      }
-    };
-
-    stream.onerror = () => {
-      stream.close();
-    };
-
-    return () => {
-      stream.close();
-    };
+      },
+    });
   }, []);
 
   const label = useMemo(

--- a/frontend/lib/managed-sse.test.ts
+++ b/frontend/lib/managed-sse.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startManagedEventStream } from "./managed-sse";
+
+class MockEventSource {
+  public static instances: MockEventSource[] = [];
+  public onopen: (() => void) | null = null;
+  public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  public onerror: (() => void) | null = null;
+  public closed = false;
+
+  constructor(
+    public readonly url: string,
+    public readonly init?: EventSourceInit,
+  ) {
+    MockEventSource.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+describe("startManagedEventStream", () => {
+  const originalFetch = globalThis.fetch;
+  const originalEventSource = globalThis.EventSource;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockEventSource.instances = [];
+    (globalThis as Record<string, unknown>).EventSource = MockEventSource;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.EventSource = originalEventSource;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("waits before reconnecting when auth probe returns 401", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const onAuthPause = vi.fn();
+    const stop = startManagedEventStream("/api/veritas/v1/events", {
+      onMessage: () => undefined,
+      onAuthPause,
+    });
+
+    await Promise.resolve();
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(onAuthPause).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    stop();
+  });
+
+  it("opens EventSource with same-origin credentials", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const stop = startManagedEventStream("/api/veritas/v1/events", {
+      onMessage: () => undefined,
+    });
+
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0]?.init).toMatchObject({ withCredentials: true });
+
+    stop();
+  });
+});

--- a/frontend/lib/managed-sse.ts
+++ b/frontend/lib/managed-sse.ts
@@ -1,0 +1,118 @@
+"use client";
+
+const BASE_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const AUTH_RETRY_PAUSE_MS = 60_000;
+
+export interface ManagedSseOptions {
+  onMessage: (event: MessageEvent<string>) => void;
+  onOpen?: () => void;
+  onDisconnected?: () => void;
+  onAuthPause?: (untilEpochMs: number | null) => void;
+  authRetryPauseMs?: number;
+}
+
+function getReconnectDelayMs(attempt: number): number {
+  const boundedAttempt = Math.max(0, attempt);
+  const exponentialDelay = Math.min(
+    BASE_RECONNECT_DELAY_MS * (2 ** boundedAttempt),
+    MAX_RECONNECT_DELAY_MS,
+  );
+  const jitterFactor = 0.8 + (Math.random() * 0.4);
+  return Math.round(exponentialDelay * jitterFactor);
+}
+
+export function startManagedEventStream(
+  url: string,
+  options: ManagedSseOptions,
+): () => void {
+  let disposed = false;
+  let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  let eventSource: EventSource | null = null;
+  let reconnectAttempt = 0;
+
+  const authPauseMs = options.authRetryPauseMs ?? AUTH_RETRY_PAUSE_MS;
+
+  const clearReconnectTimeout = (): void => {
+    if (!reconnectTimeout) {
+      return;
+    }
+    clearTimeout(reconnectTimeout);
+    reconnectTimeout = null;
+  };
+
+  const closeEventSource = (): void => {
+    if (!eventSource) {
+      return;
+    }
+    eventSource.close();
+    eventSource = null;
+    options.onDisconnected?.();
+  };
+
+  const scheduleReconnect = (delayMs: number): void => {
+    if (disposed) {
+      return;
+    }
+    clearReconnectTimeout();
+    reconnectTimeout = setTimeout(() => {
+      void connect();
+    }, delayMs);
+  };
+
+  const connect = async (): Promise<void> => {
+    if (disposed) {
+      return;
+    }
+
+    clearReconnectTimeout();
+    closeEventSource();
+
+    try {
+      const probe = await fetch(url, {
+        credentials: "same-origin",
+        method: "GET",
+      });
+
+      if (probe.status === 401 || probe.status === 403) {
+        options.onAuthPause?.(Date.now() + authPauseMs);
+        scheduleReconnect(authPauseMs);
+        return;
+      }
+
+      if (!probe.ok) {
+        throw new Error(`sse probe failed: ${probe.status}`);
+      }
+    } catch {
+      const delayMs = getReconnectDelayMs(reconnectAttempt);
+      reconnectAttempt += 1;
+      scheduleReconnect(delayMs);
+      return;
+    }
+
+    options.onAuthPause?.(null);
+    reconnectAttempt = 0;
+
+    eventSource = new EventSource(url, { withCredentials: true });
+    eventSource.onopen = () => {
+      reconnectAttempt = 0;
+      options.onOpen?.();
+    };
+    eventSource.onmessage = options.onMessage;
+    eventSource.onerror = () => {
+      closeEventSource();
+      const delayMs = getReconnectDelayMs(reconnectAttempt);
+      reconnectAttempt += 1;
+      scheduleReconnect(delayMs);
+    };
+  };
+
+  void connect();
+
+  return () => {
+    disposed = true;
+    clearReconnectTimeout();
+    closeEventSource();
+    options.onAuthPause?.(null);
+  };
+}


### PR DESCRIPTION
### Motivation
- `/v1/events` の認証依存により未認証時にブラウザ側で過剰な再接続ループが発生するリスクを低減するため、最小限の運用安定化を行った。 
- 変更は BFF の allowlist やバックエンド経路の公開を伴わない監視／接続制御の強化に限定する方針とした。 
- セキュリティ警告として、Cookie 認証（`__veritas_bff`）の設定不備があると監視欠落リスクが残るため運用設定の確認を推奨する。 

### Description
- 受信ストリーム接続共通化ヘルパーとして `frontend/lib/managed-sse.ts` を追加し、接続前に `fetch(..., credentials: "same-origin")` による事前プローブを行うよう実装した。 
- `401/403` を検知した場合は 60 秒の待機を挟んで再試行し、その他の接続障害は指数バックオフで再接続する制御を導入した。 
- 直接 `EventSource` を使っていた `frontend/app/console/page.tsx` と `frontend/features/console/components/eu-ai-act-governance-dashboard.tsx` を `startManagedEventStream` 呼び出しへ置換した。 
- `frontend/lib/managed-sse.test.ts` を追加して `401` 時の待機動作と `withCredentials: true` による接続を検証し、ドキュメント `docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md` に実施内容（節7.3）を追記した。 

### Testing
- 実行した自動テストは `pnpm --filter frontend test -- managed-sse api-client` で、`vitest` による該当テスト群はすべて成功（合計 18 tests, 0 failed）。 
- 追加したテストファイルは `frontend/lib/managed-sse.test.ts` で、既存の `lib/api-client.test.ts` と合わせて動作確認済み。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca580dded08326a45c3abb375c0863)