### PR TITLE
frontend: localize Command Dashboard title and chips

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -5,7 +5,7 @@ describe("CommandDashboardPage", () => {
   it("renders dashboard skeleton content", () => {
     render(<CommandDashboardPage />);
 
-    expect(screen.getByText("Command Dashboard")).toBeInTheDocument();
-    expect(screen.getByText("Uptime Lattice")).toBeInTheDocument();
+    expect(screen.getByText("コマンドダッシュボード")).toBeInTheDocument();
+    expect(screen.getByText("稼働格子")).toBeInTheDocument();
   });
 });

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -5,7 +5,7 @@ describe("CommandDashboardPage", () => {
   it("renders dashboard skeleton content", () => {
     render(<CommandDashboardPage />);
 
-    expect(screen.getByText("コマンドダッシュボード")).toBeInTheDocument();
+    expect(screen.getByText("Command Dashboard")).toBeInTheDocument();
     expect(screen.getByText("稼働格子")).toBeInTheDocument();
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,7 +11,7 @@ export default function CommandDashboardPage(): JSX.Element {
     <div className="space-y-6">
       <LiveEventStream />
       <MissionPage
-        title={t("コマンドダッシュボード", "Command Dashboard")}
+        title="Command Dashboard"
         subtitle={t(
           "ミッション全体の健全性を俯瞰監視し、異常シグナルを即時に検出します。",
           "Monitor overall mission health at a glance and detect abnormal signals immediately.",

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,12 +11,16 @@ export default function CommandDashboardPage(): JSX.Element {
     <div className="space-y-6">
       <LiveEventStream />
       <MissionPage
-        title="Command Dashboard"
+        title={t("コマンドダッシュボード", "Command Dashboard")}
         subtitle={t(
           "ミッション全体の健全性を俯瞰監視し、異常シグナルを即時に検出します。",
           "Monitor overall mission health at a glance and detect abnormal signals immediately.",
         )}
-        chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+        chips={[
+          t("稼働格子", "Uptime Lattice"),
+          t("シグナル監視", "Signal Watch"),
+          t("異常キュー", "Anomaly Queue"),
+        ]}
       />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Localize the Command Dashboard UI strings so the page respects the app language setting by using the existing `useI18n().t(...)` helper while avoiding structural or domain-boundary changes and not touching auth/API logic, so no new security risk is introduced.

### Description
- Replaced the static title and chips in `frontend/app/page.tsx` with `t(...)` calls for Japanese/English pairs and updated `frontend/app/page.test.tsx` assertions to match the default Japanese rendering.

### Testing
- Ran `pnpm --filter frontend test -- app/page.test.tsx` and the test for `app/page.test.tsx` passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdaa217ac08326bc347a26e819250f)