### PR TITLE
Formalize decision Evidence Bundle schema and add generation/verification CLI

### DIFF
--- a/docs/en/validation/external-audit-readiness.md
+++ b/docs/en/validation/external-audit-readiness.md
@@ -194,6 +194,7 @@ cryptographic evidence needed to independently verify decisions.
 veritas_bundle_decision_<uuid>/
 ├── manifest.json              # SHA-256 hashes, metadata, optional signature
 ├── witness_entries.jsonl       # Witness ledger slice
+├── decision_record.json        # Auditor-facing single-decision snapshot
 ├── verification_report.json   # Automated verification results
 ├── signer_metadata.json       # Ed25519 signer info
 ├── anchor_receipts/
@@ -206,6 +207,16 @@ veritas_bundle_decision_<uuid>/
 ├── incident_metadata.json     # (incident bundles only)
 └── release_provenance.json    # (release bundles only)
 ```
+
+`decision_record.json` is the canonical external handoff artifact for one
+decision. It includes:
+
+- full compact `decision_payload`
+- `gate_decision` / `business_decision` / `next_action`
+- `required_evidence` / `human_review_required`
+- TrustLog references (`payload_hash`, `full_payload_hash`, signature/anchor/mirror)
+- verification pointer (`verification_report.json`)
+- provenance metadata + runtime context (posture/backend/version)
 
 ### Generating Bundles
 
@@ -255,6 +266,25 @@ else:
     for error in result["errors"]:
         print(f"  - {error}")
 ```
+
+### CLI (recommended for ops runbooks)
+
+```bash
+veritas-evidence-bundle generate \
+  --bundle-type decision \
+  --witness-ledger runtime/dev/logs/trustlog.jsonl \
+  --output-dir ./bundles \
+  --request-id req-12345
+
+veritas-evidence-bundle verify \
+  --bundle-dir ./bundles/veritas_bundle_decision_<uuid>
+```
+
+### Financial template sample bundle
+
+Representative fixture:
+
+- `veritas_os/benchmarks/evidence/fixtures/financial_template_bundle_sample.json`
 
 ### Creating Archives
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
 [project.scripts]
 veritas-trustlog-verify = "veritas_os.cli.verify_trustlog:main"
 veritas-migrate = "veritas_os.cli.migrate:main"
+veritas-evidence-bundle = "veritas_os.cli.evidence_bundle:main"
 
 [project.urls]
 Homepage = "https://github.com/veritasfuji-japan/veritas_os"

--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -30,10 +30,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from veritas_os.audit.evidence_bundle_schema import (
-    BUNDLE_SCHEMA_VERSION,
-    BUNDLE_TYPES,
-)
+from veritas_os.audit.evidence_bundle_schema import BUNDLE_SCHEMA_VERSION, BUNDLE_TYPES
 from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
 
 _logger = logging.getLogger(__name__)
@@ -146,6 +143,68 @@ def _collect_file_hashes(directory: Path) -> Dict[str, str]:
             rel = str(file_path.relative_to(directory))
             hashes[rel] = _sha256_file(file_path)
     return hashes
