### PR TITLE
Disallow cross-origin CSP report-only endpoint overrides and fall back to same-origin default

### DIFF
--- a/frontend/middleware.test.ts
+++ b/frontend/middleware.test.ts
@@ -66,6 +66,15 @@ describe("middleware CSP", () => {
     );
   });
 
+  it("falls back to default report-only endpoint for cross-origin override", () => {
+    vi.stubEnv("VERITAS_CSP_REPORT_ONLY_ENDPOINT", "https://collector.example/csp");
+
+    expect(resolveCspReportOnlyEndpoint()).toBe("/api/veritas/csp-report");
+    expect(buildCspReportOnly("sample-nonce")).toContain(
+      "report-uri /api/veritas/csp-report",
+    );
+  });
+
   it("defaults nonce enforcement flag to false in non-production profile", () => {
     vi.stubEnv("VERITAS_ENV", "development");
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -147,7 +147,10 @@ export function resolveCspReportOnlyEndpoint(): string {
   const configuredEndpoint = process.env[REPORT_ONLY_ENDPOINT_ENV] ?? "";
   const normalizedEndpoint = configuredEndpoint.trim();
   if (normalizedEndpoint) {
-    return normalizedEndpoint;
+    if (normalizedEndpoint.startsWith("/")) {
+      return normalizedEndpoint;
+    }
+    return "/api/veritas/csp-report";
   }
   return "/api/veritas/csp-report";
 }


### PR DESCRIPTION
### Motivation

- Prevent configured CSP report-only endpoints from being set to cross-origin URLs to avoid sending violation reports to external collectors.

### Description

- Update `resolveCspReportOnlyEndpoint` in `frontend/middleware.ts` to accept only same-origin overrides that start with `/` and otherwise fall back to the default `"/api/veritas/csp-report"` value.
- Add a unit test in `frontend/middleware.test.ts` named `falls back to default report-only endpoint for cross-origin override` to assert that an absolute URL in `VERITAS_CSP_REPORT_ONLY_ENDPOINT` is ignored.

### Testing

- Ran the unit test suite with `vitest` and the tests succeeded. 
- The new test `falls back to default report-only endpoint for cross-origin override` passed along with existing CSP-related tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9197578588326afef76d2fbc3af51)