### PR TITLE
Align bind-boundary docs with 7 outcomes and add ExecutionIntent.policy_lineage to OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It is about making AI decisions **reviewable, traceable, replayable, auditable, 
 VERITAS OS is a **Decision Governance OS for AI Agents**.
 It is the governance layer from **decision adjudication through bind-time boundary checks**:
 it determines whether an AI decision may proceed and whether an approved decision
-can be committed, blocked, escalated, or rolled back at bind time before
+can be committed, blocked, escalated, rolled back, or fail safely at bind time before
 real-world effect.
 
 ### What problem it solves
@@ -317,7 +317,7 @@ VERITAS optimizes for **governance**:
 - **Enterprise governance** — **4-eyes approval** for policy changes, **RBAC/ABAC** access control, **SSE real-time governance alerts**, external secret manager enforcement
 - **Memory & world state** as first-class inputs (MemoryOS with vector search + WorldModel with causal transitions)
 - **Operational visibility** via a full-stack **Mission Control dashboard** (Next.js) with real-time event streaming, risk analytics, and governance policy management
-- **Bind-boundary visibility** in Mission Control via bind-phase outcomes (`COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK`) with execution intent and bind receipt lineage pointers
+- **Bind-boundary visibility** in Mission Control via bind-phase outcomes (`COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK`/`APPLY_FAILED`/`SNAPSHOT_FAILED`/`PRECONDITION_FAILED`) with execution intent and bind receipt lineage pointers
 - **EU AI Act compliance** — built-in compliance reporting, audit export, and deployment readiness checks
 
 **Target users**
@@ -351,10 +351,10 @@ Key fields (simplified):
 | `required_evidence[]` | Evidence keys required by current policy/risk boundary |
 | `human_review_required` | Explicit human-review requirement flag |
 | `trust_log` | Hash-chained TrustLog entry (`sha256_prev`) |
-| `bind_outcome` | Bind-phase terminal outcome (`COMMITTED` / `BLOCKED` / `ESCALATED` / `ROLLED_BACK`) |
+| `bind_outcome` | Bind-phase terminal outcome (`COMMITTED` / `BLOCKED` / `ESCALATED` / `ROLLED_BACK` / `APPLY_FAILED` / `SNAPSHOT_FAILED` / `PRECONDITION_FAILED`) |
 | `execution_intent_id` | Lineage pointer to bind attempt context |
 | `bind_receipt_id` | Lineage pointer to TrustLog-linked bind receipt artifact |
-| `bind_failure_reason` | Operator-facing reason when bind-phase is blocked/escalated/rolled back |
+| `bind_failure_reason` | Operator-facing reason when bind-phase is blocked/escalated/rolled back/fails safely |
 | `extras.metrics` | Per-stage latency, memory hits, web hits |
 
 Decision output semantics:
@@ -363,7 +363,7 @@ Decision output semantics:
 - **Value Core** compares option value and informs `business_decision` + `next_action`.
 - UI must show `gate_decision`, `business_decision`, and `next_action` as different concepts.
 - `allow` is gate-level permissive status only; it must not be presented as case approval.
-- Bind-phase `COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK` is a separate adjudication layer from decision-phase approval.
+- Bind-phase outcomes (`COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK`/`APPLY_FAILED`/`SNAPSHOT_FAILED`/`PRECONDITION_FAILED`) are a separate adjudication layer from decision-phase approval.
 - Financial/regulatory governance prompt templates are available as canonical fixtures for
   regression and demo workflows (`veritas_os/sample_data/governance/financial_regulatory_templates.json`);
   see `docs/en/guides/financial-governance-templates.md`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -714,6 +714,10 @@ components:
           type: object
           nullable: true
           additionalProperties: true
+        policy_lineage:
+          type: object
+          nullable: true
+          additionalProperties: true
 
     BindReceipt:
       type: object

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -112,6 +112,10 @@ def test_openapi_includes_bind_artifact_schemas() -> None:
 
     assert "ExecutionIntent" in schemas
     assert "BindReceipt" in schemas
+    policy_lineage = schemas["ExecutionIntent"]["properties"]["policy_lineage"]
+    assert policy_lineage["type"] == "object"
+    assert policy_lineage["nullable"] is True
+    assert policy_lineage["additionalProperties"] is True
 
     bind_outcomes = schemas["BindReceipt"]["properties"]["final_outcome"]["enum"]
     assert bind_outcomes == [


### PR DESCRIPTION
### Motivation
- README の bind-boundary 説明が OpenAPI/ランタイム側の 7 個の bind outcome とずれていたため、公開契約とドキュメントの不整合を最小差分で解消するため。 
- `ExecutionIntent` に `policy_lineage` を公開契約に明記して、API スキーマと実装間のラインエージ情報の記述を揃えるため。 
- ランタイム動作やエンドポイントは変更せず、後方互換性を維持することを優先するため。 

### Description
- `README.md` の bind-phase 説明を 7 outcome（`COMMITTED` / `BLOCKED` / `ESCALATED` / `ROLLED_BACK` / `APPLY_FAILED` / `SNAPSHOT_FAILED` / `PRECONDITION_FAILED`）に揃え、Mission Control 表示・`/v1/decide` のフィールド表記・セマンティクス説明を最小差分で修正しました。 
- `openapi.yaml` の `ExecutionIntent` スキーマに `policy_lineage` を追加し、形状を次のとおりに定義しました: `type: object`, `nullable: true`, `additionalProperties: true`. 
- 回帰テスト `veritas_os/tests/test_openapi_spec.py` に `ExecutionIntent.policy_lineage` の存在と shape を検証するアサーションを追加しました。 
- 変更ファイル: `README.md`, `openapi.yaml`, `veritas_os/tests/test_openapi_spec.py`。

### Testing
- 実行したテスト: `pytest -q veritas_os/tests/test_openapi_spec.py` を実行し、全て成功して `7 passed` でした。 
- 追加したテストは `ExecutionIntent.policy_lineage` の `type/nullable/additionalProperties` を検証し、既存の bind outcome 関連テストも通っています。 
- リスク/互換性: 追加はスキーマの拡張（後方互換的）に限定していますが、OpenAPI 検証を行うクライアントは新しいプロパティによりバリデーションの挙動が変わる可能性があるため注意が必要です。 
- セキュリティ: 本 PR はドキュメントと OpenAPI スキーマ／テストの変更のみでランタイム挙動に影響しないため直接的な新規セキュリティリスクはありませんが、公開契約変更がクライアントの実装や検証フローに影響する点は確認してください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72ca513588326b357a14c5fc18e78)