### PR TITLE
Strengthen Value Core next_action selection with ranked action candidates

### DIFF
--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -59,6 +59,218 @@ BACKWARD_COMPAT_FIELDS = (
     "options",
 )
 
+ACTION_CANDIDATE_WEIGHTS = {
+    "expected_value": 0.35,
+    "risk_reduction": 0.30,
+    "urgency": 0.20,
+    "cost": 0.10,
+    "dependency": 0.05,
+}
+
+
+def _is_dev_mode_enabled(context: Dict[str, Any]) -> bool:
+    """Return whether action-candidate diagnostics should be exposed."""
+    explicit_flag = context.get("dev_mode") or context.get("debug")
+    if isinstance(explicit_flag, bool):
+        return explicit_flag
+    env_value = str(os.getenv("VERITAS_DEV_MODE", "")).strip().lower()
+    return env_value in {"1", "true", "yes", "on"}
+
+
+def _calc_action_score(candidate: Dict[str, Any]) -> float:
+    """Compute a weighted score for an action candidate."""
+    score = (
+        ACTION_CANDIDATE_WEIGHTS["expected_value"] * float(candidate["expected_value"])
+        + ACTION_CANDIDATE_WEIGHTS["risk_reduction"] * float(candidate["risk_reduction"])
+        + ACTION_CANDIDATE_WEIGHTS["urgency"] * float(candidate["urgency"])
+        - ACTION_CANDIDATE_WEIGHTS["cost"] * float(candidate["cost"])
+        - ACTION_CANDIDATE_WEIGHTS["dependency"] * float(candidate["dependency"])
+    )
+    return round(score, 4)
+
+
+def _make_action_candidate(
+    *,
+    action: str,
+    expected_value: float,
+    risk_reduction: float,
+    cost: float,
+    dependency: float,
+    urgency: float,
+    reason: str,
+) -> Dict[str, Any]:
+    """Build one ranked action candidate entry."""
+    candidate = {
+        "action": action,
+        "expected_value": round(expected_value, 4),
+        "risk_reduction": round(risk_reduction, 4),
+        "cost": round(cost, 4),
+        "dependency": round(dependency, 4),
+        "urgency": round(urgency, 4),
+        "reason": reason,
+    }
+    candidate["score"] = _calc_action_score(candidate)
+    return candidate
+
+
+def _rank_action_candidates(
+    *,
+    gate_decision: str,
+    business_decision: str,
+    stop_reasons: List[str],
+    missing_evidence: List[str],
+    human_review_required: bool,
+) -> List[Dict[str, Any]]:
+    """Return sorted action candidates aligned to FUJI gate constraints."""
+    if gate_decision == "block":
+        candidates = [
+            _make_action_candidate(
+                action="DO_NOT_EXECUTE",
+                expected_value=0.78,
+                risk_reduction=0.98,
+                cost=0.05,
+                dependency=0.02,
+                urgency=0.97,
+                reason="FUJI gate is BLOCK; safest high-value action is to halt execution.",
+            ),
+            _make_action_candidate(
+                action="ESCALATE_POLICY_EXCEPTION_REVIEW",
+                expected_value=0.52,
+                risk_reduction=0.75,
+                cost=0.34,
+                dependency=0.65,
+                urgency=0.84,
+                reason="Policy exception path may recover value but needs human/process dependencies.",
+            ),
+            _make_action_candidate(
+                action="COLLECT_REQUIRED_EVIDENCE",
+                expected_value=0.40,
+                risk_reduction=0.62,
+                cost=0.46,
+                dependency=0.48,
+                urgency=0.70,
+                reason="Additional evidence can support later re-assessment without executing now.",
+            ),
+        ]
+    elif business_decision == "REVIEW_REQUIRED":
+        candidates = [
+            _make_action_candidate(
+                action="PREPARE_HUMAN_REVIEW_PACKET",
+                expected_value=0.74,
+                risk_reduction=0.88,
+                cost=0.22,
+                dependency=0.44,
+                urgency=0.86,
+                reason="Boundary ambiguity requires rapid preparation for reviewer adjudication.",
+            ),
+            _make_action_candidate(
+                action="COLLECT_REQUIRED_EVIDENCE",
+                expected_value=0.68,
+                risk_reduction=0.80,
+                cost=0.31,
+                dependency=0.36,
+                urgency=0.79,
+                reason="Evidence strengthens review quality and reduces rework during adjudication.",
+            ),
+            _make_action_candidate(
+                action="ROUTE_TO_HUMAN_REVIEW",
+                expected_value=0.66,
+                risk_reduction=0.83,
+                cost=0.28,
+                dependency=0.50,
+                urgency=0.82,
+                reason="Formal human handoff aligns with gate constraints and governance policy.",
+            ),
+        ]
+    elif business_decision in {"HOLD", "EVIDENCE_REQUIRED", "POLICY_DEFINITION_REQUIRED"}:
+        candidates = [
+            _make_action_candidate(
+                action="COLLECT_REQUIRED_EVIDENCE",
+                expected_value=0.76 if missing_evidence else 0.64,
+                risk_reduction=0.84,
+                cost=0.24,
+                dependency=0.30,
+                urgency=0.83,
+                reason="Missing evidence is the shortest path to unlock the decision safely.",
+            ),
+            _make_action_candidate(
+                action="REVISE_AND_RESUBMIT",
+                expected_value=0.62,
+                risk_reduction=0.70,
+                cost=0.38,
+                dependency=0.42,
+                urgency=0.72,
+                reason="Plan revision may unblock policy-fit gaps but has wider rework cost.",
+            ),
+            _make_action_candidate(
+                action="DEFINE_POLICY_AND_REASSESS",
+                expected_value=0.58 if "rule_undefined" in stop_reasons else 0.44,
+                risk_reduction=0.64,
+                cost=0.52,
+                dependency=0.66,
+                urgency=0.69,
+                reason="Policy work is valuable when rules are undefined but heavier operationally.",
+            ),
+        ]
+    else:
+        candidates = [
+            _make_action_candidate(
+                action="EXECUTE_WITH_STANDARD_MONITORING",
+                expected_value=0.83,
+                risk_reduction=0.47,
+                cost=0.22,
+                dependency=0.18,
+                urgency=0.75,
+                reason="Gate permits proceed; monitored execution captures value with bounded risk.",
+            ),
+            _make_action_candidate(
+                action="RUN_TARGETED_VALIDATION_CHECKS",
+                expected_value=0.60,
+                risk_reduction=0.71,
+                cost=0.33,
+                dependency=0.26,
+                urgency=0.64,
+                reason="Targeted checks reduce tail risk but delay immediate value realization.",
+            ),
+        ]
+    return sorted(candidates, key=lambda item: item["score"], reverse=True)
+
+
+def _build_question_first_answer(
+    *,
+    query: str,
+    required_evidence: List[str],
+    missing_evidence: List[str],
+    stop_reasons: List[str],
+) -> Dict[str, Any] | None:
+    """Return a structured answer when the user asks condition/evidence questions."""
+    query_lower = (query or "").strip().lower()
+    if not query_lower:
+        return None
+    asks_minimum = any(token in query_lower for token in ("最低条件", "minimum", "必須条件"))
+    asks_boundary = any(token in query_lower for token in ("境界条件", "boundary"))
+    asks_evidence = any(
+        token in query_lower for token in ("必要証拠", "必要な証拠", "required evidence", "evidence")
+    )
+    if not (asks_minimum or asks_boundary or asks_evidence):
+        return None
+    return {
+        "minimum_conditions": {
+            "required_evidence_count": len(required_evidence),
+            "missing_evidence_count": len(missing_evidence),
+            "all_required_evidence_ready": len(missing_evidence) == 0,
+        },
+        "boundary_conditions": {
+            "stop_reasons": sorted(set(stop_reasons)),
+            "has_policy_boundary_risk": any(
+                item in {"rule_undefined", "approval_boundary_unknown", "rollback_not_supported"}
+                for item in stop_reasons
+            ),
+        },
+        "required_evidence": required_evidence,
+        "missing_evidence": missing_evidence,
+    }
+
 
 def _as_string_list(value: Any) -> list[str]:
     """Normalize arbitrary values to a list[str] for public response fields."""
