### PR TITLE
Debate JSON救出ロジックの外出し・Critiqueのゼロ除算ガード・Pipeline doc追記

### DIFF
--- a/docs/notes/CRITIQUE_DEBATE_REVIEW.md
+++ b/docs/notes/CRITIQUE_DEBATE_REVIEW.md
@@ -126,8 +126,25 @@
    - risk negation の加算抑制
    - 実リスクでの加算維持
 
+6. **[中][完了] D-4 `_safe_json_extract_like` のネスト関数をモジュールレベルへ分離**
+   - `_truncate_string` / `_validate_option` / `_sanitize_options` / `_extract_objects_from_array` をトップレベル化。
+   - 目的: 単体テスト容易性と責務分離を改善し、JSON救出ロジックの追跡性を向上。
+
+7. **[中][完了] P-2 `_run_critique_best_effort` の async 意図を明文化**
+   - 現在は同期処理中心であること、将来の非同期 Critique 実装差し替えのために async 契約を維持していることを docstring に追記。
+
+8. **[中][完了] C-2 リスク/価値ゼロ除算回避ロジックの明確化**
+   - `risk * 100.0` を廃止し、`value_floor=0.01` を使う有界比率 (`risk / max(value, 0.01)`) に変更。
+   - マジックナンバーの意味を `value_floor` として `details` に露出し、監査性を向上。
+
+9. **[テスト追加][完了] JSON救出とリスク/価値比率の単体テスト追加**
+   - 破損JSONからの options 救出（不正scoreの除外を含む）
+   - 深すぎるネストの除外
+   - value=0 時の有限比率保証
+
 ### セキュリティ注意（実装時点）
 
 - benign context の導入により false positive は低減される一方、**攻撃者が安全語を混ぜて回避を試みるリスク**がある。
 - そのため、明示的有害意図パターンは優先的に評価し、検出時は benign 判定より強くブロックする設計とした。
 - 追加で、将来的には FUJI 側の判定結果・ユーザー意図分類・監査ログ相関で多層化することを推奨。
+- JSON救出ロジックは防御的だが、**巨大入力によるCPU/メモリ負荷リスク**は依然として存在する。`MAX_OPTIONS_PAYLOAD_BYTES` / `MAX_JSON_NESTED_DEPTH` / tail-trim retry cap ログを継続監視すること。

--- a/tests/test_critique_risk_value_balance.py
+++ b/tests/test_critique_risk_value_balance.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for critique risk/value balance zero-division guard."""
+
+from __future__ import annotations
+
+from veritas_os.core import critique
+
+
+def test_analyze_handles_zero_value_without_infinite_ratio() -> None:
+    """When value=0, risk/value ratio should remain finite with floor value."""
+    option = {
+        "title": "high risk zero value",
+        "risk": 0.8,
+        "value": 0.0,
+        "complexity": 0.3,
+        "feasibility": 0.8,
+        "timeline": 7,
+    }
+    evidence = [{"source": "s1", "confidence": 0.9}]
+    ctx = {
+        "risk_value_ratio_threshold": 2.0,
+        "risk_threshold": 0.7,
+        "min_evidence": 1,
+    }
+
+    findings = critique.analyze(option, evidence, ctx)
+    rv_items = [item for item in findings if item.get("code") == "CRITIQUE_RISK_VALUE_IMBALANCE"]
+
+    assert rv_items
+    ratio = rv_items[0]["details"]["risk_value_ratio"]
+    assert ratio != float("inf")
+    assert ratio > 2.0
+    assert rv_items[0]["details"]["value_floor"] == 0.01

--- a/tests/test_debate_json_extract_helpers.py
+++ b/tests/test_debate_json_extract_helpers.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for module-level JSON extraction helpers in debate module."""
+
+from __future__ import annotations
+
+from veritas_os.core import debate
+
+
+def test_safe_json_extract_like_rescues_options_from_broken_json() -> None:
+    """Broken trailing JSON should still rescue complete option objects."""
+    raw = (
+        '{"options":[{"id":"o1","title":"A","score":0.7},{"id":"o2","title":"B","score":0.6}'
+        ',{"id":"o3","title":"C","score":"bad"}],"chosen_id":"o1"'
+    )
+
+    parsed = debate._safe_json_extract_like(raw)
+
+    assert isinstance(parsed, dict)
+    assert parsed.get("chosen_id") is None
+    options = parsed.get("options") or []
+    assert [opt.get("id") for opt in options] == ["o1", "o2"]
+
+
+def test_extract_objects_from_array_obeys_depth_limit() -> None:
+    """Overly-nested objects should be ignored by depth guard."""
+    nested = '{"a":{"b":{"c":{"d":1}}}}'
+    text = f'{{"options":[{nested}]}}'
+
+    objs = debate._extract_objects_from_array(text, "options", max_depth=2)
+
+    assert objs == []

