### PR TITLE
Add 20 new frontend test files to improve coverage (142 new tests)

### DIFF
--- a/frontend/app/audit/audit-types.test.ts
+++ b/frontend/app/audit/audit-types.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  getString,
+  shortHash,
+  toPrettyJson,
+  classifyChain,
+  buildHumanSummary,
+  computeAuditSummary,
+} from "./audit-types";
+import type { TrustLogItem } from "@veritas/types";
+
+function makeItem(overrides: Partial<TrustLogItem> = {}): TrustLogItem {
+  return {
+    sha256: "abc123",
+    sha256_prev: "prev123",
+    request_id: "req-1",
+    decision_id: "dec-1",
+    ...overrides,
+  } as TrustLogItem;
+}
+
+describe("getString", () => {
+  it("returns string value for existing key", () => {
+    const item = makeItem({ stage: "retrieval" } as Partial<TrustLogItem>);
+    expect(getString(item, "stage")).toBe("retrieval");
+  });
+
+  it("returns '-' for missing key", () => {
+    const item = makeItem();
+    expect(getString(item, "nonexistent")).toBe("-");
+  });
+});
+
+describe("shortHash", () => {
+  it("returns --- for nullish", () => {
+    expect(shortHash(null)).toBe("---");
+    expect(shortHash(undefined)).toBe("---");
+  });
+
+  it("returns short strings as-is", () => {
+    expect(shortHash("abc")).toBe("abc");
+  });
+
+  it("truncates long strings", () => {
+    const hash = "abcdefghijklmnopqrstuvwxyz1234567890";
+    const result = shortHash(hash);
+    expect(result).toContain("...");
+    expect(result.length).toBeLessThan(hash.length);
+  });
+});
+
+describe("toPrettyJson", () => {
+  it("formats objects as indented JSON", () => {
+    expect(toPrettyJson({ a: 1 })).toBe(JSON.stringify({ a: 1 }, null, 2));
+  });
+});
+
+describe("classifyChain", () => {
+  it("returns missing when current sha256 is absent", () => {
+    const item = makeItem({ sha256: undefined });
+    expect(classifyChain(item, null)).toEqual({ status: "missing", reason: "current sha256 missing" });
+  });
+
+  it("returns verified for genesis entry (no prev, no previous item)", () => {
+    const item = makeItem({ sha256_prev: undefined });
+    expect(classifyChain(item, null)).toEqual({ status: "verified", reason: "genesis entry" });
+  });
+
+  it("returns orphan when sha256_prev missing but previous exists", () => {
+    const item = makeItem({ sha256_prev: undefined });
+    const prev = makeItem();
+    expect(classifyChain(item, prev)).toEqual({ status: "orphan", reason: "no sha256_prev while previous exists" });
+  });
+
+  it("returns missing when previous sha256 is absent", () => {
+    const item = makeItem({ sha256_prev: "some" });
+    const prev = makeItem({ sha256: undefined });
+    expect(classifyChain(item, prev)).toEqual({ status: "missing", reason: "previous sha256 missing" });
+  });
+
+  it("returns broken when hashes do not match", () => {
+    const item = makeItem({ sha256_prev: "wrong" });
+    const prev = makeItem({ sha256: "correct" });
+    expect(classifyChain(item, prev)).toEqual({ status: "broken", reason: "sha256_prev does not match previous sha256" });
+  });
+
+  it("returns verified when hashes match", () => {
+    const item = makeItem({ sha256_prev: "match" });
+    const prev = makeItem({ sha256: "match" });
+    expect(classifyChain(item, prev)).toEqual({ status: "verified", reason: "hash chain match" });
+  });
+});
+
+describe("buildHumanSummary", () => {
+  it("builds readable summary", () => {
+    const item = makeItem({ stage: "safety", status: "pass", request_id: "req-123", severity: "low" } as Partial<TrustLogItem>);
+    const summary = buildHumanSummary(item);
+    expect(summary).toContain("safety");
+    expect(summary).toContain("pass");
+    expect(summary).toContain("req-123");
+    expect(summary).toContain("low");
+  });
+});
+
+describe("computeAuditSummary", () => {
+  it("computes correct summary from items", () => {
+    const items: TrustLogItem[] = [
+      makeItem({ sha256: "a", sha256_prev: "b", replay_id: "r1", policy_version: "v1" }),
+      makeItem({ sha256: "b", sha256_prev: undefined }),
+    ];
+    const summary = computeAuditSummary(items);
+    expect(summary.total).toBe(2);
+    expect(summary.replayLinked).toBe(1);
+    expect(summary.policyVersions["v1"]).toBe(1);
+  });
+
+  it("returns zero counts for empty array", () => {
+    const summary = computeAuditSummary([]);
+    expect(summary.total).toBe(0);
+    expect(summary.verified).toBe(0);
+  });
+});

--- a/frontend/app/audit/constants.test.ts
+++ b/frontend/app/audit/constants.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { PAGE_LIMIT, STATUS_COLORS, STATUS_BG, STATUS_DOT } from "./constants";
+
+describe("audit constants", () => {
+  it("PAGE_LIMIT is 50", () => {
+    expect(PAGE_LIMIT).toBe(50);
+  });
+
+  it("STATUS_COLORS covers all verification statuses", () => {
+    expect(STATUS_COLORS.verified).toContain("success");
+    expect(STATUS_COLORS.broken).toContain("danger");
+    expect(STATUS_COLORS.missing).toContain("warning");
+    expect(STATUS_COLORS.orphan).toContain("info");
+  });
+
+  it("STATUS_BG covers all verification statuses", () => {
+    for (const key of ["verified", "broken", "missing", "orphan"] as const) {
+      expect(STATUS_BG[key]).toBeTruthy();
+    }
+  });
+
+  it("STATUS_DOT covers all verification statuses", () => {
+    for (const key of ["verified", "broken", "missing", "orphan"] as const) {
+      expect(STATUS_DOT[key]).toBeTruthy();
+    }
+  });
+});

