### PR TITLE
Finalize low-priority polish: F-8/F-9, add dev deps (T-10) and revalidate T-11

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@
 # VERITAS_API_KEY=
 
 # LLM provider and model selection.
+# gpt-4.1-mini is the project default baseline model.
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-4.1-mini
 

--- a/REPOSITORY_REVIEW_2026-04-07.md
+++ b/REPOSITORY_REVIEW_2026-04-07.md
@@ -130,13 +130,15 @@
 - **Issue:** `request_id` にフォーマットバリデーションなし。`encodeURIComponent` は使用されているが、期待フォーマット ("req-" prefix) のチェックがない。
 - **Fix:** パターンバリデーションを追加。
 
-### [LOW] F-8: Array Index as Key in LoadingSkeleton
+### ~~[LOW] F-8: Array Index as Key in LoadingSkeleton~~ **FIXED (2026-04-09)**
 - **File:** `frontend/components/ui/loading-skeleton.tsx:15-21`
 - **Issue:** `key={i}` パターン。スケルトンコンポーネントでは実害は少ないが、ベストプラクティスに反する。
+- **Fix:** ✅ `skeleton-line-{n}` 形式の安定キーを生成する実装へ変更。
 
-### [LOW] F-9: Hardcoded Locale in AppShell Skip Link
+### ~~[LOW] F-9: Hardcoded Locale in AppShell Skip Link~~ **FIXED (2026-04-09)**
 - **File:** `packages/design-system/src/app-shell.tsx:26`
 - **Issue:** "メインコンテンツへスキップ" が日本語ハードコード。i18n システムを使用すべき。
+- **Fix:** ✅ `skipLinkLabel` prop を追加し、既定値を英語へ変更。呼び出し側でロケール別文言を注入可能にした。
 
 ---
 
@@ -189,13 +191,15 @@
 - **Issue:** `/tmp/frontend-dev.log` がハードコード。`${TMPDIR:-/tmp}` を使用すべき。
 - **Fix:** ✅ `${TMPDIR:-/tmp}` に変更。環境変数 `TMPDIR` が設定されていればそれを使用。
 
-### [LOW] T-10: Missing Dev Dependencies in pyproject.toml
+### ~~[LOW] T-10: Missing Dev Dependencies in pyproject.toml~~ **FIXED (2026-04-09)**
 - **File:** `setup.sh:114-116`, `pyproject.toml`
 - **Issue:** `pytest`, `pytest-cov` 等の開発依存が `pyproject.toml` に `[project.optional-dependencies] dev` として定義されていない。
+- **Fix:** ✅ `[project.optional-dependencies].dev` を追加し、`setup.sh` は `pip install ".[dev]"` へ統一。
 
-### [LOW] T-11: .env.example Contains Invalid Model Name
+### ~~[LOW] T-11: .env.example Contains Invalid Model Name~~ **FALSE POSITIVE (2026-04-09 Revalidated)**
 - **File:** `.env.example:9`
 - **Issue:** `LLM_MODEL=gpt-4.1-mini` は存在しないモデル名。`gpt-4o-mini` が正しい可能性あり。
+- **Revalidation Result:** 既存レビュー方針どおり **False positive**。`.env.example` / `setup.sh` に既定モデル注記を追加し、モデル名整合性を明文化。
 
 ---
 
@@ -260,6 +264,6 @@
 | F-1 | `controller.abort()` がアンマウント時の中断を処理済み。内部バッファパースは同期処理で race condition なし |
 | F-2 | `Set` state は参照比較の問題があるが、実害なし (理論的リスクのみ) |
 | P-4, P-5 | 動作に問題なし。リファクタリングの実益が薄い |
-| F-5, F-7, F-8, F-9 | Low/Medium のフロントエンド改善。実害なし |
-| T-5, T-7(FP), T-8, T-10 | CI/CD の追加改善。優先度低 |
+| F-5, F-7 | Low/Medium のフロントエンド改善。実害なし |
+| T-5, T-7(FP), T-8 | CI/CD の追加改善。優先度低 |
 | T-11 | **False positive**: `gpt-4.1-mini` は 2025年4月リリースの有効なモデル名 |

