### PR TITLE
docs: add External Technical Proof Pack and reviewer artifacts for DD/pilot handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ VERITAS OS focuses on **decision governance**:
 - **AML/KYC Beachhead (1-day PoC quickstart)**: [`docs/en/guides/poc-pack-financial-quickstart.md`](docs/en/guides/poc-pack-financial-quickstart.md)
 - **AML/KYC Governance Template Contract**: [`docs/en/guides/financial-governance-templates.md`](docs/en/guides/financial-governance-templates.md)
 - **External Audit / Evidence Bundle Readiness**: [`docs/en/validation/external-audit-readiness.md`](docs/en/validation/external-audit-readiness.md)
+- **External Technical Proof Pack (review/pilot/DD/audit)**: [`docs/en/validation/technical-proof-pack.md`](docs/en/validation/technical-proof-pack.md)
 - **AML/KYC Short Positioning (customer / operator / investor)**: [`docs/en/positioning/aml-kyc-beachhead-short-positioning.md`](docs/en/positioning/aml-kyc-beachhead-short-positioning.md)
 - **GitHub**: https://github.com/veritasfuji-japan/veritas_os
 - **Zenodo paper (EN)**: https://doi.org/10.5281/zenodo.17838349

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -51,6 +51,14 @@
 | `docs/en/validation/production-validation.md` | EN only | Production validation strategy |
 | `docs/en/validation/backend-parity-coverage.md` | EN only | JSONL vs PostgreSQL parity |
 | `docs/en/validation/external-audit-readiness.md` | EN only | External audit evidence pack |
+| `docs/en/validation/technical-proof-pack.md` | EN only | External review proof-pack entrypoint |
+| `docs/en/validation/governance-capability-matrix.md` | EN only | Governance implemented/pending matrix |
+| `docs/en/validation/validation-evidence-map.md` | EN only | Validation layer to artifact mapping |
+| `docs/en/validation/aml-kyc-pilot-evidence-map.md` | EN only | AML/KYC pilot evidence map |
+| `docs/en/validation/external-reviewer-checklist.md` | EN only | External reviewer verification checklist |
+| `docs/en/validation/implemented-vs-pending-boundary.md` | EN only | Implemented vs pending boundary |
+| `docs/en/validation/short-dd-summary.md` | EN only | Short due-diligence summary |
+| `docs/en/validation/benchmark-reproducibility-appendix.md` | EN only | Optional benchmark/repro appendix |
 
 #### Governance / ガバナンス
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -39,6 +39,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [Production Validation Strategy](validation/production-validation.md)
 - [Backend Parity Coverage](validation/backend-parity-coverage.md)
 - [External Audit Readiness](validation/external-audit-readiness.md)
+- [Technical Proof Pack (external review)](validation/technical-proof-pack.md)
 
 ### Governance & Compliance
 - [Decision Semantics Contract](architecture/decision-semantics.md)

--- a/docs/en/positioning/aml-kyc-beachhead-short-positioning.md
+++ b/docs/en/positioning/aml-kyc-beachhead-short-positioning.md
@@ -10,6 +10,7 @@ Implemented references:
 - [1-day PoC quickstart](../guides/poc-pack-financial-quickstart.md)
 - [Financial governance templates](../guides/financial-governance-templates.md)
 - [External audit readiness](../validation/external-audit-readiness.md)
+- [Technical proof pack for external review](../validation/technical-proof-pack.md)
 
 ## Customer-facing short explanation
 

