### PR TITLE
Add bare-except CI guardrail and TLS/load production validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,9 @@ jobs:
       - name: runtime pickle artifact check
         run: python scripts/security/check_runtime_pickle_artifacts.py
 
+      - name: bare except usage check
+        run: python scripts/security/check_bare_except_usage.py
+
       - name: Bandit security scan
         run: |
           bandit -r veritas_os/ \

--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -62,6 +62,12 @@ jobs:
           python -m pip install -r veritas_os/requirements.txt
           python -m pip install pytest pytest-cov httpx anyio
 
+      - name: Enforce runtime pickle artifact ban
+        run: python scripts/security/check_runtime_pickle_artifacts.py
+
+      - name: Enforce bare except reduction gate
+        run: python scripts/security/check_bare_except_usage.py
+
       - name: Run production-like tests
         run: |
           set -euxo pipefail
@@ -79,6 +85,70 @@ jobs:
           name: production-test-report
           path: test-reports/production.xml
           if-no-files-found: warn
+
+  tls-validation:
+    name: tls-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      OPENAI_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_API_KEY: "DUMMY_FOR_CI"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r veritas_os/requirements.txt
+          python -m pip install pytest httpx anyio
+
+      - name: Run TLS production validation tests
+        run: |
+          set -euxo pipefail
+          pytest -q veritas_os/tests/ -m tls -v --tb=short
+
+  load-validation:
+    name: load-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      OPENAI_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_API_KEY: "DUMMY_FOR_CI"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r veritas_os/requirements.txt
+          python -m pip install pytest httpx anyio
+
+      - name: Run load production validation tests
+        run: |
+          set -euxo pipefail
+          pytest -q veritas_os/tests/ -m load -v --tb=short
 
   # ── Docker Compose smoke test ─────────────────────────────────────────
   docker-smoke:

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -11,6 +11,26 @@ permissions:
   contents: read
 
 jobs:
+  runtime-guards:
+    name: Runtime guardrails (pickle + bare except)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enforce runtime pickle artifact ban
+        run: python scripts/security/check_runtime_pickle_artifacts.py
+
+      - name: Enforce bare except reduction gate
+        run: python scripts/security/check_bare_except_usage.py
+
   dependency-audit:
     name: Dependency audit (Python + Node)
     runs-on: ubuntu-latest

--- a/docs/PRODUCTION_VALIDATION.md
+++ b/docs/PRODUCTION_VALIDATION.md
@@ -13,9 +13,11 @@ deployment topology, and fail-closed security controls.
 |---------|--------|------------|-------------|
 | **Unit** | *(default)* | Every push/PR | Fast, isolated, mocked dependencies |
 | **Slow** | `@pytest.mark.slow` | Every push/PR (parallel job) | Heavier computation, larger datasets |
-| **Production** | `@pytest.mark.production` | `workflow_dispatch` / opt-in | Production-like flows with real subsystems |
+| **Production** | `@pytest.mark.production` | `workflow_dispatch` / weekly schedule | Production-like flows with real subsystems |
 | **Smoke** | `@pytest.mark.smoke` | `workflow_dispatch` / opt-in | Lightweight deployment verification |
 | **External** | `@pytest.mark.external` | `workflow_dispatch` + secrets | Tests requiring live network/API keys |
+| **TLS** | `@pytest.mark.tls` | `workflow_dispatch` / weekly schedule | TLS/security-header posture verification |
+| **Load** | `@pytest.mark.load` | `workflow_dispatch` / weekly schedule | Lightweight burst/concurrency validation |
 
 ## Running Production Validation
 
