### PR TITLE
fix(api): sanitize non-finite alternative scores

### DIFF
--- a/veritas_os/api/utils.py
+++ b/veritas_os/api/utils.py
@@ -96,7 +96,8 @@ def _coerce_alt_list(v: Any) -> list:
         d.setdefault("description", d.get("description") or "")
         if "score" in d and d["score"] is not None:
             try:
-                d["score"] = float(d["score"])
+                score_value = float(d["score"])
+                d["score"] = score_value if math.isfinite(score_value) else 1.0
             except Exception:
                 d["score"] = 1.0
         else:

--- a/veritas_os/tests/test_api_utils.py
+++ b/veritas_os/tests/test_api_utils.py
@@ -112,6 +112,11 @@ class TestCoerceAltList:
         result = _coerce_alt_list([{"title": "x", "score": "bad"}])
         assert result[0]["score"] == 1.0
 
+    @pytest.mark.parametrize("score", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_score(self, score):
+        result = _coerce_alt_list([{"title": "x", "score": score}])
+        assert result[0]["score"] == 1.0
+
 
 class TestCoerceDecidePayload:
     def test_non_dict(self):


### PR DESCRIPTION
### Motivation
- Prevent non-finite (`NaN`, `Infinity`, `-Infinity`) alternative `score` values from propagating through API responses and logs, which can break JSON serialization and downstream audit/metrics processing.

### Description
- Normalize non-finite `score` values to `1.0` in `veritas_os.api.utils._coerce_alt_list` by checking `math.isfinite()` after `float()` conversion; keep existing fallback for parse errors. (changed `veritas_os/api/utils.py`)
- Add regression test that parameterizes `NaN`, `inf`, and `-inf` inputs to ensure they are coerced to `1.0`. (changed `veritas_os/tests/test_api_utils.py`)
- Change is minimal and confined to the API utilities layer without touching Planner/Kernel/FUJI/MemoryOS responsibilities.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_utils.py` and observed `53 passed`.
- Additional targeted test runs related to logging/path helpers and small utility suites were executed earlier and remained green (all relevant tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7dfff3c48326a274d451e1b88fe5)