### PR TITLE
audit: complete bind_receipt_id query trace focus flow

### DIFF
--- a/frontend/app/audit/hooks/useAuditData.test.ts
+++ b/frontend/app/audit/hooks/useAuditData.test.ts
@@ -307,6 +307,47 @@ describe("useAuditData", () => {
       expect.any(Object),
     );
     expect(result.current.bindReceiptFoundInTimeline).toBe(true);
+    expect(result.current.filteredItems).toHaveLength(1);
+    expect(result.current.selected?.bind_receipt_id).toBe("br-001");
+    expect(result.current.detailTab).toBe("related");
+  });
+
+  it("includes bind receipt identifiers in cross-search all-field matching", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          items: [
+            {
+              ...MOCK_ITEMS[0],
+              bind_receipt_id: "br-direct",
+            },
+            {
+              ...MOCK_ITEMS[1],
+              bind_receipt: { bind_receipt_id: "br-nested" },
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
+        }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    act(() => {
+      result.current.setCrossSearch({ query: "br-direct", field: "all" });
+    });
+    expect(result.current.filteredItems).toHaveLength(1);
+    expect(result.current.filteredItems[0].bind_receipt_id).toBe("br-direct");
+
+    act(() => {
+      result.current.setCrossSearch({ query: "br-nested", field: "all" });
+    });
+    expect(result.current.filteredItems).toHaveLength(1);
+    expect(result.current.filteredItems[0].request_id).toBe("req-002");
   });
 
   it("handles invalid bind_receipt_id query param without fetch", async () => {

--- a/frontend/app/audit/hooks/useAuditData.ts
+++ b/frontend/app/audit/hooks/useAuditData.ts
@@ -202,6 +202,17 @@ export function useAuditData(): AuditDataState {
         item.decision_id,
         item.replay_id,
         item.policy_version,
+        item.bind_receipt_id,
+        item.metadata &&
+        typeof item.metadata === "object" &&
+        item.metadata !== null
+          ? (item.metadata as Record<string, unknown>).bind_receipt_id
+          : undefined,
+        item.bind_receipt &&
+        typeof item.bind_receipt === "object" &&
+        item.bind_receipt !== null
+          ? (item.bind_receipt as Record<string, unknown>).bind_receipt_id
+          : undefined,
       ]
         .map((v) => String(v ?? "").toLowerCase())
         .join(" ");

--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -347,4 +347,38 @@ describe("TrustLogExplorerPage", () => {
     expect(screen.getByText("チェーン")).toBeInTheDocument();
   });
 
+  it("consumes governance bind receipt query URL and shows trace focus status", async () => {
+    window.history.replaceState({}, "", "/audit?bind_receipt_id=br-001");
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ bind_receipt_id: "br-001" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: [
+            {
+              ...MOCK_ITEMS_CHAINED[0],
+              bind_receipt_id: "br-001",
+            },
+          ],
+          cursor: "0",
+          next_cursor: null,
+          limit: 50,
+          has_more: false,
+        }),
+      } as Response);
+
+    render(<TrustLogExplorerPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bind Receipt Trace")).toBeInTheDocument();
+      expect(screen.getByText("br-001")).toBeInTheDocument();
+      expect(screen.getByText("関連する監査ログをタイムラインで選択しました。")).toBeInTheDocument();
+    });
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Complete the operator trace path so `/audit?bind_receipt_id=...` reliably surfaces the target bind receipt in the existing Audit UI without touching backend/OpenAPI/runtime contracts.  
- The audit hook already bootstraps the query param and fetches the bind receipt but `field="all"` cross-search did not include bind receipt identifiers, reducing the likelihood of matching timeline entries.  
- Keep the change small and safe while preserving existing validation and UI patterns; note that tests uncovered existing React `act(...)` warnings unrelated to this feature.

### Description
- Include `bind_receipt_id` and nested `metadata.bind_receipt_id` and `bind_receipt.bind_receipt_id` in the `all` cross-search haystack inside `useAuditData` so query-driven focus can match timeline entries.  
- Ensure the existing query-bootstrapping flow still sets `bindReceiptIdFromQuery`, triggers bind-receipt fetch, reloads trust logs, and focuses the matching timeline entry (existing behavior preserved, tests assert focus and `detailTab` set to `related`).  
- Add/extend unit and page tests to cover: query-param bootstrap + focus behavior, `all`-field matching for top-level and nested bind receipt identifiers, and a Governance-style URL consumption on the Audit page.  
- Files changed: `frontend/app/audit/hooks/useAuditData.ts`, `frontend/app/audit/hooks/useAuditData.test.ts`, and `frontend/app/audit/page.test.tsx`.

### Testing
- Ran the targeted frontend tests with `pnpm vitest run app/audit/hooks/useAuditData.test.ts app/audit/page.test.tsx`, and both test files passed.  
- New/updated tests exercised: `loads bind receipt from query param and then loads trust logs` (now asserts `filteredItems`, `selected.bind_receipt_id`, and `detailTab`), `includes bind receipt identifiers in cross-search all-field matching`, and `consumes governance bind receipt query URL and shows trace focus status`.  
- Test run completed successfully but emitted pre-existing React `act(...)` warnings from async hook tests; these are warnings (not failures) and are out of scope for this small PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e776762a388326a728aab6936424ab)