### PR TITLE
middleware: add production detection, BFF cookie controls, secure-cookie logic, and tests

### DIFF
--- a/frontend/app/audit/hooks/useAuditData.ts
+++ b/frontend/app/audit/hooks/useAuditData.ts
@@ -18,7 +18,6 @@ import {
   type DetailTab,
   type ExportFormat,
   type RedactionMode,
-  type SearchField,
 } from "../audit-types";
 import { PAGE_LIMIT } from "../constants";
 

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -29,7 +29,7 @@ export default function GovernanceControlPage(): JSX.Element {
     <div className="space-y-6">
       {state.pendingConfirm ? (
         <ConfirmDialog
-          open={true}
+          open
           title={t("確認", "Confirm")}
           description={state.pendingConfirm.description}
           confirmLabel={t("確認する", "Confirm")}

--- a/frontend/middleware.test.ts
+++ b/frontend/middleware.test.ts
@@ -4,8 +4,11 @@ import {
   buildCspEnforced,
   buildCspReportOnly,
   generateNonce,
+  isProductionRuntime,
   middleware,
   resolveCspReportOnlyEndpoint,
+  shouldIssueDefaultBffSessionCookie,
+  shouldUseSecureCookie,
   shouldWarnInsecureCspReportOnlyEndpoint,
   shouldEnforceNonceCsp,
   shouldWarnInsecureProductionCspConfig,
@@ -134,6 +137,48 @@ describe("middleware CSP", () => {
     expect(shouldWarnInsecureCspReportOnlyEndpoint()).toBe(true);
   });
 
+  it("detects production runtime from VERITAS_ENV", () => {
+    vi.stubEnv("VERITAS_ENV", "production");
+
+    expect(isProductionRuntime()).toBe(true);
+  });
+
+  it("detects production runtime from NODE_ENV", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(isProductionRuntime()).toBe(true);
+  });
+
+  it("does not treat development runtime as production", () => {
+    vi.stubEnv("VERITAS_ENV", "development");
+    vi.stubEnv("NODE_ENV", "development");
+
+    expect(isProductionRuntime()).toBe(false);
+  });
+
+  it("allows shared BFF session cookie issuance in non-production", () => {
+    vi.stubEnv("VERITAS_ENV", "development");
+    vi.stubEnv("NODE_ENV", "development");
+
+    expect(shouldIssueDefaultBffSessionCookie()).toBe(true);
+  });
+
+  it("denies shared BFF session cookie issuance in production by default", () => {
+    vi.stubEnv("VERITAS_ENV", "production");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERITAS_BFF_ALLOW_GLOBAL_SESSION_IN_PROD", "false");
+
+    expect(shouldIssueDefaultBffSessionCookie()).toBe(false);
+  });
+
+  it("allows shared BFF session cookie issuance in production only with explicit override", () => {
+    vi.stubEnv("VERITAS_ENV", "production");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERITAS_BFF_ALLOW_GLOBAL_SESSION_IN_PROD", "true");
+
+    expect(shouldIssueDefaultBffSessionCookie()).toBe(true);
+  });
+
   it("sets CSP headers and forwards nonce to the Next.js request", () => {
     const response = middleware({ headers: new Headers() } as never);
     const csp = response.headers.get("Content-Security-Policy") ?? "";
@@ -155,6 +200,56 @@ describe("middleware CSP", () => {
     expect(forwardedNonce).not.toBe("");
     expect(reportOnlyScriptDirective).toContain(`'nonce-${forwardedNonce}'`);
     expect(reportOnlyScriptDirective).not.toContain("'unsafe-inline'");
+  });
+
+  it("uses x-forwarded-proto to determine secure cookie semantics", () => {
+    const request = {
+      headers: new Headers({ "x-forwarded-proto": "https" }),
+      nextUrl: { protocol: "http:" },
+    } as never;
+
+    expect(shouldUseSecureCookie(request)).toBe(true);
+  });
+
+  it("falls back to request protocol for secure cookie semantics", () => {
+    const request = {
+      headers: new Headers(),
+      nextUrl: { protocol: "https:" },
+    } as never;
+
+    expect(shouldUseSecureCookie(request)).toBe(true);
+  });
+
+  it("does not mint shared BFF cookie in production unless explicitly allowed", () => {
+    vi.stubEnv("VERITAS_ENV", "production");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERITAS_BFF_SESSION_TOKEN", "session-token");
+    vi.stubEnv("VERITAS_BFF_ALLOW_GLOBAL_SESSION_IN_PROD", "false");
+
+    const response = middleware({
+      headers: new Headers({ "x-forwarded-proto": "https" }),
+      cookies: { get: () => undefined },
+      nextUrl: { protocol: "https:" },
+    } as never);
+
+    expect(response.cookies.get("__veritas_bff")).toBeUndefined();
+  });
+
+  it("mints shared BFF cookie with secure flag when explicitly allowed in production", () => {
+    vi.stubEnv("VERITAS_ENV", "production");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERITAS_BFF_SESSION_TOKEN", "session-token");
+    vi.stubEnv("VERITAS_BFF_ALLOW_GLOBAL_SESSION_IN_PROD", "true");
+
+    const response = middleware({
+      headers: new Headers({ "x-forwarded-proto": "https" }),
+      cookies: { get: () => undefined },
+      nextUrl: { protocol: "http:" },
+    } as never);
+
+    const cookie = response.cookies.get("__veritas_bff");
+    expect(cookie?.value).toBe("session-token");
+    expect(cookie?.secure).toBe(true);
   });
 
   it("emits a security warning when NODE_ENV=production without CSP strict rollout", () => {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -4,6 +4,7 @@ const NONCE_BYTES = 16;
 const ENFORCE_NONCE_ENV = "VERITAS_CSP_ENFORCE_NONCE";
 const ALLOW_UNSAFE_INLINE_COMPAT_ENV = "VERITAS_CSP_ALLOW_UNSAFE_INLINE_COMPAT";
 const REPORT_ONLY_ENDPOINT_ENV = "VERITAS_CSP_REPORT_ONLY_ENDPOINT";
+const ALLOW_GLOBAL_BFF_SESSION_IN_PROD_ENV = "VERITAS_BFF_ALLOW_GLOBAL_SESSION_IN_PROD";
 
 /**
  * Generates a CSP nonce for the current response.
@@ -152,6 +153,55 @@ export function resolveCspReportOnlyEndpoint(): string {
 }
 
 /**
+ * Returns whether the runtime should be treated as production.
+ */
+export function isProductionRuntime(): boolean {
+  const veritasEnv = (process.env.VERITAS_ENV ?? "").toLowerCase();
+  const nodeEnv = (process.env.NODE_ENV ?? "").toLowerCase();
+  return (
+    veritasEnv === "prod" ||
+    veritasEnv === "production" ||
+    nodeEnv === "production"
+  );
+}
+
+/**
+ * Returns whether middleware may mint the shared BFF session cookie.
+ *
+ * Security behavior:
+ * - Shared session cookie issuance is allowed by default in non-production
+ *   environments for local/demo ergonomics.
+ * - In production runtime, issuance is denied by default to avoid globally
+ *   granting a static role-bearing token to every browser session.
+ * - Operators can temporarily re-enable in production only through
+ *   VERITAS_BFF_ALLOW_GLOBAL_SESSION_IN_PROD=true.
+ */
+export function shouldIssueDefaultBffSessionCookie(): boolean {
+  if (!isProductionRuntime()) {
+    return true;
+  }
+  return process.env[ALLOW_GLOBAL_BFF_SESSION_IN_PROD_ENV] === "true";
+}
+
+/**
+ * Resolves whether request should use secure cookie semantics.
+ *
+ * Honors trusted reverse-proxy signaling via `x-forwarded-proto` and falls
+ * back to Next.js URL protocol when proxy headers are unavailable.
+ */
+export function shouldUseSecureCookie(request: NextRequest): boolean {
+  const forwardedProto = request.headers
+    .get("x-forwarded-proto")
+    ?.split(",")[0]
+    ?.trim()
+    ?.toLowerCase();
+  if (forwardedProto) {
+    return forwardedProto === "https";
+  }
+  return request.nextUrl.protocol === "https:";
+}
+
+/**
  * Name of the httpOnly cookie used for BFF session auth.
  * Must match the constant in route-auth.ts.
  */
@@ -207,10 +257,14 @@ export function middleware(request: NextRequest): NextResponse {
 
   // Set httpOnly BFF session cookie when configured and not already present.
   const sessionToken = process.env[BFF_SESSION_TOKEN_ENV] ?? "";
-  if (sessionToken && !request.cookies.get(BFF_SESSION_COOKIE)) {
+  if (
+    sessionToken &&
+    shouldIssueDefaultBffSessionCookie() &&
+    !request.cookies.get(BFF_SESSION_COOKIE)
+  ) {
     response.cookies.set(BFF_SESSION_COOKIE, sessionToken, {
       httpOnly: true,
-      secure: request.nextUrl.protocol === "https:",
+      secure: shouldUseSecureCookie(request),
       sameSite: "strict",
       path: "/api/veritas",
     });


### PR DESCRIPTION
### Motivation
- Tighten security around the shared BFF session cookie and cookie semantics by defaulting to safer behavior in production and honoring proxy signals for secure cookies.
- Provide a clear runtime detection helper to distinguish VERITAS production vs non-production environments for feature gating.
- Remove a now-unused type import and simplify a JSX boolean prop in the governance page.

### Description
- Added `isProductionRuntime`, `shouldIssueDefaultBffSessionCookie`, and `shouldUseSecureCookie` helpers to `frontend/middleware.ts`, and wired them into middleware behavior to control whether a default BFF session cookie is minted and whether it should be marked `secure` based on `x-forwarded-proto` or request protocol, and added `VERITAS_BFF_ALLOW_GLOBAL_SESSION_IN_PROD` to gate production overrides.
- Updated `middleware` to skip issuing the global BFF cookie in production by default and to use `shouldUseSecureCookie(request)` for the cookie `secure` flag; introduced the `ALLOW_GLOBAL_BFF_SESSION_IN_PROD_ENV` constant for the env var name.
- Added comprehensive unit tests in `frontend/middleware.test.ts` to cover runtime detection, cookie issuance gating, secure-cookie determination, and related CSP behaviors; imported newly exported helpers into the test file.
- Minor cleanups: removed unused `SearchField` type import from `frontend/app/audit/hooks/useAuditData.ts` and simplified the `ConfirmDialog` `open` prop usage in `frontend/app/governance/page.tsx`.

### Testing
- Ran the updated middleware unit tests via `vitest` (`frontend/middleware.test.ts`) which exercise `isProductionRuntime`, `shouldIssueDefaultBffSessionCookie`, `shouldUseSecureCookie`, and existing CSP assertions, and they passed.
- Confirmed CSP-related tests that assert header generation and warning emission still pass after the changes.
- No UI integration tests were modified; TypeScript/ESBuild compilation completed successfully during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1c10f3a0832694e62c807595d9ec)