### PR TITLE
Enhance TrustLog signer metadata for long-term auditability

### DIFF
--- a/veritas_os/README.md
+++ b/veritas_os/README.md
@@ -573,6 +573,34 @@ python -m veritas_os.api.merge_trust_logs \
 * Default: auto-discover existing logs, deduplicate by `request_id` / timestamp
 * `--no-rehash` can disable recomputation (recommended to keep rehash **ON**)
 
+#### Signed witness metadata (auditability across rotation/migration)
+
+`trustlog.jsonl` witness rows include `signer_metadata` (metadata version `v2`) so
+auditors can reconstruct which signing material and verification policy applied
+at signing time:
+
+* `signer_type`: backend (`file`, `aws_kms`, etc.)
+* `signer_key_id`: backend key identifier (KMS key ARN or local key id)
+* `signer_key_version`: normalized key version at sign time
+  * local file keys are recorded as `unversioned`
+  * AWS KMS asymmetric sign does not expose a per-sign key version; recorded as `unknown`
+* `signature_algorithm`: explicit algorithm identifier (`ed25519`, `eddsa_ed25519`)
+* `public_key_fingerprint`: SHA-256-based fingerprint when available (`null` when unavailable)
+* `signed_at`: RFC3339 UTC signing timestamp used for this signature
+* `verification_policy_version`: verifier policy profile used when entry was produced
+
+Backward compatibility:
+
+* Legacy entries without `signer_metadata` are still verifiable.
+* Existing top-level `signer_type` / `signer_key_id` fields are retained for
+  older tooling.
+
+Key rotation representation:
+
+* Each entry stores its own signer identity metadata.
+* During verification, signer selection is resolved from the entry’s signer
+  metadata first, so mixed-backend or rotated-key histories remain auditable.
+
 ### 6.2 Dataset Output
 
 Decisions can be exported as training data via `dataset_writer.py`:

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -49,6 +49,8 @@ PUBLIC_KEY_PATH = SIGNED_TRUSTLOG_KEYS / "trustlog_ed25519_public.key"
 
 _lock = threading.RLock()
 _logger = logging.getLogger(__name__)
+TRUSTLOG_SIGNER_METADATA_VERSION = "v2"
+TRUSTLOG_VERIFICATION_POLICY_VERSION = "trustlog_witness_v2"
 
 
 class SignedTrustLogWriteError(RuntimeError):
@@ -269,8 +271,12 @@ def _resolve_signer_for_entry(entry: Dict[str, Any]) -> Signer:
     The signer is selected from entry metadata first so mixed-backend
     historical logs remain verifiable after backend migrations.
     """
+    signer_meta = entry.get("signer_metadata")
     signer_type = str(entry.get("signer_type", "")).strip().lower()
     signer_key_id = str(entry.get("signer_key_id", "")).strip()
+    if isinstance(signer_meta, dict):
+        signer_type = str(signer_meta.get("signer_type", signer_type)).strip().lower()
+        signer_key_id = str(signer_meta.get("signer_key_id", signer_key_id)).strip()
     if signer_type:
         return build_trustlog_signer(
             private_key_path=PRIVATE_KEY_PATH,
@@ -279,6 +285,30 @@ def _resolve_signer_for_entry(entry: Dict[str, Any]) -> Signer:
             kms_key_id=signer_key_id or None,
         )
     return _resolve_signer()
+
+
+def _build_signer_metadata(signer: Signer, *, signed_at: str) -> Dict[str, Any]:
+    """Build normalized signer metadata for long-term witness verification.
+
+    Normalization rules:
+        - ``signer_key_version`` may be ``unknown`` for backends like AWS KMS
+          that do not expose per-sign operation key versions.
+        - ``public_key_fingerprint`` can be ``None`` when a backend cannot
+          provide a public key during write-time.
+    """
+    public_key_fp = signer.public_key_fingerprint()
+    return {
+        "metadata_version": TRUSTLOG_SIGNER_METADATA_VERSION,
+        "signer_type": signer.signer_type,
+        "signer_key_id": signer.signer_key_id(),
+        "signer_key_version": signer.signer_key_version(),
+        "signature_algorithm": signer.signature_algorithm(),
+        "public_key_fingerprint": public_key_fp,
+        "signed_at": signed_at,
+        "verification_policy_version": TRUSTLOG_VERIFICATION_POLICY_VERSION,
+        "key_version_normalized": signer.signer_key_version() == "unknown",
+        "fingerprint_missing": public_key_fp is None,
+    }
 
 
 def _entry_chain_hash(entry: Dict[str, Any]) -> str:
@@ -558,10 +588,12 @@ def append_signed_decision(
 
             payload_hash = sha256_of_canonical_json(compact_payload)
             signature = signer.sign_payload_hash(payload_hash)
+            signed_at = _utc_now_iso8601()
+            signer_metadata = _build_signer_metadata(signer, signed_at=signed_at)
 
             entry = {
                 "decision_id": _uuid7(),
-                "timestamp": _utc_now_iso8601(),
+                "timestamp": signed_at,
                 "previous_hash": previous_hash,
                 "decision_payload": compact_payload,
                 "payload_hash": payload_hash,
@@ -569,6 +601,7 @@ def append_signed_decision(
                 "signature": signature,
                 "signer_type": signer.signer_type,
                 "signer_key_id": signer.signer_key_id(),
+                "signer_metadata": signer_metadata,
             }
             if enable_artifact_ref:
                 artifact_ref = _build_artifact_reference(decision_payload)

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -296,17 +296,35 @@ def _build_signer_metadata(signer: Signer, *, signed_at: str) -> Dict[str, Any]:
         - ``public_key_fingerprint`` can be ``None`` when a backend cannot
           provide a public key during write-time.
     """
