### PR TITLE
audit: show compact bind receipt fallback details in Bind Receipt Trace card

### DIFF
--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -379,6 +379,57 @@ describe("TrustLogExplorerPage", () => {
       expect(screen.getByText("br-001")).toBeInTheDocument();
       expect(screen.getByText("関連する監査ログをタイムラインで選択しました。")).toBeInTheDocument();
     });
+    expect(screen.queryByText("Bind check summary")).not.toBeInTheDocument();
+  });
+
+  it("renders compact bind receipt fallback detail when timeline misses the receipt", async () => {
+    window.history.replaceState({}, "", "/audit?bind_receipt_id=br-001");
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          bind_receipt_id: "br-001",
+          execution_intent_id: "exec-001",
+          final_outcome: "BLOCKED",
+          bind_failure_reason: "policy_denied",
+          authority_check_result: { passed: true },
+          constraint_check_result: { passed: false },
+          drift_check_result: { result: "warn" },
+          risk_check_result: null,
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: MOCK_ITEMS_CHAINED,
+          cursor: "0",
+          next_cursor: null,
+          limit: 50,
+          has_more: false,
+        }),
+      } as Response);
+
+    render(<TrustLogExplorerPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bind Receipt Trace")).toBeInTheDocument();
+      expect(screen.getByText("Bind check summary")).toBeInTheDocument();
+      expect(screen.getByText("bindFailureReason")).toBeInTheDocument();
+      expect(screen.getByText("policy_denied")).toBeInTheDocument();
+      expect(screen.getByText("execution_intent_id")).toBeInTheDocument();
+      expect(screen.getByText("exec-001")).toBeInTheDocument();
+      expect(screen.getByText("BLOCKED")).toBeInTheDocument();
+      expect(screen.getByText("authorityCheckResult")).toBeInTheDocument();
+      expect(screen.getByText("PASS")).toBeInTheDocument();
+      expect(screen.getByText("FAIL")).toBeInTheDocument();
+      expect(screen.getByText("WARN")).toBeInTheDocument();
+      expect(screen.getByText("Raw fallback detail")).toBeInTheDocument();
+      expect(
+        screen.getByText("bind receipt は取得済みですが、現在読み込まれているタイムラインには未表示です。"),
+      ).toBeInTheDocument();
+    });
   });
 
 });

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -2,7 +2,7 @@
 
 import { Card } from "@veritas/design-system";
 import { useI18n } from "../../components/i18n-provider";
-import { ErrorBanner } from "../../components/ui";
+import { ErrorBanner, StatusBadge } from "../../components/ui";
 import { classifyChain } from "./audit-types";
 import { useAuditData } from "./hooks/useAuditData";
 import { SearchPanel } from "./components/SearchPanel";
