### PR TITLE
T-8: Align local `make test-cov` coverage gate with CI (85%)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ PYTHON_VERSION ?= 3.12.12
 PYTHON_FALLBACK ?= 3.12
 UV ?= uv
 TEST_ARGS ?=
+COVERAGE_FAIL_UNDER ?= 85
+PYTEST_MARKEXPR ?= not slow
+COVERAGE_XML ?= coverage.xml
+COVERAGE_HTML_DIR ?= coverage-html
 
 .PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke quality-checks
 
@@ -64,18 +68,49 @@ test:
 
 test-cov:
 	@command -v $(UV) >/dev/null 2>&1 || { echo "Error: uv is required. Install from https://docs.astral.sh/uv/."; exit 1; }
+	@mkdir -p $(COVERAGE_HTML_DIR)
 	@set -e; \
 	if [ -x .venv/bin/python ] && .venv/bin/python -c "import pytest" >/dev/null 2>&1; then \
 		echo "[veritas] Using existing .venv"; \
-		.venv/bin/python -m pytest --cov=veritas_os $(TEST_ARGS); \
+		.venv/bin/python -m pytest -q veritas_os/tests \
+			--cov=veritas_os \
+			--cov-config=veritas_os/tests/.coveragerc \
+			--cov-report=term-missing \
+			--cov-report=xml:$(COVERAGE_XML) \
+			--cov-report=html:$(COVERAGE_HTML_DIR) \
+			--cov-fail-under=$(COVERAGE_FAIL_UNDER) \
+			-m "$(PYTEST_MARKEXPR)" \
+			--durations=20 \
+			--tb=short \
+			$(TEST_ARGS); \
 		exit 0; \
 	fi; \
 	echo "[veritas] Running coverage tests with Python $(PYTHON_VERSION) via uv"; \
-	if UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_VERSION) --with pytest --with pytest-cov pytest --cov=veritas_os $(TEST_ARGS); then \
+	if UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_VERSION) --with pytest --with pytest-cov pytest -q veritas_os/tests \
+		--cov=veritas_os \
+		--cov-config=veritas_os/tests/.coveragerc \
+		--cov-report=term-missing \
+		--cov-report=xml:$(COVERAGE_XML) \
+		--cov-report=html:$(COVERAGE_HTML_DIR) \
+		--cov-fail-under=$(COVERAGE_FAIL_UNDER) \
+		-m "$(PYTEST_MARKEXPR)" \
+		--durations=20 \
+		--tb=short \
+		$(TEST_ARGS); then \
 		exit 0; \
 	fi; \
 	echo "[veritas] Falling back to Python $(PYTHON_FALLBACK) (local or managed)"; \
-	UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_FALLBACK) --with pytest --with pytest-cov pytest --cov=veritas_os $(TEST_ARGS)
+	UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_FALLBACK) --with pytest --with pytest-cov pytest -q veritas_os/tests \
+		--cov=veritas_os \
+		--cov-config=veritas_os/tests/.coveragerc \
+		--cov-report=term-missing \
+		--cov-report=xml:$(COVERAGE_XML) \
+		--cov-report=html:$(COVERAGE_HTML_DIR) \
+		--cov-fail-under=$(COVERAGE_FAIL_UNDER) \
+		-m "$(PYTEST_MARKEXPR)" \
+		--durations=20 \
+		--tb=short \
+		$(TEST_ARGS)
 
 
 test-split:

--- a/README.md
+++ b/README.md
@@ -758,7 +758,14 @@ make test-cov
 ```
 
 These targets use `uv` with `PYTHON_VERSION=3.12.12` and automatically download the
-interpreter if it is not already installed.
+interpreter if it is not already installed. `make test-cov` now mirrors the CI
+coverage gate (`--cov-fail-under=85`, `veritas_os/tests/.coveragerc`, XML/HTML reports,
+and `-m "not slow"`).
+
+```bash
+# Optional: override the local gate/marker to troubleshoot
+make test-cov COVERAGE_FAIL_UNDER=0 PYTEST_MARKEXPR=""
+```
 
 Fast smoke check:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -751,7 +751,12 @@ make test
 make test-cov
 ```
 
-これらのターゲットは `uv` + `PYTHON_VERSION=3.12.12` を利用し、未導入時はインタプリタを自動取得します。
+これらのターゲットは `uv` + `PYTHON_VERSION=3.12.12` を利用し、未導入時はインタプリタを自動取得します。`make test-cov` は CI と同じカバレッジゲート（`--cov-fail-under=85`、`veritas_os/tests/.coveragerc`、XML/HTML レポート、`-m "not slow"`）で検証します。
+
+```bash
+# 任意: ローカル検証時のみ閾値/マーカーを上書き
+make test-cov COVERAGE_FAIL_UNDER=0 PYTEST_MARKEXPR=""
+```
 
 スモークチェック:
 


### PR DESCRIPTION
### Motivation
- Close T-8 by making local coverage runs enforce the same minimum gate as CI so developers can validate the `--cov-fail-under=85` requirement before pushing changes. 
- Prevent silent divergence between CI and local workflows while noting the operational risk that environments with restricted PyPI/network access cannot reproduce CI dependency installs and thus may be unable to run the gate locally.

### Description
- Added configurable Makefile variables `COVERAGE_FAIL_UNDER`, `PYTEST_MARKEXPR`, `COVERAGE_XML`, and `COVERAGE_HTML_DIR` to allow local override of the coverage gate and outputs. 
- Updated the `test-cov` target in `Makefile` to run `pytest -q veritas_os/tests` with `--cov=veritas_os`, `--cov-config=veritas_os/tests/.coveragerc`, `--cov-report=term-missing`, XML/HTML reports, `--cov-fail-under=$(COVERAGE_FAIL_UNDER)`, `-m "$(PYTEST_MARKEXPR)"`, and timing/traceback flags to mirror CI execution. 
- Ensure coverage HTML directory is created prior to the run by adding `mkdir -p $(COVERAGE_HTML_DIR)`. 
- Documented the change and added a local-override example to `README.md` and `README_JP.md` so maintainers know how to temporarily relax the gate for troubleshooting.

### Testing
- Verified the expanded invocation via `make -n test-cov`, which printed the CI-equivalent pytest + coverage command expansion successfully. 
- Attempted a focused local smoke run with `make test TEST_ARGS='-q veritas_os/tests/test_api_constants.py'`, but the run failed due to PyPI/network tunnel errors during dependency fetch, which is an environment/network constraint and not caused by these changes. 
- No unit test code was modified; existing test suites remain unchanged and will continue to be executed under the updated `make test-cov` invocation when dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70d72a0508326a8153a478859d942)