### PR TITLE
Add additive WAT governance policy schema blocks

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -464,6 +464,172 @@ components:
           minimum: 100
           maximum: 1000000
 
+    RolloutControls:
+      type: object
+      description: "段階的適用コントロール"
+      properties:
+        strategy:
+          type: string
+          default: "disabled"
+          enum: ["disabled", "canary", "staged", "full"]
+        canary_percent:
+          type: integer
+          default: 0
+          minimum: 0
+          maximum: 100
+        stage:
+          type: integer
+          default: 0
+          minimum: 0
+          maximum: 10
+        staged_enforcement:
+          type: boolean
+          default: false
+
+    ApprovalWorkflowConfig:
+      type: object
+      description: "人手承認ワークフロー設定"
+      properties:
+        human_review_ticket:
+          type: string
+          default: ""
+        human_review_required:
+          type: boolean
+          default: false
+        approver_identity_binding:
+          type: boolean
+          default: true
+        approver_identities:
+          type: array
+          items:
+            type: string
+
+    WatConfig:
+      type: object
+      description: "WAT 発行制御設定"
+      properties:
+        enabled:
+          type: boolean
+          default: false
+        issuance_mode:
+          type: string
+          default: "shadow_only"
+          enum: ["shadow_only", "disabled"]
+        require_observable_digest:
+          type: boolean
+          default: true
+        default_ttl_seconds:
+          type: integer
+          default: 300
+          minimum: 1
+          maximum: 86400
+        signer_backend:
+          type: string
+          default: "existing_signer"
+
+    PsidConfig:
+      type: object
+      description: "PSID 表示・適用設定"
+      properties:
+        enforcement_mode:
+          type: string
+          default: "full_digest_only"
+          enum: ["full_digest_only"]
+        display_length:
+          type: integer
+          default: 12
+          minimum: 4
+          maximum: 128
+
+    ShadowValidationConfig:
+      type: object
+      description: "シャドウ検証設定"
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        partial_validation_default:
+          type: string
+          default: "non_admissible"
+          enum: ["non_admissible"]
+        warning_only_until:
+          type: string
+          default: ""
+        timestamp_skew_tolerance_seconds:
+          type: integer
+          default: 5
+          minimum: 0
+          maximum: 3600
+        replay_binding_required:
+          type: boolean
+          default: false
+
+    RevocationConfig:
+      type: object
+      description: "失効反映の整合性設定"
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        mode:
+          type: string
+          default: "bounded_eventual_consistency"
+          enum: ["bounded_eventual_consistency"]
+        alert_target_seconds:
+          type: integer
+          default: 30
+          minimum: 1
+          maximum: 86400
+        convergence_target_p95_seconds:
+          type: integer
+          default: 60
+          minimum: 1
+          maximum: 86400
+        degrade_on_pending:
+          type: boolean
+          default: true
+
+    DriftScoringConfig:
+      type: object
+      description: "ドリフト評価スコア重み"
+      properties:
+        policy_weight:
+          type: number
+          format: float
+          default: 0.4
+          minimum: 0
+          maximum: 1
+        signature_weight:
+          type: number
+          format: float
+          default: 0.3
+          minimum: 0
+          maximum: 1
+        observable_weight:
+          type: number
+          format: float
+          default: 0.2
+          minimum: 0
+          maximum: 1
+        temporal_weight:
+          type: number
+          format: float
+          default: 0.1
+          minimum: 0
+          maximum: 1
+        healthy_threshold:
+          type: number
+          format: float
+          default: 0.2
+          minimum: 0
+          maximum: 1
+        critical_threshold:
+          type: number
+          format: float
+          default: 0.5
+          minimum: 0
+          maximum: 1
+
     GovernancePolicy:
       type: object
       description: "ガバナンスポリシー設定"
@@ -479,6 +645,20 @@ components:
           $ref: '#/components/schemas/AutoStop'
         log_retention:
           $ref: '#/components/schemas/LogRetention'
+        rollout_controls:
+          $ref: '#/components/schemas/RolloutControls'
+        approval_workflow:
+          $ref: '#/components/schemas/ApprovalWorkflowConfig'
+        wat:
+          $ref: '#/components/schemas/WatConfig'
+        psid:
+          $ref: '#/components/schemas/PsidConfig'
+        shadow_validation:
+          $ref: '#/components/schemas/ShadowValidationConfig'
+        revocation:
+          $ref: '#/components/schemas/RevocationConfig'
+        drift_scoring:
+          $ref: '#/components/schemas/DriftScoringConfig'
         updated_at:
           type: string
           format: date-time

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -105,6 +105,54 @@ class ApprovalWorkflowConfig(BaseModel):
     approver_identities: list[str] = Field(default_factory=list)
 
 
