### PR TITLE
Decision Semantics & Governance Fixture Contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ VERITAS OS is built to solve that layer.
 - **Review Document Map**: [`docs/ja/reviews/code-review-document-map.md`](docs/ja/reviews/code-review-document-map.md)
 - **Documentation Hub (EN)**: [`docs/en/README.md`](docs/en/README.md)
 - **Documentation Hub (JA)**: [`docs/ja/README.md`](docs/ja/README.md)
+- **Decision Semantics Contract**: [`docs/en/architecture/decision-semantics.md`](docs/en/architecture/decision-semantics.md)
+- **Required Evidence Taxonomy v0**: [`docs/en/governance/required-evidence-taxonomy.md`](docs/en/governance/required-evidence-taxonomy.md)
 - **Documentation Map**: [`docs/DOCUMENTATION_MAP.md`](docs/DOCUMENTATION_MAP.md)
 - **Operations Runbook**: [`docs/ja/operations/enterprise_slo_sli_runbook_ja.md`](docs/ja/operations/enterprise_slo_sli_runbook_ja.md)
 - **Governance Signing Runbook**: [`docs/en/operations/governance-artifact-signing.md`](docs/en/operations/governance-artifact-signing.md)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -31,6 +31,8 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [External Audit Readiness](validation/external-audit-readiness.md)
 
 ### Governance & Compliance
+- [Decision Semantics Contract](architecture/decision-semantics.md)
+- [Required Evidence Taxonomy v0](governance/required-evidence-taxonomy.md)
 - [Governance Artifact Lifecycle](governance/governance-artifact-lifecycle.md)
 
 ### Guides

--- a/docs/en/architecture/decision-semantics.md
+++ b/docs/en/architecture/decision-semantics.md
@@ -1,0 +1,91 @@
+# Decision Semantics (Phase-1 Contract)
+
+This document is the **source-of-truth contract** for Phase-1 decision semantics.
+
+## Current behavior
+
+This spec records the current behavior implemented in `veritas_os/core/pipeline/pipeline_response.py::_derive_business_fields` and related schema literals.
+It does **not** introduce a runtime change.
+
+## Legacy / alias values
+
+`gate_decision` currently accepts both canonical values and legacy/alias values for compatibility.
+
+## Future tightening candidates
+
+- Restrict `gate_decision` to canonical values (`proceed|hold|block|human_review_required`).
+- Move legacy values (`allow|deny|modify|rejected|abstain|unknown`) to adapter-only input normalization.
+- Enforce invalid combination checks at response validation.
+
+## A. gate_decision semantics table
+
+| value | current meaning | primary intent | UI label expectation | legacy / alias | recommended | relation / notes | priority level |
+|---|---|---|---|---|---|---|---|
+| `proceed` | Safe to continue execution path | Execute with normal monitoring | Proceed | No | Yes | Canonical positive gate | Lowest stop priority |
+| `hold` | Do not execute yet; gather evidence/policy readiness | Pause and remediate | Hold | No | Yes | Canonical pause state | Medium |
+| `block` | Fail-closed stop, execution denied | Prevent execution | Blocked | No | Yes | Canonical deny state | Highest |
+| `human_review_required` | Escalate to human adjudication boundary | Human handoff | Human review required | No | Yes | Canonical escalation state | High |
+| `allow` | Legacy synonym for non-blocked FUJI status | Compatibility with older payloads | “response generation allowed (not case approval)” | Yes | Limited | Usually normalized to `proceed` unless other stop reasons override | Low |
+| `deny` | Legacy deny-like signal | Compatibility | Blocked by gate | Yes | Limited | Normalized to `block` in derivation | High |
+| `modify` | Legacy “allowed with modification” | Compatibility | Gate hold | Yes | Limited | Often mapped into `hold` path | Medium |
+| `rejected` | Legacy deny alias | Compatibility | Blocked by gate | Yes | Limited | Treated same as `block` | High |
+| `abstain` | Legacy deferred/abstain signal | Compatibility | Gate hold | Yes | Limited | Treated as `hold` in public semantics | Medium |
+| `unknown` | Fallback when decision is absent | Defensive default | Gate status | Yes | No (except fallback) | Eventually resolved through stop reasons and defaults | Lowest |
+
+### Clarifications
+
+- `allow` and `proceed` are **not equivalent labels** at API semantics level. `allow` is legacy status input; `proceed` is canonical public gate output.
+- `block`, `deny`, and `rejected` are treated as deny-family, with `block` as canonical output.
+- `human_review_required` is a canonical **gate decision** value in current API output, while `human_review_required` boolean remains a parallel flag.
+
+## B. business_decision semantics
+
+| value | meaning | when used | gate coupling |
+|---|---|---|---|
+| `APPROVE` | Case can proceed in business lifecycle | No stop reasons and no evidence/policy gaps | Usually with `proceed` |
+| `DENY` | Case denied | Hard fail-closed stop | `block` |
+| `HOLD` | Case paused for non-terminal governance reasons | Rule/control/audit readiness incomplete | Usually `hold` |
+| `REVIEW_REQUIRED` | Human adjudication required | Ambiguity/boundary/human flag requires review | `human_review_required` |
+| `POLICY_DEFINITION_REQUIRED` | Policy boundary/rule definition missing | Explicit policy-definition reason present | Often `hold` |
+| `EVIDENCE_REQUIRED` | Required evidence is incomplete | `missing_evidence` non-empty | Typically `hold` |
+
+## C. gate_decision × business_decision combination rules
+
+| combination | status |
+|---|---|
+| `gate=block` + `business=APPROVE` | Forbidden |
+| `gate=hold` + `business=APPROVE` | Forbidden |
+| `gate=human_review_required` + `human_review_required=false` | Forbidden |
+| `gate=proceed` + `business=DENY` | Forbidden |
+| `gate=proceed` + `business=APPROVE` | Allowed |
+| `gate=hold` + `business=HOLD` | Allowed |
+| `gate=hold` + `business=EVIDENCE_REQUIRED` | Allowed |
+| `gate=human_review_required` + `business=REVIEW_REQUIRED` | Allowed |
+| legacy gate values with canonical business values | Non-recommended but currently tolerated |
+
+## D. stop_reasons priority (current implementation order)
+
+Current order in `_derive_business_fields`:
+
+1. `rollback_not_supported` → `block`
+2. `irreversible_action` + `audit_trail_incomplete` → `block`
+3. `secure_prod_controls_missing` → `block`
+4. deny-family input (`deny/rejected/block`) → `block`
+5. `required_evidence_missing` → `hold`
+6. `high_risk_ambiguity` (with `risk_score >= 0.8`) → `human_review_required`
+7. `approval_boundary_unknown` OR `human_review_required=true` → `human_review_required`
+8. Any of `rule_undefined` / `audit_trail_incomplete` / `secure_controls_missing` OR legacy hold-family input (`hold/modify/abstain`) → `hold`
+9. else → `proceed`
+
+## E. `human_review_required` positioning
+
+- Boolean flag meaning: operator/human adjudication is required before execution.
+- Relationship to gate: if true (or boundary ambiguity exists), gate is elevated to `human_review_required`.
+- Relationship to business decision: typically maps to `REVIEW_REQUIRED`.
+- UI guidance: show gate value first, then show flag as explicit reviewer obligation.
+
+## F. relationship with `decision_status`
+
+- `decision_status` remains for backward compatibility with older FUJI-facing payloads.
+- `gate_decision` / `business_decision` are public semantics for case governance.
+- Legacy clients may still emit/consume `decision_status` (`allow|modify|rejected|block|abstain`).

