### PR TITLE
Improve frontend API contract consistency method inference

### DIFF
--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -171,3 +171,17 @@
 
 セキュリティ補足:
 - 本修正はテストの整合性のみを対象としており、実行時の認可・公開 API・BFF 境界は変更していない。
+
+### 7.5 2026-03-31 追加改善（最小・抽出精度補強）
+
+無駄な機能追加は行わず、指摘C（静的突合チェックの検証精度）に限定して最小改善を実施。
+
+- `scripts/quality/check_frontend_api_contract_consistency.py`
+  - `fetch(url, optionsVar)` / `veritasFetch(url, optionsVar)` 形式で、`optionsVar` が `const putOptions = { method: "PUT" }` のような **定数オブジェクト（およびそのエイリアス）** を参照するケースを解決。
+  - これにより method の静的推定漏れ（GET 誤判定）を抑え、BFF/OpenAPI との突合精度を改善。
+- `veritas_os/tests/test_frontend_api_contract_consistency.py`
+  - options オブジェクトのエイリアス連鎖経由で `PUT` が正しく抽出されることを検証する回帰テストを追加。
+
+セキュリティ補足:
+- 本改善は契約整合性チェックの検出品質向上のみを対象とし、BFF 許可行列・認可ロジック・公開 API は不変。
+- したがって新たな API 露出リスクは増やしていない。

--- a/scripts/quality/check_frontend_api_contract_consistency.py
+++ b/scripts/quality/check_frontend_api_contract_consistency.py
@@ -52,6 +52,14 @@ PATH_ALIAS_PATTERN = re.compile(
     r"(?P<ref>[A-Za-z_][A-Za-z0-9_]*)\s*;"
 )
 METHOD_PATTERN = re.compile(r'method\s*:\s*[\"\'](?P<method>GET|POST|PUT|PATCH|DELETE)[\"\']')
+OPTIONS_METHOD_PATTERN = re.compile(
+    r"(?:const|let|var)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*\{"
+    r"(?P<body>.*?)\}\s*;",
+    re.DOTALL,
+)
+OPTIONS_IDENTIFIER_PATTERN = re.compile(
+    r"^\s*,\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+)
 ROUTE_POLICY_PATTERN = re.compile(
     r'pathPattern:\s*/\^(?P<pattern>.+?)\$/\s*,\s*method:\s*"(?P<method>[A-Z]+)"',
 )
@@ -105,6 +113,13 @@ def collect_frontend_usages() -> list[FrontendRouteUsage]:
                 match.group("name"): match.group("ref")
                 for match in PATH_ALIAS_PATTERN.finditer(content)
             }
+            options_methods = {
+                match.group("name"): _extract_method_from_options_body(match.group("body"))
+                for match in OPTIONS_METHOD_PATTERN.finditer(content)
+            }
+            options_methods = {
+                key: value for key, value in options_methods.items() if value is not None
+            }
             for _ in range(len(alias_variables)):
                 updated = False
                 for alias, ref in alias_variables.items():
@@ -115,9 +130,18 @@ def collect_frontend_usages() -> list[FrontendRouteUsage]:
                 if not updated:
                     break
 
+            for _ in range(len(alias_variables)):
+                updated = False
+                for alias, ref in alias_variables.items():
+                    resolved_method = options_methods.get(ref)
+                    if resolved_method and options_methods.get(alias) != resolved_method:
+                        options_methods[alias] = resolved_method
+                        updated = True
+                if not updated:
+                    break
+
             for match in VERITAS_FETCH_CALL_PATTERN.finditer(content):
