### PR TITLE
全189テスト関数に日本語docstringを追加

### DIFF
--- a/tests/test_continuation_eval_harness.py
+++ b/tests/test_continuation_eval_harness.py
@@ -277,42 +277,42 @@ class TestEvalHarness:
     """Evaluation harness as pytest tests."""
 
     def test_divergence_detection_rate_is_perfect(self):
-        """All known divergence scenarios must be detected."""
+        """既知の全ての乖離シナリオが検出されることを検証する。"""
         metrics = _compute_metrics()
         assert metrics.divergence_detection_rate == 1.0
 
     def test_false_alarm_rate_is_zero(self):
-        """No false alarms on non-divergent scenarios."""
+        """非乖離シナリオで誤報が発生しないことを検証する。"""
         metrics = _compute_metrics()
         assert metrics.false_alarm_rate == 0.0
 
     def test_support_loss_capture_rate_is_perfect(self):
-        """All support-loss scenarios captured."""
+        """全てのサポート喪失シナリオが検出されることを検証する。"""
         metrics = _compute_metrics()
         assert metrics.support_loss_capture_rate == 1.0
 
     def test_burden_headroom_drift_usefulness_is_perfect(self):
-        """All burden/headroom drift scenarios detected."""
+        """全ての負担/ヘッドルームドリフトシナリオが検出されることを検証する。"""
         metrics = _compute_metrics()
         assert metrics.burden_headroom_drift_usefulness == 1.0
 
     def test_replay_explanatory_usefulness_is_perfect(self):
-        """All receipts have sufficient data for replay explanation."""
+        """全レシートがリプレイ説明に十分なデータを持つことを検証する。"""
         metrics = _compute_metrics()
         assert metrics.replay_explanatory_usefulness == 1.0
 
     def test_state_receipt_separation_clarity_is_perfect(self):
-        """State and receipt never contaminate each other."""
+        """状態とレシートが互いに汚染しないことを検証する。"""
         metrics = _compute_metrics()
         assert metrics.state_receipt_separation_clarity == 1.0
 
     def test_scenario_count_minimum(self):
-        """Harness has at least 8 scenarios."""
+        """ハーネスが最低8つのシナリオを持つことを検証する。"""
         metrics = _compute_metrics()
         assert metrics.total_scenarios >= 8
 
     def test_metrics_printable_report(self):
