### PR TITLE
Bind-enable governance policy PUT path with execution lineage

### DIFF
--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -108,6 +108,19 @@ def _bind_response_payload(bind_receipt: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _resolve_bind_failure_status_code(bind_receipt: Dict[str, Any]) -> int:
+    """Map bind outcome classes to legacy-compatible HTTP failure status codes."""
+    outcome = str(bind_receipt.get("final_outcome") or "")
+    if outcome in {
+        FinalOutcome.PRECONDITION_FAILED.value,
+        FinalOutcome.APPLY_FAILED.value,
+    }:
+        return 400
+    if outcome in {FinalOutcome.BLOCKED.value, FinalOutcome.ESCALATED.value}:
+        return 403
+    return 500
+
+
 # ------------------------------------------------------------------
 # RBAC helpers
 # ------------------------------------------------------------------
@@ -255,7 +268,7 @@ def governance_put(body: dict):
         bind_payload = _bind_response_payload(bind_receipt)
         if bind_receipt.get("final_outcome") != FinalOutcome.COMMITTED.value:
             return JSONResponse(
-                status_code=500,
+                status_code=_resolve_bind_failure_status_code(bind_receipt),
                 content={
                     "ok": False,
                     "error": "Failed to update governance policy",

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -6,6 +6,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Annotated, Any, Dict, Optional
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -22,7 +23,9 @@ from veritas_os.api.schemas import (
     GovernancePolicyHistoryResponse,
 )
 from veritas_os.policy.bind_artifacts import FinalOutcome, find_bind_receipts
+from veritas_os.policy.governance_policy_update import update_governance_policy_with_bind_boundary
 from veritas_os.policy.policy_bundle_promotion import promote_policy_bundle_with_bind_boundary
+from veritas_os.security.hash import sha256_of_canonical_json
 
 # Governance functions accessed via _get_server() for test monkeypatching compat
 
@@ -227,13 +230,45 @@ def governance_put(body: dict):
     try:
         srv.enforce_four_eyes_approval(body)
         previous = srv.get_policy()
-        updated = srv.update_policy(body)
+        decision_id = str(body.get("decision_id") or uuid4().hex)
+        request_id = str(body.get("request_id") or decision_id)
+        policy_snapshot_id = str(previous.get("updated_at") or previous.get("version") or "governance_policy")
+        bind_receipt = update_governance_policy_with_bind_boundary(
+            decision_id=decision_id,
+            request_id=request_id,
+            actor_identity=str(body.get("updated_by") or "api"),
+            policy_snapshot_id=policy_snapshot_id,
+            decision_hash=sha256_of_canonical_json(body),
+            policy_patch=body,
+            policy_reader=srv.get_policy,
+            policy_updater=srv.update_policy,
+            policy_rollback=getattr(srv, "rollback_policy", None),
+            approval_context={"governance_policy_update_approved": True},
+            approval_records=body.get("approvals") if isinstance(body.get("approvals"), list) else None,
+            policy_lineage=body.get("policy_lineage")
+            if isinstance(body.get("policy_lineage"), dict)
+            else None,
+            execution_intent_id=str(body.get("execution_intent_id") or "") or None,
+            bind_receipt_id=str(body.get("bind_receipt_id") or "") or None,
+        ).to_dict()
+        updated = srv.get_policy()
+        bind_payload = _bind_response_payload(bind_receipt)
+        if bind_receipt.get("final_outcome") != FinalOutcome.COMMITTED.value:
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "ok": False,
+                    "error": "Failed to update governance policy",
+                    "policy": updated,
+                    **bind_payload,
+                },
+            )
         srv._publish_event(
             "governance.updated",
             {"updated_by": updated.get("updated_by", "api")},
         )
         _emit_governance_change_alert(previous=previous, updated=updated)
-        return {"ok": True, "policy": updated}
+        return {"ok": True, "policy": updated, **bind_payload}
     except PermissionError as e:
         logger.warning("governance_put rejected: %s", e)
         return JSONResponse(

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1301,6 +1301,12 @@ class GovernancePolicyResponse(BaseModel):
 
     ok: bool = True
     policy: Optional[Dict[str, Any]] = None
+    bind_receipt: Optional[BindReceipt] = None
+    bind_outcome: Optional[FinalOutcome] = None
+    bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    bind_receipt_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    execution_intent_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
     error: Optional[str] = None
 
 

--- a/veritas_os/policy/bind_boundary_adapters.py
+++ b/veritas_os/policy/bind_boundary_adapters.py
@@ -143,6 +143,7 @@ def _governance_effective_patch(policy_patch: dict[str, Any]) -> dict[str, Any]:
     """Filter transient governance request metadata from postcondition checks."""
     ignored_fields = {
         "approvals",
+        "approval",
         "_event_type",
         "policy_lineage",
         "execution_intent_id",

--- a/veritas_os/policy/bind_boundary_adapters.py
+++ b/veritas_os/policy/bind_boundary_adapters.py
@@ -9,12 +9,148 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from veritas_os.core.atomic_io import atomic_write_json
 from veritas_os.policy.bind_artifacts import ExecutionIntent
 from veritas_os.policy.bind_core.contracts import BindAdapterContract
 from veritas_os.security.hash import sha256_of_canonical_json
+
+
+@dataclass
+class GovernancePolicyUpdateAdapter(BindAdapterContract):
+    """Bind adapter for governed policy update execution.
+
+    The adapter wraps the existing governance policy update and rollback paths,
+    preserving four-eyes approval and policy history semantics while exposing
+    deterministic bind-boundary snapshots.
+    """
+
+    policy_reader: Callable[[], dict[str, Any]]
+    policy_updater: Callable[[dict[str, Any]], dict[str, Any]]
+    policy_patch: dict[str, Any]
+    policy_rollback: Callable[..., dict[str, Any]] | None = None
+    revert_actor: str = "bind_boundary"
+    approval_records: list[dict[str, Any]] | None = None
+    target_description: str = "governance/policy"
+
+    def __post_init__(self) -> None:
+        self._last_updated_policy: dict[str, Any] | None = None
+        self._effective_patch = _governance_effective_patch(self.policy_patch)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Capture deterministic policy snapshot."""
+        return {"policy": self.policy_reader()}
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        """Return deterministic fingerprint for policy snapshot."""
+        if not isinstance(snapshot, dict):
+            raise ValueError("BIND_STATE_SNAPSHOT_INVALID")
+        policy = snapshot.get("policy")
+        if not isinstance(policy, dict):
+            raise ValueError("BIND_POLICY_SNAPSHOT_INVALID")
+        return sha256_of_canonical_json(policy)
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        """Require explicit authority flag in bind approval context."""
+        del snapshot
+        if not isinstance(intent.approval_context, dict):
+            return False
+        return bool(intent.approval_context.get("governance_policy_update_approved"))
+
+    def validate_constraints(
+        self,
+        intent: ExecutionIntent,
+        snapshot: Any,
+    ) -> dict[str, bool] | None:
+        """Validate deterministic local constraints for policy patch."""
+        del intent
+        policy = snapshot.get("policy") if isinstance(snapshot, dict) else None
+        return {
+            "patch_is_dict": isinstance(self._effective_patch, dict),
+            "snapshot_has_policy": isinstance(policy, dict),
+        }
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        """Assess runtime risk for in-process governed policy update."""
+        del intent, snapshot
+        return True
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Apply governed policy patch via existing update path."""
+        del intent, snapshot
+        updated = self.policy_updater(self.policy_patch)
+        if not isinstance(updated, dict):
+            raise ValueError("BIND_POLICY_UPDATE_INVALID")
+        self._last_updated_policy = updated
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Verify that patched fields are reflected in the persisted policy."""
+        del intent
+        if not isinstance(snapshot, dict) or not isinstance(snapshot.get("policy"), dict):
+            return False
+
+        latest = self._last_updated_policy if isinstance(self._last_updated_policy, dict) else self.policy_reader()
+        if not isinstance(latest, dict):
+            return False
+        return _dict_contains_patch(latest, self._effective_patch)
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Revert failed apply by restoring pre-apply policy snapshot."""
+        del intent
+        if not isinstance(snapshot, dict):
+            return False
+        previous_policy = snapshot.get("policy")
+        if not isinstance(previous_policy, dict):
+            return False
+
+        if callable(self.policy_rollback):
+            self.policy_rollback(
+                previous_policy,
+                rolled_back_by=self.revert_actor,
+                approvals=self.approval_records,
+                reason="bind_postcondition_failure_revert",
+            )
+            return True
+
+        self.policy_updater(previous_policy)
+        return True
+
+    def describe_target(self) -> str:
+        """Return human-readable target descriptor."""
+        return self.target_description
+
+
+def _dict_contains_patch(target: dict[str, Any], patch: dict[str, Any]) -> bool:
+    """Return True when ``target`` recursively includes all ``patch`` values."""
+    for key, expected in patch.items():
+        if key not in target:
+            return False
+        actual = target[key]
+        if isinstance(expected, dict):
+            if not isinstance(actual, dict):
+                return False
+            if not _dict_contains_patch(actual, expected):
+                return False
+            continue
+        if actual != expected:
+            return False
+    return True
+
+
+def _governance_effective_patch(policy_patch: dict[str, Any]) -> dict[str, Any]:
+    """Filter transient governance request metadata from postcondition checks."""
+    ignored_fields = {
+        "approvals",
+        "_event_type",
+        "policy_lineage",
+        "execution_intent_id",
+        "bind_receipt_id",
+        "decision_id",
+        "request_id",
+    }
+    return {key: value for key, value in policy_patch.items() if key not in ignored_fields}
 
 
 @dataclass

--- a/veritas_os/policy/governance_policy_update.py
+++ b/veritas_os/policy/governance_policy_update.py
@@ -1,0 +1,80 @@
+"""Bind-controlled governance policy update helpers.
+
+This module wires the existing governance policy update path through
+bind-boundary adjudication without altering legacy policy repository behavior.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+from uuid import uuid4
+
+from veritas_os.policy.bind_artifacts import BindReceipt, ExecutionIntent
+from veritas_os.policy.bind_boundary_adapters import GovernancePolicyUpdateAdapter
+from veritas_os.policy.bind_core import execute_bind_adjudication
+
+
+def update_governance_policy_with_bind_boundary(
+    *,
+    decision_id: str,
+    request_id: str,
+    actor_identity: str,
+    policy_snapshot_id: str,
+    decision_hash: str,
+    policy_patch: dict[str, Any],
+    policy_reader: Callable[[], dict[str, Any]],
+    policy_updater: Callable[[dict[str, Any]], dict[str, Any]],
+    policy_rollback: Callable[..., dict[str, Any]] | None = None,
+    approval_context: dict[str, Any] | None = None,
+    policy_lineage: dict[str, Any] | None = None,
+    approval_records: list[dict[str, Any]] | None = None,
+    decision_ts: str | None = None,
+    append_trustlog: bool = True,
+    bind_ts: str | None = None,
+    execution_intent_id: str | None = None,
+    bind_receipt_id: str | None = None,
+) -> BindReceipt:
+    """Apply governance policy patch through bind-boundary adjudication."""
+    adapter = GovernancePolicyUpdateAdapter(
+        policy_reader=policy_reader,
+        policy_updater=policy_updater,
+        policy_patch=dict(policy_patch),
+        policy_rollback=policy_rollback,
+        approval_records=approval_records,
+    )
+
+    pre_snapshot = adapter.snapshot()
+    expected_fingerprint = adapter.fingerprint_state(pre_snapshot)
+
+    merged_approval_context: dict[str, Any] = dict(approval_context or {})
+    merged_approval_context.setdefault("governance_policy_update_approved", True)
+
+    intent = ExecutionIntent(
+        execution_intent_id=execution_intent_id or uuid4().hex,
+        decision_id=decision_id,
+        request_id=request_id,
+        policy_snapshot_id=policy_snapshot_id,
+        actor_identity=actor_identity,
+        target_system="governance",
+        target_resource="governance/policy",
+        intended_action="update_governance_policy",
+        decision_hash=decision_hash,
+        decision_ts=decision_ts or _utc_now_iso8601(),
+        expected_state_fingerprint=expected_fingerprint,
+        approval_context=merged_approval_context,
+        policy_lineage=dict(policy_lineage or {}),
+    )
+
+    return execute_bind_adjudication(
+        execution_intent=intent,
+        adapter=adapter,
+        bind_ts=bind_ts,
+        bind_receipt_id=bind_receipt_id,
+        append_trustlog=append_trustlog,
+    )
+
+
+def _utc_now_iso8601() -> str:
+    """Return current UTC timestamp in canonical bind intent format."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -23,6 +23,7 @@ from pydantic import ValidationError
 
 from veritas_os.api import governance as gov_mod
 from veritas_os.api import server as srv
+from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome
 
 client = TestClient(srv.app)
 HEADERS = {"X-API-Key": "test-governance-key", "X-Role": "admin"}
@@ -185,6 +186,41 @@ class TestPutPolicy:
         )
         resp = client.get("/v1/governance/policy", headers=HEADERS)
         assert resp.json()["policy"]["risk_thresholds"]["warn_upper"] == 0.55
+
+    def test_put_returns_bind_lineage_fields(self):
+        resp = client.put(
+            "/v1/governance/policy",
+            headers=HEADERS,
+            json=_approved({"fuji_rules": {"pii_check": False}}),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["bind_outcome"] == "COMMITTED"
+        assert body["bind_receipt_id"]
+        assert body["execution_intent_id"]
+        assert body["bind_receipt"]["final_outcome"] == "COMMITTED"
+
+    def test_put_preserves_backward_compatible_response_shape(self, monkeypatch):
+        monkeypatch.setattr(
+            "veritas_os.api.routes_governance.update_governance_policy_with_bind_boundary",
+            lambda **_kwargs: BindReceipt(
+                bind_receipt_id="br-gov-backward",
+                execution_intent_id="ei-gov-backward",
+                decision_id="dec-gov-backward",
+                final_outcome=FinalOutcome.COMMITTED,
+            ),
+        )
+        resp = client.put(
+            "/v1/governance/policy",
+            headers=HEADERS,
+            json=_approved({"fuji_rules": {"pii_check": False}}),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert "policy" in body
+        assert "fuji_rules" in body["policy"]
 
 
 class TestGovernanceModule:

--- a/veritas_os/tests/test_governance_policy_bind_path.py
+++ b/veritas_os/tests/test_governance_policy_bind_path.py
@@ -1,0 +1,168 @@
+"""Tests for bind-controlled governance policy update integration path."""
+
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.logging.encryption import generate_key
+from veritas_os.policy.bind_artifacts import FinalOutcome, find_bind_receipts
+from veritas_os.policy.bind_boundary_adapters import GovernancePolicyUpdateAdapter
+from veritas_os.policy.governance_policy_update import update_governance_policy_with_bind_boundary
+
+
+@pytest.fixture()
+def trustlog_env(tmp_path, monkeypatch):
+    """Redirect TrustLog writes to a temporary log path."""
+    from veritas_os.logging import trust_log
+
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    monkeypatch.setattr(trust_log, "LOG_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSON", tmp_path / "trust_log.json", raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSONL", tmp_path / "trust_log.jsonl", raising=False)
+    monkeypatch.setattr(trust_log, "_append_stats", {"success": 0, "failure": 0}, raising=False)
+
+    def _open_for_append():
+        trust_log.LOG_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        return open(trust_log.LOG_JSONL, "a", encoding="utf-8")
+
+    monkeypatch.setattr(trust_log, "open_trust_log_for_append", _open_for_append)
+    return tmp_path
+
+
+def _policy_store() -> tuple[dict[str, object], list[dict[str, object]]]:
+    state = {
+        "version": "1",
+        "updated_at": "2026-04-20T12:00:00Z",
+        "updated_by": "api",
+        "fuji_rules": {"pii_check": True, "self_harm_block": True},
+    }
+    history: list[dict[str, object]] = []
+    return state, history
+
+
+def _reader_factory(state: dict[str, object]):
+    return lambda: dict(state)
+
+
+def _updater_factory(state: dict[str, object], history: list[dict[str, object]]):
+    def _update(patch: dict[str, object]) -> dict[str, object]:
+        for key, value in patch.items():
+            if isinstance(value, dict) and isinstance(state.get(key), dict):
+                merged = dict(state[key])
+                merged.update(value)
+                state[key] = merged
+            else:
+                state[key] = value
+        history.append(dict(state))
+        return dict(state)
+
+    return _update
+
+
+def _rollback_factory(state: dict[str, object], history: list[dict[str, object]]):
+    def _rollback(target_policy: dict[str, object], **_kwargs) -> dict[str, object]:
+        state.clear()
+        state.update(target_policy)
+        history.append(dict(state))
+        return dict(state)
+
+    return _rollback
+
+
+def _execute(**overrides):
+    state, history = _policy_store()
+    kwargs = {
+        "decision_id": "dec-gov-1",
+        "request_id": "req-gov-1",
+        "actor_identity": "operator",
+        "policy_snapshot_id": "policy-v1",
+        "decision_hash": "h" * 64,
+        "policy_patch": {"fuji_rules": {"pii_check": False}},
+        "policy_reader": _reader_factory(state),
+        "policy_updater": _updater_factory(state, history),
+        "policy_rollback": _rollback_factory(state, history),
+        "append_trustlog": False,
+    }
+    kwargs.update(overrides)
+    return update_governance_policy_with_bind_boundary(**kwargs), state, history
+
+
+def test_governance_policy_update_bind_committed() -> None:
+    receipt, state, history = _execute()
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert state["fuji_rules"]["pii_check"] is False
+    assert history
+
+
+def test_governance_policy_update_bind_blocked() -> None:
+    receipt, state, _history = _execute(
+        approval_context={"governance_policy_update_approved": False}
+    )
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert state["fuji_rules"]["pii_check"] is True
+
+
+def test_governance_policy_update_bind_escalated_when_signal_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        GovernancePolicyUpdateAdapter,
+        "assess_runtime_risk",
+        lambda self, intent, snapshot: None,
+    )
+    receipt, _state, _history = _execute(
+        policy_lineage={"bind_adjudication": {"missing_signal_default": "escalate"}}
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+
+
+def test_governance_policy_update_bind_rolled_back_on_postcondition_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        GovernancePolicyUpdateAdapter,
+        "verify_postconditions",
+        lambda self, intent, snapshot: False,
+    )
+    receipt, state, history = _execute()
+    assert receipt.final_outcome is FinalOutcome.ROLLED_BACK
+    assert state["fuji_rules"]["pii_check"] is True
+    assert len(history) >= 2
+
+
+def test_governance_policy_update_bind_precondition_failed() -> None:
+    receipt, _state, _history = _execute(decision_id="")
+    assert receipt.final_outcome is FinalOutcome.PRECONDITION_FAILED
+
+
+def test_governance_policy_update_bind_persists_receipt_lineage(trustlog_env) -> None:
+    receipt, _state, _history = _execute(
+        decision_id="dec-gov-persist",
+        request_id="req-gov-persist",
+        execution_intent_id="ei-gov-persist",
+        bind_receipt_id="br-gov-persist",
+        append_trustlog=True,
+    )
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+
+    by_decision = find_bind_receipts(decision_id="dec-gov-persist")
+    by_intent = find_bind_receipts(execution_intent_id="ei-gov-persist")
+    by_receipt = find_bind_receipts(bind_receipt_id="br-gov-persist")
+
+    assert len(by_decision) == 1
+    assert len(by_intent) == 1
+    assert len(by_receipt) == 1
+    assert by_receipt[0].bind_receipt_id == "br-gov-persist"
+
+
+def test_governance_policy_update_bind_backward_compatible_execute_call() -> None:
+    state, history = _policy_store()
+    receipt = update_governance_policy_with_bind_boundary(
+        decision_id="dec-gov-legacy",
+        request_id="req-gov-legacy",
+        actor_identity="legacy",
+        policy_snapshot_id="policy-v1",
+        decision_hash="h" * 64,
+        policy_patch={"fuji_rules": {"pii_check": False}},
+        policy_reader=_reader_factory(state),
+        policy_updater=_updater_factory(state, history),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert state["fuji_rules"]["pii_check"] is False


### PR DESCRIPTION
### Motivation
- Apply the reusable bind framework introduced in PR1 to a second real effect path so bind boundaries become a standard execution pattern rather than a special-case (target: `PUT /v1/governance/policy`).
- Preserve existing approval / history semantics while attaching `execution_intent` → bind adjudication → `bind_receipt` lineage to governance policy updates.
- Expose bind lineage to callers in an additive, backward-compatible way so operators and audit tooling can consume the same vocabulary across paths.

### Description
- Wire `PUT /v1/governance/policy` to build a `decision_id/request_id` and `ExecutionIntent`, then route through the bind flow via the new helper `update_governance_policy_with_bind_boundary` which calls `execute_bind_adjudication` and returns a `BindReceipt` (changes in `veritas_os/api/routes_governance.py`).
- Add `GovernancePolicyUpdateAdapter` implementing the bind adapter contract (snapshot/fingerprint/authority/constraints/apply/verify/revert) and filter transient request metadata from postcondition checks (added to `veritas_os/policy/bind_boundary_adapters.py`).
- Introduce `veritas_os/policy/governance_policy_update.py` with `update_governance_policy_with_bind_boundary` helper that reuses existing `policy_reader`, `policy_updater`, and optional `policy_rollback` to preserve persistence and history behavior.
- Add additive response/schema fields to surface lineage (`bind_receipt`, `bind_outcome`, `bind_receipt_id`, `execution_intent_id`, `bind_failure_reason`, `bind_reason_code`) in `GovernancePolicyResponse` so existing clients remain compatible (`veritas_os/api/schemas.py`).
- Add focused tests exercising the new path and semantics in `veritas_os/tests/test_governance_policy_bind_path.py` and extend route-level integration tests in `veritas_os/tests/integration/test_governance_api.py` with backward-compatibility checks.
- Note: `decision_hash` is computed as `sha256_of_canonical_json(body)` for lineage stability; consider removing or redacting sensitive fields (e.g. approval signatures) from the hash if that is undesired for your operational privacy model. This is a security consideration rather than a breaking change.

### Testing
- Ran the new unit/integration tests: `veritas_os/tests/test_governance_policy_bind_path.py` and the modified `TestPutPolicy` cases in `veritas_os/tests/integration/test_governance_api.py`, and they passed (`9 passed` for the focused subset then full run below).
- Ran OpenAPI / schema checks: `veritas_os/tests/test_openapi_spec.py::test_openapi_yaml_is_parseable` and `::test_openapi_includes_runtime_audit_and_governance_routes`, and they passed.
- Full targeted verification combining the updated governance tests succeeded: `21 passed` (all invoked tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84844b4b08326b11ed945f947cfde)