### PR TITLE
Add POST /v1/governance/policy-bundles/promote endpoint (bind-boundary promotion)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2163,6 +2163,65 @@ paths:
                     nullable: true
                     additionalProperties: true
 
+  /v1/governance/policy-bundles/promote:
+    post:
+      summary: Promote policy bundle with bind-boundary governance workflow
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bundle_id:
+                  type: string
+                bundle_dir_name:
+                  type: string
+                decision_id:
+                  type: string
+                request_id:
+                  type: string
+                policy_snapshot_id:
+                  type: string
+                decision_hash:
+                  type: string
+                approval_context:
+                  type: object
+                  additionalProperties: true
+              required:
+                - decision_id
+                - request_id
+                - policy_snapshot_id
+                - decision_hash
+      responses:
+        "200":
+          description: Bind receipt lineage for promotion execution
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  bind_outcome:
+                    type: string
+                    nullable: true
+                    enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
+                  bind_failure_reason:
+                    type: string
+                    nullable: true
+                  bind_reason_code:
+                    type: string
+                    nullable: true
+                  bind_receipt_id:
+                    type: string
+                    nullable: true
+                  execution_intent_id:
+                    type: string
+                    nullable: true
+                  bind_receipt:
+                    $ref: '#/components/schemas/BindReceipt'
+
   /v1/compliance/config:
     get:
       summary: Compliance config read

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from typing import Annotated, Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
@@ -15,10 +16,13 @@ from veritas_os.api.schemas import (
     GovernanceBindReceiptListResponse,
     GovernanceBindReceiptResponse,
     GovernanceDecisionExportResponse,
+    GovernancePolicyBundlePromoteRequest,
+    GovernancePolicyBundlePromoteResponse,
     GovernancePolicyResponse,
     GovernancePolicyHistoryResponse,
 )
 from veritas_os.policy.bind_artifacts import FinalOutcome, find_bind_receipts
+from veritas_os.policy.policy_bundle_promotion import promote_policy_bundle_with_bind_boundary
 
 # Governance functions accessed via _get_server() for test monkeypatching compat
 
@@ -70,6 +74,35 @@ def _resolve_bind_reason_code(bind_receipt: Dict[str, Any]) -> str | None:
         if isinstance(raw, str) and raw.strip():
             return raw.strip()
     return None