+
+
+def _runtime_context_from_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Build runtime metadata describing active posture/backends/versions."""
+    decision_payload = entry.get("decision_payload") if isinstance(entry, dict) else {}
+    decision_payload = decision_payload if isinstance(decision_payload, dict) else {}
+    return {
+        "posture": os.getenv("VERITAS_POSTURE", "dev"),
+        "trustlog_backend": os.getenv("VERITAS_TRUSTLOG_BACKEND", "jsonl"),
+        "memory_backend": os.getenv("VERITAS_MEMORY_BACKEND", "json"),
+        "trustlog_signer_backend": os.getenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file"),
+        "api_version": os.getenv("VERITAS_API_VERSION", "veritas-api 1.x"),
+        "kernel_version": os.getenv("VERITAS_KERNEL_VERSION", "core-kernel 0.x"),
+        "pipeline_version": os.getenv("VERITAS_PIPELINE_VERSION", "unknown"),
+        "decision_version": decision_payload.get("version"),
+    }
+
+
+def _decision_record(entry: Dict[str, Any], verification_report: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract auditor-facing decision snapshot from one TrustLog witness entry."""
+    payload = entry.get("decision_payload")
+    payload = payload if isinstance(payload, dict) else {}
+    governance_identity = payload.get("governance_identity")
+    decision_id = entry.get("decision_id") or payload.get("decision_id")
+
+    return {
+        "decision_payload": payload,
+        "gate_decision": payload.get("gate_decision", "unknown"),
+        "business_decision": payload.get("business_decision", "HOLD"),
+        "next_action": payload.get("next_action", "REVISE_AND_RESUBMIT"),
+        "required_evidence": payload.get("required_evidence", []),
+        "human_review_required": bool(payload.get("human_review_required", False)),
+        "trustlog_references": {
+            "decision_id": decision_id,
+            "request_id": payload.get("request_id"),
+            "previous_hash": entry.get("previous_hash"),
+            "payload_hash": entry.get("payload_hash"),
+            "full_payload_hash": entry.get("full_payload_hash"),
+            "signature": entry.get("signature"),
+            "anchor_backend": entry.get("anchor_backend"),
+            "anchor_status": entry.get("anchor_status"),
+            "anchor_receipt": entry.get("anchor_receipt"),
+            "mirror_backend": entry.get("mirror_backend"),
+            "mirror_receipt": entry.get("mirror_receipt"),
+            "artifact_ref": entry.get("artifact_ref"),
+        },
+        "verification": {
+            "report_path": "verification_report.json",
+            "ledger_ok": verification_report.get("ok"),
+            "chain_ok": verification_report.get("chain_ok"),
+            "signature_ok": verification_report.get("signature_ok"),
+            "errors": verification_report.get("total_errors"),
+            "notes": verification_report.get("total_notes"),
+        },
+        "provenance": {
+            "witness_timestamp": entry.get("timestamp"),
+            "bundle_generated_at": _utc_now_iso8601(),
+            "signer_metadata": entry.get("signer_metadata"),
+            "governance_identity": governance_identity,
+        },
+        "runtime_context": _runtime_context_from_entry(entry),
+    }
 
 
 def generate_evidence_bundle(
@@ -287,6 +346,7 @@ def generate_evidence_bundle(
         _write_json_file(bundle_dir, "release_provenance.json", release_provenance)
         written_files.append("release_provenance.json")
 
+    verify_result: Dict[str, Any] = {}
     # Run verification and include report
     try:
         from veritas_os.audit.trustlog_verify import verify_witness_ledger
@@ -302,6 +362,12 @@ def generate_evidence_bundle(
         written_files.append("verification_report.json")
     except Exception as exc:  # noqa: BLE001
         _logger.warning("Bundle verification skipped: %s", exc)
+
+    if bundle_type == "decision":
+        decision_entry = entries[0]
+        decision_record = _decision_record(decision_entry, verify_result)
+        _write_json_file(bundle_dir, "decision_record.json", decision_record)
+        written_files.append("decision_record.json")
 
     # Compute file hashes for manifest
     file_hashes = _collect_file_hashes(bundle_dir)

--- a/veritas_os/audit/evidence_bundle_schema.py
+++ b/veritas_os/audit/evidence_bundle_schema.py
@@ -5,12 +5,12 @@ Bundles are self-contained, deterministic archives that package all
 cryptographic evidence needed for third-party verification of decisions,
 incidents, or releases.
 
-Schema version: 1.0.0
+Schema version: 1.1.0
 """
 
 from __future__ import annotations
 
-BUNDLE_SCHEMA_VERSION = "1.0.0"
+BUNDLE_SCHEMA_VERSION = "1.1.0"
 
 #: Required top-level manifest fields.
 MANIFEST_REQUIRED_FIELDS = frozenset({
@@ -20,6 +20,22 @@ MANIFEST_REQUIRED_FIELDS = frozenset({
     "created_at",
     "created_by",
     "contents",
+    "file_hashes",
+    "entry_count",
+})
+
+#: Required keys for the decision snapshot payload used in decision bundles.
+DECISION_SNAPSHOT_REQUIRED_FIELDS = frozenset({
+    "decision_payload",
+    "gate_decision",
+    "business_decision",
+    "next_action",
+    "required_evidence",
+    "human_review_required",
+    "trustlog_references",
+    "verification",
+    "provenance",
+    "runtime_context",
 })
 
 #: Valid bundle types.
@@ -28,7 +44,7 @@ BUNDLE_TYPES = frozenset({"decision", "incident", "release"})
 #: File entries expected in each bundle type.
 BUNDLE_TYPE_CONTENTS = {
     "decision": {
-        "required": ["manifest.json", "witness_entries.jsonl"],
+        "required": ["manifest.json", "witness_entries.jsonl", "decision_record.json"],
         "optional": [
             "artifacts/",
             "anchor_receipts/",
@@ -63,3 +79,32 @@ BUNDLE_TYPE_CONTENTS = {
         ],
     },
 }
+
+
+def validate_decision_snapshot_shape(payload: dict) -> list[str]:
+    """Validate required fields for ``decision_record.json``.
+
+    Returns a list of human-readable validation errors.
+    """
+    errors: list[str] = []
+    missing = DECISION_SNAPSHOT_REQUIRED_FIELDS - set(payload.keys())
+    if missing:
+        errors.append(f"decision_record missing fields: {sorted(missing)}")
+
+    if "required_evidence" in payload and not isinstance(payload.get("required_evidence"), list):
+        errors.append("decision_record.required_evidence must be a list")
+
+    if "human_review_required" in payload and not isinstance(
+        payload.get("human_review_required"), bool
+    ):
+        errors.append("decision_record.human_review_required must be a boolean")
+
+    references = payload.get("trustlog_references")
+    if references is not None and not isinstance(references, dict):
+        errors.append("decision_record.trustlog_references must be an object")
+
+    verification = payload.get("verification")
+    if verification is not None and not isinstance(verification, dict):
+        errors.append("decision_record.verification must be an object")
+
+    return errors

--- a/veritas_os/audit/verify_bundle.py
+++ b/veritas_os/audit/verify_bundle.py
@@ -16,9 +16,11 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from veritas_os.audit.evidence_bundle_schema import (
+    BUNDLE_TYPE_CONTENTS,
     BUNDLE_SCHEMA_VERSION,
     BUNDLE_TYPES,
     MANIFEST_REQUIRED_FIELDS,
+    validate_decision_snapshot_shape,
 )
 
 _logger = logging.getLogger(__name__)
@@ -104,6 +106,29 @@ def verify_evidence_bundle(
     if bundle_type not in BUNDLE_TYPES:
         errors.append(f"Invalid bundle_type: {bundle_type}")
         result["ok"] = False
+    else:
+        required_contents = BUNDLE_TYPE_CONTENTS.get(bundle_type, {}).get("required", [])
+        for required in required_contents:
+            if not (bundle_dir / required).exists():
+                errors.append(f"Required bundle content missing: {required}")
+                result["tampered"] = True
+
+    if bundle_type == "decision":
+        decision_record_path = bundle_dir / "decision_record.json"
+        if decision_record_path.exists():
+            try:
+                decision_record = json.loads(decision_record_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                errors.append(f"Failed to read decision_record.json: {exc}")
+                result["tampered"] = True
+            else:
+                shape_errors = validate_decision_snapshot_shape(decision_record)
+                if shape_errors:
+                    errors.extend(shape_errors)
+                    result["tampered"] = True
+        else:
+            errors.append("decision bundle missing decision_record.json")
+            result["tampered"] = True
 
     # Verify file hashes
     expected_hashes = manifest.get("file_hashes", {})

--- a/veritas_os/benchmarks/evidence/fixtures/financial_template_bundle_sample.json
+++ b/veritas_os/benchmarks/evidence/fixtures/financial_template_bundle_sample.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.1.0",
+  "bundle_type": "decision",
+  "case": "financial.high_risk_wire_transfer",
+  "decision_record": {
+    "decision_payload": {
+      "request_id": "fin-wire-2026-0001",
+      "decision_id": "dec-fin-wire-2026-0001",
+      "gate_decision": "human_review_required",
+      "business_decision": "REVIEW_REQUIRED",
+      "next_action": "ROUTE_TO_HUMAN_REVIEW",
+      "required_evidence": [
+        "kyc_verification",
+        "source_of_funds_attestation",
+        "aml_screening_receipt"
+      ],
+      "human_review_required": true
+    },
+    "trustlog_references": {
+      "decision_id": "dec-fin-wire-2026-0001",
+      "request_id": "fin-wire-2026-0001",
+      "anchor_status": "anchored"
+    },
+    "verification": {
+      "report_path": "verification_report.json",
+      "ledger_ok": true
+    }
+  }
+}

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -1,0 +1,100 @@
+"""CLI for generating and verifying VERITAS evidence bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+from veritas_os.audit.verify_bundle import verify_evidence_bundle
+
+
+def _parse_key_value_pairs(values: Optional[list[str]]) -> Dict[str, str]:
+    """Parse ``key=value`` arguments into a mapping."""
+    result: Dict[str, str] = {}
+    if not values:
+        return result
+    for item in values:
+        if "=" not in item:
+            raise ValueError(f"invalid --meta value: {item!r}. expected key=value")
+        key, value = item.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build argparse parser for evidence bundle CLI."""
+    parser = argparse.ArgumentParser(description="Generate/verify VERITAS evidence bundles")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gen = sub.add_parser("generate", help="Generate evidence bundle")
+    gen.add_argument("--bundle-type", required=True, choices=["decision", "incident", "release"])
+    gen.add_argument("--witness-ledger", required=True, type=Path)
+    gen.add_argument("--output-dir", required=True, type=Path)
+    gen.add_argument("--request-id", action="append", dest="request_ids")
+    gen.add_argument("--time-range-start")
+    gen.add_argument("--time-range-end")
+    gen.add_argument("--created-by", default="veritas_os")
+    gen.add_argument("--governance-meta", action="append")
+    gen.add_argument("--release-meta", action="append")
+    gen.add_argument("--incident-meta", action="append")
+    gen.add_argument("--json", action="store_true")
+
+    verify = sub.add_parser("verify", help="Verify evidence bundle")
+    verify.add_argument("--bundle-dir", required=True, type=Path)
+    verify.add_argument("--json", action="store_true")
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Run the evidence bundle CLI entrypoint."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "generate":
+        try:
+            governance = _parse_key_value_pairs(args.governance_meta)
+            release = _parse_key_value_pairs(args.release_meta)
+            incident = _parse_key_value_pairs(args.incident_meta)
+        except ValueError as exc:
+            parser.error(str(exc))
+            return 2
+
+        result = generate_evidence_bundle(
+            bundle_type=args.bundle_type,
+            witness_ledger_path=args.witness_ledger,
+            output_dir=args.output_dir,
+            request_ids=args.request_ids,
+            time_range_start=args.time_range_start,
+            time_range_end=args.time_range_end,
+            governance_identity=governance or None,
+            release_provenance=release or None,
+            incident_metadata=incident or None,
+            created_by=args.created_by,
+        )
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=False))
+        else:
+            print(f"bundle_dir={result['bundle_dir']}")
+            print(f"manifest_hash={result['manifest_hash']}")
+            print(f"entry_count={result['entry_count']}")
+        return 0
+
+    verify_result: Dict[str, Any] = verify_evidence_bundle(args.bundle_dir)
+    if args.json:
+        print(json.dumps(verify_result, indent=2, sort_keys=True, ensure_ascii=False))
+    else:
+        status = "PASS" if verify_result.get("ok") else "FAIL"
+        print(f"Evidence bundle verification: {status}")
+        for err in verify_result.get("errors", []):
+            print(f"  error: {err}")
+        for warning in verify_result.get("warnings", []):
+            print(f"  warning: {warning}")
+    return 0 if verify_result.get("ok") else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -1,0 +1,75 @@
+"""Tests for evidence bundle CLI and financial sample fixture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from veritas_os.audit import trustlog_signed
+
+
+def test_evidence_bundle_cli_generate_and_verify(tmp_path, monkeypatch) -> None:
+    """CLI can generate and verify a decision evidence bundle."""
+    log_path = tmp_path / "trustlog.jsonl"
+    private_key = tmp_path / "keys" / "priv.key"
+    public_key = tmp_path / "keys" / "pub.key"
+
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", log_path)
+    monkeypatch.setattr(trustlog_signed, "PRIVATE_KEY_PATH", private_key)
+    monkeypatch.setattr(trustlog_signed, "PUBLIC_KEY_PATH", public_key)
+
+    trustlog_signed.append_signed_decision(
+        {
+            "request_id": "fin-wire-2026-0001",
+            "gate_decision": "human_review_required",
+            "business_decision": "REVIEW_REQUIRED",
+            "next_action": "ROUTE_TO_HUMAN_REVIEW",
+            "required_evidence": [
+                "kyc_verification",
+                "source_of_funds_attestation",
+                "aml_screening_receipt",
+            ],
+            "human_review_required": True,
+        }
+    )
+
+    from veritas_os.cli.evidence_bundle import main
+
+    out_dir = tmp_path / "bundles"
+    exit_code = main(
+        [
+            "generate",
+            "--bundle-type",
+            "decision",
+            "--witness-ledger",
+            str(log_path),
+            "--output-dir",
+            str(out_dir),
+            "--request-id",
+            "fin-wire-2026-0001",
+            "--json",
+        ]
+    )
+    assert exit_code == 0
+
+    generated_dirs = list(out_dir.glob("veritas_bundle_decision_*"))
+    assert generated_dirs
+    bundle_dir = generated_dirs[0]
+
+    verify_exit = main(["verify", "--bundle-dir", str(bundle_dir), "--json"])
+    assert verify_exit == 0
+
+
+def test_financial_bundle_sample_fixture_exists() -> None:
+    """Repository includes a representative financial decision bundle sample."""
+    fixture_path = Path(
+        "veritas_os/benchmarks/evidence/fixtures/financial_template_bundle_sample.json"
+    )
+    assert fixture_path.exists()
+
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "1.1.0"
+    decision_record = payload["decision_record"]
+    assert decision_record["decision_payload"]["gate_decision"] == "human_review_required"
+    assert decision_record["decision_payload"]["business_decision"] == "REVIEW_REQUIRED"
+    assert decision_record["decision_payload"]["human_review_required"] is True

--- a/veritas_os/tests/test_external_audit_readiness.py
+++ b/veritas_os/tests/test_external_audit_readiness.py
@@ -491,9 +491,13 @@ class TestEvidenceBundleGeneration:
         # Verify manifest on disk
         bundle_dir = Path(result["bundle_dir"])
         manifest = json.loads((bundle_dir / "manifest.json").read_text())
-        assert manifest["schema_version"] == "1.0.0"
+        assert manifest["schema_version"] == "1.1.0"
         assert manifest["bundle_type"] == "decision"
         assert manifest["entry_count"] == 1
+        decision_record = json.loads((bundle_dir / "decision_record.json").read_text())
+        assert decision_record["decision_payload"]["request_id"] == "r-bundle-1"
+        assert "trustlog_references" in decision_record
+        assert decision_record["verification"]["report_path"] == "verification_report.json"
 
     def test_incident_bundle_generation(self, _trustlog_env):
         """Generate an incident evidence bundle with multiple entries."""
@@ -848,7 +852,7 @@ class TestEvidenceBundleSchema:
 
     def test_schema_version(self):
         from veritas_os.audit.evidence_bundle_schema import BUNDLE_SCHEMA_VERSION
-        assert BUNDLE_SCHEMA_VERSION == "1.0.0"
+        assert BUNDLE_SCHEMA_VERSION == "1.1.0"
 
     def test_bundle_types(self):
         from veritas_os.audit.evidence_bundle_schema import BUNDLE_TYPES
@@ -861,3 +865,10 @@ class TestEvidenceBundleSchema:
         assert "schema_version" in MANIFEST_REQUIRED_FIELDS
         assert "bundle_type" in MANIFEST_REQUIRED_FIELDS
         assert "bundle_id" in MANIFEST_REQUIRED_FIELDS
+
+    def test_decision_snapshot_required_fields(self):
+        from veritas_os.audit.evidence_bundle_schema import DECISION_SNAPSHOT_REQUIRED_FIELDS
+
+        assert "gate_decision" in DECISION_SNAPSHOT_REQUIRED_FIELDS
+        assert "business_decision" in DECISION_SNAPSHOT_REQUIRED_FIELDS
+        assert "next_action" in DECISION_SNAPSHOT_REQUIRED_FIELDS


### PR DESCRIPTION
### Motivation
- Provide a formal, auditable Evidence Bundle format suitable for handing a single VERITAS decision to auditors/customers/legal without inventing a large new format. 
- Ensure a deterministic, tamper-evident artifact that bundles decision payload, gate/business outputs, required evidence, TrustLog references, verification results and provenance so third parties can independently verify one decision. 
- Offer an operator-friendly CLI to generate and verify bundles for runbooks and automation.

### Description
- Bumped Evidence Bundle schema to `1.1.0` and added manifest required fields `file_hashes` and `entry_count`, plus a `DECISION_SNAPSHOT_REQUIRED_FIELDS` contract and `decision_record.json` requirement for `decision` bundles (file: `veritas_os/audit/evidence_bundle_schema.py`).
- Extended `generate_evidence_bundle` to emit `decision_record.json` for `decision` bundles, containing `decision_payload`, `gate_decision`/`business_decision`/`next_action`, `required_evidence`/`human_review_required`, TrustLog references, `verification` pointer, `provenance` and `runtime_context` (file: `veritas_os/audit/evidence_bundle.py`).
- Hardened `verify_evidence_bundle` to validate per-type required contents (e.g. `decision_record.json` for decision bundles) and to validate the decision snapshot shape using `validate_decision_snapshot_shape` (file: `veritas_os/audit/verify_bundle.py`).
- Added a small CLI entrypoint `veritas-evidence-bundle` with `generate` and `verify` commands to produce and verify bundles programmatically or from shell (file: `veritas_os/cli/evidence_bundle.py`, `pyproject.toml` entrypoint).
- Added a representative financial sample bundle fixture for a high-risk wire-transfer decision and updated docs to explain `decision_record.json` meaning and CLI usage (files: `veritas_os/benchmarks/evidence/fixtures/financial_template_bundle_sample.json`, `docs/en/validation/external-audit-readiness.md`).
- Tests updated/added to exercise generation and verification and to assert new schema version and decision snapshot fields (files: `veritas_os/tests/test_external_audit_readiness.py`, `veritas_os/tests/test_evidence_bundle_cli.py`).

### Testing
- Ran targeted pytest suite: `pytest -q veritas_os/tests/test_external_audit_readiness.py::TestEvidenceBundleGeneration::test_decision_bundle_generation veritas_os/tests/test_external_audit_readiness.py::TestEvidenceBundleVerification::test_verify_valid_bundle veritas_os/tests/test_external_audit_readiness.py::TestEvidenceBundleSchema veritas_os/tests/test_external_audit_readiness.py::TestLegacyCompatibility veritas_os/tests/test_evidence_bundle_cli.py` and all tests passed (`11 passed`).
- Compiled modules to validate syntax with `python -m compileall -q veritas_os/audit veritas_os/cli` which completed successfully.
- Note: bundle internal ledger verification currently uses a no-op signature verifier by default when generating bundles; for external submissions enable witness signature checks via `verify_evidence_bundle(..., verify_witness_signatures=True, witness_signature_fn=...)` (security warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc5a3ce588326a73952788a45c4be)