### PR TITLE
Add production guard to disable NEXT_PUBLIC danger presets

### DIFF
--- a/docs/ja/reviews/precision_review_2026_04_20_agent_ja.md
+++ b/docs/ja/reviews/precision_review_2026_04_20_agent_ja.md
@@ -54,7 +54,12 @@
   非本番スキップ・本番fail条件・CLI終了コードを検証。
 - CodeQL 指摘（clear-text logging of sensitive information）に対応し、CLI失敗時ログは
   フラグ名/値を出力せず `redacted` 表記に統一。
+- `scripts/security/check_danger_presets_production_flag.py` を追加し、`VERITAS_ENV` または `NODE_ENV` が `prod/production` の場合に
+  `NEXT_PUBLIC_ENABLE_DANGER_PRESETS` が有効化されていれば **fail** するガードを実装。
+- `scripts/production_validation.sh` の Phase 0 で danger preset 本番ガードを実行するよう更新。
+- 回帰テスト `veritas_os/tests/test_check_danger_presets_flag.py` を追加し、
+  非本番スキップ・本番fail条件・CLI終了コード・redactedログを検証。
 
 ## 追加提案（任意）
 - セキュリティフラグ（query認証移行フラグ、danger presetフラグ）の**起動時サマリー出力**を1箇所へ集約し、SREの可観測性を向上。
-- フロントエンドの `NEXT_PUBLIC_ENABLE_DANGER_PRESETS` についても、`production_validation.sh` で明示ガードを追加すると運用事故をさらに減らせる。
+- danger preset ガードの検知結果を監視基盤に転送し、デプロイ前の運用監査を自動化するとさらに堅牢化できる。

--- a/scripts/production_validation.sh
+++ b/scripts/production_validation.sh
@@ -63,6 +63,13 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
+if python scripts/security/check_danger_presets_production_flag.py; then
+    log_info "Phase 0: Danger preset production flag guard PASSED ✓"
+else
+    log_error "Phase 0: Danger preset production flag guard FAILED ✗"
+    FAILURES=$((FAILURES + 1))
+fi
+
 # ── Phase 1: Python production-like tests ─────────────────────────────────
 
 if $RUN_TESTS; then

