### PR TITLE
Enforce posture-aware governance signature verification and thread governance_identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ VERITAS OS wraps an LLM (e.g. OpenAI GPT-4.1-mini) with a **reproducible, fail-c
 - **Documentation Hub (JA)**: `docs/ja/README.md`
 - **Documentation Map**: `docs/DOCUMENTATION_MAP.md`
 - **Operations Runbook**: `docs/ja/operations/enterprise_slo_sli_runbook_ja.md`
+- **Governance Signing Runbook**: `docs/operations/governance_artifact_signing_operations.md`
+- **Governance Upgrade Press Summary**: `docs/press/governance_control_plane_upgrade_2026-04.md`
 
 ## 🚀 Quick Start (TL;DR)
 
@@ -139,6 +141,21 @@ VERITAS OS uses a single **runtime posture** (`VERITAS_POSTURE`) to control gove
 | Transparency log anchoring | `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` | TrustLog writes fail when transparency anchor is missing |
 | WORM hard-fail | `VERITAS_TRUSTLOG_WORM_HARD_FAIL` | TrustLog writes fail when WORM mirror write fails |
 | Strict replay | `VERITAS_REPLAY_STRICT` | Critical replay divergences abort |
+| Governance artifact signatures | `VERITAS_POLICY_VERIFY_KEY` (+ posture strictness) | In secure/prod, reject unsigned or non-Ed25519 governance policy bundles |
+
+### Governance artifact identity in decision outputs
+
+When compiled policy governance is active, `/v1/decide` responses include
+`governance_identity` with:
+
+- `policy_version`
+- `digest` (compiled bundle semantic hash)
+- `signature_verified`
+- `signer_id` (if bundle metadata provides `signing.key_id`)
+- `verified_at`
+
+This identity is threaded into decision, replay, and audit artifacts so that
+operators can prove which governance control-plane asset was in force.
 
 ### What causes startup refusal (secure/prod)
 

--- a/docs/governance_artifact_lifecycle.md
+++ b/docs/governance_artifact_lifecycle.md
@@ -63,10 +63,10 @@ Verification behavior depends on the runtime posture:
 
 | Posture     | Ed25519 Signed | SHA-256 Only | Missing Signature |
 |-------------|----------------|--------------|-------------------|
-| **dev**     | ✅ Accept      | ⚠️ Accept    | ❌ Fail           |
-| **staging** | ✅ Accept      | ⚠️ Accept    | ❌ Fail           |
-| **secure**  | ✅ Accept      | ❌ Reject    | ❌ Fail           |
-| **prod**    | ✅ Accept      | ❌ Reject    | ❌ Fail           |
+| **dev**     | ✅ Accept      | ⚠️ Accept    | ⚠️ Accept         |
+| **staging** | ✅ Accept      | ⚠️ Accept    | ⚠️ Accept         |
+| **secure**  | ✅ Accept      | ❌ Reject    | ❌ Reject         |
+| **prod**    | ✅ Accept      | ❌ Reject    | ❌ Reject         |
 
 In secure/prod posture, only Ed25519-signed bundles are accepted.  SHA-256
 integrity-only bundles are rejected because they do not provide authenticity
@@ -155,7 +155,9 @@ print('Keys generated: policy_signing.pem (KEEP SECRET), policy_verify.pem')
   falls back to SHA-256 but will be rejected in strict posture
 - **Invalid signature**: Bundle loading fails with `ValueError`
 - **Corrupt manifest**: Bundle loading fails with `ValueError`
-- **Missing manifest.sig**: Verification returns `False`, loading fails
+- **Missing manifest.sig**:
+  - `dev` / `staging`: warning + accept (migration compatibility)
+  - `secure` / `prod`: reject (fail-closed)
 
 ## Migration Notes
 
@@ -187,8 +189,8 @@ VERITAS OS はガバナンスアーティファクトを**署名付きで検証�
 
 | ポスチャ     | Ed25519署名 | SHA-256のみ | 署名なし |
 |-------------|-------------|-------------|---------|
