### PR TITLE
Add staged external TLS/load production validation tests

### DIFF
--- a/docs/PRODUCTION_VALIDATION.md
+++ b/docs/PRODUCTION_VALIDATION.md
@@ -35,6 +35,9 @@ pytest -m production veritas_os/tests/ -v --tb=long
 
 # Run external tests (requires API keys)
 VERITAS_WEBSEARCH_KEY=<key> pytest -m external veritas_os/tests/
+
+# Run staging TLS/load external checks
+VERITAS_STAGING_BASE_URL=https://staging.example.com pytest -m "external and (tls or load)" veritas_os/tests/test_production_tls_load.py -v
 ```
 
 ### CI Execution
@@ -164,12 +167,14 @@ docker compose down
 |------|-----|----------------------|
 | HSTS header present | `/health` response header assertion | Browser HTTPS enforcement posture verified |
 | Baseline security headers | `/health` response header assertion | CSP / anti-clickjacking / MIME hardening verified |
+| Staging TLS header validation (`@external`) | HTTPS `/health` against `VERITAS_STAGING_BASE_URL` | Reverse-proxy TLS hardening verified in staging |
 
 ### 8. Load Burst Validation (`test_production_tls_load.py`)
 
 | What | How | Production Gap Closed |
 |------|-----|----------------------|
 | Concurrent health burst (32 req / 8 workers) | ThreadPool + TestClient | Lightweight load regression signal added |
+| Staging burst p95 check (`@external`) | 32 HTTPS requests + p95 latency assertion | Staging-level performance regression signal added |
 
 ## Architecture: CI Role Separation
 
@@ -203,8 +208,8 @@ docker compose down
 | Full Docker compose E2E | Script-ready, not in CI | `scripts/production_validation.sh` runs locally |
 | Database persistence | N/A (file-based) | TrustLog file tests cover persistence |
 | Multi-node clustering | Not applicable | Single-node architecture |
-| TLS certificate chain/e2e HTTPS handshake | Partially covered | Add staging reverse-proxy cert tests |
-| Load/stress at scale (p95/p99 latency SLO) | Partially covered | Add k6/locust long-run performance tests |
+| TLS certificate chain/e2e HTTPS handshake | Partially covered | `@external` staging HTTPS tests added; expand to cert-chain expiry and OCSP checks |
+| Load/stress at scale (p95/p99 latency SLO) | Partially covered | Staging p95 smoke added; add k6/locust long-run and p99 SLO validation |
 | Kubernetes deployment | Not covered | Add Helm chart tests when K8s support added |
 
 ## What This Validation Adds

--- a/veritas_os/tests/test_production_tls_load.py
+++ b/veritas_os/tests/test_production_tls_load.py
@@ -7,9 +7,12 @@ These tests strengthen production validation coverage by checking:
 
 from __future__ import annotations
 
+import os
 from concurrent.futures import ThreadPoolExecutor
+from time import perf_counter
 
 import pytest
+import requests
 from fastapi.testclient import TestClient
 
 
@@ -68,3 +71,62 @@ class TestProductionLoadSmoke:
 
         assert len(statuses) == 32
         assert all(status == 200 for status in statuses)
+
+
+@pytest.mark.production
+@pytest.mark.external
+class TestStagingExternalTlsLoad:
+    """Validate TLS posture and lightweight latency budget on staging."""
+
+    @pytest.fixture()
+    def staging_base_url(self) -> str:
+        """Return staging URL from env and skip when not configured."""
+        url = os.environ.get("VERITAS_STAGING_BASE_URL", "").strip()
+        if not url:
+            pytest.skip("VERITAS_STAGING_BASE_URL is required for @external tests")
+        if not url.startswith("https://"):
+            pytest.skip("VERITAS_STAGING_BASE_URL must start with https://")
+        return url.rstrip("/")
+
+    @pytest.mark.tls
+    def test_staging_health_enforces_tls_headers(self, staging_base_url: str) -> None:
+        """Staging health endpoint should expose TLS hardening headers."""
+        response = requests.get(
+            f"{staging_base_url}/health",
+            timeout=5,
+            verify=True,
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers.get("Strict-Transport-Security")
+            == "max-age=31536000; includeSubDomains"
+        )
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("X-Frame-Options") == "DENY"
+
+    @pytest.mark.load
+    def test_staging_health_lightweight_burst_slo(
+        self, staging_base_url: str
+    ) -> None:
+        """Staging health should handle short burst with basic p95 threshold."""
+
+        def _single_request_latency_ms() -> float:
+            start = perf_counter()
+            response = requests.get(
+                f"{staging_base_url}/health",
+                timeout=5,
+                verify=True,
+            )
+            assert response.status_code == 200
+            return (perf_counter() - start) * 1000.0
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            latencies_ms = list(
+                pool.map(lambda _: _single_request_latency_ms(), range(32))
+            )
+
+        assert len(latencies_ms) == 32
+        sorted_latencies = sorted(latencies_ms)
+        p95_index = int(0.95 * (len(sorted_latencies) - 1))
+        p95_ms = sorted_latencies[p95_index]
+        assert p95_ms < 800.0


### PR DESCRIPTION
### Motivation
- Increase production confidence by covering previously untested areas (TLS headers and lightweight external load) against a staging reverse-proxy to raise production readiness. 
- Provide an opt-in, non-blocking external validation path so CI is not flaky while enabling real-world checks when configured. 
- Require `VERITAS_STAGING_BASE_URL` for staging checks and warn that this value must be managed as a CI/CD secret and limited to trusted `https://` endpoints to avoid external communication and data-leak risks.

### Description
- Add `TestStagingExternalTlsLoad` to `veritas_os/tests/test_production_tls_load.py` with a `staging_base_url` fixture that reads `VERITAS_STAGING_BASE_URL`, skips when unset, and enforces `https://` only. 
- Implement `test_staging_health_enforces_tls_headers` to assert HSTS and baseline security headers from the staging `/health` endpoint using `requests`. 
- Implement `test_staging_health_lightweight_burst_slo` to run a lightweight burst (32 requests, 8 workers) against staging and assert a p95 latency guardrail (`p95 < 800ms`) using `perf_counter`. 
- Add necessary imports (`os`, `requests`, `perf_counter`) and update `docs/PRODUCTION_VALIDATION.md` to include the staging run command, verification-matrix entries for staging TLS/load checks, and updated remaining-risk notes.

### Testing
- Ran `pytest -q veritas_os/tests/test_production_tls_load.py`; result: `3 passed, 2 skipped`, where skips are expected when `VERITAS_STAGING_BASE_URL` is not configured. 
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77c3d7d0083269f46c02aae389c25)