### PR TITLE
Schema-first: Add ExecutionIntent and BindReceipt bind-boundary governance artifacts

### DIFF
--- a/docs/en/architecture/bind-boundary-governance-artifacts.md
+++ b/docs/en/architecture/bind-boundary-governance-artifacts.md
@@ -1,0 +1,39 @@
+# Bind-Boundary Governance Artifacts (Schema-First)
+
+## What this PR adds
+
+This change introduces two **native VERITAS governance artifacts** as first-class
+contracts:
+
+1. `ExecutionIntent`
+2. `BindReceipt`
+
+It also introduces `FinalOutcome` for bind-time terminal status.
+
+## Why these artifacts exist
+
+VERITAS already treats the decision artifact as the primary governance record.
+This extension keeps that architecture intact and adds bind-boundary lineage:
+
+- `ExecutionIntent` links an execution attempt directly to a `decision_id` and
+  governance lineage (`policy_snapshot_id`, `actor_identity`, `decision_hash`).
+- `BindReceipt` records bind-time checks (authority/constraint/drift/risk/
+  admissibility), links back to both decision and execution intent, and carries
+  TrustLog chain linkage (`trustlog_hash`, `prev_bind_hash`).
+
+This provides explicit governance-native artifacts at the decision → bind
+boundary without creating a parallel subsystem.
+
+## Intentionally deferred
+
+This PR is **schema-first only** and does not introduce:
+
+- external side-effect adapters
+- runtime bind orchestration
+- rollback engine implementation
+- Mission Control UI workflow rewiring
+- broad pipeline behavior changes
+
+## Runtime behavior impact
+
+None. Existing decision flows remain backward compatible.

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -12,6 +12,7 @@ from pydantic import (
     model_validator,
     field_validator,
 )
+from veritas_os.policy.bind_artifacts import FinalOutcome
 from veritas_os.core.decision_semantics import (
     COMPATIBLE_GATE_DECISION_VALUES,
     LEGACY_GATE_DECISION_ALIASES,
@@ -320,6 +321,50 @@ class TrustLog(BaseModel):
         Literal["verified", "degraded", "broken", "unknown"]
     ] = None
     chain_verification_reason: Optional[str] = None
