### PR TITLE
docs: align bind-boundary governance positioning across README, positioning and operator guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![README JP](https://img.shields.io/badge/README-日本語-0f766e.svg)](README_JP.md)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Takeshi%20Fujishita-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/in/takeshi-fujishita-279709392?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app)
 
-VERITAS OS is a **Decision Governance OS** for AI agents.
+VERITAS OS is a **Decision Governance and Bind-Boundary Control Plane** for AI agents.
 Instead of passing model output directly to execution, VERITAS routes each decision through a **reproducible, fail-closed, safety-gated, hash-chained governance pipeline** with operational visibility through **Mission Control**.
 
 This project is not only about running agents.
@@ -32,7 +32,7 @@ It is about making AI decisions **reviewable, traceable, replayable, auditable, 
 
 ## What VERITAS OS is
 
-VERITAS OS is a **Decision Governance OS for AI Agents**.
+VERITAS OS is a **Decision Governance and Bind-Boundary Control Plane for AI Agents**.
 It is the governance layer from **decision adjudication through bind-time boundary checks**:
 it determines whether an AI decision may proceed and whether an approved decision
 can be committed, blocked, escalated, rolled back, or fail safely at bind time before
@@ -52,12 +52,12 @@ VERITAS addresses this by making decisions:
 ### How it differs from runtime/orchestration tools
 
 Many agent stacks optimize task execution and tool wiring.
-VERITAS OS focuses on **decision governance**:
+VERITAS OS focuses on **decision governance and bind-boundary control**:
 
 - Governance controls are applied **before real-world effect**.
 - FUJI gate behavior is **fail-closed by default** on unsafe/undefined paths.
 - TrustLog + governance identity create **audit-grade decision lineage**.
-- Mission Control provides an operator-facing governance surface, not only developer telemetry.
+- Mission Control + governance APIs provide an operator-facing governance surface, not only developer telemetry.
 
 ### Why this fits regulated / enterprise use
 
@@ -68,13 +68,19 @@ VERITAS OS focuses on **decision governance**:
 
 ## What VERITAS OS is / is not
 
-- **Is:** a Decision Governance OS for AI agents, covering decision governance and bind-boundary governance before real-world effect.
+- **Is:** a Decision Governance and Bind-Boundary Control Plane for AI agents, covering decision governance and bind-boundary governance before real-world effect.
 - **Is not:** a replacement for all agent runtimes, nor only an orchestration convenience wrapper.
 
 ## Fact vs roadmap (read this first)
 
 - **Current fact (beta):** Core decision pipeline, bind artifact lineage (`decision -> execution_intent -> bind_receipt`), bind-time admissibility checks, FUJI fail-closed gating, TrustLog lineage, Mission Control workflows, and governance endpoints are implemented.
+- **Current fact (bind policy surface):** Bind-boundary adjudication is currently wired on at least two operator-governed effect paths:
+  1) `PUT /v1/governance/policy` (governance policy update path), and
+  2) `POST /v1/governance/policy-bundles/promote` (policy bundle promotion path).
+- **Current fact (bind outcome public contract):** Governance bind responses expose `bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `execution_intent_id`, and `bind_receipt_id`, with full receipt retrieval via `/v1/governance/bind-receipts*`.
+- **Current fact (replay/operator flow):** Bind receipts are persisted as governance artifacts and can be fetched for replay/revalidation-oriented operator and audit workflows.
 - **Current fact (boundary):** Production readiness still depends on environment-specific hardening, integration, and operational controls.
+- **Roadmap / future direction:** Bind-boundary policy surface is expected to expand to more effect paths and become a broader standardization framework for multi-path effect governance; this is direction, not a claim of full completion today.
 - **Roadmap:** Expanded enterprise integrations (for example deeper IdP/JWT scope models and broader distributed failure-mode validation).
 
 ### Technical Maturity Snapshot (internal)

--- a/README_JP.md
+++ b/README_JP.md
@@ -18,7 +18,7 @@
 **Release Status**: ベータ版  
 **Author**: Takeshi Fujishita
 
-VERITAS OS は **Decision Governance OS for AI Agents**（AIエージェント向け意思決定ガバナンスOS）です。
+VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agents**（AIエージェント向け意思決定ガバナンス / bind-boundary 制御プレーン）です。
 エージェント実行の前段に **governance layer before execution** を置き、現実世界に影響する前に意思決定を制御します。
 
 > メンタルモデル: **LLM = CPU**、**VERITAS OS = その上に載る Decision Governance OS**
@@ -42,7 +42,7 @@ VERITAS OS は次を実現します。
 
 ## runtime/orchestration ツールとの違い
 
-- 主眼はタスク実行最適化ではなく、**意思決定ガバナンス**
+- 主眼はタスク実行最適化ではなく、**意思決定ガバナンスと bind-boundary 統制**
 - ポリシー・安全ゲートは **real-world effect の前** に適用
 - TrustLog と governance identity により、監査可能な意思決定系譜を保持
 
@@ -54,13 +54,19 @@ VERITAS OS は次を実現します。
 
 ## VERITAS OS が「あるもの」と「ないもの」
 
-- **あるもの**: AIエージェント向け Decision Governance OS（実行前ガバナンス層）
+- **あるもの**: AIエージェント向け Decision Governance and Bind-Boundary Control Plane（実行前ガバナンス＋bind-boundary統制層）
 - **ないもの**: すべてのランタイムを置き換える実行基盤、または単なるオーケストレーション便利層
 
 ## 事実とロードマップの境界
 
 - **現時点の事実（ベータ）**: `/v1/decide` 中心の意思決定パイプライン、FUJI fail-closed、TrustLog、Mission Control、ガバナンスAPIが実装済みで、公開上は **ベータ品質のガバナンス基盤** として位置づけます
+- **現時点の事実（bind policy surface）**: bind-boundary adjudication は少なくとも次の2つの運用経路で実装されています。
+  1) `PUT /v1/governance/policy`（governance policy update path）
+  2) `POST /v1/governance/policy-bundles/promote`（policy bundle promotion path）
+- **現時点の事実（bind outcome公開契約）**: ガバナンス系レスポンスでは `bind_outcome` / `bind_failure_reason` / `bind_reason_code` / `execution_intent_id` / `bind_receipt_id` を返し、`/v1/governance/bind-receipts*` でレシート本体を取得可能です
+- **現時点の事実（replay/運用フロー）**: bind receipt はガバナンス成果物として保存され、運用・監査フローで再検証（revalidation/replay）に使える形へ進んでいます
 - **現時点の境界**: 本番適用には環境ごとのハードニング・統合・運用審査が必要
+- **将来方向（標準化）**: bind-boundary は複数の effect path を統治する標準枠組みへ拡張していく方針ですが、現時点で全経路完了を主張するものではありません
 - **ロードマップ**: IdP/JWT スコープ連携の深耕、分散障害モード検証の拡張
 
 ### Technical Maturity Snapshot（内部）

--- a/docs/en/guides/aml-kyc-operator-runbook.md
+++ b/docs/en/guides/aml-kyc-operator-runbook.md
@@ -5,6 +5,9 @@
 Operational runbook for AML/KYC pilot execution using synthetic fixtures.
 No production customer data is allowed.
 
+This runbook assumes VERITAS is used as a **Decision Governance and
+Bind-Boundary Control Plane**, not as a generic runtime replacement.
+
 ## Inputs
 
 - Runner CLI: `scripts/run_financial_poc.py`
@@ -63,6 +66,7 @@ Additionally, confirm bind-boundary lineage visibility on sampled decisions:
 - `bind_outcome` is present when bind adjudication ran.
 - `execution_intent_id` and `bind_receipt_id` are present for bind-tracked cases.
 - `bind_outcome` is interpreted separately from decision approval status.
+- Use `bind_reason_code` first, then `bind_failure_reason` for triage ordering.
 
 ### 5) Failure-path validation
 
@@ -84,6 +88,21 @@ curl -s "http://localhost:8000/v1/governance/bind-receipts/<bind_receipt_id>"
 
 Expected: receipt includes authority/constraint/drift/risk/admissibility
 payloads and a terminal bind outcome (`COMMITTED`/`BLOCKED`/`ESCALATED`/`ROLLED_BACK`).
+
+## Current fact vs future direction (operator notes)
+
+Current fact:
+
+- Bind-boundary lineage is available in operator APIs and tied to decision lineage
+  (`decision -> execution_intent -> bind_receipt`).
+- Bind-governed effect paths currently include governance policy update and policy
+  bundle promotion paths.
+
+Future direction (do not over-claim during pilot readout):
+
+- Additional effect paths are expected to adopt the same bind-boundary contract.
+- Treat receipt artifacts as replayable governance artifacts; do not claim complete
+  standardization across all effect paths yet.
 
 ## Operator triage rubric
 

--- a/docs/en/guides/governance-policy-bundle-promotion.md
+++ b/docs/en/guides/governance-policy-bundle-promotion.md
@@ -7,6 +7,9 @@ This guide describes the operator-facing workflow for:
 It is part of VERITAS OS Decision Governance OS operations and uses the existing
 bind-boundary execution path.
 
+VERITAS is not positioned as a generic runtime replacement; this endpoint is an
+operator-facing governance control-plane path.
+
 ---
 
 ## What this endpoint does
@@ -24,6 +27,15 @@ The endpoint requires governance write permission.
 Use this endpoint when an approved governance decision needs to move runtime to
 another already-present policy bundle directory (for example, from `bundle-v1`
 to `bundle-v2`) while preserving bind execution lineage.
+
+## Current bind policy surface (operator fact)
+
+Current implemented operator-governed bind paths include:
+
+1. `POST /v1/governance/policy-bundles/promote` (this guide)
+2. `PUT /v1/governance/policy` (governance policy update path)
+
+Do not claim that all effect paths are bind-governed yet.
 
 ---
 
@@ -80,6 +92,8 @@ curl -X POST "http://127.0.0.1:8000/v1/governance/policy-bundles/promote" \
 - `execution_intent_id`: bind execution intent lineage identifier.
 - `bind_receipt`: full receipt payload with check results.
 
+This is the public bind outcome contract for governance-facing operator flow.
+
 ### Representative `bind_outcome` values
 
 - `COMMITTED`
@@ -104,6 +118,12 @@ When promotion does not cleanly commit:
    - `GET /v1/governance/bind-receipts/{bind_receipt_id}`
 5. Correlate with decision exports if needed:
    - `GET /v1/governance/decisions/export`
+
+## Receipt replayability note
+
+Bind receipts can be treated as replay/revalidation-oriented governance artifacts.
+Use this wording as current direction and avoid claiming complete cross-path
+standardization in this release.
 
 ---
 

--- a/docs/en/positioning/public-positioning.md
+++ b/docs/en/positioning/public-positioning.md
@@ -2,7 +2,7 @@
 
 ## Official public positioning
 
-**VERITAS OS = Decision Governance OS for AI Agents**
+**VERITAS OS = Decision Governance and Bind-Boundary Control Plane for AI Agents**
 
 Core promise:
 
@@ -10,11 +10,29 @@ Core promise:
 - VERITAS OS functions as a governance layer from **decision adjudication through bind-boundary enforcement**, not only an execution runtime.
 - Current implemented bind-boundary lineage is:
   `decision artifact -> execution intent -> bind receipt` (TrustLog-integrated).
+- Operator-facing bind public contract includes `bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `execution_intent_id`, and `bind_receipt_id`.
 
 ## What VERITAS OS is / is not
 
 - **Is:** a governance-first operating layer for AI agent decisions in enterprise and regulated workflows.
 - **Is not:** a blanket replacement for all orchestration/runtimes, or a speculative AGI narrative product.
