### PR TITLE
Improve frontend test coverage from 88.92% to 93.96%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ coverage.json
 htmlcov/
 test-reports/
 coverage-html/
+**/coverage/
 
 # Build artifacts
 *.egg-info/

--- a/frontend/app/api/veritas/[...path]/route.test.ts
+++ b/frontend/app/api/veritas/[...path]/route.test.ts
@@ -184,6 +184,255 @@ describe("resolveTraceId", () => {
 });
 
 
+describe("veritas bff route proxy - full request lifecycle", () => {
+  it("returns 404 when path does not match any policy", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/unknown/endpoint", {
+      headers: { authorization: "Bearer token-admin" },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "unknown", "endpoint"] }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ error: "unsupported_path" });
+  });
+
+  it("returns 403 when role is not allowed for the endpoint", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-viewer":"viewer"}');
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      method: "PUT",
+      headers: {
+        authorization: "Bearer token-viewer",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ version: "v1" }),
+    });
+
+    const { PUT } = await import("./route");
+    const response = await PUT(request, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
+
+  it("returns 503 when VERITAS_API_BASE_URL is not configured in production", async () => {
+    vi.stubEnv("VERITAS_ENV", "production");
+    vi.stubEnv("VERITAS_API_BASE_URL", "");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      headers: { authorization: "Bearer token-admin" },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "server_misconfigured",
+      detail: "VERITAS_API_BASE_URL must be configured in production.",
+    });
+  });
+
+  it("proxies a successful GET request with content-type forwarding", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ policy: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/governance/policy?foo=bar", {
+      headers: { authorization: "Bearer token-admin" },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchMock.mock.calls[0]?.[0] as URL;
+    expect(calledUrl.toString()).toContain("internal-api:8000/v1/governance/policy");
+    expect(calledUrl.toString()).toContain("foo=bar");
+    expect(response.headers.get("content-type")).toBe("application/json");
+  });
+
+  it("proxies a POST request with body", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await import("./route");
+    const request = new NextRequest("http://localhost/api/veritas/v1/decide", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer token-admin",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ query: "test" }),
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ path: ["v1", "decide"] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledInit = fetchMock.mock.calls[0]?.[1];
+    expect(calledInit?.method).toBe("POST");
+    expect(calledInit?.body).toContain("test");
+    expect((calledInit?.headers as Headers).get("Content-Type")).toBe("application/json");
+  });
+
+  it("returns 413 when POST body exceeds 1MB", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const { POST } = await import("./route");
+    const largeBody = "x".repeat(1024 * 1024 + 1);
+    const request = new NextRequest("http://localhost/api/veritas/v1/decide", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer token-admin",
+        "content-type": "application/json",
+      },
+      body: largeBody,
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ path: ["v1", "decide"] }),
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({ error: "payload_too_large" });
+  });
+
+  it("forwards trace-id header from request to upstream and response", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const fetchMock = vi.fn(async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      headers: {
+        authorization: "Bearer token-admin",
+        "x-trace-id": "my-trace-123",
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(response.headers.get("x-trace-id")).toBe("my-trace-123");
+    const upstreamHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(upstreamHeaders.get("x-trace-id")).toBe("my-trace-123");
+    expect(upstreamHeaders.get("X-Request-Id")).toBe("my-trace-123");
+  });
+
+  it("forwards upstream content-type to client response", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const fetchMock = vi.fn(async () => {
+      const resp = new Response('{"data":"ok"}', { status: 200 });
+      // Overwrite with specific content-type
+      Object.defineProperty(resp, "headers", {
+        value: new Headers({ "content-type": "application/vnd.api+json" }),
+      });
+      return resp;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      headers: { authorization: "Bearer token-admin" },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/vnd.api+json");
+  });
+
+  it("returns auth error response with trace-id header", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"token-admin":"admin"}');
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      headers: { "x-trace-id": "trace-abc" },
+      // no auth header
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("x-trace-id")).toBe("trace-abc");
+  });
+
+  it("authenticates via cookie when no Authorization header", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.stubEnv("VERITAS_BFF_AUTH_TOKENS_JSON", '{"cookie-token":"admin"}');
+
+    const fetchMock = vi.fn(async () =>
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("http://localhost/api/veritas/v1/governance/policy", {
+      headers: {
+        cookie: "__veritas_bff=cookie-token",
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["v1", "governance", "policy"] }),
+    });
+
+    expect(response.status).toBe(200);
+  });
+});
+
 describe("veritas bff route runtime api key resolution", () => {
   it("returns 503 when VERITAS_API_KEY is missing at request time", async () => {
     vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");

--- a/frontend/app/audit/components/components.test.tsx
+++ b/frontend/app/audit/components/components.test.tsx
@@ -189,6 +189,183 @@ describe("DetailPanel", () => {
     fireEvent.click(screen.getByText("Metadata"));
     expect(onDetailTabChange).toHaveBeenCalledWith("metadata");
   });
+
+  it("renders metadata tab content", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "ok" }}
+        detailTab="metadata"
+      />,
+    );
+    expect(screen.getByText("Metadata Card")).toBeInTheDocument();
+    expect(screen.getByText(/"key": "value"/)).toBeInTheDocument();
+  });
+
+  it("renders hash tab with previous/current/next entries", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "ok" }}
+        previousEntry={mockItem2 as any}
+        nextEntry={mockItem2 as any}
+        detailTab="hash"
+      />,
+    );
+    expect(screen.getByText("Previous")).toBeInTheDocument();
+    expect(screen.getByText("Current")).toBeInTheDocument();
+    expect(screen.getByText("Next")).toBeInTheDocument();
+  });
+
+  it("renders hash tab with none when no adjacent entries", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "ok" }}
+        previousEntry={null}
+        nextEntry={null}
+        detailTab="hash"
+      />,
+    );
+    const noneLabels = screen.getAllByText("none");
+    expect(noneLabels).toHaveLength(2);
+  });
+
+  it("renders hash tab with chain broken warning", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "broken" as any, reason: "mismatch" }}
+        detailTab="hash"
+      />,
+    );
+    expect(screen.getByText(/Hash mismatch detected/)).toBeInTheDocument();
+    expect(screen.getByText(/Reason.*mismatch/)).toBeInTheDocument();
+  });
+
+  it("renders hash tab with chain missing warning", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "missing" as any, reason: "hash absent" }}
+        detailTab="hash"
+      />,
+    );
+    expect(screen.getByText(/Hash missing/)).toBeInTheDocument();
+  });
+
+  it("renders hash tab with orphan warning", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "orphan" as any, reason: "no prev link" }}
+        detailTab="hash"
+      />,
+    );
+    expect(screen.getByText(/Orphan entry/)).toBeInTheDocument();
+  });
+
+  it("renders related IDs tab", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "ok" }}
+        detailTab="related"
+      />,
+    );
+    expect(screen.getByText("request_id:")).toBeInTheDocument();
+    expect(screen.getByText("req-001")).toBeInTheDocument();
+    expect(screen.getByText("decision_id:")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("replay_id:")).toBeInTheDocument();
+    expect(screen.getByText("replay-001")).toBeInTheDocument();
+  });
+
+  it("renders continuation tab with no-data message", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "ok" }}
+        detailTab="continuation"
+      />,
+    );
+    expect(screen.getByText(/No continuation data/)).toBeInTheDocument();
+  });
+
+  it("renders continuation tab with full data", () => {
+    const continuationItem = {
+      ...mockItem,
+      continuation_claim_status: "live",
+      continuation_revalidation_status: "passed",
+      continuation_revalidation_outcome: "accept",
+      continuation_divergence_flag: false,
+      continuation_should_refuse: false,
+      continuation_reason_codes: ["R001", "R002"],
+      continuation_law_version_id: "law-v1",
+      continuation_support_basis_digest: "digest-abc",
+      continuation_burden_headroom_digest: "burden-xyz",
+      continuation_local_step_result: "pass",
+    };
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={continuationItem as any}
+        selectedChain={{ status: "verified", reason: "ok" }}
+        detailTab="continuation"
+      />,
+    );
+    expect(screen.getByText("LIVE")).toBeInTheDocument();
+    expect(screen.getByText("law-v1")).toBeInTheDocument();
+    expect(screen.getByText("digest-abc")).toBeInTheDocument();
+    expect(screen.getByText("burden-xyz")).toBeInTheDocument();
+    expect(screen.getByText("passed")).toBeInTheDocument();
+    expect(screen.getByText("accept")).toBeInTheDocument();
+    expect(screen.getByText("pass")).toBeInTheDocument();
+    expect(screen.getByText("R001, R002")).toBeInTheDocument();
+  });
+
+  it("renders continuation tab with divergence banner", () => {
+    const divergedItem = {
+      ...mockItem,
+      continuation_claim_status: "narrowed",
+      continuation_divergence_flag: true,
+      continuation_should_refuse: true,
+    };
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={divergedItem as any}
+        selectedChain={{ status: "verified", reason: "ok" }}
+        detailTab="continuation"
+      />,
+    );
+    expect(screen.getByText(/Step passed but chain-level continuation/)).toBeInTheDocument();
+    expect(screen.getByText("NARROWED")).toBeInTheDocument();
+    // Both shouldRefuse and divergenceFlag show YES
+    const yesElements = screen.getAllByText("YES");
+    expect(yesElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders raw JSON tab", () => {
+    render(
+      <DetailPanel
+        {...baseProps}
+        selected={mockItem as any}
+        selectedChain={{ status: "verified", reason: "ok" }}
+        detailTab="raw"
+      />,
+    );
+    expect(screen.getByText("Expand JSON")).toBeInTheDocument();
+    expect(screen.getByText(/"request_id": "req-001"/)).toBeInTheDocument();
+  });
 });
 
 /* ================================================================== */

