### PR TITLE
Add production guard for query API key compatibility flags

### DIFF
--- a/docs/ja/reviews/precision_review_2026_04_20_agent_ja.md
+++ b/docs/ja/reviews/precision_review_2026_04_20_agent_ja.md
@@ -52,8 +52,9 @@
 - `scripts/production_validation.sh` に Phase 0 を追加し、上記ガードを本番検証フローの先頭で実行するよう更新。
 - 回帰テスト `veritas_os/tests/test_check_query_compat_flags.py` を追加し、
   非本番スキップ・本番fail条件・CLI終了コードを検証。
+- CodeQL 指摘（clear-text logging of sensitive information）に対応し、CLI失敗時ログは
+  フラグ名/値を出力せず `redacted` 表記に統一。
 
 ## 追加提案（任意）
 - セキュリティフラグ（query認証移行フラグ、danger presetフラグ）の**起動時サマリー出力**を1箇所へ集約し、SREの可観測性を向上。
 - フロントエンドの `NEXT_PUBLIC_ENABLE_DANGER_PRESETS` についても、`production_validation.sh` で明示ガードを追加すると運用事故をさらに減らせる。
-

--- a/docs/ja/reviews/precision_review_2026_04_20_agent_ja.md
+++ b/docs/ja/reviews/precision_review_2026_04_20_agent_ja.md
@@ -46,7 +46,14 @@
 - CORSは wildcard + credentials を防止する実装で、典型的な誤設定事故を抑止している。
 - TrustLog/ガバナンス周辺の対象テストは今回実行範囲で全件成功。
 
+## 改善対応（2026-04-20 実施）
+- `scripts/security/check_query_api_key_compat_flags.py` を追加し、`VERITAS_ENV` が `prod/production` の場合に
+  `VERITAS_ALLOW_SSE_QUERY_API_KEY` / `VERITAS_ALLOW_WS_QUERY_API_KEY` が有効化されていれば **fail** するガードを実装。
+- `scripts/production_validation.sh` に Phase 0 を追加し、上記ガードを本番検証フローの先頭で実行するよう更新。
+- 回帰テスト `veritas_os/tests/test_check_query_compat_flags.py` を追加し、
+  非本番スキップ・本番fail条件・CLI終了コードを検証。
+
 ## 追加提案（任意）
 - セキュリティフラグ（query認証移行フラグ、danger presetフラグ）の**起動時サマリー出力**を1箇所へ集約し、SREの可観測性を向上。
-- `scripts/production_validation.sh` に「query API key フラグ=OFF」を検証する明示チェックを追加。
+- フロントエンドの `NEXT_PUBLIC_ENABLE_DANGER_PRESETS` についても、`production_validation.sh` で明示ガードを追加すると運用事故をさらに減らせる。
 

--- a/scripts/production_validation.sh
+++ b/scripts/production_validation.sh
@@ -53,6 +53,16 @@ fi
 cd "${REPO_ROOT}"
 FAILURES=0
 
+# ── Phase 0: Security configuration guards ────────────────────────────────
+
+log_info "Phase 0: Running security configuration guards..."
+if python scripts/security/check_query_api_key_compat_flags.py; then
+    log_info "Phase 0: Query API key compatibility flag guard PASSED ✓"
+else
+    log_error "Phase 0: Query API key compatibility flag guard FAILED ✗"
+    FAILURES=$((FAILURES + 1))
+fi
+
 # ── Phase 1: Python production-like tests ─────────────────────────────────
 
 if $RUN_TESTS; then

--- a/scripts/security/check_query_api_key_compat_flags.py
+++ b/scripts/security/check_query_api_key_compat_flags.py
@@ -68,7 +68,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     del argv  # reserved for future CLI options
 
     profile = (os.environ.get("VERITAS_ENV", "") or "").strip().lower()
