### PR TITLE
critique: annotate recycled padding items for auditability

### DIFF
--- a/docs/notes/CRITIQUE_DEBATE_REVIEW.md
+++ b/docs/notes/CRITIQUE_DEBATE_REVIEW.md
@@ -166,6 +166,11 @@
    - 既存の否定語判定（`no risk`, `safe` など）との併用を維持しつつ、不要なリスク加算を低減。
    - 単体テストを追加し、`"Bank transfer ... No risk"` 文脈で負方向（安全寄り）デルタを維持することを確認。
 
+15. **[低][完了] C-3 追加強化: `ensure_min_items` の重複パディング意図を監査可能化**
+   - `min_items > len(_DEFAULT_PAD_CRITIQUES)` の場合にテンプレート循環再利用される仕様を docstring に明記。
+   - 再利用パディング項目には `details.pad_reused=True` と `details.pad_cycle_index` を付与し、監査ログ上で「重複由来」を判別可能にした。
+   - 単体テストを追加し、4件目以降のパディング項目に再利用メタデータが入ることを検証。
+
 ### セキュリティ注意（実装時点）
 
 - benign context の導入により false positive は低減される一方、**攻撃者が安全語を混ぜて回避を試みるリスク**がある。

--- a/tests/test_critique_ensure_min_items_padding.py
+++ b/tests/test_critique_ensure_min_items_padding.py
@@ -1,0 +1,16 @@
+from veritas_os.core.critique import ensure_min_items
+
+
+def test_ensure_min_items_marks_reused_padding_entries() -> None:
+    """min_items がテンプレート件数を超える場合の再利用情報を検証する。"""
+    padded = ensure_min_items([], min_items=5)
+
+    assert len(padded) == 5
+    assert padded[0]["details"].get("pad_reused") is None
+    assert padded[1]["details"].get("pad_reused") is None
+    assert padded[2]["details"].get("pad_reused") is None
+
+    assert padded[3]["details"]["pad_reused"] is True
+    assert padded[3]["details"]["pad_cycle_index"] == 3
+    assert padded[4]["details"]["pad_reused"] is True
+    assert padded[4]["details"]["pad_cycle_index"] == 4

--- a/veritas_os/core/critique.py
+++ b/veritas_os/core/critique.py
@@ -453,6 +453,12 @@ def ensure_min_items(
     """
     監査/UI都合で Critique を最低件数までパッドする。
     analyze() の意味（問題が無ければ空）を壊さないため、別関数で提供する。
+
+    Notes:
+        `_DEFAULT_PAD_CRITIQUES` は固定テンプレートのため、`min_items` が
+        テンプレート件数を上回る場合は循環して再利用される。
+        監査時の判別性を高めるため、再利用された項目には
+        `details["pad_reused"] = True` と `details["pad_cycle_index"]` を付与する。
     """
     _ = context or {}
     try:
@@ -463,12 +469,17 @@ def ensure_min_items(
     out = list(critiques or [])
     i = 0
     while len(out) < int(min_items):
-        template = _DEFAULT_PAD_CRITIQUES[i % len(_DEFAULT_PAD_CRITIQUES)]
+        template_index = i % len(_DEFAULT_PAD_CRITIQUES)
+        template = _DEFAULT_PAD_CRITIQUES[template_index]
+        details = dict(template["details"])
+        if i >= len(_DEFAULT_PAD_CRITIQUES):
+            details["pad_reused"] = True
+            details["pad_cycle_index"] = i
         out.append(
             _crit(
                 issue=str(template["issue"]),
                 severity=_norm_severity(template["severity"]),
-                details=dict(template["details"]),
+                details=details,
                 fix=str(template["fix"]),
                 code=str(template["code"]),
             )


### PR DESCRIPTION
### Motivation
- 明示的なパディング重複の仕様化により、`ensure_min_items` がテンプレート循環で項目を再利用する場合に「実データ由来」か「パッド由来」かを監査できるようにするため。 
- 変更は監査性向上が目的であり、危険判定ロジックや Planner/Kernel/Fuji/MemoryOS の責務には触れていない。 
- セキュリティ留意点として、今回の変更はメタデータ追加のみで安全判定を緩めず、既存の大入力や回避表現リスクは継続監視が必要である。

### Description
- `veritas_os/core/critique.py`: `ensure_min_items()` の docstring を拡張してテンプレート循環仕様を明記し、再利用されたパディング項目に `details["pad_reused"] = True` と `details["pad_cycle_index"] = <index>` を付与するよう実装を追加した。 
- テンプレートの `details` をコピーしてからメタデータを付与する方式にし、既存の `issue/severity/fix/code` 生成は変更していないため意味論的な動作は維持している。 
- `tests/test_critique_ensure_min_items_padding.py` を追加し、`min_items` がテンプレート件数を超えた際に 4 件目以降に再利用メタデータが入ることを検証する単体テストを実装した。 
- `docs/notes/CRITIQUE_DEBATE_REVIEW.md` を更新し、本改善（C-3 追補）を実施済み項目として記録した。

### Testing
- 単体テストを追加後、`PYTHONPATH=. pytest -q tests/test_critique_ensure_min_items_padding.py tests/test_critique_risk_value_balance.py tests/test_debate_safety_heuristics.py tests/test_pipeline_critique_pad_findings_single_pass.py` を実行し、全テストが成功して `10 passed` を確認した。 
- 追加テスト `test_ensure_min_items_marks_reused_padding_entries` により、再利用パディングのメタデータが期待どおり設定されることを検証した。 
- 変更は PEP8 準拠で docstring とテストを含めたため、可観測性・監査性の向上要件を満たしている。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36bb36b008326a7d30c49484f984d)