### PR TITLE
Handle TypeScript-cast options in frontend API consistency checker

### DIFF
--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -185,3 +185,17 @@
 セキュリティ補足:
 - 本改善は契約整合性チェックの検出品質向上のみを対象とし、BFF 許可行列・認可ロジック・公開 API は不変。
 - したがって新たな API 露出リスクは増やしていない。
+
+### 7.6 2026-03-31 追加改善（最小・TypeScript 型キャスト対応）
+
+無駄な機能追加は行わず、指摘C（静的突合チェックの検証精度）に限定して最小改善を実施。
+
+- `scripts/quality/check_frontend_api_contract_consistency.py`
+  - `fetch(url, options as RequestInit)` / `veritasFetch(url, options as RequestInit)` のような **TypeScript の型キャスト付き options 参照** から method を静的解決できるよう改善。
+  - 既存の `options` 変数解決ロジックへ最小分岐を追加し、`GET` への誤推定を抑制。
+- `veritas_os/tests/test_frontend_api_contract_consistency.py`
+  - `fetch(endpoint, patchOptions as RequestInit)` で `PATCH` が正しく抽出される回帰テストを追加。
+
+セキュリティ補足:
+- 本改善は抽出器の判定精度のみを向上させるもので、BFF 許可境界・認可判定・公開 API 挙動は不変。
+- 新規経路の公開や権限昇格リスクは追加していない。

--- a/scripts/quality/check_frontend_api_contract_consistency.py
+++ b/scripts/quality/check_frontend_api_contract_consistency.py
@@ -60,6 +60,10 @@ OPTIONS_METHOD_PATTERN = re.compile(
 OPTIONS_IDENTIFIER_PATTERN = re.compile(
     r"^\s*,\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
 )
+OPTIONS_IDENTIFIER_CAST_PATTERN = re.compile(
+    r"^\s*,\s*\(?\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s+"
+    r"(?:as|satisfies)\b"
+)
 ROUTE_POLICY_PATTERN = re.compile(
     r'pathPattern:\s*/\^(?P<pattern>.+?)\$/\s*,\s*method:\s*"(?P<method>[A-Z]+)"',
 )
@@ -205,6 +209,11 @@ def _infer_method(tail: str, options_methods: dict[str, str]) -> str:
     options_identifier_match = OPTIONS_IDENTIFIER_PATTERN.search(tail)
     if options_identifier_match:
         option_name = options_identifier_match.group("name")
+        if option_name in options_methods:
+            return options_methods[option_name]
+    options_identifier_cast_match = OPTIONS_IDENTIFIER_CAST_PATTERN.search(tail)
+    if options_identifier_cast_match:
+        option_name = options_identifier_cast_match.group("name")
         if option_name in options_methods:
             return options_methods[option_name]
 

--- a/veritas_os/tests/test_frontend_api_contract_consistency.py
+++ b/veritas_os/tests/test_frontend_api_contract_consistency.py
@@ -150,3 +150,35 @@ def test_collect_frontend_usages_resolves_method_options_aliases(
 
     found = {(usage.method, usage.raw_path) for usage in usages}
     assert ("PUT", "/api/veritas/v1/governance/policy") in found
+
+
+def test_collect_frontend_usages_resolves_options_type_cast_reference(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Collector should resolve method when options arg uses TypeScript cast."""
+    frontend_root = tmp_path / "frontend"
+    source_file = frontend_root / "app" / "method-cast.ts"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        textwrap.dedent(
+            """
+            const endpoint = "/api/veritas/v1/governance/policy";
+            const patchOptions = { method: "PATCH" };
+
+            async function savePolicy() {
+              await fetch(endpoint, patchOptions as RequestInit);
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    original_frontend_root = checker.FRONTEND_ROOT
+    checker.FRONTEND_ROOT = frontend_root
+    try:
+        usages = checker.collect_frontend_usages()
+    finally:
+        checker.FRONTEND_ROOT = original_frontend_root
+
+    found = {(usage.method, usage.raw_path) for usage in usages}
+    assert ("PATCH", "/api/veritas/v1/governance/policy") in found


### PR DESCRIPTION
### Motivation
- Improve static extraction precision for frontend API usages to avoid false `GET` inferences when options are passed with TypeScript casts (addressing review 指摘C). 
- Make a minimal, targeted change that only enhances the extractor and does not modify BFF allowlists, auth logic, or public API behavior.

### Description
- Add `OPTIONS_IDENTIFIER_CAST_PATTERN` to `scripts/quality/check_frontend_api_contract_consistency.py` to detect constructs like `fetch(url, options as RequestInit)` or `fetch(url, options satisfies ...)`.
- Extend `_infer_method` to consult the cast-aware identifier pattern and resolve the HTTP method from previously-collected `options` object definitions when present.
- Add `test_collect_frontend_usages_resolves_options_type_cast_reference` to `veritas_os/tests/test_frontend_api_contract_consistency.py` and append a corresponding note (section 7.6) to `docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md`.

### Testing
- Ran unit tests with `pytest -q veritas_os/tests/test_frontend_api_contract_consistency.py`, which passed (`7 passed`).
- Ran the consistency script with `python scripts/quality/check_frontend_api_contract_consistency.py`, which reported `Frontend/BFF/OpenAPI consistency checks passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbacdd5b508326aaf23427c47c56b4)