### PR TITLE
Add deterministic fail-closed bind-time admissibility evaluator

### DIFF
--- a/docs/en/architecture/bind_time_admissibility_evaluator.md
+++ b/docs/en/architecture/bind_time_admissibility_evaluator.md
@@ -1,0 +1,22 @@
+# Bind-time Admissibility Evaluator (Internal)
+
+## Purpose
+
+This module adds a deterministic internal re-check layer for bind-time
+admissibility before any real-world effect boundary is crossed.
+
+## Non-goals in this PR
+
+- Does **not** replace or reinterpret FUJI.
+- Does **not** change continuation runtime observe/advisory/enforce semantics.
+- Does **not** introduce external side-effect execution or adapters.
+- Does **not** add public API behavior.
+
+## Why this exists
+
+Decision-time approval alone is not sufficient when live authority,
+constraints, environment fingerprints, risk posture, or freshness windows may
+change before commit/bind time.
+
+This evaluator provides a fail-closed re-check contract that can be reused by
+future bind-boundary orchestration.

--- a/tests/test_bind_admissibility.py
+++ b/tests/test_bind_admissibility.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""Focused tests for deterministic fail-closed bind-time admissibility."""
+
+from veritas_os.core.continuation_runtime.bind_admissibility import (
+    AdmissibilityOutcome,
+    BindAdmissibilityInput,
+    CheckStatus,
+    evaluate_bind_admissibility,
+)
+
+
+def _base_input(**overrides) -> BindAdmissibilityInput:
+    payload = {
+        "execution_intent": "bind:commit_order",
+        "current_timestamp": "2026-04-20T10:00:00+00:00",
+        "authority_signal": True,
+        "constraint_signals": {"region_allowed": True, "policy_current": True},
+        "live_state_fingerprint": "abc123",
+        "expected_state_fingerprint": "abc123",
+        "runtime_risk_signal": True,
+        "drift_sensitive": True,
+        "ttl_expires_at": "2026-04-20T10:30:00+00:00",
+        "approval_expires_at": "2026-04-20T10:15:00+00:00",
+    }
+    payload.update(overrides)
+    return BindAdmissibilityInput(**payload)
+
+
+def test_all_checks_pass_is_eligible_to_commit() -> None:
+    result = evaluate_bind_admissibility(_base_input())
+
+    assert result.admissibility_result is True
+    assert result.recommended_outcome is AdmissibilityOutcome.ELIGIBLE_TO_COMMIT
+    assert result.reason_codes == []
+
+
+def test_authority_failure_fails_closed() -> None:
+    result = evaluate_bind_admissibility(_base_input(authority_signal=False))
+
+    assert result.admissibility_result is False
+    assert result.authority_check_result.status is CheckStatus.FAIL
+    assert result.recommended_outcome is AdmissibilityOutcome.BLOCK
+
+
+def test_constraint_failure_fails_closed() -> None:
+    result = evaluate_bind_admissibility(
+        _base_input(constraint_signals={"region_allowed": False, "policy_current": True})
+    )
+
+    assert result.admissibility_result is False
+    assert result.constraint_check_result.status is CheckStatus.FAIL
+    assert result.recommended_outcome is AdmissibilityOutcome.BLOCK
+
+
+def test_drift_detected_blocks() -> None:
+    result = evaluate_bind_admissibility(
+        _base_input(live_state_fingerprint="live999", expected_state_fingerprint="exp111")
+    )
+
+    assert result.admissibility_result is False
+    assert result.drift_check_result.status is CheckStatus.FAIL
+    assert result.recommended_outcome is AdmissibilityOutcome.BLOCK
+
+
+def test_runtime_risk_failure_fails_closed() -> None:
+    result = evaluate_bind_admissibility(_base_input(runtime_risk_signal=False))
+
+    assert result.admissibility_result is False
+    assert result.risk_check_result.status is CheckStatus.FAIL
+    assert result.recommended_outcome is AdmissibilityOutcome.BLOCK
+
+
+def test_missing_authority_signal_fails_closed() -> None:
+    result = evaluate_bind_admissibility(_base_input(authority_signal=None))
+
+    assert result.admissibility_result is False
+    assert result.authority_check_result.reason_code == "BIND_AUTHORITY_MISSING"
+    assert result.recommended_outcome is AdmissibilityOutcome.BLOCK
+
+
+def test_missing_constraint_signal_fails_closed() -> None:
+    result = evaluate_bind_admissibility(_base_input(constraint_signals=None))
+
+    assert result.admissibility_result is False
+    assert result.constraint_check_result.reason_code == "BIND_CONSTRAINTS_MISSING"
+    assert result.recommended_outcome is AdmissibilityOutcome.BLOCK
+
+
+def test_missing_runtime_state_on_drift_sensitive_path_fails_closed() -> None:
+    result = evaluate_bind_admissibility(_base_input(live_state_fingerprint=None))
+
+    assert result.admissibility_result is False
+    assert result.drift_check_result.reason_code == "BIND_DRIFT_SIGNAL_MISSING"
+    assert result.recommended_outcome is AdmissibilityOutcome.BLOCK
+
+
+def test_expired_ttl_escalates_fail_closed() -> None:
+    result = evaluate_bind_admissibility(
+        _base_input(
+            current_timestamp="2026-04-20T10:00:01+00:00",
+            ttl_expires_at="2026-04-20T10:00:00+00:00",
+        )
+    )
+
+    assert result.admissibility_result is False
+    assert result.freshness_check_result.status is CheckStatus.ESCALATE
+    assert result.recommended_outcome is AdmissibilityOutcome.ESCALATE
+
+
+def test_deterministic_output_stability_for_same_inputs() -> None:
+    bind_input = _base_input()
+
+    result1 = evaluate_bind_admissibility(bind_input)
+    result2 = evaluate_bind_admissibility(bind_input)
+
+    assert result1 == result2

--- a/veritas_os/core/continuation_runtime/__init__.py
+++ b/veritas_os/core/continuation_runtime/__init__.py
@@ -42,6 +42,14 @@ from .revalidator import (
     PresentCondition,
     run_continuation_revalidation_shadow,
 )
+from .bind_admissibility import (
+    AdmissibilityOutcome,
+    CheckStatus,
+    CheckResult,
+    BindAdmissibilityInput,
+    BindAdmissibilityResult,
+    evaluate_bind_admissibility,
+)
 from .enforcement import (
     EnforcementMode,
     EnforcementAction,
@@ -77,6 +85,13 @@ __all__ = [
     "ContinuationRevalidator",
     "PresentCondition",
     "run_continuation_revalidation_shadow",
+    # bind-time admissibility
+    "AdmissibilityOutcome",
+    "CheckStatus",
+    "CheckResult",
+    "BindAdmissibilityInput",
+    "BindAdmissibilityResult",
+    "evaluate_bind_admissibility",
     # enforcement (Phase-2)
     "EnforcementMode",
     "EnforcementAction",

--- a/veritas_os/core/continuation_runtime/bind_admissibility.py
+++ b/veritas_os/core/continuation_runtime/bind_admissibility.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+"""Deterministic bind-time admissibility evaluator.
+
+This module provides a pure, fail-closed re-check layer for bind-time
+admissibility. It does not generate decisions, does not execute side effects,
+and does not modify FUJI or continuation runtime semantics.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, List, Optional
+
+
+class AdmissibilityOutcome(str, Enum):
+    """Recommended bind-time outcome."""
+
+    ELIGIBLE_TO_COMMIT = "eligible_to_commit"
+    BLOCK = "block"
+    ESCALATE = "escalate"
+
+
+class CheckStatus(str, Enum):
+    """Per-check status for admissibility dimensions."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    ESCALATE = "escalate"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome for a single admissibility dimension."""
+
+    status: CheckStatus
+    reason_code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class BindAdmissibilityInput:
+    """Input contract for bind-time admissibility re-check."""
+
+    execution_intent: str
+    current_timestamp: str
+    authority_signal: Optional[bool]
+    constraint_signals: Optional[Dict[str, bool]]
+    live_state_fingerprint: Optional[str]
+    expected_state_fingerprint: Optional[str]
+    runtime_risk_signal: Optional[bool]
+    drift_sensitive: bool = True
+    ttl_expires_at: Optional[str] = None
+    approval_expires_at: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class BindAdmissibilityResult:
+    """Deterministic bind-time admissibility evaluation result."""
+
+    authority_check_result: CheckResult
+    constraint_check_result: CheckResult
+    drift_check_result: CheckResult
+    risk_check_result: CheckResult
+    freshness_check_result: CheckResult
+    admissibility_result: bool
+    recommended_outcome: AdmissibilityOutcome
+    reason_codes: List[str] = field(default_factory=list)
+
+
+def evaluate_bind_admissibility(
+    evaluation_input: BindAdmissibilityInput,
+) -> BindAdmissibilityResult:
+    """Evaluate bind-time admissibility with fail-closed defaults."""
+    authority = _check_authority(evaluation_input)
+    constraints = _check_constraints(evaluation_input)
+    drift = _check_drift(evaluation_input)
+    risk = _check_runtime_risk(evaluation_input)
+    freshness = _check_freshness(evaluation_input)
+
+    checks = [authority, constraints, drift, risk, freshness]
+    has_fail = any(c.status is CheckStatus.FAIL for c in checks)
+    has_escalate = any(c.status is CheckStatus.ESCALATE for c in checks)
+
+    if has_fail:
+        admissible = False
+        outcome = AdmissibilityOutcome.BLOCK
+    elif has_escalate:
+        admissible = False
+        outcome = AdmissibilityOutcome.ESCALATE
+    else:
+        admissible = True
+        outcome = AdmissibilityOutcome.ELIGIBLE_TO_COMMIT
+
+    reason_codes = [c.reason_code for c in checks if c.status is not CheckStatus.PASS]
+
+    return BindAdmissibilityResult(
+        authority_check_result=authority,
+        constraint_check_result=constraints,
+        drift_check_result=drift,
+        risk_check_result=risk,
+        freshness_check_result=freshness,
+        admissibility_result=admissible,
+        recommended_outcome=outcome,
+        reason_codes=reason_codes,
+    )
+
+
+def _check_authority(evaluation_input: BindAdmissibilityInput) -> CheckResult:
+    signal = evaluation_input.authority_signal
+    if signal is None:
+        return CheckResult(
+            status=CheckStatus.FAIL,
+            reason_code="BIND_AUTHORITY_MISSING",
+            message="Authority signal is missing; fail-closed block applied.",
+        )
+    if signal is False:
+        return CheckResult(
+            status=CheckStatus.FAIL,
+            reason_code="BIND_AUTHORITY_INVALID",
+            message="Authority is not currently valid.",
+        )
+    return CheckResult(
+        status=CheckStatus.PASS,
+        reason_code="BIND_AUTHORITY_VALID",
+        message="Authority remains valid.",
+    )
+
+
+def _check_constraints(evaluation_input: BindAdmissibilityInput) -> CheckResult:
+    signals = evaluation_input.constraint_signals
+    if not signals:
+        return CheckResult(
+            status=CheckStatus.FAIL,
+            reason_code="BIND_CONSTRAINTS_MISSING",
+            message="Constraint signals are missing; fail-closed block applied.",
+        )
+
+    violating_constraints = sorted(name for name, passed in signals.items() if not passed)
+    if violating_constraints:
+        return CheckResult(
+            status=CheckStatus.FAIL,
+            reason_code="BIND_CONSTRAINTS_VIOLATED",
+            message=(
+                "Constraints are not satisfied: "
+                + ", ".join(violating_constraints)
+            ),
+        )
+    return CheckResult(
+        status=CheckStatus.PASS,
+        reason_code="BIND_CONSTRAINTS_VALID",
+        message="All constraints are currently satisfied.",
+    )
+
+
+def _check_drift(evaluation_input: BindAdmissibilityInput) -> CheckResult:
+    if not evaluation_input.drift_sensitive:
+        return CheckResult(
+            status=CheckStatus.PASS,
+            reason_code="BIND_DRIFT_NOT_REQUIRED",
+            message="Drift check is not required for this execution intent.",
+        )
+
+    live = evaluation_input.live_state_fingerprint
+    expected = evaluation_input.expected_state_fingerprint
+
+    if not live or not expected:
+        return CheckResult(
+            status=CheckStatus.FAIL,
+            reason_code="BIND_DRIFT_SIGNAL_MISSING",
+            message="Drift-sensitive path lacks live or expected state fingerprint.",
+        )
+
+    if live != expected:
+        return CheckResult(
+            status=CheckStatus.FAIL,
+            reason_code="BIND_DRIFT_DETECTED",
+            message="Live state has drifted from decision-time assumptions.",
+        )
+
+    return CheckResult(
+        status=CheckStatus.PASS,
+        reason_code="BIND_DRIFT_NOT_DETECTED",
+        message="No live-state drift detected.",
+    )
+
+
+def _check_runtime_risk(evaluation_input: BindAdmissibilityInput) -> CheckResult:
+    signal = evaluation_input.runtime_risk_signal
+    if signal is None:
+        return CheckResult(
+            status=CheckStatus.FAIL,
+            reason_code="BIND_RUNTIME_RISK_MISSING",
+            message="Runtime risk signal is missing; fail-closed block applied.",
+        )
+    if signal is False:
+        return CheckResult(
+            status=CheckStatus.FAIL,
+            reason_code="BIND_RUNTIME_RISK_UNACCEPTABLE",
+            message="Runtime risk is not currently acceptable.",
+        )
+    return CheckResult(
+        status=CheckStatus.PASS,
+        reason_code="BIND_RUNTIME_RISK_ACCEPTABLE",
+        message="Runtime risk remains acceptable.",
+    )
+
+
+def _check_freshness(evaluation_input: BindAdmissibilityInput) -> CheckResult:
+    now = _parse_timestamp(evaluation_input.current_timestamp)
+
+    expiry_fields = [
+        ("ttl", evaluation_input.ttl_expires_at, "BIND_TTL_EXPIRED"),
+        ("approval", evaluation_input.approval_expires_at, "BIND_APPROVAL_STALE"),
+    ]
+
+    expired = []
+    for name, expiry_raw, reason_code in expiry_fields:
+        if not expiry_raw:
+            continue
+        expiry = _parse_timestamp(expiry_raw)
+        if now > expiry:
+            expired.append((name, reason_code))
+
+    if expired:
+        labels = ", ".join(name for name, _ in expired)
+        primary_reason = expired[0][1]
+        return CheckResult(
+            status=CheckStatus.ESCALATE,
+            reason_code=primary_reason,
+            message=f"Freshness window expired ({labels}); escalation required.",
+        )
+
+    return CheckResult(
+        status=CheckStatus.PASS,
+        reason_code="BIND_FRESHNESS_VALID",
+        message="TTL and approval freshness checks are valid.",
+    )
+
+
+def _parse_timestamp(raw_timestamp: str) -> datetime:
+    normalized = raw_timestamp.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)


