### PR TITLE
Sanitize boolean risk values in trust-log PROV export

### DIFF
--- a/veritas_os/api/routes_trust.py
+++ b/veritas_os/api/routes_trust.py
@@ -42,6 +42,8 @@ def _parse_risk_from_trust_entry(entry: Dict[str, Any]) -> float | None:
         try:
             if item is None:
                 continue
+            if isinstance(item, bool):
+                continue
             risk_value = float(item)
             if not math.isfinite(risk_value):
                 continue

--- a/veritas_os/api/utils.py
+++ b/veritas_os/api/utils.py
@@ -249,6 +249,8 @@ def _parse_risk_from_trust_entry(entry: Dict[str, Any]) -> float | None:
         try:
             if item is None:
                 continue
+            if isinstance(item, bool):
+                continue
             risk_value = float(item)
             if not math.isfinite(risk_value):
                 continue

--- a/veritas_os/tests/test_api_utils.py
+++ b/veritas_os/tests/test_api_utils.py
@@ -216,6 +216,10 @@ class TestParseRiskFromTrustEntry:
         assert _parse_risk_from_trust_entry({"risk": float("nan")}) is None
         assert _parse_risk_from_trust_entry({"risk": float("inf")}) is None
 
+    def test_boolean_risk_is_ignored(self):
+        assert _parse_risk_from_trust_entry({"risk": True}) is None
+        assert _parse_risk_from_trust_entry({"gate": {"risk": False}}) is None
+
 
 class TestProvActorForEntry:
     def test_updated_by(self):

--- a/veritas_os/tests/test_prov_export.py
+++ b/veritas_os/tests/test_prov_export.py
@@ -77,3 +77,29 @@ def test_prov_export_non_finite_risk_is_sanitized(monkeypatch) -> None:
 
     assert resp.status_code == 200
     assert observed["risk"] is None
+
+
+def test_prov_export_boolean_risk_is_sanitized(monkeypatch) -> None:
+    """Endpoint should ignore boolean risk values before PROV export."""
+    monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+    monkeypatch.setattr(
+        server,
+        "get_trust_logs_by_request",
+        lambda _rid: [{"request_id": "req-1", "risk": True}],
+    )
+
+    observed: dict[str, object] = {}
+
+    def _build_w3c_prov_document(**kwargs):
+        observed["risk"] = kwargs.get("risk")
+        return {"entity": {}, "activity": {}, "agent": {}}
+
+    monkeypatch.setattr(server, "build_w3c_prov_document", _build_w3c_prov_document)
+
+    resp = client.get(
+        "/v1/trust/req-1/prov",
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert resp.status_code == 200
+    assert observed["risk"] is None


### PR DESCRIPTION
### Motivation
- Prevent boolean `True`/`False` from being coerced into numeric risk (`1.0`/`0.0`) when extracting `risk` from trust-log entries to avoid misleading audit/provenance outputs.
- This is a hardening fix because incorrect risk propagation into PROV/audit data could cause incorrect operational signals or misinterpretation of trustworthiness.

### Description
- Add a boolean guard in `_parse_risk_from_trust_entry` to skip `bool` values before attempting `float()` conversion in `veritas_os/api/utils.py`.
- Apply the same boolean guard to the duplicate implementation in `veritas_os/api/routes_trust.py` to keep behavior consistent across codepaths.
- Add unit tests in `veritas_os/tests/test_api_utils.py` and an endpoint test in `veritas_os/tests/test_prov_export.py` that assert boolean `risk` values are ignored.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_utils.py veritas_os/tests/test_prov_export.py` and all tests passed (`58 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc811a76788326a156a239b311b062)