### PR TITLE
Make Governance repository backend configurable (file/postgresql) and wire DI at startup

### DIFF
--- a/docs/en/operations/env-reference.md
+++ b/docs/en/operations/env-reference.md
@@ -205,6 +205,7 @@ Variables prefixed with `VERITAS_` are project-specific.
 | `VERITAS_GOVERNANCE_ENFORCE_RBAC` | `1` | Enforce role-based access control |
 | `VERITAS_GOVERNANCE_ALLOWED_ROLES` | `admin,compliance_owner` | Comma-separated roles for governance operations |
 | `VERITAS_GOVERNANCE_TENANT_ID` | `""` | Tenant ID for multi-tenant isolation |
+| `VERITAS_GOVERNANCE_BACKEND` | `file` | Governance repository backend (`file` or `postgresql`) |
 | `VERITAS_EU_AI_ACT_MODE` | `false` | Enable EU AI Act compliance features |
 | `VERITAS_HUMAN_REVIEW_WEBHOOK_URL` | — | Webhook URL for human review escalation notifications |
 | `VERITAS_HUMAN_REVIEW_SLA_SECONDS` | *(module default)* | SLA timeout for human review completion |

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -15,6 +15,8 @@ from typing import Any, Callable, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
 from veritas_os.governance import file_repository as _file_repo_mod
+from veritas_os.governance.config import get_governance_backend
+from veritas_os.governance.factory import create_governance_repository
 from veritas_os.governance.file_repository import FileGovernanceRepository
 from veritas_os.governance.models import GovernancePolicyEventRecord
 from veritas_os.governance.repository import GovernanceRepository
@@ -132,8 +134,8 @@ def _policy_path() -> Path:
 
 
 def _build_default_repository() -> GovernanceRepository:
-    """Create file-based governance repository for current module paths."""
-    return FileGovernanceRepository(
+    """Create governance repository selected by environment backend config."""
+    return create_governance_repository(
         policy_path=_DEFAULT_POLICY_PATH,
         history_path=_POLICY_HISTORY_PATH,
         lock=_policy_lock,
@@ -154,6 +156,14 @@ def _get_repository() -> GovernanceRepository:
     if _governance_repository_factory is None:
         return _build_default_repository()
     return _governance_repository_factory()
+
+
+def configure_governance_repository_from_env() -> GovernanceRepository:
+    """Configure repository DI factory from backend env and fail fast on errors."""
+    repository = _build_default_repository()
+    set_governance_repository_factory(lambda: repository)
+    logger.info("Governance repository configured (backend=%s)", get_governance_backend())
+    return repository
 
 
 def _load() -> Dict[str, Any]:

--- a/veritas_os/api/lifespan.py
+++ b/veritas_os/api/lifespan.py
@@ -43,12 +43,14 @@ async def run_lifespan(
 
     # ── Posture: resolve, validate, log banner (before resource allocation) ──
     from veritas_os.core.posture import init_posture, set_active_posture
+    from veritas_os.api.governance import configure_governance_repository_from_env
 
     posture_defaults = init_posture(fail_on_error=True)
     set_active_posture(posture_defaults)
 
     # Storage DI: validate backend environment before constructing instances.
     validate_backend_config()
+    configure_governance_repository_from_env()
 
     # Storage DI: initialize backend instances once per application lifecycle.
     trust_log_store = create_trust_log_store()

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -1,14 +1,19 @@
 """Governance domain persistence abstractions."""
 
+from veritas_os.governance.config import get_governance_backend, validate_governance_backend
+from veritas_os.governance.factory import create_governance_repository
 from veritas_os.governance.file_repository import FileGovernanceRepository
 from veritas_os.governance.models import GovernancePolicyEventRecord, GovernancePolicyRecord
 from veritas_os.governance.postgresql_repository import PostgresGovernanceRepository
 from veritas_os.governance.repository import GovernanceRepository
 
 __all__ = [
+    "create_governance_repository",
     "FileGovernanceRepository",
+    "get_governance_backend",
     "GovernancePolicyEventRecord",
     "GovernancePolicyRecord",
     "PostgresGovernanceRepository",
     "GovernanceRepository",
+    "validate_governance_backend",
 ]

--- a/veritas_os/governance/config.py
+++ b/veritas_os/governance/config.py
@@ -1,0 +1,40 @@
+"""Configuration helpers for governance repository backend selection."""
+
+from __future__ import annotations
+
+import os
+
+_GOVERNANCE_BACKENDS = {"file", "postgresql"}
+
+
+def get_governance_backend() -> str:
+    """Return normalized governance backend name from environment.
+
+    Defaults to ``file`` for backward compatibility.
+    """
+    return os.getenv("VERITAS_GOVERNANCE_BACKEND", "file").strip().lower()
+
+
+def validate_governance_backend() -> str:
+    """Validate and return configured governance backend.
+
+    Raises:
+        ValueError: If backend is unknown.
+        RuntimeError: If PostgreSQL backend is requested without DB URL.
+    """
+    backend = get_governance_backend()
+    if backend not in _GOVERNANCE_BACKENDS:
+        raise ValueError(
+            f"Unknown VERITAS_GOVERNANCE_BACKEND={backend!r}. "
+            f"Supported: {sorted(_GOVERNANCE_BACKENDS)}"
+        )
+
+    if backend == "postgresql":
+        database_url = os.getenv("VERITAS_DATABASE_URL", "").strip()
+        if not database_url:
+            raise RuntimeError(
+                "Governance backend is set to 'postgresql' but "
+                "VERITAS_DATABASE_URL is not set. "
+                "Set VERITAS_DATABASE_URL to a PostgreSQL DSN."
+            )
+    return backend

--- a/veritas_os/governance/factory.py
+++ b/veritas_os/governance/factory.py
@@ -1,0 +1,38 @@
+"""Factory for governance repositories."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+
+from veritas_os.governance.config import validate_governance_backend
+from veritas_os.governance.file_repository import FileGovernanceRepository
+from veritas_os.governance.postgresql_repository import PostgresGovernanceRepository
+from veritas_os.governance.repository import GovernanceRepository
+
+logger = logging.getLogger(__name__)
+
+
+def create_governance_repository(
+    *,
+    policy_path: Path,
+    history_path: Path,
+    lock: threading.Lock,
+    policy_history_max: int,
+    has_atomic_io: bool,
+) -> GovernanceRepository:
+    """Create governance repository based on ``VERITAS_GOVERNANCE_BACKEND``."""
+    backend = validate_governance_backend()
+    if backend == "postgresql":
+        logger.info("Governance backend: postgresql")
+        return PostgresGovernanceRepository()
+
+    logger.info("Governance backend: file")
+    return FileGovernanceRepository(
+        policy_path=policy_path,
+        history_path=history_path,
+        lock=lock,
+        policy_history_max=policy_history_max,
+        has_atomic_io=has_atomic_io,
+    )

--- a/veritas_os/tests/test_governance_backend_selection.py
+++ b/veritas_os/tests/test_governance_backend_selection.py
@@ -1,0 +1,185 @@
+"""Tests for governance backend selection and API backend wiring."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from veritas_os.api import governance as gov
+from veritas_os.governance import factory as governance_factory
+from veritas_os.governance.config import validate_governance_backend
+from veritas_os.governance.file_repository import FileGovernanceRepository
+
+
+class _InMemoryGovernanceRepository:
+    """Simple in-memory repository used to emulate PostgreSQL backend in tests."""
+
+    def __init__(self) -> None:
+        self.policy = gov.GovernancePolicy().model_dump()
+        self.history: list[dict[str, Any]] = []
+
+    def get_current_policy(self, *, default_factory):
+        return self.policy or default_factory()
+
+    def save_policy(self, policy: dict[str, Any]) -> None:
+        self.policy = policy
+
+    def append_policy_event(self, event) -> None:
+        self.history.append(event.to_dict())
+
+    def list_policy_history(self, *, limit: int, max_records: int) -> list[dict[str, Any]]:
+        bounded_limit = max(1, min(limit, max_records))
+        return list(reversed(self.history))[:bounded_limit]
+
+    def update_policy(
+        self,
+        *,
+        previous: dict[str, Any],
+        updated: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+        event_type: str,
+        approval_records: list[dict[str, str]] | None = None,
+        reason: str = "",
+    ) -> None:
+        self.policy = updated
+        self.history.append(
+            {
+                "changed_at": updated.get(
+                    "updated_at",
+                    datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                ),
+                "changed_by": updated.get("updated_by", proposer),
+                "proposer": proposer,
+                "approvers": approvers,
+                "approvals": approval_records or [],
+                "event_type": event_type,
+                "previous_policy": previous,
+                "new_policy": updated,
+                "reason": reason,
+            }
+        )
+
+    def rollback_policy(
+        self,
+        *,
+        previous: dict[str, Any],
+        restored: dict[str, Any],
+        proposer: str,
+        approvers: list[str],
+        approval_records: list[dict[str, str]] | None = None,
+        reason: str = "",
+    ) -> None:
+        self.update_policy(
+            previous=previous,
+            updated=restored,
+            proposer=proposer,
+            approvers=approvers,
+            event_type="rollback",
+            approval_records=approval_records,
+            reason=reason,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_governance_repo_factory() -> None:
+    gov.set_governance_repository_factory(None)
+    yield
+    gov.set_governance_repository_factory(None)
+
+
+def test_governance_backend_file_path_works(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File backend selection keeps legacy file persistence behavior."""
+    monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "file")
+    repo = governance_factory.create_governance_repository(
+        policy_path=tmp_path / "governance.json",
+        history_path=tmp_path / "governance_history.jsonl",
+        lock=threading.Lock(),
+        policy_history_max=50,
+        has_atomic_io=False,
+    )
+    assert isinstance(repo, FileGovernanceRepository)
+
+
+def test_governance_backend_postgresql_path_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PostgreSQL backend selection returns PostgreSQL repository class."""
+    monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://user:pass@localhost:5432/veritas")
+
+    class _StubPostgresRepo:
+        pass
+
+    monkeypatch.setattr(governance_factory, "PostgresGovernanceRepository", _StubPostgresRepo)
+
+    repo = governance_factory.create_governance_repository(
+        policy_path=Path("unused-policy.json"),
+        history_path=Path("unused-history.jsonl"),
+        lock=threading.Lock(),
+        policy_history_max=50,
+        has_atomic_io=False,
+    )
+    assert isinstance(repo, _StubPostgresRepo)
+
+
+def test_governance_backend_invalid_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unknown governance backend should fail fast during validation."""
+    monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "invalid")
+    with pytest.raises(ValueError, match="Unknown VERITAS_GOVERNANCE_BACKEND"):
+        validate_governance_backend()
+
+
+def test_configure_governance_repository_fails_fast_for_invalid_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup configuration should fail fast for unknown backend values."""
+    monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "unknown-backend")
+    with pytest.raises(ValueError, match="Unknown VERITAS_GOVERNANCE_BACKEND"):
+        gov.configure_governance_repository_from_env()
+
+
+def test_governance_api_history_rollback_approval_flow_postgresql_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API workflow works with PostgreSQL backend selection via DI factory."""
+    monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://user:pass@localhost:5432/veritas")
+
+    in_memory_repo = _InMemoryGovernanceRepository()
+
+    def _fake_create_repo(**_kwargs):
+        return in_memory_repo
+
+    monkeypatch.setattr(gov, "create_governance_repository", _fake_create_repo)
+    gov.configure_governance_repository_from_env()
+
+    approvals = [
+        {"reviewer": "alice", "signature": "sig-1"},
+        {"reviewer": "bob", "signature": "sig-2"},
+    ]
+
+    gov.enforce_four_eyes_approval({"approvals": approvals})
+    updated = gov.update_policy(
+        {
+            "version": "governance_v2",
+            "updated_by": "alice",
+            "approvals": approvals,
+        }
+    )
+    assert updated["version"] == "governance_v2"
+
+    rolled_back = gov.rollback_policy(
+        {**updated, "version": "governance_v1_restored"},
+        rolled_back_by="bob",
+        approvals=approvals,
+        reason="postgresql test rollback",
+    )
+    assert rolled_back["version"] == "governance_v1_restored"
+
+    history = gov.get_policy_history(limit=10)
+    assert len(history) == 2
+    assert history[0]["event_type"] == "rollback"
+    assert history[1]["event_type"] == "update"


### PR DESCRIPTION
### Motivation

- Allow the Governance API/service layer to use a pluggable repository backend (file-based or PostgreSQL) so PostgreSQL can be a production-ready persistence option.  
- Ensure backend selection is controlled by configuration and is fail-fast for unknown or incomplete setups to avoid silent fallback.  
- Preserve existing API contract and file-backend behavior while providing DI wiring so tests and startup can inject alternate repositories.

### Description

- Add `veritas_os/governance/config.py` with `get_governance_backend()` and `validate_governance_backend()` to parse and validate `VERITAS_GOVERNANCE_BACKEND` and require `VERITAS_DATABASE_URL` when `postgresql` is selected.  
- Add `veritas_os/governance/factory.py` with `create_governance_repository()` that returns `FileGovernanceRepository` or `PostgresGovernanceRepository` according to validated config.  
- Update `veritas_os/api/governance.py` to resolve the repository via the new factory (`create_governance_repository`) instead of hardcoding file I/O and add `configure_governance_repository_from_env()` to set the DI factory and log backend selection.  
- Call `configure_governance_repository_from_env()` from application startup (`veritas_os/api/lifespan.py`) so invalid governance backend configuration fails at boot rather than silently at runtime, while keeping default backend `file`.  
- Export new helpers from `veritas_os/governance/__init__.py` and document the new env var in `docs/en/operations/env-reference.md`.  
- Add `veritas_os/tests/test_governance_backend_selection.py` to verify file/postgresql selection, invalid backend fail-fast, and that history/rollback/4-eyes approval flows continue to work when a DI-backed repository is used.

### Testing

- Ran unit tests covering the changes: `pytest -q veritas_os/tests/test_governance_backend_selection.py` — all tests passed.  
- Ran existing governance contract tests: `pytest -q veritas_os/tests/test_governance_repository.py` and `pytest -q veritas_os/tests/test_governance_postgresql_repository.py` — all passed.  
- Ran broader governance test subsets: `pytest -q veritas_os/tests -k "governance"` and `pytest -q veritas_os/tests -k "governance and postgresql"` — both succeeded in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34078b2a4832685575cfcc4b04b7c)