### PR TITLE
L-5: narrow reflection exception handling and add structured warning logs

### DIFF
--- a/veritas_os/core/reflection.py
+++ b/veritas_os/core/reflection.py
@@ -1,9 +1,13 @@
 # veritas_os/core/reflection.py
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List
 
 from .utils import _clip01
+
+
+logger = logging.getLogger(__name__)
 
 # trust_log / value_core は他モジュールに依存するので、
 # 失敗しても落ちないように try-import しておく。
@@ -35,14 +39,22 @@ def _get_decision_id(decision: Any) -> str:
     if hasattr(decision, "id"):
         try:
             return str(getattr(decision, "id"))
-        except Exception:
-            pass
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            logger.warning(
+                "reflection_decision_id_attr_cast_failed",
+                extra={"event": "reflection.decision_id.attr_cast_failed"},
+                exc_info=True,
+            )
 
     if isinstance(decision, dict) and "id" in decision:
         try:
             return str(decision["id"])
-        except Exception:
-            pass
+        except (TypeError, ValueError, RuntimeError):
+            logger.warning(
+                "reflection_decision_id_dict_cast_failed",
+                extra={"event": "reflection.decision_id.dict_cast_failed"},
+                exc_info=True,
+            )
 
     return str(decision)
 
@@ -59,9 +71,12 @@ def _compute_score(decision: Any, outcome: Dict[str, Any] | None) -> float:
         try:
             raw = trust_log.evaluate(decision, outcome)  # type: ignore[call-arg]
             return _clip01(raw, 0.5)
-        except Exception:
-            # 評価失敗時は下のフォールバックへ
-            pass
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            logger.warning(
+                "reflection_trust_log_evaluate_failed",
+                extra={"event": "reflection.trust_log.evaluate_failed"},
+                exc_info=True,
+            )
 
     # 2) outcome に score が載っていればそれを使う
     if isinstance(outcome, dict) and "score" in outcome:
@@ -95,8 +110,12 @@ def evaluate_decision(
     if score < 0.5 and value_core is not None and hasattr(value_core, "adjust_weights"):
         try:
             value_core.adjust_weights("prudence", +0.1)  # type: ignore[attr-defined]
-        except Exception:
-            pass
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            logger.warning(
+                "reflection_adjust_weights_failed",
+                extra={"event": "reflection.adjust_weights.failed"},
+                exc_info=True,
+            )
 
     memory.append(
         {
@@ -105,4 +124,3 @@ def evaluate_decision(
         }
     )
     return score
-

--- a/veritas_os/tests/test_reflection.py
+++ b/veritas_os/tests/test_reflection.py
@@ -123,3 +123,29 @@ def test_evaluate_decision_raises_on_none_memory(monkeypatch):
     with pytest.raises(ValueError):
         reflection.evaluate_decision("x", {"score": 0.1}, None)  # type: ignore[arg-type]
 
+
+def test_evaluate_decision_logs_structured_warning_on_trust_log_failure(
+    monkeypatch,
+    caplog,
+):
+    """trust_log.evaluate 失敗時に構造化 warning を残し、outcome fallback を使う。"""
+
+    class FailingTrustLog:
+        def evaluate(self, decision: Any, outcome: Dict[str, Any]) -> float:
+            raise RuntimeError("trust log evaluate failure")
+
+    monkeypatch.setattr(reflection, "trust_log", FailingTrustLog(), raising=False)
+    monkeypatch.setattr(reflection, "value_core", StubValueCore, raising=False)
+
+    memory: List[Dict[str, Any]] = []
+    with caplog.at_level("WARNING", logger=reflection.__name__):
+        score = reflection.evaluate_decision({"id": "d-3"}, {"score": 0.8}, memory)
+
+    assert score == 0.8
+    assert memory == [{"decision_id": "d-3", "score": 0.8}]
+    assert any(
+        record.msg == "reflection_trust_log_evaluate_failed"
+        and getattr(record, "event", "")
+        == "reflection.trust_log.evaluate_failed"
+        for record in caplog.records
+    )


### PR DESCRIPTION
### Motivation
- Reduce broad `except Exception` usage in `core/reflection.py` as part of the L-5 staged remediation to improve root-cause analysis and security observability.
- Preserve fail-safe fallback behavior while making unexpected errors more visible via structured logs for faster incident triage.
- Keep changes localized to the reflection subsystem and avoid crossing Planner / Kernel / Fuji / MemoryOS responsibilities.
- Security note: broad excepts remain in other parts of the repo and should be remediated similarly; this PR reduces risk locally but does not remove repository-wide exposure.

### Description
- Replace broad `except Exception` handlers in `veritas_os/core/reflection.py` with explicit exception tuples for attribute/dict casting, `trust_log.evaluate`, and `value_core.adjust_weights` to avoid silently swallowing unexpected errors.
- Add a module `logger` and emit structured `WARNING` logs with `extra={"event": ...}` and `exc_info=True` on each fallback path to retain exception context.
- Add a regression test `test_evaluate_decision_logs_structured_warning_on_trust_log_failure` in `veritas_os/tests/test_reflection.py` to assert fallback behavior and structured log emission.
- Changes are limited to `veritas_os/core/reflection.py` and its tests; functional fallbacks and behavior remain unchanged.

### Testing
- Ran `pytest -q veritas_os/tests/test_reflection.py` and all tests passed (`6 passed`).
- New test `test_evaluate_decision_logs_structured_warning_on_trust_log_failure` verifies that a failing `trust_log.evaluate` writes a structured warning and that the outcome fallback is used (test succeeded).
- No other automated test suites were run in this PR; change surface is small and covered by the added unit test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d76d68416c83269d3845d105121734)