### PR TITLE
Bind receipts: add replay/revalidation metadata and lineage checks

### DIFF
--- a/docs/en/architecture/bind-boundary-governance-artifacts.md
+++ b/docs/en/architecture/bind-boundary-governance-artifacts.md
@@ -23,6 +23,9 @@ This extension keeps that architecture intact and adds bind-boundary lineage:
 - `BindReceipt` records bind-time checks (authority/constraint/drift/risk/
   admissibility), links back to both decision and execution intent, and carries
   TrustLog chain linkage (`trustlog_hash`, `prev_bind_hash`).
+- `BindReceipt` also stores minimal replay/revalidation metadata:
+  `bind_receipt_hash`, `execution_intent_hash`, copied governance identity,
+  and a compact `revalidation_context` used for admissibility replay.
 
 This provides explicit governance-native artifacts at the decision → bind
 boundary without creating a parallel subsystem.
@@ -52,6 +55,9 @@ Not guaranteed by this document alone:
   in TrustLog (`bind_receipt_hash`), not from a new logging plane.
 - Retrieval helpers resolve bind receipts by `bind_receipt_id`,
   `execution_intent_id`, or `decision_id` directly from TrustLog entries.
+- Internal helper `veritas_os.policy.bind_revalidation.revalidate_bind_receipt`
+  can re-run admissibility from receipt-contained context and verify lineage/hash
+  linkage against an optional execution intent payload.
 
 This keeps decision artifacts primary while extending native VERITAS governance
 lineage toward bind-boundary control.

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -42,6 +42,9 @@ def _get_server():
 
 def _resolve_bind_failure_reason(bind_receipt: Dict[str, Any]) -> str | None:
     """Resolve a compact operator-facing bind failure reason from receipt fields."""
