### PR TITLE
Add dependency manifest sync guard to CI and quality checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Review improvements consistency check
         run: python scripts/quality/check_review_improvements_consistency.py
 
+      - name: requirements.txt sync check
+        run: python scripts/quality/check_requirements_sync.py
+
       - name: Memory directory allowlist check
         env:
           VERITAS_ENV: "production"

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ quality-checks:
 	@python scripts/quality/check_operational_docs_consistency.py
 	@python scripts/quality/check_frontend_docs_consistency.py
 	@python scripts/quality/check_review_improvements_consistency.py
+	@python scripts/quality/check_requirements_sync.py
 	@python scripts/quality/check_frontend_api_contract_consistency.py
 	@python scripts/security/check_memory_dir_allowlist.py
 	@python scripts/security/check_httpx_raw_upload_usage.py

--- a/REPOSITORY_REVIEW_2026-04-07.md
+++ b/REPOSITORY_REVIEW_2026-04-07.md
@@ -162,10 +162,10 @@
 - **Issue:** Docker build-push-action にキャッシュ設定なし。毎ビルドで全レイヤーを再構築。
 - **Fix:** ✅ `cache-from: type=gha` / `cache-to: type=gha,mode=max` を追加。
 
-### [HIGH] T-5: requirements.txt / pyproject.toml Sync Not Validated
+### ~~[HIGH] T-5: requirements.txt / pyproject.toml Sync Not Validated~~ **FIXED (2026-04-08)**
 - **File:** `veritas_os/requirements.txt`, `pyproject.toml`
 - **Issue:** `requirements.txt` が `pyproject.toml[full]` と同期されていることを保証する自動チェックがない。バージョンドリフトのリスク。
-- **Fix:** CI に `pip-compile` ベースの同期チェックステップを追加。
+- **Fix:** ✅ `scripts/quality/check_requirements_sync.py` を追加し、`pyproject.toml` (`dependencies` + `optional-dependencies.full`) と `veritas_os/requirements.txt` の依存名ドリフトを CI / Makefile で自動検知。
 
 ### ~~[MEDIUM] T-6: Frontend Security Check Without Error Handling~~ **FIXED**
 - **File:** `.github/workflows/main.yml:287-293`
@@ -209,7 +209,7 @@
 5. ~~**S-4:** Chainlit 入力バリデーション追加~~ → ✅ **DONE**
 6. ~~**F-1:** SSE ストリームの `mounted` チェック強化~~ → **対応不要** (abort controller で十分)
 7. ~~**T-4:** Docker ビルドキャッシュ設定~~ → ✅ **DONE**
-8. ~~**T-5:** requirements.txt 同期チェック~~ → **対応不要** (CI/CD 追加改善、優先度低)
+8. ~~**T-5:** requirements.txt 同期チェック~~ → ✅ **DONE**
 
 ### Medium-term (1 month)
 9. ~~**S-3:** OpenAPI セキュリティ定義の網羅~~ → ✅ **DONE**
@@ -238,6 +238,7 @@
 | F-3 | HIGH | `useGovernanceState.ts` | catch ブロックに `console.error()` 追加 |
 | T-4 | HIGH | `publish-ghcr.yml` | Docker build に GHA キャッシュ設定追加 |
 | S-4 | HIGH | `chainlit_app.py` | 入力長制限 (10,000字) と制御文字除去を追加 |
+| T-5 | HIGH | `.github/workflows/main.yml`, `Makefile`, `scripts/quality/check_requirements_sync.py` | requirements と pyproject の依存名同期チェックを CI / ローカル品質ゲートへ追加 |
 | S-8 | MEDIUM | `chainlit_app.py` | エラーログからクエリ本文を除外 (PII 保護) |
 | S-5 | MEDIUM | `veritas_os/policy/evaluator.py` | `concurrent.futures.ThreadPoolExecutor` による regex 実行タイムアウト (1秒) 追加 |
 | P-3 | MEDIUM | `veritas_os/core/memory/memory_store.py` | `_normalize()` の例外が未処理で伝播する問題を修正。`except Exception` で捕捉しログ記録 |

