### PR TITLE
fix: policy_runtime_enforce string handling bug + signature verification logging

### DIFF
--- a/docs/reviews/POLICY_AS_CODE_IMPLEMENTATION_REVIEW_2026-04-02.md
+++ b/docs/reviews/POLICY_AS_CODE_IMPLEMENTATION_REVIEW_2026-04-02.md
@@ -473,6 +473,7 @@ def _apply_compiled_policy_runtime_bridge(ctx):
 - ✅ `value_ema` の NaN/Inf ガードを追加。既存の `risk_val` ガード（`math.isfinite`）と同一パターンで一貫性を確保し、NaN 伝播による `telos_threshold` / `effective_risk` の破損を防止。
 - ✅ `_apply_compiled_policy_runtime_bridge()` の例外キャッチに `KeyError` を追加。コンパイル済み JSON が破損し evaluator 内部で `KeyError` が発生した場合でもリクエスト処理がクラッシュしない防御層を強化。
 - ✅ `policy_runtime_enforce` の文字列値ハンドリングを修正。コンテキスト辞書から文字列（例: `"false"`, `"0"`）が渡された場合に `bool("false")` → `True` として誤って enforcement が有効化されるバグを修正。env var パスと同一の正規化パターン（`"1"`, `"true"`, `"yes"`）を適用。
+- ✅ `risk_val` 例外時のデフォルト値を `0.0`（fail-open）から `1.0`（fail-closed）に修正。NaN/Inf 時の `1.0` と一貫した fail-closed 動作に統一。
 
 ---
 
@@ -575,8 +576,8 @@ python -m veritas_os.scripts.compile_policy \
 | `test_policy_generated_vectors.py` | 2 | 37 | テストベクトル自動生成（5ポリシー）、決定論性 |
 | `test_warning_allowlist_policy.py` | 3 | 116 | 警告許可リスト検証 |
 | `test_governance_api.py`（統合） | 95 | 1050+ | API全エンドポイント、RBAC、4-eyes、履歴、**監査履歴スレッドセーフ並行アクセス** |
-| `test_pipeline_stages_ext.py`（bridge） | 10 | — | パイプライン bridge enforcement（全4 outcome→status マッピング + 非強制時 warning + env var フォールバック + enforcement 監査ログ + NaN EMA ガード + **文字列 enforce 値ハンドリング**） |
-| **合計** | **194** | **2,970+** | |
+| `test_pipeline_stages_ext.py`（bridge） | 11 | — | パイプライン bridge enforcement（全4 outcome→status マッピング + 非強制時 warning + env var フォールバック + enforcement 監査ログ + NaN EMA ガード + **文字列 enforce 値ハンドリング** + **risk_val fail-closed**） |
+| **合計** | **195** | **2,990+** | |
 
 ### 4.2 テストパターン分析
 
@@ -661,6 +662,7 @@ python -m veritas_os.scripts.compile_policy \
 | outcome 欠損キー防御 | ✅ | `policy.outcome` に `decision`/`reason` キーが欠落しても `KeyError` を送出せず安全にデフォルト値で動作 |
 | `policy_runtime_enforce` 文字列値ハンドリング | ✅ | 文字列 `"false"` が enforcement を有効化しないことを検証（`bool("false")` バグ修正） |
 | 署名検証ファイル欠落時の警告ログ | ✅ | `verify_manifest_signature()` で manifest/sig ファイル欠落時に警告ログが出力されることを検証 |
+| risk_val 変換不能時の fail-closed | ✅ | 非数値 risk 値で `risk_val` が `1.0`（最大リスク）にフォールバックすることを検証 |
 
 **改善余地:**
 - ✅ ~~複数ポリシーの同時評価（優先度解決）の明示的テストが追加できる。~~ → `test_multiple_policy_precedence_resolution` で対応済み
@@ -1281,6 +1283,12 @@ python -m veritas_os.scripts.compile_policy \
   - 従来はサイレントに `False` を返却しており、`load_runtime_bundle()` は `ValueError("manifest signature verification failed")` を送出するが、原因（ファイル欠落 vs 署名不一致 vs 破損）の区別がつかなかった
   - デプロイ時のトラブルシューティングを容易化: ログから「どのファイルが欠落しているか」を即座に特定可能
   - テスト1件追加: `test_verify_manifest_signature_logs_warning_on_missing_files`（空ディレクトリに対する検証で missing ファイルが警告ログに出力されることを検証）
