### PR TITLE
Expose bind-boundary artifacts in governance public API contract

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -676,6 +676,128 @@ components:
         policy:
           $ref: '#/components/schemas/GovernancePolicy'
 
+    ExecutionIntent:
+      type: object
+      description: "Decision-linked execution attempt descriptor."
+      properties:
+        execution_intent_id:
+          type: string
+        decision_id:
+          type: string
+        request_id:
+          type: string
+        policy_snapshot_id:
+          type: string
+        actor_identity:
+          type: string
+        target_system:
+          type: string
+        target_resource:
+          type: string
+        intended_action:
+          type: string
+        evidence_refs:
+          type: array
+          items:
+            type: string
+        decision_hash:
+          type: string
+        decision_ts:
+          type: string
+        ttl_seconds:
+          type: integer
+          nullable: true
+        expected_state_fingerprint:
+          type: string
+          nullable: true
+        approval_context:
+          type: object
+          nullable: true
+          additionalProperties: true
+
+    BindReceipt:
+      type: object
+      description: "Bind-time governance artifact linked to decision lineage."
+      properties:
+        bind_receipt_id:
+          type: string
+        execution_intent_id:
+          type: string
+        decision_id:
+          type: string
+        bind_ts:
+          type: string
+        live_state_fingerprint_before:
+          type: string
+        live_state_fingerprint_after:
+          type: string
+        authority_check_result:
+          type: object
+          additionalProperties: true
+        constraint_check_result:
+          type: object
+          additionalProperties: true
+        drift_check_result:
+          type: object
+          additionalProperties: true
+        risk_check_result:
+          type: object
+          additionalProperties: true
+        admissibility_result:
+          type: object
+          additionalProperties: true
+        final_outcome:
+          type: string
+          enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED"]
+        rollback_reason:
+          type: string
+          nullable: true
+        escalation_reason:
+          type: string
+          nullable: true
+        trustlog_hash:
+          type: string
+        prev_bind_hash:
+          type: string
+          nullable: true
+
+    GovernanceDecisionExportItem:
+      type: object
+      description: "Governance decision export row with bind summary."
+      properties:
+        request_id:
+          type: string
+        decision_id:
+          type: string
+        decision_status:
+          type: string
+        risk:
+          type: number
+          nullable: true
+        created_at:
+          type: string
+        approver:
+          type: string
+        trace_sha256:
+          type: string
+          nullable: true
+        bind_outcome:
+          type: string
+          nullable: true
+          enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED"]
+        bind_failure_reason:
+          type: string
+          nullable: true
+        bind_reason_code:
+          type: string
+          nullable: true
+        bind_receipt_id:
+          type: string
+          nullable: true
+        execution_intent_id:
+          type: string
+          nullable: true
+
     TrustFeedbackRequest:
       type: object
       description: "信頼フィードバックリクエスト（全フィールドにデフォルト値あり）"
@@ -1854,6 +1976,109 @@ paths:
                           $ref: '#/components/schemas/GovernancePolicy'
                         new:
                           $ref: '#/components/schemas/GovernancePolicy'
+
+  /v1/governance/decisions/export:
+    get:
+      summary: Governance decision export
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 1000
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: bind_outcome
+          required: false
+          schema:
+            type: string
+            enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED"]
+      responses:
+        "200":
+          description: Decision export rows
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  count:
+                    type: integer
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/GovernanceDecisionExportItem'
+
+  /v1/governance/bind-receipts:
+    get:
+      summary: Bind receipt search by lineage filters
+      parameters:
+        - in: query
+          name: decision_id
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: execution_intent_id
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Bind receipts by filter
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  count:
+                    type: integer
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BindReceipt'
+
+  /v1/governance/bind-receipts/{bind_receipt_id}:
+    get:
+      summary: Bind receipt retrieval by ID
+      parameters:
+        - in: path
+          name: bind_receipt_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Bind receipt artifact
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  bind_receipt:
+                    $ref: '#/components/schemas/BindReceipt'
+                  bind_outcome:
+                    type: string
+                    nullable: true
+                    enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED"]
+                  bind_failure_reason:
+                    type: string
+                    nullable: true
+                  bind_reason_code:
+                    type: string
+                    nullable: true
 
   /v1/compliance/config:
     get:

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -12,6 +12,9 @@ from fastapi.responses import JSONResponse
 from veritas_os.api.auth import require_permission
 from veritas_os.api.rbac import Permission
 from veritas_os.api.schemas import (
+    GovernanceBindReceiptListResponse,
+    GovernanceBindReceiptResponse,
+    GovernanceDecisionExportResponse,
     GovernancePolicyResponse,
     GovernancePolicyHistoryResponse,
 )
