### PR TITLE
Add reproducible financial PoC runner and English quickstart pack

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -37,6 +37,8 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 
 ### Guides
 - [3-Minute Demo Script](guides/demo-script.md)
+- [Financial PoC Pack (1-day quickstart, EN)](guides/poc-pack-financial-quickstart.md)
+- [Financial PoC Success Criteria](guides/financial-poc-success-criteria.md)
 - [File-to-PostgreSQL Migration Guide](guides/migration-guide.md) (bilingual)
 - [Financial PoC Pack (1-day quickstart, JA)](../ja/guides/poc-pack-financial-quickstart.md)
 

--- a/docs/en/guides/demo-script.md
+++ b/docs/en/guides/demo-script.md
@@ -82,6 +82,23 @@ Open browser to `http://localhost:3000`.
 
 ---
 
+## Optional PoC Reproducibility Add-on (60 sec)
+
+After the UI demo, run a deterministic PoC summary:
+
+```bash
+python scripts/run_financial_poc.py \
+  --dry-run \
+  --output-json veritas_os/scripts/logs/financial_poc_dry_run_report.json
+```
+
+Then point to:
+
+- [Financial PoC Pack (1-day quickstart, EN)](poc-pack-financial-quickstart.md)
+- [Financial PoC Success Criteria](financial-poc-success-criteria.md)
+
+---
+
 ## CI Quality Checklist
 
 - [x] Backend: ruff + bandit + pytest (40%+ coverage)

--- a/docs/en/guides/financial-governance-templates.md
+++ b/docs/en/guides/financial-governance-templates.md
@@ -83,3 +83,15 @@ This domain is used as the first expansion anchor because it combines:
 
 Template fixtures should remain synthetic and free of PII, account numbers,
 production sanctions watchlists, and customer-identifiable traces.
+
+## PoC Reproducibility Runner
+
+To execute the lightweight PoC fixture set and compare expected semantics against
+runtime output, use:
+
+- `scripts/run_financial_poc.py`
+- `veritas_os/scripts/financial_poc_runner.py`
+
+Runbook:
+
+- [Financial PoC Pack (1-day quickstart, EN)](poc-pack-financial-quickstart.md)

--- a/docs/en/guides/financial-poc-success-criteria.md
+++ b/docs/en/guides/financial-poc-success-criteria.md
@@ -1,0 +1,48 @@
+# Financial PoC Success Criteria (quantitative)
+
+## Objective
+
+Define a machine-checkable success contract for the financial PoC runner.
+
+---
+
+## Metrics and thresholds
+
+For one run report:
+
+- `total`: total PoC questions executed
+- `pass_count`: cases with zero semantic mismatches
+- `fail_count`: cases with one or more semantic mismatches
+- `warning_count`: cases not evaluated due to runtime issues (HTTP errors/timeouts)
+- `evaluated_count = total - warning_count`
+- `pass_rate = pass_count / evaluated_count`
+
+### Target thresholds
+
+- **Gate A (minimum reproducibility)**
+  - `evaluated_count >= 5`
+  - `pass_rate >= 0.90`
+- **Gate B (demo-ready quality)**
+  - `fail_count = 0`
+  - `warning_count = 0`
+- **Gate C (beachhead consistency)**
+  - `aml_kyc` anchor case status is `pass`
+
+---
+
+## Outcome bands
+
+- **PASS**
+  - Gate A + Gate B + Gate C satisfied.
+- **WARNING**
+  - Gate A satisfied, but warnings exist (`warning_count > 0`) and no fails.
+- **FAIL**
+  - `fail_count > 0`, or `pass_rate < 0.90`, or `evaluated_count < 5`.
+
+---
+
+## Operational notes
+
+- Keep the fixture synthetic and deterministic.
+- Treat warning-only runs as operational instability, not semantics correctness.
+- Track mismatch deltas over time as a regression signal.

