### PR TITLE
Tighten URL-credential regex to avoid false positives in query strings

### DIFF
--- a/veritas_os/core/sanitize.py
+++ b/veritas_os/core/sanitize.py
@@ -167,7 +167,7 @@ RE_IPV6 = re.compile(
 #   既存実装は ``user:password`` のみを検出しており、アクセストークン等を
 #   user 部分に埋め込んだ URL を見逃す可能性があったため包括的に検出する。
 RE_URL_CREDENTIAL = re.compile(
-    r'(?:https?|ftp)://[^@\s/]+@[^\s/]+',
+    r'(?:https?|ftp)://[^/?#@\s]+@[^/?#\s]+',
     re.IGNORECASE,
 )
 

--- a/veritas_os/tests/unit/test_sanitize.py
+++ b/veritas_os/tests/unit/test_sanitize.py
@@ -200,6 +200,28 @@ def test_mask_pii_handles_non_string_bytes_via_detector() -> None:
     assert "〔メール〕" in masked
 
 
+def test_url_credential_detection_ignores_query_email_like_values() -> None:
+    """Query strings containing emails must not be treated as URL credentials."""
+    text = "参照: https://example.com?contact=a@b.com"
+
+    result = detect_pii(text)
+
+    assert not any(item["type"] == "url_credential" for item in result)
+
+
+def test_url_credential_detection_keeps_authority_userinfo() -> None:
+    """Actual userinfo@host URLs should still be detected."""
+    text = "危険URL: https://token123@example.com/path"
+
+    result = detect_pii(text)
+
+    assert any(
+        item["type"] == "url_credential"
+        and item["value"] == "https://token123@example.com"
+        for item in result
+    )
+
+
 def test_detect_resolves_cross_pattern_overlap_by_confidence() -> None:
     """Overlap resolution should keep only the highest-confidence match."""
     detector = PIIDetector(validate_checksums=False)


### PR DESCRIPTION
### Motivation
- Fix a false positive where email-like values in URL query strings (e.g. `https://example.com?contact=a@b.com`) were being classified as `url_credential`, causing over-masking and noisy findings. 
- Preserve detection of real userinfo credentials embedded in the URL authority (e.g. `https://token123@example.com`).
- Reduce operational/security noise because excessive masking can reduce the usefulness of audit logs and alerts.

### Description
- Updated the `RE_URL_CREDENTIAL` regular expression in `veritas_os/core/sanitize.py` to restrict `userinfo@host` matching to the URL authority segment (changed pattern to `r'(?:https?|ftp)://[^/?#@\s]+@[^/?#\s]+'`).
- Added two regression tests in `veritas_os/tests/unit/test_sanitize.py` to assert that query-string emails are not flagged and that true authority userinfo URLs are still detected.
- The change is narrowly scoped to PII detection logic and preserves backward-compatible masking behavior.

### Testing
- Ran `pytest -q veritas_os/tests/unit/test_sanitize.py -k "url_credential_detection or mask_pii_handles_non_string_bytes_via_detector"` with all tests passing (3 passed, 106 deselected). 
- Ran the full sanitize unit tests with `pytest -q veritas_os/tests/unit/test_sanitize.py` and observed all tests passing (109 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc50aa303083268f2fc57b45fd7557)