### PR TITLE
Add PostgreSQL governance repository + Alembic migration and tests

### DIFF
--- a/alembic/versions/0002_governance_policy_tables.py
+++ b/alembic/versions/0002_governance_policy_tables.py
@@ -1,0 +1,175 @@
+"""governance policy persistence tables
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-18
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "governance_policies",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column("policy_version", sa.Text, nullable=False),
+        sa.Column(
+            "policy_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("digest", sa.Text, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("updated_by", sa.Text, nullable=False),
+        sa.Column("is_current", sa.Boolean, nullable=False, server_default=sa.text("false")),
+        sa.Column("policy_revision", sa.BigInteger, nullable=False, server_default=sa.text("1")),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_governance_policies_updated_at",
+        "governance_policies",
+        ["updated_at"],
+    )
+    op.create_index(
+        "ix_governance_policies_payload_gin",
+        "governance_policies",
+        ["policy_payload"],
+        postgresql_using="gin",
+    )
+    op.create_index(
+        "uq_governance_policies_single_current",
+        "governance_policies",
+        ["is_current"],
+        unique=True,
+        postgresql_where=sa.text("is_current = true"),
+    )
+
+    op.create_table(
+        "governance_policy_events",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column(
+            "event_order",
+            sa.BigInteger,
+            sa.Identity(always=False),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("event_type", sa.Text, nullable=False),
+        sa.Column(
+            "previous_policy_id",
+            sa.BigInteger,
+            sa.ForeignKey("governance_policies.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "new_policy_id",
+            sa.BigInteger,
+            sa.ForeignKey("governance_policies.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("previous_digest", sa.Text, nullable=False, server_default=""),
+        sa.Column("new_digest", sa.Text, nullable=False, server_default=""),
+        sa.Column("proposer", sa.Text, nullable=False),
+        sa.Column("changed_by", sa.Text, nullable=False),
+        sa.Column(
+            "changed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("reason", sa.Text, nullable=False, server_default=""),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_governance_policy_events_changed_at",
+        "governance_policy_events",
+        ["changed_at"],
+    )
+    op.create_index(
+        "ix_governance_policy_events_event_type",
+        "governance_policy_events",
+        ["event_type"],
+    )
+
+    op.create_table(
+        "governance_approvals",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column(
+            "event_id",
+            sa.BigInteger,
+            sa.ForeignKey("governance_policy_events.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("reviewer", sa.Text, nullable=False),
+        sa.Column("signature", sa.Text, nullable=False, server_default=""),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("event_id", "reviewer", name="uq_governance_approvals_event_reviewer"),
+    )
+    op.create_index(
+        "uq_governance_approvals_event_signature_non_empty",
+        "governance_approvals",
+        ["event_id", "signature"],
+        unique=True,
+        postgresql_where=sa.text("signature <> ''"),
+    )
+    op.create_index(
+        "ix_governance_approvals_event_id",
+        "governance_approvals",
+        ["event_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("governance_approvals")
+    op.drop_table("governance_policy_events")
+    op.drop_index("uq_governance_policies_single_current", table_name="governance_policies")
+    op.drop_table("governance_policies")

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -388,6 +388,7 @@ def update_policy(patch: Dict[str, Any]) -> Dict[str, Any]:
         proposer=proposer,
         approvers=approver_ids,
         event_type=event_type,
+        approval_records=approvals if isinstance(approvals, list) else None,
     )
 
     # Notify subscribers (e.g. FUJI hot-reload) — best-effort, non-blocking
@@ -533,6 +534,8 @@ def rollback_policy(
         restored=result,
         proposer=_sanitize_updated_by(rolled_back_by),
         approvers=approver_ids,
+        approval_records=approvals if isinstance(approvals, list) else None,
+        reason=reason,
     )
 
     _notify_policy_update(result)

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -2,11 +2,13 @@
 
 from veritas_os.governance.file_repository import FileGovernanceRepository
 from veritas_os.governance.models import GovernancePolicyEventRecord, GovernancePolicyRecord
+from veritas_os.governance.postgresql_repository import PostgresGovernanceRepository
 from veritas_os.governance.repository import GovernanceRepository
 
 __all__ = [
     "FileGovernanceRepository",
     "GovernancePolicyEventRecord",
     "GovernancePolicyRecord",
+    "PostgresGovernanceRepository",
     "GovernanceRepository",
 ]

--- a/veritas_os/governance/file_repository.py
+++ b/veritas_os/governance/file_repository.py
@@ -121,7 +121,10 @@ class FileGovernanceRepository(GovernanceRepository):
         proposer: str,
         approvers: list[str],
         event_type: str,
+        approval_records: list[dict[str, str]] | None = None,
+        reason: str = "",
     ) -> None:
+        del approval_records, reason
         self.save_policy(updated)
         self.append_policy_event(
             self._build_event(
@@ -140,7 +143,10 @@ class FileGovernanceRepository(GovernanceRepository):
         restored: dict[str, Any],
         proposer: str,
         approvers: list[str],
+        approval_records: list[dict[str, str]] | None = None,
+        reason: str = "",
     ) -> None:
+        del approval_records, reason
         self.save_policy(restored)
         self.append_policy_event(
             self._build_event(

--- a/veritas_os/governance/postgresql_repository.py
+++ b/veritas_os/governance/postgresql_repository.py
@@ -1,0 +1,384 @@
+"""PostgreSQL-backed governance repository implementation.
+
+This repository stores governance policy snapshots, policy change events,
+and event-scoped approvals in PostgreSQL while preserving the existing
+repository contract used by the API layer.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterator
+
+from veritas_os.governance.models import GovernancePolicyEventRecord
+from veritas_os.governance.repository import GovernanceRepository
+
+
+class PostgresGovernanceRepository(GovernanceRepository):
+    """PostgreSQL-backed repository for governance policy state and history."""
+
+    def __init__(self, *, database_url: str | None = None) -> None:
+        self._database_url = database_url
+
+    @contextmanager
+    def _connect(self) -> Iterator[Any]:
+        """Open a transaction-capable psycopg connection."""
+        from veritas_os.storage.db import build_conninfo
+
+        try:
+            import psycopg
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "psycopg is required for PostgresGovernanceRepository"
+            ) from exc
+
+        dsn = self._database_url or build_conninfo()
+        conn = psycopg.connect(dsn)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def get_current_policy(
+        self,
+        *,
+        default_factory: Callable[[], dict[str, Any]],
+    ) -> dict[str, Any]:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT policy_payload FROM governance_policies "
+                    "WHERE is_current = TRUE LIMIT 1"
+                )
+                row = cur.fetchone()
+                if row is None:
+                    conn.rollback()
+                    return default_factory()
+                payload = row[0]
+                conn.rollback()
+                return payload if isinstance(payload, dict) else default_factory()
+
+    def save_policy(self, policy: dict[str, Any]) -> None:
+        self.update_policy(
+            previous={},
+            updated=policy,
+            proposer=str(policy.get("updated_by", "unknown")),
+            approvers=[],
+            event_type="save",
+            approval_records=[],
+        )
+
+    def append_policy_event(self, event: GovernancePolicyEventRecord) -> None:
+        # Keep this helper for interface parity; insert event-only row.
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO governance_policy_events (
+                        event_type,
+                        previous_policy_id,
+                        new_policy_id,
+                        previous_digest,
+                        new_digest,
+                        proposer,
+                        changed_by,
+                        changed_at,
+                        reason,
+                        metadata_json
+                    ) VALUES (%s, NULL, NULL, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        event.event_type,
+                        event.previous_digest,
+                        event.new_digest,
+                        event.proposer,
+                        event.changed_by,
+                        self._parse_timestamp(event.changed_at),
+                        "",
+                        {
+                            "previous_version": event.previous_version,
+                            "new_version": event.new_version,
+                        },
+                    ),
+                )
+            conn.commit()
+
+    def list_policy_history(self, *, limit: int, max_records: int) -> list[dict[str, Any]]:
+        bounded_limit = max(1, min(limit, max_records))
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT
+                        e.id,
+                        e.event_type,
+                        e.previous_digest,
+                        e.new_digest,
+                        e.proposer,
+                        e.changed_by,
+                        e.changed_at,
+                        e.reason,
+                        COALESCE(p_prev.policy_payload, '{}'::jsonb) AS previous_policy,
+                        COALESCE(p_new.policy_payload, '{}'::jsonb) AS new_policy
+                    FROM governance_policy_events e
+                    LEFT JOIN governance_policies p_prev ON p_prev.id = e.previous_policy_id
+                    LEFT JOIN governance_policies p_new ON p_new.id = e.new_policy_id
+                    ORDER BY e.event_order DESC
+                    LIMIT %s
+                    """,
+                    (bounded_limit,),
+                )
+                rows = cur.fetchall()
+
+                event_ids = [row[0] for row in rows]
+                approvals_by_event: dict[int, list[dict[str, str]]] = {}
+                if event_ids:
+                    cur.execute(
+                        """
+                        SELECT event_id, reviewer, signature
+                        FROM governance_approvals
+                        WHERE event_id = ANY(%s)
+                        ORDER BY event_id, id
+                        """,
+                        (event_ids,),
+                    )
+                    for event_id, reviewer, signature in cur.fetchall():
+                        approvals_by_event.setdefault(event_id, []).append(
+                            {"reviewer": reviewer, "signature": signature}
+                        )
+
+                conn.rollback()
+
+        records: list[dict[str, Any]] = []
+        for (
+            event_id,
+            event_type,
+            previous_digest,
+            new_digest,
+            proposer,
+            changed_by,
+            changed_at,
+            reason,
+            previous_policy,
+            new_policy,
+        ) in rows:
+            approvals = approvals_by_event.get(event_id, [])
+            records.append(
+                {
+                    "changed_at": self._as_iso_utc(changed_at),
+                    "changed_by": changed_by,
+                    "proposer": proposer,
+                    "approvers": [item["reviewer"] for item in approvals],
+                    "approvals": approvals,
+                    "event_type": event_type,
+                    "previous_digest": previous_digest,
+                    "new_digest": new_digest,
+                    "previous_policy": previous_policy,
+                    "new_policy": new_policy,
+                    "reason": reason,
+                }
+            )
+        return records
+
+    def update_policy(
+        self,
+        *,
+        previous: dict[str, Any],
+        updated: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+        event_type: str,
+        approval_records: list[dict[str, str]] | None = None,
+        reason: str = "",
+    ) -> None:
+        self._write_policy_event(
+            previous=previous,
+            updated=updated,
+            proposer=proposer,
+            approvers=approvers,
+            event_type=event_type,
+            approval_records=approval_records,
+            reason=reason,
+        )
+
+    def rollback_policy(
+        self,
+        *,
+        previous: dict[str, Any],
+        restored: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+        approval_records: list[dict[str, str]] | None = None,
+        reason: str = "",
+    ) -> None:
+        self._write_policy_event(
+            previous=previous,
+            updated=restored,
+            proposer=proposer,
+            approvers=approvers,
+            event_type="rollback",
+            approval_records=approval_records,
+            reason=reason,
+        )
+
+    def _write_policy_event(
+        self,
+        *,
+        previous: dict[str, Any],
+        updated: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+        event_type: str,
+        approval_records: list[dict[str, str]] | None,
+        reason: str,
+    ) -> None:
+        from veritas_os.policy.governance_identity import compute_governance_digest
+
+        normalized_approvals = self._normalize_approvals(
+            approvers=approvers,
+            approval_records=approval_records,
+        )
+
+        prev_digest = compute_governance_digest(previous) if previous else ""
+        new_digest = compute_governance_digest(updated)
+        changed_by = str(updated.get("updated_by") or proposer or "unknown")
+        changed_at = self._parse_timestamp(updated.get("updated_at"))
+
+        with self._connect() as conn:
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT id FROM governance_policies "
+                        "WHERE is_current = TRUE "
+                        "ORDER BY id DESC LIMIT 1 FOR UPDATE"
+                    )
+                    row = cur.fetchone()
+                    previous_policy_id = row[0] if row is not None else None
+
+                    if previous_policy_id is not None:
+                        cur.execute(
+                            "UPDATE governance_policies SET is_current = FALSE "
+                            "WHERE id = %s",
+                            (previous_policy_id,),
+                        )
+
+                    cur.execute(
+                        """
+                        INSERT INTO governance_policies (
+                            policy_version,
+                            policy_payload,
+                            digest,
+                            updated_at,
+                            updated_by,
+                            is_current,
+                            policy_revision,
+                            metadata_json
+                        ) VALUES (%s, %s, %s, %s, %s, TRUE, %s, %s)
+                        RETURNING id
+                        """,
+                        (
+                            str(updated.get("version", "")),
+                            updated,
+                            new_digest,
+                            changed_at,
+                            changed_by,
+                            int(updated.get("policy_revision", 1)),
+                            {},
+                        ),
+                    )
+                    new_policy_id = cur.fetchone()[0]
+
+                    cur.execute(
+                        """
+                        INSERT INTO governance_policy_events (
+                            event_type,
+                            previous_policy_id,
+                            new_policy_id,
+                            previous_digest,
+                            new_digest,
+                            proposer,
+                            changed_by,
+                            changed_at,
+                            reason,
+                            metadata_json
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        RETURNING id
+                        """,
+                        (
+                            event_type,
+                            previous_policy_id,
+                            new_policy_id,
+                            prev_digest,
+                            new_digest,
+                            proposer,
+                            changed_by,
+                            changed_at,
+                            reason,
+                            {
+                                "previous_version": previous.get("version"),
+                                "new_version": updated.get("version"),
+                            },
+                        ),
+                    )
+                    event_id = cur.fetchone()[0]
+
+                    for approval in normalized_approvals:
+                        cur.execute(
+                            """
+                            INSERT INTO governance_approvals (
+                                event_id,
+                                reviewer,
+                                signature,
+                                metadata_json
+                            ) VALUES (%s, %s, %s, %s)
+                            """,
+                            (
+                                event_id,
+                                approval["reviewer"],
+                                approval["signature"],
+                                {},
+                            ),
+                        )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+    def _normalize_approvals(
+        self,
+        *,
+        approvers: list[str],
+        approval_records: list[dict[str, str]] | None,
+    ) -> list[dict[str, str]]:
+        records = approval_records or [
+            {"reviewer": reviewer, "signature": ""}
+            for reviewer in approvers
+        ]
+        normalized: list[dict[str, str]] = []
+        seen_reviewers: set[str] = set()
+        for item in records:
+            reviewer = str(item.get("reviewer", "")).strip()
+            signature = str(item.get("signature", "")).strip()
+            if not reviewer:
+                raise ValueError("approval reviewer must be non-empty")
+            if reviewer in seen_reviewers:
+                raise ValueError("duplicate approval reviewer is not allowed")
+            seen_reviewers.add(reviewer)
+            normalized.append({"reviewer": reviewer, "signature": signature})
+        return normalized
+
+    @staticmethod
+    def _parse_timestamp(raw: Any) -> datetime:
+        if isinstance(raw, datetime):
+            return raw.astimezone(timezone.utc)
+        if isinstance(raw, str) and raw.strip():
+            candidate = raw.strip().replace("Z", "+00:00")
+            return datetime.fromisoformat(candidate).astimezone(timezone.utc)
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def _as_iso_utc(value: Any) -> str:
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        return str(value)

--- a/veritas_os/governance/repository.py
+++ b/veritas_os/governance/repository.py
@@ -34,6 +34,8 @@ class GovernanceRepository(Protocol):
         proposer: str,
         approvers: list[str],
         event_type: str,
+        approval_records: list[dict[str, str]] | None = None,
+        reason: str = "",
     ) -> None:
         """Persist updated policy and record an update event."""
 
@@ -44,5 +46,7 @@ class GovernanceRepository(Protocol):
         restored: dict[str, Any],
         proposer: str,
         approvers: list[str],
+        approval_records: list[dict[str, str]] | None = None,
+        reason: str = "",
     ) -> None:
         """Persist restored policy and record a rollback event."""

--- a/veritas_os/tests/test_alembic_migrations.py
+++ b/veritas_os/tests/test_alembic_migrations.py
@@ -131,6 +131,28 @@ class TestInitialMigration:
         assert source.count('"metadata"') >= 2
 
 
+class TestGovernanceMigration:
+    """Verify governance-specific migration metadata and DDL intent."""
+
+    @pytest.fixture()
+    def migration(self) -> ModuleType:
+        return _load_migration("0002_governance_policy_tables")
+
+    def test_revision_id(self, migration: ModuleType):
+        assert migration.revision == "0002"
+
+    def test_down_revision(self, migration: ModuleType):
+        assert migration.down_revision == "0001"
+
+    def test_upgrade_contains_governance_tables(self, migration: ModuleType):
+        import inspect
+
+        source = inspect.getsource(migration.upgrade)
+        assert "governance_policies" in source
+        assert "governance_policy_events" in source
+        assert "governance_approvals" in source
+
+
 # ── Revision chain integrity ────────────────────────────────────────────
 
 

--- a/veritas_os/tests/test_governance_postgresql_repository.py
+++ b/veritas_os/tests/test_governance_postgresql_repository.py
@@ -1,0 +1,336 @@
+"""Tests for PostgreSQL governance repository.
+
+These tests run against an in-memory SQL dispatcher (no live DB) and validate:
+- current policy retrieval
+- transactional update (policy + event + approvals)
+- rollback event persistence
+- deterministic history ordering
+- duplicate approval validation
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from veritas_os.governance.postgresql_repository import PostgresGovernanceRepository
+
+
+class _MockCursor:
+    def __init__(self, state: dict[str, Any]) -> None:
+        self._state = state
+        self._rows: list[tuple[Any, ...]] = []
+
+    def execute(self, query: str, params: tuple[Any, ...] | None = None) -> None:
+        sql = " ".join(query.strip().split()).lower()
+        params = params or tuple()
+
+        if sql.startswith("select policy_payload from governance_policies"):
+            current = [p for p in self._state["policies"] if p["is_current"]]
+            if not current:
+                self._rows = []
+            else:
+                self._rows = [(current[-1]["policy_payload"],)]
+            return
+
+        if sql.startswith("select id from governance_policies"):
+            current = [p for p in self._state["policies"] if p["is_current"]]
+            self._rows = [(current[-1]["id"],)] if current else []
+            return
+
+        if sql.startswith("update governance_policies set is_current = false"):
+            policy_id = params[0]
+            for policy in self._state["policies"]:
+                if policy["id"] == policy_id:
+                    policy["is_current"] = False
+            self._rows = []
+            return
+
+        if sql.startswith("insert into governance_policies"):
+            self._state["policy_seq"] += 1
+            policy_id = self._state["policy_seq"]
+            self._state["policies"].append(
+                {
+                    "id": policy_id,
+                    "policy_version": params[0],
+                    "policy_payload": params[1],
+                    "digest": params[2],
+                    "updated_at": params[3],
+                    "updated_by": params[4],
+                    "is_current": True,
+                }
+            )
+            self._rows = [(policy_id,)]
+            return
+
+        if sql.startswith("insert into governance_policy_events"):
+            self._state["event_seq"] += 1
+            event_id = self._state["event_seq"]
+            self._state["events"].append(
+                {
+                    "id": event_id,
+                    "event_order": event_id,
+                    "event_type": params[0],
+                    "previous_policy_id": params[1],
+                    "new_policy_id": params[2],
+                    "previous_digest": params[3],
+                    "new_digest": params[4],
+                    "proposer": params[5],
+                    "changed_by": params[6],
+                    "changed_at": params[7],
+                    "reason": params[8],
+                }
+            )
+            self._rows = [(event_id,)]
+            return
+
+        if sql.startswith("insert into governance_approvals"):
+            event_id, reviewer, signature, _metadata = params
+            for existing in self._state["approvals"]:
+                if existing["event_id"] == event_id and existing["reviewer"] == reviewer:
+                    raise ValueError("duplicate reviewer")
+                if (
+                    signature
+                    and existing["event_id"] == event_id
+                    and existing["signature"] == signature
+                ):
+                    raise ValueError("duplicate signature")
+            self._state["approvals"].append(
+                {
+                    "event_id": event_id,
+                    "reviewer": reviewer,
+                    "signature": signature,
+                }
+            )
+            self._rows = []
+            return
+
+        if sql.startswith("select e.id,"):
+            ordered = sorted(
+                self._state["events"],
+                key=lambda item: item["event_order"],
+                reverse=True,
+            )
+            limit = params[0]
+            selected = ordered[:limit]
+            rows: list[tuple[Any, ...]] = []
+            for event in selected:
+                previous_policy = {}
+                new_policy = {}
+                if event["previous_policy_id"]:
+                    previous_policy = next(
+                        p["policy_payload"]
+                        for p in self._state["policies"]
+                        if p["id"] == event["previous_policy_id"]
+                    )
+                if event["new_policy_id"]:
+                    new_policy = next(
+                        p["policy_payload"]
+                        for p in self._state["policies"]
+                        if p["id"] == event["new_policy_id"]
+                    )
+                rows.append(
+                    (
+                        event["id"],
+                        event["event_type"],
+                        event["previous_digest"],
+                        event["new_digest"],
+                        event["proposer"],
+                        event["changed_by"],
+                        event["changed_at"],
+                        event["reason"],
+                        previous_policy,
+                        new_policy,
+                    )
+                )
+            self._rows = rows
+            return
+
+        if sql.startswith("select event_id, reviewer, signature"):
+            event_ids = set(params[0])
+            rows = [
+                (a["event_id"], a["reviewer"], a["signature"])
+                for a in self._state["approvals"]
+                if a["event_id"] in event_ids
+            ]
+            rows.sort(key=lambda row: (row[0], row[1]))
+            self._rows = rows
+            return
+
+        raise ValueError(f"Unhandled SQL: {query}")
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return list(self._rows)
+
+
+class _MockConn:
+    def __init__(self, state: dict[str, Any]) -> None:
+        self._state = state
+
+    @contextmanager
+    def cursor(self):
+        yield _MockCursor(self._state)
+
+    def commit(self) -> None:
+        self._state["committed"] += 1
+
+    def rollback(self) -> None:
+        self._state["rolled_back"] += 1
+
+    def close(self) -> None:
+        return
+
+
+@pytest.fixture()
+def repository() -> tuple[PostgresGovernanceRepository, dict[str, Any]]:
+    state = {
+        "policies": [],
+        "events": [],
+        "approvals": [],
+        "policy_seq": 0,
+        "event_seq": 0,
+        "committed": 0,
+        "rolled_back": 0,
+    }
+    repo = PostgresGovernanceRepository(database_url="postgresql://unused")
+
+    @contextmanager
+    def _mock_connect():
+        yield _MockConn(state)
+
+    repo._connect = _mock_connect  # type: ignore[assignment]
+    return repo, state
+
+
+def _policy(version: str, updated_by: str) -> dict[str, Any]:
+    return {
+        "version": version,
+        "updated_by": updated_by,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "fuji_rules": {"pii_check": True},
+        "risk_thresholds": {"allow_upper": 0.5},
+        "rollout_controls": {"strategy": "immediate", "canary_percent": 0},
+        "log_retention": {"days": 30, "encrypted": True},
+        "auto_stop": {"max_risk_score": 0.9, "halt_on_missing_evidence": True},
+    }
+
+
+def test_get_current_policy_works(repository) -> None:
+    repo, _state = repository
+    fallback = repo.get_current_policy(default_factory=lambda: {"version": "default"})
+    assert fallback["version"] == "default"
+
+    updated = _policy("governance_v2", "alice")
+    repo.update_policy(
+        previous={},
+        updated=updated,
+        proposer="alice",
+        approvers=["r1", "r2"],
+        event_type="update",
+        approval_records=[
+            {"reviewer": "r1", "signature": "sig1"},
+            {"reviewer": "r2", "signature": "sig2"},
+        ],
+    )
+
+    current = repo.get_current_policy(default_factory=dict)
+    assert current["version"] == "governance_v2"
+
+
+def test_update_creates_policy_event_and_approvals(repository) -> None:
+    repo, state = repository
+    previous = _policy("governance_v1", "seed")
+    updated = _policy("governance_v2", "alice")
+
+    repo.update_policy(
+        previous=previous,
+        updated=updated,
+        proposer="alice",
+        approvers=["r1", "r2"],
+        event_type="update",
+        approval_records=[
+            {"reviewer": "r1", "signature": "sig1"},
+            {"reviewer": "r2", "signature": "sig2"},
+        ],
+    )
+
+    assert len(state["policies"]) == 1
+    assert len(state["events"]) == 1
+    assert len(state["approvals"]) == 2
+    assert state["events"][0]["event_type"] == "update"
+    assert state["committed"] == 1
+
+
+def test_rollback_creates_rollback_event(repository) -> None:
+    repo, state = repository
+    v1 = _policy("governance_v1", "seed")
+    v2 = _policy("governance_v2", "alice")
+    rollback_target = _policy("governance_v1_restored", "bob")
+
+    repo.update_policy(
+        previous=v1,
+        updated=v2,
+        proposer="alice",
+        approvers=["r1", "r2"],
+        event_type="update",
+    )
+    repo.rollback_policy(
+        previous=v2,
+        restored=rollback_target,
+        proposer="bob",
+        approvers=["r3", "r4"],
+        approval_records=[
+            {"reviewer": "r3", "signature": "sig3"},
+            {"reviewer": "r4", "signature": "sig4"},
+        ],
+        reason="manual rollback",
+    )
+
+    assert len(state["events"]) == 2
+    assert state["events"][1]["event_type"] == "rollback"
+    assert state["events"][1]["reason"] == "manual rollback"
+
+
+def test_list_policy_history_ordering_desc(repository) -> None:
+    repo, _state = repository
+
+    repo.update_policy(
+        previous=_policy("v1", "seed"),
+        updated=_policy("v2", "alice"),
+        proposer="alice",
+        approvers=["r1", "r2"],
+        event_type="update",
+    )
+    repo.rollback_policy(
+        previous=_policy("v2", "alice"),
+        restored=_policy("v1-restored", "bob"),
+        proposer="bob",
+        approvers=["r3", "r4"],
+    )
+
+    history = repo.list_policy_history(limit=10, max_records=500)
+    assert len(history) == 2
+    assert history[0]["event_type"] == "rollback"
+    assert history[1]["event_type"] == "update"
+
+
+def test_duplicate_approval_reviewer_rejected(repository) -> None:
+    repo, _state = repository
+    with pytest.raises(ValueError):
+        repo.update_policy(
+            previous=_policy("v1", "seed"),
+            updated=_policy("v2", "alice"),
+            proposer="alice",
+            approvers=["r1", "r1"],
+            event_type="update",
+            approval_records=[
+                {"reviewer": "r1", "signature": "sig1"},
+                {"reviewer": "r1", "signature": "sig2"},
+            ],
+        )

--- a/veritas_os/tests/test_governance_repository.py
+++ b/veritas_os/tests/test_governance_repository.py
@@ -73,7 +73,18 @@ class _InMemoryRepository:
     def list_policy_history(self, *, limit, max_records):
         return list(reversed(self.history))[: max(1, min(limit, max_records))]
 
-    def update_policy(self, *, previous, updated, proposer, approvers, event_type):
+    def update_policy(
+        self,
+        *,
+        previous,
+        updated,
+        proposer,
+        approvers,
+        event_type,
+        approval_records=None,
+        reason="",
+    ):
+        del approval_records, reason
         self.policy = updated
         self.history.append(
             {
@@ -85,7 +96,17 @@ class _InMemoryRepository:
             }
         )
 
-    def rollback_policy(self, *, previous, restored, proposer, approvers):
+    def rollback_policy(
+        self,
+        *,
+        previous,
+        restored,
+        proposer,
+        approvers,
+        approval_records=None,
+        reason="",
+    ):
+        del approval_records, reason
         self.policy = restored
         self.history.append(
             {


### PR DESCRIPTION
### Motivation
- Provide a PostgreSQL-backed persistence layer for governance policy, events, and approvals while keeping the existing file-based backend intact to allow a later safe rollout. 
- Ensure policy updates, corresponding audit events, and approval records are persisted atomically and can be queried in stable time order for audit/rollback visibility. 
- Make schema extensible with JSONB metadata so signer/artifact metadata can be added later without DDL churn. 

### Description
- Added `PostgresGovernanceRepository` implementing the `GovernanceRepository` contract with transactional writes that persist policy snapshot, event row, and approval rows in a single transaction and provide `get_current_policy`, `update_policy`, `rollback_policy`, `list_policy_history`, and `append_policy_event` behaviors. (file: `veritas_os/governance/postgresql_repository.py`).
- Added Alembic revision `0002_governance_policy_tables.py` creating three tables: `governance_policies`, `governance_policy_events`, and `governance_approvals`, with JSONB columns for payload/metadata, `is_current` for current snapshot, `event_order` for stable ordering, and constraints to enforce distinct approvers and partial uniqueness for non-empty signatures. (file: `alembic/versions/0002_governance_policy_tables.py`).
- Extended repository interface to accept structured `approval_records` and `reason` for rollback; API wiring now passes `approvals` and `reason` through to the repository; file-based repository remains and ignores the new args for backward compatibility. (files: `veritas_os/governance/repository.py`, `veritas_os/api/governance.py`, `veritas_os/governance/file_repository.py`, `veritas_os/governance/__init__.py`).
- Added unit tests that exercise PG repository behaviors using an in-memory SQL dispatcher (no live DB): transactional update creates policy + event + approvals, rollback creates rollback event and reason, history ordering is newest-first, and duplicate approval handling is validated. (file: `veritas_os/tests/test_governance_postgresql_repository.py`).

### Testing
- Ran targeted unit tests for the new code: `pytest -q veritas_os/tests/test_governance_postgresql_repository.py veritas_os/tests/test_governance_repository.py veritas_os/tests/test_alembic_migrations.py` — all tests in that run passed (`34 passed`).
- Ran the governance+postgresql slice: `pytest -q veritas_os/tests -k "governance and postgresql"` — passed (`5 passed`, others deselected).
- Verified migration module content with added assertions in the alembic test suite; those tests passed as part of the test runs above.
- Attempted `alembic upgrade head` in the local environment but it failed because `VERITAS_DATABASE_URL` is not set; the migration file is present and validated by tests but applying it to a real DB requires `VERITAS_DATABASE_URL` to be configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e336146fe88326a12386786b3db999)