+
+## Current fact vs future direction
+
+### Current fact (implemented)
+
+- Bind-boundary is implemented on at least two operator-governed effect paths:
+  1. `PUT /v1/governance/policy` (governance policy update path)
+  2. `POST /v1/governance/policy-bundles/promote` (policy bundle promotion path)
+- Receipts can be listed/fetched via `/v1/governance/bind-receipts` and
+  `/v1/governance/bind-receipts/{bind_receipt_id}` for operator and audit flow.
+- Replay/revalidation helpers exist and move receipts toward replayable governance artifacts.
+
+### Future direction (not yet complete)
+
+- Expand bind-boundary coverage across additional effect paths.
+- Converge toward a standardized governance framework that governs multiple effect paths consistently.
+- Keep this framed as direction; do not claim all effect paths are complete today.
 
 ## Recommended language
 
@@ -24,6 +42,9 @@ Core promise:
 - reviewable / traceable / replayable / auditable / enforceable
 - fail-closed safety gate
 - tamper-evident TrustLog lineage
+- decision -> execution_intent -> bind_receipt lineage
+- operator-facing governance surface
+- bind outcome public contract
 
 ## Caution / restricted language
 

--- a/docs/ja/positioning/public-positioning.md
+++ b/docs/ja/positioning/public-positioning.md
@@ -2,17 +2,35 @@
 
 ## 公式の公開ポジション
 
