### PR TITLE
Fail-close invalid SSE enum payloads in LiveEventStream

### DIFF
--- a/frontend/components/live-event-stream.test.tsx
+++ b/frontend/components/live-event-stream.test.tsx
@@ -149,6 +149,30 @@ describe("LiveEventStream", () => {
     expect(screen.queryByText("evt-bad")).not.toBeInTheDocument();
   });
 
+  it("ignores SSE events with invalid enum fields", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: createReadableStream([
+          "data: {\"id\":\"evt-invalid\",\"type\":\"risk_burst\",\"severity\":\"urgent\",\"stage\":\"detect\",\"request_id\":\"req_invalid\",\"decision_id\":\"dec_invalid\",\"occurred_at\":\"2026-03-09T06:25:00Z\",\"owner\":\"Risk Ops\",\"linked_page\":\"risk\",\"summary\":\"Should be dropped due to invalid severity.\"}\n\n",
+          "data: {\"id\":\"evt-007\",\"type\":\"risk_burst\",\"severity\":\"critical\",\"stage\":\"detect\",\"request_id\":\"req_107\",\"decision_id\":\"dec_107\",\"occurred_at\":\"2026-03-09T06:27:00Z\",\"owner\":\"Risk Ops\",\"linked_page\":\"risk\",\"summary\":\"Valid event remains visible.\"}\n\n",
+        ]),
+      }),
+    );
+
+    render(
+      <I18nProvider>
+        <LiveEventStream />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Valid event remains visible.")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Should be dropped due to invalid severity.")).not.toBeInTheDocument();
+  });
+
   it("parses an SSE message that arrives in incomplete chunks", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/components/live-event-stream.tsx
+++ b/frontend/components/live-event-stream.tsx
@@ -35,6 +35,9 @@ const MAX_RECONNECT_DELAY_MS = 30000;
 const AUTH_RETRY_PAUSE_MS = 60000;
 
 const FILTERS: EventFilter[] = ["all", "critical", "degraded", "health"];
+const EVENT_SEVERITIES: EventSeverity[] = ["critical", "degraded", "health"];
+const EVENT_STAGES: EventStage[] = ["detect", "triage", "mitigate", "resolved"];
+const LINKED_PAGES: LiveEvent["linked_page"][] = ["decision", "trustlog", "governance", "risk"];
 
 const EVENT_TYPE_LABEL: Record<EventType, string> = {
   fuji_reject: "FUJI reject",
@@ -130,25 +133,34 @@ function toLiveEvent(payload: unknown): LiveEvent | null {
   const validType = Object.keys(EVENT_TYPE_LABEL).includes(record.type ?? "")
     ? (record.type as EventType)
     : null;
+  const validSeverity = EVENT_SEVERITIES.includes(record.severity as EventSeverity)
+    ? (record.severity as EventSeverity)
+    : null;
+  const validStage = EVENT_STAGES.includes(record.stage as EventStage)
+    ? (record.stage as EventStage)
+    : null;
+  const validLinkedPage = LINKED_PAGES.includes(record.linked_page as LiveEvent["linked_page"])
+    ? (record.linked_page as LiveEvent["linked_page"])
+    : null;
 
   if (!validType || !record.id) {
     return null;
   }
 
-  if (!record.severity || !record.stage || !record.request_id || !record.decision_id || !record.occurred_at || !record.owner || !record.linked_page || !record.summary) {
+  if (!validSeverity || !validStage || !record.request_id || !record.decision_id || !record.occurred_at || !record.owner || !validLinkedPage || !record.summary) {
     return null;
   }
 
   return {
     id: String(record.id),
     type: validType,
-    severity: record.severity,
-    stage: record.stage,
+    severity: validSeverity,
+    stage: validStage,
     request_id: record.request_id,
     decision_id: record.decision_id,
     occurred_at: record.occurred_at,
     owner: record.owner,
-    linked_page: record.linked_page,
+    linked_page: validLinkedPage,
     summary: record.summary,
   } as LiveEvent;
 }


### PR DESCRIPTION
### Motivation
- SSE payloads with truthy but invalid enum values (e.g. `severity: "urgent"`) could be accepted by the parser and lead to inconsistent rendering or undefined lookups, so events should be validated and dropped early.

### Description
- Add explicit enum lists (`EVENT_SEVERITIES`, `EVENT_STAGES`, `LINKED_PAGES`) and perform strict validation for `severity`, `stage`, and `linked_page` in `toLiveEvent` to fail-close malformed events. 
- Use the validated enum values in the returned `LiveEvent` object to avoid downstream undefined behavior. 
- Add a regression test `ignores SSE events with invalid enum fields` to ensure invalid-enum SSE messages are dropped while subsequent valid events are still processed (`frontend/components/live-event-stream.test.tsx`).

### Testing
- Ran `pnpm --dir frontend test live-event-stream.test.tsx`; Vitest run completed and the file's tests passed (11 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc693f07c48326b36fd13dcd874079)