--- a/frontend/app/governance/constants.test.ts
+++ b/frontend/app/governance/constants.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  FUJI_LABELS,
+  MODE_EXPLANATIONS,
+  ROLE_CAPABILITIES,
+  DIFF_CATEGORY_LABELS,
+  APPROVAL_STATUS_ACCENT,
+} from "./constants";
+
+describe("governance constants", () => {
+  it("FUJI_LABELS covers all expected rule keys", () => {
+    const keys = Object.keys(FUJI_LABELS);
+    expect(keys).toContain("pii_check");
+    expect(keys).toContain("self_harm_block");
+    expect(keys).toContain("llm_safety_head");
+    expect(keys.length).toBe(8);
+  });
+
+  it("MODE_EXPLANATIONS has standard and eu_ai_act", () => {
+    expect(MODE_EXPLANATIONS.standard.summary).toBeTruthy();
+    expect(MODE_EXPLANATIONS.eu_ai_act.summary).toBeTruthy();
+    expect(MODE_EXPLANATIONS.eu_ai_act.affects.length).toBeGreaterThan(0);
+  });
+
+  it("ROLE_CAPABILITIES covers viewer, operator, admin", () => {
+    expect(ROLE_CAPABILITIES.viewer.permissions.length).toBeGreaterThan(0);
+    expect(ROLE_CAPABILITIES.operator.permissions.length).toBeGreaterThan(0);
+    expect(ROLE_CAPABILITIES.admin.permissions.length).toBeGreaterThan(0);
+  });
+
+  it("DIFF_CATEGORY_LABELS covers all categories", () => {
+    const cats = ["rule", "threshold", "escalation", "retention", "rollout", "approval", "meta"] as const;
+    for (const cat of cats) {
+      expect(DIFF_CATEGORY_LABELS[cat]).toBeTruthy();
+    }
+  });
+
+  it("APPROVAL_STATUS_ACCENT maps statuses to accent types", () => {
+    expect(APPROVAL_STATUS_ACCENT.approved).toBe("success");
+    expect(APPROVAL_STATUS_ACCENT.pending).toBe("warning");
+    expect(APPROVAL_STATUS_ACCENT.rejected).toBe("danger");
+    expect(APPROVAL_STATUS_ACCENT.draft).toBe("info");
+  });
+});

--- a/frontend/app/governance/helpers.test.ts
+++ b/frontend/app/governance/helpers.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { deepEqual, collectChanges, bumpDraftVersion } from "./helpers";
+
+describe("deepEqual", () => {
+  it("returns true for identical primitives", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("a", "a")).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+  });
+
+  it("returns false for different primitives", () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("a", "b")).toBe(false);
+  });
+
+  it("returns false when types differ", () => {
+    expect(deepEqual(1, "1")).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+  });
+
+  it("compares arrays deeply", () => {
+    expect(deepEqual([1, 2], [1, 2])).toBe(true);
+    expect(deepEqual([1, 2], [1, 3])).toBe(false);
+    expect(deepEqual([1], [1, 2])).toBe(false);
+  });
+
+  it("compares nested objects deeply", () => {
+    expect(deepEqual({ a: { b: 1 } }, { a: { b: 1 } })).toBe(true);
+    expect(deepEqual({ a: { b: 1 } }, { a: { b: 2 } })).toBe(false);
+  });
+
+  it("returns false for array vs object", () => {
+    expect(deepEqual([1], { 0: 1 })).toBe(false);
+  });
+});
+
+describe("collectChanges", () => {
+  it("detects added and changed keys", () => {
+    const changes = collectChanges("", { a: 1 }, { a: 2, b: 3 });
+    expect(changes).toHaveLength(2);
+    expect(changes[0]).toMatchObject({ path: "a", old: "1", next: "2" });
+    expect(changes[1]).toMatchObject({ path: "b", next: "3" });
+  });
+
+  it("categorizes paths correctly", () => {
+    const changes = collectChanges("", { fuji_rules: 1 }, { fuji_rules: 2 });
+    expect(changes[0].category).toBe("rule");
+  });
+
+  it("categorizes risk thresholds", () => {
+    const changes = collectChanges("", { risk_thresholds: 1 }, { risk_thresholds: 2 });
+    expect(changes[0].category).toBe("threshold");
+  });
+
+  it("categorizes auto_stop as escalation", () => {
+    const changes = collectChanges("", { auto_stop: true }, { auto_stop: false });
+    expect(changes[0].category).toBe("escalation");
+  });
+
+  it("categorizes log_retention as retention", () => {
+    const changes = collectChanges("", { log_retention: 30 }, { log_retention: 90 });
+    expect(changes[0].category).toBe("retention");
+  });
+
+  it("categorizes rollout_controls as rollout", () => {
+    const changes = collectChanges("", { rollout_controls: "a" }, { rollout_controls: "b" });
+    expect(changes[0].category).toBe("rollout");
+  });
+
+  it("categorizes approval_workflow as approval", () => {
+    const changes = collectChanges("", { approval_workflow: "x" }, { approval_workflow: "y" });
+    expect(changes[0].category).toBe("approval");
+  });
+
+  it("defaults unknown paths to meta", () => {
+    const changes = collectChanges("", { name: "a" }, { name: "b" });
+    expect(changes[0].category).toBe("meta");
+  });
+
+  it("recurses into nested objects", () => {
+    const changes = collectChanges("", { a: { b: 1 } }, { a: { b: 2 } });
+    expect(changes[0].path).toBe("a.b");
+  });
+
+  it("returns empty when objects are equal", () => {
+    expect(collectChanges("", { a: 1 }, { a: 1 })).toHaveLength(0);
+  });
+});
+
+describe("bumpDraftVersion", () => {
+  it("increments trailing number and appends -draft", () => {
+    expect(bumpDraftVersion("1.0.3")).toBe("1.0.4-draft");
+  });
+
+  it("appends -draft.1 when version has no trailing number pattern", () => {
+    expect(bumpDraftVersion("alpha")).toBe("alpha-draft.1");
+  });
+});

