### PR TITLE
Handle parenthesized options in frontend API contract checker

### DIFF
--- a/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
+++ b/docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md
@@ -241,3 +241,17 @@
 セキュリティ補足:
 - 本改善は契約整合性チェックの抽出精度向上のみを対象とし、BFF 許可行列・認可ロジック・公開 API の挙動は不変。
 - 新規の API 露出は増加していない。静的解析の限界（動的生成キー/値）は引き続き残るため、CI と実行時監査の併用を継続すること。
+
+### 7.10 2026-03-31 追加改善（最小・options 参照の括弧表記対応）
+
+無駄な機能追加は行わず、指摘C（静的突合チェックの検証精度）に限定して最小改善を実施。
+
+- `scripts/quality/check_frontend_api_contract_consistency.py`
+  - `fetch(endpoint, (putOptions))` のような **options 変数が括弧で包まれた表記** でも method を静的抽出できるよう、options 参照の正規表現を最小修正。
+  - これによりコード整形や可読性目的の括弧付与で `GET` へ誤フォールバックするケースを抑制。
+- `veritas_os/tests/test_frontend_api_contract_consistency.py`
+  - `fetch(endpoint, (putOptions))` で `PUT` を正しく抽出できる回帰テストを追加。
+
+セキュリティ補足:
+- 本改善は契約整合性チェックの判定精度向上のみを対象とし、BFF 許可行列・認可ロジック・公開 API は不変。
+- 新規の API 露出は増加していない。静的解析の限界（動的に組み立てた options）は引き続き残るため、CI と実行時監査の併用を継続すること。

--- a/scripts/quality/check_frontend_api_contract_consistency.py
+++ b/scripts/quality/check_frontend_api_contract_consistency.py
@@ -62,7 +62,7 @@ OPTIONS_METHOD_PATTERN = re.compile(
     re.DOTALL,
 )
 OPTIONS_IDENTIFIER_PATTERN = re.compile(
-    r"^\s*,\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+    r"^\s*,\s*\(?\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\)?"
 )
 OPTIONS_IDENTIFIER_CAST_PATTERN = re.compile(
     r"^\s*,\s*\(?\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s+"

--- a/veritas_os/tests/test_frontend_api_contract_consistency.py
+++ b/veritas_os/tests/test_frontend_api_contract_consistency.py
@@ -278,3 +278,35 @@ def test_collect_frontend_usages_resolves_quoted_method_key(
 
     found = {(usage.method, usage.raw_path) for usage in usages}
     assert ("POST", "/api/veritas/v1/decide") in found
+
+
+def test_collect_frontend_usages_resolves_parenthesized_options_identifier(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Collector should resolve method when options identifier is parenthesized."""
+    frontend_root = tmp_path / "frontend"
+    source_file = frontend_root / "app" / "parenthesized-options.ts"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        textwrap.dedent(
+            """
+            const endpoint = "/api/veritas/v1/governance/policy";
+            const putOptions = { method: "PUT" };
+
+            async function savePolicy() {
+              await fetch(endpoint, (putOptions));
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    original_frontend_root = checker.FRONTEND_ROOT
+    checker.FRONTEND_ROOT = frontend_root
+    try:
+        usages = checker.collect_frontend_usages()
+    finally:
+        checker.FRONTEND_ROOT = original_frontend_root
+
+    found = {(usage.method, usage.raw_path) for usage in usages}
+    assert ("PUT", "/api/veritas/v1/governance/policy") in found


### PR DESCRIPTION
### Motivation
- Improve the static frontend API extraction so `fetch(endpoint, (putOptions))` (options identifier wrapped in parentheses) is correctly resolved and avoids falling back to `GET`, while keeping the change minimal and avoiding any runtime API or BFF behavior changes.

### Description
- Adjusted the options-identifier regex in `scripts/quality/check_frontend_api_contract_consistency.py` to accept parenthesized identifiers, added a regression test `test_collect_frontend_usages_resolves_parenthesized_options_identifier` in `veritas_os/tests/test_frontend_api_contract_consistency.py`, and appended the review document `docs/reviews/FRONTEND_BACKEND_CONSISTENCY_REVIEW_2026_03_30_JP.md` with a note describing the change (7.10); the change is constrained to static-analysis precision only.

### Testing
- Ran `pytest -q veritas_os/tests/test_frontend_api_contract_consistency.py` and received `11 passed` indicating the new regression test and existing tests all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc15138c4c8326ad47b18341ba212b)