### PR TITLE
Harden TrustLog S3 mirror receipt verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1078,6 +1078,9 @@ All environment variables in one place. Set these in `.env` (git-ignored) or you
 | `VERITAS_TRUSTLOG_S3_REGION` | — | AWS region override for S3 client |
 | `VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE` | — | Object Lock mode (`GOVERNANCE` or `COMPLIANCE`) |
 | `VERITAS_TRUSTLOG_S3_RETENTION_DAYS` | — | Retention period in days for S3 Object Lock |
+| `VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE` | `0` | Enable remote S3 mirror verification during TrustLog verification |
+| `VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT` | `0` | Strict mirror verification: fail on missing receipts (legacy entries) and retention gaps |
+| `VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_REQUIRE_LEGAL_HOLD` | `0` | Require S3 Object Legal Hold (`ON`) when remote mirror verification is enabled |
 | `VERITAS_TRUSTLOG_SIGNER_BACKEND` | `file` | TrustLog signer backend (`file` or `aws_kms`) |
 | `VERITAS_TRUSTLOG_KMS_KEY_ID` | — | AWS KMS key id/ARN (required when `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms`) |
 
@@ -1086,6 +1089,22 @@ All environment variables in one place. Set these in `.env` (git-ignored) or you
 - Existing deployments continue to work with no change because `VERITAS_TRUSTLOG_MIRROR_BACKEND` defaults to `local` and keeps `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` behavior.
 - To migrate to S3 Object Lock, set `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` and provide at minimum `VERITAS_TRUSTLOG_S3_BUCKET` (plus optional prefix/region/retention settings).
 - `VERITAS_TRUSTLOG_WORM_HARD_FAIL` semantics are unchanged and apply to both backends.
+
+#### TrustLog mirror verification modes
+
+- **Offline mode (default)**: `VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE=0` validates receipt schema only and keeps legacy compatibility.
+- **Remote mode**: `VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE=1` performs S3-backed checks for `s3_object_lock` receipts:
+  - object existence (`Bucket` + `Key`)
+  - `version_id` match (when receipt has `version_id`)
+  - `etag` match (when receipt has `etag`)
+  - retention state (when receipt records retention metadata)
+- **Strict mode**: `VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT=1` is intended for high-assurance/prod verification jobs:
+  - fails entries with missing mirror receipts (`mirror_receipt_missing`)
+  - fails retention verification gaps (`mirror_retention_missing`)
+  - can break verification for old ledgers created before receipt support.
+- **Legal hold enforcement**: `VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_REQUIRE_LEGAL_HOLD=1` additionally requires object legal hold to be `ON` (`mirror_legal_hold_missing`).
+
+> Security caveat: remote verification depends on live AWS API access and IAM permissions (`s3:HeadObject`, `s3:GetObjectRetention`, `s3:GetObjectLegalHold`). Use least privilege and isolate verifier credentials.
 
 ### Replay
 

--- a/docs/notes/TRUSTLOG_VERIFICATION_REPORT.md
+++ b/docs/notes/TRUSTLOG_VERIFICATION_REPORT.md
@@ -35,7 +35,18 @@ CLI / API summary fields:
 
 - Legacy witness entries without `full_payload_hash` or `mirror_receipt` remain valid.
 - `full_payload_hash` is validated only when present (must be SHA-256 hex).
-- `mirror_receipt` structure is validated only when present.
+- `mirror_receipt` structure is validated when present and now emits explicit reasons:
+  - `mirror_receipt_missing`
+  - `mirror_receipt_malformed`
+  - `mirror_object_not_found`
+  - `mirror_version_mismatch`
+  - `mirror_etag_mismatch`
+  - `mirror_retention_missing`
+  - `mirror_legal_hold_missing`
+- Remote S3-backed mirror verification is opt-in via environment flags:
+  - `VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE=1`
+  - `VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT=1`
+  - `VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_REQUIRE_LEGAL_HOLD=1`
 - Existing APIs (`verify_trust_log`, `verify_trustlog_chain`) continue to work and now reuse shared verification logic.
 
 ---

--- a/veritas_os/audit/trustlog_verify.py
+++ b/veritas_os/audit/trustlog_verify.py
@@ -13,6 +13,8 @@ The public API is intentionally stable:
 from __future__ import annotations
 
 import json
+import importlib
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -131,12 +133,47 @@ def _entry_chain_hash(entry: Dict[str, Any]) -> str:
     return sha256_hex(canonical_json_dumps(entry))
 
 