+
+- **`risk_val` 例外時のデフォル���値を fail-closed に修正（`pipeline_policy.py`）**
+  - `stage_fuji_precheck()` で `risk` 値の `float()` 変換が `ValueError` / `TypeError` で失敗した場合のデフォルト値を `0.0`（fail-open）から `1.0`（fail-closed）に変更
+  - 修正前: NaN/Inf は `1.0`（fail-closed）だが、変換不能な値（非数値文字列等）は `0.0`（fail-open）で不整合
+  - 修正後: 両ケースとも `1.0`（最大リスク）に統一。「変換できない = 安全でない」の原則に一貫
+  - テスト1件追加: `test_risk_val_invalid_type_fails_closed`（非数値 risk で fail-closed 動作を検証）
 
 ---
 

--- a/docs/reviews/POLICY_AS_CODE_IMPLEMENTATION_REVIEW_2026-04-02.md
+++ b/docs/reviews/POLICY_AS_CODE_IMPLEMENTATION_REVIEW_2026-04-02.md
@@ -345,6 +345,7 @@ load_and_validate → to_canonical_ir → semantic_hash
 - ✅ `verify_manifest_signature()` でマニフェストが `algorithm: ed25519` を宣言しているにもかかわらず公開鍵が未設定の場合、SHA-256 フォールバック前に `logger.warning()` で警告を出力。署名バイパスの検出性を向上。✅ さらに `VERITAS_POLICY_REQUIRE_ED25519=true` 環境変数による厳格モードを追加。設定時は SHA-256 フォールバックを拒否し `ValueError` を送出。本番環境での設定ミスによるサイレントダウングレードを防止。
 - ✅ `verify_manifest_signature()` で `manifest.json` のパースに失敗した場合（JSONDecodeError/OSError）に `logger.warning()` で警告を出力。バンドル破損時のサイレントフォールバックを排除し、運用時の異常検出性を向上。
 - ✅ `verify_manifest_signature()` のファイル読み込みを一元化: マニフェストをバイト列として1回だけ読み込み、アルゴリズム検出と署名検証の両方に使用。従来は `read_text()` + `read_bytes()` の二重読み込みで TOCTOU 競合の余地があったが、これを解消。ファイル読み込みの `OSError` を個別にキャッチし `logger.warning()` 付きで `False` を返却。SHA-256 フォールバックも読み込み済みバイト列から直接計算し `hmac.compare_digest()` で定数時間比較。
+- ✅ `verify_manifest_signature()` で `manifest.json` / `manifest.sig` が存在しない場合に `logger.warning()` で欠落ファイル名を出力。従来はサイレントに `False` を返却しており、デプロイ時の原因特定が困難だった。
 
 ---
 
@@ -471,6 +472,7 @@ def _apply_compiled_policy_runtime_bridge(ctx):
 - ✅ enforcement 適用時に `logger.info()` で outcome・変更先 status・トリガポリシー ID を出力。ガバナンス監査証跡として enforcement 実行の追跡が可能に。
 - ✅ `value_ema` の NaN/Inf ガードを追加。既存の `risk_val` ガード（`math.isfinite`）と同一パターンで一貫性を確保し、NaN 伝播による `telos_threshold` / `effective_risk` の破損を防止。
 - ✅ `_apply_compiled_policy_runtime_bridge()` の例外キャッチに `KeyError` を追加。コンパイル済み JSON が破損し evaluator 内部で `KeyError` が発生した場合でもリクエスト処理がクラッシュしない防御層を強化。
+- ✅ `policy_runtime_enforce` の文字列値ハンドリングを修正。コンテキスト辞書から文字列（例: `"false"`, `"0"`）が渡された場合に `bool("false")` → `True` として誤って enforcement が有効化されるバグを修正。env var パスと同一の正規化パターン（`"1"`, `"true"`, `"yes"`）を適用。
 
 ---
 
@@ -567,14 +569,14 @@ python -m veritas_os.scripts.compile_policy \
 | テストファイル | テスト数 | 行数 | 主要カバレッジ |
 |---------------|---------|------|---------------|
 | `test_policy_compiler.py` | 12 | 230+ | コンパイル成功/失敗、成果物構造、決定性、署名、I/Oエラーラッピング、コンパイル監査ログ、署名鍵エラーラッピング、**アーカイブバイト決定性、シンボリックリンク除外** |
