### PR TITLE
Enforce AWS KMS TrustLog signer in secure/prod with break-glass override

### DIFF
--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -61,6 +61,9 @@ Variables prefixed with `VERITAS_` are project-specific.
 |----------|---------|-------------|
 | `VERITAS_ENCRYPTION_KEY` | *(required)* | Base64-encoded 32-byte key for AES-256-GCM encryption |
 | `VERITAS_ENCRYPTION_LEGACY_DECRYPT` | `false` | Enable legacy `ENC:<payload>` decryption during migrations |
+| `VERITAS_TRUSTLOG_SIGNER_BACKEND` | `file` | TrustLog signature backend (`file` for local/dev/test only, `aws_kms` required in `secure`/`prod`) |
+| `VERITAS_TRUSTLOG_KMS_KEY_ID` | `""` | AWS KMS Ed25519 key identifier/ARN required when `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms` |
+| `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` | `0` | **Unsupported emergency break-glass only**. `1` allows `file` signer in `secure`/`prod` but emits a critical security warning |
 | `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` | `""` | Optional mirror path for WORM (Write-Once-Read-Many) audit log |
 | `VERITAS_TRUSTLOG_WORM_HARD_FAIL` | `0` | Fail hard if WORM mirror write fails (`0` = warn, `1` = error) |
 | `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` | `""` | Path to transparency log for blockchain-like anchoring |

--- a/docs/operations/governance_artifact_signing_operations.md
+++ b/docs/operations/governance_artifact_signing_operations.md
@@ -10,9 +10,46 @@ verification, key rotation, and failure handling across runtime posture levels.
 - `dev` / `staging`
   - Ed25519 signatures are verified when available.
   - SHA-256-only and missing-signature bundles are accepted with warnings.
+- TrustLog signer backend:
+  - `file` signer is allowed for local workflows only.
+  - `aws_kms` signer is recommended for pre-production parity testing.
 - `secure` / `prod`
   - Only Ed25519-signed governance bundles are accepted.
   - Missing signatures, invalid signatures, and SHA-256-only artifacts are rejected.
+  - TrustLog signer backend must be `aws_kms` with an AWS KMS Ed25519 key.
+  - `file` signer startup is refused unless break-glass override is explicitly set.
+
+## TrustLog signer hardening policy
+
+### Why file signer is dev-only
+
+- The file signer stores private key material on the application host.
+- Even with restrictive filesystem permissions, host-level compromise, backup
+  exposure, or misconfiguration can leak key material.
+- Leaked signing keys allow forged TrustLog entries, weakening non-repudiation
+  and reducing external audit credibility.
+
+### Required secure/prod configuration (AWS KMS Ed25519)
+
+Set:
+
+1. `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms`
+2. `VERITAS_TRUSTLOG_KMS_KEY_ID=<kms-key-id-or-arn>`
+
+Operational notes:
+
+- Use an asymmetric AWS KMS key with Ed25519 signing support (`EDDSA`).
+- Scope IAM permissions to the specific key and required KMS actions only.
+- Validate startup logs show the KMS signer backend and key id metadata.
+
+### Emergency break-glass (unsupported)
+
+- Env: `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD=1`
+- Effect: allows startup to continue with `file` signer in `secure`/`prod`.
+- Security warning: this mode is unsupported for enterprise deployments and
+  should be used only for short-lived emergency recovery.
+- Exit criteria: remove override, restore `aws_kms` signer, and document
+  incident timeline in governance/audit records.
 
 ## Signer verification
 

--- a/veritas_os/core/posture.py
+++ b/veritas_os/core/posture.py
@@ -212,6 +212,26 @@ class PostureStartupError(RuntimeError):
     """Raised when the active posture detects a fatal misconfiguration."""
 
 