@@ -237,7 +240,11 @@ def governance_policy_history(limit: int = Query(default=50, ge=1, le=500)):
         )
 
 
-@router.get("/v1/governance/decisions/export", dependencies=[Depends(require_permission(Permission.governance_read))])
+@router.get(
+    "/v1/governance/decisions/export",
+    response_model=GovernanceDecisionExportResponse,
+    dependencies=[Depends(require_permission(Permission.governance_read))],
+)
 def governance_decision_export(
     limit: int = Query(default=100, ge=1, le=1000),
     status: str | None = Query(default=None),
@@ -287,7 +294,36 @@ def governance_decision_export(
 
 
 @router.get(
+    "/v1/governance/bind-receipts",
+    response_model=GovernanceBindReceiptListResponse,
+    dependencies=[Depends(require_permission(Permission.governance_read))],
+)
+def governance_bind_receipts(
+    decision_id: str | None = Query(default=None),
+    execution_intent_id: str | None = Query(default=None),
+):
+    """Return bind receipt artifacts filtered by decision/execution intent lineage."""
+    try:
+        receipts = find_bind_receipts(
+            decision_id=decision_id,
+            execution_intent_id=execution_intent_id,
+        )
+        return {
+            "ok": True,
+            "count": len(receipts),
+            "items": [receipt.to_dict() for receipt in receipts],
+        }
+    except Exception as e:
+        logger.error("governance_bind_receipts failed: %s", e, exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": "Failed to load bind receipts"},
+        )
+
+
+@router.get(
     "/v1/governance/bind-receipts/{bind_receipt_id}",
+    response_model=GovernanceBindReceiptResponse,
     dependencies=[Depends(require_permission(Permission.governance_read))],
 )
 def governance_bind_receipt(bind_receipt_id: str):

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1310,3 +1310,49 @@ class GovernancePolicyHistoryResponse(BaseModel):
     count: int = 0
     history: List[Dict[str, Any]] = Field(default_factory=list)
     error: Optional[str] = None
+
+
+class GovernanceDecisionExportItem(BaseModel):
+    """Public governance decision export record with bind summary fields."""
+
+    request_id: str = ""
+    decision_id: str = ""
+    decision_status: str = "unknown"
+    risk: Optional[float] = None
+    created_at: str = ""
+    approver: str = "system"
+    trace_sha256: Optional[str] = None
+    bind_outcome: Optional[FinalOutcome] = None
+    bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    bind_receipt_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    execution_intent_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+
+
+class GovernanceDecisionExportResponse(BaseModel):
+    """Response envelope for GET /v1/governance/decisions/export."""
+
+    ok: bool = True
+    count: int = 0
+    items: List[GovernanceDecisionExportItem] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class GovernanceBindReceiptResponse(BaseModel):
+    """Response envelope for GET /v1/governance/bind-receipts/{bind_receipt_id}."""
+
+    ok: bool = True
+    bind_receipt: Optional[BindReceipt] = None
+    bind_outcome: Optional[FinalOutcome] = None
+    bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    error: Optional[str] = None
+
+
+class GovernanceBindReceiptListResponse(BaseModel):
+    """Response envelope for GET /v1/governance/bind-receipts."""
+
+    ok: bool = True
+    count: int = 0
+    items: List[BindReceipt] = Field(default_factory=list)
+    error: Optional[str] = None

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -421,6 +421,59 @@ def test_governance_bind_receipt_endpoint(monkeypatch) -> None:
     assert missing_body["ok"] is False
 
 
+def test_governance_bind_receipts_list_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "veritas_os.api.routes_governance.find_bind_receipts",
+        lambda decision_id=None, execution_intent_id=None, **_kwargs: [
+            type(
+                "Receipt",
+                (),
+                {
+                    "to_dict": lambda self: {
+                        "bind_receipt_id": "br-list-1",
+                        "execution_intent_id": execution_intent_id or "ei-list-1",
+                        "decision_id": decision_id or "dec-list-1",
+                        "final_outcome": "COMMITTED",
+                    }
+                },
+            )()
+        ],
+    )
+    resp = client.get(
+        "/v1/governance/bind-receipts?decision_id=dec-list-1&execution_intent_id=ei-list-1",
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["count"] == 1
+    assert body["items"][0]["bind_receipt_id"] == "br-list-1"
+    assert body["items"][0]["decision_id"] == "dec-list-1"
+    assert body["items"][0]["execution_intent_id"] == "ei-list-1"
+
+
+def test_governance_decision_export_backward_compatible_fields(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "veritas_os.api.routes_governance.find_bind_receipts",
+        lambda **_kwargs: [],
+    )
+    resp = client.get("/v1/governance/decisions/export?limit=1", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    if body["items"]:
+        item = body["items"][0]
+        assert "request_id" in item
+        assert "decision_id" in item
+        assert "decision_status" in item
+        assert "created_at" in item
+        assert "approver" in item
+        assert "trace_sha256" in item
+        assert item.get("bind_outcome") is None
+        assert item.get("bind_receipt_id") is None
+        assert item.get("execution_intent_id") is None
+
+
 
 # ----------------------------------------------------------------
 # Server governance endpoint error paths

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -56,6 +56,9 @@ def test_openapi_includes_runtime_audit_and_governance_routes() -> None:
     critical = {
         "/v1/governance/policy",
         "/v1/governance/policy/history",
+        "/v1/governance/decisions/export",
+        "/v1/governance/bind-receipts",
+        "/v1/governance/bind-receipts/{bind_receipt_id}",
         "/v1/trustlog/verify",
         "/v1/trust/{request_id}/prov",
     }
@@ -100,3 +103,19 @@ def test_openapi_decide_response_decision_semantics_contract() -> None:
     ]
     assert decide_schema["next_action"]["type"] == "string"
     assert "governance_identity" in decide_schema
+
+
+def test_openapi_includes_bind_artifact_schemas() -> None:
+    """OpenAPI should expose bind-boundary artifact models and summary fields."""
+    spec = _load_openapi_spec()
+    schemas = spec["components"]["schemas"]
+
+    assert "ExecutionIntent" in schemas
+    assert "BindReceipt" in schemas
+
+    export_item = schemas["GovernanceDecisionExportItem"]["properties"]
+    assert "bind_outcome" in export_item
+    assert "bind_failure_reason" in export_item
+    assert "bind_reason_code" in export_item
+    assert "bind_receipt_id" in export_item
+    assert "execution_intent_id" in export_item


### PR DESCRIPTION
### Motivation
- Align the OpenAPI document with runtime schemas so bind-boundary artifacts are first-class in the public API contract.
- Surface minimal bind summary fields on decision-facing export responses so UIs/integrations can link to bind receipts and execution intents.
- Provide a small, safe retrieval surface for bind receipts (list + by-id) without redesigning existing models or creating duplicate artifact types.

### Description
- Added typed response models in `veritas_os/api/schemas.py`: `GovernanceDecisionExportItem`, `GovernanceDecisionExportResponse`, `GovernanceBindReceiptResponse`, and `GovernanceBindReceiptListResponse`, reusing existing `ExecutionIntent`/`BindReceipt` models and keeping extras `extra="allow"` where appropriate.
- Annotated runtime routes with response models and/or added a new route in `veritas_os/api/routes_governance.py`: added `response_model=GovernanceDecisionExportResponse` on `/v1/governance/decisions/export`, added `GET /v1/governance/bind-receipts` (filters `decision_id` and `execution_intent_id`), and added `response_model=GovernanceBindReceiptResponse` on `/v1/governance/bind-receipts/{bind_receipt_id}`; implementation reuses existing `find_bind_receipts` and existing helper resolvers for failure reason/code.
- Updated `openapi.yaml` to expose `ExecutionIntent`, `BindReceipt`, `GovernanceDecisionExportItem`, and to document the three governance bind-related paths (`/v1/governance/decisions/export`, `/v1/governance/bind-receipts`, `/v1/governance/bind-receipts/{bind_receipt_id}`).
- Tests and docstrings added; PEP8 respected and no second artifact model was introduced (only schema-facing response types added).

Security note: these endpoints remain guarded by the existing `governance_read` permission, but bind receipts can contain operational/state detail — ensure RBAC/API key configuration is tightened in deployed environments to avoid inadvertent data exposure.

### Testing
- Ran targeted integration and OpenAPI tests with `pytest -q` for governance/OpenAPI changes; command executed the updated integration tests and OpenAPI spec test and returned `10 passed` in ~10s.
- Tests executed include `test_governance_decision_export_includes_bind_summary`, `test_governance_bind_receipt_endpoint`, `test_governance_bind_receipts_list_endpoint`, `test_governance_decision_export_backward_compatible_fields`, and `test_openapi_spec.py` additions, and all passed.
- These tests validate that the OpenAPI YAML is parseable, the new schemas are present, the new list endpoint returns bind receipts, the by-id endpoint returns expected shapes, and decision export remains backward-compatible with nullable bind summary fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6438ff77c83268a378e574ead9a41)