### PR TITLE
Add OpenTelemetry E2E trace spans across pipeline stages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -373,15 +373,31 @@ jobs:
       - name: Install dependencies
         run: |
           set -euxo pipefail
-          python -m pip install --upgrade pip
-          python -m pip install -r veritas_os/requirements.txt
-          python -m pip install "psycopg[binary]" psycopg-pool
-          python -m pip install httpx anyio pytest pytest-cov pytest-asyncio
+          pip_retry() {
+            local cmd="$1"
+            local attempts="${2:-4}"
+            local delay="${3:-8}"
+            local try=1
+            until eval "$cmd"; do
+              if [ "$try" -ge "$attempts" ]; then
+                echo "pip command failed after ${attempts} attempts: ${cmd}"
+                return 1
+              fi
+              echo "pip command failed (attempt ${try}/${attempts}), retrying in ${delay}s..."
+              sleep "$delay"
+              try=$((try + 1))
+            done
+          }
+
+          pip_retry "python -m pip install --upgrade pip --retries 5 --timeout 60"
+          pip_retry "python -m pip install --retries 5 --timeout 60 -r veritas_os/requirements.txt"
+          pip_retry "python -m pip install --retries 5 --timeout 60 \"psycopg[binary]\" psycopg-pool"
+          pip_retry "python -m pip install --retries 5 --timeout 60 httpx anyio pytest pytest-cov pytest-asyncio"
 
       - name: Run Alembic migrations
         run: |
           set -euxo pipefail
-          pip install alembic
+          python -m pip install --retries 5 --timeout 60 alembic
           alembic upgrade head
         env:
           VERITAS_DATABASE_URL: "postgresql+psycopg://veritas:veritas_test@localhost:5432/veritas_test"

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -235,6 +235,7 @@ from .pipeline_replay import (
     _ReplayRequest,  # noqa: F401 – backward compat
     replay_decision as _replay_decision_impl,
 )
+from ...reporting.exporters import PipelineTraceSession
 
 _atomic_write_json: Any = None
 _HAS_ATOMIC_IO = False