--- a/scripts/quality/check_requirements_sync.py
+++ b/scripts/quality/check_requirements_sync.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Validate dependency name sync between pyproject extras and requirements.txt.
+
+This guard enforces that ``veritas_os/requirements.txt`` stays aligned with the
+packages resolved by ``pyproject.toml``'s core dependencies plus the ``full``
+extra closure. Version-pinning strategy can differ between files; this checker
+intentionally validates normalized package *names* to prevent silent drift.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+import tomllib
+from collections.abc import Mapping
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+REQUIREMENTS_PATH = REPO_ROOT / "veritas_os" / "requirements.txt"
+
+_SELF_PACKAGE = "veritas-os"
+_NAME_SPLIT_PATTERN = re.compile(r"[<>=!~;\s]")
+_NORMALIZE_PATTERN = re.compile(r"[-_.]+")
+
+
+def normalize_name(raw_name: str) -> str:
+    """Return a canonicalized dependency name suitable for set comparisons."""
+    return _NORMALIZE_PATTERN.sub("-", raw_name.strip().lower())
+
+
+def extract_dependency_name(spec: str) -> str:
+    """Extract package name from a dependency specification string."""
+    candidate = _NAME_SPLIT_PATTERN.split(spec.strip(), maxsplit=1)[0]
+    name_only = candidate.split("[", maxsplit=1)[0]
+    return normalize_name(name_only)
+
+
+def _expand_extra(
+    extra: str,
+    optional_deps: Mapping[str, list[str]],
+    visited: set[str],
+) -> set[str]:
+    """Recursively expand package names declared by an optional dependency extra."""
+    if extra in visited:
+        return set()
+
+    visited.add(extra)
+    expanded: set[str] = set()
+
+    for spec in optional_deps.get(extra, []):
+        dep_name = extract_dependency_name(spec)
+        if dep_name != _SELF_PACKAGE:
+            expanded.add(dep_name)
+            continue
+
+        nested_match = re.search(r"\[(.+?)\]", spec)
+        if not nested_match:
+            continue
+        nested_extras = [token.strip() for token in nested_match.group(1).split(",")]
+        for nested_extra in nested_extras:
+            expanded.update(_expand_extra(nested_extra, optional_deps, visited))
+
+    return expanded
+
+
+def expected_dependency_names(pyproject_data: dict[str, object]) -> set[str]:
+    """Build expected dependency-name set from core + full extra dependencies."""
+    project_table = pyproject_data.get("project")
+    if not isinstance(project_table, dict):
+        raise ValueError("[project] table is missing in pyproject.toml")
+
+    dependencies = project_table.get("dependencies", [])
+    optional_deps = project_table.get("optional-dependencies", {})
+    if not isinstance(dependencies, list) or not isinstance(optional_deps, dict):
+        raise ValueError("[project] dependency fields are malformed")
+
+    expected = {extract_dependency_name(spec) for spec in dependencies}
+    expected.update(_expand_extra("full", optional_deps, visited=set()))
+    return expected
+
+
+def requirements_dependency_names(requirements_content: str) -> set[str]:
+    """Parse normalized dependency names from requirements.txt content."""
+    names: set[str] = set()
+    for raw_line in requirements_content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        names.add(extract_dependency_name(line))
+    return names
+
+
+def main() -> int:
+    """Run requirements sync check and print actionable drift diagnostics."""
+    if not PYPROJECT_PATH.exists() or not REQUIREMENTS_PATH.exists():
+        print("[SYNC] Required dependency manifest file is missing.")
+        return 1
+
+    pyproject_data = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    expected = expected_dependency_names(pyproject_data)
+    actual = requirements_dependency_names(REQUIREMENTS_PATH.read_text(encoding="utf-8"))
+
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+
+    if not missing and not unexpected:
+        print("Dependency manifests are in sync (name-level).")
+        return 0
+
+    print("[SYNC] requirements.txt is out of sync with pyproject full dependency set:")
+    for pkg in missing:
+        print(f"- missing in requirements.txt: {pkg}")
+    for pkg in unexpected:
+        print(f"- unexpected in requirements.txt: {pkg}")
+
+    print(
+        "Hint: align veritas_os/requirements.txt with pyproject.toml "
+        "([project.dependencies] + [project.optional-dependencies].full).",
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/veritas_os/tests/test_check_requirements_sync.py
+++ b/veritas_os/tests/test_check_requirements_sync.py
@@ -1,0 +1,51 @@
+"""Tests for scripts.quality.check_requirements_sync."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.quality import check_requirements_sync as checker
+
+
+def test_extract_dependency_name_normalizes_extras_and_markers() -> None:
+    """Dependency parser should normalize package names deterministically."""
+    assert checker.extract_dependency_name("Foo_Bar[baz]>=1.2; python_version<'3.13'") == "foo-bar"
+
+
+def test_expected_dependency_names_expands_full_extra_closure() -> None:
+    """Expected set should include nested extras referenced by ``full``."""
+    pyproject_data = {
+        "project": {
+            "dependencies": ["alpha==1.0"],
+            "optional-dependencies": {
+                "ml": ["beta==2.0"],
+                "ops": ["gamma>=3.0"],
+                "full": ["veritas-os[ml,ops]"],
+            },
+        }
+    }
+
+    expected = checker.expected_dependency_names(pyproject_data)
+
+    assert expected == {"alpha", "beta", "gamma"}
+
+
+def test_main_returns_success_for_current_repository_manifests(capsys) -> None:
+    """Current repository dependency manifests should remain synchronized."""
+    exit_code = checker.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Dependency manifests are in sync" in output
+
+
+def test_ci_and_makefile_include_requirements_sync_guard() -> None:
+    """CI and local quality checks should enforce requirements sync guard."""
+    root = Path(__file__).resolve().parents[2]
+    workflow_content = (root / ".github" / "workflows" / "main.yml").read_text(
+        encoding="utf-8",
+    )
+    makefile_content = (root / "Makefile").read_text(encoding="utf-8")
+
+    assert "python scripts/quality/check_requirements_sync.py" in workflow_content
+    assert "python scripts/quality/check_requirements_sync.py" in makefile_content


### PR DESCRIPTION
### Motivation
- Prevent silent drift between `pyproject.toml` (core + `full` extra) and `veritas_os/requirements.txt` by validating dependency names automatically. 
- Address reviewer item T-5 from the repository review without making unrelated changes or expanding responsibilities beyond CI/quality tooling. 

### Description
- Added `scripts/quality/check_requirements_sync.py` which normalizes and compares package names from `pyproject.toml` (`[project.dependencies]` + expanded `optional-dependencies.full`) and `veritas_os/requirements.txt`. 
- Added tests in `veritas_os/tests/test_check_requirements_sync.py` that validate name extraction, `full` extra expansion, repository manifest sanity, and CI/Makefile integration. 
- Wired the new guard into the CI lint job in `.github/workflows/main.yml` and into the local `make quality-checks` target in `Makefile`. 
- Updated `REPOSITORY_REVIEW_2026-04-07.md` to mark T-5 as fixed and recorded the implemented approach. 

### Testing
- Ran unit tests: `python -m pytest -q veritas_os/tests/test_check_requirements_sync.py veritas_os/tests/test_check_review_improvements_consistency.py`, and all tests passed (`8 passed`). 
- Ran the guard script directly: `python scripts/quality/check_requirements_sync.py`, which reported `Dependency manifests are in sync (name-level).`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d665f6d940832680d795e11bcc9405)