### PR TITLE
Make IO error test deterministic by monkeypatching write path to raise OSError

### DIFF
--- a/veritas_os/tests/test_policy_compiler.py
+++ b/veritas_os/tests/test_policy_compiler.py
@@ -183,16 +183,28 @@ def test_runtime_adapter_rejects_tampered_manifest_signature(tmp_path: Path) -> 
         load_runtime_bundle(result.bundle_dir)
 
 
-def test_compile_wraps_io_error_as_policy_compilation_error(tmp_path: Path) -> None:
-    """OSError during bundle writing surfaces as PolicyCompilationError."""
-    read_only_dir = tmp_path / "readonly"
-    read_only_dir.mkdir()
-    read_only_dir.chmod(0o444)
+def test_compile_wraps_io_error_as_policy_compilation_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OSError during bundle writing surfaces as PolicyCompilationError.
+
+    NOTE:
+        Permission-based failure tests can be flaky across environments
+        (e.g., root containers). Use monkeypatch to deterministically trigger
+        an OSError in the write path.
+    """
+    from veritas_os.policy import compiler as policy_compiler
+
+    def _raise_oserror(*_args, **_kwargs):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(policy_compiler, "write_stable_json", _raise_oserror)
 
     with pytest.raises(PolicyCompilationError, match="failed to write bundle artifacts"):
         compile_policy_to_bundle(
             EXAMPLES_DIR / "low_risk_route_allow.yaml",
-            read_only_dir,
+            tmp_path,
             compiled_at="2026-04-02T00:00:00Z",
         )
 


### PR DESCRIPTION
### Motivation

- Permission-based failure tests can be flaky across environments (for example, running as root or in certain container setups), so the IO error test needs a deterministic way to simulate write failures.

### Description

- Replace permission-manipulation approach in `test_compile_wraps_io_error_as_policy_compilation_error` with a deterministic monkeypatch that makes `veritas_os.policy.compiler.write_stable_json` raise an `OSError`.
- Update the test signature to accept a `monkeypatch` fixture and add a short note in the test docstring explaining the reason for the change.
- Use `tmp_path` as the bundle target directory instead of creating a read-only directory.

### Testing

- Ran the test file `veritas_os/tests/test_policy_compiler.py` under `pytest`, and `test_compile_wraps_io_error_as_policy_compilation_error` passed.
- The rest of the tests in the file ran successfully under the same `pytest` invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6789dd8448326a634414d239eccf8)