### PR TITLE
Wire decide shadow WAT to real signing and strict local verification

### DIFF
--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import time
+from pathlib import Path
 from typing import Any, Dict
 from uuid import uuid4
 
@@ -28,12 +29,17 @@ from veritas_os.audit.wat_events import (
     persist_wat_validation_event,
 )
 from veritas_os.security.wat_token import (
+    WAT_VERSION_V1,
+    build_wat_claims,
     compute_action_digest,
     compute_observable_digests,
     compute_observable_digest,
     make_psid_display,
+    sign_wat,
 )
 from veritas_os.security.wat_verifier import validate_local
+from veritas_os.security.signing import Signer, build_trustlog_signer
+from veritas_os.logging.paths import LOG_DIR
 from veritas_os.api.utils import (
     _classify_decide_failure,
     _coerce_decide_payload,
@@ -135,6 +141,32 @@ def _policy_section(policy: Dict[str, Any], key: str) -> Dict[str, Any]:
     return {}
 
 
+
+
+def _build_wat_signer_metadata(signer: Signer) -> Dict[str, Any]:
+    """Build normalized signer metadata embedded into WAT claims."""
+    return {
+        "signer_type": signer.signer_type,
+        "signer_key_id": signer.signer_key_id(),
+        "signer_key_version": signer.signer_key_version(),
+        "signature_algorithm": signer.signature_algorithm(),
+        "public_key_fingerprint": signer.public_key_fingerprint(),
+    }
+
+
+def _resolve_wat_shadow_signer(wat_cfg: Dict[str, Any]) -> Signer:
+    """Resolve shadow-lane WAT signer using existing signing abstraction."""
+    keys_dir = Path(LOG_DIR) / "keys"
+    backend_raw = str(wat_cfg.get("signer_backend", "existing_signer")).strip().lower()
+    backend = None if backend_raw in {"", "existing_signer"} else backend_raw
+    ensure_local_keys = backend in {None, "file", "file_ed25519"}
+    return build_trustlog_signer(
+        private_key_path=keys_dir / "trustlog_ed25519_private.key",
+        public_key_path=keys_dir / "trustlog_ed25519_public.key",
+        ensure_local_keys=ensure_local_keys,
+        backend=backend,
+    )
+
 def _run_wat_shadow_observer(
     *,
     srv: Any,
@@ -202,19 +234,21 @@ def _run_wat_shadow_observer(
     )
 
     replay_cache = srv.get_wat_shadow_replay_cache()
-    signed_wat = {
-        "claims": {
-            "wat_id": wat_id,
-            "psid_full": psid_full,
-            "action_digest": action_digest,
-            "observable_digest": aggregate_observable_digest,
-            "issuance_ts": now_ts,
-            "expiry_ts": expiry_ts,
-            "nonce": request_id or "unknown-request",
-            "session_id": request_id or "unknown-session",
-        },
-        "signature": "observer-only-shadow",
-    }
+    signer = _resolve_wat_shadow_signer(wat_cfg)
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        wat_id=wat_id,
+        psid_full=psid_full,
+        action_payload=candidate_action,
+        observable_refs=observables,
+        issuance_ts=now_ts,
+        expiry_ts=expiry_ts,
+        nonce=request_id or "unknown-request",
+        session_id=request_id or "unknown-session",
+        signer_metadata=_build_wat_signer_metadata(signer),
+        psid_display_length=int(psid_cfg.get("display_length", 12)),
+    )
+    signed_wat = sign_wat(claims, signer)
 
     verifier_result = validate_local(
         signed_wat=signed_wat,
@@ -237,8 +271,8 @@ def _run_wat_shadow_observer(
                 shadow_cfg.get("warning_only_until")
             ),
             "replay_binding_required": bool(shadow_cfg.get("replay_binding_required", False)),
-            "signature_verifier": lambda _claims, _signature: True,
         },
+        signer=signer,
         replay_cache=replay_cache,
     )
 

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -21,6 +21,7 @@ import os
 import time
 import hmac
 import hashlib
+from pathlib import Path
 from types import SimpleNamespace
 
 # ★ テスト用APIキーを設定（認証付きエンドポイントのテスト用）
