### PR TITLE
fix(fuji): make FUJI gate fail-closed on internal exceptions

### DIFF
--- a/veritas_os/core/kernel_qa.py
+++ b/veritas_os/core/kernel_qa.py
@@ -15,6 +15,7 @@ kernel.py は decision 本体、pipeline.py はオーケストレーションを
 """
 from __future__ import annotations
 
+import logging
 import re
 import uuid
 from datetime import datetime, timezone
@@ -23,6 +24,8 @@ from typing import Any, Dict, List, Optional
 from . import adapt
 from . import fuji as fuji_core
 from .utils import _safe_float
+
+logger = logging.getLogger(__name__)
 
 
 # ============================================================
@@ -430,18 +433,31 @@ def handle_knowledge_qa(
             alternatives=[chosen],
         )
     except Exception as e:
+        # Fail-closed: FUJI Gate exceptions MUST produce a rejection with
+        # maximum risk. Silent pass-through would allow unsafe outputs to
+        # bypass the safety gate (CLAUDE.md §4.2).
+        logger.error(
+            "FUJI gate (knowledge QA) failed, defaulting to deny: %s",
+            repr(e),
+            exc_info=True,
+        )
         fuji_result = {
-            "status": "allow",
-            "decision_status": "allow",
-            "rejection_reason": None,
+            "status": "deny",
+            "decision_status": "deny",
+            "rejection_reason": f"fuji_internal_error:{type(e).__name__}",
             "reasons": [f"fuji_error:{repr(e)[:80]}"],
-            "violations": [],
-            "risk": 0.05,
+            "violations": ["FUJI_INTERNAL_ERROR"],
+            "risk": 1.0,
             "checks": [],
-            "guidance": None,
+            "guidance": "FUJI safety gate raised an internal exception; "
+            "failing closed per safety policy.",
             "modifications": [],
             "redactions": [],
             "safe_instructions": [],
+            "meta": {
+                "fuji_internal_error": True,
+                "exception_type": type(e).__name__,
+            },
         }
 
     gate = {

--- a/veritas_os/core/kernel_stages.py
+++ b/veritas_os/core/kernel_stages.py
@@ -522,19 +522,27 @@ def run_fuji_gate(
         return fuji_result
 
     except Exception as e:
-        log.error("FUJI Gate failed: %s", e)
+        # Fail-closed: FUJI Gate exceptions MUST produce a rejection with
+        # maximum risk. Silent pass-through would allow unsafe outputs to
+        # bypass the safety gate (CLAUDE.md §4.2).
+        log.error("FUJI Gate failed (fail-closed): %s", e, exc_info=True)
         return {
-            "status": "allow",
-            "decision_status": "allow",
-            "rejection_reason": None,
+            "status": "deny",
+            "decision_status": "deny",
+            "rejection_reason": f"fuji_internal_error:{type(e).__name__}",
             "reasons": [f"fuji_error:{repr(e)[:80]}"],
-            "violations": [],
-            "risk": 0.05,
+            "violations": ["FUJI_INTERNAL_ERROR"],
+            "risk": 1.0,
             "checks": [],
-            "guidance": None,
+            "guidance": "FUJI safety gate raised an internal exception; "
+            "failing closed per safety policy.",
             "modifications": [],
             "redactions": [],
             "safe_instructions": [],
+            "meta": {
+                "fuji_internal_error": True,
+                "exception_type": type(e).__name__,
+            },
         }
 
 

--- a/veritas_os/tests/unit/test_kernel_decide.py
+++ b/veritas_os/tests/unit/test_kernel_decide.py
@@ -1159,15 +1159,13 @@ class TestRunFujiGate:
         assert "risk" in result
         assert "violations" in result
 
-    def test_handles_fuji_error(self):
-        """FUJI エラー時にフォールバックが動作するか"""
+    def test_handles_fuji_error_fail_closed(self):
+        """FUJI 例外時に fail-closed で拒否を返すか (CLAUDE.md §4.2)"""
         from veritas_os.core.kernel_stages import run_fuji_gate
 
-        # fuji モジュールを直接パッチ
         with patch("veritas_os.core.fuji.evaluate") as mock_evaluate:
-            mock_evaluate.side_effect = Exception("FUJI error")
+            mock_evaluate.side_effect = RuntimeError("FUJI error")
 
-            # エラーでもクラッシュせずに結果を返す
             result = run_fuji_gate(
                 query="test",
                 context={"user_id": "test"},
@@ -1175,9 +1173,35 @@ class TestRunFujiGate:
                 alternatives=[],
             )
 
-            # エラー時は allow で低リスクを返す
-            assert result["status"] == "allow"
-            assert result["risk"] == 0.05
+            # Fail-closed: 例外発生時は必ず deny + risk=1.0
+            assert result["status"] == "deny"
+            assert result["decision_status"] == "deny"
+            assert result["risk"] == 1.0
+            assert result["rejection_reason"] is not None
+            assert "RuntimeError" in result["rejection_reason"]
+            assert "FUJI_INTERNAL_ERROR" in result["violations"]
+            assert result.get("meta", {}).get("fuji_internal_error") is True
+
+    def test_fail_closed_on_generic_exception(self):
+        """任意の Exception サブクラスでも fail-closed になるか"""
+        from veritas_os.core.kernel_stages import run_fuji_gate
+
+        class _CustomErr(Exception):
+            pass
+
+        with patch("veritas_os.core.fuji.evaluate") as mock_evaluate:
+            mock_evaluate.side_effect = _CustomErr("boom")
+
+            result = run_fuji_gate(
+                query="test",
+                context={"user_id": "test"},
+                evidence=[],
+                alternatives=[],
+            )
+
+            assert result["status"] == "deny"
+            assert result["decision_status"] == "deny"
+            assert result["risk"] == 1.0
 
 
 # =============================================================================
@@ -1639,8 +1663,8 @@ class TestRunFujiGateFullExecution:
         mock_evaluate.assert_called_once()
 
     @patch("veritas_os.core.fuji.evaluate")
-    def test_fuji_evaluate_exception_returns_allow(self, mock_evaluate):
-        """fuji.evaluate raises → fallback allow result."""
+    def test_fuji_evaluate_exception_fail_closed(self, mock_evaluate):
+        """fuji.evaluate raises → fail-closed deny (CLAUDE.md §4.2)."""
         from veritas_os.core import kernel_stages
 
         mock_evaluate.side_effect = Exception("fuji crash")
@@ -1652,8 +1676,11 @@ class TestRunFujiGateFullExecution:
             alternatives=[],
         )
 
-        assert result["status"] == "allow"
-        assert result["risk"] == 0.05
+        assert result["status"] == "deny"
+        assert result["decision_status"] == "deny"
+        assert result["risk"] == 1.0
+        assert result["rejection_reason"] is not None
+        assert "FUJI_INTERNAL_ERROR" in result["violations"]
         assert any("fuji_error" in r for r in result["reasons"])
 
 


### PR DESCRIPTION
The `run_fuji_gate` helper in `kernel_stages.py` and the knowledge-QA
fallback in `kernel_qa.py` previously returned `status="allow"` with
`risk=0.05` when `fuji_core.evaluate` raised. This violates the
fail-closed contract in CLAUDE.md §4.2: "ALL exceptions → status=rejected,
risk=1.0. Never silently pass."

This change makes both handlers return `status="deny"` /
`decision_status="deny"` / `risk=1.0` with an explicit
`rejection_reason`, `FUJI_INTERNAL_ERROR` violation and
`meta.fuji_internal_error=True`, matching the canonical rejection
shape produced by `fuji.evaluate()` itself.

Regression tests in `test_kernel_decide.py` are updated to assert the
fail-closed contract; a second test verifies that arbitrary Exception
subclasses also trigger deny.

https://claude.ai/code/session_014rv8Fh3ZUDX1u1xN6iFgSc
Signed-off-by: Claude <noreply@anthropic.com>