### PR TITLE
Harden evidence bundle delivery contract (minimum/full profiles, checklist, README, UI hook)

### DIFF
--- a/docs/en/validation/external-audit-readiness.md
+++ b/docs/en/validation/external-audit-readiness.md
@@ -195,6 +195,9 @@ veritas_bundle_decision_<uuid>/
 ├── manifest.json              # SHA-256 hashes, metadata, optional signature
 ├── witness_entries.jsonl       # Witness ledger slice
 ├── decision_record.json        # Auditor-facing single-decision snapshot
+├── acceptance_checklist.json   # Submission acceptance contract checks
+├── README.txt                  # Human-readable review and handoff guide
+├── ui_delivery_hook.json       # Backend hook for future UI integrations
 ├── verification_report.json   # Automated verification results
 ├── signer_metadata.json       # Ed25519 signer info
 ├── anchor_receipts/
@@ -217,6 +220,29 @@ decision. It includes:
 - TrustLog references (`payload_hash`, `full_payload_hash`, signature/anchor/mirror)
 - verification pointer (`verification_report.json`)
 - provenance metadata + runtime context (posture/backend/version)
+
+#### decision_record contract profiles
+
+- **minimum set** (baseline external review): `decision_payload`,
+  `gate_decision`, `business_decision`, `next_action`,
+  `trustlog_references`, `verification`, `provenance`.
+- **full set** (legal/deep forensic review): minimum set +
+  `required_evidence`, `human_review_required`, `runtime_context`.
+
+`veritas-evidence-bundle generate` defaults to minimum set and can opt into
+full set with `--decision-record-profile full`.
+
+#### Acceptance checklist contract
+
+Each bundle now ships `acceptance_checklist.json` with machine-readable checks:
+
+- manifest + file hash integrity material present
+- witness entries present
+- verification report present
+- decision_record contract profile declared (decision bundles)
+
+This checklist is intended to be the explicit pre-submission gate for
+external auditors/customers/legal.
 
 ### Generating Bundles
 
@@ -274,7 +300,8 @@ veritas-evidence-bundle generate \
   --bundle-type decision \
   --witness-ledger runtime/dev/logs/trustlog.jsonl \
   --output-dir ./bundles \
-  --request-id req-12345
+  --request-id req-12345 \
+  --decision-record-profile full
 
 veritas-evidence-bundle verify \
   --bundle-dir ./bundles/veritas_bundle_decision_<uuid>
