### PR TITLE
frontend: improve MissionLayout i18n labels

### DIFF
--- a/frontend/components/mission-layout.test.tsx
+++ b/frontend/components/mission-layout.test.tsx
@@ -19,8 +19,9 @@ describe("MissionLayout", () => {
       "href",
       "/governance"
     );
-    expect(screen.getByText("Environment")).toBeInTheDocument();
-    expect(screen.getByText("Latest Event")).toBeInTheDocument();
+    expect(screen.getByText("環境")).toBeInTheDocument();
+    expect(screen.getByText("最新イベント")).toBeInTheDocument();
+    expect(screen.getByText("稼働中")).toBeInTheDocument();
     expect(screen.getByText("可読性を優先した運用ビュー")).toBeInTheDocument();
   });
 });

--- a/frontend/components/mission-layout.tsx
+++ b/frontend/components/mission-layout.tsx
@@ -130,19 +130,22 @@ const NAV_ITEMS = [
 
 const HEADER_METRICS = [
   {
-    title: "Environment",
+    titleJa: "環境",
+    titleEn: "Environment",
     valueJa: "本番準備済みサンドボックス",
     valueEn: "Production-ready Sandbox",
     status: "success" as const,
   },
   {
-    title: "Connection",
+    titleJa: "接続",
+    titleEn: "Connection",
     valueJa: "Neural Mesh 安定 · 99.982%",
     valueEn: "Neural Mesh Stable · 99.982%",
     status: "info" as const,
   },
   {
-    title: "Latest Event",
+    titleJa: "最新イベント",
+    titleEn: "Latest Event",
     valueJa: "Policy Sync #4821 完了",
     valueEn: "Policy Sync #4821 Completed",
     status: "primary" as const,
@@ -213,12 +216,17 @@ export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
           {/* Live indicator */}
           <div className="flex items-center gap-1.5 rounded-full border border-sidebar-border px-2 py-1">
             <span className="status-dot-live h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
-            <span className="text-[10px] font-medium uppercase tracking-wide text-sidebar-muted">Live</span>
+            <span className="text-[10px] font-medium uppercase tracking-wide text-sidebar-muted">
+              {t("稼働中", "Live")}
+            </span>
           </div>
         </div>
 
         {/* Navigation ── */}
-        <nav aria-label="Main navigation" className="flex-1 overflow-y-auto px-3 py-4">
+        <nav
+          aria-label={t("メインナビゲーション", "Main navigation")}
+          className="flex-1 overflow-y-auto px-3 py-4"
+        >
           <div className="mb-2 px-2">
             <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-sidebar-muted">
               {t("ナビゲーション", "Navigation")}
@@ -324,7 +332,7 @@ export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
         <div className="grid gap-3 md:grid-cols-3">
           {HEADER_METRICS.map((metric) => (
             <div
-              key={metric.title}
+              key={metric.titleEn}
               className="flex items-center gap-3 rounded-lg border border-border/50 bg-background/60 px-4 py-2.5 shadow-xs"
             >
               <span
@@ -333,7 +341,7 @@ export function MissionLayout({ children }: MissionLayoutProps): JSX.Element {
               />
               <div className="min-w-0">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                  {metric.title}
+                  {t(metric.titleJa, metric.titleEn)}
                 </p>
                 <p className={`truncate text-xs font-medium ${STATUS_TEXT[metric.status]}`}>
                   {t(metric.valueJa, metric.valueEn)}


### PR DESCRIPTION
### Motivation
- Localize additional `MissionLayout` UI text so language switching is consistent and accessible across the header and sidebar.

### Description
- Replace header metric `title` with `titleJa`/`titleEn` and render through `t()` in `frontend/components/mission-layout.tsx` so metric headings follow the selected language.
- Localize the sidebar Live badge text and the navigation `aria-label`, and update the unit test expectations in `frontend/components/mission-layout.test.tsx` to assert the new Japanese labels.

### Testing
- Ran `cd frontend && pnpm test -- components/mission-layout.test.tsx` and the updated test suite passed (1 test, 1 passed).
- No automated security checks failed and the change only touches presentation/i18n text, so no new security risk was introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda5fc965083268ef59af3197bd8ba)