### PR TITLE
Refine TrustLog verification failure taxonomy and machine-readable codes

### DIFF
--- a/veritas_os/README.md
+++ b/veritas_os/README.md
@@ -825,6 +825,29 @@ python verify_trust_log.py          # if implemented
 python ../api/merge_trust_logs.py --out logs/trust_log_merged.jsonl
 ```
 
+TrustLog verifier output now includes machine-readable `code` values on each
+`detailed_errors` item, plus `verification_notes` for legacy/skipped checks.
+
+#### TrustLog verification taxonomy
+
+| Category code | Typical meaning | Operator response | Tamper suspected |
+|---|---|---|---|
+| `tamper_suspected` | Hash/receipt state mismatch indicating potential post-write mutation | Escalate incident, preserve artifacts, compare with immutable backups | Yes |
+| `chain_broken` | Hash chain continuity broken (`previous_hash` / `sha256_prev`) | Halt trust in affected range, rebuild from last known-good checkpoint | Yes |
+| `signature_invalid` | Signature does not verify | Check signer keys/rotation history; quarantine entries | Yes |
+| `payload_hash_mismatch` | Witness payload hash differs from recomputed payload | Investigate entry mutation or signing pipeline corruption | Yes |
+| `linkage_hash_mismatch` | Full-artifact hash differs from witness linkage hash | Treat as potential tampering between ledgers | Yes |
+| `decrypt_failed` | Full-ledger line cannot be decrypted/decoded | Validate ciphertext integrity and encryption configuration | No |
+| `key_missing` | Encryption key unavailable during verification | Restore verifier key provisioning and rerun verification | No |
+| `signer_unavailable` | Signature verifier callback/backend unavailable | Restore signer backend and rerun verification | No |
+| `artifact_missing` | Referenced full artifact cannot be resolved | Restore artifact retention/search roots; rerun | No |
+| `mirror_unreachable` | Mirror object/receipt expected but not reachable | Check mirror endpoint/IAM/network and object retention policies | No |
+| `mirror_receipt_malformed` | Mirror receipt shape invalid | Fix writer schema or reject malformed rows | No |
+| `legacy_entry` | Entry validated in compatibility mode with modern fields absent | Plan migration/re-signing; keep for audit continuity | No |
+| `schema_invalid` | Invalid entry metadata/anchor/artifact schema | Fix producer schema and reject bad rows | No |
+| `unsupported_backend` | Artifact backend unsupported by verifier | Add backend verifier support or disable backend usage | No |
+| `verification_skipped` | A check was intentionally skipped (e.g., remote backend unavailable) | Resolve dependencies and rerun full verification | No |
+
 ---
 
 ## 📜 11. License

--- a/veritas_os/audit/artifact_linkage.py
+++ b/veritas_os/audit/artifact_linkage.py
@@ -183,7 +183,7 @@ def _resolve_payload_for_entry(
                 return None
             return payload
 
-        raise ValueError("malformed_artifact_ref")
+        raise ValueError("unsupported_artifact_backend")
 
     # Legacy fallback: recover from full ledger by sha256/request_id, then decide files.
     payload = _resolve_via_full_ledger(

--- a/veritas_os/audit/trustlog_verify.py
+++ b/veritas_os/audit/trustlog_verify.py
@@ -34,10 +34,91 @@ class VerificationError:
     ledger: str
     index: int
     reason: str
+    code: str
+    tamper_suspected: bool = False
 
 
 def _as_dict(error: VerificationError) -> Dict[str, Any]:
-    return {"ledger": error.ledger, "index": error.index, "reason": error.reason}
+    return {
+        "ledger": error.ledger,
+        "index": error.index,
+        "reason": error.reason,
+        "code": error.code,
+        "tamper_suspected": error.tamper_suspected,
+    }
+
+
+_REASON_CODE_MAP = {
+    "sha256_prev_mismatch": "chain_broken",
+    "previous_hash_mismatch": "chain_broken",
+    "sha256_mismatch": "tamper_suspected",
+    "signature_invalid": "signature_invalid",
+    "payload_hash_mismatch": "payload_hash_mismatch",
+    "linkage_hash_mismatch": "linkage_hash_mismatch",
+    "full_payload_hash_invalid": "schema_invalid",
+    "malformed_artifact_ref": "schema_invalid",
+    "canonicalization_failed": "schema_invalid",
+    "artifact_missing": "artifact_missing",
+    "artifact_unreadable": "artifact_missing",
+    "mirror_object_not_found": "mirror_unreachable",
+    "mirror_receipt_missing": "mirror_unreachable",
+    "mirror_version_mismatch": "tamper_suspected",
+    "mirror_etag_mismatch": "tamper_suspected",
+    "mirror_retention_missing": "tamper_suspected",
+    "mirror_legal_hold_missing": "tamper_suspected",
+    "mirror_receipt_malformed": "mirror_receipt_malformed",
+    "signer_metadata_malformed": "schema_invalid",
+    "anchor_backend_invalid": "schema_invalid",
+    "anchor_status_invalid": "schema_invalid",
+    "anchor_receipt_missing": "schema_invalid",
+    "anchor_receipt_malformed": "schema_invalid",
+    "entry_not_dict": "schema_invalid",
+    "json_decode_error": "decrypt_failed",
+    "decrypt_failed": "decrypt_failed",
+    "key_missing": "key_missing",
+    "legacy_missing_full_payload_hash": "legacy_entry",
+    "legacy_missing_signer_metadata": "legacy_entry",
+    "legacy_anchor_not_present": "legacy_entry",
+    "unsupported_artifact_backend": "unsupported_backend",
+    "verify_signature_unavailable": "signer_unavailable",
+    "mirror_remote_verification_skipped": "verification_skipped",
+}
+
+
+def _error_code(reason: str) -> str:
+    return _REASON_CODE_MAP.get(reason, "schema_invalid")
+
+
+def _is_tamper_code(code: str) -> bool:
+    return code in {
+        "tamper_suspected",
+        "chain_broken",
+        "signature_invalid",
+        "payload_hash_mismatch",
+        "linkage_hash_mismatch",
+    }
+
+
+def _make_error(ledger: str, index: int, reason: str) -> VerificationError:
+    code = _error_code(reason)
+    return VerificationError(
+        ledger=ledger,
+        index=index,
+        reason=reason,
+        code=code,
+        tamper_suspected=_is_tamper_code(code),
+    )
+
+
+def _make_note(ledger: str, index: int, reason: str) -> Dict[str, Any]:
+    code = _error_code(reason)
+    return {
+        "ledger": ledger,
+        "index": index,
+        "reason": reason,
+        "code": code,
+        "tamper_suspected": _is_tamper_code(code),
+    }
 
 
 def _canonical_entry_json(entry: Dict[str, Any]) -> str:
@@ -64,7 +145,13 @@ def _iter_full_entries(log_path: Path) -> Iterable[Dict[str, Any]]:
             try:
                 decoded = decrypt(line)
                 entry = json.loads(decoded)
-            except (json.JSONDecodeError, ValueError, EncryptionKeyMissing, DecryptionError):
+            except EncryptionKeyMissing:
+                yield {"__invalid__": True, "__index__": idx, "__reason__": "key_missing"}
+                continue
+            except DecryptionError:
+                yield {"__invalid__": True, "__index__": idx, "__reason__": "decrypt_failed"}
+                continue
+            except (json.JSONDecodeError, ValueError):
                 yield {"__invalid__": True, "__index__": idx, "__reason__": "json_decode_error"}
                 continue
             if not isinstance(entry, dict):
@@ -95,19 +182,19 @@ def verify_full_ledger(
         total_entries += 1
 
         if entry.get("__invalid__"):
-            errors.append(VerificationError("full", index, str(entry.get("__reason__", "invalid_entry"))))
+            errors.append(_make_error("full", index, str(entry.get("__reason__", "invalid_entry"))))
             continue
 
         actual_prev = entry.get("sha256_prev")
         if prev_hash is not None and actual_prev != prev_hash:
-            errors.append(VerificationError("full", index, "sha256_prev_mismatch"))
+            errors.append(_make_error("full", index, "sha256_prev_mismatch"))
             prev_hash = entry.get("sha256")
             continue
 
         expected_prev = prev_hash if prev_hash is not None else actual_prev
         expected_hash = _compute_full_entry_hash(entry, expected_prev)
         if entry.get("sha256") != expected_hash:
-            errors.append(VerificationError("full", index, "sha256_mismatch"))
+            errors.append(_make_error("full", index, "sha256_mismatch"))
             prev_hash = entry.get("sha256")
             continue
 
@@ -125,6 +212,7 @@ def verify_full_ledger(
         "mirror_ok": True,
         "last_hash": prev_hash,
         "detailed_errors": [_as_dict(err) for err in errors],
+        "verification_notes": [],
         "ok": len(errors) == 0,
     }
 
@@ -355,6 +443,7 @@ def verify_witness_ledger(
         as valid legacy rows.
     """
     errors: List[VerificationError] = []
+    notes: List[Dict[str, Any]] = []
     prev_hash: Optional[str] = None
     valid_entries = 0
     chain_ok = True
@@ -375,19 +464,23 @@ def verify_witness_ledger(
             resolved_s3_client = boto3.client("s3")
         except Exception:  # noqa: BLE001
             resolved_s3_client = None
+            notes.append(_make_note("witness", -1, "mirror_remote_verification_skipped"))
 
     for index, entry in enumerate(entries):
         payload_hash = sha256_of_canonical_json(entry.get("decision_payload", {}))
         if payload_hash != entry.get("payload_hash"):
-            errors.append(VerificationError("witness", index, "payload_hash_mismatch"))
+            errors.append(_make_error("witness", index, "payload_hash_mismatch"))
 
         if entry.get("previous_hash") != prev_hash:
             chain_ok = False
-            errors.append(VerificationError("witness", index, "previous_hash_mismatch"))
+            errors.append(_make_error("witness", index, "previous_hash_mismatch"))
 
-        if not verify_signature_fn(entry):
+        if verify_signature_fn is None:
             signature_ok = False
-            errors.append(VerificationError("witness", index, "signature_invalid"))
+            errors.append(_make_error("witness", index, "verify_signature_unavailable"))
+        elif not verify_signature_fn(entry):
+            signature_ok = False
+            errors.append(_make_error("witness", index, "signature_invalid"))
 
         linkage_result = verify_entry_artifact_linkage(
             entry,
@@ -396,11 +489,7 @@ def verify_witness_ledger(
         if not linkage_result.ok:
             linkage_ok = False
             errors.append(
-                VerificationError(
-                    "witness",
-                    index,
-                    str(linkage_result.reason or "linkage_verification_failed"),
-                )
+                _make_error("witness", index, str(linkage_result.reason or "linkage_verification_failed"))
             )
 
         mirror_error = _verify_mirror_receipt(
@@ -413,15 +502,22 @@ def verify_witness_ledger(
         )
         if mirror_error:
             mirror_ok = False
-            errors.append(VerificationError("witness", index, mirror_error))
+            errors.append(_make_error("witness", index, mirror_error))
 
         signer_meta_error = _verify_signer_metadata(entry)
         if signer_meta_error:
-            errors.append(VerificationError("witness", index, signer_meta_error))
+            errors.append(_make_error("witness", index, signer_meta_error))
+        elif "signer_metadata" not in entry:
+            notes.append(_make_note("witness", index, "legacy_missing_signer_metadata"))
 
         anchor_error = _verify_anchor_receipt(entry)
         if anchor_error:
-            errors.append(VerificationError("witness", index, anchor_error))
+            errors.append(_make_error("witness", index, anchor_error))
+        elif all(key not in entry for key in ("anchor_backend", "anchor_status", "anchor_receipt")):
+            notes.append(_make_note("witness", index, "legacy_anchor_not_present"))
+
+        if "full_payload_hash" not in entry:
+            notes.append(_make_note("witness", index, "legacy_missing_full_payload_hash"))
 
         if not any(err.index == index and err.ledger == "witness" for err in errors):
             valid_entries += 1
@@ -439,6 +535,7 @@ def verify_witness_ledger(
         "mirror_ok": mirror_ok,
         "last_hash": prev_hash,
         "detailed_errors": [_as_dict(err) for err in errors],
+        "verification_notes": notes,
         "ok": len(errors) == 0,
     }
 
@@ -472,6 +569,7 @@ def verify_trustlogs(
         "mirror_ok": witness["mirror_ok"],
         "last_hash": last_hash,
         "detailed_errors": full["detailed_errors"] + witness["detailed_errors"],
+        "verification_notes": full.get("verification_notes", []) + witness.get("verification_notes", []),
         "full_ledger": full,
         "witness_ledger": witness,
         "ok": full["ok"] and witness["ok"],

--- a/veritas_os/logging/trust_log.py
+++ b/veritas_os/logging/trust_log.py
@@ -722,7 +722,13 @@ def get_trust_logs_by_request(request_id: str) -> Dict[str, Any]:
 # =============================================================================
 
 def verify_trust_log(max_entries: Optional[int] = None) -> Dict[str, Any]:
-    """Verify encrypted full TrustLog integrity with stable compatibility fields."""
+    """Verify encrypted full TrustLog integrity with stable compatibility fields.
+
+    Compatibility note:
+        ``broken_reason`` is preserved for legacy callers that expect historical
+        reason strings such as ``json_decode_error``. New structured callers
+        should rely on ``broken_code`` and ``summary.detailed_errors[*].code``.
+    """
     try:
         result = verify_full_ledger(log_path=LOG_JSONL, max_entries=max_entries)
     except OSError as exc:
@@ -752,7 +758,11 @@ def verify_trust_log(max_entries: Optional[int] = None) -> Dict[str, Any]:
     broken_index = None
     if result["detailed_errors"]:
         first = result["detailed_errors"][0]
-        broken_reason = first.get("reason")
+        raw_reason = first.get("reason")
+        if raw_reason in {"decrypt_failed", "key_missing"}:
+            broken_reason = "json_decode_error"
+        else:
+            broken_reason = raw_reason
         broken_index = first.get("index")
 
     return {
@@ -761,6 +771,7 @@ def verify_trust_log(max_entries: Optional[int] = None) -> Dict[str, Any]:
         "broken": not result["ok"],
         "broken_index": broken_index,
         "broken_reason": broken_reason,
+        "broken_code": (result["detailed_errors"][0].get("code") if result["detailed_errors"] else None),
         "summary": {
             "total_entries": result["total_entries"],
             "valid_entries": result["valid_entries"],

--- a/veritas_os/scripts/verify_trust_log.py
+++ b/veritas_os/scripts/verify_trust_log.py
@@ -130,13 +130,28 @@ def _print_human(result: dict) -> None:
     errors = result.get("detailed_errors", [])
     if not errors:
         print("  []")
+    else:
+        for error in errors:
+            print(
+                "  - "
+                f"ledger={error.get('ledger')} "
+                f"index={error.get('index')} "
+                f"reason={error.get('reason')} "
+                f"code={error.get('code')} "
+                f"tamper_suspected={error.get('tamper_suspected')}"
+            )
+    notes = result.get("verification_notes", [])
+    print("verification_notes:")
+    if not notes:
+        print("  []")
         return
-    for error in errors:
+    for note in notes:
         print(
             "  - "
-            f"ledger={error.get('ledger')} "
-            f"index={error.get('index')} "
-            f"reason={error.get('reason')}"
+            f"ledger={note.get('ledger')} "
+            f"index={note.get('index')} "
+            f"reason={note.get('reason')} "
+            f"code={note.get('code')}"
         )
 
 

--- a/veritas_os/tests/test_trustlog_verify_unified.py
+++ b/veritas_os/tests/test_trustlog_verify_unified.py
@@ -128,6 +128,8 @@ def test_unified_verifier_good_path(tmp_path: Path, monkeypatch) -> None:
     assert result["linkage_ok"] is True
     assert result["mirror_ok"] is True
     assert result["invalid_entries"] == 0
+    note_codes = {note["code"] for note in result["verification_notes"]}
+    assert "legacy_entry" in note_codes
 
 
 def test_unified_verifier_broken_path(tmp_path: Path, monkeypatch) -> None:
@@ -154,10 +156,15 @@ def test_unified_verifier_broken_path(tmp_path: Path, monkeypatch) -> None:
     assert result["mirror_ok"] is False
     assert result["invalid_entries"] > 0
     reasons = {error["reason"] for error in result["detailed_errors"]}
+    codes = {error["code"] for error in result["detailed_errors"]}
     assert "previous_hash_mismatch" in reasons
     assert "signature_invalid" in reasons
     assert "full_payload_hash_invalid" in reasons
     assert "mirror_receipt_malformed" in reasons
+    assert "chain_broken" in codes
+    assert "signature_invalid" in codes
+    assert "schema_invalid" in codes
+    assert "mirror_receipt_malformed" in codes
 
 
 
@@ -358,6 +365,7 @@ def test_verify_trust_log_cli_json_output(tmp_path: Path, monkeypatch) -> None:
         "mirror_ok",
         "last_hash",
         "detailed_errors",
+        "verification_notes",
     }
     assert required.issubset(data.keys())
     assert completed.returncode == 0
@@ -418,8 +426,11 @@ def test_mirror_remote_object_missing(monkeypatch) -> None:
     monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE", "1")
     client = _FakeS3Client(head_error=RuntimeError("not found"))
     result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=client)
-    reasons = {error["reason"] for error in result["detailed_errors"]}
+    errors = result["detailed_errors"]
+    reasons = {error["reason"] for error in errors}
+    codes = {error["code"] for error in errors}
     assert "mirror_object_not_found" in reasons
+    assert "mirror_unreachable" in codes
 
 
 def test_mirror_remote_version_mismatch(monkeypatch) -> None:
@@ -427,7 +438,9 @@ def test_mirror_remote_version_mismatch(monkeypatch) -> None:
     client = _FakeS3Client(head_response={"VersionId": "v2", "ETag": '"etag-1"'})
     result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=client)
     reasons = {error["reason"] for error in result["detailed_errors"]}
+    codes = {error["code"] for error in result["detailed_errors"]}
     assert "mirror_version_mismatch" in reasons
+    assert "tamper_suspected" in codes
 
 
 def test_mirror_remote_retention_missing_in_strict_mode(monkeypatch) -> None:
@@ -455,7 +468,9 @@ def test_mirror_receipt_missing_strict_vs_non_strict(monkeypatch) -> None:
     monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_S3_STRICT", "1")
     strict_result = verify_witness_ledger([entry], lambda _: True)
     reasons = {error["reason"] for error in strict_result["detailed_errors"]}
+    codes = {error["code"] for error in strict_result["detailed_errors"]}
     assert "mirror_receipt_missing" in reasons
+    assert "mirror_unreachable" in codes
 
 
 def test_mirror_remote_offline_mode_skips_validation(monkeypatch) -> None:
@@ -464,3 +479,59 @@ def test_mirror_remote_offline_mode_skips_validation(monkeypatch) -> None:
     result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=client)
     assert result["ok"] is True
     assert client.head_calls == 0
+
+
+def test_full_ledger_key_missing_classification(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    full_log = tmp_path / "trust_log.jsonl"
+    full_log.write_text("not-encrypted\n", encoding="utf-8")
+    result = verify_full_ledger(full_log)
+    codes = {error["code"] for error in result["detailed_errors"]}
+    assert "key_missing" in codes or "decrypt_failed" in codes
+
+
+def test_witness_payload_hash_mismatch_code() -> None:
+    payload = {"request_id": "r-payload"}
+    entry = {
+        "decision_payload": payload,
+        "payload_hash": "0" * 64,
+        "previous_hash": None,
+        "signature": "sig-ok",
+    }
+    result = verify_witness_ledger([entry], lambda _: True)
+    codes = {error["code"] for error in result["detailed_errors"]}
+    assert "payload_hash_mismatch" in codes
+
+
+def test_witness_unsupported_backend_code(tmp_path: Path) -> None:
+    payload = {"request_id": "r-backend"}
+    witness = [
+        {
+            "decision_payload": payload,
+            "payload_hash": sha256_of_canonical_json(payload),
+            "previous_hash": None,
+            "signature": "sig-ok",
+            "full_payload_hash": "a" * 64,
+            "artifact_ref": {
+                "artifact_ref": "trustlog_full_payload",
+                "artifact_type": "trust_log_entry",
+                "artifact_storage_backend": "unknown_backend",
+                "artifact_locator": "sha256:" + "b" * 64,
+                "artifact_hash_algorithm": "sha256_canonical_json",
+            },
+        }
+    ]
+    result = verify_witness_ledger(witness, lambda _: True, artifact_search_roots=[tmp_path])
+    codes = {error["code"] for error in result["detailed_errors"]}
+    assert "unsupported_backend" in codes
+
+
+def test_mirror_remote_verification_skipped_note(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VERIFY_MIRROR_REMOTE", "1")
+    monkeypatch.setattr(
+        "veritas_os.audit.trustlog_verify.importlib.import_module",
+        lambda _: (_ for _ in ()).throw(RuntimeError("no boto3")),
+    )
+    result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=None)
+    note_codes = {note["code"] for note in result["verification_notes"]}
+    assert "verification_skipped" in note_codes

--- a/veritas_os/tests/unit/test_trustlog.py
+++ b/veritas_os/tests/unit/test_trustlog.py
@@ -796,6 +796,7 @@ class TestTruncatedLine:
         # Truncated encrypted lines fail decryption → reported as decode error
         assert result["broken"] is True
         assert result["broken_reason"] in ("json_decode_error",)
+        assert result["broken_code"] in ("decrypt_failed", "key_missing")
 
     def test_extract_last_sha256_skips_truncated_lines(self, monkeypatch):
         _set_valid_key(monkeypatch, raw=b"I" * 32)


### PR DESCRIPTION
### Motivation
- Improve classification of TrustLog verification failures so operators and auditors can distinguish tampering from config/key/legacy/mirror issues. 
- Provide a stable, machine-readable `code` field alongside human-readable `reason` and surface a `tamper_suspected` flag for high-confidence tamper indicators. 
- Preserve human-friendly CLI output while enabling downstream automation and non-fatal visibility for legacy/skipped checks. 
- Warn that non-fatal notes such as `legacy_entry` and `verification_skipped` reduce false alerts but may hide coverage gaps if ignored by operators.

### Description
- Introduced `code` and `tamper_suspected` into the structured `VerificationError` and added `_REASON_CODE_MAP` with mapping from existing reason strings to taxonomy codes (e.g., `chain_broken`, `tamper_suspected`, `signature_invalid`, `artifact_missing`, `mirror_unreachable`, `unsupported_backend`, `verification_skipped`).
- Added helper constructors `_make_error` and `_make_note` to produce consistent error objects and non-fatal notes; witness and full-ledger APIs now return `detailed_errors` (with new fields) and `verification_notes` for legacy/skipped items.
- Improved full-ledger decoding classification to distinguish `key_missing` and `decrypt_failed` from generic JSON decode errors, avoiding collapse of root causes.
- Enhanced artifact linkage handling to raise `unsupported_artifact_backend` where appropriate, mapped to `unsupported_backend` code for automation.
- Kept CLI human output readable and extended it to print `code`, `tamper_suspected`, and a `verification_notes` section without breaking current non-JSON behavior.
- Added focused unit tests exercising representative failure categories and JSON shape expectations, and documented the new taxonomy and operator guidance in the README.

### Testing
- Ran the updated unit suite for the verifier: `pytest -q veritas_os/tests/test_trustlog_verify_unified.py`, and all tests passed (19 passed).
- Added/updated unit tests that cover chain break, signature invalid, payload/hash/linkage mismatches, key/decrypt classification, mirror unreachable/receipt issues, legacy notes, unsupported artifact backend, and CLI JSON shape; these tests passed in the run above.
- No other automated test failures were introduced in the modified verification tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9eca753888326a0788db126b1424b)