### PR TITLE
Add sealed-segment S3 mirror mode with manifest verification

### DIFF
--- a/docs/en/operations/trustlog_observability.md
+++ b/docs/en/operations/trustlog_observability.md
@@ -70,3 +70,28 @@ This document defines production-focused TrustLog metrics, alerting guidance, an
 ## Security note
 
 Any sustained increase in `trustlog_verify_failure_total`, `trustlog_sign_failure_total`, or mirror/anchor failures in hardened posture should be treated as a potential security and integrity incident until ruled out.
+
+## S3 mirror mode selection (scalability tradeoffs)
+
+`VERITAS_TRUSTLOG_S3_MIRROR_MODE` now supports two modes:
+
+- `single_entry_objects` (default)
+  - One S3 object per witness entry.
+  - Best when volume is low/moderate and per-entry retrieval simplicity is preferred.
+  - Tradeoff: high object-count growth, expensive list operations at large scale.
+- `sealed_segments`
+  - Buffers entries and seals bounded segments using `VERITAS_TRUSTLOG_S3_SEGMENT_MAX_ENTRIES`.
+  - Writes one JSONL payload object plus one manifest object per sealed segment.
+  - Manifest stores segment boundaries (`first_hash`/`last_hash`), payload digest, timestamps, and object keys.
+  - Best for high-throughput audit pipelines and archive/export packaging.
+  - Tradeoff: latest entries remain in a short-lived in-memory buffer until seal threshold is reached.
+
+Recommended operational guidance:
+
+- Use `single_entry_objects` for small deployments and incident forensics workflows that mostly fetch single rows.
+- Use `sealed_segments` when S3 listing cost/object-count pressure becomes material.
+- Keep `VERITAS_TRUSTLOG_WORM_HARD_FAIL=1` in secure/prod so mirror write failures continue to fail closed.
+
+### Security warning
+
+If `VERITAS_TRUSTLOG_S3_SEGMENT_MANIFEST_HMAC_KEY` is used, protect it in an external secret manager (do not commit or hardcode). Compromise of this key weakens manifest-authenticity guarantees and should be treated as a security incident.

--- a/veritas_os/audit/storage_mirror.py
+++ b/veritas_os/audit/storage_mirror.py
@@ -8,12 +8,16 @@ logic can consistently enforce hard-fail posture semantics.
 from __future__ import annotations
 
 import importlib
+import hmac
+import json
 import os
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
+
+from veritas_os.security.hash import canonical_json_dumps, sha256_hex, sha256_of_canonical_json
 
 
 class StorageMirror(ABC):
@@ -83,6 +87,9 @@ class S3ObjectLockMirror(StorageMirror):
         *,
         bucket: str,
         prefix: str,
+        mirror_mode: str = "single_entry_objects",
+        segment_max_entries: int = 100,
+        manifest_hmac_key: Optional[str] = None,
         region: Optional[str] = None,
         object_lock_mode: Optional[str] = None,
         retention_days: Optional[int] = None,
@@ -90,10 +97,15 @@ class S3ObjectLockMirror(StorageMirror):
     ) -> None:
         self.bucket = bucket.strip()
         self.prefix = prefix.strip("/")
+        self.mirror_mode = mirror_mode.strip().lower()
+        self.segment_max_entries = max(1, int(segment_max_entries))
+        self.manifest_hmac_key = (manifest_hmac_key or "").strip() or None
         self.region = (region or "").strip() or None
         self.object_lock_mode = (object_lock_mode or "").strip() or None
         self.retention_days = retention_days
         self._s3_client = s3_client
+        self._segment_lines: list[str] = []
+        self._segment_entries: list[Dict[str, Any]] = []
 
     @property
     def s3_client(self) -> object:
@@ -107,12 +119,172 @@ class S3ObjectLockMirror(StorageMirror):
         return self._s3_client
 
     def _build_key(self) -> str:
+        if self.mirror_mode == "sealed_segments":
+            return self._build_segment_key(segment_id=uuid.uuid4().hex)
         now = datetime.now(timezone.utc)
         suffix = uuid.uuid4().hex
         key = f"trustlog/{now.strftime('%Y/%m/%d/%H/%M/%S')}-{suffix}.jsonl"
         if not self.prefix:
             return key
         return f"{self.prefix}/{key}"