-    public_key_fp = signer.public_key_fingerprint()
+    signer_key_version_fn = getattr(signer, "signer_key_version", None)
+    signature_algorithm_fn = getattr(signer, "signature_algorithm", None)
+    public_key_fingerprint_fn = getattr(signer, "public_key_fingerprint", None)
+
+    signer_key_version = (
+        signer_key_version_fn()
+        if callable(signer_key_version_fn)
+        else "unknown"
+    )
+    signature_algorithm = (
+        signature_algorithm_fn()
+        if callable(signature_algorithm_fn)
+        else "unknown"
+    )
+    public_key_fp = (
+        public_key_fingerprint_fn()
+        if callable(public_key_fingerprint_fn)
+        else None
+    )
     return {
         "metadata_version": TRUSTLOG_SIGNER_METADATA_VERSION,
         "signer_type": signer.signer_type,
         "signer_key_id": signer.signer_key_id(),
-        "signer_key_version": signer.signer_key_version(),
-        "signature_algorithm": signer.signature_algorithm(),
+        "signer_key_version": signer_key_version,
+        "signature_algorithm": signature_algorithm,
         "public_key_fingerprint": public_key_fp,
         "signed_at": signed_at,
         "verification_policy_version": TRUSTLOG_VERIFICATION_POLICY_VERSION,
-        "key_version_normalized": signer.signer_key_version() == "unknown",
+        "key_version_normalized": signer_key_version == "unknown",
         "fingerprint_missing": public_key_fp is None,
     }
 

