### PR TITLE
frontend: localize command dashboard title

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -5,7 +5,7 @@ describe("CommandDashboardPage", () => {
   it("renders dashboard skeleton content", () => {
     render(<CommandDashboardPage />);
 
-    expect(screen.getByText("Command Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("コマンドダッシュボード")).toBeInTheDocument();
     expect(screen.getByText("稼働格子")).toBeInTheDocument();
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,7 +11,7 @@ export default function CommandDashboardPage(): JSX.Element {
     <div className="space-y-6">
       <LiveEventStream />
       <MissionPage
-        title="Command Dashboard"
+        title={t("コマンドダッシュボード", "Command Dashboard")}
         subtitle={t(
           "ミッション全体の健全性を俯瞰監視し、異常シグナルを即時に検出します。",
           "Monitor overall mission health at a glance and detect abnormal signals immediately.",

--- a/frontend/e2e/i18n-mobile.spec.ts
+++ b/frontend/e2e/i18n-mobile.spec.ts
@@ -2,17 +2,20 @@ import { test, expect, devices } from "@playwright/test";
 
 test.describe("i18n: language toggle", () => {
   const pages = [
-    { path: "/", heading: "Command Dashboard" },
+    { path: "/", headingJa: "コマンドダッシュボード", headingEn: "Command Dashboard" },
     { path: "/console", heading: "Decision Console" },
     { path: "/governance", heading: "Governance Control" },
     { path: "/audit", heading: "TrustLog Explorer" },
   ];
 
-  for (const { path, heading } of pages) {
+  for (const { path, heading, headingJa, headingEn } of pages) {
+    const jaHeading = headingJa ?? heading ?? "";
+    const enHeading = headingEn ?? heading ?? "";
+
     test(`${path} renders heading in both languages`, async ({ page }) => {
       await page.goto(path);
       await expect(
-        page.getByRole("heading", { name: heading }),
+        page.getByRole("heading", { name: jaHeading }),
       ).toBeVisible();
 
       // Toggle language via localStorage and reload
@@ -21,7 +24,7 @@ test.describe("i18n: language toggle", () => {
       });
       await page.reload();
       await expect(
-        page.getByRole("heading", { name: heading }),
+        page.getByRole("heading", { name: enHeading }),
       ).toBeVisible();
 
       // Switch back to Japanese
@@ -30,7 +33,7 @@ test.describe("i18n: language toggle", () => {
       });
       await page.reload();
       await expect(
-        page.getByRole("heading", { name: heading }),
+        page.getByRole("heading", { name: jaHeading }),
       ).toBeVisible();
     });
   }

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -46,7 +46,9 @@ test.describe("Smoke: 3-minute demo flow", () => {
   // 4. Navigation works across all pages
   test("Navigation sidebar links work", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: "Command Dashboard" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /(コマンドダッシュボード|Command Dashboard)/ }),
+    ).toBeVisible();
 
     // Click Console
     await page.getByRole("link", { name: /Decision Console/i }).click();


### PR DESCRIPTION
### Motivation
- Localize the Command Dashboard page title so the UI reflects the active language setting while keeping the change minimal and without impacting authentication or data flows.

### Description
- Replace the hard-coded title with `useI18n().t(...)` in `frontend/app/page.tsx` and update `frontend/app/page.test.tsx` to assert the default Japanese title.

### Testing
- Ran `cd frontend && pnpm vitest run app/page.test.tsx`, and the test file passed (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdc324928883269bef19039cdeff4e)