### PR TITLE
Harden governance PostgreSQL datastore for production reliability

### DIFF
--- a/alembic/versions/0003_governance_integrity_hardening.py
+++ b/alembic/versions/0003_governance_integrity_hardening.py
@@ -1,0 +1,53 @@
+"""governance datastore integrity hardening
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-18
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_check_constraint(
+        "ck_governance_policies_policy_revision_positive",
+        "governance_policies",
+        sa.text("policy_revision > 0"),
+    )
+    op.create_index(
+        "uq_governance_policies_policy_revision",
+        "governance_policies",
+        ["policy_revision"],
+        unique=True,
+    )
+    op.create_check_constraint(
+        "ck_governance_approvals_reviewer_non_empty",
+        "governance_approvals",
+        sa.text("btrim(reviewer) <> ''"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_governance_approvals_reviewer_non_empty",
+        "governance_approvals",
+        type_="check",
+    )
+    op.drop_index(
+        "uq_governance_policies_policy_revision",
+        table_name="governance_policies",
+    )
+    op.drop_constraint(
+        "ck_governance_policies_policy_revision_positive",
+        "governance_policies",
+        type_="check",
+    )

--- a/docs/en/operations/database-migrations.md
+++ b/docs/en/operations/database-migrations.md
@@ -1,6 +1,6 @@
 # Database Migrations (Alembic)
 
-> **Last updated**: 2026-04-11
+> **Last updated**: 2026-04-18
 > **Applies to**: PostgreSQL backend only (file-based backends are unaffected)
 
 ---
@@ -77,6 +77,8 @@ Migrations live in `alembic/versions/` and follow this naming pattern:
 | Revision | Description | Tables |
 |----------|-------------|--------|
 | `0001`   | Initial schema | `memory_records`, `trustlog_entries`, `trustlog_chain_state` |
+| `0002`   | Governance policy datastore tables | `governance_policies`, `governance_policy_events`, `governance_approvals` |
+| `0003`   | Governance integrity hardening | Adds revision uniqueness + approval reviewer non-empty checks |
 
 ---
 

--- a/docs/en/operations/postgresql-production-guide.md
+++ b/docs/en/operations/postgresql-production-guide.md
@@ -236,6 +236,32 @@ make db-downgrade        # → alembic downgrade -1
 alembic upgrade head --sql > migration.sql
 ```
 
+### Governance datastore migration validation
+
+After applying migrations, run governance-specific integrity checks before
+shipping traffic:
+
+```bash
+# Ensure latest governance constraints/indexes are applied.
+alembic upgrade head
+
+# Validate governance PostgreSQL repository behavior.
+pytest -q veritas_os/tests -k "governance and postgresql"
+pytest -q veritas_os/tests -k "governance and concurrency"
+```
+
+Governance migration `0003` hardens production invariants:
+
+- `governance_policies.policy_revision` must remain positive and unique.
+- `governance_approvals.reviewer` must be non-empty after trim.
+
+If an emergency rollback is required, validate downgrade in staging first:
+
+```bash
+alembic downgrade -1
+alembic upgrade head
+```
+
 ### Auto-migration on startup
 
 ```bash

--- a/veritas_os/governance/factory.py
+++ b/veritas_os/governance/factory.py
@@ -10,6 +10,7 @@ from veritas_os.governance.config import validate_governance_backend
 from veritas_os.governance.file_repository import FileGovernanceRepository
 from veritas_os.governance.postgresql_repository import PostgresGovernanceRepository
 from veritas_os.governance.repository import GovernanceRepository
+from veritas_os.observability.metrics import set_db_backend_selected
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +27,13 @@ def create_governance_repository(
     backend = validate_governance_backend()
     if backend == "postgresql":
         logger.info("Governance backend: postgresql")
-        return PostgresGovernanceRepository()
+        set_db_backend_selected("governance", "postgresql")
+        repository = PostgresGovernanceRepository()
+        repository.health_check()
+        return repository
 
     logger.info("Governance backend: file")
+    set_db_backend_selected("governance", "file")
     return FileGovernanceRepository(
         policy_path=policy_path,
         history_path=history_path,

--- a/veritas_os/governance/postgresql_repository.py
+++ b/veritas_os/governance/postgresql_repository.py
@@ -9,10 +9,20 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from time import monotonic
 from typing import Any, Callable, Iterator
 
+from veritas_os.governance.repository import (
+    GovernanceRepository,
+    GovernanceWriteConflictError,
+)
 from veritas_os.governance.models import GovernancePolicyEventRecord
-from veritas_os.governance.repository import GovernanceRepository
+from veritas_os.observability.metrics import (
+    record_db_connect_failure,
+    record_governance_repository_conflict,
+    record_governance_repository_operation,
+    set_db_health_status,
+)
 
 
 class PostgresGovernanceRepository(GovernanceRepository):
@@ -20,6 +30,7 @@ class PostgresGovernanceRepository(GovernanceRepository):
 
     def __init__(self, *, database_url: str | None = None) -> None:
         self._database_url = database_url
+        self._backend_name = "postgresql"
 
     @contextmanager
     def _connect(self) -> Iterator[Any]:
@@ -34,7 +45,12 @@ class PostgresGovernanceRepository(GovernanceRepository):
             ) from exc
 
         dsn = self._database_url or build_conninfo()
-        conn = psycopg.connect(dsn)
+        try:
+            conn = psycopg.connect(dsn)
+        except Exception as exc:
+            record_db_connect_failure(type(exc).__name__)
+            set_db_health_status(False)
+            raise
         try:
             yield conn
         finally:
@@ -45,19 +61,33 @@ class PostgresGovernanceRepository(GovernanceRepository):
         *,
         default_factory: Callable[[], dict[str, Any]],
     ) -> dict[str, Any]:
-        with self._connect() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT policy_payload FROM governance_policies "
-                    "WHERE is_current = TRUE LIMIT 1"
-                )
-                row = cur.fetchone()
-                if row is None:
+        started_at = monotonic()
+        status = "ok"
+        try:
+            with self._connect() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT policy_payload FROM governance_policies "
+                        "WHERE is_current = TRUE LIMIT 1"
+                    )
+                    row = cur.fetchone()
+                    if row is None:
+                        conn.rollback()
+                        return default_factory()
+                    payload = row[0]
                     conn.rollback()
-                    return default_factory()
-                payload = row[0]
-                conn.rollback()
-                return payload if isinstance(payload, dict) else default_factory()
+                    return payload if isinstance(payload, dict) else default_factory()
+        except Exception:
+            status = "error"
+            set_db_health_status(False)
+            raise
+        finally:
+            record_governance_repository_operation(
+                backend=self._backend_name,
+                operation="get_current_policy",
+                status=status,
+                duration_seconds=monotonic() - started_at,
+            )
 
     def save_policy(self, policy: dict[str, Any]) -> None:
         self.update_policy(
@@ -71,38 +101,53 @@ class PostgresGovernanceRepository(GovernanceRepository):
 
     def append_policy_event(self, event: GovernancePolicyEventRecord) -> None:
         # Keep this helper for interface parity; insert event-only row.
-        with self._connect() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO governance_policy_events (
-                        event_type,
-                        previous_policy_id,
-                        new_policy_id,
-                        previous_digest,
-                        new_digest,
-                        proposer,
-                        changed_by,
-                        changed_at,
-                        reason,
-                        metadata_json
-                    ) VALUES (%s, NULL, NULL, %s, %s, %s, %s, %s, %s, %s)
-                    """,
-                    (
-                        event.event_type,
-                        event.previous_digest,
-                        event.new_digest,
-                        event.proposer,
-                        event.changed_by,
-                        self._parse_timestamp(event.changed_at),
-                        "",
-                        {
-                            "previous_version": event.previous_version,
-                            "new_version": event.new_version,
-                        },
-                    ),
-                )
-            conn.commit()
+        started_at = monotonic()
+        status = "ok"
+        try:
+            with self._connect() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO governance_policy_events (
+                            event_type,
+                            previous_policy_id,
+                            new_policy_id,
+                            previous_digest,
+                            new_digest,
+                            proposer,
+                            changed_by,
+                            changed_at,
+                            reason,
+                            metadata_json
+                        ) VALUES (%s, NULL, NULL, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            event.event_type,
+                            event.previous_digest,
+                            event.new_digest,
+                            event.proposer,
+                            event.changed_by,
+                            self._parse_timestamp(event.changed_at),
+                            "",
+                            {
+                                "previous_version": event.previous_version,
+                                "new_version": event.new_version,
+                            },
+                        ),
+                    )
+                conn.commit()
+                set_db_health_status(True)
+        except Exception:
+            status = "error"
+            set_db_health_status(False)
+            raise
+        finally:
+            record_governance_repository_operation(
+                backend=self._backend_name,
+                operation="append_policy_event",
+                status=status,
+                duration_seconds=monotonic() - started_at,
+            )
 
     def list_policy_history(self, *, limit: int, max_records: int) -> list[dict[str, Any]]:
         bounded_limit = max(1, min(limit, max_records))
