### PR TITLE
Add local pre-commit coverage-gate hook to enforce >=85% test coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,12 @@ repos:
           - --python-version=3.11
           - --ignore-missing-imports
         files: ^veritas_os/.*\.py$
+
+  - repo: local
+    hooks:
+      - id: coverage-gate
+        name: coverage-gate (pytest-cov >= 85%)
+        entry: make test-cov
+        language: system
+        pass_filenames: false
+        files: ^(veritas_os/|tests/|pyproject\.toml|Makefile|\.github/workflows/main\.yml)


### PR DESCRIPTION
### Motivation
- Enforce a test-coverage gate as part of pre-commit so `pytest-cov` coverage (>=85%) must pass before commits touching core code, tests, or CI-related files.

### Description
- Add a local pre-commit hook `coverage-gate` that runs `make test-cov` with `language: system` and `pass_filenames: false`, and restrict it to files matching `^(veritas_os/|tests/|pyproject\.toml|Makefile|\.github/workflows/main\.yml)`.

### Testing
- No automated tests were executed as part of this configuration-only change; the hook will run `make test-cov` when triggered by pre-commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68811ae808326bcf47e8c57473b57)