### PR TITLE
fix(bff): remove dead /v1/wat/settings BFF policy and canonicalize governance/policy

### DIFF
--- a/frontend/app/api/veritas/[...path]/route-auth.test.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.test.ts
@@ -134,16 +134,9 @@ describe("matchPolicy", () => {
     expect(result!.policy.roles).toContain("operator");
   });
 
-  it("matches WAT settings read endpoint for viewer", () => {
-    const result = matchPolicy(["v1", "wat", "settings"], "GET");
-    expect(result).not.toBeNull();
-    expect(result!.policy.roles).toContain("viewer");
-  });
-
-  it("blocks WAT settings mutation for non-admin", () => {
-    const result = matchPolicy(["v1", "wat", "settings"], "PUT");
-    expect(result).not.toBeNull();
-    expect(result!.policy.roles).toEqual(["admin"]);
+  it("does not expose legacy WAT settings endpoints in BFF policy", () => {
+    expect(matchPolicy(["v1", "wat", "settings"], "GET")).toBeNull();
+    expect(matchPolicy(["v1", "wat", "settings"], "PUT")).toBeNull();
   });
 
   it("matches system halt for admin only", () => {

--- a/frontend/app/api/veritas/[...path]/route-auth.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.ts
@@ -60,7 +60,8 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
     roles: ["viewer", "operator", "admin"],
   },
   {
-    pathPattern: /^v1\/wat\/[^/]+$/,
+    // WAT settings are governed via /v1/governance/policy (canonical source of truth).
+    pathPattern: /^v1\/wat\/(?!settings$)[^/]+$/,
     method: "GET",
     roles: ["viewer", "operator", "admin"],
   },
@@ -68,16 +69,6 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
     pathPattern: /^v1\/wat\/events$/,
     method: "GET",
     roles: ["viewer", "operator", "admin"],
-  },
-  {
-    pathPattern: /^v1\/wat\/settings$/,
-    method: "GET",
-    roles: ["viewer", "operator", "admin"],
-  },
-  {
-    pathPattern: /^v1\/wat\/settings$/,
-    method: "PUT",
-    roles: ["admin"],
   },
   {
     pathPattern: /^v1\/wat\/issue-shadow$/,


### PR DESCRIPTION
### Motivation
- The BFF `route-auth.ts` contained explicit GET/PUT policies for `/v1/wat/settings` but the backend has no corresponding `/v1/wat/settings` routes, creating an auth policy ↔ backend contract drift.
- The repository treats `governance/policy` as the canonical settings surface, so avoid adding new backend routes for WAT settings and unify on governance policy instead.

### Description
- Chosen direction: **B** — removed dedicated `/v1/wat/settings` entries from the BFF allowlist and made governance policy the canonical source of truth. 
- Removed explicit `GET /v1/wat/settings` and `PUT /v1/wat/settings` entries and changed the generic WAT GET matcher to exclude the `settings` segment via a negative lookahead. 
- Updated tests to assert that `matchPolicy` no longer permits `/v1/wat/settings` for GET or PUT. 
- Changed files: `frontend/app/api/veritas/[...path]/route-auth.ts` and `frontend/app/api/veritas/[...path]/route-auth.test.ts`.

### Testing
- Ran BFF unit tests with Vitest: `pnpm test app/api/veritas/[...path]/route-auth.test.ts app/api/veritas/[...path]/route.test.ts`, both test files passed (total 65 tests passed). 
- Ran repository consistency checks: `pytest -q veritas_os/tests/test_frontend_api_contract_consistency.py`, which passed (13 tests passed). 
- Result: automated tests succeeded and the BFF policy now matches backend availability (no dead `/v1/wat/settings` policy remains).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fa3a2a1c83269a77b7507d609d97)