### PR TITLE
Add 12 test files to improve frontend coverage (58→70 files, 466→570 tests)

### DIFF
--- a/frontend/app/api/veritas/[...path]/body-size.test.ts
+++ b/frontend/app/api/veritas/[...path]/body-size.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { getBodySizeBytes } from "./body-size";
+
+describe("getBodySizeBytes", () => {
+  it("returns correct byte length for ASCII strings", () => {
+    expect(getBodySizeBytes("hello")).toBe(5);
+    expect(getBodySizeBytes("")).toBe(0);
+  });
+
+  it("returns UTF-8 byte length for multi-byte characters", () => {
+    // Japanese characters are 3 bytes each in UTF-8
+    expect(getBodySizeBytes("あ")).toBe(3);
+    expect(getBodySizeBytes("日本語")).toBe(9);
+  });
+
+  it("returns correct byte length for emoji", () => {
+    // Most emoji are 4 bytes in UTF-8
+    expect(getBodySizeBytes("😀")).toBe(4);
+  });
+
+  it("handles mixed ASCII and multi-byte", () => {
+    expect(getBodySizeBytes("hi あ")).toBe(2 + 1 + 3); // "hi" + space + "あ"
+  });
+});

--- a/frontend/app/api/veritas/[...path]/route-auth.test.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasUnsafeSegment,
+  parseAuthTokensConfig,
+  matchPolicy,
+  authenticateRoleFromHeaders,
+} from "./route-auth";
+
+describe("hasUnsafeSegment", () => {
+  it("returns false for safe segments", () => {
+    expect(hasUnsafeSegment(["v1", "governance", "policy"])).toBe(false);
+  });
+
+  it("returns true for path traversal (..)", () => {
+    expect(hasUnsafeSegment(["v1", "..", "secret"])).toBe(true);
+  });
+
+  it("returns true for dot segment", () => {
+    expect(hasUnsafeSegment(["v1", ".", "policy"])).toBe(true);
+  });
+
+  it("returns true for empty segments", () => {
+    expect(hasUnsafeSegment(["v1", "", "policy"])).toBe(true);
+  });
+
+  it("returns true for encoded characters", () => {
+    expect(hasUnsafeSegment(["v1", "%2e%2e"])).toBe(true);
+  });
+
+  it("returns true for null bytes", () => {
+    expect(hasUnsafeSegment(["v1", "test\x00"])).toBe(true);
+  });
+
+  it("returns true for backslash", () => {
+    expect(hasUnsafeSegment(["v1", "test\\path"])).toBe(true);
+  });
+});
+
+describe("parseAuthTokensConfig", () => {
+  it("returns empty map for undefined input", () => {
+    expect(parseAuthTokensConfig(undefined).size).toBe(0);
+  });
+
+  it("returns empty map for empty string", () => {
+    expect(parseAuthTokensConfig("").size).toBe(0);
+  });
+
+  it("returns empty map for whitespace-only string", () => {
+    expect(parseAuthTokensConfig("   ").size).toBe(0);
+  });
+
+  it("parses valid token-role mapping", () => {
+    const config = JSON.stringify({ tokenA: "viewer", tokenB: "admin", tokenC: "operator" });
+    const result = parseAuthTokensConfig(config);
+    expect(result.size).toBe(3);
+    expect(result.get("tokenA")).toBe("viewer");
+    expect(result.get("tokenB")).toBe("admin");
+    expect(result.get("tokenC")).toBe("operator");
+  });
+
+  it("ignores unsupported role values", () => {
+    const config = JSON.stringify({ tokenA: "viewer", tokenB: "superadmin" });
+    const result = parseAuthTokensConfig(config);
+    expect(result.size).toBe(1);
+    expect(result.get("tokenA")).toBe("viewer");
+  });
+
+  it("returns empty map for invalid JSON", () => {
+    expect(parseAuthTokensConfig("{invalid").size).toBe(0);
+  });
+
+  it("returns empty map for array JSON", () => {
+    expect(parseAuthTokensConfig("[]").size).toBe(0);
+  });
+
+  it("ignores non-string values", () => {
+    const config = JSON.stringify({ tokenA: "admin", tokenB: 123 });
+    const result = parseAuthTokensConfig(config);
+    expect(result.size).toBe(1);
+  });
+});
+
+describe("matchPolicy", () => {
+  it("matches GET governance/policy for viewer", () => {
+    const result = matchPolicy(["v1", "governance", "policy"], "GET");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toContain("viewer");
+  });
+
+  it("matches PUT governance/policy for admin only", () => {
+    const result = matchPolicy(["v1", "governance", "policy"], "PUT");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toEqual(["admin"]);
+  });
+
+  it("matches POST decide for operator/admin", () => {
+    const result = matchPolicy(["v1", "decide"], "POST");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toContain("operator");
+    expect(result!.policy.roles).toContain("admin");
+  });
+
+  it("returns null for unregistered path", () => {
+    expect(matchPolicy(["v1", "unknown", "endpoint"], "GET")).toBeNull();
+  });
+
+  it("returns null for wrong method", () => {
+    expect(matchPolicy(["v1", "decide"], "GET")).toBeNull();
+  });
+
+  it("returns null for unsafe segments", () => {
+    expect(matchPolicy(["v1", "..", "decide"], "POST")).toBeNull();
+  });
+
+  it("normalizes method to uppercase", () => {
+    const result = matchPolicy(["v1", "governance", "policy"], "get");
+    expect(result).not.toBeNull();
+  });
+
+  it("matches trust log single item path", () => {
+    const result = matchPolicy(["v1", "trust", "req-123"], "GET");
+    expect(result).not.toBeNull();
+  });
+
+  it("matches system halt for admin only", () => {
+    const result = matchPolicy(["v1", "system", "halt"], "POST");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toEqual(["admin"]);
+  });
+});
+
+describe("authenticateRoleFromHeaders", () => {
+  const tokenMap = new Map([
+    ["token-viewer", "viewer" as const],
+    ["token-admin", "admin" as const],
+  ]);
+
+  it("returns 503 when tokenRoleMap is empty", () => {
+    const headers = new Headers({ authorization: "Bearer some-token" });
+    const result = authenticateRoleFromHeaders(headers, new Map());
+    expect(result.errorResponse).toBeDefined();
+  });
+
+  it("authenticates via Bearer token", () => {
+    const headers = new Headers({ authorization: "Bearer token-admin" });
+    const result = authenticateRoleFromHeaders(headers, tokenMap);
+    expect(result.role).toBe("admin");
+    expect(result.errorResponse).toBeUndefined();
+  });
+
+  it("returns 403 for invalid Bearer token", () => {
+    const headers = new Headers({ authorization: "Bearer invalid-token" });
+    const result = authenticateRoleFromHeaders(headers, tokenMap);
+    expect(result.errorResponse).toBeDefined();
+    expect(result.role).toBeUndefined();
+  });
+
+  it("authenticates via session cookie", () => {
+    const headers = new Headers({ cookie: "__veritas_bff=token-viewer; other=value" });
+    const result = authenticateRoleFromHeaders(headers, tokenMap);
+    expect(result.role).toBe("viewer");
+  });
+
+  it("returns 403 for invalid session cookie", () => {
+    const headers = new Headers({ cookie: "__veritas_bff=bad-token" });
+    const result = authenticateRoleFromHeaders(headers, tokenMap);
+    expect(result.errorResponse).toBeDefined();
+  });
+
+  it("returns 401 when no credentials provided", () => {
+    const headers = new Headers();
+    const result = authenticateRoleFromHeaders(headers, tokenMap);
+    expect(result.errorResponse).toBeDefined();
+  });
+
+  it("prefers Bearer token over cookie", () => {
+    const headers = new Headers({
+      authorization: "Bearer token-admin",
+      cookie: "__veritas_bff=token-viewer",
+    });
+    const result = authenticateRoleFromHeaders(headers, tokenMap);
+    expect(result.role).toBe("admin");
+  });
+});

