### PR TITLE
Add Mission Control policy-bundle promotion operator workflow

### DIFF
--- a/frontend/app/governance/components/PolicyBundlePromotionFlow.test.tsx
+++ b/frontend/app/governance/components/PolicyBundlePromotionFlow.test.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@veritas/design-system", () => ({
+  Card: ({ children, title }: { children: React.ReactNode; title?: string }) => (
+    <div>
+      {title ? <h3>{title}</h3> : null}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("../../../components/ui", () => ({
+  StatusBadge: ({ label }: { label: string }) => <span data-testid="status-badge">{label}</span>,
+}));
+
+const mockFetch = vi.fn();
+vi.mock("../../../lib/api-client", () => ({
+  veritasFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { PolicyBundlePromotionFlow } from "./PolicyBundlePromotionFlow";
+
+function fillRequiredFields(): void {
+  fireEvent.change(screen.getByLabelText("bundle_id"), { target: { value: "bundle-001" } });
+  fireEvent.change(screen.getByLabelText("decision_id"), { target: { value: "decision-001" } });
+  fireEvent.change(screen.getByLabelText("request_id"), { target: { value: "request-001" } });
+  fireEvent.change(screen.getByLabelText("policy_snapshot_id"), { target: { value: "snapshot-001" } });
+  fireEvent.change(screen.getByLabelText("decision_hash"), { target: { value: "hash-001" } });
+}
+
+describe("PolicyBundlePromotionFlow", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("renders compact promotion form", () => {
+    render(<PolicyBundlePromotionFlow canOperate />);
+    expect(screen.getByText("Policy Bundle Promotion")).toBeInTheDocument();
+    expect(screen.getByLabelText("bundle_id")).toBeInTheDocument();
+    expect(screen.getByLabelText("bundle_dir_name")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "promote bundle" })).toBeInTheDocument();
+  });
+
+  it("validates exactly one selector", async () => {
+    render(<PolicyBundlePromotionFlow canOperate />);
+    fireEvent.change(screen.getByLabelText("bundle_id"), { target: { value: "bundle-001" } });
+    fireEvent.change(screen.getByLabelText("bundle_dir_name"), { target: { value: "dir-001" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(await screen.findByText("bundle_id と bundle_dir_name は同時に指定できません。")).toBeInTheDocument();
+  });
+
+  it("sends promote request with expected payload shape", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        bind_outcome: "success",
+        bind_receipt_id: "br-001",
+        execution_intent_id: "ei-001",
+      }),
+    });
+
+    render(<PolicyBundlePromotionFlow canOperate />);
+    fillRequiredFields();
+    fireEvent.change(screen.getByLabelText("approval_context"), { target: { value: '{"ticket":"GOV-1"}' } });
+
+    fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/veritas/v1/governance/policy-bundles/promote",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const requestInit = mockFetch.mock.calls[0][1] as { body: string };
+    expect(JSON.parse(requestInit.body)).toEqual({
+      bundle_id: "bundle-001",
+      decision_id: "decision-001",
+      request_id: "request-001",
+      policy_snapshot_id: "snapshot-001",
+      decision_hash: "hash-001",
+      approval_context: { ticket: "GOV-1" },
+    });
+  });
+
+  it("renders blocked outcome and bind identifiers", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        bind_outcome: "blocked",
+        bind_failure_reason: "risk gate denied",
+        bind_reason_code: "RISK_BLOCK",
+        bind_receipt_id: "br-777",
+        execution_intent_id: "ei-777",
+      }),
+    });
+
+    render(<PolicyBundlePromotionFlow canOperate />);
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
+
+    expect(await screen.findByText("Promotion Result")).toBeInTheDocument();
+    expect(screen.getByText("bind_outcome:")).toBeInTheDocument();
+    expect(screen.getByText("risk gate denied")).toBeInTheDocument();
+    expect(screen.getByText("RISK_BLOCK")).toBeInTheDocument();
+    expect(screen.getByText("br-777")).toBeInTheDocument();
+    expect(screen.getByText("ei-777")).toBeInTheDocument();
+  });
+
+  it("loads bind receipt detail through existing endpoint", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, bind_outcome: "success", bind_receipt_id: "br-100", execution_intent_id: "ei-100" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, bind_receipt: { bind_receipt_id: "br-100", final_outcome: "success" } }),
+      });
+
+    render(<PolicyBundlePromotionFlow canOperate />);
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
+
+    const loadButton = await screen.findByRole("button", { name: "load bind receipt detail" });
+    fireEvent.click(loadButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        "/api/veritas/v1/governance/bind-receipts/br-100",
+      );
+    });
+
+    expect(await screen.findByText("bind receipt detail")).toBeInTheDocument();
+  });
+
+  it("handles promote endpoint error response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ ok: false, error: "backend failure" }),
+    });
+
+    render(<PolicyBundlePromotionFlow canOperate />);
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
+
+    expect(await screen.findByText("backend failure")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/governance/components/PolicyBundlePromotionFlow.tsx
+++ b/frontend/app/governance/components/PolicyBundlePromotionFlow.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Card } from "@veritas/design-system";
+import { StatusBadge } from "../../../components/ui";
+import { veritasFetch } from "../../../lib/api-client";
+
+interface PolicyBundlePromotionFlowProps {
+  canOperate: boolean;
+}
+
+type BindOutcome =
+  | "success"
+  | "blocked"
+  | "rolled_back"
+  | "escalated"
+  | "apply_failed"
+  | "snapshot_failed"
+  | "precondition_failed";
+
+interface PromoteResponse {
+  ok: boolean;
+  bind_outcome?: string;
+  bind_failure_reason?: string;
+  bind_reason_code?: string;
+  bind_receipt_id?: string;
+  execution_intent_id?: string;
+  error?: string;
+}
+
+interface BindReceiptResponse {
+  ok: boolean;
+  bind_receipt?: Record<string, unknown>;
+  bind_outcome?: string;
+  bind_failure_reason?: string;
+  bind_reason_code?: string;
+  bind_receipt_id?: string;
+  execution_intent_id?: string;
+  error?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parsePromoteResponse(value: unknown): PromoteResponse | null {
+  if (!isRecord(value) || typeof value.ok !== "boolean") {
+    return null;
+  }
+  return {
+    ok: value.ok,
+    bind_outcome: typeof value.bind_outcome === "string" ? value.bind_outcome : undefined,
+    bind_failure_reason: typeof value.bind_failure_reason === "string" ? value.bind_failure_reason : undefined,
+    bind_reason_code: typeof value.bind_reason_code === "string" ? value.bind_reason_code : undefined,
+    bind_receipt_id: typeof value.bind_receipt_id === "string" ? value.bind_receipt_id : undefined,
+    execution_intent_id: typeof value.execution_intent_id === "string" ? value.execution_intent_id : undefined,
+    error: typeof value.error === "string" ? value.error : undefined,
+  };
+}
+
+function parseBindReceiptResponse(value: unknown): BindReceiptResponse | null {
+  if (!isRecord(value) || typeof value.ok !== "boolean") {
+    return null;
+  }
+  return {
+    ok: value.ok,
+    bind_receipt: isRecord(value.bind_receipt) ? value.bind_receipt : undefined,
+    bind_outcome: typeof value.bind_outcome === "string" ? value.bind_outcome : undefined,
+    bind_failure_reason: typeof value.bind_failure_reason === "string" ? value.bind_failure_reason : undefined,
+    bind_reason_code: typeof value.bind_reason_code === "string" ? value.bind_reason_code : undefined,
+    bind_receipt_id: typeof value.bind_receipt_id === "string" ? value.bind_receipt_id : undefined,
+    execution_intent_id: typeof value.execution_intent_id === "string" ? value.execution_intent_id : undefined,
+    error: typeof value.error === "string" ? value.error : undefined,
+  };
+}
+
+function resolveOutcomeVariant(outcome?: string): "success" | "warning" | "danger" | "muted" {
+  const normalized = (outcome ?? "").toLowerCase() as BindOutcome;
+  if (normalized === "success") {
+    return "success";
+  }
+  if (normalized === "blocked" || normalized === "rolled_back" || normalized === "precondition_failed") {
+    return "warning";
+  }
+  if (normalized === "escalated" || normalized === "apply_failed" || normalized === "snapshot_failed") {
+    return "danger";
+  }
+  return "muted";
+}
+
+/**
+ * Compact operator-facing workflow to submit policy bundle promotion
+ * using the existing governance promote endpoint and inspect bind lineage.
+ */
+export function PolicyBundlePromotionFlow({ canOperate }: PolicyBundlePromotionFlowProps): JSX.Element {
+  const [bundleId, setBundleId] = useState("");
+  const [bundleDirName, setBundleDirName] = useState("");
+  const [decisionId, setDecisionId] = useState("");
+  const [requestId, setRequestId] = useState("");
+  const [policySnapshotId, setPolicySnapshotId] = useState("");
+  const [decisionHash, setDecisionHash] = useState("");
+  const [approvalContextText, setApprovalContextText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<PromoteResponse | null>(null);
+  const [receiptLoading, setReceiptLoading] = useState(false);
+  const [receiptError, setReceiptError] = useState<string | null>(null);
+  const [receiptDetail, setReceiptDetail] = useState<BindReceiptResponse | null>(null);
+
+  const selectorError = useMemo(() => {
+    const hasBundleId = bundleId.trim().length > 0;
+    const hasBundleDirName = bundleDirName.trim().length > 0;
+    if (hasBundleId && hasBundleDirName) {
+      return "bundle_id と bundle_dir_name は同時に指定できません。";
+    }
+    if (!hasBundleId && !hasBundleDirName) {
+      return "bundle_id または bundle_dir_name のどちらか1つが必須です。";
+    }
+    const selected = hasBundleId ? bundleId.trim() : bundleDirName.trim();
+    if ([".", ".."].includes(selected) || selected.includes("/") || selected.includes("\\")) {
+      return "bundle selector に path 文字は使えません。";
+    }
+    return null;
+  }, [bundleDirName, bundleId]);
+
+  const handleSubmit = async (): Promise<void> => {
+    setError(null);
+    setReceiptDetail(null);
+    setReceiptError(null);
+
+    if (!canOperate) {
+      setError("RBAC: promotion は operator 以上のみ実行可能です。");
+      return;
+    }
+    if (selectorError) {
+      return;
+    }
+    if (!decisionId.trim() || !requestId.trim() || !policySnapshotId.trim() || !decisionHash.trim()) {
+      setError("decision_id / request_id / policy_snapshot_id / decision_hash は必須です。");
+      return;
+    }
+
+    let approvalContext: Record<string, unknown> | undefined;
+    const trimmedApprovalContext = approvalContextText.trim();
+    if (trimmedApprovalContext.length > 0) {
+      try {
+        const parsed: unknown = JSON.parse(trimmedApprovalContext);
+        if (!isRecord(parsed)) {
+          setError("approval_context は JSON object で入力してください。");
+          return;
+        }
+        approvalContext = parsed;
+      } catch {
+        setError("approval_context は有効な JSON を入力してください。");
+        return;
+      }
+    }
+
+    const payload: Record<string, unknown> = {
+      decision_id: decisionId.trim(),
+      request_id: requestId.trim(),
+      policy_snapshot_id: policySnapshotId.trim(),
+      decision_hash: decisionHash.trim(),
+    };
+
+    if (bundleId.trim()) {
+      payload.bundle_id = bundleId.trim();
+    }
+    if (bundleDirName.trim()) {
+      payload.bundle_dir_name = bundleDirName.trim();
+    }
+    if (approvalContext) {
+      payload.approval_context = approvalContext;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await veritasFetch("/api/veritas/v1/governance/policy-bundles/promote", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+      const data = parsePromoteResponse(await response.json());
+      if (!response.ok) {
+        setResult(data);
+        setError(data?.error ?? `HTTP ${response.status}: promotion の実行に失敗しました。`);
+        return;
+      }
+      if (!data) {
+        setError("promotion レスポンスの形式が不正です。");
+        return;
+      }
+      setResult(data);
+    } catch (caught: unknown) {
+      const message = caught instanceof Error ? caught.message : "Network error";
+      setError(`promotion request failed: ${message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleLoadReceipt = async (): Promise<void> => {
+    if (!result?.bind_receipt_id) {
+      return;
+    }
+    setReceiptError(null);
+    setReceiptLoading(true);
+    try {
+      const response = await veritasFetch(
+        `/api/veritas/v1/governance/bind-receipts/${encodeURIComponent(result.bind_receipt_id)}`,
+      );
+      const data = parseBindReceiptResponse(await response.json());
+      if (!response.ok || !data) {
+        setReceiptError(data?.error ?? `HTTP ${response.status}: bind receipt の取得に失敗しました。`);
+        return;
+      }
+      setReceiptDetail(data);
+    } catch (caught: unknown) {
+      const message = caught instanceof Error ? caught.message : "Network error";
+      setReceiptError(`bind receipt request failed: ${message}`);
+    } finally {
+      setReceiptLoading(false);
+    }
+  };
+
+  return (
+    <Card title="Policy Bundle Promotion" titleSize="md" variant="elevated" accent="info">
+      <div className="space-y-3 text-xs">
+        <p className="text-muted-foreground">
+          Existing bind-boundary endpoint を使って promotion を実行し、bind outcome / receipt lineage を追跡します。
+        </p>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="space-y-1">
+            <span>bundle_id</span>
+            <input
+              aria-label="bundle_id"
+              type="text"
+              value={bundleId}
+              onChange={(event) => setBundleId(event.target.value.slice(0, 128))}
+              className="w-full rounded border px-2 py-1"
+              placeholder="bundle-2026-04"
+              disabled={!canOperate || submitting}
+            />
+          </label>
+          <label className="space-y-1">
+            <span>bundle_dir_name</span>
+            <input
+              aria-label="bundle_dir_name"
+              type="text"
+              value={bundleDirName}
+              onChange={(event) => setBundleDirName(event.target.value.slice(0, 128))}
+              className="w-full rounded border px-2 py-1"
+              placeholder="policy_bundle_prod"
+              disabled={!canOperate || submitting}
+            />
+          </label>
+          <label className="space-y-1">
+            <span>decision_id</span>
+            <input aria-label="decision_id" type="text" value={decisionId} onChange={(event) => setDecisionId(event.target.value.slice(0, 128))} className="w-full rounded border px-2 py-1" disabled={!canOperate || submitting} />
+          </label>
+          <label className="space-y-1">
+            <span>request_id</span>
+            <input aria-label="request_id" type="text" value={requestId} onChange={(event) => setRequestId(event.target.value.slice(0, 128))} className="w-full rounded border px-2 py-1" disabled={!canOperate || submitting} />
+          </label>
+          <label className="space-y-1">
+            <span>policy_snapshot_id</span>
+            <input aria-label="policy_snapshot_id" type="text" value={policySnapshotId} onChange={(event) => setPolicySnapshotId(event.target.value.slice(0, 128))} className="w-full rounded border px-2 py-1" disabled={!canOperate || submitting} />
+          </label>
+          <label className="space-y-1">
+            <span>decision_hash</span>
+            <input aria-label="decision_hash" type="text" value={decisionHash} onChange={(event) => setDecisionHash(event.target.value.slice(0, 128))} className="w-full rounded border px-2 py-1" disabled={!canOperate || submitting} />
+          </label>
+        </div>
+
+        <label className="space-y-1 block">
+          <span>approval_context (optional JSON)</span>
+          <textarea
+            aria-label="approval_context"
+            value={approvalContextText}
+            onChange={(event) => setApprovalContextText(event.target.value.slice(0, 5000))}
+            className="min-h-[88px] w-full rounded border px-2 py-1 font-mono"
+            placeholder='{"ticket_id":"GOV-123"}'
+            disabled={!canOperate || submitting}
+          />
+        </label>
+
+        {selectorError ? (
+          <p className="rounded border border-warning/30 bg-warning/10 px-2 py-1 text-warning-foreground">{selectorError}</p>
+        ) : null}
+        {!canOperate ? (
+          <p className="rounded border border-warning/30 bg-warning/10 px-2 py-1 text-warning-foreground">
+            RBAC: promotion は operator または admin ロールが必要です。
+          </p>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className="rounded border px-3 py-1.5"
+            onClick={() => void handleSubmit()}
+            disabled={!canOperate || submitting}
+          >
+            {submitting ? "promoting..." : "promote bundle"}
+          </button>
+          {result?.bind_receipt_id ? (
+            <button
+              type="button"
+              className="rounded border px-3 py-1.5"
+              onClick={() => void handleLoadReceipt()}
+              disabled={receiptLoading}
+            >
+              {receiptLoading ? "loading receipt..." : "load bind receipt detail"}
+            </button>
+          ) : null}
+          {result?.bind_receipt_id ? (
+            <a className="rounded border px-3 py-1.5" href="/audit">
+              open TrustLog Explorer
+            </a>
+          ) : null}
+        </div>
+
+        {error ? (
+          <p className="rounded border border-danger/30 bg-danger/10 px-2 py-1 text-danger">{error}</p>
+        ) : null}
+
+        {result ? (
+          <div className="space-y-2 rounded border p-3">
+            <div className="flex items-center gap-2">
+              <span className="font-semibold">Promotion Result</span>
+              <StatusBadge label={result.bind_outcome ?? "unknown"} variant={resolveOutcomeVariant(result.bind_outcome)} />
+            </div>
+            <div className="grid gap-1 md:grid-cols-2">
+              <p>bind_outcome: <span className="font-mono">{result.bind_outcome ?? "-"}</span></p>
+              <p>bind_reason_code: <span className="font-mono">{result.bind_reason_code ?? "-"}</span></p>
+              <p className="md:col-span-2">bind_failure_reason: <span className="font-mono">{result.bind_failure_reason ?? "-"}</span></p>
+              <p>bind_receipt_id: <span className="font-mono">{result.bind_receipt_id ?? "-"}</span></p>
+              <p>execution_intent_id: <span className="font-mono">{result.execution_intent_id ?? "-"}</span></p>
+            </div>
+          </div>
+        ) : null}
+
+        {receiptError ? (
+          <p className="rounded border border-danger/30 bg-danger/10 px-2 py-1 text-danger">{receiptError}</p>
+        ) : null}
+
+        {receiptDetail?.bind_receipt ? (
+          <details className="rounded border p-2">
+            <summary className="cursor-pointer font-semibold">bind receipt detail</summary>
+            <pre className="mt-2 overflow-x-auto rounded bg-muted/20 p-2 text-[11px]">{JSON.stringify(receiptDetail.bind_receipt, null, 2)}</pre>
+          </details>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/app/governance/page.test.tsx
+++ b/frontend/app/governance/page.test.tsx
@@ -131,6 +131,7 @@ describe("GovernanceControlPage", () => {
       expect(screen.getByText("WAT Settings")).toBeInTheDocument();
       expect(screen.getByText("Current vs Draft Diff")).toBeInTheDocument();
       expect(screen.getByText("Apply Flow")).toBeInTheDocument();
+      expect(screen.getByText("Policy Bundle Promotion")).toBeInTheDocument();
       expect(screen.getByText("Change History")).toBeInTheDocument();
     });
   });

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -15,6 +15,7 @@ import { ApprovalWorkflow } from "./components/ApprovalWorkflow";
 import { ApplyFlow } from "./components/ApplyFlow";
 import { TrustLogStream } from "./components/TrustLogStream";
 import { ChangeHistory } from "./components/ChangeHistory";
+import { PolicyBundlePromotionFlow } from "./components/PolicyBundlePromotionFlow";
 import { ConfirmDialog } from "../../components/ui/confirm-dialog";
 
 /* ------------------------------------------------------------------ */
@@ -375,6 +376,8 @@ export default function GovernanceControlPage(): JSX.Element {
             onApply={(mode) => void state.applyPolicy(mode)}
             onRollback={state.rollback}
           />
+
+          <PolicyBundlePromotionFlow canOperate={state.canOperate} />
 
           <TrustLogStream entries={state.trustLog} />
           <ChangeHistory entries={state.history} />


### PR DESCRIPTION
### Motivation

- Provide a small operator-facing workflow in Mission Control to invoke and inspect `POST /v1/governance/policy-bundles/promote` without changing existing bind-boundary substrate or governance backends.  
- Keep the UI compact and operator-focused so promotion, bind outcome, and lineage (bind receipt / execution intent) are immediately visible and navigable from the existing Governance surface.

### Description

- Added a compact React component `PolicyBundlePromotionFlow` that renders a minimal promotion form (exactly-one selector: `bundle_id` xor `bundle_dir_name`, and required `decision_id`, `request_id`, `policy_snapshot_id`, `decision_hash`, optional `approval_context` JSON) and performs frontend validation.  
- The component calls the existing BFF endpoint via the shared client: `veritasFetch("/api/veritas/v1/governance/policy-bundles/promote", ...)`, parses the response, and displays `bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `bind_receipt_id`, and `execution_intent_id` with a status badge.  
- Adds a drill-down action that reuses the existing endpoint `GET /v1/governance/bind-receipts/{bind_receipt_id}` to fetch and display bind receipt detail (no new backend endpoints or auth changes).  
- Integrated the flow into the existing Governance page near `ApplyFlow` to extend the current operator/action surface without creating a new dashboard.  
- Tests added and updated: `PolicyBundlePromotionFlow` unit tests validate render, selector validation, payload shape on submit, outcome rendering, bind receipt retrieval, and error handling; `page.test.tsx` updated to assert the new section remains compatible with existing rendering.

### Testing

- Ran the component and page unit tests with: `cd frontend && pnpm -s vitest run app/governance/components/PolicyBundlePromotionFlow.test.tsx app/governance/page.test.tsx app/governance/hooks/useGovernanceState.test.ts --reporter=dot`, and the test suite passed.  
- New tests exercise exactly-one selector validation, correct payload shape sent to `POST /v1/governance/policy-bundles/promote`, blocked/success outcome rendering, bind receipt detail retrieval via the existing `GET /v1/governance/bind-receipts/{id}`, and promote endpoint error handling.  
- No integration/BFF server changes were required and existing governance state tests were executed to ensure non‑regression of the Governance UI logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7456e3eb48326af1ab623a62c4abe)