### PR TITLE
Fix boolean score coercion in alternatives normalization

### DIFF
--- a/veritas_os/api/utils.py
+++ b/veritas_os/api/utils.py
@@ -96,6 +96,8 @@ def _coerce_alt_list(v: Any) -> list:
         d.setdefault("description", d.get("description") or "")
         if "score" in d and d["score"] is not None:
             try:
+                if isinstance(d["score"], bool):
+                    raise TypeError("boolean score is not supported")
                 score_value = float(d["score"])
                 d["score"] = score_value if math.isfinite(score_value) else 1.0
             except Exception:

--- a/veritas_os/tests/test_api_utils.py
+++ b/veritas_os/tests/test_api_utils.py
@@ -112,6 +112,11 @@ class TestCoerceAltList:
         result = _coerce_alt_list([{"title": "x", "score": "bad"}])
         assert result[0]["score"] == 1.0
 
+    @pytest.mark.parametrize("score", [True, False])
+    def test_boolean_score_is_rejected(self, score):
+        result = _coerce_alt_list([{"title": "x", "score": score}])
+        assert result[0]["score"] == 1.0
+
     @pytest.mark.parametrize("score", [float("nan"), float("inf"), float("-inf")])
     def test_non_finite_score(self, score):
         result = _coerce_alt_list([{"title": "x", "score": score}])


### PR DESCRIPTION
### Motivation
- Prevent boolean `score` values from being interpreted as numeric (`True` → `1.0`, `False` → `0.0`) which can silently skew alternative rankings.

### Description
- Modify `_coerce_alt_list` in `veritas_os/api/utils.py` to explicitly reject boolean `score` values and fall back to the safe default `1.0`, and add a parametrized regression test in `veritas_os/tests/test_api_utils.py` to cover both `True` and `False` inputs.

### Testing
- Ran `pytest -q veritas_os/tests/test_api_utils.py`, which passed (`57 passed`).
- Ran `ruff check .`, which reported `All checks passed!`.
- Note: a full test run prior to this change reported `6942 passed, 24 skipped` for the repository test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8ecbee1883268b388d3c95578279)