### PR TITLE
docs: align parity/validation/operations source-of-truth boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ development and migration workflows, not as the recommended production baseline.
 
 Verification-oriented docs:
 
-- [`docs/postgresql-production-guide.md` (canonical: `docs/en/operations/postgresql-production-guide.md`)](docs/en/operations/postgresql-production-guide.md)
-- [`docs/BACKEND_PARITY_COVERAGE.md` (canonical: `docs/en/validation/backend-parity-coverage.md`)](docs/en/validation/backend-parity-coverage.md)
-- [`docs/PRODUCTION_VALIDATION.md` (canonical: `docs/en/validation/production-validation.md`)](docs/en/validation/production-validation.md)
-- [`docs/live-postgresql-validation.md` (single-entry public evidence for live PostgreSQL validation)](docs/live-postgresql-validation.md)
+- [`docs/en/validation/backend-parity-coverage.md` — canonical parity/implementation verification source](docs/en/validation/backend-parity-coverage.md)
+- [`docs/en/validation/production-validation.md` — canonical tier/promotion/release-gate source](docs/en/validation/production-validation.md)
+- [`docs/en/operations/postgresql-production-guide.md` — canonical PostgreSQL operations/monitoring/recovery source](docs/en/operations/postgresql-production-guide.md)
+- [`docs/live-postgresql-validation.md` — canonical public evidence entrypoint for live PostgreSQL validation](docs/live-postgresql-validation.md)
 
 ### Guarantee boundary (current)
 

--- a/docs/en/operations/postgresql-production-guide.md
+++ b/docs/en/operations/postgresql-production-guide.md
@@ -1,5 +1,16 @@
 # PostgreSQL Production Guide
 
+> **この文書の目的 / Document purpose**: This is the canonical source for
+> PostgreSQL production operations: deployment configuration, monitoring,
+> backup/restore, recovery drills, and runtime hardening.
+>
+> **Role in documentation set**: 運用・監視・復旧・本番設定の正本
+>
+> For backend parity / implementation verification, see
+> [`../validation/backend-parity-coverage.md`](../validation/backend-parity-coverage.md).
+> For tier and release/promotion gate rules, see
+> [`../validation/production-validation.md`](../validation/production-validation.md).
+>
 > **Audience**: Operations / DevOps / SRE teams deploying VERITAS OS with PostgreSQL  
 > **Last updated**: 2026-04-12
 >
@@ -63,7 +74,12 @@ VERITAS OS supports two storage backend families:
 
 - Single-process development or demo deployments.
 - Air-gapped environments where PostgreSQL infrastructure is unavailable.
-- CI test pipelines (mock pools simulate PostgreSQL behaviour without a live database).
+- CI test pipelines where fast mock-pool regression coverage is preferred.
+
+For real PostgreSQL evidence boundaries (what is live-tested vs mock-tested),
+refer to [`../../live-postgresql-validation.md`](../../live-postgresql-validation.md)
+and parity details in
+[`../validation/backend-parity-coverage.md`](../validation/backend-parity-coverage.md).
 
 ### Environment variables for backend selection
 

--- a/docs/en/validation/backend-parity-coverage.md
+++ b/docs/en/validation/backend-parity-coverage.md
@@ -1,11 +1,18 @@
 # Backend Parity Coverage — JSONL ↔ PostgreSQL
 
-> **Document purpose**: Describe what is tested, what semantic differences
-> exist, and what remains uncovered for the JSONL ↔ PostgreSQL backend
-> switch capability in VERITAS OS.
+> **この文書の目的 / Document purpose**: This is the canonical source for
+> backend parity and PostgreSQL implementation verification (what is covered,
+> what differs, and what is intentionally out of parity scope).
+>
+> **Role in documentation set**: parity 正本（backend parity / PostgreSQL 実装検証）
 >
 > For a single-entry public evidence summary focused on **live PostgreSQL**
 > validation, see [`../../live-postgresql-validation.md`](../../live-postgresql-validation.md).
+>
+> For release gate / tier / promotion rules, see
+> [`production-validation.md`](production-validation.md). For operations,
+> monitoring, recovery, and production configuration, see
+> [`../operations/postgresql-production-guide.md`](../operations/postgresql-production-guide.md).
 
 ## 1. Architecture Overview
 
@@ -54,15 +61,19 @@ and raises `ValueError` for unknown backends.
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### How Mock Pools Work
+### How Mock Pools Work (mock vs real PostgreSQL split)
 
-All PostgreSQL tests use **in-memory mock pools** that simulate the
-SQL behaviour of `psycopg3` without requiring a live database. This
-allows the tests to run in any CI environment, including those without
-PostgreSQL.
+Most PostgreSQL-focused tests use **in-memory mock pools** that simulate
+the SQL behaviour of `psycopg3` without requiring a live database. This
+keeps parity/contract regression fast and stable in CI.
 
 The CI job `test-postgresql` additionally runs Alembic migrations
 against a real PostgreSQL 16 service container.
+
+Real PostgreSQL evidence is concentrated in contention-focused tests and
+Docker/service validation paths; see
+[`../../live-postgresql-validation.md`](../../live-postgresql-validation.md)
+for the public single-entry evidence view.
 
 ## 3. Coverage Matrix
 
