### PR TITLE
Refactor TrustLog signing to pluggable backends with AWS KMS Ed25519

### DIFF
--- a/README.md
+++ b/README.md
@@ -1071,6 +1071,8 @@ All environment variables in one place. Set these in `.env` (git-ignored) or you
 |---|---|---|
 | `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` | `0` (posture: `1` in secure/prod) | Require transparency log anchoring (fail-closed) |
 | `VERITAS_TRUSTLOG_WORM_HARD_FAIL` | `0` (posture: `1` in secure/prod) | WORM mirror write failure raises error |
+| `VERITAS_TRUSTLOG_SIGNER_BACKEND` | `file` | TrustLog signer backend (`file` or `aws_kms`) |
+| `VERITAS_TRUSTLOG_KMS_KEY_ID` | — | AWS KMS key id/ARN (required when `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms`) |
 
 ### Replay
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
-    "next": "16.1.7",
+    "next": "16.2.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tailwind-merge": "^2.6.0"
@@ -36,7 +36,7 @@
     "autoprefixer": "^10.4.20",
     "axe-core": "^4.11.1",
     "eslint": "^8.57.1",
-    "eslint-config-next": "15.5.10",
+    "eslint-config-next": "16.2.3",
     "jsdom": "^25.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
-    "next": "16.2.3",
+    "next": "16.1.7",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tailwind-merge": "^2.6.0"
@@ -36,7 +36,7 @@
     "autoprefixer": "^10.4.20",
     "axe-core": "^4.11.1",
     "eslint": "^8.57.1",
-    "eslint-config-next": "16.2.3",
+    "eslint-config-next": "15.5.10",
     "jsdom": "^25.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -224,6 +224,24 @@ def _resolve_signer(*, ensure_local_keys: bool = False) -> Signer:
     )
 
 
+def _resolve_signer_for_entry(entry: Dict[str, Any]) -> Signer:
+    """Resolve signer for a persisted TrustLog entry.
+
+    The signer is selected from entry metadata first so mixed-backend
+    historical logs remain verifiable after backend migrations.
+    """
+    signer_type = str(entry.get("signer_type", "")).strip().lower()
+    signer_key_id = str(entry.get("signer_key_id", "")).strip()
+    if signer_type:
+        return build_trustlog_signer(
+            private_key_path=PRIVATE_KEY_PATH,
+            public_key_path=PUBLIC_KEY_PATH,
+            backend=signer_type,
+            kms_key_id=signer_key_id or None,
+        )
+    return _resolve_signer()
+
+
 def _entry_chain_hash(entry: Dict[str, Any]) -> str:
     return sha256_hex(canonical_json_dumps(entry))
 
@@ -509,7 +527,7 @@ def verify_signature(entry: Dict[str, Any]) -> bool:
     if not required.issubset(entry):
         return False
     try:
-        signer = _resolve_signer()
+        signer = _resolve_signer_for_entry(entry)
         return signer.verify_payload_signature(
             payload_hash=str(entry["payload_hash"]),
             signature_b64=str(entry["signature"]),

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -33,10 +33,9 @@ from typing import Any, Dict, List, Optional
 from veritas_os.logging.paths import LOG_DIR
 from veritas_os.security.hash import canonical_json_dumps, sha256_hex, sha256_of_canonical_json
 from veritas_os.security.signing import (
-    public_key_fingerprint,
-    sign_payload_hash,
+    Signer,
+    build_trustlog_signer,
     store_keypair,
-    verify_payload_signature,
 )
 
 SIGNED_TRUSTLOG_JSONL = LOG_DIR / "trustlog.jsonl"
@@ -211,10 +210,18 @@ def _utc_now_iso8601() -> str:
     )
 
 
-def _ensure_signing_keys() -> None:
-    if PRIVATE_KEY_PATH.exists() and PUBLIC_KEY_PATH.exists():
-        return
-    store_keypair(PRIVATE_KEY_PATH, PUBLIC_KEY_PATH)
+def _resolve_signer(*, ensure_local_keys: bool = False) -> Signer:
+    """Resolve active TrustLog signer backend.
+
+    Environment:
+        - VERITAS_TRUSTLOG_SIGNER_BACKEND=file|aws_kms (default: file)
+        - VERITAS_TRUSTLOG_KMS_KEY_ID=... (required for aws_kms)
+    """
+    return build_trustlog_signer(
+        private_key_path=PRIVATE_KEY_PATH,
+        public_key_path=PUBLIC_KEY_PATH,
+        ensure_local_keys=ensure_local_keys,
+    )
 
 
 def _entry_chain_hash(entry: Dict[str, Any]) -> str:
