### PR TITLE
docs: align README frontend framework version with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ The frontend is a **Next.js 16** (React 18, TypeScript) dashboard that provides 
 
 | Layer | Technology |
 |---|---|
-| Framework | Next.js 16.2 (App Router) |
+| Framework | Next.js 16.2.3 (App Router) |
 | Language | TypeScript 5.7 |
 | Styling | Tailwind CSS 3.4 + CVA (class-variance-authority) |
 | Icons | Lucide React |

--- a/README_JP.md
+++ b/README_JP.md
@@ -340,7 +340,7 @@ veritas_os/                  ← モノレポルート
 
 | レイヤー | 技術 |
 |---|---|
-| フレームワーク | Next.js 16.1（App Router） |
+| フレームワーク | Next.js 16.2.3（App Router） |
 | 言語 | TypeScript 5.7 |
 | スタイリング | Tailwind CSS 3.4 + CVA（class-variance-authority） |
 | アイコン | Lucide React |


### PR DESCRIPTION
### Motivation
- Keep documentation accurate by aligning the English and Japanese README tech-stack entries with the actual frontend dependency version (`Next.js 16.2.3`) declared in `frontend/package.json`.

### Description
- Updated `README.md` and `README_JP.md` tech stack tables to show `Next.js 16.2.3 (App Router)` for EN/JP consistency; this is a documentation-only change and does not modify runtime code or responsibilities.

### Testing
- Ran `python scripts/quality/check_frontend_docs_consistency.py` and `python scripts/quality/check_operational_docs_consistency.py`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0148d39083269c6524cab3599f16)