--- a/frontend/app/api/veritas/[...path]/route-config.test.ts
+++ b/frontend/app/api/veritas/[...path]/route-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { resolveApiBaseUrl, resetApiBaseUrlWarningStateForTest } from "./route-config";
+
+describe("resolveApiBaseUrl", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.VERITAS_API_BASE_URL;
+    delete process.env.VERITAS_ENV;
+    delete process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL;
+    process.env.NODE_ENV = "test";
+    resetApiBaseUrlWarningStateForTest();
+  });
+
+  it("returns VERITAS_API_BASE_URL when set", () => {
+    process.env.VERITAS_API_BASE_URL = "https://api.example.com";
+    expect(resolveApiBaseUrl()).toBe("https://api.example.com");
+  });
+
+  it("returns localhost fallback in non-production mode", () => {
+    expect(resolveApiBaseUrl()).toBe("http://localhost:8000");
+  });
+
+  it("returns null in production when VERITAS_API_BASE_URL is missing", () => {
+    process.env.VERITAS_ENV = "production";
+    expect(resolveApiBaseUrl()).toBeNull();
+  });
+
+  it("returns null in production when NEXT_PUBLIC var is set (security block)", () => {
+    process.env.VERITAS_ENV = "prod";
+    process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL = "https://public.example.com";
+    process.env.VERITAS_API_BASE_URL = "https://api.example.com";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(resolveApiBaseUrl()).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  it("treats NODE_ENV=production as production mode", () => {
+    process.env.NODE_ENV = "production";
+    expect(resolveApiBaseUrl()).toBeNull();
+  });
+
+  it("trims whitespace from env values", () => {
+    process.env.VERITAS_API_BASE_URL = "  https://api.example.com  ";
+    expect(resolveApiBaseUrl()).toBe("https://api.example.com");
+  });
+
+  it("warns only once about NEXT_PUBLIC env var", () => {
+    process.env.NEXT_PUBLIC_VERITAS_API_BASE_URL = "https://public.example.com";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resolveApiBaseUrl();
+    resolveApiBaseUrl();
+    const securityWarnings = warnSpy.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("[security-warning]"),
+    );
+    expect(securityWarnings).toHaveLength(1);
+    warnSpy.mockRestore();
+  });
+});

