### PR TITLE
Improve Mission Control decision readability and add financial UI fixture

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -43,6 +43,11 @@ pnpm -r test
 
 **重要:** `gate_decision=allow` は「案件承認」ではなく「応答出力を継続可能」の意味です。UI では承認語として表示しないでください。
 
+### 金融ケース UI フィクスチャ
+
+- Mission Control Console 用の金融サンプルは `frontend/features/console/fixtures/financial-case.ts` を利用してください。
+- 本フィクスチャは `financial.high_risk_wire_transfer` 想定で、`required_evidence` / `missing_evidence` / `next_action` / `human_review_required` の視認回帰をテストします。
+
 
 ## Docker Compose で一括起動
 

--- a/frontend/features/console/adapters/decision-view.test.ts
+++ b/frontend/features/console/adapters/decision-view.test.ts
@@ -134,14 +134,22 @@ describe("toPublicDecisionSchemaView", () => {
       business_decision: "REVIEW_REQUIRED",
       next_action: "ROUTE_TO_HUMAN_REVIEW",
       required_evidence: ["approval_ticket"],
+      missing_evidence: ["approval_ticket"],
       human_review_required: true,
+      active_posture: "strict",
+      backend: "gpt-5.3-mini",
+      verify_status: "verified",
     } as never);
     const view = toPublicDecisionSchemaView(result);
     expect(view.gateDecision).toBe("allow");
     expect(view.businessDecision).toBe("REVIEW_REQUIRED");
     expect(view.nextAction).toBe("ROUTE_TO_HUMAN_REVIEW");
     expect(view.requiredEvidence).toEqual(["approval_ticket"]);
+    expect(view.missingEvidence).toEqual(["approval_ticket"]);
     expect(view.humanReviewRequired).toBe(true);
