### PR TITLE
Add PolicyBundlePromotionAdapter (real bind-boundary adapter)

### DIFF
--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -14,6 +14,7 @@ from .bind_artifacts import (
     hash_bind_receipt,
     hash_execution_intent,
 )
+from .bind_boundary_adapters import PolicyBundlePromotionAdapter
 from .bind_execution import BindBoundaryAdapter, ReferenceBindAdapter, execute_bind_boundary
 from .evaluator import PolicyEvaluationResult, evaluate_runtime_policies
 from .generated_tests import GeneratedPolicyTestCase, build_generated_test_cases
@@ -35,6 +36,7 @@ __all__ = [
     "FinalOutcome",
     "BindBoundaryAdapter",
     "ReferenceBindAdapter",
+    "PolicyBundlePromotionAdapter",
     "execute_bind_boundary",
     "append_execution_intent_trustlog",
     "append_bind_receipt_trustlog",

--- a/veritas_os/policy/bind_boundary_adapters.py
+++ b/veritas_os/policy/bind_boundary_adapters.py
@@ -1,0 +1,156 @@
+"""Concrete bind-boundary adapters for production-adjacent operations.
+
+This module provides one real adapter that promotes an active policy bundle
+pointer in local governance operations. The adapter is file-based, deterministic,
+and supports explicit rollback via snapshot restoration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from veritas_os.core.atomic_io import atomic_write_json
+from veritas_os.policy.bind_artifacts import ExecutionIntent
+from veritas_os.security.hash import sha256_of_canonical_json
+
+
+@dataclass
+class PolicyBundlePromotionAdapter:
+    """Bind adapter for active policy-bundle pointer promotion.
+
+    The adapter promotes a single pointer file that identifies the active
+    compiled policy bundle directory used by operational code paths.
+    """
+
+    pointer_path: Path
+    allowed_root: Path
+    require_signature: bool = False
+    target_description: str = "governance/policy_bundle_promotion"
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return deterministic snapshot of current pointer state."""
+        if not self.pointer_path.exists():
+            return {
+                "pointer_exists": False,
+                "active_bundle_dir": "",
+                "decision_id": "",
+                "execution_intent_id": "",
+            }
+
+        payload = self._read_pointer_payload(self.pointer_path)
+        return {
+            "pointer_exists": True,
+            "active_bundle_dir": str(payload.get("active_bundle_dir") or ""),
+            "decision_id": str(payload.get("decision_id") or ""),
+            "execution_intent_id": str(payload.get("execution_intent_id") or ""),
+        }
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        """Return deterministic state fingerprint for snapshot payload."""
+        if not isinstance(snapshot, dict):
+            raise ValueError("BIND_STATE_SNAPSHOT_INVALID")
+        return sha256_of_canonical_json(snapshot)
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        """Require explicit promotion approval in execution intent context."""
+        del snapshot
+        if not isinstance(intent.approval_context, dict):
+            return False
+        return bool(intent.approval_context.get("policy_bundle_promotion_approved"))
+
+    def validate_constraints(
+        self,
+        intent: ExecutionIntent,
+        snapshot: Any,
+    ) -> dict[str, bool] | None:
+        """Validate deterministic local constraints for promotion target."""
+        del snapshot
+        target_dir = self._resolve_target(intent)
+        return {
+            "target_within_allowed_root": self._is_within_allowed_root(target_dir),
+            "manifest_exists": (target_dir / "manifest.json").exists(),
+            "canonical_ir_exists": (target_dir / "compiled" / "canonical_ir.json").exists(),
+        }
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        """Assess runtime risk by checking pointer write safety conditions."""
+        del snapshot
+        target_dir = self._resolve_target(intent)
+        return self._is_within_allowed_root(target_dir)
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Apply promotion by atomically writing active bundle pointer."""
+        del snapshot
+        target_dir = self._resolve_target(intent)
+        pointer_payload = {
+            "active_bundle_dir": str(target_dir),
+            "decision_id": intent.decision_id,
+            "execution_intent_id": intent.execution_intent_id,
+        }
+        self.pointer_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(self.pointer_path, pointer_payload, indent=2)
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Verify pointer now references a valid target bundle directory."""
+        del snapshot
+        target_dir = self._resolve_target(intent)
+        payload = self._read_pointer_payload(self.pointer_path)
+        points_to_target = str(payload.get("active_bundle_dir") or "") == str(target_dir)
+        if not points_to_target:
+            return False
+
+        if not (target_dir / "manifest.json").exists():
+            return False
+        if not (target_dir / "compiled" / "canonical_ir.json").exists():
+            return False
+
+        if self.require_signature and not (target_dir / "manifest.sig").exists():
+            return False
+        return True
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Revert promotion by restoring pre-apply pointer snapshot."""
+        del intent
+        if not isinstance(snapshot, dict):
+            return False
+
+        pointer_exists = bool(snapshot.get("pointer_exists"))
+        if not pointer_exists:
+            self.pointer_path.unlink(missing_ok=True)
+            return True
+
+        restored_payload = {
+            "active_bundle_dir": str(snapshot.get("active_bundle_dir") or ""),
+            "decision_id": str(snapshot.get("decision_id") or ""),
+            "execution_intent_id": str(snapshot.get("execution_intent_id") or ""),
+        }
+        self.pointer_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(self.pointer_path, restored_payload, indent=2)
+        return True
+
+    def describe_target(self) -> str:
+        """Return human-readable target descriptor."""
+        return self.target_description
+
+    def _resolve_target(self, intent: ExecutionIntent) -> Path:
+        target = Path(intent.target_resource).expanduser().resolve()
+        return target
+
+    def _is_within_allowed_root(self, target_dir: Path) -> bool:
+        try:
+            target_dir.relative_to(self.allowed_root.resolve())
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _read_pointer_payload(path: Path) -> dict[str, Any]:
+        import json
+
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            raise ValueError("BIND_POINTER_PAYLOAD_INVALID")
+        return loaded

--- a/veritas_os/tests/test_bind_execution_policy_bundle_adapter.py
+++ b/veritas_os/tests/test_bind_execution_policy_bundle_adapter.py
@@ -1,0 +1,221 @@
+"""Tests for real policy bundle promotion bind-boundary adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from veritas_os.logging.encryption import generate_key
+from veritas_os.policy.bind_artifacts import ExecutionIntent, FinalOutcome, find_bind_receipts
+from veritas_os.policy.bind_boundary_adapters import PolicyBundlePromotionAdapter
+from veritas_os.policy.bind_execution import execute_bind_boundary
+
+
+def _write_bundle(bundle_dir, *, with_signature: bool) -> None:
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "compiled").mkdir(parents=True, exist_ok=True)
+
+    canonical_ir = {
+        "policy_id": "policy.operations",
+        "version": "1.0.0",
+        "title": "Ops Policy",
+        "description": "Operations policy for testing",
+        "effective_date": "2026-04-20",
+        "scope": {
+            "domains": ["operations"],
+            "routes": ["/v1/decide"],
+            "actors": ["operator"],
+        },
+        "conditions": [],
+        "constraints": [],
+        "requirements": {},
+        "outcome": {"default_action": "allow"},
+        "obligations": [],
+        "test_vectors": [],
+        "metadata": {},
+        "source_refs": [],
+    }
+    (bundle_dir / "compiled" / "canonical_ir.json").write_text(
+        json.dumps(canonical_ir, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "schema_version": "0.1",
+        "policy_id": "policy.operations",
+        "version": "1.0.0",
+        "semantic_hash": "dummy-semantic-hash",
+        "compiler_version": "test",
+        "compiled_at": "2026-04-20T00:00:00Z",
+        "signing": {"algorithm": "sha256"},
+    }
+    manifest_bytes = json.dumps(manifest, ensure_ascii=False, indent=2).encode("utf-8")
+    (bundle_dir / "manifest.json").write_bytes(manifest_bytes)
+
+    if with_signature:
+        (bundle_dir / "manifest.sig").write_text(
+            hashlib.sha256(manifest_bytes).hexdigest(),
+            encoding="utf-8",
+        )
+
+
+def _intent(*, bundle_dir: str, expected_fingerprint: str, approved: bool = True) -> ExecutionIntent:
+    return ExecutionIntent(
+        execution_intent_id="ei-policy-bundle",
+        decision_id="dec-policy-bundle",
+        request_id="req-policy-bundle",
+        policy_snapshot_id="policy-snapshot-1",
+        actor_identity="governance-operator",
+        target_system="governance",
+        target_resource=bundle_dir,
+        intended_action="promote_policy_bundle",
+        decision_hash="b" * 64,
+        decision_ts="2026-04-20T12:00:00Z",
+        expected_state_fingerprint=expected_fingerprint,
+        approval_context={"policy_bundle_promotion_approved": approved},
+    )
+
+
+def test_real_adapter_successful_commit(tmp_path) -> None:
+    bundles_root = tmp_path / "bundles"
+    old_bundle = bundles_root / "bundle-v1"
+    new_bundle = bundles_root / "bundle-v2"
+    _write_bundle(old_bundle, with_signature=True)
+    _write_bundle(new_bundle, with_signature=True)
+
+    pointer_path = tmp_path / "runtime" / "active_bundle.json"
+    pointer_path.parent.mkdir(parents=True, exist_ok=True)
+    pointer_path.write_text(
+        json.dumps(
+            {
+                "active_bundle_dir": str(old_bundle.resolve()),
+                "decision_id": "dec-old",
+                "execution_intent_id": "ei-old",
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    adapter = PolicyBundlePromotionAdapter(
+        pointer_path=pointer_path,
+        allowed_root=bundles_root,
+        require_signature=True,
+    )
+    before_snapshot = adapter.snapshot()
+    assert before_snapshot == adapter.snapshot()
+
+    intent = _intent(
+        bundle_dir=str(new_bundle.resolve()),
+        expected_fingerprint=adapter.fingerprint_state(before_snapshot),
+    )
+    receipt = execute_bind_boundary(
+        execution_intent=intent,
+        adapter=adapter,
+        append_trustlog=False,
+    )
+
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    stored_pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    assert stored_pointer["active_bundle_dir"] == str(new_bundle.resolve())
+
+
+def test_real_adapter_blocked_bind_by_authority(tmp_path) -> None:
+    bundles_root = tmp_path / "bundles"
+    bundle = bundles_root / "bundle-v1"
+    _write_bundle(bundle, with_signature=True)
+
+    pointer_path = tmp_path / "runtime" / "active_bundle.json"
+    adapter = PolicyBundlePromotionAdapter(pointer_path=pointer_path, allowed_root=bundles_root)
+    snapshot = adapter.snapshot()
+
+    intent = _intent(
+        bundle_dir=str(bundle.resolve()),
+        expected_fingerprint=adapter.fingerprint_state(snapshot),
+        approved=False,
+    )
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter, append_trustlog=False)
+
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert not pointer_path.exists()
+
+
+def test_real_adapter_postcondition_failure_rolls_back(tmp_path) -> None:
+    bundles_root = tmp_path / "bundles"
+    old_bundle = bundles_root / "bundle-v1"
+    new_bundle = bundles_root / "bundle-v2"
+    _write_bundle(old_bundle, with_signature=True)
+    _write_bundle(new_bundle, with_signature=False)
+
+    pointer_path = tmp_path / "runtime" / "active_bundle.json"
+    pointer_path.parent.mkdir(parents=True, exist_ok=True)
+    pointer_path.write_text(
+        json.dumps(
+            {
+                "active_bundle_dir": str(old_bundle.resolve()),
+                "decision_id": "dec-old",
+                "execution_intent_id": "ei-old",
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    adapter = PolicyBundlePromotionAdapter(
+        pointer_path=pointer_path,
+        allowed_root=bundles_root,
+        require_signature=True,
+    )
+    intent = _intent(
+        bundle_dir=str(new_bundle.resolve()),
+        expected_fingerprint=adapter.fingerprint_state(adapter.snapshot()),
+    )
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter, append_trustlog=False)
+
+    assert receipt.final_outcome is FinalOutcome.ROLLED_BACK
+    restored_pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    assert restored_pointer["active_bundle_dir"] == str(old_bundle.resolve())
+
+
+def test_real_adapter_trustlog_lineage_and_receipt(tmp_path, monkeypatch) -> None:
+    from veritas_os.logging import trust_log
+
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    monkeypatch.setattr(trust_log, "LOG_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSON", tmp_path / "trust_log.json", raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSONL", tmp_path / "trust_log.jsonl", raising=False)
+    monkeypatch.setattr(trust_log, "_append_stats", {"success": 0, "failure": 0}, raising=False)
+
+    def _open_for_append():
+        trust_log.LOG_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        return open(trust_log.LOG_JSONL, "a", encoding="utf-8")
+
+    monkeypatch.setattr(trust_log, "open_trust_log_for_append", _open_for_append)
+
+    bundles_root = tmp_path / "bundles"
+    bundle = bundles_root / "bundle-v1"
+    _write_bundle(bundle, with_signature=True)
+
+    pointer_path = tmp_path / "runtime" / "active_bundle.json"
+    adapter = PolicyBundlePromotionAdapter(
+        pointer_path=pointer_path,
+        allowed_root=bundles_root,
+        require_signature=True,
+    )
+    intent = _intent(
+        bundle_dir=str(bundle.resolve()),
+        expected_fingerprint=adapter.fingerprint_state(adapter.snapshot()),
+    )
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert receipt.trustlog_hash
+    by_decision = find_bind_receipts(decision_id=intent.decision_id)
+    by_intent = find_bind_receipts(execution_intent_id=intent.execution_intent_id)
+    by_receipt = find_bind_receipts(bind_receipt_id=receipt.bind_receipt_id)
+    assert len(by_decision) == 1
+    assert len(by_intent) == 1
+    assert len(by_receipt) == 1


### PR DESCRIPTION
### Motivation
- Provide a single, production-adjacent concrete `BindBoundaryAdapter` implementation that exercises the existing `execute_bind_boundary()` orchestration without changing its semantics. The chosen target is safe, internal: promotion of an active policy bundle pointer used by governance paths.
- Ensure the adapter supports clear `snapshot`/`apply`/`verify_postconditions`/`revert` semantics so bind execution can deterministically commit, detect postcondition failures, and rollback when needed.
- Preserve TrustLog / BindReceipt lineage and keep the change minimal and low-risk by avoiding external network integrations.

### Description
- Added a new concrete adapter `PolicyBundlePromotionAdapter` at `veritas_os/policy/bind_boundary_adapters.py` implementing the full `BindBoundaryAdapter` contract with deterministic `snapshot` and `fingerprint_state`, explicit `apply` (atomic pointer write), meaningful `verify_postconditions`, and functional `revert` (restore pre-apply snapshot or remove pointer). The adapter constrains promotion targets to an `allowed_root` subtree. 
- Exported the adapter from `veritas_os.policy` by adding `PolicyBundlePromotionAdapter` to `veritas_os/policy/__init__.py` so it is available through the public policy interface.
- Added deterministic, documented tests at `veritas_os/tests/test_bind_execution_policy_bundle_adapter.py` that cover: successful commit, blocked bind due to missing authority, postcondition failure leading to rollback, and TrustLog lineage / receipt correctness.
- Included module- and function-level docstrings and kept everything PEP8-compliant; no changes to `execute_bind_boundary()` orchestration logic.
- Security note: the adapter limits path targets to an `allowed_root` to reduce risk, but symlink/hardlink and filesystem ownership checks remain a recommended hardening follow-up; signature verification is currently enforced by presence of `manifest.sig` when `require_signature=True` and should be extended to full public-key verification in a later change.

### Testing
- Ran adapter unit/integration tests: `pytest -q veritas_os/tests/test_bind_execution_policy_bundle_adapter.py veritas_os/tests/test_bind_execution.py` — result: `22 passed` (all tests in those files passed). 
- Ran style checks: `ruff check veritas_os/policy/bind_boundary_adapters.py veritas_os/policy/__init__.py veritas_os/tests/test_bind_execution_policy_bundle_adapter.py` — result: All checks passed.

Files changed
- Added `veritas_os/policy/bind_boundary_adapters.py` (new adapter implementation).
- Modified `veritas_os/policy/__init__.py` to export `PolicyBundlePromotionAdapter`.
- Added tests `veritas_os/tests/test_bind_execution_policy_bundle_adapter.py` covering commit, blocked bind, rollback on postcondition failure, and TrustLog/receipt lineage.

Follow-ups left for subsequent PRs
- Extend pointer promotion adapter to operate against DB-backed governance repository (Postgres) instead of just file pointer.
- Replace presence-only `manifest.sig` check with full Ed25519 public-key signature verification in production posture.
- Harden filesystem checks against symlink/hardlink and add ownership/permission validation for stricter operation in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d8a1fd088326a895d0bae2e7564a)