### PR TITLE
Canonical-Only Public Gate Decision Tightening

### DIFF
--- a/docs/en/architecture/decision-semantics.md
+++ b/docs/en/architecture/decision-semantics.md
@@ -27,6 +27,14 @@ response finalization.
 - Forbidden combination checks are enforced on canonicalized values.
 - `unknown` remains fallback-compatible, but normal runtime derivation converges to canonical values.
 - Mission Control adapters now canonicalize legacy gate aliases before UI rendering.
+- PoC compare helper normalizes gate decisions to canonical public values before diffing.
+- Evidence Bundle `decision_record.gate_decision` is canonicalized for external-facing audit payloads.
+
+### Canonical-only public surface policy (current)
+
+- Public response assembly (`/v1/decide`) emits canonical gate values by default.
+- `allow|deny|modify|rejected|abstain` remain accepted as backward-compatibility input.
+- Legacy gate labels are compatibility-only and should not be used as new output contracts.
 
 ## A. gate_decision semantics table
 

--- a/frontend/features/console/adapters/decision-semantics.ts
+++ b/frontend/features/console/adapters/decision-semantics.ts
@@ -1,0 +1,47 @@
+const CANONICAL_GATE_DECISIONS = new Set([
+  "proceed",
+  "hold",
+  "block",
+  "human_review_required",
+] as const);
+
+const GATE_ALIAS_TO_CANONICAL: Record<string, string> = {
+  allow: "proceed",
+  deny: "block",
+  rejected: "block",
+  modify: "hold",
+  abstain: "hold",
+  proceed: "proceed",
+  hold: "hold",
+  block: "block",
+  human_review_required: "human_review_required",
+  unknown: "unknown",
+};
+
+export function canonicalizePublicGateDecision(value: unknown): string {
+  if (typeof value !== "string") {
+    return "unknown";
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return "unknown";
+  }
+  const mapped = GATE_ALIAS_TO_CANONICAL[normalized] ?? normalized;
+  return CANONICAL_GATE_DECISIONS.has(mapped as never) ? mapped : "unknown";
+}
+
+export function gateDecisionLabel(gateDecision: string): string {
+  if (gateDecision === "proceed") {
+    return "proceed (execution guidance, not business approval)";
+  }
+  if (gateDecision === "hold") {
+    return "gate hold";
+  }
+  if (gateDecision === "block") {
+    return "blocked by gate";
+  }
+  if (gateDecision === "human_review_required") {
+    return "human review required by gate";
+  }
+  return "gate status";
+}

--- a/frontend/features/console/adapters/decision-view.test.ts
+++ b/frontend/features/console/adapters/decision-view.test.ts
@@ -163,6 +163,12 @@ describe("toPublicDecisionSchemaView", () => {
     const view = toPublicDecisionSchemaView(result);
     expect(view.gateDecisionLabel).toBe("proceed (execution guidance, not business approval)");
   });
+
+  it("falls back to unknown for non-canonical gate outputs", () => {
+    const result = makeResponse({ gate_decision: "totally_custom_status" } as never);
+    const view = toPublicDecisionSchemaView(result);
+    expect(view.gateDecision).toBe("unknown");
+  });
 });
 
 

--- a/frontend/features/console/adapters/decision-view.ts
+++ b/frontend/features/console/adapters/decision-view.ts
@@ -1,6 +1,7 @@
 import { type DecideResponse } from "@veritas/types";
 import { toArray } from "../analytics/utils";
 import { PIPELINE_STAGES, type PipelineStageName } from "../constants";
