### PR TITLE
Harden canonical decision semantics in schema, OpenAPI and docs

### DIFF
--- a/docs/en/architecture/decision-semantics.md
+++ b/docs/en/architecture/decision-semantics.md
@@ -104,6 +104,15 @@ Additional runtime invariants:
 - `business=REVIEW_REQUIRED` + `human_review_required=false` is forbidden.
 - `business=APPROVE` + `human_review_required=true` is forbidden.
 
+Contract hardening policy:
+
+- Runtime assembly (`pipeline_response`) validates combinations before emitting
+  the public payload.
+- Schema validation (`DecideResponse`) also rejects forbidden combinations
+  instead of silently coercing boolean flags.
+- Legacy gate aliases remain compatibility-only inputs and are canonicalized
+  before public output.
+
 ## D. stop_reasons priority (current implementation order)
 
 Current order is implemented in

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -647,7 +647,71 @@ components:
           type: string
           enum: ["allow", "modify", "rejected", "block", "abstain"]
           default: "allow"
+          description: "Legacy compatibility decision status. Public contract should prefer gate_decision."
         rejection_reason:
+          type: string
+          nullable: true
+        gate_decision:
+          type: string
+          enum:
+            [
+              "proceed",
+              "hold",
+              "block",
+              "human_review_required",
+              "allow",
+              "deny",
+              "modify",
+              "rejected",
+              "abstain",
+              "unknown",
+            ]
+          default: "unknown"
+          description: "Canonical public values are proceed|hold|block|human_review_required. Legacy aliases remain compatibility-only inputs and are normalized before public output."
+          examples: ["proceed", "hold", "human_review_required", "block"]
+        business_decision:
+          type: string
+          enum:
+            [
+              "APPROVE",
+              "DENY",
+              "HOLD",
+              "REVIEW_REQUIRED",
+              "POLICY_DEFINITION_REQUIRED",
+              "EVIDENCE_REQUIRED",
+            ]
+          default: "HOLD"
+          description: "Business lifecycle decision state. Keep distinct from next_action."
+        next_action:
+          type: string
+          default: "REVISE_AND_RESUBMIT"
+          description: "Operational guidance action; separate from business_decision state."
+        required_evidence:
+          type: array
+          default: []
+          maxItems: 100
+          items:
+            type: string
+        missing_evidence:
+          type: array
+          default: []
+          maxItems: 100
+          items:
+            type: string
+        satisfied_evidence:
+          type: array
+          default: []
+          maxItems: 100
+          items:
+            type: string
+        human_review_required:
+          type: boolean
+          default: false
+          description: "Must be true when gate_decision=human_review_required or business_decision=REVIEW_REQUIRED."
+        rationale:
+          type: string
+          nullable: true
+        refusal_reason:
           type: string
           nullable: true
         values:
@@ -715,6 +779,11 @@ components:
           nullable: true
           additionalProperties: true
           description: "決定の決定論的再現に必要なスナップショット"
+        governance_identity:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Identity of the governance artifact in force at decision time."
 
     DecideRequest:
       type: object

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -870,11 +870,17 @@ class DecideResponse(BaseModel):
 
     @model_validator(mode="after")
     def _unify_and_sanitize(self) -> "DecideResponse":
-        """Normalize response payload and expose coercion metadata for audits.
+        """Normalize response payload and enforce canonical decision semantics.
 
         ``alternatives`` is the canonical response contract. Legacy ``options``
         remains available for compatibility, but is kept synchronized so that
         clients can migrate without semantic drift.
