### PR TITLE
Unify TrustLog verification API and CLI across full + witness ledgers

### DIFF
--- a/docs/notes/TRUSTLOG_VERIFICATION_REPORT.md
+++ b/docs/notes/TRUSTLOG_VERIFICATION_REPORT.md
@@ -5,6 +5,41 @@
 
 ---
 
+## 2026-04 Unified verifier update
+
+### Stable API
+
+- `veritas_os.audit.trustlog_verify.verify_full_ledger(path, max_entries=None)`
+- `veritas_os.audit.trustlog_verify.verify_witness_ledger(entries, verify_signature_fn)`
+- `veritas_os.audit.trustlog_verify.verify_trustlogs(full_log_path, witness_entries, verify_signature_fn, max_entries=None)`
+
+### Stable CLI
+
+```bash
+python -m veritas_os.scripts.verify_trust_log --json
+python -m veritas_os.scripts.verify_trust_log --full-log /path/to/trust_log.jsonl --witness-log /path/to/trustlog.jsonl
+```
+
+CLI / API summary fields:
+- `total_entries`
+- `valid_entries`
+- `invalid_entries`
+- `chain_ok`
+- `signature_ok`
+- `linkage_ok`
+- `mirror_ok`
+- `last_hash`
+- `detailed_errors`
+
+### Compatibility behavior
+
+- Legacy witness entries without `full_payload_hash` or `mirror_receipt` remain valid.
+- `full_payload_hash` is validated only when present (must be SHA-256 hex).
+- `mirror_receipt` structure is validated only when present.
+- Existing APIs (`verify_trust_log`, `verify_trustlog_chain`) continue to work and now reuse shared verification logic.
+
+---
+
 ## 📊 論文記載との整合性
 
 ### 論文の記述 (Section 2.3)

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional
 from veritas_os.logging.paths import LOG_DIR
 from veritas_os.audit.storage_mirror import build_storage_mirror
 from veritas_os.security.hash import canonical_json_dumps, sha256_hex, sha256_of_canonical_json
