### PR TITLE
Fix WAT shadow decide hook to use dict-based governance policy access

### DIFF
--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -127,6 +127,14 @@ def _coerce_warning_only_until_epoch(value: Any) -> int | None:
     return None
 
 
+def _policy_section(policy: Dict[str, Any], key: str) -> Dict[str, Any]:
+    """Return a policy subsection as dict, falling back to empty mapping."""
+    section = policy.get(key)
+    if isinstance(section, dict):
+        return section
+    return {}
+
+
 def _run_wat_shadow_observer(
     *,
     srv: Any,
@@ -143,16 +151,19 @@ def _run_wat_shadow_observer(
     except Exception:
         logger.debug("WAT shadow policy load failed", exc_info=True)
         return None
-
-    wat_cfg = getattr(policy, "wat", None)
-    if wat_cfg is None or not bool(getattr(wat_cfg, "enabled", False)):
-        return None
-    if str(getattr(wat_cfg, "issuance_mode", "shadow_only")) != "shadow_only":
+    if not isinstance(policy, dict):
         return None
 
-    psid_cfg = getattr(policy, "psid", None)
-    shadow_cfg = getattr(policy, "shadow_validation", None)
-    revocation_cfg = getattr(policy, "revocation", None)
+    wat_cfg = _policy_section(policy, "wat")
+    if not bool(wat_cfg.get("enabled", False)):
+        return None
+    if str(wat_cfg.get("issuance_mode", "shadow_only")) != "shadow_only":
+        return None
+
+    psid_cfg = _policy_section(policy, "psid")
+    shadow_cfg = _policy_section(policy, "shadow_validation")
+    revocation_cfg = _policy_section(policy, "revocation")
+    _policy_section(policy, "drift_scoring")
     request_id = str(coerced.get("request_id") or "")
     query = str(getattr(req, "query", "") or coerced.get("query") or "")
     candidate_action = _resolve_candidate_action(coerced)
@@ -163,7 +174,7 @@ def _run_wat_shadow_observer(
     )
     psid_display = make_psid_display(
         psid_full,
-        display_length=int(getattr(psid_cfg, "display_length", 12)),
+        display_length=int(psid_cfg.get("display_length", 12)),
     )
 
     observables = _build_shadow_observables(coerced)
@@ -171,7 +182,7 @@ def _run_wat_shadow_observer(
     action_digest = compute_action_digest(candidate_action)
     aggregate_observable_digest = compute_observable_digest(observables)
     now_ts = int(time.time())
-    ttl = int(getattr(wat_cfg, "default_ttl_seconds", 300))
+    ttl = int(wat_cfg.get("default_ttl_seconds", 300))
     expiry_ts = now_ts + max(1, ttl)
     wat_id = f"wat_{uuid4().hex}"
 
@@ -215,16 +226,17 @@ def _run_wat_shadow_observer(
         expiry_ts_local=expiry_ts,
         execution_nonce=request_id or "unknown-request",
         session_id=request_id or "unknown-session",
-        revocation_state="revoked_pending" if bool(getattr(revocation_cfg, "degrade_on_pending", True)) else "active",
+        revocation_state="revoked_pending" if bool(revocation_cfg.get("degrade_on_pending", True)) else "active",
         config={
             "observer_only_mode": True,
             "allow_partial_validation": False,
             "timestamp_skew_tolerance_seconds": int(
-                getattr(shadow_cfg, "timestamp_skew_tolerance_seconds", 5)
+                shadow_cfg.get("timestamp_skew_tolerance_seconds", 5)
             ),
             "warning_only_until": _coerce_warning_only_until_epoch(
-                getattr(shadow_cfg, "warning_only_until", None)
+                shadow_cfg.get("warning_only_until")
             ),
+            "replay_binding_required": bool(shadow_cfg.get("replay_binding_required", False)),
             "signature_verifier": lambda _claims, _signature: True,
         },
         replay_cache=replay_cache,
@@ -275,7 +287,7 @@ def _run_wat_shadow_observer(
         "admissibility_state": verifier_result.get("admissibility_state"),
         "drift_vector": drift_vector,
         "replay_status": replay_status,
-        "revocation_status": "revoked_pending" if bool(getattr(revocation_cfg, "degrade_on_pending", True)) else "active",
+        "revocation_status": "revoked_pending" if bool(revocation_cfg.get("degrade_on_pending", True)) else "active",
         "integrity_summary": integrity_summary,
         "issue_event_id": issue_event.get("event_id"),
         "validation_event_id": persisted_validation.get("event_id"),

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -966,6 +966,11 @@ def test_decide_wat_shadow_disabled_keeps_response_shape(monkeypatch):
 
     monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
     monkeypatch.setattr(routes_decide, "get_policy", server.get_policy)
+    monkeypatch.setattr(
+        routes_decide,
+        "persist_wat_issuance_event",
+        lambda **_kwargs: pytest.fail("shadow hook should not run when WAT is disabled"),
+    )
 
     response = client.post(
         "/v1/decide",
@@ -997,14 +1002,20 @@ def test_decide_wat_shadow_enabled_emits_events_without_mutating_action(monkeypa
                 "selected_option": {"title": "Ship"},
             }
 
-    class _Policy:
-        wat = SimpleNamespace(enabled=True, issuance_mode="shadow_only", default_ttl_seconds=60)
-        psid = SimpleNamespace(display_length=10)
-        shadow_validation = SimpleNamespace(timestamp_skew_tolerance_seconds=5, warning_only_until=None)
-        revocation = SimpleNamespace(degrade_on_pending=False)
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 10},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": False},
+        "drift_scoring": {},
+    }
 
     monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
-    monkeypatch.setattr(routes_decide, "get_policy", lambda: _Policy())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
     monkeypatch.setattr(
         routes_decide,
         "persist_wat_issuance_event",
@@ -1056,14 +1067,20 @@ def test_decide_wat_shadow_validation_failure_does_not_change_decision(monkeypat
                 "result": "ok",
             }
 
-    class _Policy:
-        wat = SimpleNamespace(enabled=True, issuance_mode="shadow_only", default_ttl_seconds=60)
-        psid = SimpleNamespace(display_length=12)
-        shadow_validation = SimpleNamespace(timestamp_skew_tolerance_seconds=5, warning_only_until=None)
-        revocation = SimpleNamespace(degrade_on_pending=False)
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": False},
+        "drift_scoring": {},
+    }
 
     monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
-    monkeypatch.setattr(routes_decide, "get_policy", lambda: _Policy())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
     monkeypatch.setattr(
         routes_decide,
         "validate_local",
@@ -1103,14 +1120,20 @@ def test_decide_wat_shadow_pointer_missing_digest_alive(monkeypatch):
                 "trust_log": {"event": "no-pointers"},
             }
 
-    class _Policy:
-        wat = SimpleNamespace(enabled=True, issuance_mode="shadow_only", default_ttl_seconds=60)
-        psid = SimpleNamespace(display_length=12)
-        shadow_validation = SimpleNamespace(timestamp_skew_tolerance_seconds=5, warning_only_until=None)
-        revocation = SimpleNamespace(degrade_on_pending=False)
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": False},
+        "drift_scoring": {},
+    }
 
     monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
-    monkeypatch.setattr(routes_decide, "get_policy", lambda: _Policy())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
 
     response = client.post(
         "/v1/decide",
@@ -1139,15 +1162,21 @@ def test_decide_wat_shadow_replay_suspected_is_surfaced(monkeypatch):
                 "result": "ok",
             }
 
-    class _Policy:
-        wat = SimpleNamespace(enabled=True, issuance_mode="shadow_only", default_ttl_seconds=60)
-        psid = SimpleNamespace(display_length=12)
-        shadow_validation = SimpleNamespace(timestamp_skew_tolerance_seconds=5, warning_only_until=None)
-        revocation = SimpleNamespace(degrade_on_pending=False)
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": False},
+        "drift_scoring": {},
+    }
 
     replay_events = []
     monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
-    monkeypatch.setattr(routes_decide, "get_policy", lambda: _Policy())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
     monkeypatch.setattr(
         routes_decide,
         "validate_local",
@@ -1173,6 +1202,53 @@ def test_decide_wat_shadow_replay_suspected_is_surfaced(monkeypatch):
     wat_shadow = response.json().get("meta", {}).get("wat_shadow", {})
     assert wat_shadow.get("replay_status") == "suspected"
     assert replay_events
+
+
+def test_decide_wat_shadow_missing_nested_config_uses_conservative_defaults(monkeypatch):
+    """Missing nested config must still keep shadow observer path stable."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            return {
+                "ok": True,
+                "request_id": "rid-defaults",
+                "query": req.query,
+                "decision": "allow",
+                "business_decision": "APPROVE",
+                "result": "ok",
+            }
+
+    captured_validate_kwargs = {}
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: {"wat": {"enabled": True}})
+    monkeypatch.setattr(
+        routes_decide,
+        "validate_local",
+        lambda **kwargs: captured_validate_kwargs.update(kwargs) or {
+            "validation_status": "valid",
+            "admissibility_state": "warning_only_shadow",
+            "failure_type": "",
+            "drift_vector": {},
+        },
+    )
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["decision"] == "allow"
+    assert payload["business_decision"] == "APPROVE"
+    wat_shadow = payload.get("meta", {}).get("wat_shadow", {})
+    assert wat_shadow.get("revocation_status") == "revoked_pending"
+    validate_config = captured_validate_kwargs.get("config", {})
+    assert validate_config.get("timestamp_skew_tolerance_seconds") == 5
+    assert validate_config.get("warning_only_until") is None
+    assert validate_config.get("replay_binding_required") is False
 
 
 def test_fuji_validate_uses_validate_action(monkeypatch):


### PR DESCRIPTION
### Motivation
- `get_policy()` returns a `Dict[str, Any]` but `_run_wat_shadow_observer()` treated it like an object and used `getattr()`, which can break WAT enablement and config reads. 
- The highest priority is ensuring the WAT shadow path actually activates when the governance policy enables it, and to make policy reads robust to missing nested sections. 

### Description
- Added a small helper ` _policy_section(policy: Dict[str, Any], key: str) -> Dict[str, Any]` that safely returns a nested policy section as a dict or `{}` when missing. 
- Guarded early with `if not isinstance(policy, dict): return None` and replaced all `getattr(policy, ...)` and nested `getattr(...)` reads with dict-based access using `.get(...)` and the helper. 
- Switched reads for the following sections to dict access and applied conservative defaults when keys are missing: `wat`, `psid`, `shadow_validation`, `revocation`, and `drift_scoring`, including `issuance_mode`, `default_ttl_seconds`, `display_length`, `timestamp_skew_tolerance_seconds`, `warning_only_until`, `replay_binding_required`, and `degrade_on_pending`. 
- Preserved observer-only semantics so the shadow hook is additive-only (does not mutate production `/v1/decide` decision) and retained event publishing and replay/validation handling. 
- Updated unit tests to use dict-shaped `policy` fixtures and added a test covering missing nested config fallback to conservative defaults; modified tests in `veritas_os/tests/unit/test_server_api.py` to validate the new dict-based behavior. 

### Testing
- Ran a focused unit test selection with `pytest -q veritas_os/tests/unit/test_server_api.py -k "wat_shadow_disabled_keeps_response_shape or wat_shadow_enabled_emits_events_without_mutating_action or wat_shadow_validation_failure_does_not_change_decision or wat_shadow_pointer_missing_digest_alive or wat_shadow_replay_suspected_is_surfaced or wat_shadow_missing_nested_config_uses_conservative_defaults"`, which resulted in `6 passed, 306 deselected`. 
- Tests exercise: (1) WAT disabled keeps response shape and does not run the shadow hook, (2) WAT enabled with `issuance_mode=shadow_only` runs shadow observer and emits events without changing the decision, (3) validation failure and replay-suspected paths remain observer-only, and (4) missing nested config uses conservative defaults and does not break the decide path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e31b60c08326bb0f1c25d5e4aa82)