### PR TITLE
frontend: harden managed SSE against stale EventSource race conditions

### DIFF
--- a/frontend/lib/managed-sse.test.ts
+++ b/frontend/lib/managed-sse.test.ts
@@ -59,6 +59,34 @@ describe("startManagedEventStream", () => {
     stop();
   });
 
+  it("ignores repeated onerror callbacks from a stale EventSource instance", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const stop = startManagedEventStream("/api/veritas/v1/events", {
+      onMessage: () => undefined,
+    });
+
+    await Promise.resolve();
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    const firstEventSource = MockEventSource.instances[0];
+    firstEventSource?.onerror?.();
+    firstEventSource?.onerror?.();
+
+    await vi.advanceTimersByTimeAsync(800);
+    await Promise.resolve();
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+
+    randomSpy.mockRestore();
+    stop();
+  });
+
   it("opens EventSource with same-origin credentials", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
 

--- a/frontend/lib/managed-sse.ts
+++ b/frontend/lib/managed-sse.ts
@@ -22,6 +22,13 @@ function getReconnectDelayMs(attempt: number): number {
   return Math.round(exponentialDelay * jitterFactor);
 }
 
+/**
+ * Start a managed SSE connection with retry/backoff and auth pause handling.
+ *
+ * Concurrency safety:
+ * - Ignores stale async probe responses when multiple connect attempts overlap.
+ * - Ensures EventSource error handlers only act on their own instance.
+ */
 export function startManagedEventStream(
   url: string,
   options: ManagedSseOptions,
@@ -30,6 +37,7 @@ export function startManagedEventStream(
   let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
   let eventSource: EventSource | null = null;
   let reconnectAttempt = 0;
+  let connectSequence = 0;
 
   const authPauseMs = options.authRetryPauseMs ?? AUTH_RETRY_PAUSE_MS;
 
@@ -65,6 +73,9 @@ export function startManagedEventStream(
       return;
     }
 
+    const currentConnectSequence = connectSequence + 1;
+    connectSequence = currentConnectSequence;
+
     clearReconnectTimeout();
     closeEventSource();
 
@@ -73,6 +84,10 @@ export function startManagedEventStream(
         credentials: "same-origin",
         method: "GET",
       });
+
+      if (disposed || currentConnectSequence !== connectSequence) {
+        return;
+      }
 
       if (probe.status === 401 || probe.status === 403) {
         options.onAuthPause?.(Date.now() + authPauseMs);
@@ -84,22 +99,33 @@ export function startManagedEventStream(
         throw new Error(`sse probe failed: ${probe.status}`);
       }
     } catch {
+      if (disposed || currentConnectSequence !== connectSequence) {
+        return;
+      }
       const delayMs = getReconnectDelayMs(reconnectAttempt);
       reconnectAttempt += 1;
       scheduleReconnect(delayMs);
       return;
     }
 
+    if (disposed || currentConnectSequence !== connectSequence) {
+      return;
+    }
+
     options.onAuthPause?.(null);
     reconnectAttempt = 0;
 
-    eventSource = new EventSource(url, { withCredentials: true });
-    eventSource.onopen = () => {
+    const nextEventSource = new EventSource(url, { withCredentials: true });
+    eventSource = nextEventSource;
+    nextEventSource.onopen = () => {
       reconnectAttempt = 0;
       options.onOpen?.();
     };
-    eventSource.onmessage = options.onMessage;
-    eventSource.onerror = () => {
+    nextEventSource.onmessage = options.onMessage;
+    nextEventSource.onerror = () => {
+      if (eventSource !== nextEventSource) {
+        return;
+      }
       closeEventSource();
       const delayMs = getReconnectDelayMs(reconnectAttempt);
       reconnectAttempt += 1;


### PR DESCRIPTION
### Motivation
- Prevent duplicate reconnects and race conditions when an earlier async probe or a replaced `EventSource` instance invokes `onerror` after a new connection has been established.
- Improve robustness of the frontend SSE manager to reduce flaky behavior around auth pauses and rapid reconnects.
- Add explicit documentation of the concurrency-safety intent for `startManagedEventStream`.

### Description
- Add a docstring and a `connectSequence` guard in `frontend/lib/managed-sse.ts` to ignore stale probe results and ensure `onerror` handlers only act on their own `EventSource` instance.
- Replace direct assignment of `eventSource` with a `nextEventSource` local and early-return from `onerror` when it does not match the current instance to avoid duplicate scheduling.
- Add a regression unit test in `frontend/lib/managed-sse.test.ts` that verifies repeated/stale `onerror` callbacks do not trigger duplicate reconnects, alongside existing auth-pause and credentialed-EventSource tests.
- Changes are limited to `frontend/lib/managed-sse.ts` and `frontend/lib/managed-sse.test.ts` only.

### Testing
- Ran `pnpm --filter frontend test lib/managed-sse.test.ts`, result: pass (`3 tests passed`).
- Ran `pnpm --filter frontend lint`, result: pass (0 errors, 11 warnings reported but no errors).
- Ran `python scripts/architecture/check_responsibility_boundaries.py`, result: pass (`Responsibility boundary check passed`).
- New test coverage focuses on normal reconnect after auth pause and abnormal cases where stale `EventSource` callbacks would previously cause duplicate reconnects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8df17eef0832692ec9fb08d89a6eb)