### PR TITLE
Add pluggable TrustLog mirror backends and S3 Object Lock mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -1071,8 +1071,21 @@ All environment variables in one place. Set these in `.env` (git-ignored) or you
 |---|---|---|
 | `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` | `0` (posture: `1` in secure/prod) | Require transparency log anchoring (fail-closed) |
 | `VERITAS_TRUSTLOG_WORM_HARD_FAIL` | `0` (posture: `1` in secure/prod) | WORM mirror write failure raises error |
+| `VERITAS_TRUSTLOG_MIRROR_BACKEND` | `local` | TrustLog mirror backend (`local` or `s3_object_lock`) |
+| `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` | — | Local append mirror destination path (used when backend is `local`) |
+| `VERITAS_TRUSTLOG_S3_BUCKET` | — | S3 bucket name for TrustLog mirror writes (`s3_object_lock` backend) |
+| `VERITAS_TRUSTLOG_S3_PREFIX` | — | S3 object key prefix for append-only TrustLog objects |
+| `VERITAS_TRUSTLOG_S3_REGION` | — | AWS region override for S3 client |
+| `VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE` | — | Object Lock mode (`GOVERNANCE` or `COMPLIANCE`) |
+| `VERITAS_TRUSTLOG_S3_RETENTION_DAYS` | — | Retention period in days for S3 Object Lock |
 | `VERITAS_TRUSTLOG_SIGNER_BACKEND` | `file` | TrustLog signer backend (`file` or `aws_kms`) |
 | `VERITAS_TRUSTLOG_KMS_KEY_ID` | — | AWS KMS key id/ARN (required when `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms`) |
+
+#### TrustLog mirror migration notes
+
+- Existing deployments continue to work with no change because `VERITAS_TRUSTLOG_MIRROR_BACKEND` defaults to `local` and keeps `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` behavior.
+- To migrate to S3 Object Lock, set `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` and provide at minimum `VERITAS_TRUSTLOG_S3_BUCKET` (plus optional prefix/region/retention settings).
+- `VERITAS_TRUSTLOG_WORM_HARD_FAIL` semantics are unchanged and apply to both backends.
 
 ### Replay
 

