### PR TITLE
Align PolicyBundlePromotionFlow with canonical bind outcomes

### DIFF
--- a/frontend/app/governance/components/PolicyBundlePromotionFlow.test.tsx
+++ b/frontend/app/governance/components/PolicyBundlePromotionFlow.test.tsx
@@ -12,7 +12,9 @@ vi.mock("@veritas/design-system", () => ({
 }));
 
 vi.mock("../../../components/ui", () => ({
-  StatusBadge: ({ label }: { label: string }) => <span data-testid="status-badge">{label}</span>,
+  StatusBadge: ({ label, variant }: { label: string; variant: string }) => (
+    <span data-testid="status-badge" data-variant={variant}>{label}</span>
+  ),
 }));
 
 const mockFetch = vi.fn();
@@ -51,7 +53,8 @@ describe("PolicyBundlePromotionFlow", () => {
     fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
 
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(await screen.findByText("bundle_id と bundle_dir_name は同時に指定できません。")).toBeInTheDocument();
+    expect(await screen.findByText("bundle_id と bundle_dir_name は同時に指定できません。"))
+      .toBeInTheDocument();
   });
 
   it("sends promote request with expected payload shape", async () => {
@@ -59,7 +62,7 @@ describe("PolicyBundlePromotionFlow", () => {
       ok: true,
       json: async () => ({
         ok: true,
-        bind_outcome: "success",
+        bind_outcome: "COMMITTED",
         bind_receipt_id: "br-001",
         execution_intent_id: "ei-001",
       }),
@@ -89,14 +92,12 @@ describe("PolicyBundlePromotionFlow", () => {
     });
   });
 
-  it("renders blocked outcome and bind identifiers", async () => {
+  it("renders canonical COMMITTED outcome with success variant", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
         ok: true,
-        bind_outcome: "blocked",
-        bind_failure_reason: "risk gate denied",
-        bind_reason_code: "RISK_BLOCK",
+        bind_outcome: "COMMITTED",
         bind_receipt_id: "br-777",
         execution_intent_id: "ei-777",
       }),
@@ -107,22 +108,61 @@ describe("PolicyBundlePromotionFlow", () => {
     fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
 
     expect(await screen.findByText("Promotion Result")).toBeInTheDocument();
-    expect(screen.getByText("bind_outcome:")).toBeInTheDocument();
-    expect(screen.getByText("risk gate denied")).toBeInTheDocument();
-    expect(screen.getByText("RISK_BLOCK")).toBeInTheDocument();
-    expect(screen.getByText("br-777")).toBeInTheDocument();
-    expect(screen.getByText("ei-777")).toBeInTheDocument();
+    expect(screen.getByTestId("status-badge")).toHaveTextContent("COMMITTED");
+    expect(screen.getByTestId("status-badge")).toHaveAttribute("data-variant", "success");
   });
 
-  it("loads bind receipt detail through existing endpoint", async () => {
+  it.each([
+    ["BLOCKED", "warning"],
+    ["ROLLED_BACK", "warning"],
+    ["ESCALATED", "danger"],
+    ["APPLY_FAILED", "danger"],
+    ["SNAPSHOT_FAILED", "danger"],
+    ["PRECONDITION_FAILED", "warning"],
+  ])("renders representative canonical outcome %s", async (outcome, variant) => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        bind_outcome: outcome,
+        bind_failure_reason: "reason",
+        bind_reason_code: "CODE",
+      }),
+    });
+
+    render(<PolicyBundlePromotionFlow canOperate />);
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
+
+    await screen.findByText("Promotion Result");
+    expect(screen.getByTestId("status-badge")).toHaveTextContent(outcome);
+    expect(screen.getByTestId("status-badge")).toHaveAttribute("data-variant", variant);
+  });
+
+  it("loads bind receipt detail and renders compact bind breakdown", async () => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ ok: true, bind_outcome: "success", bind_receipt_id: "br-100", execution_intent_id: "ei-100" }),
+        json: async () => ({
+          ok: true,
+          bind_outcome: "BLOCKED",
+          bind_receipt_id: "br-100",
+          execution_intent_id: "ei-100",
+        }),
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ ok: true, bind_receipt: { bind_receipt_id: "br-100", final_outcome: "success" } }),
+        json: async () => ({
+          ok: true,
+          bind_receipt: {
+            bind_receipt_id: "br-100",
+            final_outcome: "BLOCKED",
+            authority_check_result: { passed: true },
+            constraint_check_result: { passed: false },
+            drift_check_result: { result: "ok" },
+            risk_check_result: { result: "deny" },
+          },
+        }),
       });
 
     render(<PolicyBundlePromotionFlow canOperate />);
