### PR TITLE
Fix Policy Pack review issues: outcome logic, regex cache, security warnings

### DIFF
--- a/veritas_os/policy/evaluator.py
+++ b/veritas_os/policy/evaluator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from datetime import date
+import functools
 import logging
 import math
 from typing import Any, Dict, Iterable, List
@@ -133,11 +134,17 @@ def _safe_regex_search(expected: Any, actual: Any) -> bool:
         return False
 
     try:
-        compiled = re.compile(expected)
+        compiled = _compile_regex_cached(expected)
     except re.error as exc:
         logger.warning("regex compilation failed for pattern %.50r: %s", expected, exc)
         return False
     return compiled.search(actual) is not None
+
+
+@functools.lru_cache(maxsize=256)
+def _compile_regex_cached(pattern: str) -> re.Pattern[str]:
+    """Compile and cache regex patterns to avoid repeated compilation."""
+    return re.compile(pattern)
 
 
 def _scope_matches(policy: RuntimePolicy, context: Dict[str, Any]) -> bool:
@@ -204,6 +211,7 @@ def _evaluate_requirements(policy: RuntimePolicy, context: Dict[str, Any]) -> Di
 
 def _choose_final_outcome(outcomes: Iterable[str]) -> str:
     selected = "allow"
+    # -1 ensures any valid outcome (min precedence is 0 for "allow") wins
     best_score = -1
     for outcome in outcomes:
         score = OUTCOME_PRECEDENCE.get(outcome)
@@ -221,11 +229,10 @@ def _choose_final_outcome(outcomes: Iterable[str]) -> str:
 
 def _is_effective(policy: RuntimePolicy, today: date) -> bool:
     """Return True when the policy's effective_date is today or in the past."""
-    effective = getattr(policy, "effective_date", None)
-    if not effective:
+    if not policy.effective_date:
         return True
     try:
-        return date.fromisoformat(effective) <= today
+        return date.fromisoformat(policy.effective_date) <= today
     except (ValueError, TypeError):
         return True
 
@@ -296,20 +303,21 @@ def evaluate_runtime_policies(
                 if outcome_reason
                 else policy.title
             )
-            outcomes.append(outcome)
             reasons.append(outcome_reason or policy.title)
             obligations.extend(policy.obligations)
             required_actions.extend(policy.obligations)
 
-        if triggered_policy and outcome == "allow":
-            if req_eval["missing_evidence"]:
-                outcome = "halt"
-                outcomes[-1] = outcome
-                reasons.append("missing required evidence")
-            elif req_eval["missing_reviewers"] or not req_eval["minimum_approval_met"]:
-                outcome = "require_human_review"
-                outcomes[-1] = outcome
-                reasons.append("required approvals are not satisfied")
+            # Escalate outcome when requirements are unmet (fail-closed).
+            # Evidence gaps escalate to "halt"; approval gaps to "require_human_review".
+            if outcome == "allow":
+                if req_eval["missing_evidence"]:
+                    outcome = "halt"
+                    reasons.append("missing required evidence")
+                elif req_eval["missing_reviewers"] or not req_eval["minimum_approval_met"]:
+                    outcome = "require_human_review"
+                    reasons.append("required approvals are not satisfied")
+
+            outcomes.append(outcome)
 
         approval_requirements.append(
             {

--- a/veritas_os/policy/generated_tests.py
+++ b/veritas_os/policy/generated_tests.py
@@ -71,11 +71,7 @@ def build_generated_test_cases(
 
         for vector in canonical_ir["test_vectors"]:
             merged_context = _deep_merge(base_context, dict(vector["input"]))
-            expected_outcome = getattr(
-                vector["expected_outcome"],
-                "value",
-                vector["expected_outcome"],
-            )
+            expected_outcome = vector["expected_outcome"]
             cases.append(
                 GeneratedPolicyTestCase(
                     policy_file=path.as_posix(),

--- a/veritas_os/policy/normalize.py
+++ b/veritas_os/policy/normalize.py
@@ -55,8 +55,15 @@ def to_canonical_ir(policy: SourcePolicy) -> CanonicalPolicyIR:
     policy_dict = policy.model_dump(mode="python")
     requirements = policy_dict["requirements"]
 
-    test_vectors = sorted(
-        policy_dict["test_vectors"],
+    test_vectors = []
+    for item in policy_dict["test_vectors"]:
+        raw_outcome = item["expected_outcome"]
+        outcome_str = raw_outcome.value if hasattr(raw_outcome, "value") else str(raw_outcome)
+        test_vectors.append({
+            **item,
+            "expected_outcome": outcome_str,
+        })
+    test_vectors.sort(
         key=lambda item: (
             item["name"],
             json.dumps(item["input"], sort_keys=True, separators=(",", ":")),

--- a/veritas_os/policy/runtime_adapter.py
+++ b/veritas_os/policy/runtime_adapter.py
@@ -217,13 +217,23 @@ def load_runtime_bundle(
     manifest = _read_json_file(root / "manifest.json")
     canonical_ir = _read_json_file(root / "compiled" / "canonical_ir.json")
 
+    signing_algorithm = manifest.get("signing", {}).get("algorithm", "sha256")
+    if signing_algorithm != "ed25519":
+        logger.warning(
+            "bundle %s loaded with SHA-256 integrity check only; "
+            "authenticity is NOT verified. Set VERITAS_POLICY_REQUIRE_ED25519=true "
+            "and provide an Ed25519 public key for production use.",
+            bundle_dir,
+        )
+
     runtime_policy = adapt_canonical_ir(canonical_ir)
 
     logger.info(
-        "bundle loaded: policy_id=%s version=%s hash=%s",
+        "bundle loaded: policy_id=%s version=%s hash=%s signing=%s",
         runtime_policy.policy_id,
         runtime_policy.version,
         manifest.get("semantic_hash", ""),
+        signing_algorithm,
     )
 
     return RuntimePolicyBundle(


### PR DESCRIPTION
- Fix evaluator outcome overwrite: replace fragile outcomes[-1] mutation
  with explicit append-after-escalation pattern to eliminate implicit
  coupling between outcome tracking and requirement escalation logic
- Add LRU cache for regex compilation in policy evaluation to avoid
  repeated re.compile() calls for the same pattern
- Add SHA-256 fallback security warning when loading bundles without
  Ed25519 verification, guiding operators toward production-safe config
- Normalize test vector expected_outcome from Enum to string in
  canonical IR, fixing the root cause instead of patching at read time
- Remove unnecessary getattr in _is_effective (field always exists)
- Document magic number in _choose_final_outcome

https://claude.ai/code/session_01KUFAACXGnSLnScNJBHjeoL