### PR TITLE
Harden Debate safety heuristics against benign-word bypass

### DIFF
--- a/docs/notes/CRITIQUE_DEBATE_REVIEW.md
+++ b/docs/notes/CRITIQUE_DEBATE_REVIEW.md
@@ -155,9 +155,15 @@
    - `_normalize_finding_item()` の alias 入力（`issue`/raw `details`/非文字 `fix`）の正規化を検証。
    - `_pad_findings()` が入力項目とデフォルト項目の双方で canonical schema を維持することを検証。
 
+13. **[高][完了] D-1 追加強化: benign 語の混入による回避耐性を向上**
+   - `_looks_dangerous_text()` に actionable intent パターン（`deploy/distribute/execute/weaponize`、`実行/配布/悪用` など）を追加。
+   - これにより `training/教育` など benign context が共存しても、攻撃実行意図を含むテキストはブロック継続。
+   - 単体テストを追加し、`"教育目的"` と `"malware deploy"` の同居ケースを危険判定することを確認。
+
 ### セキュリティ注意（実装時点）
 
 - benign context の導入により false positive は低減される一方、**攻撃者が安全語を混ぜて回避を試みるリスク**がある。
 - そのため、明示的有害意図パターンは優先的に評価し、検出時は benign 判定より強くブロックする設計とした。
+- さらに actionable intent（実行/配布/悪用、deploy/distribute など）を危険意図として上位評価し、**安全語付きプロンプトでのすり抜け耐性**を補強した。
 - 追加で、将来的には FUJI 側の判定結果・ユーザー意図分類・監査ログ相関で多層化することを推奨。
 - JSON救出ロジックは防御的だが、**巨大入力によるCPU/メモリ負荷リスク**は依然として存在する。`MAX_OPTIONS_PAYLOAD_BYTES` / `MAX_JSON_NESTED_DEPTH` / tail-trim retry cap ログを継続監視すること。

--- a/tests/test_debate_safety_heuristics.py
+++ b/tests/test_debate_safety_heuristics.py
@@ -28,6 +28,15 @@ def test_looks_dangerous_text_blocks_explicit_harmful_intent() -> None:
     assert debate._looks_dangerous_text(option) is True
 
 
+def test_looks_dangerous_text_blocks_actionable_harm_even_with_safe_words() -> None:
+    option = {
+        "title": "セキュリティ訓練",
+        "description": "教育目的だが malware を deploy する手順を説明する",
+    }
+
+    assert debate._looks_dangerous_text(option) is True
+
+
 def test_calc_risk_delta_ignores_negated_risk_phrases() -> None:
     """Negated safety phrases should avoid risk keyword inflation."""
     chosen = {

--- a/veritas_os/core/debate.py
+++ b/veritas_os/core/debate.py
@@ -89,6 +89,13 @@ _DANGEROUS_INTENT_PATTERNS = [
     re.compile(r"\b(?:how to make|how to build|steps? to|guide to)\b.{0,24}\b(?:bomb|malware|virus|drugs?|hack(?:ing)?)\b", re.IGNORECASE),
 ]
 
+_ACTIONABLE_INTENT_PATTERNS = [
+    re.compile(r"(?:実行|実施|導入|配布|拡散|悪用).{0,8}(?:ハッキング|ウイルス|爆弾|麻薬|侵入)", re.IGNORECASE),
+    re.compile(r"(?:ハッキング|ウイルス|爆弾|麻薬|侵入).{0,8}(?:実行|実施|導入|配布|拡散|悪用)", re.IGNORECASE),
+    re.compile(r"\b(?:deploy|distribute|execute|weaponize|abuse)\b.{0,24}\b(?:malware|virus|bomb|drugs?|hack(?:ing)?)\b", re.IGNORECASE),
+    re.compile(r"\b(?:malware|virus|bomb|drugs?|hack(?:ing)?)\b.{0,24}\b(?:deploy|distribute|execute|weaponize|abuse)\b", re.IGNORECASE),
+]
+
 _RISK_NEGATION_TERMS = (
     "問題なし",
     "問題はない",
@@ -270,6 +277,9 @@ def _looks_dangerous_text(opt: Dict[str, Any]) -> bool:
         return False
 
     if any(pattern.search(normalized) for pattern in _DANGEROUS_INTENT_PATTERNS):
+        return True
+
+    if any(pattern.search(normalized) for pattern in _ACTIONABLE_INTENT_PATTERNS):
         return True
 
     if _contains_benign_context(normalized):


### PR DESCRIPTION
### Motivation
- Reduce false negatives where benign/educational words (e.g., "training", "education") are mixed with actionable harmful intent and incorrectly allowed. 
- Improve safety by making explicit actionable-intent patterns (deploy/distribute/execute/weaponize and Japanese equivalents) take precedence over benign-context heuristics. 

### Description
- Add `_ACTIONABLE_INTENT_PATTERNS` to `veritas_os/core/debate.py` and check these patterns in `_looks_dangerous_text()` so actionable harm triggers a block even when benign terms co-occur. 
- Add a regression test `test_looks_dangerous_text_blocks_actionable_harm_even_with_safe_words` in `tests/test_debate_safety_heuristics.py` to cover mixed benign + actionable harm cases. 
- Update `docs/notes/CRITIQUE_DEBATE_REVIEW.md` to record the change in the implementation log and note the strengthened bypass resistance in security notes. 

### Testing
- Running `pytest -q tests/test_debate_safety_heuristics.py` without `PYTHONPATH` initially failed during collection due to import path setup, which is an environment issue and not a code regression. 
- Running `PYTHONPATH=. pytest -q tests/test_debate_safety_heuristics.py` executed the suite and completed successfully with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d358ef61c48326b78f98d673b2a267)