### PR TITLE
Add policy runtime rollout controls (canary→full) and rollback metadata

### DIFF
--- a/docs/policy_as_code.md
+++ b/docs/policy_as_code.md
@@ -207,6 +207,23 @@ Ed25519 署名により、秘密鍵を保有しない攻撃者はバンドルの
 1. transparency log / trust log 連携
 2. rollout / rollback policy pack metadata の追加
 
+### Rollout / Rollback metadata（2026-04）
+
+`metadata` に以下を追加すると、runtime bridge が段階ロールアウトを自動解釈します。
+
+- `metadata.rollout_controls.strategy`
+  - `disabled` / `canary` / `staged` / `full`
+- `metadata.rollout_controls.canary_percent`
+  - `0..100`（`canary` / `staged` 時に使用）
+- `metadata.rollout_controls.full_enforce_after`
+  - ISO-8601 datetime。到達後は canary から自動で `full` へ昇格
+- `metadata.rollback`
+  - `target_policy_version`, `reason` など rollback 用監査メタデータ
+
+runtime bridge は `governance.compiled_policy_rollout` に
+`enforced/state/rollback` を出力し、`policy_runtime_enforce=true` でも
+canary 対象外リクエストは observe-only に維持します。
+
 ---
 
 ## Validation / Compile Flow

--- a/veritas_os/core/pipeline/pipeline_policy.py
+++ b/veritas_os/core/pipeline/pipeline_policy.py
@@ -15,6 +15,8 @@ import logging
 import math
 import os
 import time
+from datetime import datetime, timezone
+import hashlib
 from typing import Any
 
 from veritas_os.policy.evaluator import evaluate_runtime_policies
@@ -42,6 +44,121 @@ def _build_fail_closed_fuji_precheck(reason: str) -> dict[str, Any]:
         "risk": 1.0,
         "modifications": [],
     }
+
+
+def _coerce_policy_enforce_flag(raw_value: Any) -> bool:
+    """Normalize explicit/runtime enforcement values into bool."""
+    if isinstance(raw_value, str):
+        return raw_value.strip().lower() in ("1", "true", "yes")
+    return bool(raw_value)
+
+
+def _resolve_rollout_controls(decision: dict[str, Any]) -> dict[str, Any]:
+    """Extract rollout controls from the first triggered policy metadata."""
+    policy_results = decision.get("policy_results", [])
+    if not isinstance(policy_results, list):
+        return {}
+
+    for result in policy_results:
+        if not isinstance(result, dict) or not result.get("triggered"):
+            continue
+        metadata = result.get("metadata", {})
+        if not isinstance(metadata, dict):
+            continue
+        rollout_controls = metadata.get("rollout_controls", {})
+        if isinstance(rollout_controls, dict):
+            return rollout_controls
+    return {}
+
+
+def _resolve_rollback_metadata(decision: dict[str, Any]) -> dict[str, Any]:
+    """Extract rollback metadata from the first triggered policy."""
+    policy_results = decision.get("policy_results", [])
+    if not isinstance(policy_results, list):
+        return {}
+
+    for result in policy_results:
+        if not isinstance(result, dict) or not result.get("triggered"):
+            continue
+        metadata = result.get("metadata", {})
+        if not isinstance(metadata, dict):
+            continue
+        rollback = metadata.get("rollback", {})
+        if isinstance(rollback, dict):
+            return rollback
+    return {}
+
+
+def _deterministic_bucket_ratio(bucket_key: str) -> float:
+    """Return deterministic ratio [0, 1) from a bucket key."""
+    digest = hashlib.sha256(bucket_key.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") / float(2**64)
+
+
+def _is_rollout_auto_promoted(rollout_controls: dict[str, Any]) -> bool:
+    """Return True when canary rollout should auto-promote to full."""
+    full_after = rollout_controls.get("full_enforce_after")
+    if not isinstance(full_after, str) or not full_after.strip():
+        return False
+    normalized = full_after.strip().replace("Z", "+00:00")
+    try:
+        full_after_dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        logger.warning("invalid full_enforce_after in rollout_controls: %r", full_after)
+        return False
+    if full_after_dt.tzinfo is None:
+        full_after_dt = full_after_dt.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) >= full_after_dt
+
+
+def _is_enforcement_enabled_for_rollout(
+    ctx_dict: dict[str, Any],
+    decision: dict[str, Any],
+) -> tuple[bool, str]:
+    """Resolve runtime enforcement state with canary/full rollout control."""
+    enforce = ctx_dict.get("policy_runtime_enforce")
+    if enforce is None:
+        enforce = os.getenv("VERITAS_POLICY_RUNTIME_ENFORCE", "")
+    if not _coerce_policy_enforce_flag(enforce):
+        return False, "enforcement_disabled"
+
+    rollout_controls = _resolve_rollout_controls(decision)
+    strategy = str(rollout_controls.get("strategy", "full")).strip().lower()
+    if strategy in {"", "full"}:
+        return True, "full"
+    if strategy == "disabled":
+        return False, "rollout_disabled"
+    if strategy in {"canary", "staged"}:
+        if _is_rollout_auto_promoted(rollout_controls):
+            return True, "full_auto_promoted"
+        canary_percent_raw = rollout_controls.get("canary_percent", 0)
+        try:
+            canary_percent = int(canary_percent_raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "invalid canary_percent in rollout_controls: %r",
+                canary_percent_raw,
+            )
+            canary_percent = 0
+        canary_percent = max(0, min(100, canary_percent))
+        bucket_key = str(
+            ctx_dict.get("policy_rollout_key")
+            or ctx_dict.get("request_id")
+            or ctx_dict.get("trace_id")
+            or ctx_dict.get("actor")
+            or ""
+        )
+        ratio = _deterministic_bucket_ratio(bucket_key)
+        in_canary = ratio < (canary_percent / 100.0)
+        if not in_canary:
+            return False, f"{strategy}_skip"
+        return True, strategy
+
+    logger.warning(
+        "unknown rollout strategy=%r; defaulting to safe full enforcement",
+        strategy,
+    )
+    return True, "full_unknown_strategy"
 
 
 def _apply_compiled_policy_runtime_bridge(ctx: PipelineContext) -> None:
