### PR TITLE
Harden production drift controls for direct FUJI API configuration

### DIFF
--- a/scripts/quality/check_deployment_env_defaults.py
+++ b/scripts/quality/check_deployment_env_defaults.py
@@ -23,6 +23,7 @@ class TemplateRule:
     relative_path: str
     required_tokens: tuple[str, ...] = ()
     forbidden_tokens: tuple[str, ...] = ()
+    forbidden_env_keys: tuple[str, ...] = ()
     forbidden_env_assignments: tuple[tuple[str, str], ...] = ()
 
 
@@ -38,6 +39,9 @@ RULES = (
             ("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),
             ("VERITAS_AUTH_STORE_FAILURE_MODE", "open"),
         ),
+        forbidden_env_keys=(
+            "VERITAS_ENABLE_DIRECT_FUJI_API",
+        ),
     ),
     TemplateRule(
         relative_path="setup.sh",
@@ -52,6 +56,9 @@ RULES = (
         forbidden_env_assignments=(
             ("VERITAS_AUTH_ALLOW_FAIL_OPEN", "true"),
             ("VERITAS_AUTH_STORE_FAILURE_MODE", "open"),
+        ),
+        forbidden_env_keys=(
+            "VERITAS_ENABLE_DIRECT_FUJI_API",
         ),
     ),
 )
@@ -94,6 +101,22 @@ def _collect_forbidden_assignment_violations(
     return violations
 
 
+def _collect_forbidden_key_violations(
+    *,
+    rule: TemplateRule,
+    assignments: Iterable[tuple[str, str]],
+) -> list[str]:
+    """Return violations when forbidden env keys appear with any value."""
+    normalized_keys = {key.strip() for key, _ in assignments}
+    violations: list[str] = []
+    for key in rule.forbidden_env_keys:
+        if key in normalized_keys:
+            violations.append(
+                f"{rule.relative_path}: forbidden env key present {key}"
+            )
+    return violations
+
+
 def _validate_rule(rule: TemplateRule) -> list[str]:
     """Return human-readable violations for the given template rule."""
     path = REPO_ROOT / rule.relative_path
@@ -115,10 +138,17 @@ def _validate_rule(rule: TemplateRule) -> list[str]:
                 f"{rule.relative_path}: forbidden token present {token!r}"
             )
 
+    assignments = list(_iter_env_assignments(content))
     violations.extend(
         _collect_forbidden_assignment_violations(
             rule=rule,
-            assignments=_iter_env_assignments(content),
+            assignments=assignments,
+        )
+    )
+    violations.extend(
+        _collect_forbidden_key_violations(
+            rule=rule,
+            assignments=assignments,
         )
     )
 
@@ -140,8 +170,8 @@ def main() -> int:
         print(f"- {violation}")
     print(
         "\nUse server-only VERITAS_* variables in operator-facing templates and "
-        "never ship fail-open auth flags or open auth-store failure modes in "
-        "default configuration."
+        "never ship fail-open auth flags, direct FUJI API flags, or open "
+        "auth-store failure modes in default configuration."
     )
     return 1
 

--- a/veritas_os/api/startup_health.py
+++ b/veritas_os/api/startup_health.py
@@ -19,6 +19,11 @@ def _is_node_env_production() -> bool:
     return node_env == "production"
 
 
+def _is_env_key_present(var_name: str) -> bool:
+    """Return True when an env key exists, regardless of configured value."""
+    return var_name in os.environ
+
+
 def should_fail_fast_startup(profile: Optional[str] = None) -> bool:
     """Return whether startup validation failures should stop app boot."""
     resolved_profile = profile if profile is not None else os.getenv("VERITAS_ENV", "")
@@ -77,6 +82,7 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
         (os.getenv("VERITAS_AUTH_STORE_FAILURE_MODE") or "closed").strip().lower()
     )
     auth_fail_open_requested = auth_store_failure_mode == "open"
+    direct_fuji_key_present = _is_env_key_present("VERITAS_ENABLE_DIRECT_FUJI_API")
     direct_fuji_enabled = _is_truthy_env("VERITAS_ENABLE_DIRECT_FUJI_API")
     public_api_base_url = (os.getenv("NEXT_PUBLIC_VERITAS_API_BASE_URL") or "").strip()
 
@@ -127,15 +133,29 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
             )
         logger.warning("%s", message)
 
-    if direct_fuji_enabled:
+    if direct_fuji_key_present:
         message = (
-            "[SECURITY] VERITAS_ENABLE_DIRECT_FUJI_API=true is enabled. "
-            "Direct FUJI endpoints bypass `/v1/decide` orchestration controls, "
-            "so this flag must remain disabled in production."
+            "[SECURITY] VERITAS_ENABLE_DIRECT_FUJI_API is present in environment "
+            "configuration. This flag is HIGH risk because direct FUJI endpoints "
+            "bypass `/v1/decide` orchestration controls."
         )
         if is_production:
