### PR TITLE
docs: package AML/KYC beachhead 1-day PoC quickstart, operator guide, and evidence-bundle readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ VERITAS OS focuses on **decision governance**:
 
 ## Quick Links
 
+- **AML/KYC Beachhead (1-day PoC quickstart)**: [`docs/en/guides/poc-pack-financial-quickstart.md`](docs/en/guides/poc-pack-financial-quickstart.md)
+- **AML/KYC Governance Template Contract**: [`docs/en/guides/financial-governance-templates.md`](docs/en/guides/financial-governance-templates.md)
+- **External Audit / Evidence Bundle Readiness**: [`docs/en/validation/external-audit-readiness.md`](docs/en/validation/external-audit-readiness.md)
+- **AML/KYC Short Positioning (customer / operator / investor)**: [`docs/en/positioning/aml-kyc-beachhead-short-positioning.md`](docs/en/positioning/aml-kyc-beachhead-short-positioning.md)
 - **GitHub**: https://github.com/veritasfuji-japan/veritas_os
 - **Zenodo paper (EN)**: https://doi.org/10.5281/zenodo.17838349
 - **Zenodo paper (JP)**: https://doi.org/10.5281/zenodo.17838456
@@ -113,6 +117,22 @@ VERITAS OS focuses on **decision governance**:
 - **Operations Runbook**: [`docs/ja/operations/enterprise_slo_sli_runbook_ja.md`](docs/ja/operations/enterprise_slo_sli_runbook_ja.md)
 - **Governance Signing Runbook**: [`docs/en/operations/governance-artifact-signing.md`](docs/en/operations/governance-artifact-signing.md)
 - **Governance Upgrade Press Summary**: [`docs/press/governance_control_plane_upgrade_2026-04.md`](docs/press/governance_control_plane_upgrade_2026-04.md)