--- a/frontend/app/governance/hooks/useGovernanceState.test.ts
+++ b/frontend/app/governance/hooks/useGovernanceState.test.ts
@@ -233,6 +233,224 @@ describe("useGovernanceState", () => {
     expect(result.current.pendingConfirm).toBeNull();
   });
 
+  it("applyPolicy shadow mode does not call PUT", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    mockFetch.mockClear();
+
+    act(() => { result.current.applyPolicy("shadow"); });
+    expect(result.current.pendingConfirm).not.toBeNull();
+    await act(async () => { result.current.pendingConfirm!.onConfirm(); });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.success).toContain("Shadow mode");
+  });
+
+  it("applyPolicy apply mode calls PUT and updates policy on success", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    const updatedPolicy = { ...MOCK_POLICY, version: "v2.0" };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: updatedPolicy }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: updatedPolicy } });
+
+    act(() => { result.current.applyPolicy("apply"); });
+    expect(result.current.pendingConfirm).not.toBeNull();
+    await act(async () => { result.current.pendingConfirm!.onConfirm(); });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/veritas/v1/governance/policy",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    expect(result.current.success).toContain("applied");
+    expect(result.current.savedPolicy!.version).toBe("v2.0");
+  });
+
+  it("applyPolicy apply mode sets error on HTTP failure", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    act(() => { result.current.applyPolicy("apply"); });
+    await act(async () => { result.current.pendingConfirm!.onConfirm(); });
+
+    expect(result.current.error).toContain("HTTP 500");
+  });
+
+  it("applyPolicy apply mode sets error on validation failure", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    mockValidate.mockReturnValue({ ok: false });
+
+    act(() => { result.current.applyPolicy("apply"); });
+    await act(async () => { result.current.pendingConfirm!.onConfirm(); });
+
+    expect(result.current.error).toContain("validation failed");
+  });
+
+  it("applyPolicy apply mode sets error on network failure", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+
+    act(() => { result.current.applyPolicy("apply"); });
+    await act(async () => { result.current.pendingConfirm!.onConfirm(); });
+
+    expect(result.current.error).toContain("Apply failed");
+  });
+
+  it("approveChanges sets draft approval_status to approved", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    // Make a change first so hasChanges is true
+    act(() => {
+      result.current.updateDraft((prev) => ({
+        ...prev,
+        fuji_rules: { ...prev.fuji_rules, pii_check: false },
+      }));
+    });
+    expect(result.current.hasChanges).toBe(true);
+
+    act(() => { result.current.approveChanges(); });
+    expect(result.current.pendingConfirm).not.toBeNull();
+    act(() => { result.current.pendingConfirm!.onConfirm(); });
+
+    expect(result.current.draft!.approval_status).toBe("approved");
+    expect(result.current.success).toContain("approved");
+  });
+
+  it("rejectChanges sets draft approval_status to rejected", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    // Make a change first
+    act(() => {
+      result.current.updateDraft((prev) => ({
+        ...prev,
+        fuji_rules: { ...prev.fuji_rules, pii_check: false },
+      }));
+    });
+
+    act(() => { result.current.rejectChanges(); });
+    expect(result.current.pendingConfirm).not.toBeNull();
+    act(() => { result.current.pendingConfirm!.onConfirm(); });
+
+    expect(result.current.draft!.approval_status).toBe("rejected");
+    expect(result.current.success).toContain("rejected");
+  });
+
+  it("approveChanges does nothing without changes", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    act(() => { result.current.approveChanges(); });
+    expect(result.current.pendingConfirm).toBeNull();
+  });
+
+  it("rejectChanges does nothing without changes", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    act(() => { result.current.rejectChanges(); });
+    expect(result.current.pendingConfirm).toBeNull();
+  });
+
+  it("draftApprovalStatus returns pending when there are changes", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    act(() => {
+      result.current.updateDraft((prev) => ({
+        ...prev,
+        fuji_rules: { ...prev.fuji_rules, pii_check: false },
+      }));
+    });
+
+    expect(result.current.draftApprovalStatus).toBe("pending");
+  });
+
+  it("draftApprovalStatus returns draft when no draft loaded", () => {
+    const { result } = renderHook(() => useGovernanceState());
+    expect(result.current.draftApprovalStatus).toBe("draft");
+  });
+
+  it("changeCount reflects the number of changed fields", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    expect(result.current.changeCount).toBe(0);
+
+    act(() => {
+      result.current.updateDraft((prev) => ({
+        ...prev,
+        fuji_rules: { ...prev.fuji_rules, pii_check: false },
+      }));
+    });
+
+    expect(result.current.changeCount).toBeGreaterThan(0);
+  });
+
   it("risk calculations are derived correctly", async () => {
     mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
     mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });

--- a/frontend/features/console/api/useDecide.test.ts
+++ b/frontend/features/console/api/useDecide.test.ts
@@ -144,6 +144,239 @@ describe("useDecide", () => {
     expect(result.current.error).not.toContain("stack trace");
     expect(setResult).toHaveBeenCalledWith(null);
   });
+  it("sets error when query is empty", async () => {
+    const setQuery = vi.fn();
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: (key) => key,
+        query: "",
+        setQuery,
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runDecision("   ");
+    });
+
+    expect(result.current.error).toBe("queryRequired");
+    expect(result.current.executionStatus).toBe("failed");
+  });
+
+  it("handles 401 auth error response", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('{"error":"unauthorized"}', {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: (key) => key,
+        query: "test",
+        setQuery: vi.fn(),
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runDecision("test query");
+    });
+
+    expect(result.current.error).toBe("authError");
+    expect(result.current.executionStatus).toBe("failed");
+    expect(setResult).toHaveBeenCalledWith(null);
+  });
+
+  it("handles 503 service unavailable response", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('{"error":"unavailable"}', {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: (key) => key,
+        query: "test",
+        setQuery: vi.fn(),
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runDecision("test query");
+    });
+
+    expect(result.current.error).toBe("serviceUnavailable");
+    expect(result.current.executionStatus).toBe("failed");
+    expect(setResult).toHaveBeenCalledWith(null);
+  });
+
+  it("handles schema validation failure", async () => {
+    const invalidPayload = { not_a_valid: "response" };
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(invalidPayload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: (key) => key,
+        query: "test",
+        setQuery: vi.fn(),
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runDecision("test query");
+    });
+
+    expect(result.current.error).toBe("schemaMismatch");
+    expect(result.current.executionStatus).toBe("failed");
+    expect(setResult).toHaveBeenCalledWith(null);
+  });
+
+  it("handles network error (non-API, non-abort exception)", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: (key) => key,
+        query: "test",
+        setQuery: vi.fn(),
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runDecision("test query");
+    });
+
+    expect(result.current.error).toBe("networkError");
+    expect(result.current.executionStatus).toBe("failed");
+    expect(setResult).toHaveBeenCalledWith(null);
+  });
+
+  it("handles generic non-ok HTTP status (e.g. 422 validation)", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('{"error":"bad request"}', {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: (key) => key,
+        query: "test",
+        setQuery: vi.fn(),
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runDecision("test query");
+    });
+
+    expect(result.current.error).toBe("validationError");
+    expect(result.current.executionStatus).toBe("failed");
+  });
+
+  it("notifySseActivity updates latestEvent and executionStatus", () => {
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: (key) => key,
+        query: "",
+        setQuery: vi.fn(),
+        setResult: vi.fn(),
+        setChatMessages: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.notifySseActivity("new event");
+    });
+
+    expect(result.current.latestEvent).toBe("new event");
+  });
+
+  it("successful response sets executionStatus to completed", async () => {
+    const payload = buildDecidePayload("req-success", "allow");
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setResult = vi.fn();
+    const setChatMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDecide({
+        t: (_ja, en) => en,
+        tk: (key) => key,
+        query: "test",
+        setQuery: vi.fn(),
+        setResult,
+        setChatMessages,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runDecision("test query");
+    });
+
+    expect(result.current.executionStatus).toBe("completed");
+    expect(result.current.loading).toBe(false);
+    expect(setResult).toHaveBeenCalledWith(payload);
+  });
+
   it("ignores stale completion and only applies latest result", async () => {
     const first = createDeferred<Response>();
     const second = createDeferred<Response>();

--- a/frontend/features/console/components/chat-panel.test.tsx
+++ b/frontend/features/console/components/chat-panel.test.tsx
@@ -19,7 +19,7 @@ function renderPanel(overrides: Partial<Parameters<typeof ChatPanel>[0]> = {}) {
     chatMessages: [],
     query: "",
     loading: false,
-    executionStatus: "idle",
+    executionStatus: "idle" as const,
     error: null,
     setQuery: vi.fn(),
     runDecision: vi.fn().mockResolvedValue(undefined),
@@ -87,12 +87,12 @@ describe("ChatPanel", () => {
   });
 
   it("shows submitting status message", () => {
-    renderPanel({ executionStatus: "submitting" as any });
+    renderPanel({ executionStatus: "submitting" });
     expect(screen.getByText("submittingStatus")).toBeInTheDocument();
   });
 
   it("shows streaming status message", () => {
-    renderPanel({ executionStatus: "streaming" as any });
+    renderPanel({ executionStatus: "streaming" });
     expect(screen.getByText("streamingStatus")).toBeInTheDocument();
   });
 

--- a/frontend/features/console/components/chat-panel.test.tsx
+++ b/frontend/features/console/components/chat-panel.test.tsx
@@ -85,4 +85,50 @@ describe("ChatPanel", () => {
     renderPanel({ loading: true });
     expect(screen.getByRole("button", { name: "sending" })).toBeDisabled();
   });
+
+  it("shows submitting status message", () => {
+    renderPanel({ executionStatus: "submitting" as any });
+    expect(screen.getByText("submittingStatus")).toBeInTheDocument();
+  });
+
+  it("shows streaming status message", () => {
+    renderPanel({ executionStatus: "streaming" as any });
+    expect(screen.getByText("streamingStatus")).toBeInTheDocument();
+  });
+
+  it("renders danger presets when enabled", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_DANGER_PRESETS", "true");
+    renderPanel();
+    expect(screen.getByText("dangerPresets")).toBeInTheDocument();
+    // Should render preset buttons
+    const presetButtons = screen.getAllByRole("button").filter(
+      (btn) => btn.className.includes("red-500"),
+    );
+    expect(presetButtons.length).toBe(3);
+    vi.unstubAllEnvs();
+  });
+
+  it("danger preset button calls runDecision with preset text", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_DANGER_PRESETS", "true");
+    const runDecision = vi.fn().mockResolvedValue(undefined);
+    renderPanel({ runDecision });
+    const presetButtons = screen.getAllByRole("button").filter(
+      (btn) => btn.className.includes("red-500"),
+    );
+    fireEvent.click(presetButtons[0]);
+    expect(runDecision).toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it("renders system role label", () => {
+    renderPanel({
+      chatMessages: [
+        { id: 1, role: "system", content: "System message" },
+      ],
+    });
+    expect(screen.getByText("chatRoleSystem")).toBeInTheDocument();
+    expect(screen.getByText("System message")).toBeInTheDocument();
+  });
 });

--- a/frontend/features/console/components/eu-ai-act-governance-dashboard.test.tsx
+++ b/frontend/features/console/components/eu-ai-act-governance-dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EUAIActGovernanceDashboard } from "./eu-ai-act-governance-dashboard";
 