@@ -294,6 +321,18 @@ from veritas_os.audit.evidence_bundle import create_bundle_archive
 archive = create_bundle_archive(Path("veritas_bundle_decision_<uuid>"))
 # → veritas_bundle_decision_<uuid>.tar.gz
 ```
+
+### External delivery policy (auditor/customer/legal)
+
+1. Generate bundle with explicit decision_record profile (`minimum` or `full`).
+2. Verify with `veritas-evidence-bundle verify`.
+3. Confirm all `acceptance_checklist.json` items are PASS.
+4. Include `README.txt` unchanged in handoff package.
+5. Deliver as read-only `.tar.gz` plus detached transfer checksum.
+
+Security note: Any tampering with `manifest.json`, `witness_entries.jsonl`,
+or hash-referenced files invalidates the delivery contract and requires
+regeneration from TrustLog source data.
 
 ---
 

--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -55,6 +55,84 @@ def _utc_now_iso8601() -> str:
     )
 
 
+def _build_acceptance_checklist(
+    bundle_type: str,
+    written_files: Sequence[str],
+    *,
+    decision_record_profile: str,
+) -> Dict[str, Any]:
+    """Build acceptance checklist used for external audit submission gating."""
+    written = set(written_files)
+    checklist = [
+        {
+            "id": "manifest_integrity",
+            "title": "Manifest and file hashes exist",
+            "required": True,
+            "status": "pass" if "manifest.json" in written else "fail",
+            "evidence": ["manifest.json"],
+        },
+        {
+            "id": "witness_entries_present",
+            "title": "Witness entries included",
+            "required": True,
+            "status": "pass" if "witness_entries.jsonl" in written else "fail",
+            "evidence": ["witness_entries.jsonl"],
+        },
+        {
+            "id": "verification_report_present",
+            "title": "Verification report included",
+            "required": True,
+            "status": "pass" if "verification_report.json" in written else "fail",
+            "evidence": ["verification_report.json"],
+        },
+        {
+            "id": "decision_record_contract",
+            "title": "Decision record contract profile declared",
+            "required": bundle_type == "decision",
+            "status": (
+                "pass" if bundle_type != "decision" or "decision_record.json" in written else "fail"
+            ),
+            "evidence": ["decision_record.json"] if bundle_type == "decision" else [],
+            "details": {"profile": decision_record_profile},
+        },
+    ]
+    return {"bundle_type": bundle_type, "items": checklist}
+
+
+def _build_bundle_readme(
+    bundle_type: str,
+    *,
+    bundle_id: str,
+    decision_record_profile: str,
+) -> str:
+    """Create a human-readable README shipped with each evidence bundle."""
+    lines = [
+        "VERITAS External Evidence Bundle",
+        "================================",
+        "",
+        f"Bundle ID: {bundle_id}",
+        f"Bundle Type: {bundle_type}",
+        f"Generated At (UTC): {_utc_now_iso8601()}",
+        "",
+        "Submission contract",
+        "-------------------",
+        "- decision_record minimum set: required for baseline external review",
+        "- decision_record full set: required for legal/deep forensic review",
+        f"- declared profile for this bundle: {decision_record_profile}",
+        "",
+        "Acceptance checklist",
+        "--------------------",
+        "- See acceptance_checklist.json and mark each item PASS before handoff.",
+        "",
+        "Verification",
+        "------------",
+        "- Run: veritas-evidence-bundle verify --bundle-dir <this-directory>",
+        "- Inspect verification_report.json for chain and signature status.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
 def _sha256_file(path: Path) -> str:
     """Compute SHA-256 hex digest of a file."""
     h = hashlib.sha256()
@@ -220,6 +298,7 @@ def generate_evidence_bundle(
     incident_metadata: Optional[Dict[str, Any]] = None,
     signer_fn: Optional[Callable[[str], str]] = None,
     signer_metadata: Optional[Dict[str, Any]] = None,
+    decision_record_profile: str = "minimum",
     bundle_id: Optional[str] = None,
     created_by: str = "veritas_os",
 ) -> Dict[str, Any]:
@@ -237,6 +316,7 @@ def generate_evidence_bundle(
         incident_metadata: Optional incident metadata.
         signer_fn: Optional callable that signs a payload hash and returns base64.
         signer_metadata: Optional signer metadata dict.
+        decision_record_profile: Contract profile used for decision_record.json.
         bundle_id: Optional explicit bundle ID (default: auto-generated UUIDv7).
         created_by: Creator identifier.
 
@@ -248,6 +328,10 @@ def generate_evidence_bundle(
     """
     if bundle_type not in BUNDLE_TYPES:
         raise ValueError(f"Invalid bundle_type: {bundle_type}. Expected one of {BUNDLE_TYPES}")
+    if decision_record_profile not in {"minimum", "full"}:
+        raise ValueError(
+            "Invalid decision_record_profile. Expected one of ['minimum', 'full']"
+        )
 
     if not bundle_id:
         bundle_id = _uuid7()
@@ -366,8 +450,50 @@ def generate_evidence_bundle(
     if bundle_type == "decision":
         decision_entry = entries[0]
         decision_record = _decision_record(decision_entry, verify_result)
+        if decision_record_profile == "minimum":
+            decision_record = {
+                "decision_payload": decision_record["decision_payload"],
+                "gate_decision": decision_record["gate_decision"],
+                "business_decision": decision_record["business_decision"],
+                "next_action": decision_record["next_action"],
+                "trustlog_references": decision_record["trustlog_references"],
+                "verification": decision_record["verification"],
+                "provenance": decision_record["provenance"],
+            }
         _write_json_file(bundle_dir, "decision_record.json", decision_record)
         written_files.append("decision_record.json")
+
+    acceptance_checklist = _build_acceptance_checklist(
+        bundle_type,
+        tuple(sorted(written_files)),
+        decision_record_profile=decision_record_profile,
+    )
+    _write_json_file(bundle_dir, "acceptance_checklist.json", acceptance_checklist)
+    written_files.append("acceptance_checklist.json")
+
+    bundle_readme = _build_bundle_readme(
+        bundle_type,
+        bundle_id=bundle_id,
+        decision_record_profile=decision_record_profile,
+    )
+    readme_path = bundle_dir / "README.txt"
+    readme_path.write_text(bundle_readme, encoding="utf-8")
+    written_files.append("README.txt")
+
+    _write_json_file(
+        bundle_dir,
+        "ui_delivery_hook.json",
+        {
+            "hook_version": "1.0",
+            "bundle_id": bundle_id,
+            "bundle_type": bundle_type,
+            "decision_record_profile": decision_record_profile,
+            "acceptance_checklist_path": "acceptance_checklist.json",
+            "readme_path": "README.txt",
+            "verify_command": "veritas-evidence-bundle verify --bundle-dir <bundle_dir>",
+        },
+    )
+    written_files.append("ui_delivery_hook.json")
 
     # Compute file hashes for manifest
     file_hashes = _collect_file_hashes(bundle_dir)
@@ -382,6 +508,12 @@ def generate_evidence_bundle(
         "contents": sorted(written_files),
         "file_hashes": file_hashes,
         "entry_count": len(entries),
+        "delivery_contract": {
+            "decision_record_profile": decision_record_profile,
+            "acceptance_checklist_path": "acceptance_checklist.json",
+            "readme_path": "README.txt",
+            "ui_delivery_hook_path": "ui_delivery_hook.json",
+        },
         "time_range": {
             "earliest": entries[0].get("timestamp") if entries else None,
             "latest": entries[-1].get("timestamp") if entries else None,

--- a/veritas_os/audit/evidence_bundle_schema.py
+++ b/veritas_os/audit/evidence_bundle_schema.py
@@ -24,8 +24,19 @@ MANIFEST_REQUIRED_FIELDS = frozenset({
     "entry_count",
 })
 
-#: Required keys for the decision snapshot payload used in decision bundles.
-DECISION_SNAPSHOT_REQUIRED_FIELDS = frozenset({
+#: Required keys for the decision snapshot payload minimum contract.
+DECISION_SNAPSHOT_MINIMUM_REQUIRED_FIELDS = frozenset({
+    "decision_payload",
+    "gate_decision",
+    "business_decision",
+    "next_action",
+    "trustlog_references",
+    "verification",
+    "provenance",
+})
+
+#: Required keys for the decision snapshot full contract.
+DECISION_SNAPSHOT_FULL_REQUIRED_FIELDS = frozenset({
     "decision_payload",
     "gate_decision",
     "business_decision",
@@ -37,6 +48,11 @@ DECISION_SNAPSHOT_REQUIRED_FIELDS = frozenset({
     "provenance",
     "runtime_context",
 })
+
+#: Backwards-compatible alias for the strict/full requirement set.
+DECISION_SNAPSHOT_REQUIRED_FIELDS = DECISION_SNAPSHOT_FULL_REQUIRED_FIELDS
+
+DECISION_RECORD_PROFILES = frozenset({"minimum", "full"})
 
 #: Valid bundle types.
 BUNDLE_TYPES = frozenset({"decision", "incident", "release"})
@@ -52,6 +68,9 @@ BUNDLE_TYPE_CONTENTS = {
             "verification_report.json",
             "signer_metadata.json",
             "governance_identity.json",
+            "acceptance_checklist.json",
+            "README.txt",
+            "ui_delivery_hook.json",
         ],
     },
     "incident": {
@@ -64,6 +83,9 @@ BUNDLE_TYPE_CONTENTS = {
             "signer_metadata.json",
             "governance_identity.json",
             "incident_metadata.json",
+            "acceptance_checklist.json",
+            "README.txt",
+            "ui_delivery_hook.json",
         ],
     },
     "release": {
@@ -76,20 +98,32 @@ BUNDLE_TYPE_CONTENTS = {
             "signer_metadata.json",
             "governance_identity.json",
             "release_provenance.json",
+            "acceptance_checklist.json",
+            "README.txt",
+            "ui_delivery_hook.json",
         ],
     },
 }
 
 
-def validate_decision_snapshot_shape(payload: dict) -> list[str]:
+def validate_decision_snapshot_shape(payload: dict, profile: str = "minimum") -> list[str]:
     """Validate required fields for ``decision_record.json``.
 
     Returns a list of human-readable validation errors.
     """
     errors: list[str] = []
-    missing = DECISION_SNAPSHOT_REQUIRED_FIELDS - set(payload.keys())
+    if profile not in DECISION_RECORD_PROFILES:
+        errors.append(f"decision_record profile must be one of {sorted(DECISION_RECORD_PROFILES)}")
+        return errors
+
+    required_fields = (
+        DECISION_SNAPSHOT_MINIMUM_REQUIRED_FIELDS
+        if profile == "minimum"
+        else DECISION_SNAPSHOT_FULL_REQUIRED_FIELDS
+    )
+    missing = required_fields - set(payload.keys())
     if missing:
-        errors.append(f"decision_record missing fields: {sorted(missing)}")
+        errors.append(f"decision_record missing fields ({profile}): {sorted(missing)}")
 
     if "required_evidence" in payload and not isinstance(payload.get("required_evidence"), list):
         errors.append("decision_record.required_evidence must be a list")
@@ -106,5 +140,9 @@ def validate_decision_snapshot_shape(payload: dict) -> list[str]:
     verification = payload.get("verification")
     if verification is not None and not isinstance(verification, dict):
         errors.append("decision_record.verification must be an object")
+
+    decision_payload = payload.get("decision_payload")
+    if decision_payload is not None and not isinstance(decision_payload, dict):
+        errors.append("decision_record.decision_payload must be an object")
 
     return errors

--- a/veritas_os/audit/verify_bundle.py
+++ b/veritas_os/audit/verify_bundle.py
@@ -114,6 +114,12 @@ def verify_evidence_bundle(
                 result["tampered"] = True
 
     if bundle_type == "decision":
+        delivery_contract = manifest.get("delivery_contract", {})
+        decision_profile = "minimum"
+        if isinstance(delivery_contract, dict):
+            maybe_profile = delivery_contract.get("decision_record_profile")
+            if isinstance(maybe_profile, str):
+                decision_profile = maybe_profile
         decision_record_path = bundle_dir / "decision_record.json"
         if decision_record_path.exists():
             try:
@@ -122,13 +128,20 @@ def verify_evidence_bundle(
                 errors.append(f"Failed to read decision_record.json: {exc}")
                 result["tampered"] = True
             else:
-                shape_errors = validate_decision_snapshot_shape(decision_record)
+                shape_errors = validate_decision_snapshot_shape(
+                    decision_record,
+                    profile=decision_profile,
+                )
                 if shape_errors:
                     errors.extend(shape_errors)
                     result["tampered"] = True
         else:
             errors.append("decision bundle missing decision_record.json")
             result["tampered"] = True
+
+    checklist_path = bundle_dir / "acceptance_checklist.json"
+    if not checklist_path.exists():
+        warnings.append("acceptance_checklist.json not found")
 
     # Verify file hashes
     expected_hashes = manifest.get("file_hashes", {})

--- a/veritas_os/cli/evidence_bundle.py
+++ b/veritas_os/cli/evidence_bundle.py
@@ -37,6 +37,11 @@ def build_parser() -> argparse.ArgumentParser:
     gen.add_argument("--time-range-start")
     gen.add_argument("--time-range-end")
     gen.add_argument("--created-by", default="veritas_os")
+    gen.add_argument(
+        "--decision-record-profile",
+        choices=["minimum", "full"],
+        default="minimum",
+    )
     gen.add_argument("--governance-meta", action="append")
     gen.add_argument("--release-meta", action="append")
     gen.add_argument("--incident-meta", action="append")
@@ -73,6 +78,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             governance_identity=governance or None,
             release_provenance=release or None,
             incident_metadata=incident or None,
+            decision_record_profile=args.decision_record_profile,
             created_by=args.created_by,
         )
         if args.json:

--- a/veritas_os/tests/test_external_audit_readiness.py
+++ b/veritas_os/tests/test_external_audit_readiness.py
@@ -487,6 +487,9 @@ class TestEvidenceBundleGeneration:
         assert result["entry_count"] == 1
         assert "manifest.json" in result["files"]
         assert "witness_entries.jsonl" in result["files"]
+        assert "acceptance_checklist.json" in result["files"]
+        assert "README.txt" in result["files"]
+        assert "ui_delivery_hook.json" in result["files"]
 
         # Verify manifest on disk
         bundle_dir = Path(result["bundle_dir"])
@@ -498,6 +501,32 @@ class TestEvidenceBundleGeneration:
         assert decision_record["decision_payload"]["request_id"] == "r-bundle-1"
         assert "trustlog_references" in decision_record
         assert decision_record["verification"]["report_path"] == "verification_report.json"
+        assert "runtime_context" not in decision_record
+
+    def test_decision_bundle_full_profile_contains_full_fields(self, _trustlog_env):
+        """Decision full profile includes runtime and evidence fields."""
+        env = _trustlog_env
+        output_dir = env["tmp_path"] / "bundles"
+
+        trustlog_signed.append_signed_decision(
+            {"request_id": "r-bundle-full", "decision": "allow"}
+        )
+
+        from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+
+        result = generate_evidence_bundle(
+            bundle_type="decision",
+            witness_ledger_path=env["log_path"],
+            output_dir=output_dir,
+            request_ids=["r-bundle-full"],
+            decision_record_profile="full",
+        )
+
+        bundle_dir = Path(result["bundle_dir"])
+        decision_record = json.loads((bundle_dir / "decision_record.json").read_text())
+        assert "runtime_context" in decision_record
+        assert "required_evidence" in decision_record
+        assert "human_review_required" in decision_record
 
     def test_incident_bundle_generation(self, _trustlog_env):
         """Generate an incident evidence bundle with multiple entries."""
@@ -649,6 +678,33 @@ class TestEvidenceBundleVerification:
         assert verify_result["ok"] is True
         assert verify_result["tampered"] is False
         assert not verify_result["errors"]
+
+    def test_verify_bundle_regression_with_contract_artifacts(self, _trustlog_env):
+        """Verification remains green with README/checklist/UI hook artifacts."""
+        env = _trustlog_env
+        output_dir = env["tmp_path"] / "bundles"
+
+        trustlog_signed.append_signed_decision(
+            {"request_id": "r-regression", "decision": "allow"}
+        )
+
+        from veritas_os.audit.evidence_bundle import generate_evidence_bundle
+        from veritas_os.audit.verify_bundle import verify_evidence_bundle
+
+        result = generate_evidence_bundle(
+            bundle_type="decision",
+            witness_ledger_path=env["log_path"],
+            output_dir=output_dir,
+            request_ids=["r-regression"],
+            decision_record_profile="minimum",
+        )
+        bundle_dir = Path(result["bundle_dir"])
+        checklist = json.loads((bundle_dir / "acceptance_checklist.json").read_text())
+        checklist_ids = {item["id"] for item in checklist["items"]}
+        assert "decision_record_contract" in checklist_ids
+
+        verify_result = verify_evidence_bundle(bundle_dir)
+        assert verify_result["ok"] is True
 
     def test_detect_tampered_file(self, _trustlog_env):
         """Verification detects tampered witness entries file."""
@@ -867,8 +923,14 @@ class TestEvidenceBundleSchema:
         assert "bundle_id" in MANIFEST_REQUIRED_FIELDS
 
     def test_decision_snapshot_required_fields(self):
-        from veritas_os.audit.evidence_bundle_schema import DECISION_SNAPSHOT_REQUIRED_FIELDS
+        from veritas_os.audit.evidence_bundle_schema import (
+            DECISION_SNAPSHOT_FULL_REQUIRED_FIELDS,
+            DECISION_SNAPSHOT_MINIMUM_REQUIRED_FIELDS,
+            DECISION_SNAPSHOT_REQUIRED_FIELDS,
+        )
 
         assert "gate_decision" in DECISION_SNAPSHOT_REQUIRED_FIELDS
         assert "business_decision" in DECISION_SNAPSHOT_REQUIRED_FIELDS
         assert "next_action" in DECISION_SNAPSHOT_REQUIRED_FIELDS
+        assert "runtime_context" in DECISION_SNAPSHOT_FULL_REQUIRED_FIELDS
+        assert "runtime_context" not in DECISION_SNAPSHOT_MINIMUM_REQUIRED_FIELDS


### PR DESCRIPTION
### Motivation
- Establish a clear external-submission contract for Evidence Bundles by defining a minimum and full `decision_record.json` profile so auditors/customers/legal have an explicit handoff contract.
- Provide machine- and human-readable submission artifacts (`acceptance_checklist.json`, `README.txt`) so ops and auditors can validate readiness before handoff.
- Enable minimal backend/UI integration points via a lightweight `ui_delivery_hook.json` and manifest `delivery_contract` metadata without adding a portal.

### Description
- Add explicit profile constants and validation in `veritas_os/audit/evidence_bundle_schema.py` (`DECISION_SNAPSHOT_MINIMUM_REQUIRED_FIELDS`, `DECISION_SNAPSHOT_FULL_REQUIRED_FIELDS`, and `validate_decision_snapshot_shape(profile=...)`).
- Extend `generate_evidence_bundle` in `veritas_os/audit/evidence_bundle.py` to accept `decision_record_profile`, emit `acceptance_checklist.json`, `README.txt`, and `ui_delivery_hook.json`, and record `delivery_contract` in `manifest.json`; the decision bundle payload is trimmed to the selected profile when `minimum` is selected.
- Add CLI flag `--decision-record-profile` in `veritas_os/cli/evidence_bundle.py` and wire it to backend generation.
- Update verification in `veritas_os/audit/verify_bundle.py` to read `manifest.delivery_contract.decision_record_profile` and validate `decision_record.json` against the declared profile, and surface missing checklist as a warning.
- Document the profiles, acceptance checklist, and an external delivery policy in `docs/en/validation/external-audit-readiness.md`, and update/extend unit tests in `veritas_os/tests/test_external_audit_readiness.py` to cover minimum/full behavior and regression with new artifacts.

### Testing
- Ran: `pytest -q veritas_os/tests/test_external_audit_readiness.py::TestEvidenceBundleGeneration::test_decision_bundle_generation veritas_os/tests/test_external_audit_readiness.py::TestEvidenceBundleGeneration::test_decision_bundle_full_profile_contains_full_fields veritas_os/tests/test_external_audit_readiness.py::TestEvidenceBundleVerification::test_verify_bundle_regression_with_contract_artifacts veritas_os/tests/test_evidence_bundle_cli.py` — result: `5 passed`.
- Ran: `pytest -q veritas_os/tests/test_external_audit_readiness.py::TestEvidenceBundleVerification::test_verify_valid_bundle veritas_os/tests/test_external_audit_readiness.py::TestEvidenceBundleVerification::test_detect_tampered_file` — result: `2 passed`.
- Updated/added tests assert presence of `acceptance_checklist.json`, `README.txt`, `ui_delivery_hook.json`, and correct behavior for `minimum` vs `full` decision profiles.
- All modified tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e190fb1690832695689d1eae055734)