### PR TITLE
Add staged TrustLog release gating matrix to release-gate.yml

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -21,8 +21,16 @@ name: Release Gate
 
 on:
   push:
+    branches:
+      - "release/**"
+      - "rc/**"
     tags:
       - "v*"
+      - "v*-rc.*"
+  pull_request:
+    branches:
+      - "release/**"
+      - "rc/**"
   workflow_dispatch:
     inputs:
       tier3_external:
@@ -46,6 +54,126 @@ env:
 # Re-run at release time to catch any drift since last PR merge.
 # ============================================================================
 jobs:
+  trustlog-production-matrix:
+    name: "[Tier 2] trustlog-production (${{ matrix.profile }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: dev
+            profile_required: "false"
+          - profile: secure
+            profile_required: "true"
+          - profile: prod
+            profile_required: "true"
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      OPENAI_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_ENV: ${{ matrix.profile }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r veritas_os/requirements.txt
+          python -m pip install pytest httpx anyio
+
+      - name: Resolve TrustLog gate mode
+        id: gate_mode
+        run: |
+          set -euo pipefail
+          REF="${GITHUB_REF}"
+          BASE_REF="${GITHUB_BASE_REF:-}"
+          REQUIRED="false"
+          if [[ "${REF}" == refs/tags/v* ]]; then
+            REQUIRED="true"
+          elif [[ "${REF}" == refs/heads/release/* || "${REF}" == refs/heads/rc/* ]]; then
+            REQUIRED="true"
+          elif [[ "${BASE_REF}" == release/* || "${BASE_REF}" == rc/* ]]; then
+            REQUIRED="true"
+          fi
+
+          if [[ "${{ matrix.profile_required }}" == "true" ]]; then
+            REQUIRED="true"
+          fi
+
+          if [[ "${REQUIRED}" == "true" ]]; then
+            echo "mode=required" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=advisory" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run TrustLog production validation
+        id: trustlog_tests
+        run: |
+          set -euo pipefail
+          mkdir -p test-reports
+          STATUS=0
+          pytest -q -v --tb=short \
+            veritas_os/tests/test_posture.py::TestValidatePostureStartup::test_prod_with_aws_kms_trustlog_signer_succeeds \
+            veritas_os/tests/test_posture.py::TestValidatePostureStartup::test_secure_missing_kms_config_has_actionable_error \
+            veritas_os/tests/test_posture.py::TestValidatePostureStartup::test_secure_missing_s3_config_has_actionable_errors \
+            veritas_os/tests/test_posture.py::TestValidatePostureStartup::test_secure_rejects_invalid_backend_combination \
+            veritas_os/tests/test_signed_trustlog.py::test_worm_hard_fail_mode_raises_when_mirror_write_fails \
+            veritas_os/tests/test_trustlog_verify_unified.py::test_unified_verifier_good_path \
+            veritas_os/tests/test_trustlog_verify_unified.py::test_witness_linkage_legacy_without_artifact_ref \
+            veritas_os/tests/test_trustlog_verify_unified.py::test_mirror_remote_verification_success \
+            veritas_os/tests/test_production_trustlog.py::TestTrustLogWriteReadVerify::test_chain_integrity_after_multiple_writes \
+            --junitxml=test-reports/trustlog-${{ matrix.profile }}.xml || STATUS=$?
+          echo "exit_code=${STATUS}" >> "$GITHUB_OUTPUT"
+          if [[ "${STATUS}" -ne 0 ]]; then
+            echo "TrustLog validation tests failed with exit code ${STATUS}."
+          fi
+
+      - name: Summarize TrustLog validation mode
+        if: always()
+        run: |
+          {
+            echo "## TrustLog validation profile=${{ matrix.profile }}"
+            echo ""
+            echo "- Gate mode: **${{ steps.gate_mode.outputs.mode }}**"
+            echo "- Test exit code: **${{ steps.trustlog_tests.outputs.exit_code }}**"
+            echo "- Coverage: KMS signer / S3 Object Lock mirror / unified verification / startup posture / hard-fail / legacy compatibility"
+            echo "- Ref: \`${GITHUB_REF}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload TrustLog test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trustlog-production-${{ matrix.profile }}-report
+          path: test-reports/trustlog-${{ matrix.profile }}.xml
+          if-no-files-found: warn
+
+      - name: Enforce required mode
+        if: always()
+        run: |
+          set -euo pipefail
+          MODE="${{ steps.gate_mode.outputs.mode }}"
+          EXIT_CODE="${{ steps.trustlog_tests.outputs.exit_code }}"
+          if [[ "${MODE}" == "required" && "${EXIT_CODE}" != "0" ]]; then
+            echo "::error::TrustLog validation is required for this ref/profile and failed (exit=${EXIT_CODE})."
+            echo "::error::Action: inspect trustlog-production-${{ matrix.profile }}-report and rerun after fixing posture/signer/mirror/verification failures."
+            exit 1
+          fi
+          if [[ "${MODE}" == "advisory" && "${EXIT_CODE}" != "0" ]]; then
+            echo "::warning::Advisory TrustLog validation failed (exit=${EXIT_CODE}) but is non-blocking for this ref."
+          fi
+
   governance-smoke:
     name: "[Tier 1] governance-smoke"
     runs-on: ubuntu-latest
@@ -412,7 +540,7 @@ jobs:
   # ============================================================================
   release-readiness:
     name: "✅ Release Readiness Gate"
-    needs: [governance-smoke, security-checks, production-tests, docker-smoke, governance-report]
+    needs: [governance-smoke, security-checks, trustlog-production-matrix, production-tests, docker-smoke, governance-report]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
@@ -422,6 +550,7 @@ jobs:
         env:
           SMOKE_RESULT: ${{ needs.governance-smoke.result }}
           SECURITY_RESULT: ${{ needs.security-checks.result }}
+          TRUSTLOG_RESULT: ${{ needs.trustlog-production-matrix.result }}
           PRODUCTION_RESULT: ${{ needs.production-tests.result }}
           DOCKER_RESULT: ${{ needs.docker-smoke.result }}
           GOVERNANCE_REPORT_RESULT: ${{ needs.governance-report.result }}
@@ -452,6 +581,7 @@ jobs:
 
           check "governance-smoke"   "[Tier 1]" "$SMOKE_RESULT"
           check "security-checks"    "[Tier 1]" "$SECURITY_RESULT"
+          check "trustlog-production-matrix" "[Tier 2]" "$TRUSTLOG_RESULT"
           check "production-tests"   "[Tier 2]" "$PRODUCTION_RESULT"
           check "docker-smoke"       "[Tier 2]" "$DOCKER_RESULT"
           check "governance-report"  "[Tier 2]" "$GOVERNANCE_REPORT_RESULT"

--- a/docs/OPERATIONAL_READINESS_RUNBOOK.md
+++ b/docs/OPERATIONAL_READINESS_RUNBOOK.md
@@ -45,6 +45,7 @@ What is proven:
 
 What is proven:
 - All Tier 1 checks (re-run)
+- TrustLog profile matrix (`dev`/`secure`/`prod`) with required secure/prod gates
 - Production-like pytest suite (`pytest -m "production or smoke"`)
 - Docker Compose full-stack health check
 - Governance readiness report (13+ checks)
@@ -64,6 +65,10 @@ What is proven:
 - Load burst validation with percentile summaries
 - Docker Compose governance endpoint reachability
 - External provider validation (when secrets configured)
+
+Notes:
+- Tier 3 remains advisory for normal development flow.
+- TrustLog release gating is enforced in Tier 2 for `release/*`, `rc/*`, and `v*`.
 
 ## Running Validation Locally
 

--- a/docs/PRODUCTION_VALIDATION.md
+++ b/docs/PRODUCTION_VALIDATION.md
@@ -17,6 +17,29 @@ VERITAS OS uses three validation tiers with explicit blocking semantics:
 | **Tier 2** | `release-gate.yml` | Every `v*` tag push | **Yes — blocks release** | Production-like validation: production pytest suite, Docker smoke, governance readiness report |
 | **Tier 3** | `production-validation.yml` | Weekly schedule + manual | Advisory (weekly), opt-in blocking (release) | Long-running, secrets-required, external/live tests |
 
+### TrustLog staged release gating (new)
+
+`release-gate.yml` now includes a dedicated **TrustLog production matrix** with
+`dev`, `secure`, and `prod` profiles.
+
+| Profile | Default mode | Becomes required on |
+|---------|--------------|---------------------|
+| `dev` | Advisory | `release/*`, `rc/*`, and `v*` refs |
+| `secure` | Required | All release-gate runs |
+| `prod` | Required | All release-gate runs |
+
+This matrix explicitly validates enterprise TrustLog promotion paths:
+
+- KMS signer path
+- S3 Object Lock mirror path
+- Unified verification path
+- Startup posture validation
+- Hard-fail semantics
+- Legacy verification compatibility
+
+Failures include actionable guidance and per-profile JUnit artifacts:
+`trustlog-production-<profile>-report`.
+
 ### What runs where
 
 #### On every PR / push to `main` (Tier 1, `main.yml`)
@@ -36,6 +59,7 @@ VERITAS OS uses three validation tiers with explicit blocking semantics:
 |-----|---------|---------|
 | `governance-smoke` | Re-runs Tier 1 smoke at release time | ✅ Yes |
 | `security-checks` | Re-runs all security scripts + Bandit | ✅ Yes |
+| `trustlog-production-matrix` | TrustLog release profile matrix (`dev`/`secure`/`prod`) | ✅ Yes (`secure`/`prod` always, `dev` on release refs) |
 | `production-tests` | `pytest -m "production or smoke"` + TLS + load | ✅ Yes |
 | `docker-smoke` | Full-stack Docker Compose health check | ✅ Yes |
 | `governance-report` | Generates governance readiness report artifact | ✅ Yes |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -15,6 +15,8 @@ VERITAS OS uses semantic versioning: `vMAJOR.MINOR.PATCH` (e.g. `v2.1.0`).
 - **Major releases** (`v3.0.0`) — breaking changes, major architecture changes
 
 Pre-release tags: `v2.1.0-rc.1`, `v2.1.0-beta.1` also trigger the release gate.
+Additionally, release preparation branches (`release/*`, `rc/*`) trigger the same
+gate so maintainers can catch TrustLog production issues before tagging.
 
 ## How to Release
 
@@ -50,8 +52,20 @@ gh run watch --workflow=release-gate.yml
 The release gate runs three parallel groups:
 
 1. **Tier 1** (`governance-smoke` + `security-checks`) — fast, ~3-5 min
-2. **Tier 2** (`production-tests` + `docker-smoke` + `governance-report`) — ~10-15 min
+2. **Tier 2** (`trustlog-production-matrix` + `production-tests` + `docker-smoke` + `governance-report`) — ~10-15 min
 3. **Final** (`release-readiness`) — 1 min summary gate
+
+### TrustLog gating policy
+
+`trustlog-production-matrix` enforces staged validation:
+
+- `dev` profile: advisory on non-release refs, required on `release/*`, `rc/*`, `v*`
+- `secure` profile: always required
+- `prod` profile: always required
+
+The matrix must pass before promotion because it covers:
+KMS signer, S3 Object Lock mirror, unified verification, startup posture,
+hard-fail semantics, and legacy verification compatibility.
 
 ### 4. Verify governance readiness
 
@@ -145,6 +159,7 @@ gh workflow run release-gate.yml --ref v2.1.0 -f tier3_external=true
 | Unit tests (85% coverage) | `main.yml` | Every PR | ✅ PR merge |
 | Frontend lint/test/E2E | `main.yml` | Every PR | ✅ PR merge |
 | Production tests + Docker smoke | `release-gate.yml` | `v*` tag push | ✅ Release |
+| TrustLog production matrix (`dev`/`secure`/`prod`) | `release-gate.yml` | `release/*`, `rc/*`, `v*` | ✅ Release candidate / release |
 | Governance readiness report | `release-gate.yml` | `v*` tag push | ✅ Release |
 | External/live tests | `release-gate.yml` | Manual only | ⚠️ Advisory |
 | Long-running production validation | `production-validation.yml` | Weekly + manual | Advisory |


### PR DESCRIPTION
### Motivation
- Strengthen TrustLog production confidence by promoting production-like TrustLog validation from advisory-only to a staged, release-gating path for release branches/tags and strict profiles.
- Ensure the release promotion gate fails fast and provides actionable failure diagnostics when KMS/S3/hard-fail/verification paths or startup posture checks are not satisfied for release candidates.

### Description
- Added a new `trustlog-production-matrix` job to `.github/workflows/release-gate.yml` that runs a matrix over `dev` / `secure` / `prod` profiles and sets per-profile `advisory` vs `required` gating based on branch/tag context.
- Expanded `release-gate.yml` triggers to include `release/*` and `rc/*` branches (push + PR) and pre-release tag patterns so release branches/RCs can be validated before tagging.
- The matrix executes a focused set of TrustLog tests (KMS signer, S3 Object Lock mirror, unified verification, startup posture, hard-fail semantics, legacy compatibility) and uploads per-profile JUnit artifacts `trustlog-production-<profile>-report` for debugging.
- The job writes a concise `GITHUB_STEP_SUMMARY` entry and emits actionable `::error::`/`::warning::` messages depending on `required` vs `advisory` mode, and its result is wired into the `release-readiness` final gate so required failures block promotion.
- Updated docs to describe the new staged gating: `docs/PRODUCTION_VALIDATION.md`, `docs/RELEASE_PROCESS.md`, and `docs/OPERATIONAL_READINESS_RUNBOOK.md` with policy for when profiles are required vs advisory and how maintainers should interpret failures.

### Testing
- Ran the targeted TrustLog pytest selection locally: the selected tests (`test_posture` cases, `test_signed_trustlog`, `test_trustlog_verify_unified` cases, and `TestTrustLogWriteReadVerify::test_chain_integrity_after_multiple_writes`) completed successfully (`9 passed` in ~4.7s).
- Validated workflow syntactic correctness with a YAML parse (`yaml.safe_load` on `.github/workflows/release-gate.yml`) which returned OK.

Security note: The `dev` profile remains advisory on non-release refs by design, so regressions can still be introduced prior to release branches/tags; teams must rely on the Tier 2 required gates (`secure`/`prod` and release refs) for promotion confidence and avoid publishing releases without a passing release gate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f6ce02bc8326b0aa13af2f7fa7ce)