--- a/veritas_os/audit/trustlog_verify.py
+++ b/veritas_os/audit/trustlog_verify.py
@@ -250,6 +250,38 @@ def _verify_mirror_receipt(
     return None
 
 
+def _verify_signer_metadata(entry: Dict[str, Any]) -> Optional[str]:
+    """Validate signer metadata format for new witness entries.
+
+    Legacy compatibility:
+        Entries without ``signer_metadata`` are accepted.
+    """
+    signer_meta = entry.get("signer_metadata")
+    if signer_meta is None:
+        return None
+    if not isinstance(signer_meta, dict):
+        return "signer_metadata_malformed"
+
+    required_str_fields = (
+        "metadata_version",
+        "signer_type",
+        "signer_key_id",
+        "signer_key_version",
+        "signature_algorithm",
+        "signed_at",
+        "verification_policy_version",
+    )
+    for field in required_str_fields:
+        value = signer_meta.get(field)
+        if not isinstance(value, str) or not value.strip():
+            return f"signer_metadata_invalid_{field}"
+
+    key_fingerprint = signer_meta.get("public_key_fingerprint")
+    if key_fingerprint is not None and not isinstance(key_fingerprint, str):
+        return "signer_metadata_invalid_public_key_fingerprint"
+    return None
+
+
 def verify_witness_ledger(
     entries: List[Dict[str, Any]],
     verify_signature_fn: Callable[[Dict[str, Any]], bool],
@@ -322,6 +354,10 @@ def verify_witness_ledger(
         if mirror_error:
             mirror_ok = False
             errors.append(VerificationError("witness", index, mirror_error))
+
+        signer_meta_error = _verify_signer_metadata(entry)
+        if signer_meta_error:
+            errors.append(VerificationError("witness", index, signer_meta_error))
 
         if not any(err.index == index and err.ledger == "witness" for err in errors):
             valid_entries += 1

--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -175,6 +175,15 @@ class Signer(Protocol):
     def signer_key_id(self) -> str:
         """Return a stable signer identity (KMS key id or local key fingerprint)."""
 
+    def signer_key_version(self) -> str:
+        """Return signer key version label used at sign time."""
+
+    def signature_algorithm(self) -> str:
+        """Return signature algorithm identifier."""
+
+    def public_key_fingerprint(self) -> Optional[str]:
+        """Return public-key fingerprint when available."""
+
 
 class FileEd25519Signer:
     """Ed25519 signer backed by local key files."""
@@ -202,6 +211,16 @@ class FileEd25519Signer:
         )
 
     def signer_key_id(self) -> str:
+        return public_key_fingerprint(self.public_key_path)
+
+    def signer_key_version(self) -> str:
+        """Return normalized key-version label for local file-backed keys."""
+        return "unversioned"
+
+    def signature_algorithm(self) -> str:
+        return "ed25519"
+
+    def public_key_fingerprint(self) -> Optional[str]:
         return public_key_fingerprint(self.public_key_path)
 
 
@@ -267,6 +286,29 @@ class AwsKmsEd25519Signer:
 
     def signer_key_id(self) -> str:
         return self.kms_key_id
+
+    def signer_key_version(self) -> str:
+        """Return normalized key-version label for AWS KMS.
+
+        AWS KMS Sign/GetPublicKey APIs do not return a per-operation key
+        version identifier for asymmetric KMS keys. We record ``unknown`` so
+        verifiers can treat the field consistently across backends.
+        """
+        return "unknown"
+
+    def signature_algorithm(self) -> str:
+        return "eddsa_ed25519"
+
+    def public_key_fingerprint(self) -> Optional[str]:
+        try:
+            public_key = self._load_public_key()
+            public_raw = public_key.public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        except Exception:  # noqa: BLE001
+            return None
+        return sha256_hex(public_raw.hex())[:16]
 
 
 def build_trustlog_signer(

--- a/veritas_os/tests/test_signed_trustlog.py
+++ b/veritas_os/tests/test_signed_trustlog.py
@@ -346,3 +346,179 @@ def test_append_signed_decision_skips_artifact_ref_by_default(monkeypatch, tmp_p
     entry = trustlog_signed.append_signed_decision({"request_id": "r-default"})
 
     assert "artifact_ref" not in entry
+
+
+def test_file_signer_metadata_population(monkeypatch, tmp_path):
+    """File-backed signer emits normalized signer metadata by default."""
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "r-file-meta"})
+    meta = entry["signer_metadata"]
+
+    assert meta["metadata_version"] == "v2"
+    assert meta["signer_type"] == "file"
+    assert meta["signer_key_id"] == entry["signer_key_id"]
+    assert meta["signer_key_version"] == "unversioned"
+    assert meta["signature_algorithm"] == "ed25519"
+    assert isinstance(meta["public_key_fingerprint"], str)
+    assert meta["signed_at"] == entry["timestamp"]
+    assert meta["verification_policy_version"] == "trustlog_witness_v2"
+    assert meta["fingerprint_missing"] is False
+
+
+def test_aws_kms_signer_metadata_population(monkeypatch, tmp_path):
+    """AWS KMS signer emits normalized metadata with explicit key-version semantics."""
+
+    class FakeKmsClient:
+        def __init__(self):
+            self.private_key = Ed25519PrivateKey.generate()
+            self.key_id = "arn:aws:kms:us-east-1:111122223333:key/meta"
+
+        def sign(self, *, KeyId, Message, MessageType, SigningAlgorithm):
+            assert KeyId == self.key_id
+            assert MessageType == "RAW"
+            assert SigningAlgorithm == "EDDSA"
+            return {"Signature": self.private_key.sign(Message)}
+
+        def get_public_key(self, *, KeyId):
+            assert KeyId == self.key_id
+            public_der = self.private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            return {"PublicKey": public_der}
+
+    class FakeBoto3:
+        def __init__(self, client):
+            self._client = client
+
+        def client(self, service_name):
+            assert service_name == "kms"
+            return self._client
+
+    log_path = tmp_path / "trustlog.jsonl"
+    fake_kms = FakeKmsClient()
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", fake_kms.key_id)
+    monkeypatch.setattr(
+        "veritas_os.security.signing.importlib.import_module",
+        lambda module_name: FakeBoto3(fake_kms),
+    )
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "r-kms-meta"})
+    meta = entry["signer_metadata"]
+    assert meta["signer_type"] == "aws_kms"
+    assert meta["signer_key_id"] == fake_kms.key_id
+    assert meta["signer_key_version"] == "unknown"
+    assert meta["signature_algorithm"] == "eddsa_ed25519"
+    assert isinstance(meta["public_key_fingerprint"], str)
+    assert meta["key_version_normalized"] is True
+
+
+def test_legacy_entry_verification_without_signer_metadata(monkeypatch, tmp_path):
+    """Legacy entries without signer_metadata remain verifiable."""
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "r-legacy"})
+    del entry["signer_metadata"]
+    log_path.write_text(json.dumps(entry, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    verify_result = trustlog_signed.verify_trustlog_chain(path=log_path)
+    assert verify_result["ok"] is True
+
+
+def test_rotated_key_verification_for_aws_kms_entries(monkeypatch, tmp_path):
+    """Witness verification succeeds after KMS key rotation using per-entry metadata."""
+
+    class RotatingFakeKmsClient:
+        def __init__(self):
+            self.private_by_key = {
+                "arn:aws:kms:us-east-1:111122223333:key/old": Ed25519PrivateKey.generate(),
+                "arn:aws:kms:us-east-1:111122223333:key/new": Ed25519PrivateKey.generate(),
+            }
+
+        def sign(self, *, KeyId, Message, MessageType, SigningAlgorithm):
+            assert MessageType == "RAW"
+            assert SigningAlgorithm == "EDDSA"
+            private_key = self.private_by_key[KeyId]
+            return {"Signature": private_key.sign(Message)}
+
+        def get_public_key(self, *, KeyId):
+            private_key = self.private_by_key[KeyId]
+            public_der = private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            return {"PublicKey": public_der}
+
+    class FakeBoto3:
+        def __init__(self, client):
+            self._client = client
+
+        def client(self, service_name):
+            assert service_name == "kms"
+            return self._client
+
+    fake_kms = RotatingFakeKmsClient()
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", tmp_path / "trustlog.jsonl")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+    monkeypatch.setattr(
+        "veritas_os.security.signing.importlib.import_module",
+        lambda module_name: FakeBoto3(fake_kms),
+    )
+
+    monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:aws:kms:us-east-1:111122223333:key/old")
+    trustlog_signed.append_signed_decision({"request_id": "r-old-key"})
+
+    monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:aws:kms:us-east-1:111122223333:key/new")
+    trustlog_signed.append_signed_decision({"request_id": "r-new-key"})
+
+    verify_result = trustlog_signed.verify_trustlog_chain(path=tmp_path / "trustlog.jsonl")
+    assert verify_result["ok"] is True
+    assert verify_result["entries_checked"] == 2
+
+
+def test_missing_fingerprint_fallback_behavior(monkeypatch, tmp_path):
+    """Missing public-key fingerprint is explicitly represented in signer metadata."""
+
+    class FakeSigner:
+        signer_type = "file"
+
+        def sign_payload_hash(self, payload_hash: str) -> str:
+            return "ZmFrZV9zaWduYXR1cmU="
+
+        def verify_payload_signature(self, payload_hash: str, signature_b64: str) -> bool:
+            return True
+
+        def signer_key_id(self) -> str:
+            return "fallback-key-id"
+
+        def signer_key_version(self) -> str:
+            return "unversioned"
+
+        def signature_algorithm(self) -> str:
+            return "ed25519"
+
+        def public_key_fingerprint(self):
+            return None
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", tmp_path / "trustlog.jsonl")
+    monkeypatch.setattr(trustlog_signed, "_resolve_signer", lambda ensure_local_keys=False: FakeSigner())
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "r-no-fp"})
+    meta = entry["signer_metadata"]
+    assert meta["public_key_fingerprint"] is None
+    assert meta["fingerprint_missing"] is True

