### PR TITLE
feat(risk): expose bind-phase outcomes in Mission Control risk list and drilldown

### DIFF
--- a/frontend/app/risk/components/DrilldownPanel.tsx
+++ b/frontend/app/risk/components/DrilldownPanel.tsx
@@ -12,6 +12,12 @@ interface DrilldownPanelProps {
 
 export const DrilldownPanel = memo(function DrilldownPanel({ entry }: DrilldownPanelProps): JSX.Element {
   const { t } = useI18n();
+  const bindBadgeClass = (outcome: FlaggedEntry["bindOutcome"]): string => {
+    if (outcome === "COMMITTED") return "bg-emerald-500/20 text-emerald-700 border-emerald-600/30";
+    if (outcome === "BLOCKED") return "bg-rose-500/20 text-rose-700 border-rose-600/30";
+    if (outcome === "ESCALATED") return "bg-amber-500/20 text-amber-700 border-amber-600/30";
+    return "bg-orange-500/20 text-orange-700 border-orange-600/30";
+  };
 
   return (
     <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs" data-testid="drilldown-panel">
@@ -42,6 +48,20 @@ export const DrilldownPanel = memo(function DrilldownPanel({ entry }: DrilldownP
                 <span className="rounded bg-muted/40 px-1 py-0.5 text-[9px]">{STATUS_LABELS[entry.status]}</span>
               </div>
             </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Decision vs Bind outcome</p>
+              <div className="mt-0.5 flex flex-wrap items-center gap-1 text-[10px]">
+                <span className="rounded border border-border/50 px-1.5 py-0.5">
+                  Decision phase: {entry.decisionOutcome}
+                </span>
+                <span className={`rounded border px-1.5 py-0.5 font-semibold ${bindBadgeClass(entry.bindOutcome)}`}>
+                  Bind phase: {entry.bindOutcome}
+                </span>
+              </div>
+              {entry.bindFailureReason !== "none" ? (
+                <p className="mt-1 text-[10px] text-warning">Failure reason: {entry.bindFailureReason}</p>
+              ) : null}
+            </div>
           </div>
           <div className="space-y-2">
             <div>
@@ -68,10 +88,22 @@ export const DrilldownPanel = memo(function DrilldownPanel({ entry }: DrilldownP
                 <p className="text-muted-foreground">No anomalies detected</p>
               )}
             </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase text-muted-foreground">Bind breakdown</p>
+              <div className="mt-0.5 grid grid-cols-2 gap-1 text-[10px]">
+                <p className="rounded border border-border/50 px-1.5 py-0.5">authority: {entry.bindBreakdown.authority}</p>
+                <p className="rounded border border-border/50 px-1.5 py-0.5">constraints: {entry.bindBreakdown.constraints}</p>
+                <p className="rounded border border-border/50 px-1.5 py-0.5">drift: {entry.bindBreakdown.drift}</p>
+                <p className="rounded border border-border/50 px-1.5 py-0.5">risk: {entry.bindBreakdown.risk}</p>
+              </div>
+            </div>
           </div>
           <div className="md:col-span-2 flex flex-wrap gap-1 border-t border-border/30 pt-2">
             <Link href={`/console?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
               <span aria-hidden>⚡</span> Open in Decision
+            </Link>
+            <Link href={entry.bindLineageHref} className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
+              <span aria-hidden>🧬</span> Bind lineage ({entry.bindReceiptId})
             </Link>
             <Link href={`/audit?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/60 px-2 py-0.5 text-[10px] font-semibold hover:bg-muted/40 inline-flex items-center gap-1">
               <span aria-hidden>📋</span> Open in TrustLog

--- a/frontend/app/risk/components/FlaggedRequestsList.tsx
+++ b/frontend/app/risk/components/FlaggedRequestsList.tsx
@@ -14,6 +14,12 @@ interface FlaggedRequestsListProps {
 
 export const FlaggedRequestsList = memo(function FlaggedRequestsList({ entries, selectedPointId, onSelectPoint }: FlaggedRequestsListProps): JSX.Element {
   const { t } = useI18n();
+  const bindBadgeClass = (outcome: FlaggedEntry["bindOutcome"]): string => {
+    if (outcome === "COMMITTED") return "bg-emerald-500/20 text-emerald-700 border-emerald-600/30";
+    if (outcome === "BLOCKED") return "bg-rose-500/20 text-rose-700 border-rose-600/30";
+    if (outcome === "ESCALATED") return "bg-amber-500/20 text-amber-700 border-amber-600/30";
+    return "bg-orange-500/20 text-orange-700 border-orange-600/30";
+  };
 
   return (
     <div className="rounded-lg border border-border/50 bg-background/60 p-3 text-xs">
@@ -42,9 +48,25 @@ export const FlaggedRequestsList = memo(function FlaggedRequestsList({ entries, 
                   </div>
                 </div>
                 <p className="mt-0.5 text-muted-foreground">risk {entry.point.risk.toFixed(2)} / uncertainty {entry.point.uncertainty.toFixed(2)}</p>
+                <div className="mt-1 flex flex-wrap items-center gap-1 text-[9px]">
+                  <span className="rounded border border-border/50 px-1.5 py-0.5">
+                    decision: {entry.decisionOutcome}
+                  </span>
+                  <span className={`rounded border px-1.5 py-0.5 font-semibold ${bindBadgeClass(entry.bindOutcome)}`}>
+                    bind: {entry.bindOutcome}
+                  </span>
+                  {entry.bindFailureReason !== "none" ? (
+                    <span className="rounded border border-warning/40 bg-warning/10 px-1.5 py-0.5 text-warning">
+                      {entry.bindFailureReason}
+                    </span>
+                  ) : null}
+                </div>
                 <div className="mt-1 flex gap-1">
                   <Link href={`/console?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/50 px-1.5 py-0.5 text-[9px] hover:bg-muted/40" onClick={(event) => event.stopPropagation()}>
                     Open in Decision
+                  </Link>
+                  <Link href={entry.bindLineageHref} className="rounded border border-border/50 px-1.5 py-0.5 text-[9px] hover:bg-muted/40" onClick={(event) => event.stopPropagation()}>
+                    Bind lineage
                   </Link>
                   <Link href={`/audit?request_id=${encodeURIComponent(entry.point.id)}`} className="rounded border border-border/50 px-1.5 py-0.5 text-[9px] hover:bg-muted/40" onClick={(event) => event.stopPropagation()}>
                     Open in TrustLog

--- a/frontend/app/risk/components/components.test.tsx
+++ b/frontend/app/risk/components/components.test.tsx
@@ -36,6 +36,17 @@ const mockEntry: FlaggedEntry = {
   cluster: "critical",
   severity: "critical",
   status: "new",
+  decisionOutcome: "modify",
+  bindOutcome: "BLOCKED",
+  bindFailureReason: "Authority denied due to critical policy risk.",
+  bindReceiptId: "bind-req-001",
+  bindLineageHref: "/audit?bind_receipt_id=bind-req-001",
+  bindBreakdown: {
+    authority: "FAIL",
+    constraints: "PASS",
+    drift: "PASS",
+    risk: "FAIL",
+  },
   reason: {
     policyConfidence: 0.2,
     unstableOutputSignal: true,
@@ -64,6 +75,9 @@ describe("DrilldownPanel", () => {
     expect(screen.getByText("critical")).toBeInTheDocument();
     expect(screen.getByText(/PII detected/)).toBeInTheDocument();
     expect(screen.getByText(/Latency spike/)).toBeInTheDocument();
+    expect(screen.getByText(/Decision phase: modify/)).toBeInTheDocument();
+    expect(screen.getByText(/Bind phase: BLOCKED/)).toBeInTheDocument();
+    expect(screen.getByText(/authority: FAIL/)).toBeInTheDocument();
   });
 
   it("renders navigation links", () => {
@@ -71,6 +85,7 @@ describe("DrilldownPanel", () => {
     expect(screen.getByText("Open in Decision")).toHaveAttribute("href", "/console?request_id=req-001");
     expect(screen.getByText("Open in TrustLog")).toHaveAttribute("href", "/audit?request_id=req-001");
     expect(screen.getByText("Adjust in Governance")).toHaveAttribute("href", "/governance");
+    expect(screen.getByText(/Bind lineage/)).toHaveAttribute("href", "/audit?bind_receipt_id=bind-req-001");
   });
 });
 
@@ -89,6 +104,8 @@ describe("FlaggedRequestsList", () => {
     expect(screen.getByText("critical")).toBeInTheDocument();
     expect(screen.getByText("Open in Decision")).toHaveAttribute("href", "/console?request_id=req-001");
     expect(screen.getByText("Open in TrustLog")).toHaveAttribute("href", "/audit?request_id=req-001");
+    expect(screen.getByText(/bind:\s*BLOCKED/i)).toBeInTheDocument();
+    expect(screen.getByText("Bind lineage")).toHaveAttribute("href", "/audit?bind_receipt_id=bind-req-001");
   });
 
   it("calls onSelectPoint when entry button clicked", () => {

--- a/frontend/app/risk/data-helpers.ts
+++ b/frontend/app/risk/data-helpers.ts
@@ -1,4 +1,15 @@
-import type { ClusterKind, FlaggedEntry, FlagReason, RiskPoint, Severity, RequestStatus, TrendBucket } from "./risk-types";
+import type {
+  BindBreakdown,
+  BindPhaseOutcome,
+  ClusterKind,
+  DecisionPhaseOutcome,
+  FlaggedEntry,
+  FlagReason,
+  RiskPoint,
+  Severity,
+  RequestStatus,
+  TrendBucket,
+} from "./risk-types";
 import {
   ALERT_CLUSTER_THRESHOLD,
   RISK_CONFIDENCE_WEIGHT,
@@ -72,6 +83,72 @@ export function deriveStatus(point: RiskPoint): RequestStatus {
   return "new";
 }
 
+function deriveDecisionOutcome(point: RiskPoint): DecisionPhaseOutcome {
+  if (point.risk >= 0.9) return "deny";
+  if (point.risk >= 0.75 || point.uncertainty >= 0.8) return "modify";
+  if (point.uncertainty >= 0.65) return "hold";
+  return "allow";
+}
+
+/**
+ * Builds synthetic bind-phase state for Mission Control visualization.
+ *
+ * The values are deterministic from risk telemetry so tests and UI state stay
+ * stable without introducing backend coupling.
+ */
+function deriveBindPhase(point: RiskPoint): {
+  outcome: BindPhaseOutcome;
+  failureReason: string;
+  breakdown: BindBreakdown;
+} {
+  if (point.risk >= 0.92) {
+    return {
+      outcome: "BLOCKED",
+      failureReason: "Authority denied due to critical policy risk.",
+      breakdown: {
+        authority: "FAIL",
+        constraints: "PASS",
+        drift: "PASS",
+        risk: "FAIL",
+      },
+    };
+  }
+  if (point.risk >= 0.84 && point.uncertainty >= 0.78) {
+    return {
+      outcome: "ESCALATED",
+      failureReason: "Human escalation required for unstable high-risk profile.",
+      breakdown: {
+        authority: "PASS",
+        constraints: "PASS",
+        drift: "FAIL",
+        risk: "FAIL",
+      },
+    };
+  }
+  if (point.uncertainty >= 0.88) {
+    return {
+      outcome: "ROLLED_BACK",
+      failureReason: "Bind was rolled back after drift threshold exceeded.",
+      breakdown: {
+        authority: "PASS",
+        constraints: "PASS",
+        drift: "FAIL",
+        risk: "PASS",
+      },
+    };
+  }
+  return {
+    outcome: "COMMITTED",
+    failureReason: "none",
+    breakdown: {
+      authority: "PASS",
+      constraints: "PASS",
+      drift: "PASS",
+      risk: "PASS",
+    },
+  };
+}
+
 export function buildFlagReason(point: RiskPoint): FlagReason {
   const cluster = getCluster(point);
   const policyConfidence = Math.max(0, 1 - point.risk * RISK_CONFIDENCE_WEIGHT - point.uncertainty * UNCERTAINTY_CONFIDENCE_WEIGHT);
@@ -117,11 +194,19 @@ function deriveStageAnomalies(point: RiskPoint): string[] {
 }
 
 export function enrichFlaggedEntry(point: RiskPoint): FlaggedEntry {
+  const bindPhase = deriveBindPhase(point);
+  const bindReceiptId = `bind-${point.id}`;
   return {
     point,
     cluster: getCluster(point),
     severity: deriveSeverity(point),
     status: deriveStatus(point),
+    decisionOutcome: deriveDecisionOutcome(point),
+    bindOutcome: bindPhase.outcome,
+    bindFailureReason: bindPhase.failureReason,
+    bindReceiptId,
+    bindLineageHref: `/audit?bind_receipt_id=${encodeURIComponent(bindReceiptId)}`,
+    bindBreakdown: bindPhase.breakdown,
     reason: buildFlagReason(point),
     relatedPolicyHits: deriveRelatedPolicyHits(point),
     stageAnomalies: deriveStageAnomalies(point),

--- a/frontend/app/risk/page.test.tsx
+++ b/frontend/app/risk/page.test.tsx
@@ -52,6 +52,17 @@ describe("RiskIntelligencePage", () => {
     expect(drilldown.textContent).toContain("Request ID / Seed");
     expect(drilldown.textContent).toContain("Uncertainty");
     expect(drilldown.textContent).toContain("Risk score");
+    expect(drilldown.textContent).toContain("Decision vs Bind outcome");
+    expect(drilldown.textContent).toContain("Bind breakdown");
+  });
+
+  it("renders bind lineage navigation and bind failure context in risk workflow", () => {
+    render(<RiskIntelligencePage />);
+    fireEvent.click(screen.getAllByRole("button", { name: /risk/i })[0]);
+
+    expect(screen.getAllByText(/Bind lineage/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Decision phase:/)).toBeInTheDocument();
+    expect(screen.getByText(/Bind phase:/)).toBeInTheDocument();
   });
 
   it("renders structured why-flagged with policy confidence and signals", () => {

--- a/frontend/app/risk/risk-types.ts
+++ b/frontend/app/risk/risk-types.ts
@@ -1,6 +1,8 @@
 export type ClusterKind = "critical" | "risky" | "uncertain" | "stable";
 export type Severity = "critical" | "high" | "medium" | "low";
 export type RequestStatus = "active" | "mitigated" | "investigating" | "new";
+export type DecisionPhaseOutcome = "allow" | "modify" | "deny" | "hold";
+export type BindPhaseOutcome = "COMMITTED" | "BLOCKED" | "ESCALATED" | "ROLLED_BACK";
 
 export interface RiskPoint {
   id: string;
@@ -23,11 +25,24 @@ export interface FlagReason {
   suggestedAction: string;
 }
 
+export interface BindBreakdown {
+  authority: "PASS" | "FAIL";
+  constraints: "PASS" | "FAIL";
+  drift: "PASS" | "FAIL";
+  risk: "PASS" | "FAIL";
+}
+
 export interface FlaggedEntry {
   point: RiskPoint;
   cluster: ClusterKind;
   severity: Severity;
   status: RequestStatus;
+  decisionOutcome: DecisionPhaseOutcome;
+  bindOutcome: BindPhaseOutcome;
+  bindFailureReason: string;
+  bindReceiptId: string;
+  bindLineageHref: string;
+  bindBreakdown: BindBreakdown;
   reason: FlagReason;
   relatedPolicyHits: string[];
   stageAnomalies: string[];

--- a/frontend/features/console/components/decision-result-panel.test.tsx
+++ b/frontend/features/console/components/decision-result-panel.test.tsx
@@ -165,4 +165,16 @@ describe("DecisionResultPanel", () => {
       expect(screen.getByText(outcome)).toBeInTheDocument();
     },
   );
+
+  it("keeps legacy decision view stable when bind fields are absent", () => {
+    const legacyResult = { ...baseResult };
+    render(
+      <I18nProvider>
+        <DecisionResultPanel result={legacyResult as never} viewerRole="operator" />
+      </I18nProvider>,
+    );
+    expect(screen.getByText(/final decision|最終判断/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/gate_decision/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/business_decision/i).length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
### Motivation
- Make bind-phase outcome (COMMITTED / BLOCKED / ESCALATED / ROLLED_BACK) natively visible in existing Mission Control Risk list/detail UI so operators and auditors can see commit vs decision state without adding a new dashboard. 
- Provide a compact bind breakdown (authority / constraints / drift / risk) and lineage link to the bind receipt to aid triage and traceability. 
- Keep the change small and non-invasive by reusing existing list/detail patterns and synthetic data in the Risk workspace. 
- Security note: bind failure reasons may reveal sensitive policy/authority logic; production masking / role-based exposure should be reviewed in a follow-up.

### Description
- Added frontend types and data derivation: `DecisionPhaseOutcome`, `BindPhaseOutcome`, `BindBreakdown` and extended `FlaggedEntry`, plus deterministic `deriveDecisionOutcome` and `deriveBindPhase` in `frontend/app/risk/data-helpers.ts` to populate bind fields for UI-only visualization. 
- List UI: `frontend/app/risk/components/FlaggedRequestsList.tsx` now shows `decision: ...` and `bind: ...` side-by-side, renders a bind outcome badge and bind failure reason, and includes a `Bind lineage` link to the receipt. 
- Detail/drilldown UI: `frontend/app/risk/components/DrilldownPanel.tsx` adds a compact "Decision vs Bind outcome" block, a 4-field bind breakdown grid (authority/constraints/drift/risk), and a bind-lineage CTA. 
- Tests and small test adjustments were added to cover render, detail panel, integration flow, and backward compatibility in the Decision view. 
- Files changed: `frontend/app/risk/risk-types.ts`, `frontend/app/risk/data-helpers.ts`, `frontend/app/risk/components/FlaggedRequestsList.tsx`, `frontend/app/risk/components/DrilldownPanel.tsx`, `frontend/app/risk/components/components.test.tsx`, `frontend/app/risk/page.test.tsx`, and `frontend/features/console/components/decision-result-panel.test.tsx`.

### Testing
- Ran `pnpm vitest run app/risk/components/components.test.tsx app/risk/page.test.tsx features/console/components/decision-result-panel.test.tsx`. 
- Outcome: all targeted tests passed after a minor test adjustment (3 test files, 42 tests total; green). 
- Note: this PR implements frontend-only synthetic bind visibility; end-to-end browser screenshots and backend API mapping are out of scope for this single small PR and are left for follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64b1642348326b5180d105dc8142c)