@@ -56,6 +58,13 @@ docker compose down
 ```
 
 ## Verification Matrix
+
+### 0. Runtime Security Guardrails (CI + Production Validation)
+
+| What | How | Production Gap Closed |
+|------|-----|----------------------|
+| Legacy `.pkl` / `.joblib` artifact ban | `check_runtime_pickle_artifacts.py` in CI + production-validation workflow | Runtime RCE surface continuously monitored |
+| Bare `except:` ban | `check_bare_except_usage.py` in CI + production-validation workflow | Silent error masking reduced in staged manner |
 
 ### 1. FastAPI + Frontend + Docker Compose Smoke (`test_production_smoke.py`)
 
@@ -149,6 +158,19 @@ docker compose down
 | `is_encryption_enabled` True | Valid key | Correct status report |
 | `is_encryption_enabled` False | No key | Correct status report |
 
+### 7. TLS Header Validation (`test_production_tls_load.py`)
+
+| What | How | Production Gap Closed |
+|------|-----|----------------------|
+| HSTS header present | `/health` response header assertion | Browser HTTPS enforcement posture verified |
+| Baseline security headers | `/health` response header assertion | CSP / anti-clickjacking / MIME hardening verified |
+
+### 8. Load Burst Validation (`test_production_tls_load.py`)
+
+| What | How | Production Gap Closed |
+|------|-----|----------------------|
+| Concurrent health burst (32 req / 8 workers) | ThreadPool + TestClient | Lightweight load regression signal added |
+
 ## Architecture: CI Role Separation
 
 ```
@@ -166,6 +188,8 @@ docker compose down
 │          production-validation.yml (Manual/Weekly)        │
 ├─────────────────────────────────────────────────────────┤
 │  production-tests: pytest -m "production or smoke"       │
+│  tls-validation: pytest -m tls                           │
+│  load-validation: pytest -m load                         │
 │  docker-smoke: docker compose up + health check          │
 │  external-tests: pytest -m external (if secrets set)     │
 └─────────────────────────────────────────────────────────┘
@@ -179,8 +203,8 @@ docker compose down
 | Full Docker compose E2E | Script-ready, not in CI | `scripts/production_validation.sh` runs locally |
 | Database persistence | N/A (file-based) | TrustLog file tests cover persistence |
 | Multi-node clustering | Not applicable | Single-node architecture |
-| TLS/HTTPS validation | Not covered | Add nginx proxy tests in staging |
-| Load/stress testing | Not covered | Consider k6/locust for performance validation |
+| TLS certificate chain/e2e HTTPS handshake | Partially covered | Add staging reverse-proxy cert tests |
+| Load/stress at scale (p95/p99 latency SLO) | Partially covered | Add k6/locust long-run performance tests |
 | Kubernetes deployment | Not covered | Add Helm chart tests when K8s support added |
 
 ## What This Validation Adds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ markers = [
   "production: production-like validation requiring real services",
   "smoke: lightweight smoke tests for deployment verification",
   "external: tests that depend on external network services",
+  "tls: tests focused on TLS/security-header production posture",
+  "load: lightweight load/stress validation tests",
   "unit: 単体テスト",
   "integration: 統合テスト",
   "scenario: ビジネスシナリオテスト",

