### PR TITLE
Require valid API keys for RBAC permission checks, record reject reasons, and add tests

### DIFF
--- a/veritas_os/README.md
+++ b/veritas_os/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17688094.svg)](https://doi.org/10.5281/zenodo.17688094)
 [![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-red.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-Production%20Ready%20(98%25)-green.svg)]()
+[![Status](https://img.shields.io/badge/status-Beta%20Governance%20Platform-blue.svg)]()
 [![CI](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml/badge.svg)](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/main.yml)
 [![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen.svg)](../docs/COVERAGE_REPORT.md)
 

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -568,7 +568,23 @@ def require_permission(permission: Permission):
         request: Request = None,  # type: ignore[assignment]
         x_api_key: str | None = Security(api_key_scheme),
     ):
-        role = _resolve_role_from_request(x_api_key)
+        key = (x_api_key or "").strip()
+        if not key:
+            _record_auth_reject_reason("missing_api_key_permission_check")
+            raise HTTPException(
+                status_code=401,
+                detail="Missing API key",
+            )
+
+        try:
+            role = resolve_role_for_key(key)
+        except ValueError:
+            _record_auth_reject_reason("invalid_api_key_permission_check")
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid API key",
+            ) from None
+
         allowed = ROLE_PERMISSIONS.get(role, frozenset())
         if permission not in allowed:
             _record_auth_reject_reason("insufficient_permission")

--- a/veritas_os/tests/test_rbac.py
+++ b/veritas_os/tests/test_rbac.py
@@ -284,6 +284,30 @@ class TestRequirePermission:
             snap = _snapshot_auth_reject_reason_metrics()
             assert snap.get("insufficient_permission", 0) >= 1
 
+    def test_missing_api_key_denied_with_401(self):
+        """Permission checks must reject missing API keys even if reused alone."""
+        from fastapi import HTTPException
+
+        checker = require_permission(Permission.decide)
+        req = self._make_request_stub("")
+        with pytest.raises(HTTPException) as exc_info:
+            checker(request=req, x_api_key="")
+        assert exc_info.value.status_code == 401
+        assert "Missing API key" in exc_info.value.detail
+
+    def test_invalid_api_key_denied_with_401(self):
+        """Permission checks must reject invalid API keys before RBAC resolution."""
+        from fastapi import HTTPException
+
+        keys_json = json.dumps([{"key": "sk-admin", "role": "admin"}])
+        with mock.patch.dict(os.environ, {"VERITAS_API_KEYS": keys_json}, clear=False):
+            checker = require_permission(Permission.decide)
+            req = self._make_request_stub("sk-invalid")
+            with pytest.raises(HTTPException) as exc_info:
+                checker(request=req, x_api_key="sk-invalid")
+        assert exc_info.value.status_code == 401
+        assert "Invalid API key" in exc_info.value.detail
+
 
 # ==============================
 # Backward compatibility


### PR DESCRIPTION
### Motivation

- Prevent implicit admin fallback when API keys are missing or invalid by enforcing explicit validation in the RBAC permission check.
- Surface and record precise reject reasons for monitoring (`_record_auth_reject_reason`).
- Clarify project status text in the README badge.

### Description

- Updated `require_permission` to explicitly reject empty API keys with a `401` and record the reason via `_record_auth_reject_reason("missing_api_key_permission_check")`.
- Updated `require_permission` to explicitly reject invalid API keys with a `401`, record the reason via `_record_auth_reject_reason("invalid_api_key_permission_check")`, and avoid silently falling back to admin by catching `ValueError` from `resolve_role_for_key` and raising `HTTPException`.
- Kept permission denial behavior for insufficient permissions (returns `403`) and preserved attaching the resolved role to `request.state.rbac_role` for downstream use.
- Adjusted README badge text from `Production Ready` to `Beta Governance Platform` in `veritas_os/README.md`.
- Added unit tests `test_missing_api_key_denied_with_401` and `test_invalid_api_key_denied_with_401` to `veritas_os/tests/test_rbac.py` to verify the new behaviors.

### Testing

- Ran the RBAC unit tests including the new tests with `pytest veritas_os/tests/test_rbac.py -q`, and the suite completed successfully.
- Verified the `TestRequirePermission` cases including `test_missing_api_key_denied_with_401` and `test_invalid_api_key_denied_with_401` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90ad4a3c88326a6b0b7c877d4a7ff)