--- a/frontend/app/api/veritas/[...path]/trace-id.test.ts
+++ b/frontend/app/api/veritas/[...path]/trace-id.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveTraceId, TRACE_ID_HEADER_NAME } from "./trace-id";
+
+describe("resolveTraceId", () => {
+  it("returns value from X-Trace-Id header", () => {
+    const headers = new Headers({ [TRACE_ID_HEADER_NAME]: "trace-abc-12345678" });
+    expect(resolveTraceId(headers)).toBe("trace-abc-12345678");
+  });
+
+  it("returns value from lowercase x-trace-id header", () => {
+    const headers = new Headers({ "x-trace-id": "lowercase-trace-id" });
+    expect(resolveTraceId(headers)).toBe("lowercase-trace-id");
+  });
+
+  it("returns value from X-Request-Id header when no trace id", () => {
+    const headers = new Headers({ "X-Request-Id": "request-id-12345678" });
+    expect(resolveTraceId(headers)).toBe("request-id-12345678");
+  });
+
+  it("generates UUID when no valid header is present", () => {
+    const mockUUID = "550e8400-e29b-41d4-a716-446655440000";
+    vi.spyOn(crypto, "randomUUID").mockReturnValueOnce(mockUUID as `${string}-${string}-${string}-${string}-${string}`);
+    const headers = new Headers();
+    expect(resolveTraceId(headers)).toBe(mockUUID);
+  });
+
+  it("rejects malformed trace IDs (too short)", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValueOnce("fallback-uuid-0000" as `${string}-${string}-${string}-${string}-${string}`);
+    const headers = new Headers({ [TRACE_ID_HEADER_NAME]: "short" });
+    expect(resolveTraceId(headers)).toBe("fallback-uuid-0000");
+  });
+
+  it("rejects trace IDs starting with invalid characters", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValueOnce("fallback-uuid-0001" as `${string}-${string}-${string}-${string}-${string}`);
+    // Starts with a space after trim is empty — falls through
+    const headers = new Headers({ [TRACE_ID_HEADER_NAME]: "!!invalid-trace-id" });
+    expect(resolveTraceId(headers)).toBe("fallback-uuid-0001");
+  });
+
+  it("trims whitespace from header values", () => {
+    const headers = new Headers({ [TRACE_ID_HEADER_NAME]: "  valid-trace-id-123  " });
+    expect(resolveTraceId(headers)).toBe("valid-trace-id-123");
+  });
+});