--- a/scripts/security/check_bare_except_usage.py
+++ b/scripts/security/check_bare_except_usage.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Detect bare ``except:`` usage in production Python code.
+
+Bare ``except:`` blocks catch ``BaseException`` (including ``KeyboardInterrupt``
+and ``SystemExit``), which can hide operational failures and interfere with safe
+shutdown behavior. This checker enforces a gradual-remediation policy by failing
+CI when new bare ``except:`` handlers appear in runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCAN_ROOTS = (
+    REPO_ROOT / "veritas_os",
+    REPO_ROOT / "scripts",
+)
+SKIP_DIR_NAMES = {
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".venv",
+    "node_modules",
+}
+SKIP_PATH_PARTS = {"tests"}
+
+
+@dataclass(frozen=True)
+class Violation:
+    """Represents one bare ``except:`` violation."""
+
+    path: Path
+    line: int
+    message: str
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(
+        description="Check Python source for bare except handlers."
+    )
+    parser.add_argument(
+        "--scan-root",
+        action="append",
+        default=[],
+        help="Optional directory/file to scan. Can be provided multiple times.",
+    )
+    return parser.parse_args(argv)
+
+
+def _iter_python_files(scan_roots: list[Path]) -> list[Path]:
+    """Return Python files under roots while skipping cache/vendor/test dirs."""
+    files: list[Path] = []
+    for root in scan_roots:
+        resolved = root.resolve(strict=False)
+        if not resolved.exists():
+            continue
+        if resolved.is_file() and resolved.suffix == ".py":
+            files.append(resolved)
+            continue
+
+        for path in resolved.rglob("*.py"):
+            if any(part in SKIP_DIR_NAMES for part in path.parts):
+                continue
+            if any(part in SKIP_PATH_PARTS for part in path.parts):
+                continue
+            files.append(path)
+    return files
+
+
+def _scan_file(path: Path) -> list[Violation]:
+    """Scan one Python file and return bare ``except:`` violations."""
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler) and node.type is None:
+            violations.append(
+                Violation(
+                    path=path,
+                    line=node.lineno,
+                    message=(
+                        "bare except is forbidden; catch explicit exception types "
+                        "to avoid masking operational failures"
+                    ),
+                )
+            )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run scan and return shell exit code."""
+    parsed = _parse_args(argv or sys.argv[1:])
+    scan_roots = DEFAULT_SCAN_ROOTS + tuple(Path(p) for p in parsed.scan_root)
+
+    violations: list[Violation] = []
+    for file_path in _iter_python_files(list(scan_roots)):
+        violations.extend(_scan_file(file_path))
+
+    if not violations:
+        print("No bare except usage detected.")
+        return 0
+
+    print("Bare except usage detected:")
+    for item in sorted(violations, key=lambda it: (str(it.path), it.line, it.message)):
+        try:
+            relative = item.path.relative_to(REPO_ROOT)
+        except ValueError:
+            relative = item.path
+        print(f"- {relative}:{item.line}: {item.message}")
+
+    print(
+        "\nSecurity remediation: replace bare except with explicit exception "
+        "classes and keep fail-closed behavior for unexpected errors."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_check_bare_except_usage.py
+++ b/veritas_os/tests/test_check_bare_except_usage.py
@@ -1,0 +1,103 @@
+"""Tests for scripts.security.check_bare_except_usage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.security import check_bare_except_usage as checker
+
+
+def test_scan_file_detects_bare_except(tmp_path: Path) -> None:
+    """Scanner should flag bare ``except:`` handlers."""
+    source = tmp_path / "bad.py"
+    source.write_text(
+        "\n".join(
+            [
+                "def run():",
+                "    try:",
+                "        return 1",
+                "    except:",
+                "        return 0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert len(violations) == 1
+    assert "bare except" in violations[0].message
+
+
+def test_scan_file_allows_explicit_exception(tmp_path: Path) -> None:
+    """Scanner should allow explicit exception classes."""
+    source = tmp_path / "good.py"
+    source.write_text(
+        "\n".join(
+            [
+                "def run():",
+                "    try:",
+                "        return int('x')",
+                "    except ValueError:",
+                "        return None",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker._scan_file(source)
+
+    assert violations == []
+
+
+def test_main_returns_non_zero_when_violation_found(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    """Command should fail and print remediation guidance on violations."""
+    source = tmp_path / "bad.py"
+    source.write_text("try:\n    pass\nexcept:\n    pass\n", encoding="utf-8")
+
+    monkeypatch.setattr(checker, "DEFAULT_SCAN_ROOTS", ())
+    exit_code = checker.main(["--scan-root", str(source)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Bare except usage detected" in output
+    assert "Security remediation" in output
+
+
+def test_main_returns_zero_when_clean(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    """Command should succeed and print clean-status output."""
+    source = tmp_path / "good.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(checker, "DEFAULT_SCAN_ROOTS", ())
+    exit_code = checker.main(["--scan-root", str(source)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "No bare except usage detected" in output
+
+
+def test_iter_python_files_skips_tests_directory(tmp_path: Path) -> None:
+    """File iterator should skip test directories to reduce false positives."""
+    app_dir = tmp_path / "veritas_os"
+    tests_dir = app_dir / "tests"
+    app_dir.mkdir()
+    tests_dir.mkdir()
+
+    prod_file = app_dir / "runtime.py"
+    test_file = tests_dir / "test_runtime.py"
+    prod_file.write_text("print('ok')\n", encoding="utf-8")
+    test_file.write_text("print('test')\n", encoding="utf-8")
+
+    files = checker._iter_python_files([app_dir])
+
+    assert prod_file.resolve() in files
+    assert test_file.resolve() not in files

--- a/veritas_os/tests/test_production_tls_load.py
+++ b/veritas_os/tests/test_production_tls_load.py
@@ -1,0 +1,70 @@
+"""Production validation tests for TLS headers and lightweight load behavior.
+
+These tests strengthen production validation coverage by checking:
+- TLS-oriented response hardening headers
+- Burst request behavior under concurrent access
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+_TEST_API_KEY = "production-load-test-key"
+
+
+@pytest.fixture()
+def api_client(monkeypatch):
+    """Return a TestClient for production marker tests."""
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
+    monkeypatch.setenv("VERITAS_GOVERNANCE_ENFORCE_RBAC", "0")
+    monkeypatch.setenv("VERITAS_GOVERNANCE_ALLOW_RBAC_BYPASS", "1")
+    from veritas_os.api.server import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.production
+@pytest.mark.tls
+class TestProductionTlsHeaders:
+    """Validate API security headers required for TLS deployment posture."""
+
+    def test_strict_transport_security_header_present(self, api_client) -> None:
+        """API responses should include HSTS to enforce HTTPS on clients."""
+        response = api_client.get("/health")
+        assert response.status_code == 200
+        assert (
+            response.headers.get("Strict-Transport-Security")
+            == "max-age=31536000; includeSubDomains"
+        )
+
+    def test_core_security_headers_present(self, api_client) -> None:
+        """Baseline anti-injection headers should be consistently applied."""
+        response = api_client.get("/health")
+        assert response.status_code == 200
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert "default-src 'none'" in response.headers.get(
+            "Content-Security-Policy", ""
+        )
+
+
+@pytest.mark.production
+@pytest.mark.load
+class TestProductionLoadSmoke:
+    """Run a lightweight concurrent request burst against health endpoint."""
+
+    def test_health_endpoint_handles_burst_requests(self, api_client) -> None:
+        """Health endpoint should stay responsive during concurrent bursts."""
+
+        def _single_request() -> int:
+            return api_client.get("/health").status_code
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            statuses = list(pool.map(lambda _: _single_request(), range(32)))
+
+        assert len(statuses) == 32
+        assert all(status == 200 for status in statuses)


### PR DESCRIPTION
### Motivation

- Enforce a P0/P1 security posture by continuously detecting and blocking runtime risky patterns: legacy pickle artifacts are already scanned and now bare `except:` handlers are also detected to reduce silent failure masking. 
- Improve production validation coverage for TLS/posture and lightweight load signals to close gaps in headers and concurrent-responsiveness checks. 
- Provide an operational, fail-closed gate so insecure patterns are rejected by CI rather than drifting into production. 
- Security warning: TLS checks validate headers only and do not replace full certificate-chain or high-load SLO testing, which remain partial and should be covered before hostile production rollouts. 

### Description

- Add an AST-based scanner `scripts/security/check_bare_except_usage.py` that fails when bare `except:` handlers are found in runtime code and includes a module docstring explaining the rationale. 
- Add unit tests `veritas_os/tests/test_check_bare_except_usage.py` that cover detection, allowed explicit exceptions, CLI exit codes, and test-dir skipping. 
- Add production TLS/load tests `veritas_os/tests/test_production_tls_load.py` that assert HSTS/CSP/X-Frame headers and run a lightweight concurrent health-burst (32 requests / 8 workers). 
- Wire the new checks into CI and validation workflows by updating `.github/workflows/main.yml`, `.github/workflows/security-gates.yml`, and `.github/workflows/production-validation.yml`; add `tls`/`load` pytest markers in `pyproject.toml`; and update `docs/PRODUCTION_VALIDATION.md` to reflect the new guardrails and verification matrix. 

### Testing

- Ran `python scripts/security/check_bare_except_usage.py` and it printed `No bare except usage detected.` (exit 0). 
- Ran `python scripts/security/check_runtime_pickle_artifacts.py` and it printed `No legacy runtime pickle artifacts detected in scanned directories.` (exit 0). 
- Ran `pytest -q veritas_os/tests/test_check_bare_except_usage.py veritas_os/tests/test_production_tls_load.py` and all tests passed (`8 passed`). 
- Ran `ruff check` for the new files with `ruff check scripts/security/check_bare_except_usage.py veritas_os/tests/test_check_bare_except_usage.py veritas_os/tests/test_production_tls_load.py` and it returned `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d750bbd4c88326a4e54f2ac813007e)