### PR DESCRIPTION
### Motivation
- Decision-time approval can become stale before bind/commit; a lightweight deterministic bind-time re-check is needed to verify authority, constraints, drift, runtime risk, and freshness before effecting changes.  
- The evaluator must be strict/fail-closed by default so unverifiable or missing safety signals do not silently permit execution.  
- This PR must not replace FUJI or alter continuation runtime semantics; it provides an internal, reusable evaluator only.

### Description
- Added a pure, deterministic internal evaluator `veritas_os/core/continuation_runtime/bind_admissibility.py` implementing typed contracts `BindAdmissibilityInput` and `BindAdmissibilityResult`, per-dimension checks (authority, constraints, drift, runtime risk, freshness), machine-readable reason codes, and a narrow recommended outcome enum (`ELIGIBLE_TO_COMMIT`, `BLOCK`, `ESCALATE`).
- Implemented strict fail-closed defaults: missing authority/constraints/runtime risk or missing drift fingerprints on drift-sensitive paths => `BLOCK`, expired TTL/approval => `ESCALATE`, and violations => `BLOCK`; freshness expiry results in escalation rather than silent pass.  
- Exported evaluator types and `evaluate_bind_admissibility` via `veritas_os.core.continuation_runtime.__init__` for internal reuse and added a short internal architecture doc stub at `docs/en/architecture/bind_time_admissibility_evaluator.md` which explicitly notes this does not replace FUJI or change continuation semantics.  
- Kept the evaluator pure and unit-testable with no network/storage/TrustLog/UI coupling or runtime side effects; added focused unit tests and docstrings; note that misuse of `drift_sensitive=False` on drift-sensitive intents is a potential operational risk and should be constrained by policy when integrated.

### Testing
- Added `tests/test_bind_admissibility.py` covering the 10 required scenarios (all pass, authority failure, constraint failure, drift detected, runtime risk failure, missing authority, missing constraints, missing runtime state on drift-sensitive path, expired TTL => escalate, deterministic stability).  
- Ran `pytest -q tests/test_bind_admissibility.py` and all tests passed: `10 passed`.  
- Byte-compiled the new module and `__init__` successfully with `python -m py_compile` to ensure syntax/PEP8-friendly codepaths compiled cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ec5f563883269228df0e4688c752)