### PR TITLE
Add strict local WAT admissibility verifier and unit tests

### DIFF
--- a/veritas_os/security/wat_verifier.py
+++ b/veritas_os/security/wat_verifier.py
@@ -1,0 +1,352 @@
+"""Strict local admissibility verifier for WAT tokens.
+
+This module is intentionally local and self-contained. It performs claim-level
+verification and returns a structured result contract that can be consumed by
+higher layers without wiring into runtime API routes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, MutableSet, Sequence
+
+from veritas_os.security.hash import canonical_json_dumps, sha256_hex
+from veritas_os.security.signing import Signer
+from veritas_os.security.wat_token import verify_wat_signature
+
+ValidationStatus = str
+AdmissibilityState = str
+
+_HEALTHY_THRESHOLD = 0.2
+_WARNING_THRESHOLD = 0.5
+
+_DEFAULT_WEIGHTS: dict[str, float] = {
+    "policy": 0.4,
+    "signature": 0.3,
+    "observable": 0.2,
+    "temporal": 0.1,
+}
+
+
+@dataclass(frozen=True)
+class DriftVector:
+    """Per-axis drift levels in the range ``[0.0, 1.0]``."""
+
+    policy_drift: float
+    signature_drift: float
+    observable_drift: float
+    temporal_drift: float
+
+
+@dataclass(frozen=True)
+class DriftScore:
+    """Weighted drift score and classification."""
+
+    score: float
+    classification: str
+
+
+@dataclass(frozen=True)
+class VerifierResult:
+    """Structured result contract for local WAT admissibility decisions."""
+
+    validation_status: ValidationStatus
+    admissibility_state: AdmissibilityState
+    failure_type: str | None
+    drift_vector: DriftVector
+    audit_event_ref: str
+    mission_control_event_name: str
+    operator_message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe dictionary representation."""
+        return asdict(self)
+
+
+def score_drift(
+    drift_vector: DriftVector,
+    weights: Mapping[str, float] | None = None,
+) -> DriftScore:
+    """Compute weighted drift score and severity classification."""
+    applied_weights = dict(_DEFAULT_WEIGHTS)
+    if weights:
+        applied_weights.update(weights)
+
+    score = (
+        drift_vector.policy_drift * applied_weights["policy"]
+        + drift_vector.signature_drift * applied_weights["signature"]
+        + drift_vector.observable_drift * applied_weights["observable"]
+        + drift_vector.temporal_drift * applied_weights["temporal"]
+    )
+
+    if score < _HEALTHY_THRESHOLD:
+        classification = "healthy"
+    elif score < _WARNING_THRESHOLD:
+        classification = "warning"
+    else:
+        classification = "critical"
+    return DriftScore(score=score, classification=classification)
+
+
+def resolve_admissibility_state(
+    *,
+    validation_status: ValidationStatus,
+    drift_score: DriftScore,
+    partial_allowed: bool,
+) -> AdmissibilityState:
+    """Resolve admissibility state from status and drift posture."""
+    if validation_status in {"invalid", "stale", "revoked_confirmed"}:
+        return "non_admissible"
+    if validation_status == "partial":
+        return "warning_only_shadow" if partial_allowed else "non_admissible"
+    if validation_status == "revoked_pending":
+        return "warning_only_shadow"
+    if drift_score.classification in {"warning", "critical"}:
+        return "warning_only_shadow"
+    return "admissible"
+
+
+def build_operator_message(result: VerifierResult) -> str:
+    """Build a concise human-readable operator message."""
+    if result.failure_type:
+        return (
+            f"WAT local verification status={result.validation_status}; "
+            f"failure={result.failure_type}; admissibility={result.admissibility_state}."
+        )
+    return (
+        f"WAT local verification status={result.validation_status}; "
+        f"admissibility={result.admissibility_state}."
+    )
+
+
+def _to_epoch(ts: Any) -> int | None:
+    if ts is None:
+        return None
+    if isinstance(ts, int):
+        return ts
+    if isinstance(ts, float):
+        return int(ts)
+    return int(str(ts))
+
+
+def _derive_revocation_status(revocation_state: Any) -> str:
+    if revocation_state is None:
+        return "active"
+    if isinstance(revocation_state, str):
+        return revocation_state
+    if isinstance(revocation_state, Mapping):
+        value = revocation_state.get("status")
+        if isinstance(value, str):
+            return value
+    return "active"
+
+
+def _is_partial_allowed(config: Mapping[str, Any], now_ts: int) -> bool:
+    observer_only_mode = bool(config.get("observer_only_mode", False))
+    if not observer_only_mode:
+        return False
+    warning_only_until = _to_epoch(config.get("warning_only_until"))
+    if warning_only_until is None:
+        return False
+    return now_ts <= warning_only_until
+
+
+def _verify_signature_local(
+    *,
+    claims: Mapping[str, Any],
+    signature_b64: str,
+    signer: Signer | None,
+    config: Mapping[str, Any],
+) -> bool:
+    verifier = config.get("signature_verifier")
+    if callable(verifier):
+        return bool(verifier(claims, signature_b64))
+    if signer is None:
+        return False
+    try:
+        return verify_wat_signature(claims, signature_b64, signer)
+    except Exception:
+        return False
+
+
+def _build_audit_event_ref(
+    *,
+    validation_status: str,
+    failure_type: str | None,
+    binding_key: str,
+) -> str:
+    event_digest = sha256_hex(
+        canonical_json_dumps(
+            {
+                "validation_status": validation_status,
+                "failure_type": failure_type,
+                "binding_key": binding_key,
+            }
+        )
+    )
+    return f"wat_local_verifier:{event_digest[:24]}"
+
+
+def validate_local(
+    *,
+    signed_wat: Mapping[str, Any],
+    psid_full_local: str,
+    action_digest_local: str,
+    observable_refs_local: Sequence[object] | None,
+    observable_digest_local: str,
+    issuance_ts_local: int | None,
+    expiry_ts_local: int | None,
+    execution_nonce: str,
+    session_id: str,
+    revocation_state: str | Mapping[str, Any] | None,
+    config: Mapping[str, Any] | None = None,
+    signer: Signer | None = None,
+    now_ts: int | None = None,
+    replay_cache: MutableSet[str] | None = None,
+) -> dict[str, Any]:
+    """Validate a signed WAT locally and return structured contract output.
+
+    Security warning:
+        This verifier enforces replay protection using
+        ``action_digest + nonce + session_id``. Callers should provide a durable
+        replay cache in production to avoid process-restart replay windows.
+    """
+    cfg = dict(config or {})
+    current_ts = now_ts if now_ts is not None else int(datetime.now(tz=timezone.utc).timestamp())
+
+    claims = signed_wat.get("claims") if isinstance(signed_wat, Mapping) else None
+    signature_b64 = signed_wat.get("signature") if isinstance(signed_wat, Mapping) else None
+    if not isinstance(claims, Mapping) or not isinstance(signature_b64, str):
+        drift_vector = DriftVector(0.0, 1.0, 0.0, 0.0)
+        result = VerifierResult(
+            validation_status="invalid",
+            admissibility_state="non_admissible",
+            failure_type="malformed_signed_wat",
+            drift_vector=drift_vector,
+            audit_event_ref=_build_audit_event_ref(
+                validation_status="invalid",
+                failure_type="malformed_signed_wat",
+                binding_key="malformed",
+            ),
+            mission_control_event_name="wat.local.invalid",
+            operator_message="WAT local verification status=invalid; "
+            "failure=malformed_signed_wat; admissibility=non_admissible.",
+        )
+        return result.to_dict()
+
+    claim_psid_full = str(claims.get("psid_full", ""))
+    claim_action_digest = str(claims.get("action_digest", ""))
+    claim_observable_digest = str(claims.get("observable_digest", ""))
+    claim_issuance_ts = _to_epoch(claims.get("issuance_ts"))
+    claim_expiry_ts = _to_epoch(claims.get("expiry_ts"))
+    claim_nonce = str(claims.get("nonce", ""))
+    claim_session_id = str(claims.get("session_id", ""))
+
+    binding_key = f"{claim_action_digest}:{execution_nonce}:{session_id}"
+    revocation_status = _derive_revocation_status(revocation_state)
+    partial_allowed = _is_partial_allowed(cfg, current_ts)
+
+    if revocation_status == "revoked_confirmed":
+        drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
+        status = "revoked_confirmed"
+        failure_type = "revoked_confirmed"
+    elif not _verify_signature_local(
+        claims=claims,
+        signature_b64=signature_b64,
+        signer=signer,
+        config=cfg,
+    ):
+        drift_vector = DriftVector(0.0, 1.0, 0.0, 0.0)
+        status = "invalid"
+        failure_type = "signature_invalid"
+    elif claim_psid_full != psid_full_local:
+        drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
+        status = "invalid"
+        failure_type = "psid_full_mismatch"
+    elif claim_action_digest != action_digest_local:
+        drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
+        status = "invalid"
+        failure_type = "action_digest_mismatch"
+    elif claim_observable_digest != observable_digest_local:
+        drift_vector = DriftVector(0.0, 0.0, 1.0, 0.0)
+        status = "invalid"
+        failure_type = "observable_digest_mismatch"
+    elif claim_nonce != execution_nonce or claim_session_id != session_id:
+        drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
+        status = "invalid"
+        failure_type = "replay_detected"
+    elif replay_cache is not None and binding_key in replay_cache:
+        drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
+        status = "invalid"
+        failure_type = "replay_detected"
+    elif claim_expiry_ts is not None and current_ts > claim_expiry_ts:
+        drift_vector = DriftVector(0.0, 0.0, 0.0, 1.0)
+        status = "stale"
+        failure_type = "expired_token"
+    elif revocation_status == "revoked_pending":
+        drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
+        status = "revoked_pending"
+        failure_type = "revocation_pending"
+    elif bool(cfg.get("allow_partial_validation", False)):
+        drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
+        status = "partial"
+        failure_type = "partial_validation_mode"
+    else:
+        temporal_drift = 0.0
+        failure_type = None
+        skew_tolerance = int(cfg.get("timestamp_skew_tolerance_seconds", 30))
+        if issuance_ts_local is not None and claim_issuance_ts is not None:
+            if abs(claim_issuance_ts - issuance_ts_local) > skew_tolerance:
+                temporal_drift = 1.0
+                failure_type = "timestamp_skew_exceeded"
+        if expiry_ts_local is not None and claim_expiry_ts is not None:
+            if abs(claim_expiry_ts - expiry_ts_local) > skew_tolerance:
+                temporal_drift = max(temporal_drift, 1.0)
+                failure_type = failure_type or "timestamp_skew_exceeded"
+        if temporal_drift == 0.0 and issuance_ts_local is not None and claim_issuance_ts is not None:
+            if claim_issuance_ts != issuance_ts_local:
+                temporal_drift = 0.4
+                failure_type = "timestamp_skew_within_tolerance"
+        drift_vector = DriftVector(0.0, 0.0, 0.0, temporal_drift)
+        status = "invalid" if failure_type == "timestamp_skew_exceeded" else "valid"
+
+    if replay_cache is not None and status in {"valid", "partial", "revoked_pending"}:
+        replay_cache.add(binding_key)
+
+    drift_score = score_drift(drift_vector, cfg.get("drift_weights"))
+    admissibility_state = resolve_admissibility_state(
+        validation_status=status,
+        drift_score=drift_score,
+        partial_allowed=partial_allowed,
+    )
+
+    if status == "partial" and not partial_allowed:
+        failure_type = "partial_validation_timebox_expired"
+
+    event_name = f"wat.local.{status}"
+    result = VerifierResult(
+        validation_status=status,
+        admissibility_state=admissibility_state,
+        failure_type=failure_type,
+        drift_vector=drift_vector,
+        audit_event_ref=_build_audit_event_ref(
+            validation_status=status,
+            failure_type=failure_type,
+            binding_key=binding_key,
+        ),
+        mission_control_event_name=event_name,
+        operator_message="",
+    )
+    operator_message = build_operator_message(result)
+    result = VerifierResult(
+        validation_status=result.validation_status,
+        admissibility_state=result.admissibility_state,
+        failure_type=result.failure_type,
+        drift_vector=result.drift_vector,
+        audit_event_ref=result.audit_event_ref,
+        mission_control_event_name=result.mission_control_event_name,
+        operator_message=operator_message,
+    )
+    _ = observable_refs_local
+    return result.to_dict()

