### PR TITLE
Fail-closed when MemoryStore.get sees duplicate keys across users

### DIFF
--- a/veritas_os/storage/json_kv.py
+++ b/veritas_os/storage/json_kv.py
@@ -19,10 +19,17 @@ class JsonMemoryStore:
 
     async def get(self, key: str) -> Optional[Dict[str, Any]]:
         records = self._store.list_all()
-        for record in records:
-            if record.get("key") == key:
-                stored = record.get("value")
-                return stored if isinstance(stored, dict) else None
+        matching = [record for record in records if record.get("key") == key]
+        if not matching:
+            return None
+
+        owners = {str(record.get("user_id", "")) for record in matching}
+        if len(owners) > 1:
+            return None
+
+        stored = matching[0].get("value")
+        if isinstance(stored, dict):
+            return stored
         return None
 
     async def search(

--- a/veritas_os/storage/postgresql.py
+++ b/veritas_os/storage/postgresql.py
@@ -397,22 +397,27 @@ class PostgresMemoryStore(_PostgresBase):
     async def get(self, key: str) -> Optional[Dict[str, Any]]:
         """Return the value stored under *key*, or ``None``.
 
-        When multiple users share the same key the earliest-inserted
-        record wins (``ORDER BY id LIMIT 1``), matching the linear-scan
-        behaviour of the JSON backend.
+        If multiple users share the same key this method returns ``None``
+        (fail-closed) to avoid cross-user data leakage when the caller
+        cannot provide ``user_id``.
         """
         pool = await self._get_pool()
         async with pool.connection() as conn:
             cur = await conn.execute(
-                "SELECT value FROM memory_records"
-                " WHERE key = %s ORDER BY id LIMIT 1",
+                "SELECT user_id, value FROM memory_records"
+                " WHERE key = %s ORDER BY id",
                 (key,),
             )
-            row = await cur.fetchone()
-            if row is None:
+            rows = await cur.fetchall()
+            if not rows:
                 return None
-            val = row[0]
-            return val if isinstance(val, dict) else None
+            owners = {str(row[0]) for row in rows}
+            if len(owners) > 1:
+                return None
+            val = rows[0][1]
+            if isinstance(val, dict):
+                return val
+            return None
 
     # --------------------------------------------------------- text extraction
 

--- a/veritas_os/tests/test_storage_backend_contract.py
+++ b/veritas_os/tests/test_storage_backend_contract.py
@@ -263,6 +263,16 @@ class _MemoryStoreContractSuite:
         u2_keys = {r.get("key") for r in u2_records}
         assert "k2" not in u1_keys and "k1" not in u2_keys
 
+    def test_get_returns_none_for_cross_user_duplicate_key(self, store) -> None:
+        """get must fail closed when multiple users share the same key."""
+
+        async def _go():
+            await store.put("shared", {"v": 1}, user_id="u1")
+            await store.put("shared", {"v": 2}, user_id="u2")
+            return await store.get("shared")
+
+        assert asyncio.run(_go()) is None
+
     # -- search -----------------------------------------------------------
 
     def test_search_respects_limit(self, store) -> None:

--- a/veritas_os/tests/test_storage_postgresql_memory.py
+++ b/veritas_os/tests/test_storage_postgresql_memory.py
@@ -87,6 +87,8 @@ class _InMemoryStorage:
             return self._handle_insert(params)
         if sql_upper.startswith("SELECT VALUE FROM"):
             return self._handle_get(params)
+        if sql_upper.startswith("SELECT USER_ID, VALUE FROM"):
+            return self._handle_get_with_user(params)
         if sql_upper.startswith("SELECT KEY, USER_ID, VALUE,"):
             if "LIKE ANY" in sql_upper:
                 return self._handle_search(sql, params)
@@ -131,6 +133,14 @@ class _InMemoryStorage:
             if row["key"] == key:
                 return _MockCursor([(row["value"],)])
         return _MockCursor([])
+
+    def _handle_get_with_user(self, params: Tuple[Any, ...]) -> _MockCursor:
+        (key,) = params
+        result: List[Tuple[Any, ...]] = []
+        for row in sorted(self._rows, key=lambda r: r["id"]):
+            if row["key"] == key:
+                result.append((row["user_id"], row["value"]))
+        return _MockCursor(result)
 
     def _handle_list(self, params: Tuple[Any, ...]) -> _MockCursor:
         (user_id,) = params


### PR DESCRIPTION
### Motivation
- `MemoryStore.get(key)` does not accept `user_id` and could previously return another user’s value when the same `key` exists for multiple users, creating a cross-tenant data-leakage risk.
- The intent is to make `get` fail-closed in ambiguous situations so callers without user context cannot retrieve someone else’s data.

### Description
- `veritas_os/storage/json_kv.py`: `get` now collects matching records for `key`, computes distinct `user_id` owners, and returns `None` when more than one owner exists (otherwise returns the stored dict).
- `veritas_os/storage/postgresql.py`: `get` now selects `user_id, value` for the key, computes the owner set, and returns `None` on ambiguity (keeps returning the value when a single owner exists and the value is a dict).
- `veritas_os/tests/test_storage_backend_contract.py`: added `test_get_returns_none_for_cross_user_duplicate_key` to enforce the contract that `get` must fail-closed when a key is shared across users.
- `veritas_os/tests/test_storage_postgresql_memory.py`: extended the in-memory PostgreSQL mock to handle the updated `SELECT user_id, value ...` query and return multiple rows for owner detection.

### Testing
- Ran `pytest -q veritas_os/tests/test_storage_backend_contract.py veritas_os/tests/test_storage_postgresql_memory.py` and all tests in those modules passed (`136 passed`).
- Ran targeted contract tests `python -m pytest -q veritas_os/tests/test_storage_backend_contract.py::TestJsonMemoryStoreContract::test_get_returns_none_for_cross_user_duplicate_key veritas_os/tests/test_storage_backend_contract.py::TestPostgresMemoryStoreContract::test_get_returns_none_for_cross_user_duplicate_key` and both passed.
- No regressions observed in the exercised storage contract and mock-backed Postgres tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc53e4e034832682acc6e4ded67bb0)