--- a/docs/en/validation/aml-kyc-pilot-evidence-map.md
+++ b/docs/en/validation/aml-kyc-pilot-evidence-map.md
@@ -1,0 +1,42 @@
+# AML/KYC Pilot Evidence Map (Synthetic Pilot Scope)
+
+**Scope boundary:** This map is for synthetic-data pilot validation and handoff preparation. It is not a claim of production AML legal determination.
+
+## 1) Pilot package components
+
+| Component | Purpose | Source |
+|---|---|---|
+| Quickstart | One-day executable PoC flow | `docs/en/guides/poc-pack-financial-quickstart.md` |
+| Operator checklist | Run/handoff/security gate | `docs/en/guides/aml-kyc-pilot-checklist.md` |
+| Governance templates | Contract and expected gate behavior | `docs/en/guides/financial-governance-templates.md` |
+| Customer handoff path | Pilot-to-customer transition framing | `docs/en/guides/aml-kyc-customer-handoff-path.md` |
+| Evidence taxonomy | Required/missing/satisfied evidence semantics | `docs/en/governance/required-evidence-taxonomy.md` |
+| Fixture cases | Synthetic pilot cases | `veritas_os/sample_data/governance/aml_kyc_pilot_cases.json` |
+| Expected evidence examples | Bundle expectation examples | `veritas_os/sample_data/governance/aml_kyc_expected_evidence_bundle_examples.json` |
+
+## 2) Validation checkpoints (minimum external-review set)
+
+1. Confirm synthetic-only scope.
+2. Confirm strict required-evidence mode in pilot runs.
+3. Confirm representative outcome families are non-permissive for missing critical evidence.
+4. Produce and retain runner JSON outputs.
+5. Generate evidence bundle and verify acceptance checklist + verifier output.
+
+References:
+- [AML/KYC Pilot Checklist](../guides/aml-kyc-pilot-checklist.md)
+- [External Audit Readiness](external-audit-readiness.md)
+
+## 3) Reviewer-ready artifact bundle (recommended)
+
+- Pilot run report JSON
+- Selected decision/incident evidence bundle
+- `verification_report.json`
+- `acceptance_checklist.json`
+- Minimal traceability note (which case IDs were used)
+
+## 4) Not-yet-guaranteed (explicit)
+
+- No claim of regulator-approved AML/KYC engine certification.
+- No claim that synthetic pilot outcomes equal production legal outcomes.
+- No claim that customer-specific sanctions/provider integrations are already certified.
+

--- a/docs/en/validation/benchmark-reproducibility-appendix.md
+++ b/docs/en/validation/benchmark-reproducibility-appendix.md
@@ -1,0 +1,27 @@
+# Benchmark / Reproducibility Appendix (Optional)
+
+This appendix is optional for reviewers who need a benchmark/replay framing beyond contract-level proof.
+
+## Existing benchmark planning artifact
+
+- [Evidence Benchmark Plan](../../benchmarks/VERITAS_EVIDENCE_BENCHMARK_PLAN.md)
+
+## Reproducibility posture (current)
+
+- Reproducibility should be evaluated through fixed fixtures, run reports, and evidence bundles (not marketing claims).
+- Replay-oriented and parity-oriented validation docs provide the correct baseline for reproducibility review.
+
+Primary references:
+- [Production Validation](production-validation.md)
+- [Backend Parity Coverage](backend-parity-coverage.md)
+- [External Audit Readiness](external-audit-readiness.md)
+
+## Recommended external benchmark handoff minimum
+
+1. Exact commit SHA
+2. Executed command list
+3. Input fixture IDs
+4. Output report JSON
+5. Evidence bundle + verification report
+6. Boundary statement (implemented vs pending)
+

--- a/docs/en/validation/external-reviewer-checklist.md
+++ b/docs/en/validation/external-reviewer-checklist.md
@@ -1,0 +1,52 @@
+# External Reviewer Checklist
+
+Use this checklist to evaluate what is implemented today without over-reading roadmap claims.
+
+## A. Reading order (fast path)
+
+- [ ] Read [Short DD Summary](short-dd-summary.md).
+- [ ] Read [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md).
+- [ ] Read [Governance Capability Matrix](governance-capability-matrix.md).
+
+## B. Contract and governance checks
+
+- [ ] Confirm canonical decision semantics and forbidden combinations are explicitly documented.
+- [ ] Confirm required evidence taxonomy and AML/KYC profile behavior are explicitly documented.
+- [ ] Confirm governance backend choices and operational constraints are documented.
+
+Primary docs:
+- `docs/en/architecture/decision-semantics.md`
+- `docs/en/governance/required-evidence-taxonomy.md`
+- `docs/en/operations/postgresql-production-guide.md`
+
+## C. Validation and evidence checks
+
+- [ ] Confirm production validation strategy and boundaries are documented.
+- [ ] Confirm external audit readiness includes verifier and bundle pathway.
+- [ ] Confirm evidence bundle acceptance checklist is part of handoff contract.
+
+Primary docs:
+- `docs/en/validation/production-validation.md`
+- `docs/en/validation/backend-parity-coverage.md`
+- `docs/en/validation/external-audit-readiness.md`
+
+## D. AML/KYC pilot proof checks
+
+- [ ] Confirm pilot package is scoped to synthetic cases.
+- [ ] Confirm strict required-evidence pilot mode path exists.
+- [ ] Confirm expected-case and failure-case fixtures are present.
+
+Primary docs/data:
+- `docs/en/guides/poc-pack-financial-quickstart.md`
+- `docs/en/guides/aml-kyc-pilot-checklist.md`
+- `veritas_os/sample_data/governance/aml_kyc_pilot_cases.json`
+
+## E. Boundary / anti-exaggeration checks
+
+- [ ] Ensure no claim of completed third-party certification unless evidence is attached.
+- [ ] Ensure no claim of universal production certification.
+- [ ] Ensure pending items are explicitly separated from implemented behavior.
+
+Use:
+- `docs/en/validation/implemented-vs-pending-boundary.md`
+