--- a/docs/en/governance/required-evidence-taxonomy.md
+++ b/docs/en/governance/required-evidence-taxonomy.md
@@ -1,0 +1,40 @@
+# Required Evidence Taxonomy v0 (Financial)
+
+## Current behavior
+
+`required_evidence`, `missing_evidence`, and `satisfied_evidence` are currently handled as free strings in runtime context.
+
+## Legacy / alias values
+
+- Free-string evidence keys remain allowed.
+- Taxonomy v0 introduces canonical keys and aliases for normalization.
+
+## Future tightening candidates
+
+- Canonicalize at ingestion (alias -> canonical key).
+- Enforce per-domain required evidence profiles.
+- Reject unknown keys only after migration telemetry is stable.
+
+## Definitions
+
+- `required_evidence`: evidence keys required for governance-safe decisioning.
+- `satisfied_evidence`: subset already available.
+- `missing_evidence`: computed as `required_evidence - satisfied_evidence`.
+
+Machine-readable source: `veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json`.
+
+## v0 catalog
+
+| canonical key | display label | category | aliases |
+|---|---|---|---|
+| `credit_bureau_report` | Credit Bureau Report | credit_underwriting | `bureau_report`, `credit_report`, `credit_file` |
+| `kyc_profile` | KYC Profile | identity_and_aml | `know_your_customer_profile`, `customer_identity_profile` |
+| `pep_screening_result` | PEP Screening Result | identity_and_aml | `pep_check`, `politically_exposed_person_screen` |
+| `sanctions_screening_trace` | Sanctions Screening Trace | sanctions | `sanctions_trace`, `ofac_screening_trace` |
+| `source_of_funds_record` | Source of Funds Record | aml_enhanced_due_diligence | `source_of_funds_document`, `sof_record` |
+| `approval_matrix` | Approval Matrix | governance_control | `approval_boundary_matrix`, `authority_matrix` |
+| `transaction_monitoring_trace` | Transaction Monitoring Trace | transaction_monitoring | `transaction_monitoring_log`, `tml_trace` |
+| `audit_trail_export` | Audit Trail Export | audit_and_attestation | `audit_log_export`, `audit_evidence_export` |
+| `secure_controls_attestation` | Secure Controls Attestation | security_controls | `security_controls_attestation`, `secure_controls_ready_attestation` |
+| `rollback_plan` | Rollback Plan | operational_resilience | `rollback_strategy`, `rollback_support_plan` |
+| `policy_definition_record` | Policy Definition Record | policy_governance | `policy_owner_confirmation`, `policy_definition_required_record` |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -20,6 +20,8 @@ English version: [../en/README.md](../en/README.md)
 - [テスト強化後カバレッジ追跡](validation/coverage-after-hardening.md)
 
 ### ガバナンス・コンプライアンス
+- [Decision Semantics 契約](architecture/decision-semantics.md)
+- [Required Evidence Taxonomy v0](governance/required-evidence-taxonomy.md)
 - [EU AI Act 準拠レビュー](governance/eu-ai-act-compliance-review.md)
 - [エンドユーザー向け EU AI Act 使用説明書](governance/user-guide-eu-ai-act.md)
 - [Policy-as-Code 解説](governance/policy-as-code.md)