+
+    def _build_segment_key(self, *, segment_id: str) -> str:
+        now = datetime.now(timezone.utc)
+        key = f"trustlog/segments/{now.strftime('%Y/%m/%d')}/segment-{segment_id}.jsonl"
+        if not self.prefix:
+            return key
+        return f"{self.prefix}/{key}"
+
+    def _build_manifest_key(self, *, segment_id: str) -> str:
+        now = datetime.now(timezone.utc)
+        key = f"trustlog/segments/{now.strftime('%Y/%m/%d')}/manifest-{segment_id}.json"
+        if not self.prefix:
+            return key
+        return f"{self.prefix}/{key}"
+
+    @staticmethod
+    def _entry_hash(entry: Dict[str, Any], line: str) -> str:
+        if isinstance(entry.get("payload_hash"), str) and entry["payload_hash"]:
+            return str(entry["payload_hash"])
+        return sha256_hex(line)
+
+    def _build_manifest(
+        self,
+        *,
+        segment_id: str,
+        segment_payload_hash: str,
+        segment_object_key: str,
+        manifest_key: str,
+    ) -> Dict[str, Any]:
+        first_entry = self._segment_entries[0]
+        last_entry = self._segment_entries[-1]
+        manifest: Dict[str, Any] = {
+            "segment_id": segment_id,
+            "entry_count": len(self._segment_entries),
+            "first_timestamp": first_entry.get("timestamp"),
+            "last_timestamp": last_entry.get("timestamp"),
+            "first_hash": self._entry_hash(first_entry, self._segment_lines[0]),
+            "last_hash": self._entry_hash(last_entry, self._segment_lines[-1]),
+            "segment_payload_hash": segment_payload_hash,
+            "object_keys_written": [segment_object_key, manifest_key],
+        }
+        if self.manifest_hmac_key:
+            signature = hmac.new(
+                self.manifest_hmac_key.encode("utf-8"),
+                canonical_json_dumps(manifest).encode("utf-8"),
+                "sha256",
+            ).hexdigest()
+            manifest["manifest_signature"] = signature
+        return manifest
+
+    def _put_object(self, *, key: str, body: bytes, content_type: str) -> Dict[str, Any]:
+        put_kwargs: Dict[str, Any] = {
+            "Bucket": self.bucket,
+            "Key": key,
+            "Body": body,
+            "ContentType": content_type,
+        }
+        if self.object_lock_mode:
+            put_kwargs["ObjectLockMode"] = self.object_lock_mode
+        if self.retention_days and self.retention_days > 0:
+            retain_until = datetime.now(timezone.utc) + timedelta(days=self.retention_days)
+            put_kwargs["ObjectLockRetainUntilDate"] = retain_until
+        return self.s3_client.put_object(**put_kwargs)
+
+    def _append_sealed_segment(self, line: str) -> Dict[str, Any]:
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            return {
+                "configured": True,
+                "ok": False,
+                "backend": self.backend_name,
+                "error": "ValueError: sealed_segments mode requires JSON line entries",
+            }
+
+        if not isinstance(parsed, dict):
+            return {
+                "configured": True,
+                "ok": False,
+                "backend": self.backend_name,
+                "error": "ValueError: sealed_segments mode requires JSON object entries",
+            }
+
+        self._segment_lines.append(line)
+        self._segment_entries.append(parsed)
+
+        if len(self._segment_lines) < self.segment_max_entries:
+            return {
+                "configured": True,
+                "ok": True,
+                "backend": self.backend_name,
+                "bucket": self.bucket,
+                "mode": "sealed_segments",
+                "segment_sealed": False,
+                "pending_entry_count": len(self._segment_lines),
+            }
+
+        segment_id = uuid.uuid4().hex
+        segment_payload = "".join(self._segment_lines)
+        segment_payload_hash = sha256_hex(segment_payload)
+        segment_key = self._build_segment_key(segment_id=segment_id)
+        manifest_key = self._build_manifest_key(segment_id=segment_id)
+        manifest = self._build_manifest(
+            segment_id=segment_id,
+            segment_payload_hash=segment_payload_hash,
+            segment_object_key=segment_key,
+            manifest_key=manifest_key,
+        )
+        manifest_hash = sha256_of_canonical_json(manifest)
+        manifest_payload = canonical_json_dumps(manifest).encode("utf-8")
+        retain_until_date: Optional[str] = None
+        if self.retention_days and self.retention_days > 0:
+            retain_until = datetime.now(timezone.utc) + timedelta(days=self.retention_days)
+            retain_until_date = retain_until.isoformat().replace("+00:00", "Z")
+
+        try:
+            segment_response = self._put_object(
+                key=segment_key,
+                body=segment_payload.encode("utf-8"),
+                content_type="application/x-ndjson",
+            )
+            manifest_response = self._put_object(
+                key=manifest_key,
+                body=manifest_payload,
+                content_type="application/json",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "configured": True,
+                "ok": False,
+                "backend": self.backend_name,
+                "bucket": self.bucket,
+                "error": f"{exc.__class__.__name__}: {exc}",
+            }
+        finally:
+            self._segment_lines = []
+            self._segment_entries = []
+
+        return {
+            "configured": True,
+            "ok": True,
+            "backend": self.backend_name,
+            "bucket": self.bucket,
+            "mode": "sealed_segments",
+            "segment_sealed": True,
+            "retention_mode": self.object_lock_mode,
+            "retain_until_date": retain_until_date,
+            "segment_id": segment_id,
+            "segment_object_key": segment_key,
+            "segment_manifest_key": manifest_key,
+            "segment_payload_hash": segment_payload_hash,
+            "manifest_hash": manifest_hash,
+            "manifest_version_id": manifest_response.get("VersionId"),
+            "manifest_etag": manifest_response.get("ETag"),
+            "version_id": segment_response.get("VersionId"),
+            "etag": segment_response.get("ETag"),
+            "manifest": manifest,
+        }
 
     def append_line(self, line: str) -> Dict[str, Any]:
         if not self.bucket:
@@ -122,24 +294,31 @@ class S3ObjectLockMirror(StorageMirror):
                 "backend": self.backend_name,
                 "error": "ValueError: VERITAS_TRUSTLOG_S3_BUCKET is required",
             }
+        if self.mirror_mode not in {"single_entry_objects", "sealed_segments"}:
+            return {
+                "configured": True,
+                "ok": False,
+                "backend": self.backend_name,
+                "error": (
+                    "ValueError: VERITAS_TRUSTLOG_S3_MIRROR_MODE must be "
+                    "'single_entry_objects' or 'sealed_segments'"
+                ),
+            }
+        if self.mirror_mode == "sealed_segments":
+            return self._append_sealed_segment(line)
 
         key = self._build_key()
-        put_kwargs: Dict[str, Any] = {
-            "Bucket": self.bucket,
-            "Key": key,
-            "Body": line.encode("utf-8"),
-            "ContentType": "application/x-ndjson",
-        }
         retain_until_date: Optional[str] = None
-        if self.object_lock_mode:
-            put_kwargs["ObjectLockMode"] = self.object_lock_mode
         if self.retention_days and self.retention_days > 0:
             retain_until = datetime.now(timezone.utc) + timedelta(days=self.retention_days)
             retain_until_date = retain_until.isoformat().replace("+00:00", "Z")
-            put_kwargs["ObjectLockRetainUntilDate"] = retain_until
 
         try:
-            response = self.s3_client.put_object(**put_kwargs)
+            response = self._put_object(
+                key=key,
+                body=line.encode("utf-8"),
+                content_type="application/x-ndjson",
+            )
         except Exception as exc:  # noqa: BLE001
             return {
                 "configured": True,
@@ -160,6 +339,7 @@ class S3ObjectLockMirror(StorageMirror):
             "etag": response.get("ETag"),
             "retention_mode": self.object_lock_mode,
             "retain_until_date": retain_until_date,
+            "mode": "single_entry_objects",
         }
 
 
@@ -175,6 +355,10 @@ def build_storage_mirror(*, append_fn: Callable[[Path, str], None]) -> StorageMi
         bucket = os.getenv("VERITAS_TRUSTLOG_S3_BUCKET", "")
         prefix = os.getenv("VERITAS_TRUSTLOG_S3_PREFIX", "")
         region = os.getenv("VERITAS_TRUSTLOG_S3_REGION", "")