-| `test_policy_runtime_adapter.py` | 39 | 930+ | ランタイム評価（全5 outcome）、ReDoS ガード、複数ポリシー優先度解決、effective_date フィルタリング、バンドルI/Oエラー、IR 不整合検出、数値比較型安全性、未知演算子警告、スコープ欠落ログ、バンドルロード監査ログ、context None ガード、マニフェスト破損時の警告ログ、**署名検証ファイル読み込みエラー耐性**、**NaN/Inf 数値比較ガード**、**contains 演算子型安全性**、**outcome 欠損キー防御** |
+| `test_policy_runtime_adapter.py` | 40 | 950+ | ランタイム評価（全5 outcome）、ReDoS ガード、複数ポリシー優先度解決、effective_date フィルタリング、バンドルI/Oエラー、IR 不整合検出、数値比較型安全性、未知演算子警告、スコープ欠落ログ、バンドルロード監査ログ、context None ガード、マニフェスト破損時の警告ログ、**署名検証ファイル読み込みエラー耐性**、**NaN/Inf 数値比較ガード**、**contains 演算子型安全性**、**outcome 欠損キー防御**、**ファイル欠落時の警告ログ** |
 | `test_policy_canonical_ir.py` | 15 | 260+ | スキーマ検証（全5例）、正規化決定性、ハッシュ安定性、ファイルI/O・パースエラーハンドリング、ハッシュ入力検証 |
 | `test_policy_signing.py` | 17 | 310+ | Ed25519 鍵生成、署名/検証ラウンドトリップ、改ざん検出、不正鍵拒否、コンパイラ統合、env var 検証、レガシー互換性、決定論性、Ed25519→SHA-256 ダウングレード警告、**SHA-256 定数時間比較検証**、**SHA-256 レガシー検証 TOCTOU 耐性**、**Ed25519 厳格モード env var** |
 | `test_policy_generated_vectors.py` | 2 | 37 | テストベクトル自動生成（5ポリシー）、決定論性 |
 | `test_warning_allowlist_policy.py` | 3 | 116 | 警告許可リスト検証 |
 | `test_governance_api.py`（統合） | 95 | 1050+ | API全エンドポイント、RBAC、4-eyes、履歴、**監査履歴スレッドセーフ並行アクセス** |
-| `test_pipeline_stages_ext.py`（bridge） | 9 | — | パイプライン bridge enforcement（全4 outcome→status マッピング + 非強制時 warning + env var フォールバック + enforcement 監査ログ + NaN EMA ガード） |
-| **合計** | **192** | **2,950+** | |
+| `test_pipeline_stages_ext.py`（bridge） | 10 | — | パイプライン bridge enforcement（全4 outcome→status マッピング + 非強制時 warning + env var フォールバック + enforcement 監査ログ + NaN EMA ガード + **文字列 enforce 値ハンドリング**） |
+| **合計** | **194** | **2,970+** | |
 
 ### 4.2 テストパターン分析
 
@@ -657,6 +659,8 @@ python -m veritas_os.scripts.compile_policy \
 | Ed25519 厳格モード拒否 | ✅ | `VERITAS_POLICY_REQUIRE_ED25519=true` 時に公開鍵なしで Ed25519 バンドルの検証が `ValueError` を送出 |
 | Ed25519 厳格モード許可 | ✅ | `VERITAS_POLICY_REQUIRE_ED25519=true` でも公開鍵が利用可能な場合は正常に検証成功 |
 | outcome 欠損キー防御 | ✅ | `policy.outcome` に `decision`/`reason` キーが欠落しても `KeyError` を送出せず安全にデフォルト値で動作 |
+| `policy_runtime_enforce` 文字列値ハンドリング | ✅ | 文字列 `"false"` が enforcement を有効化しないことを検証（`bool("false")` バグ修正） |
+| 署名検証ファイル欠落時の警告ログ | ✅ | `verify_manifest_signature()` で manifest/sig ファイル欠落時に警告ログが出力されることを検証 |
 
 **改善余地:**
 - ✅ ~~複数ポリシーの同時評価（優先度解決）の明示的テストが追加できる。~~ → `test_multiple_policy_precedence_resolution` で対応済み