+
+## AML/KYC Beachhead PoC Pack (what you can run in 1 day)
+
+For regulated teams evaluating VERITAS OS in AML/KYC workflows, the beachhead
+pack is documented as an executable path, not only positioning text:
+
+1. Run the 1-day PoC fixture set and quantify pass/fail/warning outcomes.
+2. Review operator checkpoints (fail-closed gate, evidence-first deltas, replay
+   consistency).
+3. Produce evidence-bundle handoff artifacts for external review readiness.
+
+Start here:
+- [1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
+- [Financial Governance Templates](docs/en/guides/financial-governance-templates.md)
+- [External Audit Readiness](docs/en/validation/external-audit-readiness.md)
+- [Short Positioning by audience](docs/en/positioning/aml-kyc-beachhead-short-positioning.md)
 
 ## 🚀 Quick Start (TL;DR)
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -11,6 +11,16 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 
 ## Sections
 
+### AML/KYC Beachhead (role-based fastest routes)
+- **Customer (business owner / compliance lead)**:
+  [AML/KYC short positioning](positioning/aml-kyc-beachhead-short-positioning.md#customer-facing-short-explanation)
+- **Operator (implementation / governance owner)**:
+  [1-day PoC quickstart + operator guide](guides/poc-pack-financial-quickstart.md)
+- **Investor / board observer**:
+  [Investor-facing short explanation](positioning/aml-kyc-beachhead-short-positioning.md#investor-facing-short-explanation)
+- **Evidence bundle readiness**:
+  [External audit readiness](validation/external-audit-readiness.md#evidence-bundle-readiness-path-for-amlkyc-poc)
+
 ### Operations & Runbooks
 - [PostgreSQL Production Guide](operations/postgresql-production-guide.md)
 - [PostgreSQL Drill Runbook](operations/postgresql-drill-runbook.md)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -13,13 +13,13 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 
 ### AML/KYC Beachhead (role-based fastest routes)
 - **Customer (business owner / compliance lead)**:
-  [AML/KYC short positioning](positioning/aml-kyc-beachhead-short-positioning.md#customer-facing-short-explanation)
+  [AML/KYC short positioning](positioning/aml-kyc-beachhead-short-positioning.md)
 - **Operator (implementation / governance owner)**:
   [1-day PoC quickstart + operator guide](guides/poc-pack-financial-quickstart.md)
 - **Investor / board observer**:
-  [Investor-facing short explanation](positioning/aml-kyc-beachhead-short-positioning.md#investor-facing-short-explanation)
+  [Investor-facing short explanation](positioning/aml-kyc-beachhead-short-positioning.md)
 - **Evidence bundle readiness**:
-  [External audit readiness](validation/external-audit-readiness.md#evidence-bundle-readiness-path-for-amlkyc-poc)
+  [External audit readiness](validation/external-audit-readiness.md)
 
 ### Operations & Runbooks
 - [PostgreSQL Production Guide](operations/postgresql-production-guide.md)

--- a/docs/en/guides/financial-governance-templates.md
+++ b/docs/en/guides/financial-governance-templates.md
@@ -6,6 +6,10 @@ This template pack defines **governance expectations**, not legal conclusions, f
 regulated decision domains where VERITAS output is consumed by financial and
 compliance workflows.
 
+This is the contract layer that the AML/KYC 1-day PoC quickstart executes
+against. It is designed so customer, operator, and investor discussions share
+the same factual semantics baseline.
+
 The templates are intentionally designed to verify fail-closed behavior around:
 
 - stop / hold / block actions under uncertainty,
@@ -107,6 +111,15 @@ runtime emits canonical keys for deterministic downstream processing.
 3. **Operationally safe behavior**
    - Templates avoid investment advice and legal determinations, and instead
      require auditable escalation and evidence collection.
+
+## Audience lens (same artifact, different question)
+
+- **Customer asks**: "Can this prevent unsafe auto-proceed in AML/KYC ambiguity?"
+  - Check `gate_decision` + `human_review_required` expectations.
+- **Operator asks**: "Where do we fail and what evidence keys are missing?"
+  - Check required/missing evidence keys and mismatch summaries from PoC runner.
+- **Investor asks**: "Is this only narrative, or measurable?"
+  - Check quantified pass/fail/warning output from the quickstart runner.
 
 ## Domain Coverage
 

--- a/docs/en/guides/poc-pack-financial-quickstart.md
+++ b/docs/en/guides/poc-pack-financial-quickstart.md
@@ -111,7 +111,7 @@ Validate that results satisfy minimum demo sign-off:
 After pass criteria, move to external handoff preparation:
 
 1. Review bundle and verifier flow:
-   [External Audit Readiness](../validation/external-audit-readiness.md#evidence-bundle-readiness-path-for-amlkyc-poc)
+   [External Audit Readiness](../validation/external-audit-readiness.md)
 2. Generate decision/incident/release bundle only for synthetic PoC data.
 3. Attach verification report + acceptance checklist before stakeholder sharing.
 
@@ -247,9 +247,9 @@ Runner summary now includes:
 ## Role-based short explanation pointers
 
 - Customer-facing short explanation:
-  [AML/KYC short positioning](../positioning/aml-kyc-beachhead-short-positioning.md#customer-facing-short-explanation)
+  [AML/KYC short positioning](../positioning/aml-kyc-beachhead-short-positioning.md)
 - Investor-facing short explanation:
-  [AML/KYC short positioning](../positioning/aml-kyc-beachhead-short-positioning.md#investor-facing-short-explanation)
+  [AML/KYC short positioning](../positioning/aml-kyc-beachhead-short-positioning.md)
 
 ---
 

--- a/docs/en/guides/poc-pack-financial-quickstart.md
+++ b/docs/en/guides/poc-pack-financial-quickstart.md
@@ -2,14 +2,23 @@
 
 ## Purpose
 
-This quickstart turns the financial beachhead PoC from "readable docs" into a
-**reproducible, measurable run**.
+This quickstart turns the AML/KYC beachhead from "docs" into a
+**1-day executable PoC pack** with operator checkpoints and evidence handoff.
 
-What this pack proves:
+What this pack proves in implemented scope:
 
 1. **Fail-closed governance behavior** in `/v1/decide`.
 2. **Expected semantics diffing** against fixture baselines.
-3. **Quantitative pass/fail/warning summary** for demo and benchmark handoff.
+3. **Quantitative pass/fail/warning summary** for demo and internal go/no-go.
+4. **Evidence-readiness path** toward external audit bundle generation.
+
+---
+
+## Who this guide is for
+
+- **Customer-side evaluator**: confirm AML/KYC governance value quickly.
+- **Operator**: run and interpret results without guessing hidden assumptions.
+- **Investor / sponsor**: understand what is already implemented vs pending.
 
 ---
 
@@ -46,6 +55,66 @@ Reference pack semantics and taxonomy:
 - Runtime module:
   `veritas_os/scripts/financial_poc_runner.py`
 
+---
+
+## 1-day PoC quickstart (operator runbook)
+
+### Step 0 — Prepare environment (30-60 min)
+
+1. Start VERITAS OS (Docker Compose recommended from repository root).
+2. Confirm backend health:
+
+```bash
+curl -s http://localhost:8000/health
+```
+
+3. Confirm PoC input fixture exists:
+
+```bash
+test -f veritas_os/sample_data/governance/financial_poc_questions.json && echo "fixture_ok"
+```
+
+### Step 1 — Dry-run baseline (15 min)
+
+Use dry-run first to validate fixture loading and expected semantics formatting:
+
+```bash
+python scripts/run_financial_poc.py \
+  --dry-run \
+  --output-json veritas_os/scripts/logs/financial_poc_dry_run_report.json
+```
+
+### Step 2 — Live governance run (30-60 min)
+
+Run against `/v1/decide` with strict required-evidence mode:
+
+```bash
+VERITAS_API_KEY=demo-key \
+python scripts/run_financial_poc.py \
+  --api-url http://localhost:8000/v1/decide \
+  --required-evidence-mode strict \
+  --output-json veritas_os/scripts/logs/financial_poc_live_report.json
+```
+
+### Step 3 — Operator checkpoint readout (30 min)
+
+Validate that results satisfy minimum demo sign-off:
+
+- `warning_count = 0`
+- `fail_count = 0`
+- `pass_rate >= 0.90`
+- `evaluated_count >= 5`
+- anchor case `poc_aml_pep_high_risk_country = pass`
+
+### Step 4 — Evidence readiness checkpoint (30 min)
+
+After pass criteria, move to external handoff preparation:
+
+1. Review bundle and verifier flow:
+   [External Audit Readiness](../validation/external-audit-readiness.md#evidence-bundle-readiness-path-for-amlkyc-poc)
+2. Generate decision/incident/release bundle only for synthetic PoC data.
+3. Attach verification report + acceptance checklist before stakeholder sharing.
+
 ### Dry-run (no API dependency)
 
 ```bash
@@ -79,6 +148,29 @@ At minimum for demo sign-off (quantitative):
 - `pass_rate >= 0.90` (on evaluated, non-warning cases)
 - `evaluated_count >= 5`
 - anchor case `poc_aml_pep_high_risk_country = pass`
+
+---
+
+## Operator-facing explanation (how to interpret output)
+
+The PoC report is designed for operational triage, not only pass/fail display.
+
+- `summary.outcome`:
+  - `pass`: evaluated cases met expected semantics.
+  - `warning`: non-fatal mismatches or schema/profile warnings need review.
+  - `fail`: one or more required semantics diverged from baseline.
+- `mismatch_summary`:
+  fast explanation of where semantics diverged (gate decision, action family,
+  or evidence keys).
+- evidence warnings (`required_evidence_runtime_warnings`):
+  highlight taxonomy/profile drift that may still pass functional routing but
+  reduce audit confidence.
+
+Operator rule of thumb:
+
+- Do **not** treat a high pass rate as sufficient if evidence warnings persist.
+- For AML/KYC beachhead, `proceed` with missing required evidence should be
+  treated as blocker-level regression.
 
 ---
 
@@ -149,6 +241,15 @@ Runner summary now includes:
    - Feed runner report counts (`pass/fail/warning`) and mismatch artifacts into
      the benchmark narrative for "fail-closed safety" and auditability claims.
    - Reference: [Evidence Benchmark Plan](../../benchmarks/VERITAS_EVIDENCE_BENCHMARK_PLAN.md)
+
+---
+
+## Role-based short explanation pointers
+
+- Customer-facing short explanation:
+  [AML/KYC short positioning](../positioning/aml-kyc-beachhead-short-positioning.md#customer-facing-short-explanation)
+- Investor-facing short explanation:
+  [AML/KYC short positioning](../positioning/aml-kyc-beachhead-short-positioning.md#investor-facing-short-explanation)
 
 ---
 

--- a/docs/en/positioning/aml-kyc-beachhead-short-positioning.md
+++ b/docs/en/positioning/aml-kyc-beachhead-short-positioning.md
@@ -1,0 +1,34 @@
+# AML/KYC Beachhead Short Positioning (Customer / Operator / Investor)
+
+## Scope and fact boundary
+
+This page summarizes the current, implemented AML/KYC beachhead posture.
+It does not claim legal determination automation or unattended production
+operations beyond documented governance controls.
+
+Implemented references:
+- [1-day PoC quickstart](../guides/poc-pack-financial-quickstart.md)
+- [Financial governance templates](../guides/financial-governance-templates.md)
+- [External audit readiness](../validation/external-audit-readiness.md)
+
+## Customer-facing short explanation
+
+VERITAS OS provides a governance layer before execution for AML/KYC workflows.
+In the beachhead pack, ambiguous or evidence-missing cases are routed to hold,
+block, or human review paths instead of silent auto-proceed, with replayable and
+audit-oriented decision artifacts.
+
+## Operator-facing short explanation
+
+The AML/KYC beachhead is an executable PoC path: run fixture-based scenarios via
+`scripts/run_financial_poc.py`, compare expected semantics against runtime
+output, triage mismatch summaries, and move successful runs into evidence-bundle
+readiness checks for external review handoff.
+
+## Investor-facing short explanation
+
+The AML/KYC beachhead shows productization discipline: not only model outcomes
+but measurable governance behavior. VERITAS OS already provides fail-closed
+decision gates, evidence-key based semantics checks, and a path to independently
+verifiable audit bundles. Positioning remains bounded to implemented controls and
+does not assume universal production certification.

--- a/docs/en/validation/external-audit-readiness.md
+++ b/docs/en/validation/external-audit-readiness.md
@@ -244,6 +244,20 @@ Each bundle now ships `acceptance_checklist.json` with machine-readable checks:
 This checklist is intended to be the explicit pre-submission gate for
 external auditors/customers/legal.
 
+### Evidence-bundle readiness path for AML/KYC PoC
+
+Use this sequence after completing the 1-day AML/KYC quickstart:
+
+1. Run PoC and keep the generated report JSON as baseline evidence.
+2. Select bundle scope (`decision`, `incident`, or `release`) based on review
+   objective.
+3. Generate the bundle and confirm `acceptance_checklist.json` passes.
+4. Run standalone verifier and include `verification_report.json`.
+5. Share only synthetic/sanitized artifacts for PoC-stage external review.
+
+Entry guide:
+- [Financial PoC Pack (1-day quickstart, EN)](../guides/poc-pack-financial-quickstart.md)
+
 ### Generating Bundles
 
 ```python


### PR DESCRIPTION
### Motivation

- Make the AML/KYC beachhead look like an adoptable, runnable package (1-day PoC) rather than scattered docs.  
- Surface operator-facing runbook and triage guidance so implementers can run, interpret, and hand off evidence for audit.  
- Create short, role-scoped positioning for customer / operator / investor that stays strictly within implemented capabilities (no legal/production claims).  

### Description

- Added a short AML/KYC entry and one-day PoC callouts to `README.md` to provide the shortest route into the beachhead materials and quickstart.  
- Expanded `docs/en/guides/poc-pack-financial-quickstart.md` into a stepwise 1-day operator runbook that includes `Step 0`–`Step 4`, dry-run and live-run commands (`scripts/run_financial_poc.py`), operator checkpoints, and evidence-readiness steps.  
- Added `docs/en/positioning/aml-kyc-beachhead-short-positioning.md` with concise, audience-specific explanations for customers, operators, and investors that explicitly state the fact boundary and implemented scope.  
- Added role-based fast routes to `docs/en/README.md`, an audience lens to `docs/en/guides/financial-governance-templates.md`, and an AML/KYC evidence-bundle readiness path to `docs/en/validation/external-audit-readiness.md` to tidy cross-doc navigation.  

### Testing

- Verified all changed relative markdown links resolve using an automated link-resolver script (`OK: links resolved`).  
- Confirmed the README contains the new shortest-route references to the quickstart, templates, audit-readiness, and short positioning (`README_ROUTE_OK`).  
- Ran a simple terminology scan for overclaim keywords in the newly added/edited docs and confirmed the new content remains bounded to implemented functionality; a pre-existing wording in the unrelated README was noted outside the changed sections.  
- This is a docs-only change; no runtime or API code paths were modified and no production behavior was altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36a6f9b8083269a3ebe9042103b7b)