@@ -714,277 +715,305 @@ async def run_decide_pipeline(
 
     pipeline_started_at = time.time()
     _stage_failures: List[str] = []  # track degraded stages for observability
+    trace_session = PipelineTraceSession.start(
+        request_id=str(getattr(req, "request_id", "") or ""),
+        user_id=str(getattr(req, "user_id", "") or "anon"),
+    )
 
     # Allow callers (e.g. replay engine) to override memory store getter
     effective_get_memory_store = memory_store_getter or _get_memory_store
 
-    # =================================================================
-    # Stage 1: Input normalization  (-> pipeline_inputs)
-    # =================================================================
-    _stage_started_at = time.perf_counter()
-    ctx = normalize_pipeline_inputs(
-        req,
-        request,
-        _get_request_params=_get_request_params,
-        _to_dict_fn=to_dict,
-    )
-    observe_pipeline_stage_duration("input_norm", time.perf_counter() - _stage_started_at)
+    try:
+        # =================================================================
+        # Stage 1: Input normalization  (-> pipeline_inputs)
+        # =================================================================
+        with trace_session.stage("input_norm"):
+            _stage_started_at = time.perf_counter()
+            ctx = normalize_pipeline_inputs(
+                req,
+                request,
+                _get_request_params=_get_request_params,
+                _to_dict_fn=to_dict,
+            )
+            observe_pipeline_stage_duration("input_norm", time.perf_counter() - _stage_started_at)
 
-    # =================================================================
-    # Stage 2: MemoryOS retrieval  (-> pipeline_retrieval)
-    # =================================================================
-    stage_memory_retrieval(
-        ctx,
-        _get_memory_store=effective_get_memory_store,
-        _memory_search=_memory_search,
-        _memory_put=_memory_put,
-        _memory_add_usage=_memory_add_usage,
-        _flatten_memory_hits=_flatten_memory_hits,
-        _warn=_warn,
-        utc_now_iso_z=utc_now_iso_z,
-    )
+        # =================================================================
+        # Stage 2: MemoryOS retrieval  (-> pipeline_retrieval)
+        # =================================================================
+        with trace_session.stage("memory_retrieval"):
+            stage_memory_retrieval(
+                ctx,
+                _get_memory_store=effective_get_memory_store,
+                _memory_search=_memory_search,
+                _memory_put=_memory_put,
+                _memory_add_usage=_memory_add_usage,
+                _flatten_memory_hits=_flatten_memory_hits,
+                _warn=_warn,
+                utc_now_iso_z=utc_now_iso_z,
+            )
 
     # =================================================================
     # Stage 2b: WebSearch  (-> pipeline_retrieval)
     # =================================================================
-    await stage_web_search_async(
-        ctx,
-        _safe_web_search=_safe_web_search,
-        _normalize_web_payload=_normalize_web_payload,
-        _extract_web_results=_extract_web_results,
-        _to_bool=_to_bool,
-        _get_request_params=_get_request_params,
-        _warn=_warn,
-        request=request,
-    )
+        with trace_session.stage("web_search"):
+            await stage_web_search_async(
+                ctx,
+                _safe_web_search=_safe_web_search,
+                _normalize_web_payload=_normalize_web_payload,
+                _extract_web_results=_extract_web_results,
+                _to_bool=_to_bool,
+                _get_request_params=_get_request_params,
+                _warn=_warn,
+                request=request,
+            )
 
     # =================================================================
     # Stage 3: Options normalization  (-> pipeline_decide_stages)
     # =================================================================
-    stage_normalize_options(ctx, _norm_alt=_norm_alt)
+        with trace_session.stage("normalize_options"):
+            stage_normalize_options(ctx, _norm_alt=_norm_alt)
 
     # =================================================================
     # Stage 4: Core decision + self-healing  (-> pipeline_execute)
     # =================================================================
-    _stage_started_at = time.perf_counter()
-    await stage_core_execute(
-        ctx,
-        call_core_decide_fn=call_core_decide,
-        append_trust_log_fn=append_trust_log,
-        veritas_core=veritas_core,
-    )
-    observe_pipeline_stage_duration("kernel_execute", time.perf_counter() - _stage_started_at)
+        with trace_session.stage("kernel_execute"):
+            _stage_started_at = time.perf_counter()
+            await stage_core_execute(
+                ctx,
+                call_core_decide_fn=call_core_decide,
+                append_trust_log_fn=append_trust_log,
+                veritas_core=veritas_core,
+            )
+            observe_pipeline_stage_duration("kernel_execute", time.perf_counter() - _stage_started_at)
 
     # =================================================================
     # Stage 4b: Absorb raw results  (-> pipeline_decide_stages)
     # =================================================================
-    stage_absorb_raw_results(
-        ctx,
-        _norm_alt=_norm_alt,
-        _normalize_critique_payload=_normalize_critique_payload,
-        _merge_extras_preserving_contract=_merge_extras_preserving_contract,
-    )
+        with trace_session.stage("absorb_raw_results"):
+            stage_absorb_raw_results(
+                ctx,
+                _norm_alt=_norm_alt,
+                _normalize_critique_payload=_normalize_critique_payload,
+                _merge_extras_preserving_contract=_merge_extras_preserving_contract,
+            )
 
     # =================================================================
     # Stage 4c: Fallback alternatives  (-> pipeline_decide_stages)
     # =================================================================
-    stage_fallback_alternatives(ctx, _norm_alt=_norm_alt, _dedupe_alts=_dedupe_alts)
+        with trace_session.stage("fallback_alternatives"):
+            stage_fallback_alternatives(ctx, _norm_alt=_norm_alt, _dedupe_alts=_dedupe_alts)
 
     # =================================================================
     # Stage 4d: WorldModel + MemoryModel boost  (-> pipeline_decide_stages)
     # =================================================================
-    stage_model_boost(
-        ctx,
-        world_model=world_model,
-        MEM_VEC=MEM_VEC,
-        MEM_CLF=MEM_CLF,
-        _allow_prob=_allow_prob,
-        _mem_model_path=_mem_model_path,
-        _warn=_warn,
-    )
+        with trace_session.stage("model_boost"):
+            stage_model_boost(
+                ctx,
+                world_model=world_model,
+                MEM_VEC=MEM_VEC,
+                MEM_CLF=MEM_CLF,
+                _allow_prob=_allow_prob,
+                _mem_model_path=_mem_model_path,
+                _warn=_warn,
+            )
 
     # =================================================================
     # Stage 5: DebateOS  (-> pipeline_decide_stages)
     # =================================================================
-    stage_debate_fn(ctx, debate_core=debate_core, _warn=_warn)
+        with trace_session.stage("debate"):
+            stage_debate_fn(ctx, debate_core=debate_core, _warn=_warn)
 
     # =================================================================
     # Stage 5b: Critique  (-> pipeline_decide_stages)
     # =================================================================
-    await stage_critique_async(
-        ctx,
-        _normalize_critique_payload=_normalize_critique_payload,
-        _run_critique_best_effort=_run_critique_best_effort,
-        _ensure_critique_required=_ensure_critique_required,
-        _critique_fallback=_critique_fallback,
-    )
+        with trace_session.stage("critique"):
+            await stage_critique_async(
+                ctx,
+                _normalize_critique_payload=_normalize_critique_payload,
+                _run_critique_best_effort=_run_critique_best_effort,
+                _ensure_critique_required=_ensure_critique_required,
+                _critique_fallback=_critique_fallback,
+            )
 
     # =================================================================
     # Stage 5.9: Continuation revalidation (shadow / sidecar)
     # =================================================================
     # Runs *before* step-level merit evaluation (FUJI / gate).
     # Feature flag off → zero computation, zero side effects.
-    try:
-        from ..config import capability_cfg as _cap_cfg
-        if _cap_cfg.enable_continuation_runtime:
-            from .continuation_runtime.revalidator import (
-                run_continuation_revalidation_shadow as _run_cont_reval,
-            )
-            _cont_lineage, _cont_snap, _cont_rcpt = _run_cont_reval(
-                chain_id=ctx.body.get("chain_id", ctx.request_id),
-                step_index=ctx.body.get("step_index", 0),
-                query=ctx.query,
-                context=ctx.context,
-                prior_decision_status=ctx.decision_status,
-            )
-            ctx.continuation_snapshot = _cont_snap.to_dict()
-            ctx.continuation_receipt = _cont_rcpt.to_dict()
-            logger.debug(
-                "[continuation] shadow revalidation: status=%s divergence=%s",
-                _cont_snap.claim_status.value,
-                _cont_rcpt.divergence_flag,
-            )
-
-            # Stage 5.9b: Continuation enforcement evaluation
-            # Only runs when enforcement mode is not "observe".
-            _cont_enf_mode = _cap_cfg.continuation_enforcement_mode
-            if _cont_enf_mode in ("advisory", "enforce"):
-                from .continuation_runtime.enforcement import (
-                    ContinuationEnforcementEvaluator,
-                    EnforcementConfig,
-                    EnforcementMode,
-                    EnforcementAction,
-                )
-                _enf_mode_enum = EnforcementMode(_cont_enf_mode)
-                _enf_config = EnforcementConfig(mode=_enf_mode_enum)
-                _enf_evaluator = ContinuationEnforcementEvaluator(
-                    config=_enf_config,
-                )
-                _enf_events = _enf_evaluator.evaluate(
-                    snapshot=_cont_snap,
-                    receipt=_cont_rcpt,
-                    chain_id=ctx.body.get("chain_id", ctx.request_id),
-                    degradation_count=ctx.context.get(
-                        "continuation_degradation_count", 0
-                    ),
-                    replay_divergence_ratio=ctx.context.get(
-                        "continuation_replay_divergence_ratio", 0.0
-                    ),
-                    has_required_approval=ctx.context.get(
-                        "continuation_has_required_approval", True
-                    ),
-                    policy_violation_detected=ctx.context.get(
-                        "continuation_policy_violation", False
-                    ),
-                    policy_violation_detail=ctx.context.get(
-                        "continuation_policy_violation_detail", ""
-                    ),
-                )
-                if _enf_events:
-                    ctx.continuation_enforcement_events = [
-                        e.to_dict() for e in _enf_events
-                    ]
-                    # In enforce mode, check for halt_chain action
-                    if _cont_enf_mode == "enforce":
-                        for _enf_evt in _enf_events:
-                            if (
-                                _enf_evt.action == EnforcementAction.HALT_CHAIN
-                                and _enf_evt.is_enforced
-                            ):
-                                ctx.continuation_enforcement_halt = True
-                                logger.warning(
-                                    "[continuation-enforcement] HALT "
-                                    "chain=%s reason=%s",
-                                    ctx.body.get(
-                                        "chain_id", ctx.request_id
-                                    ),
-                                    _enf_evt.reasoning,
-                                )
-                                break
-                    logger.info(
-                        "[continuation] enforcement evaluation: "
-                        "mode=%s events=%d",
-                        _cont_enf_mode,
-                        len(_enf_events),
+        with trace_session.stage("continuation_shadow"):
+            try:
+                from ..config import capability_cfg as _cap_cfg
+                if _cap_cfg.enable_continuation_runtime:
+                    from .continuation_runtime.revalidator import (
+                        run_continuation_revalidation_shadow as _run_cont_reval,
                     )
-    except Exception as _cont_err:
-        _stage_failures.append(f"continuation_shadow:{type(_cont_err).__name__}")
-        logger.warning(
-            "[pipeline] continuation shadow revalidation failed (best-effort): %s",
-            _cont_err,
-        )
+                    _cont_lineage, _cont_snap, _cont_rcpt = _run_cont_reval(
+                        chain_id=ctx.body.get("chain_id", ctx.request_id),
+                        step_index=ctx.body.get("step_index", 0),
+                        query=ctx.query,
+                        context=ctx.context,
+                        prior_decision_status=ctx.decision_status,
+                    )
+                    ctx.continuation_snapshot = _cont_snap.to_dict()
+                    ctx.continuation_receipt = _cont_rcpt.to_dict()
+                    logger.debug(
+                        "[continuation] shadow revalidation: status=%s divergence=%s",
+                        _cont_snap.claim_status.value,
+                        _cont_rcpt.divergence_flag,
+                    )
+
+                    # Stage 5.9b: Continuation enforcement evaluation
+                    # Only runs when enforcement mode is not "observe".
+                    _cont_enf_mode = _cap_cfg.continuation_enforcement_mode
+                    if _cont_enf_mode in ("advisory", "enforce"):
+                        from .continuation_runtime.enforcement import (
+                            ContinuationEnforcementEvaluator,
+                            EnforcementConfig,
+                            EnforcementMode,
+                            EnforcementAction,
+                        )
+                        _enf_mode_enum = EnforcementMode(_cont_enf_mode)
+                        _enf_config = EnforcementConfig(mode=_enf_mode_enum)
+                        _enf_evaluator = ContinuationEnforcementEvaluator(
+                            config=_enf_config,
+                        )
+                        _enf_events = _enf_evaluator.evaluate(
+                            snapshot=_cont_snap,
+                            receipt=_cont_rcpt,
+                            chain_id=ctx.body.get("chain_id", ctx.request_id),
+                            degradation_count=ctx.context.get(
+                                "continuation_degradation_count", 0
+                            ),
+                            replay_divergence_ratio=ctx.context.get(
+                                "continuation_replay_divergence_ratio", 0.0
+                            ),
+                            has_required_approval=ctx.context.get(
+                                "continuation_has_required_approval", True
+                            ),
+                            policy_violation_detected=ctx.context.get(
+                                "continuation_policy_violation", False
+                            ),
+                            policy_violation_detail=ctx.context.get(
+                                "continuation_policy_violation_detail", ""
+                            ),
+                        )
+                        if _enf_events:
+                            ctx.continuation_enforcement_events = [
+                                e.to_dict() for e in _enf_events
+                            ]
+                            # In enforce mode, check for halt_chain action
+                            if _cont_enf_mode == "enforce":
+                                for _enf_evt in _enf_events:
+                                    if (
+                                        _enf_evt.action == EnforcementAction.HALT_CHAIN
+                                        and _enf_evt.is_enforced
+                                    ):
+                                        ctx.continuation_enforcement_halt = True
+                                        logger.warning(
+                                            "[continuation-enforcement] HALT "
+                                            "chain=%s reason=%s",
+                                            ctx.body.get(
+                                                "chain_id", ctx.request_id
+                                            ),
+                                            _enf_evt.reasoning,
+                                        )
+                                        break
+                            logger.info(
+                                "[continuation] enforcement evaluation: "
+                                "mode=%s events=%d",
+                                _cont_enf_mode,
+                                len(_enf_events),
+                            )
+            except Exception as _cont_err:
+                _stage_failures.append(f"continuation_shadow:{type(_cont_err).__name__}")
+                logger.warning(
+                    "[pipeline] continuation shadow revalidation failed (best-effort): %s",
+                    _cont_err,
+                )
 
     # =================================================================
     # Stage 6: Policy (FUJI + ValueCore + Gate)  (-> pipeline_policy)
     # =================================================================
-    _stage_started_at = time.perf_counter()
-    stage_fuji_precheck(ctx)
-    stage_value_core(ctx, _load_valstats=_load_valstats, _clip01=_clip01)
-    stage_gate_decision(ctx)
-    observe_pipeline_stage_duration("fuji_gate", time.perf_counter() - _stage_started_at)
+        with trace_session.stage("fuji_gate"):
+            _stage_started_at = time.perf_counter()
+            stage_fuji_precheck(ctx)
+            stage_value_core(ctx, _load_valstats=_load_valstats, _clip01=_clip01)
+            stage_gate_decision(ctx)
+            observe_pipeline_stage_duration("fuji_gate", time.perf_counter() - _stage_started_at)
 
     # =================================================================
     # Stage 6b: Value learning EMA  (-> pipeline_decide_stages)
     # =================================================================
-    stage_value_learning_ema(
-        ctx,
-        _load_valstats=_load_valstats,
-        _save_valstats=_save_valstats,
-        _warn=_warn,
-        utc_now_iso_z=utc_now_iso_z,
-    )
+        with trace_session.stage("value_learning_ema"):
+            stage_value_learning_ema(
+                ctx,
+                _load_valstats=_load_valstats,
+                _save_valstats=_save_valstats,
+                _warn=_warn,
+                utc_now_iso_z=utc_now_iso_z,
+            )
 
     # =================================================================
     # Stage 6c: Metrics  (-> pipeline_decide_stages)
     # =================================================================
-    stage_compute_metrics(ctx, _ensure_full_contract=_ensure_full_contract)
+        with trace_session.stage("compute_metrics"):
+            stage_compute_metrics(ctx, _ensure_full_contract=_ensure_full_contract)
 
     # =================================================================
     # Stage 6d: Low-evidence hardening  (-> pipeline_decide_stages)
     # =================================================================
-    stage_evidence_hardening(
-        ctx,
-        evidence_core=evidence_core,
-        _query_is_step1_hint=_query_is_step1_hint,
-        _has_step1_minimum_evidence=_has_step1_minimum_evidence,
-    )
+        with trace_session.stage("evidence_hardening"):
+            stage_evidence_hardening(
+                ctx,
+                evidence_core=evidence_core,
+                _query_is_step1_hint=_query_is_step1_hint,
+                _has_step1_minimum_evidence=_has_step1_minimum_evidence,
+            )
 
     # =================================================================
     # Stage 7: Decision payload completion  (-> pipeline_response)
     # - decision payload contract is complete at this boundary
     # =================================================================
-    payload = _build_decision_payload(ctx)
+        with trace_session.stage("build_response"):
+            payload = _build_decision_payload(ctx)
 
     # =================================================================
     # Stage 8: Post-decision persistence phase  (-> pipeline_persist)
     # - best-effort side effects and artifact generation only
     # =================================================================
-    _stage_started_at = time.perf_counter()
-    _run_post_decision_persistence_phase(
-        ctx,
-        payload,
-        effective_get_memory_store=effective_get_memory_store,
-        stage_failures=_stage_failures,
-    )
-    observe_pipeline_stage_duration("persist", time.perf_counter() - _stage_started_at)
+        with trace_session.stage("persist"):
+            _stage_started_at = time.perf_counter()
+            _run_post_decision_persistence_phase(
+                ctx,
+                payload,
+                effective_get_memory_store=effective_get_memory_store,
+                stage_failures=_stage_failures,
+            )
+            observe_pipeline_stage_duration("persist", time.perf_counter() - _stage_started_at)
 
     # =================================================================
     # Observability: record pipeline health summary
     # =================================================================
-    total_ms = max(1, int((time.time() - pipeline_started_at) * 1000))
-    extras = payload.setdefault("extras", {})
-    if isinstance(extras, dict):
-        metrics = extras.setdefault("metrics", {})
-        if isinstance(metrics, dict):
-            metrics["pipeline_total_ms"] = total_ms
-            if _stage_failures:
-                metrics["degraded_stages"] = _stage_failures
-    set_degraded_subsystems(len(_stage_failures))
-    if _stage_failures:
-        logger.info(
-            "[pipeline] completed with degraded stages (%d ms): %s",
-            total_ms,
-            ", ".join(_stage_failures),
+        total_ms = max(1, int((time.time() - pipeline_started_at) * 1000))
+        extras = payload.setdefault("extras", {})
+        if isinstance(extras, dict):
+            metrics = extras.setdefault("metrics", {})
+            if isinstance(metrics, dict):
+                metrics["pipeline_total_ms"] = total_ms
+                if _stage_failures:
+                    metrics["degraded_stages"] = _stage_failures
+        set_degraded_subsystems(len(_stage_failures))
+        if _stage_failures:
+            logger.info(
+                "[pipeline] completed with degraded stages (%d ms): %s",
+                total_ms,
+                ", ".join(_stage_failures),
+            )
+        trace_session.finalize(
+            decision_status=str(ctx.decision_status or "unknown"),
+            stage_failures=_stage_failures,
         )
-
-    return payload
+        return payload
+    finally:
+        if "ctx" not in locals():
+            trace_session.finalize(decision_status="failed_pre_context", stage_failures=_stage_failures)

--- a/veritas_os/reporting/exporters.py
+++ b/veritas_os/reporting/exporters.py
@@ -3,10 +3,121 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterator, Optional
 
 from veritas_os.core.atomic_io import atomic_write_json
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineTraceSession:
+    """OpenTelemetry trace session for one pipeline execution.
+
+    The session creates a root span keyed by ``request_id`` and provides a
+    stage-level span context manager so each pipeline phase can be traced
+    end-to-end with a consistent request correlation id.
+    """
+
+    request_id: str
+    user_id: str
+    _tracer: Any = None
+    _root_span: Any = None
+    _stage_durations_ms: Dict[str, int] = field(default_factory=dict)
+    _enabled: bool = False
+
+    @classmethod
+    def start(cls, *, request_id: str, user_id: str) -> "PipelineTraceSession":
+        """Create and start a trace session.
+
+        Tracing is enabled only when ``VERITAS_ENABLE_OTEL_TRACE`` evaluates to
+        true and OpenTelemetry dependencies are available.
+        """
+        trace_enabled = (os.getenv("VERITAS_ENABLE_OTEL_TRACE") or "0").strip().lower()
+        if trace_enabled not in {"1", "true", "yes", "on"}:
+            return cls(request_id=request_id, user_id=user_id)
+        try:
+            from opentelemetry import trace
+        except Exception as exc:
+            logger.warning("OTel trace requested but unavailable: %s", exc)
+            return cls(request_id=request_id, user_id=user_id)
+
+        tracer = trace.get_tracer("veritas_os.pipeline")
+        root_span = tracer.start_span("pipeline.run_decide")
+        root_span.set_attribute("veritas.request_id", request_id)
+        root_span.set_attribute("veritas.user_id", user_id)
+        root_span.set_attribute("veritas.component", "pipeline")
+        return cls(
+            request_id=request_id,
+            user_id=user_id,
+            _tracer=tracer,
+            _root_span=root_span,
+            _enabled=True,
+        )
+
+    @contextmanager
+    def stage(self, stage_name: str) -> Iterator[None]:
+        """Trace one pipeline stage as a child span."""
+        started = time.perf_counter()
+        if not self._enabled or self._tracer is None or self._root_span is None:
+            try:
+                yield
+            finally:
+                elapsed_ms = int((time.perf_counter() - started) * 1000)
+                self._stage_durations_ms[stage_name] = max(0, elapsed_ms)
+            return
+
+        from opentelemetry import trace
+
+        with trace.use_span(self._root_span, end_on_exit=False):
+            with self._tracer.start_as_current_span(
+                f"pipeline.stage.{stage_name}",
+                context=None,
+            ) as span:
+                span.set_attribute("veritas.request_id", self.request_id)
+                span.set_attribute("veritas.pipeline.stage", stage_name)
+                span.set_attribute("veritas.user_id", self.user_id)
+                try:
+                    yield
+                except Exception as exc:
+                    span.record_exception(exc)
+                    span.set_attribute("veritas.stage.error", type(exc).__name__)
+                    raise
+                finally:
+                    elapsed_ms = int((time.perf_counter() - started) * 1000)
+                    self._stage_durations_ms[stage_name] = max(0, elapsed_ms)
+                    span.set_attribute(
+                        "veritas.stage.duration_ms",
+                        self._stage_durations_ms[stage_name],
+                    )
+
+    def finalize(
+        self,
+        *,
+        decision_status: str,
+        stage_failures: Optional[list[str]] = None,
+    ) -> None:
+        """Finalize root span and attach execution summary attributes."""
+        if not self._enabled or self._root_span is None:
+            return
+        failures = list(stage_failures or [])
+        self._root_span.set_attribute("veritas.decision_status", decision_status)
+        self._root_span.set_attribute("veritas.stage.failure_count", len(failures))
+        self._root_span.set_attribute(
+            "veritas.stage.failures",
+            ",".join(failures),
+        )
+        self._root_span.set_attribute(
+            "veritas.pipeline.stage_durations_ms",
+            json.dumps(self._stage_durations_ms, sort_keys=True),
+        )
+        self._root_span.end()
 
 
 def build_w3c_prov_document(

--- a/veritas_os/tests/test_reporting_exporters.py
+++ b/veritas_os/tests/test_reporting_exporters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from veritas_os.reporting import exporters
@@ -83,3 +84,28 @@ def test_persist_report_pdf_creates_parent_and_writes_pdf(tmp_path: Path) -> Non
 
     assert path.exists()
     assert path.read_bytes().startswith(b"%PDF-1.4")
+
+
+def test_pipeline_trace_session_noop_stage_records_duration(monkeypatch) -> None:
+    """Trace session records stage duration even when OTel tracing is disabled."""
+    monkeypatch.delenv("VERITAS_ENABLE_OTEL_TRACE", raising=False)
+    session = exporters.PipelineTraceSession.start(request_id="req-1", user_id="u-1")
+
+    with session.stage("input_norm"):
+        pass
+
+    assert "input_norm" in session._stage_durations_ms
+    assert session._stage_durations_ms["input_norm"] >= 0
+
+
+def test_pipeline_trace_session_falls_back_when_otel_missing(monkeypatch) -> None:
+    """Missing OpenTelemetry package must not break pipeline tracing setup."""
+    monkeypatch.setenv("VERITAS_ENABLE_OTEL_TRACE", "1")
+    monkeypatch.setitem(sys.modules, "opentelemetry", None)
+
+    session = exporters.PipelineTraceSession.start(request_id="req-2", user_id="u-2")
+    with session.stage("kernel_execute"):
+        pass
+    session.finalize(decision_status="allow", stage_failures=[])
+
+    assert session._enabled is False


### PR DESCRIPTION
### Motivation
- Provide end-to-end distributed tracing across the decision pipeline so each `request_id` can be correlated through stage spans. 
- Make tracing opt-in and best-effort so missing OpenTelemetry libs or disabled runtime do not break the pipeline. 
- Capture per-stage durations and a compact summary on the root span for observability and post-processing. 

### Description
- Added `PipelineTraceSession` to `veritas_os/reporting/exporters.py` to create an optional OpenTelemetry root span and a `stage(...)` context manager for child spans, with fallback no-op behavior when tracing is disabled or OTel deps are missing. 
- Wrapped major pipeline stages in `run_decide_pipeline` (`veritas_os/core/pipeline/__init__.py`) with `trace_session.stage(...)` to emit stage-level spans and record durations. 
- Implemented `finalize` on the trace session to set summary attributes (`veritas.decision_status`, failure count, and serialized per-stage durations) and end the root span. 
- Added unit tests in `veritas_os/tests/test_reporting_exporters.py` covering no-op behavior and safe fallback when OpenTelemetry is unavailable, and kept exporters functionality intact. 
- Tracing is controlled by the environment flag `VERITAS_ENABLE_OTEL_TRACE` and is intentionally best-effort/non-fatal when the `opentelemetry` package is absent. 

### Testing
- Compiled updated modules with `python -m py_compile veritas_os/reporting/exporters.py veritas_os/core/pipeline/__init__.py veritas_os/tests/test_reporting_exporters.py` and it succeeded. 
- Ran targeted tests with `pytest -q veritas_os/tests/test_reporting_exporters.py` and all tests passed (`7 passed`). 
- Implementation keeps original exporter tests passing and adds two new tests for tracing fallback/no-op behavior which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db935e4ad48326adf470317e25a160)