--- a/frontend/app/risk/constants.test.ts
+++ b/frontend/app/risk/constants.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import {
+  STREAM_WINDOW_MS,
+  ALERT_CLUSTER_THRESHOLD,
+  SEVERITY_CLASSES,
+  STATUS_LABELS,
+} from "./constants";
+
+describe("risk constants", () => {
+  it("STREAM_WINDOW_MS is 24 hours", () => {
+    expect(STREAM_WINDOW_MS).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("ALERT_CLUSTER_THRESHOLD is 0.82", () => {
+    expect(ALERT_CLUSTER_THRESHOLD).toBe(0.82);
+  });
+
+  it("SEVERITY_CLASSES covers all severities", () => {
+    expect(SEVERITY_CLASSES.critical).toContain("danger");
+    expect(SEVERITY_CLASSES.high).toContain("warning");
+    expect(SEVERITY_CLASSES.medium).toContain("info");
+    expect(SEVERITY_CLASSES.low).toContain("muted");
+  });
+
+  it("STATUS_LABELS covers all request statuses", () => {
+    expect(STATUS_LABELS.active).toBe("Active");
+    expect(STATUS_LABELS.mitigated).toBe("Mitigated");
+    expect(STATUS_LABELS.investigating).toBe("Investigating");
+    expect(STATUS_LABELS.new).toBe("New");
+  });
+});

--- a/frontend/app/risk/data-helpers.test.ts
+++ b/frontend/app/risk/data-helpers.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import type { RiskPoint, TrendBucket } from "./risk-types";
+import {
+  createInitialPoints,
+  createStreamPoint,
+  getCluster,
+  deriveSeverity,
+  deriveStatus,
+  buildFlagReason,
+  enrichFlaggedEntry,
+  buildTrendBuckets,
+  bucketMeaning,
+  pointFill,
+} from "./data-helpers";
+
+const now = Date.now();
+
+describe("createInitialPoints", () => {
+  it("generates 160 seed points", () => {
+    const points = createInitialPoints(now);
+    expect(points).toHaveLength(160);
+    points.forEach((p) => {
+      expect(p.id).toMatch(/^seed-\d+$/);
+      expect(p.uncertainty).toBeGreaterThanOrEqual(0);
+      expect(p.uncertainty).toBeLessThanOrEqual(1);
+      expect(p.risk).toBeGreaterThanOrEqual(0);
+      expect(p.risk).toBeLessThanOrEqual(1);
+    });
+  });
+});
+
+describe("createStreamPoint", () => {
+  it("generates a point with valid fields", () => {
+    const point = createStreamPoint(now);
+    expect(point.id).toContain(String(now));
+    expect(point.uncertainty).toBeGreaterThanOrEqual(0);
+    expect(point.risk).toBeLessThanOrEqual(1);
+    expect(point.timestamp).toBe(now);
+  });
+});
+
+describe("getCluster", () => {
+  it("returns critical when both high", () => {
+    expect(getCluster({ id: "t", uncertainty: 0.9, risk: 0.9, timestamp: 0 })).toBe("critical");
+  });
+
+  it("returns risky when only risk is high", () => {
+    expect(getCluster({ id: "t", uncertainty: 0.1, risk: 0.9, timestamp: 0 })).toBe("risky");
+  });
+
+  it("returns uncertain when only uncertainty is high", () => {
+    expect(getCluster({ id: "t", uncertainty: 0.9, risk: 0.1, timestamp: 0 })).toBe("uncertain");
+  });
+
+  it("returns stable when both low", () => {
+    expect(getCluster({ id: "t", uncertainty: 0.1, risk: 0.1, timestamp: 0 })).toBe("stable");
+  });
+});
+
+describe("deriveSeverity", () => {
+  it("returns critical for combined >= 0.85", () => {
+    expect(deriveSeverity({ id: "t", risk: 1, uncertainty: 1, timestamp: 0 })).toBe("critical");
+  });
+
+  it("returns high for combined >= 0.7", () => {
+    expect(deriveSeverity({ id: "t", risk: 0.8, uncertainty: 0.55, timestamp: 0 })).toBe("high");
+  });
+
+  it("returns medium for combined >= 0.5", () => {
+    expect(deriveSeverity({ id: "t", risk: 0.6, uncertainty: 0.35, timestamp: 0 })).toBe("medium");
+  });
+
+  it("returns low for combined < 0.5", () => {
+    expect(deriveSeverity({ id: "t", risk: 0.1, uncertainty: 0.1, timestamp: 0 })).toBe("low");
+  });
+});
+
+describe("deriveStatus", () => {
+  it("returns mitigated for seed indices divisible by 7", () => {
+    expect(deriveStatus({ id: "seed-7", uncertainty: 0, risk: 0, timestamp: 0 })).toBe("mitigated");
+  });
+
+  it("returns investigating for seed indices divisible by 5", () => {
+    expect(deriveStatus({ id: "seed-5", uncertainty: 0, risk: 0, timestamp: 0 })).toBe("investigating");
+  });
+
+  it("returns new for non-seed points", () => {
+    expect(deriveStatus({ id: "live-1", uncertainty: 0, risk: 0, timestamp: 0 })).toBe("new");
+  });
+});
+
+describe("buildFlagReason", () => {
+  it("returns critical summary for critical cluster", () => {
+    const reason = buildFlagReason({ id: "t", uncertainty: 0.9, risk: 0.9, timestamp: 0 });
+    expect(reason.summary).toContain("High uncertainty");
+    expect(reason.policyConfidence).toBeLessThan(0.5);
+    expect(reason.unstableOutputSignal).toBe(true);
+    expect(reason.retrievalAnomaly).toBe(true);
+  });
+
+  it("returns stable summary for stable cluster", () => {
+    const reason = buildFlagReason({ id: "t", uncertainty: 0.1, risk: 0.1, timestamp: 0 });
+    expect(reason.summary).toContain("expected safety envelope");
+    expect(reason.suggestedAction).toContain("No immediate action");
+  });
+});
+
+describe("enrichFlaggedEntry", () => {
+  it("returns a complete flagged entry", () => {
+    const point: RiskPoint = { id: "seed-0", uncertainty: 0.9, risk: 0.95, timestamp: now };
+    const entry = enrichFlaggedEntry(point);
+    expect(entry.point).toBe(point);
+    expect(entry.cluster).toBe("critical");
+    expect(entry.severity).toBe("critical");
+    expect(entry.relatedPolicyHits.length).toBeGreaterThan(0);
+    expect(entry.stageAnomalies.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildTrendBuckets", () => {
+  it("returns 8 buckets", () => {
+    const points = createInitialPoints(now);
+    const buckets = buildTrendBuckets(points, now);
+    expect(buckets).toHaveLength(8);
+    buckets.forEach((b) => {
+      expect(b.label).toMatch(/\d+-\d+h/);
+      expect(b.total).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
+describe("bucketMeaning", () => {
+  it("returns unsafe burst for high-risk count >= 6", () => {
+    const bucket: TrendBucket = { label: "0-3h", total: 10, highRisk: 6 };
+    expect(bucketMeaning(bucket)).toContain("Unsafe burst");
+  });
+
+  it("returns elevated risk for high-risk count >= 3", () => {
+    const bucket: TrendBucket = { label: "0-3h", total: 10, highRisk: 3 };
+    expect(bucketMeaning(bucket)).toContain("Elevated risk");
+  });
+
+  it("returns low-level for small high-risk count", () => {
+    const bucket: TrendBucket = { label: "0-3h", total: 10, highRisk: 1 };
+    expect(bucketMeaning(bucket)).toContain("Low-level");
+  });
+
+  it("returns no activity for empty bucket", () => {
+    const bucket: TrendBucket = { label: "0-3h", total: 0, highRisk: 0 };
+    expect(bucketMeaning(bucket)).toContain("No activity");
+  });
+
+  it("returns normal operation for no high-risk events", () => {
+    const bucket: TrendBucket = { label: "0-3h", total: 5, highRisk: 0 };
+    expect(bucketMeaning(bucket)).toContain("Normal operation");
+  });
+});
+
+describe("pointFill", () => {
+  it("returns destructive color for critical", () => {
+    expect(pointFill("critical")).toContain("destructive");
+  });
+
+  it("returns warning color for risky", () => {
+    expect(pointFill("risky")).toContain("warning");
+  });
+
+  it("returns info color for uncertain", () => {
+    expect(pointFill("uncertain")).toContain("info");
+  });
+
+  it("returns primary color for stable", () => {
+    expect(pointFill("stable")).toContain("primary");
+  });
+});

--- a/frontend/components/critical-rail.test.tsx
+++ b/frontend/components/critical-rail.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CriticalRail } from "./critical-rail";
+import type { CriticalRailMetric } from "./dashboard-types";
+
+const items: CriticalRailMetric[] = [
+  {
+    key: "latency",
+    label: "P99 Latency",
+    severity: "healthy",
+    currentValue: "120ms",
+    baselineDelta: "+5ms",
+    owner: "SRE",
+    lastUpdated: "2025-01-01",
+    openIncidents: 0,
+    href: "/metrics/latency",
+  },
+  {
+    key: "errors",
+    label: "Error Rate",
+    severity: "critical",
+    currentValue: "4.2%",
+    baselineDelta: "+3.8%",
+    owner: "Backend",
+    lastUpdated: "2025-01-01",
+    openIncidents: 2,
+    href: "/metrics/errors",
+  },
+];
+
+describe("CriticalRail", () => {
+  it("renders all items with labels and values", () => {
+    render(<CriticalRail items={items} />);
+    expect(screen.getByText("P99 Latency")).toBeInTheDocument();
+    expect(screen.getByText("120ms")).toBeInTheDocument();
+    expect(screen.getByText("Error Rate")).toBeInTheDocument();
+    expect(screen.getByText("4.2%")).toBeInTheDocument();
+  });
+
+  it("renders severity badges", () => {
+    render(<CriticalRail items={items} />);
+    expect(screen.getByText("healthy")).toBeInTheDocument();
+    expect(screen.getByText("critical")).toBeInTheDocument();
+  });
+
+  it("renders owner and incident info", () => {
+    render(<CriticalRail items={items} />);
+    expect(screen.getByText("Owner: SRE")).toBeInTheDocument();
+    expect(screen.getByText("Open incidents: 2")).toBeInTheDocument();
+  });
+
+  it("has accessible section label", () => {
+    render(<CriticalRail items={items} />);
+    expect(screen.getByRole("region", { name: "critical rail" })).toBeInTheDocument();
+  });
+});

--- a/frontend/components/global-health-summary.test.tsx
+++ b/frontend/components/global-health-summary.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GlobalHealthSummary } from "./global-health-summary";
+import type { GlobalHealthSummaryModel } from "./dashboard-types";
+
+const summary: GlobalHealthSummaryModel = {
+  band: "healthy",
+  todayChanges: ["Policy v2.1 deployed", "Trust score improved"],
+  incidents24h: "3",
+  policyDrift: "0.02",
+  trustDegradation: "none",
+  decisionAnomalies: "1",
+};
+
+describe("GlobalHealthSummary", () => {
+  it("renders current band", () => {
+    render(<GlobalHealthSummary summary={summary} />);
+    expect(screen.getByText("healthy")).toBeInTheDocument();
+  });
+
+  it("renders today's changes", () => {
+    render(<GlobalHealthSummary summary={summary} />);
+    expect(screen.getByText("Policy v2.1 deployed")).toBeInTheDocument();
+    expect(screen.getByText("Trust score improved")).toBeInTheDocument();
+  });
+
+  it("renders metrics", () => {
+    render(<GlobalHealthSummary summary={summary} />);
+    expect(screen.getByText("24h incidents: 3")).toBeInTheDocument();
+    expect(screen.getByText("Policy drift: 0.02")).toBeInTheDocument();
+    expect(screen.getByText("Decision anomalies: 1")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/i18n-provider.test.tsx
+++ b/frontend/components/i18n-provider.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { I18nProvider, useI18n } from "./i18n-provider";
+
+function TestConsumer() {
+  const { language, t, setLanguage } = useI18n();
+  return (
+    <div>
+      <span data-testid="lang">{language}</span>
+      <span data-testid="translated">{t("日本語", "English")}</span>
+      <button type="button" onClick={() => setLanguage("en")}>Switch to EN</button>
+      <button type="button" onClick={() => setLanguage("ja")}>Switch to JA</button>
+    </div>
+  );
+}
+
+describe("I18nProvider", () => {
+  it("defaults to Japanese", () => {
+    render(
+      <I18nProvider>
+        <TestConsumer />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId("lang").textContent).toBe("ja");
+    expect(screen.getByTestId("translated").textContent).toBe("日本語");
+  });
+
+  it("switches language to English", async () => {
+    render(
+      <I18nProvider>
+        <TestConsumer />
+      </I18nProvider>,
+    );
+    await act(async () => {
+      screen.getByText("Switch to EN").click();
+    });
+    expect(screen.getByTestId("lang").textContent).toBe("en");
+    expect(screen.getByTestId("translated").textContent).toBe("English");
+  });
+
+  it("persists language to localStorage", async () => {
+    render(
+      <I18nProvider>
+        <TestConsumer />
+      </I18nProvider>,
+    );
+    await act(async () => {
+      screen.getByText("Switch to EN").click();
+    });
+    expect(window.localStorage.getItem("veritas_language")).toBe("en");
+  });
+});
+
+describe("useI18n outside provider", () => {
+  it("uses default context values", () => {
+    render(<TestConsumer />);
+    expect(screen.getByTestId("lang").textContent).toBe("ja");
+  });
+});

--- a/frontend/components/ops-priority-card.test.tsx
+++ b/frontend/components/ops-priority-card.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { OpsPriorityCard } from "./ops-priority-card";
+import { I18nProvider } from "./i18n-provider";
+import type { OpsPriorityItem } from "./dashboard-types";
+
+const item: OpsPriorityItem = {
+  key: "drift",
+  titleJa: "ドリフト対応",
+  titleEn: "Drift Response",
+  owner: "Platform Team",
+  whyNowJa: "乖離が増加中",
+  whyNowEn: "Drift is increasing",
+  impactWindowJa: "24時間以内",
+  impactWindowEn: "Within 24 hours",
+  ctaJa: "確認する",
+  ctaEn: "Review",
+  href: "/governance",
+};
+
+describe("OpsPriorityCard", () => {
+  it("renders Japanese content by default", () => {
+    render(
+      <I18nProvider>
+        <OpsPriorityCard item={item} priority={1} />
+      </I18nProvider>,
+    );
+    expect(screen.getByText("ドリフト対応")).toBeInTheDocument();
+    expect(screen.getByText("Owner: Platform Team")).toBeInTheDocument();
+    expect(screen.getByText("乖離が増加中")).toBeInTheDocument();
+  });
+
+  it("renders link with href", () => {
+    render(
+      <I18nProvider>
+        <OpsPriorityCard item={item} priority={2} />
+      </I18nProvider>,
+    );
+    const link = screen.getByRole("link", { name: "確認する" });
+    expect(link).toHaveAttribute("href", "/governance");
+  });
+});

--- a/frontend/components/ui/confirm-dialog.test.tsx
+++ b/frontend/components/ui/confirm-dialog.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmDialog } from "./confirm-dialog";
+
+describe("ConfirmDialog", () => {
+  const baseProps = {
+    open: true,
+    title: "Delete item?",
+    description: "This cannot be undone.",
+    confirmLabel: "Delete",
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it("renders nothing when open is false", () => {
+    const { container } = render(<ConfirmDialog {...baseProps} open={false} />);
+    expect(container.querySelector("dialog")).toBeNull();
+  });
+
+  it("renders title and description when open", () => {
+    render(<ConfirmDialog {...baseProps} />);
+    expect(screen.getByText("Delete item?")).toBeInTheDocument();
+    expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when confirm button clicked", () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...baseProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when cancel button clicked", () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...baseProps} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("uses custom cancelLabel", () => {
+    render(<ConfirmDialog {...baseProps} cancelLabel="Abort" />);
+    expect(screen.getByRole("button", { name: "Abort" })).toBeInTheDocument();
+  });
+
+  it("calls onCancel on Escape key", () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...baseProps} onCancel={onCancel} />);
+    const dialog = screen.getByRole("dialog");
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/components/ui/section-header.test.tsx
+++ b/frontend/components/ui/section-header.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SectionHeader } from "./section-header";
+
+describe("SectionHeader", () => {
+  it("renders title", () => {
+    render(<SectionHeader title="My Section" />);
+    expect(screen.getByText("My Section")).toBeInTheDocument();
+  });
+
+  it("renders description when provided", () => {
+    render(<SectionHeader title="Title" description="Some description" />);
+    expect(screen.getByText("Some description")).toBeInTheDocument();
+  });
+
+  it("does not render description when not provided", () => {
+    const { container } = render(<SectionHeader title="Title" />);
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs).toHaveLength(1); // only title
+  });
+
+  it("renders trailing element", () => {
+    render(<SectionHeader title="Title" trailing={<button type="button">Action</button>} />);
+    expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
+  });
+});

--- a/frontend/components/ui/stat-card.test.tsx
+++ b/frontend/components/ui/stat-card.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatCard } from "./stat-card";
+
+describe("StatCard", () => {
+  it("renders label and value", () => {
+    render(<StatCard label="Total" value={42} />);
+    expect(screen.getByText("Total")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("applies variant-specific color class", () => {
+    render(<StatCard label="Errors" value={5} variant="danger" />);
+    const valueEl = screen.getByText("5");
+    expect(valueEl.className).toContain("danger");
+  });
+
+  it("defaults to default variant", () => {
+    render(<StatCard label="Count" value={10} />);
+    const valueEl = screen.getByText("10");
+    expect(valueEl.className).toContain("foreground");
+  });
+
+  it("accepts string values", () => {
+    render(<StatCard label="Status" value="OK" />);
+    expect(screen.getByText("OK")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/ui/status-badge.test.tsx
+++ b/frontend/components/ui/status-badge.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusBadge } from "./status-badge";
+
+describe("StatusBadge", () => {
+  it("renders label text", () => {
+    render(<StatusBadge label="Active" variant="success" />);
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("applies success variant styles", () => {
+    render(<StatusBadge label="OK" variant="success" />);
+    expect(screen.getByText("OK").className).toContain("success");
+  });
+
+  it("applies danger variant styles", () => {
+    render(<StatusBadge label="Error" variant="danger" />);
+    expect(screen.getByText("Error").className).toContain("danger");
+  });
+
+  it("applies custom className", () => {
+    render(<StatusBadge label="Test" variant="info" className="my-custom" />);
+    expect(screen.getByText("Test").className).toContain("my-custom");
+  });
+});

--- a/frontend/features/console/analytics/pipeline.test.ts
+++ b/frontend/features/console/analytics/pipeline.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import type { DecideResponse } from "@veritas/types";
+import { buildPipelineStepViews, buildGovernanceDriftAlert } from "./pipeline";
+
+function makeResult(overrides: Partial<DecideResponse> = {}): DecideResponse {
+  return {
+    decision_status: "approved",
+    chosen: "option A",
+    rejection_reason: null,
+    ...overrides,
+  } as DecideResponse;
+}
+
+describe("buildPipelineStepViews", () => {
+  it("returns plan steps when plan is provided", () => {
+    const result = makeResult({
+      plan: [
+        { title: "Step 1", objective: "Gather data" },
+        { title: "Step 2", objective: "Analyze" },
+      ],
+    });
+    const steps = buildPipelineStepViews(result);
+    expect(steps).toHaveLength(2);
+    expect(steps[0].name).toBe("Step 1");
+    expect(steps[0].status).toBe("complete");
+  });
+
+  it("falls back to evidence/critique/debate/gate when no plan", () => {
+    const result = makeResult({
+      evidence: ["ev1", "ev2"],
+      critique: ["c1"],
+      debate: [],
+      gate: { decision_status: "approved" },
+    });
+    const steps = buildPipelineStepViews(result);
+    expect(steps).toHaveLength(4);
+    expect(steps[0].name).toBe("Evidence");
+    expect(steps[0].summary).toContain("2 items");
+    expect(steps[3].name).toBe("FUJI Gate");
+  });
+
+  it("skips plan entries without title or objective", () => {
+    const result = makeResult({
+      plan: [{ title: "Valid" }, {}, { objective: "Also valid" }],
+    });
+    const steps = buildPipelineStepViews(result);
+    expect(steps).toHaveLength(2);
+  });
+
+  it("uses objective when title is missing", () => {
+    const result = makeResult({
+      plan: [{ objective: "My objective" }],
+    });
+    const steps = buildPipelineStepViews(result);
+    expect(steps[0].name).toBe("My objective");
+  });
+});
+
+describe("buildGovernanceDriftAlert", () => {
+  it("returns null for null result", () => {
+    expect(buildGovernanceDriftAlert(null)).toBeNull();
+  });
+
+  it("returns null when drift and risk are low", () => {
+    const result = makeResult({
+      values: { valuecore_drift: 2 },
+      gate: { risk: 0.1 },
+    });
+    expect(buildGovernanceDriftAlert(result)).toBeNull();
+  });
+
+  it("returns alert when drift >= 10", () => {
+    const result = makeResult({
+      values: { valuecore_drift: 15 },
+      gate: { risk: 0.1 },
+    });
+    const alert = buildGovernanceDriftAlert(result);
+    expect(alert).not.toBeNull();
+    expect(alert!.title).toBe("1 Issue");
+  });
+
+  it("returns alert when risk >= 0.7", () => {
+    const result = makeResult({
+      values: {},
+      gate: { risk: 0.8 },
+    });
+    const alert = buildGovernanceDriftAlert(result);
+    expect(alert).not.toBeNull();
+  });
+});

--- a/frontend/features/console/analytics/utils.test.ts
+++ b/frontend/features/console/analytics/utils.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { renderValue, toArray, toFiniteNumber, toAssistantMessage } from "./utils";
+import type { DecideResponse } from "@veritas/types";
+
+describe("renderValue", () => {
+  it("returns 'null' for null", () => {
+    expect(renderValue(null)).toBe("null");
+  });
+
+  it("returns 'undefined' for undefined", () => {
+    expect(renderValue(undefined)).toBe("undefined");
+  });
+
+  it("returns string as-is", () => {
+    expect(renderValue("hello")).toBe("hello");
+  });
+
+  it("JSON-stringifies objects", () => {
+    expect(renderValue({ a: 1 })).toBe(JSON.stringify({ a: 1 }, null, 2));
+  });
+
+  it("handles circular references gracefully", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    // Should not throw; falls back to String()
+    expect(typeof renderValue(obj)).toBe("string");
+  });
+});
+
+describe("toArray", () => {
+  it("returns arrays as-is", () => {
+    expect(toArray([1, 2])).toEqual([1, 2]);
+  });
+
+  it("returns empty array for null and undefined", () => {
+    expect(toArray(null)).toEqual([]);
+    expect(toArray(undefined)).toEqual([]);
+  });
+
+  it("wraps single values in array", () => {
+    expect(toArray("hello")).toEqual(["hello"]);
+    expect(toArray(42)).toEqual([42]);
+  });
+});
+
+describe("toFiniteNumber", () => {
+  it("returns finite numbers as-is", () => {
+    expect(toFiniteNumber(42)).toBe(42);
+    expect(toFiniteNumber(0)).toBe(0);
+  });
+
+  it("returns null for Infinity and NaN", () => {
+    expect(toFiniteNumber(Infinity)).toBeNull();
+    expect(toFiniteNumber(NaN)).toBeNull();
+  });
+
+  it("parses numeric strings", () => {
+    expect(toFiniteNumber("3.14")).toBe(3.14);
+    expect(toFiniteNumber("42")).toBe(42);
+  });
+
+  it("returns null for non-numeric strings", () => {
+    expect(toFiniteNumber("abc")).toBeNull();
+    expect(toFiniteNumber("")).toBeNull();
+    expect(toFiniteNumber("  ")).toBeNull();
+  });
+
+  it("returns null for non-number types", () => {
+    expect(toFiniteNumber(null)).toBeNull();
+    expect(toFiniteNumber(undefined)).toBeNull();
+    expect(toFiniteNumber({})).toBeNull();
+  });
+});
+
+describe("toAssistantMessage", () => {
+  it("formats decision response for Japanese", () => {
+    const payload = {
+      decision_status: "approved",
+      chosen: "Option A",
+      rejection_reason: null,
+    } as DecideResponse;
+    const t = (ja: string, _en: string) => ja;
+    const message = toAssistantMessage(payload, t);
+    expect(message).toContain("判定: approved");
+    expect(message).toContain("採択案: Option A");
+    expect(message).toContain("拒否理由: なし");
+  });
+
+  it("formats decision response for English", () => {
+    const payload = {
+      decision_status: "rejected",
+      chosen: null,
+      rejection_reason: "Too risky",
+    } as unknown as DecideResponse;
+    const t = (_ja: string, en: string) => en;
+    const message = toAssistantMessage(payload, t);
+    expect(message).toContain("Decision: rejected");
+    expect(message).toContain("Chosen: none");
+    expect(message).toContain("Rejection: Too risky");
+  });
+});

--- a/frontend/features/console/components/cost-benefit-panel.test.tsx
+++ b/frontend/features/console/components/cost-benefit-panel.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CostBenefitPanel } from "./cost-benefit-panel";
+import type { DecideResponse } from "@veritas/types";
+
+function makeResult(overrides: Partial<DecideResponse> = {}): DecideResponse {
+  return {
+    decision_status: "approved",
+    chosen: "A",
+    rejection_reason: null,
+    gate: { decision_status: "approved", risk: 0.3 },
+    evidence: ["ev1"],
+    critique: ["c1"],
+    debate: [],
+    ...overrides,
+  } as DecideResponse;
+}
+
+describe("CostBenefitPanel", () => {
+  it("renders section with heading", () => {
+    render(<CostBenefitPanel result={makeResult()} />);
+    expect(screen.getByRole("region", { name: "cost-benefit analytics" })).toBeInTheDocument();
+    expect(screen.getByText("Cost-Benefit Analytics")).toBeInTheDocument();
+  });
+
+  it("renders table with step rows", () => {
+    render(<CostBenefitPanel result={makeResult()} />);
+    expect(screen.getByText("Step")).toBeInTheDocument();
+    expect(screen.getByText("Executed")).toBeInTheDocument();
+  });
+
+  it("shows inferred banner when analytics are inferred", () => {
+    // Without cost_benefit_analytics from backend, the component should show inferred
+    render(<CostBenefitPanel result={makeResult()} />);
+    expect(screen.getByText(/推定表示/)).toBeInTheDocument();
+  });
+
+  it("renders total token cost and uncertainty reduction", () => {
+    render(<CostBenefitPanel result={makeResult()} />);
+    expect(screen.getByText("Total Token Cost")).toBeInTheDocument();
+    expect(screen.getByText("Uncertainty Reduction")).toBeInTheDocument();
+  });
+});

--- a/frontend/features/console/components/drift-alert.test.tsx
+++ b/frontend/features/console/components/drift-alert.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DriftAlert } from "./drift-alert";
+
+describe("DriftAlert", () => {
+  it("returns null when alert is null", () => {
+    const { container } = render(
+      <DriftAlert alert={null} showAlert={false} setShowAlert={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders title button when alert is provided", () => {
+    const alert = { title: "1 Issue", description: "Drift detected" };
+    render(<DriftAlert alert={alert} showAlert={false} setShowAlert={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "1 Issue" })).toBeInTheDocument();
+  });
+
+  it("shows description when showAlert is true", () => {
+    const alert = { title: "1 Issue", description: "Drift detected" };
+    render(<DriftAlert alert={alert} showAlert={true} setShowAlert={vi.fn()} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Drift detected")).toBeInTheDocument();
+  });
+
+  it("hides description when showAlert is false", () => {
+    const alert = { title: "1 Issue", description: "Drift detected" };
+    render(<DriftAlert alert={alert} showAlert={false} setShowAlert={vi.fn()} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("toggles alert on button click", () => {
+    const setShowAlert = vi.fn();
+    const alert = { title: "1 Issue", description: "Drift detected" };
+    render(<DriftAlert alert={alert} showAlert={false} setShowAlert={setShowAlert} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(setShowAlert).toHaveBeenCalledOnce();
+    // The callback receives a toggle function
+    const toggleFn = setShowAlert.mock.calls[0][0];
+    expect(typeof toggleFn).toBe("function");
+    expect(toggleFn(false)).toBe(true);
+  });
+});

--- a/frontend/features/console/components/result-section.test.tsx
+++ b/frontend/features/console/components/result-section.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ResultSection } from "./result-section";
+
+describe("ResultSection", () => {
+  it("renders title and string value", () => {
+    render(<ResultSection title="Evidence" value="Some evidence text" />);
+    expect(screen.getByText("Evidence")).toBeInTheDocument();
+    expect(screen.getByText("Some evidence text")).toBeInTheDocument();
+  });
+
+  it("renders object value as JSON", () => {
+    render(<ResultSection title="Data" value={{ key: "val" }} />);
+    expect(screen.getByText("Data")).toBeInTheDocument();
+    expect(screen.getByText(/key/)).toBeInTheDocument();
+  });
+
+  it("renders null value", () => {
+    render(<ResultSection title="Empty" value={null} />);
+    expect(screen.getByText("null")).toBeInTheDocument();
+  });
+
+  it("has accessible section labelled by title", () => {
+    render(<ResultSection title="My Section" value="content" />);
+    const section = screen.getByRole("region", { name: "My Section" });
+    expect(section).toBeInTheDocument();
+  });
+});

--- a/frontend/features/console/components/step-expansion-panel.test.tsx
+++ b/frontend/features/console/components/step-expansion-panel.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StepExpansionPanel } from "./step-expansion-panel";
+import type { DecideResponse } from "@veritas/types";
+
+function makeResult(overrides: Partial<DecideResponse> = {}): DecideResponse {
+  return {
+    decision_status: "approved",
+    chosen: "A",
+    rejection_reason: null,
+    evidence: ["ev1"],
+    critique: [],
+    debate: [],
+    gate: { decision_status: "approved" },
+    ...overrides,
+  } as DecideResponse;
+}
+
+describe("StepExpansionPanel", () => {
+  it("returns null when result is null", () => {
+    const { container } = render(<StepExpansionPanel result={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders pipeline step views", () => {
+    render(<StepExpansionPanel result={makeResult()} />);
+    expect(screen.getByText(/Evidence/)).toBeInTheDocument();
+    expect(screen.getByText(/FUJI Gate/)).toBeInTheDocument();
+  });
+
+  it("renders stage metrics when present", () => {
+    const result = makeResult({
+      extras: {
+        stage_metrics: {
+          retrieval: { latency_ms: 150, health: "healthy" },
+          safety: { latency_ms: 300, health: "warning" },
+        },
+      },
+    });
+    render(<StepExpansionPanel result={result} />);
+    expect(screen.getByText("retrieval")).toBeInTheDocument();
+    expect(screen.getByText("safety")).toBeInTheDocument();
+    expect(screen.getByText(/150/)).toBeInTheDocument();
+    expect(screen.getByText("healthy")).toBeInTheDocument();
+    expect(screen.getByText("warning")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Cover previously untested modules: governance helpers/constants, risk
data-helpers/constants, audit types/constants, shared components
(critical-rail, global-health-summary, i18n-provider, ops-priority-card),
console components (cost-benefit-panel, drift-alert, result-section,
step-expansion-panel), console analytics (pipeline, utils), and UI
components (confirm-dialog, status-badge, section-header, stat-card).

https://claude.ai/code/session_01MoPomPJmmG93mLjDt6uYBC