### PR TITLE
Improve debate safety heuristics and align critique/debate type contracts

### DIFF
--- a/docs/notes/CRITIQUE_DEBATE_REVIEW.md
+++ b/docs/notes/CRITIQUE_DEBATE_REVIEW.md
@@ -97,3 +97,37 @@
 4. **[中] D-4**: `_safe_json_extract_like` 内のネスト関数をモジュールレベルに引き上げ
 5. **[中] P-2**: `_run_critique_best_effort` の async 意図をコメントで明示
 6. **[中] C-2**: リスク/価値バランスのゼロ除算回避ロジック見直し
+
+
+---
+
+## 7. 実施ログ（2026-04-06 更新）
+
+優先度順に、以下を実装済み。
+
+1. **[高][完了] T-1/T-2 型定義の乖離修正**
+   - `CritiquePoint.severity` を `"low" | "med" | "medium" | "high"` に拡張し、実装互換性を確保。
+   - `DebateViewpoint.role` を実装上の `Architect/Critic/Safety/Judge` を含む Literal に拡張。
+
+2. **[高][完了] D-2 `_calc_risk_delta` の否定表現誤検知を修正**
+   - `_is_keyword_negated()` を追加し、`「リスクなし」「問題なし」「違反なし」` 等の否定文脈ではリスク加算を抑制。
+   - 従来どおり、実際のリスク表現（重大/違反/深刻）では加算されることを維持。
+
+3. **[高][完了] D-1 `_looks_dangerous_text` の文脈考慮導入**
+   - 防御的・教育的文脈（対策/予防/セキュリティ/training 等）を benign context として導入。
+   - ただし `「爆弾の作り方」` や `"how to make ..."` など明示的有害意図パターンは強制ブロック。
+
+4. **[低〜中][完了] D-3 メタ情報の定数化**
+   - `source: "openai_llm"` を `DEBATE_SOURCE_OPENAI` に定数化。
+
+5. **[テスト追加][完了] Debate 安全ヒューリスティクスの単体テスト追加**
+   - benign context false positive 抑制
+   - 明示的有害意図のブロック継続
+   - risk negation の加算抑制
+   - 実リスクでの加算維持
+
+### セキュリティ注意（実装時点）
+
+- benign context の導入により false positive は低減される一方、**攻撃者が安全語を混ぜて回避を試みるリスク**がある。
+- そのため、明示的有害意図パターンは優先的に評価し、検出時は benign 判定より強くブロックする設計とした。
+- 追加で、将来的には FUJI 側の判定結果・ユーザー意図分類・監査ログ相関で多層化することを推奨。