-    ok, findings = validate_query_api_key_compat_flags(dict(os.environ))
+    ok, _findings = validate_query_api_key_compat_flags(dict(os.environ))
     if ok:
         if profile in PRODUCTION_ALIASES:
             print("Query API key compatibility flags are disabled for production.")
@@ -79,8 +79,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         return 0
 
-    for line in findings:
-        print(line)
+    print(
+        "[SECURITY] Query API key compatibility flags must be disabled in "
+        "production deployments."
+    )
+    print(
+        "- enabled_compatibility_flags_detected: true "
+        "(redacted for safe logging)"
+    )
+    print("- action: unset the compatibility flags before release.")
     return 1
 
 

--- a/scripts/security/check_query_api_key_compat_flags.py
+++ b/scripts/security/check_query_api_key_compat_flags.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate query API key compatibility flags for production safety.
+
+This check prevents production deployments from enabling legacy query-string
+API key authentication for SSE/WebSocket endpoints. Query-string credentials are
+more likely to leak via access logs, referrers, and monitoring systems.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Sequence
+
+PRODUCTION_ALIASES = {"prod", "production"}
+DISALLOWED_FLAGS = (
+    "VERITAS_ALLOW_SSE_QUERY_API_KEY",
+    "VERITAS_ALLOW_WS_QUERY_API_KEY",
+)
+TRUTHY_VALUES = {"1", "true", "yes", "on"}
+
+
+def _is_truthy(value: str | None) -> bool:
+    """Return True when an environment variable value is explicitly enabled."""
+    if value is None:
+        return False
+    return value.strip().lower() in TRUTHY_VALUES
+
+
+def validate_query_api_key_compat_flags(
+    env: dict[str, str] | None = None,
+) -> tuple[bool, list[str]]:
+    """Validate query API key compatibility flags for the active profile.
+
+    Returns:
+        tuple[bool, list[str]]: Success flag and findings. Empty findings
+        indicates the configuration is safe for the current profile.
+    """
+    environ = env if env is not None else os.environ
+    profile = (environ.get("VERITAS_ENV", "") or "").strip().lower()
+    findings: list[str] = []
+
+    if profile not in PRODUCTION_ALIASES:
+        return True, findings
+
+    enabled_flags = [
+        flag_name
+        for flag_name in DISALLOWED_FLAGS
+        if _is_truthy(environ.get(flag_name))
+    ]
+    if enabled_flags:
+        findings.append(
+            "[SECURITY] Query API key compatibility flags must be disabled in "
+            "production deployments."
+        )
+        findings.append("- enabled_flags: " + ", ".join(enabled_flags))
+        findings.append(
+            "- action: unset the flags or set them to false/0/off before "
+            "release."
+        )
+        return False, findings
+
+    return True, findings
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the query API key compatibility flag validation check."""
+    del argv  # reserved for future CLI options
+
+    profile = (os.environ.get("VERITAS_ENV", "") or "").strip().lower()
+    ok, findings = validate_query_api_key_compat_flags(dict(os.environ))
+    if ok:
+        if profile in PRODUCTION_ALIASES:
+            print("Query API key compatibility flags are disabled for production.")
+        else:
+            print(
+                "Query API key compatibility flag check skipped "
+                "(non-production profile)."
+            )
+        return 0
+
+    for line in findings:
+        print(line)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/veritas_os/tests/test_check_query_compat_flags.py
+++ b/veritas_os/tests/test_check_query_compat_flags.py
@@ -1,0 +1,64 @@
+"""Tests for scripts.security.check_query_api_key_compat_flags."""
+
+from __future__ import annotations
+
+from scripts.security import check_query_api_key_compat_flags as checker
+
+
+def test_validate_skips_non_production_profile() -> None:
+    """Non-production profiles should not fail this deployment guard."""
+    ok, findings = checker.validate_query_api_key_compat_flags(
+        {
+            "VERITAS_ENV": "dev",
+            "VERITAS_ALLOW_SSE_QUERY_API_KEY": "true",
+        }
+    )
+
+    assert ok is True
+    assert findings == []
+
+
+def test_validate_fails_when_query_flags_enabled_in_production() -> None:
+    """Production must reject legacy query API key compatibility flags."""
+    ok, findings = checker.validate_query_api_key_compat_flags(
+        {
+            "VERITAS_ENV": "production",
+            "VERITAS_ALLOW_SSE_QUERY_API_KEY": "true",
+            "VERITAS_ALLOW_WS_QUERY_API_KEY": "1",
+        }
+    )
+
+    assert ok is False
+    assert any("must be disabled in production" in line for line in findings)
+    assert any("VERITAS_ALLOW_SSE_QUERY_API_KEY" in line for line in findings)
+    assert any("VERITAS_ALLOW_WS_QUERY_API_KEY" in line for line in findings)
+
+
+def test_main_returns_zero_when_production_flags_are_disabled(
+    monkeypatch, capsys
+) -> None:
+    """CLI succeeds for production profiles with compatibility flags off."""
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.delenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", raising=False)
+    monkeypatch.setenv("VERITAS_ALLOW_WS_QUERY_API_KEY", "false")
+
+    exit_code = checker.main([])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "disabled for production" in output
+
+
+def test_main_returns_non_zero_when_production_flag_is_enabled(
+    monkeypatch, capsys
+) -> None:
+    """CLI fails and prints a security warning for unsafe production flags."""
+    monkeypatch.setenv("VERITAS_ENV", "prod")
+    monkeypatch.setenv("VERITAS_ALLOW_WS_QUERY_API_KEY", "on")
+
+    exit_code = checker.main([])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "[SECURITY]" in output
+    assert "VERITAS_ALLOW_WS_QUERY_API_KEY" in output

--- a/veritas_os/tests/test_check_query_compat_flags.py
+++ b/veritas_os/tests/test_check_query_compat_flags.py
@@ -61,4 +61,4 @@ def test_main_returns_non_zero_when_production_flag_is_enabled(
 
     assert exit_code == 1
     assert "[SECURITY]" in output
-    assert "VERITAS_ALLOW_WS_QUERY_API_KEY" in output
+    assert "redacted for safe logging" in output


### PR DESCRIPTION
### Motivation
- 精密レビューで指摘された SSE/WebSocket の query API key 互換フラグが本番環境で有効になると資格情報漏洩リスクがあるため、その誤設定をデプロイ前に検出・阻止する目的で追加実装を行った。 

### Description
- 新規に `scripts/security/check_query_api_key_compat_flags.py` を追加し、`VERITAS_ENV` が `prod/production` の場合に `VERITAS_ALLOW_SSE_QUERY_API_KEY` / `VERITAS_ALLOW_WS_QUERY_API_KEY` が真値だと失敗するガードを実装した。 
- `scripts/production_validation.sh` に Phase 0 を追加して上記ガードを検証フローの先頭で実行するよう統合した。 
- 回帰テスト `veritas_os/tests/test_check_query_compat_flags.py` を追加して非本番スキップ・本番fail条件・CLI終了コードを検証するテストを用意した。 
- ドキュメント `docs/ja/reviews/precision_review_2026_04_20_agent_ja.md` を更新して実施内容を明記した。 
- 実装は最小限に留め、既存の責務境界や設計方針を超える変更は行っていない。 

### Testing
- `python -m pytest -q veritas_os/tests/test_check_query_compat_flags.py` → 4 passed (成功)。
- `python -m pytest -q veritas_os/tests/test_check_query_compat_flags.py veritas_os/tests/test_check_memory_dir_allowlist.py` → 14 passed (成功)。
- `VERITAS_ENV=production VERITAS_ALLOW_WS_QUERY_API_KEY=true python scripts/security/check_query_api_key_compat_flags.py` → スクリプトは期待どおり `exit 1` を返し、`[SECURITY]` 警告を出力した（期待どおりの失敗）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5953967f0832698a594a7c0faec9e)