--- a/docs/ja/architecture/decision-semantics.md
+++ b/docs/ja/architecture/decision-semantics.md
@@ -1,0 +1,90 @@
+# Decision Semantics（Phase-1 共通契約）
+
+本書は Phase-1 の **decision semantics 正本仕様** です。
+
+## Current behavior
+
+本仕様は `veritas_os/core/pipeline/pipeline_response.py::_derive_business_fields` の現挙動を文書化したものです。ランタイム挙動の変更は目的としません。
+
+## Legacy / alias values
+
+`gate_decision` は後方互換のため canonical 値と legacy/alias 値を併存で受け付けます。
+
+## Future tightening candidates
+
+- `gate_decision` を canonical 値（`proceed|hold|block|human_review_required`）へ段階的収束。
+- `allow|deny|modify|rejected|abstain|unknown` は入力互換レイヤでのみ許容。
+- 禁則組み合わせを schema レベルで強制。
+
+## A. gate_decision 正式 semantics
+
+| 値 | current meaning | primary intent | UI 期待ラベル | legacy/alias | 推奨 | 他値との関係 | 優先レベル |
+|---|---|---|---|---|---|---|---|
+| `proceed` | 実行継続可能 | 通常実行 | Proceed | いいえ | 推奨 | canonical の肯定ゲート | 最低 |
+| `hold` | 即時実行せず保留 | 証拠/統制の補完 | Hold | いいえ | 推奨 | canonical の保留 | 中 |
+| `block` | fail-closed で停止 | 実行拒否 | Blocked | いいえ | 推奨 | canonical の拒否 | 最上位 |
+| `human_review_required` | 人手審査境界へエスカレーション | 人手判定へのハンドオフ | Human review required | いいえ | 推奨 | canonical の審査要求 | 高 |
+| `allow` | 旧 FUJI の許可系入力 | 後方互換 | response generation allowed | はい | 限定 | 通常は `proceed` 系へ正規化 | 低 |
+| `deny` | 旧拒否系入力 | 後方互換 | Blocked by gate | はい | 限定 | `block` に正規化 | 高 |
+| `modify` | 旧修正付き許可 | 後方互換 | Gate hold | はい | 限定 | `hold` 系へ寄る | 中 |
+| `rejected` | 旧拒否 alias | 後方互換 | Blocked by gate | はい | 限定 | `block` 同等 | 高 |
+| `abstain` | 旧保留/回答回避 | 後方互換 | Gate hold | はい | 限定 | `hold` 系として扱う | 中 |
+| `unknown` | 欠損時 fallback | 防御的デフォルト | Gate status | はい | 原則非推奨 | stop reasons で再分類される | 最低 |
+
+### 重要な明示
+
+- `allow` と `proceed` は同義ではありません。`allow` は legacy 入力互換、`proceed` は canonical 出力です。
+- `block` / `deny` / `rejected` は拒否系で、公開契約は `block` を正本とします。
+- `human_review_required` は **gate 値** であり、同名 boolean flag と並行して保持します。
+
+## B. business_decision 正式 semantics
+
+| 値 | 意味 | 利用タイミング | gate との組み合わせ |
+|---|---|---|---|
+| `APPROVE` | 案件ライフサイクル上で承認可能 | stop reason なし | 通常 `proceed` |
+| `DENY` | 案件拒否 | fail-closed 停止 | `block` |
+| `HOLD` | 案件保留 | 統制/証跡/ルール準備不足 | 通常 `hold` |
+| `REVIEW_REQUIRED` | 人手審査必須 | 境界曖昧/審査フラグ | `human_review_required` |
+| `POLICY_DEFINITION_REQUIRED` | ポリシー定義不足 | policy 定義要求理由が明示 | 多くは `hold` |
+| `EVIDENCE_REQUIRED` | 証拠不足 | missing_evidence が存在 | 多くは `hold` |
+
+## C. gate × business の禁則/許容
+
+| 組み合わせ | 判定 |
+|---|---|
+| `gate=block` + `business=APPROVE` | 不可 |
+| `gate=hold` + `business=APPROVE` | 不可 |
+| `gate=human_review_required` + `human_review_required=false` | 不可 |
+| `gate=proceed` + `business=DENY` | 不可 |
+| `gate=proceed` + `business=APPROVE` | 許容 |
+| `gate=hold` + `business=HOLD` | 許容 |
+| `gate=hold` + `business=EVIDENCE_REQUIRED` | 許容 |
+| `gate=human_review_required` + `business=REVIEW_REQUIRED` | 許容 |
+| legacy gate 値 + canonical business 値 | 非推奨だが現状許容 |
+
+## D. stop_reasons 優先順位（現実装）
+
+`_derive_business_fields` の判定順（現挙動）:
+
+1. `rollback_not_supported` → `block`
+2. `irreversible_action` + `audit_trail_incomplete` → `block`
+3. `secure_prod_controls_missing` → `block`
+4. 拒否系入力（`deny/rejected/block`）→ `block`
+5. `required_evidence_missing` → `hold`
+6. `high_risk_ambiguity`（`risk_score >= 0.8`）→ `human_review_required`
+7. `approval_boundary_unknown` または `human_review_required=true` → `human_review_required`
+8. `rule_undefined` / `audit_trail_incomplete` / `secure_controls_missing` または `hold/modify/abstain` → `hold`
+9. それ以外 → `proceed`
+
+## E. human_review_required の位置づけ
+
+- flag 意味: 実行前に人間の裁定が必要。
+- gate との関係: true または境界曖昧時に `gate_decision=human_review_required` へ昇格。
+- business との関係: 原則 `REVIEW_REQUIRED`。
+- UI 解釈: gate 値を主表示し、flag を審査義務として補助表示する。
+
+## F. decision_status との関係
+
+- `decision_status` は legacy 互換のため残存。
+- 公開契約は `gate_decision` / `business_decision` を優先。
+- 旧クライアントの `decision_status`（`allow|modify|rejected|block|abstain`）を継続受理する。