@@ -174,30 +386,64 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
     else:
         business_decision = "APPROVE"
 
-    next_action_map = {
-        "APPROVE": "EXECUTE_WITH_STANDARD_MONITORING",
-        "DENY": "DO_NOT_EXECUTE",
-        "HOLD": "REVISE_AND_RESUBMIT",
-        "REVIEW_REQUIRED": "ROUTE_TO_HUMAN_REVIEW",
-        "POLICY_DEFINITION_REQUIRED": "DEFINE_POLICY_AND_REASSESS",
-        "EVIDENCE_REQUIRED": "COLLECT_REQUIRED_EVIDENCE",
-    }
+    action_candidates = _rank_action_candidates(
+        gate_decision=gate_decision,
+        business_decision=business_decision,
+        stop_reasons=stop_reasons,
+        missing_evidence=missing_evidence,
+        human_review_required=human_review_required,
+    )
+    selected_candidate = action_candidates[0]
+    next_action = selected_candidate["action"]
+    next_action_reason = selected_candidate["reason"]
     rationale_parts = [gate_reason] if gate_reason else []
     if stop_reasons:
         rationale_parts.append(f"stop_reasons={', '.join(sorted(set(stop_reasons)))}")
     if not rationale_parts:
         rationale_parts.append("Decision derived from FUJI gate outcome and available evidence.")
