### PR TITLE
FujiGateを裁定器へ強化し fail-closed gate_decision を導入

### DIFF
--- a/veritas_os/README.md
+++ b/veritas_os/README.md
@@ -58,7 +58,7 @@ Key fields (simplified):
 | `debate[]`         | Pseudo multi-agent debate results (pro / con / third-party views)                                    |
 | `telos_score`      | Alignment score vs. ValueCore’s value function                                                       |
 | `fuji`             | FUJI Gate safety / ethics judgement (allow / modify / rejected)                                      |
-| `gate_decision`    | Safety gate outcome (`allow`/`hold`/`deny`...) for control-plane gating                              |
+| `gate_decision`    | Canonical gate outcome (`proceed`/`hold`/`block`/`human_review_required`) with fail-closed posture  |
 | `business_decision`| Case lifecycle state (`APPROVE`/`DENY`/`HOLD`/`REVIEW_REQUIRED`/...)                                  |
 | `next_action`      | Action guidance derived from business state (kept separate from `business_decision`)                  |
 | `human_review_required` | Explicit human-review flag                                                                      |
@@ -71,6 +71,11 @@ Pipeline mental model:
 Options → Evidence → Critique → Debate → Planner → ValueCore → FUJI → TrustLog
 (Local FastAPI server with OpenAPI 3.1 / Swagger UI, no external deps after startup)
 ````
+
+Fail-closed gate behavior highlights:
+- Missing required evidence / undefined policy / incomplete audit trail => `hold`
+- Unknown approval boundary => `human_review_required`
+- Non-rollbackable change or secure/prod control gap => `block`
 
 Bundled subsystems:
 

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -32,7 +32,18 @@ MAX_KIND_LENGTH = 50  # Max characters for kind/retention_class fields
 
 # Shared decision status literal used across FujiDecision, Gate, DecideResponse
 DecisionStatusLiteral = Literal["allow", "modify", "rejected", "block", "abstain"]
