### PR TITLE
Add KMS/Vault provider interfaces for encryption and signing with migration path

### DIFF
--- a/veritas_os/logging/encryption.py
+++ b/veritas_os/logging/encryption.py
@@ -31,11 +31,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import importlib
 import logging
 import os
 import secrets
 import struct
-from typing import Optional, Tuple
+from typing import Optional, Protocol, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,154 @@ def _derive_hmac_ctr_keys(master: bytes) -> tuple[bytes, bytes]:
     return enc_key, hmac_key
 _STREAM_BLOCK = 32  # SHA-256 output size
 _LEGACY_DECRYPT_ENV = "VERITAS_ENCRYPTION_LEGACY_DECRYPT"
+_ENCRYPTION_PROVIDER_ENV = "VERITAS_ENCRYPTION_KEY_PROVIDER"
+_ALLOW_ENV_FALLBACK_ENV = "VERITAS_ENCRYPTION_ALLOW_ENV_FALLBACK"
+
+
+class EncryptionKeyProvider(Protocol):
+    """Provider interface for retrieving the 32-byte at-rest encryption key."""
+
+    provider_name: str
+
+    def load_key(self) -> Optional[bytes]:
+        """Return key bytes, or ``None`` when the key is intentionally absent."""
+
+
+def _is_truthy(raw: str) -> bool:
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+class EnvEncryptionKeyProvider:
+    """Load encryption key from ``VERITAS_ENCRYPTION_KEY`` for legacy compatibility."""
+
+    provider_name = "env"
+
+    def load_key(self) -> Optional[bytes]:
+        raw = os.environ.get("VERITAS_ENCRYPTION_KEY")
+        if not raw:
+            return None
+        try:
+            key = base64.b64decode(raw.encode("ascii"), altchars=b"-_", validate=True)
+        except (ValueError, TypeError, UnicodeEncodeError) as exc:
+            raise EncryptionKeyMissing(
+                "VERITAS_ENCRYPTION_KEY is set but contains invalid base64 encoding"
+            ) from exc
+        if len(key) != 32:
+            raise EncryptionKeyMissing(
+                "VERITAS_ENCRYPTION_KEY must decode to exactly 32 bytes"
+            )
+        return key
+
+
+class AwsKmsEncryptionKeyProvider:
+    """Retrieve a data key by decrypting KMS ciphertext (AWS KMS envelope path)."""
+
+    provider_name = "aws_kms"
+
+    def __init__(self, kms_client: Optional[object] = None) -> None:
+        self._kms_client = kms_client
+
+    @property
+    def kms_client(self) -> object:
+        if self._kms_client is None:
+            boto3 = importlib.import_module("boto3")
+            self._kms_client = boto3.client("kms")
+        return self._kms_client
+
+    def load_key(self) -> Optional[bytes]:
+        blob_b64 = (os.getenv("VERITAS_ENCRYPTION_AWS_KMS_CIPHERTEXT_B64") or "").strip()
+        if not blob_b64:
+            return None
+        try:
+            blob = _decode_urlsafe_b64(blob_b64)
+        except ValueError as exc:
+            raise EncryptionKeyMissing(
+                "VERITAS_ENCRYPTION_AWS_KMS_CIPHERTEXT_B64 must be valid base64"
+            ) from exc
+        decrypt_kwargs = {"CiphertextBlob": blob}
+        kms_key_id = (os.getenv("VERITAS_ENCRYPTION_AWS_KMS_KEY_ID") or "").strip()
+        if kms_key_id:
+            decrypt_kwargs["KeyId"] = kms_key_id
+        response = self.kms_client.decrypt(**decrypt_kwargs)
+        key = response.get("Plaintext", b"")
+        if not isinstance(key, (bytes, bytearray)) or len(key) != 32:
+            raise EncryptionKeyMissing("AWS KMS decrypt did not return a 32-byte key")
+        return bytes(key)
+
+
+class GcpKmsEncryptionKeyProvider:
+    """Retrieve a data key by decrypting KMS ciphertext (GCP Cloud KMS path)."""
+
+    provider_name = "gcp_kms"
+
+    def __init__(self, kms_client: Optional[object] = None) -> None:
+        self._kms_client = kms_client
+
+    @property
+    def kms_client(self) -> object:
+        if self._kms_client is None:
+            kms_mod = importlib.import_module("google.cloud.kms_v1")
+            self._kms_client = kms_mod.KeyManagementServiceClient()
+        return self._kms_client
+
+    def load_key(self) -> Optional[bytes]:
+        key_name = (os.getenv("VERITAS_ENCRYPTION_GCP_KMS_KEY_NAME") or "").strip()
+        blob_b64 = (os.getenv("VERITAS_ENCRYPTION_GCP_KMS_CIPHERTEXT_B64") or "").strip()
+        if not key_name or not blob_b64:
+            return None
+        try:
+            blob = _decode_urlsafe_b64(blob_b64)
+        except ValueError as exc:
+            raise EncryptionKeyMissing(
+                "VERITAS_ENCRYPTION_GCP_KMS_CIPHERTEXT_B64 must be valid base64"
+            ) from exc
+        response = self.kms_client.decrypt(request={"name": key_name, "ciphertext": blob})
+        key = getattr(response, "plaintext", b"")
+        if not isinstance(key, (bytes, bytearray)) or len(key) != 32:
+            raise EncryptionKeyMissing("GCP KMS decrypt did not return a 32-byte key")
+        return bytes(key)
+
+
+class VaultTransitEncryptionKeyProvider:
+    """Retrieve encryption key material from Vault KV path during migration."""
+
+    provider_name = "vault"
+
+    def __init__(self, vault_client: Optional[object] = None) -> None:
+        self._vault_client = vault_client
+
+    @property
+    def vault_client(self) -> object:
+        if self._vault_client is None:
+            hvac = importlib.import_module("hvac")
+            url = os.getenv("VERITAS_ENCRYPTION_VAULT_ADDR")
+            token = os.getenv("VERITAS_ENCRYPTION_VAULT_TOKEN")
+            self._vault_client = hvac.Client(url=url, token=token)
+        return self._vault_client
+
+    def load_key(self) -> Optional[bytes]:
+        mount_point = (os.getenv("VERITAS_ENCRYPTION_VAULT_KV_MOUNT") or "secret").strip()
+        secret_path = (os.getenv("VERITAS_ENCRYPTION_VAULT_SECRET_PATH") or "").strip()
+        secret_field = (os.getenv("VERITAS_ENCRYPTION_VAULT_SECRET_FIELD") or "key_b64").strip()
+        if not secret_path:
+            return None
+        response = self.vault_client.secrets.kv.v2.read_secret_version(
+            path=secret_path,
+            mount_point=mount_point,
+        )
+        data = response.get("data", {}).get("data", {})
+        raw_value = data.get(secret_field, "")
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            raise EncryptionKeyMissing(
+                "Vault secret missing encryption key value in configured field"
+            )
+        try:
+            key = base64.b64decode(raw_value.encode("ascii"), altchars=b"-_", validate=True)
+        except (ValueError, TypeError, UnicodeEncodeError) as exc:
+            raise EncryptionKeyMissing("Vault encryption key must be valid base64") from exc
+        if len(key) != 32:
+            raise EncryptionKeyMissing("Vault encryption key must decode to exactly 32 bytes")
+        return key
 
 
 class EncryptionKeyMissing(RuntimeError):
