### PR TITLE
Harden FUJI gate stop conditions and improve action-selection consistency

### DIFF
--- a/veritas_os/core/pipeline/pipeline_policy.py
+++ b/veritas_os/core/pipeline/pipeline_policy.py
@@ -469,6 +469,49 @@ def stage_gate_decision(ctx: PipelineContext) -> None:
         )
         ctx.chosen, ctx.alternatives = {}, []
 
+    # Context-aware fail-closed stop conditions.
+    # Keep this stage focused on FUJI gate posture, and leave public shaping
+    # (business_decision / next_action) to pipeline_response.
+    required_evidence = [
+        str(item).strip()
+        for item in (ctx.context.get("required_evidence") or [])
+        if str(item).strip()
+    ]
+    satisfied_evidence = {
+        str(item).strip()
+        for item in (ctx.context.get("satisfied_evidence") or [])
+        if str(item).strip()
+    }
+    missing_evidence = [item for item in required_evidence if item not in satisfied_evidence]
+    if ctx.decision_status == "allow" and missing_evidence:
+        ctx.decision_status = "hold"
+        ctx.context["human_review_required"] = True
+        ctx.rejection_reason = (
+            "FUJI gate: required_evidence_missing="
+            + ",".join(sorted(set(missing_evidence)))
+        )
+
+    high_risk_ambiguity = bool(ctx.context.get("high_risk_ambiguity")) or (
+        bool(ctx.context.get("ambiguity_detected")) and ctx.effective_risk >= 0.80
+    )
+    if high_risk_ambiguity:
+        ctx.context["human_review_required"] = True
+        if ctx.decision_status == "allow":
+            ctx.decision_status = "hold"
+            ctx.rejection_reason = (
+                "FUJI gate: high_risk_ambiguity_requires_human_review"
+            )
+
+    irreversible_action = bool(ctx.context.get("irreversible_action"))
+    audit_trail_complete = bool(ctx.context.get("audit_trail_complete", True))
+    if irreversible_action and not audit_trail_complete:
+        ctx.context["human_review_required"] = True
+        ctx.decision_status = "rejected"
+        ctx.rejection_reason = (
+            "FUJI gate: irreversible_action_without_audit_trail"
+        )
+        ctx.chosen, ctx.alternatives = {}, []
+
     ctx.response_extras["metrics"]["stage_latency"]["gate"] = max(
         0,
         int((time.time() - gate_stage_started_at) * 1000),

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -120,8 +120,16 @@ def _rank_action_candidates(
     stop_reasons: List[str],
     missing_evidence: List[str],
     human_review_required: bool,
+    context: Dict[str, Any],
+    value_total: float,
 ) -> List[Dict[str, Any]]:
-    """Return sorted action candidates aligned to FUJI gate constraints."""
+    """Return sorted action candidates aligned to FUJI gate constraints.
+
+    Candidate scoring remains rule-based but adapts to:
+    - governance stop reasons (fail-closed conditions),
+    - dependency/urgency context hints, and
+    - Value Core aggregate score (`value_total`).
+    """
     if gate_decision == "block":
         candidates = [
             _make_action_candidate(
@@ -233,6 +241,33 @@ def _rank_action_candidates(
                 reason="Targeted checks reduce tail risk but delay immediate value realization.",
             ),
         ]
+    normalized_value_total = min(1.0, max(0.0, float(value_total)))
+    dependency_penalty = 0.08 if bool(context.get("critical_dependency_pending")) else 0.0
+    urgency_boost = 0.06 if bool(context.get("urgency_high")) else 0.0
+    for candidate in candidates:
+        if candidate["action"] == "EXECUTE_WITH_STANDARD_MONITORING":
+            if human_review_required or "high_risk_ambiguity" in stop_reasons:
+                candidate["risk_reduction"] = min(1.0, candidate["risk_reduction"] + 0.22)
+                candidate["expected_value"] = max(0.0, candidate["expected_value"] - 0.28)
+        if candidate["action"] == "COLLECT_REQUIRED_EVIDENCE" and missing_evidence:
+            candidate["expected_value"] = min(1.0, candidate["expected_value"] + 0.10)
+            candidate["urgency"] = min(1.0, candidate["urgency"] + 0.08)
+        if candidate["action"] in {"PREPARE_HUMAN_REVIEW_PACKET", "ROUTE_TO_HUMAN_REVIEW"}:
+            if human_review_required:
+                candidate["expected_value"] = min(1.0, candidate["expected_value"] + 0.08)
+                candidate["risk_reduction"] = min(1.0, candidate["risk_reduction"] + 0.05)
+        if dependency_penalty > 0.0 and candidate["action"] in {
+            "ESCALATE_POLICY_EXCEPTION_REVIEW",
+            "DEFINE_POLICY_AND_REASSESS",
+            "ROUTE_TO_HUMAN_REVIEW",
+        }:
+            candidate["dependency"] = min(1.0, candidate["dependency"] + dependency_penalty)
+        if urgency_boost > 0.0:
+            candidate["urgency"] = min(1.0, candidate["urgency"] + urgency_boost)
+        if normalized_value_total <= 0.40:
+            candidate["expected_value"] = max(0.0, candidate["expected_value"] - 0.04)
+            candidate["risk_reduction"] = min(1.0, candidate["risk_reduction"] + 0.03)
+        candidate["score"] = _calc_action_score(candidate)
     return sorted(candidates, key=lambda item: item["score"], reverse=True)
 
 
@@ -311,10 +346,20 @@ def _extract_stop_reasons(
         reasons.append("audit_trail_incomplete")
     if _is_falsey_flag(context.get("rollback_supported")):
         reasons.append("rollback_not_supported")
+    if bool(context.get("irreversible_action")):
+        reasons.append("irreversible_action")
     if _is_falsey_flag(context.get("secure_controls_ready")):
         reasons.append("secure_controls_missing")
     if secure_or_prod and _is_falsey_flag(context.get("production_controls_ready")):
         reasons.append("secure_prod_controls_missing")
+    try:
+        context_risk_score = float(context.get("risk_score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        context_risk_score = 0.0
+    if bool(context.get("high_risk_ambiguity")) or (
+        bool(context.get("ambiguity_detected")) and context_risk_score >= 0.8
+    ):
+        reasons.append("high_risk_ambiguity")
 
     return reasons
 
@@ -339,6 +384,10 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
     missing_evidence = [item for item in required_evidence if item not in satisfied_evidence]
 
     fuji_status = str(ctx.fuji_dict.get("status") or "").lower()
+    try:
+        risk_score = float(ctx.context.get("risk_score", ctx.fuji_dict.get("risk", 0.0)) or 0.0)
+    except (TypeError, ValueError):
+        risk_score = 0.0
     human_review_required = bool(
         ctx.context.get("human_review_required")
         or fuji_status == "needs_human_review"
@@ -352,12 +401,17 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
 
     if "rollback_not_supported" in stop_reasons:
         gate_decision = "block"
+    elif "irreversible_action" in stop_reasons and "audit_trail_incomplete" in stop_reasons:
+        gate_decision = "block"
     elif "secure_prod_controls_missing" in stop_reasons:
         gate_decision = "block"
     elif raw_gate_decision in {"deny", "rejected", "block"} or str(ctx.decision_status).lower() in {"rejected", "block"}:
         gate_decision = "block"
     elif "required_evidence_missing" in stop_reasons:
         gate_decision = "hold"
+    elif "high_risk_ambiguity" in stop_reasons and risk_score >= 0.8:
+        gate_decision = "human_review_required"
+        human_review_required = True
     elif "approval_boundary_unknown" in stop_reasons or human_review_required:
         gate_decision = "human_review_required"
         human_review_required = True
@@ -392,6 +446,8 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         stop_reasons=stop_reasons,
         missing_evidence=missing_evidence,
         human_review_required=human_review_required,
+        context=ctx.context,
+        value_total=float(ctx.values_payload.get("total", 0.0) or 0.0),
     )
     selected_candidate = action_candidates[0]
     next_action = selected_candidate["action"]

--- a/veritas_os/tests/test_financial_regulatory_templates.py
+++ b/veritas_os/tests/test_financial_regulatory_templates.py
@@ -132,3 +132,68 @@ def test_regression_approval_boundary_undefined_requires_human_review() -> None:
     assert payload["gate_decision"] == "human_review_required"
     assert payload["business_decision"] == "REVIEW_REQUIRED"
     assert payload["human_review_required"] is True
+
+
+def test_regression_representative_financial_templates_governance_alignment() -> None:
+    """Representative templates should map to stable gate/business decisions."""
+    templates = {item.template_id: item for item in _load_templates()}
+    fixture_contexts = {
+        "credit_missing_bureau_data_no_auto_approval": {
+            "required_evidence": [
+                "credit_bureau_report",
+                "income_verification",
+                "affordability_assessment",
+            ],
+            "satisfied_evidence": ["income_verification", "affordability_assessment"],
+        },
+        "aml_kyc_high_risk_country_wire_manual_review": {
+            "required_evidence": [
+                "kyc_profile",
+                "pep_screening_result",
+                "source_of_funds_document",
+                "transaction_purpose_statement",
+            ],
+            "satisfied_evidence": [
+                "kyc_profile",
+                "pep_screening_result",
+                "source_of_funds_document",
+                "transaction_purpose_statement",
+            ],
+            "high_risk_ambiguity": True,
+            "risk_score": 0.91,
+        },
+        "high_risk_transaction_pending_release": {
+            "required_evidence": [
+                "transaction_chain_graph",
+                "counterparty_risk_rating",
+                "aml_alert_case_id",
+            ],
+            "satisfied_evidence": [
+                "transaction_chain_graph",
+                "counterparty_risk_rating",
+                "aml_alert_case_id",
+            ],
+            "irreversible_action": True,
+            "audit_trail_complete": False,
+        },
+    }
+
+    for template_id, context in fixture_contexts.items():
+        template = templates[template_id]
+        expected = template.expected_governance_behavior
+        ctx = PipelineContext(
+            request_id=f"financial-template-{template_id}",
+            query=template.question,
+            fuji_dict={"decision_status": "allow", "status": "allow"},
+            decision_status="allow",
+            rejection_reason=None,
+            context=context,
+        )
+
+        payload = assemble_response(
+            ctx,
+            load_persona_fn=lambda: {},
+            plan={"steps": [], "source": "test"},
+        )
+        assert payload["gate_decision"] == expected.gate_decision
+        assert payload["business_decision"] == expected.business_decision

--- a/veritas_os/tests/unit/test_pipeline_gate_stop_conditions.py
+++ b/veritas_os/tests/unit/test_pipeline_gate_stop_conditions.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for FUJI gate stop-condition hardening."""
+
+from veritas_os.core.pipeline.pipeline_policy import stage_gate_decision
+from veritas_os.core.pipeline.pipeline_types import PipelineContext
+
+
+def _make_context() -> PipelineContext:
+    """Create a minimal pipeline context usable by stage_gate_decision."""
+    return PipelineContext(
+        request_id="gate-stop-conditions",
+        query="test",
+        fuji_dict={"status": "allow", "risk": 0.2},
+        decision_status="allow",
+        context={},
+        response_extras={"metrics": {"stage_latency": {}}},
+    )
+
+
+def test_stage_gate_decision_holds_when_required_evidence_is_missing() -> None:
+    """Required evidence gaps should fail closed to hold, not allow."""
+    ctx = _make_context()
+    ctx.context = {
+        "required_evidence": ["risk_assessment", "approval_ticket"],
+        "satisfied_evidence": ["risk_assessment"],
+    }
+
+    stage_gate_decision(ctx)
+
+    assert ctx.decision_status == "hold"
+    assert ctx.rejection_reason is not None
+    assert "required_evidence_missing" in ctx.rejection_reason
+    assert ctx.context.get("human_review_required") is True
+
+
+def test_stage_gate_decision_rejects_irreversible_action_without_audit_trail() -> None:
+    """Irreversible action without audit evidence should be rejected."""
+    ctx = _make_context()
+    ctx.context = {
+        "irreversible_action": True,
+        "audit_trail_complete": False,
+    }
+
+    stage_gate_decision(ctx)
+
+    assert ctx.decision_status == "rejected"
+    assert ctx.rejection_reason == "FUJI gate: irreversible_action_without_audit_trail"
+    assert ctx.chosen == {}
+    assert ctx.alternatives == []
+

--- a/veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py
+++ b/veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py
@@ -259,3 +259,80 @@ def test_non_dev_mode_hides_action_candidates() -> None:
     )
 
     assert payload["action_candidates"] == []
+
+
+def test_missing_required_evidence_never_returns_approve() -> None:
+    """required_evidence 欠損時は APPROVE を返さない。"""
+    ctx = PipelineContext(
+        request_id="req-11",
+        query="実行してよいか？",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={
+            "required_evidence": ["approval_ticket", "audit_log_ref"],
+            "satisfied_evidence": ["approval_ticket"],
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "hold"
+    assert payload["business_decision"] == "EVIDENCE_REQUIRED"
+    assert payload["business_decision"] != "APPROVE"
+
+
+def test_high_risk_ambiguity_forces_human_review() -> None:
+    """高リスク曖昧案件は human_review_required=true を強制する。"""
+    ctx = PipelineContext(
+        request_id="req-12",
+        query="重大影響だが確証がない案件を通すべきか",
+        fuji_dict={"decision_status": "allow", "status": "allow", "risk": 0.92},
+        decision_status="allow",
+        rejection_reason=None,
+        context={
+            "ambiguity_detected": True,
+            "risk_score": 0.91,
+            "required_evidence": ["decision_rationale"],
+            "satisfied_evidence": ["decision_rationale"],
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "human_review_required"
+    assert payload["business_decision"] == "REVIEW_REQUIRED"
+    assert payload["human_review_required"] is True
+
+
+def test_irreversible_action_without_audit_trail_is_blocked() -> None:
+    """不可逆アクションかつ監査証跡不足は BLOCK に倒す。"""
+    ctx = PipelineContext(
+        request_id="req-13",
+        query="監査なしで不可逆実行してよいか",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={
+            "irreversible_action": True,
+            "audit_trail_complete": False,
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "block"
+    assert payload["business_decision"] == "DENY"
+    assert payload["next_action"] == "DO_NOT_EXECUTE"


### PR DESCRIPTION
### Motivation
- Reduce over-reliance on "まず調査する" and make FujiGate/Value Core produce more consistent governance outputs for financial/regulatory templates. 
- Ensure missing evidence, high-risk ambiguity, irreversible actions, and audit gaps push outputs toward fail-closed / human review rather than accidental approval. 
- Keep changes scoped to pipeline gate/response responsibilities and preserve the public DecideResponse schema and fail-closed posture.

### Description
- Strengthened gate-stage logic in `veritas_os/core/pipeline/pipeline_policy.py` to detect context-driven stop conditions and enforce fail-closed behavior for missing evidence, high-risk ambiguity, and irreversible actions without audit trails. (added context normalization, `human_review_required` propagation and explicit rejection/hold flows). 
- Improved action candidate ranking in `veritas_os/core/pipeline/pipeline_response.py` so scoring adapts to `context` hints and Value Core aggregate (`value_total`), and adjusted candidate attributes (expected value, risk reduction, urgency, dependency) to prefer evidence-collection / human-review under risk/ambiguity. 
- Extended stop-reason extraction to include `irreversible_action` and `high_risk_ambiguity` and tightened mapping from stop reasons to `gate_decision` and `business_decision` to prevent `APPROVE` when required evidence is missing. 
- Tests added/updated to cover the new behaviors: new unit tests `veritas_os/tests/unit/test_pipeline_gate_stop_conditions.py`, additional assertions in `veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py` (missing evidence / high-risk ambiguity / irreversible+audit gap), and a representative regression check in `veritas_os/tests/test_financial_regulatory_templates.py` that validates selected financial templates still map to expected gate/business decisions. 
- Public schema unchanged and changes are limited to pipeline policy/response layers; no planner/kernel/memory boundary changes were made.

### Testing
- Ran `pytest -q veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py veritas_os/tests/unit/test_pipeline_gate_stop_conditions.py veritas_os/tests/test_financial_regulatory_templates.py` and received `20 passed` (all tests in that run passed). 
- Ran `pytest -q veritas_os/tests/unit/test_pipeline_stages_ext.py -k "stage_gate_decision"` and received `2 passed, 627 deselected` (relevant stage tests passed). 
- All newly added and modified unit tests passed locally, validating: missing evidence does not produce `APPROVE`, high-risk ambiguity forces `human_review_required=true`, irreversible+audit-gap trends to block/deny, and representative financial templates align with the reinforced gate/business decisions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb088d7688326998f84f04ec18593)