### PR TITLE
Warn when compiled policy yields high-severity outcome but enforcement is disabled

### DIFF
--- a/docs/reviews/POLICY_AS_CODE_IMPLEMENTATION_REVIEW_2026-04-02.md
+++ b/docs/reviews/POLICY_AS_CODE_IMPLEMENTATION_REVIEW_2026-04-02.md
@@ -122,11 +122,17 @@ evaluator は policy 単位で下記を判定する。
     - ネスト量指定子（例: `(a+)+`）を含む高コスト化しやすいパターンの拒否
     - 不正 regex（`re.error`）の安全失敗（match しない扱い）
   - 既存判定フローは維持し、`regex` 条件が危険/過大な入力の場合のみ不成立に倒す最小変更とした。
+  - pipeline bridge の非強制モードに運用警告を追加。
+    - `compiled_policy` の判定が `deny / halt / escalate / require_human_review` の場合、
+      `policy_runtime_enforce=false` で未反映のまま通過していることを warning ログで明示。
+    - FUJI の既存判定ロジックは変更せず、設定ミス検知性のみを向上させた。
 
 - **追加テスト**
   - 正常な `regex` 条件は従来どおり一致して発火すること。
   - 上限超過入力では `regex` 条件が発火せず、policy outcome が適用されないこと。
   - ネスト量指定子パターンでは `regex` 条件が発火せず、policy outcome が適用されないこと。
+  - `policy_runtime_enforce=false` かつ compiled policy の最終判定が `deny` のとき、
+    FUJI のステータスを強制変更しないこと、および warning が出ること。
 
 - **セキュリティ補足**
   - 本対応は ReDoS リスクを「低減」するものであり、完全排除ではない。

--- a/veritas_os/core/pipeline/pipeline_policy.py
+++ b/veritas_os/core/pipeline/pipeline_policy.py
@@ -68,10 +68,16 @@ def _apply_compiled_policy_runtime_bridge(ctx: PipelineContext) -> None:
         ctx.response_extras["governance"] = governance
     governance["compiled_policy"] = decision
 
+    outcome = decision.get("final_outcome")
     if not bool((ctx.context or {}).get("policy_runtime_enforce", False)):
+        if outcome in {"deny", "halt", "escalate", "require_human_review"}:
+            logger.warning(
+                "compiled policy outcome=%s observed but not enforced "
+                "(policy_runtime_enforce=false)",
+                outcome,
+            )
         return
 
-    outcome = decision.get("final_outcome")
     if outcome in {"deny", "halt"}:
         ctx.fuji_dict["status"] = "rejected"
         ctx.fuji_dict.setdefault("reasons", []).append(

--- a/veritas_os/tests/unit/test_pipeline_stages_ext.py
+++ b/veritas_os/tests/unit/test_pipeline_stages_ext.py
@@ -7422,6 +7422,40 @@ def test_pipeline_bridge_enforcement_updates_fuji_status(tmp_path: Path) -> None
     assert "compiled_policy:halt" in ctx.fuji_dict["reasons"]
 
 
+def test_pipeline_bridge_warns_when_not_enforced(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    compiled = compile_policy_to_bundle(
+        EXAMPLES_DIR / "external_tool_usage_denied.yaml",
+        tmp_path,
+        compiled_at="2026-03-28T00:00:00Z",
+    )
+
+    ctx = PipelineContext(
+        query="use external tool",
+        context={
+            "compiled_policy_bundle_dir": compiled.bundle_dir.as_posix(),
+            "policy_runtime_enforce": False,
+            "domain": "security",
+            "route": "/api/tools",
+            "actor": "kernel",
+            "tool": {"external": True, "name": "unapproved_webhook"},
+            "data": {"classification": "restricted"},
+            "evidence": {"available": ["data_classification_label"]},
+            "approvals": {"approved_by": ["security_officer"]},
+        },
+    )
+
+    with caplog.at_level("WARNING"):
+        stage_fuji_precheck(ctx)
+
+    assert ctx.fuji_dict.get("status") != "rejected"
+    assert (
+        "compiled policy outcome=deny observed but not enforced "
+        "(policy_runtime_enforce=false)"
+    ) in caplog.text
+
+
 # ============================================================
 # Source: test_pipeline_web_adapter.py
 # ============================================================


### PR DESCRIPTION
### Motivation
- Improve operational visibility for a minimal safety gap where compiled policies produce high-severity decisions but the pipeline is configured with `policy_runtime_enforce=false` so outcomes are only observed and not enforced.

### Description
- Log a warning in the compiled-policy bridge when `compiled_policy.final_outcome` is one of `deny`, `halt`, `escalate`, or `require_human_review` and `policy_runtime_enforce` is false by adding a lightweight `logger.warning` in `_apply_compiled_policy_runtime_bridge` in `veritas_os/core/pipeline/pipeline_policy.py`.
- Add a unit test `test_pipeline_bridge_warns_when_not_enforced` in `veritas_os/tests/unit/test_pipeline_stages_ext.py` to assert the warning is emitted and FUJI status is not force-changed when enforcement is disabled.
- Update `docs/reviews/POLICY_AS_CODE_IMPLEMENTATION_REVIEW_2026-04-02.md` to record the change and the new test coverage.

### Testing
- Ran `pytest -q veritas_os/tests/unit/test_pipeline_stages_ext.py -k "compiled_policy"` which passed (`1 passed, 618 deselected`).
- Ran `pytest -q veritas_os/tests/unit/test_pipeline_stages_ext.py -k "pipeline_bridge_surfaces_compiled_policy_decision or pipeline_bridge_enforcement_updates_fuji_status or pipeline_bridge_warns_when_not_enforced"` which passed (`3 passed, 616 deselected`).
- All added tests passed locally and no existing pipeline enforcement behavior was changed (warning-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf1894d44832685a608e9a3e14278)