@@ -235,6 +280,8 @@ class PostgresGovernanceRepository(GovernanceRepository):
     ) -> None:
         from veritas_os.policy.governance_identity import compute_governance_digest
 
+        started_at = monotonic()
+        status = "ok"
         normalized_approvals = self._normalize_approvals(
             approvers=approvers,
             approval_records=approval_records,
@@ -249,20 +296,43 @@ class PostgresGovernanceRepository(GovernanceRepository):
             try:
                 with conn.cursor() as cur:
                     cur.execute(
-                        "SELECT id FROM governance_policies "
+                        "SELECT id, digest, policy_revision FROM governance_policies "
                         "WHERE is_current = TRUE "
                         "ORDER BY id DESC LIMIT 1 FOR UPDATE"
                     )
                     row = cur.fetchone()
                     previous_policy_id = row[0] if row is not None else None
+                    current_digest = row[1] if row is not None else ""
+                    current_revision = int(row[2]) if row is not None else 0
+                    expected_digest = compute_governance_digest(previous) if previous else ""
+
+                    if previous and previous_policy_id is None:
+                        status = "conflict"
+                        record_governance_repository_conflict(
+                            backend=self._backend_name
+                        )
+                        raise GovernanceWriteConflictError(
+                            "governance policy write conflict: caller expected an "
+                            "existing policy but no current row was found"
+                        )
+
+                    if previous and previous_policy_id is not None and current_digest != expected_digest:
+                        status = "conflict"
+                        record_governance_repository_conflict(
+                            backend=self._backend_name
+                        )
+                        raise GovernanceWriteConflictError(
+                            "governance policy write conflict: current policy "
+                            "digest does not match caller-provided previous state"
+                        )
 
                     if previous_policy_id is not None:
                         cur.execute(
                             "UPDATE governance_policies SET is_current = FALSE "
-                            "WHERE id = %s",
-                            (previous_policy_id,),
+                            "WHERE is_current = TRUE",
                         )
 
+                    next_revision = current_revision + 1
                     cur.execute(
                         """
                         INSERT INTO governance_policies (
@@ -283,8 +353,8 @@ class PostgresGovernanceRepository(GovernanceRepository):
                             new_digest,
                             changed_at,
                             changed_by,
-                            int(updated.get("policy_revision", 1)),
-                            {},
+                            next_revision,
+                            {"expected_previous_digest": expected_digest},
                         ),
                     )
                     new_policy_id = cur.fetchone()[0]
@@ -318,6 +388,8 @@ class PostgresGovernanceRepository(GovernanceRepository):
                             {
                                 "previous_version": previous.get("version"),
                                 "new_version": updated.get("version"),
+                                "previous_revision": current_revision,
+                                "new_revision": next_revision,
                             },
                         ),
                     )
@@ -341,9 +413,20 @@ class PostgresGovernanceRepository(GovernanceRepository):
                             ),
                         )
                 conn.commit()
+                set_db_health_status(True)
             except Exception:
                 conn.rollback()
+                if status != "conflict":
+                    status = "error"
+                set_db_health_status(False)
                 raise
+            finally:
+                record_governance_repository_operation(
+                    backend=self._backend_name,
+                    operation="write_policy_event",
+                    status=status,
+                    duration_seconds=monotonic() - started_at,
+                )
 
     def _normalize_approvals(
         self,
@@ -365,8 +448,31 @@ class PostgresGovernanceRepository(GovernanceRepository):
             if reviewer in seen_reviewers:
                 raise ValueError("duplicate approval reviewer is not allowed")
             seen_reviewers.add(reviewer)
+            if signature and any(
+                normalized_signature["signature"] == signature
+                for normalized_signature in normalized
+            ):
+                raise ValueError("duplicate approval signature is not allowed")
             normalized.append({"reviewer": reviewer, "signature": signature})
         return normalized
+
+    def health_check(self) -> None:
+        """Verify governance tables are reachable and writable state is coherent."""
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                cur.execute(
+                    "SELECT COUNT(*) FROM governance_policies WHERE is_current = TRUE"
+                )
+                row = cur.fetchone()
+                current_count = int(row[0]) if row else 0
+                if current_count > 1:
+                    raise RuntimeError(
+                        "governance current policy integrity violated: more than one "
+                        "current policy row exists"
+                    )
+            conn.rollback()
+        set_db_health_status(True)
 
     @staticmethod
     def _parse_timestamp(raw: Any) -> datetime:

--- a/veritas_os/governance/repository.py
+++ b/veritas_os/governance/repository.py
@@ -7,6 +7,10 @@ from typing import Any, Callable, Protocol
 from veritas_os.governance.models import GovernancePolicyEventRecord
 
 
+class GovernanceWriteConflictError(RuntimeError):
+    """Raised when governance policy writes detect a stale caller state."""
+
+
 class GovernanceRepository(Protocol):
     """Persistence contract for governance policy and history operations."""
 

--- a/veritas_os/observability/metrics.py
+++ b/veritas_os/observability/metrics.py
@@ -226,6 +226,21 @@ DB_HEALTH_STATUS = _gauge(
     "db_health_status",
     "Database health (1 = healthy, 0 = unhealthy)",
 )
+GOVERNANCE_REPOSITORY_OPERATION_TOTAL = _counter(
+    "governance_repository_operation_total",
+    "Governance repository operations by backend/operation/status",
+    labelnames=("backend", "operation", "status"),
+)
+GOVERNANCE_REPOSITORY_OPERATION_LATENCY_SECONDS = _histogram(
+    "governance_repository_operation_latency_seconds",
+    "Governance repository operation latency by backend/operation",
+    labelnames=("backend", "operation"),
+)
+GOVERNANCE_REPOSITORY_CONFLICT_TOTAL = _counter(
+    "governance_repository_conflict_total",
+    "Governance repository optimistic-lock conflicts",
+    labelnames=("backend",),
+)
 
 # Desirable / advanced PostgreSQL metrics
 LONG_RUNNING_QUERY_COUNT = _gauge(
@@ -480,6 +495,33 @@ def set_db_backend_selected(component: str, backend: str) -> None:
 
 def set_db_health_status(healthy: bool) -> None:
     DB_HEALTH_STATUS.set(1.0 if healthy else 0.0)
+
+
+def record_governance_repository_operation(
+    *,
+    backend: Any,
+    operation: Any,
+    status: Any,
+    duration_seconds: float,
+) -> None:
+    """Record governance repository operation counters and latency."""
+    labels = {
+        "backend": _label(backend, "unknown"),
+        "operation": _label(operation, "unknown"),
+        "status": _label(status, "unknown"),
+    }
+    GOVERNANCE_REPOSITORY_OPERATION_TOTAL.labels(**labels).inc()
+    GOVERNANCE_REPOSITORY_OPERATION_LATENCY_SECONDS.labels(
+        backend=labels["backend"],
+        operation=labels["operation"],
+    ).observe(max(0.0, duration_seconds))
+
+
+def record_governance_repository_conflict(*, backend: Any) -> None:
+    """Record optimistic-lock conflicts for governance writes."""
+    GOVERNANCE_REPOSITORY_CONFLICT_TOTAL.labels(
+        backend=_label(backend, "unknown")
+    ).inc()
 
 
 def set_long_running_query_count(count: int) -> None:

--- a/veritas_os/tests/test_alembic_migrations.py
+++ b/veritas_os/tests/test_alembic_migrations.py
@@ -153,6 +153,27 @@ class TestGovernanceMigration:
         assert "governance_approvals" in source
 
 
+class TestGovernanceIntegrityMigration:
+    """Verify governance integrity hardening migration metadata and DDL intent."""
+
+    @pytest.fixture()
+    def migration(self) -> ModuleType:
+        return _load_migration("0003_governance_integrity_hardening")
+
+    def test_revision_id(self, migration: ModuleType):
+        assert migration.revision == "0003"
+
+    def test_down_revision(self, migration: ModuleType):
+        assert migration.down_revision == "0002"
+
+    def test_upgrade_contains_integrity_constraints(self, migration: ModuleType):
+        import inspect
+
+        source = inspect.getsource(migration.upgrade)
+        assert "ck_governance_policies_policy_revision_positive" in source
+        assert "uq_governance_policies_policy_revision" in source
+        assert "ck_governance_approvals_reviewer_non_empty" in source
+
 # ── Revision chain integrity ────────────────────────────────────────────
 
 

--- a/veritas_os/tests/test_governance_backend_selection.py
+++ b/veritas_os/tests/test_governance_backend_selection.py
@@ -111,7 +111,8 @@ def test_governance_backend_postgresql_path_works(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://user:pass@localhost:5432/veritas")
 
     class _StubPostgresRepo:
-        pass
+        def health_check(self) -> None:
+            return
 
     monkeypatch.setattr(governance_factory, "PostgresGovernanceRepository", _StubPostgresRepo)
 

--- a/veritas_os/tests/test_governance_postgresql_repository.py
+++ b/veritas_os/tests/test_governance_postgresql_repository.py
@@ -6,6 +6,8 @@ These tests run against an in-memory SQL dispatcher (no live DB) and validate:
 - rollback event persistence
 - deterministic history ordering
 - duplicate approval validation
+- optimistic conflict detection
+- startup health checks
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ from typing import Any
 import pytest
 
 from veritas_os.governance.postgresql_repository import PostgresGovernanceRepository
+from veritas_os.governance.repository import GovernanceWriteConflictError
 
 
 class _MockCursor:
@@ -28,6 +31,15 @@ class _MockCursor:
         sql = " ".join(query.strip().split()).lower()
         params = params or tuple()
 
+        if sql == "select 1":
+            self._rows = [(1,)]
+            return
+
+        if sql.startswith("select count(*) from governance_policies where is_current = true"):
+            current = [p for p in self._state["policies"] if p["is_current"]]
+            self._rows = [(len(current),)]
+            return
+
         if sql.startswith("select policy_payload from governance_policies"):
             current = [p for p in self._state["policies"] if p["is_current"]]
             if not current:
@@ -36,16 +48,16 @@ class _MockCursor:
                 self._rows = [(current[-1]["policy_payload"],)]
             return
 
-        if sql.startswith("select id from governance_policies"):
+        if sql.startswith("select id, digest, policy_revision from governance_policies"):
             current = [p for p in self._state["policies"] if p["is_current"]]
-            self._rows = [(current[-1]["id"],)] if current else []
+            self._rows = [
+                (current[-1]["id"], current[-1]["digest"], current[-1]["policy_revision"])
+            ] if current else []
             return
 
-        if sql.startswith("update governance_policies set is_current = false"):
-            policy_id = params[0]
+        if sql.startswith("update governance_policies set is_current = false where is_current = true"):
             for policy in self._state["policies"]:
-                if policy["id"] == policy_id:
-                    policy["is_current"] = False
+                policy["is_current"] = False
             self._rows = []
             return
 
@@ -61,6 +73,8 @@ class _MockCursor:
                     "updated_at": params[3],
                     "updated_by": params[4],
                     "is_current": True,
+                    "policy_revision": params[5],
+                    "metadata_json": params[6],
                 }
             )
             self._rows = [(policy_id,)]
@@ -82,9 +96,10 @@ class _MockCursor:
                     "changed_by": params[6],
                     "changed_at": params[7],
                     "reason": params[8],
+                    "metadata_json": params[9],
                 }
             )
-            self._rows = [(event_id,)]
+            self._rows = [(event_id,)] if "returning id" in sql else []
             return
 
         if sql.startswith("insert into governance_approvals"):
@@ -245,11 +260,10 @@ def test_get_current_policy_works(repository) -> None:
 
 def test_update_creates_policy_event_and_approvals(repository) -> None:
     repo, state = repository
-    previous = _policy("governance_v1", "seed")
     updated = _policy("governance_v2", "alice")
 
     repo.update_policy(
-        previous=previous,
+        previous={},
         updated=updated,
         proposer="alice",
         approvers=["r1", "r2"],
@@ -261,6 +275,7 @@ def test_update_creates_policy_event_and_approvals(repository) -> None:
     )
 
     assert len(state["policies"]) == 1
+    assert state["policies"][0]["policy_revision"] == 1
     assert len(state["events"]) == 1
     assert len(state["approvals"]) == 2
     assert state["events"][0]["event_type"] == "update"
@@ -273,6 +288,13 @@ def test_rollback_creates_rollback_event(repository) -> None:
     v2 = _policy("governance_v2", "alice")
     rollback_target = _policy("governance_v1_restored", "bob")
 
+    repo.update_policy(
+        previous={},
+        updated=v1,
+        proposer="seed",
+        approvers=["r1", "r2"],
+        event_type="seed",
+    )
     repo.update_policy(
         previous=v1,
         updated=v2,
@@ -292,30 +314,40 @@ def test_rollback_creates_rollback_event(repository) -> None:
         reason="manual rollback",
     )
 
-    assert len(state["events"]) == 2
-    assert state["events"][1]["event_type"] == "rollback"
-    assert state["events"][1]["reason"] == "manual rollback"
+    assert len(state["events"]) == 3
+    assert state["events"][2]["event_type"] == "rollback"
+    assert state["events"][2]["reason"] == "manual rollback"
 
 
 def test_list_policy_history_ordering_desc(repository) -> None:
     repo, _state = repository
 
+    v1 = _policy("v1", "seed")
+    v2 = _policy("v2", "alice")
     repo.update_policy(
-        previous=_policy("v1", "seed"),
-        updated=_policy("v2", "alice"),
+        previous={},
+        updated=v1,
+        proposer="seed",
+        approvers=["r1", "r2"],
+        event_type="seed",
+    )
+    repo.update_policy(
+        previous=v1,
+        updated=v2,
         proposer="alice",
         approvers=["r1", "r2"],
         event_type="update",
     )
+
     repo.rollback_policy(
-        previous=_policy("v2", "alice"),
+        previous=v2,
         restored=_policy("v1-restored", "bob"),
         proposer="bob",
         approvers=["r3", "r4"],
     )
 
     history = repo.list_policy_history(limit=10, max_records=500)
-    assert len(history) == 2
+    assert len(history) == 3
     assert history[0]["event_type"] == "rollback"
     assert history[1]["event_type"] == "update"
 
@@ -334,3 +366,83 @@ def test_duplicate_approval_reviewer_rejected(repository) -> None:
                 {"reviewer": "r1", "signature": "sig2"},
             ],
         )
+
+
+def test_duplicate_approval_signature_rejected(repository) -> None:
+    repo, _state = repository
+    with pytest.raises(ValueError, match="duplicate approval signature"):
+        repo.update_policy(
+            previous=_policy("v1", "seed"),
+            updated=_policy("v2", "alice"),
+            proposer="alice",
+            approvers=["r1", "r2"],
+            event_type="update",
+            approval_records=[
+                {"reviewer": "r1", "signature": "sig-dup"},
+                {"reviewer": "r2", "signature": "sig-dup"},
+            ],
+        )
+
+
+def test_conflict_detection_on_stale_previous_state(repository) -> None:
+    repo, _state = repository
+    v1 = _policy("v1", "seed")
+    v2 = _policy("v2", "alice")
+    stale_previous = _policy("v1-stale", "seed")
+
+    repo.update_policy(
+        previous={},
+        updated=v1,
+        proposer="seed",
+        approvers=["r1", "r2"],
+        event_type="seed",
+    )
+    repo.update_policy(
+        previous=v1,
+        updated=v2,
+        proposer="alice",
+        approvers=["r1", "r2"],
+        event_type="update",
+    )
+
+    with pytest.raises(GovernanceWriteConflictError):
+        repo.update_policy(
+            previous=stale_previous,
+            updated=_policy("v3", "charlie"),
+            proposer="charlie",
+            approvers=["r5", "r6"],
+            event_type="update",
+        )
+
+
+def test_health_check_detects_double_current_policy(repository) -> None:
+    repo, state = repository
+    state["policies"].append(
+        {
+            "id": 1,
+            "policy_version": "v1",
+            "policy_payload": _policy("v1", "seed"),
+            "digest": "d1",
+            "updated_at": datetime.now(timezone.utc),
+            "updated_by": "seed",
+            "is_current": True,
+            "policy_revision": 1,
+            "metadata_json": {},
+        }
+    )
+    state["policies"].append(
+        {
+            "id": 2,
+            "policy_version": "v2",
+            "policy_payload": _policy("v2", "alice"),
+            "digest": "d2",
+            "updated_at": datetime.now(timezone.utc),
+            "updated_by": "alice",
+            "is_current": True,
+            "policy_revision": 2,
+            "metadata_json": {},
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="more than one current"):
+        repo.health_check()

--- a/veritas_os/tests/test_pg_metrics.py
+++ b/veritas_os/tests/test_pg_metrics.py
@@ -139,12 +139,15 @@ class TestMetricDefinitions:
             "DB_STATEMENT_TIMEOUTS_TOTAL",
             "TRUSTLOG_APPEND_CONFLICT_TOTAL",
             "SLOW_APPEND_WARNING_TOTAL",
+            "GOVERNANCE_REPOSITORY_OPERATION_TOTAL",
+            "GOVERNANCE_REPOSITORY_CONFLICT_TOTAL",
         ):
             obj = getattr(self.m, name)
             assert hasattr(obj, "inc"), f"{name} must be a Counter-like"
 
     def test_histogram_metrics_exist(self):
         assert hasattr(self.m.TRUSTLOG_APPEND_LATENCY_SECONDS, "observe")
+        assert hasattr(self.m.GOVERNANCE_REPOSITORY_OPERATION_LATENCY_SECONDS, "observe")
 
     def test_backend_and_health_gauges(self):
         assert hasattr(self.m.DB_BACKEND_SELECTED, "labels")
@@ -248,6 +251,37 @@ class TestRecordingHelpers:
             monkeypatch.setattr(self.m, name, probe)
             setter(5)
             assert any(c.get("set") == 5.0 for c in probe.calls)
+
+    def test_record_governance_repository_operation(self, monkeypatch):
+        counter_probe = _MetricProbe()
+        histogram_probe = _MetricProbe()
+        monkeypatch.setattr(self.m, "GOVERNANCE_REPOSITORY_OPERATION_TOTAL", counter_probe)
+        monkeypatch.setattr(
+            self.m,
+            "GOVERNANCE_REPOSITORY_OPERATION_LATENCY_SECONDS",
+            histogram_probe,
+        )
+        self.m.record_governance_repository_operation(
+            backend="postgresql",
+            operation="write_policy_event",
+            status="ok",
+            duration_seconds=0.25,
+        )
+        assert any(
+            c.get("labels") == {
+                "backend": "postgresql",
+                "operation": "write_policy_event",
+                "status": "ok",
+            }
+            for c in counter_probe.calls
+        )
+        assert any(c.get("observe") == 0.25 for c in histogram_probe.calls)
+
+    def test_record_governance_repository_conflict(self, monkeypatch):
+        probe = _MetricProbe()
+        monkeypatch.setattr(self.m, "GOVERNANCE_REPOSITORY_CONFLICT_TOTAL", probe)
+        self.m.record_governance_repository_conflict(backend="postgresql")
+        assert any(c.get("labels") == {"backend": "postgresql"} for c in probe.calls)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Elevate the existing PostgreSQL governance backend from a direct-psycopg proof-of-concept to a production-grade datastore by improving durability, concurrency safety, and observability.
- The previous implementation lacked robust stale-write detection, clear transaction/locking semantics, startup health checks, and dedicated telemetry for governance operations.
- Add schema-level invariants so migrations can enforce integrity (prevent blank reviewers, duplicate/invalid revisions) and make failures fail-closed rather than silently corrupting state.

### Description
- Implement optimistic write-conflict detection and explicit error semantics by comparing caller-provided `previous` digest to the DB current digest and raising `GovernanceWriteConflictError` on mismatch or missing expected current row. 
- Strengthen transaction boundaries and revision management by `SELECT ... FOR UPDATE`, atomic `is_current` flip inside the same transaction, and deterministic `policy_revision` allocation (`next_revision = current + 1`).
- Harden approval normalization to reject duplicate reviewers and duplicate signatures, and add a startup `health_check()` that validates governance table reachability and single-current-row integrity.
- Add observability: new metrics and helpers in `veritas_os.observability.metrics` to record governance repository operation counts/latency and conflict totals, record DB connect failures and health, and wire `set_db_backend_selected` on factory selection; repository methods now record operation latency/status and set DB health gauge.
- Add Alembic migration `0003_governance_integrity_hardening` to enforce `policy_revision > 0`, unique `policy_revision`, and `btrim(reviewer) <> ''` with a downgrade path.
- Keep API and repository contract unchanged except for an explicit `GovernanceWriteConflictError` type; add small factory change to run backend self-check on startup and emit backend selection metric.
- Update and add unit tests covering conflict detection, health checks, approval signature duplicate rejection, metrics helpers, and migration metadata; update docs to include governance migration validation steps.

### Testing
- Ran unit tests focused on governance and migrations: `pytest -q veritas_os/tests/test_governance_postgresql_repository.py veritas_os/tests/test_governance_backend_selection.py veritas_os/tests/test_pg_metrics.py veritas_os/tests/test_alembic_migrations.py` — all passed (`72 passed`).
- Executed `pytest -q veritas_os/tests -k "governance and postgresql"` and `pytest -q veritas_os/tests -k "governance and concurrency"` during development; repository-specific tests passed after fixes; the `governance and concurrency` selector yielded no matching tests in this tree at time of run.
- Attempted `alembic upgrade head` locally but it failed in this environment because `VERITAS_DATABASE_URL` was not set; the migration file `0003_governance_integrity_hardening.py` is included and should be validated in a DB-enabled CI job (see docs additions for recommended preflight commands).
- All added tests are included and exercised in the test runs above; no regressions observed against the test subsets executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37e8215488326a560fd95c3be3bbc)