@@ -1258,6 +1262,25 @@ python -m veritas_os.scripts.compile_policy \
   - evaluator やランタイムアダプタ内部で `KeyError` が発生した場合のバックストップ（防御層の深化）
   - evaluator 側の防御的アクセスと組み合わせた二重防御: evaluator が `.get()` で処理し、万一漏れた場合もパイプライン bridge でキャッチ
   - リクエスト処理のクラッシュを防止し、fail-safe（安全側デフォルト）動作を保証
+
+---
+
+### 11.16 改善実施ログ（2026-04-05 第7弾）
+
+以下は本日追加実施したバグ修正・運用可観測性改善項目:
+
+- **`policy_runtime_enforce` 文字列値ハンドリングのバグ修正（`pipeline_policy.py`）**
+  - `_apply_compiled_policy_runtime_bridge()` でコンテキスト辞書から取得した `policy_runtime_enforce` が文字列（例: `"false"`, `"0"`）の場合に enforcement が誤って有効化されるバグを修正
+  - 修正前: `bool("false")` → `True`（Python の文字列 truthiness）により、文字列 `"false"` が enforcement 有効として解釈される
+  - 修正後: `isinstance(enforce, str)` チェックを追加し、文字列の場合は env var と同一のパターン（`"1"`, `"true"`, `"yes"` で有効化）で正規化
+  - env var パス（`VERITAS_POLICY_RUNTIME_ENFORCE`）との一貫性を確保
+  - テスト1件追加: `test_pipeline_bridge_string_false_enforcement_not_enforced`（文字列 `"false"` が enforcement を有効化しないことを検証）
+
+- **署名検証ファイル欠落時の警告ログ追加（`runtime_adapter.py`）**
+  - `verify_manifest_signature()` で `manifest.json` または `manifest.sig` が存在しない場合に `logger.warning()` で欠落ファイル名とバンドルディレクトリを出力
+  - 従来はサイレントに `False` を返却しており、`load_runtime_bundle()` は `ValueError("manifest signature verification failed")` を送出するが、原因（ファイル欠落 vs 署名不一致 vs 破損）の区別がつかなかった
+  - デプロイ時のトラブルシューティングを容易化: ログから「どのファイルが欠落しているか」を即座に特定可能
+  - テスト1件追加: `test_verify_manifest_signature_logs_warning_on_missing_files`（空ディレクトリに対する検証で missing ファイルが警告ログに出力されることを検証）
 
 ---
 

--- a/veritas_os/core/pipeline/pipeline_policy.py
+++ b/veritas_os/core/pipeline/pipeline_policy.py
@@ -79,6 +79,8 @@ def _apply_compiled_policy_runtime_bridge(ctx: PipelineContext) -> None:
             "true",
             "yes",
         )