+class WatConfig(BaseModel):
+    """Witness attestation token (WAT) issuance controls."""
+
+    enabled: bool = False
+    issuance_mode: Literal["shadow_only", "disabled"] = "shadow_only"
+    require_observable_digest: bool = True
+    default_ttl_seconds: int = Field(default=300, ge=1, le=86_400)
+    signer_backend: str = "existing_signer"
+
+
+class PsidConfig(BaseModel):
+    """Policy-scoped identifier display and enforcement settings."""
+
+    enforcement_mode: Literal["full_digest_only"] = "full_digest_only"
+    display_length: int = Field(default=12, ge=4, le=128)
+
+
+class ShadowValidationConfig(BaseModel):
+    """Shadow validation behavior for non-disruptive rollout checks."""
+
+    enabled: bool = True
+    partial_validation_default: Literal["non_admissible"] = "non_admissible"
+    warning_only_until: str = ""
+    timestamp_skew_tolerance_seconds: int = Field(default=5, ge=0, le=3600)
+    replay_binding_required: bool = False
+
+
+class RevocationConfig(BaseModel):
+    """Revocation consistency targets and degraded-mode posture."""
+
+    enabled: bool = True
+    mode: Literal["bounded_eventual_consistency"] = "bounded_eventual_consistency"
+    alert_target_seconds: int = Field(default=30, ge=1, le=86_400)
+    convergence_target_p95_seconds: int = Field(default=60, ge=1, le=86_400)
+    degrade_on_pending: bool = True
+
+
+class DriftScoringConfig(BaseModel):
+    """Weights and thresholds used for drift scoring telemetry."""
+
+    policy_weight: float = Field(default=0.4, ge=0.0, le=1.0)
+    signature_weight: float = Field(default=0.3, ge=0.0, le=1.0)
+    observable_weight: float = Field(default=0.2, ge=0.0, le=1.0)
+    temporal_weight: float = Field(default=0.1, ge=0.0, le=1.0)
+    healthy_threshold: float = Field(default=0.2, ge=0.0, le=1.0)
+    critical_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
 class GovernancePolicy(BaseModel):
     version: str = "governance_v1"
     fuji_rules: FujiRules = Field(default_factory=FujiRules)
@@ -113,6 +161,11 @@ class GovernancePolicy(BaseModel):
     log_retention: LogRetention = Field(default_factory=LogRetention)
     rollout_controls: RolloutControls = Field(default_factory=RolloutControls)
     approval_workflow: ApprovalWorkflowConfig = Field(default_factory=ApprovalWorkflowConfig)
+    wat: WatConfig = Field(default_factory=WatConfig)
+    psid: PsidConfig = Field(default_factory=PsidConfig)
+    shadow_validation: ShadowValidationConfig = Field(default_factory=ShadowValidationConfig)
+    revocation: RevocationConfig = Field(default_factory=RevocationConfig)
+    drift_scoring: DriftScoringConfig = Field(default_factory=DriftScoringConfig)
     updated_at: str = ""
     updated_by: str = "system"
 
@@ -124,6 +177,11 @@ _NESTED_POLICY_MODELS = {
     "log_retention": LogRetention,
     "rollout_controls": RolloutControls,
     "approval_workflow": ApprovalWorkflowConfig,
+    "wat": WatConfig,
+    "psid": PsidConfig,
+    "shadow_validation": ShadowValidationConfig,
+    "revocation": RevocationConfig,
+    "drift_scoring": DriftScoringConfig,
 }
 
 

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -204,6 +204,62 @@ class TestGovernanceModule:
         assert policy.risk_thresholds.allow_upper == 0.40
         assert policy.auto_stop.enabled is True
         assert policy.log_retention.retention_days == 90
