### PR TITLE
Freeze public decision semantics contract and add conformance suite

### DIFF
--- a/docs/en/architecture/decision-semantics.md
+++ b/docs/en/architecture/decision-semantics.md
@@ -1,6 +1,8 @@
-# Decision Semantics (Phase-1 Contract)
+# Decision Semantics (Public Contract Freeze)
 
-This document is the **source-of-truth contract** for Phase-1 decision semantics.
+This document is the **frozen public contract** for decision semantics.
+For external integrations (finance, AML/KYC, audit), wording and value meaning
+in this document MUST be treated as stable contract terms.
 
 ## Runtime enforcement status
 
@@ -51,6 +53,7 @@ labels and are not recommended for new public payload contracts.
 - Public response assembly (`/v1/decide`) emits canonical gate values by default.
 - `allow|deny|modify|rejected|abstain` remain accepted as backward-compatibility input.
 - Legacy gate labels are compatibility-only and should not be used as new output contracts.
+- `proceed` indicates gate pass-through only and does **not** mean business approval (`proceed` is not business approval).
 
 ## A. gate_decision semantics table
 
@@ -102,6 +105,8 @@ Additional runtime invariants:
 
 - `gate=proceed` + `human_review_required=true` is forbidden.
 - `business=REVIEW_REQUIRED` + `human_review_required=false` is forbidden.
+- `business=REVIEW_REQUIRED` + `gate!=human_review_required` is forbidden.
+- `gate=human_review_required` + `business!=REVIEW_REQUIRED` is forbidden.
 - `business=APPROVE` + `human_review_required=true` is forbidden.
 
 Contract hardening policy:
@@ -141,3 +146,25 @@ and consumed from `_derive_business_fields`:
 - `decision_status` remains for backward compatibility with older FUJI-facing payloads.
 - `gate_decision` / `business_decision` are public semantics for case governance.
 - Legacy clients may still emit/consume `decision_status` (`allow|modify|rejected|block|abstain`).
+
+## G. legacy alias compatibility matrix (frozen)
+
+| input surface | accepted value | normalized public `gate_decision` | status |
+|---|---|---|---|
+| `gate_decision` | `allow` | `proceed` | compatibility-only |
+| `gate_decision` | `deny` | `block` | compatibility-only |
+| `gate_decision` | `modify` | `hold` | compatibility-only |
+| `gate_decision` | `rejected` | `block` | compatibility-only |
+| `gate_decision` | `abstain` | `hold` | compatibility-only |
+| `decision_status` | `allow` | `proceed` | compatibility-only |
+| `decision_status` | `modify` | `hold` | compatibility-only |
+| `decision_status` | `rejected` | `block` | compatibility-only |
+| `decision_status` | `block` | `block` | compatibility-only |
+| `decision_status` | `abstain` | `hold` | compatibility-only |
+
+Freeze policy:
+
+- New external integrations MUST consume canonical gate values:
+  `proceed|hold|block|human_review_required`.
+- Legacy aliases remain accepted only for migration compatibility.
+- `allow` MUST NOT be reintroduced as public canonical label.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -667,7 +667,7 @@ components:
               "unknown",
             ]
           default: "unknown"
-          description: "Canonical public values are proceed|hold|block|human_review_required. Legacy aliases remain compatibility-only inputs and are normalized before public output."
+          description: "Canonical public values are proceed|hold|block|human_review_required. Legacy aliases remain compatibility-only inputs and are normalized before public output. proceed indicates gate pass-through only and is not business approval."
           examples: ["proceed", "hold", "human_review_required", "block"]
         business_decision:
           type: string
@@ -707,7 +707,7 @@ components:
         human_review_required:
           type: boolean
           default: false