@@ -90,28 +239,47 @@ def generate_key() -> str:
     return base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii")
 
 
-def _get_key_bytes() -> Optional[bytes]:
-    """Return the 32-byte master key from the environment, or None.
+def _build_key_provider(provider: str) -> EncryptionKeyProvider:
+    normalized = provider.strip().lower()
+    if normalized in {"", "env", "legacy_env"}:
+        return EnvEncryptionKeyProvider()
+    if normalized in {"aws_kms", "aws-kms"}:
+        return AwsKmsEncryptionKeyProvider()
+    if normalized in {"gcp_kms", "gcp-kms"}:
+        return GcpKmsEncryptionKeyProvider()
+    if normalized in {"vault", "vault_kv"}:
+        return VaultTransitEncryptionKeyProvider()
+    raise EncryptionKeyMissing(
+        f"Unsupported encryption key provider: {provider!r}. "
+        "Expected one of env/aws_kms/gcp_kms/vault."
+    )
 
-    Returns ``None`` when the environment variable is not set.
-    Raises :class:`EncryptionKeyMissing` when the variable **is** set but
-    cannot be decoded to a valid 32-byte key, so that a misconfigured key
-    is never silently treated as "no key".
+
+def _get_key_bytes() -> Optional[bytes]:
+    """Return the 32-byte master key from configured key provider.
+
+    Migration path:
+        ``VERITAS_ENCRYPTION_KEY_PROVIDER`` defaults to ``env`` for backward
+        compatibility. To migrate from direct env-key management to KMS/Vault,
+        set the provider to ``aws_kms``, ``gcp_kms``, or ``vault``.
+        During migration you can temporarily allow fallback to env key with:
+        ``VERITAS_ENCRYPTION_ALLOW_ENV_FALLBACK=1``.
     """
-    raw = os.environ.get("VERITAS_ENCRYPTION_KEY")
-    if not raw:
-        return None
-    try:
-        key = base64.b64decode(raw.encode("ascii"), altchars=b"-_", validate=True)
-    except (ValueError, TypeError, UnicodeEncodeError) as exc:
-        raise EncryptionKeyMissing(
-            "VERITAS_ENCRYPTION_KEY is set but contains invalid base64 encoding"
-        ) from exc
-    if len(key) != 32:
-        raise EncryptionKeyMissing(
-            "VERITAS_ENCRYPTION_KEY must decode to exactly 32 bytes"
+    provider_name = os.getenv(_ENCRYPTION_PROVIDER_ENV, "env")
+    provider = _build_key_provider(provider_name)
+    key = provider.load_key()
+    if key is not None:
+        return key
+
+    allow_fallback = _is_truthy(os.getenv(_ALLOW_ENV_FALLBACK_ENV, ""))
+    if provider.provider_name != "env" and allow_fallback:
+        logger.warning(
+            "%s enabled: falling back to legacy VERITAS_ENCRYPTION_KEY; "
+            "disable fallback after KMS/Vault cutover.",
+            _ALLOW_ENV_FALLBACK_ENV,
         )
-    return key
+        return EnvEncryptionKeyProvider().load_key()
+    return None
 
 
 def is_encryption_enabled() -> bool:
@@ -338,9 +506,11 @@ def get_encryption_status() -> dict:
     """Return current encryption configuration status."""
     enabled = is_encryption_enabled()
     backend = "AES-256-GCM" if _USE_REAL_AES else "HMAC-SHA256 CTR-mode"
+    provider = os.getenv(_ENCRYPTION_PROVIDER_ENV, "env").strip().lower() or "env"
     return {
         "encryption_enabled": enabled,
         "algorithm": backend if enabled else "none",
+        "key_provider": provider,
         "key_configured": enabled,
         "secure_by_default": True,
         "eu_ai_act_article": "Art. 12",

--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -185,6 +185,30 @@ class Signer(Protocol):
         """Return public-key fingerprint when available."""
 
 
+class KmsEd25519Provider(Protocol):
+    """Provider interface for remote Ed25519 signing backends."""
+
+    provider_name: str
+
+    def sign(self, payload_hash: str) -> bytes:
+        """Sign payload hash bytes and return raw signature bytes."""
+
+    def verify(self, payload_hash: str, signature: bytes) -> bool:
+        """Verify raw signature bytes for payload hash."""
+
+    def key_id(self) -> str:
+        """Return stable key identifier."""
+
+    def key_version(self) -> str:
+        """Return key-version label if available."""
+
+    def algorithm(self) -> str:
+        """Return signature algorithm name."""
+
+    def public_key_fingerprint(self) -> Optional[str]:
+        """Return stable public key fingerprint if provider exposes one."""
+
+
 class FileEd25519Signer:
     """Ed25519 signer backed by local key files."""
 
@@ -224,22 +248,12 @@ class FileEd25519Signer:
         return public_key_fingerprint(self.public_key_path)
 
 
-class AwsKmsEd25519Signer:
-    """Ed25519 signer backed by AWS KMS asymmetric keys.
+class AwsKmsEd25519Provider:
+    """AWS KMS provider for asymmetric Ed25519 signing."""
 