--- a/veritas_os/core/critique.py
+++ b/veritas_os/core/critique.py
@@ -50,6 +50,7 @@ _SEVERITY_SCORE: Dict[str, int] = {
     "med": 1,
     "high": 2,
 }
+_RISK_VALUE_ZERO_GUARD = 0.01
 
 
 def _now_iso() -> str:
@@ -324,8 +325,8 @@ def analyze(
     # ==== 8. リスク・価値バランスチェック ====
     if isinstance(risk, (int, float)) and not isinstance(risk, bool) and isinstance(value, (int, float)) and not isinstance(value, bool):
         rv = float(value)
-        # Use bounded value instead of float("inf") to avoid infinity propagation
-        ratio = float(risk) / rv if rv > 0 else float(risk) * 100.0
+        # Zero-division guard: floor near-zero value to keep finite ratio.
+        ratio = float(risk) / max(rv, _RISK_VALUE_ZERO_GUARD)
         if ratio > risk_value_ratio_threshold and float(risk) > 0.6 and float(value) < 0.5:
             critiques.append(
                 _crit(
@@ -336,6 +337,7 @@ def analyze(
                         "value": float(value),
                         "risk_value_ratio": ratio,
                         "ratio_threshold": risk_value_ratio_threshold,
+                        "value_floor": _RISK_VALUE_ZERO_GUARD,
                     },
                     fix="価値向上（スコープ調整）かリスク低減策を講じるまで、実行を保留することを検討してください。",
                     code="CRITIQUE_RISK_VALUE_IMBALANCE",

--- a/veritas_os/core/debate.py
+++ b/veritas_os/core/debate.py
@@ -445,6 +445,173 @@ def _create_warning_message(chosen: Dict[str, Any], mode: str, all_rejected: boo
 # ============================
 
 
+def _truncate_string(value: Any, max_len: int = MAX_OPTION_STRING_LENGTH) -> Optional[str]:
+    """Safely truncate string values to prevent resource exhaustion."""
+    if value is None:
+        return None
+    if max_len <= 0:
+        max_len = MAX_OPTION_STRING_LENGTH
+    if not isinstance(value, str):
+        return str(value)[:max_len]
+    return value[:max_len]
+
+
+def _validate_option(opt: Any) -> bool:
+    """Validate that an option has expected structure and bounded field sizes."""
+    if not isinstance(opt, dict):
+        return False
+
+    for key in ("id", "title", "summary", "verdict"):
+        val = opt.get(key)
+        if val is not None and not isinstance(val, str):
+            return False
+        if isinstance(val, str) and len(val) > MAX_OPTION_STRING_LENGTH:
+            return False
+
+    for key in ("score", "score_raw"):
+        if key in opt:
+            try:
+                float(opt[key])
+            except (TypeError, ValueError):
+                return False
+    return True
+
+
+def _estimate_option_payload_size(opt: Dict[str, Any]) -> int:
+    """Estimate payload bytes for a single option."""
+    payload_chars = 0
+    for value in opt.values():
+        if value is None:
+            continue
+        if isinstance(value, str):
+            payload_chars += len(value)
+        else:
+            payload_chars += len(str(value))
+    return payload_chars
+
+
+def _sanitize_options(options: List[Any]) -> List[Dict[str, Any]]:
+    """Filter and sanitize options list to prevent malicious data."""
+    sanitized: List[Dict[str, Any]] = []
+    cumulative_payload_size = 0
+    for opt in options[:MAX_OPTIONS]:
+        if _validate_option(opt):
+            for key in (
+                "id",
+                "title",
+                "summary",
+                "verdict",
+                "safety_view",
+                "critic_view",
+                "architect_view",
+            ):
+                if key in opt and opt[key] is not None:
+                    opt[key] = _truncate_string(opt[key])
+
+            option_size = _estimate_option_payload_size(opt)
+            if cumulative_payload_size + option_size > MAX_OPTIONS_PAYLOAD_BYTES:
+                logger.warning(
+                    "DebateOS: Truncated options due to payload limit (%d bytes)",
+                    MAX_OPTIONS_PAYLOAD_BYTES,
+                )
+                break
+
+            cumulative_payload_size += option_size
+            sanitized.append(opt)
+        else:
+            logger.warning("DebateOS: Skipping invalid option structure: %r", type(opt))
+    if len(options) > MAX_OPTIONS:
+        logger.warning("DebateOS: Truncated options from %d to %d", len(options), MAX_OPTIONS)
+    return sanitized
+
+
+def _wrap_extracted_json(obj: Any) -> Dict[str, Any]:
+    """Normalize parsed JSON object into debate payload contract."""
+    if isinstance(obj, dict):
+        options = obj.get("options") or []
+        if not isinstance(options, list):
+            options = []
+        obj["options"] = _sanitize_options(options)
+        chosen_id = obj.get("chosen_id")
+        if isinstance(chosen_id, (str, type(None))):
+            obj["chosen_id"] = _truncate_string(chosen_id, 1000)
+        else:
+            obj["chosen_id"] = None
+        return obj
+    if isinstance(obj, list):
+        return {"options": _sanitize_options(obj), "chosen_id": None}
+    return {"options": [], "chosen_id": None}
+
+
+def _extract_objects_from_array(
+    text: str,
+    key: str,
+    max_objects: int = 50,
+    max_depth: int = MAX_JSON_NESTED_DEPTH,
+) -> List[Dict[str, Any]]:
+    """Extract complete JSON objects from array in broken JSON text."""
+    idx = text.find(f'"{key}"')
+    if idx == -1:
+        return []
+    idx = text.find("[", idx)
+    if idx == -1:
+        return []
+
+    i = idx + 1
+    n = len(text)
+    in_str = False
+    esc = False
+    depth = 0
+    buf_start: Optional[int] = None
+    objs: List[Dict[str, Any]] = []
+
+    while i < n:
+        ch = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+        else:
+            if ch == '"':
+                in_str = True
+            elif ch == "{":
+                if depth == 0:
+                    buf_start = i
+                depth += 1
+                if depth > max_depth:
+                    logger.warning(
+                        "DebateOS: options JSON nesting depth exceeded limit (%d)",
+                        max_depth,
+                    )
+                    break
+            elif ch == "}":
+                if depth > 0:
+                    depth -= 1
+                if depth == 0 and buf_start is not None:
+                    s = text[buf_start : i + 1]
+                    nesting = s.count("{") + s.count("[")
+                    if nesting > max_depth:
+                        logger.warning(
+                            "DebateOS: object cumulative nesting complexity %d exceeds limit %d, skipping",
+                            nesting, max_depth,
+                        )
+                    else:
+                        try:
+                            objs.append(json.loads(s))
+                        except Exception as e:
+                            logger.debug("DebateOS: skipping unparseable JSON object: %s", e)
+                    buf_start = None
+                    if len(objs) >= max_objects:
+                        break
+            elif ch == "]":
+                break
+        i += 1
+    return objs
+
+
 def _safe_json_extract_like(raw: str) -> Dict[str, Any]:
     """
     planner._safe_json_extract と同格の“救出力”を持つ版。
@@ -465,109 +632,15 @@ def _safe_json_extract_like(raw: str) -> Dict[str, Any]:
         if cleaned.endswith("```"):
             cleaned = cleaned[:-3].strip()
 
-    def _truncate_string(value: Any, max_len: int = MAX_OPTION_STRING_LENGTH) -> Optional[str]:
-        """Safely truncate string values to prevent resource exhaustion.
-
-        If *max_len* is non-positive, falls back to
-        ``MAX_OPTION_STRING_LENGTH``.
-        """
-        if value is None:
-            return None
-        if max_len <= 0:
-            max_len = MAX_OPTION_STRING_LENGTH
-        if not isinstance(value, str):
-            return str(value)[:max_len]
-        return value[:max_len]
-
-    def _validate_option(opt: Any) -> bool:
-        """Validate that an option has expected structure."""
-        if not isinstance(opt, dict):
-            return False
-        # Options must have valid types for key fields if present
-        for key in ("id", "title", "summary", "verdict"):
-            val = opt.get(key)
-            if val is not None and not isinstance(val, str):
-                return False
-            # Check string length limits
-            if isinstance(val, str) and len(val) > MAX_OPTION_STRING_LENGTH:
-                return False
-        for key in ("score", "score_raw"):
-            if key in opt:
-                try:
-                    float(opt[key])
-                except (TypeError, ValueError):
-                    return False
-        return True
-
-    def _estimate_option_payload_size(opt: Dict[str, Any]) -> int:
-        """Estimate payload bytes for a single option.
-
-        The estimate only counts values to bound resource usage and avoid
-        constructing a massive intermediate JSON string.
-        """
-        payload_chars = 0
-        for value in opt.values():
-            if value is None:
-                continue
-            if isinstance(value, str):
-                payload_chars += len(value)
-            else:
-                payload_chars += len(str(value))
-        return payload_chars
-
-    def _sanitize_options(options: List[Any]) -> List[Dict[str, Any]]:
-        """Filter and sanitize options list to prevent malicious data.
-
-        A hard upper bound is applied to the cumulative option payload so a
-        single debate response cannot consume excessive memory.
-        """
-        sanitized = []
-        cumulative_payload_size = 0
-        for opt in options[:MAX_OPTIONS]:  # Limit number of options
-            if _validate_option(opt):
-                # Truncate string fields for safety
-                for key in ("id", "title", "summary", "verdict", "safety_view", "critic_view", "architect_view"):
-                    if key in opt and opt[key] is not None:
-                        opt[key] = _truncate_string(opt[key])
-
-                option_size = _estimate_option_payload_size(opt)
-                if cumulative_payload_size + option_size > MAX_OPTIONS_PAYLOAD_BYTES:
-                    logger.warning(
-                        "DebateOS: Truncated options due to payload limit (%d bytes)",
-                        MAX_OPTIONS_PAYLOAD_BYTES,
-                    )
-                    break
-
-                cumulative_payload_size += option_size
-                sanitized.append(opt)
-            else:
-                logger.warning("DebateOS: Skipping invalid option structure: %r", type(opt))
-        if len(options) > MAX_OPTIONS:
-            logger.warning("DebateOS: Truncated options from %d to %d", len(options), MAX_OPTIONS)
-        return sanitized
-
-    def _wrap(obj: Any) -> Dict[str, Any]:
-        if isinstance(obj, dict):
-            options = obj.get("options") or []
-            if not isinstance(options, list):
-                options = []
-            obj["options"] = _sanitize_options(options)
-            chosen_id = obj.get("chosen_id")
-            obj["chosen_id"] = _truncate_string(chosen_id, 1000) if isinstance(chosen_id, (str, type(None))) else None
-            return obj
-        if isinstance(obj, list):
-            return {"options": _sanitize_options(obj), "chosen_id": None}
-        return {"options": [], "chosen_id": None}
-
     try:
-        return _wrap(json.loads(cleaned))
+        return _wrap_extracted_json(json.loads(cleaned))
     except Exception:
         logger.debug("_safe_json_extract_like: direct JSON parse failed")
 
     try:
         start = cleaned.index("{")
         end = cleaned.rindex("}") + 1
-        return _wrap(json.loads(cleaned[start:end]))
+        return _wrap_extracted_json(json.loads(cleaned[start:end]))
     except Exception:
         logger.debug("_safe_json_extract_like: brace-delimited JSON parse failed")
 
@@ -575,84 +648,17 @@ def _safe_json_extract_like(raw: str) -> Dict[str, Any]:
     attempts = 0
     for cut in range(len(cleaned), 1, -1):
         if attempts >= 50:
+            logger.warning("DebateOS: tail-trim parse reached retry cap (%d)", attempts)
             break
         if cleaned[cut - 1] not in ("}", "]"):
             continue
         attempts += 1
         try:
-            return _wrap(json.loads(cleaned[:cut]))
+            return _wrap_extracted_json(json.loads(cleaned[:cut]))
         except Exception:
             continue
 
     # "options":[{...},{...}] から完成objだけ拾う（最後の保険）
-    def _extract_objects_from_array(
-        text: str,
-        key: str,
-        max_objects: int = 50,
-        max_depth: int = MAX_JSON_NESTED_DEPTH,
-    ) -> List[Dict[str, Any]]:
-        idx = text.find(f'"{key}"')
-        if idx == -1:
-            return []
-        idx = text.find("[", idx)
-        if idx == -1:
-            return []
-
-        i = idx + 1
-        n = len(text)
-        in_str = False
-        esc = False
-        depth = 0
-        buf_start: Optional[int] = None
-        objs: List[Dict[str, Any]] = []
-
-        while i < n:
-            ch = text[i]
-            if in_str:
-                if esc:
-                    esc = False
-                elif ch == "\\":
-                    esc = True
-                elif ch == '"':
-                    in_str = False
-            else:
-                if ch == '"':
-                    in_str = True
-                elif ch == "{":
-                    if depth == 0:
-                        buf_start = i
-                    depth += 1
-                    if depth > max_depth:
-                        logger.warning(
-                            "DebateOS: options JSON nesting depth exceeded limit (%d)",
-                            max_depth,
-                        )
-                        break
-                elif ch == "}":
-                    if depth > 0:
-                        depth -= 1
-                    if depth == 0 and buf_start is not None:
-                        s = text[buf_start : i + 1]
-                        # 累積複雑度チェック: ネスト構造文字数が過大ならスキップ（DoS軽減）
-                        _nesting = s.count("{") + s.count("[")
-                        if _nesting > max_depth:
-                            logger.warning(
-                                "DebateOS: object cumulative nesting complexity %d exceeds limit %d, skipping",
-                                _nesting, max_depth,
-                            )
-                        else:
-                            try:
-                                objs.append(json.loads(s))
-                            except Exception as e:
-                                logger.debug("DebateOS: skipping unparseable JSON object: %s", e)
-                        buf_start = None
-                        if len(objs) >= max_objects:
-                            break
-                elif ch == "]":
-                    break
-            i += 1
-        return objs
-
     rescued = _extract_objects_from_array(cleaned, "options")
     if rescued:
         return {"options": _sanitize_options(rescued), "chosen_id": None}

--- a/veritas_os/core/pipeline/pipeline_critique.py
+++ b/veritas_os/core/pipeline/pipeline_critique.py
@@ -383,6 +383,8 @@ async def _run_critique_best_effort(
     例外は出さない。findings >= min_findings の dict を返す。
 
     NOTE: analyze() が list を返してもここで dict に正規化する。
+    NOTE: 現状は同期呼び出しのみだが、将来の非同期 Critique 実装
+    （例: LLM ベース批評）を差し替え可能にするため async 契約を維持する。
     """
     crit_mod = _lazy_import("veritas_os.core.critique", None)
     if crit_mod is None:


### PR DESCRIPTION
### Motivation
- CRITIQUE/DEBATE レビューで指摘された中優先項目（D-4, C-2, P-2）に従い、安全性・テスト可能性・透明性を向上させるために実装を行った。 
- 破損JSONの救出ロジックをテストしやすくし、巨大/悪意ある入力によるリソース負荷の観測性を高める狙いがある。 
- リスク/価値比のゼロ除算に起因する不安定な挙動を防ぎ、値の意味を明示して監査性を高める必要があった。 

### Description
- `veritas_os/core/debate.py` の `_safe_json_extract_like` 内でネストしていたヘルパーをモジュールレベルへ移設し、`_truncate_string`, `_validate_option`, `_estimate_option_payload_size`, `_sanitize_options`, `_wrap_extracted_json`, `_extract_objects_from_array` を追加して責務を分離した。 
- 同ファイルで tail-trim ループの上限到達時に警告ログを出すようにし、`chosen_id` の安全な取り扱いとオプションサニタイズ（文字列切り詰め/ペイロード上限）を導入した。 
- `veritas_os/core/critique.py` に `_RISK_VALUE_ZERO_GUARD = 0.01` を追加し、従来のマジック処理を `ratio = risk / max(value, value_floor)` に置換してゼロ除算を防ぎ、該当する `details[

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d35393cfd08326b580e921182caad6)