### PR TITLE
Enforce replay-binding required semantics in local WAT verifier

### DIFF
--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -291,7 +291,7 @@ def _run_wat_shadow_observer(
             "warning_only_until": _coerce_warning_only_until_epoch(
                 shadow_cfg.get("warning_only_until")
             ),
-            "replay_binding_required": bool(shadow_cfg.get("replay_binding_required", False)),
+            "replay_binding_required": shadow_cfg.get("replay_binding_required", False),
             "drift_weights": drift_runtime_cfg["drift_weights"],
             "drift_thresholds": drift_runtime_cfg["drift_thresholds"],
         },

--- a/veritas_os/security/wat_verifier.py
+++ b/veritas_os/security/wat_verifier.py
@@ -205,6 +205,51 @@ def _build_audit_event_ref(
     return f"wat_local_verifier:{event_digest[:24]}"
 
 
+def _is_missing_text(value: Any) -> bool:
+    """Return ``True`` when a replay-binding text field is missing."""
+    return not str(value or "").strip()
+
+
+def _resolve_replay_binding_failure(
+    *,
+    required: bool,
+    claim_action_digest: str,
+    action_digest_local: str,
+    claim_nonce: str,
+    execution_nonce: str,
+    claim_session_id: str,
+    session_id: str,
+) -> str | None:
+    """Resolve replay-binding failures for strict and observer-only modes.
+
+    Strict mode requires action-digest + nonce + session-id to all exist and
+    match exactly. Observer-only mode keeps historical behavior by rejecting
+    only explicit mismatches.
+    """
+    claim_missing = {
+        "action_digest": _is_missing_text(claim_action_digest),
+        "nonce": _is_missing_text(claim_nonce),
+        "session_id": _is_missing_text(claim_session_id),
+    }
+    local_missing = {
+        "action_digest": _is_missing_text(action_digest_local),
+        "nonce": _is_missing_text(execution_nonce),
+        "session_id": _is_missing_text(session_id),
+    }
+
+    if required:
+        missing_any = any(claim_missing.values()) or any(local_missing.values())
+        if missing_any:
+            missing_count = sum(claim_missing.values()) + sum(local_missing.values())
+            return "replay_binding_missing" if missing_count >= 4 else "replay_binding_incomplete"
+
+    if claim_action_digest != action_digest_local:
+        return "action_digest_mismatch"
+    if claim_nonce != execution_nonce or claim_session_id != session_id:
+        return "replay_binding_incomplete" if required else "replay_detected"
+    return None
+
+
 def validate_local(
     *,
     signed_wat: Mapping[str, Any],
@@ -263,6 +308,7 @@ def validate_local(
     binding_key = f"{claim_action_digest}:{execution_nonce}:{session_id}"
     revocation_status = _derive_revocation_status(revocation_state)
     partial_allowed = _is_partial_allowed(cfg, current_ts)
+    replay_binding_required = bool(cfg.get("replay_binding_required", False))
 
     if revocation_status == "revoked_confirmed":
         drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
@@ -281,52 +327,58 @@ def validate_local(
         drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
         status = "invalid"
         failure_type = "psid_full_mismatch"
-    elif claim_action_digest != action_digest_local:
-        drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
-        status = "invalid"
-        failure_type = "action_digest_mismatch"
-    elif claim_observable_digest != observable_digest_local:
-        drift_vector = DriftVector(0.0, 0.0, 1.0, 0.0)
-        status = "invalid"
-        failure_type = "observable_digest_mismatch"
-    elif claim_nonce != execution_nonce or claim_session_id != session_id:
-        drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
-        status = "invalid"
-        failure_type = "replay_detected"
-    elif replay_cache is not None and binding_key in replay_cache:
-        drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
-        status = "invalid"
-        failure_type = "replay_detected"
-    elif claim_expiry_ts is not None and current_ts > claim_expiry_ts:
-        drift_vector = DriftVector(0.0, 0.0, 0.0, 1.0)
-        status = "stale"
-        failure_type = "expired_token"
-    elif revocation_status == "revoked_pending":
-        drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
-        status = "revoked_pending"
-        failure_type = "revocation_pending"
-    elif bool(cfg.get("allow_partial_validation", False)):
-        drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
-        status = "partial"
-        failure_type = "partial_validation_mode"
     else:
-        temporal_drift = 0.0
-        failure_type = None
-        skew_tolerance = int(cfg.get("timestamp_skew_tolerance_seconds", 30))
-        if issuance_ts_local is not None and claim_issuance_ts is not None:
-            if abs(claim_issuance_ts - issuance_ts_local) > skew_tolerance:
-                temporal_drift = 1.0
-                failure_type = "timestamp_skew_exceeded"
-        if expiry_ts_local is not None and claim_expiry_ts is not None:
-            if abs(claim_expiry_ts - expiry_ts_local) > skew_tolerance:
-                temporal_drift = max(temporal_drift, 1.0)
-                failure_type = failure_type or "timestamp_skew_exceeded"
-        if temporal_drift == 0.0 and issuance_ts_local is not None and claim_issuance_ts is not None:
-            if claim_issuance_ts != issuance_ts_local:
-                temporal_drift = 0.4
-                failure_type = "timestamp_skew_within_tolerance"
-        drift_vector = DriftVector(0.0, 0.0, 0.0, temporal_drift)
-        status = "invalid" if failure_type == "timestamp_skew_exceeded" else "valid"
+        replay_binding_failure = _resolve_replay_binding_failure(
+            required=replay_binding_required,
+            claim_action_digest=claim_action_digest,
+            action_digest_local=action_digest_local,
+            claim_nonce=claim_nonce,
+            execution_nonce=execution_nonce,
+            claim_session_id=claim_session_id,
+            session_id=session_id,
+        )
+        if replay_binding_failure is not None:
+            drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
+            status = "invalid"
+            failure_type = replay_binding_failure
+        elif claim_observable_digest != observable_digest_local:
+            drift_vector = DriftVector(0.0, 0.0, 1.0, 0.0)
+            status = "invalid"
+            failure_type = "observable_digest_mismatch"
+        elif replay_cache is not None and binding_key in replay_cache:
+            drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
+            status = "invalid"
+            failure_type = "replay_detected"
+        elif claim_expiry_ts is not None and current_ts > claim_expiry_ts:
+            drift_vector = DriftVector(0.0, 0.0, 0.0, 1.0)
+            status = "stale"
+            failure_type = "expired_token"
+        elif revocation_status == "revoked_pending":
+            drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
+            status = "revoked_pending"
+            failure_type = "revocation_pending"
+        elif bool(cfg.get("allow_partial_validation", False)):
+            drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
+            status = "partial"
+            failure_type = "partial_validation_mode"
+        else:
+            temporal_drift = 0.0
+            failure_type = None
+            skew_tolerance = int(cfg.get("timestamp_skew_tolerance_seconds", 30))
+            if issuance_ts_local is not None and claim_issuance_ts is not None:
+                if abs(claim_issuance_ts - issuance_ts_local) > skew_tolerance:
+                    temporal_drift = 1.0
+                    failure_type = "timestamp_skew_exceeded"
+            if expiry_ts_local is not None and claim_expiry_ts is not None:
+                if abs(claim_expiry_ts - expiry_ts_local) > skew_tolerance:
+                    temporal_drift = max(temporal_drift, 1.0)
+                    failure_type = failure_type or "timestamp_skew_exceeded"
+            if temporal_drift == 0.0 and issuance_ts_local is not None and claim_issuance_ts is not None:
+                if claim_issuance_ts != issuance_ts_local:
+                    temporal_drift = 0.4
+                    failure_type = "timestamp_skew_within_tolerance"
+            drift_vector = DriftVector(0.0, 0.0, 0.0, temporal_drift)
+            status = "invalid" if failure_type == "timestamp_skew_exceeded" else "valid"
 
     if replay_cache is not None and status in {"valid", "partial", "revoked_pending"}:
         replay_cache.add(binding_key)

--- a/veritas_os/tests/test_wat_verifier.py
+++ b/veritas_os/tests/test_wat_verifier.py
@@ -34,6 +34,22 @@ def _signed_wat(tmp_path: Path) -> tuple[FileEd25519Signer, dict[str, object]]:
     return signer, sign_wat(claims, signer)
 
 
+def _signed_wat_with_claim_overrides(
+    tmp_path: Path,
+    *,
+    remove_keys: set[str] | None = None,
+    updates: dict[str, object] | None = None,
+) -> tuple[FileEd25519Signer, dict[str, object]]:
+    """Build a signed WAT with controlled claim mutations for verifier tests."""
+    signer, signed_wat = _signed_wat(tmp_path)
+    claims = dict(signed_wat["claims"])
+    for key in remove_keys or set():
+        claims.pop(key, None)
+    if updates:
+        claims.update(updates)
+    return signer, sign_wat(claims, signer)
+
+
 def test_validate_local_valid_path(tmp_path: Path) -> None:
     signer, signed_wat = _signed_wat(tmp_path)
     claims = signed_wat["claims"]
@@ -187,6 +203,160 @@ def test_validate_local_replay_detected_by_binding_reuse(tmp_path: Path) -> None
     )
     assert first["validation_status"] == "valid"
     assert second["failure_type"] == "replay_detected"
+
+
+def test_validate_local_replay_cache_hit_fails_when_required_true(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    claims = signed_wat["claims"]
+    replay_cache: set[str] = set()
+    _ = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        config={"replay_binding_required": True},
+        signer=signer,
+        now_ts=1_712_000_100,
+        replay_cache=replay_cache,
+    )
+    replay = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        config={"replay_binding_required": True},
+        signer=signer,
+        now_ts=1_712_000_100,
+        replay_cache=replay_cache,
+    )
+    assert replay["validation_status"] == "invalid"
+    assert replay["failure_type"] == "replay_detected"
+
+
+def test_validate_local_required_true_fails_on_missing_nonce(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat_with_claim_overrides(tmp_path, remove_keys={"nonce"})
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        config={"replay_binding_required": True},
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "invalid"
+    assert result["failure_type"] == "replay_binding_incomplete"
+    assert "replay_binding_incomplete" in result["operator_message"]
+
+
+def test_validate_local_required_true_fails_on_missing_session(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat_with_claim_overrides(tmp_path, remove_keys={"session_id"})
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        config={"replay_binding_required": True},
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "invalid"
+    assert result["failure_type"] == "replay_binding_incomplete"
+
+
+def test_validate_local_required_true_fails_on_missing_action_digest(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat_with_claim_overrides(tmp_path, remove_keys={"action_digest"})
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local="",
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce=str(claims["nonce"]),
+        session_id=str(claims["session_id"]),
+        revocation_state="active",
+        config={"replay_binding_required": True},
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "invalid"
+    assert result["failure_type"] == "replay_binding_incomplete"
+
+
+def test_validate_local_required_true_fails_on_binding_mismatch(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-mismatch",
+        session_id="session-1",
+        revocation_state="active",
+        config={"replay_binding_required": True},
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "invalid"
+    assert result["failure_type"] == "replay_binding_incomplete"
+
+
+def test_validate_local_required_false_keeps_observer_friendly_missing_binding(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat_with_claim_overrides(
+        tmp_path,
+        remove_keys={"nonce", "session_id"},
+    )
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="",
+        session_id="",
+        revocation_state="active",
+        config={"replay_binding_required": False},
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "valid"
+    assert result["failure_type"] is None
 
 
 def test_validate_local_revoked_pending_is_warning_only(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Connect the governance `shadow_validation.replay_binding_required` flag to runtime local WAT verification so policy decisions about strict replay binding actually take effect. 
- Ensure that when replay binding is required the `action_digest + nonce + session_id` tuple must be present and consistent to prevent ambiguous pre-pilot replays. 
- Preserve existing observer-only semantics when `replay_binding_required=false` while still rejecting explicit mismatches and replay-cache hits. 

### Description
- Add helper functions `_is_missing_text` and `_resolve_replay_binding_failure` in `veritas_os/security/wat_verifier.py` to centralize strict vs observer-only replay-binding checks and produce clear failure types. 
- Wire `config["replay_binding_required"]` into `validate_local()` and evaluate replay-binding issues early in the validation flow, returning new failure types `replay_binding_missing` / `replay_binding_incomplete` / `replay_detected` as appropriate. 
- Keep replay-cache behavior authoritative and failing in both modes, and preserve existing `operator_message` / `mission_control_event_name` construction. 
- Pass the policy `shadow_validation.replay_binding_required` through from the decide shadow path without forcing a boolean coercion in `veritas_os/api/routes_decide.py`. 
- Add unit tests in `veritas_os/tests/test_wat_verifier.py` to cover required=true missing nonce/session/action_digest, binding mismatches, required=false backward-compatible behavior, and replay-cache hit behavior. 

### Testing
- Ran `pytest -q veritas_os/tests/test_wat_verifier.py` and observed `20 passed`, confirming the verifier unit test suite for WAT. 
- Ran a targeted test selection with `pytest -q veritas_os/tests/test_wat_verifier.py veritas_os/tests/unit/test_server_api.py -k 'wat_shadow_missing_nested_config_uses_conservative_defaults or replay_binding_required or test_validate_local_required_true_fails_on_missing_nonce or test_validate_local_required_true_fails_on_missing_session or test_validate_local_required_true_fails_on_missing_action_digest or test_validate_local_required_true_fails_on_binding_mismatch or test_validate_local_required_false_keeps_observer_friendly_missing_binding or test_validate_local_replay_cache_hit_fails_when_required_true or test_validate_local_replay_detected_by_binding_reuse'` and observed `8 passed, 328 deselected`, all passing. 
- Note: this change tightens replay protection when `replay_binding_required=true` but production deployments still require a durable replay cache to avoid replay windows after process restarts, which is a security consideration to be addressed operationally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e509e1c9248326ac5315d5f76e3fd8)