--- a/veritas_os/tests/test_signed_trustlog.py
+++ b/veritas_os/tests/test_signed_trustlog.py
@@ -522,3 +522,28 @@ def test_missing_fingerprint_fallback_behavior(monkeypatch, tmp_path):
     meta = entry["signer_metadata"]
     assert meta["public_key_fingerprint"] is None
     assert meta["fingerprint_missing"] is True
+
+
+def test_legacy_signer_object_without_extended_metadata_methods(monkeypatch, tmp_path):
+    """Backward compatibility: legacy signer doubles without new methods still work."""
+
+    class LegacySigner:
+        signer_type = "file"
+
+        def sign_payload_hash(self, payload_hash: str) -> str:
+            return "ZmFrZV9zaWduYXR1cmU="
+
+        def verify_payload_signature(self, payload_hash: str, signature_b64: str) -> bool:
+            return True
+
+        def signer_key_id(self) -> str:
+            return "legacy-key-id"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", tmp_path / "trustlog.jsonl")
+    monkeypatch.setattr(trustlog_signed, "_resolve_signer", lambda ensure_local_keys=False: LegacySigner())
+
+    entry = trustlog_signed.append_signed_decision({"request_id": "r-legacy-signer"})
+    signer_metadata = entry["signer_metadata"]
+    assert signer_metadata["signer_key_version"] == "unknown"
+    assert signer_metadata["signature_algorithm"] == "unknown"
+    assert signer_metadata["public_key_fingerprint"] is None