-GateDecisionLiteral = Literal["allow", "hold", "deny", "modify", "rejected", "block", "abstain", "unknown"]
+GateDecisionLiteral = Literal[
+    "proceed",
+    "hold",
+    "block",
+    "human_review_required",
+    "allow",
+    "deny",
+    "modify",
+    "rejected",
+    "abstain",
+    "unknown",
+]
 BusinessDecisionLiteral = Literal[
     "APPROVE",
     "DENY",

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 try:
     from pydantic import ValidationError as _PydanticValidationError
@@ -67,6 +67,46 @@ def _as_string_list(value: Any) -> list[str]:
     return []
 
 
+def _is_falsey_flag(value: Any) -> bool:
+    """Return True when a context flag explicitly indicates missing readiness."""
+    if isinstance(value, bool):
+        return value is False
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized in {"0", "false", "no", "off", "missing", "unknown", "undefined"}
+    return False
+
+
+def _extract_stop_reasons(
+    *,
+    gate_reason: str,
+    missing_evidence: List[str],
+    context: Dict[str, Any],
+) -> List[str]:
+    """Collect fail-closed stop reasons used for gate decision classification."""
+    reasons: List[str] = []
+    reason_lc = gate_reason.lower()
+    env_name = str(context.get("environment") or os.getenv("VERITAS_ENV", "")).lower()
+    secure_or_prod = env_name in {"secure", "prod", "production"}
+
+    if missing_evidence:
+        reasons.append("required_evidence_missing")
+    if ("policy_definition_required" in reason_lc) or _is_falsey_flag(context.get("rule_defined")):
+        reasons.append("rule_undefined")
+    if _is_falsey_flag(context.get("approval_boundary_defined")):
+        reasons.append("approval_boundary_unknown")
+    if _is_falsey_flag(context.get("audit_trail_complete")):
+        reasons.append("audit_trail_incomplete")
+    if _is_falsey_flag(context.get("rollback_supported")):
+        reasons.append("rollback_not_supported")
+    if _is_falsey_flag(context.get("secure_controls_ready")):
+        reasons.append("secure_controls_missing")
+    if secure_or_prod and _is_falsey_flag(context.get("production_controls_ready")):
+        reasons.append("secure_prod_controls_missing")
+
+    return reasons
+
+
 def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
     """Derive public decision semantics from internal gate outputs.
 
@@ -75,7 +115,7 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
     - business_decision: case lifecycle status (APPROVE/HOLD/...)
     - next_action: operator/system action guidance
     """
-    gate_decision = str(
+    raw_gate_decision = str(
         ctx.fuji_dict.get("decision_status")
         or ctx.fuji_dict.get("status")
         or ctx.decision_status
@@ -90,16 +130,44 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
     human_review_required = bool(
         ctx.context.get("human_review_required")
         or fuji_status == "needs_human_review"
-        or gate_decision == "hold"
+        or raw_gate_decision == "hold"
     )
+    stop_reasons = _extract_stop_reasons(
+        gate_reason=gate_reason,
+        missing_evidence=missing_evidence,
+        context=ctx.context,
+    )
+
+    if "rollback_not_supported" in stop_reasons:
+        gate_decision = "block"
+    elif "secure_prod_controls_missing" in stop_reasons:
+        gate_decision = "block"
+    elif raw_gate_decision in {"deny", "rejected", "block"} or str(ctx.decision_status).lower() in {"rejected", "block"}:
+        gate_decision = "block"
+    elif "required_evidence_missing" in stop_reasons:
+        gate_decision = "hold"
+    elif "approval_boundary_unknown" in stop_reasons or human_review_required:
+        gate_decision = "human_review_required"
+        human_review_required = True
+    elif any(
+        item in stop_reasons
+        for item in {
+            "rule_undefined",
+            "audit_trail_incomplete",
+            "secure_controls_missing",
+        }
+    ) or raw_gate_decision in {"hold", "modify", "abstain"}:
+        gate_decision = "hold"
+    else:
+        gate_decision = "proceed"
 
     if missing_evidence:
         business_decision = "EVIDENCE_REQUIRED"
-    elif gate_decision in {"deny", "rejected", "block"} or str(ctx.decision_status).lower() in {"rejected", "block"}:
+    elif gate_decision == "block":
         business_decision = "DENY"
-    elif human_review_required:
+    elif gate_decision == "human_review_required":
         business_decision = "REVIEW_REQUIRED"
-    elif gate_decision in {"hold", "modify", "abstain"}:
+    elif gate_decision == "hold":
         business_decision = "HOLD"
     elif "policy_definition_required" in gate_reason.lower():
         business_decision = "POLICY_DEFINITION_REQUIRED"
@@ -114,8 +182,12 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         "POLICY_DEFINITION_REQUIRED": "DEFINE_POLICY_AND_REASSESS",
         "EVIDENCE_REQUIRED": "COLLECT_REQUIRED_EVIDENCE",
     }
-    rationale = gate_reason or "Decision derived from FUJI gate outcome and available evidence."
-    refusal_reason = gate_reason if business_decision == "DENY" else None
+    rationale_parts = [gate_reason] if gate_reason else []
+    if stop_reasons:
+        rationale_parts.append(f"stop_reasons={', '.join(sorted(set(stop_reasons)))}")
+    if not rationale_parts:
+        rationale_parts.append("Decision derived from FUJI gate outcome and available evidence.")
+    refusal_reason = "; ".join(rationale_parts) if gate_decision == "block" else None
     return {
         "gate_decision": gate_decision,
         "business_decision": business_decision,
@@ -123,7 +195,7 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         "required_evidence": required_evidence,
         "missing_evidence": missing_evidence,
         "human_review_required": human_review_required,
-        "rationale": rationale,
+        "rationale": " | ".join(rationale_parts),
         "refusal_reason": refusal_reason,
     }
 

--- a/veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py
+++ b/veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py
@@ -22,7 +22,7 @@ def test_assemble_response_includes_public_decision_semantics() -> None:
         plan={"steps": [], "source": "test"},
     )
 
-    assert payload["gate_decision"] == "allow"
+    assert payload["gate_decision"] == "hold"
     assert payload["business_decision"] == "EVIDENCE_REQUIRED"
     assert payload["next_action"] == "COLLECT_REQUIRED_EVIDENCE"
     assert payload["required_evidence"] == ["risk_assessment", "approval_ticket"]
@@ -56,3 +56,121 @@ def test_business_decision_is_state_not_action_sentence() -> None:
         "EVIDENCE_REQUIRED",
     }
     assert payload["next_action"] == "DO_NOT_EXECUTE"