-| **dev**     | ✅ 許可     | ⚠️ 許可     | ❌ 拒否  |
-| **staging** | ✅ 許可     | ⚠️ 許可     | ❌ 拒否  |
+| **dev**     | ✅ 許可     | ⚠️ 許可     | ⚠️ 許可  |
+| **staging** | ✅ 許可     | ⚠️ 許可     | ⚠️ 許可  |
 | **secure**  | ✅ 許可     | ❌ 拒否     | ❌ 拒否  |
 | **prod**    | ✅ 許可     | ❌ 拒否     | ❌ 拒否  |
 

--- a/docs/operations/governance_artifact_signing_operations.md
+++ b/docs/operations/governance_artifact_signing_operations.md
@@ -1,0 +1,65 @@
+# Governance Artifact Signing Operations
+
+## Scope
+
+This runbook defines operator actions for governance artifact signature
+verification, key rotation, and failure handling across runtime posture levels.
+
+## Posture-specific behavior
+
+- `dev` / `staging`
+  - Ed25519 signatures are verified when available.
+  - SHA-256-only and missing-signature bundles are accepted with warnings.
+- `secure` / `prod`
+  - Only Ed25519-signed governance bundles are accepted.
+  - Missing signatures, invalid signatures, and SHA-256-only artifacts are rejected.
+
+## Signer verification
+
+1. Set `VERITAS_POLICY_VERIFY_KEY` to the current Ed25519 public key PEM path.
+2. Compile policy bundles with signing metadata (`signing.algorithm=ed25519`).
+3. Confirm `/v1/decide` output includes `governance_identity.signature_verified=true`.
+4. Confirm `governance_identity.signer_id` is populated when `manifest.signing.key_id`
+   is present.
+
+## Key rotation procedure
+
+1. Generate a new Ed25519 key pair.
+2. Re-sign bundles using the new private key.
+3. Deploy the new public key through `VERITAS_POLICY_VERIFY_KEY`.
+4. Verify staged rollout in `staging` posture.
+5. Promote to `secure`/`prod` only after successful verification.
+
+## Failure handling
+
+### Invalid signature
+
+- Runtime behavior: bundle load fails.
+- Operator response:
+  1. Stop rollout.
+  2. Rebuild bundle from trusted source.
+  3. Re-sign and re-verify.
+
+### Missing signature
+
+- Runtime behavior:
+  - `dev` / `staging`: warning and accept.
+  - `secure` / `prod`: fail-closed rejection.
+- Operator response:
+  1. Treat as release blocker for `secure`/`prod`.
+  2. Sign bundle and redeploy.
+
+### Missing verification key
+
+- Runtime behavior:
+  - Ed25519 authenticity cannot be verified without `VERITAS_POLICY_VERIFY_KEY`.
+  - In strict posture this should be treated as a misconfiguration and fixed before
+    promotion.
+- Operator response:
+  1. Restore public key path and file permissions.
+  2. Re-run bundle verification checks.
+
+## Migration note for legacy unsigned flows
+
+- Legacy SHA-256/missing-signature bundles may continue in `dev`/`staging` for migration.
+- Before `secure`/`prod` promotion, all governance bundles must be Ed25519 signed.

--- a/docs/press/governance_control_plane_upgrade_2026-04.md
+++ b/docs/press/governance_control_plane_upgrade_2026-04.md
@@ -1,0 +1,37 @@
+# Press Release Summary: Governance Artifacts as Signed Control-Plane Assets
+
+## Problem
+
+Governance artifacts were historically treated as deploy-time options, which made
+provenance and authenticity harder to prove during production audits.
+
+## Trust model
+
+VERITAS OS now treats governance bundles as control-plane assets that require:
+
+- cryptographic signature verification,
+- attributable approvals,
+- digest-linked change history,
+- decision-time identity threading (`governance_identity`).
+
+## Posture differences
+
+- `dev` / `staging`: support practical migration by allowing unsigned/legacy bundles with warnings.
+- `secure` / `prod`: fail-closed; reject unsigned, invalid, or SHA-256-only governance artifacts.
+
+## Migration challenge
+
+Main migration work is converting existing unsigned artifacts and rollout workflows
+into Ed25519-signed bundles while maintaining release velocity.
+
+## Residual risks
+
+- Key custody/operational mistakes can still block rollout.
+- Signer metadata quality (`key_id` hygiene) remains an operator responsibility.
+- Non-strict postures can still run with warnings if teams do not enforce promotion gates.
+
+## Governance artifact lifecycle (short note)
+
+Author → Approve (4-eyes) → Sign (Ed25519) → Verify (posture-aware) → Activate
+→ Thread into decisions (`policy_version`, `digest`, `signature_verified`, `signer_id`)
+→ Audit digest transitions (`previous_digest` → `new_digest`) → Governed rollback.