+def _trustlog_signer_backend() -> str:
+    """Return normalized TrustLog signer backend name.
+
+    Supported aliases are normalized so startup validation can apply posture
+    policy consistently.
+    """
+    raw = (os.getenv("VERITAS_TRUSTLOG_SIGNER_BACKEND") or "file").strip().lower()
+    if raw in {"", "file", "file_ed25519"}:
+        return "file"
+    if raw in {"aws_kms", "aws_kms_ed25519"}:
+        return "aws_kms"
+    return raw
+
+
+def _allow_insecure_signer_override() -> bool:
+    """Return True when the unsupported production break-glass is enabled."""
+    raw = (os.getenv("VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD") or "").strip()
+    return raw == "1"
+
+
 def validate_posture_startup(defaults: PostureDefaults) -> List[str]:
     """Validate required integrations for the active posture.
 
@@ -253,6 +273,43 @@ def validate_posture_startup(defaults: PostureDefaults) -> List[str]:
                 "VERITAS_TRUSTLOG_WORM_MIRROR_PATH must be set when "
                 "WORM hard-fail is required "
                 f"(posture={defaults.posture.value})."
+            )
+
+    signer_backend = _trustlog_signer_backend()
+    insecure_override = _allow_insecure_signer_override()
+    if defaults.posture in {PostureLevel.SECURE, PostureLevel.PROD}:
+        if signer_backend == "file":
+            if insecure_override:
+                _logger.warning(
+                    "[SECURITY][UNSUPPORTED] "
+                    "VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD=1 is active "
+                    "while VERITAS_TRUSTLOG_SIGNER_BACKEND=file in %s posture. "
+                    "This break-glass mode is NOT enterprise supported and weakens "
+                    "TrustLog non-repudiation because private key material remains "
+                    "file-based on application hosts.",
+                    defaults.posture.value,
+                )
+            else:
+                errors.append(
+                    "VERITAS_TRUSTLOG_SIGNER_BACKEND=file is not allowed in "
+                    f"{defaults.posture.value} posture. Configure "
+                    "VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms and set "
+                    "VERITAS_TRUSTLOG_KMS_KEY_ID to an AWS KMS Ed25519 key. "
+                    "Emergency-only break-glass: "
+                    "VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD=1 "
+                    "(unsupported; startup refusal bypass)."
+                )
+        elif signer_backend == "aws_kms":
+            kms_key_id = (os.getenv("VERITAS_TRUSTLOG_KMS_KEY_ID") or "").strip()
+            if not kms_key_id:
+                errors.append(
+                    "VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms requires "
+                    "VERITAS_TRUSTLOG_KMS_KEY_ID in secure/prod posture."
+                )
+        else:
+            errors.append(
+                "VERITAS_TRUSTLOG_SIGNER_BACKEND must be 'aws_kms' in secure/prod "
+                f"posture (got {signer_backend!r})."
             )
 
     return errors

--- a/veritas_os/tests/test_posture.py
+++ b/veritas_os/tests/test_posture.py
@@ -54,10 +54,21 @@ def _clean_env(monkeypatch):
         "VERITAS_API_SECRET_REF",
         "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH",
         "VERITAS_TRUSTLOG_WORM_MIRROR_PATH",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID",
+        "VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD",
     ]
     for k in keys:
         monkeypatch.delenv(k, raising=False)
     reset_active_posture()
+
+
+def _set_minimum_strict_integrations(monkeypatch) -> None:
+    """Set non-signer strict integrations so signer tests stay focused."""
+    monkeypatch.setenv("VERITAS_SECRET_PROVIDER", "vault")
+    monkeypatch.setenv("VERITAS_API_SECRET_REF", "secret/ref")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/var/transparency")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/var/worm")
 
 
 # ============================================================
@@ -250,19 +261,31 @@ class TestValidatePostureStartup:
         _clean_env(monkeypatch)
         d = derive_defaults(PostureLevel.PROD)
         errors = validate_posture_startup(d)
-        # 4 errors: secret provider, secret ref, transparency path, worm path
-        assert len(errors) == 4
+        # 5 errors: base strict integrations + trustlog signer enforcement.
+        assert len(errors) == 5
         assert any("VERITAS_SECRET_PROVIDER" in e for e in errors)
         assert any("VERITAS_API_SECRET_REF" in e for e in errors)
         assert any("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH" in e for e in errors)
         assert any("VERITAS_TRUSTLOG_WORM_MIRROR_PATH" in e for e in errors)
+        assert any(
+            "VERITAS_TRUSTLOG_SIGNER_BACKEND=file is not allowed" in e
+            for e in errors
+        )
 
     def test_prod_all_integrations_present(self, monkeypatch):
         _clean_env(monkeypatch)
         monkeypatch.setenv("VERITAS_SECRET_PROVIDER", "vault")
         monkeypatch.setenv("VERITAS_API_SECRET_REF", "my/secret")
-        monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/var/transparency")
+        monkeypatch.setenv(
+            "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH",
+            "/var/transparency",
+        )
         monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/var/worm")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv(
+            "VERITAS_TRUSTLOG_KMS_KEY_ID",
+            "arn:aws:kms:us-east-1:111:key/prod",
+        )
         d = derive_defaults(PostureLevel.PROD)
         assert validate_posture_startup(d) == []
 
@@ -278,6 +301,62 @@ class TestValidatePostureStartup:
         d = derive_defaults(PostureLevel.DEV)
         errors = validate_posture_startup(d)
         assert any("VERITAS_SECRET_PROVIDER" in e for e in errors)
+
+    def test_dev_with_file_trustlog_signer_succeeds(self, monkeypatch):
+        """Dev posture keeps local file signer workflow available."""
+        _clean_env(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
+        defaults = derive_defaults(PostureLevel.DEV)
+
+        assert validate_posture_startup(defaults) == []
+
+    def test_prod_with_file_trustlog_signer_fails(self, monkeypatch):
+        """Prod posture must reject local file-based TrustLog signing."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
+        defaults = derive_defaults(PostureLevel.PROD)
+        errors = validate_posture_startup(defaults)
+
+        assert any(
+            "VERITAS_TRUSTLOG_SIGNER_BACKEND=file is not allowed" in err
+            for err in errors
+        )
+
+    def test_prod_with_aws_kms_trustlog_signer_succeeds(self, monkeypatch):
+        """Prod posture accepts AWS KMS-backed TrustLog signer."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv(
+            "VERITAS_TRUSTLOG_KMS_KEY_ID",
+            "arn:aws:kms:us-east-1:111122223333:key/example-ed25519",
+        )
+        defaults = derive_defaults(PostureLevel.PROD)
+
+        assert validate_posture_startup(defaults) == []
+
+    def test_prod_with_file_signer_override_succeeds_with_warning(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        """Break-glass override allows startup but emits unsupported warning."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD", "1")
+        defaults = derive_defaults(PostureLevel.PROD)
+
+        with caplog.at_level(logging.WARNING):
+            errors = validate_posture_startup(defaults)
+
+        assert errors == []
+        assert (
+            "VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD=1 is active"
+            in caplog.text
+        )
+        assert "NOT enterprise supported" in caplog.text
 
 
 # ============================================================
