### PR TITLE
Enforce decision semantics contract across runtime, validation, and evidence taxonomy

### DIFF
--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -12,6 +12,12 @@ from pydantic import (
     model_validator,
     field_validator,
 )
+from veritas_os.core.decision_semantics import (
+    canonicalize_gate_decision,
+    normalize_required_evidence_keys,
+    unique_preserve_order,
+    validate_gate_business_combination,
+)
 
 # =========================
 # Input Length Constraints (Security)
@@ -940,6 +946,26 @@ class DecideResponse(BaseModel):
                 len(extras),
                 sorted(extras.keys()),
             )
+
+        canonical_gate_decision = canonicalize_gate_decision(self.gate_decision)
+        if canonical_gate_decision != self.gate_decision:
+            self.gate_decision = canonical_gate_decision
+            events.append("coercion.gate_decision_canonicalized")
+
+        if self.required_evidence:
+            required_set = set(normalize_required_evidence_keys(self.required_evidence))
+            self.missing_evidence = [
+                item
+                for item in self.missing_evidence
+                if normalize_required_evidence_keys([item])[0] in required_set
+            ]
+            self.missing_evidence = unique_preserve_order(self.missing_evidence)
+
+        validate_gate_business_combination(
+            gate_decision=self.gate_decision,
+            business_decision=self.business_decision,
+            human_review_required=self.human_review_required,
+        )
 
         if events:
             unique_events = sorted(set(events))

--- a/veritas_os/core/decision_semantics.py
+++ b/veritas_os/core/decision_semantics.py
@@ -1,0 +1,192 @@
+"""Runtime contract helpers for public decision semantics.
+
+This module centralizes:
+- gate decision canonicalization (legacy aliases -> canonical public values),
+- stop-reason gate priority classification,
+- required evidence taxonomy normalization.
+
+The goal is to keep runtime behavior stable while making the semantics explicit
+and reusable across pipeline stages, schema validation, and adapters.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, Mapping
+
+CANONICAL_GATE_DECISIONS = {
+    "proceed",
+    "hold",
+    "block",
+    "human_review_required",
+}
+
+GATE_DECISION_ALIAS_TO_CANONICAL = {
+    "allow": "proceed",
+    "deny": "block",
+    "rejected": "block",
+    "modify": "hold",
+    "abstain": "hold",
+    "unknown": "proceed",
+    "proceed": "proceed",
+    "hold": "hold",
+    "block": "block",
+    "human_review_required": "human_review_required",
+}
+
+# Decision-semantics.md section D: single source-of-truth ordering.
+STOP_REASON_GATE_PRIORITY: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("rollback_not_supported",), "block"),
+    (("irreversible_action", "audit_trail_incomplete"), "block"),
+    (("secure_prod_controls_missing",), "block"),
+    (("required_evidence_missing",), "hold"),
+    (("high_risk_ambiguity",), "human_review_required"),
+    (("approval_boundary_unknown",), "human_review_required"),
+    (("rule_undefined",), "hold"),
+    (("audit_trail_incomplete",), "hold"),
+    (("secure_controls_missing",), "hold"),
+)
+
+STOP_REASONS_REQUIRING_HUMAN_REVIEW = {
+    "approval_boundary_unknown",
+    "high_risk_ambiguity",
+}
+
+TAXONOMY_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "sample_data"
+    / "governance"
+    / "required_evidence_taxonomy_v0.json"
+)
+
+
+@lru_cache(maxsize=1)
+def _load_required_evidence_taxonomy() -> dict[str, object]:
+    """Load required evidence taxonomy JSON once per process."""
+    with TAXONOMY_PATH.open("r", encoding="utf-8") as fp:
+        payload = json.load(fp)
+    if not isinstance(payload, dict):
+        return {"allow_free_string": True, "items": []}
+    return payload
+
+
+@lru_cache(maxsize=1)
+def get_required_evidence_alias_map() -> dict[str, str]:
+    """Return lower-cased alias->canonical map from taxonomy v0."""
+    payload = _load_required_evidence_taxonomy()
+    items = payload.get("items")
+    alias_to_canonical: dict[str, str] = {}
+    if not isinstance(items, list):
+        return alias_to_canonical
+
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        canonical = str(item.get("canonical_key", "")).strip()
+        if not canonical:
+            continue
+        canonical_lc = canonical.lower()
+        alias_to_canonical[canonical_lc] = canonical_lc
+        aliases = item.get("aliases")
+        if not isinstance(aliases, list):
+            continue
+        for alias in aliases:
+            alias_lc = str(alias).strip().lower()
+            if alias_lc:
+                alias_to_canonical.setdefault(alias_lc, canonical_lc)
+    return alias_to_canonical
+
+
+def canonicalize_gate_decision(value: object) -> str:
+    """Canonicalize gate_decision-compatible values.
+
+    Unknown values are preserved in lower-case for backward compatibility.
+    """
+    normalized = str(value or "unknown").strip().lower()
+    if not normalized:
+        normalized = "unknown"
+    return GATE_DECISION_ALIAS_TO_CANONICAL.get(normalized, normalized)
+
+
+def normalize_required_evidence_keys(values: Iterable[object] | None) -> list[str]:
+    """Normalize evidence keys via taxonomy aliases while keeping free strings."""
+    if values is None:
+        return []
+    alias_map = get_required_evidence_alias_map()
+    out: list[str] = []
+    for value in values:
+        key = str(value).strip().lower()
+        if not key:
+            continue
+        out.append(alias_map.get(key, key))
+    return out
+
+
+def unique_preserve_order(values: Iterable[str]) -> list[str]:
+    """Return unique items preserving first-seen order."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def derive_gate_decision_from_stop_reasons(
+    *,
+    stop_reasons: Iterable[str],
+    raw_gate_decision: str,
+    decision_status: str,
+    risk_score: float,
+    human_review_required: bool,
+) -> tuple[str, bool]:
+    """Classify canonical gate decision using a single priority definition."""
+    reasons = set(stop_reasons)
+    deny_family = {"deny", "rejected", "block"}
+    hold_family = {"hold", "modify", "abstain"}
+    # Decision-semantics.md section D priority order.
+    if "rollback_not_supported" in reasons:
+        return "block", human_review_required
+    if {"irreversible_action", "audit_trail_incomplete"} <= reasons:
+        return "block", human_review_required
+    if "secure_prod_controls_missing" in reasons:
+        return "block", human_review_required
+    if raw_gate_decision in deny_family or decision_status in deny_family:
+        return "block", human_review_required
+    if "required_evidence_missing" in reasons:
+        return "hold", human_review_required
+    if "high_risk_ambiguity" in reasons and risk_score >= 0.8:
+        return "human_review_required", True
+    if "approval_boundary_unknown" in reasons or human_review_required:
+        return "human_review_required", True
+    if (
+        {"rule_undefined", "audit_trail_incomplete", "secure_controls_missing"} & reasons
+        or raw_gate_decision in hold_family
+    ):
+        return "hold", human_review_required
+    return "proceed", human_review_required
+
+
+def validate_gate_business_combination(
+    *, gate_decision: str, business_decision: str, human_review_required: bool
+) -> None:
+    """Raise ValueError when gate/business combination is forbidden."""
+    forbidden = {
+        ("block", "APPROVE"),
+        ("hold", "APPROVE"),
+        ("proceed", "DENY"),
+    }
+    if (gate_decision, business_decision) in forbidden:
+        raise ValueError(
+            "forbidden gate/business combination: "
+            f"gate_decision={gate_decision}, business_decision={business_decision}"
+        )
+    if gate_decision == "human_review_required" and not human_review_required:
+        raise ValueError(
+            "forbidden combination: gate_decision=human_review_required "
+            "requires human_review_required=true"
+        )