+
+
+def _resolve_policy_bundle_paths(bundle_name: str) -> tuple[Path, Path, Path]:
+    """Resolve promotion paths from server config/env with traversal protection."""
+    bundles_root = Path(
+        (os.getenv("VERITAS_POLICY_BUNDLES_ROOT") or "runtime/policy_bundles").strip()
+    ).expanduser().resolve()
+    pointer_path = Path(
+        (os.getenv("VERITAS_POLICY_ACTIVE_POINTER_PATH") or "runtime/active_bundle.json").strip()
+    ).expanduser().resolve()
+    target_bundle_dir = (bundles_root / bundle_name).resolve()
+    try:
+        target_bundle_dir.relative_to(bundles_root)
+    except ValueError as exc:
+        raise ValueError("invalid_bundle_id") from exc
+    return target_bundle_dir, pointer_path, bundles_root
+
+
+def _bind_response_payload(bind_receipt: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize bind receipt summary payload for governance API responses."""
+    return {
+        "ok": True,
+        "bind_receipt": bind_receipt,
+        "bind_outcome": bind_receipt.get("final_outcome"),
+        "bind_failure_reason": _resolve_bind_failure_reason(bind_receipt),
+        "bind_reason_code": _resolve_bind_reason_code(bind_receipt),
+        "bind_receipt_id": bind_receipt.get("bind_receipt_id"),
+        "execution_intent_id": bind_receipt.get("execution_intent_id"),
+    }
 
 
 # ------------------------------------------------------------------
@@ -355,4 +388,45 @@ def governance_bind_receipt(bind_receipt_id: str):
         return JSONResponse(
             status_code=500,
             content={"ok": False, "error": "Failed to load bind receipt"},
+        )
+
+
+@router.post(
+    "/v1/governance/policy-bundles/promote",
+    response_model=GovernancePolicyBundlePromoteResponse,
+    dependencies=[Depends(require_permission(Permission.governance_write))],
+)
+def governance_promote_policy_bundle(
+    body: GovernancePolicyBundlePromoteRequest,
+    x_role: Optional[str] = Header(default=None, alias="X-Role"),
+):
+    """Promote policy bundle pointer via existing bind-boundary adapter path."""
+    bundle_name = (body.bundle_id or body.bundle_dir_name or "").strip()
+    actor_identity = (x_role or "").strip() or "governance_api"
+    try:
+        target_bundle_dir, pointer_path, bundles_root = _resolve_policy_bundle_paths(bundle_name)
+    except ValueError:
+        return JSONResponse(status_code=400, content={"ok": False, "error": "invalid_bundle_id"})
+
+    try:
+        receipt = promote_policy_bundle_with_bind_boundary(
+            decision_id=body.decision_id,
+            request_id=body.request_id,
+            actor_identity=actor_identity,
+            policy_snapshot_id=body.policy_snapshot_id,
+            decision_hash=body.decision_hash,
+            target_bundle_dir=target_bundle_dir,
+            pointer_path=pointer_path,
+            allowed_root=bundles_root,
+            approval_context=dict(body.approval_context or {}),
+        )
+        return _bind_response_payload(receipt.to_dict())
+    except (ValueError, TypeError) as exc:
+        logger.warning("governance_promote_policy_bundle validation error: %s", exc)
+        return JSONResponse(status_code=400, content={"ok": False, "error": "invalid_promotion_request"})
+    except Exception as exc:
+        logger.error("governance_promote_policy_bundle failed: %s", exc, exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": "Failed to promote policy bundle"},
         )

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1360,6 +1360,46 @@ class GovernanceBindReceiptResponse(BaseModel):
     error: Optional[str] = None
 
 
+class GovernancePolicyBundlePromoteRequest(BaseModel):
+    """Request body for POST /v1/governance/policy-bundles/promote."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    bundle_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    bundle_dir_name: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    decision_id: str = Field(..., max_length=MAX_ID_LENGTH)
+    request_id: str = Field(..., max_length=MAX_ID_LENGTH)
+    policy_snapshot_id: str = Field(..., max_length=MAX_ID_LENGTH)
+    decision_hash: str = Field(..., max_length=MAX_ID_LENGTH)
+    approval_context: Optional[Dict[str, Any]] = None
+
+    @model_validator(mode="after")
+    def _validate_bundle_selector(self) -> "GovernancePolicyBundlePromoteRequest":
+        """Require exactly one bundle selector and reject traversal patterns."""
+        selector_count = int(bool(self.bundle_id)) + int(bool(self.bundle_dir_name))
+        if selector_count != 1:
+            raise ValueError("exactly one of bundle_id or bundle_dir_name must be provided")
+        candidate = (self.bundle_id or self.bundle_dir_name or "").strip()
+        if not candidate:
+            raise ValueError("bundle selector cannot be empty")
+        if any(sep in candidate for sep in ("/", "\\")) or candidate in {".", ".."}:
+            raise ValueError("invalid bundle selector")
+        return self
+
+
+class GovernancePolicyBundlePromoteResponse(BaseModel):
+    """Response envelope for POST /v1/governance/policy-bundles/promote."""
+
+    ok: bool = True
+    bind_receipt: Optional[BindReceipt] = None
+    bind_outcome: Optional[FinalOutcome] = None
+    bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    bind_receipt_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    execution_intent_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    error: Optional[str] = None
+
+
 class GovernanceBindReceiptListResponse(BaseModel):
     """Response envelope for GET /v1/governance/bind-receipts."""
 

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -462,6 +462,143 @@ def test_governance_bind_receipts_list_endpoint(monkeypatch) -> None:
     assert body["items"][0]["execution_intent_id"] == "ei-list-1"
 
 
+def test_governance_policy_bundle_promote_success(monkeypatch, tmp_path: Path) -> None:
+    bundles_root = tmp_path / "bundles"
+    bundle_dir = bundles_root / "bundle-v2"
+    (bundle_dir / "compiled").mkdir(parents=True)
+    (bundle_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    (bundle_dir / "manifest.sig").write_text("sig", encoding="utf-8")
+    (bundle_dir / "compiled" / "canonical_ir.json").write_text("{}", encoding="utf-8")
+    pointer_path = tmp_path / "runtime" / "active_bundle.json"
+
+    monkeypatch.setenv("VERITAS_POLICY_BUNDLES_ROOT", str(bundles_root))
+    monkeypatch.setenv("VERITAS_POLICY_ACTIVE_POINTER_PATH", str(pointer_path))
+
+    resp = client.post(
+        "/v1/governance/policy-bundles/promote",
+        headers=HEADERS,
+        json={
+            "bundle_id": "bundle-v2",
+            "decision_id": "dec-promote-1",
+            "request_id": "req-promote-1",
+            "policy_snapshot_id": "snap-promote-1",
+            "decision_hash": "hash-promote-1",
+            "approval_context": {"policy_bundle_promotion_approved": True},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["bind_outcome"] == "COMMITTED"
+    assert body["bind_receipt_id"]
+    assert body["execution_intent_id"]
+    assert body["bind_receipt"]["final_outcome"] == "COMMITTED"
+
+
+def test_governance_policy_bundle_promote_blocked_returns_lineage(monkeypatch) -> None:
+    class _DummyReceipt:
+        def to_dict(self) -> dict:
+            return {
+                "bind_receipt_id": "br-blocked-1",
+                "execution_intent_id": "ei-blocked-1",
+                "final_outcome": "BLOCKED",
+                "constraint_check_result": {"reason_code": "CONSTRAINT_MISMATCH"},
+                "escalation_reason": "bundle blocked by constraints",
+            }
+
+    monkeypatch.setattr(
+        "veritas_os.api.routes_governance.promote_policy_bundle_with_bind_boundary",
+        lambda **_kwargs: _DummyReceipt(),
+    )
+    resp = client.post(
+        "/v1/governance/policy-bundles/promote",
+        headers=HEADERS,
+        json={
+            "bundle_dir_name": "bundle-v2",
+            "decision_id": "dec-blocked-1",
+            "request_id": "req-blocked-1",
+            "policy_snapshot_id": "snap-blocked-1",
+            "decision_hash": "hash-blocked-1",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["bind_outcome"] == "BLOCKED"
+    assert body["bind_failure_reason"] == "bundle blocked by constraints"
+    assert body["bind_reason_code"] == "CONSTRAINT_MISMATCH"
+    assert body["bind_receipt_id"] == "br-blocked-1"
+    assert body["execution_intent_id"] == "ei-blocked-1"
+
+
+def test_governance_policy_bundle_promote_rollback_returns_lineage(monkeypatch) -> None:
+    class _DummyReceipt:
+        def to_dict(self) -> dict:
+            return {
+                "bind_receipt_id": "br-rollback-1",
+                "execution_intent_id": "ei-rollback-1",
+                "final_outcome": "ROLLED_BACK",
+                "rollback_reason": "postcondition failed",
+                "risk_check_result": {"reason_code": "POSTCONDITION_FAIL"},
+            }
+
+    monkeypatch.setattr(
+        "veritas_os.api.routes_governance.promote_policy_bundle_with_bind_boundary",
+        lambda **_kwargs: _DummyReceipt(),
+    )
+    resp = client.post(
+        "/v1/governance/policy-bundles/promote",
+        headers=HEADERS,
+        json={
+            "bundle_id": "bundle-v2",
+            "decision_id": "dec-rollback-1",
+            "request_id": "req-rollback-1",
+            "policy_snapshot_id": "snap-rollback-1",
+            "decision_hash": "hash-rollback-1",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bind_outcome"] == "ROLLED_BACK"
+    assert body["bind_failure_reason"] == "postcondition failed"
+    assert body["bind_reason_code"] == "POSTCONDITION_FAIL"
+    assert body["bind_receipt"]["bind_receipt_id"] == "br-rollback-1"
+
+
+def test_governance_policy_bundle_promote_rejects_traversal_selector() -> None:
+    resp = client.post(
+        "/v1/governance/policy-bundles/promote",
+        headers=HEADERS,
+        json={
+            "bundle_id": "../etc/passwd",
+            "decision_id": "dec-invalid-1",
+            "request_id": "req-invalid-1",
+            "policy_snapshot_id": "snap-invalid-1",
+            "decision_hash": "hash-invalid-1",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_governance_policy_bundle_promote_backward_compat_bind_receipts_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "veritas_os.api.routes_governance.find_bind_receipts",
+        lambda bind_receipt_id=None, **_kwargs: [
+            type(
+                "Receipt",
+                (),
+                {"to_dict": lambda self: {"bind_receipt_id": bind_receipt_id, "final_outcome": "COMMITTED"}},
+            )()
+        ],
+    )
+    resp = client.get("/v1/governance/bind-receipts/br-backward-1", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["bind_receipt_id"] == "br-backward-1"
+    assert body["bind_outcome"] == "COMMITTED"
+
+
 def test_governance_decision_export_backward_compatible_fields(monkeypatch) -> None:
     monkeypatch.setattr(
         "veritas_os.api.routes_governance.find_bind_receipts",

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -59,6 +59,7 @@ def test_openapi_includes_runtime_audit_and_governance_routes() -> None:
         "/v1/governance/decisions/export",
         "/v1/governance/bind-receipts",
         "/v1/governance/bind-receipts/{bind_receipt_id}",
+        "/v1/governance/policy-bundles/promote",
         "/v1/trustlog/verify",
         "/v1/trust/{request_id}/prov",
     }


### PR DESCRIPTION
### Motivation
- Provide a small, operator-facing governance entrypoint that reuses the existing bind-boundary promotion flow (`promote_policy_bundle_with_bind_boundary`) without adding new adapters or changing bind execution responsibilities.
- Accept a minimal, safe request surface for bundle promotion (no arbitrary filesystem paths from clients) and return bind receipt lineage for auditability.
- Prevent path traversal and enforce server-side resolution of bundle roots/pointer paths to reduce risk from malformed requests.
- Security note: traversal protection and selector validation are implemented, but tightening allowed bundle name character sets and documenting `VERITAS_POLICY_BUNDLES_ROOT`/`VERITAS_POLICY_ACTIVE_POINTER_PATH` for operators is recommended.

### Description
- Added a new endpoint `POST /v1/governance/policy-bundles/promote` protected by `Permission.governance_write` that invokes the existing `promote_policy_bundle_with_bind_boundary()` helper and returns bind receipt lineage fields.
- Introduced Pydantic request/response models: `GovernancePolicyBundlePromoteRequest` and `GovernancePolicyBundlePromoteResponse` in `veritas_os/api/schemas.py`, with validation that requires exactly one of `bundle_id` or `bundle_dir_name` and rejects separator/traversal patterns (no `/`, `\`, `.` or `..`).
- Server-side path resolution and traversal protection implemented in `veritas_os/api/routes_governance.py`: resolve `VERITAS_POLICY_BUNDLES_ROOT` and `VERITAS_POLICY_ACTIVE_POINTER_PATH`, compute `target_bundle_dir = bundles_root / bundle_name`, and assert `target_bundle_dir.relative_to(bundles_root)` to prevent escape.
- Normalized bind-lineage response payload to include `ok`, `bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `bind_receipt_id`, `execution_intent_id`, and the raw `bind_receipt`.
- OpenAPI `openapi.yaml` updated to include the new path and request/response shape, and OpenAPI regression test adjusted to include the new route.
- Integration tests added/updated in `veritas_os/tests/integration/test_governance_api.py` covering: successful promotion, blocked promotion, rollback lineage, traversal-selector rejection, and backward compatibility of bind-receipts endpoint.

Files changed (key): `veritas_os/api/routes_governance.py`, `veritas_os/api/schemas.py`, `openapi.yaml`, `veritas_os/tests/integration/test_governance_api.py`, `veritas_os/tests/test_openapi_spec.py`.

### Testing
- Ran promotion-related integration tests: `pytest -q veritas_os/tests/integration/test_governance_api.py -k "policy_bundle_promote or bind_receipt_endpoint or bind_receipts_list_endpoint or decision_export_backward"` — result: all tests passed (`8 passed`).
- Ran OpenAPI spec checks: `pytest -q veritas_os/tests/test_openapi_spec.py` — result: all tests passed (`7 passed`).
- Tests exercise success, blocked, rollback, traversal rejection, bind-lineage fields, and OpenAPI route coverage; all automated tests included here passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7333b3744832695c729f64aec37c5)