--- a/frontend/app/audit/hooks/useAuditData.test.ts
+++ b/frontend/app/audit/hooks/useAuditData.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("../../../components/i18n-provider", () => ({
+  useI18n: () => ({
+    language: "en",
+    t: (_ja: string, en: string) => en,
+    tk: (k: string) => k,
+    setLanguage: () => {},
+  }),
+}));
+
+const mockFetch = vi.fn();
+vi.mock("../../../lib/api-client", () => ({
+  veritasFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+vi.mock("@veritas/types", async () => {
+  const actual = await vi.importActual("@veritas/types");
+  return {
+    ...actual,
+    isTrustLogsResponse: (payload: unknown) => {
+      if (!payload || typeof payload !== "object") return false;
+      return "items" in payload;
+    },
+    isRequestLogResponse: (payload: unknown) => {
+      if (!payload || typeof payload !== "object") return false;
+      return "items" in payload;
+    },
+  };
+});
+
+vi.mock("../audit-types", async () => {
+  const actual = await vi.importActual("../audit-types");
+  return {
+    ...actual,
+    classifyChain: () => ({ status: "verified", reason: "ok" }),
+    computeAuditSummary: () => ({
+      total: 0,
+      verified: 0,
+      broken: 0,
+      missing: 0,
+      orphan: 0,
+      policyVersions: [],
+    }),
+  };
+});
+
+import { useAuditData } from "./useAuditData";
+
+const MOCK_ITEMS = [
+  {
+    request_id: "req-001",
+    decision_id: "42",
+    sha256: "abc123",
+    sha256_prev: "prev123",
+    created_at: "2026-01-02T00:00:00Z",
+    stage: "retrieval",
+    status: "ok",
+    severity: "info",
+    policy_version: "v1",
+  },
+  {
+    request_id: "req-002",
+    decision_id: "43",
+    sha256: "def456",
+    sha256_prev: "abc123",
+    created_at: "2026-01-01T00:00:00Z",
+    stage: "generation",
+    status: "ok",
+    severity: "info",
+    policy_version: "v1",
+  },
+];
+
+describe("useAuditData", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("initialises with correct defaults", () => {
+    const { result } = renderHook(() => useAuditData());
+    expect(result.current.items).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.stageFilter).toBe("ALL");
+    expect(result.current.detailTab).toBe("summary");
+  });
+
+  it("loadLogs fetches and stores items", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: "cursor-1", has_more: true }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    expect(result.current.items).toHaveLength(2);
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.cursor).toBe("cursor-1");
+  });
+
+  it("loadLogs appends items when replace is false", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+    expect(result.current.items).toHaveLength(2);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: [{ ...MOCK_ITEMS[0], request_id: "req-003" }], next_cursor: null, has_more: false }),
+    });
+
+    await act(async () => {
+      await result.current.loadLogs("cursor-1", false);
+    });
+    expect(result.current.items).toHaveLength(3);
+  });
+
+  it("loadLogs handles HTTP error", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+    expect(result.current.error).toContain("HTTP 500");
+  });
+
+  it("loadLogs handles invalid response format", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ unexpected: "data" }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+    expect(result.current.error).toContain("format error");
+  });
+
+  it("loadLogs handles network error", async () => {
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+    expect(result.current.error).toContain("Network error");
+  });
+
+  it("sortedItems sorts by created_at descending", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    expect(result.current.sortedItems[0].request_id).toBe("req-001");
+    expect(result.current.sortedItems[1].request_id).toBe("req-002");
+  });
+
+  it("stageOptions derive from loaded items", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    expect(result.current.stageOptions).toContain("ALL");
+    expect(result.current.stageOptions).toContain("retrieval");
+    expect(result.current.stageOptions).toContain("generation");
+  });
+
+  it("filteredItems filters by stageFilter", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    act(() => { result.current.setStageFilter("retrieval"); });
+    expect(result.current.filteredItems).toHaveLength(1);
+    expect(result.current.filteredItems[0].request_id).toBe("req-001");
+  });
+
+  it("crossSearch filters items", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    act(() => {
+      result.current.setCrossSearch({ query: "req-001", field: "request_id" });
+    });
+    expect(result.current.filteredItems).toHaveLength(1);
+  });
+
+  it("searchByRequestId requires non-empty input", async () => {
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.searchByRequestId();
+    });
+    expect(result.current.error).toContain("enter request_id");
+  });
+
+  it("decisionIds derive from loaded items", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    expect(result.current.decisionIds).toContain("42");
+    expect(result.current.decisionIds).toContain("43");
+  });
+
+  it("state setters work correctly", () => {
+    const { result } = renderHook(() => useAuditData());
+
+    act(() => { result.current.setDetailTab("metadata"); });
+    expect(result.current.detailTab).toBe("metadata");
+
+    act(() => { result.current.setRedactionMode("redacted"); });
+    expect(result.current.redactionMode).toBe("redacted");
+
+    act(() => { result.current.setExportFormat("pdf"); });
+    expect(result.current.exportFormat).toBe("pdf");
+
+    act(() => { result.current.setConfirmPiiRisk(true); });
+    expect(result.current.confirmPiiRisk).toBe(true);
+  });
+});

