### PR TITLE
Make TrustLog startup validation backend-aware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,27 @@ VERITAS_CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 # VERITAS_POSTURE_OVERRIDE_TRUSTLOG_TRANSPARENCY=0
 # VERITAS_POSTURE_OVERRIDE_TRUSTLOG_WORM=0
 # VERITAS_POSTURE_OVERRIDE_REPLAY_STRICT=0
+
+# ──────────────────────────────────────────────────────────────
+# TrustLog backend selection
+# ──────────────────────────────────────────────────────────────
+# Signer backend: file | aws_kms
+# In secure/prod posture, aws_kms + VERITAS_TRUSTLOG_KMS_KEY_ID is required.
+# VERITAS_TRUSTLOG_SIGNER_BACKEND=file
+# VERITAS_TRUSTLOG_KMS_KEY_ID=arn:aws:kms:us-east-1:111122223333:key/your-ed25519-key
+
+# Mirror backend: local | s3_object_lock
+# In secure/prod posture, s3_object_lock is required.
+# VERITAS_TRUSTLOG_MIRROR_BACKEND=local
+# VERITAS_TRUSTLOG_WORM_MIRROR_PATH=/var/lib/veritas/trustlog_worm.jsonl
+# VERITAS_TRUSTLOG_S3_BUCKET=veritas-trustlog-prod
+# VERITAS_TRUSTLOG_S3_PREFIX=audit/trustlog
+
+# WORM hard-fail (posture defaults to true in secure/prod).
+# VERITAS_TRUSTLOG_WORM_HARD_FAIL=1
+
+# Anchor backend: local | noop
+# In secure/prod, noop is rejected when transparency is required.
+# VERITAS_TRUSTLOG_ANCHOR_BACKEND=local
+# VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH=/var/lib/veritas/trustlog_transparency.jsonl
+# VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED=1

--- a/README.md
+++ b/README.md
@@ -207,8 +207,11 @@ operators can prove which governance control-plane asset was in force.
 Startup will refuse with an actionable error when:
 - `VERITAS_SECRET_PROVIDER` is not set (external secret manager enforcement)
 - `VERITAS_API_SECRET_REF` is not set (external secret manager enforcement)
-- `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` is not set (transparency anchoring)
-- `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` is not set (WORM hard-fail)
+- `VERITAS_TRUSTLOG_SIGNER_BACKEND` is not `aws_kms`, or `VERITAS_TRUSTLOG_KMS_KEY_ID` is missing
+- `VERITAS_TRUSTLOG_MIRROR_BACKEND` is not `s3_object_lock`
+- `VERITAS_TRUSTLOG_S3_BUCKET` / `VERITAS_TRUSTLOG_S3_PREFIX` are missing for S3 mirror mode
+- `VERITAS_TRUSTLOG_ANCHOR_BACKEND=noop` while `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED=1`
+- `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` is missing when anchor backend is `local` and transparency is required
 
 ### Escape hatches (secure posture only)
 
@@ -1075,6 +1078,8 @@ All environment variables in one place. Set these in `.env` (git-ignored) or you
 | `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` | — | Local append mirror destination path (used when backend is `local`) |
 | `VERITAS_TRUSTLOG_S3_BUCKET` | — | S3 bucket name for TrustLog mirror writes (`s3_object_lock` backend) |
 | `VERITAS_TRUSTLOG_S3_PREFIX` | — | S3 object key prefix for append-only TrustLog objects |
+| `VERITAS_TRUSTLOG_ANCHOR_BACKEND` | `local` | TrustLog anchor backend (`local` or `noop`) |
+| `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` | — | Local transparency anchor path (required when anchor backend is `local` and transparency is required) |
 | `VERITAS_TRUSTLOG_S3_REGION` | — | AWS region override for S3 client |
 | `VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE` | — | Object Lock mode (`GOVERNANCE` or `COMPLIANCE`) |
 | `VERITAS_TRUSTLOG_S3_RETENTION_DAYS` | — | Retention period in days for S3 Object Lock |
@@ -1089,6 +1094,7 @@ All environment variables in one place. Set these in `.env` (git-ignored) or you
 - Existing deployments continue to work with no change because `VERITAS_TRUSTLOG_MIRROR_BACKEND` defaults to `local` and keeps `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` behavior.
 - To migrate to S3 Object Lock, set `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` and provide at minimum `VERITAS_TRUSTLOG_S3_BUCKET` (plus optional prefix/region/retention settings).
 - `VERITAS_TRUSTLOG_WORM_HARD_FAIL` semantics are unchanged and apply to both backends.
