### PR TITLE
Expose minimal bind_adjudication policy surface and wire into runtime

### DIFF
--- a/docs/en/governance/governance-artifact-lifecycle.md
+++ b/docs/en/governance/governance-artifact-lifecycle.md
@@ -37,6 +37,16 @@ A governance policy change is proposed via `PUT /v1/governance/policy`.
 The proposer identity is captured in the `updated_by` field and recorded
 in the audit history as `proposer`.
 
+When bind adjudication behavior needs an operator-level change, use the
+`bind_adjudication` section in the same policy document. The runtime currently
+consumes only these fields:
+
+- `missing_signal_default` (`block` or `escalate`)
+- `drift_required`
+- `ttl_required`
+- `approval_freshness_required`
+- `rollback_on_apply_failure`
+
 ### 2. Approve (4-Eyes)
 
 By default, governance updates require two distinct approvals (4-eyes

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -629,6 +629,26 @@ components:
           default: 0.5
           minimum: 0
           maximum: 1
+    BindAdjudicationPolicyConfig:
+      type: object
+      description: "Bind adjudication runtime controls."
+      properties:
+        missing_signal_default:
+          type: string
+          enum: ["block", "escalate"]
+          default: "block"
+        drift_required:
+          type: boolean
+          default: true
+        ttl_required:
+          type: boolean
+          default: false
+        approval_freshness_required:
+          type: boolean
+          default: false
+        rollback_on_apply_failure:
+          type: boolean
+          default: false
 
     GovernancePolicy:
       type: object
@@ -659,6 +679,8 @@ components:
           $ref: '#/components/schemas/RevocationConfig'
         drift_scoring:
           $ref: '#/components/schemas/DriftScoringConfig'
+        bind_adjudication:
+          $ref: '#/components/schemas/BindAdjudicationPolicyConfig'
         updated_at:
           type: string
           format: date-time

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -153,6 +153,16 @@ class DriftScoringConfig(BaseModel):
     critical_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
 
 
+class BindAdjudicationPolicyConfig(BaseModel):
+    """Runtime bind-adjudication controls used by bind core/adapters."""
+
+    missing_signal_default: Literal["block", "escalate"] = "block"
+    drift_required: bool = True
+    ttl_required: bool = False
+    approval_freshness_required: bool = False
+    rollback_on_apply_failure: bool = False
+
+
 class GovernancePolicy(BaseModel):
     version: str = "governance_v1"
     fuji_rules: FujiRules = Field(default_factory=FujiRules)
@@ -166,6 +176,7 @@ class GovernancePolicy(BaseModel):
     shadow_validation: ShadowValidationConfig = Field(default_factory=ShadowValidationConfig)
     revocation: RevocationConfig = Field(default_factory=RevocationConfig)
     drift_scoring: DriftScoringConfig = Field(default_factory=DriftScoringConfig)
+    bind_adjudication: BindAdjudicationPolicyConfig = Field(default_factory=BindAdjudicationPolicyConfig)
     updated_at: str = ""
     updated_by: str = "system"
 
@@ -182,6 +193,7 @@ _NESTED_POLICY_MODELS = {
     "shadow_validation": ShadowValidationConfig,
     "revocation": RevocationConfig,
     "drift_scoring": DriftScoringConfig,
+    "bind_adjudication": BindAdjudicationPolicyConfig,
 }
 
 

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -279,6 +279,7 @@ def governance_put(body: dict):
             policy_lineage=body.get("policy_lineage")
             if isinstance(body.get("policy_lineage"), dict)
             else None,
+            governance_policy=previous if isinstance(previous, dict) else None,
             execution_intent_id=str(body.get("execution_intent_id") or "") or None,
             bind_receipt_id=str(body.get("bind_receipt_id") or "") or None,
         ).to_dict()