--- a/veritas_os/core/pipeline/pipeline_policy.py
+++ b/veritas_os/core/pipeline/pipeline_policy.py
@@ -203,6 +203,18 @@ def _apply_compiled_policy_runtime_bridge(ctx: PipelineContext) -> None:
         governance = {}
         ctx.response_extras["governance"] = governance
     governance["compiled_policy"] = decision
+    signing = runtime_bundle.manifest.get("signing", {})
+    signing_algorithm = str(signing.get("algorithm", "sha256")).strip().lower()
+    signer_id = str(signing.get("key_id", "")).strip()
+    ctx.governance_identity = {
+        "policy_version": runtime_bundle.version,
+        "digest": runtime_bundle.semantic_hash,
+        "signature_verified": signing_algorithm == "ed25519",
+        "signer_id": signer_id,
+        "verified_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+    }
 
     outcome = decision.get("final_outcome")
     rollback_metadata = _resolve_rollback_metadata(decision)

--- a/veritas_os/core/pipeline/pipeline_policy.py
+++ b/veritas_os/core/pipeline/pipeline_policy.py
@@ -203,12 +203,19 @@ def _apply_compiled_policy_runtime_bridge(ctx: PipelineContext) -> None:
         governance = {}
         ctx.response_extras["governance"] = governance
     governance["compiled_policy"] = decision
-    signing = runtime_bundle.manifest.get("signing", {})
+    manifest = getattr(runtime_bundle, "manifest", {})
+    if not isinstance(manifest, dict):
+        manifest = {}
+    signing = manifest.get("signing", {})
+    if not isinstance(signing, dict):
+        signing = {}
     signing_algorithm = str(signing.get("algorithm", "sha256")).strip().lower()
     signer_id = str(signing.get("key_id", "")).strip()
+    policy_version = str(getattr(runtime_bundle, "version", "") or "")
+    policy_digest = str(getattr(runtime_bundle, "semantic_hash", "") or "")
     ctx.governance_identity = {
-        "policy_version": runtime_bundle.version,
-        "digest": runtime_bundle.semantic_hash,
+        "policy_version": policy_version,
+        "digest": policy_digest,
         "signature_verified": signing_algorithm == "ed25519",
         "signer_id": signer_id,
         "verified_at": datetime.now(timezone.utc)

--- a/veritas_os/policy/runtime_adapter.py
+++ b/veritas_os/policy/runtime_adapter.py
@@ -216,15 +216,6 @@ def load_runtime_bundle(
         public_key_pem: Optional Ed25519 public key in PEM format for
             signature verification.  Falls back to SHA-256 integrity check.
     """
-    root = Path(bundle_dir)
-    if not verify_manifest_signature(root, public_key_pem=public_key_pem):
-        raise ValueError("manifest signature verification failed")
-    manifest = _read_json_file(root / "manifest.json")
-    canonical_ir = _read_json_file(root / "compiled" / "canonical_ir.json")
-
-    signing_algorithm = manifest.get("signing", {}).get("algorithm", "sha256")
-
-    # Posture-aware enforcement: reject non-Ed25519 bundles in strict posture.
     is_strict = False
     try:
         from veritas_os.core.posture import get_active_posture
@@ -232,6 +223,29 @@ def load_runtime_bundle(
     except (ImportError, AttributeError):
         pass
 
+    root = Path(bundle_dir)
+    manifest = _read_json_file(root / "manifest.json")
+
+    signing = manifest.get("signing", {})
+    signing_algorithm = signing.get("algorithm", "sha256")
+    signature_path = root / "manifest.sig"
+
+    if not signature_path.exists():
+        if is_strict:
+            raise ValueError(
+                f"bundle {bundle_dir} is missing manifest.sig; unsigned governance "
+                "artifacts are rejected in secure/prod posture."
+            )
+        logger.warning(
+            "bundle %s is missing manifest.sig; accepting unsigned artifact in "
+            "non-strict posture for developer workflow compatibility.",
+            bundle_dir,
+        )
+    else:
+        if not verify_manifest_signature(root, public_key_pem=public_key_pem):
+            raise ValueError("manifest signature verification failed")
+
+    # Posture-aware enforcement: reject non-Ed25519 bundles in strict posture.
     if signing_algorithm != "ed25519":
         if is_strict:
             raise ValueError(
@@ -246,6 +260,7 @@ def load_runtime_bundle(
             bundle_dir,
         )
 
+    canonical_ir = _read_json_file(root / "compiled" / "canonical_ir.json")
     runtime_policy = adapt_canonical_ir(canonical_ir)
 
     logger.info(

--- a/veritas_os/tests/test_governance_artifact_signing.py
+++ b/veritas_os/tests/test_governance_artifact_signing.py
@@ -655,6 +655,118 @@ class TestMissingSignatureBehavior:
         # No manifest.sig
         assert verify_manifest_signature(bundle_dir) is False
 
+    def test_missing_sig_rejected_in_strict_posture(self, tmp_path, monkeypatch):
+        from veritas_os.policy.runtime_adapter import load_runtime_bundle
+        from veritas_os.core.posture import PostureDefaults, PostureLevel
+
+        bundle_dir = tmp_path / "bundle"
+        (bundle_dir / "compiled").mkdir(parents=True, exist_ok=True)
+        (bundle_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "0.1",
+                    "policy_id": "missing-sig-policy",
+                    "version": "1.0",
+                    "semantic_hash": "abc123",
+                    "compiler_version": "0.1.0",
+                    "compiled_at": "2026-01-01T00:00:00Z",
+                    "signing": {"algorithm": "sha256", "status": "unsigned"},
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        (bundle_dir / "compiled" / "canonical_ir.json").write_text(
+            json.dumps(
+                {
+                    "policy_id": "missing-sig-policy",
+                    "version": "1.0",
+                    "title": "Missing Sig",
+                    "description": "Test",
+                    "scope": {"domains": [], "routes": [], "actors": []},
+                    "conditions": [],
+                    "constraints": [],
+                    "requirements": {
+                        "min_evidence": 0,
+                        "min_approvals": 0,
+                        "reviewer_count": 0,
+                    },
+                    "outcome": {"decision": "allow", "reason": "test"},
+                    "obligations": [],
+                    "test_vectors": [],
+                    "metadata": {},
+                    "source_refs": [],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "veritas_os.core.posture.get_active_posture",
+            lambda: PostureDefaults(posture=PostureLevel.PROD),
+        )
+
+        with pytest.raises(ValueError, match="missing manifest.sig"):
+            load_runtime_bundle(bundle_dir)
+
+    def test_missing_sig_accepted_in_dev_posture(self, tmp_path, monkeypatch):
+        from veritas_os.policy.runtime_adapter import load_runtime_bundle
+        from veritas_os.core.posture import PostureDefaults, PostureLevel
+
+        bundle_dir = tmp_path / "bundle"
+        (bundle_dir / "compiled").mkdir(parents=True, exist_ok=True)
+        (bundle_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "0.1",
+                    "policy_id": "missing-sig-policy-dev",
+                    "version": "1.1",
+                    "semantic_hash": "def456",
+                    "compiler_version": "0.1.0",
+                    "compiled_at": "2026-01-01T00:00:00Z",
+                    "signing": {"algorithm": "sha256", "status": "unsigned"},
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        (bundle_dir / "compiled" / "canonical_ir.json").write_text(
+            json.dumps(
+                {
+                    "policy_id": "missing-sig-policy-dev",
+                    "version": "1.1",
+                    "title": "Missing Sig Dev",
+                    "description": "Test",
+                    "scope": {"domains": [], "routes": [], "actors": []},
+                    "conditions": [],
+                    "constraints": [],
+                    "requirements": {
+                        "min_evidence": 0,
+                        "min_approvals": 0,
+                        "reviewer_count": 0,
+                    },
+                    "outcome": {"decision": "allow", "reason": "test"},
+                    "obligations": [],
+                    "test_vectors": [],
+                    "metadata": {},
+                    "source_refs": [],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "veritas_os.core.posture.get_active_posture",
+            lambda: PostureDefaults(posture=PostureLevel.DEV),
+        )
+
+        bundle = load_runtime_bundle(bundle_dir)
+        assert bundle.policy_id == "missing-sig-policy-dev"
+
     def test_unsigned_governance_warns_in_dev(self, caplog):
         from veritas_os.policy.governance_identity import require_signed_governance
 
@@ -677,3 +789,73 @@ class TestMissingSignatureBehavior:
                 posture_is_strict=True,
                 signature_verified=False,
             )
+
+
+def test_compiled_policy_bridge_sets_governance_identity(monkeypatch):
+    from veritas_os.core.pipeline.pipeline_policy import (
+        _apply_compiled_policy_runtime_bridge,
+    )
+    from veritas_os.core.pipeline.pipeline_types import PipelineContext
+    from veritas_os.policy.runtime_adapter import RuntimePolicy, RuntimePolicyBundle
+
+    runtime_bundle = RuntimePolicyBundle(
+        schema_version="0.1",
+        policy_id="policy.bridge",
+        version="governance_v9",
+        semantic_hash="abcde12345",
+        compiler_version="0.1.0",
+        compiled_at="2026-01-01T00:00:00Z",
+        runtime_policies=[
+            RuntimePolicy(
+                policy_id="policy.bridge",
+                version="governance_v9",
+                title="Bridge",
+                description="Bridge test",
+                effective_date=None,
+                scope={"domains": [], "routes": [], "actors": []},
+                conditions=[],
+                constraints=[],
+                requirements={},
+                outcome={"decision": "allow", "reason": "ok"},
+                obligations=[],
+                test_vectors=[],
+                metadata={},
+                source_refs=[],
+            )
+        ],
+        manifest={
+            "signing": {"algorithm": "ed25519", "status": "signed-ed25519", "key_id": "ops-key-1"}
+        },
+    )
+    monkeypatch.setattr(
+        "veritas_os.core.pipeline.pipeline_policy.load_runtime_bundle",
+        lambda *_args, **_kwargs: runtime_bundle,
+    )
+    monkeypatch.setattr(
+        "veritas_os.core.pipeline.pipeline_policy.evaluate_runtime_policies",
+        lambda *_args, **_kwargs: type("R", (), {"to_dict": lambda self: {"final_outcome": "allow"}})(),
+    )
+
+    ctx = PipelineContext(
+        body={},
+        query="q",
+        user_id="u",
+        request_id="r",
+        fast_mode=False,
+        replay_mode=False,
+        mock_external_apis=False,
+        seed=0,
+        min_ev=1,
+        started_at=0.0,
+        is_veritas_query=False,
+        context={"compiled_policy_bundle_dir": "/mock/bundle", "policy_runtime_enforce": True},
+        response_extras={},
+        plan={},
+    )
+
+    _apply_compiled_policy_runtime_bridge(ctx)
+    assert ctx.governance_identity is not None
+    assert ctx.governance_identity["policy_version"] == "governance_v9"
+    assert ctx.governance_identity["digest"] == "abcde12345"
+    assert ctx.governance_identity["signature_verified"] is True
+    assert ctx.governance_identity["signer_id"] == "ops-key-1"

--- a/veritas_os/tests/test_policy_runtime_adapter.py
+++ b/veritas_os/tests/test_policy_runtime_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 
 import pytest
@@ -468,13 +469,59 @@ def test_load_runtime_bundle_invalid_json(tmp_path: Path) -> None:
         load_runtime_bundle(bundle_dir)
 
 
-def test_load_runtime_bundle_missing_manifest(tmp_path: Path) -> None:
-    """load_runtime_bundle raises ValueError when manifest.sig is missing."""
-    bundle_dir = tmp_path / "no_sig"
-    bundle_dir.mkdir()
-    (bundle_dir / "manifest.json").write_text("{}", encoding="utf-8")
+def test_load_runtime_bundle_missing_manifest_rejected_in_strict_posture(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Missing ``manifest.sig`` is rejected in secure/prod posture."""
+    from veritas_os.core.posture import PostureDefaults, PostureLevel
 
-    with pytest.raises(ValueError, match="signature verification failed"):
+    bundle_dir = tmp_path / "no_sig"
+    (bundle_dir / "compiled").mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "policy_id": "test-policy",
+                "version": "1.0",
+                "semantic_hash": "abc123",
+                "compiler_version": "0.1.0",
+                "compiled_at": "2026-01-01T00:00:00Z",
+                "signing": {"algorithm": "sha256", "status": "unsigned"},
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    (bundle_dir / "compiled" / "canonical_ir.json").write_text(
+        json.dumps(
+            {
+                "policy_id": "test-policy",
+                "version": "1.0",
+                "title": "Test",
+                "description": "Test policy",
+                "scope": {"domains": [], "routes": [], "actors": []},
+                "conditions": [],
+                "constraints": [],
+                "requirements": {"min_evidence": 0, "min_approvals": 0, "reviewer_count": 0},
+                "outcome": {"decision": "allow", "reason": "test"},
+                "obligations": [],
+                "test_vectors": [],
+                "metadata": {},
+                "source_refs": [],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "veritas_os.core.posture.get_active_posture",
+        lambda: PostureDefaults(posture=PostureLevel.PROD),
+    )
+
+    with pytest.raises(ValueError, match="missing manifest.sig"):
         load_runtime_bundle(bundle_dir)
 
 


### PR DESCRIPTION
### Motivation
- Governance bundles must be treated as verifiable control-plane assets so production environments require authentic, signed artifacts and auditable provenance.  
- Secure/prod posture must fail-closed on unsigned or non-Ed25519 artifacts to prevent runtime authenticity gaps while preserving developer ergonomics in `dev`/`staging` for migration.  
- Decisions and replay/audit surfaces need an explicit `governance_identity` so operators can prove which governance artifact was in force for any decision.  

### Description
- Make `load_runtime_bundle` posture-aware: require `manifest.sig` in `secure`/`prod` (raise `ValueError`), and accept missing signatures in `dev`/`staging` with a warning; continue to reject non-Ed25519 signing in strict posture.  
- Verify manifest signature using existing `verify_manifest_signature` when `manifest.sig` exists and fail on verification failures.  
- Thread governance identity in the compiled policy bridge by setting `ctx.governance_identity` with `policy_version`, `digest` (semantic hash), `signature_verified`, `signer_id`, and `verified_at` during `_apply_compiled_policy_runtime_bridge`.  
- Add and update unit tests to cover missing-signature posture behavior and governance identity propagation, and update runtime/docs: `README.md`, `docs/governance_artifact_lifecycle.md`, an operator runbook `docs/operations/governance_artifact_signing_operations.md`, and a press summary `docs/press/governance_control_plane_upgrade_2026-04.md`.  

### Testing
- Ran targeted signing/runtime-adapter tests: `pytest -q veritas_os/tests/test_governance_artifact_signing.py -k "MissingSignatureBehavior or compiled_policy_bridge_sets_governance_identity or RuntimeAdapterPostureAwareness"` which passed (`9 passed, 30 deselected`).  
- Ran the posture-specific runtime adapter test: `pytest -q veritas_os/tests/test_policy_runtime_adapter.py -k "missing_manifest_rejected_in_strict_posture"` which passed (`1 passed, 41 deselected`).  
- All added/updated tests for missing-signature behavior and governance-identity propagation passed in the CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e388f3e88326b483fea0a1b971c5)