@@ -139,7 +179,28 @@ describe("PolicyBundlePromotionFlow", () => {
       );
     });
 
-    expect(await screen.findByText("bind receipt detail")).toBeInTheDocument();
+    expect(await screen.findByText("bind receipt detail loaded")).toBeInTheDocument();
+    expect(screen.getByText(/authority:/)).toBeInTheDocument();
+    expect(screen.getByText(/constraints:/)).toBeInTheDocument();
+    expect(screen.getByText(/drift:/)).toBeInTheDocument();
+    expect(screen.getByText(/risk:/)).toBeInTheDocument();
+  });
+
+  it("normalizes legacy success outcome into canonical COMMITTED", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        bind_outcome: "success",
+      }),
+    });
+
+    render(<PolicyBundlePromotionFlow canOperate />);
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: "promote bundle" }));
+
+    expect(await screen.findByTestId("status-badge")).toHaveTextContent("COMMITTED");
+    expect(screen.getByTestId("status-badge")).toHaveAttribute("data-variant", "success");
   });
 
   it("handles promote endpoint error response", async () => {

--- a/frontend/app/governance/components/PolicyBundlePromotionFlow.tsx
+++ b/frontend/app/governance/components/PolicyBundlePromotionFlow.tsx
@@ -9,14 +9,16 @@ interface PolicyBundlePromotionFlowProps {
   canOperate: boolean;
 }
 
-type BindOutcome =
-  | "success"
-  | "blocked"
-  | "rolled_back"
-  | "escalated"
-  | "apply_failed"
-  | "snapshot_failed"
-  | "precondition_failed";
+type CanonicalBindOutcome =
+  | "COMMITTED"
+  | "BLOCKED"
+  | "ESCALATED"
+  | "ROLLED_BACK"
+  | "APPLY_FAILED"
+  | "SNAPSHOT_FAILED"
+  | "PRECONDITION_FAILED";
+
+type BindCheckSummary = "PASS" | "FAIL" | "UNKNOWN";
 
 interface PromoteResponse {
   ok: boolean;
@@ -25,6 +27,11 @@ interface PromoteResponse {
   bind_reason_code?: string;
   bind_receipt_id?: string;
   execution_intent_id?: string;
+  authority_check_result?: unknown;
+  constraint_check_result?: unknown;
+  drift_check_result?: unknown;
+  risk_check_result?: unknown;
+  bind_receipt?: Record<string, unknown>;
   error?: string;
 }
 
@@ -54,6 +61,11 @@ function parsePromoteResponse(value: unknown): PromoteResponse | null {
     bind_reason_code: typeof value.bind_reason_code === "string" ? value.bind_reason_code : undefined,
     bind_receipt_id: typeof value.bind_receipt_id === "string" ? value.bind_receipt_id : undefined,
     execution_intent_id: typeof value.execution_intent_id === "string" ? value.execution_intent_id : undefined,
+    authority_check_result: value.authority_check_result,
+    constraint_check_result: value.constraint_check_result,
+    drift_check_result: value.drift_check_result,
+    risk_check_result: value.risk_check_result,
+    bind_receipt: isRecord(value.bind_receipt) ? value.bind_receipt : undefined,
     error: typeof value.error === "string" ? value.error : undefined,
   };
 }
@@ -74,18 +86,73 @@ function parseBindReceiptResponse(value: unknown): BindReceiptResponse | null {
   };
 }
 
+function normalizeBindOutcome(outcome?: string): CanonicalBindOutcome | "UNKNOWN" {
+  const normalized = (outcome ?? "").trim().toUpperCase();
+  switch (normalized) {
+    case "COMMITTED":
+    case "SUCCESS":
+      return "COMMITTED";
+    case "BLOCKED":
+      return "BLOCKED";
+    case "ROLLED_BACK":
+      return "ROLLED_BACK";
+    case "ESCALATED":
+      return "ESCALATED";
+    case "APPLY_FAILED":
+      return "APPLY_FAILED";
+    case "SNAPSHOT_FAILED":
+      return "SNAPSHOT_FAILED";
+    case "PRECONDITION_FAILED":
+      return "PRECONDITION_FAILED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 function resolveOutcomeVariant(outcome?: string): "success" | "warning" | "danger" | "muted" {
-  const normalized = (outcome ?? "").toLowerCase() as BindOutcome;
-  if (normalized === "success") {
+  const canonical = normalizeBindOutcome(outcome);
+  if (canonical === "COMMITTED") {
     return "success";
   }
-  if (normalized === "blocked" || normalized === "rolled_back" || normalized === "precondition_failed") {
+  if (canonical === "BLOCKED" || canonical === "ROLLED_BACK" || canonical === "PRECONDITION_FAILED") {
     return "warning";
   }
-  if (normalized === "escalated" || normalized === "apply_failed" || normalized === "snapshot_failed") {
+  if (canonical === "ESCALATED" || canonical === "APPLY_FAILED" || canonical === "SNAPSHOT_FAILED") {
     return "danger";
   }
   return "muted";
+}
+
+function summarizeBindCheck(value: unknown): BindCheckSummary {
+  if (!isRecord(value)) {
+    return "UNKNOWN";
+  }
+  if (typeof value.passed === "boolean") {
+    return value.passed ? "PASS" : "FAIL";
+  }
+  if (typeof value.result === "string") {
+    const result = value.result.trim().toUpperCase();
+    if (result === "PASS" || result === "OK" || result === "ALLOW") {
+      return "PASS";
+    }
+    if (result === "FAIL" || result === "DENY" || result === "BLOCK") {
+      return "FAIL";
+    }
+  }
+  return "UNKNOWN";
+}
+
+function resolveCheckResult(
+  result: PromoteResponse | null,
+  receipt: BindReceiptResponse | null,
+  key: "authority_check_result" | "constraint_check_result" | "drift_check_result" | "risk_check_result",
+): BindCheckSummary {
+  const fromResult = summarizeBindCheck(result?.[key]);
+  if (fromResult !== "UNKNOWN") {
+    return fromResult;
+  }
+  const fromReceipt = summarizeBindCheck(receipt?.bind_receipt?.[key]);
+  return fromReceipt;
 }
 
 /**
@@ -122,6 +189,8 @@ export function PolicyBundlePromotionFlow({ canOperate }: PolicyBundlePromotionF
     }
     return null;
   }, [bundleDirName, bundleId]);
+
+  const canonicalOutcome = normalizeBindOutcome(result?.bind_outcome);
 
   const handleSubmit = async (): Promise<void> => {
     setError(null);
@@ -312,11 +381,11 @@ export function PolicyBundlePromotionFlow({ canOperate }: PolicyBundlePromotionF
               onClick={() => void handleLoadReceipt()}
               disabled={receiptLoading}
             >
-              {receiptLoading ? "loading receipt..." : "load bind receipt detail"}
+              {receiptLoading ? "loading receipt..." : receiptDetail ? "reload bind receipt detail" : "load bind receipt detail"}
             </button>
           ) : null}
           {result?.bind_receipt_id ? (
-            <a className="rounded border px-3 py-1.5" href="/audit">
+            <a className="rounded border px-3 py-1.5" href={`/audit?bind_receipt_id=${encodeURIComponent(result.bind_receipt_id)}`}>
               open TrustLog Explorer
             </a>
           ) : null}
@@ -330,15 +399,41 @@ export function PolicyBundlePromotionFlow({ canOperate }: PolicyBundlePromotionF
           <div className="space-y-2 rounded border p-3">
             <div className="flex items-center gap-2">
               <span className="font-semibold">Promotion Result</span>
-              <StatusBadge label={result.bind_outcome ?? "unknown"} variant={resolveOutcomeVariant(result.bind_outcome)} />
+              <StatusBadge label={canonicalOutcome} variant={resolveOutcomeVariant(canonicalOutcome)} />
             </div>
             <div className="grid gap-1 md:grid-cols-2">
-              <p>bind_outcome: <span className="font-mono">{result.bind_outcome ?? "-"}</span></p>
+              <p>bind_outcome: <span className="font-mono">{canonicalOutcome}</span></p>
               <p>bind_reason_code: <span className="font-mono">{result.bind_reason_code ?? "-"}</span></p>
               <p className="md:col-span-2">bind_failure_reason: <span className="font-mono">{result.bind_failure_reason ?? "-"}</span></p>
-              <p>bind_receipt_id: <span className="font-mono">{result.bind_receipt_id ?? "-"}</span></p>
+              <p>
+                bind_receipt_id:{" "}
+                {result.bind_receipt_id ? (
+                  <a
+                    className="font-mono underline underline-offset-2"
+                    href={`/audit?bind_receipt_id=${encodeURIComponent(result.bind_receipt_id)}`}
+                  >
+                    {result.bind_receipt_id}
+                  </a>
+                ) : (
+                  <span className="font-mono">-</span>
+                )}
+              </p>
               <p>execution_intent_id: <span className="font-mono">{result.execution_intent_id ?? "-"}</span></p>
             </div>
+
+            <div className="rounded border border-muted p-2">
+              <p className="font-semibold">bind check summary</p>
+              <div className="mt-1 grid gap-1 md:grid-cols-2">
+                <p>authority: <span className="font-mono">{resolveCheckResult(result, receiptDetail, "authority_check_result")}</span></p>
+                <p>constraints: <span className="font-mono">{resolveCheckResult(result, receiptDetail, "constraint_check_result")}</span></p>
+                <p>drift: <span className="font-mono">{resolveCheckResult(result, receiptDetail, "drift_check_result")}</span></p>
+                <p>risk: <span className="font-mono">{resolveCheckResult(result, receiptDetail, "risk_check_result")}</span></p>
+              </div>
+            </div>
+
+            {receiptDetail ? (
+              <p className="text-muted-foreground">bind receipt detail loaded</p>
+            ) : null}
           </div>
         ) : null}
 


### PR DESCRIPTION
### Motivation
- Bring the Governance promotion UI into exact alignment with the repo canonical bind outcome contract (seven canonical outcomes) so Mission Control renders backend responses without relying on legacy lower-case vocabulary.
- Make operator-facing status semantics clearer by mapping canonical outcomes to existing `StatusBadge` variants and surface minimal bind-check summaries top-level for faster triage.
- Improve receipt tracking affordances (linking, deep-linking to TrustLog Explorer, explicit loaded state) without changing backend APIs or OpenAPI.

### Description
- Replaced local lower-case outcome handling with canonical outcome handling and added a small normalizer (`normalizeBindOutcome`) that maps legacy `success` -> `COMMITTED` while keeping UI state canonical; added `CanonicalBindOutcome` type.
- Remapped badge variants to operator semantics via `resolveOutcomeVariant` (`COMMITTED=success`, `BLOCKED/ROLLED_BACK/PRECONDITION_FAILED=warning`, `ESCALATED/APPLY_FAILED/SNAPSHOT_FAILED=danger`).
- Added compact bind check breakdown (authority/constraints/drift/risk) to the top-level Promotion Result panel with a small summarizer (`summarizeBindCheck`) and logic (`resolveCheckResult`) to prefer top-level response fields but fall back to receipt detail.
- Improved bind receipt UX: `bind_receipt_id` is rendered as an `/audit?bind_receipt_id=...` link, the TrustLog Explorer CTA deep-links with the receipt id, the load button shows loading/reload state, and receipt-loaded status is displayed.
- Updated tests to use canonical outcomes and added a focused normalization test for legacy `success`; changed files: `frontend/app/governance/components/PolicyBundlePromotionFlow.tsx` and `frontend/app/governance/components/PolicyBundlePromotionFlow.test.tsx`.

### Testing
- Ran the focused component tests with `pnpm --filter frontend test -- frontend/app/governance/components/PolicyBundlePromotionFlow.test.tsx` and iterated until green; the updated test file passes.
- Ran the full frontend test suite with `pnpm --filter frontend test` and observed the frontend test run finish with all tests passing (`75 files, 717 tests` passed in the run executed during validation).
- No backend or OpenAPI changes were made, so no API contract tests were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74d83204483269ba6a8078175f060)