@@ -19,6 +19,31 @@ import { ExportPanel } from "./components/ExportPanel";
 export default function TrustLogExplorerPage(): JSX.Element {
   const { t } = useI18n();
   const data = useAuditData();
+
+  const summarizeBindCheck = (value: Record<string, unknown> | null): string => {
+    if (!value) return "-";
+    if (typeof value.passed === "boolean") {
+      return value.passed ? "PASS" : "FAIL";
+    }
+    if (typeof value.result === "string" && value.result.trim().length > 0) {
+      return value.result.trim().toUpperCase();
+    }
+    return "UNKNOWN";
+  };
+
+  const resolveOutcomeVariant = (
+    outcome: string | null,
+  ): "success" | "warning" | "danger" | "muted" => {
+    const normalized = outcome?.trim().toUpperCase() ?? "";
+    if (normalized === "COMMITTED" || normalized === "SUCCESS") return "success";
+    if (normalized === "BLOCKED" || normalized === "ROLLED_BACK" || normalized === "PRECONDITION_FAILED") {
+      return "warning";
+    }
+    if (normalized === "ESCALATED" || normalized === "APPLY_FAILED" || normalized === "SNAPSHOT_FAILED") {
+      return "danger";
+    }
+    return "muted";
+  };
 
   const verifySelectedDecision = (): void => {
     if (!data.selectedDecisionEntry) {
@@ -132,34 +157,46 @@ export default function TrustLogExplorerPage(): JSX.Element {
                   <dt>execution_intent_id</dt>
                   <dd className="font-mono">{data.bindReceiptLookupDetail.executionIntentId ?? "-"}</dd>
                   <dt>final_outcome</dt>
-                  <dd>{data.bindReceiptLookupDetail.finalOutcome ?? "-"}</dd>
-                  <dt>bind_failure_reason</dt>
+                  <dd>
+                    {data.bindReceiptLookupDetail.finalOutcome ? (
+                      <StatusBadge
+                        label={data.bindReceiptLookupDetail.finalOutcome}
+                        variant={resolveOutcomeVariant(data.bindReceiptLookupDetail.finalOutcome)}
+                      />
+                    ) : (
+                      "-"
+                    )}
+                  </dd>
+                  <dt>bindFailureReason</dt>
                   <dd>{data.bindReceiptLookupDetail.bindFailureReason ?? "-"}</dd>
-                  <dt>authority_check_result</dt>
-                  <dd className="font-mono">
-                    {data.bindReceiptLookupDetail.authorityCheckResult
-                      ? JSON.stringify(data.bindReceiptLookupDetail.authorityCheckResult)
-                      : "-"}
-                  </dd>
-                  <dt>constraint_check_result</dt>
-                  <dd className="font-mono">
-                    {data.bindReceiptLookupDetail.constraintCheckResult
-                      ? JSON.stringify(data.bindReceiptLookupDetail.constraintCheckResult)
-                      : "-"}
-                  </dd>
-                  <dt>drift_check_result</dt>
-                  <dd className="font-mono">
-                    {data.bindReceiptLookupDetail.driftCheckResult
-                      ? JSON.stringify(data.bindReceiptLookupDetail.driftCheckResult)
-                      : "-"}
-                  </dd>
-                  <dt>risk_check_result</dt>
-                  <dd className="font-mono">
-                    {data.bindReceiptLookupDetail.riskCheckResult
-                      ? JSON.stringify(data.bindReceiptLookupDetail.riskCheckResult)
-                      : "-"}
-                  </dd>
                 </dl>
+                <div className="mt-2 rounded border border-border/70 bg-background/60 px-2 py-1.5">
+                  <p className="font-semibold text-muted-foreground">Bind check summary</p>
+                  <dl className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                    <dt>authorityCheckResult</dt>
+                    <dd className="font-mono">
+                      {summarizeBindCheck(data.bindReceiptLookupDetail.authorityCheckResult)}
+                    </dd>
+                    <dt>constraintCheckResult</dt>
+                    <dd className="font-mono">
+                      {summarizeBindCheck(data.bindReceiptLookupDetail.constraintCheckResult)}
+                    </dd>
+                    <dt>driftCheckResult</dt>
+                    <dd className="font-mono">
+                      {summarizeBindCheck(data.bindReceiptLookupDetail.driftCheckResult)}
+                    </dd>
+                    <dt>riskCheckResult</dt>
+                    <dd className="font-mono">
+                      {summarizeBindCheck(data.bindReceiptLookupDetail.riskCheckResult)}
+                    </dd>
+                  </dl>
+                </div>
+                <details className="mt-2">
+                  <summary className="cursor-pointer text-muted-foreground">Raw fallback detail</summary>
+                  <pre className="mt-1 max-h-64 overflow-auto rounded border border-border/60 bg-background/70 p-2 font-mono text-[10px]">
+                    {JSON.stringify(data.bindReceiptLookupDetail, null, 2)}
+                  </pre>
+                </details>
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
### Motivation
- Ensure operators can read a compact bind receipt summary when a timeline-miss occurs without changing hook/backend responsibilities or redesigning the Audit page.
- Make the fallback display more actionable by surfacing key receipt fields and a one-line summary of bind checks instead of raw JSON dumps.

### Description
- Add a small local helper `summarizeBindCheck` and `resolveOutcomeVariant` in `frontend/app/audit/page.tsx` to produce compact one-line summaries for bind checks and map `final_outcome` to `StatusBadge` variants.  
- Import and reuse existing `StatusBadge` from the design system to highlight `final_outcome` consistently.  
- Extend the existing `Bind Receipt Trace` card (no new card) to render the compact fallback section only when `data.showBindReceiptFallback && data.bindReceiptLookupDetail` and show `bind_receipt_id`, `execution_intent_id`, `final_outcome`, and `bindFailureReason`.  
- Show a concise bind-check summary for `authorityCheckResult`, `constraintCheckResult`, `driftCheckResult`, and `riskCheckResult`, and keep an optional `<details>` block with raw JSON for deep inspection.

### Testing
- Updated `frontend/app/audit/page.test.tsx` to (1) assert the compact fallback is not shown on timeline hit, and (2) assert the compact fallback and its fields/summaries/raw `<details>` are rendered when timeline misses.  
- Ran `pnpm --filter frontend test -- audit/page.test.tsx` (and the frontend test run observed in CI for the workspace); the updated tests passed locally (frontend tests reported green).
- No backend/OpenAPI/hook contract changes were made and existing behaviors for loading, hit/miss messaging, errors and timeline focus were preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79ff0bae48326a631687e0045fc71)