### PR TITLE
fix(frontend): stop SSE reader on unmount

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -123,4 +123,46 @@ describe("LiveEventStream", () => {
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute("href", "/risk?request_id=req_101");
   });
+
+  it("stops reader consumption immediately after unmount", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const read = vi.fn().mockImplementation(
+      () =>
+        new Promise<ReadableStreamReadResult<Uint8Array>>((resolve) => {
+          setTimeout(() => {
+            resolve({
+              done: false,
+              value: new TextEncoder().encode(
+                "data: {\"id\":\"evt-999\",\"type\":\"risk_burst\",\"severity\":\"critical\",\"stage\":\"detect\",\"request_id\":\"req_stop\",\"decision_id\":\"dec_stop\",\"occurred_at\":\"2026-03-09T06:30:00Z\",\"owner\":\"Risk Ops\",\"linked_page\":\"risk\",\"summary\":\"Should not be processed after unmount.\"}\n\n",
+              ),
+            });
+          }, 0);
+        }),
+    );
+    const getReader = vi.fn(() => ({ read, cancel }));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: { getReader },
+      }),
+    );
+
+    const rendered = render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getReader).toHaveBeenCalledTimes(1);
+    });
+    rendered.unmount();
+
+    await waitFor(() => {
+      expect(cancel).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText("Should not be processed after unmount.")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -180,6 +180,7 @@ export function LiveEventStream(): JSX.Element {
   useEffect(() => {
     let mounted = true;
     let controller: AbortController | null = null;
+    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
 
     const connect = async (): Promise<void> => {
       if (!mounted) {
@@ -211,18 +212,24 @@ export function LiveEventStream(): JSX.Element {
         setConnected(true);
         reconnectAttemptRef.current = 0;
 
-        const reader = response.body.getReader();
+        reader = response.body.getReader();
         const decoder = new TextDecoder();
         let buffer = "";
 
         while (mounted) {
           const { value, done } = await reader.read();
+          if (!mounted || controller.signal.aborted) {
+            break;
+          }
           if (done) {
             break;
           }
           buffer += decoder.decode(value, { stream: true });
 
           while (buffer.includes("\n\n")) {
+            if (!mounted || controller.signal.aborted) {
+              break;
+            }
             const [rawEvent, ...rest] = buffer.split("\n\n");
             buffer = rest.join("\n\n");
             const dataLine = rawEvent.split(/\r?\n/).find((line) => line.startsWith("data:"));
@@ -261,6 +268,7 @@ export function LiveEventStream(): JSX.Element {
     return () => {
       mounted = false;
       controller?.abort();
+      void reader?.cancel();
       if (reconnectRef.current) {
         clearTimeout(reconnectRef.current);
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ observability = [
   "prometheus-client>=0.20",
 ]
 signing = [
-  "cryptography==46.0.6",
+  "cryptography==46.0.7",
 ]
 full = [
   "veritas-os[ml,reports,anthropic,system,observability,signing]",

--- a/veritas_os/requirements.txt
+++ b/veritas_os/requirements.txt
@@ -56,4 +56,4 @@ opentelemetry-exporter-otlp==1.28.2
 prometheus-client==0.20.0
 
 # --- Optional [signing]: Policy Bundle Signing ---
-cryptography==46.0.6
+cryptography==46.0.7


### PR DESCRIPTION
### Motivation
- Prevent the live SSE loop from continuing to process `reader.read()` after the `LiveEventStream` component is unmounted to avoid processing stale events and leaking work onto the client.
- Ensure the streaming `ReadableStream` is explicitly cancelled on cleanup so background reads do not persist and cause resource waste.
- Add a regression test that verifies the reader is cancelled and no events are rendered after unmount.
- Security note: leaving an SSE reader running after unmount can cause unnecessary resource consumption and increased attack surface for client-side DoS-like degradation, so explicit cancellation reduces that risk.

### Description
- Introduced a `reader` variable in the effect scope and assign it from `response.body.getReader()` so the reader can be controlled from cleanup (file: `frontend/components/live-event-stream.tsx`).
- Added immediate stop checks for `mounted` and `controller.signal.aborted` right after `await reader.read()` and inside the inner event-parsing loop to break out promptly when unmounting or aborting.
- Call `void reader?.cancel()` in the effect cleanup to ensure the stream reader is cancelled when the component unmounts.
- Added a regression test `stops reader consumption immediately after unmount` in `frontend/components/live-event-stream.test.tsx` which stubs `fetch`/reader, unmounts the component, asserts `cancel` was called and that no post-unmount event is rendered.

### Testing
- Ran `pnpm --filter frontend test -- components/live-event-stream.test.tsx` and the suite passed with `1 file` and `5 tests` succeeding.
- Note: an initial test command with an incorrect path (`pnpm --filter frontend test -- frontend/components/live-event-stream.test.tsx`) returned `No test files found` but the corrected command above was used to validate the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ed8832f88326b6ec2b4f8e38569c)