-          description: "Must be true when gate_decision=human_review_required or business_decision=REVIEW_REQUIRED."
+          description: "Must be true when gate_decision=human_review_required or business_decision=REVIEW_REQUIRED. REVIEW_REQUIRED must be paired with gate_decision=human_review_required."
         rationale:
           type: string
           nullable: true

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -669,6 +669,7 @@ class DecideResponse(BaseModel):
         description=(
             "Canonical public values: "
             f"{', '.join(CANONICAL_GATE_DECISION_VALUES)}. "
+            "`proceed` is a gate pass-through state and is not business approval. "
             "Legacy aliases are compatibility-only and normalized at runtime: "
             f"{', '.join(LEGACY_GATE_DECISION_ALIASES)}. "
             "Accepted compatibility surface: "

--- a/veritas_os/core/decision_semantics.py
+++ b/veritas_os/core/decision_semantics.py
@@ -385,7 +385,14 @@ def derive_gate_decision_from_stop_reasons(
 def validate_gate_business_combination(
     *, gate_decision: str, business_decision: str, human_review_required: bool
 ) -> None:
-    """Raise ValueError when gate/business combination is forbidden."""
+    """Raise ``ValueError`` when public decision contract invariants are violated.
+
+    Public contract freeze invariants:
+    - ``gate_decision`` is validated on canonical public values.
+    - ``human_review_required`` gate and ``REVIEW_REQUIRED`` business state are
+      coupled (bidirectional) and require ``human_review_required=true``.
+    - ``proceed`` is a gate pass-through signal only, not business approval.
+    """
     gate_decision = canonicalize_public_gate_decision(gate_decision)
     if (gate_decision, business_decision) in FORBIDDEN_GATE_BUSINESS_COMBINATIONS:
         raise ValueError(
@@ -406,6 +413,16 @@ def validate_gate_business_combination(
         raise ValueError(
             "forbidden combination: business_decision=REVIEW_REQUIRED "
             "requires human_review_required=true"
+        )
+    if business_decision == "REVIEW_REQUIRED" and gate_decision != "human_review_required":
+        raise ValueError(
+            "forbidden combination: business_decision=REVIEW_REQUIRED "
+            "requires gate_decision=human_review_required"
+        )
+    if gate_decision == "human_review_required" and business_decision != "REVIEW_REQUIRED":
+        raise ValueError(
+            "forbidden combination: gate_decision=human_review_required "
+            "requires business_decision=REVIEW_REQUIRED"
         )
     if business_decision == "APPROVE" and human_review_required:
         raise ValueError(

--- a/veritas_os/sample_data/governance/financial_regulatory_templates.json
+++ b/veritas_os/sample_data/governance/financial_regulatory_templates.json
@@ -236,7 +236,7 @@
         "secure_controls_ready": true
       },
       "expected_semantics": {
-        "gate_decision": "hold",
+        "gate_decision": "human_review_required",
         "business_decision": "REVIEW_REQUIRED",
         "next_action": "PREPARE_HUMAN_REVIEW_PACKET",
         "required_evidence": [

--- a/veritas_os/tests/integration/test_decision_sample_question_schema.py
+++ b/veritas_os/tests/integration/test_decision_sample_question_schema.py
@@ -44,7 +44,12 @@ def test_sample_questions_return_public_decision_schema(query: str) -> None:
         plan={"steps": [], "source": "test"},
     )
 
-    assert payload["gate_decision"] in {"allow", "proceed", "hold", "human_review_required", "block"}
+    assert payload["gate_decision"] in {
+        "proceed",
+        "hold",
+        "human_review_required",
+        "block",
+    }
     assert payload["business_decision"] in {
         "APPROVE",
         "DENY",
@@ -74,6 +79,6 @@ def test_allow_is_not_used_as_public_business_decision() -> None:
         plan={"steps": [], "source": "test"},
     )
 
-    assert payload["gate_decision"] in {"allow", "proceed"}
+    assert payload["gate_decision"] == "proceed"
     assert payload["business_decision"] != "allow"
     assert payload["next_action"] != payload["business_decision"]

--- a/veritas_os/tests/snapshots/decision_semantics_openapi_snapshot.json
+++ b/veritas_os/tests/snapshots/decision_semantics_openapi_snapshot.json
@@ -1,0 +1,36 @@
+{
+  "gate_decision_enum": [
+    "proceed",
+    "hold",
+    "block",
+    "human_review_required",
+    "allow",
+    "deny",
+    "modify",
+    "rejected",
+    "abstain",
+    "unknown"
+  ],
+  "gate_decision_examples": [
+    "proceed",
+    "hold",
+    "human_review_required",
+    "block"
+  ],
+  "business_decision_enum": [
+    "APPROVE",
+    "DENY",
+    "HOLD",
+    "REVIEW_REQUIRED",
+    "POLICY_DEFINITION_REQUIRED",
+    "EVIDENCE_REQUIRED"
+  ],
+  "human_review_required_type": "boolean",
+  "decision_status_enum": [
+    "allow",
+    "modify",
+    "rejected",
+    "block",
+    "abstain"
+  ]
+}

--- a/veritas_os/tests/test_decision_semantics_conformance.py
+++ b/veritas_os/tests/test_decision_semantics_conformance.py
@@ -1,0 +1,159 @@
+"""Decision semantics public-contract conformance tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.core.decision_semantics import (
+    CANONICAL_GATE_DECISION_VALUES,
+    GATE_DECISION_ALIAS_TO_CANONICAL,
+)
+from veritas_os.core.pipeline.pipeline_response import assemble_response
+from veritas_os.core.pipeline.pipeline_types import PipelineContext
+from veritas_os.scripts.expected_semantics_compare import compare_expected_semantics
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPENAPI_SNAPSHOT_PATH = (
+    REPO_ROOT / "veritas_os" / "tests" / "snapshots" / "decision_semantics_openapi_snapshot.json"
+)
+
+
+def _load_openapi_spec() -> dict[str, Any]:
+    with (REPO_ROOT / "openapi.yaml").open("r", encoding="utf-8") as file_obj:
+        return yaml.safe_load(file_obj)
+
+
+def _extract_openapi_decision_contract() -> dict[str, Any]:
+    spec = _load_openapi_spec()
+    decide_properties = spec["components"]["schemas"]["DecideResponse"]["properties"]
+    return {
+        "gate_decision_enum": decide_properties["gate_decision"]["enum"],
+        "gate_decision_examples": decide_properties["gate_decision"]["examples"],
+        "business_decision_enum": decide_properties["business_decision"]["enum"],
+        "human_review_required_type": decide_properties["human_review_required"]["type"],
+        "decision_status_enum": decide_properties["decision_status"]["enum"],
+    }
+
+
+@pytest.mark.parametrize(
+    "legacy_status, expected_gate",
+    [
+        ("allow", "proceed"),
+        ("modify", "hold"),
+        ("abstain", "hold"),
+        ("rejected", "block"),
+        ("block", "block"),
+    ],
+)
+def test_public_api_emits_canonical_gate_values(legacy_status: str, expected_gate: str) -> None:
+    """Public response payloads must emit canonical gate labels."""
+    ctx = PipelineContext(
+        request_id=f"req-gate-{legacy_status}",
+        query="conformance",
+        fuji_dict={"decision_status": legacy_status, "status": legacy_status},
+        decision_status=legacy_status,
+        context={},
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+    assert payload["gate_decision"] == expected_gate
+    assert payload["gate_decision"] in set(CANONICAL_GATE_DECISION_VALUES)
+
+
+def test_forbidden_review_required_pairings_are_rejected() -> None:
+    """REVIEW_REQUIRED and human review gate/flag coupling must be strict."""
+    with pytest.raises(ValidationError, match="requires gate_decision=human_review_required"):
+        DecideResponse.model_validate(
+            {
+                "gate_decision": "hold",
+                "business_decision": "REVIEW_REQUIRED",
+                "human_review_required": True,
+            }
+        )
+    with pytest.raises(ValidationError, match="requires business_decision=REVIEW_REQUIRED"):
+        DecideResponse.model_validate(
+            {
+                "gate_decision": "human_review_required",
+                "business_decision": "HOLD",
+                "human_review_required": True,
+            }
+        )
+
+
+def test_openapi_decision_contract_matches_snapshot() -> None:
+    """Decision semantics section of OpenAPI must remain frozen."""
+    snapshot = json.loads(OPENAPI_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    assert _extract_openapi_decision_contract() == snapshot
+
+
+def test_sample_expected_semantics_conform_to_response_schema() -> None:
+    """Bundled sample expected semantics must validate against DecideResponse."""
+    sample_paths = [
+        REPO_ROOT / "veritas_os" / "sample_data" / "governance" / "financial_poc_questions.json",
+        REPO_ROOT
+        / "veritas_os"
+        / "sample_data"
+        / "governance"
+        / "financial_regulatory_templates.json",
+    ]
+    expected_semantics_records: list[dict[str, Any]] = []
+
+    poc_data = json.loads(sample_paths[0].read_text(encoding="utf-8"))
+    expected_semantics_records.extend(
+        [
+            item["expected_semantics"]
+            for item in poc_data
+            if isinstance(item, dict) and isinstance(item.get("expected_semantics"), dict)
+        ]
+    )
+    templates_data = json.loads(sample_paths[1].read_text(encoding="utf-8"))
+    expected_semantics_records.extend(
+        [
+            item["expected_semantics"]
+            for item in templates_data.get("templates", [])
+            if isinstance(item, dict) and isinstance(item.get("expected_semantics"), dict)
+        ]
+    )
+
+    assert expected_semantics_records, "No expected_semantics records found in sample data."
+    for expected in expected_semantics_records:
+        payload = {
+            "gate_decision": expected.get("gate_decision", "unknown"),
+            "business_decision": expected.get("business_decision", "HOLD"),
+            "next_action": expected.get("next_action", "REVISE_AND_RESUBMIT"),
+            "required_evidence": expected.get("required_evidence", []),
+            "missing_evidence": expected.get("missing_evidence", []),
+            "human_review_required": bool(expected.get("human_review_required", False)),
+        }
+        validated = DecideResponse.model_validate(payload)
+        assert validated.gate_decision in set(CANONICAL_GATE_DECISION_VALUES)
+
+
+def test_compare_helper_and_runtime_alias_maps_stay_consistent() -> None:
+    """Compare helper assumptions must follow runtime canonical alias mapping."""
+    for raw_gate in ("allow", "modify", "rejected", "abstain", "deny"):
+        expected_payload = {
+            "gate_decision": raw_gate,
+            "business_decision": "HOLD",
+            "required_evidence": [],
+            "missing_evidence": [],
+            "human_review_required": False,
+        }
+        actual_payload = {
+            "gate_decision": GATE_DECISION_ALIAS_TO_CANONICAL[raw_gate],
+            "business_decision": "HOLD",
+            "required_evidence": [],
+            "missing_evidence": [],
+            "human_review_required": False,
+        }
+        assert compare_expected_semantics(expected_payload, actual_payload) == {}

--- a/veritas_os/tests/test_decision_semantics_docs.py
+++ b/veritas_os/tests/test_decision_semantics_docs.py
@@ -37,6 +37,17 @@ def test_decision_semantics_doc_declares_runtime_source_of_truth() -> None:
     assert "FORBIDDEN_GATE_BUSINESS_COMBINATIONS" in content
 
 
+def test_decision_semantics_doc_freeze_wording_and_legacy_matrix_present() -> None:
+    """EN semantics doc should declare freeze policy and legacy alias matrix."""
+    content = Path("docs/en/architecture/decision-semantics.md").read_text(
+        encoding="utf-8"
+    )
+    assert "frozen public contract" in content
+    assert "legacy alias compatibility matrix" in content.lower()
+    assert "`allow` MUST NOT be reintroduced as public canonical label." in content
+    assert "proceed" in content and "not business approval" in content
+
+
 def test_readme_links_to_new_decision_docs() -> None:
     """README hubs should route to the new semantics/taxonomy docs."""
     for path in DOC_FILES:

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -84,7 +84,12 @@ def test_openapi_decide_response_decision_semantics_contract() -> None:
         "human_review_required",
         "block",
     ]
+    assert "not business approval" in decide_schema["gate_decision"]["description"]
     assert decide_schema["human_review_required"]["type"] == "boolean"
+    assert (
+        "REVIEW_REQUIRED must be paired with gate_decision=human_review_required"
+        in decide_schema["human_review_required"]["description"]
+    )
     assert decide_schema["business_decision"]["enum"] == [
         "APPROVE",
         "DENY",


### PR DESCRIPTION
### Motivation
- Lock the public decision semantics as a stable external contract to avoid semantic drift across docs, runtime, schema, examples and tests for regulated use-cases (finance/AML/KYC/audit). 
- Eliminate ambiguity between gate-level and business-level signals (notably `proceed` vs business approval and the `REVIEW_REQUIRED` ↔ `human_review_required` relationship). 
- Provide automated conformance checks and a snapshot to prevent accidental future regressions.

### Description
- Hardened runtime invariants in `veritas_os/core/decision_semantics.py` by adding bidirectional checks so `business_decision=REVIEW_REQUIRED` ↔ `gate_decision=human_review_required` and by documenting that `proceed` is a gate pass-through, not business approval. 
- Frozen and clarified public wording in `docs/en/architecture/decision-semantics.md`, including a legacy alias compatibility matrix and a policy that `allow` must not be reintroduced as a canonical public label. 
- Aligned API surface text in `openapi.yaml` and `veritas_os/api/schemas.py` to reflect the frozen contract and the `REVIEW_REQUIRED` / `human_review_required` invariant. 
- Updated sample fixture `veritas_os/sample_data/governance/financial_regulatory_templates.json` to match the canonical semantics and tightened integration expectations in `veritas_os/tests/integration/test_decision_sample_question_schema.py`. 
- Added conformance tests and snapshot: `veritas_os/tests/test_decision_semantics_conformance.py` and `veritas_os/tests/snapshots/decision_semantics_openapi_snapshot.json` to assert runtime/schema/docs/examples remain consistent, plus small test updates for doc and OpenAPI wording checks.

### Testing
- Ran `pytest -q veritas_os/tests -k "decision_semantics or schema or conformance"` and the targeted suite passed with `231 passed` and `0 failed` (6595 deselected). 
- The new conformance tests include: canonical emission checks, forbidden-combination validation, OpenAPI decision-contract snapshot equality, sample expected-semantics schema validation, and compare-helper/runtime alias consistency (covered by `veritas_os/tests/test_decision_semantics_conformance.py`). 
- OpenAPI snapshot regression is included at `veritas_os/tests/snapshots/decision_semantics_openapi_snapshot.json` and is asserted by tests to prevent accidental drift.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38913fb388326b48ef709206baecc)