### PR DESCRIPTION
### Motivation
- Provide stable, structured signer metadata so witness entries remain auditable across key rotation, backend migration, and long-term verification.
- Ensure metadata is explicit and machine-readable while preserving verification compatibility with legacy entries.

### Description
- Added a versioned `signer_metadata` object to witness entries containing `metadata_version`, `signer_type`, `signer_key_id`, `signer_key_version`, `signature_algorithm`, `public_key_fingerprint`, `signed_at`, and `verification_policy_version`, and flags `key_version_normalized`/`fingerprint_missing` for clarity; metadata is produced by `append_signed_decision` (entry timestamp now uses `signed_at`).
- Extended the `Signer` protocol with `signer_key_version`, `signature_algorithm`, and `public_key_fingerprint` and implemented these for `FileEd25519Signer` (key_version=`unversioned`, algo=`ed25519`) and `AwsKmsEd25519Signer` (key_version=`unknown`, algo=`eddsa_ed25519`, fingerprint computed when public key is available).
- Updated signer resolution to prefer per-entry `signer_metadata` when present so verification reconstructs the signing context even after backend/KeyId changes, while retaining existing top-level `signer_type` / `signer_key_id` for backwards compatibility.
- Added verifier-side validation (`_verify_signer_metadata`) that accepts legacy rows without `signer_metadata` but validates shape and types when metadata is present.
- Documented the new fields, backward compatibility rules, and key-rotation representation in `README.md`.

### Testing
- Added unit tests exercising: file signer metadata population, AWS KMS signer metadata population, legacy entry verification, rotated KMS key scenario, and missing fingerprint fallback behavior in `veritas_os/tests/test_signed_trustlog.py`.
- Ran `pytest -q veritas_os/tests/test_signed_trustlog.py` and `pytest -q veritas_os/tests/test_trustlog_verify_unified.py`, both suites passed (`17 passed` and `15 passed` respectively).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d3c187cc8326ae6e4d2ded9755c2)