### PR TITLE
AML/KYC Evidence Strictness Telemetry & Profile Hardening

### DIFF
--- a/docs/en/governance/required-evidence-taxonomy.md
+++ b/docs/en/governance/required-evidence-taxonomy.md
@@ -26,15 +26,32 @@ while preserving free-string compatibility for unknown keys (`allow_free_string=
 
 ## Runtime hardening status (AML/KYC)
 
-AML/KYC profile hardening now operates in warning-first mode:
+AML/KYC profile hardening now supports runtime modes:
+
+- `warn` (default): unknown/profile misses are surfaced as warnings + telemetry.
+- `strict` (AML/KYC-only rollout): unknown/profile misses are routed to stronger
+  hold/review posture (no immediate global hard reject).
+
+In both modes:
 
 - Profile `required` keys are enforced during runtime evidence shaping.
+- Profile `escalation_sensitive` keys missing from `satisfied_evidence` force
+  `human_review_required=true`.
+- Profile `optional` keys are tracked but do not force immediate fail.
 - Unknown keys are not hard-rejected yet, but emit warnings and telemetry:
   - `unknown_required_evidence_key_total`
   - `required_evidence_alias_normalized_total`
   - `required_evidence_profile_miss_total`
-- Telemetry includes domain/template identifiers and top unknown keys to
-  prepare strict-mode migration.
+- Telemetry includes `domain`, `template_id`, `source`, `mode`, top unknown
+  keys, profile-missing keys, and normalization hit rate to prepare strict-mode
+  migration.
+
+Runtime response exposes:
+
+- `required_evidence_mode`
+- `required_evidence_assessment.internal_reasons`
+- `required_evidence_assessment.profile_missing_required_keys`
+- `required_evidence_assessment.escalation_sensitive_missing_keys`
 
 ## Definitions
 

--- a/docs/en/guides/financial-governance-templates.md
+++ b/docs/en/guides/financial-governance-templates.md
@@ -62,6 +62,9 @@ with `required`, `optional`, and `escalation_sensitive` key classes for
 regression and response shaping. Runtime hardening now also emits unknown-key
 warnings + telemetry counters instead of immediate hard-fail, so PoC and
 template suites can quantify migration readiness before strict reject mode.
+`strict` mode can now be enabled for AML/KYC beachhead experiments via runtime
+context (`required_evidence_mode=strict`) to route unknown/profile misses into
+stronger hold/review behavior while keeping full reject rollout deferred.
 
 ## Role Split: Regulatory Templates vs PoC Questions
 

--- a/docs/en/guides/poc-pack-financial-quickstart.md
+++ b/docs/en/guides/poc-pack-financial-quickstart.md
@@ -50,6 +50,7 @@ python scripts/run_financial_poc.py \
 VERITAS_API_KEY=demo-key \
 python scripts/run_financial_poc.py \
   --api-url http://localhost:8000/v1/decide \
+  --required-evidence-mode strict \
   --output-json veritas_os/scripts/logs/financial_poc_live_report.json
 ```
 
@@ -79,6 +80,7 @@ The runner compares these fields per case:
 - `required_evidence`
 - `missing_evidence`
 - `human_review_required`
+- runtime evidence warnings (`required_evidence_runtime_warnings`)
 
 Comparator helper:
 
@@ -87,6 +89,11 @@ Comparator helper:
   with gate canonicalization, taxonomy-aware evidence comparison, and next-action
   family fallback. Runner output now also includes `mismatch_summary` for
   faster AML/KYC triage.
+  It also surfaces:
+  - canonicalized expected/actual evidence deltas (`only_in_expected`,
+    `only_in_actual`),
+  - unknown key warnings (`top_unknown_keys`), and
+  - profile miss warnings (`profile_missing_keys`).
 
 Example mismatch output (JSON excerpt):
 

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -441,11 +441,27 @@ def _build_required_evidence_telemetry(
 def _should_enforce_aml_kyc_profile(
     decision_domain: str,
     profile_required_keys: List[str],
+    required_evidence: List[str],
+    template_id: str,
+    mode: str,
 ) -> bool:
-    """Return whether AML/KYC profile strictness should be applied."""
+    """Return whether AML/KYC full profile strictness should be applied.
+
+    Enforcement is intentionally scoped to avoid unexpected false-fail regressions
+    in non-beachhead AML/KYC-adjacent templates:
+    - always on for strict mode experiments,
+    - always on for beachhead template id,
+    - on when the incoming required evidence already includes beachhead anchors.
+    """
     if decision_domain != "aml_kyc":
         return False
-    return bool(AML_KYC_PROFILE_ENFORCEMENT_KEYS & set(profile_required_keys))
+    if not profile_required_keys:
+        return False
+    if mode == "strict":
+        return True
+    if template_id == "aml_kyc_high_risk_country_wire_manual_review":
+        return True
+    return bool(AML_KYC_PROFILE_ENFORCEMENT_KEYS & set(required_evidence))
 
 
 def _resolve_required_evidence_mode(context: Dict[str, Any], decision_domain: str) -> str:
@@ -504,16 +520,19 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
     profile_escalation_sensitive_keys = unique_preserve_order(
         normalize_required_evidence_keys(domain_profile.get("escalation_sensitive"))
     )
-    enforce_profile = bool(
-        profile_required_keys
-        and _should_enforce_aml_kyc_profile(decision_domain, profile_required_keys)
+    mode = _resolve_required_evidence_mode(ctx.context, decision_domain)
+    enforce_profile = _should_enforce_aml_kyc_profile(
+        decision_domain,
+        profile_required_keys,
+        required_evidence,
+        template_id,
+        mode,
     )
     profile_missing_keys = (
         [key for key in profile_required_keys if key not in set(required_evidence)]
         if enforce_profile
         else []
     )
-    mode = _resolve_required_evidence_mode(ctx.context, decision_domain)
     if enforce_profile:
         required_evidence = unique_preserve_order(required_evidence + profile_required_keys)
     unknown_keys = unique_preserve_order(

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -30,6 +30,7 @@ from veritas_os.core.decision_semantics import (
     unique_preserve_order,
     validate_gate_business_combination,
 )
+from veritas_os.observability.metrics import record_required_evidence_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -410,33 +411,53 @@ def _build_required_evidence_telemetry(
     *,
     decision_domain: str,
     template_id: str,
+    source: str,
+    mode: str,
     required_diagnostics: Dict[str, Any],
     satisfied_diagnostics: Dict[str, Any],
     unknown_keys: List[str],
     profile_missing_keys: List[str],
 ) -> Dict[str, Any]:
     """Build required-evidence telemetry counters for warning-first rollout."""
+    normalization_total = len(unknown_keys) + len(profile_missing_keys)
+    alias_hits = int(required_diagnostics.get("alias_normalized_count", 0)) + int(
+        satisfied_diagnostics.get("alias_normalized_count", 0)
+    )
+    denominator = max(1, normalization_total + alias_hits)
     return {
         "domain": decision_domain or "unknown",
         "template_id": template_id or "unknown",
+        "source": source or "unknown",
+        "mode": mode or "warn",
         "unknown_required_evidence_key_total": len(unknown_keys),
-        "required_evidence_alias_normalized_total": int(
-            required_diagnostics.get("alias_normalized_count", 0)
-        ) + int(satisfied_diagnostics.get("alias_normalized_count", 0)),
+        "required_evidence_alias_normalized_total": alias_hits,
         "required_evidence_profile_miss_total": len(profile_missing_keys),
         "top_unknown_keys": unknown_keys[:5],
         "profile_missing_keys": profile_missing_keys,
+        "required_evidence_normalization_hit_rate": round(alias_hits / denominator, 4),
     }
 
 
 def _should_enforce_aml_kyc_profile(
     decision_domain: str,
-    required_evidence: List[str],
+    profile_required_keys: List[str],
 ) -> bool:
     """Return whether AML/KYC profile strictness should be applied."""
     if decision_domain != "aml_kyc":
         return False
-    return bool(AML_KYC_PROFILE_ENFORCEMENT_KEYS & set(required_evidence))
+    return bool(AML_KYC_PROFILE_ENFORCEMENT_KEYS & set(profile_required_keys))
+
+
+def _resolve_required_evidence_mode(context: Dict[str, Any], decision_domain: str) -> str:
+    """Resolve required evidence hardening mode for runtime behavior."""
+    raw_mode = str(
+        context.get("required_evidence_mode")
+        or os.getenv("VERITAS_REQUIRED_EVIDENCE_MODE", "warn")
+    ).strip().lower()
+    mode = "strict" if raw_mode == "strict" else "warn"
+    if mode == "strict" and decision_domain != "aml_kyc":
+        return "warn"
+    return mode
 
 
 def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
@@ -460,6 +481,7 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         or ""
     ).strip().lower()
     template_id = str(ctx.context.get("template_id") or "").strip()
+    source = str(ctx.context.get("source") or "").strip()
     required_evidence_input = unique_preserve_order(
         _as_string_list(ctx.context.get("required_evidence"))
     )
@@ -479,15 +501,19 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
     profile_required_keys = unique_preserve_order(
         normalize_required_evidence_keys(domain_profile.get("required"))
     )
+    profile_escalation_sensitive_keys = unique_preserve_order(
+        normalize_required_evidence_keys(domain_profile.get("escalation_sensitive"))
+    )
     enforce_profile = bool(
         profile_required_keys
-        and _should_enforce_aml_kyc_profile(decision_domain, required_evidence)
+        and _should_enforce_aml_kyc_profile(decision_domain, profile_required_keys)
     )
     profile_missing_keys = (
         [key for key in profile_required_keys if key not in set(required_evidence)]
         if enforce_profile
         else []
     )
+    mode = _resolve_required_evidence_mode(ctx.context, decision_domain)
     if enforce_profile:
         required_evidence = unique_preserve_order(required_evidence + profile_required_keys)
     unknown_keys = unique_preserve_order(
@@ -511,6 +537,28 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         missing_evidence=missing_evidence,
         context=ctx.context,
     )
+    escalation_sensitive_missing = [
+        key for key in profile_escalation_sensitive_keys if key not in satisfied_canonical
+    ]
+    internal_evidence_reasons: list[str] = []
+    if unknown_keys:
+        if mode == "strict":
+            internal_evidence_reasons.append("unknown_required_evidence_key_strict")
+            human_review_required = True
+            stop_reasons.append("unknown_required_evidence_key")
+        else:
+            internal_evidence_reasons.append("unknown_required_evidence_key_warn")
+    if profile_missing_keys:
+        if mode == "strict":
+            internal_evidence_reasons.append("required_evidence_profile_miss_strict")
+            human_review_required = True
+            stop_reasons.append("required_evidence_profile_miss")
+        else:
+            internal_evidence_reasons.append("required_evidence_profile_miss_warn")
+    if escalation_sensitive_missing:
+        human_review_required = True
+        stop_reasons.append("escalation_sensitive_evidence_missing")
+        internal_evidence_reasons.append("escalation_sensitive_evidence_missing")
 
     gate_decision, human_review_required = derive_gate_decision_from_stop_reasons(
         stop_reasons=stop_reasons,
@@ -585,11 +633,21 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         "required_evidence_telemetry": _build_required_evidence_telemetry(
             decision_domain=decision_domain,
             template_id=template_id,
+            source=source,
+            mode=mode,
             required_diagnostics=required_diag,
             satisfied_diagnostics=satisfied_diag,
             unknown_keys=unknown_keys,
-            profile_missing_keys=profile_missing_keys,
+            profile_missing_keys=(
+                profile_missing_keys + escalation_sensitive_missing
+            ),
         ),
+        "required_evidence_mode": mode,
+        "required_evidence_assessment": {
+            "internal_reasons": unique_preserve_order(internal_evidence_reasons),
+            "profile_missing_required_keys": profile_missing_keys,
+            "escalation_sensitive_missing_keys": escalation_sensitive_missing,
+        },
         "human_review_required": human_review_required,
         "rationale": " | ".join(rationale_parts),
         "refusal_reason": refusal_reason,
@@ -627,6 +685,24 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         result.setdefault("warnings", []).append(
             "required_evidence_profile_missing_keys"
         )
+    if escalation_sensitive_missing:
+        result.setdefault("warnings", []).append(
+            "escalation_sensitive_required_evidence_missing"
+        )
+    telemetry = result["required_evidence_telemetry"]
+    record_required_evidence_telemetry(
+        domain=telemetry.get("domain"),
+        template_id=telemetry.get("template_id"),
+        source=telemetry.get("source"),
+        mode=telemetry.get("mode"),
+        unknown_key_total=int(telemetry.get("unknown_required_evidence_key_total", 0)),
+        alias_normalized_total=int(
+            telemetry.get("required_evidence_alias_normalized_total", 0)
+        ),
+        profile_miss_total=int(
+            telemetry.get("required_evidence_profile_miss_total", 0)
+        ),
+    )
     if _is_dev_mode_enabled(ctx.context):
         result["action_candidates"] = action_candidates
         result["action_selection"]["ranking_trace"] = {

--- a/veritas_os/observability/metrics.py
+++ b/veritas_os/observability/metrics.py
@@ -244,6 +244,21 @@ SLOW_APPEND_WARNING_TOTAL = _counter(
     "slow_append_warning_total",
     "Total TrustLog appends exceeding the slow-append threshold",
 )
+UNKNOWN_REQUIRED_EVIDENCE_KEY_TOTAL = _counter(
+    "unknown_required_evidence_key_total",
+    "Unknown required evidence keys observed after canonicalization",
+    labelnames=("domain", "template_id", "source", "mode"),
+)
+REQUIRED_EVIDENCE_ALIAS_NORMALIZED_TOTAL = _counter(
+    "required_evidence_alias_normalized_total",
+    "Alias->canonical normalizations for required evidence keys",
+    labelnames=("domain", "template_id", "source", "mode"),
+)
+REQUIRED_EVIDENCE_PROFILE_MISS_TOTAL = _counter(
+    "required_evidence_profile_miss_total",
+    "Profile misses for required/escalation-sensitive evidence",
+    labelnames=("domain", "template_id", "source", "mode"),
+)
 
 
 def _label(value: Any, fallback: str = "unknown") -> str:
@@ -486,3 +501,30 @@ def set_advisory_lock_contention_count(count: int) -> None:
         ADVISORY_LOCK_CONTENTION_COUNT.set(float(count))
     except (TypeError, ValueError):
         return
+
+
+def record_required_evidence_telemetry(
+    *,
+    domain: Any,
+    template_id: Any,
+    source: Any,
+    mode: Any,
+    unknown_key_total: int,
+    alias_normalized_total: int,
+    profile_miss_total: int,
+) -> None:
+    """Record required-evidence hardening counters for observability."""
+    labels = {
+        "domain": _label(domain, "unknown"),
+        "template_id": _label(template_id, "unknown"),
+        "source": _label(source, "unknown"),
+        "mode": _label(mode, "warn"),
+    }
+    if unknown_key_total > 0:
+        UNKNOWN_REQUIRED_EVIDENCE_KEY_TOTAL.labels(**labels).inc(float(unknown_key_total))
+    if alias_normalized_total > 0:
+        REQUIRED_EVIDENCE_ALIAS_NORMALIZED_TOTAL.labels(**labels).inc(
+            float(alias_normalized_total)
+        )
+    if profile_miss_total > 0:
+        REQUIRED_EVIDENCE_PROFILE_MISS_TOTAL.labels(**labels).inc(float(profile_miss_total))

--- a/veritas_os/scripts/expected_semantics_compare.py
+++ b/veritas_os/scripts/expected_semantics_compare.py
@@ -77,7 +77,9 @@ def compare_expected_semantics(
             }
 
     expected_required = unique_preserve_order(
-        normalize_required_evidence_keys(expected.get("required_evidence"))
+        normalize_required_evidence_keys(
+            expected.get("expected_required_evidence", expected.get("required_evidence"))
+        )
     )
     actual_required = unique_preserve_order(
         normalize_required_evidence_keys(actual.get("required_evidence"))
@@ -86,10 +88,14 @@ def compare_expected_semantics(
         mismatches["required_evidence"] = {
             "expected": expected_required,
             "actual": actual_required,
+            "only_in_expected": [item for item in expected_required if item not in set(actual_required)],
+            "only_in_actual": [item for item in actual_required if item not in set(expected_required)],
         }
 
     expected_missing = unique_preserve_order(
-        normalize_required_evidence_keys(expected.get("missing_evidence"))
+        normalize_required_evidence_keys(
+            expected.get("expected_missing_evidence", expected.get("missing_evidence"))
+        )
     )
     actual_missing = unique_preserve_order(
         normalize_required_evidence_keys(actual.get("missing_evidence"))
@@ -98,6 +104,8 @@ def compare_expected_semantics(
         mismatches["missing_evidence"] = {
             "expected": expected_missing,
             "actual": actual_missing,
+            "only_in_expected": [item for item in expected_missing if item not in set(actual_missing)],
+            "only_in_actual": [item for item in actual_missing if item not in set(expected_missing)],
         }
 
     expected_human = bool(expected.get("human_review_required"))
@@ -107,6 +115,21 @@ def compare_expected_semantics(
             "expected": expected_human,
             "actual": actual_human,
         }
+    telemetry = actual.get("required_evidence_telemetry")
+    if isinstance(telemetry, Mapping):
+        unknown_keys = telemetry.get("top_unknown_keys") or []
+        profile_missing = telemetry.get("profile_missing_keys") or []
+        if unknown_keys or profile_missing:
+            mismatches["required_evidence_runtime_warnings"] = {
+                "expected": {
+                    "unknown_keys": [],
+                    "profile_missing_keys": [],
+                },
+                "actual": {
+                    "unknown_keys": list(unknown_keys),
+                    "profile_missing_keys": list(profile_missing),
+                },
+            }
 
     return mismatches
 
@@ -122,6 +145,7 @@ def summarize_semantic_mismatches(mismatches: Mapping[str, Mapping[str, Any]]) -
         "business_decision",
         "required_evidence",
         "missing_evidence",
+        "required_evidence_runtime_warnings",
         "human_review_required",
         "next_action",
     ):

--- a/veritas_os/scripts/financial_poc_runner.py
+++ b/veritas_os/scripts/financial_poc_runner.py
@@ -96,16 +96,21 @@ def _call_decide_api(
     api_key: str,
     timeout_seconds: float,
     question: PocQuestion,
+    required_evidence_mode: str,
 ) -> dict[str, Any]:
     """Call `/v1/decide` and return parsed JSON payload."""
     headers = {
         "Content-Type": "application/json",
         "X-API-Key": api_key,
     }
+    payload = _build_request_payload(question)
+    payload_context = payload.setdefault("context", {})
+    if required_evidence_mode:
+        payload_context["required_evidence_mode"] = required_evidence_mode
     response = requests.post(
         api_url,
         headers=headers,
-        json=_build_request_payload(question),
+        json=payload,
         timeout=timeout_seconds,
     )
     response.raise_for_status()
@@ -194,6 +199,7 @@ def run_financial_poc(
     api_url: str,
     api_key: str,
     timeout_seconds: float,
+    required_evidence_mode: str = "warn",
 ) -> dict[str, Any]:
     """Run financial PoC pack and return machine-readable report."""
     questions = load_questions(input_path)
@@ -207,6 +213,7 @@ def run_financial_poc(
                 api_key=api_key,
                 timeout_seconds=timeout_seconds,
                 question=question,
+                required_evidence_mode=required_evidence_mode,
             ),
         )
 
@@ -216,6 +223,7 @@ def run_financial_poc(
             "mode": "dry-run" if dry_run else "live",
             "input_path": str(input_path),
             "api_url": api_url,
+            "required_evidence_mode": required_evidence_mode,
         },
         "summary": summary,
         "cases": [
@@ -261,6 +269,12 @@ def _parse_args() -> argparse.Namespace:
         help="HTTP timeout seconds for each /v1/decide call.",
     )
     parser.add_argument(
+        "--required-evidence-mode",
+        default=os.getenv("VERITAS_REQUIRED_EVIDENCE_MODE", "warn"),
+        choices=("warn", "strict"),
+        help="Required evidence hardening mode injected into request context.",
+    )
+    parser.add_argument(
         "--output-json",
         default="",
         help="Optional output report path in JSON format.",
@@ -297,6 +311,7 @@ def main() -> None:
         api_url=str(args.api_url),
         api_key=str(args.api_key),
         timeout_seconds=float(args.timeout),
+        required_evidence_mode=str(args.required_evidence_mode),
     )
 
     summary = report["summary"]

--- a/veritas_os/tests/test_financial_poc_runner.py
+++ b/veritas_os/tests/test_financial_poc_runner.py
@@ -105,6 +105,7 @@ def test_financial_poc_runner_dry_run_produces_quantified_summary() -> None:
         api_url="http://localhost:8000/v1/decide",
         api_key="",
         timeout_seconds=5.0,
+        required_evidence_mode="warn",
     )
 
     summary = report["summary"]
@@ -115,6 +116,25 @@ def test_financial_poc_runner_dry_run_produces_quantified_summary() -> None:
     assert counts["fail"] == 0
     assert counts["warning"] == 0
     assert summary["pass_rate"] == 1.0
+
+
+def test_compare_expected_semantics_exposes_evidence_runtime_warnings() -> None:
+    """Comparator should highlight unknown/profile miss telemetry from runtime."""
+    expected = {"required_evidence": ["kyc_profile"]}
+    actual = {
+        "required_evidence": ["kyc_profile"],
+        "required_evidence_telemetry": {
+            "top_unknown_keys": ["unknown_custom_doc"],
+            "profile_missing_keys": ["approval_matrix"],
+        },
+    }
+
+    diff = compare_expected_semantics(expected, actual)
+
+    assert "required_evidence_runtime_warnings" in diff
+    warning_payload = diff["required_evidence_runtime_warnings"]["actual"]
+    assert warning_payload["unknown_keys"] == ["unknown_custom_doc"]
+    assert warning_payload["profile_missing_keys"] == ["approval_matrix"]
 
 
 def test_en_quickstart_links_resolve_and_success_criteria_doc_exists() -> None:

--- a/veritas_os/tests/test_observability_metrics.py
+++ b/veritas_os/tests/test_observability_metrics.py
@@ -84,6 +84,49 @@ def test_fuji_and_memory_metrics(monkeypatch):
     assert any(call.get("labels") == {"operation": "search", "kind": "semantic"} for call in mem_ops.calls)
 
 
+def test_required_evidence_telemetry_metrics(monkeypatch):
+    """Required-evidence hardening counters should emit domain/template labels."""
+    metrics = importlib.import_module("veritas_os.observability.metrics")
+    unknown_total = _MetricProbe()
+    alias_total = _MetricProbe()
+    profile_miss_total = _MetricProbe()
+
+    monkeypatch.setattr(metrics, "UNKNOWN_REQUIRED_EVIDENCE_KEY_TOTAL", unknown_total)
+    monkeypatch.setattr(
+        metrics,
+        "REQUIRED_EVIDENCE_ALIAS_NORMALIZED_TOTAL",
+        alias_total,
+    )
+    monkeypatch.setattr(
+        metrics,
+        "REQUIRED_EVIDENCE_PROFILE_MISS_TOTAL",
+        profile_miss_total,
+    )
+
+    metrics.record_required_evidence_telemetry(
+        domain="aml_kyc",
+        template_id="tmpl-1",
+        source="financial_poc_pack",
+        mode="strict",
+        unknown_key_total=2,
+        alias_normalized_total=3,
+        profile_miss_total=1,
+    )
+
+    expected_labels = {
+        "domain": "aml_kyc",
+        "template_id": "tmpl-1",
+        "source": "financial_poc_pack",
+        "mode": "strict",
+    }
+    assert any(call.get("labels") == expected_labels for call in unknown_total.calls)
+    assert any(call.get("inc") == 2.0 for call in unknown_total.calls)
+    assert any(call.get("labels") == expected_labels for call in alias_total.calls)
+    assert any(call.get("inc") == 3.0 for call in alias_total.calls)
+    assert any(call.get("labels") == expected_labels for call in profile_miss_total.calls)
+    assert any(call.get("inc") == 1.0 for call in profile_miss_total.calls)
+
+
 def test_noop_mode_without_prometheus_client(monkeypatch):
     monkeypatch.setitem(sys.modules, "prometheus_client", None)
     metrics = importlib.reload(importlib.import_module("veritas_os.observability.metrics"))

--- a/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
+++ b/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
@@ -226,6 +226,7 @@ def test_unknown_required_evidence_generates_warning_and_telemetry() -> None:
     )
     telemetry = payload["required_evidence_telemetry"]
     assert telemetry["unknown_required_evidence_key_total"] >= 1
+    assert telemetry["mode"] == "warn"
     assert "unknown_required_evidence_keys_detected" in payload.get("warnings", [])
 
 
@@ -249,6 +250,80 @@ def test_alias_normalization_counter_is_recorded() -> None:
     )
     telemetry = payload["required_evidence_telemetry"]
     assert telemetry["required_evidence_alias_normalized_total"] >= 2
+
+
+def test_strict_mode_unknown_key_moves_to_human_review_path() -> None:
+    """Strict mode should treat unknown keys as stronger hold/review signals."""
+    ctx = PipelineContext(
+        request_id="req-strict-unknown",
+        query="strict unknown key",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        context={
+            "category": "aml_kyc",
+            "required_evidence_mode": "strict",
+            "required_evidence": ["kyc_profile", "unknown_custom_doc"],
+            "satisfied_evidence": ["kyc_profile"],
+        },
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+    assert payload["required_evidence_mode"] == "strict"
+    assert payload["gate_decision"] in {"hold", "human_review_required"}
+    assert payload["human_review_required"] is True
+    assert "unknown_required_evidence_key_strict" in payload[
+        "required_evidence_assessment"
+    ]["internal_reasons"]
+
+
+def test_aml_kyc_escalation_sensitive_missing_requires_human_review() -> None:
+    """Missing escalation-sensitive evidence must force human review flow."""
+    ctx = PipelineContext(
+        request_id="req-escalation-sensitive",
+        query="escalation sensitive missing",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        context={
+            "decision_domain": "aml_kyc",
+            "required_evidence": ["kyc_profile", "sanctions_screening_trace"],
+            "satisfied_evidence": ["kyc_profile"],
+        },
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+    assert payload["human_review_required"] is True
+    assert "sanctions_screening_trace" in payload["required_evidence_assessment"][
+        "escalation_sensitive_missing_keys"
+    ]
+
+
+def test_approval_matrix_missing_is_reported_as_escalation_sensitive() -> None:
+    """approval_matrix missing should appear in escalation-sensitive diagnostics."""
+    ctx = PipelineContext(
+        request_id="req-approval-missing",
+        query="approval matrix missing",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        context={
+            "decision_domain": "aml_kyc",
+            "required_evidence": ["kyc_profile", "approval_boundary_matrix"],
+            "satisfied_evidence": ["kyc_profile"],
+        },
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+    assert "approval_matrix" in payload["required_evidence_assessment"][
+        "escalation_sensitive_missing_keys"
+    ]
 
 
 def test_question_first_response_prioritizes_structure_not_investigate_decision() -> None:

--- a/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
+++ b/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
@@ -326,6 +326,31 @@ def test_approval_matrix_missing_is_reported_as_escalation_sensitive() -> None:
     ]
 
 
+def test_non_beachhead_aml_kyc_template_keeps_declared_required_evidence() -> None:
+    """Warn mode should not force full AML/KYC profile on non-beachhead templates."""
+    ctx = PipelineContext(
+        request_id="req-aml-boundary-template",
+        query="approval boundary undefined",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        context={
+            "decision_domain": "aml_kyc",
+            "template_id": "approval_boundary_undefined_stop",
+            "approval_boundary_defined": False,
+            "required_evidence": ["approval_matrix", "policy_definition_record"],
+            "satisfied_evidence": ["approval_matrix", "policy_definition_record"],
+        },
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+    assert payload["required_evidence"] == ["approval_matrix", "policy_definition_record"]
+    assert payload["missing_evidence"] == []
+    assert payload["gate_decision"] == "human_review_required"
+
+
 def test_question_first_response_prioritizes_structure_not_investigate_decision() -> None:
     """Question-first flow must keep business_decision structured and next_action for follow-up."""
     ctx = PipelineContext(


### PR DESCRIPTION
### Motivation
- Improve observability of unknown `required_evidence` keys so migrations from warning-first to strict reject can be safely measured. 
- Make the AML/KYC beachhead profile enforceable at runtime (required/optional/escalation_sensitive) while preserving free-string backward compatibility. 
- Provide a runtime `warn`/`strict` mode that lets AML/KYC experiments route unknown/profile-miss cases toward stronger hold/review behavior without a global immediate hard reject. 

### Description
- Added Prometheus counters and a recorder API in `veritas_os/observability/metrics.py` for `unknown_required_evidence_key_total`, `required_evidence_alias_normalized_total`, and `required_evidence_profile_miss_total` with labels `domain`, `template_id`, `source`, and `mode`, and `record_required_evidence_telemetry` to emit them. 
- Extended `_derive_business_fields` in `veritas_os/core/pipeline/pipeline_response.py` to canonicalize alias inputs, enforce AML/KYC `profiles` after normalization, track `escalation_sensitive` missing keys as `human_review_required`, compute `required_evidence_telemetry` (now including `source`, `mode`, `required_evidence_normalization_hit_rate`), expose `required_evidence_mode` and `required_evidence_assessment`, and call the metrics recorder. 
- Implemented runtime mode resolution `_resolve_required_evidence_mode` (context or `VERITAS_REQUIRED_EVIDENCE_MODE`) with `warn`/`strict` semantics and constrained `strict` to AML/KYC beachhead. 
- Enhanced PoC tooling: `veritas_os/scripts/financial_poc_runner.py` now accepts `--required-evidence-mode` and propagates it to requests; `veritas_os/scripts/expected_semantics_compare.py` now compares canonicalized `expected_required_evidence`/`expected_missing_evidence`, reports `only_in_expected`/`only_in_actual` diffs, and surfaces runtime `required_evidence_runtime_warnings` from telemetry. 
- Added regression/unit tests and updates verifying alias normalization telemetry, unknown-key warnings, strict-mode routing to human-review path, escalation-sensitive behavior, top-unknown/profile-miss visibility, and metrics labeling; and updated docs in `docs/en/governance/required-evidence-taxonomy.md`, `docs/en/guides/financial-governance-templates.md`, and `docs/en/guides/poc-pack-financial-quickstart.md` to document modes, telemetry, and PoC usage. 

### Testing
- Ran: `pytest -q veritas_os/tests/unit/test_decision_semantics_runtime_contract.py veritas_os/tests/test_financial_poc_runner.py veritas_os/tests/test_observability_metrics.py` and observed `36 passed in 4.51s`. 
- Ran: `pytest -q veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py` and observed `16 passed in 2.25s`. 
- All modified/added unit tests passed locally (no failing tests reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e302b6d0e88326bbf6f9091d326b01)