@@ -380,7 +387,7 @@ def build_trustlog_summary(full_payload: Dict[str, Any]) -> Dict[str, Any]:
     return summary
 
 
-def _enforce_entry_size(entry: Dict[str, Any]) -> Dict[str, Any]:
+def _enforce_entry_size(entry: Dict[str, Any], signer: Signer) -> Dict[str, Any]:
     """Ensure the serialized entry does not exceed ``MAX_ENTRY_LINE_BYTES``.
 
     If the entry is oversized, the ``decision_payload`` is replaced with
@@ -420,9 +427,7 @@ def _enforce_entry_size(entry: Dict[str, Any]) -> Dict[str, Any]:
     # can validate the on-disk entry without false-positive mismatches.
     entry["payload_hash"] = sha256_of_canonical_json(stub_payload)
     try:
-        entry["signature"] = sign_payload_hash(
-            entry["payload_hash"], PRIVATE_KEY_PATH,
-        )
+        entry["signature"] = signer.sign_payload_hash(entry["payload_hash"])
     except Exception:
         _logger.warning(
             "Failed to re-sign oversized stub entry; signature will be stale",
@@ -445,7 +450,7 @@ def append_signed_decision(decision_payload: Dict[str, Any]) -> Dict[str, Any]:
     """
     try:
         with _lock:
-            _ensure_signing_keys()
+            signer = _resolve_signer(ensure_local_keys=True)
             last_entry = _read_last_entry(SIGNED_TRUSTLOG_JSONL)
             previous_hash = _entry_chain_hash(last_entry) if last_entry else None
 
@@ -455,7 +460,7 @@ def append_signed_decision(decision_payload: Dict[str, Any]) -> Dict[str, Any]:
             compact_payload = build_trustlog_summary(decision_payload)
 
             payload_hash = sha256_of_canonical_json(compact_payload)
-            signature = sign_payload_hash(payload_hash, PRIVATE_KEY_PATH)
+            signature = signer.sign_payload_hash(payload_hash)
 
             entry = {
                 "decision_id": _uuid7(),
@@ -465,11 +470,12 @@ def append_signed_decision(decision_payload: Dict[str, Any]) -> Dict[str, Any]:
                 "payload_hash": payload_hash,
                 "full_payload_hash": full_payload_hash,
                 "signature": signature,
-                "signature_key_fingerprint": public_key_fingerprint(PUBLIC_KEY_PATH),
+                "signer_type": signer.signer_type,
+                "signer_key_id": signer.signer_key_id(),
             }
 
             # Enforce maximum entry size before writing
-            entry = _enforce_entry_size(entry)
+            entry = _enforce_entry_size(entry, signer)
 
             line = json.dumps(entry, ensure_ascii=False) + "\n"
             _append_line(SIGNED_TRUSTLOG_JSONL, line)
@@ -502,13 +508,11 @@ def verify_signature(entry: Dict[str, Any]) -> bool:
     required = {"payload_hash", "signature"}
     if not required.issubset(entry):
         return False
-    if not PUBLIC_KEY_PATH.exists():
-        return False
     try:
-        return verify_payload_signature(
+        signer = _resolve_signer()
+        return signer.verify_payload_signature(
             payload_hash=str(entry["payload_hash"]),
             signature_b64=str(entry["signature"]),
-            public_key_path=PUBLIC_KEY_PATH,
         )
     except Exception:  # noqa: BLE001
         # Malformed signatures (bad base64, wrong length, etc.) are treated
@@ -563,9 +567,15 @@ def verify_trustlog_chain(path: Optional[Path] = None) -> Dict[str, Any]:
             "exists": transparency_path.exists(),
         })
 
