### PR TITLE
Enforce dual-block runtime/CI guard against legacy pickle artifacts

### DIFF
--- a/.github/workflows/runtime-pickle-guard.yml
+++ b/.github/workflows/runtime-pickle-guard.yml
@@ -1,0 +1,28 @@
+name: Runtime Pickle Guard (Required)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-pickle-guard:
+    name: runtime-pickle-guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enforce runtime pickle artifact ban
+        run: python scripts/security/check_runtime_pickle_artifacts.py

--- a/veritas_os/core/memory/memory_security.py
+++ b/veritas_os/core/memory/memory_security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Iterable, Set
+from typing import Iterable, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +18,14 @@ def is_explicitly_enabled(env_key: str) -> bool:
     if value is None:
         return False
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+
+def should_fail_fast_legacy_pickle_guard(profile: Optional[str] = None) -> bool:
+    """Return whether legacy pickle detection should stop startup immediately."""
+    resolved_profile = profile if profile is not None else os.getenv("VERITAS_ENV", "")
+    normalized_profile = resolved_profile.strip().lower()
+    return normalized_profile in {"prod", "production", "stg", "staging"}
 
 
 def emit_legacy_pickle_runtime_blocked(path: Path, artifact_name: str) -> None:
@@ -34,8 +42,14 @@ def emit_legacy_pickle_runtime_blocked(path: Path, artifact_name: str) -> None:
 
 
 def warn_for_legacy_pickle_artifacts(scan_roots: Iterable[Path]) -> None:
-    """Scan directories and report legacy pickle artifacts without deserializing."""
+    """Scan directories and report legacy pickle artifacts without deserializing.
+
+    In operational profiles (``VERITAS_ENV`` = prod/production/stg/staging),
+    detections are treated as fatal and raise ``RuntimeError`` to fail fast.
+    """
     checked_roots: Set[Path] = set()
+    findings: list[Path] = []
+
     for raw_root in scan_roots:
         root = raw_root.resolve(strict=False)
         if root in checked_roots or not root.exists() or not root.is_dir():
@@ -47,7 +61,14 @@ def warn_for_legacy_pickle_artifacts(scan_roots: Iterable[Path]) -> None:
                 continue
             if candidate.suffix.lower() not in {".pkl", ".joblib", ".pickle"}:
                 continue
+            findings.append(candidate)
             emit_legacy_pickle_runtime_blocked(
                 path=candidate,
                 artifact_name="runtime artifact",
             )
+
+    if findings and should_fail_fast_legacy_pickle_guard():
+        raise RuntimeError(
+            "[SECURITY] Legacy runtime pickle artifacts detected in operational "
+            "profile. Refusing startup due to RCE risk."
+        )

--- a/veritas_os/tests/test_memory_vector.py
+++ b/veritas_os/tests/test_memory_vector.py
@@ -18,6 +18,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List
 
+import pytest
+
 from veritas_os.core import memory
 
 
@@ -278,6 +280,35 @@ def test_warn_for_legacy_pickle_artifacts_ignores_missing_paths(caplog):
         memory._warn_for_legacy_pickle_artifacts([missing, file_path])
 
     assert caplog.text == ""
+
+
+def test_warn_for_legacy_pickle_artifacts_fail_fast_in_operational_profile(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """運用プロファイルでは .pkl 検知時に fail-fast で起動停止する。"""
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    (runtime_dir / "legacy.pkl").write_bytes(b"x")
+    monkeypatch.setenv("VERITAS_ENV", "production")
+
+    with pytest.raises(RuntimeError, match="Refusing startup"):
+        memory._warn_for_legacy_pickle_artifacts([runtime_dir])
+
+
+def test_warn_for_legacy_pickle_artifacts_no_fail_fast_in_dev_profile(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """開発プロファイルでは .pkl 検知時に警告ログのみに留める。"""
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    (runtime_dir / "legacy.pkl").write_bytes(b"x")
+    monkeypatch.setenv("VERITAS_ENV", "development")
+
+    memory._warn_for_legacy_pickle_artifacts([runtime_dir])
+
+
 def test_legacy_pickle_migration_disabled_by_default(tmp_path: Path, monkeypatch):
     """オプトインなしではレガシーpickleを読み込まないことを確認する。"""
     import numpy as np


### PR DESCRIPTION
### Motivation
- Ensure arbitrary-code-execution (RCE) risk from legacy pickle artifacts is operationally blocked by making detection both a CI gate and a runtime fail-fast in operational profiles.
- Prevent accidental deployment of `.pkl`/`.joblib`/`.pickle` artifacts by making the runtime detection behavior stricter for production/staging while keeping developer workflows permissive.
- Provide an auditable, automated check so PRs are rejected early if unsafe artifacts are present.

### Description
- Added `should_fail_fast_legacy_pickle_guard` and updated `warn_for_legacy_pickle_artifacts` in `veritas_os/core/memory/memory_security.py` so detections are logged and then raise `RuntimeError` in operational profiles (`VERITAS_ENV` in `prod|production|stg|staging`).
- Kept non-operational profiles (e.g., `development`) warning-only to avoid blocking local/test workflows while preserving visibility.
- Added a new GitHub Actions workflow `.github/workflows/runtime-pickle-guard.yml` that runs `python scripts/security/check_runtime_pickle_artifacts.py` on `pull_request` and `push` to `main` so CI enforces artifact bans independently of other CI steps.
- Added unit tests in `veritas_os/tests/test_memory_vector.py` that verify fail-fast behavior in an operational profile and warning-only behavior in a development profile, and added the minimal typing import change used by the new helper.

### Testing
- Ran `ruff check veritas_os/core/memory/memory_security.py veritas_os/tests/test_memory_vector.py` and it passed.
- Ran `pytest -q veritas_os/tests/test_memory_vector.py -k "warn_for_legacy_pickle_artifacts"` and the targeted tests passed (`4 passed, 7 deselected`).
- Executed `python scripts/security/check_runtime_pickle_artifacts.py` locally and it returned success with message `No legacy runtime pickle artifacts detected in scanned directories.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75d4e258c83269e8fd4a70c8fbd68)