### PR TITLE
F-7: Validate request_id format in TraceabilityRail (frontend)

### DIFF
--- a/frontend/components/traceability-rail.test.tsx
+++ b/frontend/components/traceability-rail.test.tsx
@@ -11,4 +11,19 @@ describe("TraceabilityRail", () => {
 
     expect(screen.getByText("high")).toBeInTheDocument();
   });
+
+  it("blocks trust log link when request_id format is invalid", () => {
+    render(<TraceabilityRail />);
+
+    fireEvent.change(screen.getByDisplayValue("req-"), {
+      target: { value: "invalid-request-id" },
+    });
+
+    expect(
+      screen.getByText("request_id は req- で始まり、英数字または . _ - を含めてください。"),
+    ).toBeInTheDocument();
+    const trustLogLink = screen.getByRole("link", { name: "TrustLog" });
+    expect(trustLogLink).toHaveAttribute("aria-disabled", "true");
+    expect(trustLogLink).toHaveAttribute("href", "#");
+  });
 });

--- a/frontend/components/traceability-rail.tsx
+++ b/frontend/components/traceability-rail.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 
 const ROLES = ["viewer", "operator", "admin"] as const;
 type Role = (typeof ROLES)[number];
+const REQUEST_ID_PATTERN = /^req-[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 
 /**
  * Global traceability rail for cross-screen jump by request_id / decision_id.
@@ -27,6 +28,13 @@ export function TraceabilityRail(): JSX.Element {
     }
     return "safe";
   }, [redaction, role]);
+  const isRequestIdValid = useMemo(
+    () => REQUEST_ID_PATTERN.test(requestId.trim()),
+    [requestId],
+  );
+  const trustLogHref = isRequestIdValid
+    ? `/audit?request_id=${encodeURIComponent(requestId.trim())}`
+    : "#";
 
   return (
     <section className="mt-3 grid gap-3 rounded-lg border border-border/60 bg-background/60 p-3 md:grid-cols-4">
@@ -35,8 +43,14 @@ export function TraceabilityRail(): JSX.Element {
         <input
           value={requestId}
           onChange={(event) => setRequestId(event.target.value)}
+          aria-invalid={!isRequestIdValid}
           className="w-full rounded-md border border-border bg-background px-2 py-1 font-mono text-xs text-foreground"
         />
+        {!isRequestIdValid ? (
+          <p className="text-2xs text-danger">
+            request_id は req- で始まり、英数字または . _ - を含めてください。
+          </p>
+        ) : null}
       </label>
       <label className="space-y-1 text-xs text-muted-foreground">
         decision_id
@@ -73,7 +87,16 @@ export function TraceabilityRail(): JSX.Element {
           </span>
         </div>
         <div className="flex flex-wrap gap-2 pt-1">
-          <Link className="rounded border border-border px-2 py-1" href={`/audit?request_id=${encodeURIComponent(requestId)}`}>
+          <Link
+            className="rounded border border-border px-2 py-1 aria-disabled:pointer-events-none aria-disabled:opacity-50"
+            href={trustLogHref}
+            aria-disabled={!isRequestIdValid}
+            onClick={(event) => {
+              if (!isRequestIdValid) {
+                event.preventDefault();
+              }
+            }}
+          >
             TrustLog
           </Link>
           <Link className="rounded border border-border px-2 py-1" href={`/console?decision_id=${encodeURIComponent(decisionId)}`}>


### PR DESCRIPTION
### Motivation
- Strengthen client-side validation for `request_id` in the TraceabilityRail UI to catch malformed values early and address the F-7 finding.
- Provide clear user feedback and prevent accidental navigation with invalid `request_id` while noting that server/BFF validation remains the ultimate authority for security.

### Description
- Add `REQUEST_ID_PATTERN = /^req-[a-zA-Z0-9][a-zA-Z0-9._-]*$/` and an `isRequestIdValid` `useMemo` that validates `requestId.trim()` in `frontend/components/traceability-rail.tsx`.
- When invalid, set `aria-invalid`, render a human-facing error hint, and compute `trustLogHref` as `"#"` to avoid constructing a malformed URL.
- Disable the TrustLog link by setting `aria-disabled=true`, preventing default navigation in the link `onClick`, and applying disabled styling to avoid accidental transitions.
- Add a unit test in `frontend/components/traceability-rail.test.tsx` that verifies the error message is shown and the TrustLog link is disabled for an invalid `request_id`.

### Testing
- Ran the component unit tests with `cd frontend && pnpm vitest run components/traceability-rail.test.tsx` and observed `2 tests passed`.
- The modified test file `components/traceability-rail.test.tsx` passed locally under the project test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d718e998d8832682d802e134afaecb)