--- a/veritas_os/audit/storage_mirror.py
+++ b/veritas_os/audit/storage_mirror.py
@@ -1,0 +1,191 @@
+"""TrustLog mirror backend abstractions.
+
+This module provides pluggable append-only mirror backends used by the
+signed TrustLog writer. Backends return a normalized status dict so caller
+logic can consistently enforce hard-fail posture semantics.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import uuid
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+
+class StorageMirror(ABC):
+    """Abstract append-only TrustLog mirror backend."""
+
+    backend_name: str
+
+    @abstractmethod
+    def append_line(self, line: str) -> Dict[str, Any]:
+        """Append one serialized JSONL line and return mirror status metadata."""
+
+
+class LocalAppendMirror(StorageMirror):
+    """Append line-oriented mirror backend for local WORM-like filesystems."""
+
+    backend_name = "local"
+
+    def __init__(
+        self,
+        *,
+        path: Optional[Path],
+        append_fn: Callable[[Path, str], None],
+    ) -> None:
+        self.path = path
+        self._append_fn = append_fn
+
+    def append_line(self, line: str) -> Dict[str, Any]:
+        if self.path is None:
+            return {
+                "configured": False,
+                "ok": False,
+                "backend": self.backend_name,
+                "path": None,
+            }
+
+        try:
+            self._append_fn(self.path, line)
+        except OSError as exc:
+            return {
+                "configured": True,
+                "ok": False,
+                "backend": self.backend_name,
+                "path": str(self.path),
+                "error": f"{exc.__class__.__name__}: {exc}",
+            }
+
+        return {
+            "configured": True,
+            "ok": True,
+            "backend": self.backend_name,
+            "path": str(self.path),
+        }
+
+
+class S3ObjectLockMirror(StorageMirror):
+    """Append-only S3 mirror backend with optional Object Lock retention.
+
+    Security warning:
+        This backend performs network writes to AWS S3. Ensure IAM principals
+        only have least-privilege permissions on the configured bucket/prefix.
+    """
+
+    backend_name = "s3_object_lock"
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str,
+        region: Optional[str] = None,
+        object_lock_mode: Optional[str] = None,
+        retention_days: Optional[int] = None,
+        s3_client: Optional[object] = None,
+    ) -> None:
+        self.bucket = bucket.strip()
+        self.prefix = prefix.strip("/")
+        self.region = (region or "").strip() or None
+        self.object_lock_mode = (object_lock_mode or "").strip() or None
+        self.retention_days = retention_days
+        self._s3_client = s3_client
+
+    @property
+    def s3_client(self) -> object:
+        """Lazily construct boto3 S3 client."""
+        if self._s3_client is None:
+            boto3 = importlib.import_module("boto3")
+            kwargs: Dict[str, Any] = {}
+            if self.region:
+                kwargs["region_name"] = self.region
+            self._s3_client = boto3.client("s3", **kwargs)
+        return self._s3_client
+
+    def _build_key(self) -> str:
+        now = datetime.now(timezone.utc)
+        suffix = uuid.uuid4().hex
+        key = f"trustlog/{now.strftime('%Y/%m/%d/%H/%M/%S')}-{suffix}.jsonl"
+        if not self.prefix:
+            return key
+        return f"{self.prefix}/{key}"
+
+    def append_line(self, line: str) -> Dict[str, Any]:
+        if not self.bucket:
+            return {
+                "configured": True,
+                "ok": False,
+                "backend": self.backend_name,
+                "error": "ValueError: VERITAS_TRUSTLOG_S3_BUCKET is required",
+            }
+
+        key = self._build_key()
+        put_kwargs: Dict[str, Any] = {
+            "Bucket": self.bucket,
+            "Key": key,
+            "Body": line.encode("utf-8"),
+            "ContentType": "application/x-ndjson",
+        }
+        retain_until_date: Optional[str] = None
+        if self.object_lock_mode:
+            put_kwargs["ObjectLockMode"] = self.object_lock_mode
+        if self.retention_days and self.retention_days > 0:
+            retain_until = datetime.now(timezone.utc) + timedelta(days=self.retention_days)
+            retain_until_date = retain_until.isoformat().replace("+00:00", "Z")
+            put_kwargs["ObjectLockRetainUntilDate"] = retain_until
+
+        try:
+            response = self.s3_client.put_object(**put_kwargs)
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "configured": True,
+                "ok": False,
+                "backend": self.backend_name,
+                "bucket": self.bucket,
+                "key": key,
+                "error": f"{exc.__class__.__name__}: {exc}",
+            }
+
+        return {
+            "configured": True,
+            "ok": True,
+            "backend": self.backend_name,
+            "bucket": self.bucket,
+            "key": key,
+            "version_id": response.get("VersionId"),
+            "etag": response.get("ETag"),
+            "retention_mode": self.object_lock_mode,
+            "retain_until_date": retain_until_date,
+        }
+
+
+def build_storage_mirror(*, append_fn: Callable[[Path, str], None]) -> StorageMirror:
+    """Build configured TrustLog mirror backend from environment variables."""
+    backend = os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local").strip().lower()
+
+    if backend == "local":
+        mirror_path = os.getenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "").strip()
+        return LocalAppendMirror(path=Path(mirror_path) if mirror_path else None, append_fn=append_fn)
+
+    if backend == "s3_object_lock":
+        bucket = os.getenv("VERITAS_TRUSTLOG_S3_BUCKET", "")
+        prefix = os.getenv("VERITAS_TRUSTLOG_S3_PREFIX", "")
+        region = os.getenv("VERITAS_TRUSTLOG_S3_REGION", "")
+        object_lock_mode = os.getenv("VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE", "")
+        retention_days_raw = os.getenv("VERITAS_TRUSTLOG_S3_RETENTION_DAYS", "").strip()
+        retention_days: Optional[int] = None
+        if retention_days_raw:
+            retention_days = int(retention_days_raw)
+        return S3ObjectLockMirror(
+            bucket=bucket,
+            prefix=prefix,
+            region=region,
+            object_lock_mode=object_lock_mode,
+            retention_days=retention_days,
+        )
+
+    raise ValueError("Unsupported mirror backend. Expected 'local' or 's3_object_lock'.")

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from veritas_os.logging.paths import LOG_DIR
+from veritas_os.audit.storage_mirror import build_storage_mirror
 from veritas_os.security.hash import canonical_json_dumps, sha256_hex, sha256_of_canonical_json
 from veritas_os.security.signing import (
     Signer,
@@ -119,26 +120,25 @@ def _append_line(path: Path, line: str) -> None:
 
 
 def _mirror_to_worm(line: str) -> Dict[str, Any]:
-    """Best-effort append to configured WORM mirror destination."""
-    path = _worm_mirror_path()
-    if path is None:
-        return {"configured": False, "ok": False, "path": None}
-
+    """Best-effort append using the configured mirror backend."""
     try:
-        _append_line(path, line)
-    except OSError as exc:
-        _logger.warning(
-            "WORM mirror write failed (path=%s): %s: %s",
-            path, exc.__class__.__name__, exc,
-        )
+        mirror_backend = build_storage_mirror(append_fn=_append_line)
+    except (ValueError, TypeError) as exc:
         return {
             "configured": True,
             "ok": False,
-            "path": str(path),
+            "backend": "invalid",
             "error": f"{exc.__class__.__name__}: {exc}",
         }
 
-    return {"configured": True, "ok": True, "path": str(path)}
+    result = mirror_backend.append_line(line)
+    if not result.get("ok"):
+        _logger.warning(
+            "WORM mirror write failed (backend=%s): %s",
+            result.get("backend"),
+            result.get("error", "unknown_error"),
+        )
+    return result
 
 
 def _append_transparency_anchor(entry_hash: str) -> Dict[str, Any]:
@@ -515,6 +515,23 @@ def append_signed_decision(decision_payload: Dict[str, Any]) -> Dict[str, Any]:
             if _worm_hard_fail_enabled() and mirror.get("configured") and not mirror.get("ok"):
                 raise SignedTrustLogWriteError("worm_mirror_write_failed")
             entry["worm_mirror"] = mirror
+            entry["mirror_backend"] = mirror.get("backend")
+            entry["mirror_receipt"] = (
+                {
+                    key: mirror.get(key)
+                    for key in (
+                        "bucket",
+                        "key",
+                        "version_id",
+                        "etag",
+                        "retention_mode",
+                        "retain_until_date",
+                    )
+                    if mirror.get(key) is not None
+                }
+                if mirror.get("ok")
+                else None
+            )
 
             transparency_anchor = _append_transparency_anchor(_entry_chain_hash(entry))
             if (
@@ -576,9 +593,13 @@ def verify_trustlog_chain(path: Optional[Path] = None) -> Dict[str, Any]:
 
         previous_hash = _entry_chain_hash(entry)
 
-    worm_path = _worm_mirror_path()
+    selected_mirror_backend = os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local").strip().lower()
+    worm_path = _worm_mirror_path() if selected_mirror_backend == "local" else None
+    s3_bucket = os.getenv("VERITAS_TRUSTLOG_S3_BUCKET", "").strip()
+    mirror_configured = worm_path is not None if selected_mirror_backend == "local" else bool(s3_bucket)
     worm_status: Dict[str, Any] = {
-        "configured": worm_path is not None,
+        "backend": selected_mirror_backend or "local",
+        "configured": mirror_configured,
         "hard_fail": _worm_hard_fail_enabled(),
     }
     if worm_path is not None:

--- a/veritas_os/tests/test_signed_trustlog.py
+++ b/veritas_os/tests/test_signed_trustlog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from datetime import timezone
 
 from fastapi.testclient import TestClient
 import pytest
@@ -231,3 +232,78 @@ def test_aws_kms_signer_requires_key_id(monkeypatch, tmp_path):
 
     with pytest.raises(trustlog_signed.SignedTrustLogWriteError, match="signed trust log append failed"):
         trustlog_signed.append_signed_decision({"request_id": "r-kms-missing", "decision": "allow"})
+
+
+def test_local_mirror_backend_metadata(monkeypatch, tmp_path):
+    log_path = tmp_path / "trustlog.jsonl"
+    mirror_path = tmp_path / "worm" / "trustlog_mirror.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", str(mirror_path))
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "r-local-mirror", "decision": "allow"})
+    assert entry["mirror_backend"] == "local"
+    assert entry["mirror_receipt"] == {}
+
+
+def test_s3_object_lock_mirror_backend(monkeypatch, tmp_path):
+    class FakeS3Client:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def put_object(self, **kwargs):
+            self.calls.append(kwargs)
+            return {
+                "VersionId": "v1",
+                "ETag": "\"etag123\"",
+            }
+
+    class FakeBoto3:
+        def __init__(self, client):
+            self._client = client
+
+        def client(self, service_name, **kwargs):
+            assert service_name == "s3"
+            assert kwargs["region_name"] == "us-east-1"
+            return self._client
+
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+    fake_s3 = FakeS3Client()
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "s3_object_lock")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_BUCKET", "trustlog-bucket")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_PREFIX", "audit/worm")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_REGION", "us-east-1")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE", "GOVERNANCE")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_RETENTION_DAYS", "30")
+    monkeypatch.setattr(
+        "veritas_os.audit.storage_mirror.importlib.import_module",
+        lambda module_name: FakeBoto3(fake_s3),
+    )
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "r-s3-mirror", "decision": "allow"})
+
+    assert entry["mirror_backend"] == "s3_object_lock"
+    assert entry["mirror_receipt"]["bucket"] == "trustlog-bucket"
+    assert entry["mirror_receipt"]["version_id"] == "v1"
+    assert entry["mirror_receipt"]["etag"] == "\"etag123\""
+    assert entry["mirror_receipt"]["retention_mode"] == "GOVERNANCE"
+    assert entry["mirror_receipt"]["retain_until_date"]
+    assert fake_s3.calls
+    assert "ObjectLockRetainUntilDate" in fake_s3.calls[0]
+    assert fake_s3.calls[0]["ObjectLockMode"] == "GOVERNANCE"
+    assert fake_s3.calls[0]["ObjectLockRetainUntilDate"].tzinfo == timezone.utc
+
+    verify_result = trustlog_signed.verify_trustlog_chain(path=log_path)
+    assert verify_result["worm_mirror"]["backend"] == "s3_object_lock"
+    assert verify_result["worm_mirror"]["configured"] is True


### PR DESCRIPTION
### Motivation
- Productionize the TrustLog WORM mirror path by making mirror backends pluggable so infrastructure can delegate to local filesystems or S3 Object Lock without changing call sites.
- Preserve existing local append-to-path semantics and the existing fail-closed posture semantics driven by `VERITAS_TRUSTLOG_WORM_HARD_FAIL` while adding a cloud-backed option.
- Capture actionable mirror receipt metadata (bucket/key/version/etag/retention) on each signed witness entry to improve auditability and operational troubleshooting.

### Description
- Added a new `veritas_os.audit.storage_mirror` module that defines a `StorageMirror` abstraction and two implementations: `LocalAppendMirror` (preserves file append behavior) and `S3ObjectLockMirror` (lazy `boto3` client, append-only object key strategy using timestamp+UUID, and optional Object Lock retention).
- Updated `veritas_os.audit.trustlog_signed` to use `build_storage_mirror` for mirror writes, to attach `mirror_backend` and a normalized `mirror_receipt` (containing `bucket`, `key`, `version_id`, `etag`, `retention_mode`, `retain_until_date` when present) to signed entries, and to preserve the existing `worm_mirror` status and hard-fail semantics.
- Introduced environment variable support for `VERITAS_TRUSTLOG_MIRROR_BACKEND`, `VERITAS_TRUSTLOG_S3_BUCKET`, `VERITAS_TRUSTLOG_S3_PREFIX`, `VERITAS_TRUSTLOG_S3_REGION`, `VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE`, and `VERITAS_TRUSTLOG_S3_RETENTION_DAYS`, while keeping `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` and `VERITAS_TRUSTLOG_WORM_HARD_FAIL` behavior unchanged by default.
- Updated `README.md` TrustLog env docs with migration notes explaining that `local` is the default backend and how to enable `s3_object_lock`; added unit tests covering local metadata and a mocked `boto3` S3 client for `S3ObjectLockMirror` behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_signed_trustlog.py` which completed successfully (`10 passed`).
- Ran `pytest -q veritas_os/tests/test_signed_trustlog.py veritas_os/tests/unit/test_trustlog.py -k "worm or mirror or s3_object_lock"` which completed successfully (`8 passed, 102 deselected`).
- Unit tests include mocked `boto3` calls for S3 `put_object` and verify that Object Lock parameters and retention metadata are passed and recorded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d931743dfc8326b3a1ba5c2cbd4a95)