-                method_match = METHOD_PATTERN.search(match.group("tail"))
-                method = method_match.group("method") if method_match else "GET"
+                method = _infer_method(match.group("tail"), options_methods)
                 usages.append(
                     FrontendRouteUsage(
                         method=method,
@@ -127,8 +151,7 @@ def collect_frontend_usages() -> list[FrontendRouteUsage]:
                 )
 
             for match in FETCH_CALL_PATTERN.finditer(content):
-                method_match = METHOD_PATTERN.search(match.group("tail"))
-                method = method_match.group("method") if method_match else "GET"
+                method = _infer_method(match.group("tail"), options_methods)
                 usages.append(
                     FrontendRouteUsage(
                         method=method,
@@ -153,8 +176,7 @@ def collect_frontend_usages() -> list[FrontendRouteUsage]:
                 if match.group("fn") == "EventSource":
                     method = "GET"
                 else:
-                    method_match = METHOD_PATTERN.search(match.group("tail"))
-                    method = method_match.group("method") if method_match else "GET"
+                    method = _infer_method(match.group("tail"), options_methods)
                 usages.append(
                     FrontendRouteUsage(
                         method=method,
@@ -164,6 +186,29 @@ def collect_frontend_usages() -> list[FrontendRouteUsage]:
                 )
 
     return usages
+
+
+def _extract_method_from_options_body(body: str) -> str | None:
+    """Extract HTTP method from an object literal body if statically available."""
+    method_match = METHOD_PATTERN.search(body)
+    if not method_match:
+        return None
+    return method_match.group("method").upper()
+
+
+def _infer_method(tail: str, options_methods: dict[str, str]) -> str:
+    """Infer HTTP method from inline options or options variable usage."""
+    method_match = METHOD_PATTERN.search(tail)
+    if method_match:
+        return method_match.group("method").upper()
+
+    options_identifier_match = OPTIONS_IDENTIFIER_PATTERN.search(tail)
+    if options_identifier_match:
+        option_name = options_identifier_match.group("name")
+        if option_name in options_methods:
+            return options_methods[option_name]
+
+    return "GET"
 
 
 def load_bff_route_matchers() -> list[RouteMatcher]:

--- a/veritas_os/tests/test_frontend_api_contract_consistency.py
+++ b/veritas_os/tests/test_frontend_api_contract_consistency.py
@@ -117,3 +117,36 @@ def test_collect_frontend_usages_resolves_variable_aliases(tmp_path: pathlib.Pat
 
     found = {(usage.method, usage.raw_path) for usage in usages}
     assert ("GET", "/api/veritas/v1/compliance/config") in found
+
+
+def test_collect_frontend_usages_resolves_method_options_aliases(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Collector should resolve method from options objects and their aliases."""
+    frontend_root = tmp_path / "frontend"
+    source_file = frontend_root / "app" / "method-alias.ts"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        textwrap.dedent(
+            """
+            const endpoint = "/api/veritas/v1/governance/policy";
+            const putOptions = { method: "PUT", headers: { "content-type": "application/json" } };
+            const requestOptions = putOptions;
+
+            async function savePolicy() {
+              await fetch(endpoint, requestOptions);
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    original_frontend_root = checker.FRONTEND_ROOT
+    checker.FRONTEND_ROOT = frontend_root
+    try:
+        usages = checker.collect_frontend_usages()
+    finally:
+        checker.FRONTEND_ROOT = original_frontend_root
+
+    found = {(usage.method, usage.raw_path) for usage in usages}
+    assert ("PUT", "/api/veritas/v1/governance/policy") in found


### PR DESCRIPTION
### Motivation
- The frontend/OpenAPI/BFF consistency checker could misclassify requests as `GET` when the HTTP method was provided via an options variable rather than inline, producing false-positive drift reports; the change aims to improve static-detection precision with minimal surface area.
- The intent is to reduce noisy CI failures while avoiding any runtime or auth-surface changes to BFF/OpenAPI behavior.

### Description
- Extended `scripts/quality/check_frontend_api_contract_consistency.py` to support extracting HTTP methods from options object constants by adding `OPTIONS_METHOD_PATTERN`, `OPTIONS_IDENTIFIER_PATTERN`, `_extract_method_from_options_body`, and `_infer_method`, and by resolving one-hop/chained aliases inside the same file.
- Wired the new inference into existing extraction paths for `fetch(...)`, `veritasFetch(...)`, and identifier-based calls so that `fetch(url, optionsVar)` correctly resolves `method` when `optionsVar` is a static object (or an alias to one), defaulting to `GET` when unknown.
- Added a unit test `veritas_os/tests/test_frontend_api_contract_consistency.py::test_collect_frontend_usages_resolves_method_options_aliases` to prevent regressions in options-based method extraction.
- Appended section `7.5` to `docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md` documenting the minimal improvement and its security considerations.

### Testing
- Ran `pytest -q veritas_os/tests/test_frontend_api_contract_consistency.py` and all tests passed (`6 passed in 0.21s`).
- Executed the checker with `python scripts/quality/check_frontend_api_contract_consistency.py` and it reported `Frontend/BFF/OpenAPI consistency checks passed.`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cba64bbfe88326b199c9bb4eb811a4)