--- a/veritas_os/core/decision_semantics.py
+++ b/veritas_os/core/decision_semantics.py
@@ -29,7 +29,9 @@ GATE_DECISION_ALIAS_TO_CANONICAL = {
     "rejected": "block",
     "modify": "hold",
     "abstain": "hold",
-    "unknown": "proceed",
+    # Keep unknown as-is for schema default/backward compatibility.
+    # Runtime derivation later resolves fallback to proceed when needed.
+    "unknown": "unknown",
     "proceed": "proceed",
     "hold": "hold",
     "block": "block",

--- a/veritas_os/core/pipeline/pipeline_policy.py
+++ b/veritas_os/core/pipeline/pipeline_policy.py
@@ -31,6 +31,10 @@ from .pipeline_types import (
 )
 from .pipeline_helpers import _lazy_import, _apply_value_boost, _warn
 from .pipeline_evidence import _norm_evidence_item
+from veritas_os.core.decision_semantics import (
+    normalize_required_evidence_keys,
+    unique_preserve_order,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -472,17 +476,18 @@ def stage_gate_decision(ctx: PipelineContext) -> None:
     # Context-aware fail-closed stop conditions.
     # Keep this stage focused on FUJI gate posture, and leave public shaping
     # (business_decision / next_action) to pipeline_response.
-    required_evidence = [
-        str(item).strip()
-        for item in (ctx.context.get("required_evidence") or [])
-        if str(item).strip()
-    ]
-    satisfied_evidence = {
-        str(item).strip()
-        for item in (ctx.context.get("satisfied_evidence") or [])
-        if str(item).strip()
-    }
-    missing_evidence = [item for item in required_evidence if item not in satisfied_evidence]
+    required_evidence = unique_preserve_order(
+        [str(item).strip().lower() for item in (ctx.context.get("required_evidence") or []) if str(item).strip()]
+    )
+    satisfied_evidence = unique_preserve_order(
+        [str(item).strip().lower() for item in (ctx.context.get("satisfied_evidence") or []) if str(item).strip()]
+    )
+    satisfied_canonical = set(normalize_required_evidence_keys(satisfied_evidence))
+    missing_evidence = []
+    for item in required_evidence:
+        canonical_item = normalize_required_evidence_keys([item])[0]
+        if canonical_item not in satisfied_canonical:
+            missing_evidence.append(item)
     if ctx.decision_status == "allow" and missing_evidence:
         ctx.decision_status = "hold"
         ctx.context["human_review_required"] = True

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -20,6 +20,12 @@ except ImportError:  # pragma: no cover - pydantic is optional at core layer
 from .pipeline_types import PipelineContext
 from .pipeline_evidence import _norm_evidence_item, _dedupe_evidence
 from .pipeline_helpers import _warn
+from veritas_os.core.decision_semantics import (
+    canonicalize_gate_decision,
+    derive_gate_decision_from_stop_reasons,
+    normalize_required_evidence_keys,
+    unique_preserve_order,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -310,7 +316,7 @@ def _build_question_first_answer(
 def _as_string_list(value: Any) -> list[str]:
     """Normalize arbitrary values to a list[str] for public response fields."""
     if isinstance(value, list):
-        return [str(item).strip() for item in value if str(item).strip()]
+        return [str(item).strip().lower() for item in value if str(item).strip()]
     return []
 
 
@@ -379,9 +385,14 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         or "unknown"
     ).lower()
     gate_reason = str(ctx.rejection_reason or ctx.fuji_dict.get("rejection_reason") or "").strip()
-    required_evidence = _as_string_list(ctx.context.get("required_evidence"))
-    satisfied_evidence = set(_as_string_list(ctx.context.get("satisfied_evidence")))
-    missing_evidence = [item for item in required_evidence if item not in satisfied_evidence]
+    required_evidence = unique_preserve_order(_as_string_list(ctx.context.get("required_evidence")))
+    satisfied_evidence = unique_preserve_order(_as_string_list(ctx.context.get("satisfied_evidence")))
+    satisfied_canonical = set(normalize_required_evidence_keys(satisfied_evidence))
+    missing_evidence = []
+    for item in required_evidence:
+        canonical_item = normalize_required_evidence_keys([item])[0]
+        if canonical_item not in satisfied_canonical:
+            missing_evidence.append(item)
 
     fuji_status = str(ctx.fuji_dict.get("status") or "").lower()
     try:
@@ -399,33 +410,14 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         context=ctx.context,
     )
 
-    if "rollback_not_supported" in stop_reasons:
-        gate_decision = "block"
-    elif "irreversible_action" in stop_reasons and "audit_trail_incomplete" in stop_reasons:
-        gate_decision = "block"
-    elif "secure_prod_controls_missing" in stop_reasons:
-        gate_decision = "block"
-    elif raw_gate_decision in {"deny", "rejected", "block"} or str(ctx.decision_status).lower() in {"rejected", "block"}:
-        gate_decision = "block"
-    elif "required_evidence_missing" in stop_reasons:
-        gate_decision = "hold"
-    elif "high_risk_ambiguity" in stop_reasons and risk_score >= 0.8:
-        gate_decision = "human_review_required"
-        human_review_required = True
-    elif "approval_boundary_unknown" in stop_reasons or human_review_required:
-        gate_decision = "human_review_required"
-        human_review_required = True
-    elif any(
-        item in stop_reasons
-        for item in {
-            "rule_undefined",
-            "audit_trail_incomplete",
-            "secure_controls_missing",
-        }
-    ) or raw_gate_decision in {"hold", "modify", "abstain"}:
-        gate_decision = "hold"
-    else:
-        gate_decision = "proceed"
+    gate_decision, human_review_required = derive_gate_decision_from_stop_reasons(
+        stop_reasons=stop_reasons,
+        raw_gate_decision=raw_gate_decision,
+        decision_status=str(ctx.decision_status).lower(),
+        risk_score=risk_score,
+        human_review_required=human_review_required,
+    )
+    gate_decision = canonicalize_gate_decision(gate_decision)
 
     if missing_evidence:
         business_decision = "EVIDENCE_REQUIRED"

--- a/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
+++ b/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
@@ -1,0 +1,96 @@
+from pydantic import ValidationError
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.core.pipeline.pipeline_response import assemble_response
+from veritas_os.core.pipeline.pipeline_types import PipelineContext
+
+
+def test_gate_decision_alias_is_canonicalized_in_schema() -> None:
+    """legacy gate aliases should normalize to canonical public semantics."""
+    payload = DecideResponse.model_validate(
+        {
+            "gate_decision": "deny",
+            "business_decision": "DENY",
+            "human_review_required": False,
+        }
+    )
+
+    assert payload.gate_decision == "block"
+
+
+def test_forbidden_gate_business_combination_is_rejected() -> None:
+    """Invalid gate/business combinations must be blocked at validation."""
+    try:
+        DecideResponse.model_validate(
+            {
+                "gate_decision": "proceed",
+                "business_decision": "DENY",
+            }
+        )
+    except ValidationError as exc:
+        assert "forbidden gate/business combination" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("ValidationError was expected")
+
+
+def test_stop_reason_priority_prefers_block_over_required_evidence() -> None:
+    """Block-priority stop reasons must override evidence-hold reasons."""
+    ctx = PipelineContext(
+        request_id="req-stop-priority",
+        query="test",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        context={
+            "rollback_supported": False,
+            "required_evidence": ["approval_ticket"],
+            "satisfied_evidence": [],
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "block"
+    assert payload["business_decision"] == "EVIDENCE_REQUIRED"
+    assert "rollback_not_supported" in payload["rationale"]
+
+
+def test_required_evidence_taxonomy_aliases_are_normalized() -> None:
+    """Taxonomy aliases should be treated equivalent for missing detection."""
+    ctx = PipelineContext(
+        request_id="req-taxonomy",
+        query="test",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        context={
+            "required_evidence": ["bureau_report", "approval_boundary_matrix"],
+            "satisfied_evidence": ["credit_bureau_report"],
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["required_evidence"] == ["bureau_report", "approval_boundary_matrix"]
+    assert payload["missing_evidence"] == ["approval_boundary_matrix"]
+
+
+def test_backward_compat_decision_status_stays_legacy_field() -> None:
+    """decision_status remains distinct from public gate semantics."""
+    payload = DecideResponse.model_validate(
+        {
+            "decision_status": "allow",
+            "gate_decision": "allow",
+            "business_decision": "APPROVE",
+            "human_review_required": False,
+        }
+    )
+
+    assert payload.decision_status == "allow"
+    assert payload.gate_decision == "proceed"


### PR DESCRIPTION
### Motivation
- Operationalize the decision-semantics and required-evidence taxonomy docs so runtime, API validation, and adapters share one source-of-truth to reduce false-pass/false-fail outcomes.  
- Centralize gate decision canonicalization and stop-reason priority to avoid duplicated logic and inconsistent behavior across pipeline stages.  
- Make required-evidence comparisons taxonomy-aware (alias → canonical mapping) while preserving free-string backward compatibility.  
- Enforce forbidden `gate_decision × business_decision` combinations at schema validation to surface contract violations early.

### Description
- Added `veritas_os/core/decision_semantics.py` to centralize: gate alias→canonical mapping, stop-reason priority resolution, required-evidence taxonomy loading/alias map, and gate/business forbidden-combination validation.  
- Updated `veritas_os/core/pipeline/pipeline_response.py` to use the shared semantics (canonicalization, single stop-reason priority via `derive_gate_decision_from_stop_reasons`, and taxonomy-aware missing-evidence computation) when deriving public `gate_decision` / `business_decision`.  
- Updated `veritas_os/core/pipeline/pipeline_policy.py` (gate stage) to compute evidence gaps equivalently using the taxonomy aliases so the FUJI-stage `decision_status`/hold behavior aligns with public semantics.  
- Extended `veritas_os/api/schemas.py::DecideResponse` post-validation to canonicalize `gate_decision`, apply taxonomy-aware consistency for `missing_evidence ⊆ required_evidence`, and call `validate_gate_business_combination()` to reject forbidden combinations.  
- Added focused unit tests `veritas_os/tests/unit/test_decision_semantics_runtime_contract.py` covering alias canonicalization, forbidden-combination validation, stop-reason priority regression, taxonomy equivalence for evidence gaps, and backward-compat `decision_status` separation.

### Testing
- Ran focused unit-suite with: `pytest -q veritas_os/tests/unit/test_decision_semantics_runtime_contract.py veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py veritas_os/tests/unit/test_pipeline_gate_stop_conditions.py veritas_os/tests/test_financial_regulatory_templates.py` which completed successfully (27 passed).  
- Ran integration/coverage subset with: `pytest -q veritas_os/tests/integration/test_decision_sample_question_schema.py veritas_os/tests/test_schemas_extra_v2.py` which completed successfully (47 passed).  
- All automated tests executed in the CI sandbox passed after iterative fixes; new tests assert the five required behaviors (alias → canonical conversion, forbidden-combination validation, stop-reason priority, required-evidence alias handling, and backward-compat decision_status semantics).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c0496f48832695859207e6ecdf65)