-    Security warning:
-        This signer performs a network call to AWS KMS for signing operations.
-        Ensure IAM permissions are scoped to the specific key and that requests
-        are routed over trusted channels.
-    """
+    provider_name = "aws_kms"
 
-    signer_type = "aws_kms"
-
-    def __init__(
-        self,
-        kms_key_id: str,
-        kms_client: Optional[object] = None,
-    ) -> None:
+    def __init__(self, kms_key_id: str, kms_client: Optional[object] = None) -> None:
         if not kms_key_id.strip():
             raise ValueError("VERITAS_TRUSTLOG_KMS_KEY_ID is required for aws_kms backend")
         self.kms_key_id = kms_key_id.strip()
@@ -248,7 +262,6 @@ class AwsKmsEd25519Signer:
 
     @property
     def kms_client(self) -> object:
-        """Lazily construct boto3 KMS client."""
         if self._kms_client is None:
             boto3 = importlib.import_module("boto3")
             self._kms_client = boto3.client("kms")
@@ -263,40 +276,32 @@ class AwsKmsEd25519Signer:
         if not isinstance(loaded, Ed25519PublicKey):
             raise ValueError("KMS key is not Ed25519")
         self._public_key = loaded
-        return self._public_key
+        return loaded
 
-    def sign_payload_hash(self, payload_hash: str) -> str:
+    def sign(self, payload_hash: str) -> bytes:
         response = self.kms_client.sign(
             KeyId=self.kms_key_id,
             Message=payload_hash.encode("utf-8"),
             MessageType="RAW",
             SigningAlgorithm="EDDSA",
         )
-        signature: bytes = response["Signature"]
-        return base64.urlsafe_b64encode(signature).decode("ascii")
+        return response["Signature"]
 
-    def verify_payload_signature(self, payload_hash: str, signature_b64: str) -> bool:
+    def verify(self, payload_hash: str, signature: bytes) -> bool:
         try:
-            signature = base64.urlsafe_b64decode(signature_b64)
             public_key = self._load_public_key()
             public_key.verify(signature, payload_hash.encode("utf-8"))
         except (InvalidSignature, ValueError, TypeError):
             return False
         return True
 
-    def signer_key_id(self) -> str:
+    def key_id(self) -> str:
         return self.kms_key_id
 
-    def signer_key_version(self) -> str:
-        """Return normalized key-version label for AWS KMS.
-
-        AWS KMS Sign/GetPublicKey APIs do not return a per-operation key
-        version identifier for asymmetric KMS keys. We record ``unknown`` so
-        verifiers can treat the field consistently across backends.
-        """
+    def key_version(self) -> str:
         return "unknown"
 
-    def signature_algorithm(self) -> str:
+    def algorithm(self) -> str:
         return "eddsa_ed25519"
 
     def public_key_fingerprint(self) -> Optional[str]:
@@ -311,6 +316,198 @@ class AwsKmsEd25519Signer:
         return sha256_hex(public_raw.hex())[:16]
 
 
+class GcpKmsEd25519Provider:
+    """GCP Cloud KMS provider for asymmetric Ed25519 signing."""
+
+    provider_name = "gcp_kms"
+
+    def __init__(self, kms_key_name: str, kms_client: Optional[object] = None) -> None:
+        if not kms_key_name.strip():
+            raise ValueError(
+                "VERITAS_TRUSTLOG_GCP_KMS_KEY_NAME is required for gcp_kms backend"
+            )
+        self.kms_key_name = kms_key_name.strip()
+        self._kms_client = kms_client
+        self._public_key: Optional[Ed25519PublicKey] = None
+
+    @property
+    def kms_client(self) -> object:
+        if self._kms_client is None:
+            kms_mod = importlib.import_module("google.cloud.kms_v1")
+            self._kms_client = kms_mod.KeyManagementServiceClient()
+        return self._kms_client
+
+    def _load_public_key(self) -> Ed25519PublicKey:
+        if self._public_key is not None:
+            return self._public_key
+        response = self.kms_client.get_public_key(request={"name": self.kms_key_name})
+        pem = getattr(response, "pem", "")
+        loaded = serialization.load_pem_public_key(pem.encode("utf-8"))
+        if not isinstance(loaded, Ed25519PublicKey):
+            raise ValueError("GCP KMS key is not Ed25519")
+        self._public_key = loaded
+        return loaded
+
+    def sign(self, payload_hash: str) -> bytes:
+        response = self.kms_client.asymmetric_sign(
+            request={
+                "name": self.kms_key_name,
+                "data": payload_hash.encode("utf-8"),
+            }
+        )
+        return response.signature
+
+    def verify(self, payload_hash: str, signature: bytes) -> bool:
+        try:
+            public_key = self._load_public_key()
+            public_key.verify(signature, payload_hash.encode("utf-8"))
+        except (InvalidSignature, ValueError, TypeError, AttributeError):
+            return False
+        return True
+
+    def key_id(self) -> str:
+        return self.kms_key_name
+
+    def key_version(self) -> str:
+        return self.kms_key_name.rsplit("/", maxsplit=1)[-1]
+
+    def algorithm(self) -> str:
+        return "eddsa_ed25519"
+
+    def public_key_fingerprint(self) -> Optional[str]:
+        try:
+            public_key = self._load_public_key()
+            public_raw = public_key.public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        except Exception:  # noqa: BLE001
+            return None
+        return sha256_hex(public_raw.hex())[:16]
+
+
+class VaultTransitEd25519Provider:
+    """HashiCorp Vault transit provider for Ed25519 signing and verification."""
+
+    provider_name = "vault"
+
+    def __init__(self, key_name: str, vault_client: Optional[object] = None) -> None:
+        if not key_name.strip():
+            raise ValueError("VERITAS_TRUSTLOG_VAULT_KEY_NAME is required for vault backend")
+        self.key_name = key_name.strip()
+        self._vault_client = vault_client
+        self._cached_fingerprint: Optional[str] = None
+
+    @property
+    def vault_client(self) -> object:
+        if self._vault_client is None:
+            hvac = importlib.import_module("hvac")
+            self._vault_client = hvac.Client(
+                url=os.getenv("VERITAS_TRUSTLOG_VAULT_ADDR"),
+                token=os.getenv("VERITAS_TRUSTLOG_VAULT_TOKEN"),
+            )
+        return self._vault_client
+
+    def _b64_input(self, payload_hash: str) -> str:
+        return base64.b64encode(payload_hash.encode("utf-8")).decode("ascii")
+
+    def sign(self, payload_hash: str) -> bytes:
+        response = self.vault_client.secrets.transit.sign_data(
+            name=self.key_name,
+            hash_input=self._b64_input(payload_hash),
+            signature_algorithm="ed25519",
+            marshaling_algorithm="jws",
+            prehashed=False,
+        )
+        signature = response.get("data", {}).get("signature", "")
+        # Format: vault:v1:<base64sig>
+        parts = signature.split(":")
+        if len(parts) != 3:
+            raise ValueError("Vault transit sign_data returned malformed signature")
+        return base64.urlsafe_b64decode(parts[2])
+
+    def verify(self, payload_hash: str, signature: bytes) -> bool:
+        wrapped_sig = f"vault:v1:{base64.urlsafe_b64encode(signature).decode('ascii')}"
+        response = self.vault_client.secrets.transit.verify_signed_data(
+            name=self.key_name,
+            hash_input=self._b64_input(payload_hash),
+            signature=wrapped_sig,
+            signature_algorithm="ed25519",
+            marshaling_algorithm="jws",
+            prehashed=False,
+        )
+        return bool(response.get("data", {}).get("valid", False))
+
+    def key_id(self) -> str:
+        return self.key_name
+
+    def key_version(self) -> str:
+        return "unknown"
+
+    def algorithm(self) -> str:
+        return "eddsa_ed25519"
+
+    def public_key_fingerprint(self) -> Optional[str]:
+        if self._cached_fingerprint is not None:
+            return self._cached_fingerprint
+        try:
+            response = self.vault_client.secrets.transit.read_key(name=self.key_name)
+            latest_version = str(response.get("data", {}).get("latest_version", ""))
+            key_data = response.get("data", {}).get("keys", {}).get(latest_version, {})
+            public_key_pem = key_data.get("public_key")
+            if not public_key_pem:
+                return None
+            loaded = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+            if not isinstance(loaded, Ed25519PublicKey):
+                return None
+            public_raw = loaded.public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+            self._cached_fingerprint = sha256_hex(public_raw.hex())[:16]
+            return self._cached_fingerprint
+        except Exception:  # noqa: BLE001
+            return None
+
+
+class KmsEd25519Signer:
+    """Signer adapter for KMS/HSM/Vault provider implementations."""
+
+    def __init__(self, provider: KmsEd25519Provider) -> None:
+        self.provider = provider
+        self.signer_type = provider.provider_name
+
+    def sign_payload_hash(self, payload_hash: str) -> str:
+        signature = self.provider.sign(payload_hash)
+        return base64.urlsafe_b64encode(signature).decode("ascii")
+
+    def verify_payload_signature(self, payload_hash: str, signature_b64: str) -> bool:
+        try:
+            signature = base64.urlsafe_b64decode(signature_b64)
+        except (ValueError, TypeError):
+            return False
+        return self.provider.verify(payload_hash, signature)
+
+    def signer_key_id(self) -> str:
+        return self.provider.key_id()
+
+    def signer_key_version(self) -> str:
+        return self.provider.key_version()
+
+    def signature_algorithm(self) -> str:
+        return self.provider.algorithm()
+
+    def public_key_fingerprint(self) -> Optional[str]:
+        return self.provider.public_key_fingerprint()
+
+
+class AwsKmsEd25519Signer(KmsEd25519Signer):
+    """Backward-compatible AWS KMS signer wrapper."""
+
+    def __init__(self, kms_key_id: str, kms_client: Optional[object] = None) -> None:
+        super().__init__(AwsKmsEd25519Provider(kms_key_id=kms_key_id, kms_client=kms_client))
+
+
 def build_trustlog_signer(
     *,
     private_key_path: Path,
@@ -319,7 +516,14 @@ def build_trustlog_signer(
     backend: Optional[str] = None,
     kms_key_id: Optional[str] = None,
 ) -> Signer:
-    """Build TrustLog signer from backend environment variables."""
+    """Build TrustLog signer from backend environment variables.
+
+    Migration path:
+        Existing deployments can keep ``backend=file`` while introducing KMS.
+        For staged rollout, set ``VERITAS_TRUSTLOG_SIGNER_BACKEND`` to one of
+        ``aws_kms`` / ``gcp_kms`` / ``vault`` and keep file-based keys only as
+        temporary fallback at the orchestrator level.
+    """
     selected_backend = (
         backend
         if backend is not None
@@ -336,7 +540,14 @@ def build_trustlog_signer(
             if kms_key_id is not None
             else os.getenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "")
         )
-        return AwsKmsEd25519Signer(kms_key_id=selected_key_id)
+        return KmsEd25519Signer(AwsKmsEd25519Provider(kms_key_id=selected_key_id))
+    if selected_backend in {"gcp_kms", "gcp_kms_ed25519"}:
+        key_name = os.getenv("VERITAS_TRUSTLOG_GCP_KMS_KEY_NAME", "")
+        return KmsEd25519Signer(GcpKmsEd25519Provider(kms_key_name=key_name))
+    if selected_backend in {"vault", "vault_transit"}:
+        key_name = os.getenv("VERITAS_TRUSTLOG_VAULT_KEY_NAME", "")
+        return KmsEd25519Signer(VaultTransitEd25519Provider(key_name=key_name))
     raise ValueError(
-        "Unsupported signer backend. Expected 'file' or 'aws_kms'."
+        "Unsupported signer backend. Expected 'file', 'aws_kms', "
+        "'gcp_kms', or 'vault'."
     )

--- a/veritas_os/tests/test_kms_provider_interfaces.py
+++ b/veritas_os/tests/test_kms_provider_interfaces.py
@@ -1,0 +1,66 @@
+"""Tests for KMS/Vault provider interfaces and migration fallbacks."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+
+def test_encryption_provider_fallback_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-env provider can use temporary env fallback during migration."""
+    from veritas_os.logging import encryption
+
+    key_b64 = encryption.generate_key()
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY_PROVIDER", "aws_kms")
+    monkeypatch.setenv("VERITAS_ENCRYPTION_ALLOW_ENV_FALLBACK", "1")
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", key_b64)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_AWS_KMS_CIPHERTEXT_B64", raising=False)
+
+    key = encryption._get_key_bytes()
+    assert key is not None
+    assert key == base64.urlsafe_b64decode(key_b64)
+
+
+def test_encryption_unknown_provider_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unknown provider names must fail closed to avoid silent plaintext writes."""
+    from veritas_os.logging.encryption import EncryptionKeyMissing, _get_key_bytes
+
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY_PROVIDER", "unsupported_provider")
+    with pytest.raises(EncryptionKeyMissing):
+        _get_key_bytes()
+
+
+def test_build_trustlog_signer_supports_gcp_backend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """GCP backend returns signer object without touching local key files."""
+    from veritas_os.security.signing import build_trustlog_signer
+
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "gcp_kms")
+    monkeypatch.setenv(
+        "VERITAS_TRUSTLOG_GCP_KMS_KEY_NAME",
+        "projects/p/locations/global/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1",
+    )
+
+    signer = build_trustlog_signer(
+        private_key_path=tmp_path / "priv.key",
+        public_key_path=tmp_path / "pub.key",
+    )
+    assert signer.signer_type == "gcp_kms"
+
+
+def test_build_trustlog_signer_supports_vault_backend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Vault transit backend is available for env-key migration."""
+    from veritas_os.security.signing import build_trustlog_signer
+
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "vault")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_VAULT_KEY_NAME", "trustlog-ed25519")
+
+    signer = build_trustlog_signer(
+        private_key_path=tmp_path / "priv.key",
+        public_key_path=tmp_path / "pub.key",
+    )
+    assert signer.signer_type == "vault"


### PR DESCRIPTION
### Motivation
- Provide a migration path from environment-variable key management to managed KMS/Vault backends so at-rest encryption keys and signing keys can be centrally managed. 
- Support AWS KMS, GCP KMS, and HashiCorp Vault for both encryption data-keys and Ed25519 signing to meet enterprise operational requirements. 
- Maintain secure-by-default behaviour (fail-closed when no valid key) and allow a controlled, temporary fallback to the legacy env-key for staged cutover. 

### Description
- Added a pluggable encryption provider interface `EncryptionKeyProvider` and concrete providers `EnvEncryptionKeyProvider`, `AwsKmsEncryptionKeyProvider`, `GcpKmsEncryptionKeyProvider`, and `VaultTransitEncryptionKeyProvider` in `veritas_os/logging/encryption.py`, and updated `_get_key_bytes()` to select providers via `VERITAS_ENCRYPTION_KEY_PROVIDER` with optional env fallback via `VERITAS_ENCRYPTION_ALLOW_ENV_FALLBACK` and `get_encryption_status()` now reports `key_provider`. 
- Introduced `KmsEd25519Provider` protocol and provider implementations (`AwsKmsEd25519Provider`, `GcpKmsEd25519Provider`, `VaultTransitEd25519Provider`) and a `KmsEd25519Signer` adapter in `veritas_os/security/signing.py`, plus an `AwsKmsEd25519Signer` wrapper for backward compatibility. 
- Extended `build_trustlog_signer()` to support `aws_kms`, `gcp_kms`, and `vault` signer backends while preserving `file`-backed signing; added docstring notes describing the migration path. 
- Added tests in `veritas_os/tests/test_kms_provider_interfaces.py` that validate the env-fallback migration behaviour, fail-closed on unknown provider, and signer backend selection for `gcp_kms` and `vault`. 

### Testing
- Ran targeted pytest: `pytest -q veritas_os/tests/test_kms_provider_interfaces.py veritas_os/tests/test_signed_trustlog.py::test_aws_kms_signer_backend veritas_os/tests/test_production_encryption.py::TestEncryptDecryptRoundTrip::test_round_trip`, which completed successfully (`6 passed`). 
- Ran static checks with `ruff check veritas_os/logging/encryption.py veritas_os/security/signing.py veritas_os/tests/test_kms_provider_interfaces.py`, which passed with no issues. 
- New unit tests exercise provider selection, migration fallback, and signer backend resolution and all assertions in these runs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9baa04748326bd9be208a300dd0b)