### PR TITLE
Expose public decision schema fields, clarify gate semantics, add UI samples and tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,8 +142,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -535,8 +533,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/sbom-nightly.yml
+++ b/.github/workflows/sbom-nightly.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -55,8 +55,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -293,8 +293,20 @@ Key fields (simplified):
 | `telos_score` | Alignment score vs ValueCore |
 | `fuji` | FUJI Gate result (allow / modify / rejected) |
 | `gate.decision_status` | Normalized final status (`DecisionStatus`) |
+| `gate_decision` | Public gate outcome (`allow`/`hold`/`deny`/`block`...). `allow` means response generation can proceed, **not** case approval. |
+| `business_decision` | Case lifecycle status (`APPROVE`/`HOLD`/`REVIEW_REQUIRED`/`DENY`/...) |
+| `next_action` | Recommended next operator/system action (separate from business state) |
+| `required_evidence[]` | Evidence keys required by current policy/risk boundary |
+| `human_review_required` | Explicit human-review requirement flag |
 | `trust_log` | Hash-chained TrustLog entry (`sha256_prev`) |
 | `extras.metrics` | Per-stage latency, memory hits, web hits |
+
+Decision output semantics:
+
+- **FujiGate** owns safety/policy gate adjudication and emits `gate_decision`.
+- **Value Core** compares option value and informs `business_decision` + `next_action`.
+- UI must show `gate_decision`, `business_decision`, and `next_action` as different concepts.
+- `allow` is gate-level permissive status only; it must not be presented as case approval.
 
 Pipeline stages:
 

--- a/docs/en/guides/demo-script.md
+++ b/docs/en/guides/demo-script.md
@@ -20,13 +20,16 @@ Open browser to `http://localhost:3000`.
 2. Enter API key: `demo-key`
 3. Click a **danger preset** (e.g. "社内認証を迂回して...")
 4. Observe the result:
-   - `decision_status` = **rejected**
+   - `gate_decision` = **block/deny/hold** (or equivalent fail-closed status)
+   - `business_decision` = **DENY** or **REVIEW_REQUIRED** depending on policy/evidence boundary
+   - `next_action` is shown separately from `business_decision`
+   - `human_review_required` shows whether manual review is mandatory
    - `fuji/gate` shows **block** or **rejected** with reasons
    - `evidence`, `critique`, `debate` stages populated
    - `trust_log` entry created with `request_id`
 5. Copy the `request_id` for Act 2
 
-**Talking point:** "FUJI Gate detected dangerous intent and blocked the request. Every decision is auditable."
+**Talking point:** "FUJI Gate decides safety boundary (`gate_decision`), while business flow and next actions stay separate (`business_decision`, `next_action`). Every decision is auditable."
 
 ---
 