-def _verify_mirror_receipt(entry: Dict[str, Any]) -> bool:
+def _env_flag(name: str, default: bool = False) -> bool:
+    """Return ``True`` when the env var is set to a truthy value."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _normalize_etag(value: Any) -> str:
+    return str(value or "").strip().strip('"')
+
+
+def _is_s3_receipt(receipt: Dict[str, Any]) -> bool:
+    return isinstance(receipt.get("bucket"), str) and isinstance(receipt.get("key"), str)
+
+
+def _verify_mirror_receipt(
+    entry: Dict[str, Any],
+    *,
+    remote_enabled: bool,
+    strict_mode: bool,
+    strict_s3: bool,
+    require_legal_hold: bool,
+    s3_client: Optional[Any],
+) -> Optional[str]:
+    """Verify mirror receipt shape and optional live S3 state.
+
+    Returns:
+        ``None`` when verification succeeds for this entry, otherwise a stable
+        reason string such as ``mirror_object_not_found``.
+    """
     receipt = entry.get("mirror_receipt")
+    mirror_backend = str(entry.get("mirror_backend") or "").strip().lower()
+    expects_receipt = strict_mode or mirror_backend == "s3_object_lock"
     if receipt is None:
-        return True
+        if expects_receipt:
+            return "mirror_receipt_missing"
+        return None
     if not isinstance(receipt, dict):
-        return False
+        return "mirror_receipt_malformed"
+
     known_keys = {
         "bucket",
         "key",
@@ -144,14 +181,80 @@ def _verify_mirror_receipt(entry: Dict[str, Any]) -> bool:
         "etag",
         "retention_mode",
         "retain_until_date",
+        "legal_hold_status",
     }
-    return all(isinstance(k, str) and k in known_keys for k in receipt.keys())
+    if not all(isinstance(k, str) and k in known_keys for k in receipt.keys()):
+        return "mirror_receipt_malformed"
+    if not _is_s3_receipt(receipt):
+        return None
+    if not remote_enabled:
+        return None
+    if s3_client is None:
+        return "mirror_object_not_found"
+
+    bucket = str(receipt["bucket"]).strip()
+    key = str(receipt["key"]).strip()
+    if not bucket or not key:
+        return "mirror_receipt_malformed"
+
+    head_kwargs: Dict[str, Any] = {"Bucket": bucket, "Key": key}
+    if receipt.get("version_id"):
+        head_kwargs["VersionId"] = receipt["version_id"]
+
+    try:
+        head = s3_client.head_object(**head_kwargs)
+    except Exception:  # noqa: BLE001
+        return "mirror_object_not_found"
+
+    expected_version = receipt.get("version_id")
+    if expected_version:
+        actual_version = head.get("VersionId")
+        if actual_version is not None and str(actual_version) != str(expected_version):
+            return "mirror_version_mismatch"
+
+    expected_etag = receipt.get("etag")
+    if expected_etag:
+        actual_etag = head.get("ETag")
+        if _normalize_etag(actual_etag) != _normalize_etag(expected_etag):
+            return "mirror_etag_mismatch"
+
+    needs_retention = bool(receipt.get("retention_mode") or receipt.get("retain_until_date"))
+    if needs_retention:
+        retention_kwargs: Dict[str, Any] = {"Bucket": bucket, "Key": key}
+        if receipt.get("version_id"):
+            retention_kwargs["VersionId"] = receipt["version_id"]
+        try:
+            retention = s3_client.get_object_retention(**retention_kwargs)
+            retention_obj = retention.get("Retention") or {}
+        except Exception:  # noqa: BLE001
+            retention_obj = {}
+        if strict_s3 and not retention_obj:
+            return "mirror_retention_missing"
+        if receipt.get("retention_mode") and retention_obj.get("Mode") != receipt.get("retention_mode"):
+            return "mirror_retention_missing"
+        if receipt.get("retain_until_date") and retention_obj.get("RetainUntilDate") is None:
+            return "mirror_retention_missing"
+
+    if require_legal_hold:
+        legal_hold_kwargs: Dict[str, Any] = {"Bucket": bucket, "Key": key}
+        if receipt.get("version_id"):
+            legal_hold_kwargs["VersionId"] = receipt["version_id"]
+        try:
+            legal_hold = s3_client.get_object_legal_hold(**legal_hold_kwargs)
+            legal_hold_status = ((legal_hold or {}).get("LegalHold") or {}).get("Status")
+        except Exception:  # noqa: BLE001
+            legal_hold_status = None
+        if legal_hold_status != "ON":
+            return "mirror_legal_hold_missing"
+
+    return None
 
 
 def verify_witness_ledger(
     entries: List[Dict[str, Any]],
     verify_signature_fn: Callable[[Dict[str, Any]], bool],
     artifact_search_roots: Optional[Sequence[Path]] = None,
+    s3_client: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """Verify witness ledger chain, payload hash, signature and metadata linkage.
 