--- a/docs/en/validation/governance-capability-matrix.md
+++ b/docs/en/validation/governance-capability-matrix.md
@@ -1,0 +1,31 @@
+# Governance Capability Matrix (Implemented vs Pending)
+
+**Snapshot date:** 2026-04-18 (UTC)
+
+This matrix is intentionally conservative. "Implemented" means repository-visible behavior exists today. "Pending" means external proof, operational rollout depth, or formal certification is still required.
+
+| Capability area | Current status | Repository evidence | Pending / boundary |
+|---|---|---|---|
+| Decision semantics contract | Implemented | Canonical gate semantics + combination rules documented and mapped to runtime enforcement paths | External integrator conformance certification is pending |
+| Gate/business consistency enforcement | Implemented | Forbidden combinations and canonicalization behavior are documented as runtime-enforced | Independent third-party protocol conformance review is pending |
+| Required evidence taxonomy | Implemented (v0 + AML/KYC profile) | Taxonomy and profile/mode behavior documented (`warn`/`strict`) | Domain expansion and hard-reject migration policy are pending |
+| Governance backend abstraction | Implemented | Governance backends documented and file/postgresql repository path exists in code and tests | Enterprise-managed DB topology certification is environment-dependent |
+| TrustLog verification path | Implemented | Standalone verifier path and evidence verification flow documented | External custody/retention legal acceptance depends on customer controls |
+| Evidence bundle generation | Implemented | Bundle schema/content/acceptance checklist documented | Customer-specific evidentiary admissibility review pending |
+| AML/KYC pilot package | Implemented for synthetic pilot scope | Pilot checklist/runbook/fixture and evidence handoff docs available | Real customer data deployment and legal sign-off are pending |
+| Governance control-plane operations | Implemented baseline | Governance artifact lifecycle + signing/operations docs exist | Full organizational SoD/change-approval evidence depends on tenant setup |
+| Production posture guarantees | Partially implemented (bounded) | Production validation and hardening docs define controls and limits | Universal HA/DR and cloud posture guarantees are not asserted |
+
+## Notes for external reviewers
+
+- Treat this matrix as a navigation/claim-boundary layer, not a certification statement.
+- When in doubt, request artifact-level proof via the reviewer checklist.
+
+## Core references
+
+- [Decision Semantics Contract](../architecture/decision-semantics.md)
+- [Required Evidence Taxonomy](../governance/required-evidence-taxonomy.md)
+- [External Audit Readiness](external-audit-readiness.md)
+- [Production Validation](production-validation.md)
+- [PostgreSQL Production Guide](../operations/postgresql-production-guide.md)
+

--- a/docs/en/validation/implemented-vs-pending-boundary.md
+++ b/docs/en/validation/implemented-vs-pending-boundary.md
@@ -1,0 +1,34 @@
+# Implemented vs Pending Boundary (External Proof Scope)
+
+**Intent:** Keep boundary statements short, explicit, and verifiable.
+
+## Implemented (repository-verifiable)
+
+1. Decision semantics contract and runtime-enforcement path are defined.
+2. Required evidence taxonomy v0 + AML/KYC profile logic is defined.
+3. Governance backend repository abstraction (file/postgresql) is implemented.
+4. Evidence bundle generation and standalone TrustLog verification paths are implemented.
+5. Validation strategy docs and pilot checklists are present for reproducible review flow.
+
+## Pending / environment-dependent
+
+1. Independent third-party certification/audit completion.
+2. Tenant-specific production controls (IdP, key custody, HA/DR topology, legal retention policy execution).
+3. Customer environment legal/compliance acceptance of bundle formats and procedures.
+4. Full production-readiness guarantee for every deployment context.
+
+## Not yet guaranteed (must read)
+
+- No claim of universal production certification.
+- No claim that self-assessment equals external certification.
+- No claim that synthetic AML/KYC pilots are legal determinations.
+- No claim that provider/integration controls not in this repository are already implemented.
+
+## Evidence pointers
+
+- [Public Positioning (self-assessment boundary)](../positioning/public-positioning.md)
+- [Decision Semantics Contract](../architecture/decision-semantics.md)
+- [Required Evidence Taxonomy](../governance/required-evidence-taxonomy.md)
+- [External Audit Readiness](external-audit-readiness.md)
+- [AML/KYC Pilot Checklist](../guides/aml-kyc-pilot-checklist.md)
+