@@ -79,21 +196,20 @@ def _apply_compiled_policy_runtime_bridge(ctx: PipelineContext) -> None:
     governance["compiled_policy"] = decision
 
     outcome = decision.get("final_outcome")
-    enforce = ctx_dict.get("policy_runtime_enforce")
-    if enforce is None:
-        enforce = os.getenv("VERITAS_POLICY_RUNTIME_ENFORCE", "").strip().lower() in (
-            "1",
-            "true",
-            "yes",
-        )
-    elif isinstance(enforce, str):
-        enforce = enforce.strip().lower() in ("1", "true", "yes")
-    if not bool(enforce):
+    rollback_metadata = _resolve_rollback_metadata(decision)
+    enforce, rollout_state = _is_enforcement_enabled_for_rollout(ctx_dict, decision)
+    governance["compiled_policy_rollout"] = {
+        "enforced": enforce,
+        "state": rollout_state,
+        "rollback": rollback_metadata,
+    }
+    if not enforce:
         if outcome in {"deny", "halt", "escalate", "require_human_review"}:
             logger.warning(
                 "compiled policy outcome=%s observed but not enforced "
-                "(policy_runtime_enforce=false)",
+                "(policy_runtime_enforce=false, rollout_state=%s)",
                 outcome,
+                rollout_state,
             )
         return
 

--- a/veritas_os/policy/evaluator.py
+++ b/veritas_os/policy/evaluator.py
@@ -378,6 +378,7 @@ def evaluate_runtime_policies(
                     "minimum_approval_met": req_eval["minimum_approval_met"],
                 },
                 "obligations": list(policy.obligations),
+                "metadata": dict(policy.metadata),
                 "explanation": explanation,
             }
         )

--- a/veritas_os/policy/models.py
+++ b/veritas_os/policy/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal
 
