### PR TITLE
Sanitize non-finite trust `risk` values (NaN/Inf) before PROV export

### DIFF
--- a/veritas_os/api/routes_trust.py
+++ b/veritas_os/api/routes_trust.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, Query
@@ -41,7 +42,10 @@ def _parse_risk_from_trust_entry(entry: Dict[str, Any]) -> float | None:
         try:
             if item is None:
                 continue
-            return float(item)
+            risk_value = float(item)
+            if not math.isfinite(risk_value):
+                continue
+            return risk_value
         except (TypeError, ValueError):
             continue
     return None

--- a/veritas_os/api/utils.py
+++ b/veritas_os/api/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import re
 import secrets
 from typing import Any, Dict, Optional
@@ -247,7 +248,10 @@ def _parse_risk_from_trust_entry(entry: Dict[str, Any]) -> float | None:
         try:
             if item is None:
                 continue
-            return float(item)
+            risk_value = float(item)
+            if not math.isfinite(risk_value):
+                continue
+            return risk_value
         except (TypeError, ValueError):
             continue
     return None

--- a/veritas_os/tests/test_api_utils.py
+++ b/veritas_os/tests/test_api_utils.py
@@ -207,6 +207,10 @@ class TestParseRiskFromTrustEntry:
     def test_non_dict(self):
         assert _parse_risk_from_trust_entry("bad") is None
 
+    def test_non_finite_risk(self):
+        assert _parse_risk_from_trust_entry({"risk": float("nan")}) is None
+        assert _parse_risk_from_trust_entry({"risk": float("inf")}) is None
+
 
 class TestProvActorForEntry:
     def test_updated_by(self):

--- a/veritas_os/tests/test_prov_export.py
+++ b/veritas_os/tests/test_prov_export.py
@@ -51,3 +51,29 @@ def test_prov_export_not_found(monkeypatch) -> None:
 
     assert resp.status_code == 404
     assert resp.json()["ok"] is False
+
+
+def test_prov_export_non_finite_risk_is_sanitized(monkeypatch) -> None:
+    """Endpoint should ignore non-finite risk values before PROV export."""
+    monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+    monkeypatch.setattr(
+        server,
+        "get_trust_logs_by_request",
+        lambda _rid: [{"request_id": "req-1", "risk": float("nan")}],
+    )
+
+    observed: dict[str, object] = {}
+
+    def _build_w3c_prov_document(**kwargs):
+        observed["risk"] = kwargs.get("risk")
+        return {"entity": {}, "activity": {}, "agent": {}}
+
+    monkeypatch.setattr(server, "build_w3c_prov_document", _build_w3c_prov_document)
+
+    resp = client.get(
+        "/v1/trust/req-1/prov",
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert resp.status_code == 200
+    assert observed["risk"] is None


### PR DESCRIPTION
### Motivation
- Prevent non-finite float values (`NaN`, `Infinity`) from propagating from TrustLog entries into PROV exports because they can break JSON consumers and downstream validation.
- Ensure consistent behavior between the shared utilities and the trust routes when extracting `risk` from trust-log entries.

### Description
- Add `math.isfinite` checks to `_parse_risk_from_trust_entry` in `veritas_os/api/utils.py` and `veritas_os/api/routes_trust.py` to ignore non-finite values when coercing to `float`.
- Import `math` where needed and change the parsing logic to skip `NaN`/`Inf` and continue scanning other candidate fields.
- Add regression tests in `veritas_os/tests/test_api_utils.py` and `veritas_os/tests/test_prov_export.py` to assert non-finite `risk` values are treated as `None` and are not passed into `build_w3c_prov_document`.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_utils.py veritas_os/tests/test_prov_export.py` and all tests passed (`53 passed`).
- Ran `ruff check` on the modified files and the checks passed (`All checks passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3f1c23a88326aae61fbe22c98ed1)