+- In `secure`/`prod`, startup validation requires `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` and both `VERITAS_TRUSTLOG_S3_BUCKET` and `VERITAS_TRUSTLOG_S3_PREFIX`.
 
 #### TrustLog mirror verification modes
 

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -93,6 +93,16 @@ def _transparency_log_path() -> Optional[Path]:
     return Path(anchor_path)
 
 
+def _transparency_anchor_backend() -> str:
+    """Resolve transparency anchor backend from environment."""
+    raw = (os.getenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND") or "local").strip().lower()
+    if raw in {"", "local", "file"}:
+        return "local"
+    if raw in {"none", "noop", "no_op"}:
+        return "noop"
+    return raw
+
+
 def _transparency_required_enabled() -> bool:
     """Return whether transparency anchoring failures must abort writes.
 
@@ -150,6 +160,21 @@ def _append_transparency_anchor(entry_hash: str) -> Dict[str, Any]:
     The transparency log can be a local spool file that is shipped to an
     external append-only system by infrastructure.
     """
+    backend = _transparency_anchor_backend()
+    if backend == "noop":
+        return {"configured": True, "ok": True, "backend": "noop", "path": None}
+    if backend != "local":
+        return {
+            "configured": True,
+            "ok": False,
+            "backend": "invalid",
+            "path": None,
+            "error": (
+                "ValueError: Unsupported VERITAS_TRUSTLOG_ANCHOR_BACKEND. "
+                "Expected 'local' or 'noop'."
+            ),
+        }
+
     path = _transparency_log_path()
     if path is None:
         return {"configured": False, "ok": False, "path": None}
@@ -176,6 +201,7 @@ def _append_transparency_anchor(entry_hash: str) -> Dict[str, Any]:
     return {
         "configured": True,
         "ok": True,
+        "backend": "local",
         "path": str(path),
         "entry_hash": entry_hash,
     }

--- a/veritas_os/core/posture.py
+++ b/veritas_os/core/posture.py
@@ -226,6 +226,26 @@ def _trustlog_signer_backend() -> str:
     return raw
 
 
+def _trustlog_mirror_backend() -> str:
+    """Return normalized TrustLog mirror backend name."""
+    raw = (os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND") or "local").strip().lower()
+    if raw in {"", "local", "filesystem"}:
+        return "local"
+    if raw in {"s3_object_lock", "s3"}:
+        return "s3_object_lock"
+    return raw
+
+
+def _trustlog_anchor_backend() -> str:
+    """Return normalized TrustLog anchor backend name."""
+    raw = (os.getenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND") or "local").strip().lower()
+    if raw in {"", "local", "file"}:
+        return "local"
+    if raw in {"none", "noop", "no_op"}:
+        return "noop"
+    return raw
+
+
 def _allow_insecure_signer_override() -> bool:
     """Return True when the unsupported production break-glass is enabled."""
     raw = (os.getenv("VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD") or "").strip()
@@ -257,22 +277,60 @@ def validate_posture_startup(defaults: PostureDefaults) -> List[str]:
                 f"(posture={defaults.posture.value})."
             )
 
-    if defaults.trustlog_transparency_required:
-        tp = (os.getenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH") or "").strip()
-        if not tp:
+    mirror_backend = _trustlog_mirror_backend()
+    if defaults.posture in {PostureLevel.SECURE, PostureLevel.PROD}:
+        if mirror_backend != "s3_object_lock":
             errors.append(
-                "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH must be set when "
-                "transparency log anchoring is required "
-                f"(posture={defaults.posture.value})."
+                "VERITAS_TRUSTLOG_MIRROR_BACKEND must be 's3_object_lock' in "
+                f"{defaults.posture.value} posture (got {mirror_backend!r})."
+            )
+    elif mirror_backend not in {"local", "s3_object_lock"}:
+        errors.append(
+            "VERITAS_TRUSTLOG_MIRROR_BACKEND must be one of "
+            "('local', 's3_object_lock')."
+        )
+
+    if mirror_backend == "local":
+        if defaults.trustlog_worm_hard_fail:
+            wp = (os.getenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH") or "").strip()
+            if not wp:
+                errors.append(
+                    "VERITAS_TRUSTLOG_WORM_MIRROR_PATH must be set when "
+                    "VERITAS_TRUSTLOG_MIRROR_BACKEND=local and WORM hard-fail "
+                    f"is required (posture={defaults.posture.value})."
+                )
+    elif mirror_backend == "s3_object_lock":
+        s3_bucket = (os.getenv("VERITAS_TRUSTLOG_S3_BUCKET") or "").strip()
+        s3_prefix = (os.getenv("VERITAS_TRUSTLOG_S3_PREFIX") or "").strip()
+        if not s3_bucket:
+            errors.append(
+                "VERITAS_TRUSTLOG_S3_BUCKET must be set when "
+                "VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock."
+            )
+        if not s3_prefix:
+            errors.append(
+                "VERITAS_TRUSTLOG_S3_PREFIX must be set when "
+                "VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock."
             )
 
-    if defaults.trustlog_worm_hard_fail:
-        wp = (os.getenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH") or "").strip()
-        if not wp:
+    anchor_backend = _trustlog_anchor_backend()
+    if anchor_backend not in {"local", "noop"}:
+        errors.append(
+            "VERITAS_TRUSTLOG_ANCHOR_BACKEND must be one of ('local', 'noop')."
+        )
+
+    if defaults.trustlog_transparency_required:
+        if anchor_backend == "noop":
             errors.append(
-                "VERITAS_TRUSTLOG_WORM_MIRROR_PATH must be set when "
-                "WORM hard-fail is required "
-                f"(posture={defaults.posture.value})."
+                "VERITAS_TRUSTLOG_ANCHOR_BACKEND=noop is not allowed when "
+                "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED=1."
+            )
+        tp = (os.getenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH") or "").strip()
+        if anchor_backend == "local" and not tp:
+            errors.append(
+                "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH must be set when "
+                "VERITAS_TRUSTLOG_ANCHOR_BACKEND=local and transparency "
+                f"anchoring is required (posture={defaults.posture.value})."
             )
 
     signer_backend = _trustlog_signer_backend()

--- a/veritas_os/tests/test_posture.py
+++ b/veritas_os/tests/test_posture.py
@@ -54,6 +54,10 @@ def _clean_env(monkeypatch):
         "VERITAS_API_SECRET_REF",
         "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH",
         "VERITAS_TRUSTLOG_WORM_MIRROR_PATH",
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND",
+        "VERITAS_TRUSTLOG_S3_BUCKET",
+        "VERITAS_TRUSTLOG_S3_PREFIX",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND",
         "VERITAS_TRUSTLOG_SIGNER_BACKEND",
         "VERITAS_TRUSTLOG_KMS_KEY_ID",
         "VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD",
@@ -67,8 +71,11 @@ def _set_minimum_strict_integrations(monkeypatch) -> None:
     """Set non-signer strict integrations so signer tests stay focused."""
     monkeypatch.setenv("VERITAS_SECRET_PROVIDER", "vault")
     monkeypatch.setenv("VERITAS_API_SECRET_REF", "secret/ref")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "s3_object_lock")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_BUCKET", "trustlog-prod")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_PREFIX", "audit/worm")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND", "local")
     monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/var/transparency")
-    monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/var/worm")
 
 
 # ============================================================
@@ -261,12 +268,12 @@ class TestValidatePostureStartup:
         _clean_env(monkeypatch)
         d = derive_defaults(PostureLevel.PROD)
         errors = validate_posture_startup(d)
-        # 5 errors: base strict integrations + trustlog signer enforcement.
-        assert len(errors) == 5
+        # 6 errors: strict integrations + backend requirements.
+        assert len(errors) == 6
         assert any("VERITAS_SECRET_PROVIDER" in e for e in errors)
         assert any("VERITAS_API_SECRET_REF" in e for e in errors)
+        assert any("VERITAS_TRUSTLOG_MIRROR_BACKEND" in e for e in errors)
         assert any("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH" in e for e in errors)
-        assert any("VERITAS_TRUSTLOG_WORM_MIRROR_PATH" in e for e in errors)
         assert any(
             "VERITAS_TRUSTLOG_SIGNER_BACKEND=file is not allowed" in e
             for e in errors
@@ -276,11 +283,14 @@ class TestValidatePostureStartup:
         _clean_env(monkeypatch)
         monkeypatch.setenv("VERITAS_SECRET_PROVIDER", "vault")
         monkeypatch.setenv("VERITAS_API_SECRET_REF", "my/secret")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "s3_object_lock")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_BUCKET", "prod-bucket")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_PREFIX", "audit/worm")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND", "local")
         monkeypatch.setenv(
             "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH",
             "/var/transparency",
         )
-        monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/var/worm")
         monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
         monkeypatch.setenv(
             "VERITAS_TRUSTLOG_KMS_KEY_ID",
@@ -295,6 +305,50 @@ class TestValidatePostureStartup:
         errors = validate_posture_startup(d)
         assert len(errors) >= 1
 
+    def test_secure_missing_kms_config_has_actionable_error(self, monkeypatch):
+        """Secure posture requires KMS key when aws_kms signer is selected."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+        defaults = derive_defaults(PostureLevel.SECURE)
+
+        errors = validate_posture_startup(defaults)
+
+        assert any(
+            "VERITAS_TRUSTLOG_KMS_KEY_ID" in err and "aws_kms" in err
+            for err in errors
+        )
+
+    def test_secure_missing_s3_config_has_actionable_errors(self, monkeypatch):
+        """Secure posture requires S3 bucket and prefix for mirror backend."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:aws:kms:us-east-1:1:key/a")
+        monkeypatch.delenv("VERITAS_TRUSTLOG_S3_BUCKET", raising=False)
+        monkeypatch.delenv("VERITAS_TRUSTLOG_S3_PREFIX", raising=False)
+        defaults = derive_defaults(PostureLevel.SECURE)
+
+        errors = validate_posture_startup(defaults)
+
+        assert any("VERITAS_TRUSTLOG_S3_BUCKET" in err for err in errors)
+        assert any("VERITAS_TRUSTLOG_S3_PREFIX" in err for err in errors)
+
+    def test_secure_rejects_invalid_backend_combination(self, monkeypatch):
+        """Secure posture rejects local mirror backend even with path set."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:aws:kms:us-east-1:1:key/a")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/var/worm")
+        defaults = derive_defaults(PostureLevel.SECURE)
+
+        errors = validate_posture_startup(defaults)
+
+        assert any("VERITAS_TRUSTLOG_MIRROR_BACKEND must be 's3_object_lock'" in err for err in errors)
+
     def test_dev_with_enforcement_on_missing_integration(self, monkeypatch):
         _clean_env(monkeypatch)
         monkeypatch.setenv("VERITAS_ENFORCE_EXTERNAL_SECRET_MANAGER", "1")
@@ -305,6 +359,8 @@ class TestValidatePostureStartup:
     def test_dev_with_file_trustlog_signer_succeeds(self, monkeypatch):
         """Dev posture keeps local file signer workflow available."""
         _clean_env(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND", "noop")
         monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
         defaults = derive_defaults(PostureLevel.DEV)
 
@@ -381,8 +437,11 @@ class TestInitPosture:
         _clean_env(monkeypatch)
         monkeypatch.setenv("VERITAS_SECRET_PROVIDER", "vault")
         monkeypatch.setenv("VERITAS_API_SECRET_REF", "path/to/secret")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "s3_object_lock")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_BUCKET", "prod-bucket")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_PREFIX", "audit/worm")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND", "local")
         monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/var/t")
-        monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/var/w")
         monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
         monkeypatch.setenv(
             "VERITAS_TRUSTLOG_KMS_KEY_ID",
@@ -410,6 +469,9 @@ class TestInitPosture:
             "VERITAS_TRUSTLOG_KMS_KEY_ID",
             "arn:aws:kms:us-east-1:111:key/secure",
         )
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "s3_object_lock")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_BUCKET", "secure-bucket")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_PREFIX", "audit/worm")
         d = init_posture(explicit="secure")
         assert d.posture == PostureLevel.SECURE
         assert d.policy_runtime_enforce is False


### PR DESCRIPTION
### Motivation
- Startup/posture validation still assumed path-based TrustLog config; it must be backend-aware to match signer/mirror/anchor abstractions and provide coherent fail-closed semantics. 
- Operators need actionable error messages when required env combinations (KMS, S3, anchor) are missing for secure/prod posture.

### Description
- Centralized backend-aware TrustLog checks inside `validate_posture_startup` (new helpers `_trustlog_mirror_backend`, `_trustlog_anchor_backend`) and normalized signer helper usage to validate signer, mirror, and anchor choices and their required envs. 
- Enforced posture-specific rules: secure/prod require `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms` + `VERITAS_TRUSTLOG_KMS_KEY_ID` and `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` with `VERITAS_TRUSTLOG_S3_BUCKET`/`VERITAS_TRUSTLOG_S3_PREFIX`; dev keeps `file` signer + `local` mirror and `noop` anchor for smooth local experience. 
- Added anchor backend handling in TrustLog writer: `VERITAS_TRUSTLOG_ANCHOR_BACKEND` supports `local` and `noop` and returns clear receipts/errors for unsupported backends. 
- Updated docs and `.env.example` to reflect new envs and startup refusal rules, and updated/extended posture tests to cover dev/secure/prod cases and invalid backend combinations.

### Testing
- Ran `pytest -q veritas_os/tests/test_posture.py` (all tests passed: 60 passed). 
- Verified module byte-compile (`python -m compileall`) and `ruff check` for modified files (no issues). 
- New/updated unit tests exercise: dev posture valid, secure posture missing KMS, secure posture missing S3 config, invalid backend combination, and actionable error messages; all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9682b3af483268fa79eddf3ca9469)