### PR TITLE
Fix AML/KYC canonical evidence profile contract and validation

### DIFF
--- a/docs/en/governance/required-evidence-taxonomy.md
+++ b/docs/en/governance/required-evidence-taxonomy.md
@@ -66,6 +66,24 @@ Machine-readable source: `veritas_os/sample_data/governance/required_evidence_ta
 The taxonomy fixture now includes a machine-readable `profiles.aml_kyc` section.
 Profile evaluation is applied **after alias -> canonical normalization**.
 
+Profile shape (runtime contract):
+
+- `profile_id`
+- `profile_version`
+- `canonical_key_list`
+- `required`
+- `optional`
+- `escalation_sensitive`
+
+Validation rules:
+
+- `canonical_key_list` must be canonical taxonomy keys only.
+- `canonical_key_list` must exactly equal
+  `required ∪ optional ∪ escalation_sensitive`.
+- `escalation_sensitive ⊆ required`.
+- Invalid profile shape is fail-soft at runtime (profile skipped) to avoid
+  crashing live decision paths.
+
 - required:
   - `kyc_profile`
   - `sanctions_screening_trace`
@@ -82,6 +100,27 @@ Profile evaluation is applied **after alias -> canonical normalization**.
   - `sanctions_screening_trace`
   - `pep_screening_result`
   - `approval_matrix`
+
+canonical-key-list:
+
+- `kyc_profile`
+- `sanctions_screening_trace`
+- `pep_screening_result`
+- `source_of_funds_record`
+- `approval_matrix`
+- `audit_trail_export`
+- `secure_controls_attestation`
+- `policy_definition_record`
+- `transaction_monitoring_trace`
+- `rollback_plan`
+
+Alias normalization behavior:
+
+- Input keys in `required_evidence` / `missing_evidence` / `satisfied_evidence`
+  are lower-cased and matched against taxonomy aliases.
+- Canonical keys are emitted in runtime response fields.
+- Unknown free strings remain accepted (`allow_free_string=true`) and are tagged
+  as non-taxonomy keys with warning/telemetry for migration readiness.
 
 ## v0 catalog
 

--- a/docs/en/guides/financial-governance-templates.md
+++ b/docs/en/guides/financial-governance-templates.md
@@ -66,6 +66,23 @@ template suites can quantify migration readiness before strict reject mode.
 context (`required_evidence_mode=strict`) to route unknown/profile misses into
 stronger hold/review behavior while keeping full reject rollout deferred.
 
+Canonical AML/KYC profile key list (`canonical_key_list`) is fixed as:
+
+- `kyc_profile`
+- `sanctions_screening_trace`
+- `pep_screening_result`
+- `source_of_funds_record`
+- `approval_matrix`
+- `audit_trail_export`
+- `secure_controls_attestation`
+- `policy_definition_record`
+- `transaction_monitoring_trace`
+- `rollback_plan`
+
+Alias normalization is applied before profile matching so templates can still
+provide legacy aliases (for example `sanctions_trace` or `pep_check`) while
+runtime emits canonical keys for deterministic downstream processing.
+
 ## Role Split: Regulatory Templates vs PoC Questions
 
 - **Regulatory templates** (`financial_regulatory_templates.json`)

--- a/veritas_os/core/decision_semantics.py
+++ b/veritas_os/core/decision_semantics.py
@@ -222,6 +222,7 @@ def get_required_evidence_profiles() -> dict[str, dict[str, Any]]:
     """Return per-domain evidence profiles keyed by normalized domain name."""
     payload = _load_required_evidence_taxonomy()
     raw_profiles = payload.get("profiles")
+    canonical_keys = set(get_required_evidence_category_map())
     out: dict[str, dict[str, Any]] = {}
     if not isinstance(raw_profiles, Mapping):
         return out
@@ -229,20 +230,70 @@ def get_required_evidence_profiles() -> dict[str, dict[str, Any]]:
         domain_key = str(domain_name).strip().lower()
         if not domain_key or not isinstance(profile, Mapping):
             continue
-        out[domain_key] = {
-            "required": unique_preserve_order(
-                normalize_required_evidence_keys(profile.get("required"))
-            ),
-            "optional": unique_preserve_order(
-                normalize_required_evidence_keys(profile.get("optional"))
-            ),
-            "escalation_sensitive": unique_preserve_order(
-                normalize_required_evidence_keys(profile.get("escalation_sensitive"))
-            ),
-            "profile_id": str(profile.get("profile_id") or "").strip(),
-            "profile_version": str(profile.get("profile_version") or "").strip(),
-        }
+        validated_profile = validate_required_evidence_profile_shape(
+            profile,
+            canonical_keys=canonical_keys,
+        )
+        if validated_profile is None:
+            continue
+        out[domain_key] = validated_profile
     return out
+
+
+def validate_required_evidence_profile_shape(
+    profile: Mapping[str, Any],
+    *,
+    canonical_keys: set[str],
+) -> dict[str, Any] | None:
+    """Validate and normalize one required-evidence profile.
+
+    The profile must include:
+    - ``profile_id`` (non-empty string),
+    - ``profile_version`` (non-empty string),
+    - ``required`` / ``optional`` / ``escalation_sensitive`` lists,
+    - ``canonical_key_list`` list.
+
+    Validation is fail-soft: malformed profiles return ``None`` so runtime can
+    continue with declared context evidence instead of crashing.
+    """
+    required_keys = unique_preserve_order(
+        normalize_required_evidence_keys(profile.get("required"))
+    )
+    optional_keys = unique_preserve_order(
+        normalize_required_evidence_keys(profile.get("optional"))
+    )
+    escalation_sensitive_keys = unique_preserve_order(
+        normalize_required_evidence_keys(profile.get("escalation_sensitive"))
+    )
+    canonical_key_list = unique_preserve_order(
+        normalize_required_evidence_keys(profile.get("canonical_key_list"))
+    )
+    profile_id = str(profile.get("profile_id") or "").strip()
+    profile_version = str(profile.get("profile_version") or "").strip()
+
+    if not profile_id or not profile_version:
+        return None
+    if not required_keys:
+        return None
+    if not canonical_key_list:
+        return None
+    if any(key not in canonical_keys for key in canonical_key_list):
+        return None
+
+    key_union = set(required_keys) | set(optional_keys) | set(escalation_sensitive_keys)
+    if set(canonical_key_list) != key_union:
+        return None
+    if not set(escalation_sensitive_keys) <= set(required_keys):
+        return None
+
+    return {
+        "required": required_keys,
+        "optional": optional_keys,
+        "escalation_sensitive": escalation_sensitive_keys,
+        "canonical_key_list": canonical_key_list,
+        "profile_id": profile_id,
+        "profile_version": profile_version,
+    }
 
 
 def build_required_evidence_profile(

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -520,6 +520,9 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
     profile_escalation_sensitive_keys = unique_preserve_order(
         normalize_required_evidence_keys(domain_profile.get("escalation_sensitive"))
     )
+    profile_canonical_key_list = unique_preserve_order(
+        normalize_required_evidence_keys(domain_profile.get("canonical_key_list"))
+    )
     mode = _resolve_required_evidence_mode(ctx.context, decision_domain)
     enforce_profile = _should_enforce_aml_kyc_profile(
         decision_domain,
@@ -663,6 +666,9 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         ),
         "required_evidence_mode": mode,
         "required_evidence_assessment": {
+            "profile_id": str(domain_profile.get("profile_id") or ""),
+            "profile_version": str(domain_profile.get("profile_version") or ""),
+            "profile_canonical_key_list": profile_canonical_key_list,
             "internal_reasons": unique_preserve_order(internal_evidence_reasons),
             "profile_missing_required_keys": profile_missing_keys,
             "escalation_sensitive_missing_keys": escalation_sensitive_missing,

--- a/veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json
+++ b/veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json
@@ -130,6 +130,18 @@
     "aml_kyc": {
       "profile_id": "aml_kyc_beachhead_v1",
       "profile_version": "1.0.0",
+      "canonical_key_list": [
+        "kyc_profile",
+        "sanctions_screening_trace",
+        "pep_screening_result",
+        "source_of_funds_record",
+        "approval_matrix",
+        "audit_trail_export",
+        "secure_controls_attestation",
+        "policy_definition_record",
+        "transaction_monitoring_trace",
+        "rollback_plan"
+      ],
       "required": [
         "kyc_profile",
         "sanctions_screening_trace",

--- a/veritas_os/tests/test_financial_regulatory_templates.py
+++ b/veritas_os/tests/test_financial_regulatory_templates.py
@@ -361,12 +361,34 @@ def test_aml_kyc_profile_shape_validation() -> None:
     assert aml_profile is not None
     assert aml_profile.get("profile_id") == "aml_kyc_beachhead_v1"
     required_keys = set(aml_profile.get("required", []))
+    optional_keys = set(aml_profile.get("optional", []))
     escalation_keys = set(aml_profile.get("escalation_sensitive", []))
+    canonical_key_list = set(aml_profile.get("canonical_key_list", []))
     assert required_keys
     assert required_keys <= canonical_keys
+    assert optional_keys <= canonical_keys
     assert escalation_keys <= canonical_keys
+    assert canonical_key_list <= canonical_keys
+    assert escalation_keys <= required_keys
+    assert canonical_key_list == (required_keys | optional_keys | escalation_keys)
     assert "source_of_funds_record" in required_keys
     assert "sanctions_screening_trace" in required_keys
+
+
+def test_docs_referenced_aml_kyc_keys_match_taxonomy_profile() -> None:
+    """Docs should list the same canonical AML/KYC profile keys as fixture."""
+    taxonomy = _load_taxonomy()
+    aml_profile = taxonomy.profiles["aml_kyc"]
+    canonical_key_list = aml_profile["canonical_key_list"]
+
+    governance_doc = Path("docs/en/governance/required-evidence-taxonomy.md")
+    guide_doc = Path("docs/en/guides/financial-governance-templates.md")
+    governance_text = governance_doc.read_text(encoding="utf-8")
+    guide_text = guide_doc.read_text(encoding="utf-8")
+
+    for key in canonical_key_list:
+        assert key in governance_text
+        assert key in guide_text
 
 
 def test_regression_financial_question_first_response_includes_structure() -> None:

--- a/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
+++ b/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
@@ -8,6 +8,9 @@ from veritas_os.core.decision_semantics import (
     LEGACY_GATE_DECISION_ALIASES,
     build_required_evidence_profile,
     canonicalize_public_gate_decision,
+    get_required_evidence_category_map,
+    get_required_evidence_profiles,
+    validate_required_evidence_profile_shape,
 )
 from veritas_os.core.pipeline.pipeline_response import assemble_response
 from veritas_os.core.pipeline.pipeline_types import PipelineContext
@@ -289,6 +292,50 @@ def test_aml_kyc_profile_required_keys_are_enforced_in_runtime() -> None:
     assert "source_of_funds_record" in payload["required_evidence"]
     assert "source_of_funds_record" in payload["missing_evidence"]
     assert payload["business_decision"] == "EVIDENCE_REQUIRED"
+
+
+def test_required_evidence_profile_shape_validation_rejects_bad_profiles() -> None:
+    """Profile shape validator should reject malformed canonical-key list payloads."""
+    canonical_keys = set(get_required_evidence_category_map())
+    invalid_profile = {
+        "profile_id": "aml_kyc_beachhead_v1",
+        "profile_version": "1.0.0",
+        "required": ["kyc_profile"],
+        "optional": [],
+        "escalation_sensitive": ["kyc_profile"],
+        "canonical_key_list": ["kyc_profile", "non_taxonomy_key"],
+    }
+    validated = validate_required_evidence_profile_shape(
+        invalid_profile,
+        canonical_keys=canonical_keys,
+    )
+    assert validated is None
+
+
+def test_runtime_profile_assessment_exposes_canonical_key_list() -> None:
+    """Runtime assessment should expose canonical key list for AML/KYC profile."""
+    profiles = get_required_evidence_profiles()
+    expected_keys = profiles["aml_kyc"]["canonical_key_list"]
+    ctx = PipelineContext(
+        request_id="req-aml-profile-shape",
+        query="aml profile shape",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        context={
+            "decision_domain": "aml_kyc",
+            "required_evidence": ["kyc_profile"],
+            "satisfied_evidence": ["kyc_profile"],
+        },
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+    assessment = payload["required_evidence_assessment"]
+    assert assessment["profile_id"] == "aml_kyc_beachhead_v1"
+    assert assessment["profile_version"] == "1.0.0"
+    assert assessment["profile_canonical_key_list"] == expected_keys
 
 
 def test_unknown_required_evidence_generates_warning_and_telemetry() -> None:


### PR DESCRIPTION
### Motivation

- Stabilize the AML/KYC beachhead required-evidence contract by making the profile machine-readable and unambiguous for runtime consumption. 
- Ensure runtime/docs/fixtures are aligned so alias normalization and enforcement behavior is deterministic and observable. 
- Add lightweight, fail-soft validation to make future strict-mode rollouts safe and testable. 

### Description

- Added a `canonical_key_list` to the AML/KYC profile in `veritas_os/sample_data/governance/required_evidence_taxonomy_v0.json` to fix the canonical set of keys for the beachhead profile. 
- Implemented `validate_required_evidence_profile_shape()` in `veritas_os/core/decision_semantics.py` to fail-soft validate `profile_id`, `profile_version`, `required`, `optional`, `escalation_sensitive`, and `canonical_key_list`, and wired `get_required_evidence_profiles()` to return only validated profiles. 
- Exposed profile metadata in runtime responses by adding `profile_id`, `profile_version`, and `profile_canonical_key_list` to `required_evidence_assessment` in `veritas_os/core/pipeline/pipeline_response.py`. 
- Documented the profile shape, validation rules, canonical key list, and alias-normalization behavior in `docs/en/governance/required-evidence-taxonomy.md` and `docs/en/guides/financial-governance-templates.md`. 
- Added and updated tests to assert profile-shape validation, canonical-key-list consistency between docs and taxonomy, runtime exposure of profile metadata, and alias/normalization behaviors in `veritas_os/tests/test_financial_regulatory_templates.py` and `veritas_os/tests/unit/test_decision_semantics_runtime_contract.py`. 

### Testing

- Ran `pytest -q veritas_os/tests -k "required_evidence or aml_kyc or financial"` which completed successfully (49 passed, 6755 deselected). 
- Ran targeted tests `pytest -q veritas_os/tests/test_financial_regulatory_templates.py veritas_os/tests/unit/test_decision_semantics_runtime_contract.py -k "profile or alias or taxonomy"` which completed successfully (`11 passed, 32 deselected`). 
- New/updated tests cover: profile shape validation rejection of malformed profiles, docs-to-taxonomy canonical-key consistency, runtime assessment exposing `profile_canonical_key_list`, alias normalization telemetry, and enforcement of AML/KYC required keys; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3622f5b58832696a14d6aa0e592a7)