### PR TITLE
refactor: extract redact payload depth constant

### DIFF
--- a/REPOSITORY_REVIEW_2026-04-07.md
+++ b/REPOSITORY_REVIEW_2026-04-07.md
@@ -86,10 +86,10 @@
 - **Issue:** ファイル後方シーク用の `while True` ループが複雑で、保守性が低い。ロジック自体は正しいが、意図が不明確。
 - **Fix:** ループをヘルパーメソッドに抽出し、各分岐にコメント追加。
 
-### [LOW] P-5: Magic Number for Recursion Depth
+### ~~[LOW] P-5: Magic Number for Recursion Depth~~ **FIXED (2026-04-08)**
 - **File:** `veritas_os/core/utils.py:350`
 - **Issue:** `redact_payload()` の最大再帰深度 `50` がハードコードされている。
-- **Fix:** `MAX_REDACTION_DEPTH = 50` 定数に抽出。
+- **Fix:** ✅ `MAX_REDACTION_DEPTH = 50` を追加し、`redact_payload()` の深度判定で参照するよう変更。
 
 ---
 

--- a/veritas_os/core/utils.py
+++ b/veritas_os/core/utils.py
@@ -346,9 +346,12 @@ def _redact_text(text: str) -> str:
     return text
 
 
+MAX_REDACTION_DEPTH = 50
+
+
 def redact_payload(value: Any, *, _depth: int = 0) -> Any:
     """文字列中の PII を再帰的にマスクする（最大再帰深度: 50）"""
-    if _depth > 50:
+    if _depth > MAX_REDACTION_DEPTH:
         return value
     if isinstance(value, str):
         return _redact_text(value)


### PR DESCRIPTION
### Motivation
- Replace the hard-coded recursion guard in `redact_payload` to improve clarity and make future adjustments safer, and mark the corresponding review item P-5 as addressed in the repository review document.

### Description
- Introduced `MAX_REDACTION_DEPTH = 50` and updated `redact_payload` to check that constant, and updated `REPOSITORY_REVIEW_2026-04-07.md` to mark P-5 as **FIXED (2026-04-08)**.

### Testing
- Ran `pytest -q veritas_os/tests/test_utils_coverage.py -k redact_payload_depth_limit` which passed, and ran `ruff check veritas_os/core/utils.py` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d660e4ce608326a20e09fae1d05aec)