--- a/frontend/components/ui/loading-skeleton.tsx
+++ b/frontend/components/ui/loading-skeleton.tsx
@@ -6,17 +6,25 @@ interface LoadingSkeletonProps {
 }
 
 export function LoadingSkeleton({ lines = 3, className }: LoadingSkeletonProps): JSX.Element {
+  const skeletonLines = Array.from({ length: lines }, (_, index) => {
+    const lineNumber = index + 1;
+    return {
+      key: `skeleton-line-${lineNumber}`,
+      widthPercent: 75 + Math.sin(index) * 20
+    };
+  });
+
   return (
     <div
       role="status"
       aria-label="Loading"
       className={`animate-pulse space-y-2${className ? ` ${className}` : ""}`}
     >
-      {Array.from({ length: lines }, (_, i) => (
+      {skeletonLines.map((line) => (
         <div
-          key={i}
+          key={line.key}
           className="h-3 rounded bg-muted/40"
-          style={{ width: `${75 + Math.sin(i) * 20}%` }}
+          style={{ width: `${line.widthPercent}%` }}
         />
       ))}
       <span className="sr-only">Loading...</span>

--- a/packages/design-system/src/app-shell.test.tsx
+++ b/packages/design-system/src/app-shell.test.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode, JSX } from "react";
+import { AppShell } from "./app-shell";
+
+function collectText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (!node || typeof node === "boolean") {
+    return "";
+  }
+  if (Array.isArray(node)) {
+    return node.map((child) => collectText(child)).join(" ");
+  }
+  if (typeof node === "object" && "props" in node) {
+    const props = (node as JSX.Element).props as { children?: ReactNode };
+    return collectText(props.children);
+  }
+  return "";
+}
+
+describe("AppShell", () => {
+  it("uses an english default skip-link label", () => {
+    const tree = AppShell({
+      title: "Dashboard",
+      children: <div>Content</div>
+    });
+
+    expect(collectText(tree)).toContain("Skip to main content");
+  });
+
+  it("allows overriding the skip-link label for locale support", () => {
+    const tree = AppShell({
+      title: "ダッシュボード",
+      skipLinkLabel: "メインコンテンツへスキップ",
+      children: <div>コンテンツ</div>
+    });
+
+    expect(collectText(tree)).toContain("メインコンテンツへスキップ");
+  });
+});

--- a/packages/design-system/src/app-shell.tsx
+++ b/packages/design-system/src/app-shell.tsx
@@ -6,6 +6,7 @@ interface AppShellProps {
   title: string;
   description?: string;
   className?: string;
+  skipLinkLabel?: string;
 }
 
 /**
@@ -15,7 +16,8 @@ export function AppShell({
   children,
   title,
   description,
-  className
+  className,
+  skipLinkLabel = "Skip to main content"
 }: AppShellProps): JSX.Element {
   return (
     <div className={cn("min-h-screen bg-background text-foreground", className)}>
@@ -23,7 +25,7 @@ export function AppShell({
         href="#main-content"
         className="sr-only z-[var(--ds-z-overlay)] rounded-md bg-primary px-3 py-2 text-primary-foreground focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[hsl(var(--ds-color-focus-ring))]"
       >
-        メインコンテンツへスキップ
+        {skipLinkLabel}
       </a>
       <header className="border-b border-border bg-surface/90 px-6 py-4 backdrop-blur" role="banner">
         <h1 className="text-xl font-semibold">{title}</h1>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 #   pip install ".[reports]"       # + matplotlib / pandas / PDF tooling
 #   pip install ".[anthropic]"     # + Anthropic LLM provider
 #   pip install ".[system]"        # + psutil / trio
+#   pip install ".[dev]"           # + pytest / test tooling
 #   pip install ".[full]"          # everything (CI / Docker default)
 # ---------------------------------------------------------------------------
 [project.optional-dependencies]
@@ -75,13 +76,13 @@ signing = [
   "cryptography==46.0.7",
 ]
 full = [
-  "veritas-os[ml,reports,anthropic,system,observability,signing]",
+  "veritas-os[ml,reports,anthropic,system,observability,signing,dev]",
 ]
 dev = [
-  "pytest>=8.0.0",
-  "pytest-asyncio>=0.23.0",
-  "pytest-cov>=5.0.0",
-  "httpx>=0.27.0",
+  "pytest==8.3.5",
+  "pytest-asyncio==0.25.3",
+  "pytest-cov==6.0.0",
+  "httpx==0.27.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ signing = [
 full = [
   "veritas-os[ml,reports,anthropic,system,observability,signing]",
 ]
+dev = [
+  "pytest>=8.0.0",
+  "pytest-asyncio>=0.23.0",
+  "pytest-cov>=5.0.0",
+  "httpx>=0.27.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/veritasfuji-japan/veritas_os"

--- a/setup.sh
+++ b/setup.sh
@@ -111,8 +111,8 @@ info "Installing runtime dependencies..."
 .venv/bin/pip install -r veritas_os/requirements.txt -q
 success "Runtime dependencies installed."
 
-info "Installing development dependencies (pytest, coverage, etc.)..."
-.venv/bin/pip install pytest pytest-cov pytest-asyncio httpx -q
+info "Installing development dependencies from pyproject.toml [dev]..."
+.venv/bin/pip install ".[dev]" -q
 success "Development dependencies installed."
 
 # ── 3. Environment configuration ───────────────────────────────────────────
@@ -141,6 +141,7 @@ if [ "$WRITE_ENV" = true ]; then
 
 # --- LLM Provider ---
 # Supported: "openai", "anthropic"
+# Baseline default model for quickstart.
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-4.1-mini
 # OPENAI_API_KEY=sk-...

--- a/veritas_os/requirements.txt
+++ b/veritas_os/requirements.txt
@@ -12,6 +12,7 @@
 #   pip install ".[ml]"                           # + ML tooling
 #   pip install ".[reports]"                      # + reporting / PDF
 #   pip install ".[anthropic]"                    # + Anthropic provider
+#   pip install ".[dev]"                          # + pytest / test tooling
 #   pip install ".[full]"                         # everything
 
 # --- Core: API / Server ---
@@ -57,3 +58,8 @@ prometheus-client==0.20.0
 
 # --- Optional [signing]: Policy Bundle Signing ---
 cryptography==46.0.7
+
+# --- Optional [dev]: Test / QA Tooling ---
+pytest==8.3.5
+pytest-asyncio==0.25.3
+pytest-cov==6.0.0

--- a/veritas_os/tests/test_dependency_profiles.py
+++ b/veritas_os/tests/test_dependency_profiles.py
@@ -28,7 +28,16 @@ _REQUIREMENTS = _ROOT / "veritas_os" / "requirements.txt"
 
 # --- Expected extras groups ---------------------------------------------------
 
-EXPECTED_EXTRAS = {"ml", "reports", "anthropic", "system", "observability", "signing", "full"}
+EXPECTED_EXTRAS = {
+    "ml",
+    "reports",
+    "anthropic",
+    "system",
+    "observability",
+    "signing",
+    "dev",
+    "full",
+}
 
 EXPECTED_CORE = {
     "fastapi",
@@ -59,6 +68,9 @@ EXPECTED_OPTIONAL = {
     "opentelemetry-exporter-otlp",
     "prometheus-client",
     "cryptography",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
 }
 
 


### PR DESCRIPTION
### Motivation
- Address low-priority front-end polish items identified in the repository review: remove unstable array-index keys and avoid hardcoded locale strings to improve correctness and i18n readiness. 
- Centralize development dependency metadata so local setup and CI use a single source of truth for dev deps. 
- Revalidate a previously flagged model-name issue and document the baseline model selection to avoid noisy false positives.

### Description
- Replaced index-based keys in `LoadingSkeleton` with stable generated keys (`skeleton-line-{n}`) and preserved the original variable widths in `frontend/components/ui/loading-skeleton.tsx`. 
- Made the AppShell skip-link text configurable via a new `skipLinkLabel` prop with English default (`"Skip to main content"`) in `packages/design-system/src/app-shell.tsx`. 
- Added `packages/design-system/src/app-shell.test.tsx` to assert the default skip-link label and allow overriding it for locale-specific labels. 
- Added `[project.optional-dependencies].dev` to `pyproject.toml` and updated `setup.sh` to install development dependencies via `pip install ".[dev]"`; annotated `.env.example` and the setup-generated `.env` with the baseline model note for clarity; updated `REPOSITORY_REVIEW_2026-04-07.md` to reflect fixes and revalidation. 

### Testing
- Ran component tests for the design-system with `pnpm --filter @veritas/design-system test`, which passed (2 files, 5 tests passed). 
- Ran frontend component tests with `pnpm --filter frontend test -- --run components/ui/loading-skeleton.test.tsx components/ui/ui-components.test.tsx`, which passed (2 files, 15 tests passed). 
- All automated tests executed for the modified frontend packages succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7298c69708326bbb1c75b3d488b87)