### PR TITLE
Unify canonical decision semantics across console, evidence bundle, and PoC compare

### DIFF
--- a/frontend/features/console/adapters/decision-semantics.ts
+++ b/frontend/features/console/adapters/decision-semantics.ts
@@ -5,6 +5,15 @@ const CANONICAL_GATE_DECISIONS = new Set([
   "human_review_required",
 ] as const);
 
+const CANONICAL_BUSINESS_DECISIONS = new Set([
+  "APPROVE",
+  "DENY",
+  "HOLD",
+  "REVIEW_REQUIRED",
+  "EVIDENCE_REQUIRED",
+  "POLICY_DEFINITION_REQUIRED",
+] as const);
+
 const GATE_ALIAS_TO_CANONICAL: Record<string, string> = {
   allow: "proceed",
   deny: "block",
@@ -18,6 +27,27 @@ const GATE_ALIAS_TO_CANONICAL: Record<string, string> = {
   unknown: "unknown",
 };
 
+const BUSINESS_ALIAS_TO_CANONICAL: Record<string, string> = {
+  allow: "APPROVE",
+  proceed: "APPROVE",
+  approve: "APPROVE",
+  deny: "DENY",
+  rejected: "DENY",
+  block: "DENY",
+  hold: "HOLD",
+  modify: "HOLD",
+  abstain: "HOLD",
+  review_required: "REVIEW_REQUIRED",
+  ambiguous_human_review: "REVIEW_REQUIRED",
+  evidence_required: "EVIDENCE_REQUIRED",
+  policy_definition_required: "POLICY_DEFINITION_REQUIRED",
+};
+
+const NEXT_ACTION_ALIAS_TO_CANONICAL: Record<string, string> = {
+  needs_human_review: "PREPARE_HUMAN_REVIEW_PACKET",
+  reject_request: "DO_NOT_EXECUTE",
+};
+
 export function canonicalizePublicGateDecision(value: unknown): string {
   if (typeof value !== "string") {
     return "unknown";
@@ -28,6 +58,27 @@ export function canonicalizePublicGateDecision(value: unknown): string {
   }
   const mapped = GATE_ALIAS_TO_CANONICAL[normalized] ?? normalized;
   return CANONICAL_GATE_DECISIONS.has(mapped as never) ? mapped : "unknown";
+}
+
+export function canonicalizeBusinessDecision(value: unknown): string {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) {
+    return "HOLD";
+  }
+  const upper = normalized.toUpperCase();
+  if (CANONICAL_BUSINESS_DECISIONS.has(upper as never)) {
+    return upper;
+  }
+  return BUSINESS_ALIAS_TO_CANONICAL[normalized.toLowerCase()] ?? "HOLD";
+}
+
+export function canonicalizeNextAction(value: unknown): string {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) {
+    return "REVISE_AND_RESUBMIT";
+  }
+  const upper = normalized.toUpperCase();
+  return NEXT_ACTION_ALIAS_TO_CANONICAL[upper.toLowerCase()] ?? upper;
 }
 
 export function gateDecisionLabel(gateDecision: string): string {

--- a/frontend/features/console/adapters/decision-view.test.ts
+++ b/frontend/features/console/adapters/decision-view.test.ts
@@ -158,6 +158,17 @@ describe("toPublicDecisionSchemaView", () => {
     expect(view.verifyStatus).toBe("verified");
   });
 
+  it("canonicalizes business_decision and next_action aliases", () => {
+    const result = makeResponse({
+      gate_decision: "allow",
+      business_decision: "allow",
+      next_action: "needs_human_review",
+    } as never);
+    const view = toPublicDecisionSchemaView(result);
+    expect(view.businessDecision).toBe("APPROVE");
+    expect(view.nextAction).toBe("PREPARE_HUMAN_REVIEW_PACKET");
+  });
+
   it("adds canonical label for proceed gate to avoid approval confusion", () => {
     const result = makeResponse({ gate_decision: "allow" } as never);
     const view = toPublicDecisionSchemaView(result);
@@ -203,6 +214,7 @@ describe("runtime status + bundle mapping", () => {
     const bundle = toEvidenceBundleDraft(result);
     expect(bundle.requestId).toBe("req-bundle");
     expect(bundle.businessDecision).toBe("REVIEW_REQUIRED");
+    expect(bundle.nextAction).toBe("ROUTE_TO_HUMAN_REVIEW");
     expect(bundle.runtimeStatus).toEqual({
       activePosture: "strict",
       backend: "gpt-5.3-mini",

--- a/frontend/features/console/adapters/decision-view.ts
+++ b/frontend/features/console/adapters/decision-view.ts
@@ -1,7 +1,12 @@
 import { type DecideResponse } from "@veritas/types";
 import { toArray } from "../analytics/utils";
 import { PIPELINE_STAGES, type PipelineStageName } from "../constants";
-import { canonicalizePublicGateDecision, gateDecisionLabel } from "./decision-semantics";
+import {
+  canonicalizeBusinessDecision,
+  canonicalizeNextAction,
+  canonicalizePublicGateDecision,
+  gateDecisionLabel,
+} from "./decision-semantics";
 import {
   type DecisionResultView,
   type FujiGateDetailView,
@@ -164,11 +169,13 @@ export function toPublicDecisionSchemaView(result: DecideResponse): PublicDecisi
   const gateDecision = canonicalizePublicGateDecision(
     readText(resultRecord, "gate_decision", "decision_status"),
   );
+  const businessDecision = canonicalizeBusinessDecision(readText(resultRecord, "business_decision"));
+  const nextAction = canonicalizeNextAction(readText(resultRecord, "next_action"));
   return {
     gateDecision,
     gateDecisionLabel: gateDecisionLabel(gateDecision),
-    businessDecision: readText(resultRecord, "business_decision"),
-    nextAction: readText(resultRecord, "next_action"),
+    businessDecision,
+    nextAction,
     requiredEvidence,
     missingEvidence,
     humanReviewRequired: result.human_review_required === true,
@@ -195,8 +202,11 @@ export function toFujiGateView(result: DecideResponse | null): FujiGateView {
   };
 
   const topLevelGateDecision = readText(result as Record<string, unknown>, "gate_decision");
+  const resolvedDecision = topLevelGateDecision !== "n/a"
+    ? topLevelGateDecision
+    : readText(merged, "decision_status", "status");
   return {
-    decision: topLevelGateDecision !== "n/a" ? topLevelGateDecision : readText(merged, "decision_status", "status"),
+    decision: canonicalizePublicGateDecision(resolvedDecision),
     ruleHit: readText(merged, "rule_hit", "rule", "policy_rule", "code"),
     severity: readText(merged, "severity", "risk_level"),
     remediationHint: readText(merged, "remediation_hint", "hint", "action"),

--- a/frontend/features/console/components/__snapshots__/decision-result-panel.snapshot.test.tsx.snap
+++ b/frontend/features/console/components/__snapshots__/decision-result-panel.snapshot.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`DecisionResultPanel snapshots > renders four fixture states without reg
             :
           </span>
            
-          AMBIGUOUS_HUMAN_REVIEW
+          REVIEW_REQUIRED
         </p>
         <p>
           <span
@@ -276,7 +276,7 @@ exports[`DecisionResultPanel snapshots > renders four fixture states without reg
             :
           </span>
            
-          AMBIGUOUS_HUMAN_REVIEW
+          REVIEW_REQUIRED
         </p>
         <p>
           <span

--- a/frontend/features/console/components/fuji-gate-status-panel.test.tsx
+++ b/frontend/features/console/components/fuji-gate-status-panel.test.tsx
@@ -17,7 +17,8 @@ describe("FujiGateStatusPanel", () => {
         } as never}
       />,
     );
-    expect(screen.getByText("allow")).toBeInTheDocument();
+    expect(screen.getByText("proceed")).toBeInTheDocument();
+    expect(screen.getByText(/not business approval/i)).toBeInTheDocument();
     expect(screen.getByText("rule hit")).toBeInTheDocument();
   });
 
@@ -64,7 +65,7 @@ describe("FujiGateStatusPanel", () => {
     );
     const statusEl = container.querySelector(".text-destructive");
     expect(statusEl).toBeInTheDocument();
-    expect(statusEl?.textContent).toBe("rejected");
+    expect(statusEl?.textContent).toContain("block");
   });
 
   it("applies destructive color for 'block' decision", () => {
@@ -81,17 +82,17 @@ describe("FujiGateStatusPanel", () => {
     expect(statusEl?.textContent).toBe("block");
   });
 
-  it("applies amber color for 'abstain' decision", () => {
+  it("applies amber color for 'human_review_required' decision", () => {
     const { container } = render(
       <FujiGateStatusPanel
         result={{
-          fuji: { decision_status: "abstain" },
-          gate: { decision_status: "abstain" },
+          fuji: { decision_status: "human_review_required" },
+          gate: { decision_status: "human_review_required" },
         } as never}
       />,
     );
     const statusEl = container.querySelector(".text-amber-400");
     expect(statusEl).toBeInTheDocument();
-    expect(statusEl?.textContent).toBe("abstain");
+    expect(statusEl?.textContent).toContain("human_review_required");
   });
 });

--- a/frontend/features/console/components/fuji-gate-status-panel.tsx
+++ b/frontend/features/console/components/fuji-gate-status-panel.tsx
@@ -5,11 +5,11 @@ export function FujiGateStatusPanel({ result }: { result: DecideResponse | null 
   const view = toFujiGateDetailView(result);
 
   const decisionColor =
-    view.decision === "rejected" || view.decision === "block"
+    view.decision === "block"
       ? "text-destructive"
-      : view.decision === "modify" || view.decision === "abstain"
+      : view.decision === "hold" || view.decision === "human_review_required"
         ? "text-amber-400"
-        : view.decision === "allow"
+        : view.decision === "proceed"
           ? "text-emerald-400"
           : "text-foreground";
 
@@ -23,6 +23,11 @@ export function FujiGateStatusPanel({ result }: { result: DecideResponse | null 
         <div className="rounded border border-border/70 bg-background/70 p-2">
           <p className="text-muted-foreground">gate decision</p>
           <p className={`font-semibold ${decisionColor}`}>{view.decision}</p>
+          {view.decision === "proceed" && (
+            <p className="text-[10px] text-muted-foreground">
+              execution guidance only (not business approval)
+            </p>
+          )}
         </div>
         <div className="rounded border border-border/70 bg-background/70 p-2">
           <p className="text-muted-foreground">rule hit</p>

--- a/veritas_os/audit/evidence_bundle.py
+++ b/veritas_os/audit/evidence_bundle.py
@@ -36,6 +36,33 @@ from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_j
 
 _logger = logging.getLogger(__name__)
 
+_CANONICAL_BUSINESS_DECISIONS = {
+    "APPROVE",
+    "DENY",
+    "HOLD",
+    "REVIEW_REQUIRED",
+    "EVIDENCE_REQUIRED",
+    "POLICY_DEFINITION_REQUIRED",
+}
+
+_BUSINESS_ALIAS_TO_CANONICAL = {
+    "allow": "APPROVE",
+    "proceed": "APPROVE",
+    "approve": "APPROVE",
+    "deny": "DENY",
+    "rejected": "DENY",
+    "block": "DENY",
+    "hold": "HOLD",
+    "modify": "HOLD",
+    "abstain": "HOLD",
+    "ambiguous_human_review": "REVIEW_REQUIRED",
+}
+
+_NEXT_ACTION_ALIASES = {
+    "NEEDS_HUMAN_REVIEW": "PREPARE_HUMAN_REVIEW_PACKET",
+    "REJECT_REQUEST": "DO_NOT_EXECUTE",
+}
+
 
 def _uuid7() -> str:
     """Generate a UUIDv7-compatible identifier."""
@@ -54,6 +81,26 @@ def _utc_now_iso8601() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
         "+00:00", "Z"
     )
+
+
+def _canonicalize_business_decision(value: Any) -> str:
+    """Normalize business_decision into canonical public decision enums."""
+    normalized = str(value or "").strip()
+    if not normalized:
+        return "HOLD"
+    upper = normalized.upper()
+    if upper in _CANONICAL_BUSINESS_DECISIONS:
+        return upper
+    return _BUSINESS_ALIAS_TO_CANONICAL.get(normalized.lower(), "HOLD")
+
+
+def _canonicalize_next_action(value: Any) -> str:
+    """Normalize next_action aliases into canonical workflow action labels."""
+    normalized = str(value or "").strip()
+    if not normalized:
+        return "REVISE_AND_RESUBMIT"
+    upper = normalized.upper()
+    return _NEXT_ACTION_ALIASES.get(upper, upper)
 
 
 def _build_acceptance_checklist(
@@ -251,8 +298,12 @@ def _decision_record(entry: Dict[str, Any], verification_report: Dict[str, Any])
     return {
         "decision_payload": payload,
         "gate_decision": canonical_gate_decision,
-        "business_decision": payload.get("business_decision", "HOLD"),
-        "next_action": payload.get("next_action", "REVISE_AND_RESUBMIT"),
+        "business_decision": _canonicalize_business_decision(
+            payload.get("business_decision", "HOLD")
+        ),
+        "next_action": _canonicalize_next_action(
+            payload.get("next_action", "REVISE_AND_RESUBMIT")
+        ),
         "required_evidence": payload.get("required_evidence", []),
         "human_review_required": bool(payload.get("human_review_required", False)),
         "trustlog_references": {

--- a/veritas_os/scripts/expected_semantics_compare.py
+++ b/veritas_os/scripts/expected_semantics_compare.py
@@ -28,6 +28,25 @@ _NEXT_ACTION_FAMILIES = {
     "REVISE_AND_RESUBMIT": "collect_evidence",
 }
 
+_CANONICAL_BUSINESS_DECISIONS = {
+    "APPROVE",
+    "DENY",
+    "HOLD",
+    "REVIEW_REQUIRED",
+    "EVIDENCE_REQUIRED",
+    "POLICY_DEFINITION_REQUIRED",
+}
+
+_BUSINESS_ALIASES = {
+    "ALLOW": "APPROVE",
+    "PROCEED": "APPROVE",
+    "REJECTED": "DENY",
+    "BLOCK": "DENY",
+    "MODIFY": "HOLD",
+    "ABSTAIN": "HOLD",
+    "AMBIGUOUS_HUMAN_REVIEW": "REVIEW_REQUIRED",
+}
+
 
 def normalize_next_action(value: Any) -> str:
     """Normalize next_action labels into stable canonical labels."""
@@ -43,6 +62,16 @@ def next_action_family(value: Any) -> str:
     return _NEXT_ACTION_FAMILIES.get(action, "other")
 
 
+def canonicalize_business_decision(value: Any) -> str:
+    """Normalize business decision values for stable semantic comparisons."""
+    normalized = str(value or "").strip().upper()
+    if not normalized:
+        return "HOLD"
+    if normalized in _CANONICAL_BUSINESS_DECISIONS:
+        return normalized
+    return _BUSINESS_ALIASES.get(normalized, "HOLD")
+
+
 def compare_expected_semantics(
     expected: Mapping[str, Any],
     actual: Mapping[str, Any],
@@ -55,8 +84,8 @@ def compare_expected_semantics(
     if expected_gate != actual_gate:
         mismatches["gate_decision"] = {"expected": expected_gate, "actual": actual_gate}
 
-    expected_business = expected.get("business_decision")
-    actual_business = actual.get("business_decision")
+    expected_business = canonicalize_business_decision(expected.get("business_decision"))
+    actual_business = canonicalize_business_decision(actual.get("business_decision"))
     if expected_business != actual_business:
         mismatches["business_decision"] = {
             "expected": expected_business,

--- a/veritas_os/tests/test_evidence_bundle_cli.py
+++ b/veritas_os/tests/test_evidence_bundle_cli.py
@@ -78,7 +78,7 @@ def test_financial_bundle_sample_fixture_exists() -> None:
 def test_evidence_bundle_decision_record_canonicalizes_gate_decision(
     tmp_path,
 ) -> None:
-    """Decision record gate_decision should use canonical public values."""
+    """Decision record decision semantics should use canonical public values."""
     log_path = tmp_path / "trustlog.jsonl"
     log_entry = {
         "decision_id": "dec-fin-wire-2026-0002",
@@ -90,8 +90,8 @@ def test_evidence_bundle_decision_record_canonicalizes_gate_decision(
         "decision_payload": {
             "request_id": "fin-wire-2026-0002",
             "gate_decision": "allow",
-            "business_decision": "APPROVE",
-            "next_action": "EXECUTE_WITH_STANDARD_MONITORING",
+            "business_decision": "allow",
+            "next_action": "needs_human_review",
             "required_evidence": [],
             "human_review_required": False,
         },
@@ -119,3 +119,5 @@ def test_evidence_bundle_decision_record_canonicalizes_gate_decision(
     bundle_dir = next(out_dir.glob("veritas_bundle_decision_*"))
     decision_record = json.loads((bundle_dir / "decision_record.json").read_text(encoding="utf-8"))
     assert decision_record["gate_decision"] == "proceed"
+    assert decision_record["business_decision"] == "APPROVE"
+    assert decision_record["next_action"] == "PREPARE_HUMAN_REVIEW_PACKET"

--- a/veritas_os/tests/test_financial_poc_runner.py
+++ b/veritas_os/tests/test_financial_poc_runner.py
@@ -85,6 +85,14 @@ def test_compare_expected_semantics_canonicalizes_gate_aliases() -> None:
     assert "gate_decision" not in diff
 
 
+def test_compare_expected_semantics_canonicalizes_business_aliases() -> None:
+    """Comparator should treat business decision aliases as canonical equivalents."""
+    expected = {"business_decision": "allow"}
+    actual = {"business_decision": "APPROVE"}
+    diff = compare_expected_semantics(expected, actual)
+    assert "business_decision" not in diff
+
+
 def test_mismatch_summary_is_readable() -> None:
     """Mismatch summary helper should produce concise field-first output."""
     summary = summarize_semantic_mismatches(


### PR DESCRIPTION
### Motivation
- Make the UI, audit export, and PoC compare helper present and compare decisions using the same canonical semantics so operators/auditors aren't confused by legacy aliases. 
- Ensure evidence bundles emit canonical public decision fields (`gate_decision`, `business_decision`, `next_action`) for reliable external review and verification.
- Avoid presenting `allow`/`proceed` as business approval by making the intent explicit in UI text and exports.

### Description
- Add canonicalization helpers and maps for `business_decision` and `next_action` in `frontend/features/console/adapters/decision-semantics.ts` and use them alongside the existing `canonicalizePublicGateDecision`.
- Update frontend adapter `toPublicDecisionSchemaView` and `toFujiGateView` in `frontend/features/console/adapters/decision-view.ts` to emit canonical `businessDecision`, `nextAction`, and canonical `gateDecision` (FUJI views normalized before rendering).
- Clarify UI text and coloring in `frontend/features/console/components/fuji-gate-status-panel.tsx` to display canonical gate values and call out that `proceed` is execution guidance (not business approval).
- Canonicalize `business_decision` and `next_action` in audit export via `_decision_record` in `veritas_os/audit/evidence_bundle.py` so generated `decision_record.json` contains canonical values.
- Make the PoC compare helper canonicalize business decisions in `veritas_os/scripts/expected_semantics_compare.py` so expected/actual diffs compare normalized values; update related tests and a snapshot.

### Testing
- Ran targeted frontend unit tests: `pnpm vitest run features/console/adapters/decision-view.test.ts features/console/components/fuji-gate-status-panel.test.tsx features/console/components/decision-result-panel.test.tsx` and all selected tests passed. 
- Updated snapshot with `pnpm vitest run -u features/console/components/decision-result-panel.snapshot.test.tsx` and accepted the updated snapshot; subsequent `pnpm test` completed with all frontend tests passing (74 files, 686 tests in run shown).
- Ran relevant Python tests: `pytest -q veritas_os/tests -k "evidence_bundle or expected_semantics_compare"` and the targeted tests passed (`3 passed`).
- Added/updated unit tests to assert canonicalization for `business_decision` and `next_action` in `frontend/features/console/adapters/decision-view.test.ts`, the FUJI panel test in `frontend/features/console/components/fuji-gate-status-panel.test.tsx`, evidence-bundle CLI test in `veritas_os/tests/test_evidence_bundle_cli.py`, and PoC compare test in `veritas_os/tests/test_financial_poc_runner.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e35b8569248326a80095d776d6dd3a)