### PR TITLE
Canonicalize financial governance templates into extensible industry pack

### DIFF
--- a/docs/en/governance/required-evidence-taxonomy.md
+++ b/docs/en/governance/required-evidence-taxonomy.md
@@ -2,11 +2,13 @@
 
 ## Current behavior
 
-`required_evidence`, `missing_evidence`, and `satisfied_evidence` are currently handled as free strings in runtime context.
+`required_evidence`, `missing_evidence`, and `satisfied_evidence` are carried in runtime context.
+For the financial industry pack, canonical taxonomy keys are the primary contract.
 
 ## Legacy / alias values
 
-- Free-string evidence keys remain allowed.
+- Canonical keys should be emitted first.
+- Free-string evidence values are treated as alias inputs only.
 - Taxonomy v0 introduces canonical keys and aliases for normalization.
 
 ## Future tightening candidates

--- a/docs/en/guides/financial-governance-templates.md
+++ b/docs/en/guides/financial-governance-templates.md
@@ -13,18 +13,48 @@ The templates are intentionally designed to verify fail-closed behavior around:
 - explicit human review boundaries, and
 - separation between `gate_decision` and `business_decision`.
 
-## Fixture Location
+## Canonical Industry Pack Location
 
 - Canonical fixture: `veritas_os/sample_data/governance/financial_regulatory_templates.json`
+
+The fixture is a **pack object** with metadata and a `templates` array.
+
+Pack-level fields include:
+
+- `pack_id` / `pack_type` / `industry` / `version`
+- `taxonomy_policy` (canonical taxonomy key policy and alias handling)
+- `beachhead` (starter domain and representative template)
 
 Each template entry includes:
 
 - `question`
-- `expected_governance_behavior.gate_decision`
-- `expected_governance_behavior.business_decision`
-- `expected_governance_behavior.required_evidence`
-- `expected_governance_behavior.human_review_required`
-- `expected_governance_behavior.rationale_expectations`
+- `context`
+- `expected_semantics.gate_decision`
+- `expected_semantics.business_decision`
+- `expected_semantics.next_action`
+- `expected_semantics.required_evidence` / `missing_evidence`
+- `expected_semantics.human_review_required`
+- `expected_semantics.rationale_summary` / `rationale_expectations`
+
+## Beachhead
+
+Current beachhead is `aml_kyc` with template
+`aml_kyc_high_risk_country_wire_manual_review`.
+This domain is used as the first expansion anchor because it combines:
+
+- high regulatory sensitivity,
+- evidence-first progression requirements, and
+- explicit human review boundaries.
+
+## Role Split: Regulatory Templates vs PoC Questions
+
+- **Regulatory templates** (`financial_regulatory_templates.json`)
+  - Canonical, context-rich fixtures for regression and contract validation.
+  - Carry full `context` and complete expected semantics for deterministic tests.
+- **PoC questions** (`financial_poc_questions.json`)
+  - Lightweight scenario prompts for demo and rapid PoC runs.
+  - May reference `template_id` directly to avoid reverse lookup from
+    `fixture_contexts`/category heuristics.
 
 ## What This Verifies
 

--- a/docs/ja/guides/poc-pack-financial-quickstart.md
+++ b/docs/ja/guides/poc-pack-financial-quickstart.md
@@ -61,6 +61,11 @@ docker compose up --build
 - `veritas_os/sample_data/governance/financial_poc_questions.json`
 - 既存テンプレート: `veritas_os/sample_data/governance/financial_regulatory_templates.json`
 
+役割分担:
+- `financial_poc_questions.json`: PoC 実行用の軽量質問セット（期待セマンティクス確認向け）
+- `financial_regulatory_templates.json`: 回帰検証用の canonical industry pack（`context` と完全期待値を保持）
+- PoC 質問は `template_id` を持てるため、`fixture_contexts` の逆引きなしで canonical template に接続できます。
+
 最低 5 件（推奨 8 件）を `/v1/decide` に投入し、各ケースで期待セマンティクスを照合します。
 
 ### Step 3: UI / API / Bundle の3点確認（120分）
@@ -156,4 +161,3 @@ PoC レビュー会では、次の順序で示すと伝わりやすいです。
 - **実データ禁止**: 顧客情報・口座番号・実在個人データは投入しない。
 - **鍵管理**: `.env` の API secret/鍵は共有しない。PoC 用にローテーション前提の値を使う。
 - **外部連携**: 本番の承認系/送金系への接続は PoC で行わない（read-only 参照に限定）。
-

--- a/veritas_os/sample_data/governance/financial_poc_questions.json
+++ b/veritas_os/sample_data/governance/financial_poc_questions.json
@@ -13,7 +13,8 @@
         "affordability_assessment"
       ],
       "human_review_required": false
-    }
+    },
+    "template_id": "credit_missing_bureau_data_no_auto_approval"
   },
   {
     "question_id": "poc_fraud_stepup_vs_block",
@@ -29,7 +30,8 @@
         "transaction_velocity_features"
       ],
       "human_review_required": false
-    }
+    },
+    "template_id": "fraud_realtime_block_vs_stepup_auth"
   },
   {
     "question_id": "poc_aml_pep_high_risk_country",
@@ -46,7 +48,8 @@
         "transaction_purpose_statement"
       ],
       "human_review_required": true
-    }
+    },
+    "template_id": "aml_kyc_high_risk_country_wire_manual_review"
   },
   {
     "question_id": "poc_sanctions_partial_match",
@@ -62,7 +65,8 @@
         "sanctions_screening_trace"
       ],
       "human_review_required": true