--- a/docs/en/guides/poc-pack-financial-quickstart.md
+++ b/docs/en/guides/poc-pack-financial-quickstart.md
@@ -1,0 +1,122 @@
+# Financial PoC Pack (1-day quickstart, EN)
+
+## Purpose
+
+This quickstart turns the financial beachhead PoC from "readable docs" into a
+**reproducible, measurable run**.
+
+What this pack proves:
+
+1. **Fail-closed governance behavior** in `/v1/decide`.
+2. **Expected semantics diffing** against fixture baselines.
+3. **Quantitative pass/fail/warning summary** for demo and benchmark handoff.
+
+---
+
+## Scope (single beachhead)
+
+This PoC is intentionally constrained to one beachhead:
+
+- **Beachhead domain**: `aml_kyc`
+- **Anchor template**: `aml_kyc_high_risk_country_wire_manual_review`
+
+Reference pack semantics and taxonomy:
+
+- [Financial Governance Templates](financial-governance-templates.md)
+- [Required Evidence Taxonomy v0](../governance/required-evidence-taxonomy.md)
+
+---
+
+## Inputs and runner
+
+- PoC question fixture:
+  `veritas_os/sample_data/governance/financial_poc_questions.json`
+- Runner:
+  `scripts/run_financial_poc.py`
+- Runtime module:
+  `veritas_os/scripts/financial_poc_runner.py`
+
+### Dry-run (no API dependency)
+
+```bash
+python scripts/run_financial_poc.py \
+  --dry-run \
+  --output-json veritas_os/scripts/logs/financial_poc_dry_run_report.json
+```
+
+### Live run (`/v1/decide`)
+
+```bash
+VERITAS_API_KEY=demo-key \
+python scripts/run_financial_poc.py \
+  --api-url http://localhost:8000/v1/decide \
+  --output-json veritas_os/scripts/logs/financial_poc_live_report.json
+```
+
+---
+
+## Success criteria (quantified)
+
+Use the criteria in:
+
+- [Financial PoC Success Criteria](financial-poc-success-criteria.md)
+
+At minimum for demo sign-off:
+
+- `warning_count = 0`
+- `fail_count = 0`
+- `pass_rate >= 0.90` (on evaluated, non-warning cases)
+
+---
+
+## Diff semantics and mismatch summary
+
+The runner compares these fields per case:
+
+- `gate_decision`
+- `business_decision`
+- `next_action`
+- `required_evidence`
+- `human_review_required`
+
+Example mismatch output (JSON excerpt):
+
+```json
+{
+  "question_id": "poc_cross_border_purpose_unknown",
+  "status": "fail",
+  "mismatch_count": 2,
+  "mismatches": {
+    "gate_decision": {
+      "expected": "hold",
+      "actual": "proceed"
+    },
+    "required_evidence": {
+      "expected": ["transaction_purpose_statement", "source_of_funds_document"],
+      "actual": []
+    }
+  }
+}
+```
+
+---
+
+## How this connects to demo and benchmark
+
+1. **3-minute demo script**
+   - Use the demo flow for UI walkthrough, then show the runner summary to prove
+     reproducibility of governance semantics.
+   - Reference: [3-Minute Demo Script](demo-script.md)
+
+2. **Evidence benchmark plan**
+   - Feed runner report counts (`pass/fail/warning`) and mismatch artifacts into
+     the benchmark narrative for "fail-closed safety" and auditability claims.
+   - Reference: [Evidence Benchmark Plan](../../benchmarks/VERITAS_EVIDENCE_BENCHMARK_PLAN.md)
+
+---
+
+## Security warnings
+
+- Do not send production PII or account identifiers in PoC payloads.
+- Avoid exposing API keys in shell history or logs.
+- Runner warns when using `http://` in live mode; keep HTTP limited to localhost.

--- a/scripts/run_financial_poc.py
+++ b/scripts/run_financial_poc.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CLI wrapper for financial PoC runner."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from veritas_os.scripts.financial_poc_runner import main
+
+
+if __name__ == "__main__":
+    main()

