### PR TITLE
Wire governance drift_scoring into WAT local verifier

### DIFF
--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -141,6 +141,26 @@ def _policy_section(policy: Dict[str, Any], key: str) -> Dict[str, Any]:
     return {}
 
 
+def _build_drift_runtime_config(drift_scoring_cfg: Dict[str, Any]) -> Dict[str, Dict[str, float]]:
+    """Build verifier drift runtime config from governance policy values.
+
+    The local verifier consumes normalized axis names:
+    ``policy``, ``signature``, ``observable``, and ``temporal``.
+    """
+    return {
+        "drift_weights": {
+            "policy": float(drift_scoring_cfg.get("policy_weight", 0.4)),
+            "signature": float(drift_scoring_cfg.get("signature_weight", 0.3)),
+            "observable": float(drift_scoring_cfg.get("observable_weight", 0.2)),
+            "temporal": float(drift_scoring_cfg.get("temporal_weight", 0.1)),
+        },
+        "drift_thresholds": {
+            "healthy": float(drift_scoring_cfg.get("healthy_threshold", 0.2)),
+            "critical": float(drift_scoring_cfg.get("critical_threshold", 0.5)),
+        },
+    }
+
+
 
 
 def _build_wat_signer_metadata(signer: Signer) -> Dict[str, Any]:
@@ -195,7 +215,8 @@ def _run_wat_shadow_observer(
     psid_cfg = _policy_section(policy, "psid")
     shadow_cfg = _policy_section(policy, "shadow_validation")
     revocation_cfg = _policy_section(policy, "revocation")
-    _policy_section(policy, "drift_scoring")
+    drift_scoring_cfg = _policy_section(policy, "drift_scoring")
+    drift_runtime_cfg = _build_drift_runtime_config(drift_scoring_cfg)
     request_id = str(coerced.get("request_id") or "")
     query = str(getattr(req, "query", "") or coerced.get("query") or "")
     candidate_action = _resolve_candidate_action(coerced)
@@ -271,6 +292,8 @@ def _run_wat_shadow_observer(
                 shadow_cfg.get("warning_only_until")
             ),
             "replay_binding_required": bool(shadow_cfg.get("replay_binding_required", False)),
+            "drift_weights": drift_runtime_cfg["drift_weights"],
+            "drift_thresholds": drift_runtime_cfg["drift_thresholds"],
         },
         signer=signer,
         replay_cache=replay_cache,

--- a/veritas_os/security/wat_verifier.py
+++ b/veritas_os/security/wat_verifier.py
@@ -18,8 +18,10 @@ from veritas_os.security.wat_token import verify_wat_signature
 ValidationStatus = str
 AdmissibilityState = str
 