@@ -36,10 +37,12 @@ import pytest
 import veritas_os.api.server as server
 import veritas_os.api.routes_decide as routes_decide
 from veritas_os.api.schemas import (
+    DecideRequest,
     MemoryGetRequest,
     MemoryPutRequest,
     MemorySearchRequest,
 )
+from veritas_os.security.signing import build_trustlog_signer
 
 
 client = TestClient(server.app)
@@ -1104,6 +1107,55 @@ def test_decide_wat_shadow_validation_failure_does_not_change_decision(monkeypat
     assert payload.get("meta", {}).get("wat_shadow", {}).get("validation_status") == "invalid"
 
 
+def test_decide_wat_shadow_uses_sign_wat(monkeypatch):
+    """Shadow lane must build/sign WAT instead of using placeholder signatures."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            return {
+                "ok": True,
+                "request_id": "rid-sign",
+                "query": req.query,
+                "decision": "allow",
+                "business_decision": "APPROVE",
+                "result": "ok",
+            }
+
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": False},
+        "drift_scoring": {},
+    }
+    calls = {"sign_wat": 0}
+
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
+    original_sign_wat = routes_decide.sign_wat
+
+    def _tracked_sign_wat(claims, signer):
+        calls["sign_wat"] += 1
+        return original_sign_wat(claims, signer)
+
+    monkeypatch.setattr(routes_decide, "sign_wat", _tracked_sign_wat)
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+
+    assert response.status_code == 200
+    assert calls["sign_wat"] == 1
+    assert response.json()["decision"] == "allow"
+
+
 def test_decide_wat_shadow_pointer_missing_digest_alive(monkeypatch):
     """Missing pointer refs should still produce digest and validation metadata."""
 
@@ -1249,6 +1301,124 @@ def test_decide_wat_shadow_missing_nested_config_uses_conservative_defaults(monk
     assert validate_config.get("timestamp_skew_tolerance_seconds") == 5
     assert validate_config.get("warning_only_until") is None
     assert validate_config.get("replay_binding_required") is False
+    assert "signature_verifier" not in validate_config
+
+
+def test_run_wat_shadow_observer_tampered_signature_invalid(monkeypatch, tmp_path):
+    """Tampered signed WAT must fail local verification as signature_invalid."""
+
+    class DummyServer:
+        def __init__(self):
+            self._cache = set()
+            self.events = []
+
+        def get_wat_shadow_replay_cache(self):
+            return self._cache
+
+        def _publish_event(self, event_type, payload):
+            self.events.append((event_type, payload))
+
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": False},
+        "drift_scoring": {},
+    }
+
+    signer = build_trustlog_signer(
+        private_key_path=Path(tmp_path) / "keys" / "private.key",
+        public_key_path=Path(tmp_path) / "keys" / "public.key",
+        ensure_local_keys=True,
+        backend="file",
+    )
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
+    monkeypatch.setattr(routes_decide, "_resolve_wat_shadow_signer", lambda _cfg: signer)
+    monkeypatch.setattr(routes_decide, "persist_wat_issuance_event", lambda **_kwargs: {"event_id": "issue-1"})
+    monkeypatch.setattr(routes_decide, "persist_wat_validation_event", lambda **_kwargs: {"event_id": "validate-1"})
+    monkeypatch.setattr(routes_decide, "persist_wat_replay_event", lambda **_kwargs: {"event_id": "replay-1"})
+
+    original_sign_wat = routes_decide.sign_wat
+
+    def _tampered_sign_wat(claims, active_signer):
+        signed = original_sign_wat(claims, active_signer)
+        signed["claims"]["nonce"] = "tampered-nonce"
+        return signed
+
+    monkeypatch.setattr(routes_decide, "sign_wat", _tampered_sign_wat)
+
+    summary = routes_decide._run_wat_shadow_observer(
+        srv=DummyServer(),
+        req=DecideRequest(query="tamper"),
+        coerced={
+            "request_id": "rid-tamper",
+            "query": "tamper",
+            "decision": "allow",
+            "business_decision": "APPROVE",
+        },
+    )
+
+    assert summary is not None
+    assert summary["validation_status"] == "invalid"
+    assert summary["admissibility_state"] == "non_admissible"
+
+
+def test_run_wat_shadow_observer_valid_signature(monkeypatch, tmp_path):
+    """Valid signed WAT should pass strict local signature verification."""
+
+    class DummyServer:
+        def __init__(self):
+            self._cache = set()
+            self.events = []
+
+        def get_wat_shadow_replay_cache(self):
+            return self._cache
+
+        def _publish_event(self, event_type, payload):
+            self.events.append((event_type, payload))
+
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": False},
+        "drift_scoring": {},
+    }
+
+    signer = build_trustlog_signer(
+        private_key_path=Path(tmp_path) / "keys" / "private.key",
+        public_key_path=Path(tmp_path) / "keys" / "public.key",
+        ensure_local_keys=True,
+        backend="file",
+    )
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
+    monkeypatch.setattr(routes_decide, "_resolve_wat_shadow_signer", lambda _cfg: signer)
+    monkeypatch.setattr(routes_decide, "persist_wat_issuance_event", lambda **_kwargs: {"event_id": "issue-1"})
+    monkeypatch.setattr(routes_decide, "persist_wat_validation_event", lambda **_kwargs: {"event_id": "validate-1"})
+    monkeypatch.setattr(routes_decide, "persist_wat_replay_event", lambda **_kwargs: {"event_id": "replay-1"})
+
+    summary = routes_decide._run_wat_shadow_observer(
+        srv=DummyServer(),
+        req=DecideRequest(query="valid"),
+        coerced={
+            "request_id": "rid-valid",
+            "query": "valid",
+            "decision": "allow",
+            "business_decision": "APPROVE",
+        },
+    )
+
+    assert summary is not None
+    assert summary["validation_status"] == "valid"
+    assert summary["admissibility_state"] == "admissible"
 
 
 def test_fuji_validate_uses_validate_action(monkeypatch):


### PR DESCRIPTION
### Motivation
- The decide shadow path used a placeholder signature and a no-op verifier which made local strict verification ineffective.
- The goal is to produce a real signed WAT in the shadow lane and run the standard signature verification flow so invalid signatures surface as non-admissible while keeping observer-only behavior.

### Description
- Replaced the placeholder `signed_wat.signature = "observer-only-shadow"` in `_run_wat_shadow_observer` with real claims built by `build_wat_claims(...)` and signed via `sign_wat(...)` and included required claim fields such as `wat_id`, `psid_full`, `action_digest`, `observable_digest`, `issuance_ts`, `expiry_ts`, `nonce`, and `session_id`.
- Added `_resolve_wat_shadow_signer(...)` and `_build_wat_signer_metadata(...)` that resolve a `Signer` using the existing `build_trustlog_signer` abstraction and embed signer metadata into claims, aligning signer resolution with the repo signer design and TrustLog key layout (`LOG_DIR/keys`).
- Removed the placeholder `signature_verifier=lambda ...: True` from `validate_local(...)` calls and instead pass the resolved `signer` so `validate_local` exercises `verify_wat_signature` for strict local verification.
- Kept observer-only semantics so production decisions remain unchanged on signature failure while surfacing `validation_status`/`admissibility_state` (e.g., `invalid` / `non_admissible`) in `meta.wat_shadow` and emitting the same telemetry events.

### Testing
- Compiled modified modules with `python -m py_compile veritas_os/tests/unit/test_server_api.py veritas_os/api/routes_decide.py` and the compilation succeeded.
- Ran the focused unit tests with `pytest -q veritas_os/tests/unit/test_server_api.py -k 'wat_shadow'` and they all passed (9 passed, 306 deselected).
- Added unit tests that assert `sign_wat()` is invoked on the decide shadow path and that tampered/valid signatures produce `invalid/non_admissible` and `valid/admissible` verifier outcomes respectively, and those tests passed.

Security note: the default local file signer uses on-disk private keys which are not encrypted at rest, so operators should ensure strict file permissions or use KMS/Vault backends in production to mitigate private key exposure risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e68fabf88326bb9ffcf66569416d)