--- a/veritas_os/tests/test_wat_verifier.py
+++ b/veritas_os/tests/test_wat_verifier.py
@@ -1,0 +1,304 @@
+"""Unit tests for strict local WAT admissibility verifier."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from veritas_os.security.signing import FileEd25519Signer
+from veritas_os.security.wat_token import WAT_VERSION_V1, build_wat_claims, sign_wat
+from veritas_os.security.wat_verifier import DriftVector, score_drift, validate_local
+
+
+def _make_signer(tmp_path: Path) -> FileEd25519Signer:
+    signer = FileEd25519Signer(
+        private_key_path=tmp_path / "keys" / "wat-private.key",
+        public_key_path=tmp_path / "keys" / "wat-public.key",
+    )
+    signer.ensure_key_material()
+    return signer
+
+
+def _signed_wat(tmp_path: Path) -> tuple[FileEd25519Signer, dict[str, object]]:
+    signer = _make_signer(tmp_path)
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        psid_full="psid-full-001",
+        action_payload={"action": "allow", "resource": "r-1"},
+        observable_refs=[{"obs": "A"}],
+        issuance_ts=1_712_000_000,
+        expiry_ts=1_712_000_600,
+        session_id="session-1",
+        nonce="nonce-1",
+        signer_metadata={"source": "unit-test"},
+    )
+    return signer, sign_wat(claims, signer)
+
+
+def test_validate_local_valid_path(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "valid"
+    assert result["admissibility_state"] == "admissible"
+
+
+def test_validate_local_signature_invalid(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    signed_wat["signature"] = "invalid-signature"
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "invalid"
+    assert result["failure_type"] == "signature_invalid"
+
+
+def test_validate_local_psid_mismatch(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="wrong-psid",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["failure_type"] == "psid_full_mismatch"
+
+
+def test_validate_local_action_digest_mismatch(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local="wrong-action-digest",
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["failure_type"] == "action_digest_mismatch"
+
+
+def test_validate_local_observable_digest_mismatch(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local="wrong-observable-digest",
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["failure_type"] == "observable_digest_mismatch"
+
+
+def test_validate_local_expired_token_returns_stale(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_601,
+    )
+    assert result["validation_status"] == "stale"
+
+
+def test_validate_local_replay_detected_by_binding_reuse(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    replay_cache: set[str] = set()
+    first = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+        replay_cache=replay_cache,
+    )
+    second = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+        replay_cache=replay_cache,
+    )
+    assert first["validation_status"] == "valid"
+    assert second["failure_type"] == "replay_detected"
+
+
+def test_validate_local_revoked_pending_is_warning_only(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="revoked_pending",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "revoked_pending"
+    assert result["admissibility_state"] == "warning_only_shadow"
+
+
+def test_validate_local_revoked_confirmed_is_hard_fail(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="revoked_confirmed",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "revoked_confirmed"
+    assert result["admissibility_state"] == "non_admissible"
+
+
+def test_validate_local_partial_requires_timebox(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    expired_timebox = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+        config={
+            "allow_partial_validation": True,
+            "observer_only_mode": True,
+            "warning_only_until": 1_712_000_050,
+        },
+    )
+    active_timebox = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+        config={
+            "allow_partial_validation": True,
+            "observer_only_mode": True,
+            "warning_only_until": 1_712_000_500,
+        },
+    )
+    assert expired_timebox["admissibility_state"] == "non_admissible"
+    assert active_timebox["admissibility_state"] == "warning_only_shadow"
+
+
+def test_psid_display_does_not_influence_enforcement(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    claims = dict(signed_wat["claims"])
+    claims["psid_display"] = "tampered-display"
+    result = validate_local(
+        signed_wat={"claims": claims, "signature": signed_wat["signature"]},
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "invalid"
+    assert result["failure_type"] == "signature_invalid"
+
+
+def test_drift_score_classification() -> None:
+    healthy = score_drift(DriftVector(0.1, 0.0, 0.0, 0.0))
+    warning = score_drift(DriftVector(0.0, 0.7, 0.0, 0.0))
+    critical = score_drift(DriftVector(1.0, 1.0, 1.0, 1.0))
+    assert healthy.classification == "healthy"
+    assert warning.classification == "warning"
+    assert critical.classification == "critical"


### PR DESCRIPTION
### Motivation
- Implement a strict, local, self-contained verifier for WAT tokens that performs claim-level checks and returns a structured result contract usable by higher layers without wiring into runtime API routes (not wired into `/v1/decide`).
- Provide a clear local enforcement surface that captures hard-fail vs soft-fail conditions, drift scoring, replay protection, and operator-facing messages so callers can act on a deterministic contract.

### Description
- Added `veritas_os/security/wat_verifier.py` implementing `validate_local(...)`, `score_drift(...)`, `resolve_admissibility_state(...)`, and `build_operator_message(...)` plus dataclass models `DriftVector`, `DriftScore`, and `VerifierResult`, and JSON-safe conversion via `to_dict`.
- Implemented default weighted drift scoring (`policy:0.4, signature:0.3, observable:0.2, temporal:0.1`) and threshold classification (`<0.2 healthy`, `>=0.2 and <0.5 warning`, `>=0.5 critical`).
- Enforced hard-fail conditions for `signature_invalid`, `psid_full_mismatch`, `action_digest_mismatch`, `observable_digest_mismatch`, `replay_detected` (binding uses `action_digest + nonce + session_id`), and `revoked_confirmed`, and soft-fail handling for `revoked_pending`, timestamp skew warnings, and partial validation gated by an explicit observer-only timebox (`observer_only_mode` + `warning_only_until`).
- Ensured `psid_display` is never used for enforcement, added audit event reference generation (`audit_event_ref`), mission control event naming, and composed human operator messages; added safe signature verification fallback and optional pluggable `signature_verifier` via `config`.
- Added unit tests in `veritas_os/tests/test_wat_verifier.py` covering valid and failure paths and included docstrings and security warning about replay cache persistence requirements.

### Testing
- Added `veritas_os/tests/test_wat_verifier.py` exercising: valid path, signature invalid, `psid_full` mismatch, `action_digest` mismatch, `observable_digest` mismatch, expired → `stale`, replay reuse detection, `revoked_pending` behavior, `revoked_confirmed` hard fail, partial validation timebox gating, `psid_display` non-influence, and drift score classification.
- Ran `pytest -q veritas_os/tests/test_wat_verifier.py veritas_os/tests/test_wat_token.py` and all tests passed (`19 passed`).
- Static sanity checks: module and tests compiled with `python -m py_compile` and unit tests exercised cryptographic verification via `FileEd25519Signer` in temporary key material.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e494b1085c8326ada6411b875d1b60)