+    elif isinstance(enforce, str):
+        enforce = enforce.strip().lower() in ("1", "true", "yes")
     if not bool(enforce):
         if outcome in {"deny", "halt", "escalate", "require_human_review"}:
             logger.warning(

--- a/veritas_os/core/pipeline/pipeline_policy.py
+++ b/veritas_os/core/pipeline/pipeline_policy.py
@@ -160,7 +160,7 @@ def stage_fuji_precheck(ctx: PipelineContext) -> None:
             risk_val = 1.0  # fail-closed: NaN/Inf は最大リスクとして扱う
         risk_val = max(0.0, min(1.0, risk_val))
     except (ValueError, TypeError):
-        risk_val = 0.0
+        risk_val = 1.0  # fail-closed: 変換不能な値は最大リスクとして扱う
     reasons_list = ctx.fuji_dict.get("reasons", []) or []
     viols = ctx.fuji_dict.get("violations", []) or []
 

--- a/veritas_os/policy/runtime_adapter.py
+++ b/veritas_os/policy/runtime_adapter.py
@@ -84,6 +84,16 @@ def verify_manifest_signature(
     manifest_path = root / "manifest.json"
     signature_path = root / "manifest.sig"
     if not manifest_path.exists() or not signature_path.exists():
+        missing = [
+            name
+            for name, p in (("manifest.json", manifest_path), ("manifest.sig", signature_path))
+            if not p.exists()
+        ]
+        logger.warning(
+            "signature verification skipped: missing %s in %s",
+            missing,
+            bundle_dir,
+        )
         return False
 
     # Resolve public key from argument or env var

--- a/veritas_os/tests/test_policy_runtime_adapter.py
+++ b/veritas_os/tests/test_policy_runtime_adapter.py
@@ -937,3 +937,19 @@ def test_outcome_missing_keys_does_not_raise_key_error() -> None:
     decision = evaluate_runtime_policies(bundle, context).to_dict()
     assert decision["final_outcome"] == "allow"
     assert "policy.malformed.outcome" in decision["triggered_policies"]
+
+
+def test_verify_manifest_signature_logs_warning_on_missing_files(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """verify_manifest_signature logs a warning when manifest/sig files are missing."""
+    import logging
+    from veritas_os.policy.runtime_adapter import verify_manifest_signature
+
+    with caplog.at_level(logging.WARNING, logger="veritas_os.policy.runtime_adapter"):
+        result = verify_manifest_signature(tmp_path)
+
+    assert result is False
+    assert "missing" in caplog.text
+    assert "manifest.json" in caplog.text

--- a/veritas_os/tests/unit/test_pipeline_stages_ext.py
+++ b/veritas_os/tests/unit/test_pipeline_stages_ext.py
@@ -7690,6 +7690,30 @@ def test_value_ema_nan_falls_back_to_neutral() -> None:
     assert math.isfinite(ctx.value_ema)
     assert ctx.value_ema == 0.5
 
+
+def test_risk_val_invalid_type_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-numeric risk value fails closed to maximum risk (1.0)."""
+    import veritas_os.core.pipeline.pipeline_policy as _mod
+
+    # Stub FUJI to return a non-numeric risk
+    class _FakeFuji:
+        @staticmethod
+        def validate_action(query, context):
+            return {"status": "allow", "risk": "not_a_number", "reasons": [], "violations": [], "modifications": []}
+
+    monkeypatch.setattr(_mod, "_lazy_import", lambda *a, **k: _FakeFuji)
+
+    ctx = PipelineContext(query="test")
+    ctx.response_extras = {"metrics": {"stage_latency": {}}}
+
+    stage_fuji_precheck(ctx)
+
+    # Evidence snippet should show risk=1.0 (fail-closed), not 0.0 (fail-open)
+    fuji_evidence = [e for e in ctx.evidence if e.get("source") == "internal:fuji"]
+    assert fuji_evidence
+    assert "risk=1.0" in fuji_evidence[0].get("snippet", "")
+
+
 # tests for veritas_os/core/pipeline_web_adapter.py
 """Tests for web search payload normalization and extraction."""
 

--- a/veritas_os/tests/unit/test_pipeline_stages_ext.py
+++ b/veritas_os/tests/unit/test_pipeline_stages_ext.py
@@ -7604,6 +7604,37 @@ def test_pipeline_bridge_env_var_enforcement_fallback(
     assert "compiled_policy:deny" in ctx.fuji_dict["reasons"]
 
 
+def test_pipeline_bridge_string_false_enforcement_not_enforced(
+    tmp_path: Path,
+) -> None:
+    """String 'false' in context correctly disables enforcement (not bool-truthy)."""
+    compiled = compile_policy_to_bundle(
+        EXAMPLES_DIR / "external_tool_usage_denied.yaml",
+        tmp_path,
+        compiled_at="2026-03-28T00:00:00Z",
+    )
+
+    ctx = PipelineContext(
+        query="use external tool",
+        context={
+            "compiled_policy_bundle_dir": compiled.bundle_dir.as_posix(),
+            "policy_runtime_enforce": "false",  # string, not bool
+            "domain": "security",
+            "route": "/api/tools",
+            "actor": "kernel",
+            "tool": {"external": True, "name": "unapproved_webhook"},
+            "data": {"classification": "restricted"},
+            "evidence": {"available": ["data_classification_label"]},
+            "approvals": {"approved_by": ["security_officer"]},
+        },
+    )
+
+    stage_fuji_precheck(ctx)
+
+    # String "false" should NOT enable enforcement — status should remain allow
+    assert ctx.fuji_dict["status"] != "rejected"
+
+
 def test_pipeline_bridge_enforcement_logs_audit_info(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
- Fix bool("false") evaluating to True in pipeline bridge enforcement,
  aligning string handling with env var normalization pattern
- Add warning log when manifest.json/manifest.sig files are missing in
  verify_manifest_signature() for deploy-time debugging
- Add 2 tests covering both fixes
- Update review document with improvement log

https://claude.ai/code/session_01WsddFh2vVXFrhWdYPgS26A