### PR TITLE
Fix pytest-asyncio fixture loop scope deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ veritas_os = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
   "ignore:invalid escape sequence.*:SyntaxWarning:sentence_transformers\\..*",
 ]


### PR DESCRIPTION
### Motivation
- Silence the `PytestDeprecationWarning` caused by an unset `asyncio_default_fixture_loop_scope` so async fixture loop scope is explicit and future-proof.

### Description
- Add `asyncio_default_fixture_loop_scope = "function"` under `[tool.pytest.ini_options]` in `pyproject.toml` to set the default asyncio fixture loop scope to `function`.

### Testing
- Ran the full test suite with `pytest -q` (pre-change) which passed (`6935 passed, 24 skipped`) but emitted the deprecation warning, and after the change ran `python -m pytest tests/test_continuation_revalidator.py -q` which passed (`67 passed`) and removes the deprecation warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc576432248326aa173c3d9e5a2887)