-**VERITAS OS = Decision Governance OS for AI Agents**
+**VERITAS OS = Decision Governance and Bind-Boundary Control Plane for AI Agents**
 
 コアメッセージ:
 
 - AIの意思決定を、現実世界に作用する前に **reviewable / traceable / replayable / auditable / enforceable** にする。
 - VERITAS OS は **governance layer before execution** であり、実行ランタイムそのものとは役割が異なる。
+- bind の公開契約として、`bind_outcome` / `bind_failure_reason` / `bind_reason_code` / `execution_intent_id` / `bind_receipt_id` を運用側で扱える。
 
 ## VERITAS OS が「あるもの / ないもの」
 
 - **あるもの:** 企業・規制領域のワークフローで意思決定統制を担うガバナンス中心のOS層。
 - **ないもの:** すべてのオーケストレーション/ランタイムを置換する基盤、または投機的AGI物語を前面に出す製品。
+
+## 現時点の事実 / 将来方向
+
+### 現時点の事実（実装済み）
+
+- bind-boundary は少なくとも次の2つの運用経路で実装済み:
+  1. `PUT /v1/governance/policy`（governance policy update path）
+  2. `POST /v1/governance/policy-bundles/promote`（policy bundle promotion path）
+- `GET /v1/governance/bind-receipts` と
+  `GET /v1/governance/bind-receipts/{bind_receipt_id}` でレシート系譜を取得可能。
+- replay/revalidation helper により、receipt は replayable governance artifact に近づいている。
+
+### 将来方向（未完了）
+
+- bind-boundary の適用範囲を追加の effect path へ拡張する。
+- 複数 effect path を一貫統治する標準枠組みへ収束させる。
+- これは方向性であり、現時点で全 effect path 完了を主張しない。
 
 ## 推奨表現
 