--- a/docs/ja/governance/required-evidence-taxonomy.md
+++ b/docs/ja/governance/required-evidence-taxonomy.md
@@ -1,0 +1,40 @@
+# Required Evidence Taxonomy v0（金融向け）
+
+## Current behavior
+
+現状ランタイムでは `required_evidence` / `missing_evidence` / `satisfied_evidence` は free string ベースで扱われます。
+
+## Legacy / alias values
+
+- free string は当面維持。
+- taxonomy v0 で canonical key と alias を追加し、正本化を開始。
+
+## Future tightening candidates
+
+- 取り込み時に alias から canonical key へ正規化。
+- 業界テンプレート単位で必須証拠プロファイルを強制。
+- 移行が安定した後に未知キー拒否を段階導入。
+
+## 用語
+
+- `required_evidence`: 判定に必要な証拠キー群。
+- `satisfied_evidence`: すでに充足済みの証拠キー群。
+- `missing_evidence`: `required_evidence - satisfied_evidence` で算出。
+
+機械可読の正本: `veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json`。
+
+## v0 カタログ
+
+| canonical key | 表示名 | category | aliases |
+|---|---|---|---|
+| `credit_bureau_report` | Credit Bureau Report | credit_underwriting | `bureau_report`, `credit_report`, `credit_file` |
+| `kyc_profile` | KYC Profile | identity_and_aml | `know_your_customer_profile`, `customer_identity_profile` |
+| `pep_screening_result` | PEP Screening Result | identity_and_aml | `pep_check`, `politically_exposed_person_screen` |
+| `sanctions_screening_trace` | Sanctions Screening Trace | sanctions | `sanctions_trace`, `ofac_screening_trace` |
+| `source_of_funds_record` | Source of Funds Record | aml_enhanced_due_diligence | `source_of_funds_document`, `sof_record` |
+| `approval_matrix` | Approval Matrix | governance_control | `approval_boundary_matrix`, `authority_matrix` |
+| `transaction_monitoring_trace` | Transaction Monitoring Trace | transaction_monitoring | `transaction_monitoring_log`, `tml_trace` |
+| `audit_trail_export` | Audit Trail Export | audit_and_attestation | `audit_log_export`, `audit_evidence_export` |
+| `secure_controls_attestation` | Secure Controls Attestation | security_controls | `security_controls_attestation`, `secure_controls_ready_attestation` |
+| `rollback_plan` | Rollback Plan | operational_resilience | `rollback_strategy`, `rollback_support_plan` |
+| `policy_definition_record` | Policy Definition Record | policy_governance | `policy_owner_confirmation`, `policy_definition_required_record` |

--- a/veritas_os/sample_data/governance/financial_regulatory_templates.json
+++ b/veritas_os/sample_data/governance/financial_regulatory_templates.json
@@ -5,6 +5,35 @@
     "decision_domain": "credit_underwriting",
     "title": "Credit underwriting blocks auto-approval when bureau data is missing",
     "question": "申込者の所得証明はあるが、主要信用情報機関の返却データが欠損している。自動承認してよいか？",