--- a/tests/test_debate_safety_heuristics.py
+++ b/tests/test_debate_safety_heuristics.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for Debate safety heuristics and risk-delta negation handling."""
+
+from __future__ import annotations
+
+from veritas_os.core import debate
+
+
+def test_looks_dangerous_text_allows_benign_security_context() -> None:
+    """Security education context should not be flagged as dangerous."""
+    option = {
+        "title": "ウイルス対策の教育プラン",
+        "description": "サイバーセキュリティ研修で malware と virus の検知を学ぶ",
+        "summary": "防止と予防を重視した安全教育",
+    }
+
+    assert debate._looks_dangerous_text(option) is False
+
+
+def test_looks_dangerous_text_blocks_explicit_harmful_intent() -> None:
+    """Harmful intent patterns must remain blocked even with mixed context."""
+    option = {
+        "title": "爆弾の作り方",
+        "description": "危険物の手順をまとめる",
+        "summary": "安全教育という名目でも有害意図を含む",
+    }
+
+    assert debate._looks_dangerous_text(option) is True
+
+
+def test_calc_risk_delta_ignores_negated_risk_phrases() -> None:
+    """Negated safety phrases should avoid risk keyword inflation."""
+    chosen = {
+        "score": 0.85,
+        "verdict": "採用推奨",
+        "safety_view": "リスクなし。問題なし。違反なし。安全に実施可能。",
+        "critic_view": "軽微な注意点のみ",
+    }
+
+    delta = debate._calc_risk_delta(chosen, [chosen])
+
+    assert delta < 0.0
+
+
+def test_calc_risk_delta_still_increases_for_real_risk_signal() -> None:
+    """Actual risk signals should continue to raise risk delta."""
+    chosen = {
+        "score": 0.45,
+        "verdict": "要検討",
+        "safety_view": "重大なリスクと違反の可能性がある",
+        "critic_view": "深刻な懸念あり",
+    }
+
+    delta = debate._calc_risk_delta(chosen, [chosen])
+
+    assert delta > 0.2

--- a/veritas_os/core/debate.py
+++ b/veritas_os/core/debate.py
@@ -60,6 +60,61 @@ _DANGER_PATTERNS_EN = [
 ]
 
 
+_BENIGN_CONTEXT_TERMS = [
+    "対策",
+    "予防",
+    "防止",
+    "教育",
+    "研究",
+    "分析",
+    "診断",
+    "治療",
+    "検知",
+    "セキュリティ",
+    "training",
+    "defense",
+    "defensive",
+    "prevention",
+    "mitigation",
+    "awareness",
+    "diagnosis",
+    "treatment",
+    "cybersecurity",
+    "security",
+]
+
+_DANGEROUS_INTENT_PATTERNS = [
+    re.compile(r"(?:作り方|作成方法|やり方|手順).{0,8}(?:爆弾|麻薬|ウイルス|ハッキング)", re.IGNORECASE),
+    re.compile(r"(?:爆弾|麻薬|ウイルス|ハッキング).{0,8}(?:作り方|作成方法|やり方|手順)", re.IGNORECASE),
+    re.compile(r"\b(?:how to make|how to build|steps? to|guide to)\b.{0,24}\b(?:bomb|malware|virus|drugs?|hack(?:ing)?)\b", re.IGNORECASE),
+]
+
+_RISK_NEGATION_TERMS = (
+    "問題なし",
+    "問題はない",
+    "問題がない",
+    "危険ではない",
+    "危険性は低い",
+    "リスクなし",
+    "リスクはない",
+    "リスクがない",
+    "低リスク",
+    "違反なし",
+    "違反はない",
+    "禁止されていない",
+    "no risk",
+    "low risk",
+    "risk free",
+    "risk-free",
+    "no issue",
+    "no issues",
+    "safe",
+    "mitigated",
+)
+
+DEBATE_SOURCE_OPENAI = "openai_llm"
+
+
 # ============================
 #  設定と定数
 # ============================
@@ -190,11 +245,13 @@ def _normalize_text_for_scan(text: str) -> str:
     return " ".join((text or "").lower().split())
 
 
+def _contains_benign_context(normalized_text: str) -> bool:
+    """Return ``True`` when the text likely describes defensive/safe context."""
+    return any(term in normalized_text for term in _BENIGN_CONTEXT_TERMS)
+
+
 def _looks_dangerous_text(opt: Dict[str, Any]) -> bool:
-    """
-    “念のため”の軽いヒューリスティクス保険。
-    ※ ここは厳密判定ではなく、最後の事故防止。
-    """
+    """Detect dangerous option text while reducing benign-context false positives."""
     text = " ".join(
         [
             str(opt.get("title") or ""),
@@ -206,10 +263,19 @@ def _looks_dangerous_text(opt: Dict[str, Any]) -> bool:
     )
     normalized = _normalize_text_for_scan(text)
 
-    if any(term in normalized for term in _DANGER_TERMS_JA):
+    has_term = any(term in normalized for term in _DANGER_TERMS_JA) or any(
+        pattern.search(normalized) for pattern in _DANGER_PATTERNS_EN
+    )
+    if not has_term:
+        return False
+
+    if any(pattern.search(normalized) for pattern in _DANGEROUS_INTENT_PATTERNS):
         return True
 
-    return any(pattern.search(normalized) for pattern in _DANGER_PATTERNS_EN)
+    if _contains_benign_context(normalized):
+        return False
+
+    return True
 
 
 # ============================
@@ -252,6 +318,29 @@ def _normalize_verdict_by_score(opt: Dict[str, Any]) -> str:
     return "却下"
 
 
+def _is_keyword_negated(text: str, keyword: str) -> bool:
+    """Return ``True`` when *keyword* appears near a risk-negation phrase."""
+    positions = []
+    start = 0
+    while True:
+        idx = text.find(keyword, start)
+        if idx == -1:
+            break
+        positions.append(idx)
+        start = idx + 1
+
+    if not positions:
+        return False
+
+    for idx in positions:
+        left = max(0, idx - 18)
+        right = min(len(text), idx + len(keyword) + 18)
+        window = text[left:right]
+        if any(neg in window for neg in _RISK_NEGATION_TERMS):
+            return True
+    return False
+
+
 def _calc_risk_delta(
     chosen: Optional[Dict[str, Any]],
     options: List[Dict[str, Any]],
@@ -276,7 +365,7 @@ def _calc_risk_delta(
         "ban": 0.15,
     }
     for kw, w in risk_keywords.items():
-        if kw in safety_view:
+        if kw in safety_view and not _is_keyword_negated(safety_view, kw):
             delta += w
 
     if verdict == "要検討":
@@ -881,7 +970,7 @@ def run_debate(
             "chosen": chosen,
             "options": enriched_list,
             "raw": parsed,
-            "source": "openai_llm",
+            "source": DEBATE_SOURCE_OPENAI,
             "mode": mode,
             "risk_delta": risk_delta,
             "warnings": warnings,

--- a/veritas_os/core/types.py
+++ b/veritas_os/core/types.py
@@ -251,7 +251,7 @@ class ValueCoreResult(TypedDict, total=False):
 
 class DebateViewpoint(TypedDict, total=False):
     """Debateの視点"""
-    role: Literal["pro", "con", "third_party", "synthesizer"]
+    role: Literal["Architect", "Critic", "Safety", "Judge", "pro", "con", "third_party", "synthesizer"]
     argument: str
     evidence: List[str]
     confidence: float
@@ -261,7 +261,7 @@ class CritiquePoint(TypedDict, total=False):
     """批評ポイント"""
     category: str
     description: str
-    severity: Literal["low", "medium", "high"]
+    severity: Literal["low", "med", "medium", "high"]
     suggestion: str
 
 


### PR DESCRIPTION
### Motivation
- 型定義と実装の不整合（`CritiquePoint.severity`, `DebateViewpoint.role`）を解消して型安全性・保守性を向上するため。
- Debate の安全判定で正当な文脈（教育/対策/研究等）での false positive を減らしつつ、明示的な有害意図は引き続き強制ブロックするため。
- `safety_view` 内の否定表現（例: 「リスクなし」「問題なし」）でリスク加算が不当に増える問題を是正するため。
- 変更に伴う動作保証として単体テストと静的チェックを追加し、セキュリティリスク（benign 語混入による回避）を明示するため。\n
### Description
- `veritas_os/core/types.py`: `DebateViewpoint.role` を `"Architect","Critic","Safety","Judge",...` を含む Literal に拡張し、`CritiquePoint.severity` に `"med"` を追加して実装互換性を確保。 
- `veritas_os/core/debate.py`: `DEBATE_SOURCE_OPENAI` 定数を追加し、従来のハードコードされた `"openai_llm"` を置換した。 
- `veritas_os/core/debate.py`: `_BENIGN_CONTEXT_TERMS`, `_DANGEROUS_INTENT_PATTERNS`, `_RISK_NEGATION_TERMS` を導入し、`_contains_benign_context` と `_is_keyword_negated` ヘルパーを追加、`_looks_dangerous_text` を改良して防御的文脈を許容しつつ明示的有害意図は優先的に検出するようにした。 
- `veritas_os/core/debate.py`: `_calc_risk_delta` を修正して `safety_view` 中のリスクキーワードを加算する前に否定表現を検出して抑制するロジックを追加した。 
- テストとドキュメント: `tests/test_debate_safety_heuristics.py` を追加して安全ヒューリスティクスの振る舞いを検証し、`docs/notes/CRITIQUE_DEBATE_REVIEW.md` に実施ログとセキュリティ注意を追記した。\n
### Testing
- 実行したテスト: `PYTHONPATH=. pytest -q tests/test_debate_safety_heuristics.py` は `4 passed` で成功した。 
- 静的チェック: `ruff check veritas_os/core/debate.py veritas_os/core/types.py tests/test_debate_safety_heuristics.py` は問題なし（All checks passed）。 
- バイトコードチェック: `python -m compileall veritas_os/core/debate.py veritas_os/core/types.py tests/test_debate_safety_heuristics.py` は正常にコンパイルされた。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d34d5e7c088326bc9785c2f0a8dd5d)