@@ -21,6 +39,9 @@
 - reviewable / traceable / replayable / auditable / enforceable
 - fail-closed safety gate
 - tamper-evident TrustLog lineage
+- decision -> execution_intent -> bind_receipt lineage
+- operator-facing governance surface
+- bind outcome public contract
 
 ## 注意表現（限定利用）
 


### PR DESCRIPTION
### Motivation
- Remove vocabulary drift between public-facing and operator-facing docs so repository messaging matches implemented behavior. 
- Make the distinction between current implemented facts and future standardization explicit for bind-boundary governance. 
- Surface the operator-visible bind contract and replayability direction without claiming broader runtime or cross-path completion.

### Description
- Updated `README.md` and `README_JP.md` to identify VERITAS as a "Decision Governance and Bind-Boundary Control Plane", add `decision -> execution_intent -> bind_receipt` lineage, expose the public bind contract fields, and state current operator-governed bind paths and future direction. 
- Synchronized `docs/en/positioning/public-positioning.md` and `docs/ja/positioning/public-positioning.md` with the same identity, added a clear "Current fact vs future direction" section, and listed the operator-facing bind outcome contract. 
- Updated operator-facing guides `docs/en/guides/aml-kyc-operator-runbook.md` and `docs/en/guides/governance-policy-bundle-promotion.md` to note VERITAS is not a generic runtime replacement, document current bind policy surface (promotion + governance policy update), add triage ordering (`bind_reason_code` then `bind_failure_reason`), and add receipt replayability framing. 
- Intentionally avoided new implementation changes and avoided claims that all effect paths are bind-governed or that VERITAS replaces runtimes.

### Testing
- Ran doc hygiene checks with `git diff --check` and fixed trailing/whitespace issues; the check passed. 
- Performed repository-wide keyword searches (`rg`) to verify consistent phrasing for the new vocabulary and current-fact statements; searches returned expected matches. 
- No unit/functional code changes were made, so no unit tests were modified or required for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87a49778083269e9a3ec1cfe51e05)