-_HEALTHY_THRESHOLD = 0.2
-_WARNING_THRESHOLD = 0.5
+_DEFAULT_THRESHOLDS: dict[str, float] = {
+    "healthy": 0.2,
+    "critical": 0.5,
+}
 
 _DEFAULT_WEIGHTS: dict[str, float] = {
     "policy": 0.4,
@@ -67,11 +69,26 @@ class VerifierResult:
 def score_drift(
     drift_vector: DriftVector,
     weights: Mapping[str, float] | None = None,
+    thresholds: Mapping[str, float] | None = None,
 ) -> DriftScore:
-    """Compute weighted drift score and severity classification."""
+    """Compute weighted drift score and severity classification.
+
+    Classification bands:
+    - ``healthy``: score < healthy threshold.
+    - ``warning``: healthy threshold <= score < critical threshold.
+    - ``critical``: score >= critical threshold.
+    """
     applied_weights = dict(_DEFAULT_WEIGHTS)
     if weights:
         applied_weights.update(weights)
+    applied_thresholds = dict(_DEFAULT_THRESHOLDS)
+    if thresholds:
+        applied_thresholds.update(thresholds)
+
+    healthy_threshold = float(applied_thresholds["healthy"])
+    critical_threshold = float(applied_thresholds["critical"])
+    if critical_threshold < healthy_threshold:
+        healthy_threshold, critical_threshold = critical_threshold, healthy_threshold
 
     score = (
         drift_vector.policy_drift * applied_weights["policy"]
@@ -80,9 +97,9 @@ def score_drift(
         + drift_vector.temporal_drift * applied_weights["temporal"]
     )
 
-    if score < _HEALTHY_THRESHOLD:
+    if score < healthy_threshold:
         classification = "healthy"
-    elif score < _WARNING_THRESHOLD:
+    elif score < critical_threshold:
         classification = "warning"
     else:
         classification = "critical"
@@ -314,7 +331,11 @@ def validate_local(
     if replay_cache is not None and status in {"valid", "partial", "revoked_pending"}:
         replay_cache.add(binding_key)
 
-    drift_score = score_drift(drift_vector, cfg.get("drift_weights"))
+    drift_score = score_drift(
+        drift_vector,
+        cfg.get("drift_weights"),
+        cfg.get("drift_thresholds"),
+    )
     admissibility_state = resolve_admissibility_state(
         validation_status=status,
         drift_score=drift_score,

--- a/veritas_os/tests/test_wat_verifier.py
+++ b/veritas_os/tests/test_wat_verifier.py
@@ -302,3 +302,32 @@ def test_drift_score_classification() -> None:
     assert healthy.classification == "healthy"
     assert warning.classification == "warning"
     assert critical.classification == "critical"
+
+
+def test_drift_score_custom_weights_affect_classification() -> None:
+    """Custom weight map from policy must influence drift classification."""
+    drift_vector = DriftVector(0.0, 0.7, 0.0, 0.0)
+    baseline = score_drift(drift_vector)
+    custom = score_drift(
+        drift_vector,
+        weights={
+            "policy": 0.7,
+            "signature": 0.1,
+            "observable": 0.1,
+            "temporal": 0.1,
+        },
+    )
+    assert baseline.classification == "warning"
+    assert custom.classification == "healthy"
+
+
+def test_drift_score_custom_thresholds_affect_classification() -> None:
+    """Custom threshold map from policy must influence drift classification."""
+    drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
+    default_score = score_drift(drift_vector)
+    custom_score = score_drift(
+        drift_vector,
+        thresholds={"healthy": 0.05, "critical": 0.15},
+    )
+    assert default_score.classification == "healthy"
+    assert custom_score.classification == "warning"

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -1312,7 +1312,84 @@ def test_decide_wat_shadow_missing_nested_config_uses_conservative_defaults(monk
     assert validate_config.get("timestamp_skew_tolerance_seconds") == 5
     assert validate_config.get("warning_only_until") is None
     assert validate_config.get("replay_binding_required") is False
+    assert validate_config.get("drift_weights") == {
+        "policy": 0.4,
+        "signature": 0.3,
+        "observable": 0.2,
+        "temporal": 0.1,
+    }
+    assert validate_config.get("drift_thresholds") == {
+        "healthy": 0.2,
+        "critical": 0.5,
+    }
     assert "signature_verifier" not in validate_config
+
+
+def test_decide_wat_shadow_passes_policy_drift_scoring_to_verifier(monkeypatch):
+    """Governance drift_scoring values must be forwarded to local verifier config."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            return {
+                "ok": True,
+                "request_id": "rid-drift",
+                "query": req.query,
+                "decision": "allow",
+                "business_decision": "APPROVE",
+                "result": "ok",
+            }
+
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": True},
+        "drift_scoring": {
+            "policy_weight": 0.5,
+            "signature_weight": 0.2,
+            "observable_weight": 0.2,
+            "temporal_weight": 0.1,
+            "healthy_threshold": 0.1,
+            "critical_threshold": 0.3,
+        },
+    }
+    captured_validate_kwargs = {}
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
+    monkeypatch.setattr(
+        routes_decide,
+        "validate_local",
+        lambda **kwargs: captured_validate_kwargs.update(kwargs) or {
+            "validation_status": "valid",
+            "admissibility_state": "admissible",
+            "failure_type": "",
+            "drift_vector": {},
+        },
+    )
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+
+    assert response.status_code == 200
+    validate_config = captured_validate_kwargs.get("config", {})
+    assert validate_config.get("drift_weights") == {
+        "policy": 0.5,
+        "signature": 0.2,
+        "observable": 0.2,
+        "temporal": 0.1,
+    }
+    assert validate_config.get("drift_thresholds") == {
+        "healthy": 0.1,
+        "critical": 0.3,
+    }
 
 
 def test_run_wat_shadow_observer_tampered_signature_invalid(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- The governance `drift_scoring` section was defined but not wired into the WAT local verifier runtime, so policy-defined drift weights and thresholds had no effect at runtime.
- The goal is to ensure shadow/observer validation uses `drift_scoring` from governance so WAT drift classification follows policy values while preserving existing hard/soft fail and observer-only behavior.

### Description
- Added `_build_drift_runtime_config(...)` in `veritas_os/api/routes_decide.py` to normalize governance `drift_scoring` into `drift_weights` and `drift_thresholds` and pass them into `validate_local(config=...)` in the shadow observer path.
- Extended `veritas_os/security/wat_verifier.py` `score_drift(...)` to accept an optional `thresholds` mapping and added `_DEFAULT_THRESHOLDS` while keeping weight defaults in `_DEFAULT_WEIGHTS` so existing defaults remain `0.4/0.3/0.2/0.1` and thresholds `healthy 0.2`, `critical 0.5`.
- Updated `validate_local(...)` to forward both `config.get("drift_weights")` and `config.get("drift_thresholds")` into `score_drift(...)`, and clarified band semantics in the docstring (`healthy`: score < healthy, `warning`: healthy <= score < critical, `critical`: score >= critical).
- Changes made to files: `veritas_os/api/routes_decide.py`, `veritas_os/security/wat_verifier.py`, and tests in `veritas_os/tests/test_wat_verifier.py` and `veritas_os/tests/unit/test_server_api.py` to cover forwarding and custom weight/threshold behaviors.

### Testing
- Ran targeted tests with `pytest -q veritas_os/tests/test_wat_verifier.py veritas_os/tests/unit/test_server_api.py -k 'wat_shadow or drift_score or validate_local'` and the run completed successfully.
- Test result: `23 passed, 307 deselected` indicating new/updated unit tests passed.
- Added tests verify that custom `drift_weights` and custom `drift_thresholds` affect `score_drift` classification and that the decide shadow path forwards policy drift config into `validate_local` while default behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5040d2e508326a4b0ef0cb367f74c)