@@ -304,6 +383,11 @@ class TestInitPosture:
         monkeypatch.setenv("VERITAS_API_SECRET_REF", "path/to/secret")
         monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/var/t")
         monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/var/w")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv(
+            "VERITAS_TRUSTLOG_KMS_KEY_ID",
+            "arn:aws:kms:us-east-1:111:key/prod",
+        )
         d = init_posture(explicit="prod")
         assert d.posture == PostureLevel.PROD
         assert d.is_strict is True
@@ -321,6 +405,11 @@ class TestInitPosture:
         monkeypatch.setenv("VERITAS_POSTURE_OVERRIDE_TRUSTLOG_TRANSPARENCY", "0")
         monkeypatch.setenv("VERITAS_POSTURE_OVERRIDE_TRUSTLOG_WORM", "0")
         monkeypatch.setenv("VERITAS_POSTURE_OVERRIDE_REPLAY_STRICT", "0")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv(
+            "VERITAS_TRUSTLOG_KMS_KEY_ID",
+            "arn:aws:kms:us-east-1:111:key/secure",
+        )
         d = init_posture(explicit="secure")
         assert d.posture == PostureLevel.SECURE
         assert d.policy_runtime_enforce is False


### PR DESCRIPTION
### Motivation
- Harden TrustLog signing in hardened environments by preventing host-local file-based private keys from being used in `secure`/`prod` postures to protect non-repudiation and audit credibility. 
- Preserve local developer workflow (file signer allowed in `dev`/`staging`) while making violations explicit and noisy at startup in strict postures. 
- Provide a documented emergency break-glass for short-lived recovery with clear warnings that it is unsupported.

### Description
- Added posture-aware signer validation in `validate_posture_startup` (new helpers `_trustlog_signer_backend` and `_allow_insecure_signer_override`) to enforce that `secure`/`prod` must use `aws_kms` and require `VERITAS_TRUSTLOG_KMS_KEY_ID` when `aws_kms` is selected (file: `veritas_os/core/posture.py`).
- Introduced an unsupported, noisy break-glass `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD=1` which permits `file` signer in strict posture but emits an explicit `[SECURITY][UNSUPPORTED]` warning describing the risk. (file: `veritas_os/core/posture.py`).
- Updated environment reference to document `VERITAS_TRUSTLOG_SIGNER_BACKEND`, `VERITAS_TRUSTLOG_KMS_KEY_ID`, and the new break-glass variable (file: `docs/env-reference.md`).
- Extended the governance/artifact signing runbook with rationale (why file signer is dev-only), KMS configuration steps, and emergency break-glass procedures and warnings (file: `docs/operations/governance_artifact_signing_operations.md`).
- Added and adjusted unit tests in `veritas_os/tests/test_posture.py` to cover the signer enforcement matrix and ensure backward-compatible behavior in `dev`/`staging` while refusing startup in strict postures when misconfigured.

### Testing
- Ran targeted tests for the new scenarios and the full posture suite: `pytest -q veritas_os/tests/test_posture.py` and the focused 4-test subset, all passed (57 passed in `test_posture.py`, and the four targeted tests passed). 
- Performed static compile checks with `python -m py_compile veritas_os/core/posture.py veritas_os/tests/test_posture.py` which succeeded. 
- Startup validation now emits explicit warnings or raises `PostureStartupError` in strict postures as intended (observed in unit tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d959d8d6d883268a0b0bdc79d5a258)