+        assert policy.wat.enabled is False
+        assert policy.wat.issuance_mode == "shadow_only"
+        assert policy.psid.enforcement_mode == "full_digest_only"
+        assert policy.shadow_validation.partial_validation_default == "non_admissible"
+        assert policy.revocation.mode == "bounded_eventual_consistency"
+        assert policy.drift_scoring.policy_weight == 0.4
+
+    def test_update_policy_patches_nested_wat_fields(self):
+        result = gov_mod.update_policy(
+            _approved(
+                {
+                    "wat": {
+                        "enabled": True,
+                        "default_ttl_seconds": 600,
+                        "require_observable_digest": True,
+                    }
+                }
+            )
+        )
+        assert result["wat"]["enabled"] is True
+        assert result["wat"]["default_ttl_seconds"] == 600
+        assert result["wat"]["issuance_mode"] == "shadow_only"
+
+    def test_policy_history_preserves_new_wat_fields(self):
+        gov_mod.update_policy(
+            _approved(
+                {
+                    "wat": {"enabled": True},
+                    "psid": {"display_length": 16},
+                    "shadow_validation": {"replay_binding_required": True},
+                }
+            )
+        )
+        records = gov_mod.get_policy_history(limit=1)
+        assert len(records) == 1
+        latest = records[0]["new_policy"]
+        assert latest["wat"]["enabled"] is True
+        assert latest["psid"]["display_length"] == 16
+        assert latest["shadow_validation"]["replay_binding_required"] is True
+
+    def test_existing_policy_without_wat_fields_still_validates(self, tmp_path):
+        policy_path = tmp_path / "legacy_governance.json"
+        legacy_payload = gov_mod.GovernancePolicy().model_dump()
+        for key in ("wat", "psid", "shadow_validation", "revocation", "drift_scoring"):
+            legacy_payload.pop(key, None)
+        policy_path.write_text(json.dumps(legacy_payload), encoding="utf-8")
+
+        with patch.object(gov_mod, "_DEFAULT_POLICY_PATH", policy_path):
+            loaded = gov_mod.get_policy()
+            assert "wat" not in loaded
+
+            updated = gov_mod.update_policy(_approved({"fuji_rules": {"pii_check": False}}))
+
+        assert updated["fuji_rules"]["pii_check"] is False
+        assert updated["wat"]["enabled"] is False
+        assert updated["psid"]["display_length"] == 12
 
     def test_load_returns_defaults_when_file_missing(self, tmp_path, monkeypatch):
         """When governance file does not exist, return defaults."""


### PR DESCRIPTION
### Motivation
- Provide an additive foundation for Witness Attestation Token (WAT) configuration so policy history, validation and hot-reload can carry new WAT-related settings without changing runtime enforcement yet. 
- Ensure conservative, fail-closed defaults so enabling the features requires explicit operator action. 
- Keep existing decide/trust/replay/frontend behavior and validation/update/history plumbing intact to preserve backward compatibility. 
- Security note: these changes only add configuration and validation; they do not implement signing, verification, revocation enforcement, or runtime checks, so enabling `wat` or related flags will not by itself enforce attestation semantics and must not be treated as providing cryptographic guarantees yet.

### Description
- Added five new Pydantic models: `WatConfig`, `PsidConfig`, `ShadowValidationConfig`, `RevocationConfig`, and `DriftScoringConfig` with conservative defaults and validation constraints. 
- Extended `GovernancePolicy` to include `wat`, `psid`, `shadow_validation`, `revocation`, and `drift_scoring`, and registered each in `_NESTED_POLICY_MODELS` so `update_policy()` continues to deep-merge and validate nested patches. 
- Updated `openapi.yaml` to expose new component schemas and reference them from the `GovernancePolicy` schema for API contract completeness. 
- Added focused integration tests in `veritas_os/tests/integration/test_governance_api.py` that assert defaults, nested patching via `update_policy()`, policy-history persistence of new fields, and continued validation of legacy policies missing the new blocks.
- Changed files: `veritas_os/api/governance.py`, `openapi.yaml`, and `veritas_os/tests/integration/test_governance_api.py`.

### Testing
- Ran the focused integration tests with `pytest -q veritas_os/tests/integration/test_governance_api.py -k "pydantic_validation or patches_nested_wat_fields or preserves_new_wat_fields or existing_policy_without_wat_fields"` and observed `4 passed, 95 deselected`. 
- Tests added: `test_pydantic_validation` (new defaults check), `test_update_policy_patches_nested_wat_fields` (nested `wat` patching), `test_policy_history_preserves_new_wat_fields` (history preservation), and `test_existing_policy_without_wat_fields_still_validates` (legacy compatibility). 
- Backward-compatibility: existing governance files missing the new keys still load and validate because `GovernancePolicy.model_validate()` fills defaults; `update_policy()` and `get_policy_history()` continue to operate unchanged and now persist the expanded schema once updates occur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45e9c6d308326b94a0c8d8233f402)