+import { canonicalizePublicGateDecision, gateDecisionLabel } from "./decision-semantics";
 import {
   type DecisionResultView,
   type FujiGateDetailView,
@@ -149,39 +150,6 @@ function readText(record: Record<string, unknown>, ...keys: string[]): string {
   return "n/a";
 }
 
-function getGateDecisionLabel(gateDecision: string): string {
-  if (gateDecision === "proceed") {
-    return "proceed (execution guidance, not business approval)";
-  }
-  if (gateDecision === "hold") {
-    return "gate hold";
-  }
-  if (gateDecision === "block") {
-    return "blocked by gate";
-  }
-  if (gateDecision === "human_review_required") {
-    return "human review required by gate";
-  }
-  return "gate status";
-}
-
-function canonicalizeGateDecision(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) {
-    return "unknown";
-  }
-  if (normalized === "allow") {
-    return "proceed";
-  }
-  if (normalized === "deny" || normalized === "rejected") {
-    return "block";
-  }
-  if (normalized === "modify" || normalized === "abstain") {
-    return "hold";
-  }
-  return normalized;
-}
-
 export function toPublicDecisionSchemaView(result: DecideResponse): PublicDecisionSchemaView {
   const resultRecord = result as Record<string, unknown>;
   const requiredEvidenceRaw = result.required_evidence;
@@ -193,12 +161,12 @@ export function toPublicDecisionSchemaView(result: DecideResponse): PublicDecisi
     ? missingEvidenceRaw.filter((item): item is string => typeof item === "string")
     : [];
   const runtimeStatus = toRuntimeStatusView(result);
-  const gateDecision = canonicalizeGateDecision(
+  const gateDecision = canonicalizePublicGateDecision(
     readText(resultRecord, "gate_decision", "decision_status"),
   );
   return {
     gateDecision,
-    gateDecisionLabel: getGateDecisionLabel(gateDecision),
+    gateDecisionLabel: gateDecisionLabel(gateDecision),
     businessDecision: readText(resultRecord, "business_decision"),
     nextAction: readText(resultRecord, "next_action"),
     requiredEvidence,

--- a/frontend/features/console/analytics/utils.test.ts
+++ b/frontend/features/console/analytics/utils.test.ts
@@ -86,7 +86,7 @@ describe("toAssistantMessage", () => {
     const t = (ja: string, _en: string) => ja;
     const message = toAssistantMessage(payload, t);
     expect(message).toContain("案件状態: APPROVE");
-    expect(message).toContain("ゲート判定: allow (案件承認ではなく、応答出力可)");
+    expect(message).toContain("ゲート判定: proceed (案件承認ではなく、応答出力可)");
     expect(message).toContain("次アクション: EXECUTE_WITH_STANDARD_MONITORING");
     expect(message).toContain("採択案: Option A");
     expect(message).toContain("拒否理由: なし");
@@ -105,7 +105,7 @@ describe("toAssistantMessage", () => {
     const t = (_ja: string, en: string) => en;
     const message = toAssistantMessage(payload, t);
     expect(message).toContain("Business Decision: DENY");
-    expect(message).toContain("Gate Decision: deny");
+    expect(message).toContain("Gate Decision: block");
     expect(message).toContain("Next Action: DO_NOT_EXECUTE");
     expect(message).toContain("Human Review: required");
     expect(message).toContain("Chosen: none");
@@ -167,6 +167,6 @@ describe("toAssistantMessage", () => {
     const message = toAssistantMessage(payload, t);
     expect(message).toContain("案件状態: REVIEW_REQUIRED");
     expect(message).not.toContain("案件状態: allow");
-    expect(message).toContain("ゲート判定: allow (案件承認ではなく、応答出力可)");
+    expect(message).toContain("ゲート判定: proceed (案件承認ではなく、応答出力可)");
   });
 });

--- a/frontend/features/console/analytics/utils.ts
+++ b/frontend/features/console/analytics/utils.ts
@@ -1,4 +1,5 @@
 import { type DecideResponse } from "@veritas/types";
+import { canonicalizePublicGateDecision } from "../adapters/decision-semantics";
 
 /**
  * Render-safe serializer for unknown values.
@@ -73,8 +74,10 @@ export function toAssistantMessage(
   }
 
   const businessDecision = payload.business_decision ?? "HOLD";
-  const gateDecision = payload.gate_decision ?? payload.decision_status ?? "unknown";
-  const gateDecisionWithMeaning = gateDecision === "allow"
+  const gateDecision = canonicalizePublicGateDecision(
+    payload.gate_decision ?? payload.decision_status ?? "unknown",
+  );
+  const gateDecisionWithMeaning = gateDecision === "proceed"
     ? `${gateDecision} (${t("案件承認ではなく、応答出力可", "not case approval; response may be returned")})`
     : gateDecision;
   const nextAction = payload.next_action ?? t("要再評価", "Reassess required");

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -13,7 +13,7 @@ from pydantic import (
     field_validator,
 )
 from veritas_os.core.decision_semantics import (
-    canonicalize_gate_decision,
+    canonicalize_public_gate_decision,
     normalize_required_evidence_keys,
     unique_preserve_order,
     validate_gate_business_combination,
@@ -948,7 +948,7 @@ class DecideResponse(BaseModel):
                 sorted(extras.keys()),
             )
 
-        canonical_gate_decision = canonicalize_gate_decision(self.gate_decision)
+        canonical_gate_decision = canonicalize_public_gate_decision(self.gate_decision)
         if canonical_gate_decision != self.gate_decision:
             self.gate_decision = canonical_gate_decision
             events.append("coercion.gate_decision_canonicalized")

--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from veritas_os.audit.evidence_bundle_schema import BUNDLE_SCHEMA_VERSION, BUNDLE_TYPES
+from veritas_os.core.decision_semantics import canonicalize_public_gate_decision
 from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
 
 _logger = logging.getLogger(__name__)
@@ -245,10 +246,11 @@ def _decision_record(entry: Dict[str, Any], verification_report: Dict[str, Any])
     payload = payload if isinstance(payload, dict) else {}
     governance_identity = payload.get("governance_identity")
     decision_id = entry.get("decision_id") or payload.get("decision_id")
+    canonical_gate_decision = canonicalize_public_gate_decision(payload.get("gate_decision"))
 
     return {
         "decision_payload": payload,
-        "gate_decision": payload.get("gate_decision", "unknown"),
+        "gate_decision": canonical_gate_decision,
         "business_decision": payload.get("business_decision", "HOLD"),
         "next_action": payload.get("next_action", "REVISE_AND_RESUBMIT"),
         "required_evidence": payload.get("required_evidence", []),

--- a/veritas_os/core/decision_semantics.py
+++ b/veritas_os/core/decision_semantics.py
@@ -112,6 +112,22 @@ def canonicalize_gate_decision(value: object) -> str:
     return GATE_DECISION_ALIAS_TO_CANONICAL.get(normalized, normalized)
 
 
+def canonicalize_public_gate_decision(
+    value: object,
+    *,
+    fallback: str = "unknown",
+) -> str:
+    """Canonicalize gate_decision for public response surfaces.
+
+    Legacy aliases are normalized to canonical values.
+    Non-canonical / unrecognized values are collapsed to ``fallback``.
+    """
+    canonical_value = canonicalize_gate_decision(value)
+    if canonical_value in CANONICAL_GATE_DECISIONS:
+        return canonical_value
+    return fallback
+
+
 def normalize_required_evidence_keys(values: Iterable[object] | None) -> list[str]:
     """Normalize evidence keys via taxonomy aliases while keeping free strings."""
     if values is None:
@@ -295,6 +311,7 @@ def validate_gate_business_combination(
     *, gate_decision: str, business_decision: str, human_review_required: bool
 ) -> None:
     """Raise ValueError when gate/business combination is forbidden."""
+    gate_decision = canonicalize_public_gate_decision(gate_decision)
     forbidden = {
         ("block", "APPROVE"),
         ("hold", "APPROVE"),

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -22,7 +22,7 @@ from .pipeline_evidence import _norm_evidence_item, _dedupe_evidence
 from .pipeline_helpers import _warn
 from veritas_os.core.decision_semantics import (
     build_required_evidence_profile,
-    canonicalize_gate_decision,
+    canonicalize_public_gate_decision,
     derive_gate_decision_from_stop_reasons,
     get_required_evidence_profiles,
     normalize_required_evidence_keys_with_diagnostics,
@@ -519,7 +519,7 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         risk_score=risk_score,
         human_review_required=human_review_required,
     )
-    gate_decision = canonicalize_gate_decision(gate_decision)
+    gate_decision = canonicalize_public_gate_decision(gate_decision)
 
     if missing_evidence:
         business_decision = "EVIDENCE_REQUIRED"

--- a/veritas_os/scripts/expected_semantics_compare.py
+++ b/veritas_os/scripts/expected_semantics_compare.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from veritas_os.core.decision_semantics import (
-    canonicalize_gate_decision,
+    canonicalize_public_gate_decision,
     normalize_required_evidence_keys,
     unique_preserve_order,
 )
@@ -50,8 +50,8 @@ def compare_expected_semantics(
     """Return field-level mismatch diff between expected and actual semantics."""
     mismatches: dict[str, dict[str, Any]] = {}
 
-    expected_gate = canonicalize_gate_decision(expected.get("gate_decision"))
-    actual_gate = canonicalize_gate_decision(actual.get("gate_decision"))
+    expected_gate = canonicalize_public_gate_decision(expected.get("gate_decision"))
+    actual_gate = canonicalize_public_gate_decision(actual.get("gate_decision"))
     if expected_gate != actual_gate:
         mismatches["gate_decision"] = {"expected": expected_gate, "actual": actual_gate}
 

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -73,3 +73,49 @@ def test_financial_bundle_sample_fixture_exists() -> None:
     assert decision_record["decision_payload"]["gate_decision"] == "human_review_required"
     assert decision_record["decision_payload"]["business_decision"] == "REVIEW_REQUIRED"
     assert decision_record["decision_payload"]["human_review_required"] is True
+
+
+def test_evidence_bundle_decision_record_canonicalizes_gate_decision(
+    tmp_path,
+) -> None:
+    """Decision record gate_decision should use canonical public values."""
+    log_path = tmp_path / "trustlog.jsonl"
+    log_entry = {
+        "decision_id": "dec-fin-wire-2026-0002",
+        "timestamp": "2026-04-18T00:00:00Z",
+        "previous_hash": None,
+        "payload_hash": "dummy",
+        "full_payload_hash": "dummy-full",
+        "signature": "dummy-signature",
+        "decision_payload": {
+            "request_id": "fin-wire-2026-0002",
+            "gate_decision": "allow",
+            "business_decision": "APPROVE",
+            "next_action": "EXECUTE_WITH_STANDARD_MONITORING",
+            "required_evidence": [],
+            "human_review_required": False,
+        },
+    }
+    log_path.write_text(json.dumps(log_entry) + "\n", encoding="utf-8")
+
+    from veritas_os.cli.evidence_bundle import main
+
+    out_dir = tmp_path / "bundles"
+    exit_code = main(
+        [
+            "generate",
+            "--bundle-type",
+            "decision",
+            "--witness-ledger",
+            str(log_path),
+            "--output-dir",
+            str(out_dir),
+            "--request-id",
+            "fin-wire-2026-0002",
+            "--json",
+        ]
+    )
+    assert exit_code == 0
+    bundle_dir = next(out_dir.glob("veritas_bundle_decision_*"))
+    decision_record = json.loads((bundle_dir / "decision_record.json").read_text(encoding="utf-8"))
+    assert decision_record["gate_decision"] == "proceed"

--- a/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
+++ b/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
@@ -134,6 +134,23 @@ def test_public_response_prefers_canonical_gate_decision() -> None:
     assert payload["gate_decision"] == "proceed"
 
 
+def test_public_response_avoids_unknown_in_normal_runtime_path() -> None:
+    """Unknown FUJI status should still resolve into canonical public gate decision."""
+    ctx = PipelineContext(
+        request_id="req-gate-unknown-normalized",
+        query="test unknown gate",
+        fuji_dict={"decision_status": "totally_unknown_status", "status": "totally_unknown_status"},
+        decision_status="totally_unknown_status",
+        context={},
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+    assert payload["gate_decision"] == "proceed"
+
+
 def test_backward_compat_decision_status_stays_legacy_field() -> None:
     """decision_status remains distinct from public gate semantics."""
     payload = DecideResponse.model_validate(


### PR DESCRIPTION
### Motivation
- Reduce ambiguity in public-facing `gate_decision` semantics by ensuring public outputs use only canonical values and confine legacy aliases to ingestion/compatibility paths.
- Centralize canonicalization logic so API, pipeline, UI, PoC helpers, and Evidence Bundle consistently expose the same public semantics.
- Prevent accidental business-approval interpretations of legacy labels like `allow` by preferring canonical labels in responses and UI.

### Description
- Added `canonicalize_public_gate_decision()` in `veritas_os/core/decision_semantics.py` that maps legacy aliases to canonical values and collapses unknown/non-canonical values to a fallback.
- Switched public-facing normalization sites to use the new canonicalizer: API schema coercion (`veritas_os/api/schemas.py`) and pipeline response assembly (`veritas_os/core/pipeline/pipeline_response.py`).
- Hardened forbidden-combination validation to canonicalize `gate_decision` before checks in `validate_gate_business_combination()`.
- Canonicalized downstream public surfaces: PoC compare helper (`veritas_os/scripts/expected_semantics_compare.py`), Evidence Bundle decision_record generation (`veritas_os/audit/evidence_bundle.py`), and Mission Control UI adapters.
- Frontend: added a single adapter `frontend/features/console/adapters/decision-semantics.ts` and updated `decision-view` adapter and analytics assistant formatter to use canonical-first logic and labels.
- Added/adjusted unit and integration tests to assert canonical public outputs and fallback behavior, and updated documentation (`docs/en/architecture/decision-semantics.md`) to record the tightening and compatibility scope.

### Testing
- Ran backend unit/integration tests: `pytest -q veritas_os/tests/unit/test_decision_semantics_runtime_contract.py veritas_os/tests/test_financial_poc_runner.py veritas_os/tests/test_evidence_bundle_cli.py` and the updated test set passed.
- Ran frontend tests: `pnpm -C frontend vitest run features/console/adapters/decision-view.test.ts features/console/analytics/utils.test.ts features/console/components/decision-result-panel.test.tsx` and all frontend tests passed.
- New/updated tests exercised: legacy->canonical mapping in schema, public response canonicalization, evidence bundle decision_record canonicalization, PoC compare canonical behavior, UI adapter rendering of canonical labels, and a test asserting `unknown` is avoided on normal runtime paths; these tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f499109083268ea303636108b1f9)