+
+
+def test_gate_decision_becomes_hold_when_rule_definition_is_missing() -> None:
+    """ルール未定義は fail-closed で HOLD 側に倒す。"""
+    ctx = PipelineContext(
+        request_id="req-3",
+        query="test",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason="policy_definition_required: route policy missing",
+        context={"rule_defined": False},
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "hold"
+    assert payload["business_decision"] == "HOLD"
+    assert "rule_undefined" in payload["rationale"]
+
+
+def test_gate_decision_requires_human_review_when_approval_boundary_unknown() -> None:
+    """approval boundary が不明な案件は人手審査を必須化する。"""
+    ctx = PipelineContext(
+        request_id="req-4",
+        query="test",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={"approval_boundary_defined": False},
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "human_review_required"
+    assert payload["business_decision"] == "REVIEW_REQUIRED"
+    assert payload["human_review_required"] is True
+
+
+def test_gate_decision_blocks_when_rollback_is_not_supported() -> None:
+    """rollback 不能変更は BLOCK とする。"""
+    ctx = PipelineContext(
+        request_id="req-5",
+        query="test",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={"rollback_supported": False},
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "block"
+    assert payload["business_decision"] == "DENY"
+    assert payload["refusal_reason"] is not None
+    assert "rollback_not_supported" in payload["refusal_reason"]
+
+
+def test_refusal_reason_and_missing_evidence_are_exposed() -> None:
+    """停止理由と不足証拠が外部レスポンスに残ることを保証する。"""
+    ctx = PipelineContext(
+        request_id="req-6",
+        query="test",
+        fuji_dict={"decision_status": "deny", "status": "deny"},
+        decision_status="rejected",
+        rejection_reason="policy_violation",
+        context={
+            "required_evidence": ["approval_ticket"],
+            "satisfied_evidence": [],
+            "audit_trail_complete": False,
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "block"
+    assert payload["missing_evidence"] == ["approval_ticket"]
+    assert payload["refusal_reason"] is not None
+    assert "required_evidence_missing" in payload["refusal_reason"]
+
+
+def test_secure_prod_control_gap_fails_closed_to_block() -> None:
+    """secure/prod 制御不足は fail-closed で BLOCK になる。"""
+    ctx = PipelineContext(
+        request_id="req-7",
+        query="test",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={
+            "environment": "prod",
+            "production_controls_ready": False,
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "block"
+    assert payload["business_decision"] == "DENY"


### PR DESCRIPTION
### Motivation
- FujiGate を「停止対象の列挙」から実際に裁定を返す gate layer に進化させ、証拠欠損・ルール未定義・approval boundary 不明・監査/rollback/secure-prod 欠落などは停止寄り (fail-closed) に扱うことで安全性を高める。 

### Description
- 公開レスポンスの `gate_decision` を canonical 値 (`proceed`, `hold`, `block`, `human_review_required`) を受け入れ、既存の互換値も保持するよう `veritas_os/api/schemas.py` を拡張しました。 
- 停止理由の抽出処理 (`_is_falsey_flag`, `_extract_stop_reasons`) を `veritas_os/core/pipeline/pipeline_response.py` に追加し、`required_evidence` / `rule_defined` / `approval_boundary_defined` / `audit_trail_complete` / `rollback_supported` / `production_controls_ready` などのコンテキストフラグから fail-closed の判定を行い `gate_decision` に反映します。 
- `gate_decision` の導出ロジックを改め、`hold` / `block` / `human_review_required` / `proceed` の境界を明確にし、`rationale` と `refusal_reason` に停止理由の要約を含めるようにしました（`pipeline_response.py`）。 
- ユニットテストを追加・更新して要件を固定化し、README に fail-closed gate posture の要点を追記しました（変更対象ファイル: `veritas_os/core/pipeline/pipeline_response.py`, `veritas_os/api/schemas.py`, `veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py`, `veritas_os/README.md`）。

### Testing
- `pytest -q veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py` を実行し `7 passed` で成功しました. 
- `pytest -q veritas_os/tests/test_schemas_extra.py` を実行し `31 passed` で成功しました. 
- `pytest -q veritas_os/tests/unit/test_pipeline_stages_ext.py -k "build_fail_closed_fuji_precheck_contract or stage_fuji_precheck_fail_closed_on_exception"` を実行し `2 passed, 627 deselected` で成功しました.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69debf682a288326a297681210178a8d)