+    direct_reason = bind_receipt.get("bind_failure_reason")
+    if isinstance(direct_reason, str) and direct_reason.strip():
+        return direct_reason.strip()
     reason_candidates = (
         bind_receipt.get("rollback_reason"),
         bind_receipt.get("escalation_reason"),
@@ -63,6 +66,9 @@ def _resolve_bind_failure_reason(bind_receipt: Dict[str, Any]) -> str | None:
 
 def _resolve_bind_reason_code(bind_receipt: Dict[str, Any]) -> str | None:
     """Extract a stable reason code when present in bind receipt check payloads."""
+    direct_reason_code = bind_receipt.get("bind_reason_code")
+    if isinstance(direct_reason_code, str) and direct_reason_code.strip():
+        return direct_reason_code.strip()
     for key in (
         "admissibility_result",
         "risk_check_result",

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -366,6 +366,15 @@ class BindReceipt(BaseModel):
     escalation_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
     trustlog_hash: str = Field(default="", max_length=128)
     prev_bind_hash: Optional[str] = Field(default=None, max_length=128)
+    bind_receipt_hash: str = Field(default="", max_length=128)
+    execution_intent_hash: str = Field(default="", max_length=128)
+    policy_snapshot_id: str = Field(default="", max_length=MAX_ID_LENGTH)
+    actor_identity: str = Field(default="", max_length=MAX_ACTOR_LENGTH)
+    decision_hash: str = Field(default="", max_length=128)
+    governance_identity: Optional[Dict[str, Any]] = None
+    revalidation_context: Dict[str, Any] = Field(default_factory=dict)
+    bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
 
 
 # =========================

--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -25,6 +25,7 @@ from .bind_core import (
     normalize_execution_intent,
 )
 from .bind_execution import BindBoundaryAdapter, ReferenceBindAdapter, execute_bind_boundary
+from .bind_revalidation import replay_bind_receipt_admissibility, revalidate_bind_receipt
 from .policy_bundle_promotion import promote_policy_bundle_with_bind_boundary
 from .evaluator import PolicyEvaluationResult, evaluate_runtime_policies
 from .generated_tests import GeneratedPolicyTestCase, build_generated_test_cases
@@ -49,6 +50,8 @@ __all__ = [
     "PolicyBundlePromotionAdapter",
     "promote_policy_bundle_with_bind_boundary",
     "execute_bind_boundary",
+    "replay_bind_receipt_admissibility",
+    "revalidate_bind_receipt",
     "execute_bind_adjudication",
     "BindAdapterContract",
     "BindOutcome",

--- a/veritas_os/policy/bind_artifacts.py
+++ b/veritas_os/policy/bind_artifacts.py
@@ -111,9 +111,23 @@ class BindReceipt:
     escalation_reason: str | None = None
     trustlog_hash: str = ""
     prev_bind_hash: str | None = None
+    bind_receipt_hash: str = ""
+    execution_intent_hash: str = ""
+    policy_snapshot_id: str = ""
+    actor_identity: str = ""
+    decision_hash: str = ""
+    governance_identity: dict[str, Any] | None = None
+    revalidation_context: dict[str, Any] = field(default_factory=dict)
+    bind_reason_code: str | None = None
+    bind_failure_reason: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation."""
+        final_outcome = (
+            self.final_outcome.value
+            if isinstance(self.final_outcome, FinalOutcome)
+            else str(self.final_outcome)
+        )
         return {
             "bind_receipt_id": self.bind_receipt_id,
             "execution_intent_id": self.execution_intent_id,
@@ -126,11 +140,20 @@ class BindReceipt:
             "drift_check_result": dict(self.drift_check_result),
             "risk_check_result": dict(self.risk_check_result),
             "admissibility_result": dict(self.admissibility_result),
-            "final_outcome": self.final_outcome.value,
+            "final_outcome": final_outcome,
             "rollback_reason": self.rollback_reason,
             "escalation_reason": self.escalation_reason,
             "trustlog_hash": self.trustlog_hash,
             "prev_bind_hash": self.prev_bind_hash,
+            "bind_receipt_hash": self.bind_receipt_hash,
+            "execution_intent_hash": self.execution_intent_hash,
+            "policy_snapshot_id": self.policy_snapshot_id,
+            "actor_identity": self.actor_identity,
+            "decision_hash": self.decision_hash,
+            "governance_identity": self.governance_identity,
+            "revalidation_context": dict(self.revalidation_context),
+            "bind_reason_code": self.bind_reason_code,
+            "bind_failure_reason": self.bind_failure_reason,
         }
 
 
@@ -198,6 +221,27 @@ def _extract_bind_receipt(entry: dict[str, Any]) -> BindReceipt | None:
             escalation_reason=payload.get("escalation_reason"),
             trustlog_hash=str(payload.get("trustlog_hash") or ""),
             prev_bind_hash=payload.get("prev_bind_hash"),
+            bind_receipt_hash=str(payload.get("bind_receipt_hash") or ""),
+            execution_intent_hash=str(payload.get("execution_intent_hash") or ""),
+            policy_snapshot_id=str(payload.get("policy_snapshot_id") or ""),
+            actor_identity=str(payload.get("actor_identity") or ""),
+            decision_hash=str(payload.get("decision_hash") or ""),
+            governance_identity=(
+                dict(payload.get("governance_identity"))
+                if isinstance(payload.get("governance_identity"), dict)
+                else None
+            ),
+            revalidation_context=dict(payload.get("revalidation_context") or {}),
+            bind_reason_code=(
+                str(payload.get("bind_reason_code"))
+                if payload.get("bind_reason_code")
+                else None
+            ),
+            bind_failure_reason=(
+                str(payload.get("bind_failure_reason"))
+                if payload.get("bind_failure_reason")
+                else None
+            ),
         )
     except (TypeError, ValueError):
         return None
@@ -237,6 +281,7 @@ def append_bind_receipt_trustlog(receipt: BindReceipt) -> BindReceipt:
     )
     candidate = replace(receipt, prev_bind_hash=prev_bind_hash)
     bind_receipt_hash = hash_bind_receipt(candidate)
+    candidate = replace(candidate, bind_receipt_hash=bind_receipt_hash)
 
     entry = append_trust_log(
         {
@@ -246,7 +291,11 @@ def append_bind_receipt_trustlog(receipt: BindReceipt) -> BindReceipt:
             "execution_intent_id": candidate.execution_intent_id,
             "bind_receipt_id": candidate.bind_receipt_id,
             "bind_ts": candidate.bind_ts,
-            "final_outcome": candidate.final_outcome.value,
+            "final_outcome": (
+                candidate.final_outcome.value
+                if isinstance(candidate.final_outcome, FinalOutcome)
+                else str(candidate.final_outcome)
+            ),
             "prev_bind_hash": candidate.prev_bind_hash,
             "bind_receipt_hash": bind_receipt_hash,
             "bind_receipt": candidate.to_dict(),

--- a/veritas_os/policy/bind_artifacts.py
+++ b/veritas_os/policy/bind_artifacts.py
@@ -178,7 +178,10 @@ def hash_execution_intent(intent: ExecutionIntent) -> str:
 
 def hash_bind_receipt(receipt: BindReceipt) -> str:
     """Compute SHA-256 over canonical ``BindReceipt`` payload."""
-    return sha256_of_canonical_json(receipt.to_dict())
+    payload = receipt.to_dict()
+    # Keep hash semantics stable/non-recursive even when receipt stores its own hash.
+    payload["bind_receipt_hash"] = ""
+    return sha256_of_canonical_json(payload)
 
 
 def build_execution_intent_trustlog_entry(intent: ExecutionIntent) -> dict[str, Any]:

--- a/veritas_os/policy/bind_core/core.py
+++ b/veritas_os/policy/bind_core/core.py
@@ -18,6 +18,7 @@ from veritas_os.policy.bind_artifacts import (
     FinalOutcome,
     append_bind_receipt_trustlog,
     append_execution_intent_trustlog,
+    hash_execution_intent,
 )
 from veritas_os.policy.bind_core.constants import BindReasonCode
 from veritas_os.policy.bind_core.contracts import BindAdapterContract
@@ -144,10 +145,32 @@ def execute_bind_adjudication(
         execution_intent_id=normalized_intent.execution_intent_id,
         decision_id=normalized_intent.decision_id,
         bind_ts=ts,
+        execution_intent_hash=hash_execution_intent(normalized_intent),
+        policy_snapshot_id=normalized_intent.policy_snapshot_id,
+        actor_identity=normalized_intent.actor_identity,
+        decision_hash=normalized_intent.decision_hash,
+        governance_identity=_extract_governance_identity(normalized_intent),
+        revalidation_context=_build_revalidation_context(
+            execution_intent=normalized_intent,
+            bind_policy=BindPolicyConfig(),
+            ttl_expires_at=_build_ttl_expiry(normalized_intent),
+            approval_expires_at=_build_approval_expiry(normalized_intent),
+        ),
     ) if bind_receipt_id else BindReceipt(
         execution_intent_id=normalized_intent.execution_intent_id,
         decision_id=normalized_intent.decision_id,
         bind_ts=ts,
+        execution_intent_hash=hash_execution_intent(normalized_intent),
+        policy_snapshot_id=normalized_intent.policy_snapshot_id,
+        actor_identity=normalized_intent.actor_identity,
+        decision_hash=normalized_intent.decision_hash,
+        governance_identity=_extract_governance_identity(normalized_intent),
+        revalidation_context=_build_revalidation_context(
+            execution_intent=normalized_intent,
+            bind_policy=BindPolicyConfig(),
+            ttl_expires_at=_build_ttl_expiry(normalized_intent),
+            approval_expires_at=_build_approval_expiry(normalized_intent),
+        ),
     )
 
     precondition_error = _validate_intent_preconditions(normalized_intent)
@@ -204,6 +227,15 @@ def execute_bind_adjudication(
     bind_policy = _resolve_bind_policy_config(normalized_intent)
     ttl_expires_at = _build_ttl_expiry(normalized_intent)
     approval_expires_at = _build_approval_expiry(normalized_intent)
+    base_receipt = _with_receipt(
+        base_receipt,
+        revalidation_context=_build_revalidation_context(
+            execution_intent=normalized_intent,
+            bind_policy=bind_policy,
+            ttl_expires_at=ttl_expires_at,
+            approval_expires_at=approval_expires_at,
+        ),
+    )
 
     admissibility = evaluate_bind_admissibility(
         BindAdmissibilityInput(
@@ -687,6 +719,9 @@ def _parse_missing_signal_outcome(raw_value: Any) -> AdmissibilityOutcome:
 def _with_receipt(base_receipt: BindReceipt, **updates: Any) -> BindReceipt:
     payload = base_receipt.to_dict()
     payload.update(updates)
+    final_outcome = payload.get("final_outcome")
+    if isinstance(final_outcome, str):
+        payload["final_outcome"] = FinalOutcome(final_outcome)
     return BindReceipt(**payload)
 
 
@@ -696,6 +731,13 @@ def _finalize_receipt(
     append_trustlog: bool,
     receipt: BindReceipt,
 ) -> BindReceipt:
+    if not receipt.bind_reason_code or not receipt.bind_failure_reason:
+        reason_code, failure_reason = _resolve_receipt_failure_fields(receipt)
+        receipt = _with_receipt(
+            receipt,
+            bind_reason_code=receipt.bind_reason_code or reason_code,
+            bind_failure_reason=receipt.bind_failure_reason or failure_reason,
+        )
     if not append_trustlog:
         return receipt
     append_execution_intent_trustlog(execution_intent)
@@ -725,3 +767,66 @@ def _parse_timestamp(raw_timestamp: str) -> datetime:
 
 def _utc_now_iso8601() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _extract_governance_identity(execution_intent: ExecutionIntent) -> dict[str, Any] | None:
+    """Extract governance identity lineage from execution intent payloads."""
+    policy_lineage = execution_intent.policy_lineage
+    if not isinstance(policy_lineage, dict):
+        return None
+    governance_identity = policy_lineage.get("governance_identity")
+    if not isinstance(governance_identity, dict):
+        return None
+    return dict(governance_identity)
+
+
+def _build_revalidation_context(
+    *,
+    execution_intent: ExecutionIntent,
+    bind_policy: BindPolicyConfig,
+    ttl_expires_at: str | None,
+    approval_expires_at: str | None,
+) -> dict[str, Any]:
+    """Build a minimal replay context required for bind admissibility re-checks."""
+    return {
+        "expected_state_fingerprint": execution_intent.expected_state_fingerprint,
+        "ttl_expires_at": ttl_expires_at,
+        "approval_expires_at": approval_expires_at,
+        "drift_required": bind_policy.drift_required,
+        "ttl_required": bind_policy.ttl_required,
+        "approval_freshness_required": bind_policy.approval_freshness_required,
+        "missing_signal_outcome": bind_policy.missing_signal_outcome.value,
+    }
+
+
+def _resolve_receipt_failure_fields(receipt: BindReceipt) -> tuple[str | None, str | None]:
+    """Resolve canonical failure reason code and summary from receipt payload."""
+    if isinstance(receipt.admissibility_result, dict):
+        reason_codes = receipt.admissibility_result.get("reason_codes")
+        if isinstance(reason_codes, list) and reason_codes:
+            first_code = reason_codes[0]
+            if isinstance(first_code, str) and first_code.strip():
+                reason = str(receipt.admissibility_result.get("reason") or "").strip() or None
+                if reason:
+                    return first_code.strip(), reason
+    for check_payload in (
+        receipt.authority_check_result,
+        receipt.constraint_check_result,
+        receipt.drift_check_result,
+        receipt.risk_check_result,
+    ):
+        if not isinstance(check_payload, dict):
+            continue
+        reason_code = str(check_payload.get("reason_code") or "").strip() or None
+        message = str(check_payload.get("message") or "").strip() or None
+        if reason_code:
+            return reason_code, message
+    for value in (
+        receipt.rollback_reason,
+        receipt.escalation_reason,
+    ):
+        if not isinstance(value, str) or not value.strip():
+            continue
+        prefix = value.split(":", 1)[0].strip()
+        return prefix or None, value.strip()
+    return None, None

--- a/veritas_os/policy/bind_core/normalizers.py
+++ b/veritas_os/policy/bind_core/normalizers.py
@@ -48,8 +48,9 @@ def normalize_execution_intent(
 def normalize_bind_receipt(payload: BindReceipt | dict[str, Any]) -> BindReceipt:
     """Return normalized ``BindReceipt`` with canonical enum mapping."""
     if isinstance(payload, BindReceipt):
-        return payload
-    data = dict(payload)
+        data = payload.to_dict()
+    else:
+        data = dict(payload)
     final_outcome = data.get("final_outcome") or FinalOutcome.BLOCKED.value
     return BindReceipt(
         bind_receipt_id=str(data.get("bind_receipt_id") or ""),
@@ -70,4 +71,19 @@ def normalize_bind_receipt(payload: BindReceipt | dict[str, Any]) -> BindReceipt
         ),
         trustlog_hash=str(data.get("trustlog_hash") or ""),
         prev_bind_hash=(str(data.get("prev_bind_hash")) if data.get("prev_bind_hash") else None),
+        bind_receipt_hash=str(data.get("bind_receipt_hash") or ""),
+        execution_intent_hash=str(data.get("execution_intent_hash") or ""),
+        policy_snapshot_id=str(data.get("policy_snapshot_id") or ""),
+        actor_identity=str(data.get("actor_identity") or ""),
+        decision_hash=str(data.get("decision_hash") or ""),
+        governance_identity=(
+            dict(data.get("governance_identity"))
+            if isinstance(data.get("governance_identity"), dict)
+            else None
+        ),
+        revalidation_context=dict(data.get("revalidation_context") or {}),
+        bind_reason_code=(str(data.get("bind_reason_code")) if data.get("bind_reason_code") else None),
+        bind_failure_reason=(
+            str(data.get("bind_failure_reason")) if data.get("bind_failure_reason") else None
+        ),
     )

--- a/veritas_os/policy/bind_revalidation.py
+++ b/veritas_os/policy/bind_revalidation.py
@@ -1,0 +1,185 @@
+"""Bind receipt replay/revalidation helpers.
+
+This module provides internal, side-effect free helpers that move bind receipts
+from simple logs toward replayable governance artifacts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from veritas_os.core.continuation_runtime.bind_admissibility import (
+    AdmissibilityOutcome,
+    BindAdmissibilityInput,
+    CheckStatus,
+    evaluate_bind_admissibility,
+)
+from veritas_os.policy.bind_artifacts import (
+    BindReceipt,
+    ExecutionIntent,
+    FinalOutcome,
+    hash_bind_receipt,
+    hash_execution_intent,
+)
+from veritas_os.policy.bind_core.normalizers import (
+    normalize_bind_receipt,
+    normalize_execution_intent,
+)
+
+
+def replay_bind_receipt_admissibility(
+    receipt: BindReceipt | dict[str, Any],
+) -> dict[str, Any]:
+    """Replay bind admissibility checks from receipt-contained metadata."""
+    normalized = normalize_bind_receipt(receipt)
+    context = dict(normalized.revalidation_context or {})
+
+    authority_signal = _status_to_signal(normalized.authority_check_result)
+    runtime_risk_signal = _status_to_signal(normalized.risk_check_result)
+    constraint_signals = _constraint_signals_from_receipt(normalized.constraint_check_result)
+    expected_state_fingerprint = context.get("expected_state_fingerprint")
+    if not isinstance(expected_state_fingerprint, str):
+        expected_state_fingerprint = None
+
+    replay_result = evaluate_bind_admissibility(
+        BindAdmissibilityInput(
+            execution_intent=normalized.execution_intent_id,
+            current_timestamp=normalized.bind_ts,
+            authority_signal=authority_signal,
+            constraint_signals=constraint_signals,
+            live_state_fingerprint=normalized.live_state_fingerprint_before,
+            expected_state_fingerprint=expected_state_fingerprint,
+            runtime_risk_signal=runtime_risk_signal,
+            drift_sensitive=bool(context.get("drift_required", True)),
+            ttl_required=bool(context.get("ttl_required", False)),
+            approval_freshness_required=bool(
+                context.get("approval_freshness_required", False)
+            ),
+            missing_signal_outcome=_parse_missing_signal_outcome(
+                context.get("missing_signal_outcome")
+            ),
+            ttl_expires_at=_to_optional_str(context.get("ttl_expires_at")),
+            approval_expires_at=_to_optional_str(context.get("approval_expires_at")),
+        )
+    )
+
+    stored_reason_codes = normalized.admissibility_result.get("reason_codes")
+    if not isinstance(stored_reason_codes, list):
+        stored_reason_codes = []
+    replay_reason_codes = list(replay_result.reason_codes)
+
+    return {
+        "replayable": bool(normalized.bind_ts and normalized.live_state_fingerprint_before),
+        "replayed_admissible": replay_result.admissibility_result,
+        "stored_admissible": bool(normalized.admissibility_result.get("admissible", False)),
+        "replayed_recommended_outcome": replay_result.recommended_outcome.value,
+        "stored_recommended_outcome": normalized.admissibility_result.get(
+            "recommended_outcome"
+        ),
+        "replayed_reason_codes": replay_reason_codes,
+        "stored_reason_codes": [str(code) for code in stored_reason_codes],
+        "admissibility_matches": (
+            replay_result.admissibility_result
+            == bool(normalized.admissibility_result.get("admissible", False))
+            and replay_reason_codes == [str(code) for code in stored_reason_codes]
+        ),
+    }
+
+
+def revalidate_bind_receipt(
+    *,
+    receipt: BindReceipt | dict[str, Any],
+    execution_intent: ExecutionIntent | dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Revalidate bind receipt integrity and replay prerequisites."""
+    normalized_receipt = normalize_bind_receipt(receipt)
+    replay = replay_bind_receipt_admissibility(normalized_receipt)
+
+    recomputed_bind_hash = hash_bind_receipt(normalized_receipt)
+    bind_hash_matches = (
+        not normalized_receipt.bind_receipt_hash
+        or normalized_receipt.bind_receipt_hash == recomputed_bind_hash
+    )
+
+    execution_intent_hash_matches = True
+    execution_intent_id_matches = execution_intent is None
+    if execution_intent is not None:
+        normalized_intent = normalize_execution_intent(execution_intent)
+        execution_intent_id_matches = (
+            normalized_intent.execution_intent_id == normalized_receipt.execution_intent_id
+        )
+        recomputed_intent_hash = hash_execution_intent(normalized_intent)
+        execution_intent_hash_matches = (
+            not normalized_receipt.execution_intent_hash
+            or normalized_receipt.execution_intent_hash == recomputed_intent_hash
+        )
+
+    lineage = {
+        "decision_id": normalized_receipt.decision_id,
+        "execution_intent_id": normalized_receipt.execution_intent_id,
+        "policy_snapshot_id": normalized_receipt.policy_snapshot_id,
+        "governance_identity_present": isinstance(
+            normalized_receipt.governance_identity, dict
+        ),
+    }
+    final_outcome = (
+        normalized_receipt.final_outcome.value
+        if isinstance(normalized_receipt.final_outcome, FinalOutcome)
+        else str(normalized_receipt.final_outcome)
+    )
+
+    return {
+        "ok": (
+            bind_hash_matches
+            and execution_intent_hash_matches
+            and execution_intent_id_matches
+            and replay["admissibility_matches"]
+        ),
+        "lineage": lineage,
+        "bind_hash_matches": bind_hash_matches,
+        "execution_intent_hash_matches": execution_intent_hash_matches,
+        "execution_intent_id_matches": execution_intent_id_matches,
+        "recorded_bind_reason_code": normalized_receipt.bind_reason_code,
+        "recorded_bind_failure_reason": normalized_receipt.bind_failure_reason,
+        "replay": replay,
+        "final_outcome": final_outcome,
+        "terminal_failure": final_outcome
+        in {
+            FinalOutcome.BLOCKED.value,
+            FinalOutcome.ESCALATED.value,
+            FinalOutcome.ROLLED_BACK.value,
+            FinalOutcome.APPLY_FAILED.value,
+            FinalOutcome.SNAPSHOT_FAILED.value,
+            FinalOutcome.PRECONDITION_FAILED.value,
+        },
+    }
+
+
+def _status_to_signal(check_result: dict[str, Any]) -> bool | None:
+    status = str(check_result.get("status") or "").strip().lower()
+    if status == CheckStatus.PASS.value:
+        return True
+    if status == CheckStatus.FAIL.value:
+        return False
+    return None
+
+
+def _constraint_signals_from_receipt(
+    check_result: dict[str, Any],
+) -> dict[str, bool] | None:
+    signal = _status_to_signal(check_result)
+    if signal is None:
+        return None
+    return {"receipt_constraint": signal}
+
+
+def _parse_missing_signal_outcome(raw_value: Any) -> AdmissibilityOutcome:
+    if isinstance(raw_value, str) and raw_value.strip().lower() == "escalate":
+        return AdmissibilityOutcome.ESCALATE
+    return AdmissibilityOutcome.BLOCK
+
+
+def _to_optional_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None

--- a/veritas_os/tests/test_bind_artifacts.py
+++ b/veritas_os/tests/test_bind_artifacts.py
@@ -156,6 +156,23 @@ def test_hashing_stability_for_bind_receipt() -> None:
     )
 
 
+def test_bind_receipt_hash_ignores_embedded_bind_receipt_hash_field() -> None:
+    """Hash calculation must stay stable even after ``bind_receipt_hash`` is embedded."""
+    receipt = BindReceipt(
+        bind_receipt_id="br-hash",
+        execution_intent_id="ei-hash",
+        decision_id="dec-hash",
+        bind_ts="2026-04-20T00:00:00Z",
+        final_outcome=FinalOutcome.COMMITTED,
+    )
+    hash_before_embedding = hash_bind_receipt(receipt)
+    hash_after_embedding = hash_bind_receipt(
+        replace(receipt, bind_receipt_hash=hash_before_embedding)
+    )
+
+    assert hash_before_embedding == hash_after_embedding
+
+
 def test_backward_compatibility_existing_decide_response_unchanged() -> None:
     """Existing decision artifact shape must remain usable without bind artifacts."""
     resp = DecideResponse(request_id="req-compat")

--- a/veritas_os/tests/test_bind_revalidation.py
+++ b/veritas_os/tests/test_bind_revalidation.py
@@ -1,0 +1,114 @@
+"""Tests for bind receipt replay/revalidation helpers."""
+
+from __future__ import annotations
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent, FinalOutcome
+from veritas_os.policy.bind_execution import ReferenceBindAdapter, execute_bind_boundary
+from veritas_os.policy.bind_revalidation import revalidate_bind_receipt
+
+
+def _intent(adapter: ReferenceBindAdapter) -> ExecutionIntent:
+    return ExecutionIntent(
+        execution_intent_id="ei-revalidate-1",
+        decision_id="dec-revalidate-1",
+        request_id="req-revalidate-1",
+        policy_snapshot_id="policy-revalidate-v1",
+        actor_identity="governance_operator",
+        target_system="reference",
+        target_resource="state",
+        intended_action="mutate",
+        decision_hash="b" * 64,
+        decision_ts="2026-04-22T10:00:00Z",
+        expected_state_fingerprint=adapter.fingerprint_state({"version": 1}),
+        policy_lineage={
+            "governance_identity": {
+                "policy_version": "v9",
+                "digest": "digest-123",
+                "signature_verified": True,
+            },
+            "bind_adjudication": {
+                "drift_required": True,
+                "ttl_required": False,
+                "approval_freshness_required": False,
+                "missing_signal_default": "block",
+            },
+        },
+    )
+
+
+def test_bind_receipt_revalidation_happy_path() -> None:
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(adapter)
+
+    receipt = execute_bind_boundary(
+        execution_intent=intent,
+        adapter=adapter,
+        bind_ts="2026-04-22T10:01:00Z",
+        append_trustlog=False,
+    )
+
+    report = revalidate_bind_receipt(receipt=receipt, execution_intent=intent)
+
+    assert report["ok"] is True
+    assert report["bind_hash_matches"] is True
+    assert report["execution_intent_hash_matches"] is True
+    assert report["execution_intent_id_matches"] is True
+    assert report["replay"]["admissibility_matches"] is True
+
+
+def test_bind_revalidation_detects_execution_intent_mismatch() -> None:
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(adapter)
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter, append_trustlog=False)
+
+    wrong_intent = ExecutionIntent(**{**intent.to_dict(), "execution_intent_id": "ei-other"})
+    report = revalidate_bind_receipt(receipt=receipt, execution_intent=wrong_intent)
+
+    assert report["ok"] is False
+    assert report["execution_intent_id_matches"] is False
+
+
+def test_bind_receipt_carries_governance_identity_and_failure_fields() -> None:
+    adapter = ReferenceBindAdapter(
+        state={"version": 1},
+        pending_changes={"version": 2},
+        authority_signal=False,
+    )
+    intent = _intent(adapter)
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter, append_trustlog=False)
+
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert receipt.governance_identity == {
+        "policy_version": "v9",
+        "digest": "digest-123",
+        "signature_verified": True,
+    }
+    assert receipt.bind_reason_code == "BIND_AUTHORITY_INVALID"
+    assert isinstance(receipt.bind_failure_reason, str)
+    assert receipt.bind_failure_reason
+
+
+def test_bind_receipt_backward_compatibility_missing_new_fields() -> None:
+    report = revalidate_bind_receipt(
+        receipt={
+            "bind_receipt_id": "br-legacy",
+            "execution_intent_id": "ei-legacy",
+            "decision_id": "dec-legacy",
+            "bind_ts": "2026-04-22T00:00:00Z",
+            "live_state_fingerprint_before": "abc",
+            "authority_check_result": {"status": "pass", "reason_code": "", "message": "ok"},
+            "constraint_check_result": {"status": "pass", "reason_code": "", "message": "ok"},
+            "drift_check_result": {"status": "pass", "reason_code": "", "message": "ok"},
+            "risk_check_result": {"status": "pass", "reason_code": "", "message": "ok"},
+            "admissibility_result": {
+                "admissible": True,
+                "recommended_outcome": "commit",
+                "reason_codes": [],
+            },
+            "final_outcome": "COMMITTED",
+        }
+    )
+
+    assert report["bind_hash_matches"] is True
+    assert report["lineage"]["governance_identity_present"] is False


### PR DESCRIPTION
### Motivation
- Make `BindReceipt` a first-class, replayable governance artifact so bind-time outcomes can be re-verified without re-running side-effecting adapters. 
- Surface minimal lineage and governance identity from `ExecutionIntent` into receipts to allow auditors to trace decision → intent → bind and to reason about why binds were blocked/rolled back. 
- Provide an internal, side-effect-free revalidation entrypoint to replay admissibility checks and verify hash/lineage integrity for forensic confirmations. 

### Description
- Extended the `BindReceipt` contract with additive metadata: `bind_receipt_hash`, `execution_intent_hash`, `policy_snapshot_id`, `actor_identity`, `decision_hash`, `governance_identity`, `revalidation_context`, `bind_reason_code`, and `bind_failure_reason`. (files: `veritas_os/policy/bind_artifacts.py`, `veritas_os/api/schemas.py`).
- Carry governance lineage and minimal revalidation context from `ExecutionIntent` into receipts at bind-time and compute `execution_intent_hash` and `bind_receipt_hash` for later integrity checks; finalize receipts fills stable `bind_reason_code`/`bind_failure_reason` when missing. (file: `veritas_os/policy/bind_core/core.py`).
- Add an internal service `veritas_os.policy.bind_revalidation` offering `replay_bind_receipt_admissibility()` and `revalidate_bind_receipt()` to replay admissibility from receipt-contained context, verify bind/intent hashes and lineage, and surface a concise revalidation report; normalizers were adjusted for backward compatibility. (files: `veritas_os/policy/bind_revalidation.py`, `veritas_os/policy/bind_core/normalizers.py`).
- API behavior and operator-facing resolution prefer explicit `bind_reason_code`/`bind_failure_reason` present on receipts while preserving existing fallbacks, and the public schema was extended additively. (files: `veritas_os/api/routes_governance.py`, `veritas_os/api/schemas.py`).
- Tests and docs: added focused revalidation tests and updated architecture docs describing the replayable receipt semantics. (files: `veritas_os/tests/test_bind_revalidation.py`, `docs/en/architecture/bind-boundary-governance-artifacts.md`).

### Testing
- Ran unit tests for bind execution and revalidation with `pytest veritas_os/tests/test_bind_execution.py veritas_os/tests/test_bind_revalidation.py` and they passed (`24 passed`).
- Ran bind-core unit tests and governance integration tests with `pytest veritas_os/tests/test_bind_core.py veritas_os/tests/integration/test_governance_api.py` and they passed (`118 passed`).
- Performed linter checks with `ruff` on modified modules and the checks passed.

Notes: this PR is intentionally additive and conservative — it does not claim deterministic guarantees for external adapters and avoids large UI changes; also, storing `governance_identity` in TrustLog can increase retention of governance metadata, so operators should avoid putting secrets in that field or apply masking policies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e862d11f808326b60bd2ffef3394bb)