+
+
+class ExecutionIntent(BaseModel):
+    """Decision-linked execution attempt descriptor (schema-first contract)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    execution_intent_id: str = Field(default_factory=lambda: uuid4().hex, max_length=MAX_ID_LENGTH)
+    decision_id: str = Field(default="", max_length=MAX_ID_LENGTH)
+    request_id: str = Field(default="", max_length=MAX_ID_LENGTH)
+    policy_snapshot_id: str = Field(default="", max_length=MAX_ID_LENGTH)
+    actor_identity: str = Field(default="", max_length=MAX_ACTOR_LENGTH)
+    target_system: str = Field(default="", max_length=MAX_TITLE_LENGTH)
+    target_resource: str = Field(default="", max_length=MAX_URI_LENGTH)
+    intended_action: str = Field(default="", max_length=MAX_TITLE_LENGTH)
+    evidence_refs: List[str] = Field(default_factory=list, max_length=MAX_LIST_ITEMS)
+    decision_hash: str = Field(default="", max_length=128)
+    decision_ts: str = ""
+    ttl_seconds: Optional[int] = Field(default=None, ge=0)
+    expected_state_fingerprint: Optional[str] = Field(default=None, max_length=256)
+    approval_context: Optional[Dict[str, Any]] = None
+
+
+class BindReceipt(BaseModel):
+    """Bind-time governance artifact linked to decision lineage."""
+
+    model_config = ConfigDict(extra="allow")
+
+    bind_receipt_id: str = Field(default_factory=lambda: uuid4().hex, max_length=MAX_ID_LENGTH)
+    execution_intent_id: str = Field(default="", max_length=MAX_ID_LENGTH)
+    decision_id: str = Field(default="", max_length=MAX_ID_LENGTH)
+    bind_ts: str = ""
+    live_state_fingerprint_before: str = Field(default="", max_length=256)
+    live_state_fingerprint_after: str = Field(default="", max_length=256)
+    authority_check_result: Dict[str, Any] = Field(default_factory=dict)
+    constraint_check_result: Dict[str, Any] = Field(default_factory=dict)
+    drift_check_result: Dict[str, Any] = Field(default_factory=dict)
+    risk_check_result: Dict[str, Any] = Field(default_factory=dict)
+    admissibility_result: Dict[str, Any] = Field(default_factory=dict)
+    final_outcome: FinalOutcome = FinalOutcome.BLOCKED
+    rollback_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    escalation_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    trustlog_hash: str = Field(default="", max_length=128)
+    prev_bind_hash: Optional[str] = Field(default=None, max_length=128)
 
 
 # =========================

--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -1,6 +1,15 @@
 """Policy-as-Code public interfaces for schema validation and canonicalization."""
 
 from .compiler import COMPILER_VERSION, CompileResult, compile_policy_to_bundle
+from .bind_artifacts import (
+    BindReceipt,
+    ExecutionIntent,
+    FinalOutcome,
+    canonical_bind_receipt_json,
+    canonical_execution_intent_json,
+    hash_bind_receipt,
+    hash_execution_intent,
+)
 from .evaluator import PolicyEvaluationResult, evaluate_runtime_policies
 from .generated_tests import GeneratedPolicyTestCase, build_generated_test_cases
 from .hash import canonical_ir_json, semantic_policy_hash
@@ -16,6 +25,9 @@ from .schema import load_and_validate_policy, validate_source_policy
 
 __all__ = [
     "OutcomeAction",
+    "ExecutionIntent",
+    "BindReceipt",
+    "FinalOutcome",
     "PolicyCompilationError",
     "PolicyValidationError",
     "SourcePolicy",
@@ -23,6 +35,8 @@ __all__ = [
     "CompileResult",
     "GeneratedPolicyTestCase",
     "canonical_ir_json",
+    "canonical_execution_intent_json",
+    "canonical_bind_receipt_json",
     "compile_policy_to_bundle",
     "build_generated_test_cases",
     "evaluate_runtime_policies",
@@ -30,6 +44,8 @@ __all__ = [
     "load_runtime_bundle",
     "PolicyEvaluationResult",
     "semantic_policy_hash",
+    "hash_execution_intent",
+    "hash_bind_receipt",
     "RuntimePolicy",
     "RuntimePolicyBundle",
     "verify_manifest_signature",

--- a/veritas_os/policy/bind_artifacts.py
+++ b/veritas_os/policy/bind_artifacts.py
@@ -1,0 +1,156 @@
+"""Bind-boundary governance artifact contracts.
+
+This module introduces schema-first, runtime-neutral artifact contracts for
+VERITAS bind-boundary governance.
+
+Artifacts
+---------
+- ``ExecutionIntent``: a decision-linked descriptor of an execution attempt.
+- ``BindReceipt``: a bind-time governance artifact recording bind checks,
+  admissibility, and final outcome.
+
+Design constraints
+------------------
+- Extends existing VERITAS governance lineage (decision_id, policy lineage,
+  governance identity, TrustLog hash references).
+- Reuses canonical JSON + SHA-256 primitives from ``veritas_os.security.hash``.
+- Does not perform external side effects or orchestration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+from uuid import uuid4
+
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+
+class FinalOutcome(str, Enum):
+    """Canonical terminal outcome labels for bind-boundary adjudication."""
+
+    COMMITTED = "COMMITTED"
+    BLOCKED = "BLOCKED"
+    ESCALATED = "ESCALATED"
+    ROLLED_BACK = "ROLLED_BACK"
+    APPLY_FAILED = "APPLY_FAILED"
+    SNAPSHOT_FAILED = "SNAPSHOT_FAILED"
+    PRECONDITION_FAILED = "PRECONDITION_FAILED"
+
+
+
+def _utc_now_iso8601() -> str:
+    """Return a UTC timestamp in ISO-8601 format with trailing ``Z``."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class ExecutionIntent:
+    """Decision-linked execution attempt descriptor.
+
+    This is a schema contract only. Runtime orchestration is intentionally
+    deferred to later PRs.
+    """
+
+    execution_intent_id: str = field(default_factory=lambda: uuid4().hex)
+    decision_id: str = ""
+    request_id: str = ""
+    policy_snapshot_id: str = ""
+    actor_identity: str = ""
+    target_system: str = ""
+    target_resource: str = ""
+    intended_action: str = ""
+    evidence_refs: list[str] = field(default_factory=list)
+    decision_hash: str = ""
+    decision_ts: str = ""
+    ttl_seconds: int | None = None
+    expected_state_fingerprint: str | None = None
+    approval_context: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return {
+            "execution_intent_id": self.execution_intent_id,
+            "decision_id": self.decision_id,
+            "request_id": self.request_id,
+            "policy_snapshot_id": self.policy_snapshot_id,
+            "actor_identity": self.actor_identity,
+            "target_system": self.target_system,
+            "target_resource": self.target_resource,
+            "intended_action": self.intended_action,
+            "evidence_refs": list(self.evidence_refs),
+            "decision_hash": self.decision_hash,
+            "decision_ts": self.decision_ts,
+            "ttl_seconds": self.ttl_seconds,
+            "expected_state_fingerprint": self.expected_state_fingerprint,
+            "approval_context": self.approval_context,
+        }
+
+
+@dataclass(frozen=True)
+class BindReceipt:
+    """Bind-time governance artifact linked to decision and execution intent."""
+
+    bind_receipt_id: str = field(default_factory=lambda: uuid4().hex)
+    execution_intent_id: str = ""
+    decision_id: str = ""
+    bind_ts: str = field(default_factory=_utc_now_iso8601)
+    live_state_fingerprint_before: str = ""
+    live_state_fingerprint_after: str = ""
+    authority_check_result: dict[str, Any] = field(default_factory=dict)
+    constraint_check_result: dict[str, Any] = field(default_factory=dict)
+    drift_check_result: dict[str, Any] = field(default_factory=dict)
+    risk_check_result: dict[str, Any] = field(default_factory=dict)
+    admissibility_result: dict[str, Any] = field(default_factory=dict)
+    final_outcome: FinalOutcome = FinalOutcome.BLOCKED
+    rollback_reason: str | None = None
+    escalation_reason: str | None = None
+    trustlog_hash: str = ""
+    prev_bind_hash: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return {
+            "bind_receipt_id": self.bind_receipt_id,
+            "execution_intent_id": self.execution_intent_id,
+            "decision_id": self.decision_id,
+            "bind_ts": self.bind_ts,
+            "live_state_fingerprint_before": self.live_state_fingerprint_before,
+            "live_state_fingerprint_after": self.live_state_fingerprint_after,
+            "authority_check_result": dict(self.authority_check_result),
+            "constraint_check_result": dict(self.constraint_check_result),
+            "drift_check_result": dict(self.drift_check_result),
+            "risk_check_result": dict(self.risk_check_result),
+            "admissibility_result": dict(self.admissibility_result),
+            "final_outcome": self.final_outcome.value,
+            "rollback_reason": self.rollback_reason,
+            "escalation_reason": self.escalation_reason,
+            "trustlog_hash": self.trustlog_hash,
+            "prev_bind_hash": self.prev_bind_hash,
+        }
+
+
+
+def canonical_execution_intent_json(intent: ExecutionIntent) -> str:
+    """Serialize ``ExecutionIntent`` with canonical deterministic JSON ordering."""
+    return canonical_json_dumps(intent.to_dict())
+
+
+
+def canonical_bind_receipt_json(receipt: BindReceipt) -> str:
+    """Serialize ``BindReceipt`` with canonical deterministic JSON ordering."""
+    return canonical_json_dumps(receipt.to_dict())
+
+
+
+def hash_execution_intent(intent: ExecutionIntent) -> str:
+    """Compute SHA-256 over canonical ``ExecutionIntent`` payload."""
+    return sha256_of_canonical_json(intent.to_dict())
+
+
+
+def hash_bind_receipt(receipt: BindReceipt) -> str:
+    """Compute SHA-256 over canonical ``BindReceipt`` payload."""
+    return sha256_of_canonical_json(receipt.to_dict())

--- a/veritas_os/tests/test_bind_artifacts.py
+++ b/veritas_os/tests/test_bind_artifacts.py
@@ -1,0 +1,160 @@
+"""Schema-first tests for bind-boundary governance artifacts."""
+
+from __future__ import annotations
+
+from veritas_os.api.schemas import BindReceipt as ApiBindReceipt
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.api.schemas import ExecutionIntent as ApiExecutionIntent
+from veritas_os.policy.bind_artifacts import BindReceipt, ExecutionIntent, FinalOutcome
+from veritas_os.policy.bind_artifacts import canonical_bind_receipt_json
+from veritas_os.policy.bind_artifacts import canonical_execution_intent_json
+from veritas_os.policy.bind_artifacts import hash_bind_receipt, hash_execution_intent
+
+
+def test_execution_intent_model_creation() -> None:
+    """ExecutionIntent should accept minimum decision-linked fields."""
+    intent = ExecutionIntent(
+        decision_id="dec-001",
+        request_id="req-001",
+        policy_snapshot_id="policy-v1",
+        actor_identity="mission-control-operator",
+        target_system="kubernetes",
+        target_resource="deployment/api",
+        intended_action="apply_patch",
+        evidence_refs=["ev-1", "ev-2"],
+        decision_hash="a" * 64,
+        decision_ts="2026-04-20T12:00:00Z",
+    )
+
+    assert intent.execution_intent_id
+    assert intent.policy_snapshot_id == "policy-v1"
+    assert intent.actor_identity == "mission-control-operator"
+
+
+def test_bind_receipt_model_creation() -> None:
+    """BindReceipt should capture bind-time checks and lineage references."""
+    receipt = BindReceipt(
+        execution_intent_id="ei-001",
+        decision_id="dec-001",
+        live_state_fingerprint_before="fp-before",
+        live_state_fingerprint_after="fp-after",
+        authority_check_result={"ok": True},
+        constraint_check_result={"ok": True},
+        drift_check_result={"ok": True},
+        risk_check_result={"ok": True},
+        admissibility_result={"ok": True},
+        final_outcome=FinalOutcome.COMMITTED,
+        trustlog_hash="b" * 64,
+        prev_bind_hash="c" * 64,
+    )
+
+    assert receipt.bind_receipt_id
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert receipt.prev_bind_hash == "c" * 64
+
+
+def test_final_outcome_enum_serialization() -> None:
+    """Enum should serialize to canonical uppercase contract values."""
+    receipt = BindReceipt(
+        execution_intent_id="ei-001",
+        decision_id="dec-001",
+        final_outcome=FinalOutcome.ESCALATED,
+    )
+
+    payload = receipt.to_dict()
+    assert payload["final_outcome"] == "ESCALATED"
+
+
+def test_deterministic_serialization_stability() -> None:
+    """Canonical JSON serialization should be deterministic for same payload."""
+    intent_a = ExecutionIntent(
+        execution_intent_id="ei-fixed",
+        decision_id="dec-001",
+        request_id="req-001",
+        policy_snapshot_id="policy-v1",
+        actor_identity="actor",
+        target_system="system",
+        target_resource="resource",
+        intended_action="action",
+        evidence_refs=["ev-1"],
+        decision_hash="d" * 64,
+        decision_ts="2026-04-20T00:00:00Z",
+    )
+    intent_b = ExecutionIntent(
+        execution_intent_id="ei-fixed",
+        decision_id="dec-001",
+        request_id="req-001",
+        policy_snapshot_id="policy-v1",
+        actor_identity="actor",
+        target_system="system",
+        target_resource="resource",
+        intended_action="action",
+        evidence_refs=["ev-1"],
+        decision_hash="d" * 64,
+        decision_ts="2026-04-20T00:00:00Z",
+    )
+
+    assert canonical_execution_intent_json(intent_a) == canonical_execution_intent_json(intent_b)
+
+
+def test_hashing_stability_for_bind_receipt() -> None:
+    """Hashing should remain stable when canonical payload is identical."""
+    receipt_a = BindReceipt(
+        bind_receipt_id="br-fixed",
+        execution_intent_id="ei-001",
+        decision_id="dec-001",
+        bind_ts="2026-04-20T00:00:00Z",
+        final_outcome=FinalOutcome.BLOCKED,
+        trustlog_hash="e" * 64,
+    )
+    receipt_b = BindReceipt(
+        bind_receipt_id="br-fixed",
+        execution_intent_id="ei-001",
+        decision_id="dec-001",
+        bind_ts="2026-04-20T00:00:00Z",
+        final_outcome=FinalOutcome.BLOCKED,
+        trustlog_hash="e" * 64,
+    )
+
+    assert canonical_bind_receipt_json(receipt_a) == canonical_bind_receipt_json(receipt_b)
+    assert hash_bind_receipt(receipt_a) == hash_bind_receipt(receipt_b)
+    assert hash_execution_intent(
+        ExecutionIntent(
+            execution_intent_id="ei-fixed",
+            decision_id="dec-001",
+            request_id="req-001",
+            policy_snapshot_id="policy-v1",
+            actor_identity="actor",
+            target_system="system",
+            target_resource="resource",
+            intended_action="action",
+            evidence_refs=["ev-1"],
+            decision_hash="f" * 64,
+            decision_ts="2026-04-20T00:00:00Z",
+        )
+    ) == hash_execution_intent(
+        ExecutionIntent(
+            execution_intent_id="ei-fixed",
+            decision_id="dec-001",
+            request_id="req-001",
+            policy_snapshot_id="policy-v1",
+            actor_identity="actor",
+            target_system="system",
+            target_resource="resource",
+            intended_action="action",
+            evidence_refs=["ev-1"],
+            decision_hash="f" * 64,
+            decision_ts="2026-04-20T00:00:00Z",
+        )
+    )
+
+
+def test_backward_compatibility_existing_decide_response_unchanged() -> None:
+    """Existing decision artifact shape must remain usable without bind artifacts."""
+    resp = DecideResponse(request_id="req-compat")
+    assert resp.request_id == "req-compat"
+
+    api_intent = ApiExecutionIntent(decision_id="dec-001", request_id="req-001")
+    api_receipt = ApiBindReceipt(execution_intent_id="ei-001", decision_id="dec-001")
+    assert api_intent.decision_id == "dec-001"
+    assert api_receipt.decision_id == "dec-001"


### PR DESCRIPTION
### Motivation
- Extend VERITAS decision-governance with a minimal native artifact layer at the bind boundary without introducing parallel subsystems or changing runtime behavior. 
- Provide first-class contracts so bind-time attempts and outcomes can be captured, audited, and canonicalized in future runtime wiring. 
- Reuse existing governance primitives (policy lineage, governance identity) and canonical hashing to remain compatible with current TrustLog and audit tooling. 
- Keep this PR schema-first and runtime-neutral to avoid side-effect wiring and architectural drift.

### Description
- Added `veritas_os/policy/bind_artifacts.py` introducing `ExecutionIntent` and `BindReceipt` dataclasses, `FinalOutcome` enum, `to_dict` canonical serializers, and deterministic hashing helpers that reuse `veritas_os.security.hash` utilities. 
- Exposed Pydantic API contracts in `veritas_os/api/schemas.py` by adding `ExecutionIntent` and `BindReceipt` models and referencing the `FinalOutcome` enum for type safety at the API/schema surface. 
- Exported the new artifacts and helper functions from the policy public API in `veritas_os/policy/__init__.py` so they are available to existing modules without renaming or replacing current artifacts. 
- Added focused schema-first tests in `veritas_os/tests/test_bind_artifacts.py` and a short architecture note `docs/en/architecture/bind-boundary-governance-artifacts.md`; no runtime orchestration, adapter, or UI wiring was introduced. 
- Security note: these artifacts carry governance-sensitive metadata (e.g., `approval_context`, actor/target identifiers); future runtime wiring must enforce redaction and access controls before persistence or external exposure.

### Testing
- Ran the new focused test module: `pytest -q veritas_os/tests/test_bind_artifacts.py` — result: `6 passed`. 
- Ran existing governance identity coverage subset: `pytest -q veritas_os/tests/test_governance_artifact_signing.py -k DecideResponseGovernanceIdentity` — result: `4 passed, 35 deselected`. 
- Deterministic serialization and hashing helpers were exercised by tests and returned stable values as asserted, and no existing decision flows or public artifacts were modified, preserving backward compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e4252a7c8326988a00fff8ac5395)