-    key_meta: Dict[str, Any] = {"public_key_present": PUBLIC_KEY_PATH.exists()}
-    if PUBLIC_KEY_PATH.exists():
-        key_meta["fingerprint"] = public_key_fingerprint(PUBLIC_KEY_PATH)
+    key_meta: Dict[str, Any] = {
+        "public_key_present": PUBLIC_KEY_PATH.exists(),
+    }
+    try:
+        signer = _resolve_signer()
+        key_meta["signer_type"] = signer.signer_type
+        key_meta["signer_key_id"] = signer.signer_key_id()
+    except Exception:
+        _logger.warning("Could not resolve TrustLog signer metadata", exc_info=True)
 
     return {
         "ok": len(issues) == 0,

--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -179,7 +179,7 @@ class Signer(Protocol):
 class FileEd25519Signer:
     """Ed25519 signer backed by local key files."""
 
-    signer_type = "file_ed25519"
+    signer_type = "file"
 
     def __init__(self, private_key_path: Path, public_key_path: Path) -> None:
         self.private_key_path = private_key_path
@@ -214,7 +214,7 @@ class AwsKmsEd25519Signer:
         are routed over trusted channels.
     """
 
-    signer_type = "aws_kms_ed25519"
+    signer_type = "aws_kms"
 
     def __init__(
         self,
@@ -274,17 +274,27 @@ def build_trustlog_signer(
     private_key_path: Path,
     public_key_path: Path,
     ensure_local_keys: bool = False,
+    backend: Optional[str] = None,
+    kms_key_id: Optional[str] = None,
 ) -> Signer:
     """Build TrustLog signer from backend environment variables."""
-    backend = os.getenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file").strip().lower()
-    if backend in {"", "file"}:
+    selected_backend = (
+        backend
+        if backend is not None
+        else os.getenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
+    ).strip().lower()
+    if selected_backend in {"", "file", "file_ed25519"}:
         signer = FileEd25519Signer(private_key_path=private_key_path, public_key_path=public_key_path)
         if ensure_local_keys:
             signer.ensure_key_material()
         return signer
-    if backend == "aws_kms":
-        kms_key_id = os.getenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "")
-        return AwsKmsEd25519Signer(kms_key_id=kms_key_id)
+    if selected_backend in {"aws_kms", "aws_kms_ed25519"}:
+        selected_key_id = (
+            kms_key_id
+            if kms_key_id is not None
+            else os.getenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "")
+        )
+        return AwsKmsEd25519Signer(kms_key_id=selected_key_id)
     raise ValueError(
-        "Unsupported VERITAS_TRUSTLOG_SIGNER_BACKEND. Expected 'file' or 'aws_kms'."
+        "Unsupported signer backend. Expected 'file' or 'aws_kms'."
     )

--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -27,11 +27,12 @@ Recommended additional hardening for production:
 from __future__ import annotations
 
 import base64
+import importlib
 import logging
 import os
 import stat
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Protocol, Tuple
 
 from veritas_os.security.hash import sha256_hex
 
@@ -158,3 +159,132 @@ def public_key_fingerprint(public_key_path: Path, *, length: int = 16) -> str:
     """
     raw = base64.urlsafe_b64decode(public_key_path.read_text(encoding="utf-8"))
     return sha256_hex(raw.hex())[:length]
+
+
+class Signer(Protocol):
+    """Pluggable signer protocol for TrustLog signatures."""
+
+    signer_type: str
+
+    def sign_payload_hash(self, payload_hash: str) -> str:
+        """Sign a canonical payload hash and return URL-safe Base64 signature."""
+
+    def verify_payload_signature(self, payload_hash: str, signature_b64: str) -> bool:
+        """Verify signature over a payload hash."""
+
+    def signer_key_id(self) -> str:
+        """Return a stable signer identity (KMS key id or local key fingerprint)."""
+
+
+class FileEd25519Signer:
+    """Ed25519 signer backed by local key files."""
+
+    signer_type = "file_ed25519"
+
+    def __init__(self, private_key_path: Path, public_key_path: Path) -> None:
+        self.private_key_path = private_key_path
+        self.public_key_path = public_key_path
+
+    def ensure_key_material(self) -> None:
+        """Create local signing keypair on first use."""
+        if self.private_key_path.exists() and self.public_key_path.exists():
+            return
+        store_keypair(self.private_key_path, self.public_key_path)
+
+    def sign_payload_hash(self, payload_hash: str) -> str:
+        return sign_payload_hash(payload_hash, self.private_key_path)
+
+    def verify_payload_signature(self, payload_hash: str, signature_b64: str) -> bool:
+        return verify_payload_signature(
+            payload_hash=payload_hash,
+            signature_b64=signature_b64,
+            public_key_path=self.public_key_path,
+        )
+
+    def signer_key_id(self) -> str:
+        return public_key_fingerprint(self.public_key_path)
+
+
+class AwsKmsEd25519Signer:
+    """Ed25519 signer backed by AWS KMS asymmetric keys.
+
+    Security warning:
+        This signer performs a network call to AWS KMS for signing operations.
+        Ensure IAM permissions are scoped to the specific key and that requests
+        are routed over trusted channels.
+    """
+
+    signer_type = "aws_kms_ed25519"
+
+    def __init__(
+        self,
+        kms_key_id: str,
+        kms_client: Optional[object] = None,
+    ) -> None:
+        if not kms_key_id.strip():
+            raise ValueError("VERITAS_TRUSTLOG_KMS_KEY_ID is required for aws_kms backend")
+        self.kms_key_id = kms_key_id.strip()
+        self._kms_client = kms_client
+        self._public_key: Optional[Ed25519PublicKey] = None
+
+    @property
+    def kms_client(self) -> object:
+        """Lazily construct boto3 KMS client."""
+        if self._kms_client is None:
+            boto3 = importlib.import_module("boto3")
+            self._kms_client = boto3.client("kms")
+        return self._kms_client
+
+    def _load_public_key(self) -> Ed25519PublicKey:
+        if self._public_key is not None:
+            return self._public_key
+        response = self.kms_client.get_public_key(KeyId=self.kms_key_id)
+        public_key_der = response["PublicKey"]
+        loaded = serialization.load_der_public_key(public_key_der)
+        if not isinstance(loaded, Ed25519PublicKey):
+            raise ValueError("KMS key is not Ed25519")
+        self._public_key = loaded
+        return self._public_key
+
+    def sign_payload_hash(self, payload_hash: str) -> str:
+        response = self.kms_client.sign(
+            KeyId=self.kms_key_id,
+            Message=payload_hash.encode("utf-8"),
+            MessageType="RAW",
+            SigningAlgorithm="EDDSA",
+        )
+        signature: bytes = response["Signature"]
+        return base64.urlsafe_b64encode(signature).decode("ascii")
+
+    def verify_payload_signature(self, payload_hash: str, signature_b64: str) -> bool:
+        try:
+            signature = base64.urlsafe_b64decode(signature_b64)
+            public_key = self._load_public_key()
+            public_key.verify(signature, payload_hash.encode("utf-8"))
+        except (InvalidSignature, ValueError, TypeError):
+            return False
+        return True
+
+    def signer_key_id(self) -> str:
+        return self.kms_key_id
+
+
+def build_trustlog_signer(
+    *,
+    private_key_path: Path,
+    public_key_path: Path,
+    ensure_local_keys: bool = False,
+) -> Signer:
+    """Build TrustLog signer from backend environment variables."""
+    backend = os.getenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file").strip().lower()
+    if backend in {"", "file"}:
+        signer = FileEd25519Signer(private_key_path=private_key_path, public_key_path=public_key_path)
+        if ensure_local_keys:
+            signer.ensure_key_material()
+        return signer
+    if backend == "aws_kms":
+        kms_key_id = os.getenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "")
+        return AwsKmsEd25519Signer(kms_key_id=kms_key_id)
+    raise ValueError(
+        "Unsupported VERITAS_TRUSTLOG_SIGNER_BACKEND. Expected 'file' or 'aws_kms'."
+    )