-        """Metrics can be rendered as a human-readable report."""
+        """メトリクスが人間可読なレポートとして出力可能であることを検証する。"""
         metrics = _compute_metrics()
         report = {
             "total_scenarios": metrics.total_scenarios,

--- a/tests/test_continuation_golden.py
+++ b/tests/test_continuation_golden.py
@@ -60,6 +60,7 @@ class TestGolden1SupportLost:
     has evaporated — authority and policy are gone."""
 
     def test_claim_revoked_despite_local_allow(self):
+        """ローカルステップがallowでもサポート喪失によりクレームが取消されることを検証する。"""
         _, snap, rcpt = _run_golden(
             {"authorization": "", "policy_ref": ""},
             chain_id="",  # no chain_id → no authority fallback
@@ -71,6 +72,7 @@ class TestGolden1SupportLost:
         assert rcpt.should_refuse_before_effect is True
 
     def test_reason_codes_indicate_support_loss(self):
+        """理由コードにサポート喪失が含まれることを検証する。"""
         _, _, rcpt = _run_golden(
             {"authorization": "", "policy_ref": ""},
             chain_id="",
@@ -82,6 +84,7 @@ class TestGolden1SupportLost:
         )
 
     def test_support_basis_empty_in_snapshot(self):
+        """スナップショットでサポート基盤が空であることを検証する。"""
         _, snap, _ = _run_golden(
             {"authorization": "", "policy_ref": ""},
             chain_id="",
@@ -102,6 +105,7 @@ class TestGolden2BurdenHeadroomCollapse:
     and headroom has collapsed to zero."""
 
     def test_halted_due_to_headroom_collapse(self):
+        """ヘッドルーム崩壊により停止状態になることを検証する。"""
         _, snap, rcpt = _run_golden({
             "required_evidence": ["e1", "e2", "e3", "e4", "e5"],
             "satisfied_evidence": [],
@@ -113,6 +117,7 @@ class TestGolden2BurdenHeadroomCollapse:
         assert rcpt.should_refuse_before_effect is True
 
     def test_burden_state_reflects_unmet_evidence(self):
+        """負担状態が未充足エビデンスを反映していることを検証する。"""
         _, snap, _ = _run_golden({
             "required_evidence": ["e1", "e2", "e3"],
             "satisfied_evidence": [],
@@ -124,6 +129,7 @@ class TestGolden2BurdenHeadroomCollapse:
         assert len(snap.burden_state.satisfied_evidence) == 0
 
     def test_headroom_zero_in_snapshot(self):
+        """スナップショットでヘッドルームがゼロであることを検証する。"""
         _, snap, _ = _run_golden({
             "required_evidence": ["e1", "e2"],
             "satisfied_evidence": [],
@@ -133,6 +139,7 @@ class TestGolden2BurdenHeadroomCollapse:
         assert snap.headroom_state.remaining == 0.0
 
     def test_reason_code_headroom_collapsed(self):
+        """ヘッドルーム崩壊の理由コードが設定されることを検証する。"""
         _, _, rcpt = _run_golden({
             "required_evidence": ["e1", "e2"],
             "satisfied_evidence": [],
@@ -151,6 +158,7 @@ class TestGolden3ScopeNarrowing:
     """The local step is fine, but the chain's scope has been restricted."""
 
     def test_narrowed_due_to_restricted_actions(self):
+        """制限アクションによりスコープが縮小されることを検証する。"""
         _, snap, rcpt = _run_golden({
             "restricted_actions": ["execute", "deploy"],
         })
@@ -160,6 +168,7 @@ class TestGolden3ScopeNarrowing:
         assert rcpt.should_refuse_before_effect is False  # narrowed, not halted
 
     def test_scope_reflects_restrictions(self):
+        """スコープが制限を正しく反映していることを検証する。"""
         _, snap, _ = _run_golden({
             "restricted_actions": ["execute", "deploy"],
         })
@@ -168,6 +177,7 @@ class TestGolden3ScopeNarrowing:
         assert "deploy" in snap.scope.restricted_action_classes
 
     def test_reason_code_action_class(self):
+        """アクションクラスの理由コードが設定されることを検証する。"""
         _, _, rcpt = _run_golden({
             "restricted_actions": ["execute"],
         })
@@ -184,6 +194,7 @@ class TestGolden4EscalationNeeded:
     """The local step is fine, but escalation is required."""
 
     def test_escalated_despite_local_allow(self):
+        """ローカルallowにもかかわらずエスカレーションが必要であることを検証する。"""
         _, snap, rcpt = _run_golden({
             "escalation_required": True,
         })
@@ -196,6 +207,7 @@ class TestGolden4EscalationNeeded:
         assert rcpt.divergence_flag is True
 
     def test_scope_escalation_flag(self):
+        """スコープのエスカレーションフラグが設定されることを検証する。"""
         _, snap, _ = _run_golden({
             "escalation_required": True,
         })
@@ -212,6 +224,7 @@ class TestGolden5Halted:
     """The local step passes, but headroom is at threshold_suspension."""
 
     def test_halted_with_zero_headroom(self):
+        """ヘッドルームゼロで停止状態になることを検証する。"""
         _, snap, rcpt = _run_golden({
             "required_evidence": ["e1", "e2", "e3"],
             "satisfied_evidence": [],
@@ -224,6 +237,7 @@ class TestGolden5Halted:
         assert rcpt.should_refuse_before_effect is True
 
     def test_halted_receipt_has_audit_digests(self):
+        """停止レシートに監査ダイジェストが含まれることを検証する。"""
         _, _, rcpt = _run_golden({
             "required_evidence": ["e1", "e2"],
             "satisfied_evidence": [],
@@ -244,6 +258,7 @@ class TestGolden6Revoked:
     """Local step passes, but continuation is fully revoked."""
 
     def test_revoked_with_full_support_loss(self):
+        """完全なサポート喪失により取消されることを検証する。"""
         lineage, snap, rcpt = _run_golden(
             {"authorization": "", "policy_ref": ""},
             chain_id="",
@@ -256,6 +271,7 @@ class TestGolden6Revoked:
         assert lineage.is_revoked is True
 
     def test_revoked_lineage_has_timestamp(self):
+        """取消されたリネージュにタイムスタンプがあることを検証する。"""
         lineage, _, _ = _run_golden(
             {"authorization": "", "policy_ref": ""},
             chain_id="",
@@ -264,7 +280,7 @@ class TestGolden6Revoked:
         assert lineage.revoked_at is not None
 
     def test_revoked_is_terminal_in_chain(self):
-        """After revocation, subsequent steps remain revoked."""
+        """取消後の後続ステップも取消状態のままであることを検証する。"""
         rv = ContinuationRevalidator()
         lineage = ContinuationClaimLineage(chain_id="", origin_ref="step:0")
 
@@ -344,7 +360,7 @@ class TestGolden7ReceiptChainContinuityWeakening:
         return lineage, results
 
     def test_progressive_status_weakening(self):
-        """State shows durable standing; receipt shows boundary progression."""
+        """状態が永続的な立場を示し、レシートが境界の進行を示すことを検証する。"""
         _, results = self._run_weakening_chain()
 
         # State (durable standing): ESCALATED is receipt-only → LIVE
@@ -362,12 +378,14 @@ class TestGolden7ReceiptChainContinuityWeakening:
         assert receipt_outcomes[3] == "revoked"
 
     def test_divergence_flags_track_weakening(self):
+        """乖離フラグが弱体化を追跡することを検証する。"""
         _, results = self._run_weakening_chain()
 
         divergences = [rcpt.divergence_flag for _, rcpt in results]
         assert divergences == [False, True, True, True]
 
     def test_receipt_chain_is_linked(self):
+        """レシートチェーンがリンクされていることを検証する。"""
         _, results = self._run_weakening_chain()
 
         for i in range(1, len(results)):
@@ -376,15 +394,14 @@ class TestGolden7ReceiptChainContinuityWeakening:
             assert curr_rcpt.parent_receipt_ref == prev_rcpt.receipt_id
 
     def test_all_prior_decisions_were_allow(self):
-        """Every step had prior_decision_status='allow', proving
-        local step outcome did not influence continuation standing."""
+        """全ステップのprior_decision_statusがallowであり、ローカルステップ結果が継続判定に影響しないことを検証する。"""
         _, results = self._run_weakening_chain()
 
         for _, rcpt in results:
             assert rcpt.prior_decision_continuity_ref == "allow"
 
     def test_snapshot_replaced_at_each_step(self):
-        """Only latest snapshot is authoritative — each step creates new."""
+        """最新のスナップショットのみが権威あるものであり、各ステップで新規作成されることを検証する。"""
         lineage, results = self._run_weakening_chain()
 
         snapshot_ids = [snap.snapshot_id for snap, _ in results]
@@ -394,6 +411,7 @@ class TestGolden7ReceiptChainContinuityWeakening:
         assert lineage.latest_snapshot_id == results[-1][0].snapshot_id
 
     def test_law_version_consistent_across_chain(self):
+        """チェーン全体でlaw_versionが一貫していることを検証する。"""
         _, results = self._run_weakening_chain()
 
         for snap, rcpt in results:
@@ -401,6 +419,7 @@ class TestGolden7ReceiptChainContinuityWeakening:
             assert rcpt.law_version_id == "v0.1.0-shadow"
 
     def test_audit_digests_present_in_every_receipt(self):
+        """全レシートに監査ダイジェストが存在することを検証する。"""
         _, results = self._run_weakening_chain()
 
         for _, rcpt in results:
@@ -409,8 +428,7 @@ class TestGolden7ReceiptChainContinuityWeakening:
             assert rcpt.burden_headroom_digest is not None
 
     def test_advisory_only_for_non_terminal_steps(self):
-        """Phase-1: should_refuse_before_effect is advisory only for
-        non-terminal statuses. HALTED/REVOKED set it True (advisory)."""
+        """Phase-1: 非終端ステータスではshould_refuse_before_effectが助言のみであることを検証する。"""
         _, results = self._run_weakening_chain()
 
         for snap, rcpt in results:

--- a/tests/test_continuation_integration.py
+++ b/tests/test_continuation_integration.py
@@ -28,13 +28,13 @@ class TestFeatureFlagOffInvariance:
     the continuation runtime must be fully inert."""
 
     def test_flag_defaults_to_false(self):
-        """Default is off — no env var needed."""
+        """デフォルトでオフであり環境変数不要であることを検証する。"""
         from veritas_os.core.config import _parse_bool
 
         assert _parse_bool("VERITAS_CAP_CONTINUATION_RUNTIME", False) is False
 
     def test_pipeline_context_has_no_continuation_by_default(self):
-        """PipelineContext continuation fields are None when flag off."""
+        """フラグオフ時にPipelineContextの継続フィールドがNoneであることを検証する。"""
         from veritas_os.core.pipeline_types import PipelineContext
 
         ctx = PipelineContext()
@@ -42,7 +42,7 @@ class TestFeatureFlagOffInvariance:
         assert ctx.continuation_receipt is None
 
     def test_response_omits_continuation_key_when_flag_off(self):
-        """assemble_response must not include 'continuation' when off."""
+        """フラグオフ時にassemble_responseがcontinuationキーを含まないことを検証する。"""
         from veritas_os.core.pipeline_types import PipelineContext
         from veritas_os.core.pipeline_response import assemble_response
 
@@ -64,7 +64,7 @@ class TestFeatureFlagOffInvariance:
         assert "continuation" not in res
 
     def test_gate_decision_status_unchanged_when_flag_off(self):
-        """gate.decision_status is exactly what PipelineContext provides."""
+        """gate.decision_statusがPipelineContextの値と完全一致することを検証する。"""
         from veritas_os.core.pipeline_types import PipelineContext
         from veritas_os.core.pipeline_response import assemble_response
 
@@ -131,6 +131,7 @@ class TestFeatureFlagOnAddsContinuation:
         )
 
     def test_response_includes_continuation_block(self):
+        """レスポンスにcontinuationブロックが含まれることを検証する。"""
         from veritas_os.core.pipeline_response import assemble_response
 
         ctx = self._make_ctx_with_continuation()
@@ -145,6 +146,7 @@ class TestFeatureFlagOnAddsContinuation:
         assert "receipt" in res["continuation"]
 
     def test_state_and_receipt_are_separate_in_response(self):
+        """レスポンス内で状態とレシートが分離されていることを検証する。"""
         from veritas_os.core.pipeline_response import assemble_response
 
         ctx = self._make_ctx_with_continuation()
@@ -166,8 +168,7 @@ class TestFeatureFlagOnAddsContinuation:
         assert "revalidation_status" not in state
 
     def test_gate_decision_status_unchanged_when_flag_on(self):
-        """gate.decision_status must remain exactly as ctx provides,
-        regardless of continuation state."""
+        """継続状態に関係なくgate.decision_statusがctxの値と一致することを検証する。"""
         from veritas_os.core.pipeline_response import assemble_response
 
         ctx = self._make_ctx_with_continuation(
@@ -184,7 +185,7 @@ class TestFeatureFlagOnAddsContinuation:
         assert res["decision_status"] == "allow"
 
     def test_fuji_output_unchanged_when_continuation_present(self):
-        """FUJI dict is exactly what ctx provides, unmodified."""
+        """FUJI辞書がctxの提供値から変更されていないことを検証する。"""
         from veritas_os.core.pipeline_types import PipelineContext
         from veritas_os.core.pipeline_response import assemble_response
 
@@ -227,8 +228,7 @@ class TestPreMeritRevalidation:
     merit evaluation and produces its own artifacts independently."""
 
     def test_revalidation_produces_snapshot_before_any_decision(self):
-        """run_continuation_revalidation_shadow works without any
-        prior_decision_status — proving it doesn't need step outcome."""
+        """prior_decision_statusなしで再検証が動作し、ステップ結果に依存しないことを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -246,7 +246,7 @@ class TestPreMeritRevalidation:
         assert rcpt.prior_decision_continuity_ref is None
 
     def test_revalidation_does_not_read_or_modify_decision_status(self):
-        """Revalidation result is independent of prior_decision_status value."""
+        """再検証結果がprior_decision_statusの値に依存しないことを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -271,7 +271,7 @@ class TestPreMeritRevalidation:
         assert snap_allow.claim_status == snap_block.claim_status
 
     def test_snapshot_receipt_pair_always_emitted(self):
-        """Every revalidation must produce both snapshot and receipt."""
+        """全ての再検証がスナップショットとレシートの両方を生成することを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -290,8 +290,7 @@ class TestPreMeritRevalidation:
         assert rcpt.snapshot_id == snap.snapshot_id
 
     def test_continuation_does_not_enforce(self):
-        """Phase-1: even when should_refuse_before_effect is True,
-        this is advisory only — no enforcement mechanism exists."""
+        """Phase-1ではshould_refuse_before_effectがTrueでも助言のみで強制機構がないことを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -319,9 +318,7 @@ class TestDivergenceObservability:
     must be observable in structured output."""
 
     def test_divergence_flag_true_when_not_live(self):
-        """Divergence observable via receipt boundary_outcome regardless
-        of whether boundary was promoted to state.
-        """
+        """境界が状態に昇格されたかに関わらずレシートのboundary_outcomeで乖離が観測可能であることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -368,6 +365,7 @@ class TestDivergenceObservability:
             assert rcpt.divergence_flag is True
 
     def test_divergence_flag_false_when_live(self):
+        """LIVE状態では乖離フラグがFalseであることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )

--- a/tests/test_continuation_receipt_enrichment.py
+++ b/tests/test_continuation_receipt_enrichment.py
@@ -60,7 +60,7 @@ class TestBoundaryOccurrenceFlags:
     """Explicit halt_occurred / narrowing_occurred booleans."""
 
     def test_live_no_halt_no_narrowing(self):
-        """LIVE: neither halt nor narrowing occurred."""
+        """LIVE状態では停止も縮小も発生しないことを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         _, receipt = rv.revalidate(lineage, _make_condition())
@@ -68,7 +68,7 @@ class TestBoundaryOccurrenceFlags:
         assert receipt.narrowing_occurred is False
 
     def test_halted_sets_halt_occurred(self):
-        """Headroom collapse → halt_occurred=True."""
+        """ヘッドルーム崩壊時にhalt_occurred=Trueとなることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(context={
@@ -80,7 +80,7 @@ class TestBoundaryOccurrenceFlags:
         assert receipt.narrowing_occurred is False
 
     def test_narrowed_sets_narrowing_occurred(self):
-        """Scope restriction → narrowing_occurred=True."""
+        """スコープ制限時にnarrowing_occurred=Trueとなることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(context={
@@ -91,7 +91,7 @@ class TestBoundaryOccurrenceFlags:
         assert receipt.halt_occurred is False
 
     def test_degraded_no_halt_no_narrowing(self):
-        """DEGRADED: neither halt nor narrowing."""
+        """DEGRADED状態では停止も縮小も発生しないことを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(context={
@@ -104,7 +104,7 @@ class TestBoundaryOccurrenceFlags:
         assert receipt.narrowing_occurred is False
 
     def test_escalated_no_halt_no_narrowing(self):
-        """ESCALATED: neither halt nor narrowing."""
+        """ESCALATED状態では停止も縮小も発生しないことを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(context={
@@ -115,7 +115,7 @@ class TestBoundaryOccurrenceFlags:
         assert receipt.narrowing_occurred is False
 
     def test_revoked_no_halt_no_narrowing(self):
-        """REVOKED: neither halt nor narrowing (revocation is its own category)."""
+        """REVOKED状態では停止も縮小も発生しないことを検証する（取消は独立カテゴリ）。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(
@@ -136,7 +136,7 @@ class TestHaltClassification:
     """Halt classification categories."""
 
     def test_durable_halt_classified_as_durable_state_transformation(self):
-        """Headroom collapse → durable_state_transformation."""
+        """ヘッドルーム崩壊がdurable_state_transformationに分類されることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(context={
@@ -147,14 +147,14 @@ class TestHaltClassification:
         assert receipt.halt_classification == "durable_state_transformation"
 
     def test_no_halt_no_classification(self):
-        """LIVE → no halt classification."""
+        """LIVE状態では停止分類がないことを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         _, receipt = rv.revalidate(lineage, _make_condition())
         assert receipt.halt_classification is None
 
     def test_classify_halt_static_durable(self):
-        """Direct static test: durable halt."""
+        """静的テスト: 永続的停止の分類を検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import HeadroomState
@@ -167,7 +167,7 @@ class TestHaltClassification:
         assert result == "durable_state_transformation"
 
     def test_classify_halt_static_safety_pause(self):
-        """Direct static test: safety pause (near escalation)."""
+        """静的テスト: 安全一時停止（エスカレーション付近）の分類を検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import HeadroomState
@@ -180,7 +180,7 @@ class TestHaltClassification:
         assert result == "safety_pause"
 
     def test_classify_halt_static_bounded_interruption(self):
-        """Direct static test: bounded interruption (headroom partially used)."""
+        """静的テスト: 制限付き中断（ヘッドルーム部分使用）の分類を検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import HeadroomState
@@ -193,7 +193,7 @@ class TestHaltClassification:
         assert result == "bounded_interruption"
 
     def test_classify_halt_static_temporary_refusal(self):
-        """Direct static test: temporary refusal (headroom=1.0, full)."""
+        """静的テスト: 一時的拒否（ヘッドルーム=1.0、満杯）の分類を検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import HeadroomState
@@ -206,7 +206,7 @@ class TestHaltClassification:
         assert result == "temporary_refusal"
 
     def test_classify_halt_non_halted_returns_none(self):
-        """Non-HALTED boundary → None."""
+        """非HALTED境界ではNoneが返ることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import HeadroomState
@@ -228,7 +228,7 @@ class TestDivergenceDetail:
     """Granular divergence classification."""
 
     def test_live_no_divergence(self):
-        """LIVE boundary, allow prior → no divergence."""
+        """LIVE境界でallow先行時に乖離がないことを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(prior_decision_status="allow")
@@ -237,7 +237,7 @@ class TestDivergenceDetail:
         assert receipt.divergence_flag is False
 
     def test_halted_durable_divergence(self):
-        """Durable halt → local_pass_durable_halt."""
+        """永続的停止がlocal_pass_durable_haltとなることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(
@@ -248,7 +248,7 @@ class TestDivergenceDetail:
         assert receipt.divergence_detail == "local_pass_durable_halt"
 
     def test_narrowed_durable_divergence(self):
-        """Durable narrowing → local_pass_durable_narrowing."""
+        """永続的縮小がlocal_pass_durable_narrowingとなることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(
@@ -259,7 +259,7 @@ class TestDivergenceDetail:
         assert receipt.divergence_detail == "local_pass_durable_narrowing"
 
     def test_revoked_divergence(self):
-        """REVOKED → local_pass_revoked."""
+        """REVOKED時にlocal_pass_revokedとなることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(
@@ -271,7 +271,7 @@ class TestDivergenceDetail:
         assert receipt.divergence_detail == "local_pass_revoked"
 
     def test_degraded_divergence(self):
-        """DEGRADED → local_pass_receipt_degraded."""
+        """DEGRADED時にlocal_pass_receipt_degradedとなることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(
@@ -286,7 +286,7 @@ class TestDivergenceDetail:
         assert receipt.divergence_detail == "local_pass_receipt_degraded"
 
     def test_escalated_divergence(self):
-        """ESCALATED → local_pass_receipt_escalated."""
+        """ESCALATED時にlocal_pass_receipt_escalatedとなることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(
@@ -297,7 +297,7 @@ class TestDivergenceDetail:
         assert receipt.divergence_detail == "local_pass_receipt_escalated"
 
     def test_local_fail_continuation_live(self):
-        """Local deny + LIVE boundary → local_fail_continuation_live."""
+        """ローカルdeny + LIVE境界でlocal_fail_continuation_liveとなることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
 
         result = ContinuationRevalidator._compute_divergence_detail(
@@ -311,7 +311,7 @@ class TestDivergenceDetail:
         assert result == "local_fail_continuation_live"
 
     def test_compute_divergence_static_halted_receipt(self):
-        """Static: non-durable halt → local_pass_receipt_halt."""
+        """静的テスト: 非永続的停止がlocal_pass_receipt_haltとなることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
@@ -323,7 +323,7 @@ class TestDivergenceDetail:
         assert result == "local_pass_receipt_halt"
 
     def test_compute_divergence_static_narrowed_receipt(self):
-        """Static: non-durable narrowing → local_pass_receipt_narrowing."""
+        """静的テスト: 非永続的縮小がlocal_pass_receipt_narrowingとなることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
@@ -344,14 +344,14 @@ class TestBoundaryPredicates:
     """Boundary predicates populated from reason codes."""
 
     def test_live_empty_predicates(self):
-        """LIVE → no predicates."""
+        """LIVE状態では述語が空であることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         _, receipt = rv.revalidate(lineage, _make_condition())
         assert receipt.boundary_predicates == []
 
     def test_halted_carries_headroom_predicate(self):
-        """Halted → HEADROOM_COLLAPSED predicate."""
+        """停止時にHEADROOM_COLLAPSED述語が設定されることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(context={
@@ -362,7 +362,7 @@ class TestBoundaryPredicates:
         assert "HEADROOM_COLLAPSED" in receipt.boundary_predicates
 
     def test_narrowed_carries_scope_predicate(self):
-        """Narrowed → ACTION_CLASS_NOT_ALLOWED predicate."""
+        """縮小時にACTION_CLASS_NOT_ALLOWED述語が設定されることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(context={
@@ -372,7 +372,7 @@ class TestBoundaryPredicates:
         assert "ACTION_CLASS_NOT_ALLOWED" in receipt.boundary_predicates
 
     def test_revoked_carries_support_predicates(self):
-        """Revoked → SUPPORT_LOST predicates."""
+        """取消時にSUPPORT_LOST述語が設定されることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         condition = _make_condition(
@@ -392,7 +392,7 @@ class TestPriorStateRef:
     """Prior state reference linkage."""
 
     def test_first_step_prior_state_ref_is_none(self):
-        """First step: no prior snapshot → prior_state_ref is None."""
+        """最初のステップで先行スナップショットがなくprior_state_refがNoneであることを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         _, receipt = rv.revalidate(lineage, _make_condition())
@@ -400,7 +400,7 @@ class TestPriorStateRef:
         assert receipt.prior_state_ref is None
 
     def test_second_step_prior_state_ref_is_set(self):
-        """Second step: prior snapshot provides prior_state_ref."""
+        """2番目のステップで先行スナップショットがprior_state_refを提供することを検証する。"""
         rv = _make_revalidator()
         lineage = _make_lineage()
         snap1, receipt1 = rv.revalidate(lineage, _make_condition(step_index=0))
@@ -418,7 +418,7 @@ class TestReceiptEnrichmentSerialization:
     """New receipt fields survive serialization."""
 
     def test_enrichment_fields_roundtrip(self):
-        """All new fields survive to_dict / from_dict."""
+        """全ての新規フィールドがto_dict/from_dictを経ても保持されることを検証する。"""
         from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
 
         receipt = ContinuationReceipt(
@@ -446,7 +446,7 @@ class TestReceiptEnrichmentSerialization:
         assert restored.prior_state_ref == "snap_abc123"
 
     def test_backward_compat_missing_new_fields(self):
-        """Old dicts without new fields still deserialize correctly."""
+        """新規フィールドのない古い辞書でも正しくデシリアライズされることを検証する。"""
         from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
 
         old_dict = {
@@ -473,7 +473,7 @@ class TestCoherenceGuardStrengthened:
     """Strengthened coherence guard for state/receipt contradiction prevention."""
 
     def test_revoked_boundary_live_state_is_violation(self):
-        """Receipt boundary_outcome=revoked + snapshot LIVE → violation."""
+        """レシートboundary_outcome=revoked + スナップショットLIVEが整合性違反となることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import (
@@ -493,7 +493,7 @@ class TestCoherenceGuardStrengthened:
             ContinuationRevalidator._assert_coherence(snap, receipt)
 
     def test_durable_promotion_with_live_state_is_violation(self):
-        """Receipt claims durable promotion + snapshot LIVE → violation."""
+        """レシートが永続昇格を主張しスナップショットがLIVEの場合に整合性違反となることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import (
@@ -513,7 +513,7 @@ class TestCoherenceGuardStrengthened:
             ContinuationRevalidator._assert_coherence(snap, receipt)
 
     def test_receipt_only_halt_with_live_state_is_valid(self):
-        """Receipt-only halt (not durable) + snapshot LIVE → valid."""
+        """レシートのみの停止（非永続）+ スナップショットLIVEが有効であることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import (
@@ -533,7 +533,7 @@ class TestCoherenceGuardStrengthened:
         ContinuationRevalidator._assert_coherence(snap, receipt)
 
     def test_durable_promotion_with_matching_state_is_valid(self):
-        """Receipt claims durable promotion + snapshot matches → valid."""
+        """レシートが永続昇格を主張しスナップショットが一致する場合に有効であることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import (

--- a/tests/test_continuation_receipt_first.py
+++ b/tests/test_continuation_receipt_first.py
@@ -52,7 +52,7 @@ class TestReceiptFirstBoundary:
     # ------------------------------------------------------------------
 
     def test_live_no_durable_consequence(self):
-        """LIVE outcome: no durable consequence, no boundary_outcome promotion."""
+        """LIVEアウトカムでは永続的結果も境界昇格もないことを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -70,7 +70,7 @@ class TestReceiptFirstBoundary:
     # ------------------------------------------------------------------
 
     def test_halted_is_receipt_first_and_durable_when_headroom_collapsed(self):
-        """Headroom collapse → halted in receipt AND state (durable halt)."""
+        """ヘッドルーム崩壊時にレシートと状態の両方で停止（永続的停止）となることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         # Set required_evidence with none satisfied → current_level=0.0 → headroom=0.0
@@ -97,7 +97,7 @@ class TestReceiptFirstBoundary:
     # ------------------------------------------------------------------
 
     def test_narrowed_receipt_first_with_durable_scope_reduction(self):
-        """Scope restriction → narrowed in receipt AND state (durable narrowing)."""
+        """スコープ制限時にレシートと状態の両方で縮小（永続的縮小）となることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition(context={
@@ -118,7 +118,7 @@ class TestReceiptFirstBoundary:
         assert snap.durable_consequence.has_durable_scope_reduction is True
 
     def test_narrowed_reopening_eligible_when_not_durable(self):
-        """Narrowed reopening test: durable → not reopenable."""
+        """縮小再開テスト: 永続的なら再開不可であることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             ContinuationRevalidator,
         )
@@ -142,7 +142,7 @@ class TestReceiptFirstBoundary:
     # ------------------------------------------------------------------
 
     def test_degraded_receipt_first(self):
-        """Burden exceeded → degraded in receipt; state reflects degraded."""
+        """負担超過時にレシートでdegradedとなることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         # 2 required, 1 satisfied → current_level=0.5; threshold=0.8
@@ -167,7 +167,7 @@ class TestReceiptFirstBoundary:
     # ------------------------------------------------------------------
 
     def test_escalated_receipt_first(self):
-        """Escalation required → escalated in receipt."""
+        """エスカレーション必要時にレシートでescalatedとなることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition(context={
@@ -186,7 +186,7 @@ class TestReceiptFirstBoundary:
     # ------------------------------------------------------------------
 
     def test_revoked_always_durable(self):
-        """Support loss → revoked in both receipt and state (irreversible)."""
+        """サポート喪失時にレシートと状態の両方で取消（不可逆）となることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         # Empty chain_id so authority isn't auto-filled; empty policy_ref
@@ -236,7 +236,7 @@ class TestProofBearingReceipt:
         return PresentCondition(**defaults)
 
     def test_receipt_has_boundary_outcome(self):
-        """Every receipt must carry a boundary_outcome."""
+        """全レシートがboundary_outcomeを持つことを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         snap, receipt = rv.revalidate(lineage, self._make_condition())
@@ -244,7 +244,7 @@ class TestProofBearingReceipt:
         assert receipt.boundary_outcome == "live"
 
     def test_receipt_has_provisional_vs_durable(self):
-        """Non-LIVE outcomes carry provisional_vs_durable assessment."""
+        """非LIVEアウトカムがprovisional_vs_durable評価を持つことを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition(context={
@@ -254,7 +254,7 @@ class TestProofBearingReceipt:
         assert receipt.provisional_vs_durable in ("provisional", "durable_promotable")
 
     def test_receipt_has_digest_summaries(self):
-        """Receipt carries digest summaries for audit."""
+        """レシートが監査用ダイジェスト要約を持つことを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         snap, receipt = rv.revalidate(lineage, self._make_condition())
@@ -263,7 +263,7 @@ class TestProofBearingReceipt:
         assert receipt.burden_headroom_digest is not None
 
     def test_receipt_carries_reason_codes(self):
-        """Non-LIVE receipts carry reason codes."""
+        """非LIVEレシートが理由コードを持つことを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition(context={
@@ -277,7 +277,7 @@ class TestDurableConsequence:
     """DurableConsequence tracking in snapshot."""
 
     def test_durable_consequence_absent_for_live(self):
-        """LIVE standing has no durable consequence."""
+        """LIVE状態では永続的結果がないことを検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import (
             ClaimStateSnapshot,
         )
@@ -285,7 +285,7 @@ class TestDurableConsequence:
         assert snap.durable_consequence is None
 
     def test_durable_consequence_serialization_roundtrip(self):
-        """DurableConsequence survives to_dict / from_dict."""
+        """DurableConsequenceがto_dict/from_dictを経ても保持されることを検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import (
             ClaimStateSnapshot,
             DurableConsequence,
@@ -308,7 +308,7 @@ class TestDurableConsequence:
         assert restored.durable_consequence.promotion_reason == "headroom collapsed"
 
     def test_durable_consequence_none_serialization_roundtrip(self):
-        """None durable_consequence survives roundtrip."""
+        """None durable_consequenceがラウンドトリップを経ても保持されることを検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
         snap = ClaimStateSnapshot()
         d = snap.to_dict()
@@ -321,7 +321,7 @@ class TestReceiptSerialization:
     """Receipt proof-bearing fields survive serialization."""
 
     def test_receipt_new_fields_roundtrip(self):
-        """New receipt fields survive to_dict / from_dict."""
+        """新規レシートフィールドがto_dict/from_dictを経ても保持されることを検証する。"""
         from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
         receipt = ContinuationReceipt(
             boundary_outcome="halted",
@@ -354,7 +354,7 @@ class TestCoherenceGuardReceiptFirst:
         return ContinuationReceipt(**kwargs)
 
     def test_revoked_must_agree_bidirectionally(self):
-        """REVOKED must be in both snapshot and receipt."""
+        """REVOKEDがスナップショットとレシートの両方に存在する必要があることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             ContinuationRevalidator,
         )
@@ -371,7 +371,7 @@ class TestCoherenceGuardReceiptFirst:
             ContinuationRevalidator._assert_coherence(snap, receipt)
 
     def test_halted_receipt_only_is_valid(self):
-        """Receipt shows HALTED, snapshot shows LIVE → valid (receipt-first)."""
+        """レシートがHALTEDでスナップショットがLIVEの場合に有効であることを検証する（レシート優先）。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             ContinuationRevalidator,
         )
@@ -388,7 +388,7 @@ class TestCoherenceGuardReceiptFirst:
         ContinuationRevalidator._assert_coherence(snap, receipt)
 
     def test_halted_durable_promotion_requires_snapshot_agreement(self):
-        """Receipt claims durable HALTED but snapshot is LIVE → violation."""
+        """レシートが永続的HALTEDを主張しスナップショットがLIVEの場合に違反となることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             ContinuationRevalidator,
         )
@@ -405,7 +405,7 @@ class TestCoherenceGuardReceiptFirst:
             ContinuationRevalidator._assert_coherence(snap, receipt)
 
     def test_halted_snapshot_requires_receipt_evidence(self):
-        """Snapshot HALTED without receipt HALTED → violation."""
+        """スナップショットがHALTEDでレシートがHALTEDでない場合に違反となることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             ContinuationRevalidator,
         )
@@ -425,6 +425,7 @@ class TestDurabilityAssessment:
     """Direct tests for _assess_durability static method."""
 
     def test_live_no_durable(self):
+        """LIVE状態では永続性がないことを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import Scope, HeadroomState
@@ -439,6 +440,7 @@ class TestDurabilityAssessment:
         assert status == ClaimStatus.LIVE
 
     def test_revoked_always_durable(self):
+        """REVOKEDは常に永続的であることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import Scope, HeadroomState
@@ -454,6 +456,7 @@ class TestDurabilityAssessment:
         assert status == ClaimStatus.REVOKED
 
     def test_halted_durable_when_collapsed(self):
+        """ヘッドルーム崩壊時にHALTEDが永続的であることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import Scope, HeadroomState
@@ -469,7 +472,7 @@ class TestDurabilityAssessment:
         assert status == ClaimStatus.HALTED
 
     def test_halted_not_durable_when_headroom_positive(self):
-        """Halted with positive headroom → receipt-only, no durable consequence."""
+        """正のヘッドルームでの停止がレシートのみで永続的結果なしであることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import Scope, HeadroomState
@@ -484,6 +487,7 @@ class TestDurabilityAssessment:
         assert status == ClaimStatus.LIVE
 
     def test_narrowed_durable_when_restrictions_present(self):
+        """制限がある場合にNARROWEDが永続的であることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import Scope, HeadroomState
@@ -499,6 +503,7 @@ class TestDurabilityAssessment:
         assert status == ClaimStatus.NARROWED
 
     def test_degraded_receipt_only(self):
+        """DEGRADEDがレシートのみであることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import Scope, HeadroomState
@@ -513,6 +518,7 @@ class TestDurabilityAssessment:
         assert status == ClaimStatus.LIVE
 
     def test_escalated_receipt_only(self):
+        """ESCALATEDがレシートのみであることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import ContinuationRevalidator
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.snapshot import Scope, HeadroomState

--- a/tests/test_continuation_replay.py
+++ b/tests/test_continuation_replay.py
@@ -55,6 +55,7 @@ class TestReplayStepPassClaimNarrowed:
     """Step passes but claim is narrowed due to scope restriction."""
 
     def test_narrowed_transition(self):
+        """LIVEからNARROWEDへの遷移を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -72,6 +73,7 @@ class TestReplayStepPassClaimNarrowed:
         assert rcpt1.divergence_flag is True
 
     def test_receipt_chain_linkage(self):
+        """レシートチェーンのリンクが正しいことを検証する。"""
         results = _run_chain([
             {"context": {}},
             {"context": {"restricted_actions": ["execute"]}},
@@ -87,6 +89,7 @@ class TestReplayStepPassClaimDegraded:
     """Step passes but claim is degraded due to burden threshold."""
 
     def test_degraded_transition(self):
+        """負担閾値超過によるDEGRADED遷移を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         # Step 0 establishes burden; step 1 carries it forward unmet
@@ -110,6 +113,7 @@ class TestReplayStepPassClaimDegraded:
         assert rcpt1.divergence_flag is True
 
     def test_burden_state_carried_forward(self):
+        """負担状態がステップ間で引き継がれることを検証する。"""
         results = _run_chain([
             {
                 "context": {
@@ -134,6 +138,7 @@ class TestReplayStepPassClaimEscalated:
     """Step passes but claim is escalated."""
 
     def test_escalated_transition(self):
+        """エスカレーションによるESCALATED遷移を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         results = _run_chain([
@@ -150,6 +155,7 @@ class TestReplayStepPassClaimHalted:
     """Step passes but claim is halted (headroom collapsed)."""
 
     def test_halted_transition(self):
+        """ヘッドルーム崩壊によるHALTED遷移を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         # Step 0 establishes zero burden → HALTED
@@ -171,7 +177,7 @@ class TestReplayStepPassClaimHalted:
         assert rcpt0.should_refuse_before_effect is True
 
     def test_halted_is_terminal(self):
-        """Once halted, remains halted even with good conditions."""
+        """一度停止すると良好な条件でも停止状態のままであることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         results = _run_chain([
@@ -193,6 +199,7 @@ class TestReplayStepPassClaimRevoked:
     """Step passes but claim is revoked (support fully lost)."""
 
     def test_revoked_transition(self):
+        """サポート完全喪失によるREVOKED遷移を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         # Use empty chain_id so authority fallback doesn't rescue support
@@ -213,7 +220,7 @@ class TestReplayStepPassClaimRevoked:
         assert lineage.is_revoked is True
 
     def test_revoked_is_terminal(self):
-        """Once revoked, stays revoked regardless of conditions."""
+        """一度取消されると条件に関わらず取消状態のままであることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         # Step 0 triggers revocation with empty chain_id
@@ -235,6 +242,7 @@ class TestReplayReceiptChainContinuityGrounding:
     """Receipt chain must demonstrate continuity grounding across steps."""
 
     def test_receipt_chain_forms_linked_list(self):
+        """レシートチェーンが連結リストを形成することを検証する。"""
         results = _run_chain([
             {"context": {}},
             {"context": {}},
@@ -248,6 +256,7 @@ class TestReplayReceiptChainContinuityGrounding:
             assert curr_rcpt.parent_receipt_ref == prev_rcpt.receipt_id
 
     def test_snapshot_id_advances_each_step(self):
+        """各ステップでスナップショットIDが更新されることを検証する。"""
         results = _run_chain([
             {"context": {}},
             {"context": {}},
@@ -258,6 +267,7 @@ class TestReplayReceiptChainContinuityGrounding:
         assert len(set(snapshot_ids)) == 3  # all unique
 
     def test_lineage_tracks_latest_snapshot(self):
+        """リネージュが最新のスナップショットを追跡することを検証する。"""
         results = _run_chain([
             {"context": {}},
             {"context": {}},
@@ -268,6 +278,7 @@ class TestReplayReceiptChainContinuityGrounding:
         assert lineage.latest_snapshot_id == last_snap.snapshot_id
 
     def test_prior_decision_continuity_carried_in_receipt(self):
+        """先行判定の継続参照がレシートに含まれることを検証する。"""
         results = _run_chain([
             {"context": {}, "prior_decision_status": "allow"},
             {"context": {}, "prior_decision_status": "allow"},
@@ -281,8 +292,7 @@ class TestReplayReceiptChainContinuityGrounding:
             assert rcpt.prior_decision_continuity_ref == "allow"
 
     def test_divergence_progressive_weakening(self):
-        """Chain shows progressive weakening: state shows durable standing,
-        receipt shows boundary progression."""
+        """チェーンの段階的弱体化を検証する: 状態は永続的立場、レシートは境界進行を示す。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         results = _run_chain([
@@ -308,6 +318,7 @@ class TestReplayReceiptChainContinuityGrounding:
         assert divergences == [False, True, True]
 
     def test_law_version_recorded_in_every_snapshot_and_receipt(self):
+        """全スナップショットとレシートにlaw_versionが記録されることを検証する。"""
         results = _run_chain([
             {"context": {}},
             {"context": {}},

--- a/tests/test_continuation_revalidator.py
+++ b/tests/test_continuation_revalidator.py
@@ -51,7 +51,7 @@ class TestContinuationRevalidator:
         return PresentCondition(**defaults)
 
     def test_basic_revalidation_returns_snapshot_and_receipt(self):
-        """Revalidation always returns both snapshot and receipt."""
+        """再検証が常にスナップショットとレシートの両方を返すことを検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
         from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
 
@@ -65,7 +65,7 @@ class TestContinuationRevalidator:
         assert isinstance(receipt, ContinuationReceipt)
 
     def test_snapshot_receipt_share_snapshot_id(self):
-        """Snapshot and receipt must reference the same snapshot_id."""
+        """スナップショットとレシートが同じsnapshot_idを参照することを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -75,7 +75,7 @@ class TestContinuationRevalidator:
         assert receipt.snapshot_id == snapshot.snapshot_id
 
     def test_snapshot_receipt_share_lineage_id(self):
-        """Both reference the same claim_lineage_id."""
+        """両方が同じclaim_lineage_idを参照することを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -86,7 +86,7 @@ class TestContinuationRevalidator:
         assert receipt.claim_lineage_id == lineage.claim_lineage_id
 
     def test_live_status_yields_renewed(self):
-        """Default conditions → LIVE / RENEWED, no divergence."""
+        """デフォルト条件でLIVE/RENEWED、乖離なしとなることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -102,7 +102,7 @@ class TestContinuationRevalidator:
         assert receipt.should_refuse_before_effect is False
 
     def test_lineage_updated_after_revalidation(self):
-        """Lineage mutable pointers are updated after revalidation."""
+        """再検証後にリネージュの可変ポインタが更新されることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -113,7 +113,7 @@ class TestContinuationRevalidator:
         assert lineage.current_claim_status == snapshot.claim_status
 
     def test_revoked_is_terminal(self):
-        """Once revoked, stays revoked regardless of new conditions."""
+        """一度取消されると新条件に関わらず取消状態のままであることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         rv = self._make_revalidator()
@@ -129,7 +129,7 @@ class TestContinuationRevalidator:
         assert receipt.should_refuse_before_effect is True
 
     def test_support_basis_lost_yields_revoked(self):
-        """No authority AND no policy → REVOKED."""
+        """権限もポリシーもない場合にREVOKEDとなることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         rv = self._make_revalidator()
@@ -146,7 +146,7 @@ class TestContinuationRevalidator:
         assert receipt.should_refuse_before_effect is True
 
     def test_scope_restriction_yields_narrowed(self):
-        """Restricted action classes present → NARROWED."""
+        """制限アクションクラスが存在する場合にNARROWEDとなることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         rv = self._make_revalidator()
@@ -161,11 +161,7 @@ class TestContinuationRevalidator:
         assert receipt.divergence_flag is True
 
     def test_escalation_required_yields_escalated(self):
-        """escalation_required in scope → ESCALATED in receipt (receipt-first).
-
-        State reflects LIVE because escalation is a boundary condition,
-        not a durable standing change.
-        """
+        """スコープのescalation_requiredによりレシートでESCALATEDとなることを検証する（レシート優先）。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -184,11 +180,7 @@ class TestContinuationRevalidator:
         assert snapshot.claim_status == ClaimStatus.LIVE
 
     def test_burden_threshold_exceeded_yields_degraded(self):
-        """Burden below threshold → DEGRADED in receipt (receipt-first).
-
-        State reflects LIVE because burden pressure is recoverable,
-        not a durable standing change.
-        """
+        """負担が閾値以下でレシートにDEGRADEDとなることを検証する（レシート優先）。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -211,7 +203,7 @@ class TestContinuationRevalidator:
         assert snapshot.claim_status == ClaimStatus.LIVE
 
     def test_snapshot_has_law_version(self):
-        """Snapshot records which law_version was applied."""
+        """スナップショットに適用されたlaw_versionが記録されることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -222,7 +214,7 @@ class TestContinuationRevalidator:
         assert snapshot.law_version == "v0.1.0-shadow"
 
     def test_receipt_has_law_version_id(self):
-        """Receipt records law_version_id."""
+        """レシートにlaw_version_idが記録されることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -232,7 +224,7 @@ class TestContinuationRevalidator:
         assert receipt.law_version_id == "v0.1.0-shadow"
 
     def test_snapshot_has_scope(self):
-        """Snapshot scope is explicit, not implicit."""
+        """スナップショットのスコープが明示的であることを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -243,7 +235,7 @@ class TestContinuationRevalidator:
         assert isinstance(snapshot.scope.allowed_action_classes, list)
 
     def test_snapshot_has_burden_state(self):
-        """Snapshot carries burden_state (not optional)."""
+        """スナップショットがburden_stateを持つことを検証する（必須フィールド）。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -254,7 +246,7 @@ class TestContinuationRevalidator:
         assert hasattr(snapshot.burden_state, "threshold")
 
     def test_snapshot_has_support_basis(self):
-        """Snapshot carries structured support_basis (not empty)."""
+        """スナップショットが構造化されたsupport_basisを持つことを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -266,7 +258,7 @@ class TestContinuationRevalidator:
         assert sb.authority or sb.policy
 
     def test_receipt_has_digests(self):
-        """Receipt carries digest summaries for audit."""
+        """レシートが監査用ダイジェスト要約を持つことを検証する。"""
         rv = self._make_revalidator()
         lineage = self._make_lineage()
         condition = self._make_condition()
@@ -278,7 +270,7 @@ class TestContinuationRevalidator:
         assert receipt.burden_headroom_digest is not None
 
     def test_snapshot_serialization_roundtrip(self):
-        """Snapshot survives to_dict → from_dict."""
+        """スナップショットがto_dict→from_dictを経ても保持されることを検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
 
         rv = self._make_revalidator()
@@ -295,7 +287,7 @@ class TestContinuationRevalidator:
         assert restored.law_version == snapshot.law_version
 
     def test_receipt_serialization_roundtrip(self):
-        """Receipt survives to_dict → from_dict."""
+        """レシートがto_dict→from_dictを経ても保持されることを検証する。"""
         from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
 
         rv = self._make_revalidator()
@@ -312,7 +304,7 @@ class TestContinuationRevalidator:
         assert restored.divergence_flag == receipt.divergence_flag
 
     def test_coherence_violation_raises(self):
-        """Coherence guard detects snapshot/receipt mismatch."""
+        """整合性ガードがスナップショット/レシートの不整合を検出することを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             ContinuationRevalidator,
         )
@@ -336,7 +328,7 @@ class TestContinuationRevalidator:
             ContinuationRevalidator._assert_coherence(snap, rcpt)
 
     def test_divergence_observable_when_claim_weakened(self):
-        """Divergence flag is True when claim_status != LIVE."""
+        """claim_statusがLIVE以外の場合に乖離フラグがTrueであることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         rv = self._make_revalidator()
@@ -360,6 +352,7 @@ class TestRunContinuationRevalidationShadow:
     """Tests for the pipeline integration helper function."""
 
     def test_returns_three_objects(self):
+        """3つのオブジェクト（リネージュ、スナップショット、レシート）を返すことを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -381,6 +374,7 @@ class TestRunContinuationRevalidationShadow:
         assert isinstance(receipt, ContinuationReceipt)
 
     def test_creates_lineage_when_none_provided(self):
+        """リネージュが未提供の場合に自動生成されることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -419,7 +413,7 @@ class TestOutputStructure:
         return snapshot.to_dict(), receipt.to_dict()
 
     def test_state_side_required_fields(self):
-        """State side must contain all required fields."""
+        """状態側に全ての必須フィールドが含まれることを検証する。"""
         snap_d, _ = self._run_revalidation()
 
         assert "claim_lineage_id" in snap_d
@@ -432,7 +426,7 @@ class TestOutputStructure:
         assert "law_version" in snap_d
 
     def test_receipt_side_required_fields(self):
-        """Receipt side must contain all required fields."""
+        """レシート側に全ての必須フィールドが含まれることを検証する。"""
         _, rcpt_d = self._run_revalidation()
 
         assert "receipt_id" in rcpt_d
@@ -445,7 +439,7 @@ class TestOutputStructure:
         assert "divergence_flag" in rcpt_d
 
     def test_state_and_receipt_are_separate(self):
-        """Snapshot and receipt are separate dicts, not merged."""
+        """スナップショットとレシートが別々の辞書であり統合されていないことを検証する。"""
         snap_d, rcpt_d = self._run_revalidation()
 
         # Receipt fields must NOT appear in snapshot
@@ -459,7 +453,7 @@ class TestOutputStructure:
         assert "headroom_state" not in rcpt_d
 
     def test_continuation_is_not_bool_or_enum_only(self):
-        """Continuation must be a rich structure, not a bool/enum."""
+        """継続がbool/enumではなくリッチな構造体であることを検証する。"""
         snap_d, rcpt_d = self._run_revalidation()
 
         # Both must be dicts with multiple fields
@@ -467,7 +461,7 @@ class TestOutputStructure:
         assert isinstance(rcpt_d, dict) and len(rcpt_d) > 5
 
     def test_law_version_present(self):
-        """law_version must be non-empty."""
+        """law_versionが空でないことを検証する。"""
         snap_d, rcpt_d = self._run_revalidation()
 
         assert snap_d["law_version"] != ""
@@ -483,7 +477,7 @@ class TestFeatureFlagOff:
     """Verify that flag off → zero computation in PipelineContext."""
 
     def test_pipeline_context_defaults_none(self):
-        """PipelineContext continuation fields default to None."""
+        """PipelineContextの継続フィールドがデフォルトでNoneであることを検証する。"""
         from veritas_os.core.pipeline_types import PipelineContext
 
         ctx = PipelineContext()
@@ -492,7 +486,7 @@ class TestFeatureFlagOff:
         assert ctx.continuation_receipt is None
 
     def test_flag_off_default(self):
-        """VERITAS_CAP_CONTINUATION_RUNTIME defaults to False."""
+        """VERITAS_CAP_CONTINUATION_RUNTIMEがデフォルトでFalseであることを検証する。"""
         # Ensure env var is not set
         env_val = os.environ.pop("VERITAS_CAP_CONTINUATION_RUNTIME", None)
         try:
@@ -503,7 +497,7 @@ class TestFeatureFlagOff:
                 os.environ["VERITAS_CAP_CONTINUATION_RUNTIME"] = env_val
 
     def test_response_omits_continuation_when_flag_off(self):
-        """assemble_response omits 'continuation' key when ctx has no snapshot."""
+        """ctxにスナップショットがない場合にassemble_responseがcontinuationキーを省略することを検証する。"""
         from veritas_os.core.pipeline_types import PipelineContext
         from veritas_os.core.pipeline_response import assemble_response
 
@@ -522,7 +516,7 @@ class TestFeatureFlagOff:
         assert "continuation" not in res
 
     def test_response_includes_continuation_when_present(self):
-        """assemble_response includes 'continuation' when snapshot/receipt set."""
+        """スナップショット/レシートが設定されている場合にcontinuationが含まれることを検証する。"""
         from veritas_os.core.pipeline_types import PipelineContext
         from veritas_os.core.pipeline_response import assemble_response
 
@@ -555,8 +549,7 @@ class TestDivergenceObservation:
     is observable in the output."""
 
     def test_local_allow_with_continuation_degraded(self):
-        """Local step allows, but continuation is degraded → divergence visible
-        in receipt. State remains LIVE (degraded is receipt-first)."""
+        """ローカルステップがallowだが継続がdegradedの場合にレシートで乖離が可視であることを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -583,7 +576,7 @@ class TestDivergenceObservation:
         assert receipt.should_refuse_before_effect is False
 
     def test_local_allow_with_continuation_revoked(self):
-        """Local step allows, but continuation is revoked → divergence + advisory refuse."""
+        """ローカルステップがallowだが継続がrevokedの場合に乖離と助言的拒否を検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -611,6 +604,7 @@ class TestContinuationClaimLineageCreation:
     """ContinuationClaimLineage creation and invariants."""
 
     def test_creation_defaults(self):
+        """リネージュのデフォルト値を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import (
             ContinuationClaimLineage,
             ClaimStatus,
@@ -624,6 +618,7 @@ class TestContinuationClaimLineageCreation:
         assert lineage.latest_snapshot_id is None
 
     def test_creation_with_chain_id(self):
+        """chain_id指定でのリネージュ生成を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ContinuationClaimLineage
 
         lineage = ContinuationClaimLineage(chain_id="c-1", origin_ref="step:0")
@@ -631,6 +626,7 @@ class TestContinuationClaimLineageCreation:
         assert lineage.origin_ref == "step:0"
 
     def test_serialization_roundtrip(self):
+        """リネージュのシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import (
             ContinuationClaimLineage,
             ClaimStatus,
@@ -648,6 +644,7 @@ class TestContinuationClaimLineageCreation:
         assert restored.chain_id == "c-rt"
 
     def test_claim_status_enum_values(self):
+        """ClaimStatusの列挙値を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
         expected = {"live", "narrowed", "degraded", "escalated", "halted", "revoked"}
@@ -659,6 +656,7 @@ class TestClaimStateSnapshotCreation:
     """ClaimStateSnapshot creation and structural invariants."""
 
     def test_creation_defaults(self):
+        """スナップショットのデフォルト値を検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
 
@@ -672,7 +670,7 @@ class TestClaimStateSnapshotCreation:
         assert snap.law_version == ""
 
     def test_snapshot_does_not_contain_receipt_fields(self):
-        """Snapshot must NOT carry revalidation_status, divergence, etc."""
+        """スナップショットにrevalidation_statusやdivergence等のレシートフィールドが含まれないことを検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import ClaimStateSnapshot
 
         snap = ClaimStateSnapshot()
@@ -688,6 +686,7 @@ class TestClaimStateSnapshotCreation:
         assert "receipt_hash_or_attestation" not in d
 
     def test_support_basis_sub_structure(self):
+        """SupportBasisのサブ構造体のシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import SupportBasis
 
         sb = SupportBasis(authority="chain:x", policy="default", evidence="ev:2")
@@ -697,6 +696,7 @@ class TestClaimStateSnapshotCreation:
         assert restored.policy == "default"
 
     def test_scope_sub_structure(self):
+        """Scopeのサブ構造体のシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import Scope
 
         scope = Scope(
@@ -710,6 +710,7 @@ class TestClaimStateSnapshotCreation:
         assert "execute" in restored.restricted_action_classes
 
     def test_burden_state_sub_structure(self):
+        """BurdenStateのサブ構造体のシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import BurdenState
 
         bs = BurdenState(
@@ -724,6 +725,7 @@ class TestClaimStateSnapshotCreation:
         assert len(restored.required_evidence) == 2
 
     def test_headroom_state_sub_structure(self):
+        """HeadroomStateのサブ構造体のシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import HeadroomState
 
         hs = HeadroomState(remaining=0.7, threshold_escalation=0.3, threshold_suspension=0.0)
@@ -732,6 +734,7 @@ class TestClaimStateSnapshotCreation:
         assert restored.remaining == 0.7
 
     def test_revocation_condition_sub_structure(self):
+        """RevocationConditionのサブ構造体のシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import RevocationCondition
 
         rc = RevocationCondition(
@@ -742,6 +745,7 @@ class TestClaimStateSnapshotCreation:
         assert restored.is_met is True
 
     def test_full_serialization_roundtrip(self):
+        """全フィールドを含むスナップショットの完全なシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.snapshot import (
             ClaimStateSnapshot,
             SupportBasis,
@@ -777,6 +781,7 @@ class TestContinuationReceiptGeneration:
     """ContinuationReceipt generation and structural invariants."""
 
     def test_creation_defaults(self):
+        """レシートのデフォルト値を検証する。"""
         from veritas_os.core.continuation_runtime.receipt import (
             ContinuationReceipt,
             RevalidationStatus,
@@ -791,7 +796,7 @@ class TestContinuationReceiptGeneration:
         assert rcpt.should_refuse_before_effect is False
 
     def test_receipt_does_not_contain_state_fields(self):
-        """Receipt must NOT carry support_basis, burden_state, etc."""
+        """レシートにsupport_basisやburden_state等の状態フィールドが含まれないことを検証する。"""
         from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
 
         rcpt = ContinuationReceipt()
@@ -803,7 +808,7 @@ class TestContinuationReceiptGeneration:
         assert "revocation_conditions" not in d
 
     def test_revalidation_status_on_receipt_side(self):
-        """revalidation_status belongs to receipt, not snapshot."""
+        """revalidation_statusがレシート側に属することを検証する。"""
         from veritas_os.core.continuation_runtime.receipt import (
             ContinuationReceipt,
             RevalidationStatus,
@@ -815,7 +820,7 @@ class TestContinuationReceiptGeneration:
         assert rcpt.revalidation_status == RevalidationStatus.DEGRADED
 
     def test_revalidation_outcome_on_receipt_side(self):
-        """revalidation_outcome belongs to receipt, not snapshot."""
+        """revalidation_outcomeがレシート側に属することを検証する。"""
         from veritas_os.core.continuation_runtime.receipt import (
             ContinuationReceipt,
             RevalidationOutcome,
@@ -827,7 +832,7 @@ class TestContinuationReceiptGeneration:
         assert rcpt.revalidation_outcome == RevalidationOutcome.ESCALATED
 
     def test_prior_decision_continuity_on_receipt_side(self):
-        """prior_decision_continuity_ref belongs to receipt, not snapshot."""
+        """prior_decision_continuity_refがレシート側に属することを検証する。"""
         from veritas_os.core.continuation_runtime.receipt import ContinuationReceipt
 
         rcpt = ContinuationReceipt(
@@ -836,6 +841,7 @@ class TestContinuationReceiptGeneration:
         assert rcpt.prior_decision_continuity_ref == "allow"
 
     def test_receipt_serialization_roundtrip_with_reason_codes(self):
+        """理由コード付きレシートのシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.receipt import (
             ContinuationReceipt,
             RevalidationStatus,
@@ -863,6 +869,7 @@ class TestContinuationReceiptGeneration:
         assert restored.divergence_flag is True
 
     def test_receipt_revalidation_status_enum_values(self):
+        """RevalidationStatusの列挙値を検証する。"""
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
         expected = {"renewed", "narrowed", "degraded", "escalated", "halted", "revoked", "failed"}
@@ -874,6 +881,7 @@ class TestContinuationLawPackResolution:
     """ContinuationLawPack resolution and invariants."""
 
     def test_default_law_pack(self):
+        """デフォルトのlaw packの値を検証する。"""
         from veritas_os.core.continuation_runtime.lawpack import (
             ContinuationLawPack,
             EvaluationMode,
@@ -886,6 +894,7 @@ class TestContinuationLawPackResolution:
         assert len(pack.rule_refs) > 0
 
     def test_law_pack_serialization_roundtrip(self):
+        """LawPackのシリアライズ往復を検証する。"""
         from veritas_os.core.continuation_runtime.lawpack import (
             ContinuationLawPack,
             EvaluationMode,
@@ -904,6 +913,7 @@ class TestContinuationLawPackResolution:
         assert len(restored.rule_refs) == 2
 
     def test_evaluation_mode_enum_values(self):
+        """EvaluationModeの列挙値を検証する。"""
         from veritas_os.core.continuation_runtime.lawpack import EvaluationMode
 
         expected = {"shadow", "advisory", "enforce"}
@@ -911,6 +921,7 @@ class TestContinuationLawPackResolution:
         assert actual == expected
 
     def test_law_pack_rule_refs_non_empty_in_default(self):
+        """デフォルトlaw packのrule_refsが空でないことを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import _default_law_pack
 
         pack = _default_law_pack()
@@ -924,6 +935,7 @@ class TestReasonCodeMapping:
     """Reason code mapping and coverage."""
 
     def test_all_reason_codes_exist(self):
+        """全ての理由コードが存在することを検証する。"""
         from veritas_os.core.continuation_runtime.reason_codes import ReasonCode
 
         expected = {
@@ -941,7 +953,7 @@ class TestReasonCodeMapping:
         assert actual == expected
 
     def test_revoked_yields_support_lost_reason(self):
-        """Revocation due to support loss carries correct reason code."""
+        """サポート喪失による取消が正しい理由コードを持つことを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -960,6 +972,7 @@ class TestReasonCodeMapping:
         )
 
     def test_burden_exceeded_yields_correct_reason(self):
+        """負担超過が正しい理由コードを生成することを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -978,6 +991,7 @@ class TestReasonCodeMapping:
         assert ReasonCode.BURDEN_THRESHOLD_EXCEEDED in receipt.revalidation_reason_codes
 
     def test_escalation_yields_action_class_not_allowed(self):
+        """エスカレーションがACTION_CLASS_NOT_ALLOWEDを生成することを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -993,6 +1007,7 @@ class TestReasonCodeMapping:
         assert ReasonCode.ACTION_CLASS_NOT_ALLOWED in receipt.revalidation_reason_codes
 
     def test_narrowed_yields_action_class_not_allowed(self):
+        """縮小がACTION_CLASS_NOT_ALLOWEDを生成することを検証する。"""
         from veritas_os.core.continuation_runtime.revalidator import (
             run_continuation_revalidation_shadow,
         )
@@ -1021,6 +1036,7 @@ class TestClaimStatusConsistency:
         return run_continuation_revalidation_shadow(**defaults)
 
     def test_live_consistency(self):
+        """LIVE状態でのスナップショット・レシート・リネージュの整合性を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -1030,6 +1046,7 @@ class TestClaimStatusConsistency:
         assert lineage.current_claim_status == ClaimStatus.LIVE
 
     def test_narrowed_consistency(self):
+        """NARROWED状態でのスナップショット・レシート・リネージュの整合性を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -1041,7 +1058,7 @@ class TestClaimStatusConsistency:
         assert lineage.current_claim_status == ClaimStatus.NARROWED
 
     def test_degraded_consistency(self):
-        """Degraded: receipt-first boundary, state remains LIVE."""
+        """DEGRADED: レシート優先境界で状態はLIVEのままであることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -1059,7 +1076,7 @@ class TestClaimStatusConsistency:
         assert lineage.current_claim_status == ClaimStatus.LIVE
 
     def test_escalated_consistency(self):
-        """Escalated: receipt-first boundary, state remains LIVE."""
+        """ESCALATED: レシート優先境界で状態はLIVEのままであることを検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -1074,6 +1091,7 @@ class TestClaimStatusConsistency:
         assert lineage.current_claim_status == ClaimStatus.LIVE
 
     def test_revoked_consistency(self):
+        """REVOKED状態でのスナップショット・レシート・リネージュの整合性を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 
@@ -1088,7 +1106,7 @@ class TestClaimStatusConsistency:
         assert lineage.revoked_at is not None
 
     def test_halted_consistency(self):
-        """Headroom collapsed → HALTED."""
+        """ヘッドルーム崩壊によるHALTEDの整合性を検証する。"""
         from veritas_os.core.continuation_runtime.lineage import ClaimStatus
         from veritas_os.core.continuation_runtime.receipt import RevalidationStatus
 


### PR DESCRIPTION
各テストファイルの全test_関数に対して個別の日本語docstringを付与。
既存の英語docstringは日本語に翻訳し、docstring未設定の関数には
新規に日本語docstringを追加した。モジュールレベルのdocstringは
英語のまま維持。

対象ファイル (7件):
- test_continuation_eval_harness.py (8テスト)
- test_continuation_golden.py (25テスト)
- test_continuation_integration.py (14テスト)
- test_continuation_receipt_enrichment.py (34テスト)
- test_continuation_receipt_first.py (26テスト)
- test_continuation_replay.py (15テスト)
- test_continuation_revalidator.py (67テスト)

https://claude.ai/code/session_01MDA71UdpnohRJi6L78HBN9