### PR TITLE
Fix aliasing between decide payload alternatives and options

### DIFF
--- a/veritas_os/api/utils.py
+++ b/veritas_os/api/utils.py
@@ -143,7 +143,10 @@ def _coerce_decide_payload(payload: Any, *, seed: str = "") -> Dict[str, Any]:
         d["alternatives"] = _coerce_alt_list(alts)
 
     if not opts and d.get("alternatives"):
-        d["options"] = list(d["alternatives"])
+        d["options"] = [
+            dict(item) if isinstance(item, dict) else item
+            for item in d["alternatives"]
+        ]
     else:
         d["options"] = _coerce_alt_list(opts)
 

--- a/veritas_os/tests/test_api_utils.py
+++ b/veritas_os/tests/test_api_utils.py
@@ -138,6 +138,11 @@ class TestCoerceDecidePayload:
         result = _coerce_decide_payload({"options": [{"title": "a"}]})
         assert len(result["alternatives"]) == 1
 
+    def test_options_and_alternatives_are_not_aliases(self):
+        result = _coerce_decide_payload({"alternatives": [{"title": "a"}]})
+        result["options"][0]["title"] = "mutated"
+        assert result["alternatives"][0]["title"] == "a"
+
 
 class TestCoerceFujiPayload:
     def test_non_dict(self):


### PR DESCRIPTION
### Motivation
- Prevent accidental cross-mutation when `alternatives` is present and `options` is synthesized from it, because a shallow copy caused both lists to share the same dict objects. 
- This protects decision payload integrity used downstream in pipeline and governance code paths. 
- Security note: shared references could lead to silent tampering of audit/governance data; isolating objects reduces that risk.

### Description
- Change `veritas_os/api/utils.py::_coerce_decide_payload` so `options` is created as a shallow-cloned list of dicts (`dict(item)` for dict entries) instead of using `list(d["alternatives"])`, breaking shared object references. 
- Add a regression test `TestCoerceDecidePayload.test_options_and_alternatives_are_not_aliases` in `veritas_os/tests/test_api_utils.py` that mutates `options` and asserts `alternatives` remain unchanged. 
- The changes are minimal and PEP8-compliant and only touch `api/utils.py` and its unit tests.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_utils.py`, which passed (`55 passed`).
- Prior full test run showed the repository test suite passing (`6941 passed, 24 skipped`) before this focused change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc863fbdf883268864a6607d1d38fd)