--- a/frontend/app/governance/hooks/useGovernanceState.test.ts
+++ b/frontend/app/governance/hooks/useGovernanceState.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("../../../components/i18n-provider", () => ({
+  useI18n: () => ({
+    language: "en",
+    t: (_ja: string, en: string) => en,
+    tk: (k: string) => k,
+    setLanguage: () => {},
+  }),
+}));
+
+const mockFetch = vi.fn();
+vi.mock("../../../lib/api-client", () => ({
+  veritasFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+const mockValidate = vi.fn();
+vi.mock("../../../lib/api-validators", () => ({
+  validateGovernancePolicyResponse: (...args: unknown[]) => mockValidate(...args),
+}));
+
+import { useGovernanceState } from "./useGovernanceState";
+
+const MOCK_POLICY = {
+  version: "v1.0",
+  updated_at: "2026-01-01T00:00:00Z",
+  updated_by: "admin",
+  fuji_rules: {
+    pii_check: true,
+    self_harm_block: true,
+    illicit_block: false,
+    violence_review: true,
+    minors_review: true,
+    keyword_hard_block: true,
+    keyword_soft_flag: false,
+    llm_safety_head: true,
+  },
+  risk_thresholds: {
+    allow_upper: 0.4,
+    warn_upper: 0.65,
+    human_review_upper: 0.85,
+    deny_upper: 1.0,
+  },
+  auto_stop: {
+    enabled: true,
+    max_risk_score: 0.85,
+    max_consecutive_rejects: 5,
+    max_requests_per_minute: 60,
+  },
+  log_retention: {
+    retention_days: 90,
+    audit_level: "full",
+    include_fields: ["status"],
+    redact_before_log: true,
+    max_log_size: 10000,
+  },
+  rollout_controls: {
+    strategy: "disabled",
+    canary_percent: 0,
+    stage: 0,
+    staged_enforcement: false,
+  },
+  approval_workflow: {
+    human_review_ticket: "TICKET-123",
+    human_review_required: false,
+    approver_identity_binding: true,
+    approver_identities: [],
+  },
+};
+
+describe("useGovernanceState", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockValidate.mockReset();
+  });
+
+  it("initialises with correct defaults", () => {
+    const { result } = renderHook(() => useGovernanceState());
+    expect(result.current.savedPolicy).toBeNull();
+    expect(result.current.draft).toBeNull();
+    expect(result.current.selectedRole).toBe("admin");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.hasChanges).toBe(false);
+    expect(result.current.canApply).toBe(true);
+    expect(result.current.canOperate).toBe(true);
+  });
+
+  it("fetchPolicy loads policy on success", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+    expect(result.current.savedPolicy).not.toBeNull();
+    expect(result.current.draft).not.toBeNull();
+    expect(result.current.savedPolicy!.version).toBe("v1.0");
+    expect(result.current.history.length).toBeGreaterThan(0);
+    expect(result.current.trustLog.length).toBeGreaterThan(0);
+  });
+
+  it("fetchPolicy sets error on HTTP failure", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+    expect(result.current.error).toContain("HTTP 500");
+  });
+
+  it("fetchPolicy sets error on validation failure", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    mockValidate.mockReturnValue({ ok: false });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+    expect(result.current.error).toContain("validation failed");
+  });
+
+  it("fetchPolicy sets error on network exception", async () => {
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+    expect(result.current.error).toContain("Network error");
+  });
+
+  it("canApply/canOperate/canApprove depend on selectedRole", () => {
+    const { result } = renderHook(() => useGovernanceState());
+
+    act(() => { result.current.setSelectedRole("viewer"); });
+    expect(result.current.canApply).toBe(false);
+    expect(result.current.canOperate).toBe(false);
+    expect(result.current.canApprove).toBe(false);
+
+    act(() => { result.current.setSelectedRole("operator"); });
+    expect(result.current.canApply).toBe(false);
+    expect(result.current.canOperate).toBe(true);
+    expect(result.current.canApprove).toBe(false);
+
+    act(() => { result.current.setSelectedRole("admin"); });
+    expect(result.current.canApply).toBe(true);
+    expect(result.current.canOperate).toBe(true);
+    expect(result.current.canApprove).toBe(true);
+  });
+
+  it("updateDraft modifies draft and sets approval_status to pending", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    act(() => {
+      result.current.updateDraft((prev) => ({
+        ...prev,
+        fuji_rules: { ...prev.fuji_rules, pii_check: false },
+      }));
+    });
+
+    expect(result.current.draft!.fuji_rules.pii_check).toBe(false);
+    expect(result.current.draft!.approval_status).toBe("pending");
+    expect(result.current.hasChanges).toBe(true);
+  });
+
+  it("applyPolicy dry-run mode does not call PUT", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    mockFetch.mockClear();
+
+    act(() => { result.current.applyPolicy("dry-run"); });
+    // Confirm the pending action
+    expect(result.current.pendingConfirm).not.toBeNull();
+    await act(async () => { result.current.pendingConfirm!.onConfirm(); });
+
+    // dry-run should not call veritasFetch for PUT
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.success).toContain("Dry-run");
+  });
+
+  it("rollback reverts draft to savedPolicy", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    // Make a change
+    act(() => {
+      result.current.updateDraft((prev) => ({
+        ...prev,
+        fuji_rules: { ...prev.fuji_rules, pii_check: false },
+      }));
+    });
+    expect(result.current.hasChanges).toBe(true);
+
+    // Rollback
+    act(() => { result.current.rollback(); });
+    expect(result.current.pendingConfirm).not.toBeNull();
+    act(() => { result.current.pendingConfirm!.onConfirm(); });
+    expect(result.current.hasChanges).toBe(false);
+  });
+
+  it("dismissConfirm clears pendingConfirm", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    act(() => { result.current.applyPolicy("dry-run"); });
+    expect(result.current.pendingConfirm).not.toBeNull();
+    act(() => { result.current.dismissConfirm(); });
+    expect(result.current.pendingConfirm).toBeNull();
+  });
+
+  it("risk calculations are derived correctly", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    // currentRisk = ((deny_upper + max_risk_score) / 2) * 100 = ((1.0 + 0.85) / 2) * 100 = 92.5 → 93
+    expect(result.current.currentRisk).toBe(93);
+    expect(result.current.riskDrift).toBe(0); // no changes yet
+  });
+});

