### PR TITLE
Add redacted security flag posture summary to Phase 0 production validation

### DIFF
--- a/docs/ja/reviews/precision_review_2026_04_20_agent_ja.md
+++ b/docs/ja/reviews/precision_review_2026_04_20_agent_ja.md
@@ -59,6 +59,12 @@
 - `scripts/production_validation.sh` の Phase 0 で danger preset 本番ガードを実行するよう更新。
 - 回帰テスト `veritas_os/tests/test_check_danger_presets_flag.py` を追加し、
   非本番スキップ・本番fail条件・CLI終了コード・redactedログを検証。
+- `scripts/security/report_security_flag_posture.py` を追加し、
+  query API key 互換フラグと danger preset フラグの有効/無効状態を**値を秘匿したまま**一括サマリー出力する運用可観測性を追加。
+- `scripts/production_validation.sh` の Phase 0 先頭で上記サマリーを出力するよう更新し、
+  本番検証ジョブでのフラグ監査を1箇所に集約。
+- 回帰テスト `veritas_os/tests/test_report_security_flag_posture.py` を追加し、
+  サマリー内容（enabled/disabled）と redacted 出力（生値非表示）を検証。
 
 ## 追加提案（任意）
 - セキュリティフラグ（query認証移行フラグ、danger presetフラグ）の**起動時サマリー出力**を1箇所へ集約し、SREの可観測性を向上。

--- a/scripts/production_validation.sh
+++ b/scripts/production_validation.sh
@@ -56,6 +56,13 @@ FAILURES=0
 # ── Phase 0: Security configuration guards ────────────────────────────────
 
 log_info "Phase 0: Running security configuration guards..."
+if python scripts/security/report_security_flag_posture.py; then
+    log_info "Phase 0: Security flag posture summary emitted ✓"
+else
+    log_error "Phase 0: Security flag posture summary FAILED ✗"
+    FAILURES=$((FAILURES + 1))
+fi
+
 if python scripts/security/check_query_api_key_compat_flags.py; then
     log_info "Phase 0: Query API key compatibility flag guard PASSED ✓"
 else

--- a/scripts/security/report_security_flag_posture.py
+++ b/scripts/security/report_security_flag_posture.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Emit a redacted summary of security-sensitive compatibility flag posture.
+
+This helper centralizes operator-facing visibility for flags that can relax
+security posture (query API key compatibility and front-end danger presets).
+The report intentionally avoids printing raw environment variable values.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Mapping, Sequence
+
+TRUTHY_VALUES = {"1", "true", "yes", "on"}
+SECURITY_FLAGS = (
+    "VERITAS_ALLOW_SSE_QUERY_API_KEY",
+    "VERITAS_ALLOW_WS_QUERY_API_KEY",
+    "NEXT_PUBLIC_ENABLE_DANGER_PRESETS",
+)
+
+
+def _is_truthy(value: str | None) -> bool:
+    """Return True when an environment variable value is explicitly enabled."""
+    if value is None:
+        return False
+    return value.strip().lower() in TRUTHY_VALUES
+
+
+def _normalized_profile(env: Mapping[str, str]) -> str:
+    """Return the most relevant deployment profile label for observability."""
+    veritas_env = (env.get("VERITAS_ENV", "") or "").strip().lower()
+    node_env = (env.get("NODE_ENV", "") or "").strip().lower()
+    if veritas_env:
+        return f"VERITAS_ENV={veritas_env}"
+    if node_env:
+        return f"NODE_ENV={node_env}"
+    return "unknown"
+
+
+def build_security_flag_posture(
+    env: Mapping[str, str] | None = None,
+) -> dict[str, bool | str]:
+    """Build a redacted snapshot for security-sensitive runtime flags."""
+    environ = env if env is not None else os.environ
+    posture: dict[str, bool | str] = {
+        "profile": _normalized_profile(environ),
+    }
+    for flag_name in SECURITY_FLAGS:
+        posture[flag_name] = _is_truthy(environ.get(flag_name))
+    return posture
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Print a redacted security flag summary for operators and CI logs."""
+    del argv  # reserved for future CLI options
+
+    posture = build_security_flag_posture(dict(os.environ))
+    print("[SECURITY] Security flag posture summary (values redacted).")
+    print(f"- profile: {posture['profile']}")
+    for flag_name in SECURITY_FLAGS:
+        state = "enabled" if posture[flag_name] else "disabled"
+        print(f"- {flag_name}: {state}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/veritas_os/tests/test_report_security_flag_posture.py
+++ b/veritas_os/tests/test_report_security_flag_posture.py
@@ -1,0 +1,36 @@
+"""Tests for scripts.security.report_security_flag_posture."""
+
+from __future__ import annotations
+
+from scripts.security import report_security_flag_posture as reporter
+
+
+def test_build_security_flag_posture_reports_enabled_states() -> None:
+    """Flag posture should only expose normalized enabled/disabled booleans."""
+    posture = reporter.build_security_flag_posture(
+        {
+            "VERITAS_ENV": "production",
+            "VERITAS_ALLOW_SSE_QUERY_API_KEY": "true",
+            "VERITAS_ALLOW_WS_QUERY_API_KEY": "false",
+            "NEXT_PUBLIC_ENABLE_DANGER_PRESETS": "on",
+        }
+    )
+
+    assert posture["profile"] == "VERITAS_ENV=production"
+    assert posture["VERITAS_ALLOW_SSE_QUERY_API_KEY"] is True
+    assert posture["VERITAS_ALLOW_WS_QUERY_API_KEY"] is False
+    assert posture["NEXT_PUBLIC_ENABLE_DANGER_PRESETS"] is True
+
+
+def test_main_prints_redacted_summary_without_raw_values(monkeypatch, capsys) -> None:
+    """CLI output must never include raw environment values."""
+    monkeypatch.setenv("VERITAS_ALLOW_SSE_QUERY_API_KEY", "secret-value")
+    monkeypatch.setenv("NODE_ENV", "dev")
+
+    exit_code = reporter.main([])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "values redacted" in output
+    assert "secret-value" not in output
+    assert "VERITAS_ALLOW_SSE_QUERY_API_KEY: disabled" in output


### PR DESCRIPTION
### Motivation

- Improve operator observability for security-sensitive runtime flags without exposing raw environment values, addressing a follow-up from the precision review.
- Keep changes minimal and focused on operability/validation responsibilities without altering architectural responsibilities.

### Description

- Added `scripts/security/report_security_flag_posture.py` to emit a redacted summary of `VERITAS_ALLOW_SSE_QUERY_API_KEY`, `VERITAS_ALLOW_WS_QUERY_API_KEY`, and `NEXT_PUBLIC_ENABLE_DANGER_PRESETS` as enabled/disabled states.
- Updated `scripts/production_validation.sh` Phase 0 to run the posture summary before existing production guard checks to centralize flag auditing.
- Added `veritas_os/tests/test_report_security_flag_posture.py` to verify normalized enabled/disabled outputs and that raw environment values are not printed.
- Updated `docs/ja/reviews/precision_review_2026_04_20_agent_ja.md` to record the implemented improvement.

### Testing

- Ran `pytest -q veritas_os/tests/test_report_security_flag_posture.py veritas_os/tests/test_check_query_compat_flags.py veritas_os/tests/test_check_danger_presets_flag.py` and all tests passed (`11 passed`).
- Executed `python scripts/security/report_security_flag_posture.py` to validate CLI output prints a redacted posture summary and observed expected redacted output.

Security note: the change redacts raw values but still logs which flags are enabled or disabled, so ensure log access controls remain strict to avoid leaking operational meta-information.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5aba331108326963b0863bd57c749)