### PR TITLE
Add WAT token canonicalization, claim builder, and signature verification

### DIFF
--- a/veritas_os/security/wat_token.py
+++ b/veritas_os/security/wat_token.py
@@ -1,0 +1,124 @@
+"""WAT token claim construction, canonicalization, and signature helpers.
+
+This module is intentionally narrow: it provides deterministic WAT claim
+construction/canonicalization and crypto sign/verify primitives only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+from uuid import uuid4
+
+from veritas_os.security.hash import canonical_json_dumps, sha256_hex
+from veritas_os.security.signing import Signer
+
+WAT_VERSION_V1 = "1"
+
+
+def canonicalize_wat_claims(claims: Mapping[str, Any]) -> bytes:
+    """Return deterministic canonical bytes for WAT claims."""
+    return canonical_json_dumps(claims).encode("utf-8")
+
+
+def make_psid_display(psid_full: str, display_length: int = 12) -> str:
+    """Create a display-only PSID preview.
+
+    Security:
+        ``psid_display`` is for UI/log display only and MUST NOT be used for
+        enforcement decisions. Always use ``psid_full`` for enforcement.
+    """
+    if display_length <= 0:
+        raise ValueError("display_length must be > 0")
+    return psid_full[:display_length]
+
+
+def compute_action_digest(action_payload: Mapping[str, Any]) -> str:
+    """Compute deterministic digest for action payload."""
+    return sha256_hex(canonical_json_dumps(action_payload))
+
+
+def compute_observable_digests(observable_refs: Sequence[object]) -> list[str]:
+    """Compute deterministic digest per observable reference."""
+    return [sha256_hex(canonical_json_dumps(ref)) for ref in observable_refs]
+
+
+def compute_observable_digest(observable_refs: Sequence[object]) -> str:
+    """Compute deterministic aggregate digest for observable references."""
+    per_ref_digests = compute_observable_digests(observable_refs)
+    return sha256_hex(canonical_json_dumps(per_ref_digests))
+
+
+def _build_signer_metadata(signer: Signer) -> dict[str, Any]:
+    return {
+        "signer_type": signer.signer_type,
+        "signer_key_id": signer.signer_key_id(),
+        "signer_key_version": signer.signer_key_version(),
+        "signature_algorithm": signer.signature_algorithm(),
+        "public_key_fingerprint": signer.public_key_fingerprint(),
+    }
+
+
+def build_wat_claims(
+    *,
+    version: str,
+    psid_full: str,
+    action_payload: Mapping[str, Any],
+    observable_refs: Sequence[object],
+    issuance_ts: int,
+    expiry_ts: int,
+    session_id: str,
+    nonce: str,
+    signer_metadata: Mapping[str, Any],
+    wat_id: str | None = None,
+    decision_reason: str | None = None,
+    action_summary: str | None = None,
+    resource_summary: str | None = None,
+    psid_display_length: int = 12,
+) -> dict[str, Any]:
+    """Build immutable WAT claims with required fields for v1."""
+    claims: dict[str, Any] = {
+        "wat_id": wat_id or str(uuid4()),
+        "version": version,
+        "psid_full": psid_full,
+        "psid_display": make_psid_display(psid_full, psid_display_length),
+        "action_digest": compute_action_digest(action_payload),
+        "observable_refs": list(observable_refs),
+        "observable_digest": compute_observable_digest(observable_refs),
+        "issuance_ts": issuance_ts,
+        "expiry_ts": expiry_ts,
+        "session_id": session_id,
+        "nonce": nonce,
+        "signer": dict(signer_metadata),
+    }
+
+    if decision_reason is not None:
+        claims["decision_reason"] = decision_reason
+    if action_summary is not None:
+        claims["action_summary"] = action_summary
+    if resource_summary is not None:
+        claims["resource_summary"] = resource_summary
+    return claims
+
+
+def sign_wat(claims: Mapping[str, Any], signer: Signer) -> dict[str, Any]:
+    """Sign canonicalized WAT claims using existing signer abstraction."""
+    canonical = canonicalize_wat_claims(claims)
+    payload_hash = sha256_hex(canonical)
+    signature = signer.sign_payload_hash(payload_hash)
+    return {
+        "claims": dict(claims),
+        "payload_hash": payload_hash,
+        "signature": signature,
+        "signer": _build_signer_metadata(signer),
+    }
+
+
+def verify_wat_signature(
+    claims: Mapping[str, Any],
+    signature_b64: str,
+    signer: Signer,
+) -> bool:
+    """Verify WAT claim signature using canonicalized claim hash."""
+    canonical = canonicalize_wat_claims(claims)
+    payload_hash = sha256_hex(canonical)
+    return signer.verify_payload_signature(payload_hash, signature_b64)

--- a/veritas_os/tests/test_wat_token.py
+++ b/veritas_os/tests/test_wat_token.py
@@ -1,0 +1,112 @@
+"""Unit tests for WAT token canonicalization and signatures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from veritas_os.security.signing import FileEd25519Signer
+from veritas_os.security.wat_token import (
+    WAT_VERSION_V1,
+    build_wat_claims,
+    canonicalize_wat_claims,
+    compute_observable_digest,
+    make_psid_display,
+    sign_wat,
+    verify_wat_signature,
+)
+
+
+def _make_signer(tmp_path: Path) -> FileEd25519Signer:
+    signer = FileEd25519Signer(
+        private_key_path=tmp_path / "keys" / "wat-private.key",
+        public_key_path=tmp_path / "keys" / "wat-public.key",
+    )
+    signer.ensure_key_material()
+    return signer
+
+
+def test_canonicalization_is_deterministic_for_same_claims() -> None:
+    claims = {"b": 2, "a": 1, "z": [3, 2, 1]}
+    assert canonicalize_wat_claims(claims) == canonicalize_wat_claims(claims)
+
+
+def test_canonicalization_same_claims_same_output() -> None:
+    claims = {"k1": "value", "k2": {"x": 1, "y": 2}}
+    first = canonicalize_wat_claims(claims)
+    second = canonicalize_wat_claims(claims)
+    assert first == second
+
+
+def test_canonicalization_ignores_key_order() -> None:
+    claims_a = {"a": 1, "b": 2, "c": {"x": 1, "y": 2}}
+    claims_b = {"c": {"y": 2, "x": 1}, "b": 2, "a": 1}
+    assert canonicalize_wat_claims(claims_a) == canonicalize_wat_claims(claims_b)
+
+
+def test_psid_display_truncation_preserves_psid_full() -> None:
+    full = "psid-prod-customer-00000123456789"
+    signer_meta = {
+        "signer_type": "file",
+        "signer_key_id": "k1",
+        "signer_key_version": "v1",
+        "signature_algorithm": "ed25519",
+    }
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        psid_full=full,
+        action_payload={"action": "allow", "resource": "acct:123"},
+        observable_refs=[{"trace_id": "t-1"}],
+        issuance_ts=1_712_000_000,
+        expiry_ts=1_712_000_600,
+        session_id="sess-1",
+        nonce="n-1",
+        signer_metadata=signer_meta,
+        psid_display_length=12,
+    )
+    assert claims["psid_full"] == full
+    assert claims["psid_display"] == full[:12]
+    assert make_psid_display(full, 12) == full[:12]
+
+
+def test_sign_and_verify_wat_signature_success(tmp_path: Path) -> None:
+    signer = _make_signer(tmp_path)
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        psid_full="psid-full-001",
+        action_payload={"action": "allow", "resource": "r-1"},
+        observable_refs=[{"obs": "A"}, {"obs": "B"}],
+        issuance_ts=1_712_000_000,
+        expiry_ts=1_712_000_600,
+        session_id="s-1",
+        nonce="n-1",
+        signer_metadata={"source": "unit-test"},
+    )
+    signed = sign_wat(claims, signer)
+    assert verify_wat_signature(claims, signed["signature"], signer)
+
+
+def test_verify_wat_signature_fails_for_tampered_claim(tmp_path: Path) -> None:
+    signer = _make_signer(tmp_path)
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        psid_full="psid-full-002",
+        action_payload={"action": "allow"},
+        observable_refs=[{"obs": "A"}],
+        issuance_ts=1_712_000_000,
+        expiry_ts=1_712_000_600,
+        session_id="s-2",
+        nonce="n-2",
+        signer_metadata={"source": "unit-test"},
+    )
+    signed = sign_wat(claims, signer)
+
+    tampered = dict(claims)
+    tampered["nonce"] = "n-tampered"
+    assert not verify_wat_signature(tampered, signed["signature"], signer)
+
+
+def test_observable_digest_is_deterministic() -> None:
+    observable_refs = [{"id": "1", "kind": "log"}, {"id": "2", "kind": "trace"}]
+    first = compute_observable_digest(observable_refs)
+    second = compute_observable_digest(observable_refs)
+    assert first == second


