### PR TITLE
Wire governance drift_scoring into WAT shadow verifier with defensive coercion

### DIFF
--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -148,16 +148,24 @@ def _build_drift_runtime_config(drift_scoring_cfg: Dict[str, Any]) -> Dict[str, 
     The local verifier consumes normalized axis names:
     ``policy``, ``signature``, ``observable``, and ``temporal``.
     """
+
+    def _safe_float(value: Any, default: float) -> float:
+        """Defensively coerce numeric policy values to float defaults."""
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
     return {
         "drift_weights": {
-            "policy": float(drift_scoring_cfg.get("policy_weight", 0.4)),
-            "signature": float(drift_scoring_cfg.get("signature_weight", 0.3)),
-            "observable": float(drift_scoring_cfg.get("observable_weight", 0.2)),
-            "temporal": float(drift_scoring_cfg.get("temporal_weight", 0.1)),
+            "policy": _safe_float(drift_scoring_cfg.get("policy_weight"), 0.4),
+            "signature": _safe_float(drift_scoring_cfg.get("signature_weight"), 0.3),
+            "observable": _safe_float(drift_scoring_cfg.get("observable_weight"), 0.2),
+            "temporal": _safe_float(drift_scoring_cfg.get("temporal_weight"), 0.1),
         },
         "drift_thresholds": {
-            "healthy": float(drift_scoring_cfg.get("healthy_threshold", 0.2)),
-            "critical": float(drift_scoring_cfg.get("critical_threshold", 0.5)),
+            "healthy": _safe_float(drift_scoring_cfg.get("healthy_threshold"), 0.2),
+            "critical": _safe_float(drift_scoring_cfg.get("critical_threshold"), 0.5),
         },
     }
 

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -1422,6 +1422,73 @@ def test_decide_wat_shadow_passes_policy_drift_scoring_to_verifier(monkeypatch):
     }
 
 
+def test_decide_wat_shadow_invalid_drift_scoring_values_fall_back_to_defaults(monkeypatch):
+    """Invalid drift_scoring values must not break shadow observer validation config."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            return {
+                "ok": True,
+                "request_id": "rid-drift-invalid",
+                "query": req.query,
+                "decision": "allow",
+                "business_decision": "APPROVE",
+                "result": "ok",
+            }
+
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {
+            "timestamp_skew_tolerance_seconds": 5,
+            "warning_only_until": None,
+            "replay_binding_required": False,
+        },
+        "revocation": {"degrade_on_pending": True},
+        "drift_scoring": {
+            "policy_weight": "not-a-float",
+            "signature_weight": None,
+            "observable_weight": {},
+            "temporal_weight": [],
+            "healthy_threshold": "bad-threshold",
+            "critical_threshold": object(),
+        },
+    }
+    captured_validate_kwargs = {}
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
+    monkeypatch.setattr(
+        routes_decide,
+        "validate_local",
+        lambda **kwargs: captured_validate_kwargs.update(kwargs) or {
+            "validation_status": "valid",
+            "admissibility_state": "admissible",
+            "failure_type": "",
+            "drift_vector": {},
+        },
+    )
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+
+    assert response.status_code == 200
+    validate_config = captured_validate_kwargs.get("config", {})
+    assert validate_config.get("drift_weights") == {
+        "policy": 0.4,
+        "signature": 0.3,
+        "observable": 0.2,
+        "temporal": 0.1,
+    }
+    assert validate_config.get("drift_thresholds") == {
+        "healthy": 0.2,
+        "critical": 0.5,
+    }
+
+
 def test_run_wat_shadow_observer_tampered_signature_invalid(monkeypatch, tmp_path):
     """Tampered signed WAT must fail local verification as signature_invalid."""
 


### PR DESCRIPTION
### Motivation
- Connect governance `policy["drift_scoring"]` values end-to-end to the local WAT verifier so runtime drift classification follows policy.
- Ensure malformed or non-numeric policy values do not break the observer path and fall back to safe defaults.
- Preserve existing default weights/thresholds and observer-only/hard-fail semantics while improving defensive runtime mapping.

### Description
- Add a defensive coercion helper `_safe_float` inside `_build_drift_runtime_config()` and use it to convert policy values into floats for `drift_weights` and `drift_thresholds` with the same defaults (`policy=0.4`, `signature=0.3`, `observable=0.2`, `temporal=0.1`, `healthy=0.2`, `critical=0.5`).
- Keep the runtime mapping that exposes policy fields into verifier config: `policy_weight -> drift_weights.policy`, `signature_weight -> drift_weights.signature`, `observable_weight -> drift_weights.observable`, `temporal_weight -> drift_weights.temporal`, `healthy_threshold -> drift_thresholds.healthy`, and `critical_threshold -> drift_thresholds.critical` via `_build_drift_runtime_config()` and pass those into `validate_local(config=...)`.
- Add a unit test `test_decide_wat_shadow_invalid_drift_scoring_values_fall_back_to_defaults` to assert invalid policy types safely fall back to defaults and do not break the shadow observer flow.
- Files changed: `veritas_os/api/routes_decide.py` and `veritas_os/tests/unit/test_server_api.py`.

### Testing
- Ran `pytest -q veritas_os/tests/unit/test_server_api.py -k "drift_scoring or missing_nested_config or shadow_enabled_emits_events_without_mutating_action or validation_failure_does_not_change_decision"` which resulted in `5 passed, 314 deselected`.
- Ran `pytest -q veritas_os/tests/test_wat_verifier.py -k "drift_score_custom_weights_affect_classification or drift_score_custom_thresholds_affect_classification or drift_score_classification"` which resulted in `3 passed, 20 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56efd3ac48326a2ef7eda497a903a)