+    expect(view.activePosture).toBe("strict");
+    expect(view.backend).toBe("gpt-5.3-mini");
+    expect(view.verifyStatus).toBe("verified");
   });
 
   it("adds non-approval label for gate allow to avoid regression", () => {

--- a/frontend/features/console/adapters/decision-view.ts
+++ b/frontend/features/console/adapters/decision-view.ts
@@ -127,18 +127,30 @@ function getGateDecisionLabel(gateDecision: string): string {
 }
 
 export function toPublicDecisionSchemaView(result: DecideResponse): PublicDecisionSchemaView {
+  const resultRecord = result as Record<string, unknown>;
   const requiredEvidenceRaw = result.required_evidence;
   const requiredEvidence = Array.isArray(requiredEvidenceRaw)
     ? requiredEvidenceRaw.filter((item): item is string => typeof item === "string")
     : [];
-  const gateDecision = readText(result as Record<string, unknown>, "gate_decision", "decision_status");
+  const missingEvidenceRaw = resultRecord.missing_evidence;
+  const missingEvidence = Array.isArray(missingEvidenceRaw)
+    ? missingEvidenceRaw.filter((item): item is string => typeof item === "string")
+    : [];
+  const activePosture = typeof resultRecord.active_posture === "string" ? resultRecord.active_posture : null;
+  const backend = typeof resultRecord.backend === "string" ? resultRecord.backend : null;
+  const verifyStatus = typeof resultRecord.verify_status === "string" ? resultRecord.verify_status : null;
+  const gateDecision = readText(resultRecord, "gate_decision", "decision_status");
   return {
     gateDecision,
     gateDecisionLabel: getGateDecisionLabel(gateDecision),
-    businessDecision: readText(result as Record<string, unknown>, "business_decision"),
-    nextAction: readText(result as Record<string, unknown>, "next_action"),
+    businessDecision: readText(resultRecord, "business_decision"),
+    nextAction: readText(resultRecord, "next_action"),
     requiredEvidence,
+    missingEvidence,
     humanReviewRequired: result.human_review_required === true,
+    activePosture,
+    backend,
+    verifyStatus,
   };
 }
 

--- a/frontend/features/console/components/__snapshots__/decision-result-panel.snapshot.test.tsx.snap
+++ b/frontend/features/console/components/__snapshots__/decision-result-panel.snapshot.test.tsx.snap
@@ -1,0 +1,501 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DecisionResultPanel snapshots > renders financial human-review scenario without regression 1`] = `
+<div
+  class="space-y-3"
+>
+  <div
+    class="overflow-x-auto rounded-md border border-border bg-background/60"
+  >
+    <table
+      aria-label="chosen vs alternatives comparison"
+      class="min-w-full text-xs"
+    >
+      <thead
+        class="border-b border-border/70 text-left text-muted-foreground"
+      >
+        <tr>
+          <th
+            class="px-2 py-1.5"
+          >
+            Option
+          </th>
+          <th
+            class="px-2 py-1.5"
+          >
+            Summary
+          </th>
+          <th
+            class="px-2 py-1.5"
+          >
+            Value Score
+          </th>
+          <th
+            class="px-2 py-1.5"
+          >
+            Trade-off / Weakness
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="border-b border-primary/20 bg-primary/5"
+        >
+          <td
+            class="px-2 py-1.5"
+          >
+            <span
+              class="inline-block rounded bg-primary/20 px-1.5 py-0.5 text-[10px] font-bold uppercase text-primary"
+            >
+              Chosen
+            </span>
+          </td>
+          <td
+            class="px-2 py-1.5 font-medium text-foreground"
+          >
+            Route to specialist review queue
+          </td>
+          <td
+            class="px-2 py-1.5"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-muted-foreground"
+              >
+                value
+                :
+              </span>
+              <div
+                class="relative h-2 w-20 rounded-full bg-muted/30"
+              >
+                <div
+                  class="absolute inset-y-0 left-0 rounded-full bg-emerald-500"
+                  style="width: 72%;"
+                />
+              </div>
+              <span
+                class="font-mono text-foreground"
+              >
+                72
+                %
+              </span>
+            </div>
+          </td>
+          <td
+            class="px-2 py-1.5 text-muted-foreground"
+          >
+            n/a
+          </td>
+        </tr>
+        <tr
+          class="border-b border-border/50"
+        >
+          <td
+            class="px-2 py-1.5"
+          >
+            <span
+              class="text-[10px] text-muted-foreground"
+            >
+              Alt 
+              1
+            </span>
+          </td>
+          <td
+            class="px-2 py-1.5 text-foreground"
+          >
+            Collect evidence and re-evaluate
+          </td>
+          <td
+            class="px-2 py-1.5"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-muted-foreground"
+              >
+                value
+                :
+              </span>
+              <div
+                class="relative h-2 w-20 rounded-full bg-muted/30"
+              >
+                <div
+                  class="absolute inset-y-0 left-0 rounded-full bg-emerald-500"
+                  style="width: 71%;"
+                />
+              </div>
+              <span
+                class="font-mono text-foreground"
+              >
+                71
+                %
+              </span>
+            </div>
+          </td>
+          <td
+            class="px-2 py-1.5 text-muted-foreground"
+          >
+            n/a
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div
+    class="grid gap-3 md:grid-cols-3"
+  >
+    <section
+      class="space-y-3 rounded-md border border-border bg-background/60 p-3 text-xs md:col-span-2"
+    >
+      <header
+        class="space-y-2"
+      >
+        <h3
+          class="text-sm font-semibold text-foreground"
+        >
+          Public decision output
+        </h3>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            gate_decision:
+          </span>
+           
+          human_review_required
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            gate meaning:
+          </span>
+           
+          gate status
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            business_decision:
+          </span>
+           
+          REVIEW_REQUIRED
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            human_review_required:
+          </span>
+           
+          true
+        </p>
+      </header>
+      <div
+        class="grid gap-3 md:grid-cols-2"
+      >
+        <article
+          class="space-y-2 rounded-md border border-amber-400/40 bg-amber-500/5 p-3"
+        >
+          <h4
+            class="font-semibold text-foreground"
+          >
+            不足証拠 / Missing evidence
+          </h4>
+          <ul
+            class="list-disc space-y-1 pl-4"
+          >
+            <li
+              class="font-mono text-[11px] text-foreground"
+            >
+              source_of_funds_attestation
+            </li>
+          </ul>
+          <p>
+            <span
+              class="text-muted-foreground"
+            >
+              required_evidence:
+            </span>
+             
+            kyc_verification, source_of_funds_attestation, aml_screening_receipt
+          </p>
+        </article>
+        <article
+          class="space-y-2 rounded-md border border-emerald-400/40 bg-emerald-500/5 p-3"
+        >
+          <h4
+            class="font-semibold text-foreground"
+          >
+            次に実行するアクション / Next action
+          </h4>
+          <p
+            class="font-mono text-[11px] text-foreground"
+          >
+            ROUTE_TO_HUMAN_REVIEW
+          </p>
+          <p
+            class="text-muted-foreground"
+          >
+            案件状態（business_decision）とは分離された実行ガイダンスです。
+          </p>
+        </article>
+      </div>
+    </section>
+    <section
+      class="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs"
+    >
+      <h3
+        class="text-sm font-semibold text-foreground"
+      >
+        Viewer focus
+      </h3>
+      <div
+        class="space-y-2 rounded-md border border-border/70 bg-background/70 p-2"
+      >
+        <p
+          class="font-medium text-foreground"
+        >
+          監査人向け
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            判定:
+          </span>
+           
+          REVIEW_REQUIRED
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            人手審査:
+          </span>
+           
+          必須
+        </p>
+      </div>
+      <div
+        class="space-y-2 rounded-md border border-border/70 bg-background/70 p-2"
+      >
+        <p
+          class="font-medium text-foreground"
+        >
+          開発者向け
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            active posture:
+          </span>
+           
+          strict
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            backend:
+          </span>
+           
+          gpt-5.3-mini
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            verify status:
+          </span>
+           
+          anchored
+        </p>
+      </div>
+    </section>
+    <section
+      class="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs"
+    >
+      <h3
+        class="text-sm font-semibold text-foreground"
+      >
+        Chosen
+      </h3>
+      <p>
+        <span
+          class="text-muted-foreground"
+        >
+          final decision:
+        </span>
+         
+        Route to specialist review queue
+      </p>
+      <p>
+        <span
+          class="text-muted-foreground"
+        >
+          why chosen:
+        </span>
+         
+        n/a
+      </p>
+      <p>
+        <span
+          class="text-muted-foreground"
+        >
+          supporting evidence summary:
+        </span>
+         
+        kyc_system
+      </p>
+      <p>
+        <span
+          class="text-muted-foreground"
+        >
+          value rationale:
+        </span>
+         
+        Human oversight required for high-risk transaction.
+      </p>
+      <div
+        class="flex items-center gap-2"
+      >
+        <span
+          class="text-muted-foreground"
+        >
+          value score
+          :
+        </span>
+        <div
+          class="relative h-2 w-20 rounded-full bg-muted/30"
+        >
+          <div
+            class="absolute inset-y-0 left-0 rounded-full bg-emerald-500"
+            style="width: 72%;"
+          />
+        </div>
+        <span
+          class="font-mono text-foreground"
+        >
+          72
+          %
+        </span>
+      </div>
+    </section>
+    <section
+      class="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs"
+    >
+      <h3
+        class="text-sm font-semibold text-foreground"
+      >
+        Alternatives
+      </h3>
+      <div
+        class="rounded border border-border/70 bg-background/70 p-2"
+      >
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            option summary:
+          </span>
+           
+          Collect evidence and re-evaluate
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            trade-off:
+          </span>
+           
+          n/a
+        </p>
+        <p>
+          <span
+            class="text-muted-foreground"
+          >
+            relative weakness:
+          </span>
+           
+          n/a
+        </p>
+        <div
+          class="flex items-center gap-2"
+        >
+          <span
+            class="text-muted-foreground"
+          >
+            value score
+            :
+          </span>
+          <div
+            class="relative h-2 w-20 rounded-full bg-muted/30"
+          >
+            <div
+              class="absolute inset-y-0 left-0 rounded-full bg-emerald-500"
+              style="width: 71%;"
+            />
+          </div>
+          <span
+            class="font-mono text-foreground"
+          >
+            71
+            %
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      class="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs"
+    >
+      <h3
+        class="text-sm font-semibold text-foreground"
+      >
+        Rejected reasons
+      </h3>
+      <p>
+        <span
+          class="text-muted-foreground"
+        >
+          FUJI block:
+        </span>
+         
+        n/a
+      </p>
+      <p>
+        <span
+          class="text-muted-foreground"
+        >
+          weak evidence:
+        </span>
+         
+        n/a
+      </p>
+      <p>
+        <span
+          class="text-muted-foreground"
+        >
+          poor debate outcome:
+        </span>
+         
+        Debate did not provide decisive support.
+      </p>
+      <p>
+        <span
+          class="text-muted-foreground"
+        >
+          value conflict:
+        </span>
+         
+        n/a
+      </p>
+    </section>
+  </div>
+</div>
+`;

--- a/frontend/features/console/components/decision-result-panel.snapshot.test.tsx
+++ b/frontend/features/console/components/decision-result-panel.snapshot.test.tsx
@@ -1,0 +1,11 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { financialHumanReviewFixture } from "../fixtures/financial-case";
+import { DecisionResultPanel } from "./decision-result-panel";
+
+describe("DecisionResultPanel snapshots", () => {
+  it("renders financial human-review scenario without regression", () => {
+    const { container } = render(<DecisionResultPanel result={financialHumanReviewFixture} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/features/console/components/decision-result-panel.test.tsx
+++ b/frontend/features/console/components/decision-result-panel.test.tsx
@@ -13,7 +13,11 @@ describe("DecisionResultPanel", () => {
     business_decision: "REVIEW_REQUIRED",
     next_action: "ROUTE_TO_HUMAN_REVIEW",
     required_evidence: ["risk_assessment", "approval_ticket"],
+    missing_evidence: ["approval_ticket"],
     human_review_required: true,
+    active_posture: "strict",
+    backend: "gpt-5.3-mini",
+    verify_status: "verified",
     rejection_reason: null,
     chosen: { id: "a1", title: "Option A" },
     alternatives: [
@@ -85,9 +89,10 @@ describe("DecisionResultPanel", () => {
     expect(screen.getByText("gate_decision:")).toBeInTheDocument();
     expect(screen.getByText("allow")).toBeInTheDocument();
     expect(screen.getByText("business_decision:")).toBeInTheDocument();
-    expect(screen.getByText("REVIEW_REQUIRED")).toBeInTheDocument();
-    expect(screen.getByText("next_action:")).toBeInTheDocument();
+    expect(screen.getAllByText("REVIEW_REQUIRED").length).toBeGreaterThan(0);
     expect(screen.getByText("ROUTE_TO_HUMAN_REVIEW")).toBeInTheDocument();
+    expect(screen.getByText("不足証拠 / Missing evidence")).toBeInTheDocument();
+    expect(screen.getByText("次に実行するアクション / Next action")).toBeInTheDocument();
     expect(screen.getByText("required_evidence:")).toBeInTheDocument();
     expect(screen.getByText("risk_assessment, approval_ticket")).toBeInTheDocument();
     expect(screen.getByText("human_review_required:")).toBeInTheDocument();
@@ -97,5 +102,17 @@ describe("DecisionResultPanel", () => {
   it("does not present gate allow as case approval in the public decision meaning", () => {
     render(<DecisionResultPanel result={baseResult as never} />);
     expect(screen.getByText("response generation allowed (not case approval)")).toBeInTheDocument();
+  });
+
+  it("shows auditor and developer focused detail blocks", () => {
+    render(<DecisionResultPanel result={baseResult as never} />);
+    expect(screen.getByText("監査人向け")).toBeInTheDocument();
+    expect(screen.getByText("開発者向け")).toBeInTheDocument();
+    expect(screen.getByText("active posture:")).toBeInTheDocument();
+    expect(screen.getByText("strict")).toBeInTheDocument();
+    expect(screen.getByText("backend:")).toBeInTheDocument();
+    expect(screen.getByText("gpt-5.3-mini")).toBeInTheDocument();
+    expect(screen.getByText("verify status:")).toBeInTheDocument();
+    expect(screen.getByText("verified")).toBeInTheDocument();
   });
 });

--- a/frontend/features/console/components/decision-result-panel.tsx
+++ b/frontend/features/console/components/decision-result-panel.tsx
@@ -37,6 +37,8 @@ function ScoreBar({ score, label }: { score: number | null; label: string }): JS
 export function DecisionResultPanel({ result }: DecisionResultPanelProps): JSX.Element {
   const view = toDecisionResultView(result);
   const publicDecision = toPublicDecisionSchemaView(result);
+  const missingEvidence = publicDecision.missingEvidence;
+  const evidencePending = missingEvidence.length > 0;
 
   return (
     <div className="space-y-3">
@@ -79,14 +81,53 @@ export function DecisionResultPanel({ result }: DecisionResultPanelProps): JSX.E
       )}
 
       <div className="grid gap-3 md:grid-cols-3">
+        <section className="space-y-3 rounded-md border border-border bg-background/60 p-3 text-xs md:col-span-2">
+          <header className="space-y-2">
+            <h3 className="text-sm font-semibold text-foreground">Public decision output</h3>
+            <p><span className="text-muted-foreground">gate_decision:</span> {publicDecision.gateDecision}</p>
+            <p><span className="text-muted-foreground">gate meaning:</span> {publicDecision.gateDecisionLabel}</p>
+            <p><span className="text-muted-foreground">business_decision:</span> {publicDecision.businessDecision}</p>
+            <p><span className="text-muted-foreground">human_review_required:</span> {publicDecision.humanReviewRequired ? "true" : "false"}</p>
+          </header>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <article className="space-y-2 rounded-md border border-amber-400/40 bg-amber-500/5 p-3">
+              <h4 className="font-semibold text-foreground">不足証拠 / Missing evidence</h4>
+              {evidencePending ? (
+                <ul className="list-disc space-y-1 pl-4">
+                  {missingEvidence.map((item) => (
+                    <li key={item} className="font-mono text-[11px] text-foreground">{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-muted-foreground">不足証拠はありません。</p>
+              )}
+              <p><span className="text-muted-foreground">required_evidence:</span> {publicDecision.requiredEvidence.length > 0 ? publicDecision.requiredEvidence.join(", ") : "none"}</p>
+            </article>
+
+            <article className="space-y-2 rounded-md border border-emerald-400/40 bg-emerald-500/5 p-3">
+              <h4 className="font-semibold text-foreground">次に実行するアクション / Next action</h4>
+              <p className="font-mono text-[11px] text-foreground">{publicDecision.nextAction}</p>
+              <p className="text-muted-foreground">
+                案件状態（business_decision）とは分離された実行ガイダンスです。
+              </p>
+            </article>
+          </div>
+        </section>
+
         <section className="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs">
-          <h3 className="text-sm font-semibold text-foreground">Public decision output</h3>
-          <p><span className="text-muted-foreground">gate_decision:</span> {publicDecision.gateDecision}</p>
-          <p><span className="text-muted-foreground">gate meaning:</span> {publicDecision.gateDecisionLabel}</p>
-          <p><span className="text-muted-foreground">business_decision:</span> {publicDecision.businessDecision}</p>
-          <p><span className="text-muted-foreground">next_action:</span> {publicDecision.nextAction}</p>
-          <p><span className="text-muted-foreground">required_evidence:</span> {publicDecision.requiredEvidence.length > 0 ? publicDecision.requiredEvidence.join(", ") : "none"}</p>
-          <p><span className="text-muted-foreground">human_review_required:</span> {publicDecision.humanReviewRequired ? "true" : "false"}</p>
+          <h3 className="text-sm font-semibold text-foreground">Viewer focus</h3>
+          <div className="space-y-2 rounded-md border border-border/70 bg-background/70 p-2">
+            <p className="font-medium text-foreground">監査人向け</p>
+            <p><span className="text-muted-foreground">判定:</span> {publicDecision.businessDecision}</p>
+            <p><span className="text-muted-foreground">人手審査:</span> {publicDecision.humanReviewRequired ? "必須" : "不要"}</p>
+          </div>
+          <div className="space-y-2 rounded-md border border-border/70 bg-background/70 p-2">
+            <p className="font-medium text-foreground">開発者向け</p>
+            <p><span className="text-muted-foreground">active posture:</span> {publicDecision.activePosture ?? "n/a"}</p>
+            <p><span className="text-muted-foreground">backend:</span> {publicDecision.backend ?? "n/a"}</p>
+            <p><span className="text-muted-foreground">verify status:</span> {publicDecision.verifyStatus ?? "n/a"}</p>
+          </div>
         </section>
 
         <section className="space-y-2 rounded-md border border-border bg-background/60 p-3 text-xs">

--- a/frontend/features/console/fixtures/financial-case.ts
+++ b/frontend/features/console/fixtures/financial-case.ts
@@ -1,0 +1,56 @@
+import { type DecideResponse } from "@veritas/types";
+
+/**
+ * Financial governance sample fixture used for Mission Control UI regression.
+ *
+ * Mirrors the bundle sample added in backend governance templates while
+ * including top-level console fields consumed by the frontend.
+ */
+export const financialHumanReviewFixture: DecideResponse = {
+  ok: true,
+  error: null,
+  request_id: "fin-wire-2026-0001",
+  version: "1.0",
+  decision_status: "hold",
+  gate_decision: "human_review_required",
+  business_decision: "REVIEW_REQUIRED",
+  next_action: "ROUTE_TO_HUMAN_REVIEW",
+  required_evidence: [
+    "kyc_verification",
+    "source_of_funds_attestation",
+    "aml_screening_receipt",
+  ],
+  missing_evidence: [
+    "source_of_funds_attestation",
+  ],
+  human_review_required: true,
+  rejection_reason: null,
+  chosen: { id: "route_review", title: "Route to specialist review queue" },
+  alternatives: [
+    { id: "collect_then_retry", title: "Collect evidence and re-evaluate", value_score: 0.71 },
+  ],
+  options: [],
+  fuji: { decision_status: "hold", rule_hit: "financial.high_risk_wire_transfer" },
+  gate: { decision_status: "hold", risk: 0.74, severity: "high" },
+  evidence: [{ source: "kyc_system", snippet: "Incomplete source of funds file", confidence: 0.92 }],
+  critique: [],
+  debate: [],
+  telos_score: 0.68,
+  values: { total: 0.72, rationale: "Human oversight required for high-risk transaction." },
+  plan: null,
+  planner: null,
+  persona: {},
+  memory_citations: [],
+  memory_used_count: 0,
+  trust_log: null,
+  extras: {},
+  meta: {},
+  ai_disclosure: "",
+  regulation_notice: "",
+  reason: null,
+  rsi_note: null,
+  evo: null,
+  active_posture: "strict",
+  backend: "gpt-5.3-mini",
+  verify_status: "anchored",
+} as unknown as DecideResponse;

--- a/frontend/features/console/types.ts
+++ b/frontend/features/console/types.ts
@@ -92,7 +92,11 @@ export interface PublicDecisionSchemaView {
   businessDecision: string;
   nextAction: string;
   requiredEvidence: string[];
+  missingEvidence: string[];
   humanReviewRequired: boolean;
+  activePosture: string | null;
+  backend: string | null;
+  verifyStatus: string | null;
 }
 
 export interface FujiViolationView {


### PR DESCRIPTION
### Motivation
- Make Mission Control / console decision output easier to scan so auditors, operators, and PoC reviewers can understand “what was stopped / what is missing / what to do next” without reading raw JSON. 
- Avoid operators mistaking `gate_decision = allow` for case-level approval while preserving backend schema semantics. 
- Provide a stable financial-case fixture for UI regression and demo readiness. 

### Description
- UI: Reworked `DecisionResultPanel` to surface `gate_decision`, `business_decision`, and `human_review_required` upfront and visually separate a color-coded “不足証拠 / Missing evidence” card and a “次に実行するアクション / Next action” card. 
- Viewer modes: Added a lightweight “Viewer focus” column with minimal auditor-facing and developer-facing blocks (shows `business_decision` / `human_review_required` and optional `active_posture` / `backend` / `verify_status`). 
- Adapter & types: Extended `toPublicDecisionSchemaView` and `PublicDecisionSchemaView` to support `missing_evidence`, `active_posture`, `backend`, and `verify_status` and sanitize these fields from `DecideResponse`. 
- Fixtures & tests: Added `financialHumanReviewFixture` and a snapshot test (`decision-result-panel.snapshot.test.tsx`) plus updated component/adapter tests to assert visibility of `gate_decision`/`business_decision`/`next_action`/`required_evidence`/`missing_evidence`/`human_review_required` and developer metadata. 
- Docs: Documented the new financial UI fixture usage in `docs/ui/README_UI.md`. 

### Testing
- Targeted tests executed: `pnpm --filter frontend exec vitest run features/console/adapters/decision-view.test.ts features/console/components/decision-result-panel.test.tsx features/console/components/decision-result-panel.snapshot.test.tsx`. 
- Result: Initial run revealed one assertion collision due to duplicated `business_decision` text and was resolved by using `getAllByText` in the test, after which the targeted tests passed and the snapshot was written. 
- Final status: the updated adapter and component tests and the new snapshot test passed (targeted suite green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01debbab88326a5495462a2055d68)