@@ -476,6 +477,7 @@ def governance_promote_policy_bundle(
         return JSONResponse(status_code=400, content={"ok": False, "error": "invalid_bundle_id"})
 
     try:
+        current_policy = _get_server().get_policy()
         receipt = promote_policy_bundle_with_bind_boundary(
             decision_id=body.decision_id,
             request_id=body.request_id,
@@ -486,6 +488,7 @@ def governance_promote_policy_bundle(
             pointer_path=pointer_path,
             allowed_root=bundles_root,
             approval_context=dict(body.approval_context or {}),
+            governance_policy=current_policy if isinstance(current_policy, dict) else None,
         )
         return _bind_response_payload(receipt.to_dict())
     except (ValueError, TypeError) as exc:

--- a/veritas_os/policy/bind_core/core.py
+++ b/veritas_os/policy/bind_core/core.py
@@ -123,6 +123,7 @@ class BindPolicyConfig:
     drift_required: bool = True
     ttl_required: bool = False
     approval_freshness_required: bool = False
+    rollback_on_apply_failure: bool = False
     missing_signal_outcome: AdmissibilityOutcome = AdmissibilityOutcome.BLOCK
 
 
@@ -258,6 +259,24 @@ def execute_bind_adjudication(
     try:
         adapter.apply(normalized_intent, pre_snapshot)
     except (OSError, TypeError, ValueError, RuntimeError) as exc:
+        if bind_policy.rollback_on_apply_failure:
+            return _finalize_receipt(
+                execution_intent=normalized_intent,
+                append_trustlog=append_trustlog,
+                receipt=_rollback_after_apply_failure(
+                    base_receipt=base_receipt,
+                    adapter=adapter,
+                    execution_intent=normalized_intent,
+                    pre_snapshot=pre_snapshot,
+                    pre_fingerprint=pre_fingerprint,
+                    authority_result=authority_result,
+                    constraint_result=constraint_result,
+                    drift_result=drift_result,
+                    risk_result=risk_result,
+                    recommended_outcome=admissibility.recommended_outcome.value,
+                    apply_error=exc,
+                ),
+            )
         return _finalize_receipt(
             execution_intent=normalized_intent,
             append_trustlog=append_trustlog,
@@ -519,6 +538,79 @@ def _rollback_after_runtime_signal_failure(
     )
 
 
+def _rollback_after_apply_failure(
+    *,
+    base_receipt: BindReceipt,
+    adapter: BindBoundaryAdapter,
+    execution_intent: ExecutionIntent,
+    pre_snapshot: Any,
+    pre_fingerprint: str,
+    authority_result: dict[str, str],
+    constraint_result: dict[str, str],
+    drift_result: dict[str, str],
+    risk_result: dict[str, str],
+    recommended_outcome: str,
+    apply_error: Exception,
+) -> BindReceipt:
+    apply_reason = f"{BindReasonCode.APPLY_FAILED.value}:{apply_error}"
+    try:
+        reverted = adapter.revert(execution_intent, pre_snapshot)
+    except (OSError, TypeError, ValueError, RuntimeError) as exc:
+        return _with_receipt(
+            base_receipt,
+            live_state_fingerprint_before=pre_fingerprint,
+            authority_check_result=authority_result,
+            constraint_check_result=constraint_result,
+            drift_check_result=drift_result,
+            risk_check_result=risk_result,
+            admissibility_result={
+                "admissible": True,
+                "recommended_outcome": recommended_outcome,
+                "reason_codes": [BindReasonCode.APPLY_FAILED.value],
+                "target": adapter.describe_target(),
+            },
+            final_outcome=FinalOutcome.ESCALATED,
+            rollback_reason=apply_reason,
+            escalation_reason=f"BIND_REVERT_FAILED_AFTER_APPLY_ERROR:{exc}",
+        )
+
+    if reverted:
+        return _with_receipt(
+            base_receipt,
+            live_state_fingerprint_before=pre_fingerprint,
+            authority_check_result=authority_result,
+            constraint_check_result=constraint_result,
+            drift_check_result=drift_result,
+            risk_check_result=risk_result,
+            admissibility_result={
+                "admissible": True,
+                "recommended_outcome": recommended_outcome,
+                "reason_codes": [BindReasonCode.APPLY_FAILED.value],
+                "target": adapter.describe_target(),
+            },
+            final_outcome=FinalOutcome.ROLLED_BACK,
+            rollback_reason=apply_reason,
+        )
+
+    return _with_receipt(
+        base_receipt,
+        live_state_fingerprint_before=pre_fingerprint,
+        authority_check_result=authority_result,
+        constraint_check_result=constraint_result,
+        drift_check_result=drift_result,
+        risk_check_result=risk_result,
+        admissibility_result={
+            "admissible": True,
+            "recommended_outcome": recommended_outcome,
+            "reason_codes": [BindReasonCode.APPLY_FAILED.value],
+            "target": adapter.describe_target(),
+        },
+        final_outcome=FinalOutcome.ESCALATED,
+        rollback_reason=apply_reason,
+        escalation_reason="BIND_REVERT_REPORTED_FALSE",
+    )
+
+
 def _check_from_runtime(check_result: Any) -> dict[str, str]:
     return BindExecutionCheckResult(
         status=check_result.status.value,
@@ -577,6 +669,7 @@ def _resolve_bind_policy_config(execution_intent: ExecutionIntent) -> BindPolicy
         drift_required=bool(merged.get("drift_required", True)),
         ttl_required=bool(merged.get("ttl_required", False)),
         approval_freshness_required=bool(merged.get("approval_freshness_required", False)),
+        rollback_on_apply_failure=bool(merged.get("rollback_on_apply_failure", False)),
         missing_signal_outcome=_parse_missing_signal_outcome(
             merged.get("missing_signal_default", AdmissibilityOutcome.BLOCK.value)
         ),

--- a/veritas_os/policy/governance_policy_update.py
+++ b/veritas_os/policy/governance_policy_update.py
@@ -30,6 +30,7 @@ def update_governance_policy_with_bind_boundary(
     policy_lineage: dict[str, Any] | None = None,
     approval_records: list[dict[str, Any]] | None = None,
     decision_ts: str | None = None,
+    governance_policy: dict[str, Any] | None = None,
     append_trustlog: bool = True,
     bind_ts: str | None = None,
     execution_intent_id: str | None = None,
@@ -63,7 +64,10 @@ def update_governance_policy_with_bind_boundary(
         decision_ts=decision_ts or _utc_now_iso8601(),
         expected_state_fingerprint=expected_fingerprint,
         approval_context=merged_approval_context,
-        policy_lineage=dict(policy_lineage or {}),
+        policy_lineage=_with_bind_policy_lineage(
+            lineage=policy_lineage,
+            governance_policy=governance_policy,
+        ),
     )
 
     return execute_bind_adjudication(
@@ -78,3 +82,18 @@ def update_governance_policy_with_bind_boundary(
 def _utc_now_iso8601() -> str:
     """Return current UTC timestamp in canonical bind intent format."""
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _with_bind_policy_lineage(
+    *,
+    lineage: dict[str, Any] | None,
+    governance_policy: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge governance bind policy surface into execution intent lineage."""
+    merged: dict[str, Any] = dict(lineage or {})
+    if not isinstance(governance_policy, dict):
+        return merged
+    bind_policy = governance_policy.get("bind_adjudication")
+    if isinstance(bind_policy, dict):
+        merged.setdefault("bind_adjudication", dict(bind_policy))
+    return merged

--- a/veritas_os/policy/policy_bundle_promotion.py
+++ b/veritas_os/policy/policy_bundle_promotion.py
@@ -28,6 +28,7 @@ def promote_policy_bundle_with_bind_boundary(
     allowed_root: str | Path,
     approval_context: dict[str, Any] | None = None,
     policy_lineage: dict[str, Any] | None = None,
+    governance_policy: dict[str, Any] | None = None,
     decision_ts: str | None = None,
     require_signature: bool = True,
     append_trustlog: bool = True,
@@ -66,7 +67,10 @@ def promote_policy_bundle_with_bind_boundary(
         decision_ts=decision_ts or _utc_now_iso8601(),
         expected_state_fingerprint=expected_fingerprint,
         approval_context=merged_approval_context,
-        policy_lineage=dict(policy_lineage or {}),
+        policy_lineage=_with_bind_policy_lineage(
+            lineage=policy_lineage,
+            governance_policy=governance_policy,
+        ),
     )
 
     return execute_bind_adjudication(
@@ -81,3 +85,18 @@ def promote_policy_bundle_with_bind_boundary(
 def _utc_now_iso8601() -> str:
     """Return current UTC timestamp in canonical bind intent format."""
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _with_bind_policy_lineage(
+    *,
+    lineage: dict[str, Any] | None,
+    governance_policy: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge governance bind policy surface into execution intent lineage."""
+    merged: dict[str, Any] = dict(lineage or {})
+    if not isinstance(governance_policy, dict):
+        return merged
+    bind_policy = governance_policy.get("bind_adjudication")
+    if isinstance(bind_policy, dict):
+        merged.setdefault("bind_adjudication", dict(bind_policy))
+    return merged

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -24,6 +24,7 @@ from pydantic import ValidationError
 from veritas_os.api import governance as gov_mod
 from veritas_os.api import server as srv
 from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome
+from veritas_os.policy.bind_boundary_adapters import GovernancePolicyUpdateAdapter
 
 client = TestClient(srv.app)
 HEADERS = {"X-API-Key": "test-governance-key", "X-Role": "admin"}
@@ -64,6 +65,7 @@ class TestGetPolicy:
         assert "log_retention" in policy
         assert "rollout_controls" in policy
         assert "approval_workflow" in policy
+        assert "bind_adjudication" in policy
 
     def test_get_requires_api_key(self):
         resp = client.get("/v1/governance/policy")
@@ -78,6 +80,18 @@ class TestGetPolicy:
 
 
 class TestPutPolicy:
+    def test_put_updates_bind_adjudication_policy(self):
+        resp = client.put(
+            "/v1/governance/policy",
+            headers=HEADERS,
+            json=_approved({"bind_adjudication": {"missing_signal_default": "escalate"}}),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["policy"]["bind_adjudication"]["missing_signal_default"] == "escalate"
+        assert body["policy"]["bind_adjudication"]["drift_required"] is True
+
     def test_put_updates_fuji_rules(self):
         resp = client.put(
             "/v1/governance/policy",
@@ -293,6 +307,28 @@ class TestPutPolicy:
         assert body["ok"] is False
         assert body["error"] == "Failed to update governance policy"
 
+    def test_put_bind_policy_effect_path_escalates_when_signal_missing(self, monkeypatch):
+        setup_resp = client.put(
+            "/v1/governance/policy",
+            headers=HEADERS,
+            json=_approved({"bind_adjudication": {"missing_signal_default": "escalate"}}),
+        )
+        assert setup_resp.status_code == 200
+        monkeypatch.setattr(
+            GovernancePolicyUpdateAdapter,
+            "assess_runtime_risk",
+            lambda self, intent, snapshot: None,
+        )
+        resp = client.put(
+            "/v1/governance/policy",
+            headers=HEADERS,
+            json=_approved({"fuji_rules": {"pii_check": False}}),
+        )
+        assert resp.status_code == 403
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["bind_outcome"] == "ESCALATED"
+
 
 class TestGovernanceModule:
     def test_get_policy_returns_dict(self):
@@ -317,6 +353,8 @@ class TestGovernanceModule:
         assert policy.shadow_validation.partial_validation_default == "non_admissible"
         assert policy.revocation.mode == "bounded_eventual_consistency"
         assert policy.drift_scoring.policy_weight == 0.4
+        assert policy.bind_adjudication.missing_signal_default == "block"
+        assert policy.bind_adjudication.drift_required is True
 
     def test_update_policy_patches_nested_wat_fields(self):
         result = gov_mod.update_policy(

--- a/veritas_os/tests/test_bind_execution.py
+++ b/veritas_os/tests/test_bind_execution.py
@@ -149,6 +149,25 @@ def test_bind_execution_apply_failure_is_apply_failed() -> None:
     assert adapter.state["version"] == 1
 
 
+def test_bind_execution_apply_failure_can_rollback_via_policy() -> None:
+    adapter = ReferenceBindAdapter(
+        state={"version": 1},
+        pending_changes={"version": 2},
+        apply_success=False,
+        revert_success=True,
+    )
+    intent = _intent(
+        expected_fingerprint=adapter.fingerprint_state({"version": 1}),
+        policy_lineage={"bind_adjudication": {"rollback_on_apply_failure": True}},
+    )
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.ROLLED_BACK
+    assert receipt.rollback_reason.startswith("BIND_APPLY_FAILED:")
+    assert adapter.state["version"] == 1
+
+
 def test_bind_execution_postcondition_failure_rolls_back() -> None:
     adapter = ReferenceBindAdapter(
         state={"version": 1},

--- a/veritas_os/tests/test_governance_policy_bind_path.py
+++ b/veritas_os/tests/test_governance_policy_bind_path.py
@@ -114,6 +114,18 @@ def test_governance_policy_update_bind_escalated_when_signal_missing(monkeypatch
     assert receipt.final_outcome is FinalOutcome.ESCALATED
 
 
+def test_governance_policy_update_uses_governance_bind_policy_surface(monkeypatch) -> None:
+    monkeypatch.setattr(
+        GovernancePolicyUpdateAdapter,
+        "assess_runtime_risk",
+        lambda self, intent, snapshot: None,
+    )
+    receipt, _state, _history = _execute(
+        governance_policy={"bind_adjudication": {"missing_signal_default": "escalate"}}
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+
+
 def test_governance_policy_update_bind_rolled_back_on_postcondition_failure(monkeypatch) -> None:
     monkeypatch.setattr(
         GovernancePolicyUpdateAdapter,


### PR DESCRIPTION
### Motivation
- Bind adjudication behavior (how missing signals, drift, freshness and apply-failures are treated) should be controlled by a formal governance policy surface instead of only adapter-local logic.
- Changes must be minimal, runtime-active only, and safe-by-default so current behaviour is preserved unless operators opt-in.

### Description
- Added `BindAdjudicationPolicyConfig` and a `bind_adjudication` field on `GovernancePolicy` with the minimal runtime fields: `missing_signal_default`, `drift_required`, `ttl_required`, `approval_freshness_required`, `rollback_on_apply_failure`, with safe defaults. (`veritas_os/api/governance.py`, `openapi.yaml`).
- Wired governance policy into execution intents so bind paths read the formal surface by merging `bind_adjudication` into `ExecutionIntent.policy_lineage` for governance policy updates and policy-bundle promotions (`veritas_os/policy/governance_policy_update.py`, `veritas_os/policy/policy_bundle_promotion.py`, `veritas_os/api/routes_governance.py`).
- Bind core now consumes the surface: `_resolve_bind_policy_config()` reads `rollback_on_apply_failure` and other flags, and `execute_bind_adjudication()` will attempt rollback on apply failure when `rollback_on_apply_failure` is enabled (preserving default behaviour when disabled). (`veritas_os/policy/bind_core/core.py`).
- Updated OpenAPI/Pydantic schema and operator docs to include the new section and listed which fields are actually consumed at runtime (`openapi.yaml`, `docs/en/governance/governance-artifact-lifecycle.md`).
- Added/extended tests to cover parsing, runtime effect, default compatibility, and route-level effect paths; kept changes deliberately small and did not add unimplemented schema fields (see tests). (`veritas_os/tests/*`).
- Deferred broader expansions (e.g., richer escalation policies, precondition-policy toggle surface) to avoid adding un-used schema; rationale: keep scope minimal and not change existing safe defaults.

### Testing
- Ran `pytest -q veritas_os/tests/test_bind_execution.py veritas_os/tests/test_governance_policy_bind_path.py veritas_os/tests/integration/test_governance_api.py -q` and all tests passed.
- Ran `pytest -q veritas_os/tests/test_openapi_spec.py -q` and it passed, confirming OpenAPI/schemas are in sync.
- Tests exercise: bind policy parsing, runtime effect (including `rollback_on_apply_failure` path), default compatibility, and route-level update+effect behaviour; all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85e0e3e388326a7097aee5c520b0b)