### PR TITLE
Policy-driven bind adjudication via ExecutionIntent.policy_lineage

### DIFF
--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -342,6 +342,7 @@ class ExecutionIntent(BaseModel):
     ttl_seconds: Optional[int] = Field(default=None, ge=0)
     expected_state_fingerprint: Optional[str] = Field(default=None, max_length=256)
     approval_context: Optional[Dict[str, Any]] = None
+    policy_lineage: Optional[Dict[str, Any]] = None
 
 
 class BindReceipt(BaseModel):

--- a/veritas_os/core/continuation_runtime/bind_admissibility.py
+++ b/veritas_os/core/continuation_runtime/bind_admissibility.py
@@ -50,6 +50,9 @@ class BindAdmissibilityInput:
     expected_state_fingerprint: Optional[str]
     runtime_risk_signal: Optional[bool]
     drift_sensitive: bool = True
+    ttl_required: bool = False
+    approval_freshness_required: bool = False
+    missing_signal_outcome: AdmissibilityOutcome = AdmissibilityOutcome.BLOCK
     ttl_expires_at: Optional[str] = None
     approval_expires_at: Optional[str] = None
 
@@ -109,10 +112,11 @@ def evaluate_bind_admissibility(
 def _check_authority(evaluation_input: BindAdmissibilityInput) -> CheckResult:
     signal = evaluation_input.authority_signal
     if signal is None:
+        status = _missing_signal_status(evaluation_input)
         return CheckResult(
-            status=CheckStatus.FAIL,
+            status=status,
             reason_code="BIND_AUTHORITY_MISSING",
-            message="Authority signal is missing; fail-closed block applied.",
+            message="Authority signal is missing; policy fallback applied.",
         )
     if signal is False:
         return CheckResult(
@@ -130,10 +134,11 @@ def _check_authority(evaluation_input: BindAdmissibilityInput) -> CheckResult:
 def _check_constraints(evaluation_input: BindAdmissibilityInput) -> CheckResult:
     signals = evaluation_input.constraint_signals
     if not signals:
+        status = _missing_signal_status(evaluation_input)
         return CheckResult(
-            status=CheckStatus.FAIL,
+            status=status,
             reason_code="BIND_CONSTRAINTS_MISSING",
-            message="Constraint signals are missing; fail-closed block applied.",
+            message="Constraint signals are missing; policy fallback applied.",
         )
 
     violating_constraints = sorted(name for name, passed in signals.items() if not passed)
@@ -165,8 +170,9 @@ def _check_drift(evaluation_input: BindAdmissibilityInput) -> CheckResult:
     expected = evaluation_input.expected_state_fingerprint
 
     if not live or not expected:
+        status = _missing_signal_status(evaluation_input)
         return CheckResult(
-            status=CheckStatus.FAIL,
+            status=status,
             reason_code="BIND_DRIFT_SIGNAL_MISSING",
             message="Drift-sensitive path lacks live or expected state fingerprint.",
         )
@@ -188,10 +194,11 @@ def _check_drift(evaluation_input: BindAdmissibilityInput) -> CheckResult:
 def _check_runtime_risk(evaluation_input: BindAdmissibilityInput) -> CheckResult:
     signal = evaluation_input.runtime_risk_signal
     if signal is None:
+        status = _missing_signal_status(evaluation_input)
         return CheckResult(
-            status=CheckStatus.FAIL,
+            status=status,
             reason_code="BIND_RUNTIME_RISK_MISSING",
-            message="Runtime risk signal is missing; fail-closed block applied.",
+            message="Runtime risk signal is missing; policy fallback applied.",
         )
     if signal is False:
         return CheckResult(
@@ -209,6 +216,20 @@ def _check_runtime_risk(evaluation_input: BindAdmissibilityInput) -> CheckResult
 def _check_freshness(evaluation_input: BindAdmissibilityInput) -> CheckResult:
     now = _parse_timestamp(evaluation_input.current_timestamp)
 
+    if evaluation_input.ttl_required and not evaluation_input.ttl_expires_at:
+        return CheckResult(
+            status=_missing_signal_status(evaluation_input),
+            reason_code="BIND_TTL_MISSING",
+            message="TTL is required by policy but no TTL signal is available.",
+        )
+
+    if evaluation_input.approval_freshness_required and not evaluation_input.approval_expires_at:
+        return CheckResult(
+            status=_missing_signal_status(evaluation_input),
+            reason_code="BIND_APPROVAL_FRESHNESS_MISSING",
+            message="Approval freshness is required by policy but signal is missing.",
+        )
+
     expiry_fields = [
         ("ttl", evaluation_input.ttl_expires_at, "BIND_TTL_EXPIRED"),
         ("approval", evaluation_input.approval_expires_at, "BIND_APPROVAL_STALE"),
@@ -225,10 +246,11 @@ def _check_freshness(evaluation_input: BindAdmissibilityInput) -> CheckResult:
     if expired:
         labels = ", ".join(name for name, _ in expired)
         primary_reason = expired[0][1]
+        expired_status = _missing_signal_status(evaluation_input)
         return CheckResult(
-            status=CheckStatus.ESCALATE,
+            status=expired_status,
             reason_code=primary_reason,
-            message=f"Freshness window expired ({labels}); escalation required.",
+            message=f"Freshness window expired ({labels}); policy fallback applied.",
         )
 
     return CheckResult(
@@ -244,3 +266,10 @@ def _parse_timestamp(raw_timestamp: str) -> datetime:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def _missing_signal_status(evaluation_input: BindAdmissibilityInput) -> CheckStatus:
+    """Return status dictated by policy for missing/invalid runtime signals."""
+    if evaluation_input.missing_signal_outcome is AdmissibilityOutcome.ESCALATE:
+        return CheckStatus.ESCALATE
+    return CheckStatus.FAIL

--- a/veritas_os/policy/bind_artifacts.py
+++ b/veritas_os/policy/bind_artifacts.py
@@ -68,6 +68,7 @@ class ExecutionIntent:
     ttl_seconds: int | None = None
     expected_state_fingerprint: str | None = None
     approval_context: dict[str, Any] | None = None
+    policy_lineage: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation."""
@@ -86,6 +87,7 @@ class ExecutionIntent:
             "ttl_seconds": self.ttl_seconds,
             "expected_state_fingerprint": self.expected_state_fingerprint,
             "approval_context": self.approval_context,
+            "policy_lineage": self.policy_lineage,
         }
 
 

--- a/veritas_os/policy/bind_execution.py
+++ b/veritas_os/policy/bind_execution.py
@@ -153,6 +153,16 @@ class ReferenceBindAdapter:
         return self.target_description
 
 
+@dataclass(frozen=True)
+class BindPolicyConfig:
+    """Policy-driven bind adjudication toggles resolved from governance lineage."""
+
+    drift_required: bool = True
+    ttl_required: bool = False
+    approval_freshness_required: bool = False
+    missing_signal_outcome: AdmissibilityOutcome = AdmissibilityOutcome.BLOCK
+
+
 def execute_bind_boundary(
     *,
     execution_intent: ExecutionIntent,
@@ -212,7 +222,9 @@ def execute_bind_boundary(
     authority_signal = adapter.validate_authority(execution_intent, pre_snapshot)
     constraint_signals = adapter.validate_constraints(execution_intent, pre_snapshot)
     runtime_risk_signal = adapter.assess_runtime_risk(execution_intent, pre_snapshot)
+    bind_policy = _resolve_bind_policy_config(execution_intent)
     ttl_expires_at = _build_ttl_expiry(execution_intent)
+    approval_expires_at = _build_approval_expiry(execution_intent)
 
     admissibility = evaluate_bind_admissibility(
         BindAdmissibilityInput(
@@ -223,9 +235,12 @@ def execute_bind_boundary(
             live_state_fingerprint=pre_fingerprint,
             expected_state_fingerprint=execution_intent.expected_state_fingerprint,
             runtime_risk_signal=runtime_risk_signal,
-            drift_sensitive=True,
+            drift_sensitive=bind_policy.drift_required,
+            ttl_required=bind_policy.ttl_required,
+            approval_freshness_required=bind_policy.approval_freshness_required,
+            missing_signal_outcome=bind_policy.missing_signal_outcome,
             ttl_expires_at=ttl_expires_at,
-            approval_expires_at=None,
+            approval_expires_at=approval_expires_at,
         )
     )
 
@@ -532,6 +547,53 @@ def _build_ttl_expiry(execution_intent: ExecutionIntent) -> str | None:
         "+00:00",
         "Z",
     )
+
+
+def _build_approval_expiry(execution_intent: ExecutionIntent) -> str | None:
+    """Return approval expiry from intent approval context when available."""
+    if not isinstance(execution_intent.approval_context, dict):
+        return None
+    approval_expires_at = execution_intent.approval_context.get("approval_expires_at")
+    if not isinstance(approval_expires_at, str) or not approval_expires_at.strip():
+        return None
+    return approval_expires_at.strip()
+
+
+def _resolve_bind_policy_config(execution_intent: ExecutionIntent) -> BindPolicyConfig:
+    """Resolve bind policy from existing governance policy-lineage style fields."""
+    lineage_bind = {}
+    if isinstance(execution_intent.policy_lineage, dict):
+        lineage_bind = execution_intent.policy_lineage.get("bind_adjudication") or {}
+
+    approval_bind = {}
+    if isinstance(execution_intent.approval_context, dict):
+        approval_bind = execution_intent.approval_context.get("bind_adjudication") or {}
+
+    merged = {}
+    if isinstance(lineage_bind, dict):
+        merged.update(lineage_bind)
+    if isinstance(approval_bind, dict):
+        merged.update(approval_bind)
+
+    return BindPolicyConfig(
+        drift_required=bool(merged.get("drift_required", True)),
+        ttl_required=bool(merged.get("ttl_required", False)),
+        approval_freshness_required=bool(merged.get("approval_freshness_required", False)),
+        missing_signal_outcome=_parse_missing_signal_outcome(
+            merged.get("missing_signal_default", AdmissibilityOutcome.BLOCK.value)
+        ),
+    )
+
+
+def _parse_missing_signal_outcome(raw_value: Any) -> AdmissibilityOutcome:
+    """Parse configured missing-signal fallback outcome with fail-safe default."""
+    if isinstance(raw_value, AdmissibilityOutcome):
+        return raw_value
+    if isinstance(raw_value, str):
+        normalized = raw_value.strip().lower()
+        if normalized == AdmissibilityOutcome.ESCALATE.value:
+            return AdmissibilityOutcome.ESCALATE
+    return AdmissibilityOutcome.BLOCK
 
 
 def _with_receipt(base_receipt: BindReceipt, **updates: Any) -> BindReceipt:

--- a/veritas_os/tests/test_bind_execution.py
+++ b/veritas_os/tests/test_bind_execution.py
@@ -10,7 +10,13 @@ from veritas_os.policy.bind_artifacts import ExecutionIntent, FinalOutcome
 from veritas_os.policy.bind_execution import ReferenceBindAdapter, execute_bind_boundary
 
 
-def _intent(expected_fingerprint: str = "") -> ExecutionIntent:
+def _intent(
+    expected_fingerprint: str = "",
+    *,
+    ttl_seconds: int | None = None,
+    approval_context: dict[str, object] | None = None,
+    policy_lineage: dict[str, object] | None = None,
+) -> ExecutionIntent:
     return ExecutionIntent(
         execution_intent_id="ei-001",
         decision_id="dec-001",
@@ -22,7 +28,10 @@ def _intent(expected_fingerprint: str = "") -> ExecutionIntent:
         intended_action="mutate",
         decision_hash="a" * 64,
         decision_ts="2026-04-20T12:00:00Z",
+        ttl_seconds=ttl_seconds,
         expected_state_fingerprint=expected_fingerprint,
+        approval_context=approval_context,
+        policy_lineage=policy_lineage,
     )
 
 
@@ -261,3 +270,82 @@ def test_bind_execution_trustlog_lineage_traversal_by_all_ids(trustlog_env) -> N
     assert len(by_bind_receipt_id) == 1
     assert by_decision_id[0].bind_receipt_id == receipt.bind_receipt_id
     assert by_execution_intent_id[0].bind_receipt_id == receipt.bind_receipt_id
+
+
+def test_bind_execution_policy_requires_drift_missing_signal_blocks() -> None:
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(
+        expected_fingerprint="",
+        policy_lineage={"bind_adjudication": {"drift_required": True}},
+    )
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert "BIND_DRIFT_SIGNAL_MISSING" in receipt.admissibility_result["reason_codes"]
+
+
+def test_bind_execution_policy_relaxes_drift_allows_commit_without_fingerprint() -> None:
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(
+        expected_fingerprint="",
+        policy_lineage={"bind_adjudication": {"drift_required": False}},
+    )
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert adapter.state["version"] == 2
+
+
+def test_bind_execution_policy_requires_approval_freshness_stale_escalates() -> None:
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(
+        expected_fingerprint=adapter.fingerprint_state({"version": 1}),
+        approval_context={"approval_expires_at": "2026-04-20T12:00:00Z"},
+        policy_lineage={
+            "bind_adjudication": {
+                "approval_freshness_required": True,
+                "missing_signal_default": "escalate",
+            }
+        },
+    )
+
+    receipt = execute_bind_boundary(
+        execution_intent=intent,
+        adapter=adapter,
+        bind_ts="2026-04-20T12:05:00Z",
+    )
+
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert "BIND_APPROVAL_STALE" in receipt.admissibility_result["reason_codes"]
+
+
+def test_bind_execution_policy_controls_missing_signal_default_block_vs_escalate() -> None:
+    block_adapter = ReferenceBindAdapter(
+        state={"version": 1},
+        pending_changes={"version": 2},
+        runtime_risk_signal=None,
+    )
+    escalate_adapter = ReferenceBindAdapter(
+        state={"version": 1},
+        pending_changes={"version": 2},
+        runtime_risk_signal=None,
+    )
+    block_intent = _intent(
+        expected_fingerprint=block_adapter.fingerprint_state({"version": 1}),
+        policy_lineage={"bind_adjudication": {"missing_signal_default": "block"}},
+    )
+    escalate_intent = _intent(
+        expected_fingerprint=escalate_adapter.fingerprint_state({"version": 1}),
+        policy_lineage={"bind_adjudication": {"missing_signal_default": "escalate"}},
+    )
+
+    block_receipt = execute_bind_boundary(execution_intent=block_intent, adapter=block_adapter)
+    escalate_receipt = execute_bind_boundary(
+        execution_intent=escalate_intent,
+        adapter=escalate_adapter,
+    )
+
+    assert block_receipt.final_outcome is FinalOutcome.BLOCKED
+    assert escalate_receipt.final_outcome is FinalOutcome.ESCALATED


### PR DESCRIPTION
### Motivation
- Replace hardcoded bind-time assumptions with policy-driven toggles so bind adjudication can be controlled by decision lineage metadata rather than local hardcode.
- Reuse existing governance pattern (execution intent / approval context / policy lineage) and keep the change additive and narrowly scoped without introducing a new policy framework.
- Note: policy lineage used to change adjudication must be treated as governance-trusted input to avoid changing runtime outcomes from untrusted sources.

### Description
- Add a minimal `BindPolicyConfig` and resolution path in `execute_bind_boundary` that reads `ExecutionIntent.policy_lineage.bind_adjudication` (with `approval_context.bind_adjudication` override) and propagates toggles into admissibility inputs. (files: `veritas_os/policy/bind_execution.py`, `veritas_os/policy/bind_artifacts.py`, `veritas_os/api/schemas.py`)
- Extend `BindAdmissibilityInput` and `evaluate_bind_admissibility` to accept `ttl_required`, `approval_freshness_required`, and `missing_signal_outcome`, and make missing signals / freshness violations follow the configured fallback (`block` or `escalate`). (file: `veritas_os/core/continuation_runtime/bind_admissibility.py`)
- Wire `approval_expires_at` extraction from `ExecutionIntent.approval_context` and TTL handling so freshness checks can be policy-required or optional. (file: `veritas_os/policy/bind_execution.py`)
- Add `policy_lineage` to the `ExecutionIntent` artifact and API schema so lineage-driven configuration can be carried with the intent. (files: `veritas_os/policy/bind_artifacts.py`, `veritas_os/api/schemas.py`)
- Tests added to `veritas_os/tests/test_bind_execution.py` that exercise: policy-required drift blocking, relaxed-drift allowing commit, approval-freshness escalation for stale approvals, and deterministic control of missing-signal default between block vs escalate.

### Testing
- Ran `pytest -q veritas_os/tests/test_bind_execution.py` and all tests passed (`18 passed`).
- New unit tests specifically cover the four requested behaviors and succeeded under the run above.
- No other automated test suites were modified or executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d1c5826c832683bd03962a49e19a)