### PR TITLE
test(pytest): add project root to pytest pythonpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ veritas_os = [
 ]
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 filterwarnings = [
   "ignore:invalid escape sequence.*:SyntaxWarning:sentence_transformers\\..*",
 ]


### PR DESCRIPTION
### Motivation
- Ensure running `pytest` from the repository root includes the project in `sys.path` to avoid `ModuleNotFoundError: No module named 'veritas_os'` when executing tests locally.

### Description
- Add `pythonpath = ["."]` under `[tool.pytest.ini_options]` in `pyproject.toml` to include the repository root for test execution; this is a test-configuration-only change with no runtime code modifications and carries low security risk.

### Testing
- Executed `pytest -q tests/test_critique_ensure_min_items_padding.py` which passed (`1 passed`) and `pytest -q veritas_os/tests/test_policy_compiler.py` which passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d694474e34832690d1f332493fa47c)