@@ -166,6 +269,20 @@ def verify_witness_ledger(
     signature_ok = True
     linkage_ok = True
     mirror_ok = True
+    remote_enabled = _env_flag("VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE", default=False)
+    strict_mode = _env_flag("VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT", default=False)
+    strict_s3 = strict_mode
+    require_legal_hold = _env_flag(
+        "VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_REQUIRE_LEGAL_HOLD",
+        default=False,
+    )
+    resolved_s3_client = s3_client
+    if remote_enabled and resolved_s3_client is None:
+        try:
+            boto3 = importlib.import_module("boto3")
+            resolved_s3_client = boto3.client("s3")
+        except Exception:  # noqa: BLE001
+            resolved_s3_client = None
 
     for index, entry in enumerate(entries):
         payload_hash = sha256_of_canonical_json(entry.get("decision_payload", {}))
@@ -194,9 +311,17 @@ def verify_witness_ledger(
                 )
             )
 
-        if not _verify_mirror_receipt(entry):
+        mirror_error = _verify_mirror_receipt(
+            entry,
+            remote_enabled=remote_enabled,
+            strict_mode=strict_mode,
+            strict_s3=strict_s3,
+            require_legal_hold=require_legal_hold,
+            s3_client=resolved_s3_client,
+        )
+        if mirror_error:
             mirror_ok = False
-            errors.append(VerificationError("witness", index, "mirror_receipt_invalid"))
+            errors.append(VerificationError("witness", index, mirror_error))
 
         if not any(err.index == index and err.ledger == "witness" for err in errors):
             valid_entries += 1

--- a/veritas_os/tests/test_trustlog_verify_unified.py
+++ b/veritas_os/tests/test_trustlog_verify_unified.py
@@ -17,6 +17,36 @@ from veritas_os.logging.encryption import encrypt, generate_key
 from veritas_os.security.hash import sha256_hex, sha256_of_canonical_json
 
 
+class _FakeS3Client:
+    def __init__(
+        self,
+        *,
+        head_response: Dict[str, Any] | None = None,
+        head_error: Exception | None = None,
+        retention_response: Dict[str, Any] | None = None,
+        retention_error: Exception | None = None,
+    ) -> None:
+        self.head_response = head_response or {}
+        self.head_error = head_error
+        self.retention_response = retention_response or {}
+        self.retention_error = retention_error
+        self.head_calls = 0
+
+    def head_object(self, **_: Any) -> Dict[str, Any]:
+        self.head_calls += 1
+        if self.head_error is not None:
+            raise self.head_error
+        return self.head_response
+
+    def get_object_retention(self, **_: Any) -> Dict[str, Any]:
+        if self.retention_error is not None:
+            raise self.retention_error
+        return self.retention_response
+
+    def get_object_legal_hold(self, **_: Any) -> Dict[str, Any]:
+        return {"LegalHold": {"Status": "ON"}}
+
+
 def _full_hash(prev_hash: str | None, entry: Dict[str, Any]) -> str:
     payload = dict(entry)
     payload.pop("sha256", None)
@@ -127,7 +157,7 @@ def test_unified_verifier_broken_path(tmp_path: Path, monkeypatch) -> None:
     assert "previous_hash_mismatch" in reasons
     assert "signature_invalid" in reasons
     assert "full_payload_hash_invalid" in reasons
-    assert "mirror_receipt_invalid" in reasons
+    assert "mirror_receipt_malformed" in reasons
 
 
 
@@ -344,3 +374,93 @@ def test_individual_apis_cover_full_and_witness(tmp_path: Path, monkeypatch) -> 
 
     assert full_result["ok"] is True
     assert witness_result["ok"] is True
