### PR TITLE
Strengthen WAT revocation model and observable_digest_list enforcement

### DIFF
--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -188,6 +188,28 @@ def _resolve_wat_shadow_signer(wat_cfg: Dict[str, Any]) -> Signer:
         backend=backend,
     )
 
+
+def _resolve_shadow_revocation_state(
+    *,
+    wat_id: str,
+    degrade_on_pending: bool,
+) -> Dict[str, Any]:
+    """Resolve shadow-lane revocation state with conservative defaults.
+
+    Security:
+        If no revocation telemetry exists and degradation is enabled, default
+        to ``revoked_pending`` to keep observer-only posture conservative.
+    """
+    state = dict(derive_latest_revocation_state(wat_id))
+    status = str(state.get("status", "active"))
+    has_event_ref = bool(state.get("event_id") or state.get("event_type"))
+    if status == "active" and degrade_on_pending and not has_event_ref:
+        status = "revoked_pending"
+        state["source"] = "shadow_default"
+    state["status"] = status
+    return state
+
+
 def _run_wat_shadow_observer(
     *,
     srv: Any,
@@ -271,13 +293,12 @@ def _run_wat_shadow_observer(
         psid_display_length=int(psid_cfg.get("display_length", 12)),
     )
     signed_wat = sign_wat(claims, signer)
-    event_lane_revocation = derive_latest_revocation_state(wat_id)
     degrade_on_pending = bool(revocation_cfg.get("degrade_on_pending", True))
-    effective_revocation_status = str(event_lane_revocation.get("status", "active"))
-    revocation_state = {
-        **event_lane_revocation,
-        "status": effective_revocation_status,
-    }
+    revocation_state = _resolve_shadow_revocation_state(
+        wat_id=wat_id,
+        degrade_on_pending=degrade_on_pending,
+    )
+    effective_revocation_status = str(revocation_state.get("status", "active"))
 
     verifier_result = validate_local(
         signed_wat=signed_wat,

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -24,6 +24,7 @@ from veritas_os.api.rbac import Permission
 from veritas_os.api.schemas import DecideRequest, DecideResponse, FujiDecision
 from veritas_os.api.pipeline_orchestrator import resolve_dynamic_steps
 from veritas_os.audit.wat_events import (
+    derive_latest_revocation_state,
     persist_wat_issuance_event,
     persist_wat_replay_event,
     persist_wat_validation_event,
@@ -270,6 +271,13 @@ def _run_wat_shadow_observer(
         psid_display_length=int(psid_cfg.get("display_length", 12)),
     )
     signed_wat = sign_wat(claims, signer)
+    event_lane_revocation = derive_latest_revocation_state(wat_id)
+    degrade_on_pending = bool(revocation_cfg.get("degrade_on_pending", True))
+    effective_revocation_status = str(event_lane_revocation.get("status", "active"))
+    revocation_state = {
+        **event_lane_revocation,
+        "status": effective_revocation_status,
+    }
 
     verifier_result = validate_local(
         signed_wat=signed_wat,
@@ -281,10 +289,11 @@ def _run_wat_shadow_observer(
         expiry_ts_local=expiry_ts,
         execution_nonce=request_id or "unknown-request",
         session_id=request_id or "unknown-session",
-        revocation_state="revoked_pending" if bool(revocation_cfg.get("degrade_on_pending", True)) else "active",
+        revocation_state=revocation_state,
         config={
             "observer_only_mode": True,
             "allow_partial_validation": False,
+            "degrade_on_pending": degrade_on_pending,
             "timestamp_skew_tolerance_seconds": int(
                 shadow_cfg.get("timestamp_skew_tolerance_seconds", 5)
             ),
@@ -344,7 +353,7 @@ def _run_wat_shadow_observer(
         "admissibility_state": verifier_result.get("admissibility_state"),
         "drift_vector": drift_vector,
         "replay_status": replay_status,
-        "revocation_status": "revoked_pending" if bool(revocation_cfg.get("degrade_on_pending", True)) else "active",
+        "revocation_status": effective_revocation_status,
         "integrity_summary": integrity_summary,
         "issue_event_id": issue_event.get("event_id"),
         "validation_event_id": persisted_validation.get("event_id"),

--- a/veritas_os/audit/wat_events.py
+++ b/veritas_os/audit/wat_events.py
@@ -223,6 +223,43 @@ def get_wat_event(wat_id: str, *, path: Optional[Path] = None) -> Optional[Dict[
     return None
 
 
+def derive_latest_revocation_state(
+    wat_id: str,
+    *,
+    path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Derive structured local revocation state from latest WAT lane event.
+
+    Returns a mapping compatible with ``validate_local(revocation_state=...)``:
+    ``status`` is always one of ``active``, ``revoked_pending``,
+    ``revoked_confirmed``.
+    """
+    target = str(wat_id or "").strip()
+    if not target:
+        return {"status": "active", "source": "wat_events"}
+
+    timeline = list_wat_events(wat_id=target, limit=500, path=path)
+    for event in timeline:
+        event_type = str(event.get("event_type", "")).strip()
+        if event_type == "wat_revoked_confirmed":
+            return {
+                "status": "revoked_confirmed",
+                "source": "wat_events",
+                "event_type": event_type,
+                "event_id": event.get("event_id"),
+                "ts": event.get("ts"),
+            }
+        if event_type == "wat_revocation_pending":
+            return {
+                "status": "revoked_pending",
+                "source": "wat_events",
+                "event_type": event_type,
+                "event_id": event.get("event_id"),
+                "ts": event.get("ts"),
+            }
+    return {"status": "active", "source": "wat_events"}
+
+
 def list_wat_events(
     *,
     wat_id: Optional[str] = None,

--- a/veritas_os/security/wat_token.py
+++ b/veritas_os/security/wat_token.py
@@ -76,6 +76,7 @@ def build_wat_claims(
     psid_display_length: int = 12,
 ) -> dict[str, Any]:
     """Build immutable WAT claims with required fields for v1."""
+    observable_digest_list = compute_observable_digests(observable_refs)
     claims: dict[str, Any] = {
         "wat_id": wat_id or str(uuid4()),
         "version": version,
@@ -83,7 +84,8 @@ def build_wat_claims(
         "psid_display": make_psid_display(psid_full, psid_display_length),
         "action_digest": compute_action_digest(action_payload),
         "observable_refs": list(observable_refs),
-        "observable_digest": compute_observable_digest(observable_refs),
+        "observable_digest_list": observable_digest_list,
+        "observable_digest": sha256_hex(canonical_json_dumps(observable_digest_list)),
         "issuance_ts": issuance_ts,
         "expiry_ts": expiry_ts,
         "session_id": session_id,

--- a/veritas_os/security/wat_verifier.py
+++ b/veritas_os/security/wat_verifier.py
@@ -13,7 +13,7 @@ from typing import Any, Mapping, MutableSet, Sequence
 
 from veritas_os.security.hash import canonical_json_dumps, sha256_hex
 from veritas_os.security.signing import Signer
-from veritas_os.security.wat_token import verify_wat_signature
+from veritas_os.security.wat_token import compute_observable_digests, verify_wat_signature
 
 ValidationStatus = str
 AdmissibilityState = str
@@ -111,6 +111,7 @@ def resolve_admissibility_state(
     validation_status: ValidationStatus,
     drift_score: DriftScore,
     partial_allowed: bool,
+    pending_is_warning: bool = True,
 ) -> AdmissibilityState:
     """Resolve admissibility state from status and drift posture."""
     if validation_status in {"invalid", "stale", "revoked_confirmed"}:
@@ -118,7 +119,7 @@ def resolve_admissibility_state(
     if validation_status == "partial":
         return "warning_only_shadow" if partial_allowed else "non_admissible"
     if validation_status == "revoked_pending":
-        return "warning_only_shadow"
+        return "warning_only_shadow" if pending_is_warning else "non_admissible"
     if drift_score.classification in {"warning", "critical"}:
         return "warning_only_shadow"
     return "admissible"
@@ -157,6 +158,15 @@ def _derive_revocation_status(revocation_state: Any) -> str:
         if isinstance(value, str):
             return value
     return "active"
+
+
+def _normalize_observable_digest_list(raw_value: Any) -> list[str] | None:
+    """Normalize observable digest list claim values for strict comparison."""
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, Sequence) or isinstance(raw_value, (str, bytes, bytearray)):
+        return None
+    return [str(item) for item in raw_value]
 
 
 def _is_partial_allowed(config: Mapping[str, Any], now_ts: int) -> bool:
@@ -300,6 +310,9 @@ def validate_local(
     claim_psid_full = str(claims.get("psid_full", ""))
     claim_action_digest = str(claims.get("action_digest", ""))
     claim_observable_digest = str(claims.get("observable_digest", ""))
+    claim_observable_digest_list = _normalize_observable_digest_list(
+        claims.get("observable_digest_list")
+    )
     claim_issuance_ts = _to_epoch(claims.get("issuance_ts"))
     claim_expiry_ts = _to_epoch(claims.get("expiry_ts"))
     claim_nonce = str(claims.get("nonce", ""))
@@ -345,6 +358,46 @@ def validate_local(
             drift_vector = DriftVector(0.0, 0.0, 1.0, 0.0)
             status = "invalid"
             failure_type = "observable_digest_mismatch"
+        elif observable_refs_local is not None and claim_observable_digest_list is not None:
+            local_observable_digest_list = compute_observable_digests(observable_refs_local)
+            if claim_observable_digest_list != local_observable_digest_list:
+                drift_vector = DriftVector(0.0, 0.0, 1.0, 0.0)
+                status = "invalid"
+                failure_type = "observable_digest_list_mismatch"
+            elif replay_cache is not None and binding_key in replay_cache:
+                drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
+                status = "invalid"
+                failure_type = "replay_detected"
+            elif claim_expiry_ts is not None and current_ts > claim_expiry_ts:
+                drift_vector = DriftVector(0.0, 0.0, 0.0, 1.0)
+                status = "stale"
+                failure_type = "expired_token"
+            elif revocation_status == "revoked_pending":
+                drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
+                status = "revoked_pending"
+                failure_type = "revocation_pending"
+            elif bool(cfg.get("allow_partial_validation", False)):
+                drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
+                status = "partial"
+                failure_type = "partial_validation_mode"
+            else:
+                temporal_drift = 0.0
+                failure_type = None
+                skew_tolerance = int(cfg.get("timestamp_skew_tolerance_seconds", 30))
+                if issuance_ts_local is not None and claim_issuance_ts is not None:
+                    if abs(claim_issuance_ts - issuance_ts_local) > skew_tolerance:
+                        temporal_drift = 1.0
+                        failure_type = "timestamp_skew_exceeded"
+                if expiry_ts_local is not None and claim_expiry_ts is not None:
+                    if abs(claim_expiry_ts - expiry_ts_local) > skew_tolerance:
+                        temporal_drift = max(temporal_drift, 1.0)
+                        failure_type = failure_type or "timestamp_skew_exceeded"
+                if temporal_drift == 0.0 and issuance_ts_local is not None and claim_issuance_ts is not None:
+                    if claim_issuance_ts != issuance_ts_local:
+                        temporal_drift = 0.4
+                        failure_type = "timestamp_skew_within_tolerance"
+                drift_vector = DriftVector(0.0, 0.0, 0.0, temporal_drift)
+                status = "invalid" if failure_type == "timestamp_skew_exceeded" else "valid"
         elif replay_cache is not None and binding_key in replay_cache:
             drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
             status = "invalid"
@@ -392,6 +445,7 @@ def validate_local(
         validation_status=status,
         drift_score=drift_score,
         partial_allowed=partial_allowed,
+        pending_is_warning=bool(cfg.get("degrade_on_pending", True)),
     )
 
     if status == "partial" and not partial_allowed:
@@ -421,5 +475,4 @@ def validate_local(
         mission_control_event_name=result.mission_control_event_name,
         operator_message=operator_message,
     )
-    _ = observable_refs_local
     return result.to_dict()

--- a/veritas_os/tests/test_wat_events.py
+++ b/veritas_os/tests/test_wat_events.py
@@ -1,0 +1,33 @@
+"""Unit tests for WAT event-lane revocation state derivation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from veritas_os.audit.wat_events import (
+    derive_latest_revocation_state,
+    persist_wat_issuance_event,
+    persist_wat_revocation_event,
+)
+
+
+def test_derive_latest_revocation_state_defaults_active(tmp_path: Path) -> None:
+    state = derive_latest_revocation_state("missing-wat", path=tmp_path / "wat_events.jsonl")
+    assert state["status"] == "active"
+
+
+def test_derive_latest_revocation_state_pending(tmp_path: Path) -> None:
+    path = tmp_path / "wat_events.jsonl"
+    persist_wat_issuance_event(wat_id="wat-1", actor="test", path=path)
+    persist_wat_revocation_event(wat_id="wat-1", actor="test", confirmed=False, path=path)
+    state = derive_latest_revocation_state("wat-1", path=path)
+    assert state["status"] == "revoked_pending"
+
+
+def test_derive_latest_revocation_state_confirmed(tmp_path: Path) -> None:
+    path = tmp_path / "wat_events.jsonl"
+    persist_wat_issuance_event(wat_id="wat-2", actor="test", path=path)
+    persist_wat_revocation_event(wat_id="wat-2", actor="test", confirmed=False, path=path)
+    persist_wat_revocation_event(wat_id="wat-2", actor="test", confirmed=True, path=path)
+    state = derive_latest_revocation_state("wat-2", path=path)
+    assert state["status"] == "revoked_confirmed"

--- a/veritas_os/tests/test_wat_token.py
+++ b/veritas_os/tests/test_wat_token.py
@@ -9,6 +9,7 @@ from veritas_os.security.wat_token import (
     WAT_VERSION_V1,
     build_wat_claims,
     canonicalize_wat_claims,
+    compute_observable_digests,
     compute_observable_digest,
     make_psid_display,
     sign_wat,
@@ -110,3 +111,35 @@ def test_observable_digest_is_deterministic() -> None:
     first = compute_observable_digest(observable_refs)
     second = compute_observable_digest(observable_refs)
     assert first == second
+
+
+def test_build_wat_claims_includes_observable_digest_list() -> None:
+    observable_refs = [{"obs": "A"}, {"obs": "B"}]
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        psid_full="psid-full-003",
+        action_payload={"action": "allow"},
+        observable_refs=observable_refs,
+        issuance_ts=1_712_000_000,
+        expiry_ts=1_712_000_600,
+        session_id="s-3",
+        nonce="n-3",
+        signer_metadata={"source": "unit-test"},
+    )
+    assert claims["observable_digest_list"] == compute_observable_digests(observable_refs)
+
+
+def test_canonicalization_contains_observable_digest_list_field() -> None:
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        psid_full="psid-full-004",
+        action_payload={"action": "allow"},
+        observable_refs=[{"obs": "A"}],
+        issuance_ts=1_712_000_000,
+        expiry_ts=1_712_000_600,
+        session_id="s-4",
+        nonce="n-4",
+        signer_metadata={"source": "unit-test"},
+    )
+    canonical = canonicalize_wat_claims(claims).decode("utf-8")
+    assert '"observable_digest_list"' in canonical

--- a/veritas_os/tests/test_wat_verifier.py
+++ b/veritas_os/tests/test_wat_verifier.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from veritas_os.security.signing import FileEd25519Signer
-from veritas_os.security.wat_token import WAT_VERSION_V1, build_wat_claims, sign_wat
+from veritas_os.security.wat_token import (
+    WAT_VERSION_V1,
+    build_wat_claims,
+    compute_observable_digest,
+    sign_wat,
+)
 from veritas_os.security.wat_verifier import DriftVector, score_drift, validate_local
 
 
@@ -147,6 +152,58 @@ def test_validate_local_observable_digest_mismatch(tmp_path: Path) -> None:
         now_ts=1_712_000_100,
     )
     assert result["failure_type"] == "observable_digest_mismatch"
+
+
+def test_validate_local_observable_digest_list_mismatch(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "B"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "invalid"
+    assert result["failure_type"] == "observable_digest_list_mismatch"
+
+
+def test_validate_local_empty_observables_with_matching_aggregate_is_valid(tmp_path: Path) -> None:
+    signer = _make_signer(tmp_path)
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        psid_full="psid-full-empty",
+        action_payload={"action": "allow", "resource": "r-1"},
+        observable_refs=[],
+        issuance_ts=1_712_000_000,
+        expiry_ts=1_712_000_600,
+        session_id="session-empty",
+        nonce="nonce-empty",
+        signer_metadata={"source": "unit-test"},
+    )
+    signed_wat = sign_wat(claims, signer)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-empty",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[],
+        observable_digest_local=compute_observable_digest([]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-empty",
+        session_id="session-empty",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "valid"
 
 
 def test_validate_local_expired_token_returns_stale(tmp_path: Path) -> None:
@@ -377,6 +434,28 @@ def test_validate_local_revoked_pending_is_warning_only(tmp_path: Path) -> None:
     )
     assert result["validation_status"] == "revoked_pending"
     assert result["admissibility_state"] == "warning_only_shadow"
+
+
+def test_validate_local_revoked_pending_blocks_when_degrade_disabled(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state={"status": "revoked_pending"},
+        config={"degrade_on_pending": False},
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "revoked_pending"
+    assert result["admissibility_state"] == "non_admissible"
 
 
 def test_validate_local_revoked_confirmed_is_hard_fail(tmp_path: Path) -> None:

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -1325,6 +1325,36 @@ def test_decide_wat_shadow_missing_nested_config_uses_conservative_defaults(monk
     assert "signature_verifier" not in validate_config
 
 
+def test_resolve_shadow_revocation_state_defaults_to_pending_when_configured(monkeypatch):
+    """No revocation telemetry should use conservative pending fallback."""
+    monkeypatch.setattr(
+        routes_decide,
+        "derive_latest_revocation_state",
+        lambda _wat_id: {"status": "active", "source": "wat_events"},
+    )
+    state = routes_decide._resolve_shadow_revocation_state(
+        wat_id="wat-missing",
+        degrade_on_pending=True,
+    )
+    assert state["status"] == "revoked_pending"
+    assert state["source"] == "shadow_default"
+
+
+def test_resolve_shadow_revocation_state_keeps_active_when_pending_disabled(monkeypatch):
+    """Conservative fallback must not trigger when pending degradation is disabled."""
+    monkeypatch.setattr(
+        routes_decide,
+        "derive_latest_revocation_state",
+        lambda _wat_id: {"status": "active", "source": "wat_events"},
+    )
+    state = routes_decide._resolve_shadow_revocation_state(
+        wat_id="wat-missing",
+        degrade_on_pending=False,
+    )
+    assert state["status"] == "active"
+    assert state["source"] == "wat_events"
+
+
 def test_decide_wat_shadow_passes_policy_drift_scoring_to_verifier(monkeypatch):
     """Governance drift_scoring values must be forwarded to local verifier config."""
 


### PR DESCRIPTION
### Motivation
- Make WAT revocation handling and observable digest validation more explicit and robust by promoting per-observable digests to a first-class signed claim and by moving revocation from ad-hoc strings toward a small structured local state model. 
- Preserve backward compatibility by keeping the aggregate `observable_digest` path while adding additive `observable_digest_list` checks for finer-grained enforcement. 
- Enable shadow issuance/validation to reflect event-lane revocation telemetry so local decisions can observe the latest pending/confirmed state. 
- Security risk: revocation remains local/event-lane-derived (not a distributed revocation protocol), and enforcement strength depends on callers providing `observable_refs_local`, so operators must ensure observables are supplied to avoid weakened checks. 

### Description
- Promote `observable_digest_list` to a signed claim in `build_wat_claims()` and compute the aggregate `observable_digest` deterministically from that list, ensuring canonicalization/signing includes the list (`veritas_os/security/wat_token.py`).
- Add strict per-observable list normalization and validation to `validate_local()`, returning explicit failure types `observable_digest_mismatch` and `observable_digest_list_mismatch` while retaining the aggregate digest path (`veritas_os/security/wat_verifier.py`).
- Introduce `derive_latest_revocation_state()` to compute a structured revocation mapping (`active`/`revoked_pending`/`revoked_confirmed`) from the WAT event lane and wire it into the shadow decide path so `validate_local()` receives a structured `revocation_state` (`veritas_os/audit/wat_events.py`, `veritas_os/api/routes_decide.py`).
- Make admissibility respect `degrade_on_pending` policy via `config` so pending revocations map to `warning_only_shadow` when allowed or `non_admissible` when disabled, preserving confirmed as a hard fail (`veritas_os/security/wat_verifier.py`).
- Files changed: `veritas_os/security/wat_token.py`, `veritas_os/security/wat_verifier.py`, `veritas_os/api/routes_decide.py`, `veritas_os/audit/wat_events.py`, plus tests `veritas_os/tests/test_wat_token.py`, `veritas_os/tests/test_wat_verifier.py`, `veritas_os/tests/test_wat_events.py`.

### Testing
- Ran `pytest -q veritas_os/tests/test_wat_token.py veritas_os/tests/test_wat_verifier.py veritas_os/tests/test_wat_events.py` and received all tests passing (`35 passed`).
- Ran `pytest -q tests/test_wat_api.py` and received all tests passing (`6 passed`).
- New/updated unit tests cover: `observable_digest_list` in claims and canonicalization, aggregate vs list mismatch paths, empty-observable compatibility, and event-lane revocation derivation for active/pending/confirmed states.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5645e7ab08326834a8f4bd07ef98f)