@@ -24,5 +24,120 @@ describe("EUAIActGovernanceDashboard", () => {
     render(<EUAIActGovernanceDashboard />);
     expect(await screen.findByRole("switch", { name: /eu ai act mode/i })).toBeInTheDocument();
     expect(screen.getByText(/Current Risk:/i)).toBeInTheDocument();
+  });
+
+  it("renders pipeline stages", () => {
+    render(<EUAIActGovernanceDashboard />);
+    expect(screen.getByText("Evidence")).toBeInTheDocument();
+    expect(screen.getByText("Debate")).toBeInTheDocument();
+    expect(screen.getByText("Critique")).toBeInTheDocument();
+    expect(screen.getByText("Safety")).toBeInTheDocument();
+  });
+
+  it("renders empty log state", () => {
+    render(<EUAIActGovernanceDashboard />);
+    expect(screen.getByText("No logs yet.")).toBeInTheDocument();
+  });
+
+  it("shows OFF label when eu_ai_act_mode is false", () => {
+    render(<EUAIActGovernanceDashboard />);
+    expect(screen.getByText("OFF")).toBeInTheDocument();
+  });
+
+  it("toggles mode on button click and reverts on API failure", async () => {
+    let callCount = 0;
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          json: async () => ({ config: { eu_ai_act_mode: false, safety_threshold: 0.8 } }),
+        };
+      }
+      return { ok: false, json: async () => ({}) };
+    }));
+
+    render(<EUAIActGovernanceDashboard />);
+    const toggle = await screen.findByRole("switch", { name: /eu ai act mode/i });
+
+    // Click to toggle - it should optimistically show ON then revert
+    await act(async () => {
+      toggle.click();
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // After failure, it should revert back to OFF
+    expect(screen.getByText("OFF")).toBeInTheDocument();
+  });
+
+  it("toggles mode on button click and updates on API success", async () => {
+    let callCount = 0;
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          json: async () => ({ config: { eu_ai_act_mode: false, safety_threshold: 0.8 } }),
+        };
+      }
+      // PUT success - return updated config
+      return {
+        ok: true,
+        json: async () => ({ config: { eu_ai_act_mode: true, safety_threshold: 0.8 } }),
+      };
+    }));
+
+    render(<EUAIActGovernanceDashboard />);
+    const toggle = await screen.findByRole("switch", { name: /eu ai act mode/i });
+
+    await act(async () => {
+      toggle.click();
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(screen.getByText("ON")).toBeInTheDocument();
+  });
+
+  it("shows Low risk when eu_ai_act_mode is disabled", () => {
+    render(<EUAIActGovernanceDashboard />);
+    expect(screen.getByText(/Current Risk: Low/)).toBeInTheDocument();
+  });
+
+  it("shows High risk when eu_ai_act_mode is enabled with threshold >= 0.4", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ config: { eu_ai_act_mode: true, safety_threshold: 0.8 } }),
+    })));
+
+    render(<EUAIActGovernanceDashboard />);
+    // Wait for fetch to complete
+    await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+
+    expect(screen.getByText(/Current Risk: High/)).toBeInTheDocument();
+  });
+
+  it("shows Unacceptable risk when threshold < 0.4", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ config: { eu_ai_act_mode: true, safety_threshold: 0.3 } }),
+    })));
+
+    render(<EUAIActGovernanceDashboard />);
+    await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+
+    expect(screen.getByText(/Current Risk: Unacceptable/)).toBeInTheDocument();
+  });
+
+  it("handles fetch failure gracefully and keeps defaults", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("Network error");
+    }));
+
+    render(<EUAIActGovernanceDashboard />);
+    await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+
+    // Should still render with defaults
+    expect(screen.getByText("OFF")).toBeInTheDocument();
+    expect(screen.getByText(/Current Risk: Low/)).toBeInTheDocument();
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^5.1.4",
+    "@vitest/coverage-v8": "^2.1.8",
     "autoprefixer": "^10.4.20",
     "axe-core": "^4.11.1",
     "eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.4
         version: 5.1.4(vite@5.4.21(@types/node@22.19.11))