@@ -170,6 +181,10 @@ or know which backend is active.
 | `postgresql-smoke` | Real PostgreSQL (service container) | Backend parity + health endpoint verification **+ real PostgreSQL advisory-lock contention tests** (Tier 3) |
 
 ### Smoke / Release Validation Path
+
+Tier semantics (promotion/release gating) are owned by
+[`production-validation.md`](production-validation.md). This section only
+maps how parity-relevant checks are exercised across those tiers.
 
 Smoke tests (`@pytest.mark.smoke`) verify that the active backend —
 whichever it is — satisfies governance invariants. In Docker Compose

--- a/docs/en/validation/production-validation.md
+++ b/docs/en/validation/production-validation.md
@@ -1,5 +1,15 @@
 # VERITAS OS — Production Validation Strategy
 
+> **この文書の目的 / Document purpose**: This is the canonical source for
+> tier definitions, promotion/release gates, and blocking semantics.
+>
+> **Role in documentation set**: promotion/release validation 正本
+>
+> For backend parity and PostgreSQL implementation coverage, see
+> [`backend-parity-coverage.md`](backend-parity-coverage.md). For operations,
+> monitoring, recovery, and production runtime configuration, see
+> [`../operations/postgresql-production-guide.md`](../operations/postgresql-production-guide.md).
+>
 > For a single-entry public evidence summary focused on **live PostgreSQL**
 > validation, see [`../../live-postgresql-validation.md`](../../live-postgresql-validation.md).
 
@@ -9,6 +19,16 @@ This document describes the **tiered CI/release validation** model for VERITAS O
 It complements the existing unit/integration test suite (5800+ tests, 87% coverage)
 with production-realistic verification that exercises external dependencies,
 deployment topology, and fail-closed security controls.
+
+Mock vs real PostgreSQL split is intentionally layered:
+
+- **Mock-heavy tests** provide broad, fast regression coverage.
+- **Real PostgreSQL validation** provides high-fidelity evidence for live DB
+  behaviour in designated jobs (e.g., contention and docker/service checks).
+
+Detailed parity-level guarantees and non-guarantees are maintained in
+[`backend-parity-coverage.md`](backend-parity-coverage.md), while this document
+defines *when* those checks block promotion/release.
 
 ## Tier Model
 

--- a/docs/live-postgresql-validation.md
+++ b/docs/live-postgresql-validation.md
@@ -2,10 +2,18 @@
 
 > Purpose: live PostgreSQL validation に関する公開証拠を 1 箇所に集約し、
 > 「何が real PostgreSQL で検証され、何が mock か」を追跡しやすくする。
+>
+> **Role in documentation set**: live PG validation の公開証拠の正本
+>
+> Canonical companions:
+> - Parity source of truth: `docs/en/validation/backend-parity-coverage.md`
+> - Promotion/release gate source of truth: `docs/en/validation/production-validation.md`
+> - Operations source of truth: `docs/en/operations/postgresql-production-guide.md`
 
 ## Scope
 
-この文書は以下の実体を突き合わせて要約する。
+この文書は以下の実体を突き合わせて要約する（本書自体は証拠集約であり、
+tier 定義・運用手順・parity 詳細の一次定義は companion docs 側）。
 
 - Validation docs:
   - `docs/en/validation/backend-parity-coverage.md`
@@ -196,4 +204,3 @@ curl -sf http://localhost:8000/health | python3 -m json.tool
 推奨アンカー文言:
 
 - **"Live PostgreSQL validation evidence (single entrypoint)"**
-


### PR DESCRIPTION
### Motivation
- Readers and operators were uncertain which document is authoritative for backend parity, promotion/release gating, production operations, and public live-PostgreSQL evidence.
- The change aims to reduce overlap and drift by making a single source-of-truth explicit for each responsibility and improving navigability between them.

### Description
- Added a short purpose / role block at the head of `docs/en/validation/backend-parity-coverage.md` to mark it as the canonical parity / PostgreSQL implementation verification source. 
- Added a short purpose / role block at the head of `docs/en/validation/production-validation.md` to mark it as the canonical tier / promotion / release-gate source. 
- Added a short purpose / role block at the head of `docs/en/operations/postgresql-production-guide.md` to mark it as the canonical PostgreSQL operations / monitoring / recovery / production-config source. 
- Added a role/purpose header and explicit companion links to `docs/live-postgresql-validation.md` to mark it as the canonical public evidence aggregation entrypoint, and normalized cross-links between the four docs. 
- Normalized wording around the `mock` vs `real PostgreSQL` role split across the three canonical docs and updated the `README.md` verification links to reference the canonical `docs/en/...` paths and role labels. 
- Minor wording clarifications to ensure `backend-parity-coverage.md` defers tier semantics to `production-validation.md` and that `live-postgresql-validation.md` is an evidence aggregator (not the primary definition source). 

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors and succeeded. 
- Verified working tree state with `git status --short` and committed the changes with message `docs: clarify PostgreSQL validation doc ownership and cross-links`. 
- No unit/integration tests or CI workflow changes were made as part of this PR and no test suites were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df561f5ee0832694966321eef6a5b0)