+    rationale_parts.append(f"next_action_reason={next_action_reason}")
+    if len(action_candidates) > 1:
+        score_gap = round(
+            float(selected_candidate["score"]) - float(action_candidates[1]["score"]),
+            4,
+        )
+        rationale_parts.append(f"next_action_score_gap={score_gap}")
+
+    structured_answer = _build_question_first_answer(
+        query=ctx.query,
+        required_evidence=required_evidence,
+        missing_evidence=missing_evidence,
+        stop_reasons=stop_reasons,
+    )
     refusal_reason = "; ".join(rationale_parts) if gate_decision == "block" else None
-    return {
+    result = {
         "gate_decision": gate_decision,
         "business_decision": business_decision,
-        "next_action": next_action_map[business_decision],
+        "next_action": next_action,
         "required_evidence": required_evidence,
         "missing_evidence": missing_evidence,
         "human_review_required": human_review_required,
         "rationale": " | ".join(rationale_parts),
         "refusal_reason": refusal_reason,
+        "action_selection": {
+            "evaluation_axes": [
+                "expected_value",
+                "risk_reduction",
+                "cost",
+                "dependency",
+                "urgency",
+            ],
+            "selected": selected_candidate,
+            "candidates_considered": len(action_candidates),
+        },
     }
+    if structured_answer is not None:
+        result["structured_answer"] = structured_answer
+    if _is_dev_mode_enabled(ctx.context):
+        result["action_candidates"] = action_candidates
+    else:
+        result["action_candidates"] = []
+    return result
 
 
 def _build_response_layers(

--- a/veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py
+++ b/veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py
@@ -28,6 +28,8 @@ def test_assemble_response_includes_public_decision_semantics() -> None:
     assert payload["required_evidence"] == ["risk_assessment", "approval_ticket"]
     assert payload["missing_evidence"] == ["approval_ticket"]
     assert payload["human_review_required"] is True
+    assert "next_action_reason=" in payload["rationale"]
+    assert payload["action_selection"]["selected"]["action"] == payload["next_action"]
 
 
 def test_business_decision_is_state_not_action_sentence() -> None:
@@ -56,6 +58,7 @@ def test_business_decision_is_state_not_action_sentence() -> None:
         "EVIDENCE_REQUIRED",
     }
     assert payload["next_action"] == "DO_NOT_EXECUTE"
+    assert payload["action_selection"]["selected"]["action"] == "DO_NOT_EXECUTE"
 
 
 def test_gate_decision_becomes_hold_when_rule_definition_is_missing() -> None:
@@ -123,6 +126,8 @@ def test_gate_decision_blocks_when_rollback_is_not_supported() -> None:
     assert payload["business_decision"] == "DENY"
     assert payload["refusal_reason"] is not None
     assert "rollback_not_supported" in payload["refusal_reason"]
+    assert payload["next_action"] == "DO_NOT_EXECUTE"
+    assert payload["next_action"] != "EXECUTE_WITH_STANDARD_MONITORING"
 
 
 def test_refusal_reason_and_missing_evidence_are_exposed() -> None:
@@ -174,3 +179,83 @@ def test_secure_prod_control_gap_fails_closed_to_block() -> None:
 
     assert payload["gate_decision"] == "block"
     assert payload["business_decision"] == "DENY"
+    assert payload["next_action"] == "DO_NOT_EXECUTE"
+
+
+def test_next_action_is_selected_from_ranked_candidates() -> None:
+    """next_action は候補比較の上位案から選ばれる。"""
+    ctx = PipelineContext(
+        request_id="req-8",
+        query="通常実行できるか",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={"dev_mode": True},
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    candidates = payload["action_candidates"]
+    assert len(candidates) >= 2
+    assert candidates[0]["score"] >= candidates[1]["score"]
+    assert payload["next_action"] == candidates[0]["action"]
+    assert payload["action_selection"]["evaluation_axes"] == [
+        "expected_value",
+        "risk_reduction",
+        "cost",
+        "dependency",
+        "urgency",
+    ]
+
+
+def test_question_first_structured_answer_is_returned_before_next_action() -> None:
+    """境界条件/必要証拠の質問には構造化回答を返してから次アクションを示す。"""
+    ctx = PipelineContext(
+        request_id="req-9",
+        query="最低条件と境界条件と必要証拠は何？",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={
+            "required_evidence": ["risk_assessment", "approval_ticket"],
+            "satisfied_evidence": ["risk_assessment"],
+            "approval_boundary_defined": False,
+            "dev_mode": True,
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert "structured_answer" in payload
+    structured = payload["structured_answer"]
+    assert structured["minimum_conditions"]["missing_evidence_count"] == 1
+    assert "approval_boundary_unknown" in structured["boundary_conditions"]["stop_reasons"]
+    assert payload["next_action"] == payload["action_candidates"][0]["action"]
+
+
+def test_non_dev_mode_hides_action_candidates() -> None:
+    """action_candidates は非devモードでは公開しない。"""
+    ctx = PipelineContext(
+        request_id="req-10",
+        query="test",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={},
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["action_candidates"] == []


### PR DESCRIPTION
### Motivation
- Value Core tended to default to "investigate/document/confirm" without explicit value comparison, making `next_action` selections weakly justified; this change makes `next_action` an explicit outcome of candidate comparison. 
- The selection must respect FUJI gate outcomes (avoid aggressive actions when `block`) and prefer evidence/review work when gate indicates `hold`/`review_required`; this PR encodes those constraints. 
- For direct user questions about minimum/ boundary/ evidence, answers should be structured and returned first, then a recommended `next_action` should be proposed.

### Description
- Added a small action-ranking subsystem in `pipeline_response` that builds and ranks `action_candidates` using five evaluation axes and fixed weights: `expected_value`, `risk_reduction`, `cost`, `dependency`, `urgency`.
- Selection logic: generate candidate sets constrained by `gate_decision`/`business_decision` (e.g., `block` → defensive-only candidates), compute weighted scores, and pick the top candidate as `next_action`; append selection rationale and score gap to `rationale` and expose `action_selection` metadata.
- Question-first behavior: detect queries asking about minimum/boundary/required evidence and return a `structured_answer` describing minimum conditions and stop_reasons before/alongside the action recommendation.
- Dev-only diagnostics: `action_candidates` are returned only when `dev_mode` or `debug` is set in context (or `VERITAS_DEV_MODE` env); otherwise `action_candidates` is an empty list to avoid leaking decision internals.
- Files changed: `veritas_os/core/pipeline/pipeline_response.py`, `veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py`.
- Provided summary of evaluation axes and selection behavior in docs/comments and added docstrings for helper functions; kept changes within pipeline response boundary (no Planner/Kernel/Fuji/MemoryOS responsibility changes).
- Security note: `action_candidates` contain insight into internal evaluation axes; they are hidden by default but enabling dev/debug mode in production risks exposing decision logic and should be guarded.

### Testing
- Added/updated unit tests in `veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py` to assert: candidate-based `next_action` selection, `next_action` rationale presence, `block` returns defensive action, question-first `structured_answer`, `action_candidates` ordering and dev-mode visibility.
- Ran `pytest -q veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py` which passed: `10 passed` after addressing an initial test mismatch.
- Ran a targeted gate-related test subset: `pytest -q veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py veritas_os/tests/unit/test_pipeline_stages_ext.py -k gate_decision --maxfail=1` which returned `5 passed, 634 deselected`.
- All automated tests exercised for this change succeeded as reported above.

Remaining notes: weights are static and may benefit from future empirical tuning; ensure operational controls around `dev_mode` to avoid exposing evaluator internals in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec5a1a798832684fa23c0dd05c3f4)