### PR TITLE
Align bind outcome public contract across runtime, OpenAPI, schemas, and console UI

### DIFF
--- a/frontend/app/risk/risk-types.ts
+++ b/frontend/app/risk/risk-types.ts
@@ -2,7 +2,14 @@ export type ClusterKind = "critical" | "risky" | "uncertain" | "stable";
 export type Severity = "critical" | "high" | "medium" | "low";
 export type RequestStatus = "active" | "mitigated" | "investigating" | "new";
 export type DecisionPhaseOutcome = "allow" | "modify" | "deny" | "hold";
-export type BindPhaseOutcome = "COMMITTED" | "BLOCKED" | "ESCALATED" | "ROLLED_BACK";
+export type BindPhaseOutcome =
+  | "COMMITTED"
+  | "BLOCKED"
+  | "ESCALATED"
+  | "ROLLED_BACK"
+  | "APPLY_FAILED"
+  | "SNAPSHOT_FAILED"
+  | "PRECONDITION_FAILED";
 
 export interface RiskPoint {
   id: string;

--- a/frontend/features/console/adapters/decision-view.test.ts
+++ b/frontend/features/console/adapters/decision-view.test.ts
@@ -252,9 +252,26 @@ describe("toBindPhaseView", () => {
     });
   });
 
-  it("falls back to UNKNOWN bind phase for unsupported values", () => {
+  it("keeps unsupported bind outcomes visible for operators", () => {
     const result = makeResponse({ bind_outcome: "CUSTOM_STATE" } as never);
     const view = toBindPhaseView(result);
-    expect(view.bindPhase).toBe("UNKNOWN");
+    expect(view.bindPhase).toBe("CUSTOM_STATE");
+    expect(view.bindPhaseCanonical).toBe(false);
+  });
+
+  it.each(["APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"])(
+    "accepts canonical runtime bind outcome %s",
+    (outcome) => {
+      const result = makeResponse({ bind_outcome: outcome } as never);
+      const view = toBindPhaseView(result);
+      expect(view.bindPhase).toBe(outcome);
+      expect(view.bindPhaseCanonical).toBe(true);
+    },
+  );
+
+  it("marks known bind outcomes as canonical", () => {
+    const result = makeResponse({ bind_outcome: "BLOCKED" } as never);
+    const view = toBindPhaseView(result);
+    expect(view.bindPhaseCanonical).toBe(true);
   });
 });

--- a/frontend/features/console/adapters/decision-view.ts
+++ b/frontend/features/console/adapters/decision-view.ts
@@ -140,9 +140,9 @@ function summarizeBindCheck(check: Record<string, unknown>): string {
   return "n/a";
 }
 