+from veritas_os.audit.trustlog_verify import verify_witness_ledger
 from veritas_os.security.signing import (
     Signer,
     build_trustlog_signer,
@@ -577,21 +578,7 @@ def verify_trustlog_chain(path: Optional[Path] = None) -> Dict[str, Any]:
     job and alert on any drift.
     """
     entries = _read_all_entries(path)
-    issues: List[TrustLogIssue] = []
-    previous_hash: Optional[str] = None
-
-    for index, entry in enumerate(entries):
-        payload_hash = sha256_of_canonical_json(entry.get("decision_payload", {}))
-        if payload_hash != entry.get("payload_hash"):
-            issues.append(TrustLogIssue(index=index, reason="payload_hash_mismatch"))
-
-        if entry.get("previous_hash") != previous_hash:
-            issues.append(TrustLogIssue(index=index, reason="previous_hash_mismatch"))
-
-        if not verify_signature(entry):
-            issues.append(TrustLogIssue(index=index, reason="signature_invalid"))
-
-        previous_hash = _entry_chain_hash(entry)
+    witness_result = verify_witness_ledger(entries=entries, verify_signature_fn=verify_signature)
 
     selected_mirror_backend = os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local").strip().lower()
     worm_path = _worm_mirror_path() if selected_mirror_backend == "local" else None
@@ -630,13 +617,29 @@ def verify_trustlog_chain(path: Optional[Path] = None) -> Dict[str, Any]:
     except Exception:
         _logger.warning("Could not resolve TrustLog signer metadata", exc_info=True)
 
+    issues = [
+        {"index": err["index"], "reason": err["reason"]}
+        for err in witness_result["detailed_errors"]
+    ]
+
     return {
-        "ok": len(issues) == 0,
-        "entries_checked": len(entries),
-        "issues": [issue.__dict__ for issue in issues],
+        "ok": witness_result["ok"],
+        "entries_checked": witness_result["total_entries"],
+        "issues": issues,
         "worm_mirror": worm_status,
         "transparency_anchor": transparency_status,
         "key_management": key_meta,
+        "summary": {
+            "total_entries": witness_result["total_entries"],
+            "valid_entries": witness_result["valid_entries"],
+            "invalid_entries": witness_result["invalid_entries"],
+            "chain_ok": witness_result["chain_ok"],
+            "signature_ok": witness_result["signature_ok"],
+            "linkage_ok": witness_result["linkage_ok"],
+            "mirror_ok": witness_result["mirror_ok"],
+            "last_hash": witness_result["last_hash"],
+            "detailed_errors": witness_result["detailed_errors"],
+        },
     }
 
 

--- a/veritas_os/audit/trustlog_verify.py
+++ b/veritas_os/audit/trustlog_verify.py
@@ -1,0 +1,240 @@
+"""Unified TrustLog verification utilities.
+
+This module centralizes verification logic for both ledgers:
+- encrypted full ledger (``trust_log.jsonl``)
+- signed witness ledger (``trustlog.jsonl``)
+
+The public API is intentionally stable:
+    - :func:`verify_full_ledger`
+    - :func:`verify_witness_ledger`
+    - :func:`verify_trustlogs`
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from veritas_os.logging.encryption import DecryptionError, EncryptionKeyMissing, decrypt
+from veritas_os.security.hash import canonical_json_dumps, sha256_hex, sha256_of_canonical_json
+
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+
+
+@dataclass
+class VerificationError:
+    """Structured verification error for CLI/API reporting."""
+
+    ledger: str
+    index: int
+    reason: str
+
+
+def _as_dict(error: VerificationError) -> Dict[str, Any]:
+    return {"ledger": error.ledger, "index": error.index, "reason": error.reason}
+
+
+def _canonical_entry_json(entry: Dict[str, Any]) -> str:
+    payload = dict(entry)
+    payload.pop("sha256", None)
+    payload.pop("sha256_prev", None)
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def _iter_full_entries(log_path: Path) -> Iterable[Dict[str, Any]]:
+    if not log_path.exists():
+        return
+    with log_path.open("r", encoding="utf-8") as file:
+        for idx, raw in enumerate(file):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                decoded = decrypt(line)
+                entry = json.loads(decoded)
+            except (json.JSONDecodeError, ValueError, EncryptionKeyMissing, DecryptionError):
+                yield {"__invalid__": True, "__index__": idx, "__reason__": "json_decode_error"}
+                continue
+            if not isinstance(entry, dict):
+                yield {"__invalid__": True, "__index__": idx, "__reason__": "entry_not_dict"}
+                continue
+            yield entry
+
+
+def _compute_full_entry_hash(entry: Dict[str, Any], expected_prev: Optional[str]) -> str:
+    entry_json = _canonical_entry_json(entry)
+    combined = f"{expected_prev}{entry_json}" if expected_prev else entry_json
+    return sha256_hex(combined)
+
+
+def verify_full_ledger(
+    log_path: Path,
+    max_entries: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Verify encrypted full-ledger chain integrity."""
+    prev_hash: Optional[str] = None
+    total_entries = 0
+    valid_entries = 0
+    errors: List[VerificationError] = []
+
+    for index, entry in enumerate(_iter_full_entries(log_path)):
+        if max_entries is not None and total_entries >= max_entries:
+            break
+        total_entries += 1
+
+        if entry.get("__invalid__"):
+            errors.append(VerificationError("full", index, str(entry.get("__reason__", "invalid_entry"))))
+            continue
+
+        actual_prev = entry.get("sha256_prev")
+        if prev_hash is not None and actual_prev != prev_hash:
+            errors.append(VerificationError("full", index, "sha256_prev_mismatch"))
+            prev_hash = entry.get("sha256")
+            continue
+
+        expected_prev = prev_hash if prev_hash is not None else actual_prev
+        expected_hash = _compute_full_entry_hash(entry, expected_prev)
+        if entry.get("sha256") != expected_hash:
+            errors.append(VerificationError("full", index, "sha256_mismatch"))
+            prev_hash = entry.get("sha256")
+            continue
+
+        valid_entries += 1
+        prev_hash = entry.get("sha256")
+
+    return {
+        "ledger": "full",
+        "total_entries": total_entries,
+        "valid_entries": valid_entries,
+        "invalid_entries": total_entries - valid_entries,
+        "chain_ok": all(err.reason not in {"sha256_prev_mismatch", "sha256_mismatch"} for err in errors),
+        "signature_ok": True,
+        "linkage_ok": True,
+        "mirror_ok": True,
+        "last_hash": prev_hash,
+        "detailed_errors": [_as_dict(err) for err in errors],
+        "ok": len(errors) == 0,
+    }
+
+
+def _entry_chain_hash(entry: Dict[str, Any]) -> str:
+    return sha256_hex(canonical_json_dumps(entry))
+
+
+def _verify_mirror_receipt(entry: Dict[str, Any]) -> bool:
+    receipt = entry.get("mirror_receipt")
+    if receipt is None:
+        return True
+    if not isinstance(receipt, dict):
+        return False
+    known_keys = {
+        "bucket",
+        "key",
+        "version_id",
+        "etag",
+        "retention_mode",
+        "retain_until_date",
+    }
+    return all(isinstance(k, str) and k in known_keys for k in receipt.keys())
+
+
+def verify_witness_ledger(
+    entries: List[Dict[str, Any]],
+    verify_signature_fn: Callable[[Dict[str, Any]], bool],
+) -> Dict[str, Any]:
+    """Verify witness ledger chain, payload hash, signature and metadata linkage.
+
+    Legacy compatibility:
+        Entries without ``full_payload_hash`` / ``mirror_receipt`` are treated
+        as valid legacy rows.
+    """
+    errors: List[VerificationError] = []
+    prev_hash: Optional[str] = None
+    valid_entries = 0
+    chain_ok = True
+    signature_ok = True
+    linkage_ok = True
+    mirror_ok = True
+
+    for index, entry in enumerate(entries):
+        payload_hash = sha256_of_canonical_json(entry.get("decision_payload", {}))
+        if payload_hash != entry.get("payload_hash"):
+            errors.append(VerificationError("witness", index, "payload_hash_mismatch"))
+
+        if entry.get("previous_hash") != prev_hash:
+            chain_ok = False
+            errors.append(VerificationError("witness", index, "previous_hash_mismatch"))
+
+        if not verify_signature_fn(entry):
+            signature_ok = False
+            errors.append(VerificationError("witness", index, "signature_invalid"))
+
+        full_payload_hash = entry.get("full_payload_hash")
+        if full_payload_hash is not None and not (
+            isinstance(full_payload_hash, str)
+            and _SHA256_HEX_RE.fullmatch(full_payload_hash)
+        ):
+            linkage_ok = False
+            errors.append(VerificationError("witness", index, "full_payload_hash_invalid"))
+
+        if not _verify_mirror_receipt(entry):
+            mirror_ok = False
+            errors.append(VerificationError("witness", index, "mirror_receipt_invalid"))
+
+        if not any(err.index == index and err.ledger == "witness" for err in errors):
+            valid_entries += 1
+
+        prev_hash = _entry_chain_hash(entry)
+
+    return {
+        "ledger": "witness",
+        "total_entries": len(entries),
+        "valid_entries": valid_entries,
+        "invalid_entries": len(entries) - valid_entries,
+        "chain_ok": chain_ok,
+        "signature_ok": signature_ok,
+        "linkage_ok": linkage_ok,
+        "mirror_ok": mirror_ok,
+        "last_hash": prev_hash,
+        "detailed_errors": [_as_dict(err) for err in errors],
+        "ok": len(errors) == 0,
+    }
+
+
+def verify_trustlogs(
+    full_log_path: Path,
+    witness_entries: List[Dict[str, Any]],
+    verify_signature_fn: Callable[[Dict[str, Any]], bool],
+    max_entries: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Run unified verification for both full and witness ledgers."""
+    full = verify_full_ledger(log_path=full_log_path, max_entries=max_entries)
+    witness = verify_witness_ledger(entries=witness_entries, verify_signature_fn=verify_signature_fn)
+
+    total_entries = full["total_entries"] + witness["total_entries"]
+    valid_entries = full["valid_entries"] + witness["valid_entries"]
+    last_hash = witness["last_hash"] or full["last_hash"]
+
+    return {
+        "total_entries": total_entries,
+        "valid_entries": valid_entries,
+        "invalid_entries": total_entries - valid_entries,
+        "chain_ok": full["chain_ok"] and witness["chain_ok"],
+        "signature_ok": witness["signature_ok"],
+        "linkage_ok": witness["linkage_ok"],
+        "mirror_ok": witness["mirror_ok"],
+        "last_hash": last_hash,
+        "detailed_errors": full["detailed_errors"] + witness["detailed_errors"],
+        "full_ledger": full,
+        "witness_ledger": witness,
+        "ok": full["ok"] and witness["ok"],
+    }

--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -41,6 +41,7 @@ from veritas_os.audit.trustlog_signed import (
     append_signed_decision,
 )
 from veritas_os.security.hash import sha256_hex
+from veritas_os.audit.trustlog_verify import verify_full_ledger
 
 
 def _load_mask_pii():
@@ -714,124 +715,57 @@ def get_trust_logs_by_request(request_id: str) -> Dict[str, Any]:
 # =============================================================================
 
 def verify_trust_log(max_entries: Optional[int] = None) -> Dict[str, Any]:
-    """
-    TrustLog 全体（または先頭から max_entries 件）について
-    ハッシュチェーンの整合性を検証する。
-
-    ★ 暗号化された行は自動復号してからハッシュチェーンを検証する。
-
-    Returns:
-        {
-          "ok": bool,
-          "checked": int,
-          "broken": bool,
-          "broken_index": int | None,
-          "broken_reason": str | None,
-        }
-    """
-    if not LOG_JSONL.exists():
-        return {
-            "ok": True,
-            "checked": 0,
-            "broken": False,
-            "broken_index": None,
-            "broken_reason": None,
-        }
-
-    prev_hash: Optional[str] = None
-    checked = 0
-
+    """Verify encrypted full TrustLog integrity with stable compatibility fields."""
     try:
-        # ★ スレッドセーフ修正: ロック下でファイルを一括読み込み
-        with _trust_log_lock:
-            with LOG_JSONL.open("r", encoding="utf-8") as f:
-                all_lines = f.readlines()
-
-        for idx, line in enumerate(all_lines):
-            if max_entries is not None and idx >= max_entries:
-                break
-
-            line = line.strip()
-            if not line:
-                continue
-
-            try:
-                # ★ 暗号化行は復号してからパース
-                line = _decrypt_line(line)
-                entry = json.loads(line)
-            except (json.JSONDecodeError, ValueError, EncryptionKeyMissing, DecryptionError):
-                return {
-                    "ok": False,
-                    "checked": checked,
-                    "broken": True,
-                    "broken_index": idx,
-                    "broken_reason": "json_decode_error",
-                }
-
-            # ★ 型安全: json.loads() が dict 以外 (null, [], "string") を返す場合を防御
-            if not isinstance(entry, dict):
-                return {
-                    "ok": False,
-                    "checked": checked,
-                    "broken": True,
-                    "broken_index": idx,
-                    "broken_reason": "entry_not_dict",
-                }
-
-            # sha256_prev の整合性チェック
-            actual_prev = entry.get("sha256_prev")
-            if prev_hash is None:
-                # 最初のエントリ: sha256_prev が None なら新規チェーン。
-                # 非 None ならログローテーション後の継続チェーンであり正常。
-                pass
-            else:
-                if actual_prev != prev_hash:
-                    return {
-                        "ok": False,
-                        "checked": checked,
-                        "broken": True,
-                        "broken_index": idx,
-                        "broken_reason": "sha256_prev_mismatch",
-                    }
-
-            # sha256 の再計算チェック
-            expected_prev = prev_hash if prev_hash is not None else actual_prev
-            entry_json = _normalize_entry_for_hash(entry)
-            if expected_prev:
-                combined = expected_prev + entry_json
-            else:
-                combined = entry_json
-            expected_hash = _sha256(combined)
-            if entry.get("sha256") != expected_hash:
-                return {
-                    "ok": False,
-                    "checked": checked,
-                    "broken": True,
-                    "broken_index": idx,
-                    "broken_reason": "sha256_mismatch",
-                }
-
-            # 状態更新
-            prev_hash = entry.get("sha256")
-            checked += 1
-
-        return {
-            "ok": True,
-            "checked": checked,
-            "broken": False,
-            "broken_index": None,
-            "broken_reason": None,
-        }
-
-    except OSError as e:
-        logger.warning("verify_trust_log failed: %s", e)
+        result = verify_full_ledger(log_path=LOG_JSONL, max_entries=max_entries)
+    except OSError as exc:
+        logger.warning("verify_trust_log failed: %s", exc)
         return {
             "ok": False,
-            "checked": checked,
+            "checked": 0,
             "broken": True,
-            "broken_index": checked,
+            "broken_index": 0,
             "broken_reason": "verification_exception",
+            "summary": {
+                "total_entries": 0,
+                "valid_entries": 0,
+                "invalid_entries": 0,
+                "chain_ok": False,
+                "signature_ok": True,
+                "linkage_ok": True,
+                "mirror_ok": True,
+                "last_hash": None,
+                "detailed_errors": [
+                    {"ledger": "full", "index": 0, "reason": "verification_exception"}
+                ],
+            },
         }
+
+    broken_reason = None
+    broken_index = None
+    if result["detailed_errors"]:
+        first = result["detailed_errors"][0]
+        broken_reason = first.get("reason")
+        broken_index = first.get("index")
+
+    return {
+        "ok": result["ok"],
+        "checked": result["total_entries"],
+        "broken": not result["ok"],
+        "broken_index": broken_index,
+        "broken_reason": broken_reason,
+        "summary": {
+            "total_entries": result["total_entries"],
+            "valid_entries": result["valid_entries"],
+            "invalid_entries": result["invalid_entries"],
+            "chain_ok": result["chain_ok"],
+            "signature_ok": result["signature_ok"],
+            "linkage_ok": result["linkage_ok"],
+            "mirror_ok": result["mirror_ok"],
+            "last_hash": result["last_hash"],
+            "detailed_errors": result["detailed_errors"],
+        },
+    }
 
 
 # =============================================================================

--- a/veritas_os/scripts/verify_trust_log.py
+++ b/veritas_os/scripts/verify_trust_log.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import hashlib
 from pathlib import Path
-from typing import Optional
+from typing import Any, Iterable, Optional
 
 from veritas_os.audit.trustlog_signed import (
     SIGNED_TRUSTLOG_JSONL,
@@ -27,6 +28,78 @@ from veritas_os.audit.trustlog_verify import verify_trustlogs
 from veritas_os.logging.paths import LOG_DIR
 
 LOG_JSONL = LOG_DIR / "trust_log.jsonl"
+
+
+def compute_hash(prev_hash: str | None, entry: dict[str, Any]) -> str:
+    """Compute chain hash for one full-ledger entry.
+
+    Backward compatibility:
+        Retained for existing tests/tools that import this helper directly.
+    """
+    payload = dict(entry)
+    payload.pop("sha256", None)
+    payload.pop("sha256_prev", None)
+    entry_json = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    combined = f"{prev_hash}{entry_json}" if prev_hash else entry_json
+    return hashlib.sha256(combined.encode("utf-8")).hexdigest()
+
+
+def iter_entries(log_path: Path = LOG_JSONL) -> Iterable[dict[str, Any]]:
+    """Yield plain JSON entries from a JSONL file, skipping invalid lines."""
+    with log_path.open("r", encoding="utf-8") as file:
+        for line in file:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                yield json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+
+
+def verify_entries(
+    entries: Iterable[dict[str, Any]],
+) -> tuple[int, list[dict[str, Any]], str | None]:
+    """Verify hash-chain continuity and per-entry hash correctness.
+
+    Backward compatibility:
+        Retained for existing tests/tools that rely on tuple output.
+    """
+    prev_hash = None
+    total = 0
+    errors: list[dict[str, Any]] = []
+
+    for idx, entry in enumerate(entries, 1):
+        total = idx
+        sha_prev = entry.get("sha256_prev")
+        sha_self = entry.get("sha256")
+
+        if sha_prev != prev_hash:
+            errors.append(
+                {
+                    "line": idx,
+                    "type": "chain_break",
+                    "expected_prev": prev_hash,
+                    "actual_prev": sha_prev,
+                    "entry_id": entry.get("request_id", "unknown"),
+                }
+            )
+
+        expected_hash = compute_hash(sha_prev, entry)
+        if expected_hash != sha_self:
+            errors.append(
+                {
+                    "line": idx,
+                    "type": "hash_mismatch",
+                    "expected": expected_hash,
+                    "actual": sha_self,
+                    "entry_id": entry.get("request_id", "unknown"),
+                }
+            )
+
+        prev_hash = sha_self
+
+    return total, errors, prev_hash
 
 
 def _parse_args() -> argparse.Namespace:

--- a/veritas_os/scripts/verify_trust_log.py
+++ b/veritas_os/scripts/verify_trust_log.py
@@ -1,185 +1,89 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""Unified TrustLog verifier CLI.
+
+Verifies both ledgers using one stable API:
+1. full ledger chain integrity
+2. witness ledger chain integrity
+3. witness payload hash correctness
+4. witness signature correctness
+5. full_payload_hash linkage (legacy-compatible)
+6. mirror receipt structure when present
 """
-Trust Log Verifier - 論文の式に準拠
 
-検証内容:
-1. sha256_prev の連続性（チェーン検証）
-2. hₜ = SHA256(hₜ₋₁ || rₜ) の正しさ
+from __future__ import annotations
 
-Usage:
-    python scripts/verify_trust_log.py
-"""
-
+import argparse
 import json
-import hashlib
 from pathlib import Path
-from typing import Iterable, Any
+from typing import Optional
 
-# パスの設定（環境に応じて調整）
-try:
-    from veritas_os.logging.paths import LOG_DIR
-    LOG_JSONL = LOG_DIR / "trust_log.jsonl"
-except ImportError:
-    # フォールバック
-    SCRIPT_DIR = Path(__file__).parent
-    REPO_ROOT = SCRIPT_DIR.parent
-    LOG_DIR = REPO_ROOT / "scripts" / "logs"
-    LOG_JSONL = LOG_DIR / "trust_log.jsonl"
+from veritas_os.audit.trustlog_signed import (
+    SIGNED_TRUSTLOG_JSONL,
+    _read_all_entries,
+    verify_signature,
+)
+from veritas_os.audit.trustlog_verify import verify_trustlogs
+from veritas_os.logging.paths import LOG_DIR
 
-
-def compute_hash(prev_hash: str | None, entry: dict) -> str:
-    """
-    論文の式に従ったハッシュ計算: hₜ = SHA256(hₜ₋₁ || rₜ)
-    
-    Args:
-        prev_hash: 直前のハッシュ値 (hₜ₋₁)
-        entry: 現在のエントリ (rₜ)
-    
-    Returns:
-        計算されたハッシュ値 (hₜ)
-    """
-    # エントリをコピーして、sha256とsha256_prevを除外
-    payload = dict(entry)
-    payload.pop("sha256", None)
-    payload.pop("sha256_prev", None)
-    
-    # rₜ を JSON化（キーをソートして一意性を保証）
-    entry_json = json.dumps(payload, sort_keys=True, ensure_ascii=False)
-    
-    # hₜ₋₁ || rₜ を結合
-    if prev_hash:
-        combined = prev_hash + entry_json
-    else:
-        # 最初のエントリの場合は rₜ のみ
-        combined = entry_json
-    
-    # SHA-256計算
-    return hashlib.sha256(combined.encode("utf-8")).hexdigest()
+LOG_JSONL = LOG_DIR / "trust_log.jsonl"
 
 
-def iter_entries(log_path: Path = LOG_JSONL) -> Iterable[dict[str, Any]]:
-    """Yield JSON entries from a trust-log JSONL file.
-
-    Invalid JSON lines are skipped with a warning so one broken line does not
-    block verification of the rest of the file.
-    """
-    with open(log_path, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                yield json.loads(line)
-            except json.JSONDecodeError as e:
-                print(f"⚠️  JSON decode error: {e}")
-                continue
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify TrustLog ledgers")
+    parser.add_argument("--full-log", type=Path, default=LOG_JSONL)
+    parser.add_argument("--witness-log", type=Path, default=SIGNED_TRUSTLOG_JSONL)
+    parser.add_argument("--max-entries", type=int, default=None)
+    parser.add_argument("--json", action="store_true", help="Print JSON output")
+    return parser.parse_args()
 
 
-def verify_entries(entries: Iterable[dict[str, Any]]) -> tuple[int, list[dict[str, Any]], str | None]:
-    """Verify trust-log chain/hash integrity for a stream of entries.
-
-    Returns a tuple of (total_entries, errors, last_hash).
-    """
-    prev_hash = None
-    total = 0
-    errors: list[dict[str, Any]] = []
-
-    for i, entry in enumerate(entries, 1):
-        total = i
-        sha_prev = entry.get("sha256_prev")
-        sha_self = entry.get("sha256")
-
-        if sha_prev != prev_hash:
-            errors.append({
-                "line": i,
-                "type": "chain_break",
-                "expected_prev": prev_hash,
-                "actual_prev": sha_prev,
-                "entry_id": entry.get("request_id", "unknown"),
-            })
-
-        calc_hash = compute_hash(sha_prev, entry)
-        if calc_hash != sha_self:
-            errors.append({
-                "line": i,
-                "type": "hash_mismatch",
-                "expected": calc_hash,
-                "actual": sha_self,
-                "entry_id": entry.get("request_id", "unknown"),
-            })
-
-        prev_hash = sha_self
-
-    return total, errors, prev_hash
-
-
-def main():
-    print("🔍 Trust Log Verification")
+def _print_human(result: dict) -> None:
+    print("🔍 Unified TrustLog Verification")
     print("=" * 60)
-    print(f"File: {LOG_JSONL}")
-    print()
-    
-    if not LOG_JSONL.exists():
-        print("❌ trust_log.jsonl not found")
-        print(f"   Expected location: {LOG_JSONL}")
-        return 1
-    
-    total, errors, last_hash = verify_entries(iter_entries())
-    
-    print(f"Total entries: {total}")
-    print()
-    
-    if errors:
-        print(f"❌ Verification FAILED ({len(errors)} errors)")
-        print()
-        
-        # エラーの種類別にカウント
-        chain_breaks = sum(1 for e in errors if e['type'] == 'chain_break')
-        hash_mismatches = sum(1 for e in errors if e['type'] == 'hash_mismatch')
-        
-        print("Error breakdown:")
-        print(f"  Chain breaks:    {chain_breaks}")
-        print(f"  Hash mismatches: {hash_mismatches}")
-        print()
-        
-        # 最初の5件のエラーを詳細表示
-        print("First errors:")
-        for err in errors[:5]:
-            print(f"  Line {err['line']}: {err['type']}")
-            if err['type'] == 'chain_break':
-                print(f"    Expected prev: {err['expected_prev']}")
-                print(f"    Actual prev:   {err['actual_prev']}")
-            else:
-                print(f"    Expected hash: {err['expected'][:16]}...")
-                print(f"    Actual hash:   {err['actual'][:16]}...")
-            print(f"    Entry ID: {err['entry_id']}")
-            print()
-        
-        if len(errors) > 5:
-            print(f"... and {len(errors) - 5} more errors")
-        
-        print()
-        print("💡 Note: If you recently updated trust_log.py, old logs")
-        print("   may fail verification. This is expected.")
-        print()
-        print("   To fix:")
-        print("   1. Back up old logs:")
-        print("      mv scripts/logs/trust_log.jsonl scripts/logs/trust_log.jsonl.old")
-        print("   2. Start fresh (next /v1/decide call will create new log)")
-        
-        return 1
+    for key in (
+        "total_entries",
+        "valid_entries",
+        "invalid_entries",
+        "chain_ok",
+        "signature_ok",
+        "linkage_ok",
+        "mirror_ok",
+        "last_hash",
+    ):
+        print(f"{key}: {result.get(key)}")
+
+    print("detailed_errors:")
+    errors = result.get("detailed_errors", [])
+    if not errors:
+        print("  []")
+        return
+    for error in errors:
+        print(
+            "  - "
+            f"ledger={error.get('ledger')} "
+            f"index={error.get('index')} "
+            f"reason={error.get('reason')}"
+        )
+
+
+def main() -> int:
+    args = _parse_args()
+    witness_entries = _read_all_entries(args.witness_log)
+    result = verify_trustlogs(
+        full_log_path=args.full_log,
+        witness_entries=witness_entries,
+        verify_signature_fn=verify_signature,
+        max_entries=args.max_entries,
+    )
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
     else:
-        print("✅ Verification PASSED")
-        print(f"   All {total} entries are valid")
-        print("   Hash chain is intact")
-        print()
-        print("   Current chain head hash: " + (last_hash[:16] if total > 0 and last_hash else "N/A") + "...")
-        if total > 0 and last_hash:
-            print(f"   Last entry hash:  {last_hash[:16]}...")
-        
-        return 0
+        _print_human(result)
+
+    return 0 if result.get("ok") else 1
 
 
 if __name__ == "__main__":
-    exit(main())
+    raise SystemExit(main())

--- a/veritas_os/tests/test_trustlog_verify_unified.py
+++ b/veritas_os/tests/test_trustlog_verify_unified.py
@@ -1,0 +1,167 @@
+"""Tests for unified TrustLog verification API and CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from veritas_os.audit.trustlog_verify import (
+    verify_full_ledger,
+    verify_trustlogs,
+    verify_witness_ledger,
+)
+from veritas_os.logging.encryption import encrypt, generate_key
+from veritas_os.security.hash import sha256_hex, sha256_of_canonical_json
+
+
+def _full_hash(prev_hash: str | None, entry: Dict[str, Any]) -> str:
+    payload = dict(entry)
+    payload.pop("sha256", None)
+    payload.pop("sha256_prev", None)
+    entry_json = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+    combined = f"{prev_hash}{entry_json}" if prev_hash else entry_json
+    return sha256_hex(combined)
+
+
+def _write_full_log(path: Path, entries: List[Dict[str, Any]]) -> None:
+    prev_hash = None
+    lines = []
+    for entry in entries:
+        row = dict(entry)
+        row["sha256_prev"] = prev_hash
+        row["sha256"] = _full_hash(prev_hash, row)
+        prev_hash = row["sha256"]
+        lines.append(encrypt(json.dumps(row, ensure_ascii=False)))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _build_witness_chain() -> List[Dict[str, Any]]:
+    entries: List[Dict[str, Any]] = []
+    previous_hash = None
+    for idx in range(2):
+        payload = {"request_id": f"r-{idx}", "decision": "allow"}
+        entry = {
+            "decision_payload": payload,
+            "payload_hash": sha256_of_canonical_json(payload),
+            "previous_hash": previous_hash,
+            "signature": "sig-ok",
+            # legacy compatibility: omit full_payload_hash on first entry
+        }
+        if idx == 1:
+            entry["full_payload_hash"] = "a" * 64
+            entry["mirror_receipt"] = {"bucket": "b", "key": "k"}
+        chain_hash = sha256_hex(
+            json.dumps(entry, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        )
+        previous_hash = chain_hash
+        entries.append(entry)
+    return entries
+
+
+def test_unified_verifier_good_path(tmp_path: Path, monkeypatch) -> None:
+    """Good path should pass with legacy witness metadata omitted."""
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    full_log = tmp_path / "trust_log.jsonl"
+    witness = _build_witness_chain()
+    _write_full_log(full_log, [{"request_id": "r-0"}, {"request_id": "r-1"}])
+
+    result = verify_trustlogs(
+        full_log_path=full_log,
+        witness_entries=witness,
+        verify_signature_fn=lambda _: True,
+    )
+
+    assert result["ok"] is True
+    assert result["chain_ok"] is True
+    assert result["signature_ok"] is True
+    assert result["linkage_ok"] is True
+    assert result["mirror_ok"] is True
+    assert result["invalid_entries"] == 0
+
+
+def test_unified_verifier_broken_path(tmp_path: Path, monkeypatch) -> None:
+    """Broken chain/signature/linkage/mirror should be reported."""
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    full_log = tmp_path / "trust_log.jsonl"
+    _write_full_log(full_log, [{"request_id": "r-0"}])
+
+    witness = _build_witness_chain()
+    witness[1]["previous_hash"] = "broken-prev"
+    witness[1]["full_payload_hash"] = "not-a-hash"
+    witness[1]["mirror_receipt"] = "invalid-receipt"
+
+    result = verify_trustlogs(
+        full_log_path=full_log,
+        witness_entries=witness,
+        verify_signature_fn=lambda _: False,
+    )
+
+    assert result["ok"] is False
+    assert result["chain_ok"] is False
+    assert result["signature_ok"] is False
+    assert result["linkage_ok"] is False
+    assert result["mirror_ok"] is False
+    assert result["invalid_entries"] > 0
+    reasons = {error["reason"] for error in result["detailed_errors"]}
+    assert "previous_hash_mismatch" in reasons
+    assert "signature_invalid" in reasons
+    assert "full_payload_hash_invalid" in reasons
+    assert "mirror_receipt_invalid" in reasons
+
+
+def test_verify_trust_log_cli_json_output(tmp_path: Path, monkeypatch) -> None:
+    """CLI must expose required stable output fields."""
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    full_log = tmp_path / "trust_log.jsonl"
+    witness_log = tmp_path / "trustlog.jsonl"
+    _write_full_log(full_log, [{"request_id": "r-0"}])
+    witness_log.write_text("", encoding="utf-8")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "veritas_os.scripts.verify_trust_log",
+        "--full-log",
+        str(full_log),
+        "--witness-log",
+        str(witness_log),
+        "--json",
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    data = json.loads(completed.stdout)
+
+    required = {
+        "total_entries",
+        "valid_entries",
+        "invalid_entries",
+        "chain_ok",
+        "signature_ok",
+        "linkage_ok",
+        "mirror_ok",
+        "last_hash",
+        "detailed_errors",
+    }
+    assert required.issubset(data.keys())
+    assert completed.returncode == 0
+
+
+def test_individual_apis_cover_full_and_witness(tmp_path: Path, monkeypatch) -> None:
+    """Stable individual APIs should remain callable for local/dev flows."""
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    full_log = tmp_path / "trust_log.jsonl"
+    _write_full_log(full_log, [{"request_id": "r-0"}])
+
+    full_result = verify_full_ledger(full_log)
+    witness_result = verify_witness_ledger(_build_witness_chain(), lambda _: True)
+
+    assert full_result["ok"] is True
+    assert witness_result["ok"] is True


### PR DESCRIPTION
### Motivation
- Reduce duplicated verification logic by centralizing checks for both the encrypted full ledger and the signed witness ledger into one stable verifier API.
- Provide a single stable CLI and API surface to verify chain integrity, payload linkage, signatures, and mirror receipts while preserving legacy compatibility for older witness rows.
- Support local/dev flows and existing callers by adapting `verify_trust_log()` and `verify_trustlog_chain()` to reuse the shared verifier, minimizing behavioral changes.
- Security note: `full_payload_hash` is validated for format/presence only (when present) to maintain compatibility; stricter artifact re-hash verification should be added as an optional hardening mode if stronger linkage guarantees are required.

### Description
- Added a new shared verifier module `veritas_os.audit.trustlog_verify` exposing `verify_full_ledger()`, `verify_witness_ledger()`, and `verify_trustlogs()` that perform full-ledger chain checks, witness chain checks, witness payload-hash checks, signature checks (via a pluggable `verify_signature_fn`), `full_payload_hash` linkage validation when present, and mirror receipt structure validation when present.
- Updated `veritas_os/logging/trust_log.verify_trust_log()` to call `verify_full_ledger()` and return legacy-compatible fields (`ok`, `checked`, `broken`, `broken_index`, `broken_reason`) plus a structured `summary` block with unified fields.
- Updated `veritas_os/audit/trustlog_signed.verify_trustlog_chain()` to call `verify_witness_ledger()` and return the existing top-level contract plus a `summary` section derived from the shared verifier results.
- Replaced the old CLI with a unified verifier CLI at `veritas_os/scripts/verify_trust_log.py` that calls `verify_trustlogs()` and prints the stable output fields (`total_entries`, `valid_entries`, `invalid_entries`, `chain_ok`, `signature_ok`, `linkage_ok`, `mirror_ok`, `last_hash`, `detailed_errors`) with both human and `--json` modes.
- Added tests in `veritas_os/tests/test_trustlog_verify_unified.py` exercising good and broken paths, CLI JSON output, and API stability; and added documentation notes in `docs/notes/TRUSTLOG_VERIFICATION_REPORT.md` describing the stable API/CLI and compatibility behavior.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_trustlog_verify_unified.py` and the new verification tests passed (`4 passed`).
- Ran `python -m pytest -q veritas_os/tests/test_logging_core_trustlog.py -q` and core trustlog tests passed (no regressions reported).
- Ran `python -m pytest -q veritas_os/tests/unit/test_trustlog.py -q` and existing unit trustlog tests passed (no regressions reported).
- Invoked the unified CLI `python -m veritas_os.scripts.verify_trust_log --json` and it produced valid JSON including the required fields and exited successfully (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d935d09f208326aa7e18ee032355c1)