### PR TITLE
Add WAT shadow audit event lane and API endpoints

### DIFF
--- a/frontend/app/api/veritas/[...path]/route-auth.test.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.test.ts
@@ -122,6 +122,18 @@ describe("matchPolicy", () => {
     expect(result).not.toBeNull();
   });
 
+  it("matches WAT read endpoint for viewer", () => {
+    const result = matchPolicy(["v1", "wat", "wat_123"], "GET");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toContain("viewer");
+  });
+
+  it("matches WAT mutate endpoint for operator/admin", () => {
+    const result = matchPolicy(["v1", "wat", "issue-shadow"], "POST");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toContain("operator");
+  });
+
   it("matches system halt for admin only", () => {
     const result = matchPolicy(["v1", "system", "halt"], "POST");
     expect(result).not.toBeNull();

--- a/frontend/app/api/veritas/[...path]/route-auth.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.ts
@@ -59,6 +59,31 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
     method: "GET",
     roles: ["viewer", "operator", "admin"],
   },
+  {
+    pathPattern: /^v1\/wat\/[^/]+$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
+  {
+    pathPattern: /^v1\/wat\/events$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
+  {
+    pathPattern: /^v1\/wat\/issue-shadow$/,
+    method: "POST",
+    roles: ["operator", "admin"],
+  },
+  {
+    pathPattern: /^v1\/wat\/validate-shadow$/,
+    method: "POST",
+    roles: ["operator", "admin"],
+  },
+  {
+    pathPattern: /^v1\/wat\/revocation\/[^/]+$/,
+    method: "POST",
+    roles: ["operator", "admin"],
+  },
 
   // Trust log chain (signed)
   {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1117,6 +1117,84 @@ components:
           maxLength: 200
           description: "消去を行うアクター名"
 
+    WatEvent:
+      type: object
+      required: [event_id, ts, lane, wat_id, event_type, actor, status]
+      properties:
+        event_id:
+          type: string
+        ts:
+          type: string
+          format: date-time
+        lane:
+          type: string
+          enum: ["wat_shadow"]
+        wat_id:
+          type: string
+        event_type:
+          type: string
+        actor:
+          type: string
+        status:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+        trustlog_anchor_ref:
+          type: object
+          additionalProperties: true
+
+    WatIssueShadowRequest:
+      type: object
+      required: [psid]
+      properties:
+        wat_id:
+          type: string
+        psid:
+          type: string
+        observable_digest:
+          type: string
+          nullable: true
+        ttl_seconds:
+          type: integer
+          minimum: 1
+          maximum: 86400
+          default: 300
+        metadata:
+          type: object
+          additionalProperties: true
+
+    WatValidateShadowRequest:
+      type: object
+      required: [wat_id]
+      properties:
+        wat_id:
+          type: string
+        outcome_event:
+          type: string
+          default: wat_validated
+        psid:
+          type: string
+          nullable: true
+        observable_digest:
+          type: string
+          nullable: true
+        details:
+          type: object
+          additionalProperties: true
+
+    WatRevocationRequest:
+      type: object
+      properties:
+        confirmed:
+          type: boolean
+          default: true
+        reason:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+
 security:
   - ApiKeyAuth: []
 
@@ -1478,6 +1556,112 @@ paths:
       responses:
         "200":
           description: PROV export payload
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+
+  /v1/wat/issue-shadow:
+    post:
+      summary: Persist shadow-only WAT issuance event
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WatIssueShadowRequest'
+      responses:
+        "200":
+          description: WAT shadow issuance recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+
+  /v1/wat/validate-shadow:
+    post:
+      summary: Persist shadow-only WAT validation event
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WatValidateShadowRequest'
+      responses:
+        "200":
+          description: WAT shadow validation recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+
+  /v1/wat/{wat_id}:
+    get:
+      summary: Get latest WAT event and timeline by WAT id
+      parameters:
+        - in: path
+          name: wat_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: WAT event summary
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+
+  /v1/wat/events:
+    get:
+      summary: List WAT shadow event lane records
+      parameters:
+        - in: query
+          name: wat_id
+          schema:
+            type: string
+        - in: query
+          name: event_type
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+      responses:
+        "200":
+          description: WAT event list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+
+  /v1/wat/revocation/{wat_id}:
+    post:
+      summary: Persist WAT revocation pending/confirmed shadow events
+      parameters:
+        - in: path
+          name: wat_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WatRevocationRequest'
+      responses:
+        "200":
+          description: WAT revocation events recorded
           content:
             application/json:
               schema:

--- a/tests/test_wat_api.py
+++ b/tests/test_wat_api.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from veritas_os.api.server import app
+from veritas_os.audit import wat_events
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    return {"X-API-Key": api_key}
+
+
+def _configure_auth(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "VERITAS_API_KEYS",
+        json.dumps(
+            [
+                {"key": "k-admin", "role": "admin"},
+                {"key": "k-operator", "role": "operator"},
+                {"key": "k-auditor", "role": "auditor"},
+            ]
+        ),
+    )
+
+
+def _configure_wat_store(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "wat_events_test.jsonl"
+    monkeypatch.setattr(wat_events, "WAT_EVENTS_JSONL", path)
+    monkeypatch.setattr(
+        wat_events,
+        "append_signed_decision",
+        lambda *_args, **_kwargs: {"decision_id": "stub", "payload_hash": "hash"},
+    )
+
+
+def test_issue_shadow_success(monkeypatch, tmp_path: Path) -> None:
+    _configure_auth(monkeypatch)
+    _configure_wat_store(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/wat/issue-shadow",
+        headers=_headers("k-operator"),
+        json={"psid": "psid-1", "observable_digest": "abc"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["event"]["event_type"] == "wat_issued"
+
+
+def test_validate_shadow_success(monkeypatch, tmp_path: Path) -> None:
+    _configure_auth(monkeypatch)
+    _configure_wat_store(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    issue = client.post(
+        "/v1/wat/issue-shadow",
+        headers=_headers("k-operator"),
+        json={"psid": "psid-2"},
+    ).json()
+    wat_id = issue["wat_id"]
+
+    response = client.post(
+        "/v1/wat/validate-shadow",
+        headers=_headers("k-operator"),
+        json={"wat_id": wat_id, "outcome_event": "wat_validated"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["event"]["event_type"] == "wat_validated"
+
+
+def test_get_wat_by_id(monkeypatch, tmp_path: Path) -> None:
+    _configure_auth(monkeypatch)
+    _configure_wat_store(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    issued = client.post(
+        "/v1/wat/issue-shadow",
+        headers=_headers("k-operator"),
+        json={"psid": "psid-3"},
+    ).json()
+
+    response = client.get(f"/v1/wat/{issued['wat_id']}", headers=_headers("k-auditor"))
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["wat_id"] == issued["wat_id"]
+    assert data["latest"]["event_type"] == "wat_issued"
+
+
+def test_list_wat_events(monkeypatch, tmp_path: Path) -> None:
+    _configure_auth(monkeypatch)
+    _configure_wat_store(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    for idx in range(2):
+        client.post(
+            "/v1/wat/issue-shadow",
+            headers=_headers("k-operator"),
+            json={"psid": f"psid-{idx}"},
+        )
+
+    response = client.get("/v1/wat/events?limit=5", headers=_headers("k-auditor"))
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["count"] >= 2
+
+
+def test_revoke_path(monkeypatch, tmp_path: Path) -> None:
+    _configure_auth(monkeypatch)
+    _configure_wat_store(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    issue = client.post(
+        "/v1/wat/issue-shadow",
+        headers=_headers("k-operator"),
+        json={"psid": "psid-r"},
+    ).json()
+
+    response = client.post(
+        f"/v1/wat/revocation/{issue['wat_id']}",
+        headers=_headers("k-operator"),
+        json={"confirmed": True, "reason": "manual"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pending"]["event_type"] == "wat_revocation_pending"
+    assert data["confirmed"]["event_type"] == "wat_revoked_confirmed"
+
+
+def test_auth_rbac_read_vs_mutation(monkeypatch, tmp_path: Path) -> None:
+    _configure_auth(monkeypatch)
+    _configure_wat_store(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    create = client.post(
+        "/v1/wat/issue-shadow",
+        headers=_headers("k-operator"),
+        json={"psid": "psid-auth"},
+    ).json()
+
+    read_response = client.get(f"/v1/wat/{create['wat_id']}", headers=_headers("k-auditor"))
+    mutate_response = client.post(
+        "/v1/wat/issue-shadow",
+        headers=_headers("k-auditor"),
+        json={"psid": "psid-blocked"},
+    )
+
+    assert read_response.status_code == 200
+    assert mutate_response.status_code == 403

--- a/veritas_os/api/routes_wat.py
+++ b/veritas_os/api/routes_wat.py
@@ -1,0 +1,185 @@
+"""WAT shadow issuance/validation/revocation API endpoints."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from veritas_os.api.auth import require_permission
+from veritas_os.api.rbac import Permission
+from veritas_os.audit.wat_events import (
+    SUPPORTED_WAT_EVENT_TYPES,
+    get_wat_event,
+    list_wat_events,
+    persist_wat_issuance_event,
+    persist_wat_replay_event,
+    persist_wat_revocation_event,
+    persist_wat_validation_event,
+)
+
+router = APIRouter()
+
+
+class WatIssueShadowRequest(BaseModel):
+    """Request body for shadow WAT issuance telemetry."""
+
+    wat_id: Optional[str] = None
+    psid: str = Field(min_length=1, max_length=500)
+    observable_digest: Optional[str] = Field(default=None, max_length=500)
+    ttl_seconds: int = Field(default=300, ge=1, le=86_400)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class WatValidateShadowRequest(BaseModel):
+    """Request body for shadow WAT validation telemetry."""
+
+    wat_id: str = Field(min_length=1, max_length=500)
+    outcome_event: str = Field(default="wat_validated")
+    psid: Optional[str] = Field(default=None, max_length=500)
+    observable_digest: Optional[str] = Field(default=None, max_length=500)
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+
+class WatRevocationRequest(BaseModel):
+    """Request body for WAT revocation transitions."""
+
+    confirmed: bool = True
+    reason: str = Field(default="", max_length=2000)
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+
+def _actor_from_request(request: Request) -> str:
+    """Derive stable actor label from request state set by RBAC dependency."""
+    role = getattr(getattr(request, "state", None), "rbac_role", None)
+    if isinstance(role, str) and role.strip():
+        return f"api:{role.strip()}"
+    return "api:unknown"
+
+
+@router.post(
+    "/v1/wat/issue-shadow",
+    dependencies=[Depends(require_permission(Permission.decide))],
+)
+def issue_shadow_wat(body: WatIssueShadowRequest, request: Request) -> Dict[str, Any]:
+    """Persist shadow-only WAT issuance telemetry."""
+    wat_id = body.wat_id or f"wat_{uuid4().hex}"
+    event = persist_wat_issuance_event(
+        wat_id=wat_id,
+        actor=_actor_from_request(request),
+        details={
+            "psid": body.psid,
+            "observable_digest": body.observable_digest,
+            "ttl_seconds": body.ttl_seconds,
+            "metadata": body.metadata,
+            "mode": "shadow",
+        },
+    )
+    return {"ok": True, "wat_id": wat_id, "event": event}
+
+
+@router.post(
+    "/v1/wat/validate-shadow",
+    dependencies=[Depends(require_permission(Permission.decide))],
+)
+def validate_shadow_wat(body: WatValidateShadowRequest, request: Request) -> Dict[str, Any]:
+    """Persist shadow-only WAT validation telemetry."""
+    if body.outcome_event == "wat_replay_suspected":
+        event = persist_wat_replay_event(
+            wat_id=body.wat_id,
+            actor=_actor_from_request(request),
+            details={
+                "psid": body.psid,
+                "observable_digest": body.observable_digest,
+                "mode": "shadow",
+                **body.details,
+            },
+        )
+        return {"ok": True, "wat_id": body.wat_id, "event": event}
+
+    if body.outcome_event not in SUPPORTED_WAT_EVENT_TYPES:
+        return JSONResponse(
+            status_code=422,
+            content={"ok": False, "error": "unsupported outcome_event"},
+        )
+
+    status = "ok" if body.outcome_event == "wat_validated" else "warning"
+    event = persist_wat_validation_event(
+        wat_id=body.wat_id,
+        actor=_actor_from_request(request),
+        event_type=body.outcome_event,
+        status=status,
+        details={
+            "psid": body.psid,
+            "observable_digest": body.observable_digest,
+            "mode": "shadow",
+            **body.details,
+        },
+    )
+    return {"ok": True, "wat_id": body.wat_id, "event": event}
+
+
+@router.get(
+    "/v1/wat/events",
+    dependencies=[Depends(require_permission(Permission.trust_log_read))],
+)
+def get_wat_events(
+    wat_id: Optional[str] = Query(default=None),
+    event_type: Optional[str] = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+) -> Dict[str, Any]:
+    """List WAT event lane records."""
+    events = list_wat_events(wat_id=wat_id, event_type=event_type, limit=limit)
+    return {"ok": True, "items": events, "count": len(events)}
+
+
+@router.get(
+    "/v1/wat/{wat_id}",
+    dependencies=[Depends(require_permission(Permission.trust_log_read))],
+)
+def get_wat_by_id(wat_id: str) -> Dict[str, Any]:
+    """Return latest WAT event and recent timeline for a WAT id."""
+    latest = get_wat_event(wat_id)
+    if latest is None:
+        return JSONResponse(status_code=404, content={"ok": False, "error": "wat_not_found"})
+
+    timeline = list_wat_events(wat_id=wat_id, limit=50)
+    return {
+        "ok": True,
+        "wat_id": wat_id,
+        "latest": latest,
+        "timeline": timeline,
+    }
+
+
+@router.post(
+    "/v1/wat/revocation/{wat_id}",
+    dependencies=[Depends(require_permission(Permission.decide))],
+)
+def revoke_wat(wat_id: str, body: WatRevocationRequest, request: Request) -> Dict[str, Any]:
+    """Persist shadow revocation events (pending + optional confirmed)."""
+    actor = _actor_from_request(request)
+    pending = persist_wat_revocation_event(
+        wat_id=wat_id,
+        actor=actor,
+        confirmed=False,
+        details={"mode": "shadow", "reason": body.reason, **body.details},
+    )
+
+    confirmed_event: Optional[Dict[str, Any]] = None
+    if body.confirmed:
+        confirmed_event = persist_wat_revocation_event(
+            wat_id=wat_id,
+            actor=actor,
+            confirmed=True,
+            details={"mode": "shadow", "reason": body.reason, **body.details},
+        )
+
+    return {
+        "ok": True,
+        "wat_id": wat_id,
+        "pending": pending,
+        "confirmed": confirmed_event,
+    }

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -895,6 +895,14 @@ from veritas_os.api.routes_system import (  # noqa: E402,F401 -- backward compat
     system_halt_status,
     compliance_deployment_readiness,
 )
+from veritas_os.api.routes_wat import router as _wat_router  # noqa: E402
+from veritas_os.api.routes_wat import (  # noqa: E402,F401 -- backward compat
+    issue_shadow_wat,
+    validate_shadow_wat,
+    get_wat_by_id,
+    get_wat_events,
+    revoke_wat,
+)
 
 # Include routers with appropriate auth dependencies.
 # Auth functions are defined above this point, so no circular import occurs.
@@ -905,6 +913,7 @@ app.include_router(_system_public_router)  # health, status, root — no auth
 app.include_router(_decide_router, dependencies=_auth_deps)
 app.include_router(_memory_router, dependencies=_auth_deps)
 app.include_router(_trust_router, dependencies=_auth_deps)
+app.include_router(_wat_router, dependencies=_auth_deps)
 app.include_router(_governance_router, dependencies=_gov_deps)
 app.include_router(_system_router, dependencies=[Depends(require_api_key)])
 app.include_router(_events_router, dependencies=[Depends(require_api_key_header_or_query)])

--- a/veritas_os/audit/wat_events.py
+++ b/veritas_os/audit/wat_events.py
@@ -1,0 +1,278 @@
+"""WAT shadow-lane audit event persistence helpers.
+
+This module provides first-class storage helpers for Witness Attestation Token
+(WAT) issue/validate/replay/revocation event telemetry.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from veritas_os.audit.trustlog_signed import append_signed_decision
+from veritas_os.logging.paths import LOG_DIR
+
+logger = logging.getLogger(__name__)
+
+WAT_EVENTS_JSONL = LOG_DIR / "wat_events.jsonl"
+_WAT_LOCK = threading.RLock()
+
+SUPPORTED_WAT_EVENT_TYPES: frozenset[str] = frozenset({
+    "wat_issued",
+    "wat_validated",
+    "wat_validation_failed",
+    "wat_psid_mismatch",
+    "wat_observable_missing",
+    "wat_observable_digest_mismatch",
+    "wat_signature_invalid",
+    "wat_replay_suspected",
+    "wat_revocation_pending",
+    "wat_revoked_confirmed",
+    "wat_partial_validation_warning",
+    "wat_partial_validation_blocked",
+})
+
+
+def _utc_now_iso_z() -> str:
+    """Return current UTC timestamp in RFC3339-like ``Z`` format."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _resolve_events_path(path: Optional[Path] = None) -> Path:
+    """Resolve WAT event lane storage path with optional env override."""
+    if path is not None:
+        return path
+    env_path = (os.getenv("VERITAS_WAT_EVENTS_PATH") or "").strip()
+    if env_path:
+        return Path(env_path).expanduser()
+    return WAT_EVENTS_JSONL
+
+
+def _load_wat_events(path: Optional[Path] = None) -> list[Dict[str, Any]]:
+    """Load WAT event lane entries from JSONL storage."""
+    events_path = _resolve_events_path(path)
+    if not events_path.exists():
+        return []
+
+    entries: list[Dict[str, Any]] = []
+    with events_path.open("r", encoding="utf-8") as file_obj:
+        for line in file_obj:
+            raw = line.strip()
+            if not raw:
+                continue
+            try:
+                row = json.loads(raw)
+                if isinstance(row, dict):
+                    entries.append(row)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed WAT event line")
+    return entries
+
+
+def _build_anchor_reference(event_payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Write a compact witness reference to signed TrustLog when available."""
+    try:
+        signed = append_signed_decision(event_payload, enable_artifact_ref=True)
+        return {
+            "trustlog_decision_id": signed.get("decision_id"),
+            "payload_hash": signed.get("payload_hash"),
+            "anchor_backend": signed.get("anchor_backend"),
+            "anchor_status": signed.get("anchor_status"),
+        }
+    except Exception as exc:  # pragma: no cover - best effort linkage
+        logger.warning("WAT event TrustLog anchor append failed: %s", exc)
+        return {"error": "anchor_append_failed"}
+
+
+def _persist_wat_event(
+    *,
+    wat_id: str,
+    event_type: str,
+    actor: str,
+    details: Optional[Dict[str, Any]] = None,
+    status: str = "ok",
+    path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Persist a WAT audit event record.
+
+    Args:
+        wat_id: Stable WAT identifier.
+        event_type: Event vocabulary item.
+        actor: Initiator identity.
+        details: Additional event metadata.
+        status: Event outcome status label.
+        path: Optional persistence path override for tests.
+    """
+    normalized_event_type = str(event_type or "").strip()
+    if normalized_event_type not in SUPPORTED_WAT_EVENT_TYPES:
+        raise ValueError(f"unsupported_wat_event_type: {normalized_event_type}")
+
+    record: Dict[str, Any] = {
+        "event_id": str(uuid.uuid4()),
+        "ts": _utc_now_iso_z(),
+        "lane": "wat_shadow",
+        "wat_id": str(wat_id).strip(),
+        "event_type": normalized_event_type,
+        "actor": str(actor or "system")[:500],
+        "status": str(status or "ok")[:50],
+        "details": details or {},
+    }
+    record["trustlog_anchor_ref"] = _build_anchor_reference(record)
+
+    events_path = _resolve_events_path(path)
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _WAT_LOCK:
+        with events_path.open("a", encoding="utf-8") as file_obj:
+            file_obj.write(json.dumps(record, ensure_ascii=False) + "\n")
+            file_obj.flush()
+            os.fsync(file_obj.fileno())
+
+    return record
+
+
+def persist_wat_issuance_event(
+    *,
+    wat_id: str,
+    actor: str,
+    details: Optional[Dict[str, Any]] = None,
+    path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Persist ``wat_issued`` event in the WAT shadow event lane."""
+    return _persist_wat_event(
+        wat_id=wat_id,
+        event_type="wat_issued",
+        actor=actor,
+        details=details,
+        path=path,
+    )
+
+
+def persist_wat_validation_event(
+    *,
+    wat_id: str,
+    actor: str,
+    event_type: str = "wat_validated",
+    details: Optional[Dict[str, Any]] = None,
+    status: str = "ok",
+    path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Persist WAT validation result events for shadow validation workflows."""
+    return _persist_wat_event(
+        wat_id=wat_id,
+        event_type=event_type,
+        actor=actor,
+        details=details,
+        status=status,
+        path=path,
+    )
+
+
+def persist_wat_replay_event(
+    *,
+    wat_id: str,
+    actor: str,
+    details: Optional[Dict[str, Any]] = None,
+    path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Persist ``wat_replay_suspected`` event."""
+    return _persist_wat_event(
+        wat_id=wat_id,
+        event_type="wat_replay_suspected",
+        actor=actor,
+        details=details,
+        status="warning",
+        path=path,
+    )
+
+
+def persist_wat_revocation_event(
+    *,
+    wat_id: str,
+    actor: str,
+    confirmed: bool,
+    details: Optional[Dict[str, Any]] = None,
+    path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Persist WAT revocation transition event."""
+    return _persist_wat_event(
+        wat_id=wat_id,
+        event_type="wat_revoked_confirmed" if confirmed else "wat_revocation_pending",
+        actor=actor,
+        details=details,
+        status="ok" if confirmed else "pending",
+        path=path,
+    )
+
+
+def get_wat_event(wat_id: str, *, path: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    """Return the latest event for a WAT id, if present."""
+    target = str(wat_id or "").strip()
+    if not target:
+        return None
+    with _WAT_LOCK:
+        events = _load_wat_events(path)
+    for event in reversed(events):
+        if str(event.get("wat_id", "")).strip() == target:
+            return event
+    return None
+
+
+def list_wat_events(
+    *,
+    wat_id: Optional[str] = None,
+    event_type: Optional[str] = None,
+    limit: int = 100,
+    path: Optional[Path] = None,
+) -> list[Dict[str, Any]]:
+    """List WAT event lane entries with optional filters."""
+    safe_limit = max(1, min(int(limit), 500))
+    with _WAT_LOCK:
+        events = _load_wat_events(path)
+
+    filtered = events
+    if wat_id:
+        needle = str(wat_id).strip()
+        filtered = [item for item in filtered if str(item.get("wat_id", "")).strip() == needle]
+    if event_type:
+        evt = str(event_type).strip()
+        filtered = [item for item in filtered if str(item.get("event_type", "")).strip() == evt]
+
+    return list(reversed(filtered))[:safe_limit]
+
+
+def prune_wat_events(*, retention_days: int = 90, path: Optional[Path] = None) -> int:
+    """Delete old WAT events beyond retention period and return deleted count."""
+    days = max(1, min(int(retention_days), 3650))
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    events_path = _resolve_events_path(path)
+    with _WAT_LOCK:
+        events = _load_wat_events(events_path)
+        kept: list[Dict[str, Any]] = []
+        deleted = 0
+        for row in events:
+            timestamp = str(row.get("ts") or "")
+            try:
+                parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            except ValueError:
+                kept.append(row)
+                continue
+            if parsed < cutoff:
+                deleted += 1
+            else:
+                kept.append(row)
+
+        events_path.parent.mkdir(parents=True, exist_ok=True)
+        with events_path.open("w", encoding="utf-8") as file_obj:
+            for row in kept:
+                file_obj.write(json.dumps(row, ensure_ascii=False) + "\n")
+            file_obj.flush()
+            os.fsync(file_obj.fileno())
+
+    return deleted


### PR DESCRIPTION
### Motivation
- WAT（Witness Attestation Token）の発行/検証/リプレイ/失効イベントを専用の shadow レーンで first-class に永続化し、監査・運用観測を容易にするために専用 helpers と API を追加した。\n- `/v1/decide` への自動 hook は追加せず、まずは observer/shadow 名称で明示的に telemetry を収集する設計にしている。\n- セキュリティ注意: `validate-shadow` は外部入力で `outcome_event` を受け取るため、運用では受信元を内部API/信頼境界に限定することを推奨する（現在は語彙制約のみ実装、fail-closed の TrustLog アンカーは行わない）。

### Description
- 追加/変更ファイル: `veritas_os/audit/wat_events.py`（新規）、`veritas_os/api/routes_wat.py`（新規）、`veritas_os/api/server.py`（router 登録を追加）、`openapi.yaml`（WAT スキーマとパスを追加）、`frontend/app/api/veritas/[...path]/route-auth.ts`（BFF パスマッピング追加）、`frontend/app/api/veritas/[...path]/route-auth.test.ts`（テスト追加）、`tests/test_wat_api.py`（API テスト追加）。
- 主要技術変更: WAT イベント永続化 helpers を実装（`persist_wat_issuance_event`, `persist_wat_validation_event`, `persist_wat_replay_event`, `persist_wat_revocation_event`, `get_wat_event`, `list_wat_events`, `prune_wat_events`）し、イベントは `wat_events.jsonl`（環境変数によるオーバーライド可）へ append + fsync で耐久的に書き込む実装。\n- TrustLog 連携: 各イベントに対して best-effort で `trustlog_anchor_ref` を付与するため、既存の署名 TrustLog へ軽量なアンカー参照を残す（失敗しても shadow 書き込みは継続）。\n- API/認可: 新規ルータで以下のパスを追加し、mutation は `Permission.decide`、read は `Permission.trust_log_read` を使用して RBAC を分離。 追加 API: `POST /v1/wat/issue-shadow`, `POST /v1/wat/validate-shadow`, `GET /v1/wat/{wat_id}`, `GET /v1/wat/events`, `POST /v1/wat/revocation/{wat_id}`。\n- OpenAPI とフロント BFF のパス許可マトリクスを更新して、フロント側ポリシーでも読み書きの役割分離を反映した。

### Testing
- 自動テスト: `pytest -q tests/test_wat_api.py` を追加し実行して **6 passed**（`tests/test_wat_api.py` にて issue/validate/get/list/revoke と RBAC 分離を検証）。
- 追加の検証: `python -m compileall veritas_os/audit/wat_events.py veritas_os/api/routes_wat.py` は成功。\n- フロントテスト: `frontend/app/api/veritas/[...path]/route-auth.test.ts` を更新済みだが、この実行環境では `vitest` が見つからずフロント側テストは実行できなかった（環境依存）。
- テストファイル: `tests/test_wat_api.py`（新規）を追加、ユニット/API レベルで動作確認済み。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49b7af4288326a4e916ecd9d8c724)