--- a/veritas_os/tests/test_signed_trustlog.py
+++ b/veritas_os/tests/test_signed_trustlog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 
 from fastapi.testclient import TestClient
@@ -30,7 +31,7 @@ def test_append_and_verify_signed_trustlog(monkeypatch, tmp_path):
 
     assert entry["decision_id"]
     assert entry["payload_hash"]
-    assert entry["signer_type"] == "file_ed25519"
+    assert entry["signer_type"] == "file"
     assert entry["signer_key_id"]
     assert trustlog_signed.verify_signature(entry) is True
 
@@ -107,7 +108,7 @@ def test_worm_mirror_and_verify_metadata(monkeypatch, tmp_path):
     assert verify_result["worm_mirror"]["exists"] is True
     assert verify_result["worm_mirror"]["entries"] == 1
     assert verify_result["key_management"]["public_key_present"] is True
-    assert verify_result["key_management"]["signer_type"] == "file_ed25519"
+    assert verify_result["key_management"]["signer_type"] == "file"
     assert verify_result["key_management"]["signer_key_id"]
 
 
@@ -167,8 +168,59 @@ def test_aws_kms_signer_backend(monkeypatch, tmp_path):
     )
 
     entry = trustlog_signed.append_signed_decision({"request_id": "r-kms", "decision": "allow"})