--- a/docs/en/validation/short-dd-summary.md
+++ b/docs/en/validation/short-dd-summary.md
@@ -1,0 +1,32 @@
+# Short DD Summary (External Review)
+
+**As of 2026-04-18 (UTC)**
+
+## What VERITAS OS currently demonstrates
+
+VERITAS OS demonstrates a governance-first decision pipeline with explicit contract semantics, evidence packaging, and audit-verification pathways documented in-repo.
+
+Key implemented themes:
+
+- Decision-level governance semantics (gate/business/human-review consistency).
+- Required evidence modeling and AML/KYC pilot-oriented profiles.
+- Evidence-bundle + TrustLog verifier path for external review handoff.
+- Governance backend operation with file/postgresql repository options.
+
+## What this is not claiming
+
+- Not a completed third-party certification statement.
+- Not a universal production guarantee across every customer environment.
+- Not a legal determination engine for AML/KYC by itself.
+
+## Review recommendation
+
+For third-party DD, evaluate this repository as a **verification-ready governance platform with explicit boundaries**, then request pilot artifacts and customer-environment controls as phase-2 evidence.
+
+## Where to verify quickly
+
+1. [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md)
+2. [Governance Capability Matrix](governance-capability-matrix.md)
+3. [Validation Evidence Map](validation-evidence-map.md)
+4. [External Reviewer Checklist](external-reviewer-checklist.md)
+

--- a/docs/en/validation/technical-proof-pack.md
+++ b/docs/en/validation/technical-proof-pack.md
@@ -1,0 +1,71 @@
+# VERITAS OS Technical Proof Pack (External Review Edition)
+
+**Snapshot date:** 2026-04-18 (UTC)  
+**Scope:** Repository-verifiable evidence for third-party review, pilot diligence, investor DD, and customer audit preparation.  
+**Positioning boundary:** This pack is a repository-level self-declared evidence bundle map, **not** third-party certification.
+
+---
+
+## 1) Purpose
+
+This pack organizes implemented evidence in VERITAS OS so external reviewers can quickly answer:
+
+1. What is implemented now?
+2. What is only planned or environment-dependent?
+3. Which artifacts are replayable/auditable from this repository alone?
+
+Use this as the top-level entrypoint before reading detailed maps and checklists.
+
+---
+
+## 2) Proof-pack document set (read in order)
+
+1. [Short DD Summary](short-dd-summary.md)
+2. [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md)
+3. [Governance Capability Matrix](governance-capability-matrix.md)
+4. [Validation Evidence Map](validation-evidence-map.md)
+5. [AML/KYC Pilot Evidence Map](aml-kyc-pilot-evidence-map.md)
+6. [External Reviewer Checklist](external-reviewer-checklist.md)
+7. [External Audit Readiness Pack](external-audit-readiness.md)
+8. Optional: [Benchmark / Reproducibility Appendix](benchmark-reproducibility-appendix.md)
+
+---
+
+## 3) Implemented control families (repository-verifiable)
+
+- Decision semantics canonicalization and forbidden-combination enforcement are runtime-defined and documented as public contract behavior.
+- Evidence and audit packaging paths exist (TrustLog verifier + evidence bundle generation).
+- Governance repository backend selection is implemented with file/postgresql backends.
+- AML/KYC pilot path is documented with checklist/runbook/evidence templates for synthetic-case pilots.
+
+Primary references:
+
+- [Decision Semantics Contract](../architecture/decision-semantics.md)
+- [Required Evidence Taxonomy v0](../governance/required-evidence-taxonomy.md)
+- [External Audit Readiness](external-audit-readiness.md)
+- [AML/KYC Pilot Checklist](../guides/aml-kyc-pilot-checklist.md)
+
+---
+
+## 4) Explicit non-guarantees (important)
+
+This pack does **not** claim any of the following:
+
+- Universal production certification across all environments.
+- Third-party audit certification already completed.
+- Legal/compliance determination by VERITAS OS alone.
+- Guaranteed correctness of external integrations not present in the repository.
+
+For concrete boundaries, see:
+- [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md)
+
+---
+
+## 5) Reviewer handoff note
+
+If you are an external reviewer, start with:
+
+1. `short-dd-summary.md` (5–10 minutes)
+2. `implemented-vs-pending-boundary.md` (boundary control)
+3. `external-reviewer-checklist.md` (evidence verification flow)
+