--- a/veritas_os/scripts/financial_poc_runner.py
+++ b/veritas_os/scripts/financial_poc_runner.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Financial PoC runner for deterministic expected-semantics validation.
+
+This runner executes a compact financial PoC question pack against `/v1/decide`
+and compares runtime response semantics to fixture `expected_semantics`.
+
+Design goals:
+- reproducible and lightweight (no benchmark infra dependencies),
+- machine-readable mismatch diffs,
+- quantified pass/fail/warning summary for demo and benchmark handoff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+import requests
+
+from veritas_os.core.decision_semantics import canonicalize_gate_decision
+
+DEFAULT_FIXTURE_PATH = Path("veritas_os/sample_data/governance/financial_poc_questions.json")
+DEFAULT_API_URL = "http://localhost:8000/v1/decide"
+DEFAULT_TIMEOUT_SECONDS = 15.0
+
+_NEXT_ACTION_ALIASES = {
+    "NEEDS_HUMAN_REVIEW": "PREPARE_HUMAN_REVIEW_PACKET",
+    "REJECT_REQUEST": "DO_NOT_EXECUTE",
+}
+
+
+@dataclass(frozen=True)
+class PocQuestion:
+    """One financial PoC question with expected semantics."""
+
+    question_id: str
+    category: str
+    question: str
+    expected_semantics: dict[str, Any]
+    template_id: str | None = None
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """Evaluation outcome for one PoC question."""
+
+    question_id: str
+    status: str
+    mismatch_count: int
+    mismatches: dict[str, dict[str, Any]]
+    template_id: str | None
+    request_id: str | None
+    error: str | None
+
+
+def _normalize_next_action(value: Any) -> str:
+    """Normalize next_action labels into stable canonical labels."""
+    normalized = str(value or "").strip().upper()
+    if not normalized:
+        return ""
+    return _NEXT_ACTION_ALIASES.get(normalized, normalized)
+
+
+def compare_expected_semantics(
+    expected: Mapping[str, Any],
+    actual: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return field-level mismatch diff between expected and actual semantics."""
+    mismatches: dict[str, dict[str, Any]] = {}
+
+    expected_gate = canonicalize_gate_decision(expected.get("gate_decision"))
+    actual_gate = canonicalize_gate_decision(actual.get("gate_decision"))
+    if expected_gate != actual_gate:
+        mismatches["gate_decision"] = {"expected": expected_gate, "actual": actual_gate}
+
+    expected_business = expected.get("business_decision")
+    actual_business = actual.get("business_decision")
+    if expected_business != actual_business:
+        mismatches["business_decision"] = {
+            "expected": expected_business,
+            "actual": actual_business,
+        }
+
+    expected_action = _normalize_next_action(expected.get("next_action"))
+    actual_action = _normalize_next_action(actual.get("next_action"))
+    if expected_action != actual_action:
+        mismatches["next_action"] = {"expected": expected_action, "actual": actual_action}
+
+    expected_evidence = expected.get("required_evidence")
+    actual_evidence = actual.get("required_evidence")
+    if expected_evidence != actual_evidence:
+        mismatches["required_evidence"] = {
+            "expected": expected_evidence,
+            "actual": actual_evidence,
+        }
+
+    expected_human = bool(expected.get("human_review_required"))
+    actual_human = bool(actual.get("human_review_required"))
+    if expected_human != actual_human:
+        mismatches["human_review_required"] = {
+            "expected": expected_human,
+            "actual": actual_human,
+        }
+
+    return mismatches
+
+
+def load_questions(path: Path) -> list[PocQuestion]:
+    """Load PoC questions from fixture JSON."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    questions: list[PocQuestion] = []
+    for item in payload:
+        questions.append(
+            PocQuestion(
+                question_id=str(item.get("question_id", "")).strip(),
+                category=str(item.get("category", "")).strip(),
+                question=str(item.get("question", "")).strip(),
+                expected_semantics=dict(item.get("expected_semantics") or {}),
+                template_id=(
+                    str(item["template_id"]).strip() if item.get("template_id") is not None else None
+                ),
+            )
+        )
+    return questions
+
+
+def _build_request_payload(question: PocQuestion) -> dict[str, Any]:
+    """Build `/v1/decide` request payload for one PoC question."""
+    context: dict[str, Any] = {
+        "user_id": "financial_poc_runner",
+        "category": question.category,
+        "source": "financial_poc_pack",
+    }
+    if question.template_id:
+        context["template_id"] = question.template_id
+
+    return {
+        "query": question.question,
+        "context": context,
+    }
+
+
+def _call_decide_api(
+    *,
+    api_url: str,
+    api_key: str,
+    timeout_seconds: float,
+    question: PocQuestion,
+) -> dict[str, Any]:
+    """Call `/v1/decide` and return parsed JSON payload."""
+    headers = {
+        "Content-Type": "application/json",
+        "X-API-Key": api_key,
+    }
+    response = requests.post(
+        api_url,
+        headers=headers,
+        json=_build_request_payload(question),
+        timeout=timeout_seconds,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _dry_run_response(question: PocQuestion) -> dict[str, Any]:
+    """Return deterministic synthetic response for dry-run validation."""
+    expected = question.expected_semantics
+    return {
+        "request_id": f"dry-run-{question.question_id}",
+        "gate_decision": expected.get("gate_decision"),
+        "business_decision": expected.get("business_decision"),
+        "next_action": expected.get("next_action"),
+        "required_evidence": expected.get("required_evidence"),
+        "human_review_required": expected.get("human_review_required"),
+    }
+
+
+def _evaluate_questions(
+    questions: list[PocQuestion],
+    fetcher: Callable[[PocQuestion], dict[str, Any]],
+) -> list[CaseResult]:
+    """Evaluate all PoC questions with provided response fetcher."""
+    results: list[CaseResult] = []
+    for question in questions:
+        try:
+            payload = fetcher(question)
+        except Exception as exc:  # pragma: no cover - guarded in tests via warning path
+            results.append(
+                CaseResult(
+                    question_id=question.question_id,
+                    status="warning",
+                    mismatch_count=0,
+                    mismatches={},
+                    template_id=question.template_id,
+                    request_id=None,
+                    error=str(exc),
+                )
+            )
+            continue
+
+        mismatches = compare_expected_semantics(question.expected_semantics, payload)
+        status = "pass" if not mismatches else "fail"
+        results.append(
+            CaseResult(
+                question_id=question.question_id,
+                status=status,
+                mismatch_count=len(mismatches),
+                mismatches=mismatches,
+                template_id=question.template_id,
+                request_id=str(payload.get("request_id", "")).strip() or None,
+                error=None,
+            )
+        )
+    return results
+
+
+def _summarize(results: list[CaseResult]) -> dict[str, Any]:
+    """Build quantitative summary from case results."""
+    counts = {
+        "pass": sum(result.status == "pass" for result in results),
+        "fail": sum(result.status == "fail" for result in results),
+        "warning": sum(result.status == "warning" for result in results),
+    }
+    total = len(results)
+    evaluated = total - counts["warning"]
+    pass_rate = (counts["pass"] / evaluated) if evaluated > 0 else 0.0
+
+    return {
+        "total": total,
+        "counts": counts,
+        "pass_rate": round(pass_rate, 4),
+        "success_criteria": {
+            "minimum_pass_rate": 0.9,
+            "no_failures_required_for_demo": True,
+            "allow_warnings_for_connectivity_only": True,
+        },
+    }
+
+
+def run_financial_poc(
+    *,
+    input_path: Path,
+    dry_run: bool,
+    api_url: str,
+    api_key: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    """Run financial PoC pack and return machine-readable report."""
+    questions = load_questions(input_path)
+    if dry_run:
+        results = _evaluate_questions(questions, fetcher=_dry_run_response)
+    else:
+        results = _evaluate_questions(
+            questions,
+            fetcher=lambda question: _call_decide_api(
+                api_url=api_url,
+                api_key=api_key,
+                timeout_seconds=timeout_seconds,
+                question=question,
+            ),
+        )
+
+    summary = _summarize(results)
+    return {
+        "meta": {
+            "mode": "dry-run" if dry_run else "live",
+            "input_path": str(input_path),
+            "api_url": api_url,
+        },
+        "summary": summary,
+        "cases": [
+            {
+                "question_id": result.question_id,
+                "template_id": result.template_id,
+                "status": result.status,
+                "mismatch_count": result.mismatch_count,
+                "mismatches": result.mismatches,
+                "request_id": result.request_id,
+                "error": result.error,
+            }
+            for result in results
+        ],
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for financial PoC runner."""
+    parser = argparse.ArgumentParser(
+        description="Run financial PoC questions and compare expected semantics."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_FIXTURE_PATH),
+        help="Path to PoC question JSON fixture.",
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.getenv("VERITAS_API_URL", DEFAULT_API_URL),
+        help="Target /v1/decide endpoint URL.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("VERITAS_API_KEY", ""),
+        help="API key for /v1/decide calls (not required for --dry-run).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="HTTP timeout seconds for each /v1/decide call.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional output report path in JSON format.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip API calls and validate fixture plumbing with synthetic responses.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI entry point for financial PoC runner."""
+    args = _parse_args()
+    input_path = Path(args.input)
+    if not input_path.exists():
+        raise SystemExit(f"[financial-poc] input file not found: {input_path}")
+
+    if not args.dry_run and not str(args.api_key).strip():
+        raise SystemExit(
+            "[financial-poc] --api-key (or VERITAS_API_KEY) is required for live mode"
+        )
+
+    if not args.dry_run and str(args.api_url).startswith("http://"):
+        print(
+            "[financial-poc][security-warning] Using HTTP endpoint. "
+            "Use HTTPS for any non-local environment."
+        )
+
+    report = run_financial_poc(
+        input_path=input_path,
+        dry_run=bool(args.dry_run),
+        api_url=str(args.api_url),
+        api_key=str(args.api_key),
+        timeout_seconds=float(args.timeout),
+    )
+
+    summary = report["summary"]
+    counts = summary["counts"]
+    print(
+        "[financial-poc] "
+        f"total={summary['total']} pass={counts['pass']} fail={counts['fail']} "
+        f"warning={counts['warning']} pass_rate={summary['pass_rate']:.4f}"
+    )
+
+    for case in report["cases"]:
+        print(
+            " - "
+            f"{case['question_id']}: status={case['status']} "
+            f"mismatch_count={case['mismatch_count']}"
+        )
+
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"[financial-poc] report saved: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/veritas_os/tests/test_financial_poc_runner.py
+++ b/veritas_os/tests/test_financial_poc_runner.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Tests for financial PoC runner and EN quickstart documentation."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from veritas_os.scripts.financial_poc_runner import (
+    compare_expected_semantics,
+    load_questions,
+    run_financial_poc,
+)
+
+POC_FIXTURE_PATH = Path("veritas_os/sample_data/governance/financial_poc_questions.json")
+EN_QUICKSTART_PATH = Path("docs/en/guides/poc-pack-financial-quickstart.md")
+SUCCESS_CRITERIA_DOC_PATH = Path("docs/en/guides/financial-poc-success-criteria.md")
+
+
+def _extract_markdown_links(content: str) -> list[str]:
+    """Extract markdown links from document content."""
+    return re.findall(r"\[[^\]]+\]\(([^)]+)\)", content)
+
+
+def test_financial_poc_runner_loads_sample_fixture() -> None:
+    """Runner should read the sample financial PoC question JSON fixture."""
+    questions = load_questions(POC_FIXTURE_PATH)
+
+    assert len(questions) >= 8
+    assert all(question.question_id for question in questions)
+    assert all(question.expected_semantics for question in questions)
+
+
+def test_compare_expected_semantics_reports_field_level_diff() -> None:
+    """Expected semantics comparator should return a machine-readable mismatch diff."""
+    expected = {
+        "gate_decision": "hold",
+        "business_decision": "EVIDENCE_REQUIRED",
+        "next_action": "COLLECT_REQUIRED_EVIDENCE",
+        "required_evidence": ["evidence_a"],
+        "human_review_required": False,
+    }
+    actual = {
+        "gate_decision": "proceed",
+        "business_decision": "APPROVE",
+        "next_action": "DO_NOT_EXECUTE",
+        "required_evidence": [],
+        "human_review_required": True,
+    }
+
+    diff = compare_expected_semantics(expected, actual)
+
+    assert diff["gate_decision"]["expected"] == "hold"
+    assert diff["gate_decision"]["actual"] == "proceed"
+    assert diff["business_decision"]["expected"] == "EVIDENCE_REQUIRED"
+    assert diff["business_decision"]["actual"] == "APPROVE"
+    assert diff["next_action"]["expected"] == "COLLECT_REQUIRED_EVIDENCE"
+    assert diff["next_action"]["actual"] == "DO_NOT_EXECUTE"
+    assert diff["required_evidence"]["expected"] == ["evidence_a"]
+    assert diff["required_evidence"]["actual"] == []
+    assert diff["human_review_required"]["expected"] is False
+    assert diff["human_review_required"]["actual"] is True
+
+
+def test_financial_poc_runner_dry_run_produces_quantified_summary() -> None:
+    """Dry-run mode should produce deterministic pass/fail/warning summary."""
+    report = run_financial_poc(
+        input_path=POC_FIXTURE_PATH,
+        dry_run=True,
+        api_url="http://localhost:8000/v1/decide",
+        api_key="",
+        timeout_seconds=5.0,
+    )
+
+    summary = report["summary"]
+    counts = summary["counts"]
+
+    assert summary["total"] >= 8
+    assert counts["pass"] == summary["total"]
+    assert counts["fail"] == 0
+    assert counts["warning"] == 0
+    assert summary["pass_rate"] == 1.0
+
+
+def test_en_quickstart_links_resolve_and_success_criteria_doc_exists() -> None:
+    """EN quickstart should have valid relative links and success criteria doc."""
+    content = EN_QUICKSTART_PATH.read_text(encoding="utf-8")
+    links = _extract_markdown_links(content)
+
+    relative_links = [
+        link for link in links if not link.startswith(("http://", "https://", "#"))
+    ]
+
+    for link in relative_links:
+        candidate = (EN_QUICKSTART_PATH.parent / link).resolve()
+        assert candidate.exists(), f"Broken link: {link} -> {candidate}"
+
+    assert SUCCESS_CRITERIA_DOC_PATH.exists()


### PR DESCRIPTION
### Motivation
- Turn the existing financial PoC documentation into a reproducible, machine-checkable PoC that reduces manual success judgment and targets a single beachhead (`aml_kyc`).
- Provide a lightweight runner that can validate `expected_semantics` vs runtime `/v1/decide` responses without adding heavy benchmark infrastructure. 
- Make pass/fail/warning criteria quantitative so demo sign-off and benchmark handoff can be automated to the extent possible. 
- Surface minimal security guidance so PoC operators avoid leaking PII or API keys during runs. 

### Description
- Add a deterministic financial PoC runner implementation at `veritas_os/scripts/financial_poc_runner.py` that loads `veritas_os/sample_data/governance/financial_poc_questions.json`, supports `--dry-run` (synthetic responses) and live `/v1/decide` mode, and emits per-case mismatches and an aggregated summary. 
- Provide a small CLI wrapper `scripts/run_financial_poc.py` to run the runner from the repository root and ensure importability. 
- Implement `compare_expected_semantics` to produce machine-readable diffs comparing `gate_decision`, `business_decision`, `next_action`, `required_evidence`, and `human_review_required` between expected and actual outputs. 
- Add English docs and links: `docs/en/guides/poc-pack-financial-quickstart.md` (EN quickstart), `docs/en/guides/financial-poc-success-criteria.md` (quantitative thresholds), update `docs/en/guides/demo-script.md`, `docs/en/guides/financial-governance-templates.md`, and `docs/en/README.md` to reference the runner and success criteria. 
- Add tests `veritas_os/tests/test_financial_poc_runner.py` covering fixture loading, comparator diffs, dry-run summary behavior, and EN quickstart link integrity; include docstrings for the new runner per repository conventions. 
- Runner prints a security warning when live mode uses `http://` and prevents live runs without an API key to avoid accidental exposure. 

### Testing
- Ran unit tests with `pytest -q veritas_os/tests/test_financial_poc_runner.py veritas_os/tests/test_financial_poc_pack.py` and observed `10 passed in 4.02s`. 
- Ran the focused runner tests with `pytest -q veritas_os/tests/test_financial_poc_runner.py` and observed `4 passed in 0.26s`. 
- Performed a dry-run execution with the CLI `python scripts/run_financial_poc.py --dry-run --output-json /tmp/financial_poc_report.json` and confirmed the runner printed a summary and saved the report (`total=8 pass=8 fail=0 warning=0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c9600bc4832698fdd0f9f776496f)