-    assert entry["signer_type"] == "aws_kms_ed25519"
+    assert entry["signer_type"] == "aws_kms"
     assert entry["signer_key_id"] == fake_kms.key_id
+    assert trustlog_signed.verify_signature(entry) is True
+
+
+def test_verify_signature_uses_entry_signer_metadata(monkeypatch):
+    class FakeKmsClient:
+        def __init__(self):
+            self.private_key = Ed25519PrivateKey.generate()
+            self.key_id = "arn:aws:kms:us-east-1:111122223333:key/verify"
+
+        def sign(self, *, KeyId, Message, MessageType, SigningAlgorithm):
+            assert KeyId == self.key_id
+            assert MessageType == "RAW"
+            assert SigningAlgorithm == "EDDSA"
+            return {"Signature": self.private_key.sign(Message)}
+
+        def get_public_key(self, *, KeyId):
+            assert KeyId == self.key_id
+            public_der = self.private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            return {"PublicKey": public_der}
+
+    class FakeBoto3:
+        def __init__(self, client):
+            self._client = client
+
+        def client(self, service_name):
+            assert service_name == "kms"
+            return self._client
+
+    fake_kms = FakeKmsClient()
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
+    monkeypatch.setattr(
+        "veritas_os.security.signing.importlib.import_module",
+        lambda module_name: FakeBoto3(fake_kms),
+    )
+
+    payload_hash = "ab" * 32
+    signature = fake_kms.sign(
+        KeyId=fake_kms.key_id,
+        Message=payload_hash.encode("utf-8"),
+        MessageType="RAW",
+        SigningAlgorithm="EDDSA",
+    )["Signature"]
+    entry = {
+        "payload_hash": payload_hash,
+        "signature": base64.urlsafe_b64encode(signature).decode("ascii"),
+        "signer_type": "aws_kms",
+        "signer_key_id": fake_kms.key_id,
+    }
     assert trustlog_signed.verify_signature(entry) is True
 
 

--- a/veritas_os/tests/test_signed_trustlog.py
+++ b/veritas_os/tests/test_signed_trustlog.py
@@ -4,6 +4,8 @@ import json
 
 from fastapi.testclient import TestClient
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 import veritas_os.api.server as server
 from veritas_os.audit import trustlog_signed
@@ -28,6 +30,8 @@ def test_append_and_verify_signed_trustlog(monkeypatch, tmp_path):
 
     assert entry["decision_id"]
     assert entry["payload_hash"]
+    assert entry["signer_type"] == "file_ed25519"
+    assert entry["signer_key_id"]
     assert trustlog_signed.verify_signature(entry) is True
 
     verify_result = trustlog_signed.verify_trustlog_chain(path=log_path)
@@ -103,7 +107,8 @@ def test_worm_mirror_and_verify_metadata(monkeypatch, tmp_path):
     assert verify_result["worm_mirror"]["exists"] is True
     assert verify_result["worm_mirror"]["entries"] == 1
     assert verify_result["key_management"]["public_key_present"] is True
-    assert verify_result["key_management"]["fingerprint"]
+    assert verify_result["key_management"]["signer_type"] == "file_ed25519"
+    assert verify_result["key_management"]["signer_key_id"]
 
 
 def test_worm_hard_fail_mode_raises_when_mirror_write_fails(monkeypatch, tmp_path):
