### PR TITLE
WATシャドウ失効状態をイベントレーン由来の構造化 state に接続する

### DIFF
--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -197,24 +197,16 @@ def _resolve_wat_shadow_signer(wat_cfg: Dict[str, Any]) -> Signer:
     )
 
 
-def _resolve_shadow_revocation_state(
-    *,
-    wat_id: str,
-    degrade_on_pending: bool,
-) -> Dict[str, Any]:
-    """Resolve shadow-lane revocation state with conservative defaults.
+def _resolve_shadow_revocation_state(*, wat_id: str) -> Dict[str, Any]:
+    """Resolve runtime revocation status from the WAT event lane source.
 
     Security:
-        If no revocation telemetry exists and degradation is enabled, default
-        to ``revoked_pending`` to keep observer-only posture conservative.
+        This observer uses event-lane-derived structured state as the single
+        runtime source of truth and does not synthesize fallback statuses.
     """
     state = dict(derive_latest_revocation_state(wat_id))
-    status = str(state.get("status", "active"))
-    has_event_ref = bool(state.get("event_id") or state.get("event_type"))
-    if status == "active" and degrade_on_pending and not has_event_ref:
-        status = "revoked_pending"
-        state["source"] = "shadow_default"
-    state["status"] = status
+    state["status"] = str(state.get("status", "active") or "active")
+    state.setdefault("source", "wat_events")
     return state
 
 
@@ -301,12 +293,9 @@ def _run_wat_shadow_observer(
         psid_display_length=int(psid_cfg.get("display_length", 12)),
     )
     signed_wat = sign_wat(claims, signer)
-    degrade_on_pending = bool(revocation_cfg.get("degrade_on_pending", True))
-    revocation_state = _resolve_shadow_revocation_state(
-        wat_id=wat_id,
-        degrade_on_pending=degrade_on_pending,
-    )
+    revocation_state = _resolve_shadow_revocation_state(wat_id=wat_id)
     effective_revocation_status = str(revocation_state.get("status", "active"))
+    degrade_on_pending = bool(revocation_cfg.get("degrade_on_pending", True))
 
     verifier_result = validate_local(
         signed_wat=signed_wat,

--- a/veritas_os/tests/test_wat_events.py
+++ b/veritas_os/tests/test_wat_events.py
@@ -14,6 +14,7 @@ from veritas_os.audit.wat_events import (
 def test_derive_latest_revocation_state_defaults_active(tmp_path: Path) -> None:
     state = derive_latest_revocation_state("missing-wat", path=tmp_path / "wat_events.jsonl")
     assert state["status"] == "active"
+    assert state["source"] == "wat_events"
 
 
 def test_derive_latest_revocation_state_pending(tmp_path: Path) -> None:
@@ -22,6 +23,7 @@ def test_derive_latest_revocation_state_pending(tmp_path: Path) -> None:
     persist_wat_revocation_event(wat_id="wat-1", actor="test", confirmed=False, path=path)
     state = derive_latest_revocation_state("wat-1", path=path)
     assert state["status"] == "revoked_pending"
+    assert state["source"] == "wat_events"
 
 
 def test_derive_latest_revocation_state_confirmed(tmp_path: Path) -> None:
@@ -31,3 +33,4 @@ def test_derive_latest_revocation_state_confirmed(tmp_path: Path) -> None:
     persist_wat_revocation_event(wat_id="wat-2", actor="test", confirmed=True, path=path)
     state = derive_latest_revocation_state("wat-2", path=path)
     assert state["status"] == "revoked_confirmed"
+    assert state["source"] == "wat_events"

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -1307,7 +1307,7 @@ def test_decide_wat_shadow_missing_nested_config_uses_conservative_defaults(monk
     assert payload["decision"] == "allow"
     assert payload["business_decision"] == "APPROVE"
     wat_shadow = payload.get("meta", {}).get("wat_shadow", {})
-    assert wat_shadow.get("revocation_status") == "revoked_pending"
+    assert wat_shadow.get("revocation_status") == "active"
     validate_config = captured_validate_kwargs.get("config", {})
     assert validate_config.get("timestamp_skew_tolerance_seconds") == 5
     assert validate_config.get("warning_only_until") is None
@@ -1325,34 +1325,89 @@ def test_decide_wat_shadow_missing_nested_config_uses_conservative_defaults(monk
     assert "signature_verifier" not in validate_config
 
 
-def test_resolve_shadow_revocation_state_defaults_to_pending_when_configured(monkeypatch):
-    """No revocation telemetry should use conservative pending fallback."""
+def test_resolve_shadow_revocation_state_uses_event_lane_active_default(monkeypatch):
+    """No revocation telemetry should preserve event-lane ``active`` state."""
     monkeypatch.setattr(
         routes_decide,
         "derive_latest_revocation_state",
         lambda _wat_id: {"status": "active", "source": "wat_events"},
     )
-    state = routes_decide._resolve_shadow_revocation_state(
-        wat_id="wat-missing",
-        degrade_on_pending=True,
-    )
-    assert state["status"] == "revoked_pending"
-    assert state["source"] == "shadow_default"
-
-
-def test_resolve_shadow_revocation_state_keeps_active_when_pending_disabled(monkeypatch):
-    """Conservative fallback must not trigger when pending degradation is disabled."""
-    monkeypatch.setattr(
-        routes_decide,
-        "derive_latest_revocation_state",
-        lambda _wat_id: {"status": "active", "source": "wat_events"},
-    )
-    state = routes_decide._resolve_shadow_revocation_state(
-        wat_id="wat-missing",
-        degrade_on_pending=False,
-    )
+    state = routes_decide._resolve_shadow_revocation_state(wat_id="wat-missing")
     assert state["status"] == "active"
     assert state["source"] == "wat_events"
+
+
+def test_resolve_shadow_revocation_state_preserves_pending_from_event_lane(monkeypatch):
+    """Pending state should be forwarded from event lane without mutation."""
+    monkeypatch.setattr(
+        routes_decide,
+        "derive_latest_revocation_state",
+        lambda _wat_id: {
+            "status": "revoked_pending",
+            "source": "wat_events",
+            "event_id": "evt-pending",
+        },
+    )
+    state = routes_decide._resolve_shadow_revocation_state(wat_id="wat-pending")
+    assert state["status"] == "revoked_pending"
+    assert state["source"] == "wat_events"
+
+
+def test_decide_wat_shadow_surfaces_revocation_status_from_derived_state(monkeypatch):
+    """Decide response must mirror event-lane-derived revocation status."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            return {
+                "ok": True,
+                "request_id": "rid-derived-revocation",
+                "query": req.query,
+                "decision": "allow",
+                "business_decision": "APPROVE",
+                "result": "ok",
+            }
+
+    policy = {
+        "wat": {"enabled": True, "issuance_mode": "shadow_only", "default_ttl_seconds": 60},
+        "psid": {"display_length": 12},
+        "shadow_validation": {"timestamp_skew_tolerance_seconds": 5},
+        "revocation": {"degrade_on_pending": True},
+        "drift_scoring": {},
+    }
+    captured_validate_kwargs = {}
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: policy)
+    monkeypatch.setattr(
+        routes_decide,
+        "derive_latest_revocation_state",
+        lambda _wat_id: {
+            "status": "revoked_pending",
+            "source": "wat_events",
+            "event_id": "evt-123",
+        },
+    )
+    monkeypatch.setattr(
+        routes_decide,
+        "validate_local",
+        lambda **kwargs: captured_validate_kwargs.update(kwargs) or {
+            "validation_status": "revoked_pending",
+            "admissibility_state": "warning_only_shadow",
+            "failure_type": "",
+            "drift_vector": {},
+        },
+    )
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("meta", {}).get("wat_shadow", {}).get("revocation_status") == "revoked_pending"
+    assert payload.get("wat_integrity", {}).get("revocation_status") == "revoked_pending"
+    assert captured_validate_kwargs.get("revocation_state", {}).get("status") == "revoked_pending"
 
 
 def test_decide_wat_shadow_passes_policy_drift_scoring_to_verifier(monkeypatch):