@@ -206,6 +206,52 @@ class SourcePolicy(BaseModel):
     def _ensure_metadata_mapping(cls, value: Dict[str, Any]) -> Dict[str, Any]:
         if not isinstance(value, dict):
             raise ValueError("metadata must be an object")
+        rollout_controls = value.get("rollout_controls")
+        if rollout_controls is not None:
+            if not isinstance(rollout_controls, dict):
+                raise ValueError("metadata.rollout_controls must be an object")
+            strategy = str(rollout_controls.get("strategy", "")).strip().lower()
+            if strategy not in {"disabled", "canary", "staged", "full"}:
+                raise ValueError(
+                    "metadata.rollout_controls.strategy must be one of "
+                    "disabled/canary/staged/full"
+                )
+            canary_percent = rollout_controls.get("canary_percent", 0)
+            try:
+                canary_int = int(canary_percent)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "metadata.rollout_controls.canary_percent must be int"
+                ) from exc
+            if canary_int < 0 or canary_int > 100:
+                raise ValueError(
+                    "metadata.rollout_controls.canary_percent must be 0..100"
+                )
+            full_after = rollout_controls.get("full_enforce_after")
+            if full_after is not None:
+                normalized = str(full_after).strip().replace("Z", "+00:00")
+                try:
+                    datetime.fromisoformat(normalized)
+                except ValueError as exc:
+                    raise ValueError(
+                        "metadata.rollout_controls.full_enforce_after must be "
+                        "ISO-8601 datetime"
+                    ) from exc
+
+        rollback = value.get("rollback")
+        if rollback is not None:
+            if not isinstance(rollback, dict):
+                raise ValueError("metadata.rollback must be an object")
+            rollback_target = rollback.get("target_policy_version")
+            if rollback_target is not None and not str(rollback_target).strip():
+                raise ValueError(
+                    "metadata.rollback.target_policy_version must be non-empty"
+                )
+            rollback_reason = rollback.get("reason")
+            if rollback_reason is not None and not str(rollback_reason).strip():
+                raise ValueError(
+                    "metadata.rollback.reason must be non-empty when provided"
+                )
         return value
 
     @field_validator("obligations")

--- a/veritas_os/tests/test_policy_compiler.py
+++ b/veritas_os/tests/test_policy_compiler.py
@@ -53,6 +53,34 @@ def test_compile_policy_failure_for_invalid_source(tmp_path: Path) -> None:
         compile_policy_to_bundle(invalid_file, tmp_path)
 
 
