### PR TITLE
Add frontend component tests for governance, audit, risk, hooks, and layout

### DIFF
--- a/frontend/app/audit/components/components.test.tsx
+++ b/frontend/app/audit/components/components.test.tsx
@@ -1,0 +1,453 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuditSummaryPanel } from "./AuditSummaryPanel";
+import { DetailPanel } from "./DetailPanel";
+import { AuditTimeline } from "./AuditTimeline";
+import { VerificationPanel } from "./VerificationPanel";
+import { SearchPanel } from "./SearchPanel";
+import { ExportPanel } from "./ExportPanel";
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../../components/i18n-provider", () => ({
+  useI18n: () => ({
+    language: "en",
+    t: (_ja: string, en: string) => en,
+    tk: (k: string) => k,
+    setLanguage: () => {},
+  }),
+}));
+
+vi.mock("@veritas/design-system", () => ({
+  Card: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title?: string;
+  }) => (
+    <div data-testid={`card-${title}`}>
+      {title && <h3>{title}</h3>}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("../../../components/ui", () => ({
+  StatCard: ({ label, value }: { label: string; value: number }) => (
+    <div data-testid={`stat-${label}`}>{value}</div>
+  ),
+}));
+
+vi.mock("../audit-types", async () => {
+  const actual = await vi.importActual("../audit-types");
+  return {
+    ...actual,
+    classifyChain: () => ({ status: "verified", reason: "ok" }),
+  };
+});
+
+/* ------------------------------------------------------------------ */
+/*  Shared mock data                                                   */
+/* ------------------------------------------------------------------ */
+
+const mockItem = {
+  request_id: "req-001",
+  decision_id: 42,
+  sha256: "abc123hash",
+  sha256_prev: "prevhash",
+  created_at: "2026-01-01T00:00:00Z",
+  stage: "retrieval",
+  status: "ok",
+  severity: "info",
+  policy_version: "v1",
+  replay_id: "replay-001",
+  metadata: { key: "value" },
+  continuation_claim_status: undefined,
+};
+
+const mockItem2 = {
+  ...mockItem,
+  request_id: "req-002",
+  decision_id: 43,
+  sha256: "def456hash",
+  sha256_prev: "abc123hash",
+  created_at: "2026-01-02T00:00:00Z",
+  stage: "planner",
+};
+
+/* ================================================================== */
+/*  AuditSummaryPanel                                                  */
+/* ================================================================== */
+
+describe("AuditSummaryPanel", () => {
+  const baseSummary = {
+    total: 10,
+    verified: 7,
+    broken: 1,
+    missing: 1,
+    orphan: 1,
+    replayLinked: 3,
+    policyVersions: { v1: 6, v2: 4 },
+  };
+
+  it("renders empty state when hasItems is false", () => {
+    render(<AuditSummaryPanel summary={baseSummary} hasItems={false} />);
+    expect(
+      screen.getByText("Load logs to see the overall audit summary here."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders stat cards when hasItems is true", () => {
+    render(<AuditSummaryPanel summary={baseSummary} hasItems={true} />);
+    expect(screen.getByTestId("stat-Total")).toHaveTextContent("10");
+    expect(screen.getByTestId("stat-Verified")).toHaveTextContent("7");
+    expect(screen.getByTestId("stat-Broken")).toHaveTextContent("1");
+    expect(screen.getByTestId("stat-Missing")).toHaveTextContent("1");
+    expect(screen.getByTestId("stat-Orphan")).toHaveTextContent("1");
+    expect(screen.getByTestId("stat-Replay Linked")).toHaveTextContent("3");
+  });
+
+  it("renders policy version distribution", () => {
+    render(<AuditSummaryPanel summary={baseSummary} hasItems={true} />);
+    expect(screen.getByText("Policy Version Distribution")).toBeInTheDocument();
+    expect(screen.getByText("v1: 6")).toBeInTheDocument();
+    expect(screen.getByText("v2: 4")).toBeInTheDocument();
+  });
+
+  it("renders integrity bar", () => {
+    render(<AuditSummaryPanel summary={baseSummary} hasItems={true} />);
+    expect(screen.getByText(/Chain integrity/)).toBeInTheDocument();
+    expect(screen.getByText(/70%/)).toBeInTheDocument();
+  });
+});
+
+/* ================================================================== */
+/*  DetailPanel                                                        */
+/* ================================================================== */
+
+describe("DetailPanel", () => {
+  const baseProps = {
+    selected: null as typeof mockItem | null,
+    selectedChain: null as { status: "verified"; reason: string } | null,
+    previousEntry: null,
+    nextEntry: null,
+    detailTab: "summary" as const,
+    onDetailTabChange: vi.fn(),
+  };
+
+  it("renders empty state when selected is null", () => {
+    render(<DetailPanel {...baseProps} />);
+    expect(
+      screen.getByText(/Select a log from the timeline to see details/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders tab bar with 6 tabs when selected", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "hash chain match" }}
+      />,
+    );
+    expect(screen.getByText("Summary")).toBeInTheDocument();
+    expect(screen.getByText("Metadata")).toBeInTheDocument();
+    expect(screen.getByText("Hash")).toBeInTheDocument();
+    expect(screen.getByText("Related")).toBeInTheDocument();
+    expect(screen.getByText("Continuation")).toBeInTheDocument();
+    expect(screen.getByText("Raw JSON")).toBeInTheDocument();
+  });
+
+  it("renders summary tab content with chain status", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "hash chain match" }}
+      />,
+    );
+    expect(screen.getByText("VERIFIED")).toBeInTheDocument();
+    expect(screen.getByText(/hash chain match/)).toBeInTheDocument();
+  });
+
+  it("switches to metadata tab on click", () => {
+    const onDetailTabChange = vi.fn();
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "hash chain match" }}
+        onDetailTabChange={onDetailTabChange}
+      />,
+    );
+    fireEvent.click(screen.getByText("Metadata"));
+    expect(onDetailTabChange).toHaveBeenCalledWith("metadata");
+  });
+});
+
+/* ================================================================== */
+/*  AuditTimeline                                                      */
+/* ================================================================== */
+
+describe("AuditTimeline", () => {
+  const baseProps = {
+    filteredItems: [] as any[],
+    stageFilter: "all",
+    stageOptions: ["all", "retrieval", "planner"],
+    selected: null,
+    onStageFilterChange: vi.fn(),
+    onSelect: vi.fn(),
+    onDetailTabChange: vi.fn(),
+  };
+
+  it("renders empty state when no items", () => {
+    render(<AuditTimeline {...baseProps} />);
+    expect(
+      screen.getByText(/No logs loaded yet/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders stage filter select with options", () => {
+    render(<AuditTimeline {...baseProps} />);
+    const select = screen.getByLabelText("Stage");
+    expect(select).toBeInTheDocument();
+    expect(screen.getByText("all")).toBeInTheDocument();
+    expect(screen.getByText("retrieval")).toBeInTheDocument();
+    expect(screen.getByText("planner")).toBeInTheDocument();
+  });
+
+  it("renders timeline items with chain status", () => {
+    render(
+      <AuditTimeline
+        {...baseProps}
+        filteredItems={[mockItem as any, mockItem2 as any]}
+      />,
+    );
+    // classifyChain is mocked to return "verified"
+    const verifiedLabels = screen.getAllByText("verified");
+    expect(verifiedLabels.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("calls onSelect when an item is clicked", () => {
+    const onSelect = vi.fn();
+    const onDetailTabChange = vi.fn();
+    render(
+      <AuditTimeline
+        {...baseProps}
+        filteredItems={[mockItem as any]}
+        onSelect={onSelect}
+        onDetailTabChange={onDetailTabChange}
+      />,
+    );
+    // Click the timeline entry button
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[0]);
+    expect(onSelect).toHaveBeenCalledWith(mockItem);
+    expect(onDetailTabChange).toHaveBeenCalledWith("summary");
+  });
+});
+
+/* ================================================================== */
+/*  VerificationPanel                                                  */
+/* ================================================================== */
+
+describe("VerificationPanel", () => {
+  const baseProps = {
+    decisionIds: ["42", "43"],
+    selectedDecisionId: "",
+    selectedDecisionEntry: null,
+    verificationMessage: null as string | null,
+    onSelectedDecisionIdChange: vi.fn(),
+    onVerify: vi.fn(),
+  };
+
+  it("renders decision ID dropdown and verify button", () => {
+    render(<VerificationPanel {...baseProps} />);
+    expect(
+      screen.getByLabelText("Decision ID for verification"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Verify hash chain" }),
+    ).toBeInTheDocument();
+    // Options include placeholder + 2 IDs
+    expect(screen.getByText("Select a decision ID")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("43")).toBeInTheDocument();
+  });
+
+  it("calls onVerify when button clicked", () => {
+    const onVerify = vi.fn();
+    render(<VerificationPanel {...baseProps} onVerify={onVerify} />);
+    fireEvent.click(screen.getByRole("button", { name: "Verify hash chain" }));
+    expect(onVerify).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders verification message when provided", () => {
+    render(
+      <VerificationPanel
+        {...baseProps}
+        verificationMessage="All 5 entries verified."
+      />,
+    );
+    expect(screen.getByText("All 5 entries verified.")).toBeInTheDocument();
+  });
+});
+
+/* ================================================================== */
+/*  SearchPanel                                                        */
+/* ================================================================== */
+
+describe("SearchPanel", () => {
+  const baseProps = {
+    requestId: "",
+    onRequestIdChange: vi.fn(),
+    requestResult: null,
+    onSearchByRequestId: vi.fn(),
+    crossSearch: { query: "", field: "all" as const },
+    onCrossSearchChange: vi.fn(),
+    filteredCount: 0,
+    loading: false,
+    hasMore: false,
+    cursor: null,
+    onLoadLogs: vi.fn(),
+  };
+
+  it("renders load latest logs button", () => {
+    render(<SearchPanel {...baseProps} />);
+    expect(
+      screen.getByRole("button", { name: "Load latest logs" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders request ID search input", () => {
+    render(<SearchPanel {...baseProps} />);
+    expect(
+      screen.getByLabelText("Search by request ID"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onSearchByRequestId when search button clicked", () => {
+    const onSearchByRequestId = vi.fn();
+    render(
+      <SearchPanel
+        {...baseProps}
+        onSearchByRequestId={onSearchByRequestId}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(onSearchByRequestId).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders cross-search with field selector", () => {
+    render(<SearchPanel {...baseProps} />);
+    expect(screen.getByLabelText("Search field")).toBeInTheDocument();
+    expect(screen.getByLabelText("cross-search")).toBeInTheDocument();
+    // Verify field options
+    expect(screen.getByText("All fields")).toBeInTheDocument();
+    expect(screen.getByText("decision_id")).toBeInTheDocument();
+    expect(screen.getByText("request_id")).toBeInTheDocument();
+  });
+
+  it("shows match count when cross-search query is present", () => {
+    render(
+      <SearchPanel
+        {...baseProps}
+        crossSearch={{ query: "req-001", field: "all" }}
+        filteredCount={3}
+      />,
+    );
+    expect(screen.getByText(/Matches.*3/)).toBeInTheDocument();
+  });
+});
+
+/* ================================================================== */
+/*  ExportPanel                                                        */
+/* ================================================================== */
+
+describe("ExportPanel", () => {
+  const baseProps = {
+    sortedItems: [mockItem as any],
+    reportStartDate: "",
+    reportEndDate: "",
+    redactionMode: "full" as const,
+    exportFormat: "json" as const,
+    confirmPiiRisk: false,
+    reportError: null as string | null,
+    latestReport: null,
+    exportTargetCount: 0,
+    onReportStartDateChange: vi.fn(),
+    onReportEndDateChange: vi.fn(),
+    onRedactionModeChange: vi.fn(),
+    onExportFormatChange: vi.fn(),
+    onConfirmPiiRiskChange: vi.fn(),
+    onReportError: vi.fn(),
+    onLatestReport: vi.fn(),
+  };
+
+  it("renders date range inputs", () => {
+    render(<ExportPanel {...baseProps} />);
+    expect(
+      screen.getByLabelText("Audit report start date"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Audit report end date"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders redaction mode radio buttons", () => {
+    render(<ExportPanel {...baseProps} />);
+    expect(screen.getByLabelText("Full")).toBeInTheDocument();
+    expect(screen.getByLabelText("Redacted")).toBeInTheDocument();
+    expect(screen.getByLabelText("Metadata only")).toBeInTheDocument();
+  });
+
+  it("renders export format radio buttons (JSON/PDF)", () => {
+    render(<ExportPanel {...baseProps} />);
+    expect(screen.getByLabelText("JSON")).toBeInTheDocument();
+    expect(screen.getByLabelText("PDF")).toBeInTheDocument();
+  });
+
+  it("renders PII warning checkbox", () => {
+    render(<ExportPanel {...baseProps} />);
+    expect(
+      screen.getByLabelText("Acknowledge PII/metadata warning"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Security warning.*PII/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error when export without PII confirmation", () => {
+    const onReportError = vi.fn();
+    render(
+      <ExportPanel
+        {...baseProps}
+        reportStartDate="2026-01-01"
+        reportEndDate="2026-01-31"
+        confirmPiiRisk={false}
+        onReportError={onReportError}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Generate JSON" }));
+    expect(onReportError).toHaveBeenCalledWith(
+      "Please acknowledge the PII/metadata warning.",
+    );
+  });
+
+  it("shows export target count", () => {
+    render(
+      <ExportPanel
+        {...baseProps}
+        reportStartDate="2026-01-01"
+        reportEndDate="2026-01-31"
+        exportTargetCount={5}
+      />,
+    );
+    expect(screen.getByText(/Export target.*5.*entries/)).toBeInTheDocument();
+  });
+});

--- a/frontend/app/audit/components/components.test.tsx
+++ b/frontend/app/audit/components/components.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -103,7 +104,7 @@ describe("AuditSummaryPanel", () => {
   });
 
   it("renders stat cards when hasItems is true", () => {
-    render(<AuditSummaryPanel summary={baseSummary} hasItems={true} />);
+    render(<AuditSummaryPanel summary={baseSummary} hasItems />);
     expect(screen.getByTestId("stat-Total")).toHaveTextContent("10");
     expect(screen.getByTestId("stat-Verified")).toHaveTextContent("7");
     expect(screen.getByTestId("stat-Broken")).toHaveTextContent("1");
@@ -113,14 +114,14 @@ describe("AuditSummaryPanel", () => {
   });
 
   it("renders policy version distribution", () => {
-    render(<AuditSummaryPanel summary={baseSummary} hasItems={true} />);
+    render(<AuditSummaryPanel summary={baseSummary} hasItems />);
     expect(screen.getByText("Policy Version Distribution")).toBeInTheDocument();
     expect(screen.getByText("v1: 6")).toBeInTheDocument();
     expect(screen.getByText("v2: 4")).toBeInTheDocument();
   });
 
   it("renders integrity bar", () => {
-    render(<AuditSummaryPanel summary={baseSummary} hasItems={true} />);
+    render(<AuditSummaryPanel summary={baseSummary} hasItems />);
     expect(screen.getByText(/Chain integrity/)).toBeInTheDocument();
     expect(screen.getByText(/70%/)).toBeInTheDocument();
   });

--- a/frontend/app/governance/components/components.test.tsx
+++ b/frontend/app/governance/components/components.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
@@ -120,7 +121,7 @@ describe("ToggleRow", () => {
 
   it("is disabled when disabled prop is true", () => {
     const onChange = vi.fn();
-    render(<ToggleRow label="Toggle" checked={true} onChange={onChange} disabled />);
+    render(<ToggleRow label="Toggle" checked onChange={onChange} disabled />);
     const btn = screen.getByRole("switch");
     expect(btn).toBeDisabled();
     fireEvent.click(btn);
@@ -210,10 +211,10 @@ describe("ApplyFlow", () => {
   it("renders all 4 buttons", () => {
     render(
       <ApplyFlow
-        hasChanges={true}
+        hasChanges
         saving={false}
-        canApply={true}
-        canOperate={true}
+        canApply
+        canOperate
         draftApprovalStatus="approved"
         onApply={() => {}}
         onRollback={() => {}}
@@ -228,10 +229,10 @@ describe("ApplyFlow", () => {
   it("disables apply/rollback when canApply is false and shows RBAC warning", () => {
     render(
       <ApplyFlow
-        hasChanges={true}
+        hasChanges
         saving={false}
         canApply={false}
-        canOperate={true}
+        canOperate
         draftApprovalStatus="approved"
         onApply={() => {}}
         onRollback={() => {}}
@@ -248,10 +249,10 @@ describe("ApplyFlow", () => {
     const onApply = vi.fn();
     render(
       <ApplyFlow
-        hasChanges={true}
+        hasChanges
         saving={false}
-        canApply={true}
-        canOperate={true}
+        canApply
+        canOperate
         draftApprovalStatus="approved"
         onApply={onApply}
         onRollback={() => {}}
@@ -267,10 +268,10 @@ describe("ApplyFlow", () => {
   it("shows approval info text when hasChanges and status != approved", () => {
     render(
       <ApplyFlow
-        hasChanges={true}
+        hasChanges
         saving={false}
-        canApply={true}
-        canOperate={true}
+        canApply
+        canOperate
         draftApprovalStatus="pending"
         onApply={() => {}}
         onRollback={() => {}}
@@ -292,9 +293,9 @@ describe("ApprovalWorkflow", () => {
       <ApprovalWorkflow
         draftApprovalStatus="pending"
         changeCount={3}
-        canApprove={true}
+        canApprove
         ticketId="TICKET-1"
-        approverIdentityBinding={true}
+        approverIdentityBinding
         onApprove={() => {}}
         onReject={() => {}}
       />,
@@ -310,7 +311,7 @@ describe("ApprovalWorkflow", () => {
       <ApprovalWorkflow
         draftApprovalStatus="pending"
         changeCount={1}
-        canApprove={true}
+        canApprove
         ticketId="T-1"
         approverIdentityBinding={false}
         onApprove={onApprove}
@@ -345,7 +346,7 @@ describe("ApprovalWorkflow", () => {
       <ApprovalWorkflow
         draftApprovalStatus="rejected"
         changeCount={1}
-        canApprove={true}
+        canApprove
         ticketId="T-1"
         approverIdentityBinding={false}
         onApprove={() => {}}
@@ -385,7 +386,7 @@ describe("PolicyMetaPanel", () => {
         savedPolicy={MOCK_DRAFT as any}
         draft={MOCK_DRAFT as any}
         draftApprovalStatus="pending"
-        hasChanges={true}
+        hasChanges
         changeCount={5}
       />,
     );
@@ -462,7 +463,7 @@ describe("FujiRulesEditor", () => {
     render(
       <FujiRulesEditor
         draft={MOCK_DRAFT as any}
-        isViewer={true}
+        isViewer
         onUpdate={() => {}}
       />,
     );

--- a/frontend/app/governance/components/components.test.tsx
+++ b/frontend/app/governance/components/components.test.tsx
@@ -1,0 +1,491 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("../../../components/i18n-provider", () => ({
+  useI18n: () => ({
+    language: "en",
+    t: (_ja: string, en: string) => en,
+    tk: (k: string) => k,
+    setLanguage: () => {},
+  }),
+}));
+
+vi.mock("@veritas/design-system", () => ({
+  Card: ({ children, title }: { children: React.ReactNode; title?: string }) => (
+    <div data-testid={`card-${title}`}>
+      {title && <h3>{title}</h3>}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("../../../components/ui", () => ({
+  StatusBadge: ({ label }: { label: string }) => (
+    <span data-testid="status-badge">{label}</span>
+  ),
+}));
+
+const mockCollectChanges = vi.fn(() => [] as DiffChange[]);
+vi.mock("../helpers", () => ({
+  collectChanges: (...args: unknown[]) => mockCollectChanges(...args),
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────────
+
+import { ToggleRow } from "./ToggleRow";
+import { RiskImpactGauge } from "./RiskImpactGauge";
+import { ChangeHistory } from "./ChangeHistory";
+import { TrustLogStream } from "./TrustLogStream";
+import { ApplyFlow } from "./ApplyFlow";
+import { ApprovalWorkflow } from "./ApprovalWorkflow";
+import { PolicyMetaPanel } from "./PolicyMetaPanel";
+import { DiffPreview } from "./DiffPreview";
+import { FujiRulesEditor } from "./FujiRulesEditor";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+import type { HistoryEntry, TrustLogEntry, DiffChange } from "../governance-types";
+
+// ── Shared fixtures ────────────────────────────────────────────────────────────
+
+const MOCK_DRAFT = {
+  version: "v1.0",
+  draft_version: "v1.1",
+  effective_at: "2026-01-01",
+  last_applied: "2026-01-01",
+  approval_status: "pending" as const,
+  updated_by: "admin",
+  fuji_rules: {
+    pii_check: true,
+    self_harm_block: true,
+    illicit_block: false,
+    violence_review: true,
+    minors_review: true,
+    keyword_hard_block: true,
+    keyword_soft_flag: false,
+    llm_safety_head: true,
+  },
+  risk_thresholds: {
+    allow_upper: 0.4,
+    warn_upper: 0.65,
+    human_review_upper: 0.85,
+    deny_upper: 1.0,
+  },
+  auto_stop: {
+    enabled: true,
+    max_risk_score: 0.85,
+    max_consecutive_rejects: 5,
+    max_requests_per_minute: 60,
+  },
+  log_retention: {
+    retention_days: 90,
+    audit_level: "full",
+    include_fields: ["status"],
+    redact_before_log: true,
+    max_log_size: 10000,
+  },
+  rollout_controls: {
+    strategy: "disabled",
+    canary_percent: 0,
+    stage: 0,
+    staged_enforcement: false,
+  },
+  approval_workflow: {
+    human_review_ticket: "TICKET-123",
+    human_review_required: false,
+    approver_identity_binding: true,
+    approver_identities: [],
+  },
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+// ── ToggleRow ──────────────────────────────────────────────────────────────────
+
+describe("ToggleRow", () => {
+  it("renders label and switch role", () => {
+    render(<ToggleRow label="My Toggle" checked={false} onChange={() => {}} />);
+    expect(screen.getByText("My Toggle")).toBeTruthy();
+    expect(screen.getByRole("switch")).toBeTruthy();
+  });
+
+  it("calls onChange with toggled value on click", () => {
+    const onChange = vi.fn();
+    render(<ToggleRow label="Toggle" checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    const onChange = vi.fn();
+    render(<ToggleRow label="Toggle" checked={true} onChange={onChange} disabled />);
+    const btn = screen.getByRole("switch");
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// ── RiskImpactGauge ────────────────────────────────────────────────────────────
+
+describe("RiskImpactGauge", () => {
+  it("renders current, pending, drift values", () => {
+    render(<RiskImpactGauge current={60} pending={40} drift={3} />);
+    expect(screen.getByText("60%")).toBeTruthy();
+    expect(screen.getByText("40%")).toBeTruthy();
+    expect(screen.getByText("+3% from baseline")).toBeTruthy();
+  });
+
+  it("shows danger styling for values > 75", () => {
+    render(<RiskImpactGauge current={80} pending={90} drift={0} />);
+    const currentLabel = screen.getByText("80%");
+    expect(currentLabel.className).toContain("text-danger");
+  });
+
+  it("shows success styling for values <= 50", () => {
+    render(<RiskImpactGauge current={30} pending={20} drift={0} />);
+    const currentLabel = screen.getByText("30%");
+    expect(currentLabel.className).toContain("text-success");
+  });
+
+  it("shows positive drift with + prefix", () => {
+    render(<RiskImpactGauge current={50} pending={50} drift={10} />);
+    expect(screen.getByText("+10% from baseline")).toBeTruthy();
+  });
+});
+
+// ── ChangeHistory ──────────────────────────────────────────────────────────────
+
+describe("ChangeHistory", () => {
+  it("renders empty state message when no entries", () => {
+    render(<ChangeHistory entries={[]} />);
+    expect(
+      screen.getByText("Change history will appear after policy operations."),
+    ).toBeTruthy();
+  });
+
+  it("renders entries with action badges", () => {
+    const entries: HistoryEntry[] = [
+      { id: "1", action: "apply", actor: "admin", at: "2026-01-01", summary: "Applied v1" },
+      { id: "2", action: "rollback", actor: "operator", at: "2026-01-02", summary: "Rolled back" },
+    ];
+    render(<ChangeHistory entries={entries} />);
+    expect(screen.getByText("apply")).toBeTruthy();
+    expect(screen.getByText("rollback")).toBeTruthy();
+    expect(screen.getByText(/Applied v1/)).toBeTruthy();
+    expect(screen.getByText(/Rolled back/)).toBeTruthy();
+  });
+});
+
+// ── TrustLogStream ─────────────────────────────────────────────────────────────
+
+describe("TrustLogStream", () => {
+  it("renders empty state message when no entries", () => {
+    render(<TrustLogStream entries={[]} />);
+    expect(
+      screen.getByText("Stream events will appear after loading a policy."),
+    ).toBeTruthy();
+  });
+
+  it("renders entries with severity badges", () => {
+    const entries: TrustLogEntry[] = [
+      { id: "1", at: "12:00", message: "Policy loaded", severity: "info" },
+      { id: "2", at: "12:01", message: "Risk spike", severity: "warning" },
+      { id: "3", at: "12:02", message: "Policy violation", severity: "policy" },
+    ];
+    render(<TrustLogStream entries={entries} />);
+    expect(screen.getByText("info")).toBeTruthy();
+    expect(screen.getByText("warning")).toBeTruthy();
+    expect(screen.getByText("policy")).toBeTruthy();
+    expect(screen.getByText("Policy loaded")).toBeTruthy();
+    expect(screen.getByText("Risk spike")).toBeTruthy();
+  });
+});
+
+// ── ApplyFlow ──────────────────────────────────────────────────────────────────
+
+describe("ApplyFlow", () => {
+  it("renders all 4 buttons", () => {
+    render(
+      <ApplyFlow
+        hasChanges={true}
+        saving={false}
+        canApply={true}
+        canOperate={true}
+        draftApprovalStatus="approved"
+        onApply={() => {}}
+        onRollback={() => {}}
+      />,
+    );
+    expect(screen.getByText("apply")).toBeTruthy();
+    expect(screen.getByText("dry-run")).toBeTruthy();
+    expect(screen.getByText("shadow mode")).toBeTruthy();
+    expect(screen.getByText("rollback")).toBeTruthy();
+  });
+
+  it("disables apply/rollback when canApply is false and shows RBAC warning", () => {
+    render(
+      <ApplyFlow
+        hasChanges={true}
+        saving={false}
+        canApply={false}
+        canOperate={true}
+        draftApprovalStatus="approved"
+        onApply={() => {}}
+        onRollback={() => {}}
+      />,
+    );
+    expect(screen.getByText("apply")).toBeDisabled();
+    expect(screen.getByText("rollback")).toBeDisabled();
+    expect(
+      screen.getByText("RBAC: apply/rollback requires admin role."),
+    ).toBeTruthy();
+  });
+
+  it("calls onApply with correct mode", () => {
+    const onApply = vi.fn();
+    render(
+      <ApplyFlow
+        hasChanges={true}
+        saving={false}
+        canApply={true}
+        canOperate={true}
+        draftApprovalStatus="approved"
+        onApply={onApply}
+        onRollback={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("dry-run"));
+    expect(onApply).toHaveBeenCalledWith("dry-run");
+
+    fireEvent.click(screen.getByText("apply"));
+    expect(onApply).toHaveBeenCalledWith("apply");
+  });
+
+  it("shows approval info text when hasChanges and status != approved", () => {
+    render(
+      <ApplyFlow
+        hasChanges={true}
+        saving={false}
+        canApply={true}
+        canOperate={true}
+        draftApprovalStatus="pending"
+        onApply={() => {}}
+        onRollback={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(
+        "Approval is required before apply. dry-run / shadow can be executed before approval.",
+      ),
+    ).toBeTruthy();
+  });
+});
+
+// ── ApprovalWorkflow ───────────────────────────────────────────────────────────
+
+describe("ApprovalWorkflow", () => {
+  it("renders approval status badge and change count", () => {
+    render(
+      <ApprovalWorkflow
+        draftApprovalStatus="pending"
+        changeCount={3}
+        canApprove={true}
+        ticketId="TICKET-1"
+        approverIdentityBinding={true}
+        onApprove={() => {}}
+        onReject={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("status-badge")).toBeTruthy();
+    expect(screen.getByTestId("status-badge").textContent).toBe("pending");
+    expect(screen.getByText("3 change(s) awaiting approval")).toBeTruthy();
+  });
+
+  it("calls onApprove on approve button click", () => {
+    const onApprove = vi.fn();
+    render(
+      <ApprovalWorkflow
+        draftApprovalStatus="pending"
+        changeCount={1}
+        canApprove={true}
+        ticketId="T-1"
+        approverIdentityBinding={false}
+        onApprove={onApprove}
+        onReject={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("approve"));
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables buttons when canApprove is false and shows RBAC warning", () => {
+    render(
+      <ApprovalWorkflow
+        draftApprovalStatus="pending"
+        changeCount={1}
+        canApprove={false}
+        ticketId="T-1"
+        approverIdentityBinding={false}
+        onApprove={() => {}}
+        onReject={() => {}}
+      />,
+    );
+    expect(screen.getByText("approve")).toBeDisabled();
+    expect(screen.getByText("reject")).toBeDisabled();
+    expect(
+      screen.getByText("RBAC: approve/reject requires admin role."),
+    ).toBeTruthy();
+  });
+
+  it("shows blocked warning when approval is blocked", () => {
+    render(
+      <ApprovalWorkflow
+        draftApprovalStatus="rejected"
+        changeCount={1}
+        canApprove={true}
+        ticketId="T-1"
+        approverIdentityBinding={false}
+        onApprove={() => {}}
+        onReject={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(
+        "Approval is blocked. To avoid showing risky changes as safe, do not apply this draft while unapproved.",
+      ),
+    ).toBeTruthy();
+  });
+});
+
+// ── PolicyMetaPanel ────────────────────────────────────────────────────────────
+
+describe("PolicyMetaPanel", () => {
+  it("renders current version and draft version", () => {
+    render(
+      <PolicyMetaPanel
+        savedPolicy={MOCK_DRAFT as any}
+        draft={MOCK_DRAFT as any}
+        draftApprovalStatus="pending"
+        hasChanges={false}
+        changeCount={0}
+      />,
+    );
+    expect(screen.getByText("Current Version")).toBeTruthy();
+    expect(screen.getByText("Draft Version")).toBeTruthy();
+    expect(screen.getByText("v1.0")).toBeTruthy();
+    expect(screen.getByText("v1.1")).toBeTruthy();
+  });
+
+  it("shows unapplied changes warning when hasChanges is true", () => {
+    render(
+      <PolicyMetaPanel
+        savedPolicy={MOCK_DRAFT as any}
+        draft={MOCK_DRAFT as any}
+        draftApprovalStatus="pending"
+        hasChanges={true}
+        changeCount={5}
+      />,
+    );
+    expect(
+      screen.getByText("5 unapplied change(s). Approve before applying."),
+    ).toBeTruthy();
+  });
+});
+
+// ── DiffPreview ────────────────────────────────────────────────────────────────
+
+describe("DiffPreview", () => {
+  beforeEach(() => {
+    mockCollectChanges.mockReset();
+  });
+
+  it("shows 'No changes.' when before and after are same/null", () => {
+    mockCollectChanges.mockReturnValue([]);
+    render(<DiffPreview before={null} after={null} />);
+    expect(screen.getByText("No changes.")).toBeTruthy();
+  });
+
+  it("renders grouped diff changes", () => {
+    const changes: DiffChange[] = [
+      { path: "fuji_rules.pii_check", old: "true", next: "false", category: "rule" },
+      { path: "risk_thresholds.allow_upper", old: "0.4", next: "0.5", category: "threshold" },
+    ];
+    mockCollectChanges.mockReturnValue(changes);
+
+    render(<DiffPreview before={MOCK_DRAFT as any} after={MOCK_DRAFT as any} />);
+    expect(screen.getByText("2 change(s) detected")).toBeTruthy();
+    expect(screen.getByText("fuji_rules.pii_check")).toBeTruthy();
+    expect(screen.getByText("risk_thresholds.allow_upper")).toBeTruthy();
+  });
+
+  it("shows high-impact warning for threshold/escalation changes", () => {
+    const changes: DiffChange[] = [
+      { path: "risk_thresholds.allow_upper", old: "0.4", next: "0.5", category: "threshold" },
+      { path: "auto_stop.max_risk_score", old: "0.85", next: "0.9", category: "escalation" },
+    ];
+    mockCollectChanges.mockReturnValue(changes);
+
+    render(<DiffPreview before={MOCK_DRAFT as any} after={MOCK_DRAFT as any} />);
+    expect(
+      screen.getByText(
+        "2 high-impact change(s): risk threshold and auto-stop updates require re-evaluation before approval.",
+      ),
+    ).toBeTruthy();
+  });
+});
+
+// ── FujiRulesEditor ────────────────────────────────────────────────────────────
+
+describe("FujiRulesEditor", () => {
+  it("renders FUJI rule toggle labels", () => {
+    render(
+      <FujiRulesEditor
+        draft={MOCK_DRAFT as any}
+        isViewer={false}
+        onUpdate={() => {}}
+      />,
+    );
+    expect(screen.getByText("PII Check")).toBeTruthy();
+    expect(screen.getByText("Self-Harm Block")).toBeTruthy();
+    expect(screen.getByText("Illicit Block")).toBeTruthy();
+    expect(screen.getByText("Violence Review")).toBeTruthy();
+    expect(screen.getByText("Minors Review")).toBeTruthy();
+    expect(screen.getByText("Keyword Hard Block")).toBeTruthy();
+    expect(screen.getByText("Keyword Soft Flag")).toBeTruthy();
+    expect(screen.getByText("LLM Safety Head")).toBeTruthy();
+  });
+
+  it("toggles are disabled when isViewer is true", () => {
+    render(
+      <FujiRulesEditor
+        draft={MOCK_DRAFT as any}
+        isViewer={true}
+        onUpdate={() => {}}
+      />,
+    );
+    const switches = screen.getAllByRole("switch");
+    switches.forEach((sw) => {
+      expect(sw).toBeDisabled();
+    });
+  });
+
+  it("calls onUpdate when a toggle is clicked", () => {
+    const onUpdate = vi.fn();
+    render(
+      <FujiRulesEditor
+        draft={MOCK_DRAFT as any}
+        isViewer={false}
+        onUpdate={onUpdate}
+      />,
+    );
+    // Click the "Illicit Block" toggle (which is currently false)
+    const illicitToggle = screen.getByLabelText("Illicit Block");
+    fireEvent.click(illicitToggle);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    // onUpdate receives an updater function
+    expect(typeof onUpdate.mock.calls[0][0]).toBe("function");
+  });
+});

--- a/frontend/app/layout.test.tsx
+++ b/frontend/app/layout.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import RootLayout, { metadata } from "./layout";
+
+vi.mock("@veritas/design-system", () => ({
+  ThemeStyles: () => <style data-testid="theme-styles" />,
+  applyThemeClass: () => "theme-light",
+}));
+vi.mock("../components/mission-layout", () => ({
+  MissionLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="mission-layout">{children}</div>
+  ),
+}));
+vi.mock("../components/i18n-provider", () => ({
+  I18nProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="i18n-provider">{children}</div>
+  ),
+}));
+vi.mock("./globals.css", () => ({}));
+
+describe("RootLayout", () => {
+  it("renders children wrapped in I18nProvider and MissionLayout", () => {
+    render(<RootLayout><span data-testid="child">hello</span></RootLayout>);
+
+    const i18n = screen.getByTestId("i18n-provider");
+    const missionLayout = screen.getByTestId("mission-layout");
+    const child = screen.getByTestId("child");
+
+    expect(i18n).toBeInTheDocument();
+    expect(missionLayout).toBeInTheDocument();
+    expect(child).toBeInTheDocument();
+
+    // MissionLayout is inside I18nProvider
+    expect(i18n).toContainElement(missionLayout);
+    // Child is inside MissionLayout
+    expect(missionLayout).toContainElement(child);
+  });
+
+  it("exports correct metadata", () => {
+    expect(metadata.title).toBe("Mission Control IA");
+    expect(metadata.description).toBe("Governance OS operations console");
+  });
+
+  it("sets lang='ja' on html element", () => {
+    const { container } = render(
+      <RootLayout><span>test</span></RootLayout>
+    );
+
+    const html = container.closest("html") ?? container.querySelector("html");
+    // In JSDOM the <html> rendered inside the test may appear as a child node
+    // since RootLayout returns an <html> element. Check the rendered output.
+    const rendered = container.innerHTML;
+    expect(rendered).toContain('lang="ja"');
+  });
+});

--- a/frontend/app/layout.test.tsx
+++ b/frontend/app/layout.test.tsx
@@ -46,7 +46,6 @@ describe("RootLayout", () => {
       <RootLayout><span>test</span></RootLayout>
     );
 
-    const html = container.closest("html") ?? container.querySelector("html");
     // In JSDOM the <html> rendered inside the test may appear as a child node
     // since RootLayout returns an <html> element. Check the rendered output.
     const rendered = container.innerHTML;

--- a/frontend/app/risk/components/components.test.tsx
+++ b/frontend/app/risk/components/components.test.tsx
@@ -126,7 +126,7 @@ describe("InsightCards", () => {
   });
 
   it("applies danger styling when unsafeBurst is true", () => {
-    const { container } = render(<InsightCards {...baseProps} unsafeBurst={true} />);
+    const { container } = render(<InsightCards {...baseProps} unsafeBurst />);
     const burstCard = container.querySelector(".border-danger\\/40");
     expect(burstCard).toBeInTheDocument();
   });
@@ -183,12 +183,12 @@ describe("TrendChart", () => {
   });
 
   it("shows spike detected message when spikeDetected is true", () => {
-    render(<TrendChart {...baseProps} spikeDetected={true} />);
+    render(<TrendChart {...baseProps} spikeDetected />);
     expect(screen.getByText(/Spike detected/)).toBeInTheDocument();
   });
 
   it("shows burst message when unsafeBurst is true", () => {
-    render(<TrendChart {...baseProps} unsafeBurst={true} />);
+    render(<TrendChart {...baseProps} unsafeBurst />);
     expect(screen.getByText(/Unsafe burst active/)).toBeInTheDocument();
   });
 

--- a/frontend/app/risk/components/components.test.tsx
+++ b/frontend/app/risk/components/components.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+import type { RiskPoint, FlaggedEntry, TrendBucket } from "../risk-types";
+
+vi.mock("../../../components/i18n-provider", () => ({
+  useI18n: () => ({ language: "en", t: (_ja: string, en: string) => en, tk: (k: string) => k, setLanguage: () => {} }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("../data-helpers", async () => {
+  const actual = await vi.importActual("../data-helpers");
+  return {
+    ...actual,
+    getCluster: () => "critical",
+    pointFill: () => "#ff0000",
+    bucketMeaning: () => "test meaning",
+  };
+});
+
+import { DrilldownPanel } from "./DrilldownPanel";
+import { FlaggedRequestsList } from "./FlaggedRequestsList";
+import { InsightCards } from "./InsightCards";
+import { RiskScatterPlot } from "./RiskScatterPlot";
+import { TrendChart } from "./TrendChart";
+import { WhyFlaggedPanel } from "./WhyFlaggedPanel";
+
+const mockPoint: RiskPoint = { id: "req-001", uncertainty: 0.8, risk: 0.9, timestamp: Date.now() };
+
+const mockEntry: FlaggedEntry = {
+  point: mockPoint,
+  cluster: "critical",
+  severity: "critical",
+  status: "new",
+  reason: {
+    policyConfidence: 0.2,
+    unstableOutputSignal: true,
+    retrievalAnomaly: false,
+    summary: "High risk detected",
+    suggestedAction: "Review immediately",
+  },
+  relatedPolicyHits: ["PII detected"],
+  stageAnomalies: ["Latency spike"],
+};
+
+/* ------------------------------------------------------------------ */
+/*  DrilldownPanel                                                     */
+/* ------------------------------------------------------------------ */
+describe("DrilldownPanel", () => {
+  it("renders empty state when entry is null", () => {
+    render(<DrilldownPanel entry={null} />);
+    expect(screen.getByTestId("empty-drilldown")).toBeInTheDocument();
+  });
+
+  it("renders entry details", () => {
+    render(<DrilldownPanel entry={mockEntry} />);
+    expect(screen.getByText("req-001")).toBeInTheDocument();
+    expect(screen.getByText("0.800")).toBeInTheDocument();
+    expect(screen.getByText("0.900")).toBeInTheDocument();
+    expect(screen.getByText("critical")).toBeInTheDocument();
+    expect(screen.getByText(/PII detected/)).toBeInTheDocument();
+    expect(screen.getByText(/Latency spike/)).toBeInTheDocument();
+  });
+
+  it("renders navigation links", () => {
+    render(<DrilldownPanel entry={mockEntry} />);
+    expect(screen.getByText("Open in Decision")).toHaveAttribute("href", "/console?request_id=req-001");
+    expect(screen.getByText("Open in TrustLog")).toHaveAttribute("href", "/audit?request_id=req-001");
+    expect(screen.getByText("Adjust in Governance")).toHaveAttribute("href", "/governance");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  FlaggedRequestsList                                                */
+/* ------------------------------------------------------------------ */
+describe("FlaggedRequestsList", () => {
+  it("renders empty state when entries is empty", () => {
+    render(<FlaggedRequestsList entries={[]} selectedPointId={null} onSelectPoint={() => {}} />);
+    expect(screen.getByTestId("empty-flagged")).toBeInTheDocument();
+  });
+
+  it("renders entries with IDs, severity badges, and links", () => {
+    render(<FlaggedRequestsList entries={[mockEntry]} selectedPointId={null} onSelectPoint={() => {}} />);
+    expect(screen.getByText("req-001")).toBeInTheDocument();
+    expect(screen.getByText("critical")).toBeInTheDocument();
+    expect(screen.getByText("Open in Decision")).toHaveAttribute("href", "/console?request_id=req-001");
+    expect(screen.getByText("Open in TrustLog")).toHaveAttribute("href", "/audit?request_id=req-001");
+  });
+
+  it("calls onSelectPoint when entry button clicked", () => {
+    const onSelect = vi.fn();
+    render(<FlaggedRequestsList entries={[mockEntry]} selectedPointId={null} onSelectPoint={onSelect} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onSelect).toHaveBeenCalledWith("req-001");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  InsightCards                                                        */
+/* ------------------------------------------------------------------ */
+describe("InsightCards", () => {
+  const baseProps = {
+    clusterRatio: 0.02,
+    clusterCount: 3,
+    filteredPointsCount: 100,
+    unsafeBurst: false,
+    latestHighRisk: 2,
+    uncertainCount: 5,
+  };
+
+  it("renders 3 cards with correct text", () => {
+    render(<InsightCards {...baseProps} />);
+    expect(screen.getByText("Policy drift")).toBeInTheDocument();
+    expect(screen.getByText("Unsafe burst")).toBeInTheDocument();
+    expect(screen.getByText("Unstable output cluster")).toBeInTheDocument();
+  });
+
+  it("applies warning styling when clusterRatio >= 0.05", () => {
+    const { container } = render(<InsightCards {...baseProps} clusterRatio={0.06} />);
+    const policyCard = container.querySelector(".border-warning\\/40");
+    expect(policyCard).toBeInTheDocument();
+  });
+
+  it("applies danger styling when unsafeBurst is true", () => {
+    const { container } = render(<InsightCards {...baseProps} unsafeBurst={true} />);
+    const burstCard = container.querySelector(".border-danger\\/40");
+    expect(burstCard).toBeInTheDocument();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  RiskScatterPlot                                                    */
+/* ------------------------------------------------------------------ */
+describe("RiskScatterPlot", () => {
+  const baseProps = {
+    filteredPoints: [mockPoint],
+    selectedPointId: null,
+    hoveredPointId: null,
+    hoveredPoint: null,
+    onSelectPoint: vi.fn(),
+    onHoverPoint: vi.fn(),
+  };
+
+  it("renders SVG with scatter points", () => {
+    render(<RiskScatterPlot {...baseProps} />);
+    const svg = screen.getByRole("img");
+    expect(svg).toBeInTheDocument();
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders hover summary when hoveredPoint is provided", () => {
+    render(<RiskScatterPlot {...baseProps} hoveredPoint={mockPoint} hoveredPointId={mockPoint.id} />);
+    expect(screen.getByTestId("hover-summary")).toBeInTheDocument();
+    expect(screen.getByText("req-001")).toBeInTheDocument();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  TrendChart                                                         */
+/* ------------------------------------------------------------------ */
+describe("TrendChart", () => {
+  const mockBuckets: TrendBucket[] = [
+    { label: "0-3h", total: 10, highRisk: 0 },
+    { label: "3-6h", total: 15, highRisk: 2 },
+  ];
+
+  const baseProps = {
+    trend: mockBuckets,
+    spikeDetected: false,
+    unsafeBurst: false,
+    onSelectCluster: vi.fn(),
+  };
+
+  it("renders trend buckets", () => {
+    render(<TrendChart {...baseProps} />);
+    expect(screen.getByText("0-3h")).toBeInTheDocument();
+    expect(screen.getByText("3-6h")).toBeInTheDocument();
+  });
+
+  it("shows spike detected message when spikeDetected is true", () => {
+    render(<TrendChart {...baseProps} spikeDetected={true} />);
+    expect(screen.getByText(/Spike detected/)).toBeInTheDocument();
+  });
+
+  it("shows burst message when unsafeBurst is true", () => {
+    render(<TrendChart {...baseProps} unsafeBurst={true} />);
+    expect(screen.getByText(/Unsafe burst active/)).toBeInTheDocument();
+  });
+
+  it("calls onSelectCluster when a bucket is clicked", () => {
+    const onSelect = vi.fn();
+    render(<TrendChart {...baseProps} onSelectCluster={onSelect} />);
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[0]);
+    expect(onSelect).toHaveBeenCalledWith("all");
+    fireEvent.click(buttons[1]);
+    expect(onSelect).toHaveBeenCalledWith("critical");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  WhyFlaggedPanel                                                    */
+/* ------------------------------------------------------------------ */
+describe("WhyFlaggedPanel", () => {
+  it("renders empty state when entry is null", () => {
+    render(<WhyFlaggedPanel entry={null} />);
+    expect(screen.getByTestId("empty-why-flagged")).toBeInTheDocument();
+  });
+
+  it("renders flag reason details", () => {
+    render(<WhyFlaggedPanel entry={mockEntry} />);
+    expect(screen.getByText("20%")).toBeInTheDocument();
+    expect(screen.getByText("Detected")).toBeInTheDocument();
+    expect(screen.getByText("Normal")).toBeInTheDocument();
+  });
+
+  it("renders analysis summary and suggested action", () => {
+    render(<WhyFlaggedPanel entry={mockEntry} />);
+    expect(screen.getByText("High risk detected")).toBeInTheDocument();
+    expect(screen.getByText("Review immediately")).toBeInTheDocument();
+  });
+});

--- a/frontend/features/console/state/useConsoleState.test.ts
+++ b/frontend/features/console/state/useConsoleState.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { useConsoleState } from "./useConsoleState";
+import { buildGovernanceDriftAlert } from "../analytics/pipeline";
+
+vi.mock("../analytics/pipeline", () => ({
+  buildGovernanceDriftAlert: vi.fn(() => null),
+}));
+
+const mockedBuildAlert = vi.mocked(buildGovernanceDriftAlert);
+
+describe("useConsoleState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns initial state", () => {
+    const { result } = renderHook(() => useConsoleState());
+
+    expect(result.current.query).toBe("");
+    expect(result.current.result).toBeNull();
+    expect(result.current.chatMessages).toEqual([]);
+    expect(result.current.showDriftAlert).toBe(false);
+  });
+
+  it("updates query via setQuery", () => {
+    const { result } = renderHook(() => useConsoleState());
+
+    act(() => {
+      result.current.setQuery("new query");
+    });
+
+    expect(result.current.query).toBe("new query");
+  });
+
+  it("shows drift alert when buildGovernanceDriftAlert returns a value", () => {
+    mockedBuildAlert.mockReturnValue({ level: "warning", message: "drift detected" } as never);
+
+    const { result } = renderHook(() => useConsoleState());
+
+    act(() => {
+      result.current.setResult({ ok: true } as never);
+    });
+
+    expect(result.current.showDriftAlert).toBe(true);
+    expect(result.current.governanceDriftAlert).toEqual({
+      level: "warning",
+      message: "drift detected",
+    });
+  });
+
+  it("hides drift alert after 8 seconds", () => {
+    mockedBuildAlert.mockReturnValue({ level: "warning", message: "drift detected" } as never);
+
+    const { result } = renderHook(() => useConsoleState());
+
+    act(() => {
+      result.current.setResult({ ok: true } as never);
+    });
+
+    expect(result.current.showDriftAlert).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    expect(result.current.showDriftAlert).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds 78 new tests across 5 test files covering previously untested components:
- Governance: ToggleRow, DiffPreview, PolicyMetaPanel, RiskImpactGauge, ApplyFlow, ChangeHistory, ApprovalWorkflow, TrustLogStream, FujiRulesEditor (27 tests)
- Audit: AuditSummaryPanel, DetailPanel, AuditTimeline, VerificationPanel, SearchPanel, ExportPanel (26 tests)
- Risk: DrilldownPanel, FlaggedRequestsList, InsightCards, RiskScatterPlot, TrendChart, WhyFlaggedPanel (18 tests)
- Hooks: useConsoleState (4 tests)
- Layout: RootLayout (3 tests)

Total: 58 test files, 466 tests (up from 53 files, 388 tests)

https://claude.ai/code/session_01Kso527m6VYMdxqLz6TJrKF