+        mirror_mode = os.getenv("VERITAS_TRUSTLOG_S3_MIRROR_MODE", "single_entry_objects")
+        segment_max_entries_raw = os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MAX_ENTRIES", "100")
+        segment_max_entries = int(segment_max_entries_raw)
+        manifest_hmac_key = os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MANIFEST_HMAC_KEY", "")
         object_lock_mode = os.getenv("VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE", "")
         retention_days_raw = os.getenv("VERITAS_TRUSTLOG_S3_RETENTION_DAYS", "").strip()
         retention_days: Optional[int] = None
@@ -183,6 +367,9 @@ def build_storage_mirror(*, append_fn: Callable[[Path, str], None]) -> StorageMi
         return S3ObjectLockMirror(
             bucket=bucket,
             prefix=prefix,
+            mirror_mode=mirror_mode,
+            segment_max_entries=segment_max_entries,
+            manifest_hmac_key=manifest_hmac_key,
             region=region,
             object_lock_mode=object_lock_mode,
             retention_days=retention_days,

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -150,26 +150,32 @@ def _mirror_to_worm(line: str) -> Dict[str, Any]:
     global _mirror_backend_cache
     started = perf_counter()
     try:
-        mirror_signature = "|".join(
-            [
-                os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local").strip().lower(),
-                os.getenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "").strip(),
-                os.getenv("VERITAS_TRUSTLOG_S3_BUCKET", "").strip(),
-                os.getenv("VERITAS_TRUSTLOG_S3_PREFIX", "").strip(),
-                os.getenv("VERITAS_TRUSTLOG_S3_REGION", "").strip(),
-                os.getenv("VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE", "").strip(),
-                os.getenv("VERITAS_TRUSTLOG_S3_RETENTION_DAYS", "").strip(),
-                os.getenv("VERITAS_TRUSTLOG_S3_MIRROR_MODE", "single_entry_objects").strip().lower(),
-                os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MAX_ENTRIES", "100").strip(),
-                os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MANIFEST_HMAC_KEY", "").strip(),
-            ]
-        )
-        if _mirror_backend_cache is None or _mirror_backend_cache[0] != mirror_signature:
-            _mirror_backend_cache = (
-                mirror_signature,
-                build_storage_mirror(append_fn=_append_line),
+        mirror_backend_name = os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local").strip().lower()
+        mirror_mode = os.getenv("VERITAS_TRUSTLOG_S3_MIRROR_MODE", "single_entry_objects").strip().lower()
+        cache_enabled = mirror_backend_name == "s3_object_lock" and mirror_mode == "sealed_segments"
+        if not cache_enabled:
+            _mirror_backend_cache = None
+            mirror_backend = build_storage_mirror(append_fn=_append_line)
+        else:
+            mirror_signature = "|".join(
+                [
+                    mirror_backend_name,
+                    os.getenv("VERITAS_TRUSTLOG_S3_BUCKET", "").strip(),
+                    os.getenv("VERITAS_TRUSTLOG_S3_PREFIX", "").strip(),
+                    os.getenv("VERITAS_TRUSTLOG_S3_REGION", "").strip(),
+                    os.getenv("VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE", "").strip(),
+                    os.getenv("VERITAS_TRUSTLOG_S3_RETENTION_DAYS", "").strip(),
+                    mirror_mode,
+                    os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MAX_ENTRIES", "100").strip(),
+                    os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MANIFEST_HMAC_KEY", "").strip(),
+                ]
             )
-        mirror_backend = _mirror_backend_cache[1]
+            if _mirror_backend_cache is None or _mirror_backend_cache[0] != mirror_signature:
+                _mirror_backend_cache = (
+                    mirror_signature,
+                    build_storage_mirror(append_fn=_append_line),
+                )
+            mirror_backend = _mirror_backend_cache[1]
     except (ValueError, TypeError) as exc:
         observe_trustlog_mirror_latency("invalid", perf_counter() - started)
         record_trustlog_mirror_failure("invalid", exc.__class__.__name__)

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -58,6 +58,7 @@ PRIVATE_KEY_PATH = SIGNED_TRUSTLOG_KEYS / "trustlog_ed25519_private.key"
 PUBLIC_KEY_PATH = SIGNED_TRUSTLOG_KEYS / "trustlog_ed25519_public.key"
 
 _lock = threading.RLock()
+_mirror_backend_cache: Optional[tuple[str, Any]] = None
 _logger = logging.getLogger(__name__)
 TRUSTLOG_SIGNER_METADATA_VERSION = "v2"
 TRUSTLOG_VERIFICATION_POLICY_VERSION = "trustlog_witness_v2"
@@ -146,9 +147,29 @@ def _append_line(path: Path, line: str) -> None:
 
 def _mirror_to_worm(line: str) -> Dict[str, Any]:
     """Best-effort append using the configured mirror backend."""
+    global _mirror_backend_cache
     started = perf_counter()
     try:
-        mirror_backend = build_storage_mirror(append_fn=_append_line)
+        mirror_signature = "|".join(
+            [
+                os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local").strip().lower(),
+                os.getenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "").strip(),
+                os.getenv("VERITAS_TRUSTLOG_S3_BUCKET", "").strip(),
+                os.getenv("VERITAS_TRUSTLOG_S3_PREFIX", "").strip(),
+                os.getenv("VERITAS_TRUSTLOG_S3_REGION", "").strip(),
+                os.getenv("VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE", "").strip(),
+                os.getenv("VERITAS_TRUSTLOG_S3_RETENTION_DAYS", "").strip(),
+                os.getenv("VERITAS_TRUSTLOG_S3_MIRROR_MODE", "single_entry_objects").strip().lower(),
+                os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MAX_ENTRIES", "100").strip(),
+                os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MANIFEST_HMAC_KEY", "").strip(),
+            ]
+        )
+        if _mirror_backend_cache is None or _mirror_backend_cache[0] != mirror_signature:
+            _mirror_backend_cache = (
+                mirror_signature,
+                build_storage_mirror(append_fn=_append_line),
+            )
+        mirror_backend = _mirror_backend_cache[1]
     except (ValueError, TypeError) as exc:
         observe_trustlog_mirror_latency("invalid", perf_counter() - started)
         record_trustlog_mirror_failure("invalid", exc.__class__.__name__)