### PR DESCRIPTION
### Motivation
- シャドウ経路で擬似的に `revoked_pending` を生成していたランタイム表現を廃止し、イベントレーン（`wat_events`）由来の構造化 state を単一のソース・オブ・トゥルースとして `validate_local` に渡すため。 
- これによりローカル検証の revocation モデルをイベントレーンの時系列ソースに接続し、将来の失効伝搬基盤を整備するため。

### Description
- `veritas_os/api/routes_decide.py` の `_resolve_shadow_revocation_state` を簡素化して `derive_latest_revocation_state(wat_id)` の返す mapping をそのまま使用するようにし、従来の合成フォールバック（no-event → `revoked_pending`）を削除した。 
- `_run_wat_shadow_observer()` で `derive_latest_revocation_state(wat_id)` 経由の `revocation_state` を取得し、その構造化 mapping を `validate_local(revocation_state=...)` に直接渡すようにした。 
- `degrade_on_pending` の挙動は verifier の `config`（admissibility posture）にのみ残し、判定（`revoked_pending` => `warning_only_shadow` 等）は `validate_local` 側で制御されるようにした。 
- テストを更新・追加してイベントレーン由来の `source` と `status` が正しく伝播されることと、observer-only の本番意思決定不変性を担保した（`veritas_os/tests/test_wat_events.py`、`veritas_os/tests/unit/test_server_api.py` を修正／追加）。

### Testing
- 実行コマンド `pytest -q veritas_os/tests/test_wat_events.py veritas_os/tests/test_wat_verifier.py::test_validate_local_revoked_pending_is_warning_only veritas_os/tests/test_wat_verifier.py::test_validate_local_revoked_confirmed_is_hard_fail veritas_os/tests/unit/test_server_api.py::test_decide_wat_shadow_missing_nested_config_uses_conservative_defaults veritas_os/tests/unit/test_server_api.py::test_resolve_shadow_revocation_state_uses_event_lane_active_default veritas_os/tests/unit/test_server_api.py::test_resolve_shadow_revocation_state_preserves_pending_from_event_lane veritas_os/tests/unit/test_server_api.py::test_decide_wat_shadow_surfaces_revocation_status_from_derived_state` が成功し、全てパスした（`9 passed`）。
- 追加で `pytest -q veritas_os/tests/unit/test_server_api.py::test_decide_wat_shadow_validation_failure_does_not_change_decision` を実行し成功（`1 passed`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5764a550483269f37c81369228863)