### PR DESCRIPTION
### Motivation
- Introduce a minimal, well-scoped WAT token module that provides deterministic claim canonicalization, immutable claim construction, and signing/verification primitives without adding API hooks or UI wiring.
- Ensure enforcement is based on full identifiers and digest checks by including both `psid_full` and a display-only `psid_display`, and by mandating observable digests for v1 tokens.
- Reuse the existing signer abstraction so key management and crypto responsibilities remain outside of WAT logic.
- Security warning: `psid_display` is display-only and must never be used for enforcement decisions.

### Description
- Added `veritas_os/security/wat_token.py` implementing `canonicalize_wat_claims`, `build_wat_claims`, `sign_wat`, `verify_wat_signature`, `make_psid_display`, `compute_action_digest`, `compute_observable_digest`, and `compute_observable_digests` with small typed functions and docstrings.
- WAT claim schema (v1) populated by `build_wat_claims` includes required fields `wat_id`, `version`, `psid_full`, `psid_display`, `action_digest`, `observable_refs`, `observable_digest`, `issuance_ts`, `expiry_ts`, `session_id`, `nonce`, and `signer` metadata, plus optional `decision_reason`, `action_summary`, and `resource_summary`.
- Signing design: compute a canonical byte representation via deterministic JSON, derive a SHA-256 hex `payload_hash`, and call the provided `Signer` protocol methods for `sign_payload_hash` / `verify_payload_signature`, while exposing signer metadata in the signed bundle; this keeps signer/key responsibilities external to WAT code.
- Added unit tests `veritas_os/tests/test_wat_token.py` covering canonicalization determinism, key-order invariance, PSID display truncation, sign/verify round-trip and tamper rejection, and observable digest determinism.

### Testing
- Ran `pytest -q veritas_os/tests/test_wat_token.py` and observed all tests pass: `7 passed`.
- Ran `ruff check veritas_os/security/wat_token.py veritas_os/tests/test_wat_token.py` and the linter returned no issues.
- Tests validate deterministic canonicalization behavior, successful sign/verify round-trip with `FileEd25519Signer`, and verification failure on tampered claims.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48b7a7f1483268280ce822e929f45)