--- a/scripts/security/check_danger_presets_production_flag.py
+++ b/scripts/security/check_danger_presets_production_flag.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Validate danger preset front-end flags are disabled in production.
+
+This check prevents accidental exposure of dangerous prompt presets in
+production-like environments. The front-end variable is public by design, so
+it must remain disabled when deployment profile indicates production.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Sequence
+
+PRODUCTION_ALIASES = {"prod", "production"}
+DANGER_PRESET_FLAG = "NEXT_PUBLIC_ENABLE_DANGER_PRESETS"
+TRUTHY_VALUES = {"1", "true", "yes", "on"}
+
+
+def _is_truthy(value: str | None) -> bool:
+    """Return True when an environment variable value is explicitly enabled."""
+    if value is None:
+        return False
+    return value.strip().lower() in TRUTHY_VALUES
+
+
+def _is_production_profile(env: dict[str, str]) -> bool:
+    """Return True when environment profile is production-like."""
+    veritas_profile = (env.get("VERITAS_ENV", "") or "").strip().lower()
+    node_profile = (env.get("NODE_ENV", "") or "").strip().lower()
+    return (
+        veritas_profile in PRODUCTION_ALIASES
+        or node_profile in PRODUCTION_ALIASES
+    )
+
+
+def validate_danger_presets_flag(
+    env: dict[str, str] | None = None,
+) -> tuple[bool, list[str]]:
+    """Validate the danger preset flag for production-like profiles."""
+    environ = env if env is not None else os.environ
+    findings: list[str] = []
+
+    if not _is_production_profile(environ):
+        return True, findings
+
+    if _is_truthy(environ.get(DANGER_PRESET_FLAG)):
+        findings.append(
+            "[SECURITY] NEXT_PUBLIC_ENABLE_DANGER_PRESETS must be disabled "
+            "in production deployments."
+        )
+        findings.append(
+            "- action: unset the flag or set it to false/0/off before release."
+        )
+        return False, findings
+
+    return True, findings
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run danger preset production guard as a CLI check."""
+    del argv  # reserved for future CLI options
+
+    ok, _findings = validate_danger_presets_flag(dict(os.environ))
+    if ok:
+        print("Danger preset production flag check passed.")
+        return 0
+
+    print(
+        "[SECURITY] NEXT_PUBLIC_ENABLE_DANGER_PRESETS must be disabled in "
+        "production deployments."
+    )
+    print("- enabled_danger_preset_flag_detected: true (redacted for safe logging)")
+    print("- action: unset the flag before release.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/veritas_os/tests/test_check_danger_presets_flag.py
+++ b/veritas_os/tests/test_check_danger_presets_flag.py
@@ -1,0 +1,69 @@
+"""Tests for scripts.security.check_danger_presets_production_flag."""
+
+from __future__ import annotations
+
+from scripts.security import check_danger_presets_production_flag as checker
+
+
+def test_validate_skips_non_production_profile() -> None:
+    """Non-production profiles should not fail this deployment guard."""
+    ok, findings = checker.validate_danger_presets_flag(
+        {
+            "VERITAS_ENV": "dev",
+            "NEXT_PUBLIC_ENABLE_DANGER_PRESETS": "true",
+        }
+    )
+
+    assert ok is True
+    assert findings == []
+
+
+def test_validate_fails_when_danger_presets_enabled_in_production() -> None:
+    """Production must reject exposed danger preset toggles."""
+    ok, findings = checker.validate_danger_presets_flag(
+        {
+            "VERITAS_ENV": "production",
+            "NEXT_PUBLIC_ENABLE_DANGER_PRESETS": "1",
+        }
+    )
+
+    assert ok is False
+    assert any("must be disabled in production" in line for line in findings)
+
+
+def test_validate_uses_node_env_production_alias() -> None:
+    """NODE_ENV=production also triggers the guard even without VERITAS_ENV."""
+    ok, findings = checker.validate_danger_presets_flag(
+        {
+            "NODE_ENV": "production",
+            "NEXT_PUBLIC_ENABLE_DANGER_PRESETS": "on",
+        }
+    )
+
+    assert ok is False
+    assert findings
+
+
+def test_main_returns_zero_when_flag_disabled(monkeypatch, capsys) -> None:
+    """CLI succeeds for production profiles with danger presets disabled."""
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("NEXT_PUBLIC_ENABLE_DANGER_PRESETS", "false")
+
+    exit_code = checker.main([])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "check passed" in output
+
+
+def test_main_returns_non_zero_when_flag_enabled(monkeypatch, capsys) -> None:
+    """CLI fails and prints a safe security warning for enabled danger flag."""
+    monkeypatch.setenv("NODE_ENV", "prod")
+    monkeypatch.setenv("NEXT_PUBLIC_ENABLE_DANGER_PRESETS", "true")
+
+    exit_code = checker.main([])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "[SECURITY]" in output
+    assert "redacted for safe logging" in output


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of dangerous front-end prompt presets by ensuring `NEXT_PUBLIC_ENABLE_DANGER_PRESETS` cannot be enabled in production-like deployments. 
- Maintain safe logging practices by not printing flag names/values on CLI failures to avoid leaking sensitive configuration. 

### Description
- Added `scripts/security/check_danger_presets_production_flag.py` which fails when `VERITAS_ENV` or `NODE_ENV` is `prod/production` and `NEXT_PUBLIC_ENABLE_DANGER_PRESETS` is truthy. 
- Updated `scripts/production_validation.sh` Phase 0 to run the new danger-preset guard alongside the existing query-API-key compatibility guard. 
- Added regression tests in `veritas_os/tests/test_check_danger_presets_flag.py` to validate non-production skips, production failure behavior, `NODE_ENV` aliasing, CLI exit codes, and redacted failure logging. 
- Updated `docs/ja/reviews/precision_review_2026_04_20_agent_ja.md` to record the implemented guard and revised optional follow-up proposal. 

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_check_danger_presets_flag.py veritas_os/tests/test_check_query_compat_flags.py`, which completed successfully (`9 passed`). 
- Executed `python scripts/security/check_danger_presets_production_flag.py` and `python scripts/security/check_query_api_key_compat_flags.py`, both returning success/expected output in a non-production profile. 
- Confirmed the `production_validation.sh` Phase 0 calls the new guard and increments failure count on guard failure via local script execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a7f05f948326868eb92448bc9948)