-    }
+    },
+    "template_id": "sanctions_partial_name_match_hold"
   },
   {
     "question_id": "poc_suitability_leveraged_product",
@@ -78,7 +82,8 @@
         "product_risk_disclosure_ack"
       ],
       "human_review_required": true
-    }
+    },
+    "template_id": "suitability_leveraged_product_retail_client"
   },
   {
     "question_id": "poc_high_risk_transaction_chain",
@@ -94,7 +99,8 @@
         "aml_alert_case_id"
       ],
       "human_review_required": true
-    }
+    },
+    "template_id": "high_risk_transaction_pending_release"
   },
   {
     "question_id": "poc_approval_boundary_undefined",
@@ -109,7 +115,8 @@
         "policy_owner_confirmation"
       ],
       "human_review_required": true
-    }
+    },
+    "template_id": "approval_boundary_undefined_stop"
   },
   {
     "question_id": "poc_cross_border_purpose_unknown",

--- a/veritas_os/sample_data/governance/financial_regulatory_templates.json
+++ b/veritas_os/sample_data/governance/financial_regulatory_templates.json
@@ -1,357 +1,330 @@
-[
-  {
-    "template_id": "credit_missing_bureau_data_no_auto_approval",
-    "industry": "financial_services",
-    "decision_domain": "credit_underwriting",
-    "title": "Credit underwriting blocks auto-approval when bureau data is missing",
-    "question": "申込者の所得証明はあるが、主要信用情報機関の返却データが欠損している。自動承認してよいか？",
-    "context": {
-      "required_evidence": [
-        "credit_bureau_report",
-        "income_verification",
-        "affordability_assessment"
-      ],
-      "satisfied_evidence": [
-        "income_verification",
-        "affordability_assessment"
-      ],
-      "risk_score": 0.42,
-      "high_risk_ambiguity": false,
-      "irreversible_action": false,
-      "audit_trail_complete": true,
-      "approval_boundary_defined": true,
-      "rule_defined": true,
-      "secure_controls_ready": true
-    },
-    "expected_next_action": "COLLECT_REQUIRED_EVIDENCE",
-    "expected_rationale_summary": "信用情報欠損は fail-closed で hold とし、証拠収集を次アクションにする。",
-    "expected_required_evidence": [
-      "credit_bureau_report",
-      "income_verification",
-      "affordability_assessment"
-    ],
-    "expected_missing_evidence": [
-      "credit_bureau_report"
-    ],
-    "expected_human_review_required": false,
-    "expected_governance_behavior": {
-      "gate_decision": "hold",
-      "business_decision": "EVIDENCE_REQUIRED",
-      "required_evidence": [
-        "credit_bureau_report",
-        "income_verification",
-        "affordability_assessment"
-      ],
-      "human_review_required": false,
-      "rationale_expectations": [
-        "信用情報の欠損時は fail-closed で審査を停止する",
-        "案件承認ではなく証拠収集を次アクションとして提示する",
-        "法的適法性の断定はせず、統治上の証拠不足として扱う"
-      ]
-    }
+{
+  "pack_id": "financial_regulatory_industry_pack_v1",
+  "pack_type": "industry_governance_templates",
+  "industry": "financial_services",
+  "version": "1.0.0",
+  "taxonomy_policy": {
+    "primary_keys": "canonical_required_evidence_taxonomy_keys",
+    "free_string_alias_handling": "allowed_as_alias_only"
   },
-  {
-    "template_id": "fraud_realtime_block_vs_stepup_auth",
-    "industry": "payments",
-    "decision_domain": "fraud_detection",
-    "title": "Fraud detection chooses immediate block vs step-up authentication",
-    "question": "既知の端末ではない高額カード決済。IP は通常地域だが、デバイス指紋と行動パターンが急変している。即時ブロックか追加認証か？",
-    "context": {
-      "required_evidence": [
-        "device_fingerprint_risk",
-        "behavioral_anomaly_score",
-        "transaction_velocity_features"
-      ],
-      "satisfied_evidence": [
-        "device_fingerprint_risk",
-        "behavioral_anomaly_score",
-        "transaction_velocity_features"
-      ],
-      "risk_score": 0.73,
-      "high_risk_ambiguity": false,
-      "irreversible_action": false,
-      "audit_trail_complete": true,
-      "approval_boundary_defined": true,
-      "rule_defined": false,
-      "secure_controls_ready": true
-    },
-    "expected_next_action": "COLLECT_REQUIRED_EVIDENCE",
-    "expected_rationale_summary": "高リスク信号が重なる場合は即時実行を避け、追加検証に寄せる。",
-    "expected_required_evidence": [
-      "device_fingerprint_risk",
-      "behavioral_anomaly_score",
-      "transaction_velocity_features"
-    ],
-    "expected_missing_evidence": [],
-    "expected_human_review_required": false,
-    "expected_governance_behavior": {
-      "gate_decision": "hold",
-      "business_decision": "HOLD",
-      "required_evidence": [
-        "device_fingerprint_risk",
-        "behavioral_anomaly_score",
-        "transaction_velocity_features"
-      ],
-      "human_review_required": false,
-      "rationale_expectations": [
-        "即時実行を避け、step-up 認証など追加検証へ誘導する",
-        "高リスク信号が重なる場合に fail-open しない",
-        "詐欺確定の断定ではなくリスク抑制行動を優先する"
-      ]
-    }
-  },
-  {
-    "template_id": "aml_kyc_high_risk_country_wire_manual_review",
-    "industry": "banking",
+  "beachhead": {
     "decision_domain": "aml_kyc",
-    "title": "High-risk country transfer requires human review",
-    "question": "KYC は完了しているが、PEP 関連者で高リスク国向けのクロスボーダー送金。自動通過できるか？",
-    "context": {
-      "required_evidence": [
-        "kyc_profile",
-        "pep_screening_result",
-        "source_of_funds_document",
-        "transaction_purpose_statement"
-      ],
-      "satisfied_evidence": [
-        "kyc_profile",
-        "pep_screening_result",
-        "source_of_funds_document",
-        "transaction_purpose_statement"
-      ],
-      "high_risk_ambiguity": true,
-      "risk_score": 0.91,
-      "irreversible_action": false,
-      "audit_trail_complete": true,
-      "approval_boundary_defined": true,
-      "rule_defined": true,
-      "secure_controls_ready": true
-    },
-    "expected_next_action": "PREPARE_HUMAN_REVIEW_PACKET",
-    "expected_rationale_summary": "高リスク曖昧性が高い場合は human review を優先し、自動通過しない。",
-    "expected_required_evidence": [
-      "kyc_profile",
-      "pep_screening_result",
-      "source_of_funds_document",
-      "transaction_purpose_statement"
-    ],
-    "expected_missing_evidence": [],
-    "expected_human_review_required": true,
-    "expected_governance_behavior": {
-      "gate_decision": "human_review_required",
-      "business_decision": "REVIEW_REQUIRED",
-      "required_evidence": [
-        "kyc_profile",
-        "pep_screening_result",
-        "source_of_funds_document",
-        "transaction_purpose_statement"
-      ],
-      "human_review_required": true,
-      "rationale_expectations": [
-        "高リスク国送金は人手審査境界へエスカレーションする",
-        "顧客属性と送金文脈を合わせて証拠化する",
-        "AML 違反の断定ではなく保留・審査で管理する"
-      ]
-    }
+    "template_id": "aml_kyc_high_risk_country_wire_manual_review",
+    "why": "high regulatory sensitivity with evidence-first escalation and clear human review boundaries"
   },
-  {
-    "template_id": "sanctions_partial_name_match_hold",
-    "industry": "banking",
-    "decision_domain": "sanctions_screening",
-    "title": "Partial sanctions match stays on hold until disambiguation",
-    "question": "送金受取人名が制裁リストと部分一致し、生年月日が未取得。送金を継続してよいか？",
-    "context": {
-      "required_evidence": [
-        "beneficiary_date_of_birth",
-        "beneficiary_address",
-        "sanctions_screening_trace"
-      ],
-      "satisfied_evidence": [
-        "sanctions_screening_trace"
-      ],
-      "high_risk_ambiguity": true,
-      "risk_score": 0.66,
-      "human_review_required": true,
-      "irreversible_action": false,
-      "audit_trail_complete": true,
-      "approval_boundary_defined": true,
-      "rule_defined": true,
-      "secure_controls_ready": true
+  "templates": [
+    {
+      "template_id": "credit_missing_bureau_data_no_auto_approval",
+      "industry": "financial_services",
+      "decision_domain": "credit_underwriting",
+      "title": "Credit underwriting blocks auto-approval when bureau data is missing",
+      "question": "申込者の所得証明はあるが、主要信用情報機関の返却データが欠損している。自動承認してよいか？",
+      "context": {
+        "required_evidence": [
+          "credit_bureau_report",
+          "income_verification",
+          "affordability_assessment"
+        ],
+        "satisfied_evidence": [
+          "income_verification",
+          "affordability_assessment"
+        ],
+        "risk_score": 0.42,
+        "high_risk_ambiguity": false,
+        "irreversible_action": false,
+        "audit_trail_complete": true,
+        "approval_boundary_defined": true,
+        "rule_defined": true,
+        "secure_controls_ready": true
+      },
+      "expected_semantics": {
+        "gate_decision": "hold",
+        "business_decision": "EVIDENCE_REQUIRED",
+        "next_action": "COLLECT_REQUIRED_EVIDENCE",
+        "required_evidence": [
+          "credit_bureau_report",
+          "income_verification",
+          "affordability_assessment"
+        ],
+        "missing_evidence": [
+          "credit_bureau_report"
+        ],
+        "human_review_required": false,
+        "rationale_summary": "信用情報欠損は fail-closed で hold とし、証拠収集を次アクションにする。",
+        "rationale_expectations": [
+          "信用情報の欠損時は fail-closed で審査を停止する",
+          "案件承認ではなく証拠収集を次アクションとして提示する",
+          "法的適法性の断定はせず、統治上の証拠不足として扱う"
+        ]
+      }
     },
-    "expected_next_action": "COLLECT_REQUIRED_EVIDENCE",
-    "expected_rationale_summary": "部分一致時は hold し、識別証拠の補完を優先する。",
-    "expected_required_evidence": [
-      "beneficiary_date_of_birth",
-      "beneficiary_address",
-      "sanctions_screening_trace"
-    ],
-    "expected_missing_evidence": [
-      "beneficiary_date_of_birth",
-      "beneficiary_address"
-    ],
-    "expected_human_review_required": true,
-    "expected_governance_behavior": {
-      "gate_decision": "hold",
-      "business_decision": "EVIDENCE_REQUIRED",
-      "required_evidence": [
-        "beneficiary_date_of_birth",
-        "beneficiary_address",
-        "sanctions_screening_trace"
-      ],
-      "human_review_required": true,
-      "rationale_expectations": [
-        "部分一致の時点では自動通過せず保留する",
-        "同一人物確認に必要な識別証拠を明示する",
-        "制裁対象と断定せず、誤検知リスクも含めて審査へ送る"
-      ]
-    }
-  },
-  {
-    "template_id": "suitability_leveraged_product_retail_client",
-    "industry": "securities",
-    "decision_domain": "client_suitability",
-    "title": "Retail suitability for leveraged product",
-    "question": "経験年数が短く損失許容度が低い個人顧客に高レバレッジ商品を提示してよいか？",
-    "context": {
-      "required_evidence": [
-        "investment_experience_profile",
-        "risk_tolerance_assessment",
-        "product_risk_disclosure_ack"
-      ],
-      "satisfied_evidence": [
-        "investment_experience_profile",
-        "risk_tolerance_assessment",
-        "product_risk_disclosure_ack"
-      ],
-      "high_risk_ambiguity": false,
-      "risk_score": 0.52,
-      "human_review_required": true,
-      "irreversible_action": false,
-      "audit_trail_complete": true,
-      "approval_boundary_defined": true,
-      "rule_defined": true,
-      "secure_controls_ready": true
+    {
+      "template_id": "fraud_realtime_block_vs_stepup_auth",
+      "industry": "payments",
+      "decision_domain": "fraud_detection",
+      "title": "Fraud detection chooses immediate block vs step-up authentication",
+      "question": "既知の端末ではない高額カード決済。IP は通常地域だが、デバイス指紋と行動パターンが急変している。即時ブロックか追加認証か？",
+      "context": {
+        "required_evidence": [
+          "device_fingerprint_risk",
+          "behavioral_anomaly_score",
+          "transaction_velocity_features"
+        ],
+        "satisfied_evidence": [
+          "device_fingerprint_risk",
+          "behavioral_anomaly_score",
+          "transaction_velocity_features"
+        ],
+        "risk_score": 0.73,
+        "high_risk_ambiguity": false,
+        "irreversible_action": false,
+        "audit_trail_complete": true,
+        "approval_boundary_defined": true,
+        "rule_defined": false,
+        "secure_controls_ready": true
+      },
+      "expected_semantics": {
+        "gate_decision": "hold",
+        "business_decision": "HOLD",
+        "next_action": "COLLECT_REQUIRED_EVIDENCE",
+        "required_evidence": [
+          "device_fingerprint_risk",
+          "behavioral_anomaly_score",
+          "transaction_velocity_features"
+        ],
+        "missing_evidence": [],
+        "human_review_required": false,
+        "rationale_summary": "高リスク信号が重なる場合は即時実行を避け、追加検証に寄せる。",
+        "rationale_expectations": [
+          "即時実行を避け、step-up 認証など追加検証へ誘導する",
+          "高リスク信号が重なる場合に fail-open しない",
+          "詐欺確定の断定ではなくリスク抑制行動を優先する"
+        ]
+      }
     },
-    "expected_next_action": "PREPARE_HUMAN_REVIEW_PACKET",
-    "expected_rationale_summary": "適合性の境界案件は human review を要求し、販売継続を即断しない。",
-    "expected_required_evidence": [
-      "investment_experience_profile",
-      "risk_tolerance_assessment",
-      "product_risk_disclosure_ack"
-    ],
-    "expected_missing_evidence": [],
-    "expected_human_review_required": true,
-    "expected_governance_behavior": {
-      "gate_decision": "hold",
-      "business_decision": "REVIEW_REQUIRED",
-      "required_evidence": [
-        "investment_experience_profile",
-        "risk_tolerance_assessment",
-        "product_risk_disclosure_ack"
-      ],
-      "human_review_required": true,
-      "rationale_expectations": [
-        "適合性が不十分な場合は販売継続を停止する",
-        "開示同意と顧客属性の整合確認を必須にする",
-        "投資助言の結論を返さず、統治的な審査行動を返す"
-      ]
-    }
-  },
-  {
-    "template_id": "high_risk_transaction_pending_release",
-    "industry": "payments",
-    "decision_domain": "high_risk_transaction_hold",
-    "title": "High-risk transaction pending release control",
-    "question": "短時間で複数口座を経由する高額送金チェーンを検知。取引を即時実行すべきか？",
-    "context": {
-      "required_evidence": [
-        "transaction_chain_graph",
-        "counterparty_risk_rating",
-        "aml_alert_case_id"
-      ],
-      "satisfied_evidence": [
-        "transaction_chain_graph",
-        "counterparty_risk_rating",
-        "aml_alert_case_id"
-      ],
-      "high_risk_ambiguity": false,
-      "risk_score": 0.87,
-      "irreversible_action": true,
-      "audit_trail_complete": false,
-      "approval_boundary_defined": true,
-      "rule_defined": true,
-      "secure_controls_ready": true,
-      "human_review_required": true
+    {
+      "template_id": "aml_kyc_high_risk_country_wire_manual_review",
+      "industry": "banking",
+      "decision_domain": "aml_kyc",
+      "title": "High-risk country transfer requires human review",
+      "question": "KYC は完了しているが、PEP 関連者で高リスク国向けのクロスボーダー送金。自動通過できるか？",
+      "context": {
+        "required_evidence": [
+          "kyc_profile",
+          "pep_screening_result",
+          "source_of_funds_document",
+          "transaction_purpose_statement"
+        ],
+        "satisfied_evidence": [
+          "kyc_profile",
+          "pep_screening_result",
+          "source_of_funds_document",
+          "transaction_purpose_statement"
+        ],
+        "high_risk_ambiguity": true,
+        "risk_score": 0.91,
+        "irreversible_action": false,
+        "audit_trail_complete": true,
+        "approval_boundary_defined": true,
+        "rule_defined": true,
+        "secure_controls_ready": true
+      },
+      "expected_semantics": {
+        "gate_decision": "human_review_required",
+        "business_decision": "REVIEW_REQUIRED",
+        "next_action": "PREPARE_HUMAN_REVIEW_PACKET",
+        "required_evidence": [
+          "kyc_profile",
+          "pep_screening_result",
+          "source_of_funds_document",
+          "transaction_purpose_statement"
+        ],
+        "missing_evidence": [],
+        "human_review_required": true,
+        "rationale_summary": "高リスク曖昧性が高い場合は human review を優先し、自動通過しない。",
+        "rationale_expectations": [
+          "高リスク国送金は人手審査境界へエスカレーションする",
+          "顧客属性と送金文脈を合わせて証拠化する",
+          "AML 違反の断定ではなく保留・審査で管理する"
+        ]
+      }
     },
-    "expected_next_action": "DO_NOT_EXECUTE",
-    "expected_rationale_summary": "不可逆操作かつ監査不備は block を優先し、実行停止する。",
-    "expected_required_evidence": [
-      "transaction_chain_graph",
-      "counterparty_risk_rating",
-      "aml_alert_case_id"
-    ],
-    "expected_missing_evidence": [],
-    "expected_human_review_required": true,
-    "expected_governance_behavior": {
-      "gate_decision": "block",
-      "business_decision": "DENY",
-      "required_evidence": [
-        "transaction_chain_graph",
-        "counterparty_risk_rating",
-        "aml_alert_case_id"
-      ],
-      "human_review_required": true,
-      "rationale_expectations": [
-        "重大リスク時は一時停止ではなく実行ブロックを許容する",
-        "解除は監査証跡付きの人手判断に限定する",
-        "犯罪性の断定ではなく被害防止の暫定停止として説明する"
-      ]
-    }
-  },
-  {
-    "template_id": "approval_boundary_undefined_stop",
-    "industry": "cross_domain_finreg",
-    "decision_domain": "governance_boundary_control",
-    "title": "Stop when approval boundary is undefined",
-    "question": "与信・AML・制裁の複合案件だが、どの権限者が最終承認するか定義がない。処理を続けるべきか？",
-    "context": {
-      "required_evidence": [
-        "approval_matrix",
-        "policy_owner_confirmation"
-      ],
-      "satisfied_evidence": [
-        "approval_matrix",
-        "policy_owner_confirmation"
-      ],
-      "high_risk_ambiguity": false,
-      "risk_score": 0.48,
-      "irreversible_action": false,
-      "audit_trail_complete": true,
-      "approval_boundary_defined": false,
-      "rule_defined": true,
-      "secure_controls_ready": true
+    {
+      "template_id": "sanctions_partial_name_match_hold",
+      "industry": "banking",
+      "decision_domain": "sanctions_screening",
+      "title": "Partial sanctions match stays on hold until disambiguation",
+      "question": "送金受取人名が制裁リストと部分一致し、生年月日が未取得。送金を継続してよいか？",
+      "context": {
+        "required_evidence": [
+          "beneficiary_date_of_birth",
+          "beneficiary_address",
+          "sanctions_screening_trace"
+        ],
+        "satisfied_evidence": [
+          "sanctions_screening_trace"
+        ],
+        "high_risk_ambiguity": true,
+        "risk_score": 0.66,
+        "human_review_required": true,
+        "irreversible_action": false,
+        "audit_trail_complete": true,
+        "approval_boundary_defined": true,
+        "rule_defined": true,
+        "secure_controls_ready": true
+      },
+      "expected_semantics": {
+        "gate_decision": "hold",
+        "business_decision": "EVIDENCE_REQUIRED",
+        "next_action": "COLLECT_REQUIRED_EVIDENCE",
+        "required_evidence": [
+          "beneficiary_date_of_birth",
+          "beneficiary_address",
+          "sanctions_screening_trace"
+        ],
+        "missing_evidence": [
+          "beneficiary_date_of_birth",
+          "beneficiary_address"
+        ],
+        "human_review_required": true,
+        "rationale_summary": "部分一致時は hold し、識別証拠の補完を優先する。",
+        "rationale_expectations": [
+          "部分一致の時点では自動通過せず保留する",
+          "同一人物確認に必要な識別証拠を明示する",
+          "制裁対象と断定せず、誤検知リスクも含めて審査へ送る"
+        ]
+      }
     },
-    "expected_next_action": "PREPARE_HUMAN_REVIEW_PACKET",
-    "expected_rationale_summary": "承認境界未定義は human review 境界へエスカレーションし処理継続しない。",
-    "expected_required_evidence": [
-      "approval_matrix",
-      "policy_owner_confirmation"
-    ],
-    "expected_missing_evidence": [],
-    "expected_human_review_required": true,
-    "expected_governance_behavior": {
-      "gate_decision": "human_review_required",
-      "business_decision": "REVIEW_REQUIRED",
-      "required_evidence": [
-        "approval_matrix",
-        "policy_owner_confirmation"
-      ],
-      "human_review_required": true,
-      "rationale_expectations": [
-        "approval boundary 未定義時は処理継続しない",
-        "権限定義の確定を再開条件として提示する",
-        "責任主体不明のまま自動化しない"
-      ]
+    {
+      "template_id": "suitability_leveraged_product_retail_client",
+      "industry": "securities",
+      "decision_domain": "client_suitability",
+      "title": "Retail suitability for leveraged product",
+      "question": "経験年数が短く損失許容度が低い個人顧客に高レバレッジ商品を提示してよいか？",
+      "context": {
+        "required_evidence": [
+          "investment_experience_profile",
+          "risk_tolerance_assessment",
+          "product_risk_disclosure_ack"
+        ],
+        "satisfied_evidence": [
+          "investment_experience_profile",
+          "risk_tolerance_assessment",
+          "product_risk_disclosure_ack"
+        ],
+        "high_risk_ambiguity": false,
+        "risk_score": 0.52,
+        "human_review_required": true,
+        "irreversible_action": false,
+        "audit_trail_complete": true,
+        "approval_boundary_defined": true,
+        "rule_defined": true,
+        "secure_controls_ready": true
+      },
+      "expected_semantics": {
+        "gate_decision": "hold",
+        "business_decision": "REVIEW_REQUIRED",
+        "next_action": "PREPARE_HUMAN_REVIEW_PACKET",
+        "required_evidence": [
+          "investment_experience_profile",
+          "risk_tolerance_assessment",
+          "product_risk_disclosure_ack"
+        ],
+        "missing_evidence": [],
+        "human_review_required": true,
+        "rationale_summary": "適合性の境界案件は human review を要求し、販売継続を即断しない。",
+        "rationale_expectations": [
+          "適合性が不十分な場合は販売継続を停止する",
+          "開示同意と顧客属性の整合確認を必須にする",
+          "投資助言の結論を返さず、統治的な審査行動を返す"
+        ]
+      }
+    },
+    {
+      "template_id": "high_risk_transaction_pending_release",
+      "industry": "payments",
+      "decision_domain": "high_risk_transaction_hold",
+      "title": "High-risk transaction pending release control",
+      "question": "短時間で複数口座を経由する高額送金チェーンを検知。取引を即時実行すべきか？",
+      "context": {
+        "required_evidence": [
+          "transaction_chain_graph",
+          "counterparty_risk_rating",
+          "aml_alert_case_id"
+        ],
+        "satisfied_evidence": [
+          "transaction_chain_graph",
+          "counterparty_risk_rating",
+          "aml_alert_case_id"
+        ],
+        "high_risk_ambiguity": false,
+        "risk_score": 0.87,
+        "irreversible_action": true,
+        "audit_trail_complete": false,
+        "approval_boundary_defined": true,
+        "rule_defined": true,
+        "secure_controls_ready": true,
+        "human_review_required": true
+      },
+      "expected_semantics": {
+        "gate_decision": "block",
+        "business_decision": "DENY",
+        "next_action": "DO_NOT_EXECUTE",
+        "required_evidence": [
+          "transaction_chain_graph",
+          "counterparty_risk_rating",
+          "aml_alert_case_id"
+        ],
+        "missing_evidence": [],
+        "human_review_required": true,
+        "rationale_summary": "不可逆操作かつ監査不備は block を優先し、実行停止する。",
+        "rationale_expectations": [
+          "重大リスク時は一時停止ではなく実行ブロックを許容する",
+          "解除は監査証跡付きの人手判断に限定する",
+          "犯罪性の断定ではなく被害防止の暫定停止として説明する"
+        ]
+      }
+    },
+    {
+      "template_id": "approval_boundary_undefined_stop",
+      "industry": "cross_domain_finreg",
+      "decision_domain": "governance_boundary_control",
+      "title": "Stop when approval boundary is undefined",
+      "question": "与信・AML・制裁の複合案件だが、どの権限者が最終承認するか定義がない。処理を続けるべきか？",
+      "context": {
+        "required_evidence": [
+          "approval_matrix",
+          "policy_owner_confirmation"
+        ],
+        "satisfied_evidence": [
+          "approval_matrix",
+          "policy_owner_confirmation"
+        ],
+        "high_risk_ambiguity": false,
+        "risk_score": 0.48,
+        "irreversible_action": false,
+        "audit_trail_complete": true,
+        "approval_boundary_defined": false,
+        "rule_defined": true,
+        "secure_controls_ready": true
+      },
+      "expected_semantics": {
+        "gate_decision": "human_review_required",
+        "business_decision": "REVIEW_REQUIRED",
+        "next_action": "PREPARE_HUMAN_REVIEW_PACKET",
+        "required_evidence": [
+          "approval_matrix",
+          "policy_owner_confirmation"
+        ],
+        "missing_evidence": [],
+        "human_review_required": true,
+        "rationale_summary": "承認境界未定義は human review 境界へエスカレーションし処理継続しない。",
+        "rationale_expectations": [
+          "approval boundary 未定義時は処理継続しない",
+          "権限定義の確定を再開条件として提示する",
+          "責任主体不明のまま自動化しない"
+        ]
+      }
     }
-  }
-]
+  ]
+}

--- a/veritas_os/tests/test_financial_poc_pack.py
+++ b/veritas_os/tests/test_financial_poc_pack.py
@@ -14,6 +14,9 @@ from veritas_os.api.schemas import DecideResponse
 
 POC_DOC_PATH = Path("docs/ja/guides/poc-pack-financial-quickstart.md")
 POC_FIXTURE_PATH = Path("veritas_os/sample_data/governance/financial_poc_questions.json")
+REGULATORY_TEMPLATE_PATH = Path(
+    "veritas_os/sample_data/governance/financial_regulatory_templates.json"
+)
 
 
 class ExpectedSemantics(BaseModel):
@@ -50,6 +53,7 @@ class FinancialPocQuestion(BaseModel):
     question_id: str
     category: str
     question: str
+    template_id: str | None = None
     expected_semantics: ExpectedSemantics
 
 
@@ -57,6 +61,13 @@ def _load_poc_questions() -> list[FinancialPocQuestion]:
     """Load and validate PoC question fixtures."""
     raw_data = json.loads(POC_FIXTURE_PATH.read_text(encoding="utf-8"))
     return [FinancialPocQuestion.model_validate(item) for item in raw_data]
+
+
+def _load_regulatory_template_ids() -> set[str]:
+    """Load canonical template IDs from the industry template pack."""
+    payload = json.loads(REGULATORY_TEMPLATE_PATH.read_text(encoding="utf-8"))
+    templates = payload.get("templates", [])
+    return {item["template_id"] for item in templates}
 
 
 def _extract_markdown_links(content: str) -> list[str]:
@@ -130,3 +141,15 @@ def test_financial_poc_sample_artifact_references_exist() -> None:
 
     for path in sample_paths:
         assert path.exists(), f"Missing sample artifact: {path}"
+
+
+def test_financial_poc_questions_reference_templates_without_reverse_lookup() -> None:
+    """PoC questions should link directly to canonical template IDs."""
+    questions = _load_poc_questions()
+    template_ids = _load_regulatory_template_ids()
+
+    linked_questions = [item for item in questions if item.template_id is not None]
+    assert linked_questions, "At least one PoC question must reference a template_id."
+
+    for item in linked_questions:
+        assert item.template_id in template_ids

--- a/veritas_os/tests/test_financial_regulatory_templates.py
+++ b/veritas_os/tests/test_financial_regulatory_templates.py
@@ -17,8 +17,8 @@ FIXTURE_PATH = Path("veritas_os/sample_data/governance/financial_regulatory_temp
 TAXONOMY_PATH = Path("veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json")
 
 
-class ExpectedGovernanceBehavior(BaseModel):
-    """Expected governance behavior for one regulated-domain template."""
+class ExpectedSemantics(BaseModel):
+    """Expected decision semantics for one regulated-domain template."""
 
     gate_decision: Literal[
         "proceed",
@@ -40,8 +40,11 @@ class ExpectedGovernanceBehavior(BaseModel):
         "POLICY_DEFINITION_REQUIRED",
         "EVIDENCE_REQUIRED",
     ]
+    next_action: str = Field(min_length=1)
     required_evidence: List[str] = Field(min_length=1)
+    missing_evidence: List[str] = Field(default_factory=list)
     human_review_required: bool
+    rationale_summary: str = Field(min_length=1)
     rationale_expectations: List[str] = Field(min_length=2)
 
 
@@ -54,12 +57,19 @@ class FinancialGovernanceTemplate(BaseModel):
     title: str
     question: str
     context: Dict[str, object]
-    expected_next_action: str = Field(min_length=1)
-    expected_rationale_summary: str = Field(min_length=1)
-    expected_required_evidence: List[str] = Field(min_length=1)
-    expected_missing_evidence: List[str] = Field(default_factory=list)
-    expected_human_review_required: bool
-    expected_governance_behavior: ExpectedGovernanceBehavior
+    expected_semantics: ExpectedSemantics
+
+
+class FinancialGovernanceTemplatePack(BaseModel):
+    """Canonical industry-pack shape for financial governance templates."""
+
+    pack_id: str
+    pack_type: Literal["industry_governance_templates"]
+    industry: str
+    version: str
+    taxonomy_policy: Dict[str, str]
+    beachhead: Dict[str, str]
+    templates: List[FinancialGovernanceTemplate] = Field(min_length=1)
 
 
 class TaxonomyItem(BaseModel):
@@ -82,10 +92,10 @@ class RequiredEvidenceTaxonomy(BaseModel):
     items: List[TaxonomyItem]
 
 
-def _load_templates() -> List[FinancialGovernanceTemplate]:
-    """Load and parse the canonical financial governance fixture file."""
+def _load_template_pack() -> FinancialGovernanceTemplatePack:
+    """Load and parse the canonical financial governance template pack file."""
     raw_data = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
-    return [FinancialGovernanceTemplate.model_validate(item) for item in raw_data]
+    return FinancialGovernanceTemplatePack.model_validate(raw_data)
 
 
 def _load_taxonomy() -> RequiredEvidenceTaxonomy:
@@ -96,15 +106,18 @@ def _load_taxonomy() -> RequiredEvidenceTaxonomy:
 
 def test_financial_templates_fixture_loads() -> None:
     """Fixture file should be loadable for dev/demo and tests."""
-    templates = _load_templates()
+    pack = _load_template_pack()
+    templates = pack.templates
 
     assert len(templates) >= 7
     assert all(template.question.strip() for template in templates)
+    assert pack.beachhead["decision_domain"] == "aml_kyc"
+    assert pack.beachhead["template_id"] == "aml_kyc_high_risk_country_wire_manual_review"
 
 
 def test_financial_templates_include_mandatory_domains() -> None:
     """Template pack must cover the required financial/regulatory domains."""
-    templates = _load_templates()
+    templates = _load_template_pack().templates
     template_ids = {item.template_id for item in templates}
 
     assert "credit_missing_bureau_data_no_auto_approval" in template_ids
@@ -118,32 +131,35 @@ def test_financial_templates_include_mandatory_domains() -> None:
 
 def test_financial_template_shape_includes_context_and_expected_fields() -> None:
     """Template fixtures must define context + explicit expected output fields."""
-    templates = _load_templates()
+    templates = _load_template_pack().templates
 
     for template in templates:
         assert isinstance(template.context.get("required_evidence"), list)
         assert isinstance(template.context.get("satisfied_evidence"), list)
-        assert template.expected_required_evidence == template.expected_governance_behavior.required_evidence
-        assert template.expected_human_review_required is template.expected_governance_behavior.human_review_required
+        expected = template.expected_semantics
+        assert expected.required_evidence == template.context["required_evidence"]
+        assert set(expected.missing_evidence) == (
+            set(expected.required_evidence) - set(template.context["satisfied_evidence"])
+        )
 
 
 def test_financial_templates_are_compatible_with_decide_response_schema() -> None:
     """Expected template outputs should map to the public DecideResponse schema."""
-    templates = _load_templates()
+    templates = _load_template_pack().templates
 
     for template in templates:
-        expected = template.expected_governance_behavior
+        expected = template.expected_semantics
         payload = DecideResponse.model_validate(
             {
                 "request_id": f"fixture-{template.template_id}",
                 "query": template.question,
                 "gate_decision": expected.gate_decision,
                 "business_decision": expected.business_decision,
-                "next_action": template.expected_next_action,
+                "next_action": expected.next_action,
                 "required_evidence": expected.required_evidence,
-                "missing_evidence": template.expected_missing_evidence,
+                "missing_evidence": expected.missing_evidence,
                 "human_review_required": expected.human_review_required,
-                "rationale": template.expected_rationale_summary,
+                "rationale": expected.rationale_summary,
             }
         )
 
@@ -155,7 +171,7 @@ def test_financial_templates_are_compatible_with_decide_response_schema() -> Non
 
 def test_regression_approval_boundary_undefined_requires_human_review() -> None:
     """Approval boundary undefined case should fail closed to review-required."""
-    template_map = {item.template_id: item for item in _load_templates()}
+    template_map = {item.template_id: item for item in _load_template_pack().templates}
     template = template_map["approval_boundary_undefined_stop"]
     ctx = PipelineContext(
         request_id="financial-template-regression",
@@ -184,11 +200,11 @@ def test_regression_representative_financial_templates_governance_alignment() ->
         "aml_kyc_high_risk_country_wire_manual_review",
         "high_risk_transaction_pending_release",
     ]
-    templates = {item.template_id: item for item in _load_templates()}
+    templates = {item.template_id: item for item in _load_template_pack().templates}
 
     for template_id in template_ids:
         template = templates[template_id]
-        expected = template.expected_governance_behavior
+        expected = template.expected_semantics
         ctx = PipelineContext(
             request_id=f"financial-template-{template_id}",
             query=template.question,
@@ -205,10 +221,21 @@ def test_regression_representative_financial_templates_governance_alignment() ->
         )
         assert payload["gate_decision"] == expected.gate_decision
         assert payload["business_decision"] == expected.business_decision
-        assert payload["next_action"] == template.expected_next_action
-        assert payload["required_evidence"] == template.expected_required_evidence
-        assert payload["missing_evidence"] == template.expected_missing_evidence
-        assert payload["human_review_required"] is template.expected_human_review_required
+        assert payload["next_action"] == expected.next_action
+        assert payload["required_evidence"] == expected.required_evidence
+        assert payload["missing_evidence"] == expected.missing_evidence
+        assert payload["human_review_required"] is expected.human_review_required
+
+
+def test_financial_templates_expected_semantics_has_required_fields() -> None:
+    """Expected semantics should include next_action and rationale expectations."""
+    templates = _load_template_pack().templates
+
+    for template in templates:
+        expected = template.expected_semantics
+        assert expected.next_action.strip()
+        assert expected.rationale_summary.strip()
+        assert len(expected.rationale_expectations) >= 2
 
 
 def test_required_evidence_taxonomy_has_unique_canonical_keys_and_aliases() -> None:


### PR DESCRIPTION
### Motivation
- Convert the ad-hoc financial/regulatory fixtures into a canonical, extendable industry pack so templates can be expanded by domain without reverse-engineering code. 
- Make PoC question artifacts directly reference canonical templates to remove brittle `fixture_contexts` reverse lookups and simplify demo runs. 
- Emphasize taxonomy-key-first handling so canonical required-evidence keys are primary while preserving legacy free-string aliases as inputs only.

### Description
- Reworked the regulatory fixture from a flat list into a top-level industry pack object with metadata fields (`pack_id`, `pack_type`, `industry`, `version`, `taxonomy_policy`, `beachhead`) and a `templates` array containing canonical templates. 
- Standardized per-template contract to `expected_semantics` containing `gate_decision`, `business_decision`, `next_action`, `required_evidence`, `missing_evidence`, `human_review_required`, `rationale_summary`, and `rationale_expectations`. 
- Added `template_id` linkage into PoC questions so PoC artifacts can reference canonical templates directly and removed the need for reverse lookup heuristics. 
- Updated documentation to declare the beachhead domain and role separation, and made `required_evidence` taxonomy-key-first expectations explicit. 
- Updated tests to validate the new pack shape and semantics and added schema checks that enforce presence of `next_action` and rationale fields while preserving decisioning regression assertions.

Changed files (high level): `veritas_os/sample_data/governance/financial_regulatory_templates.json`, `veritas_os/sample_data/governance/financial_poc_questions.json`, `veritas_os/tests/test_financial_regulatory_templates.py`, `veritas_os/tests/test_financial_poc_pack.py`, `docs/en/guides/financial-governance-templates.md`, `docs/en/governance/required-evidence-taxonomy.md`, `docs/ja/guides/poc-pack-financial-quickstart.md`.

Beachhead: `aml_kyc` (representative template `aml_kyc_high_risk_country_wire_manual_review`).

Template shape summary: Top-level pack metadata plus `templates` array, and per-template keys `template_id`, `industry`, `decision_domain`, `title`, `question`, `context`, and `expected_semantics` (see above for required semantics fields).

### Testing
- Ran the targeted test suite with `pytest -q veritas_os/tests/test_financial_regulatory_templates.py veritas_os/tests/test_financial_poc_pack.py` and all tests passed. 
- Test run result: `13 passed` (no failures). 
- Tests were updated to validate pack loading, direct PoC-to-template linkage, expected semantics completeness, and regression assertions against `assemble_response`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d6ddb0fc832688d265b32e9fcf51)