--- a/docs/en/validation/validation-evidence-map.md
+++ b/docs/en/validation/validation-evidence-map.md
@@ -1,0 +1,57 @@
+# Validation Evidence Map
+
+**Objective:** Map implemented validation layers to concrete repository artifacts.
+
+## Layered evidence model
+
+### L1 — Contract-level semantics
+
+- Decision semantics public contract with canonical values and forbidden combinations.
+- Required evidence taxonomy/profile behavior (`warn` / `strict`) for AML/KYC path.
+
+References:
+- [Decision Semantics Contract](../architecture/decision-semantics.md)
+- [Required Evidence Taxonomy](../governance/required-evidence-taxonomy.md)
+
+### L2 — Runtime implementation path
+
+- Decision response derivation and gate semantics canonicalization are implemented in backend modules.
+- Governance backend selection path implemented via factory/config/repository split.
+- Audit evidence generation/verification modules are present.
+
+Representative code paths:
+- `veritas_os/core/decision_semantics.py`
+- `veritas_os/core/pipeline/pipeline_response.py`
+- `veritas_os/governance/factory.py`
+- `veritas_os/audit/evidence_bundle.py`
+- `veritas_os/audit/trustlog_verify.py`
+
+### L3 — Test and parity coverage layer
+
+- Backend parity and production validation strategy are documented with CI/live validation posture.
+- Governance/trustlog/evidence related tests exist in repository test suites.
+
+References:
+- [Backend Parity Coverage](backend-parity-coverage.md)
+- [Production Validation](production-validation.md)
+
+### L4 — Audit handoff layer
+
+- Evidence bundle contract (`decision_record`, `acceptance_checklist`) is documented.
+- External audit readiness path includes verifier and timestamp-anchoring options.
+
+Reference:
+- [External Audit Readiness](external-audit-readiness.md)
+
+---
+
+## Evidence request mapping for reviewers
+
+| Reviewer question | Start artifact |
+|---|---|
+| Is gate semantics stable and bounded? | `docs/en/architecture/decision-semantics.md` |
+| Is required evidence contract explicit? | `docs/en/governance/required-evidence-taxonomy.md` |
+| Is external bundle handoff defined? | `docs/en/validation/external-audit-readiness.md` |
+| Is production validation posture documented with boundaries? | `docs/en/validation/production-validation.md` + `docs/en/operations/postgresql-production-guide.md` |
+| Is AML/KYC pilot evidence path runnable? | `docs/en/guides/poc-pack-financial-quickstart.md` + `docs/en/guides/aml-kyc-pilot-checklist.md` |
+


### PR DESCRIPTION
### Motivation
- Provide a concise, non-exaggerated entrypoint that assembles repository-verifiable evidence for external reviewers, pilots, investor DD, and customer audits. 
- Shorten and clarify the implemented vs pending boundary so external reviewers can quickly request artifact-level proof instead of inferring roadmap claims. 
- Keep scope conservative and explicit about non-guarantees (no third-party certification claims or universal production guarantees). 

### Description
- Add a top-level Technical Proof Pack and seven reviewer-focused documents under `docs/en/validation/`: `technical-proof-pack.md`, `short-dd-summary.md`, `implemented-vs-pending-boundary.md`, `governance-capability-matrix.md`, `validation-evidence-map.md`, `aml-kyc-pilot-evidence-map.md`, `external-reviewer-checklist.md`, and an optional `benchmark-reproducibility-appendix.md`. 
- Add README and docs hub navigation links to surface the proof pack and register the new docs in `docs/DOCUMENTATION_MAP.md` and `docs/en/positioning/aml-kyc-beachhead-short-positioning.md` so external reviewers have a clear reading path. 
- Keep language conservative and explicit about what is implemented versus environment-dependent, and call out AML/KYC pilot scope as synthetic-only. 
- This is documentation-only; there are no runtime code or secret-management changes, and pending operational items (IdP, key custody, HA/DR, legal acceptance) are listed for reviewer attention. 

### Testing
- Ran an automated local Markdown link integrity check across all new/updated docs and README which reported no broken local links. 
- Ran automated existence checks for referenced implementation artifacts (`veritas_os/core/decision_semantics.py`, `veritas_os/core/pipeline/pipeline_response.py`, `veritas_os/governance/factory.py`, `veritas_os/audit/evidence_bundle.py`, `veritas_os/audit/trustlog_verify.py`, and AML/KYC fixtures) and all resolved successfully. 
- Performed `rg`-style scan to confirm the new doc links appear in `README.md`, `docs/en/README.md`, `docs/DOCUMENTATION_MAP.md`, and the AML/KYC positioning page. 
- No unit/test-suite changes were necessary because this is docs-only, and no runtime security changes were introduced; reviewers are advised to validate key custody, environment hardening, and legal/admissibility items when moving to phase-2 external proof.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39272bd248326b134ac8e764635eb)