### PR TITLE
docs: align product definition with implemented bind-boundary governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VERITAS OS v2.0 — Decision Governance OS for AI Agents
 
-**Reviewable, traceable, replayable, and enforceable AI decisions before real-world effect.**
+**Reviewable, traceable, replayable, and enforceable AI decisions through decision and bind boundaries before real-world effect.**
 
 [![DOI](https://doi.org/10.5281/zenodo.17838349.svg)](https://doi.org/10.5281/zenodo.17838349)
 [![DOI (JP Paper)](https://zenodo.org/badge/DOI/10.5281/zenodo.17838456.svg)](https://doi.org/10.5281/zenodo.17838456)
@@ -33,7 +33,10 @@ It is about making AI decisions **reviewable, traceable, replayable, auditable, 
 ## What VERITAS OS is
 
 VERITAS OS is a **Decision Governance OS for AI Agents**.
-It is the **governance layer before execution** that determines whether an AI decision may proceed, must be held, blocked, or escalated for human review.
+It is the governance layer from **decision adjudication through bind-time boundary checks**:
+it determines whether an AI decision may proceed and whether an approved decision
+can be committed, blocked, escalated, or rolled back at bind time before
+real-world effect.
 
 ### What problem it solves
 
@@ -65,12 +68,12 @@ VERITAS OS focuses on **decision governance**:
 
 ## What VERITAS OS is / is not
 
-- **Is:** a Decision Governance OS for AI agents and a governance layer before execution.
+- **Is:** a Decision Governance OS for AI agents, covering decision governance and bind-boundary governance before real-world effect.
 - **Is not:** a replacement for all agent runtimes, nor only an orchestration convenience wrapper.
 
 ## Fact vs roadmap (read this first)
 
-- **Current fact (beta):** Core decision pipeline, FUJI fail-closed gating, TrustLog lineage, Mission Control workflows, and governance endpoints are implemented.
+- **Current fact (beta):** Core decision pipeline, bind artifact lineage (`decision -> execution_intent -> bind_receipt`), bind-time admissibility checks, FUJI fail-closed gating, TrustLog lineage, Mission Control workflows, and governance endpoints are implemented.
 - **Current fact (boundary):** Production readiness still depends on environment-specific hardening, integration, and operational controls.
 - **Roadmap:** Expanded enterprise integrations (for example deeper IdP/JWT scope models and broader distributed failure-mode validation).
 
@@ -112,6 +115,8 @@ VERITAS OS focuses on **decision governance**:
 - **Public Positioning Guide (EN)**: [`docs/en/positioning/public-positioning.md`](docs/en/positioning/public-positioning.md)
 - **Public Positioning Guide (JA)**: [`docs/ja/positioning/public-positioning.md`](docs/ja/positioning/public-positioning.md)
 - **Decision Semantics Contract**: [`docs/en/architecture/decision-semantics.md`](docs/en/architecture/decision-semantics.md)
+- **Bind-Boundary Governance Artifacts**: [`docs/en/architecture/bind-boundary-governance-artifacts.md`](docs/en/architecture/bind-boundary-governance-artifacts.md)
+- **Bind-Time Admissibility Evaluator**: [`docs/en/architecture/bind_time_admissibility_evaluator.md`](docs/en/architecture/bind_time_admissibility_evaluator.md)
 - **Required Evidence Taxonomy v0**: [`docs/en/governance/required-evidence-taxonomy.md`](docs/en/governance/required-evidence-taxonomy.md)
 - **AML/KYC contract hardening (canonical gate + evidence profile)**: [`docs/en/guides/financial-governance-templates.md`](docs/en/guides/financial-governance-templates.md)
 - **Documentation Map**: [`docs/DOCUMENTATION_MAP.md`](docs/DOCUMENTATION_MAP.md)
@@ -312,6 +317,7 @@ VERITAS optimizes for **governance**:
 - **Enterprise governance** — **4-eyes approval** for policy changes, **RBAC/ABAC** access control, **SSE real-time governance alerts**, external secret manager enforcement
 - **Memory & world state** as first-class inputs (MemoryOS with vector search + WorldModel with causal transitions)
 - **Operational visibility** via a full-stack **Mission Control dashboard** (Next.js) with real-time event streaming, risk analytics, and governance policy management
+- **Bind-boundary visibility** in Mission Control via bind-phase outcomes (`COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK`) with execution intent and bind receipt lineage pointers
 - **EU AI Act compliance** — built-in compliance reporting, audit export, and deployment readiness checks
 
 **Target users**
@@ -345,6 +351,10 @@ Key fields (simplified):
 | `required_evidence[]` | Evidence keys required by current policy/risk boundary |
 | `human_review_required` | Explicit human-review requirement flag |
 | `trust_log` | Hash-chained TrustLog entry (`sha256_prev`) |
+| `bind_outcome` | Bind-phase terminal outcome (`COMMITTED` / `BLOCKED` / `ESCALATED` / `ROLLED_BACK`) |
+| `execution_intent_id` | Lineage pointer to bind attempt context |
+| `bind_receipt_id` | Lineage pointer to TrustLog-linked bind receipt artifact |
+| `bind_failure_reason` | Operator-facing reason when bind-phase is blocked/escalated/rolled back |
 | `extras.metrics` | Per-stage latency, memory hits, web hits |
 
 Decision output semantics:
@@ -353,6 +363,7 @@ Decision output semantics:
 - **Value Core** compares option value and informs `business_decision` + `next_action`.
 - UI must show `gate_decision`, `business_decision`, and `next_action` as different concepts.
 - `allow` is gate-level permissive status only; it must not be presented as case approval.
+- Bind-phase `COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK` is a separate adjudication layer from decision-phase approval.
 - Financial/regulatory governance prompt templates are available as canonical fixtures for
   regression and demo workflows (`veritas_os/sample_data/governance/financial_regulatory_templates.json`);
   see `docs/en/guides/financial-governance-templates.md`.
@@ -651,6 +662,8 @@ All protected endpoints require `X-API-Key`. The full list of endpoints:
 | GET | `/v1/governance/policy/history` | Policy change audit trail (with digest transitions) |
 | GET | `/v1/governance/value-drift` | Monitor value weight EMA drift |
 | GET | `/v1/governance/decisions/export` | Export decisions for governance audit |
+| GET | `/v1/governance/bind-receipts` | List bind receipts (filter by decision or execution intent lineage) |
+| GET | `/v1/governance/bind-receipts/{bind_receipt_id}` | Retrieve a single bind receipt artifact |
 
 > **Signed governance artifacts** — In secure/prod posture, policy bundles must be Ed25519-signed.
 > Decision artifacts include a `governance_identity` field showing which governance policy was in

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,6 +14,7 @@
 | **Validation** | [Validation](en/validation/) | [Validation](ja/validation/) |
 | **Governance** | [Governance](en/governance/) | [Governance](ja/governance/) |
 | **Architecture** | [Architecture](architecture/) | — |
+| **Bind Boundary (EN)** | [Bind-Boundary Governance](en/architecture/bind-boundary-governance-artifacts.md) | — |
 | **EU AI Act** | [EU AI Act](eu_ai_act/) | [EU AI Act (JA)](ja/governance/) |
 | **Guides** | [Guides](en/guides/) | [Guides](ja/guides/) |
 | **Reviews (EN)** | [Reviews](en/reviews/) | — |

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -43,6 +43,8 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 
 ### Governance & Compliance
 - [Decision Semantics Contract](architecture/decision-semantics.md)
+- [Bind-Boundary Governance Artifacts](architecture/bind-boundary-governance-artifacts.md)
+- [Bind-Time Admissibility Evaluator](architecture/bind_time_admissibility_evaluator.md)
 - [Required Evidence Taxonomy v0](governance/required-evidence-taxonomy.md)
 - [Governance Artifact Lifecycle](governance/governance-artifact-lifecycle.md)
 

--- a/docs/en/architecture/bind-boundary-governance-artifacts.md
+++ b/docs/en/architecture/bind-boundary-governance-artifacts.md
@@ -1,16 +1,15 @@
-# Bind-Boundary Governance Artifacts (Schema-First)
+# Bind-Boundary Governance Artifacts
 
-## What this PR adds
+## Implemented scope
 
-This change introduces two **native VERITAS governance artifacts** as first-class
-contracts:
+VERITAS includes two **native governance artifacts** as first-class contracts:
 
 1. `ExecutionIntent`
 2. `BindReceipt`
 
-It also introduces `FinalOutcome` for bind-time terminal status.
-In addition, bind-boundary artifacts are now appended to the existing TrustLog
-path so auditors can traverse native lineage:
+`FinalOutcome` models bind-time terminal status.
+Bind-boundary artifacts append to the existing TrustLog path so auditors can
+traverse native lineage:
 
 `decision artifact -> execution intent -> bind receipt`
 
@@ -28,15 +27,20 @@ This extension keeps that architecture intact and adds bind-boundary lineage:
 This provides explicit governance-native artifacts at the decision → bind
 boundary without creating a parallel subsystem.
 
-## Intentionally deferred
+## Current boundary and caveats
 
-This PR is **schema-first only** and does not introduce:
+Implemented in this repository:
 
-- external side-effect adapters
-- runtime bind orchestration
-- rollback engine implementation
-- Mission Control UI workflow rewiring
-- broad pipeline behavior changes
+- bind-time admissibility adjudication inputs on bind receipts
+- bind terminal outcomes (`COMMITTED`, `BLOCKED`, `ESCALATED`, `ROLLED_BACK`)
+- TrustLog lineage pointers and bind receipt retrieval endpoints
+- Mission Control bind-phase rendering on decision results
+
+Not guaranteed by this document alone:
+
+- tenant-specific external side-effect adapter coverage
+- environment-specific production hardening and operational controls
+- universal production-readiness claims across every deployment context
 
 ## TrustLog and lineage integration
 
@@ -54,8 +58,8 @@ lineage toward bind-boundary control.
 
 ## Runtime behavior impact
 
-Low and additive. Existing decision flows remain backward compatible, and no
-execution adapter/orchestration behavior is introduced in this PR.
+Additive to existing decision flows. Decision-phase semantics remain primary;
+bind-phase semantics add an explicit boundary between approval and commitment.
 
 ## Operator interpretation in Mission Control
 

--- a/docs/en/guides/aml-kyc-operator-runbook.md
+++ b/docs/en/guides/aml-kyc-operator-runbook.md
@@ -58,6 +58,12 @@ Pilot pass requires:
 - `summary.pass_rate >= 0.90`
 - `summary.evaluated >= 5`
 
+Additionally, confirm bind-boundary lineage visibility on sampled decisions:
+
+- `bind_outcome` is present when bind adjudication ran.
+- `execution_intent_id` and `bind_receipt_id` are present for bind-tracked cases.
+- `bind_outcome` is interpreted separately from decision approval status.
+
 ### 5) Failure-path validation
 
 Use the failure scenario file to ensure evaluator has bounded expectations:
@@ -65,6 +71,19 @@ Use the failure scenario file to ensure evaluator has bounded expectations:
 - run scenarios that should hold/block/review, not auto-proceed
 - document each scenario result in pilot readout
 - if runtime behavior diverges, mark as explicit gap (not hidden backlog)
+
+### 6) Bind receipt spot-check (operator API)
+
+```bash
+curl -s "http://localhost:8000/v1/governance/bind-receipts?limit=5"
+```
+
+```bash
+curl -s "http://localhost:8000/v1/governance/bind-receipts/<bind_receipt_id>"
+```
+
+Expected: receipt includes authority/constraint/drift/risk/admissibility
+payloads and a terminal bind outcome (`COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK`).
 
 ## Operator triage rubric
 

--- a/docs/en/positioning/public-positioning.md
+++ b/docs/en/positioning/public-positioning.md
@@ -7,7 +7,9 @@
 Core promise:
 
 - AI decisions are **reviewable, traceable, replayable, auditable, and enforceable before real-world effect**.
-- VERITAS OS functions as a **governance layer before execution**, not only an execution runtime.
+- VERITAS OS functions as a governance layer from **decision adjudication through bind-boundary enforcement**, not only an execution runtime.
+- Current implemented bind-boundary lineage is:
+  `decision artifact -> execution intent -> bind receipt` (TrustLog-integrated).
 
 ## What VERITAS OS is / is not
 
@@ -18,6 +20,7 @@ Core promise:
 
 - Decision Governance OS
 - governance layer before execution
+- decision-to-bind governance boundary
 - reviewable / traceable / replayable / auditable / enforceable
 - fail-closed safety gate
 - tamper-evident TrustLog lineage

--- a/docs/en/validation/implemented-vs-pending-boundary.md
+++ b/docs/en/validation/implemented-vs-pending-boundary.md
@@ -9,6 +9,8 @@
 3. Governance backend repository abstraction (file/postgresql) is implemented.
 4. Evidence bundle generation and standalone TrustLog verification paths are implemented.
 5. Validation strategy docs and pilot checklists are present for reproducible review flow.
+6. Bind-boundary governance artifacts and lineage (`decision -> execution_intent -> bind_receipt`) are implemented.
+7. Bind-time admissibility and terminal bind outcomes (`COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK`) are represented in API and operator-facing views.
 
 ## Pending / environment-dependent
 
@@ -31,4 +33,3 @@
 - [Required Evidence Taxonomy](../governance/required-evidence-taxonomy.md)
 - [External Audit Readiness](external-audit-readiness.md)
 - [AML/KYC Pilot Checklist](../guides/aml-kyc-pilot-checklist.md)
-


### PR DESCRIPTION
### Motivation
- The README and positioning language underrepresented the repository's implemented bind-boundary features (`decision -> execution_intent -> bind_receipt`) and risked understating that bind-time admissibility and bind receipts are part of the current code truth. 
- Update the public product definition to accurately describe the implemented governance boundary (decision adjudication through bind-phase checks) while preserving the beta/guarantee caveats and avoiding overclaiming production readiness. 
- Keep wording technical and factual (no marketing), and ensure operator/docs guidance references live API/schema/UI semantics.

### Description
- Updated high-level product wording in `README.md` to reflect that VERITAS governs from decision adjudication through bind-time checks and added `bind_outcome`, `execution_intent_id`, `bind_receipt_id`, and `bind_failure_reason` descriptions and the two bind-receipt API endpoints (`GET /v1/governance/bind-receipts`, `GET /v1/governance/bind-receipts/{bind_receipt_id}`).
- Revised the bind-boundary architecture note in `docs/en/architecture/bind-boundary-governance-artifacts.md` to state implemented scope and caveats (bind-time admissibility, terminal outcomes, TrustLog integration, Mission Control visibility) instead of a schema-first-only framing.
- Added bind-boundary wording and lineage statement to `docs/en/positioning/public-positioning.md`, added references in documentation hubs (`docs/en/README.md`, `docs/INDEX.md`), and extended the AML/KYC operator runbook (`docs/en/guides/aml-kyc-operator-runbook.md`) with bind receipt spot-check commands.
- Extended `docs/en/validation/implemented-vs-pending-boundary.md` to enumerate bind-boundary items as repository-verifiable facts; files changed: `README.md`, `docs/INDEX.md`, `docs/en/README.md`, `docs/en/architecture/bind-boundary-governance-artifacts.md`, `docs/en/guides/aml-kyc-operator-runbook.md`, `docs/en/positioning/public-positioning.md`, `docs/en/validation/implemented-vs-pending-boundary.md`.
- Note: this is documentation-only; no runtime code or policy behavior was changed and no new production guarantees are asserted.

### Testing
- Ran an automated local link check script (checked relative markdown links in modified files) and it returned `OK` with no broken links.
- Cross-checked documentation text against repository implementation using `rg` searches to confirm referenced fields/endpoints exist in `veritas_os/api/routes_governance.py`, `veritas_os/api/schemas.py`, and frontend bind-phase UI code; matches were found for `bind_outcome`, `execution_intent_id`, `bind_receipt_id`, and the bind-receipts endpoints.
- Per-PR validation: markdown diffs reviewed and documentation hub/INDEX links verified locally; all checks passed.
- Security note: this change is docs-only and does not modify runtime behavior, but operator runbook examples include API calls; adhere to existing security guidance (do not expose API keys, follow `SECURITY.md`) when executing runbook commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6f9c884248326af8fb5a2c3a783e5)