### PR TITLE
Auto-link bind orchestration receipts into TrustLog lineage

### DIFF
--- a/veritas_os/policy/bind_execution.py
+++ b/veritas_os/policy/bind_execution.py
@@ -18,7 +18,13 @@ from veritas_os.core.continuation_runtime.bind_admissibility import (
     CheckStatus,
     evaluate_bind_admissibility,
 )
-from veritas_os.policy.bind_artifacts import BindReceipt, ExecutionIntent, FinalOutcome
+from veritas_os.policy.bind_artifacts import (
+    BindReceipt,
+    ExecutionIntent,
+    FinalOutcome,
+    append_bind_receipt_trustlog,
+    append_execution_intent_trustlog,
+)
 from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
 
 
@@ -153,6 +159,7 @@ def execute_bind_boundary(
     adapter: BindBoundaryAdapter,
     bind_ts: str | None = None,
     bind_receipt_id: str | None = None,
+    append_trustlog: bool = True,
 ) -> BindReceipt:
     """Orchestrate snapshot -> admissibility -> apply -> verify -> commit/revert.
 
@@ -179,7 +186,10 @@ def execute_bind_boundary(
         pre_snapshot = adapter.snapshot()
         pre_fingerprint = adapter.fingerprint_state(pre_snapshot)
     except (TypeError, ValueError, RuntimeError) as exc:
-        return _with_receipt(
+        return _finalize_receipt(
+            execution_intent=execution_intent,
+            append_trustlog=append_trustlog,
+            receipt=_with_receipt(
             base_receipt,
             live_state_fingerprint_before="",
             authority_check_result=_check_unknown("BIND_AUTHORITY_UNKNOWN", "snapshot unavailable"),
@@ -196,6 +206,7 @@ def execute_bind_boundary(
                 "reason": str(exc),
             },
             final_outcome=FinalOutcome.SNAPSHOT_FAILED,
+            ),
         )
 
     authority_signal = adapter.validate_authority(execution_intent, pre_snapshot)
@@ -230,7 +241,10 @@ def execute_bind_boundary(
             blocked_outcome = FinalOutcome.ESCALATED
             escalation_reason = "BIND_ADMISSIBILITY_ESCALATION_REQUIRED"
 
-        return _with_receipt(
+        return _finalize_receipt(
+            execution_intent=execution_intent,
+            append_trustlog=append_trustlog,
+            receipt=_with_receipt(
             base_receipt,
             live_state_fingerprint_before=pre_fingerprint,
             authority_check_result=authority_result,
@@ -245,12 +259,16 @@ def execute_bind_boundary(
             },
             final_outcome=blocked_outcome,
             escalation_reason=escalation_reason,
+            ),
         )
 
     try:
         adapter.apply(execution_intent, pre_snapshot)
     except (TypeError, ValueError, RuntimeError) as exc:
-        return _with_receipt(
+        return _finalize_receipt(
+            execution_intent=execution_intent,
+            append_trustlog=append_trustlog,
+            receipt=_with_receipt(
             base_receipt,
             live_state_fingerprint_before=pre_fingerprint,
             authority_check_result=authority_result,
@@ -265,11 +283,15 @@ def execute_bind_boundary(
             },
             final_outcome=FinalOutcome.APPLY_FAILED,
             rollback_reason=f"BIND_APPLY_FAILED:{exc}",
+            ),
         )
 
     verified = adapter.verify_postconditions(execution_intent, pre_snapshot)
     if not verified:
-        return _rollback_after_verification_failure(
+        return _finalize_receipt(
+            execution_intent=execution_intent,
+            append_trustlog=append_trustlog,
+            receipt=_rollback_after_verification_failure(
             base_receipt=base_receipt,
             adapter=adapter,
             execution_intent=execution_intent,
@@ -280,13 +302,17 @@ def execute_bind_boundary(
             drift_result=drift_result,
             risk_result=risk_result,
             recommended_outcome=admissibility.recommended_outcome.value,
+            ),
         )
 
     try:
         post_snapshot = adapter.snapshot()
         post_fingerprint = adapter.fingerprint_state(post_snapshot)
     except (TypeError, ValueError, RuntimeError) as exc:
-        return _rollback_after_runtime_signal_failure(
+        return _finalize_receipt(
+            execution_intent=execution_intent,
+            append_trustlog=append_trustlog,
+            receipt=_rollback_after_runtime_signal_failure(
             base_receipt=base_receipt,
             adapter=adapter,
             execution_intent=execution_intent,
@@ -298,23 +324,28 @@ def execute_bind_boundary(
             risk_result=risk_result,
             reason=f"BIND_POST_FINGERPRINT_FAILED:{exc}",
             recommended_outcome=admissibility.recommended_outcome.value,
+            ),
         )
 
-    return _with_receipt(
-        base_receipt,
-        live_state_fingerprint_before=pre_fingerprint,
-        live_state_fingerprint_after=post_fingerprint,
-        authority_check_result=authority_result,
-        constraint_check_result=constraint_result,
-        drift_check_result=drift_result,
-        risk_check_result=risk_result,
-        admissibility_result={
-            "admissible": True,
-            "recommended_outcome": admissibility.recommended_outcome.value,
-            "reason_codes": [],
-            "target": adapter.describe_target(),
-        },
-        final_outcome=FinalOutcome.COMMITTED,
+    return _finalize_receipt(
+        execution_intent=execution_intent,
+        append_trustlog=append_trustlog,
+        receipt=_with_receipt(
+            base_receipt,
+            live_state_fingerprint_before=pre_fingerprint,
+            live_state_fingerprint_after=post_fingerprint,
+            authority_check_result=authority_result,
+            constraint_check_result=constraint_result,
+            drift_check_result=drift_result,
+            risk_check_result=risk_result,
+            admissibility_result={
+                "admissible": True,
+                "recommended_outcome": admissibility.recommended_outcome.value,
+                "reason_codes": [],
+                "target": adapter.describe_target(),
+            },
+            final_outcome=FinalOutcome.COMMITTED,
+        ),
     )
 
 
@@ -508,6 +539,19 @@ def _with_receipt(base_receipt: BindReceipt, **updates: Any) -> BindReceipt:
     payload = base_receipt.to_dict()
     payload.update(updates)
     return BindReceipt(**payload)
+
+
+def _finalize_receipt(
+    *,
+    execution_intent: ExecutionIntent,
+    append_trustlog: bool,
+    receipt: BindReceipt,
+) -> BindReceipt:
+    """Return receipt with optional TrustLog lineage append for orchestration paths."""
+    if not append_trustlog:
+        return receipt
+    append_execution_intent_trustlog(execution_intent)
+    return append_bind_receipt_trustlog(receipt)
 
 
 def _deep_copy_mapping(value: dict[str, Any]) -> dict[str, Any]:

--- a/veritas_os/tests/test_bind_execution.py
+++ b/veritas_os/tests/test_bind_execution.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+from veritas_os.logging.encryption import generate_key
+from veritas_os.policy.bind_artifacts import find_bind_receipts
 from veritas_os.policy.bind_artifacts import ExecutionIntent, FinalOutcome
 from veritas_os.policy.bind_execution import ReferenceBindAdapter, execute_bind_boundary
 
@@ -20,6 +24,25 @@ def _intent(expected_fingerprint: str = "") -> ExecutionIntent:
         decision_ts="2026-04-20T12:00:00Z",
         expected_state_fingerprint=expected_fingerprint,
     )
+
+
+@pytest.fixture()
+def trustlog_env(tmp_path, monkeypatch):
+    """Redirect TrustLog writes to a temporary log path."""
+    from veritas_os.logging import trust_log
+
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    monkeypatch.setattr(trust_log, "LOG_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSON", tmp_path / "trust_log.json", raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSONL", tmp_path / "trust_log.jsonl", raising=False)
+    monkeypatch.setattr(trust_log, "_append_stats", {"success": 0, "failure": 0}, raising=False)
+
+    def _open_for_append():
+        trust_log.LOG_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        return open(trust_log.LOG_JSONL, "a", encoding="utf-8")
+
+    monkeypatch.setattr(trust_log, "open_trust_log_for_append", _open_for_append)
+    return tmp_path
 
 
 def test_bind_execution_success_committed() -> None:
@@ -158,12 +181,83 @@ def test_bind_execution_is_deterministic_for_same_inputs() -> None:
         adapter=adapter_a,
         bind_ts="2026-04-20T12:00:10Z",
         bind_receipt_id="br-deterministic",
+        append_trustlog=False,
     )
     receipt_b = execute_bind_boundary(
         execution_intent=intent,
         adapter=adapter_b,
         bind_ts="2026-04-20T12:00:10Z",
         bind_receipt_id="br-deterministic",
+        append_trustlog=False,
     )
 
     assert receipt_a.to_dict() == receipt_b.to_dict()
+
+
+def test_bind_execution_success_auto_appends_trustlog_receipt(trustlog_env) -> None:
+    """Committed outcome should be returned as TrustLog-linked bind receipt."""
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(expected_fingerprint=adapter.fingerprint_state({"version": 1}))
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert receipt.trustlog_hash
+    matched = find_bind_receipts(bind_receipt_id=receipt.bind_receipt_id)
+    assert len(matched) == 1
+    assert matched[0].final_outcome is FinalOutcome.COMMITTED
+
+
+def test_bind_execution_blocked_auto_appends_trustlog_receipt(trustlog_env) -> None:
+    """Blocked outcome should also be persisted to TrustLog lineage."""
+    adapter = ReferenceBindAdapter(
+        state={"version": 1},
+        pending_changes={"version": 2},
+        authority_signal=False,
+    )
+    intent = _intent(expected_fingerprint=adapter.fingerprint_state({"version": 1}))
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert receipt.trustlog_hash
+    matched = find_bind_receipts(bind_receipt_id=receipt.bind_receipt_id)
+    assert len(matched) == 1
+    assert matched[0].final_outcome is FinalOutcome.BLOCKED
+
+
+def test_bind_execution_rolled_back_auto_appends_trustlog_receipt(trustlog_env) -> None:
+    """Rolled-back outcome should be persisted to TrustLog lineage."""
+    adapter = ReferenceBindAdapter(
+        state={"version": 1},
+        pending_changes={"version": 2},
+        postcondition_success=False,
+        revert_success=True,
+    )
+    intent = _intent(expected_fingerprint=adapter.fingerprint_state({"version": 1}))
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.ROLLED_BACK
+    assert receipt.trustlog_hash
+    matched = find_bind_receipts(bind_receipt_id=receipt.bind_receipt_id)
+    assert len(matched) == 1
+    assert matched[0].final_outcome is FinalOutcome.ROLLED_BACK
+
+
+def test_bind_execution_trustlog_lineage_traversal_by_all_ids(trustlog_env) -> None:
+    """Bind lineage must be traversable by decision/intent/receipt identifiers."""
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(expected_fingerprint=adapter.fingerprint_state({"version": 1}))
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    by_decision_id = find_bind_receipts(decision_id=intent.decision_id)
+    by_execution_intent_id = find_bind_receipts(execution_intent_id=intent.execution_intent_id)
+    by_bind_receipt_id = find_bind_receipts(bind_receipt_id=receipt.bind_receipt_id)
+
+    assert len(by_decision_id) == 1
+    assert len(by_execution_intent_id) == 1
+    assert len(by_bind_receipt_id) == 1
+    assert by_decision_id[0].bind_receipt_id == receipt.bind_receipt_id
+    assert by_execution_intent_id[0].bind_receipt_id == receipt.bind_receipt_id


### PR DESCRIPTION
### Motivation
- Close the gap between bind execution orchestration and native TrustLog lineage by ensuring orchestration results are recorded end-to-end. 
- Keep `ExecutionIntent` as the primary decision artifact and avoid introducing a second logging path while preserving existing fail-closed semantics. 
- Reuse the existing TrustLog append/hash/sign path so lineage chaining is explicit and testable.

### Description
- Extend `execute_bind_boundary()` with an `append_trustlog: bool = True` opt-out and route all terminal receipt return paths through a new `_finalize_receipt()` that calls `append_execution_intent_trustlog()` then `append_bind_receipt_trustlog()` when enabled. 
- Import and reuse existing functions `append_execution_intent_trustlog` and `append_bind_receipt_trustlog` from `veritas_os.policy.bind_artifacts` and do not create any second logging path. 
- Preserve all existing admissibility/rollback/escalation logic and fail-closed behavior; TrustLog writes occur only after the receipt is finalized. 
- Files changed: `veritas_os/policy/bind_execution.py` (add import, `append_trustlog` flag, `_finalize_receipt`) and `veritas_os/tests/test_bind_execution.py` (add TrustLog test fixture and tests for COMMITTED/BLOCKED/ROLLED_BACK and lineage traversal).

### Testing
- Ran `pytest -q veritas_os/tests/test_bind_execution.py veritas_os/tests/test_bind_artifacts.py` and all tests passed: `22 passed`.
- Ran static checks with `ruff` on the modified files and they passed (`All checks passed!`).
- Confirmed source compiles with `python -m compileall` for the modified module and tests (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cc056be08326a7b9dce4a94d939e)