+      '@vitest/coverage-v8':
+        specifier: ^2.1.8
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.11)(jsdom@25.0.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.24(postcss@8.5.6)
@@ -135,6 +138,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -234,6 +241,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -578,6 +588,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -666,6 +684,10 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
@@ -1033,6 +1055,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1083,6 +1114,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1090,6 +1125,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1179,6 +1218,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.8:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
     engines: {node: '>=6.0.0'}
@@ -1193,6 +1236,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1393,8 +1440,14 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -1622,6 +1675,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -1683,6 +1740,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -1732,6 +1794,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1823,6 +1888,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -1896,9 +1965,28 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -2003,6 +2091,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2027,6 +2122,10 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2036,6 +2135,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2142,6 +2245,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2163,6 +2269,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2424,6 +2534,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2440,6 +2554,14 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -2467,6 +2589,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2516,6 +2642,10 @@ packages:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -2751,6 +2881,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2785,6 +2923,11 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -2914,6 +3057,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -3152,6 +3297,17 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3221,6 +3377,9 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@playwright/test@1.58.2':
     dependencies:
@@ -3552,6 +3711,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.11)(jsdom@25.0.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@22.19.11)(jsdom@25.0.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -3609,11 +3786,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -3726,6 +3907,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.8: {}
 
   binary-extensions@2.3.0: {}
@@ -3738,6 +3921,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -3928,7 +4115,11 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.286: {}
+
+  emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
 
@@ -4326,6 +4517,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -4397,6 +4593,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -4444,6 +4649,8 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -4543,6 +4750,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -4613,6 +4822,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -4621,6 +4851,12 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.7: {}
 
@@ -4728,6 +4964,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -4745,6 +4991,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -4754,6 +5004,8 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -4871,6 +5123,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4886,6 +5140,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@1.1.2: {}
 
@@ -5205,6 +5464,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
@@ -5217,6 +5478,18 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -5271,6 +5544,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -5334,6 +5611,12 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   text-table@0.2.0: {}
 
@@ -5620,6 +5903,18 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
Add 55 new tests across 6 test files targeting the lowest-coverage areas:
- route.ts: 52.85% → 100% (proxy lifecycle, auth, error responses)
- DetailPanel.tsx: 46.41% → 99.31% (all tab views including continuation)
- useDecide.ts: 57.98% → 79.28% (401/503/422 errors, empty query, schema)
- eu-ai-act-governance-dashboard.tsx: 65.13% → higher (toggle, risk levels)
- useGovernanceState.ts: 71.9% → higher (apply/shadow/approve/reject flows)
- chat-panel.tsx: 83.33% → 100% (danger presets, status messages, roles)

https://claude.ai/code/session_01YXk4gxBAqpjYrPqk74mDbr