+def test_compile_rejects_invalid_rollout_metadata(tmp_path: Path) -> None:
+    invalid_file = tmp_path / "invalid_rollout.yaml"
+    invalid_file.write_text(
+        """
+        schema_version: "1.0"
+        policy_id: "policy.invalid.rollout"
+        version: "1"
+        title: "invalid rollout"
+        description: "rollout metadata has invalid canary percent"
+        scope:
+          domains: ["security"]
+          routes: ["/api/tools"]
+          actors: ["kernel"]
+        outcome:
+          decision: "deny"
+          reason: "invalid rollout metadata"
+        metadata:
+          rollout_controls:
+            strategy: "canary"
+            canary_percent: 101
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PolicyValidationError):
+        compile_policy_to_bundle(invalid_file, tmp_path)
+
+
 def test_manifest_contents_and_explanation_metadata(tmp_path: Path) -> None:
     result = compile_policy_to_bundle(
         EXAMPLES_DIR / "external_tool_usage_denied.yaml",

--- a/veritas_os/tests/unit/test_pipeline_stages_ext.py
+++ b/veritas_os/tests/unit/test_pipeline_stages_ext.py
@@ -7450,10 +7450,8 @@ def test_pipeline_bridge_warns_when_not_enforced(
         stage_fuji_precheck(ctx)
 
     assert ctx.fuji_dict.get("status") != "rejected"
-    assert (
-        "compiled policy outcome=deny observed but not enforced "
-        "(policy_runtime_enforce=false)"
-    ) in caplog.text
+    assert "compiled policy outcome=deny observed but not enforced" in caplog.text
+    assert "rollout_state=enforcement_disabled" in caplog.text
 
 
 def test_pipeline_bridge_enforcement_deny_sets_rejected(tmp_path: Path) -> None:
@@ -7670,6 +7668,136 @@ def test_pipeline_bridge_enforcement_logs_audit_info(
         "compiled policy enforcement" in record.message and "status=rejected" in record.message
         for record in caplog.records
     )
+
+
+def test_pipeline_bridge_canary_rollout_skips_enforcement_outside_bucket() -> None:
+    """Canary strategy should observe-only when request is outside canary bucket."""
+    from unittest.mock import patch
+
+    from veritas_os.policy.runtime_adapter import RuntimePolicy, RuntimePolicyBundle
+
+    deny_policy = RuntimePolicy(
+        policy_id="policy.test.canary",
+        version="1",
+        title="Canary deny",
+        description="Canary policy deny for test.",
+        effective_date=None,
+        scope={"domains": ["security"], "routes": ["/api/tools"], "actors": ["kernel"]},
+        conditions=[{"field": "tool.external", "operator": "eq", "value": True}],
+        requirements={"required_evidence": [], "required_reviewers": [], "minimum_approval_count": 0},
+        constraints=[],
+        outcome={"decision": "deny", "reason": "Denied in canary."},
+        obligations=[],
+        test_vectors=[],
+        metadata={
+            "rollout_controls": {
+                "strategy": "canary",
+                "canary_percent": 0,
+            },
+            "rollback": {
+                "target_policy_version": "2026.03.20",
+                "reason": "canary regression safeguard",
+            },
+        },
+        source_refs=[],
+    )
+    bundle = RuntimePolicyBundle(
+        schema_version="0.1",
+        policy_id="policy.test.canary",
+        version="1",
+        semantic_hash="sha256:test",
+        compiler_version="0.1.0",
+        compiled_at="2026-04-02T00:00:00Z",
+        manifest={"schema_version": "0.1"},
+        runtime_policies=[deny_policy],
+    )
+
+    with patch(
+        "veritas_os.core.pipeline.pipeline_policy.load_runtime_bundle",
+        return_value=bundle,
+    ):
+        ctx = PipelineContext(
+            query="external tool request",
+            context={
+                "compiled_policy_bundle_dir": "/mock/bundle",
+                "policy_runtime_enforce": True,
+                "domain": "security",
+                "route": "/api/tools",
+                "actor": "kernel",
+                "tool": {"external": True},
+                "request_id": "outside-canary",
+            },
+        )
+        stage_fuji_precheck(ctx)
+
+    assert ctx.fuji_dict["status"] != "rejected"
+    rollout = ctx.response_extras["governance"]["compiled_policy_rollout"]
+    assert rollout["enforced"] is False
+    assert rollout["state"] == "canary_skip"
+    assert rollout["rollback"]["target_policy_version"] == "2026.03.20"
+
+
+def test_pipeline_bridge_canary_rollout_auto_promotes_to_full() -> None:
+    """Canary strategy should auto-promote to full after full_enforce_after."""
+    from unittest.mock import patch
+
+    from veritas_os.policy.runtime_adapter import RuntimePolicy, RuntimePolicyBundle
+
+    deny_policy = RuntimePolicy(
+        policy_id="policy.test.canary.promote",
+        version="1",
+        title="Canary auto promote deny",
+        description="Canary policy deny auto-promoted to full.",
+        effective_date=None,
+        scope={"domains": ["security"], "routes": ["/api/tools"], "actors": ["kernel"]},
+        conditions=[{"field": "tool.external", "operator": "eq", "value": True}],
+        requirements={"required_evidence": [], "required_reviewers": [], "minimum_approval_count": 0},
+        constraints=[],
+        outcome={"decision": "deny", "reason": "Denied after promotion."},
+        obligations=[],
+        test_vectors=[],
+        metadata={
+            "rollout_controls": {
+                "strategy": "canary",
+                "canary_percent": 1,
+                "full_enforce_after": "2020-01-01T00:00:00Z",
+            },
+        },
+        source_refs=[],
+    )
+    bundle = RuntimePolicyBundle(
+        schema_version="0.1",
+        policy_id="policy.test.canary.promote",
+        version="1",
+        semantic_hash="sha256:test",
+        compiler_version="0.1.0",
+        compiled_at="2026-04-02T00:00:00Z",
+        manifest={"schema_version": "0.1"},
+        runtime_policies=[deny_policy],
+    )
+
+    with patch(
+        "veritas_os.core.pipeline.pipeline_policy.load_runtime_bundle",
+        return_value=bundle,
+    ):
+        ctx = PipelineContext(
+            query="external tool request",
+            context={
+                "compiled_policy_bundle_dir": "/mock/bundle",
+                "policy_runtime_enforce": True,
+                "domain": "security",
+                "route": "/api/tools",
+                "actor": "kernel",
+                "tool": {"external": True},
+                "request_id": "any-id",
+            },
+        )
+        stage_fuji_precheck(ctx)
+
+    assert ctx.fuji_dict["status"] == "rejected"
+    rollout = ctx.response_extras["governance"]["compiled_policy_rollout"]
+    assert rollout["enforced"] is True
+    assert rollout["state"] == "full_auto_promoted"
 
 
 def test_value_ema_nan_falls_back_to_neutral() -> None:


### PR DESCRIPTION
### Motivation
- Provide automated, metadata-driven phased enforcement for Policy-as-Code so compiled policy bundles can be rolled out safely (canary → staged → full) without operator intervention. 
- Surface rollback audit metadata alongside rollout state so operators can inspect safe rollback targets and reasons. 
- Fail-closed on invalid rollout definitions during compile/validation to avoid silent misconfigurations. 
- Security note: rollback metadata is audit-only (no automatic rollback execution) and Ed25519/signature/configuration mistakes (e.g. malformed `full_enforce_after`) may prevent intended promotion—operators must validate rollout settings and signing keys.

### Description
- Added strict validation for rollout/rollback metadata in `SourcePolicy.metadata` (`metadata.rollout_controls.strategy`, `canary_percent`, `full_enforce_after`; `metadata.rollback.target_policy_version` / `reason`) so invalid definitions raise `PolicyValidationError` at compile time (`veritas_os/policy/models.py`).
- Extended runtime policy evaluation output to include each policy's `metadata` by adding `metadata` into `policy_results` returned by `evaluate_runtime_policies()` (`veritas_os/policy/evaluator.py`).
- Implemented rollout resolution and enforcement gating in the pipeline bridge: deterministic SHA-256 bucketing, `canary_percent` handling, `full_enforce_after` auto-promotion, and safe fallbacks; the bridge now writes `governance.compiled_policy_rollout = {enforced, state, rollback}` into `ctx.response_extras` and honors `policy_runtime_enforce` / `VERITAS_POLICY_RUNTIME_ENFORCE` (`veritas_os/core/pipeline/pipeline_policy.py`).
- Added unit tests validating compile-time rejection of invalid rollout metadata and runtime behaviors (canary skip, auto-promotion) and updated Policy-as-Code docs to document the new `metadata` contract (`docs/policy_as_code.md`).

### Testing
- Ran targeted compile validation test `pytest -q veritas_os/tests/test_policy_compiler.py::test_compile_rejects_invalid_rollout_metadata` and two pipeline rollout tests and all three passed (3/3 passed).
- Ran `pytest -q veritas_os/tests/unit/test_pipeline_stages_ext.py -k 'pipeline_bridge_'` to cover pipeline bridge scenarios and all relevant tests passed (11 passed).
- Ran `pytest -q veritas_os/tests/test_policy_compiler.py -k 'rollout_metadata or policy_failure_for_invalid_source'` and the focused policy-compiler tests passed (2 passed).
- Ran `ruff check` against the modified files (`veritas_os/policy/models.py`, `veritas_os/policy/evaluator.py`, `veritas_os/core/pipeline/pipeline_policy.py`, `veritas_os/tests/test_policy_compiler.py`) and format/lint checks passed for those files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77de1b27c8326a32dd086c5b65dcf)