### PR TITLE
debate: improve tail-trim observability and add test

### DIFF
--- a/docs/notes/CRITIQUE_DEBATE_REVIEW.md
+++ b/docs/notes/CRITIQUE_DEBATE_REVIEW.md
@@ -176,6 +176,11 @@
    - `教育/研究/training` など benign context が同居していても、`「ハッキングの手順」「malware script/tutorial」` のような**実行可能性を高める説明**を含む場合は危険判定を優先。
    - 単体テストを追加し、`研究/教育` を含む文面でも「具体的手順+コード+危険語」の同居ケースがブロックされることを確認。
 
+17. **[低][完了] D-5 末尾削りループの監視ログを強化**
+   - `_safe_json_extract_like()` の tail-trim retry cap を `TAIL_TRIM_RETRY_CAP` 定数化し、運用調整時の可視性を改善。
+   - 打ち切り時ログに `attempts/cap/candidate_endings/payload_bytes` を追加し、巨大入力や異常フォーマット時の解析容易性を向上。
+   - 単体テストを追加し、retry cap 到達時に warning ログが出ることを検証。
+
 ### セキュリティ注意（実装時点）
 
 - benign context の導入により false positive は低減される一方、**攻撃者が安全語を混ぜて回避を試みるリスク**がある。

--- a/tests/test_debate_json_extract_helpers.py
+++ b/tests/test_debate_json_extract_helpers.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from veritas_os.core import debate
 
 
@@ -29,3 +31,15 @@ def test_extract_objects_from_array_obeys_depth_limit() -> None:
     objs = debate._extract_objects_from_array(text, "options", max_depth=2)
 
     assert objs == []
+
+
+def test_safe_json_extract_like_logs_tail_trim_retry_cap(caplog) -> None:
+    """Tail-trim retry cap should emit operational warning metrics."""
+    raw = "x" + ("}" * (debate.TAIL_TRIM_RETRY_CAP + 10))
+
+    with caplog.at_level(logging.WARNING):
+        parsed = debate._safe_json_extract_like(raw)
+
+    assert parsed == {"options": [], "chosen_id": None}
+    assert "tail-trim parse reached retry cap" in caplog.text
+    assert "payload_bytes=" in caplog.text

--- a/veritas_os/core/debate.py
+++ b/veritas_os/core/debate.py
@@ -176,6 +176,7 @@ MAX_OPTION_STRING_LENGTH = 10000
 MAX_OPTIONS = 100
 MAX_OPTIONS_PAYLOAD_BYTES = 1_000_000
 MAX_JSON_NESTED_DEPTH = 100
+TAIL_TRIM_RETRY_CAP = 50
 
 
 # ============================
@@ -695,12 +696,21 @@ def _safe_json_extract_like(raw: str) -> Dict[str, Any]:
 
     # 末尾削り（軽め）
     attempts = 0
+    candidate_endings = 0
     for cut in range(len(cleaned), 1, -1):
-        if attempts >= 50:
-            logger.warning("DebateOS: tail-trim parse reached retry cap (%d)", attempts)
+        if attempts >= TAIL_TRIM_RETRY_CAP:
+            logger.warning(
+                "DebateOS: tail-trim parse reached retry cap attempts=%d cap=%d "
+                "candidate_endings=%d payload_bytes=%d",
+                attempts,
+                TAIL_TRIM_RETRY_CAP,
+                candidate_endings,
+                len(cleaned.encode("utf-8")),
+            )
             break
         if cleaned[cut - 1] not in ("}", "]"):
             continue
+        candidate_endings += 1
         attempts += 1
         try:
             return _wrap_extracted_json(json.loads(cleaned[:cut]))


### PR DESCRIPTION
### Motivation
- Improve observability and remove a magic-number retry cap in the `_safe_json_extract_like` tail-trim loop to aid debugging of malformed/oversized Debate outputs.
- Provide richer operational context when the tail-trim retry cap is hit so that root-cause (huge payload vs many candidate endings) is easier to diagnose.
- Security note: the warning log now includes `payload_bytes`, so consumption and retention of these logs should be governed by appropriate access control and retention policy.

### Description
- Introduced `TAIL_TRIM_RETRY_CAP` constant in `veritas_os/core/debate.py` to replace the inline `50` retry cap used by `_safe_json_extract_like`.
- Added a `candidate_endings` counter and expanded the tail-trim warning to include `attempts`, `cap`, `candidate_endings`, and `payload_bytes` for better operational telemetry in `veritas_os/core/debate.py`.
- Added unit test `test_safe_json_extract_like_logs_tail_trim_retry_cap` to `tests/test_debate_json_extract_helpers.py` to assert that the retry-cap emits a warning and includes `payload_bytes` in the log.
- Updated `docs/notes/CRITIQUE_DEBATE_REVIEW.md` to record completion of the D-5 review item describing the change and the new test.

### Testing
- Running `pytest -q tests/test_debate_json_extract_helpers.py` initially failed due to test import path, then `PYTHONPATH=. pytest -q tests/test_debate_json_extract_helpers.py` succeeded with `3 passed`.
- The new test verifies the tail-trim retry-cap warning is emitted and contains the `payload_bytes` metric.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d376365f908326a87838ae9a74f3ba)