+    "context": {
+      "required_evidence": [
+        "credit_bureau_report",
+        "income_verification",
+        "affordability_assessment"
+      ],
+      "satisfied_evidence": [
+        "income_verification",
+        "affordability_assessment"
+      ],
+      "risk_score": 0.42,
+      "high_risk_ambiguity": false,
+      "irreversible_action": false,
+      "audit_trail_complete": true,
+      "approval_boundary_defined": true,
+      "rule_defined": true,
+      "secure_controls_ready": true
+    },
+    "expected_next_action": "COLLECT_REQUIRED_EVIDENCE",
+    "expected_rationale_summary": "信用情報欠損は fail-closed で hold とし、証拠収集を次アクションにする。",
+    "expected_required_evidence": [
+      "credit_bureau_report",
+      "income_verification",
+      "affordability_assessment"
+    ],
+    "expected_missing_evidence": [
+      "credit_bureau_report"
+    ],
+    "expected_human_review_required": false,
     "expected_governance_behavior": {
       "gate_decision": "hold",
       "business_decision": "EVIDENCE_REQUIRED",
@@ -27,6 +56,34 @@
     "decision_domain": "fraud_detection",
     "title": "Fraud detection chooses immediate block vs step-up authentication",
     "question": "既知の端末ではない高額カード決済。IP は通常地域だが、デバイス指紋と行動パターンが急変している。即時ブロックか追加認証か？",
+    "context": {
+      "required_evidence": [
+        "device_fingerprint_risk",
+        "behavioral_anomaly_score",
+        "transaction_velocity_features"
+      ],
+      "satisfied_evidence": [
+        "device_fingerprint_risk",
+        "behavioral_anomaly_score",
+        "transaction_velocity_features"
+      ],
+      "risk_score": 0.73,
+      "high_risk_ambiguity": false,
+      "irreversible_action": false,
+      "audit_trail_complete": true,
+      "approval_boundary_defined": true,
+      "rule_defined": false,
+      "secure_controls_ready": true
+    },
+    "expected_next_action": "COLLECT_REQUIRED_EVIDENCE",
+    "expected_rationale_summary": "高リスク信号が重なる場合は即時実行を避け、追加検証に寄せる。",
+    "expected_required_evidence": [
+      "device_fingerprint_risk",
+      "behavioral_anomaly_score",
+      "transaction_velocity_features"
+    ],
+    "expected_missing_evidence": [],
+    "expected_human_review_required": false,
     "expected_governance_behavior": {
       "gate_decision": "hold",
       "business_decision": "HOLD",
@@ -49,6 +106,37 @@
     "decision_domain": "aml_kyc",
     "title": "High-risk country transfer requires human review",
     "question": "KYC は完了しているが、PEP 関連者で高リスク国向けのクロスボーダー送金。自動通過できるか？",
+    "context": {
+      "required_evidence": [
+        "kyc_profile",
+        "pep_screening_result",
+        "source_of_funds_document",
+        "transaction_purpose_statement"
+      ],
+      "satisfied_evidence": [
+        "kyc_profile",
+        "pep_screening_result",
+        "source_of_funds_document",
+        "transaction_purpose_statement"
+      ],
+      "high_risk_ambiguity": true,
+      "risk_score": 0.91,
+      "irreversible_action": false,
+      "audit_trail_complete": true,
+      "approval_boundary_defined": true,
+      "rule_defined": true,
+      "secure_controls_ready": true
+    },
+    "expected_next_action": "PREPARE_HUMAN_REVIEW_PACKET",
+    "expected_rationale_summary": "高リスク曖昧性が高い場合は human review を優先し、自動通過しない。",
+    "expected_required_evidence": [
+      "kyc_profile",
+      "pep_screening_result",
+      "source_of_funds_document",
+      "transaction_purpose_statement"
+    ],
+    "expected_missing_evidence": [],
+    "expected_human_review_required": true,
     "expected_governance_behavior": {
       "gate_decision": "human_review_required",
       "business_decision": "REVIEW_REQUIRED",
@@ -72,6 +160,36 @@
     "decision_domain": "sanctions_screening",
     "title": "Partial sanctions match stays on hold until disambiguation",
     "question": "送金受取人名が制裁リストと部分一致し、生年月日が未取得。送金を継続してよいか？",
+    "context": {
+      "required_evidence": [
+        "beneficiary_date_of_birth",
+        "beneficiary_address",
+        "sanctions_screening_trace"
+      ],
+      "satisfied_evidence": [
+        "sanctions_screening_trace"
+      ],
+      "high_risk_ambiguity": true,
+      "risk_score": 0.66,
+      "human_review_required": true,
+      "irreversible_action": false,
+      "audit_trail_complete": true,
+      "approval_boundary_defined": true,
+      "rule_defined": true,
+      "secure_controls_ready": true
+    },
+    "expected_next_action": "COLLECT_REQUIRED_EVIDENCE",
+    "expected_rationale_summary": "部分一致時は hold し、識別証拠の補完を優先する。",
+    "expected_required_evidence": [
+      "beneficiary_date_of_birth",
+      "beneficiary_address",
+      "sanctions_screening_trace"
+    ],
+    "expected_missing_evidence": [
+      "beneficiary_date_of_birth",
+      "beneficiary_address"
+    ],
+    "expected_human_review_required": true,
     "expected_governance_behavior": {
       "gate_decision": "hold",
       "business_decision": "EVIDENCE_REQUIRED",
@@ -94,6 +212,35 @@
     "decision_domain": "client_suitability",
     "title": "Retail suitability for leveraged product",
     "question": "経験年数が短く損失許容度が低い個人顧客に高レバレッジ商品を提示してよいか？",
+    "context": {
+      "required_evidence": [
+        "investment_experience_profile",
+        "risk_tolerance_assessment",
+        "product_risk_disclosure_ack"
+      ],
+      "satisfied_evidence": [
+        "investment_experience_profile",
+        "risk_tolerance_assessment",
+        "product_risk_disclosure_ack"
+      ],
+      "high_risk_ambiguity": false,
+      "risk_score": 0.52,
+      "human_review_required": true,
+      "irreversible_action": false,
+      "audit_trail_complete": true,
+      "approval_boundary_defined": true,
+      "rule_defined": true,
+      "secure_controls_ready": true
+    },
+    "expected_next_action": "PREPARE_HUMAN_REVIEW_PACKET",
+    "expected_rationale_summary": "適合性の境界案件は human review を要求し、販売継続を即断しない。",
+    "expected_required_evidence": [
+      "investment_experience_profile",
+      "risk_tolerance_assessment",
+      "product_risk_disclosure_ack"
+    ],
+    "expected_missing_evidence": [],
+    "expected_human_review_required": true,
     "expected_governance_behavior": {
       "gate_decision": "hold",
       "business_decision": "REVIEW_REQUIRED",
@@ -116,6 +263,35 @@
     "decision_domain": "high_risk_transaction_hold",
     "title": "High-risk transaction pending release control",
     "question": "短時間で複数口座を経由する高額送金チェーンを検知。取引を即時実行すべきか？",
+    "context": {
+      "required_evidence": [
+        "transaction_chain_graph",
+        "counterparty_risk_rating",
+        "aml_alert_case_id"
+      ],
+      "satisfied_evidence": [
+        "transaction_chain_graph",
+        "counterparty_risk_rating",
+        "aml_alert_case_id"
+      ],
+      "high_risk_ambiguity": false,
+      "risk_score": 0.87,
+      "irreversible_action": true,
+      "audit_trail_complete": false,
+      "approval_boundary_defined": true,
+      "rule_defined": true,
+      "secure_controls_ready": true,
+      "human_review_required": true
+    },
+    "expected_next_action": "DO_NOT_EXECUTE",
+    "expected_rationale_summary": "不可逆操作かつ監査不備は block を優先し、実行停止する。",
+    "expected_required_evidence": [
+      "transaction_chain_graph",
+      "counterparty_risk_rating",
+      "aml_alert_case_id"
+    ],
+    "expected_missing_evidence": [],
+    "expected_human_review_required": true,
     "expected_governance_behavior": {
       "gate_decision": "block",
       "business_decision": "DENY",
@@ -138,6 +314,31 @@
     "decision_domain": "governance_boundary_control",
     "title": "Stop when approval boundary is undefined",
     "question": "与信・AML・制裁の複合案件だが、どの権限者が最終承認するか定義がない。処理を続けるべきか？",
+    "context": {
+      "required_evidence": [
+        "approval_matrix",
+        "policy_owner_confirmation"
+      ],
+      "satisfied_evidence": [
+        "approval_matrix",
+        "policy_owner_confirmation"
+      ],
+      "high_risk_ambiguity": false,
+      "risk_score": 0.48,
+      "irreversible_action": false,
+      "audit_trail_complete": true,
+      "approval_boundary_defined": false,
+      "rule_defined": true,
+      "secure_controls_ready": true
+    },
+    "expected_next_action": "PREPARE_HUMAN_REVIEW_PACKET",
+    "expected_rationale_summary": "承認境界未定義は human review 境界へエスカレーションし処理継続しない。",
+    "expected_required_evidence": [
+      "approval_matrix",
+      "policy_owner_confirmation"
+    ],
+    "expected_missing_evidence": [],
+    "expected_human_review_required": true,
     "expected_governance_behavior": {
       "gate_decision": "human_review_required",
       "business_decision": "REVIEW_REQUIRED",

--- a/veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json
+++ b/veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json
@@ -1,0 +1,95 @@
+{
+  "version": "v0",
+  "scope": "financial_services",
+  "allow_free_string": true,
+  "items": [
+    {
+      "canonical_key": "credit_bureau_report",
+      "display_label": "Credit Bureau Report",
+      "aliases": ["bureau_report", "credit_report", "credit_file"],
+      "category": "credit_underwriting",
+      "description": "External credit bureau output used for underwriting and affordability checks.",
+      "notes": "Retail and SME lending; keep bureau source and pull timestamp for audit."
+    },
+    {
+      "canonical_key": "kyc_profile",
+      "display_label": "KYC Profile",
+      "aliases": ["know_your_customer_profile", "customer_identity_profile"],
+      "category": "identity_and_aml",
+      "description": "Consolidated customer identity profile used for KYC verification.",
+      "notes": "Applies to onboarding and high-risk transaction reviews."
+    },
+    {
+      "canonical_key": "pep_screening_result",
+      "display_label": "PEP Screening Result",
+      "aliases": ["pep_check", "politically_exposed_person_screen"],
+      "category": "identity_and_aml",
+      "description": "Outcome and trace of politically exposed person screening.",
+      "notes": "Store match confidence and screening provider metadata."
+    },
+    {
+      "canonical_key": "sanctions_screening_trace",
+      "display_label": "Sanctions Screening Trace",
+      "aliases": ["sanctions_trace", "ofac_screening_trace"],
+      "category": "sanctions",
+      "description": "Sanctions screening execution trace including list version and match details.",
+      "notes": "Required when sanctions false-positive/true-positive adjudication is needed."
+    },
+    {
+      "canonical_key": "source_of_funds_record",
+      "display_label": "Source of Funds Record",
+      "aliases": ["source_of_funds_document", "sof_record"],
+      "category": "aml_enhanced_due_diligence",
+      "description": "Documented evidence for origin and legitimacy of funds.",
+      "notes": "Used in cross-border wires and enhanced due diligence scenarios."
+    },
+    {
+      "canonical_key": "approval_matrix",
+      "display_label": "Approval Matrix",
+      "aliases": ["approval_boundary_matrix", "authority_matrix"],
+      "category": "governance_control",
+      "description": "Authority boundary definition for who can approve which case types.",
+      "notes": "Cross-domain governance boundary control and escalation workflows."
+    },
+    {
+      "canonical_key": "transaction_monitoring_trace",
+      "display_label": "Transaction Monitoring Trace",
+      "aliases": ["transaction_monitoring_log", "tml_trace"],
+      "category": "transaction_monitoring",
+      "description": "Trace output of transaction monitoring rules/signals tied to the case.",
+      "notes": "Include rule hits and model signal snapshots when available."
+    },
+    {
+      "canonical_key": "audit_trail_export",
+      "display_label": "Audit Trail Export",
+      "aliases": ["audit_log_export", "audit_evidence_export"],
+      "category": "audit_and_attestation",
+      "description": "Export package of audit trail records supporting the decision lifecycle.",
+      "notes": "Needed for external audit submission and evidence bundles."
+    },
+    {
+      "canonical_key": "secure_controls_attestation",
+      "display_label": "Secure Controls Attestation",
+      "aliases": ["security_controls_attestation", "secure_controls_ready_attestation"],
+      "category": "security_controls",
+      "description": "Attestation proving required secure/prod controls are in place.",
+      "notes": "Critical for secure/prod fail-closed paths."
+    },
+    {
+      "canonical_key": "rollback_plan",
+      "display_label": "Rollback Plan",
+      "aliases": ["rollback_strategy", "rollback_support_plan"],
+      "category": "operational_resilience",
+      "description": "Documented rollback procedure for irreversible or high-impact operations.",
+      "notes": "Used when rollback capability gates decision execution."
+    },
+    {
+      "canonical_key": "policy_definition_record",
+      "display_label": "Policy Definition Record",
+      "aliases": ["policy_owner_confirmation", "policy_definition_required_record"],
+      "category": "policy_governance",
+      "description": "Record proving policy/rule definition and ownership for the decision domain.",
+      "notes": "Required when rule_undefined or boundary ownership issues appear."
+    }
+  ]
+}

--- a/veritas_os/tests/test_decision_semantics_docs.py
+++ b/veritas_os/tests/test_decision_semantics_docs.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Checks for newly added decision semantics / taxonomy documentation links."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DOC_FILES = [
+    Path("README.md"),
+    Path("docs/en/README.md"),
+    Path("docs/ja/README.md"),
+]
+
+
+def _extract_markdown_links(content: str) -> list[str]:
+    """Extract relative markdown links from markdown content."""
+    return re.findall(r"\[[^\]]+\]\(([^)]+)\)", content)
+
+
+def test_decision_semantics_docs_exist() -> None:
+    """Core semantics docs should exist in EN/JA."""
+    assert Path("docs/en/architecture/decision-semantics.md").exists()
+    assert Path("docs/ja/architecture/decision-semantics.md").exists()
+    assert Path("docs/en/governance/required-evidence-taxonomy.md").exists()
+    assert Path("docs/ja/governance/required-evidence-taxonomy.md").exists()
+
+
+def test_readme_links_to_new_decision_docs() -> None:
+    """README hubs should route to the new semantics/taxonomy docs."""
+    for path in DOC_FILES:
+        content = path.read_text(encoding="utf-8")
+        assert "decision-semantics" in content
+        assert "required-evidence-taxonomy" in content
+
+
+def test_new_doc_links_resolve() -> None:
+    """Relative links from modified doc hubs should resolve on disk."""
+    for path in DOC_FILES:
+        content = path.read_text(encoding="utf-8")
+        links = _extract_markdown_links(content)
+        for link in links:
+            if link.startswith(("http://", "https://", "#", "mailto:")):
+                continue
+            candidate = (path.parent / link).resolve()
+            assert candidate.exists(), f"Broken link in {path}: {link} -> {candidate}"

--- a/veritas_os/tests/test_financial_regulatory_templates.py
+++ b/veritas_os/tests/test_financial_regulatory_templates.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List, Literal
+from typing import Dict, List, Literal
 
 from pydantic import BaseModel, Field
 
@@ -14,6 +14,7 @@ from veritas_os.core.pipeline.pipeline_response import assemble_response
 from veritas_os.core.pipeline.pipeline_types import PipelineContext
 
 FIXTURE_PATH = Path("veritas_os/sample_data/governance/financial_regulatory_templates.json")
+TAXONOMY_PATH = Path("veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json")
 
 
 class ExpectedGovernanceBehavior(BaseModel):
@@ -52,13 +53,45 @@ class FinancialGovernanceTemplate(BaseModel):
     decision_domain: str
     title: str
     question: str
+    context: Dict[str, object]
+    expected_next_action: str = Field(min_length=1)
+    expected_rationale_summary: str = Field(min_length=1)
+    expected_required_evidence: List[str] = Field(min_length=1)
+    expected_missing_evidence: List[str] = Field(default_factory=list)
+    expected_human_review_required: bool
     expected_governance_behavior: ExpectedGovernanceBehavior
+
+
+class TaxonomyItem(BaseModel):
+    """Machine-readable required evidence taxonomy item."""
+
+    canonical_key: str
+    display_label: str
+    aliases: List[str]
+    category: str
+    description: str
+    notes: str
+
+
+class RequiredEvidenceTaxonomy(BaseModel):
+    """Required evidence taxonomy definition payload."""
+
+    version: str
+    scope: str
+    allow_free_string: bool
+    items: List[TaxonomyItem]
 
 
 def _load_templates() -> List[FinancialGovernanceTemplate]:
     """Load and parse the canonical financial governance fixture file."""
     raw_data = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
     return [FinancialGovernanceTemplate.model_validate(item) for item in raw_data]
+
+
+def _load_taxonomy() -> RequiredEvidenceTaxonomy:
+    """Load required evidence taxonomy fixture."""
+    payload = json.loads(TAXONOMY_PATH.read_text(encoding="utf-8"))
+    return RequiredEvidenceTaxonomy.model_validate(payload)
 
 
 def test_financial_templates_fixture_loads() -> None:
@@ -83,6 +116,17 @@ def test_financial_templates_include_mandatory_domains() -> None:
     assert "approval_boundary_undefined_stop" in template_ids
 
 
+def test_financial_template_shape_includes_context_and_expected_fields() -> None:
+    """Template fixtures must define context + explicit expected output fields."""
+    templates = _load_templates()
+
+    for template in templates:
+        assert isinstance(template.context.get("required_evidence"), list)
+        assert isinstance(template.context.get("satisfied_evidence"), list)
+        assert template.expected_required_evidence == template.expected_governance_behavior.required_evidence
+        assert template.expected_human_review_required is template.expected_governance_behavior.human_review_required
+
+
 def test_financial_templates_are_compatible_with_decide_response_schema() -> None:
     """Expected template outputs should map to the public DecideResponse schema."""
     templates = _load_templates()
@@ -95,10 +139,11 @@ def test_financial_templates_are_compatible_with_decide_response_schema() -> Non
                 "query": template.question,
                 "gate_decision": expected.gate_decision,
                 "business_decision": expected.business_decision,
-                "next_action": "COLLECT_REQUIRED_EVIDENCE",
+                "next_action": template.expected_next_action,
                 "required_evidence": expected.required_evidence,
+                "missing_evidence": template.expected_missing_evidence,
                 "human_review_required": expected.human_review_required,
-                "rationale": " | ".join(expected.rationale_expectations),
+                "rationale": template.expected_rationale_summary,
             }
         )
 
@@ -110,17 +155,15 @@ def test_financial_templates_are_compatible_with_decide_response_schema() -> Non
 
 def test_regression_approval_boundary_undefined_requires_human_review() -> None:
     """Approval boundary undefined case should fail closed to review-required."""
+    template_map = {item.template_id: item for item in _load_templates()}
+    template = template_map["approval_boundary_undefined_stop"]
     ctx = PipelineContext(
         request_id="financial-template-regression",
         query="承認境界が未定義の複合案件を継続できるか",
         fuji_dict={"decision_status": "allow", "status": "allow"},
         decision_status="allow",
         rejection_reason=None,
-        context={
-            "required_evidence": ["approval_matrix", "policy_owner_confirmation"],
-            "satisfied_evidence": ["approval_matrix", "policy_owner_confirmation"],
-            "approval_boundary_defined": False,
-        },
+        context=template.context,
     )
 
     payload = assemble_response(
@@ -136,49 +179,14 @@ def test_regression_approval_boundary_undefined_requires_human_review() -> None:
 
 def test_regression_representative_financial_templates_governance_alignment() -> None:
     """Representative templates should map to stable gate/business decisions."""
+    template_ids = [
+        "credit_missing_bureau_data_no_auto_approval",
+        "aml_kyc_high_risk_country_wire_manual_review",
+        "high_risk_transaction_pending_release",
+    ]
     templates = {item.template_id: item for item in _load_templates()}
-    fixture_contexts = {
-        "credit_missing_bureau_data_no_auto_approval": {
-            "required_evidence": [
-                "credit_bureau_report",
-                "income_verification",
-                "affordability_assessment",
-            ],
-            "satisfied_evidence": ["income_verification", "affordability_assessment"],
-        },
-        "aml_kyc_high_risk_country_wire_manual_review": {
-            "required_evidence": [
-                "kyc_profile",
-                "pep_screening_result",
-                "source_of_funds_document",
-                "transaction_purpose_statement",
-            ],
-            "satisfied_evidence": [
-                "kyc_profile",
-                "pep_screening_result",
-                "source_of_funds_document",
-                "transaction_purpose_statement",
-            ],
-            "high_risk_ambiguity": True,
-            "risk_score": 0.91,
-        },
-        "high_risk_transaction_pending_release": {
-            "required_evidence": [
-                "transaction_chain_graph",
-                "counterparty_risk_rating",
-                "aml_alert_case_id",
-            ],
-            "satisfied_evidence": [
-                "transaction_chain_graph",
-                "counterparty_risk_rating",
-                "aml_alert_case_id",
-            ],
-            "irreversible_action": True,
-            "audit_trail_complete": False,
-        },
-    }
 
-    for template_id, context in fixture_contexts.items():
+    for template_id in template_ids:
         template = templates[template_id]
         expected = template.expected_governance_behavior
         ctx = PipelineContext(
@@ -187,7 +195,7 @@ def test_regression_representative_financial_templates_governance_alignment() ->
             fuji_dict={"decision_status": "allow", "status": "allow"},
             decision_status="allow",
             rejection_reason=None,
-            context=context,
+            context=template.context,
         )
 
         payload = assemble_response(
@@ -197,3 +205,26 @@ def test_regression_representative_financial_templates_governance_alignment() ->
         )
         assert payload["gate_decision"] == expected.gate_decision
         assert payload["business_decision"] == expected.business_decision
+        assert payload["next_action"] == template.expected_next_action
+        assert payload["required_evidence"] == template.expected_required_evidence
+        assert payload["missing_evidence"] == template.expected_missing_evidence
+        assert payload["human_review_required"] is template.expected_human_review_required
+
+
+def test_required_evidence_taxonomy_has_unique_canonical_keys_and_aliases() -> None:
+    """Taxonomy canonical keys and aliases should stay collision-free."""
+    taxonomy = _load_taxonomy()
+    canonical_keys = [item.canonical_key for item in taxonomy.items]
+
+    assert taxonomy.version == "v0"
+    assert taxonomy.allow_free_string is True
+    assert len(canonical_keys) >= 11
+    assert len(canonical_keys) == len(set(canonical_keys))
+
+    alias_to_canonical: dict[str, str] = {}
+    for item in taxonomy.items:
+        for alias in item.aliases:
+            assert alias != item.canonical_key
+            existing = alias_to_canonical.get(alias)
+            assert existing in {None, item.canonical_key}
+            alias_to_canonical[alias] = item.canonical_key


### PR DESCRIPTION
### Motivation
- Reduce implicit, distributed governance semantics by documenting Phase-1 decision semantics and making fixture shapes authoritative without changing runtime logic. 
- Stabilize template-derived test fixtures and a minimal machine-readable evidence taxonomy to avoid duplicated ad-hoc strings and ease future Phase-1 work (templates, FUJI/value core, Evidence Bundles, Mission Control). 
- Surface and document current behavior (not a tightening): capture `gate_decision` vs `business_decision` mapping, stop-reasons priority, `human_review_required` positioning, and `decision_status` legacy handling so future changes are deliberate. 
- Security note: runtime still allows free-string evidence values; taxonomy v0 is introduced to reduce ambiguity but free-string allowance is retained for migration—this is documented as a migration risk to be tightened later. 

### Description
- Added Phase-1 canonical decision semantics docs in English and Japanese at `docs/en/architecture/decision-semantics.md` and `docs/ja/architecture/decision-semantics.md`, including gate/business semantics, forbidden combinations, stop-reason priority (current implementation order), and `human_review_required` positioning. 
- Added Required Evidence Taxonomy v0 docs (EN/JA) at `docs/en/governance/required-evidence-taxonomy.md` and `docs/ja/governance/required-evidence-taxonomy.md` and a machine-readable taxonomy fixture at `veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json` with canonical keys, aliases, category, description, and notes for the initial financial scope. 
- Canonicalized the financial governance templates file `veritas_os/sample_data/governance/financial_regulatory_templates.json` by adding per-template `context` and explicit expected fields: `expected_next_action`, `expected_rationale_summary`, `expected_required_evidence`, `expected_missing_evidence`, and `expected_human_review_required` (keeps prior `expected_governance_behavior`). 
- Refactored tests to consume template-derived context and validate shapes by updating `veritas_os/tests/test_financial_regulatory_templates.py` and adding `veritas_os/tests/test_decision_semantics_docs.py` to verify docs/README links; minimal README/doc-hub links were added to `README.md`, `docs/en/README.md`, and `docs/ja/README.md` to route to the new docs. 
- Non-invasive: no changes to core pipeline logic, Value Core weights, or FUJI gate runtime behavior; this PR is spec-first and fixture-first only. 

### Testing
- Ran the focused test suite: `pytest -q veritas_os/tests/test_financial_regulatory_templates.py veritas_os/tests/test_financial_poc_pack.py veritas_os/tests/test_decision_semantics_docs.py`, resulting in all tests passing (`14 passed`). 
- Added schema/shape validation in `veritas_os/tests/test_financial_regulatory_templates.py` for template shape and taxonomy integrity checks, and added a doc-link resolution test in `veritas_os/tests/test_decision_semantics_docs.py`; these automated tests succeeded. 
- Manual verification: validated that new docs exist and are reachable from README hubs and that the machine-readable taxonomy file loads and has unique canonical keys and non-colliding aliases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e074d8e8bc832684828249de2f3248)