### PR TITLE
docs: elevate policy bundle promotion as operator-facing governance workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,8 +662,34 @@ All protected endpoints require `X-API-Key`. The full list of endpoints:
 | GET | `/v1/governance/policy/history` | Policy change audit trail (with digest transitions) |
 | GET | `/v1/governance/value-drift` | Monitor value weight EMA drift |
 | GET | `/v1/governance/decisions/export` | Export decisions for governance audit |
+| POST | `/v1/governance/policy-bundles/promote` | Execute policy bundle promotion as a bind-boundary governance workflow (returns bind receipt lineage; requires governance write permission) |
 | GET | `/v1/governance/bind-receipts` | List bind receipts (filter by decision or execution intent lineage) |
 | GET | `/v1/governance/bind-receipts/{bind_receipt_id}` | Retrieve a single bind receipt artifact |
+
+#### Operator workflow: promote a policy bundle
+
+Use `POST /v1/governance/policy-bundles/promote` when you need to promote the active policy bundle pointer via the existing bind-boundary path.
+
+- Request accepts **exactly one** selector: `bundle_id` **or** `bundle_dir_name`.
+- Arbitrary filesystem paths are rejected (`/`, `\`, `.`, `..` are not accepted in selectors).
+- Response includes bind lineage fields: `bind_outcome`, `bind_receipt_id`, `execution_intent_id`, plus `bind_receipt`.
+- Use `GET /v1/governance/bind-receipts` or `GET /v1/governance/bind-receipts/{bind_receipt_id}` to inspect the resulting receipt.
+
+```bash
+curl -X POST "http://127.0.0.1:8000/v1/governance/policy-bundles/promote" \
+  -H "X-API-Key: ${VERITAS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "bundle_id": "bundle-v2",
+    "decision_id": "dec-promote-1",
+    "request_id": "req-promote-1",
+    "policy_snapshot_id": "snap-promote-1",
+    "decision_hash": "hash-promote-1"
+  }'
+```
+
+For operator guidance and outcome interpretation, see
+[`docs/en/guides/governance-policy-bundle-promotion.md`](docs/en/guides/governance-policy-bundle-promotion.md).
 
 > **Signed governance artifacts** — In secure/prod posture, policy bundles must be Ed25519-signed.
 > Decision artifacts include a `governance_identity` field showing which governance policy was in

--- a/README_JP.md
+++ b/README_JP.md
@@ -98,6 +98,7 @@ VERITAS OS は次を実現します。
 - **ドキュメント対応表**: [`docs/DOCUMENTATION_MAP.md`](docs/DOCUMENTATION_MAP.md)
 - **運用Runbook**: [`docs/ja/operations/enterprise_slo_sli_runbook_ja.md`](docs/ja/operations/enterprise_slo_sli_runbook_ja.md)
 - **ガバナンス署名運用Runbook**: [`docs/en/operations/governance-artifact-signing.md`](docs/en/operations/governance-artifact-signing.md)
+- **ポリシーバンドル昇格ガイド（EN）**: [`docs/en/guides/governance-policy-bundle-promotion.md`](docs/en/guides/governance-policy-bundle-promotion.md)
 - **ガバナンスアップグレード概要（Press）**: [`docs/press/governance_control_plane_upgrade_2026-04.md`](docs/press/governance_control_plane_upgrade_2026-04.md)
 
 ## 🚀 Quick Start（TL;DR）
@@ -592,6 +593,9 @@ VERITAS_MEMORY_BACKEND=postgresql VERITAS_TRUSTLOG_BACKEND=postgresql \
 | GET | `/v1/governance/policy/history` | ポリシー変更監査証跡 |
 | GET | `/v1/governance/value-drift` | 価値重みEMAドリフト監視 |
 | GET | `/v1/governance/decisions/export` | ガバナンス監査用意思決定エクスポート |
+| POST | `/v1/governance/policy-bundles/promote` | bind-boundaryガバナンスワークフローでポリシーバンドル昇格を実行（bind receipt系譜を返却。governance write権限が必要） |
+| GET | `/v1/governance/bind-receipts` | bind receipt一覧（decision / execution intent 系譜でフィルタ可） |
+| GET | `/v1/governance/bind-receipts/{bind_receipt_id}` | 単一bind receipt成果物を取得 |
 
 > **署名付きガバナンス成果物** — secure/prodポスチャでは、ポリシーバンドルにEd25519署名が必須です。
 > 意思決定成果物には、適用中のガバナンスポリシー（バージョン、ダイジェスト、署名検証結果、署名者ID）を

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -71,6 +71,7 @@
 | EN Path | Status | Description |
 |---------|--------|-------------|
 | `docs/en/guides/demo-script.md` | EN only | 3-minute demo script |
+| `docs/en/guides/governance-policy-bundle-promotion.md` | EN only | Operator-facing policy bundle promotion workflow |
 
 #### Architecture / アーキテクチャ
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,7 @@
 - [Documentation Map (bilingual correspondence)](DOCUMENTATION_MAP.md)
 - [Bilingual Maintenance Rules](BILINGUAL_RULES.md)
 - [Path Migration Table](PATH_MIGRATION.md)
+- [Operator Guide: Policy Bundle Promotion (EN)](en/guides/governance-policy-bundle-promotion.md)
 - [金融 PoC パック（JA）](ja/guides/poc-pack-financial-quickstart.md)
 
 ## Directory Structure

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -52,6 +52,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [3-Minute Demo Script](guides/demo-script.md)
 - [Financial PoC Pack (1-day quickstart, EN)](guides/poc-pack-financial-quickstart.md)
 - [Financial PoC Success Criteria](guides/financial-poc-success-criteria.md)
+- [Operator Guide: Policy Bundle Promotion](guides/governance-policy-bundle-promotion.md)
 - [File-to-PostgreSQL Migration Guide](guides/migration-guide.md) (bilingual)
 - [Financial PoC Pack (1-day quickstart, JA)](../ja/guides/poc-pack-financial-quickstart.md)
 

--- a/docs/en/guides/governance-policy-bundle-promotion.md
+++ b/docs/en/guides/governance-policy-bundle-promotion.md
@@ -1,0 +1,114 @@
+# Operator Guide: Policy Bundle Promotion (Bind-Boundary Workflow)
+
+This guide describes the operator-facing workflow for:
+
+- `POST /v1/governance/policy-bundles/promote`
+
+It is part of VERITAS OS Decision Governance OS operations and uses the existing
+bind-boundary execution path.
+
+---
+
+## What this endpoint does
+
+`POST /v1/governance/policy-bundles/promote` promotes the active policy bundle
+pointer through bind-boundary adjudication and returns bind receipt lineage in
+the API response.
+
+The endpoint requires governance write permission.
+
+---
+
+## When to use it
+
+Use this endpoint when an approved governance decision needs to move runtime to
+another already-present policy bundle directory (for example, from `bundle-v1`
+to `bundle-v2`) while preserving bind execution lineage.
+
+---
+
+## Request fields and meaning
+
+Required fields:
+
+- `decision_id`: decision artifact identifier tied to this promotion intent.
+- `request_id`: request lineage identifier.
+- `policy_snapshot_id`: policy snapshot identifier used for bind lineage.
+- `decision_hash`: decision hash used by bind execution intent.
+
+Bundle selector (exactly one is required):
+
+- `bundle_id`
+- `bundle_dir_name`
+
+Optional:
+
+- `approval_context`: additional operator approval metadata.
+
+### Why arbitrary filesystem paths are not accepted
+
+Promotion accepts only a bundle selector name (not an arbitrary path). The API
+rejects traversal patterns in selectors, and bundle resolution is constrained to
+the configured policy bundles root before bind execution proceeds.
+
+---
+
+## Minimal request example
+
+```bash
+curl -X POST "http://127.0.0.1:8000/v1/governance/policy-bundles/promote" \
+  -H "X-API-Key: ${VERITAS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "bundle_id": "bundle-v2",
+    "decision_id": "dec-promote-1",
+    "request_id": "req-promote-1",
+    "policy_snapshot_id": "snap-promote-1",
+    "decision_hash": "hash-promote-1",
+    "approval_context": {"policy_bundle_promotion_approved": true}
+  }'
+```
+
+---
+
+## Response fields: how to read result
+
+- `bind_outcome`: terminal bind outcome classification.
+- `bind_failure_reason`: compact operator-facing reason when not clean commit.
+- `bind_reason_code`: stable reason code if provided by bind checks.
+- `bind_receipt_id`: bind receipt lineage identifier.
+- `execution_intent_id`: bind execution intent lineage identifier.
+- `bind_receipt`: full receipt payload with check results.
+
+### Representative `bind_outcome` values
+
+- `COMMITTED`
+- `BLOCKED`
+- `ROLLED_BACK`
+- `ESCALATED`
+- `APPLY_FAILED`
+- `SNAPSHOT_FAILED`
+- `PRECONDITION_FAILED`
+
+---
+
+## Failure triage checklist
+
+When promotion does not cleanly commit:
+
+1. Check `bind_reason_code` first for machine-stable cause category.
+2. Check `bind_failure_reason` for compact operator summary.
+3. Inspect `bind_receipt` for authority / constraint / drift / risk check details.
+4. Retrieve persisted receipt lineage by ID:
+   - `GET /v1/governance/bind-receipts`
+   - `GET /v1/governance/bind-receipts/{bind_receipt_id}`
+5. Correlate with decision exports if needed:
+   - `GET /v1/governance/decisions/export`
+
+---
+
+## Related endpoints
+
+- `GET /v1/governance/bind-receipts`
+- `GET /v1/governance/bind-receipts/{bind_receipt_id}`
+- `GET /v1/governance/decisions/export`


### PR DESCRIPTION
### Motivation

- Promote the already-implemented `POST /v1/governance/policy-bundles/promote` endpoint to an operator-facing, documented governance workflow while remaining faithful to code truth (route implementation, request/response schemas, OpenAPI and tests). 
- Provide concise operator guidance describing when to use the endpoint, what request fields mean, why arbitrary filesystem paths are rejected, and how to read bind receipt lineage while highlighting RBAC protection (`governance_write`).

### Description

- Added `POST /v1/governance/policy-bundles/promote` to the README API Overview and a short operator usage snippet showing selector constraints, returned lineage fields, and a minimal `curl` example (`README.md`, `README_JP.md`).
- Created an operator guide `docs/en/guides/governance-policy-bundle-promotion.md` that explains endpoint purpose, when to use it, request field meanings (`bundle_id` / `bundle_dir_name`, `decision_id`, `request_id`, `policy_snapshot_id`, `decision_hash`, `approval_context`), why arbitrary paths are rejected, how to interpret response fields (`bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `bind_receipt_id`, `execution_intent_id`, `bind_receipt`), representative outcomes, triage checklist, and related endpoints.
- Updated documentation navigation to surface the new guide (`docs/en/README.md`, `docs/INDEX.md`, `docs/DOCUMENTATION_MAP.md`) and added minimal Japanese-side follow-up link and table entries (`README_JP.md`).
- This PR is documentation-only: no runtime behavior, endpoint implementation, schema, or OpenAPI shape was changed; all content was aligned to the existing implementation in `veritas_os/api/routes_governance.py`, `veritas_os/api/schemas.py`, `openapi.yaml`, and existing tests.

### Testing

- Ran targeted integration tests covering the promote and bind-receipts flow with `python -m pytest veritas_os/tests/integration/test_governance_api.py -k "policy_bundle_promote or bind_receipts"`, which completed with `6 passed, 102 deselected`.
- Verified that the endpoint, request validation (selector traversal rejection), and returned lineage fields match current code truth (route handler, Pydantic schemas, OpenAPI) by inspecting relevant files and test expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73b2809c88326a0ec91710fa39e6b)