+
+        Decision hardening rules:
+        - ``gate_decision`` is canonicalized to public values first.
+        - Legacy aliases are accepted as compatibility-only inputs.
+        - Forbidden ``gate_decision``/``business_decision``/``human_review_required``
+          combinations are rejected (no silent correction).
         """
         events: List[str] = []
 
@@ -971,15 +977,6 @@ class DecideResponse(BaseModel):
         if canonical_gate_decision != self.gate_decision:
             self.gate_decision = canonical_gate_decision
             events.append("coercion.gate_decision_canonicalized")
-
-        # REVIEW_REQUIRED / human_review_required の不整合は fail ではなく
-        # 後方互換優先で安全側へ補正する。
-        if self.business_decision == "REVIEW_REQUIRED" and not self.human_review_required:
-            self.human_review_required = True
-            events.append("coercion.human_review_required_for_review_required")
-        if self.gate_decision == "human_review_required" and not self.human_review_required:
-            self.human_review_required = True
-            events.append("coercion.human_review_required_for_gate_escalation")
 
         if self.required_evidence:
             self.required_evidence = unique_preserve_order(

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -63,3 +63,35 @@ def test_openapi_includes_runtime_audit_and_governance_routes() -> None:
     for path in critical:
         assert path in runtime_paths
         assert path in paths
+
+
+def test_openapi_decide_response_decision_semantics_contract() -> None:
+    """DecideResponse schema should expose hardened canonical decision fields."""
+    spec = _load_openapi_spec()
+    decide_schema = spec["components"]["schemas"]["DecideResponse"]["properties"]
+
+    gate_enum = decide_schema["gate_decision"]["enum"]
+    assert gate_enum[:4] == [
+        "proceed",
+        "hold",
+        "block",
+        "human_review_required",
+    ]
+    assert "allow" in gate_enum
+    assert decide_schema["gate_decision"]["examples"] == [
+        "proceed",
+        "hold",
+        "human_review_required",
+        "block",
+    ]
+    assert decide_schema["human_review_required"]["type"] == "boolean"
+    assert decide_schema["business_decision"]["enum"] == [
+        "APPROVE",
+        "DENY",
+        "HOLD",
+        "REVIEW_REQUIRED",
+        "POLICY_DEFINITION_REQUIRED",
+        "EVIDENCE_REQUIRED",
+    ]
+    assert decide_schema["next_action"]["type"] == "string"
+    assert "governance_identity" in decide_schema

--- a/veritas_os/tests/test_schemas_extra.py
+++ b/veritas_os/tests/test_schemas_extra.py
@@ -173,8 +173,10 @@ class TestDecideResponse:
         """business_decision は action ではなく案件状態 enum で保持する。"""
         resp = schemas_mod.DecideResponse(
             request_id="req-enum",
+            gate_decision="human_review_required",
             business_decision="REVIEW_REQUIRED",
             next_action="ROUTE_TO_HUMAN_REVIEW",
+            human_review_required=True,
         )
         assert resp.business_decision == "REVIEW_REQUIRED"
         assert resp.next_action == "ROUTE_TO_HUMAN_REVIEW"

--- a/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
+++ b/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
@@ -102,16 +102,41 @@ def test_forbidden_pair_table_is_centralized_and_enforced() -> None:
     )
 
 
-def test_review_required_coerces_human_review_required_true() -> None:
-    """REVIEW_REQUIRED は後方互換のため human_review_required=true に補正する。"""
-    payload = DecideResponse.model_validate(
-        {
-            "gate_decision": "human_review_required",
-            "business_decision": "REVIEW_REQUIRED",
-            "human_review_required": False,
-        }
-    )
-    assert payload.human_review_required is True
+def test_review_required_requires_human_review_required_true() -> None:
+    """REVIEW_REQUIRED requires explicit human_review_required=true."""
+    try:
+        DecideResponse.model_validate(
+            {
+                "gate_decision": "human_review_required",
+                "business_decision": "REVIEW_REQUIRED",
+                "human_review_required": False,
+            }
+        )
+    except ValidationError as exc:
+        message = str(exc)
+        assert (
+            "business_decision=REVIEW_REQUIRED" in message
+            or "gate_decision=human_review_required" in message
+        )
+    else:  # pragma: no cover
+        raise AssertionError("ValidationError was expected")
+
+
+def test_gate_human_review_required_requires_boolean_true() -> None:
+    """gate_decision=human_review_required cannot be combined with false flag."""
+    try:
+        DecideResponse.model_validate(
+            {
+                "gate_decision": "human_review_required",
+                "business_decision": "HOLD",
+                "human_review_required": False,
+            }
+        )
+    except ValidationError as exc:
+        message = str(exc)
+        assert "gate_decision=human_review_required" in message
+    else:  # pragma: no cover
+        raise AssertionError("ValidationError was expected")
 
 
 def test_proceed_requires_human_review_false() -> None:


### PR DESCRIPTION
### Motivation
- Ensure public responses always use canonical gate semantics and prevent ambiguous/unsafe combinations from being silently coerced.
- Make legacy gate aliases compatibility-only while enforcing canonical-first output and stricter invariants for `human_review_required` / `business_decision` / `gate_decision` combinations.
- Security note: rejecting invalid/ambiguous payloads surfaces bad inputs as early 4xx failures rather than hiding them, so downstream clients must be notified prior to rollout.

### Description
- Strengthened `DecideResponse` after-validator to canonicalize `gate_decision` and stop silently coercing `human_review_required`; forbidden combinations are now validated and raise errors instead of being auto-corrected (primary change in `veritas_os/api/schemas.py`).
- Extended OpenAPI `DecideResponse` schema (`openapi.yaml`) to explicitly list decision fields (`gate_decision`, `business_decision`, `next_action`, evidence lists, `human_review_required`, `governance_identity`) with canonical-first `gate_decision` enum ordering and examples.
- Documented the contract hardening policy in `docs/en/architecture/decision-semantics.md` to state runtime + schema dual enforcement and legacy-alias compatibility policy.
- Updated/added tests to reflect hardened contract semantics and canonical-first behavior (tests in `veritas_os/tests/*` were adjusted to require `human_review_required=true` where appropriate and OpenAPI schema checks were added).

### Testing
- Ran decision-semantics-focused test selection: `pytest -q veritas_os/tests -k "decision_semantics or schemas or pipeline_response"` and the selection passed (`200 passed`).
- Ran OpenAPI regression checks: `pytest -q veritas_os/tests/test_openapi_spec.py` and they passed (`5 passed`).
- Full targeted assertions exercised: canonicalization of legacy aliases, forbidden-combination rejection, `REVIEW_REQUIRED`/`human_review_required` invariants, required-evidence normalization and OpenAPI alignment (all automated assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3557857fc8326822a13b62981e3ef)