-            raise RuntimeError(f"{message} Refusing startup in production.")
-        logger.warning("%s", message)
+            raise RuntimeError(
+                f"{message} Treating this as production drift; remove the key "
+                "from environment distribution before startup."
+            )
+        if direct_fuji_enabled:
+            logger.warning(
+                "%s It is explicitly enabled and should stay limited to isolated "
+                "local testing.",
+                message,
+            )
+        else:
+            logger.warning(
+                "%s Even disabled values should be removed from shared env "
+                "templates to prevent production drift.",
+                message,
+            )
 
 
 def check_runtime_feature_health(

--- a/veritas_os/tests/test_api_startup_health.py
+++ b/veritas_os/tests/test_api_startup_health.py
@@ -189,26 +189,27 @@ def test_validate_startup_security_flags_warns_direct_fuji_non_production(
     monkeypatch,
     caplog,
 ):
-    """Direct FUJI flag must raise a warning even in non-production."""
+    """Direct FUJI env key presence must warn even when disabled."""
     monkeypatch.setenv("VERITAS_ENV", "local")
-    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "true")
+    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "0")
 
     with caplog.at_level(logging.WARNING):
         startup_health.validate_startup_security_flags(
             logger=logging.getLogger("test.startup_health")
         )
 
-    assert "VERITAS_ENABLE_DIRECT_FUJI_API=true is enabled" in caplog.text
+    assert "VERITAS_ENABLE_DIRECT_FUJI_API is present" in caplog.text
+    assert "removed from shared env templates" in caplog.text
 
 
 def test_validate_startup_security_flags_rejects_direct_fuji_in_production(
     monkeypatch,
 ):
-    """Production must reject direct FUJI API mode to preserve pipeline controls."""
+    """Production must reject direct FUJI env drift before startup."""
     monkeypatch.setenv("VERITAS_ENV", "production")
-    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "true")
+    monkeypatch.setenv("VERITAS_ENABLE_DIRECT_FUJI_API", "false")
 
-    with pytest.raises(RuntimeError, match="VERITAS_ENABLE_DIRECT_FUJI_API=true"):
+    with pytest.raises(RuntimeError, match="VERITAS_ENABLE_DIRECT_FUJI_API is present"):
         startup_health.validate_startup_security_flags(
             logger=logging.getLogger("test.startup_health")
         )

--- a/veritas_os/tests/test_deployment_env_defaults.py
+++ b/veritas_os/tests/test_deployment_env_defaults.py
@@ -115,3 +115,32 @@ def test_validate_rule_passes_without_forbidden_defaults(tmp_path: Path) -> None
         deployment_defaults.REPO_ROOT = original_root
 
     assert violations == []
+
+
+def test_validate_rule_flags_direct_fuji_api_key_presence(tmp_path: Path) -> None:
+    """Direct FUJI API flag must not appear in operator env templates."""
+    template = tmp_path / ".env.example"
+    template.write_text(
+        """
+        VERITAS_API_BASE_URL=http://localhost:8000
+        VERITAS_ENV=production
+        VERITAS_ENABLE_DIRECT_FUJI_API=0
+        """,
+        encoding="utf-8",
+    )
+    rule = deployment_defaults.TemplateRule(
+        relative_path=str(template.relative_to(tmp_path)),
+        required_tokens=("VERITAS_API_BASE_URL", "VERITAS_ENV=production"),
+        forbidden_env_keys=("VERITAS_ENABLE_DIRECT_FUJI_API",),
+    )
+
+    original_root = deployment_defaults.REPO_ROOT
+    deployment_defaults.REPO_ROOT = tmp_path
+    try:
+        violations = deployment_defaults._validate_rule(rule)
+    finally:
+        deployment_defaults.REPO_ROOT = original_root
+
+    assert violations == [
+        ".env.example: forbidden env key present VERITAS_ENABLE_DIRECT_FUJI_API"
+    ]


### PR DESCRIPTION
### Motivation
- Prevent accidental/operator distribution of the `VERITAS_ENABLE_DIRECT_FUJI_API` key in IaC/templates which can enable direct FUJI endpoints and bypass `/v1/decide` pipeline controls. 
- Treat presence of this key as a production drift risk and fail-fast at startup to eliminate /v1/decide bypass misconfiguration. 
- Provide a guard both at template-scan time and at runtime startup to ensure configuration distribution and boot-time drift are covered. 
- Security: this change addresses a HIGH-risk bypass path and enforces fail-closed behavior for production. 

### Description
- Add `forbidden_env_keys` to `TemplateRule` and implement `_collect_forbidden_key_violations` to detect any presence of specified env keys in operator-facing templates, and include `VERITAS_ENABLE_DIRECT_FUJI_API` in the rules for `.env.example` and `setup.sh` (`scripts/quality/check_deployment_env_defaults.py`).
- Enhance startup validation by adding `_is_env_key_present` and treating presence of `VERITAS_ENABLE_DIRECT_FUJI_API` as a production-fatal drift, while emitting warnings in non-production and advising removal from shared templates (`veritas_os/api/startup_health.py`).
- Update and add tests to validate the new template-scan rule and the startup behavior (non-prod warning and prod fail-fast) (`veritas_os/tests/test_deployment_env_defaults.py` and `veritas_os/tests/test_api_startup_health.py`).
- Small messaging/text updates to the deployment checker to call out direct FUJI API flags as forbidden in operator templates. 

### Testing
- Ran focused pytest for the modified test modules with `python -m pytest -q veritas_os/tests/test_api_startup_health.py veritas_os/tests/test_deployment_env_defaults.py veritas_os/tests/test_check_deployment_env_defaults.py` and all tests passed (`28 passed`).
- Executed the deployment template smoke-check with `python scripts/quality/check_deployment_env_defaults.py` which printed success: `Deployment env templates passed smoke checks.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7624694f48326b230676e0c7dcb68)