@@ -121,3 +126,56 @@ def test_worm_hard_fail_mode_raises_when_mirror_write_fails(monkeypatch, tmp_pat
 
     with pytest.raises(trustlog_signed.SignedTrustLogWriteError, match="worm_mirror_write_failed"):
         trustlog_signed.append_signed_decision({"request_id": "r-hard-fail", "decision": "allow"})
+
+
+def test_aws_kms_signer_backend(monkeypatch, tmp_path):
+    class FakeKmsClient:
+        def __init__(self):
+            self.private_key = Ed25519PrivateKey.generate()
+            self.key_id = "arn:aws:kms:us-east-1:111122223333:key/example"
+
+        def sign(self, *, KeyId, Message, MessageType, SigningAlgorithm):
+            assert KeyId == self.key_id
+            assert MessageType == "RAW"
+            assert SigningAlgorithm == "EDDSA"
+            return {"Signature": self.private_key.sign(Message)}
+
+        def get_public_key(self, *, KeyId):
+            assert KeyId == self.key_id
+            public_der = self.private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            return {"PublicKey": public_der}
+
+    class FakeBoto3:
+        def __init__(self, client):
+            self._client = client
+
+        def client(self, service_name):
+            assert service_name == "kms"
+            return self._client
+
+    log_path = tmp_path / "trustlog.jsonl"
+    fake_kms = FakeKmsClient()
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", fake_kms.key_id)
+    monkeypatch.setattr(
+        "veritas_os.security.signing.importlib.import_module",
+        lambda module_name: FakeBoto3(fake_kms),
+    )
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "r-kms", "decision": "allow"})
+    assert entry["signer_type"] == "aws_kms_ed25519"
+    assert entry["signer_key_id"] == fake_kms.key_id
+    assert trustlog_signed.verify_signature(entry) is True
+
+
+def test_aws_kms_signer_requires_key_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", tmp_path / "trustlog.jsonl")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(trustlog_signed.SignedTrustLogWriteError, match="signed trust log append failed"):
+        trustlog_signed.append_signed_decision({"request_id": "r-kms-missing", "decision": "allow"})


### PR DESCRIPTION
### Motivation
- Make TrustLog signing pluggable so alternative key backends (e.g., cloud KMS/HSM) can be used without breaking the existing local file-based signer.
- Support AWS KMS Ed25519 signing to allow hardware-backed/managed signing while preserving the current local/dev behavior by default.
- Surface signer identity metadata in signed entries to aid auditing and operator visibility.

### Description
- Introduced a `Signer` protocol and two implementations in `veritas_os/security/signing.py`: `FileEd25519Signer` (preserves existing file-based Ed25519 signing) and `AwsKmsEd25519Signer` (uses boto3 KMS `Sign` with `EDDSA`), plus a `build_trustlog_signer()` factory driven by `VERITAS_TRUSTLOG_SIGNER_BACKEND` and `VERITAS_TRUSTLOG_KMS_KEY_ID`.
- Updated TrustLog code in `veritas_os/audit/trustlog_signed.py` to resolve and use the pluggable signer for signing, oversized-entry re-signing, and verification, and to include `signer_type` and `signer_key_id` in each signed entry and in verification metadata.
- Kept payload hashing, compact-summary generation, WORM mirror logic, and chain verification behavior unchanged; replaced direct file-signing calls with the signer interface so local/default behavior is preserved.
- Added tests in `veritas_os/tests/test_signed_trustlog.py` that mock a boto3 KMS client (`FakeBoto3`/`FakeKmsClient`) to validate KMS signing/verification and added a test for missing KMS key-id handling; updated README to document the new env vars `VERITAS_TRUSTLOG_SIGNER_BACKEND` and `VERITAS_TRUSTLOG_KMS_KEY_ID`.
- Included a docstring warning in the AWS KMS signer about operational security considerations (IAM scope, network trust).

### Testing
- Ran targeted signed TrustLog tests with `pytest -q veritas_os/tests/test_signed_trustlog.py` and obtained `7 passed`.
- Executed the new KMS-backed tests individually with `pytest -q veritas_os/tests/test_signed_trustlog.py::test_append_and_verify_signed_trustlog veritas_os/tests/test_signed_trustlog.py::test_aws_kms_signer_backend veritas_os/tests/test_signed_trustlog.py::test_aws_kms_signer_requires_key_id` and all selected tests passed (`3 passed`).
- Ran selected unit checks `pytest -q veritas_os/tests/unit/test_trustlog.py -k "verify_trustlog_chain_detects_forged_signature or signed_trustlog_payload_hash_mismatch_detected"` and those checks passed (`2 passed, 98 deselected`).
- Note: an initial test-collection ImportError (missing re-export) was fixed during the rollout and subsequent full test runs succeeded.

Changed files: `veritas_os/security/signing.py`, `veritas_os/audit/trustlog_signed.py`, `veritas_os/tests/test_signed_trustlog.py`, `README.md`.

Signer-related environment variables added/updated: `VERITAS_TRUSTLOG_SIGNER_BACKEND` (default `file`) and `VERITAS_TRUSTLOG_KMS_KEY_ID` (required when `aws_kms`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9256532648326bfec430e570e5d98)