--- a/frontend/app/risk/hooks/useRiskStream.test.ts
+++ b/frontend/app/risk/hooks/useRiskStream.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("../data-helpers", () => ({
+  createInitialPoints: (now: number) => [
+    { id: "p1", uncertainty: 0.1, risk: 0.2, timestamp: now - 1000 },
+    { id: "p2", uncertainty: 0.9, risk: 0.95, timestamp: now - 500 },
+    { id: "p3", uncertainty: 0.5, risk: 0.5, timestamp: now - 200 },
+  ],
+  createStreamPoint: (tick: number) => ({
+    id: `stream-${tick}`,
+    uncertainty: 0.3,
+    risk: 0.4,
+    timestamp: tick,
+  }),
+  getCluster: (point: { risk: number; uncertainty: number }) => {
+    if (point.risk > 0.8 && point.uncertainty > 0.8) return "critical";
+    if (point.risk > 0.5) return "risky";
+    if (point.uncertainty > 0.5) return "uncertain";
+    return "stable";
+  },
+  enrichFlaggedEntry: (point: { id: string; uncertainty: number; risk: number; timestamp: number }) => ({
+    point,
+    cluster: "critical",
+    severity: "critical",
+    status: "new",
+    reason: { policyConfidence: 0.1, unstableOutputSignal: true, retrievalAnomaly: false, summary: "test", suggestedAction: "test" },
+    relatedPolicyHits: [],
+    stageAnomalies: [],
+  }),
+  buildTrendBuckets: () =>
+    Array.from({ length: 8 }, (_, i) => ({ label: `${i * 3}-${(i + 1) * 3}h`, total: 10, highRisk: i === 7 ? 2 : 0 })),
+  pointFill: () => "#000",
+}));
+
+import { useRiskStream } from "./useRiskStream";
+
+describe("useRiskStream", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("initialises with points from createInitialPoints", () => {
+    const { result } = renderHook(() => useRiskStream());
+    expect(result.current.visiblePoints.length).toBe(3);
+  });
+
+  it("filters by time window", () => {
+    const { result } = renderHook(() => useRiskStream());
+    // Default 24h window should include all points
+    expect(result.current.visiblePoints.length).toBe(3);
+
+    act(() => { result.current.setTimeWindowHours(24); });
+    expect(result.current.visiblePoints.length).toBe(3);
+  });
+
+  it("filters by selected cluster", () => {
+    const { result } = renderHook(() => useRiskStream());
+
+    act(() => { result.current.setSelectedCluster("critical"); });
+    // Only p2 has risk > 0.8 and uncertainty > 0.8
+    expect(result.current.filteredPoints.length).toBe(1);
+    expect(result.current.filteredPoints[0].id).toBe("p2");
+
+    act(() => { result.current.setSelectedCluster("all"); });
+    expect(result.current.filteredPoints.length).toBe(3);
+  });
+
+  it("tracks selected and hovered point IDs", () => {
+    const { result } = renderHook(() => useRiskStream());
+
+    act(() => { result.current.setSelectedPointId("p1"); });
+    expect(result.current.selectedPointId).toBe("p1");
+
+    act(() => { result.current.setHoveredPointId("p2"); });
+    expect(result.current.hoveredPointId).toBe("p2");
+    expect(result.current.hoveredPoint).not.toBeNull();
+    expect(result.current.hoveredPoint!.id).toBe("p2");
+
+    act(() => { result.current.setHoveredPointId(null); });
+    expect(result.current.hoveredPoint).toBeNull();
+  });
+
+  it("computes flaggedEntries from non-stable points", () => {
+    const { result } = renderHook(() => useRiskStream());
+    // Non-stable points are flagged (getCluster mock determines which are stable)
+    expect(result.current.flaggedEntries.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("provides trend data", () => {
+    const { result } = renderHook(() => useRiskStream());
+    expect(result.current.trend).toHaveLength(8);
+  });
+
+  it("selectedEntry defaults to first flaggedEntry", () => {
+    const { result } = renderHook(() => useRiskStream());
+    expect(result.current.selectedEntry).not.toBeNull();
+  });
+});

--- a/frontend/components/ui/empty-state.test.tsx
+++ b/frontend/components/ui/empty-state.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EmptyState } from "./empty-state";
+
+describe("EmptyState", () => {
+  it("renders title and description", () => {
+    render(<EmptyState title="No items" description="Nothing to display" />);
+    expect(screen.getByText("No items")).toBeInTheDocument();
+    expect(screen.getByText("Nothing to display")).toBeInTheDocument();
+  });
+
+  it("renders icon when provided", () => {
+    render(
+      <EmptyState
+        title="No items"
+        description="Nothing"
+        icon={<span data-testid="icon">★</span>}
+      />,
+    );
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("does not render icon wrapper when icon is not provided", () => {
+    const { container } = render(
+      <EmptyState title="No items" description="Nothing" />,
+    );
+    expect(container.querySelector(".border-dashed")).toBeNull();
+  });
+
+  it("renders action when provided", () => {
+    render(
+      <EmptyState
+        title="No items"
+        description="Nothing"
+        action={<button type="button">Add</button>}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <EmptyState title="T" description="D" className="extra" />,
+    );
+    expect(container.firstElementChild?.className).toContain("extra");
+  });
+});

--- a/frontend/components/ui/error-banner.test.tsx
+++ b/frontend/components/ui/error-banner.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ErrorBanner } from "./error-banner";
+
+describe("ErrorBanner", () => {
+  it("renders message with alert role", () => {
+    render(<ErrorBanner message="Something went wrong" />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong");
+  });
+
+  it("applies danger styles by default", () => {
+    render(<ErrorBanner message="Error" />);
+    expect(screen.getByRole("alert").className).toContain("text-danger");
+  });
+
+  it("applies warning styles for warning variant", () => {
+    render(<ErrorBanner message="Warning" variant="warning" />);
+    expect(screen.getByRole("alert").className).toContain("text-warning");
+  });
+
+  it("renders retry button when onRetry is provided", () => {
+    const onRetry = vi.fn();
+    render(<ErrorBanner message="Fail" onRetry={onRetry} />);
+    const btn = screen.getByRole("button", { name: "Retry" });
+    fireEvent.click(btn);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("uses custom retryLabel", () => {
+    render(<ErrorBanner message="Fail" onRetry={() => {}} retryLabel="Try again" />);
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("does not render retry button when onRetry is omitted", () => {
+    render(<ErrorBanner message="Fail" />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("applies custom className", () => {
+    render(<ErrorBanner message="E" className="custom" />);
+    expect(screen.getByRole("alert").className).toContain("custom");
+  });
+});

--- a/frontend/components/ui/loading-skeleton.test.tsx
+++ b/frontend/components/ui/loading-skeleton.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LoadingSkeleton } from "./loading-skeleton";
+
+describe("LoadingSkeleton", () => {
+  it("renders with status role and accessible label", () => {
+    render(<LoadingSkeleton />);
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("renders 3 skeleton lines by default", () => {
+    const { container } = render(<LoadingSkeleton />);
+    const lines = container.querySelectorAll(".h-3");
+    expect(lines).toHaveLength(3);
+  });
+
+  it("renders custom number of lines", () => {
+    const { container } = render(<LoadingSkeleton lines={5} />);
+    const lines = container.querySelectorAll(".h-3");
+    expect(lines).toHaveLength(5);
+  });
+
+  it("applies custom className", () => {
+    render(<LoadingSkeleton className="my-class" />);
+    expect(screen.getByRole("status").className).toContain("my-class");
+  });
+});

--- a/frontend/components/ui/stale-banner.test.tsx
+++ b/frontend/components/ui/stale-banner.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StaleBanner } from "./stale-banner";
+
+describe("StaleBanner", () => {
+  it("renders message with status role", () => {
+    render(<StaleBanner message="Data is stale" />);
+    expect(screen.getByRole("status")).toHaveTextContent("Data is stale");
+  });
+
+  it("renders refresh button when onRefresh is provided", () => {
+    const onRefresh = vi.fn();
+    render(<StaleBanner message="Stale" onRefresh={onRefresh} />);
+    const btn = screen.getByRole("button", { name: "Refresh" });
+    fireEvent.click(btn);
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("uses custom refreshLabel", () => {
+    render(<StaleBanner message="Stale" onRefresh={() => {}} refreshLabel="Reload" />);
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+  });
+
+  it("does not render refresh button when onRefresh is omitted", () => {
+    render(<StaleBanner message="Stale" />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("applies custom className", () => {
+    render(<StaleBanner message="S" className="extra" />);
+    expect(screen.getByRole("status").className).toContain("extra");
+  });
+});

--- a/frontend/components/ui/success-banner.test.tsx
+++ b/frontend/components/ui/success-banner.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SuccessBanner } from "./success-banner";
+
+describe("SuccessBanner", () => {
+  it("renders message with status role", () => {
+    render(<SuccessBanner message="Operation succeeded" />);
+    expect(screen.getByRole("status")).toHaveTextContent("Operation succeeded");
+  });
+
+  it("applies success styles", () => {
+    render(<SuccessBanner message="Done" />);
+    expect(screen.getByRole("status").className).toContain("text-success");
+  });
+
+  it("applies custom className", () => {
+    render(<SuccessBanner message="OK" className="my-class" />);
+    expect(screen.getByRole("status").className).toContain("my-class");
+  });
+});


### PR DESCRIPTION
Covers previously untested UI components, custom hooks, and API route
utilities: empty-state, error-banner, loading-skeleton, stale-banner,
success-banner, useGovernanceState, useRiskStream, useAuditData,
body-size, route-auth, route-config, trace-id.

https://claude.ai/code/session_01C2dRXincXJ86WnBcTwW63p