+
+
+def _s3_receipt_witness() -> List[Dict[str, Any]]:
+    payload = {"request_id": "r-s3", "decision": "allow"}
+    return [
+        {
+            "decision_payload": payload,
+            "payload_hash": sha256_of_canonical_json(payload),
+            "previous_hash": None,
+            "signature": "sig-ok",
+            "mirror_backend": "s3_object_lock",
+            "mirror_receipt": {
+                "bucket": "trustlog-bucket",
+                "key": "mirror/path.jsonl",
+                "version_id": "v1",
+                "etag": '"etag-1"',
+                "retention_mode": "GOVERNANCE",
+                "retain_until_date": "2030-01-01T00:00:00Z",
+            },
+        }
+    ]
+
+
+def test_mirror_remote_verification_success(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE", "1")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT", "1")
+    client = _FakeS3Client(
+        head_response={"VersionId": "v1", "ETag": '"etag-1"'},
+        retention_response={
+            "Retention": {
+                "Mode": "GOVERNANCE",
+                "RetainUntilDate": "2030-01-01T00:00:00Z",
+            }
+        },
+    )
+    result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=client)
+    assert result["ok"] is True
+    assert result["mirror_ok"] is True
+
+
+def test_mirror_remote_object_missing(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE", "1")
+    client = _FakeS3Client(head_error=RuntimeError("not found"))
+    result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=client)
+    reasons = {error["reason"] for error in result["detailed_errors"]}
+    assert "mirror_object_not_found" in reasons
+
+
+def test_mirror_remote_version_mismatch(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE", "1")
+    client = _FakeS3Client(head_response={"VersionId": "v2", "ETag": '"etag-1"'})
+    result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=client)
+    reasons = {error["reason"] for error in result["detailed_errors"]}
+    assert "mirror_version_mismatch" in reasons
+
+
+def test_mirror_remote_retention_missing_in_strict_mode(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE", "1")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT", "1")
+    client = _FakeS3Client(
+        head_response={"VersionId": "v1", "ETag": '"etag-1"'},
+        retention_response={},
+    )
+    result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=client)
+    reasons = {error["reason"] for error in result["detailed_errors"]}
+    assert "mirror_retention_missing" in reasons
+
+
+def test_mirror_receipt_missing_strict_vs_non_strict(monkeypatch) -> None:
+    entry = {
+        "decision_payload": {"request_id": "r-old"},
+        "payload_hash": sha256_of_canonical_json({"request_id": "r-old"}),
+        "previous_hash": None,
+        "signature": "sig-ok",
+    }
+    result = verify_witness_ledger([entry], lambda _: True)
+    assert result["ok"] is True
+
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT", "1")
+    strict_result = verify_witness_ledger([entry], lambda _: True)
+    reasons = {error["reason"] for error in strict_result["detailed_errors"]}
+    assert "mirror_receipt_missing" in reasons
+
+
+def test_mirror_remote_offline_mode_skips_validation(monkeypatch) -> None:
+    monkeypatch.delenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE", raising=False)
+    client = _FakeS3Client(head_error=RuntimeError("offline-skip"))
+    result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=client)
+    assert result["ok"] is True
+    assert client.head_calls == 0


### PR DESCRIPTION
### Motivation
- Strengthen mirror verification from shape-only checks to optional live S3-backed validation for S3 Object Lock receipts.
- Preserve offline/local verification by default while providing opt-in strict remote checks for high-assurance verification runs.
- Security caveat: remote verification requires AWS API access and scoped IAM permissions and can produce false negatives if permissions/credentials are misconfigured.

### Description
- Add opt-in env flags `VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE`, `VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT`, and `VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_REQUIRE_LEGAL_HOLD` to control remote verification and strictness. 
- Replace the prior shape-only mirror check with `_verify_mirror_receipt(...)` which optionally performs live S3 checks using an injected `s3_client` (or a `boto3` client when remote mode is enabled) and returns specific failure reasons instead of a boolean.  
- Remote checks performed: bucket/key existence (`head_object`), optional `VersionId` match, optional `ETag` match, optional Object Lock retention via `get_object_retention`, and optional legal-hold via `get_object_legal_hold`.
- Introduce explicit mirror error reason strings: `mirror_receipt_missing`, `mirror_receipt_malformed`, `mirror_object_not_found`, `mirror_version_mismatch`, `mirror_etag_mismatch`, `mirror_retention_missing`, and `mirror_legal_hold_missing`.
- Keep legacy compatibility: missing receipts do not fail verification unless strict mode is enabled or backend indicates `s3_object_lock` and strictness requires receipts. 
- Add `s3_client` dependency injection to `verify_witness_ledger` to enable deterministic unit tests and avoid hard dependency on live AWS during test runs.
- Update documentation (`README.md` and `docs/notes/TRUSTLOG_VERIFICATION_REPORT.md`) to describe offline vs remote verification, strict mode, legal-hold enforcement, and required IAM permissions.

### Testing
- Added unit tests with a mocked `_FakeS3Client` covering: object exists and matches, object missing, version mismatch, retention missing in strict mode, strict vs non-strict missing-receipt behavior, and offline mode skipping remote validation. 
- Ran `pytest -q veritas_os/tests/test_trustlog_verify_unified.py` and all tests passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95291b670832689e34305f2908284)