### PR TITLE
Improve frontend API contract checker for TypeScript `as const` methods

### DIFF
--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -213,3 +213,17 @@
 セキュリティ補足:
 - 本改善は契約整合性チェックの見落とし低減のみを目的とし、BFF の許可行列・認可判定・公開 API の挙動は不変。
 - 新規の API 公開面は増加していないが、静的解析である以上、動的に組み立てたメソッド値は引き続き検出限界があるため、CI と実行時監査の併用を継続すること。
+
+### 7.8 2026-03-31 追加改善（最小・TypeScript `as const` メソッド指定対応）
+
+無駄な機能追加は行わず、指摘C（静的突合チェックの検証精度）に限定して最小改善を実施。
+
+- `scripts/quality/check_frontend_api_contract_consistency.py`
+  - `const postOptions = { method: "POST" as const }` のような **TypeScript の `as const` 付き method リテラル**を静的抽出できるよう、method 抽出正規表現を最小修正。
+  - これにより options 定数経由の `fetch(endpoint, postOptions)` でも `POST` を正確に推定し、`GET` への誤フォールバックを抑制。
+- `veritas_os/tests/test_frontend_api_contract_consistency.py`
+  - `method: "POST" as const` を使った options 参照の回帰テストを追加し、再発を防止。
+
+セキュリティ補足:
+- 本改善は契約整合性チェックの抽出精度向上のみを対象とし、BFF 許可行列・認可ロジック・公開 API は不変。
+- 新規の API 露出は増加していないが、動的に算出される method は静的解析の限界があるため、引き続き CI と実行時監査を併用すること。

--- a/scripts/quality/check_frontend_api_contract_consistency.py
+++ b/scripts/quality/check_frontend_api_contract_consistency.py
@@ -52,7 +52,7 @@ PATH_ALIAS_PATTERN = re.compile(
     r"(?P<ref>[A-Za-z_][A-Za-z0-9_]*)\s*;"
 )
 METHOD_PATTERN = re.compile(
-    r'method\s*:\s*[\"\'](?P<method>GET|POST|PUT|PATCH|DELETE)[\"\']',
+    r'method\s*:\s*[\"\'](?P<method>GET|POST|PUT|PATCH|DELETE)[\"\'](?:\s+as\s+const)?',
     re.IGNORECASE,
 )
 OPTIONS_METHOD_PATTERN = re.compile(

--- a/veritas_os/tests/test_frontend_api_contract_consistency.py
+++ b/veritas_os/tests/test_frontend_api_contract_consistency.py
@@ -214,3 +214,35 @@ def test_collect_frontend_usages_normalizes_lowercase_method_literals(
 
     found = {(usage.method, usage.raw_path) for usage in usages}
     assert ("POST", "/api/veritas/v1/decide") in found
+
+
+def test_collect_frontend_usages_resolves_method_with_const_assertion(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Collector should resolve method when literal uses TypeScript const assertion."""
+    frontend_root = tmp_path / "frontend"
+    source_file = frontend_root / "app" / "method-const-assertion.ts"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        textwrap.dedent(
+            """
+            const endpoint = "/api/veritas/v1/governance/policy";
+            const postOptions = { method: "POST" as const };
+
+            async function savePolicy() {
+              await fetch(endpoint, postOptions);
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    original_frontend_root = checker.FRONTEND_ROOT
+    checker.FRONTEND_ROOT = frontend_root
+    try:
+        usages = checker.collect_frontend_usages()
+    finally:
+        checker.FRONTEND_ROOT = original_frontend_root
+
+    found = {(usage.method, usage.raw_path) for usage in usages}
+    assert ("POST", "/api/veritas/v1/governance/policy") in found


### PR DESCRIPTION
### Motivation
- Reduce false-negative method inference from frontend static analysis when options use TypeScript `as const` without changing runtime behavior or BFF/OpenAPI boundaries.
- Keep the change minimal and focused on extractor accuracy to avoid unnecessary feature additions.
- Preserve security posture by not modifying BFF allowlist or API surface and by documenting the scope in the review notes.

### Description
- Relax `METHOD_PATTERN` in `scripts/quality/check_frontend_api_contract_consistency.py` to accept `method: "POST" as const` style TypeScript literals so the extractor recognizes the method correctly.
- Add `test_collect_frontend_usages_resolves_method_with_const_assertion` to `veritas_os/tests/test_frontend_api_contract_consistency.py` to cover the `as const` method literal case.
- Append section `7.8` to `docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md` describing the minimal change and reiterating the security note that BFF/OpenAPI behavior is unchanged.

### Testing
- Ran the unit test suite for the checker with `pytest -q veritas_os/tests/test_frontend_api_contract_consistency.py` and observed all tests passing (`9 passed in 0.31s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0dc14c488326993f37d45497f54a)