-function normalizeBindOutcome(value: unknown): BindOutcomeStatus {
+function normalizeBindOutcome(value: unknown): { value: string; canonical: boolean; present: boolean } {
   if (typeof value !== "string") {
-    return "UNKNOWN";
+    return { value: "UNKNOWN", canonical: true, present: false };
   }
   const normalized = value.trim().toUpperCase();
   switch (normalized) {
@@ -150,9 +150,16 @@ function normalizeBindOutcome(value: unknown): BindOutcomeStatus {
     case "BLOCKED":
     case "ESCALATED":
     case "ROLLED_BACK":
-      return normalized;
+    case "APPLY_FAILED":
+    case "SNAPSHOT_FAILED":
+    case "PRECONDITION_FAILED":
+      return { value: normalized as BindOutcomeStatus, canonical: true, present: true };
     default:
-      return "UNKNOWN";
+      return {
+        value: normalized.length > 0 ? normalized : "UNKNOWN",
+        canonical: false,
+        present: normalized.length > 0,
+      };
   }
 }
 
@@ -186,7 +193,8 @@ export function toBindPhaseView(result: DecideResponse): BindPhaseView {
   const gateDecision = readText(record, "gate_decision", "decision_status");
   return {
     decisionPhase: gateDecision,
-    bindPhase: bindOutcome,
+    bindPhase: bindOutcome.value,
+    bindPhaseCanonical: bindOutcome.canonical || !bindOutcome.present,
     bindReceiptId: readText(record, "bind_receipt_id"),
     executionIntentId: readText(record, "execution_intent_id"),
     bindFailureReason: readText(record, "bind_failure_reason", "rollback_reason", "escalation_reason"),

--- a/frontend/features/console/components/decision-result-panel.test.tsx
+++ b/frontend/features/console/components/decision-result-panel.test.tsx
@@ -154,7 +154,15 @@ describe("DecisionResultPanel", () => {
     expect(screen.getByText("PASS")).toBeInTheDocument();
   });
 
-  it.each(["COMMITTED", "BLOCKED", "ESCALATED", "ROLLED_BACK"])(
+  it.each([
+    "COMMITTED",
+    "BLOCKED",
+    "ESCALATED",
+    "ROLLED_BACK",
+    "APPLY_FAILED",
+    "SNAPSHOT_FAILED",
+    "PRECONDITION_FAILED",
+  ])(
     "renders bind outcome badge for %s",
     (outcome) => {
       render(
@@ -165,6 +173,16 @@ describe("DecisionResultPanel", () => {
       expect(screen.getByText(outcome)).toBeInTheDocument();
     },
   );
+
+  it("shows unsupported bind outcomes without collapsing to UNKNOWN", () => {
+    render(
+      <I18nProvider>
+        <DecisionResultPanel result={{ ...baseResult, bind_outcome: "CUSTOM_STATE" } as never} viewerRole="operator" />
+      </I18nProvider>,
+    );
+    expect(screen.getByText("CUSTOM_STATE")).toBeInTheDocument();
+    expect(screen.getByText(/Non-canonical bind outcome reported by runtime contract/)).toBeInTheDocument();
+  });
 
   it("keeps legacy decision view stable when bind fields are absent", () => {
     const legacyResult = { ...baseResult };

--- a/frontend/features/console/components/decision-result-panel.tsx
+++ b/frontend/features/console/components/decision-result-panel.tsx
@@ -78,6 +78,12 @@ export function DecisionResultPanel({
         ? "bg-amber-500/20 text-amber-700"
         : bindPhase.bindPhase === "ROLLED_BACK"
           ? "bg-orange-500/20 text-orange-700"
+          : bindPhase.bindPhase === "APPLY_FAILED"
+            ? "bg-red-600/20 text-red-700"
+            : bindPhase.bindPhase === "SNAPSHOT_FAILED"
+              ? "bg-fuchsia-500/20 text-fuchsia-700"
+              : bindPhase.bindPhase === "PRECONDITION_FAILED"
+                ? "bg-violet-500/20 text-violet-700"
           : "bg-muted text-muted-foreground";
 
   const bundleHandler = () => {
@@ -176,6 +182,9 @@ export function DecisionResultPanel({
             <p><span className="text-muted-foreground">{tk("decisionPanelExecutionIntentLabel")}:</span> <span className="font-mono text-[11px]">{bindPhase.executionIntentId}</span></p>
             <p><span className="text-muted-foreground">{tk("decisionPanelBindFailureReasonLabel")}:</span> {bindPhase.bindFailureReason}</p>
             <p><span className="text-muted-foreground">{tk("decisionPanelBindReasonCodeLabel")}:</span> <span className="font-mono text-[11px]">{bindPhase.bindReasonCode}</span></p>
+            {!bindPhase.bindPhaseCanonical ? (
+              <p className="text-muted-foreground">Non-canonical bind outcome reported by runtime contract.</p>
+            ) : null}
             <div className="grid grid-cols-2 gap-2 rounded border border-border/60 bg-background/60 p-2">
               <p><span className="text-muted-foreground">{tk("decisionPanelBindAuthorityLabel")}:</span> {bindPhase.checks.authority}</p>
               <p><span className="text-muted-foreground">{tk("decisionPanelBindConstraintsLabel")}:</span> {bindPhase.checks.constraints}</p>

--- a/frontend/features/console/types.ts
+++ b/frontend/features/console/types.ts
@@ -86,7 +86,14 @@ export interface DecisionResultView {
   rejectedReasons: DecisionRejectedReasonsView;
 }
 
-export type BindOutcomeStatus = "COMMITTED" | "BLOCKED" | "ESCALATED" | "ROLLED_BACK" | "UNKNOWN";
+export type BindOutcomeStatus =
+  | "COMMITTED"
+  | "BLOCKED"
+  | "ESCALATED"
+  | "ROLLED_BACK"
+  | "APPLY_FAILED"
+  | "SNAPSHOT_FAILED"
+  | "PRECONDITION_FAILED";
 
 export interface BindCheckBreakdownView {
   authority: string;
@@ -97,7 +104,8 @@ export interface BindCheckBreakdownView {
 
 export interface BindPhaseView {
   decisionPhase: string;
-  bindPhase: BindOutcomeStatus;
+  bindPhase: string;
+  bindPhaseCanonical: boolean;
   bindReceiptId: string;
   executionIntentId: string;
   bindFailureReason: string;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -748,7 +748,7 @@ components:
           additionalProperties: true
         final_outcome:
           type: string
-          enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED"]
+          enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
         rollback_reason:
           type: string
           nullable: true
@@ -784,7 +784,7 @@ components:
         bind_outcome:
           type: string
           nullable: true
-          enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED"]
+          enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
         bind_failure_reason:
           type: string
           nullable: true
@@ -797,6 +797,22 @@ components:
         execution_intent_id:
           type: string
           nullable: true
+        authority_check_result:
+          type: object
+          nullable: true
+          additionalProperties: true
+        constraint_check_result:
+          type: object
+          nullable: true
+          additionalProperties: true
+        drift_check_result:
+          type: object
+          nullable: true
+          additionalProperties: true
+        risk_check_result:
+          type: object
+          nullable: true
+          additionalProperties: true
 
     TrustFeedbackRequest:
       type: object
@@ -1132,6 +1148,47 @@ components:
           nullable: true
           additionalProperties: true
           description: "Identity of the governance artifact in force at decision time."
+        bind_outcome:
+          type: string
+          nullable: true
+          enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
+          description: "Bind-phase governance outcome linked to this decision when available."
+        bind_failure_reason:
+          type: string
+          nullable: true
+          description: "Operator-facing reason when bind phase was blocked/escalated/rolled back."
+        bind_reason_code:
+          type: string
+          nullable: true
+          description: "Machine-readable bind reason code for compact governance filtering."
+        bind_receipt_id:
+          type: string
+          nullable: true
+          description: "Lineage pointer to the bind receipt artifact."
+        execution_intent_id:
+          type: string
+          nullable: true
+          description: "Lineage pointer to the execution intent linked to bind phase."
+        authority_check_result:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Authority check summary from bind-phase adjudication."
+        constraint_check_result:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Constraint check summary from bind-phase adjudication."
+        drift_check_result:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Drift check summary from bind-phase adjudication."
+        risk_check_result:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Runtime risk check summary from bind-phase adjudication."
         wat_integrity:
           $ref: '#/components/schemas/WatIntegrity'
           nullable: true
@@ -1999,7 +2056,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED"]
+            enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
       responses:
         "200":
           description: Decision export rows
@@ -2072,13 +2129,35 @@ paths:
                   bind_outcome:
                     type: string
                     nullable: true
-                    enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED"]
+                    enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
                   bind_failure_reason:
                     type: string
                     nullable: true
                   bind_reason_code:
                     type: string
                     nullable: true
+                  bind_receipt_id:
+                    type: string
+                    nullable: true
+                  execution_intent_id:
+                    type: string
+                    nullable: true
+                  authority_check_result:
+                    type: object
+                    nullable: true
+                    additionalProperties: true
+                  constraint_check_result:
+                    type: object
+                    nullable: true
+                    additionalProperties: true
+                  drift_check_result:
+                    type: object
+                    nullable: true
+                    additionalProperties: true
+                  risk_check_result:
+                    type: object
+                    nullable: true
+                    additionalProperties: true
 
   /v1/compliance/config:
     get:

--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -16,6 +16,14 @@ export type BusinessDecisionStatus =
   | "REVIEW_REQUIRED"
   | "POLICY_DEFINITION_REQUIRED"
   | "EVIDENCE_REQUIRED";
+export type FinalOutcomeStatus =
+  | "COMMITTED"
+  | "BLOCKED"
+  | "ESCALATED"
+  | "ROLLED_BACK"
+  | "APPLY_FAILED"
+  | "SNAPSHOT_FAILED"
+  | "PRECONDITION_FAILED";
 
 /** Severity level used in CritiqueItem. */
 export type CritiqueSeverity = "low" | "med" | "high";
@@ -618,6 +626,24 @@ export interface DecideResponse extends DecideResponseMeta {
   ai_disclosure: string;
   /** Art. 50 — regulation reference notice. Always present. */
   regulation_notice: string;
+  /** Bind-phase governance outcome linked to this decision when available. */
+  bind_outcome?: FinalOutcomeStatus | null;
+  /** Operator-facing reason when bind phase was blocked/escalated/rolled back. */
+  bind_failure_reason?: string | null;
+  /** Machine-readable bind reason code for compact governance filtering. */
+  bind_reason_code?: string | null;
+  /** Lineage pointer to the bind receipt artifact. */
+  bind_receipt_id?: string | null;
+  /** Lineage pointer to the execution intent linked to bind phase. */
+  execution_intent_id?: string | null;
+  /** Authority check summary from bind-phase adjudication. */
+  authority_check_result?: Record<string, unknown> | null;
+  /** Constraint check summary from bind-phase adjudication. */
+  constraint_check_result?: Record<string, unknown> | null;
+  /** Drift check summary from bind-phase adjudication. */
+  drift_check_result?: Record<string, unknown> | null;
+  /** Runtime risk check summary from bind-phase adjudication. */
+  risk_check_result?: Record<string, unknown> | null;
   /** Art. 13 — notification record for individuals affected by high-risk decisions. */
   affected_parties_notice?: Record<string, unknown> | null;
 
@@ -688,6 +714,15 @@ export function isDecideResponse(value: unknown): value is DecideResponse {
     (value.trust_log === null || isRecord(value.trust_log)) &&
     typeof value.ai_disclosure === "string" &&
     typeof value.regulation_notice === "string" &&
+    (value.bind_outcome === null || value.bind_outcome === undefined || isFinalOutcomeStatus(value.bind_outcome)) &&
+    (value.bind_failure_reason === null || value.bind_failure_reason === undefined || typeof value.bind_failure_reason === "string") &&
+    (value.bind_reason_code === null || value.bind_reason_code === undefined || typeof value.bind_reason_code === "string") &&
+    (value.bind_receipt_id === null || value.bind_receipt_id === undefined || typeof value.bind_receipt_id === "string") &&
+    (value.execution_intent_id === null || value.execution_intent_id === undefined || typeof value.execution_intent_id === "string") &&
+    (value.authority_check_result === null || value.authority_check_result === undefined || isRecord(value.authority_check_result)) &&
+    (value.constraint_check_result === null || value.constraint_check_result === undefined || isRecord(value.constraint_check_result)) &&
+    (value.drift_check_result === null || value.drift_check_result === undefined || isRecord(value.drift_check_result)) &&
+    (value.risk_check_result === null || value.risk_check_result === undefined || isRecord(value.risk_check_result)) &&
     (value.affected_parties_notice === null || value.affected_parties_notice === undefined || isRecord(value.affected_parties_notice)) &&
     (value.query === null || value.query === undefined || typeof value.query === "string") &&
     (value.pipeline_steps === null || value.pipeline_steps === undefined || Array.isArray(value.pipeline_steps)) &&
@@ -699,6 +734,16 @@ export function isDecideResponse(value: unknown): value is DecideResponse {
 
 function isDecisionStatus(value: unknown): value is DecisionStatus {
   return value === "allow" || value === "modify" || value === "rejected" || value === "block" || value === "abstain";
+}
+
+function isFinalOutcomeStatus(value: unknown): value is FinalOutcomeStatus {
+  return value === "COMMITTED"
+    || value === "BLOCKED"
+    || value === "ESCALATED"
+    || value === "ROLLED_BACK"
+    || value === "APPLY_FAILED"
+    || value === "SNAPSHOT_FAILED"
+    || value === "PRECONDITION_FAILED";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/types/src/index.test.ts
+++ b/packages/types/src/index.test.ts
@@ -618,6 +618,15 @@ describe("types", () => {
       query: "test query",
       pipeline_steps: ["step1", "step2"],
       deterministic_replay: { seed: 42 },
+      bind_outcome: "SNAPSHOT_FAILED",
+      bind_failure_reason: "snapshot unavailable",
+      bind_reason_code: "BIND_SNAPSHOT_FAILED",
+      bind_receipt_id: "br-1",
+      execution_intent_id: "ei-1",
+      authority_check_result: { passed: true },
+      constraint_check_result: { passed: true },
+      drift_check_result: { result: "stable" },
+      risk_check_result: { result: "high" },
     })).toBe(true);
   });
 
@@ -665,6 +674,12 @@ describe("types", () => {
 
     // deterministic_replay must be null, undefined, or object
     expect(isDecideResponse({ ...base, deterministic_replay: "invalid" })).toBe(false);
+
+    // bind_outcome must be null, undefined, or FinalOutcomeStatus
+    expect(isDecideResponse({ ...base, bind_outcome: "NOT_A_BIND_STATE" })).toBe(false);
+
+    // bind check results must be object-like when present
+    expect(isDecideResponse({ ...base, authority_check_result: "invalid" })).toBe(false);
   });
 
   it("DecideResponse critique and debate use typed arrays (CritiqueItem[] and DebateView[])", () => {

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -18,7 +18,7 @@ from veritas_os.api.schemas import (
     GovernancePolicyResponse,
     GovernancePolicyHistoryResponse,
 )
-from veritas_os.policy.bind_artifacts import find_bind_receipts
+from veritas_os.policy.bind_artifacts import FinalOutcome, find_bind_receipts
 
 # Governance functions accessed via _get_server() for test monkeypatching compat
 
@@ -248,7 +248,7 @@ def governance_policy_history(limit: int = Query(default=50, ge=1, le=500)):
 def governance_decision_export(
     limit: int = Query(default=100, ge=1, le=1000),
     status: str | None = Query(default=None),
-    bind_outcome: str | None = Query(default=None),
+    bind_outcome: FinalOutcome | None = Query(default=None),
 ):
     """Export recent decisions for governance/audit integrations."""
     srv = _get_server()
@@ -266,7 +266,7 @@ def governance_decision_export(
             bind_receipts = find_bind_receipts(decision_id=decision_id) if decision_id else []
             latest_bind = bind_receipts[-1].to_dict() if bind_receipts else {}
             latest_bind_outcome = str(latest_bind.get("final_outcome") or "")
-            if bind_outcome and latest_bind_outcome != bind_outcome:
+            if bind_outcome and latest_bind_outcome != bind_outcome.value:
                 continue
             normalized.append(
                 {
@@ -282,6 +282,10 @@ def governance_decision_export(
                     "execution_intent_id": latest_bind.get("execution_intent_id"),
                     "bind_failure_reason": _resolve_bind_failure_reason(latest_bind),
                     "bind_reason_code": _resolve_bind_reason_code(latest_bind),
+                    "authority_check_result": latest_bind.get("authority_check_result"),
+                    "constraint_check_result": latest_bind.get("constraint_check_result"),
+                    "drift_check_result": latest_bind.get("drift_check_result"),
+                    "risk_check_result": latest_bind.get("risk_check_result"),
                 }
             )
         return {"ok": True, "count": len(normalized), "items": normalized}
@@ -339,6 +343,12 @@ def governance_bind_receipt(bind_receipt_id: str):
             "bind_outcome": receipt.get("final_outcome"),
             "bind_failure_reason": _resolve_bind_failure_reason(receipt),
             "bind_reason_code": _resolve_bind_reason_code(receipt),
+            "bind_receipt_id": receipt.get("bind_receipt_id"),
+            "execution_intent_id": receipt.get("execution_intent_id"),
+            "authority_check_result": receipt.get("authority_check_result"),
+            "constraint_check_result": receipt.get("constraint_check_result"),
+            "drift_check_result": receipt.get("drift_check_result"),
+            "risk_check_result": receipt.get("risk_check_result"),
         }
     except Exception as e:
         logger.error("governance_bind_receipt failed: %s", e, exc_info=True)

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Annotated, Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -248,7 +248,7 @@ def governance_policy_history(limit: int = Query(default=50, ge=1, le=500)):
 def governance_decision_export(
     limit: int = Query(default=100, ge=1, le=1000),
     status: str | None = Query(default=None),
-    bind_outcome: FinalOutcome | None = Query(default=None),
+    bind_outcome: Annotated[FinalOutcome | None, Query()] = None,
 ):
     """Export recent decisions for governance/audit integrations."""
     srv = _get_server()

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1328,6 +1328,10 @@ class GovernanceDecisionExportItem(BaseModel):
     bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
     bind_receipt_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
     execution_intent_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    authority_check_result: Optional[Dict[str, Any]] = None
+    constraint_check_result: Optional[Dict[str, Any]] = None
+    drift_check_result: Optional[Dict[str, Any]] = None
+    risk_check_result: Optional[Dict[str, Any]] = None
 
 
 class GovernanceDecisionExportResponse(BaseModel):
@@ -1347,6 +1351,12 @@ class GovernanceBindReceiptResponse(BaseModel):
     bind_outcome: Optional[FinalOutcome] = None
     bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
     bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    bind_receipt_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    execution_intent_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    authority_check_result: Optional[Dict[str, Any]] = None
+    constraint_check_result: Optional[Dict[str, Any]] = None
+    drift_check_result: Optional[Dict[str, Any]] = None
+    risk_check_result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
 
 

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -381,6 +381,10 @@ def test_governance_decision_export_includes_bind_summary(monkeypatch) -> None:
         assert item["execution_intent_id"] == "ei-101"
         assert item["bind_reason_code"] == "CONSTRAINT_MISMATCH"
         assert item["bind_failure_reason"] == "operator escalation required"
+        assert item["authority_check_result"] is None
+        assert item["constraint_check_result"] == {"reason_code": "CONSTRAINT_MISMATCH"}
+        assert item["drift_check_result"] is None
+        assert item["risk_check_result"] is None
 
 
 def test_governance_bind_receipt_endpoint(monkeypatch) -> None:
@@ -413,6 +417,12 @@ def test_governance_bind_receipt_endpoint(monkeypatch) -> None:
     assert ok_body["bind_outcome"] == "ROLLED_BACK"
     assert ok_body["bind_reason_code"] == "POSTCONDITION_FAIL"
     assert ok_body["bind_failure_reason"] == "postcondition failed"
+    assert ok_body["bind_receipt_id"] == "br-501"
+    assert ok_body["execution_intent_id"] == "ei-501"
+    assert ok_body["authority_check_result"] == {"passed": True}
+    assert ok_body["constraint_check_result"] == {"passed": True}
+    assert ok_body["drift_check_result"] == {"passed": False}
+    assert ok_body["risk_check_result"] == {"reason_code": "POSTCONDITION_FAIL"}
     assert ok_body["bind_receipt"]["bind_receipt_id"] == "br-501"
 
     missing_resp = client.get("/v1/governance/bind-receipts/br-missing", headers=HEADERS)

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -113,9 +113,39 @@ def test_openapi_includes_bind_artifact_schemas() -> None:
     assert "ExecutionIntent" in schemas
     assert "BindReceipt" in schemas
 
+    bind_outcomes = schemas["BindReceipt"]["properties"]["final_outcome"]["enum"]
+    assert bind_outcomes == [
+        "COMMITTED",
+        "BLOCKED",
+        "ROLLED_BACK",
+        "ESCALATED",
+        "APPLY_FAILED",
+        "SNAPSHOT_FAILED",
+        "PRECONDITION_FAILED",
+    ]
+
     export_item = schemas["GovernanceDecisionExportItem"]["properties"]
     assert "bind_outcome" in export_item
     assert "bind_failure_reason" in export_item
     assert "bind_reason_code" in export_item
     assert "bind_receipt_id" in export_item
     assert "execution_intent_id" in export_item
+    assert "authority_check_result" in export_item
+    assert "constraint_check_result" in export_item
+    assert "drift_check_result" in export_item
+    assert "risk_check_result" in export_item
+
+
+def test_openapi_decide_response_includes_bind_contract_fields() -> None:
+    """DecideResponse should expose bind contract fields used by console and audit tooling."""
+    spec = _load_openapi_spec()
+    decide_schema = spec["components"]["schemas"]["DecideResponse"]["properties"]
+    assert "bind_outcome" in decide_schema
+    assert "bind_failure_reason" in decide_schema
+    assert "bind_reason_code" in decide_schema
+    assert "bind_receipt_id" in decide_schema
+    assert "execution_intent_id" in decide_schema
+    assert "authority_check_result" in decide_schema
+    assert "constraint_check_result" in decide_schema
+    assert "drift_check_result" in decide_schema
+    assert "risk_check_result" in decide_schema


### PR DESCRIPTION
### Motivation
- Runtime `FinalOutcome` included additional canonical outcomes (`APPLY_FAILED`, `SNAPSHOT_FAILED`, `PRECONDITION_FAILED`) that were not fully represented in the public API schema, governance responses, shared TS types, or console rendering, producing a cross-layer mismatch.
- Governance export / bind-receipt endpoints omitted bind check summaries and lineage fields at the top-level that are present in runtime artifacts, causing inconsistent consumer surface.
- Frontend adapter collapsed unknown runtime bind outcomes to `UNKNOWN`, losing operator-observable values and reducing debuggability.

### Description
- Extended the canonical bind outcome vocabulary across the stack to include `APPLY_FAILED`, `SNAPSHOT_FAILED`, and `PRECONDITION_FAILED` and reflected them in OpenAPI `BindReceipt`/`GovernanceDecisionExportItem`/response schemas and query enums.
- Added top-level bind contract fields to the public DecideResponse contract and Pydantic models: `bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `bind_receipt_id`, `execution_intent_id`, and the four check summaries (`authority_check_result`, `constraint_check_result`, `drift_check_result`, `risk_check_result`).
- Made governance export and bind-receipt retrieval return lineage and check-summary fields consistently (export rows and bind-receipt detail now include the same set of bind fields).
- Updated shared TypeScript types and runtime guard (`@veritas/types`) with new `FinalOutcomeStatus` and added bind fields to `DecideResponse` plus validation in `isDecideResponse`.
- Changed console adapter to preserve non-canonical runtime bind outcomes (no silent collapse to `UNKNOWN`), expose a boolean `bindPhaseCanonical` for UI to mark non-canonical values, and added lightweight badge styles and an explanatory note when outcomes are non-canonical.
- Updated OpenAPI document (`openapi.yaml`), Pydantic models (`veritas_os/api/schemas.py`), governance routes (`veritas_os/api/routes_governance.py`), frontend adapters/components/types/tests, and shared TS types/tests to keep all layers aligned.

### Testing
- Backend OpenAPI and governance integration tests: ran `pytest veritas_os/tests/test_openapi_spec.py veritas_os/tests/integration/test_governance_api.py` and the suite passed (110 tests passed).
- Shared types: ran `pnpm --filter @veritas/types test -- --run packages/types/src/index.test.ts` and the `@veritas/types` unit tests passed (57 tests passed).
- Frontend adapters and panel: ran the adapter and DecisionResultPanel test suites (including snapshot and i18n snapshots) with `vitest` for the targeted files and fixed initial snapshot mismatches; the updated targeted frontend tests passed (all adapter and panel tests/snapshots passed).

Notes: all changes are additive to maintain backward compatibility; expanding governance export/detail surfaces may expose more diagnostic text—apply redaction/policy controls if sensitive information must be restricted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e3d2b89c8326b42608447d2304e7)