### PR TITLE
Standardize /health security posture visibility

### DIFF
--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -54,6 +54,10 @@ describe("MissionPage", () => {
     expect(screen.getByText("Verification:", { exact: false })).toBeInTheDocument();
     expect(screen.getByText("Governance approval risk")).toBeInTheDocument();
     expect(screen.getByText("Risk → Decision → Evidence → Report")).toBeInTheDocument();
+    expect(screen.getByText("/health security posture (mandatory)")).toBeInTheDocument();
+    expect(screen.getByText("Encryption algorithm:", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Authentication mode:", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Direct FUJI API:", { exact: false })).toBeInTheDocument();
     expect(screen.getByText("degraded:", { exact: false })).toBeInTheDocument();
   });
 });

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -173,6 +173,12 @@ const POLICY_DIFF_IMPACT_PREVIEW = {
   summary: "Policy diff/impact preview is now linked to Mission Control action flow.",
 };
 
+const HEALTH_SECURITY_POSTURE = {
+  encryptionAlgorithm: "AES-256-GCM",
+  authenticationMode: "requested=redis / effective=memory (fail-closed)",
+  directFujiApi: "disabled",
+};
+
 /**
  * MissionPage renders the operational command-center view.
  *
@@ -229,6 +235,15 @@ export function MissionPage({ title, subtitle, chips }: MissionPageProps): JSX.E
             <p className="text-muted-foreground">Missing approvers: {GOVERNANCE_APPROVAL.missingApprovers.join(", ")}</p>
           </div>
         </Card>
+      </section>
+
+      <section aria-label="health security posture" className="rounded-xl border border-warning/40 bg-warning/10 p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-warning">/health security posture (mandatory)</p>
+        <ul className="mt-2 space-y-1 text-xs">
+          <li>Encryption algorithm: <span className="font-semibold">{HEALTH_SECURITY_POSTURE.encryptionAlgorithm}</span></li>
+          <li>Authentication mode: <span className="font-semibold">{HEALTH_SECURITY_POSTURE.authenticationMode}</span></li>
+          <li>Direct FUJI API: <span className="font-semibold">{HEALTH_SECURITY_POSTURE.directFujiApi}</span></li>
+        </ul>
       </section>
 
       <section aria-label={`${title} operational cards`} className="grid gap-4 md:grid-cols-3">

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -85,9 +85,22 @@ def _trust_log_health(srv: Any) -> Dict[str, Any]:
 
 def _security_posture_snapshot() -> Dict[str, Any]:
     """Return security-sensitive runtime toggles for operations visibility."""
+    srv = _get_server()
+    auth_snapshot = _auth_store_health(srv)
+    auth_details = auth_snapshot["details"]
     encryption_status = get_encryption_status()
     return {
         "direct_fuji_api_enabled": _is_direct_fuji_api_enabled(),
+        "authentication": {
+            "status": auth_snapshot["status"],
+            "requested_mode": auth_details.get("requested_mode", "memory"),
+            "effective_mode": auth_details.get("effective_mode", "memory"),
+            "requested_failure_mode": auth_details.get(
+                "requested_failure_mode",
+                "closed",
+            ),
+            "failure_mode": auth_details.get("failure_mode", "closed"),
+        },
         "encryption": encryption_status,
     }
 

--- a/veritas_os/tests/test_api_backend_improvements.py
+++ b/veritas_os/tests/test_api_backend_improvements.py
@@ -129,6 +129,11 @@ class TestEnhancedHealth:
         assert isinstance(data["alert_policy"]["alerts"], list)
         assert "security_posture" in data
         assert "direct_fuji_api_enabled" in data["security_posture"]
+        assert "authentication" in data["security_posture"]
+        assert "requested_mode" in data["security_posture"]["authentication"]
+        assert "effective_mode" in data["security_posture"]["authentication"]
+        assert "requested_failure_mode" in data["security_posture"]["authentication"]
+        assert "failure_mode" in data["security_posture"]["authentication"]
         assert "encryption" in data["security_posture"]
         assert "algorithm" in data["security_posture"]["encryption"]
 


### PR DESCRIPTION
### Motivation
- Prevent operator misinterpretation by making cryptography, authentication mode, and Direct FUJI API state visible in the same `/health` payload and on the dashboard.  
- Improve runbook-aligned observability so operators can quickly detect insecure or fail-open configurations without changing Planner/Kernel/FUJI/MemoryOS responsibilities.

### Description
- Extend `_security_posture_snapshot()` in `veritas_os/api/routes_system.py` to include an `authentication` object derived from `_auth_store_health()` containing `status`, `requested_mode`, `effective_mode`, `requested_failure_mode`, and `failure_mode`.  
- Add assertions in `veritas_os/tests/test_api_backend_improvements.py` to require the new `security_posture.authentication` fields in the health contract.  
- Add a mandatory `/health security posture` block to the Mission Dashboard in `frontend/components/mission-page.tsx` that displays `Encryption algorithm`, `Authentication mode`, and `Direct FUJI API` state.  
- Add UI assertions in `frontend/components/mission-page.test.tsx` to validate the new mandatory dashboard display.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_backend_improvements.py::TestEnhancedHealth::test_health_includes_checks`, which passed.  
- Ran `cd frontend && pnpm vitest run components/mission-page.test.tsx`, which passed (1 file, 3 tests).  
- All automated tests exercised for these changes passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d775d2e75c83268fa68a34d431c420)