### PR TITLE
ci: fallback to browser-only Playwright install when `--with-deps` is blocked

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -309,7 +309,12 @@ jobs:
       - name: Install Playwright browsers
         if: matrix.gate == 'e2e'
         working-directory: frontend
-        run: pnpm exec playwright install --with-deps chromium chromium-headless-shell
+        run: |
+          set -euo pipefail
+          if ! pnpm exec playwright install --with-deps chromium chromium-headless-shell; then
+            echo "Playwright --with-deps failed (apt restricted). Retrying browser-only install." >&2
+            pnpm exec playwright install chromium chromium-headless-shell
+          fi
 
       - name: Build frontend
         if: matrix.gate == 'e2e'


### PR DESCRIPTION
### Motivation
- The frontend e2e job can fail in CI environments where `playwright install --with-deps` cannot access OS package repositories, so add a fallback to allow CI to proceed when only browser binaries can be installed.

### Description
- Update the Playwright install step in `.github/workflows/main.yml` to run `pnpm exec playwright install --with-deps chromium chromium-headless-shell` and, if that command fails, retry `pnpm exec playwright install chromium chromium-headless-shell` inside a `set -euo pipefail` wrapper.

### Testing
- Ran the repository quality and security checks (`ruff check veritas_os/` and the scripts under `scripts/architecture`, `scripts/quality`, and `scripts/security`) and they all passed.
- Ran the Python test suite with `pytest -q veritas_os/tests -m 'not slow'` which completed successfully (`5676 passed, 8 skipped`).
- Ran frontend checks where `pnpm -C frontend lint` emitted warnings but no errors, `pnpm -C frontend test` passed, and `pnpm -C frontend exec playwright --version` returned a Playwright version; the prior `playwright install --with-deps` attempt failed due to apt/proxy restrictions which motivated this fallback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdb73cfc308326a609a03ff609ce49)