### PR TITLE
Extract governance policy persistence behind repository interface

### DIFF
--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -1,10 +1,5 @@
 # veritas_os/api/governance.py
-"""
-Governance Policy API — GET / PUT /v1/governance/policy
-
-Storage: file-based (governance.json) with an interface that can be
-swapped to a DB backend later by replacing `_load` / `_save`.
-"""
+"""Governance Policy API — GET / PUT /v1/governance/policy."""
 from __future__ import annotations
 
 import json
@@ -12,7 +7,6 @@ import logging
 import os
 import re
 import threading
-from collections import deque
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
@@ -20,11 +14,10 @@ from typing import Any, Callable, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
-try:
-    from veritas_os.core.atomic_io import atomic_write_json as _atomic_write_json
-    _HAS_ATOMIC_IO = True
-except ImportError:  # pragma: no cover
-    _HAS_ATOMIC_IO = False
+from veritas_os.governance import file_repository as _file_repo_mod
+from veritas_os.governance.file_repository import FileGovernanceRepository
+from veritas_os.governance.models import GovernancePolicyEventRecord
+from veritas_os.governance.repository import GovernanceRepository
 
 logger = logging.getLogger(__name__)
 
@@ -34,9 +27,13 @@ _POLICY_HISTORY_PATH = Path(__file__).resolve().parent / "governance_history.jso
 
 # Maximum number of policy change records kept in the history file
 _POLICY_HISTORY_MAX = 500
+_HAS_ATOMIC_IO = _file_repo_mod._HAS_ATOMIC_IO
 
 # Thread-safe lock for file I/O
 _policy_lock = threading.Lock()
+
+# Repository provider; override in tests if needed.
+_governance_repository_factory: Callable[[], GovernanceRepository] | None = None
 
 # Callbacks invoked after each successful policy update (e.g. for FUJI hot-reload).
 # Each callable receives the full updated policy dict.
@@ -134,45 +131,41 @@ def _policy_path() -> Path:
     return _DEFAULT_POLICY_PATH
 
 
+def _build_default_repository() -> GovernanceRepository:
+    """Create file-based governance repository for current module paths."""
+    return FileGovernanceRepository(
+        policy_path=_DEFAULT_POLICY_PATH,
+        history_path=_POLICY_HISTORY_PATH,
+        lock=_policy_lock,
+        policy_history_max=_POLICY_HISTORY_MAX,
+        has_atomic_io=_HAS_ATOMIC_IO,
+    )
+
+
+def set_governance_repository_factory(
+    factory: Callable[[], GovernanceRepository] | None,
+) -> None:
+    """Set repository factory used by governance API persistence helpers."""
+    global _governance_repository_factory
+    _governance_repository_factory = factory
+
+
+def _get_repository() -> GovernanceRepository:
+    if _governance_repository_factory is None:
+        return _build_default_repository()
+    return _governance_repository_factory()
+
+
 def _load() -> Dict[str, Any]:
-    """Load governance policy from JSON file."""
-    path = _policy_path()
-    with _policy_lock:
-        if not path.exists():
-            # Return defaults
-            default = GovernancePolicy()
-            return default.model_dump()
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except (OSError, json.JSONDecodeError, ValueError, UnicodeDecodeError) as e:
-            logger.warning("Failed to load governance policy: %s", e)
-            return GovernancePolicy().model_dump()
+    """Load governance policy through repository abstraction."""
+    return _get_repository().get_current_policy(
+        default_factory=lambda: GovernancePolicy().model_dump()
+    )
 
 
 def _save(data: Dict[str, Any]) -> None:
-    """Save governance policy to JSON file atomically (crash-safe)."""
-    path = _policy_path()
-    with _policy_lock:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        if _HAS_ATOMIC_IO:
-            _atomic_write_json(path, data, indent=2)
-        else:
-            # Fallback: write to temp file then rename for best-effort atomicity
-            tmp = path.with_suffix(".tmp")
-            try:
-                with open(tmp, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-                    f.write("\n")
-                    f.flush()
-                    os.fsync(f.fileno())
-                tmp.replace(path)
-            except Exception:
-                try:
-                    tmp.unlink(missing_ok=True)
-                except OSError:
-                    pass
-                raise
+    """Persist governance policy through repository abstraction."""
+    _get_repository().save_policy(data)
 
 
 def _append_policy_history(
@@ -183,56 +176,37 @@ def _append_policy_history(
     approvers: Optional[List[str]] = None,
     event_type: str = "update",
 ) -> None:
-    """Append a policy change record to the audit history JSONL (best-effort).
-
-    Enhanced with provenance tracking: digest transitions, proposer, approvers,
-    and event classification for audit-grade governance history.
-    """
+    """Append policy history through repository abstraction."""
     try:
         from veritas_os.policy.governance_identity import compute_governance_digest
+
         prev_digest = compute_governance_digest(previous)
         new_digest = compute_governance_digest(updated)
     except Exception:
         prev_digest = ""
         new_digest = ""
 
-    record = {
-        "changed_at": updated.get("updated_at", datetime.now(timezone.utc).isoformat()),
-        "changed_by": updated.get("updated_by", "unknown"),
-        "proposer": proposer or updated.get("updated_by", "unknown"),
-        "approvers": approvers or [],
-        "event_type": event_type,
-        "previous_version": previous.get("version"),
-        "new_version": updated.get("version"),
-        "previous_digest": prev_digest,
-        "new_digest": new_digest,
-        "previous_policy": previous,
-        "new_policy": updated,
-    }
-    line = json.dumps(record, ensure_ascii=False)
-    try:
-        _POLICY_HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with _policy_lock:
-            with open(_POLICY_HISTORY_PATH, "a", encoding="utf-8") as f:
-                f.write(line + "\n")
-            _trim_policy_history()
-    except Exception as e:
-        logger.warning("Failed to append governance policy history: %s", e)
+    event = GovernancePolicyEventRecord(
+        changed_at=updated.get("updated_at", datetime.now(timezone.utc).isoformat()),
+        changed_by=updated.get("updated_by", "unknown"),
+        proposer=proposer or updated.get("updated_by", "unknown"),
+        approvers=approvers or [],
+        event_type=event_type,
+        previous_version=previous.get("version"),
+        new_version=updated.get("version"),
+        previous_digest=prev_digest,
+        new_digest=new_digest,
+        previous_policy=previous,
+        new_policy=updated,
+    )
+    _get_repository().append_policy_event(event)
 
 
 def _trim_policy_history() -> None:
-    """Keep only the most recent _POLICY_HISTORY_MAX records in the history file."""
-    try:
-        if not _POLICY_HISTORY_PATH.exists():
-            return
-        lines = _POLICY_HISTORY_PATH.read_text(encoding="utf-8").splitlines(keepends=True)
-        if len(lines) > _POLICY_HISTORY_MAX:
-            trimmed = "".join(lines[-_POLICY_HISTORY_MAX:])
-            tmp = _POLICY_HISTORY_PATH.with_suffix(".tmp")
-            tmp.write_text(trimmed, encoding="utf-8")
-            tmp.replace(_POLICY_HISTORY_PATH)
-    except Exception as e:
-        logger.warning("Failed to trim governance policy history: %s", e)
+    """Keep only the most recent _POLICY_HISTORY_MAX records in history."""
+    repository = _get_repository()
+    if isinstance(repository, FileGovernanceRepository):
+        repository.trim_policy_history()
 
 
 def _notify_policy_update(policy: Dict[str, Any]) -> None:
@@ -396,8 +370,6 @@ def update_policy(patch: Dict[str, Any]) -> Dict[str, Any]:
     validated = GovernancePolicy.model_validate(current)
     result = validated.model_dump()
 
-    _save(result)
-
     # Extract provenance metadata from the patch for audit trail.
     approvals = patch.get("approvals")
     approver_ids: List[str] = []
@@ -410,10 +382,9 @@ def update_policy(patch: Dict[str, Any]) -> Dict[str, Any]:
     proposer = _sanitize_updated_by(patch.get("updated_by", "api"))
     event_type = str(patch.get("_event_type", "update"))
 
-    # Record what changed for compliance audit trail
-    _append_policy_history(
-        previous,
-        result,
+    _get_repository().update_policy(
+        previous=previous,
+        updated=result,
         proposer=proposer,
         approvers=approver_ids,
         event_type=event_type,
@@ -471,27 +442,9 @@ def get_policy_history(limit: int = 50) -> List[Dict[str, Any]]:
     Args:
         limit: Maximum number of records to return (capped at _POLICY_HISTORY_MAX).
     """
-    limit = max(1, min(limit, _POLICY_HISTORY_MAX))
-    with _policy_lock:
-        if not _POLICY_HISTORY_PATH.exists():
-            return []
-        try:
-            lines = _POLICY_HISTORY_PATH.read_text(encoding="utf-8").splitlines()
-        except (OSError, UnicodeDecodeError) as e:
-            logger.warning("Failed to read governance policy history: %s", e)
-            return []
-    records: List[Dict[str, Any]] = []
-    for line in reversed(lines):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            records.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-        if len(records) >= limit:
-            break
-    return records
+    return _get_repository().list_policy_history(
+        limit=limit, max_records=_POLICY_HISTORY_MAX
+    )
 
 
 def get_value_drift(telos_baseline: float = DEFAULT_TELOS_BASELINE) -> Dict[str, Any]:
@@ -566,8 +519,6 @@ def rollback_policy(
     validated = GovernancePolicy.model_validate(target_policy)
     result = validated.model_dump()
 
-    _save(result)
-
     # Extract approver identities
     approver_ids: List[str] = []
     if isinstance(approvals, list):
@@ -577,12 +528,11 @@ def rollback_policy(
                 if r:
                     approver_ids.append(r)
 
-    _append_policy_history(
-        previous,
-        result,
+    _get_repository().rollback_policy(
+        previous=previous,
+        restored=result,
         proposer=_sanitize_updated_by(rolled_back_by),
         approvers=approver_ids,
-        event_type="rollback",
     )
 
     _notify_policy_update(result)

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -1,0 +1,12 @@
+"""Governance domain persistence abstractions."""
+
+from veritas_os.governance.file_repository import FileGovernanceRepository
+from veritas_os.governance.models import GovernancePolicyEventRecord, GovernancePolicyRecord
+from veritas_os.governance.repository import GovernanceRepository
+
+__all__ = [
+    "FileGovernanceRepository",
+    "GovernancePolicyEventRecord",
+    "GovernancePolicyRecord",
+    "GovernanceRepository",
+]

--- a/veritas_os/governance/file_repository.py
+++ b/veritas_os/governance/file_repository.py
@@ -1,0 +1,205 @@
+"""File-based governance repository implementation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from veritas_os.governance.models import GovernancePolicyEventRecord
+from veritas_os.governance.repository import GovernanceRepository
+
+try:
+    from veritas_os.core.atomic_io import atomic_write_json as _atomic_write_json
+
+    _HAS_ATOMIC_IO = True
+except ImportError:  # pragma: no cover
+    _HAS_ATOMIC_IO = False
+
+logger = logging.getLogger(__name__)
+
+
+class FileGovernanceRepository(GovernanceRepository):
+    """File-backed repository for governance policy state and history."""
+
+    def __init__(
+        self,
+        *,
+        policy_path: Path,
+        history_path: Path,
+        lock: threading.Lock,
+        policy_history_max: int,
+        has_atomic_io: bool | None = None,
+    ) -> None:
+        self._policy_path = policy_path
+        self._history_path = history_path
+        self._lock = lock
+        self._policy_history_max = policy_history_max
+        self._has_atomic_io = _HAS_ATOMIC_IO if has_atomic_io is None else has_atomic_io
+
+    def get_current_policy(
+        self,
+        *,
+        default_factory: Callable[[], dict[str, Any]],
+    ) -> dict[str, Any]:
+        with self._lock:
+            if not self._policy_path.exists():
+                return default_factory()
+            try:
+                with open(self._policy_path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except (OSError, json.JSONDecodeError, ValueError, UnicodeDecodeError) as exc:
+                logger.warning("Failed to load governance policy: %s", exc)
+                return default_factory()
+
+    def save_policy(self, policy: dict[str, Any]) -> None:
+        with self._lock:
+            self._policy_path.parent.mkdir(parents=True, exist_ok=True)
+            if self._has_atomic_io:
+                _atomic_write_json(self._policy_path, policy, indent=2)
+                return
+
+            tmp = self._policy_path.with_suffix(".tmp")
+            try:
+                with open(tmp, "w", encoding="utf-8") as f:
+                    json.dump(policy, f, ensure_ascii=False, indent=2)
+                    f.write("\n")
+                    f.flush()
+                    os.fsync(f.fileno())
+                tmp.replace(self._policy_path)
+            except Exception:
+                try:
+                    tmp.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                raise
+
+    def append_policy_event(self, event: GovernancePolicyEventRecord) -> None:
+        line = json.dumps(event.to_dict(), ensure_ascii=False)
+        try:
+            self._history_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._lock:
+                with open(self._history_path, "a", encoding="utf-8") as f:
+                    f.write(line + "\n")
+                self._trim_policy_history_locked()
+        except Exception as exc:
+            logger.warning("Failed to append governance policy history: %s", exc)
+
+    def list_policy_history(self, *, limit: int, max_records: int) -> list[dict[str, Any]]:
+        bounded_limit = max(1, min(limit, max_records))
+        with self._lock:
+            if not self._history_path.exists():
+                return []
+            try:
+                lines = self._history_path.read_text(encoding="utf-8").splitlines()
+            except (OSError, UnicodeDecodeError) as exc:
+                logger.warning("Failed to read governance policy history: %s", exc)
+                return []
+
+        records: list[dict[str, Any]] = []
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+            if len(records) >= bounded_limit:
+                break
+        return records
+
+    def update_policy(
+        self,
+        *,
+        previous: dict[str, Any],
+        updated: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+        event_type: str,
+    ) -> None:
+        self.save_policy(updated)
+        self.append_policy_event(
+            self._build_event(
+                previous=previous,
+                updated=updated,
+                proposer=proposer,
+                approvers=approvers,
+                event_type=event_type,
+            )
+        )
+
+    def rollback_policy(
+        self,
+        *,
+        previous: dict[str, Any],
+        restored: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+    ) -> None:
+        self.save_policy(restored)
+        self.append_policy_event(
+            self._build_event(
+                previous=previous,
+                updated=restored,
+                proposer=proposer,
+                approvers=approvers,
+                event_type="rollback",
+            )
+        )
+
+    def _trim_policy_history_locked(self) -> None:
+        try:
+            if not self._history_path.exists():
+                return
+            lines = self._history_path.read_text(encoding="utf-8").splitlines(keepends=True)
+            if len(lines) <= self._policy_history_max:
+                return
+
+            trimmed = "".join(lines[-self._policy_history_max :])
+            tmp = self._history_path.with_suffix(".tmp")
+            tmp.write_text(trimmed, encoding="utf-8")
+            tmp.replace(self._history_path)
+        except Exception as exc:
+            logger.warning("Failed to trim governance policy history: %s", exc)
+
+    def trim_policy_history(self) -> None:
+        """Trim history file to policy_history_max records."""
+        with self._lock:
+            self._trim_policy_history_locked()
+
+    def _build_event(
+        self,
+        *,
+        previous: dict[str, Any],
+        updated: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+        event_type: str,
+    ) -> GovernancePolicyEventRecord:
+        try:
+            from veritas_os.policy.governance_identity import compute_governance_digest
+
+            prev_digest = compute_governance_digest(previous)
+            new_digest = compute_governance_digest(updated)
+        except Exception:
+            prev_digest = ""
+            new_digest = ""
+
+        return GovernancePolicyEventRecord(
+            changed_at=updated.get("updated_at", datetime.now(timezone.utc).isoformat()),
+            changed_by=updated.get("updated_by", "unknown"),
+            proposer=proposer or updated.get("updated_by", "unknown"),
+            approvers=approvers,
+            event_type=event_type,
+            previous_version=previous.get("version"),
+            new_version=updated.get("version"),
+            previous_digest=prev_digest,
+            new_digest=new_digest,
+            previous_policy=previous,
+            new_policy=updated,
+        )

--- a/veritas_os/governance/models.py
+++ b/veritas_os/governance/models.py
@@ -1,0 +1,46 @@
+"""Data records used by governance persistence repositories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class GovernancePolicyRecord:
+    """Current policy snapshot persisted by repository implementations."""
+
+    policy: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class GovernancePolicyEventRecord:
+    """Append-only audit event for governance policy mutations."""
+
+    changed_at: str
+    changed_by: str
+    proposer: str
+    approvers: list[str] = field(default_factory=list)
+    event_type: str = "update"
+    previous_version: str | None = None
+    new_version: str | None = None
+    previous_digest: str = ""
+    new_digest: str = ""
+    previous_policy: dict[str, Any] = field(default_factory=dict)
+    new_policy: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return {
+            "changed_at": self.changed_at,
+            "changed_by": self.changed_by,
+            "proposer": self.proposer,
+            "approvers": self.approvers,
+            "event_type": self.event_type,
+            "previous_version": self.previous_version,
+            "new_version": self.new_version,
+            "previous_digest": self.previous_digest,
+            "new_digest": self.new_digest,
+            "previous_policy": self.previous_policy,
+            "new_policy": self.new_policy,
+        }

--- a/veritas_os/governance/repository.py
+++ b/veritas_os/governance/repository.py
@@ -1,0 +1,48 @@
+"""Repository interfaces for governance policy persistence."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol
+
+from veritas_os.governance.models import GovernancePolicyEventRecord
+
+
+class GovernanceRepository(Protocol):
+    """Persistence contract for governance policy and history operations."""
+
+    def get_current_policy(
+        self,
+        *,
+        default_factory: Callable[[], dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Return current policy snapshot, falling back to default_factory."""
+
+    def save_policy(self, policy: dict[str, Any]) -> None:
+        """Persist full current policy atomically."""
+
+    def append_policy_event(self, event: GovernancePolicyEventRecord) -> None:
+        """Append one immutable policy-change event to history."""
+
+    def list_policy_history(self, *, limit: int, max_records: int) -> list[dict[str, Any]]:
+        """Return history events in newest-first order."""
+
+    def update_policy(
+        self,
+        *,
+        previous: dict[str, Any],
+        updated: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+        event_type: str,
+    ) -> None:
+        """Persist updated policy and record an update event."""
+
+    def rollback_policy(
+        self,
+        *,
+        previous: dict[str, Any],
+        restored: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+    ) -> None:
+        """Persist restored policy and record a rollback event."""

--- a/veritas_os/tests/test_governance_repository.py
+++ b/veritas_os/tests/test_governance_repository.py
@@ -1,0 +1,142 @@
+"""Governance repository abstraction regression tests."""
+
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+
+from veritas_os.api import governance as gov
+from veritas_os.governance.file_repository import FileGovernanceRepository
+
+
+@pytest.fixture(autouse=True)
+def _reset_repo_factory() -> None:
+    gov.set_governance_repository_factory(None)
+    yield
+    gov.set_governance_repository_factory(None)
+
+
+def test_file_repository_roundtrip(tmp_path):
+    """File repository persists current policy and history with rollback records."""
+    repo = FileGovernanceRepository(
+        policy_path=tmp_path / "governance.json",
+        history_path=tmp_path / "governance_history.jsonl",
+        lock=threading.Lock(),
+        policy_history_max=10,
+    )
+
+    default = repo.get_current_policy(
+        default_factory=lambda: gov.GovernancePolicy().model_dump()
+    )
+    assert default["version"] == "governance_v1"
+
+    updated = {**default, "version": "governance_v2", "updated_by": "alice"}
+    repo.update_policy(
+        previous=default,
+        updated=updated,
+        proposer="alice",
+        approvers=["r1", "r2"],
+        event_type="update",
+    )
+    assert repo.get_current_policy(default_factory=dict)["version"] == "governance_v2"
+
+    restored = {**default, "version": "governance_v1_rollback", "updated_by": "bob"}
+    repo.rollback_policy(
+        previous=updated,
+        restored=restored,
+        proposer="bob",
+        approvers=["r3", "r4"],
+    )
+
+    history = repo.list_policy_history(limit=10, max_records=500)
+    assert len(history) == 2
+    assert history[0]["event_type"] == "rollback"
+    assert history[1]["event_type"] == "update"
+
+
+class _InMemoryRepository:
+    def __init__(self) -> None:
+        self.policy = gov.GovernancePolicy().model_dump()
+        self.history: list[dict] = []
+
+    def get_current_policy(self, *, default_factory):
+        return self.policy or default_factory()
+
+    def save_policy(self, policy):
+        self.policy = policy
+
+    def append_policy_event(self, event):
+        self.history.append(event.to_dict())
+
+    def list_policy_history(self, *, limit, max_records):
+        return list(reversed(self.history))[: max(1, min(limit, max_records))]
+
+    def update_policy(self, *, previous, updated, proposer, approvers, event_type):
+        self.policy = updated
+        self.history.append(
+            {
+                "previous_policy": previous,
+                "new_policy": updated,
+                "proposer": proposer,
+                "approvers": approvers,
+                "event_type": event_type,
+            }
+        )
+
+    def rollback_policy(self, *, previous, restored, proposer, approvers):
+        self.policy = restored
+        self.history.append(
+            {
+                "previous_policy": previous,
+                "new_policy": restored,
+                "proposer": proposer,
+                "approvers": approvers,
+                "event_type": "rollback",
+            }
+        )
+
+
+def test_governance_api_uses_repository_interface(monkeypatch):
+    """API-level operations should flow through repository interface methods."""
+    repo = _InMemoryRepository()
+    gov.set_governance_repository_factory(lambda: repo)
+    monkeypatch.setenv("VERITAS_GOVERNANCE_REQUIRE_FOUR_EYES", "0")
+
+    updated = gov.update_policy({"version": "governance_v2", "updated_by": "alice"})
+    assert updated["version"] == "governance_v2"
+
+    history = gov.get_policy_history(limit=5)
+    assert history[0]["event_type"] == "update"
+
+    rolled_back = gov.rollback_policy(
+        {**repo.policy, "version": "governance_v1_restored"},
+        rolled_back_by="bob",
+        approvals=[
+            {"reviewer": "r1", "signature": "s1"},
+            {"reviewer": "r2", "signature": "s2"},
+        ],
+    )
+    assert rolled_back["version"] == "governance_v1_restored"
+
+    latest_history = gov.get_policy_history(limit=1)
+    assert latest_history[0]["event_type"] == "rollback"
+
+
+def test_file_mode_behavior_unchanged_for_load_save(tmp_path, monkeypatch):
+    """Backward-compatible helpers still read/write JSON file based policy."""
+    policy_path = tmp_path / "governance.json"
+    history_path = tmp_path / "governance_history.jsonl"
+    monkeypatch.setattr(gov, "_DEFAULT_POLICY_PATH", policy_path)
+    monkeypatch.setattr(gov, "_POLICY_HISTORY_PATH", history_path)
+
+    policy = gov.GovernancePolicy().model_dump()
+    policy["version"] = "legacy-file-mode"
+    gov._save(policy)
+
+    loaded = gov._load()
+    assert loaded["version"] == "legacy-file-mode"
+
+    on_disk = json.loads(policy_path.read_text(encoding="utf-8"))
+    assert on_disk["version"] == "legacy-file-mode"


### PR DESCRIPTION
### Motivation
- Decouple governance policy persistence from API logic so storage can be swapped (e.g., PostgreSQL) without changing API/validation/approval semantics.
- Preserve existing file-based behaviour and public API contracts while moving file I/O into a repository layer for clear responsibility separation.

### Description
- Introduced a `GovernanceRepository` protocol and record models `GovernancePolicyRecord` and `GovernancePolicyEventRecord` under `veritas_os/governance/` to define persistence contracts.
- Added `FileGovernanceRepository` implementing the contract with atomic-write fallback, history append/read, trimming, update and rollback recording in `veritas_os/governance/file_repository.py`.
- Refactored `veritas_os/api/governance.py` to route load/save/history/update/rollback calls through a repository factory (`_get_repository()` / `set_governance_repository_factory`) while keeping validation, 4-eyes checks, sanitization, callbacks and endpoint behaviour unchanged.
- Added regression tests `veritas_os/tests/test_governance_repository.py` to exercise file repo roundtrip, API wiring through a pluggable in-memory repo, and backwards-compatible `_load`/`_save` helpers.

### Testing
- Ran targeted repo & approval tests: `pytest -q veritas_os/tests/test_governance_repository.py veritas_os/tests/test_governance_artifact_signing.py -k "history or rollback or four_eyes"` which passed (`7 passed`).
- Ran integration subset for history/atomic write fallback: `pytest -q veritas_os/tests/integration/test_governance_api.py -k "trim_policy_history_keeps_max or save_fallback"` which passed (`3 passed`).
- Ran the governance-focused test set: `pytest -q veritas_os/tests -k "governance"` after fixing initial edge-cases, which succeeded (`190 passed, 6591 deselected`, 62 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3307066788326951c4fcb50fb7f11)