@@ -172,6 +193,32 @@ def _mirror_to_worm(line: str) -> Dict[str, Any]:
             result.get("error", "unknown_error"),
         )
     return result
+
+
+def _build_mirror_receipt(mirror_result: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize mirror backend output into a stable witness receipt shape."""
+    base_keys = (
+        "bucket",
+        "key",
+        "version_id",
+        "etag",
+        "retention_mode",
+        "retain_until_date",
+        "mode",
+        "segment_id",
+        "segment_object_key",
+        "segment_manifest_key",
+        "segment_payload_hash",
+        "manifest_hash",
+        "manifest_version_id",
+        "manifest_etag",
+        "manifest",
+    )
+    return {
+        key: mirror_result.get(key)
+        for key in base_keys
+        if mirror_result.get(key) is not None
+    }
 
 
 def _append_transparency_anchor(entry_hash: str) -> Dict[str, Any]:
@@ -843,22 +890,7 @@ def append_signed_decision(
                 raise SignedTrustLogWriteError("worm_mirror_write_failed")
             entry["worm_mirror"] = mirror
             entry["mirror_backend"] = mirror.get("backend")
-            entry["mirror_receipt"] = (
-                {
-                    key: mirror.get(key)
-                    for key in (
-                        "bucket",
-                        "key",
-                        "version_id",
-                        "etag",
-                        "retention_mode",
-                        "retain_until_date",
-                    )
-                    if mirror.get(key) is not None
-                }
-                if mirror.get("ok")
-                else None
-            )
+            entry["mirror_receipt"] = _build_mirror_receipt(mirror) if mirror.get("ok") else None
 
             transparency_anchor = _anchor_entry_hash(_entry_chain_hash(entry))
             if (

--- a/veritas_os/audit/trustlog_verify.py
+++ b/veritas_os/audit/trustlog_verify.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import importlib
+import hmac
 import os
 import re
 from dataclasses import dataclass
@@ -67,6 +68,9 @@ _REASON_CODE_MAP = {
     "mirror_retention_missing": "tamper_suspected",
     "mirror_legal_hold_missing": "tamper_suspected",
     "mirror_receipt_malformed": "mirror_receipt_malformed",
+    "segment_manifest_malformed": "schema_invalid",
+    "manifest_hash_mismatch": "tamper_suspected",
+    "segment_manifest_signature_invalid": "tamper_suspected",
     "signer_metadata_malformed": "schema_invalid",
     "anchor_backend_invalid": "schema_invalid",
     "anchor_status_invalid": "schema_invalid",
@@ -237,6 +241,58 @@ def _is_s3_receipt(receipt: Dict[str, Any]) -> bool:
     return isinstance(receipt.get("bucket"), str) and isinstance(receipt.get("key"), str)
 
 
+def _verify_segment_manifest_receipt(receipt: Dict[str, Any]) -> Optional[str]:
+    """Validate sealed-segment manifest metadata embedded in receipt."""
+    manifest = receipt.get("manifest")
+    manifest_hash = receipt.get("manifest_hash")
+    if not isinstance(manifest, dict) or not isinstance(manifest_hash, str):
+        return "segment_manifest_malformed"
+
+    expected_hash = sha256_of_canonical_json(manifest)
+    if expected_hash != manifest_hash:
+        return "manifest_hash_mismatch"
+
+    required = {
+        "segment_id": str,
+        "entry_count": int,
+        "first_timestamp": str,
+        "last_timestamp": str,
+        "first_hash": str,
+        "last_hash": str,
+        "segment_payload_hash": str,
+        "object_keys_written": list,
+    }
+    for key, expected_type in required.items():
+        value = manifest.get(key)
+        if not isinstance(value, expected_type):
+            return "segment_manifest_malformed"
+
+    if manifest["entry_count"] <= 0:
+        return "segment_manifest_malformed"
+
+    hash_fields = ("first_hash", "last_hash", "segment_payload_hash")
+    if not all(_SHA256_HEX_RE.match(str(manifest.get(field, ""))) for field in hash_fields):
+        return "segment_manifest_malformed"
+
+    if not all(isinstance(key, str) and key for key in manifest["object_keys_written"]):
+        return "segment_manifest_malformed"
+
+    signature = manifest.get("manifest_signature")
+    hmac_key = os.getenv("VERITAS_TRUSTLOG_S3_SEGMENT_MANIFEST_HMAC_KEY")
+    if isinstance(signature, str) and hmac_key:
+        payload = dict(manifest)
+        payload.pop("manifest_signature", None)
+        expected_signature = hmac.new(
+            hmac_key.encode("utf-8"),
+            canonical_json_dumps(payload).encode("utf-8"),
+            "sha256",
+        ).hexdigest()
+        if not hmac.compare_digest(signature, expected_signature):
+            return "segment_manifest_signature_invalid"
+
+    return None
+
+
 def _verify_mirror_receipt(
     entry: Dict[str, Any],
     *,
@@ -270,10 +326,21 @@ def _verify_mirror_receipt(
         "retention_mode",
         "retain_until_date",
         "legal_hold_status",
+        "mode",
+        "segment_id",
+        "segment_object_key",
+        "segment_manifest_key",
+        "segment_payload_hash",
+        "manifest_hash",
+        "manifest_version_id",
+        "manifest_etag",
+        "manifest",
     }
     if not all(isinstance(k, str) and k in known_keys for k in receipt.keys()):
         return "mirror_receipt_malformed"
     if not _is_s3_receipt(receipt):
+        if receipt.get("mode") == "sealed_segments":
+            return _verify_segment_manifest_receipt(receipt)
         return None
     if not remote_enabled:
         return None

--- a/veritas_os/tests/test_storage_mirror_segmented.py
+++ b/veritas_os/tests/test_storage_mirror_segmented.py
@@ -1,0 +1,86 @@
+"""Tests for TrustLog S3 mirror segmentation modes."""
+
+from __future__ import annotations
+
+import json
+
+from veritas_os.audit.storage_mirror import S3ObjectLockMirror, build_storage_mirror
+
+
+class _FakeS3Client:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def put_object(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "VersionId": f"v{len(self.calls)}",
+            "ETag": f'"etag-{len(self.calls)}"',
+        }
+
+
+def test_single_entry_mode_still_writes_one_object_per_entry() -> None:
+    client = _FakeS3Client()
+    mirror = S3ObjectLockMirror(
+        bucket="trustlog-bucket",
+        prefix="audit",
+        mirror_mode="single_entry_objects",
+        s3_client=client,
+    )
+
+    first = mirror.append_line(
+        json.dumps({"timestamp": "2026-04-11T00:00:00Z", "payload_hash": "a" * 64}) + "\n"
+    )
+    second = mirror.append_line(
+        json.dumps({"timestamp": "2026-04-11T00:00:01Z", "payload_hash": "b" * 64}) + "\n"
+    )
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert first["mode"] == "single_entry_objects"
+    assert second["mode"] == "single_entry_objects"
+    assert len(client.calls) == 2
+
+
+def test_sealed_segment_mode_accumulates_then_seals() -> None:
+    client = _FakeS3Client()
+    mirror = S3ObjectLockMirror(
+        bucket="trustlog-bucket",
+        prefix="audit",
+        mirror_mode="sealed_segments",
+        segment_max_entries=2,
+        s3_client=client,
+    )
+
+    pending = mirror.append_line(
+        json.dumps({"timestamp": "2026-04-11T00:00:00Z", "payload_hash": "a" * 64}) + "\n"
+    )
+    sealed = mirror.append_line(
+        json.dumps({"timestamp": "2026-04-11T00:00:01Z", "payload_hash": "b" * 64}) + "\n"
+    )
+
+    assert pending["ok"] is True
+    assert pending["segment_sealed"] is False
+    assert pending["pending_entry_count"] == 1
+
+    assert sealed["ok"] is True
+    assert sealed["segment_sealed"] is True
+    assert sealed["mode"] == "sealed_segments"
+    assert sealed["segment_object_key"]
+    assert sealed["segment_manifest_key"]
+    assert sealed["manifest"]["entry_count"] == 2
+    assert len(client.calls) == 2
+
+
+def test_build_storage_mirror_reads_segment_mode_env(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "s3_object_lock")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_BUCKET", "trustlog-bucket")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_PREFIX", "audit")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_MIRROR_MODE", "sealed_segments")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_S3_SEGMENT_MAX_ENTRIES", "3")
+
+    mirror = build_storage_mirror(append_fn=lambda path, line: (path, line))
+
+    assert isinstance(mirror, S3ObjectLockMirror)
+    assert mirror.mirror_mode == "sealed_segments"
+    assert mirror.segment_max_entries == 3

--- a/veritas_os/tests/test_trustlog_verify_unified.py
+++ b/veritas_os/tests/test_trustlog_verify_unified.py
@@ -535,3 +535,60 @@ def test_mirror_remote_verification_skipped_note(monkeypatch) -> None:
     result = verify_witness_ledger(_s3_receipt_witness(), lambda _: True, s3_client=None)
     note_codes = {note["code"] for note in result["verification_notes"]}
     assert "verification_skipped" in note_codes
+
+
+def test_segment_manifest_hash_validation() -> None:
+    manifest = {
+        "segment_id": "seg-001",
+        "entry_count": 2,
+        "first_timestamp": "2026-04-11T00:00:00Z",
+        "last_timestamp": "2026-04-11T00:00:02Z",
+        "first_hash": "a" * 64,
+        "last_hash": "b" * 64,
+        "segment_payload_hash": "c" * 64,
+        "object_keys_written": ["audit/segments/seg-001.jsonl", "audit/segments/seg-001.manifest.json"],
+    }
+    payload = {"request_id": "r-segment", "decision": "allow"}
+    entry = {
+        "decision_payload": payload,
+        "payload_hash": sha256_of_canonical_json(payload),
+        "previous_hash": None,
+        "signature": "sig-ok",
+        "mirror_receipt": {
+            "mode": "sealed_segments",
+            "manifest": manifest,
+            "manifest_hash": sha256_of_canonical_json(manifest),
+        },
+    }
+    result = verify_witness_ledger([entry], lambda _: True)
+    assert result["ok"] is True
+
+
+def test_segment_manifest_tamper_detected() -> None:
+    manifest = {
+        "segment_id": "seg-002",
+        "entry_count": 1,
+        "first_timestamp": "2026-04-11T00:00:00Z",
+        "last_timestamp": "2026-04-11T00:00:00Z",
+        "first_hash": "d" * 64,
+        "last_hash": "d" * 64,
+        "segment_payload_hash": "e" * 64,
+        "object_keys_written": ["audit/segments/seg-002.jsonl", "audit/segments/seg-002.manifest.json"],
+    }
+    payload = {"request_id": "r-segment-tampered", "decision": "allow"}
+    entry = {
+        "decision_payload": payload,
+        "payload_hash": sha256_of_canonical_json(payload),
+        "previous_hash": None,
+        "signature": "sig-ok",
+        "mirror_receipt": {
+            "mode": "sealed_segments",
+            "manifest": manifest,
+            "manifest_hash": "f" * 64,
+        },
+    }
+    result = verify_witness_ledger([entry], lambda _: True)
+    reasons = {error["reason"] for error in result["detailed_errors"]}
+    codes = {error["code"] for error in result["detailed_errors"]}
+    assert "manifest_hash_mismatch" in reasons
+    assert "tamper_suspected" in codes


### PR DESCRIPTION
### Motivation
- One-object-per-witness-entry S3 mirrors cause operational overhead at scale (high small-object counts, expensive listing, and awkward audit packaging), so a buffered/segmented approach is needed to improve scalability while preserving append-only semantics.
- Introduce an optional `sealed_segments` mode that batches entries into bounded segments, seals them with a final digest, and publishes a manifest describing the segment for efficient retrieval and tamper-evidence.
- Preserve existing `single_entry_objects` behavior and verification to ensure backward compatibility with current deployments.
- Warn that optional manifest HMAC protection depends on a secret key which must be protected (compromise weakens manifest-authenticity guarantees).

### Description
- Added `VERITAS_TRUSTLOG_S3_MIRROR_MODE`, `VERITAS_TRUSTLOG_S3_SEGMENT_MAX_ENTRIES`, and `VERITAS_TRUSTLOG_S3_SEGMENT_MANIFEST_HMAC_KEY` environment-driven configuration and hooked them into `build_storage_mirror` and `S3ObjectLockMirror` construction. 
- Implemented `sealed_segments` in `S3ObjectLockMirror` with in-process accumulation, segment JSONL payload object upload, manifest generation containing `segment_id`, `entry_count`, `first_timestamp`, `last_timestamp`, `first_hash`, `last_hash`, `segment_payload_hash`, and `object_keys_written`, plus optional HMAC `manifest_signature`. 
- Added helper `_put_object` abstraction and manifest/segment key layout under `trustlog/segments/`, and returned stable metadata (`mode`, `segment_id`, `segment_object_key`, `segment_manifest_key`, `segment_payload_hash`, `manifest_hash`, etc.) in mirror responses. 
- Made `trustlog_signed` cache the configured mirror backend instance so in-memory segment accumulation persists across consecutive appends and added `_build_mirror_receipt` to normalize receipts to include segmented metadata while remaining compatible with legacy receipt fields. 
- Extended verification in `trustlog_verify` with `_verify_segment_manifest_receipt` that validates manifest shape, canonical manifest hash (`manifest_hash`), optional HMAC signature validation, and produces clear failure reasons (`segment_manifest_malformed`, `manifest_hash_mismatch`, `segment_manifest_signature_invalid`) used in existing error classification. 
- Added unit tests `veritas_os/tests/test_storage_mirror_segmented.py` and verification tests in `veritas_os/tests/test_trustlog_verify_unified.py`, and updated operational docs `docs/en/operations/trustlog_observability.md` describing tradeoffs and HMAC key security guidance.

### Testing
- Ran `pytest -q veritas_os/tests/test_storage_mirror_segmented.py veritas_os/tests/test_trustlog_verify_unified.py veritas_os/tests/test_signed_trustlog.py` and observed all tests pass: `46 passed in 6.08s`.
- Ran style/static checks with `python -m ruff check veritas_os/audit/storage_mirror.py veritas_os/audit/trustlog_signed.py veritas_os/audit/trustlog_verify.py veritas_os/tests/test_storage_mirror_segmented.py veritas_os/tests/test_trustlog_verify_unified.py` and received no issues.
- New tests cover `single_entry_objects` compatibility, segment accumulation and sealing behavior, manifest hash validation, and tampered-manifest detection; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9face234883268a9f0a91af41581e)