### PR TITLE
Refine critique severity mapping and pipeline finding normalization

### DIFF
--- a/docs/notes/CRITIQUE_DEBATE_REVIEW.md
+++ b/docs/notes/CRITIQUE_DEBATE_REVIEW.md
@@ -142,6 +142,19 @@
    - 深すぎるネストの除外
    - value=0 時の有限比率保証
 
+10. **[中][完了] P-1 `_pad_findings` の二重正規化を単一パス化**
+   - `pipeline_critique.py` に `_normalize_finding_item()` を追加し、1件ごとの正規化責務を分離。
+   - `_pad_findings()` は `list/dict/other` それぞれで同ヘルパーを再利用し、再走査なしで `min_items` パディングまで完了する構成へ変更。
+   - 期待効果: 可読性・テスト容易性の向上、不要な2回目走査の削減。
+
+11. **[低][完了] C-1 severity マッピングの共通化**
+   - `critique.py` に `_SEVERITY_ALIASES` を追加し、`_norm_severity` と `_severity_rank` で同一テーブルを利用。
+   - これにより `"medium"`/`"critical"` など同義語追加時のメンテナンスポイントを1箇所へ集約。
+
+12. **[テスト追加][完了] Pipeline Critique 正規化の単体テスト追加**
+   - `_normalize_finding_item()` の alias 入力（`issue`/raw `details`/非文字 `fix`）の正規化を検証。
+   - `_pad_findings()` が入力項目とデフォルト項目の双方で canonical schema を維持することを検証。
+
 ### セキュリティ注意（実装時点）
 
 - benign context の導入により false positive は低減される一方、**攻撃者が安全語を混ぜて回避を試みるリスク**がある。

--- a/tests/test_pipeline_critique_pad_findings_single_pass.py
+++ b/tests/test_pipeline_critique_pad_findings_single_pass.py
@@ -1,0 +1,33 @@
+"""Unit tests for finding normalization/padding in pipeline_critique."""
+
+from veritas_os.core.pipeline.pipeline_critique import (
+    _normalize_finding_item,
+    _pad_findings,
+)
+
+
+def test_normalize_finding_item_converts_alias_fields() -> None:
+    """`issue` and raw `details` should be converted into canonical finding shape."""
+    finding = _normalize_finding_item(
+        {
+            "severity": "high",
+            "issue": "raw issue",
+            "details": "text-details",
+            "fix": 123,
+        }
+    )
+    assert finding["severity"] == "high"
+    assert finding["message"] == "raw issue"
+    assert finding["code"] == "CRITIQUE_GENERIC"
+    assert finding["details"] == {"raw": "text-details"}
+    assert finding["fix"] == "123"
+
+
+def test_pad_findings_keeps_schema_for_defaults_and_input_items() -> None:
+    """Padding should preserve canonical fields for both input and default items."""
+    findings = _pad_findings([{"message": "hello"}], min_items=3)
+    assert len(findings) == 3
+    for item in findings:
+        assert item["severity"] in {"low", "med", "high"}
+        assert isinstance(item["message"], str) and item["message"]
+        assert isinstance(item["code"], str) and item["code"]

--- a/veritas_os/core/critique.py
+++ b/veritas_os/core/critique.py
@@ -50,6 +50,17 @@ _SEVERITY_SCORE: Dict[str, int] = {
     "med": 1,
     "high": 2,
 }
+_SEVERITY_ALIASES: Dict[str, Severity] = {
+    "high": "high",
+    "h": "high",
+    "critical": "high",
+    "crit": "high",
+    "med": "med",
+    "m": "med",
+    "medium": "med",
+    "low": "low",
+    "l": "low",
+}
 _RISK_VALUE_ZERO_GUARD = 0.01
 
 
@@ -67,11 +78,7 @@ def _norm_severity(x: Any) -> Severity:
         s = str(x).lower().strip()
     except (TypeError, ValueError):
         return "med"
-    if s in ("high", "h", "critical", "crit"):
-        return "high"
-    if s in ("low", "l"):
-        return "low"
-    return "med"
+    return _SEVERITY_ALIASES.get(s, "med")
 
 
 def _severity_rank(x: Any, *, unknown_rank: int = 0) -> int:
@@ -86,13 +93,9 @@ def _severity_rank(x: Any, *, unknown_rank: int = 0) -> int:
         s = str(x).lower().strip()
     except (TypeError, ValueError):
         return int(unknown_rank)
-
-    if s in ("high", "h", "critical", "crit"):
-        return _SEVERITY_SCORE["high"]
-    if s in ("med", "m", "medium"):
-        return _SEVERITY_SCORE["med"]
-    if s in ("low", "l"):
-        return _SEVERITY_SCORE["low"]
+    normalized = _SEVERITY_ALIASES.get(s)
+    if normalized in _SEVERITY_SCORE:
+        return _SEVERITY_SCORE[normalized]
     # unknown => 0 扱い（=全件通る）などに使う
     return int(unknown_rank)
 

--- a/veritas_os/core/pipeline/pipeline_critique.py
+++ b/veritas_os/core/pipeline/pipeline_critique.py
@@ -60,87 +60,59 @@ def _default_findings() -> List[Dict[str, Any]]:
 # findings パディング（正規化 + min_items 保証）
 # =========================================================
 
+def _normalize_finding_item(item: Any) -> Dict[str, Any]:
+    """Normalize a single finding-like payload into the canonical dict shape."""
+    if isinstance(item, dict):
+        normalized = dict(item)
+        normalized["severity"] = _norm_severity(normalized.get("severity", "med"))
+        normalized["message"] = _as_str(
+            normalized.get("message")
+            or normalized.get("issue")
+            or normalized.get("msg")
+            or "Critique finding",
+            limit=1000,
+        )
+        normalized["code"] = _as_str(
+            normalized.get("code") or "CRITIQUE_GENERIC",
+            limit=120,
+        )
+        if "details" in normalized and not isinstance(normalized.get("details"), dict):
+            normalized["details"] = {"raw": _as_str(normalized.get("details"), limit=500)}
+        if "fix" in normalized and normalized.get("fix") is not None:
+            normalized["fix"] = _as_str(normalized.get("fix"), limit=1000)
+        return normalized
+
+    return {
+        "severity": "med",
+        "message": _as_str(item, limit=500),
+        "code": "CRITIQUE_TEXT",
+    }
+
+
 def _pad_findings(findings: Any, *, min_items: int = 3) -> List[Dict[str, Any]]:
-    """findings を List[Dict] に正規化し、min_items 件まで不足分をパッドする。"""
+    """findings を List[Dict] に正規化し、min_items 件まで不足分をパッドする。
+
+    実装上は「単一アイテム正規化 -> 不足分パッド」の1パスで整形し、
+    二重走査を避けて CPU 負荷を抑える。
+    """
     out: List[Dict[str, Any]] = []
 
     if isinstance(findings, list):
         for it in findings:
-            if isinstance(it, dict):
-                it2 = dict(it)
-                it2["severity"] = _norm_severity(it2.get("severity", "med"))
-                it2.setdefault(
-                    "message",
-                    it2.get("message")
-                    or it2.get("issue")
-                    or it2.get("msg")
-                    or "Critique finding",
-                )
-                it2.setdefault("code", it2.get("code") or "CRITIQUE_GENERIC")
-                if "details" in it2 and not isinstance(it2.get("details"), dict):
-                    it2["details"] = {"raw": _as_str(it2.get("details"), limit=500)}
-                if "fix" in it2 and it2.get("fix") is not None:
-                    it2["fix"] = _as_str(it2.get("fix"), limit=1000)
-                out.append(it2)
-            else:
-                out.append(
-                    {
-                        "severity": "med",
-                        "message": _as_str(it, limit=500),
-                        "code": "CRITIQUE_TEXT",
-                    }
-                )
+            out.append(_normalize_finding_item(it))
 
     elif isinstance(findings, dict):
-        it2 = dict(findings)
-        it2["severity"] = _norm_severity(it2.get("severity", "med"))
-        it2.setdefault(
-            "message",
-            it2.get("message") or it2.get("issue") or it2.get("msg") or "Critique finding",
-        )
-        it2.setdefault("code", it2.get("code") or "CRITIQUE_GENERIC")
-        if "details" in it2 and not isinstance(it2.get("details"), dict):
-            it2["details"] = {"raw": _as_str(it2.get("details"), limit=500)}
-        if "fix" in it2 and it2.get("fix") is not None:
-            it2["fix"] = _as_str(it2.get("fix"), limit=1000)
-        out = [it2]
+        out = [_normalize_finding_item(findings)]
 
     elif findings is not None:
-        out = [
-            {
-                "severity": "med",
-                "message": _as_str(findings, limit=500),
-                "code": "CRITIQUE_TEXT",
-            }
-        ]
+        out = [_normalize_finding_item(findings)]
 
     defaults = _default_findings()
     i = 0
     while len(out) < int(min_items):
-        out.append(dict(defaults[i % len(defaults)]))
+        out.append(_normalize_finding_item(defaults[i % len(defaults)]))
         i += 1
-
-    # 最終固定（必須キー保証）
-    fixed: List[Dict[str, Any]] = []
-    for it in out:
-        if not isinstance(it, dict):
-            fixed.append(
-                {
-                    "severity": "med",
-                    "message": _as_str(it, limit=500),
-                    "code": "CRITIQUE_TEXT",
-                }
-            )
-            continue
-        it2 = dict(it)
-        it2["severity"] = _norm_severity(it2.get("severity", "med"))
-        it2["message"] = _as_str(it2.get("message") or "Critique finding", limit=1000)
-        it2["code"] = _as_str(it2.get("code") or "CRITIQUE_GENERIC", limit=120)
-        if "details" in it2 and not isinstance(it2.get("details"), dict):
-            it2["details"] = {"raw": _as_str(it2.get("details"), limit=500)}
-        fixed.append(it2)
-
-    return fixed
+    return out
 
 
 # =========================================================
@@ -426,6 +398,7 @@ async def _run_critique_best_effort(
 
 __all__ = [
     "_default_findings",
+    "_normalize_finding_item",
     "_pad_findings",
     "_critique_fallback",
     "_list_to_findings",


### PR DESCRIPTION
### Motivation
- Reduce duplicated severity-mapping logic and make severity alias handling single-source-of-truth (addresses C-1 from the review). 
- Eliminate redundant two-pass normalization in pipeline critique to reduce CPU work and improve testability (addresses P-1). 
- Improve test coverage for the normalization/padding behavior and record the work in the review notes. 
- Keep changes limited to Critique / Debate / Pipeline responsibilities and avoid touching Planner / Kernel / Fuji / MemoryOS.

### Description
- Introduced `_SEVERITY_ALIASES` in `veritas_os/core/critique.py` and updated `_norm_severity` and `_severity_rank` to use this table for consistent alias handling of severity values.
- Added `_normalize_finding_item()` to `veritas_os/core/pipeline/pipeline_critique.py` to encapsulate single-item normalization into the canonical finding shape.
- Refactored `_pad_findings()` to use the new per-item normalizer and complete normalization + padding in a single pass, removing the previous double-traverse logic.
- Added unit tests `tests/test_pipeline_critique_pad_findings_single_pass.py` covering alias-field normalization and schema stability after padding.
- Updated `docs/notes/CRITIQUE_DEBATE_REVIEW.md` to record the completed actions (P-1 and C-1) and the new tests added.

### Testing
- Ran `pytest -q tests/test_pipeline_critique_pad_findings_single_pass.py tests/test_critique_risk_value_balance.py tests/test_debate_safety_heuristics.py tests/test_debate_json_extract_helpers.py` and observed an initial collection error without `PYTHONPATH` due to test import path resolution (`ModuleNotFoundError`).
- Re-ran with `PYTHONPATH=. pytest -q tests/test_pipeline_critique_pad_findings_single_pass.py tests/test_critique_risk_value_balance.py tests/test_debate_safety_heuristics.py tests/test_debate_json_extract_helpers.py` and all tests passed (`9 passed`).

Security note: the changes are normalization/refactor-only and do not expand external I/O or privileges; nevertheless the existing warnings about CPU/memory risk on very large or malicious payloads remain relevant and should continue to be monitored (limits such as `MAX_OPTIONS_PAYLOAD_BYTES` and `MAX_JSON_NESTED_DEPTH` are still relied upon).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3560d22ac8326a18f648584f8f33b)