--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -33,6 +33,16 @@ pnpm -r typecheck
 pnpm -r test
 ```
 
+## Decision Console の公開出力表示ルール
+
+- `gate_decision`: FujiGate によるゲート判定（安全境界）。
+- `business_decision`: 案件状態（承認/保留/却下/要審査）。
+- `next_action`: 次に実行すべき行動提案（案件状態とは別物）。
+- `required_evidence`: 判定に必要な証拠キー一覧。
+- `human_review_required`: 人手審査必須フラグ。
+
+**重要:** `gate_decision=allow` は「案件承認」ではなく「応答出力を継続可能」の意味です。UI では承認語として表示しないでください。
+
 
 ## Docker Compose で一括起動
 

--- a/frontend/app/console/page.test.tsx
+++ b/frontend/app/console/page.test.tsx
@@ -16,6 +16,13 @@ describe("DecisionConsolePage", () => {
     expect(screen.getByRole("button", { name: /Input/i })).toBeInTheDocument();
   });
 
+  it("shows sample QA fixtures in empty state", () => {
+    render(<DecisionConsolePage />);
+    expect(screen.getByText("Sample QA fixtures")).toBeInTheDocument();
+    expect(screen.getByText(/最低条件は何か/)).toBeInTheDocument();
+    expect(screen.getByText(/FujiGate と Value Core の責務を分離/)).toBeInTheDocument();
+  });
+
 
   it("renders structured sections from decide response", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue({

--- a/frontend/app/console/page.tsx
+++ b/frontend/app/console/page.tsx
@@ -17,6 +17,7 @@ import { StepExpansionPanel } from "../../features/console/components/step-expan
 import { ReplayDiffViewer } from "../../features/console/components/replay-diff-viewer";
 import { ContinuationStatusCard } from "../../features/console/components/continuation-status-card";
 import { useConsoleState } from "../../features/console/state/useConsoleState";
+import { DECISION_SAMPLE_QUESTIONS } from "../../features/console/constants";
 import { startManagedEventStream } from "../../lib/managed-sse";
 
 export default function DecisionConsolePage(): JSX.Element {
@@ -155,6 +156,14 @@ export default function DecisionConsolePage(): JSX.Element {
             <p className="font-semibold text-foreground">{tk("startPromptTitle")}</p>
             <p className="mt-1">{tk("startPromptHint")}</p>
             <p className="mt-1">{tk("startPromptExplainer")}</p>
+            <div className="mt-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Sample QA fixtures</p>
+              <ul className="mt-1 list-disc space-y-1 pl-5 text-xs">
+                {DECISION_SAMPLE_QUESTIONS.map((sample) => (
+                  <li key={sample}>{sample}</li>
+                ))}
+              </ul>
+            </div>
           </div>
         )}
       </Card>

--- a/frontend/e2e/console-flow.spec.ts
+++ b/frontend/e2e/console-flow.spec.ts
@@ -11,14 +11,15 @@ test.describe("Console: decision flow", () => {
   test("renders pipeline stages and empty result placeholder", async ({
     page,
   }) => {
-    await expect(page.getByText("Pipeline Operations View")).toBeVisible();
+    const pipeline = page.getByRole("region", { name: "pipeline visualizer" });
+    await expect(pipeline.getByText("Pipeline Operations View")).toBeVisible();
     await expect(
       page.getByText(/Start with a real decision question|実際の意思決定を問いかけましょう/),
     ).toBeVisible();
     // Evidence, FUJI, TrustLog stages visible
-    await expect(page.locator("li", { hasText: "Evidence" })).toBeVisible();
-    await expect(page.locator("li", { hasText: "FUJI" })).toBeVisible();
-    await expect(page.locator("li", { hasText: "TrustLog" })).toBeVisible();
+    await expect(pipeline.getByRole("button", { name: /2\.\s*Evidence/i })).toBeVisible();
+    await expect(pipeline.getByRole("button", { name: /7\.\s*FUJI/i })).toBeVisible();
+    await expect(pipeline.getByRole("button", { name: /8\.\s*TrustLog/i })).toBeVisible();
   });
 
   test("query input accepts text and shows send button", async ({ page }) => {

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -11,12 +11,11 @@ test.describe("Smoke: 3-minute demo flow", () => {
     await page.goto("/console");
     // Use heading role to avoid strict-mode clash with the sidebar nav text
     await expect(page.getByRole("heading", { name: "Decision Console" })).toBeVisible();
-    await expect(page.getByText("Pipeline Operations View")).toBeVisible();
-    await expect(page.locator("li", { hasText: "Evidence" })).toBeVisible();
-    // Scope to <li> so strict mode won't match the separate "FUJI Gate Status" heading
-    await expect(page.locator("li", { hasText: "FUJI" })).toBeVisible();
-    // Scope to <li> to avoid matching sidebar's "TrustLog Explorer"
-    await expect(page.locator("li", { hasText: "TrustLog" })).toBeVisible();
+    const pipeline = page.getByRole("region", { name: "pipeline visualizer" });
+    await expect(pipeline.getByText("Pipeline Operations View")).toBeVisible();
+    await expect(pipeline.getByRole("button", { name: /2\.\s*Evidence/i })).toBeVisible();
+    await expect(pipeline.getByRole("button", { name: /7\.\s*FUJI/i })).toBeVisible();
+    await expect(pipeline.getByRole("button", { name: /8\.\s*TrustLog/i })).toBeVisible();
 
     const presetButtons = page.locator("button").filter({ hasText: "..." });
     const hasDangerPresets = process.env.NEXT_PUBLIC_ENABLE_DANGER_PRESETS === "true";

--- a/frontend/features/console/adapters/decision-view.test.ts
+++ b/frontend/features/console/adapters/decision-view.test.ts
@@ -1,6 +1,6 @@
 import { type DecideResponse } from "@veritas/types";
 import { describe, expect, it } from "vitest";
-import { toDecisionResultView, toFujiGateDetailView } from "./decision-view";
+import { toDecisionResultView, toFujiGateDetailView, toPublicDecisionSchemaView } from "./decision-view";
 
 function makeResponse(overrides: Partial<DecideResponse> = {}): DecideResponse {
   return {
@@ -124,5 +124,29 @@ describe("toFujiGateDetailView", () => {
     const result = makeResponse();
     const view = toFujiGateDetailView(result);
     expect(view.violations).toEqual([]);
+  });
+});
+
+describe("toPublicDecisionSchemaView", () => {
+  it("separates gate_decision from business_decision and next_action", () => {
+    const result = makeResponse({
+      gate_decision: "allow",
+      business_decision: "REVIEW_REQUIRED",
+      next_action: "ROUTE_TO_HUMAN_REVIEW",
+      required_evidence: ["approval_ticket"],
+      human_review_required: true,
+    } as never);
+    const view = toPublicDecisionSchemaView(result);
+    expect(view.gateDecision).toBe("allow");
+    expect(view.businessDecision).toBe("REVIEW_REQUIRED");
+    expect(view.nextAction).toBe("ROUTE_TO_HUMAN_REVIEW");
+    expect(view.requiredEvidence).toEqual(["approval_ticket"]);
+    expect(view.humanReviewRequired).toBe(true);
+  });
+
+  it("adds non-approval label for gate allow to avoid regression", () => {
+    const result = makeResponse({ gate_decision: "allow" } as never);
+    const view = toPublicDecisionSchemaView(result);
+    expect(view.gateDecisionLabel).toBe("response generation allowed (not case approval)");
   });
 });

--- a/frontend/features/console/adapters/decision-view.ts
+++ b/frontend/features/console/adapters/decision-view.ts
@@ -6,6 +6,7 @@ import {
   type FujiGateDetailView,
   type FujiGateView,
   type FujiViolationView,
+  type PublicDecisionSchemaView,
   type PipelineStageStatus,
   type PipelineStageView,
 } from "../types";
@@ -110,6 +111,35 @@ function readText(record: Record<string, unknown>, ...keys: string[]): string {
     }
   }
   return "n/a";
+}
+
+function getGateDecisionLabel(gateDecision: string): string {
+  if (gateDecision === "allow") {
+    return "response generation allowed (not case approval)";
+  }
+  if (gateDecision === "hold") {
+    return "gate hold";
+  }
+  if (gateDecision === "deny" || gateDecision === "rejected" || gateDecision === "block") {
+    return "blocked by gate";
+  }
+  return "gate status";
+}
+
+export function toPublicDecisionSchemaView(result: DecideResponse): PublicDecisionSchemaView {
+  const requiredEvidenceRaw = result.required_evidence;
+  const requiredEvidence = Array.isArray(requiredEvidenceRaw)
+    ? requiredEvidenceRaw.filter((item): item is string => typeof item === "string")
+    : [];
+  const gateDecision = readText(result as Record<string, unknown>, "gate_decision", "decision_status");
+  return {
+    gateDecision,
+    gateDecisionLabel: getGateDecisionLabel(gateDecision),
+    businessDecision: readText(result as Record<string, unknown>, "business_decision"),
+    nextAction: readText(result as Record<string, unknown>, "next_action"),
+    requiredEvidence,
+    humanReviewRequired: result.human_review_required === true,
+  };
 }
 
 export function toFujiGateView(result: DecideResponse | null): FujiGateView {

--- a/frontend/features/console/analytics/utils.test.ts
+++ b/frontend/features/console/analytics/utils.test.ts
@@ -86,7 +86,7 @@ describe("toAssistantMessage", () => {
     const t = (ja: string, _en: string) => ja;
     const message = toAssistantMessage(payload, t);
     expect(message).toContain("案件状態: APPROVE");
-    expect(message).toContain("ゲート判定: allow");
+    expect(message).toContain("ゲート判定: allow (案件承認ではなく、応答出力可)");
     expect(message).toContain("次アクション: EXECUTE_WITH_STANDARD_MONITORING");
     expect(message).toContain("採択案: Option A");
     expect(message).toContain("拒否理由: なし");
@@ -167,5 +167,6 @@ describe("toAssistantMessage", () => {
     const message = toAssistantMessage(payload, t);
     expect(message).toContain("案件状態: REVIEW_REQUIRED");
     expect(message).not.toContain("案件状態: allow");
+    expect(message).toContain("ゲート判定: allow (案件承認ではなく、応答出力可)");
   });
 });

--- a/frontend/features/console/analytics/utils.ts
+++ b/frontend/features/console/analytics/utils.ts
@@ -74,13 +74,16 @@ export function toAssistantMessage(
 
   const businessDecision = payload.business_decision ?? "HOLD";
   const gateDecision = payload.gate_decision ?? payload.decision_status ?? "unknown";
+  const gateDecisionWithMeaning = gateDecision === "allow"
+    ? `${gateDecision} (${t("案件承認ではなく、応答出力可", "not case approval; response may be returned")})`
+    : gateDecision;
   const nextAction = payload.next_action ?? t("要再評価", "Reassess required");
   const humanReviewRequired = payload.human_review_required === true ? t("要", "required") : t("不要", "not required");
   const chosen = payload.chosen ? renderValue(payload.chosen) : t("なし", "none");
   const rejection = payload.refusal_reason ?? payload.rejection_reason ?? t("なし", "none");
   return [
     `${t("案件状態", "Business Decision")}: ${businessDecision}`,
-    `${t("ゲート判定", "Gate Decision")}: ${gateDecision}`,
+    `${t("ゲート判定", "Gate Decision")}: ${gateDecisionWithMeaning}`,
     `${t("次アクション", "Next Action")}: ${nextAction}`,
     `${t("人手レビュー", "Human Review")}: ${humanReviewRequired}`,
     `${t("採択案", "Chosen")}: ${chosen}`,

--- a/frontend/features/console/components/decision-result-panel.test.tsx
+++ b/frontend/features/console/components/decision-result-panel.test.tsx
@@ -9,6 +9,11 @@ describe("DecisionResultPanel", () => {
     request_id: "req-test",
     version: "1.0",
     decision_status: "allow",
+    gate_decision: "allow",
+    business_decision: "REVIEW_REQUIRED",
+    next_action: "ROUTE_TO_HUMAN_REVIEW",
+    required_evidence: ["risk_assessment", "approval_ticket"],
+    human_review_required: true,
     rejection_reason: null,
     chosen: { id: "a1", title: "Option A" },
     alternatives: [
@@ -72,5 +77,25 @@ describe("DecisionResultPanel", () => {
     render(<DecisionResultPanel result={baseResult as never} />);
     expect(screen.getByText("Rejected reasons")).toBeInTheDocument();
     expect(screen.getByText("FUJI block:")).toBeInTheDocument();
+  });
+
+  it("renders separated public decision schema fields", () => {
+    render(<DecisionResultPanel result={baseResult as never} />);
+    expect(screen.getByText("Public decision output")).toBeInTheDocument();
+    expect(screen.getByText("gate_decision:")).toBeInTheDocument();
+    expect(screen.getByText("allow")).toBeInTheDocument();
+    expect(screen.getByText("business_decision:")).toBeInTheDocument();
+    expect(screen.getByText("REVIEW_REQUIRED")).toBeInTheDocument();
+    expect(screen.getByText("next_action:")).toBeInTheDocument();
+    expect(screen.getByText("ROUTE_TO_HUMAN_REVIEW")).toBeInTheDocument();
+    expect(screen.getByText("required_evidence:")).toBeInTheDocument();
+    expect(screen.getByText("risk_assessment, approval_ticket")).toBeInTheDocument();
+    expect(screen.getByText("human_review_required:")).toBeInTheDocument();
+    expect(screen.getByText("true")).toBeInTheDocument();
+  });
+
+  it("does not present gate allow as case approval in the public decision meaning", () => {
+    render(<DecisionResultPanel result={baseResult as never} />);
+    expect(screen.getByText("response generation allowed (not case approval)")).toBeInTheDocument();
   });
 });

--- a/frontend/features/console/components/decision-result-panel.tsx
+++ b/frontend/features/console/components/decision-result-panel.tsx
@@ -1,5 +1,5 @@
 import { type DecideResponse } from "@veritas/types";
-import { toDecisionResultView } from "../adapters/decision-view";
+import { toDecisionResultView, toPublicDecisionSchemaView } from "../adapters/decision-view";
 
 interface DecisionResultPanelProps {
   result: DecideResponse;
@@ -36,6 +36,7 @@ function ScoreBar({ score, label }: { score: number | null; label: string }): JS
  */
 export function DecisionResultPanel({ result }: DecisionResultPanelProps): JSX.Element {
   const view = toDecisionResultView(result);
+  const publicDecision = toPublicDecisionSchemaView(result);
 
   return (
     <div className="space-y-3">
@@ -78,6 +79,16 @@ export function DecisionResultPanel({ result }: DecisionResultPanelProps): JSX.E
       )}
 
       <div className="grid gap-3 md:grid-cols-3">
+        <section className="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs">
+          <h3 className="text-sm font-semibold text-foreground">Public decision output</h3>
+          <p><span className="text-muted-foreground">gate_decision:</span> {publicDecision.gateDecision}</p>
+          <p><span className="text-muted-foreground">gate meaning:</span> {publicDecision.gateDecisionLabel}</p>
+          <p><span className="text-muted-foreground">business_decision:</span> {publicDecision.businessDecision}</p>
+          <p><span className="text-muted-foreground">next_action:</span> {publicDecision.nextAction}</p>
+          <p><span className="text-muted-foreground">required_evidence:</span> {publicDecision.requiredEvidence.length > 0 ? publicDecision.requiredEvidence.join(", ") : "none"}</p>
+          <p><span className="text-muted-foreground">human_review_required:</span> {publicDecision.humanReviewRequired ? "true" : "false"}</p>
+        </section>
+
         <section className="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs">
           <h3 className="text-sm font-semibold text-foreground">Chosen</h3>
           <p><span className="text-muted-foreground">final decision:</span> {view.chosen.finalDecision}</p>

--- a/frontend/features/console/constants.test.ts
+++ b/frontend/features/console/constants.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isDangerPresetsEnabled } from "./constants";
+import { DECISION_SAMPLE_QUESTIONS, isDangerPresetsEnabled } from "./constants";
 
 describe("isDangerPresetsEnabled", () => {
   afterEach(() => {
@@ -26,5 +26,18 @@ describe("isDangerPresetsEnabled", () => {
     vi.stubEnv("NEXT_PUBLIC_ENABLE_DANGER_PRESETS", "false");
 
     expect(isDangerPresetsEnabled()).toBe(false);
+  });
+});
+
+describe("DECISION_SAMPLE_QUESTIONS", () => {
+  it("includes regression-focused prompts for the public decision schema", () => {
+    expect(DECISION_SAMPLE_QUESTIONS.length).toBeGreaterThanOrEqual(6);
+    expect(DECISION_SAMPLE_QUESTIONS.some((q) => q.includes("最低条件は何か"))).toBe(true);
+    expect(DECISION_SAMPLE_QUESTIONS.some((q) => q.includes("人手審査境界"))).toBe(true);
+    expect(DECISION_SAMPLE_QUESTIONS.some((q) => q.includes("必要証拠"))).toBe(true);
+    expect(DECISION_SAMPLE_QUESTIONS.some((q) => q.includes("通しすぎと止めすぎ"))).toBe(true);
+    expect(DECISION_SAMPLE_QUESTIONS.some((q) => q.includes("ルールを形式化"))).toBe(true);
+    expect(DECISION_SAMPLE_QUESTIONS.some((q) => q.includes("FujiGate と Value Core"))).toBe(true);
+    expect(DECISION_SAMPLE_QUESTIONS.some((q) => q.includes("gate_decision"))).toBe(true);
   });
 });

--- a/frontend/features/console/constants.ts
+++ b/frontend/features/console/constants.ts
@@ -26,6 +26,15 @@ export const DANGER_PRESETS = [
   },
 ] as const;
 
+export const DECISION_SAMPLE_QUESTIONS = [
+  "最低条件は何か。gate_decision / business_decision / next_action / required_evidence / human_review_required で返してください。",
+  "人手審査境界はどこか。どの条件で human_review_required=true になるかを示してください。",
+  "必要証拠は何か。required_evidence と missing_evidence を分けて返してください。",
+  "通しすぎと止めすぎを比較し、最も妥当な next_action を示してください。",
+  "ルールを形式化してください。FujiGate 判定条件と Value Core 比較軸を分離して列挙してください。",
+  "FujiGate と Value Core の責務を分離して説明し、最終出力を構造化してください。",
+] as const;
+
 /**
  * 危険プロンプトの表示可否を返します。
  *

--- a/frontend/features/console/types.ts
+++ b/frontend/features/console/types.ts
@@ -86,6 +86,15 @@ export interface DecisionResultView {
   rejectedReasons: DecisionRejectedReasonsView;
 }
 
+export interface PublicDecisionSchemaView {
+  gateDecision: string;
+  gateDecisionLabel: string;
+  businessDecision: string;
+  nextAction: string;
+  requiredEvidence: string[];
+  humanReviewRequired: boolean;
+}
+
 export interface FujiViolationView {
   rule: string;
   detail: string;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veritas-os-monorepo",
   "private": true,
-  "packageManager": "pnpm@9.15.3",
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "ui:dev": "pnpm --filter frontend dev",
     "ui:build": "pnpm --filter frontend build",

--- a/veritas_os/tests/integration/test_decision_sample_question_schema.py
+++ b/veritas_os/tests/integration/test_decision_sample_question_schema.py
@@ -1,0 +1,79 @@
+"""Sample-question regression coverage for the public decision schema."""
+
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.core.pipeline.pipeline_response import assemble_response
+from veritas_os.core.pipeline.pipeline_types import PipelineContext
+
+pytestmark = pytest.mark.integration
+
+
+SAMPLE_QUESTIONS = [
+    "最低条件は何か",
+    "人手審査境界は何か",
+    "必要証拠は何か",
+    "通しすぎと止めすぎを比較してください",
+    "ルールを形式化してください",
+    "FujiGate / Value Core の分離を説明してください",
+    "出力を gate_decision / business_decision / next_action / required_evidence / human_review_required で返してください",
+]
+
+
+@pytest.mark.parametrize("query", SAMPLE_QUESTIONS)
+def test_sample_questions_return_public_decision_schema(query: str) -> None:
+    """Sample prompts must always produce the public decision contract fields."""
+    ctx = PipelineContext(
+        request_id=f"sample-{abs(hash(query))}",
+        query=query,
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={
+            "required_evidence": ["risk_assessment", "approval_ticket"],
+            "satisfied_evidence": ["risk_assessment"],
+            "approval_boundary_defined": False,
+            "dev_mode": True,
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] in {"allow", "proceed", "hold", "human_review_required", "block"}
+    assert payload["business_decision"] in {
+        "APPROVE",
+        "DENY",
+        "HOLD",
+        "REVIEW_REQUIRED",
+        "POLICY_DEFINITION_REQUIRED",
+        "EVIDENCE_REQUIRED",
+    }
+    assert isinstance(payload["next_action"], str)
+    assert isinstance(payload["required_evidence"], list)
+    assert isinstance(payload["human_review_required"], bool)
+
+
+def test_allow_is_not_used_as_public_business_decision() -> None:
+    """Regression guard: allow is gate-level only, never business-level output."""
+    ctx = PipelineContext(
+        request_id="sample-allow-guard",
+        query="出力を構造化してください",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] in {"allow", "proceed"}
+    assert payload["business_decision"] != "allow"
+    assert payload["next_action"] != payload["business_decision"]


### PR DESCRIPTION
### Motivation

- Clarify the public decision contract by separating gate-level safety outcomes from business/state outputs and make the semantics explicit to avoid misrepresenting `gate_decision=allow` as case approval.
- Surface small regression-focused QA samples in the console to make it easier to exercise and validate the public decision schema during manual testing and demos.

### Description

- Add a public decision schema view via `toPublicDecisionSchemaView` and `PublicDecisionSchemaView` to extract `gate_decision`, `business_decision`, `next_action`, `required_evidence`, and `human_review_required` from `DecideResponse` and compute a human-facing gate label (`response generation allowed (not case approval)`).
- Render the public decision fields in the UI by adding `DECISION_SAMPLE_QUESTIONS`, showing sample QA fixtures in the empty console state, and displaying the extracted public decision output in `DecisionResultPanel` and related adapter code.
- Update analytics formatting in `toAssistantMessage` to append a non-approval explanation when `gate_decision` is `allow` and ensure other UI/strings/docs reflect the new public fields (README and UI docs updated).
- Add/adjust tests and CI-related files: unit tests for adapters and utils, Playwright e2e tests updated to scope pipeline assertions, a new Python integration test `test_decision_sample_question_schema.py` to assert backend responses include the public decision schema, and bump `pnpm` in `package.json` while removing fixed `pnpm` setup lines in workflows.

### Testing

- Ran frontend unit tests with `vitest` which include new assertions for `toPublicDecisionSchemaView`, `DECISION_SAMPLE_QUESTIONS`, and assistant message formatting, and they passed.
- Ran Playwright smoke/e2e specs which were updated to target the pipeline visualizer region and they passed.
- Ran backend integration tests with `pytest`, including the new `test_decision_sample_question_schema.py`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded233c9bc832697834558e98dc613)