### PR TITLE
Bind-govern PUT /v1/compliance/config (add bind adjudication)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ VERITAS OS focuses on **decision governance and bind-boundary control**:
 ## Fact vs roadmap (read this first)
 
 - **Current fact (beta):** Core decision pipeline, bind artifact lineage (`decision -> execution_intent -> bind_receipt`), bind-time admissibility checks, FUJI fail-closed gating, TrustLog lineage, Mission Control workflows, and governance endpoints are implemented.
-- **Current fact (bind policy surface):** Bind-boundary adjudication is currently wired on at least two operator-governed effect paths:
-  1) `PUT /v1/governance/policy` (governance policy update path), and
-  2) `POST /v1/governance/policy-bundles/promote` (policy bundle promotion path).
+- **Current fact (bind policy surface):** Bind-boundary adjudication is currently wired on at least three operator-governed effect paths:
+  1) `PUT /v1/governance/policy` (governance policy update path),
+  2) `POST /v1/governance/policy-bundles/promote` (policy bundle promotion path), and
+  3) `PUT /v1/compliance/config` (runtime compliance config mutation path).
 - **Current fact (bind outcome public contract):** Governance bind responses expose `bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `execution_intent_id`, and `bind_receipt_id`, with full receipt retrieval via `/v1/governance/bind-receipts*`.
 - **Current fact (replay/operator flow):** Bind receipts are persisted as governance artifacts and can be fetched for replay/revalidation-oriented operator and audit workflows.
 - **Current fact (boundary):** Production readiness still depends on environment-specific hardening, integration, and operational controls.

--- a/docs/en/guides/aml-kyc-operator-runbook.md
+++ b/docs/en/guides/aml-kyc-operator-runbook.md
@@ -95,8 +95,14 @@ Current fact:
 
 - Bind-boundary lineage is available in operator APIs and tied to decision lineage
   (`decision -> execution_intent -> bind_receipt`).
-- Bind-governed effect paths currently include governance policy update and policy
-  bundle promotion paths.
+- Bind-governed effect paths currently include:
+  - `PUT /v1/governance/policy` (governance policy update)
+  - `POST /v1/governance/policy-bundles/promote` (policy bundle promotion)
+  - `PUT /v1/compliance/config` (runtime compliance config mutation)
+- For `PUT /v1/compliance/config`, operators should trace
+  `execution_intent_id` and `bind_receipt_id`, then inspect bind receipt fields
+  (`authority_check_result`, `constraint_check_result`, `risk_check_result`,
+  `admissibility_result`, and `final_outcome`) when troubleshooting failures.
 
 Future direction (do not over-claim during pilot readout):
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -698,6 +698,43 @@ components:
         policy:
           $ref: '#/components/schemas/GovernancePolicy'
 
+    ComplianceConfigResponse:
+      type: object
+      description: "Compliance config response with optional bind lineage fields on mutation."
+      properties:
+        ok:
+          type: boolean
+        config:
+          type: object
+          nullable: true
+          additionalProperties: true
+        bind_outcome:
+          type: string
+          nullable: true
+          description: "Present when bind adjudication runs for compliance config mutation."
+          enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
+        bind_failure_reason:
+          type: string
+          nullable: true
+          description: "Compact bind failure reason resolved from receipt checks."
+        bind_reason_code:
+          type: string
+          nullable: true
+          description: "Stable bind reason code when available."
+        bind_receipt_id:
+          type: string
+          nullable: true
+        execution_intent_id:
+          type: string
+          nullable: true
+        bind_receipt:
+          allOf:
+            - $ref: '#/components/schemas/BindReceipt'
+          nullable: true
+        error:
+          type: string
+          nullable: true
+
     ExecutionIntent:
       type: object
       description: "Decision-linked execution attempt descriptor."
@@ -2253,15 +2290,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                  config:
-                    type: object
-                    additionalProperties: true
+                $ref: '#/components/schemas/ComplianceConfigResponse'
     put:
-      summary: Compliance config update
+      summary: Compliance config update via bind-boundary adjudication
       requestBody:
         required: true
         content:
@@ -2279,12 +2310,11 @@ paths:
                   maximum: 1.0
       responses:
         "200":
-          description: Updated config
+          description: Updated config with bind receipt lineage fields
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/ComplianceConfigResponse'
 
   /v1/compliance/deployment-readiness:
     get:

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -11,6 +11,7 @@ import queue
 import time
 from pathlib import Path
 from typing import Any, Dict
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -18,12 +19,18 @@ from pydantic import BaseModel, Field
 
 from veritas_os.api.auth import require_permission
 from veritas_os.api.rbac import Permission
+from veritas_os.api.schemas import ComplianceConfigResponse
 from veritas_os.api.utils import _is_direct_fuji_api_enabled
 from veritas_os.api.pipeline_orchestrator import (
     get_runtime_config,
     update_runtime_config,
 )
 from veritas_os.logging.encryption import get_encryption_status
+from veritas_os.policy.bind_artifacts import FinalOutcome
+from veritas_os.policy.compliance_config_update import (
+    update_compliance_config_with_bind_boundary,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
 from veritas_os.storage.factory import get_backend_info
 # Note: report/compliance functions accessed via _get_server() to support
 # test monkeypatching on the server module.
@@ -44,6 +51,78 @@ def _get_server():
     """Late import to avoid circular dependency at module load time."""
     from veritas_os.api import server as srv
     return srv
+
+
+def _resolve_bind_failure_reason(bind_receipt: Dict[str, Any]) -> str | None:
+    """Resolve compact operator-facing bind failure reason from receipt fields."""
+    direct_reason = bind_receipt.get("bind_failure_reason")
+    if isinstance(direct_reason, str) and direct_reason.strip():
+        return direct_reason.strip()
+    for key in (
+        "rollback_reason",
+        "escalation_reason",
+        "admissibility_result",
+        "risk_check_result",
+        "constraint_check_result",
+        "authority_check_result",
+        "drift_check_result",
+    ):
+        candidate = bind_receipt.get(key)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+        if isinstance(candidate, dict):
+            nested = candidate.get("reason") or candidate.get("message") or candidate.get("detail")
+            if isinstance(nested, str) and nested.strip():
+                return nested.strip()
+    return None
+
+
+def _resolve_bind_reason_code(bind_receipt: Dict[str, Any]) -> str | None:
+    """Extract a stable bind reason code from the receipt payload."""
+    direct_reason_code = bind_receipt.get("bind_reason_code")
+    if isinstance(direct_reason_code, str) and direct_reason_code.strip():
+        return direct_reason_code.strip()
+    for key in (
+        "admissibility_result",
+        "risk_check_result",
+        "constraint_check_result",
+        "authority_check_result",
+        "drift_check_result",
+    ):
+        value = bind_receipt.get(key)
+        if not isinstance(value, dict):
+            continue
+        raw = value.get("reason_code") or value.get("code")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return None
+
+
+def _bind_response_payload(bind_receipt: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize bind receipt summary payload for compliance API responses."""
+    return {
+        "bind_receipt": bind_receipt,
+        "bind_outcome": bind_receipt.get("final_outcome"),
+        "bind_failure_reason": _resolve_bind_failure_reason(bind_receipt),
+        "bind_reason_code": _resolve_bind_reason_code(bind_receipt),
+        "bind_receipt_id": bind_receipt.get("bind_receipt_id"),
+        "execution_intent_id": bind_receipt.get("execution_intent_id"),
+    }
+
+
+def _compliance_bind_failure_status_and_error(bind_receipt: Dict[str, Any]) -> tuple[int, str]:
+    """Map bind outcomes to compatibility-preserving compliance config errors."""
+    outcome = str(bind_receipt.get("final_outcome") or "")
+    rollback_reason = str(bind_receipt.get("rollback_reason") or "")
+    if outcome == FinalOutcome.PRECONDITION_FAILED.value:
+        return 400, "Failed to update compliance config"
+    if outcome == FinalOutcome.APPLY_FAILED.value:
+        if "COMPLIANCE_CONFIG_VALIDATION_FAILED" in rollback_reason:
+            return 400, "Failed to update compliance config"
+        return 500, "Failed to update compliance config"
+    if outcome in {FinalOutcome.BLOCKED.value, FinalOutcome.ESCALATED.value}:
+        return 403, "compliance bind approval validation failed"
+    return 500, "Failed to update compliance config"
 
 
 def _runtime_feature_checks(srv: Any) -> Dict[str, str]:
@@ -651,22 +730,58 @@ async def trustlog_ws(websocket: WebSocket):
 # Compliance config
 # ------------------------------------------------------------------
 
-@router.get("/v1/compliance/config", dependencies=[Depends(require_permission(Permission.compliance_read))])
+@router.get(
+    "/v1/compliance/config",
+    response_model=ComplianceConfigResponse,
+    dependencies=[Depends(require_permission(Permission.compliance_read))],
+)
 def compliance_get_config() -> Dict[str, Any]:
     """Return runtime compliance config for UI toggle."""
     return {"ok": True, "config": get_runtime_config()}
 
 
-@router.put("/v1/compliance/config", dependencies=[Depends(require_permission(Permission.config_write))])
+@router.put(
+    "/v1/compliance/config",
+    response_model=ComplianceConfigResponse,
+    dependencies=[Depends(require_permission(Permission.config_write))],
+)
 def compliance_put_config(body: ComplianceConfigBody) -> Dict[str, Any]:
-    """Update runtime compliance config."""
+    """Update runtime compliance config via bind-boundary adjudication."""
     srv = _get_server()
-    updated = update_runtime_config(
-        eu_ai_act_mode=body.eu_ai_act_mode,
-        safety_threshold=body.safety_threshold,
-    )
+    current = get_runtime_config()
+    payload = {
+        "eu_ai_act_mode": body.eu_ai_act_mode,
+        "safety_threshold": body.safety_threshold,
+    }
+    decision_id = uuid4().hex
+    bind_receipt = update_compliance_config_with_bind_boundary(
+        decision_id=decision_id,
+        request_id=decision_id,
+        actor_identity="api",
+        policy_snapshot_id="compliance_runtime_config",
+        decision_hash=sha256_of_canonical_json(payload),
+        config_patch=payload,
+        config_reader=get_runtime_config,
+        config_updater=update_runtime_config,
+        approval_context={"compliance_config_update_approved": True},
+        governance_policy=current if isinstance(current, dict) else None,
+    ).to_dict()
+    bind_payload = _bind_response_payload(bind_receipt)
+    updated = get_runtime_config()
+    if bind_receipt.get("final_outcome") != FinalOutcome.COMMITTED.value:
+        status_code, error_message = _compliance_bind_failure_status_and_error(bind_receipt)
+        return JSONResponse(
+            status_code=status_code,
+            content={
+                "ok": False,
+                "error": error_message,
+                "config": updated,
+                **bind_payload,
+            },
+        )
+
     srv._publish_event("compliance.config.updated", {"config": updated})
-    return {"ok": True, "config": updated}
+    return {"ok": True, "config": updated, **bind_payload}
 
 
 # ------------------------------------------------------------------

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1415,6 +1415,20 @@ class GovernancePolicyBundlePromoteResponse(BaseModel):
     error: Optional[str] = None
 
 
+class ComplianceConfigResponse(BaseModel):
+    """Response envelope for GET/PUT /v1/compliance/config."""
+
+    ok: bool = True
+    config: Optional[Dict[str, Any]] = None
+    bind_receipt: Optional[BindReceipt] = None
+    bind_outcome: Optional[FinalOutcome] = None
+    bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    bind_receipt_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    execution_intent_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    error: Optional[str] = None
+
+
 class GovernanceBindReceiptListResponse(BaseModel):
     """Response envelope for GET /v1/governance/bind-receipts."""
 

--- a/veritas_os/policy/bind_boundary_adapters.py
+++ b/veritas_os/policy/bind_boundary_adapters.py
@@ -315,3 +315,116 @@ class PolicyBundlePromotionAdapter(BindAdapterContract):
         if not isinstance(loaded, dict):
             raise ValueError("BIND_POINTER_PAYLOAD_INVALID")
         return loaded
+
+
+@dataclass
+class ComplianceConfigUpdateAdapter(BindAdapterContract):
+    """Bind adapter for runtime compliance configuration updates.
+
+    The adapter wraps the existing compliance runtime config accessors so
+    bind adjudication can govern config mutation without changing the
+    underlying orchestrator semantics.
+    """
+
+    config_reader: Callable[[], dict[str, Any]]
+    config_updater: Callable[..., dict[str, Any]]
+    config_patch: dict[str, Any]
+    target_description: str = "compliance/config"
+
+    def __post_init__(self) -> None:
+        self._last_updated_config: dict[str, Any] | None = None
+
+    def snapshot(self) -> dict[str, Any]:
+        """Capture deterministic compliance config snapshot."""
+        return {"config": self.config_reader()}
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        """Return deterministic fingerprint for compliance config snapshot."""
+        if not isinstance(snapshot, dict):
+            raise ValueError("BIND_STATE_SNAPSHOT_INVALID")
+        config = snapshot.get("config")
+        if not isinstance(config, dict):
+            raise ValueError("BIND_COMPLIANCE_CONFIG_SNAPSHOT_INVALID")
+        return sha256_of_canonical_json(config)
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        """Require explicit authority signal in bind approval context."""
+        del snapshot
+        if not isinstance(intent.approval_context, dict):
+            return False
+        return bool(intent.approval_context.get("compliance_config_update_approved"))
+
+    def validate_constraints(
+        self,
+        intent: ExecutionIntent,
+        snapshot: Any,
+    ) -> dict[str, bool] | None:
+        """Validate deterministic local constraints for config patch."""
+        del intent
+        config = snapshot.get("config") if isinstance(snapshot, dict) else None
+        threshold = self.config_patch.get("safety_threshold")
+        threshold_is_valid = isinstance(threshold, (int, float)) and 0.0 <= float(threshold) <= 1.0
+        return {
+            "patch_is_dict": isinstance(self.config_patch, dict),
+            "snapshot_has_config": isinstance(config, dict),
+            "safety_threshold_in_range": threshold_is_valid,
+            "contains_supported_fields": set(self.config_patch).issubset(
+                {"eu_ai_act_mode", "safety_threshold"}
+            ),
+        }
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        """Assess runtime risk for in-process compliance config update."""
+        del intent, snapshot
+        return True
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Apply compliance config patch through the runtime updater."""
+        del intent, snapshot
+        try:
+            updated = self.config_updater(
+                eu_ai_act_mode=bool(self.config_patch.get("eu_ai_act_mode", False)),
+                safety_threshold=float(self.config_patch.get("safety_threshold", 0.8)),
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"COMPLIANCE_CONFIG_VALIDATION_FAILED:{exc}") from exc
+        except Exception as exc:
+            raise RuntimeError(f"COMPLIANCE_CONFIG_UPDATE_INTERNAL:{exc}") from exc
+        if not isinstance(updated, dict):
+            raise ValueError("BIND_COMPLIANCE_CONFIG_UPDATE_INVALID")
+        self._last_updated_config = updated
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Verify that patched fields are reflected in runtime config."""
+        del intent, snapshot
+        latest = (
+            self._last_updated_config
+            if isinstance(self._last_updated_config, dict)
+            else self.config_reader()
+        )
+        if not isinstance(latest, dict):
+            return False
+        expected = {
+            "eu_ai_act_mode": bool(self.config_patch.get("eu_ai_act_mode", False)),
+            "safety_threshold": float(self.config_patch.get("safety_threshold", 0.8)),
+        }
+        return _dict_contains_patch(latest, expected)
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Restore pre-apply compliance config snapshot."""
+        del intent
+        if not isinstance(snapshot, dict):
+            return False
+        previous = snapshot.get("config")
+        if not isinstance(previous, dict):
+            return False
+        self.config_updater(
+            eu_ai_act_mode=bool(previous.get("eu_ai_act_mode", False)),
+            safety_threshold=float(previous.get("safety_threshold", 0.8)),
+        )
+        return True
+
+    def describe_target(self) -> str:
+        """Return human-readable target descriptor."""
+        return self.target_description

--- a/veritas_os/policy/compliance_config_update.py
+++ b/veritas_os/policy/compliance_config_update.py
@@ -1,0 +1,91 @@
+"""Bind-controlled runtime compliance config update helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+from uuid import uuid4
+
+from veritas_os.policy.bind_artifacts import BindReceipt, ExecutionIntent
+from veritas_os.policy.bind_boundary_adapters import ComplianceConfigUpdateAdapter
+from veritas_os.policy.bind_core import execute_bind_adjudication
+
+
+def update_compliance_config_with_bind_boundary(
+    *,
+    decision_id: str,
+    request_id: str,
+    actor_identity: str,
+    policy_snapshot_id: str,
+    decision_hash: str,
+    config_patch: dict[str, Any],
+    config_reader: Callable[[], dict[str, Any]],
+    config_updater: Callable[..., dict[str, Any]],
+    approval_context: dict[str, Any] | None = None,
+    policy_lineage: dict[str, Any] | None = None,
+    governance_policy: dict[str, Any] | None = None,
+    decision_ts: str | None = None,
+    append_trustlog: bool = True,
+    bind_ts: str | None = None,
+    execution_intent_id: str | None = None,
+    bind_receipt_id: str | None = None,
+) -> BindReceipt:
+    """Apply compliance config patch through bind-boundary adjudication."""
+    adapter = ComplianceConfigUpdateAdapter(
+        config_reader=config_reader,
+        config_updater=config_updater,
+        config_patch=dict(config_patch),
+    )
+
+    pre_snapshot = adapter.snapshot()
+    expected_fingerprint = adapter.fingerprint_state(pre_snapshot)
+
+    merged_approval_context: dict[str, Any] = dict(approval_context or {})
+    merged_approval_context.setdefault("compliance_config_update_approved", True)
+
+    intent = ExecutionIntent(
+        execution_intent_id=execution_intent_id or uuid4().hex,
+        decision_id=decision_id,
+        request_id=request_id,
+        policy_snapshot_id=policy_snapshot_id,
+        actor_identity=actor_identity,
+        target_system="compliance",
+        target_resource="compliance/config",
+        intended_action="update_compliance_config",
+        decision_hash=decision_hash,
+        decision_ts=decision_ts or _utc_now_iso8601(),
+        expected_state_fingerprint=expected_fingerprint,
+        approval_context=merged_approval_context,
+        policy_lineage=_with_bind_policy_lineage(
+            lineage=policy_lineage,
+            governance_policy=governance_policy,
+        ),
+    )
+
+    return execute_bind_adjudication(
+        execution_intent=intent,
+        adapter=adapter,
+        bind_ts=bind_ts,
+        bind_receipt_id=bind_receipt_id,
+        append_trustlog=append_trustlog,
+    )
+
+
+def _utc_now_iso8601() -> str:
+    """Return current UTC timestamp in canonical bind intent format."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _with_bind_policy_lineage(
+    *,
+    lineage: dict[str, Any] | None,
+    governance_policy: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge governance bind policy surface into execution intent lineage."""
+    merged: dict[str, Any] = dict(lineage or {})
+    if not isinstance(governance_policy, dict):
+        return merged
+    bind_policy = governance_policy.get("bind_adjudication")
+    if isinstance(bind_policy, dict):
+        merged.setdefault("bind_adjudication", dict(bind_policy))
+    return merged

--- a/veritas_os/tests/test_api_compliance_config.py
+++ b/veritas_os/tests/test_api_compliance_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from fastapi.testclient import TestClient
 
 from veritas_os.api import server
@@ -7,6 +9,7 @@ from veritas_os.api.pipeline_orchestrator import (
     get_runtime_config,
     update_runtime_config,
 )
+from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome
 
 
 def test_compliance_config_get_and_put(monkeypatch) -> None:
@@ -32,14 +35,60 @@ def test_compliance_config_get_and_put(monkeypatch) -> None:
         put_payload = put_resp.json()
         assert put_payload["config"]["eu_ai_act_mode"] is True
         assert put_payload["config"]["safety_threshold"] == 0.77
+        assert put_payload["bind_outcome"] == "COMMITTED"
+        assert put_payload["bind_receipt_id"]
+        assert put_payload["execution_intent_id"]
+        assert put_payload["bind_receipt"]["final_outcome"] == "COMMITTED"
 
         get_resp = client.get("/v1/compliance/config", headers=headers)
         assert get_resp.status_code == 200
         get_payload = get_resp.json()
         assert get_payload["config"]["eu_ai_act_mode"] is True
+        assert get_payload.get("bind_outcome") is None
     finally:
         server.API_KEY_DEFAULT = original
         update_runtime_config(
             eu_ai_act_mode=bool(original_cfg["eu_ai_act_mode"]),
             safety_threshold=float(original_cfg["safety_threshold"]),
         )
+
+
+def test_compliance_config_put_bind_blocked(monkeypatch) -> None:
+    """Bind BLOCKED outcome should preserve route-level error semantics."""
+    client = TestClient(server.app)
+    headers = {"X-API-Key": "test-key"}
+
+    original = server.API_KEY_DEFAULT
+    server.API_KEY_DEFAULT = "test-key"
+    monkeypatch.setenv("VERITAS_API_KEY", "test-key")
+
+    blocked_receipt = replace(
+        BindReceipt(
+            bind_receipt_id="br-comp-blocked",
+            execution_intent_id="ei-comp-blocked",
+            decision_id="dec-comp-blocked",
+            final_outcome=FinalOutcome.BLOCKED,
+        ),
+        admissibility_result={
+            "admissible": False,
+            "reason_codes": ["BIND_AUTHORITY_DENIED"],
+            "reason": "authority denied",
+        },
+    )
+    monkeypatch.setattr(
+        "veritas_os.api.routes_system.update_compliance_config_with_bind_boundary",
+        lambda **kwargs: blocked_receipt,
+    )
+    try:
+        resp = client.put(
+            "/v1/compliance/config",
+            headers=headers,
+            json={"eu_ai_act_mode": True, "safety_threshold": 0.77},
+        )
+        assert resp.status_code == 403
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["bind_outcome"] == "BLOCKED"
+        assert body["bind_receipt_id"] == "br-comp-blocked"
+    finally:
+        server.API_KEY_DEFAULT = original

--- a/veritas_os/tests/test_bind_adapter_contract.py
+++ b/veritas_os/tests/test_bind_adapter_contract.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import pytest
 
 from veritas_os.policy.bind_artifacts import ExecutionIntent
-from veritas_os.policy.bind_boundary_adapters import PolicyBundlePromotionAdapter
+from veritas_os.policy.bind_boundary_adapters import (
+    ComplianceConfigUpdateAdapter,
+    PolicyBundlePromotionAdapter,
+)
 from veritas_os.policy.bind_core import BindAdapterContract
 
 
@@ -36,6 +39,42 @@ def test_policy_bundle_promotion_adapter_satisfies_contract(tmp_path) -> None:
         intended_action="promote_policy_bundle",
         decision_hash="a" * 64,
         decision_ts="2026-04-20T00:00:00Z",
+    )
+    snapshot = adapter.snapshot()
+    assert isinstance(adapter.fingerprint_state(snapshot), str)
+    assert isinstance(adapter.validate_authority(intent, snapshot), bool)
+
+
+def test_compliance_config_update_adapter_satisfies_contract() -> None:
+    state = {"eu_ai_act_mode": False, "safety_threshold": 0.8}
+
+    def _reader() -> dict[str, float | bool]:
+        return dict(state)
+
+    def _updater(*, eu_ai_act_mode: bool, safety_threshold: float):
+        state["eu_ai_act_mode"] = eu_ai_act_mode
+        state["safety_threshold"] = safety_threshold
+        return dict(state)
+
+    adapter = ComplianceConfigUpdateAdapter(
+        config_reader=_reader,
+        config_updater=_updater,
+        config_patch={"eu_ai_act_mode": True, "safety_threshold": 0.75},
+    )
+    assert isinstance(adapter, BindAdapterContract)
+
+    intent = ExecutionIntent(
+        execution_intent_id="ei-2",
+        decision_id="dec-2",
+        request_id="req-2",
+        policy_snapshot_id="snap-2",
+        actor_identity="ops",
+        target_system="compliance",
+        target_resource="compliance/config",
+        intended_action="update_compliance_config",
+        decision_hash="b" * 64,
+        decision_ts="2026-04-20T00:00:00Z",
+        approval_context={"compliance_config_update_approved": True},
     )
     snapshot = adapter.snapshot()
     assert isinstance(adapter.fingerprint_state(snapshot), str)

--- a/veritas_os/tests/test_bind_execution_compliance_config_adapter.py
+++ b/veritas_os/tests/test_bind_execution_compliance_config_adapter.py
@@ -1,0 +1,105 @@
+"""Unit tests for ComplianceConfigUpdateAdapter behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.policy.bind_artifacts import ExecutionIntent
+from veritas_os.policy.bind_boundary_adapters import ComplianceConfigUpdateAdapter
+
+
+def _intent(*, approved: bool = True) -> ExecutionIntent:
+    return ExecutionIntent(
+        execution_intent_id="ei-compliance-adapter",
+        decision_id="dec-compliance-adapter",
+        request_id="req-compliance-adapter",
+        policy_snapshot_id="snapshot-1",
+        actor_identity="operator",
+        target_system="compliance",
+        target_resource="compliance/config",
+        intended_action="update_compliance_config",
+        decision_hash="e" * 64,
+        decision_ts="2026-04-20T00:00:00Z",
+        approval_context={"compliance_config_update_approved": approved},
+    )
+
+
+def test_compliance_adapter_snapshot_and_fingerprint() -> None:
+    state = {"eu_ai_act_mode": False, "safety_threshold": 0.8}
+
+    def _reader() -> dict[str, bool | float]:
+        return dict(state)
+
+    def _updater(*, eu_ai_act_mode: bool, safety_threshold: float):
+        state["eu_ai_act_mode"] = eu_ai_act_mode
+        state["safety_threshold"] = safety_threshold
+        return dict(state)
+
+    adapter = ComplianceConfigUpdateAdapter(
+        config_reader=_reader,
+        config_updater=_updater,
+        config_patch={"eu_ai_act_mode": True, "safety_threshold": 0.77},
+    )
+    snapshot = adapter.snapshot()
+    assert snapshot == {"config": state}
+    assert adapter.fingerprint_state(snapshot)
+
+
+def test_compliance_adapter_authority_constraint_risk_signals() -> None:
+    state = {"eu_ai_act_mode": False, "safety_threshold": 0.8}
+    adapter = ComplianceConfigUpdateAdapter(
+        config_reader=lambda: dict(state),
+        config_updater=lambda **kwargs: dict(kwargs),
+        config_patch={"eu_ai_act_mode": True, "safety_threshold": 0.77},
+    )
+    snapshot = adapter.snapshot()
+    assert adapter.validate_authority(_intent(approved=True), snapshot) is True
+    assert adapter.validate_authority(_intent(approved=False), snapshot) is False
+    constraints = adapter.validate_constraints(_intent(), snapshot)
+    assert constraints == {
+        "patch_is_dict": True,
+        "snapshot_has_config": True,
+        "safety_threshold_in_range": True,
+        "contains_supported_fields": True,
+    }
+    assert adapter.assess_runtime_risk(_intent(), snapshot) is True
+
+
+def test_compliance_adapter_apply_verify_and_revert() -> None:
+    state = {"eu_ai_act_mode": False, "safety_threshold": 0.8}
+
+    def _updater(*, eu_ai_act_mode: bool, safety_threshold: float):
+        state["eu_ai_act_mode"] = eu_ai_act_mode
+        state["safety_threshold"] = safety_threshold
+        return dict(state)
+
+    adapter = ComplianceConfigUpdateAdapter(
+        config_reader=lambda: dict(state),
+        config_updater=_updater,
+        config_patch={"eu_ai_act_mode": True, "safety_threshold": 0.7},
+    )
+    snapshot = adapter.snapshot()
+    assert adapter.apply(_intent(), snapshot) is True
+    assert adapter.verify_postconditions(_intent(), snapshot) is True
+    assert state["eu_ai_act_mode"] is True
+    assert adapter.revert(_intent(), snapshot) is True
+    assert state == {"eu_ai_act_mode": False, "safety_threshold": 0.8}
+
+
+def test_compliance_adapter_apply_validation_failure() -> None:
+    adapter = ComplianceConfigUpdateAdapter(
+        config_reader=lambda: {"eu_ai_act_mode": False, "safety_threshold": 0.8},
+        config_updater=lambda **kwargs: (_ for _ in ()).throw(ValueError("bad threshold")),
+        config_patch={"eu_ai_act_mode": True, "safety_threshold": 1.5},
+    )
+    with pytest.raises(ValueError, match="COMPLIANCE_CONFIG_VALIDATION_FAILED"):
+        adapter.apply(_intent(), adapter.snapshot())
+
+
+def test_compliance_adapter_revert_failure_on_invalid_snapshot() -> None:
+    adapter = ComplianceConfigUpdateAdapter(
+        config_reader=lambda: {"eu_ai_act_mode": False, "safety_threshold": 0.8},
+        config_updater=lambda **kwargs: dict(kwargs),
+        config_patch={"eu_ai_act_mode": True, "safety_threshold": 0.75},
+    )
+    assert adapter.revert(_intent(), {"config": None}) is False

--- a/veritas_os/tests/test_compliance_config_bind_path.py
+++ b/veritas_os/tests/test_compliance_config_bind_path.py
@@ -1,0 +1,155 @@
+"""Tests for bind-controlled runtime compliance config update integration path."""
+
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.logging.encryption import generate_key
+from veritas_os.policy.bind_artifacts import FinalOutcome, find_bind_receipts
+from veritas_os.policy.bind_boundary_adapters import ComplianceConfigUpdateAdapter
+from veritas_os.policy.compliance_config_update import (
+    update_compliance_config_with_bind_boundary,
+)
+
+
+@pytest.fixture()
+def trustlog_env(tmp_path, monkeypatch):
+    """Redirect TrustLog writes to a temporary log path."""
+    from veritas_os.logging import trust_log
+
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+    monkeypatch.setattr(trust_log, "LOG_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSON", tmp_path / "trust_log.json", raising=False)
+    monkeypatch.setattr(trust_log, "LOG_JSONL", tmp_path / "trust_log.jsonl", raising=False)
+    monkeypatch.setattr(trust_log, "_append_stats", {"success": 0, "failure": 0}, raising=False)
+
+    def _open_for_append():
+        trust_log.LOG_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        return open(trust_log.LOG_JSONL, "a", encoding="utf-8")
+
+    monkeypatch.setattr(trust_log, "open_trust_log_for_append", _open_for_append)
+    return tmp_path
+
+
+def _config_store() -> dict[str, bool | float]:
+    return {"eu_ai_act_mode": False, "safety_threshold": 0.8}
+
+
+def _reader_factory(state: dict[str, bool | float]):
+    return lambda: dict(state)
+
+
+def _updater_factory(state: dict[str, bool | float]):
+    def _update(*, eu_ai_act_mode: bool, safety_threshold: float) -> dict[str, bool | float]:
+        state["eu_ai_act_mode"] = bool(eu_ai_act_mode)
+        state["safety_threshold"] = float(safety_threshold)
+        return dict(state)
+
+    return _update
+
+
+def _execute(**overrides):
+    state = _config_store()
+    kwargs = {
+        "decision_id": "dec-compliance-1",
+        "request_id": "req-compliance-1",
+        "actor_identity": "operator",
+        "policy_snapshot_id": "compliance-config-v1",
+        "decision_hash": "c" * 64,
+        "config_patch": {"eu_ai_act_mode": True, "safety_threshold": 0.77},
+        "config_reader": _reader_factory(state),
+        "config_updater": _updater_factory(state),
+        "append_trustlog": False,
+    }
+    kwargs.update(overrides)
+    return update_compliance_config_with_bind_boundary(**kwargs), state
+
+
+def test_compliance_config_bind_committed() -> None:
+    receipt, state = _execute()
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert state["eu_ai_act_mode"] is True
+    assert state["safety_threshold"] == 0.77
+
+
+def test_compliance_config_bind_blocked() -> None:
+    receipt, state = _execute(approval_context={"compliance_config_update_approved": False})
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert state["eu_ai_act_mode"] is False
+
+
+def test_compliance_config_bind_escalated_when_signal_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ComplianceConfigUpdateAdapter,
+        "assess_runtime_risk",
+        lambda self, intent, snapshot: None,
+    )
+    receipt, _state = _execute(
+        policy_lineage={"bind_adjudication": {"missing_signal_default": "escalate"}}
+    )
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+
+
+def test_compliance_config_bind_precondition_failed() -> None:
+    receipt, _state = _execute(decision_id="")
+    assert receipt.final_outcome is FinalOutcome.PRECONDITION_FAILED
+
+
+def test_compliance_config_bind_rolled_back_on_postcondition_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ComplianceConfigUpdateAdapter,
+        "verify_postconditions",
+        lambda self, intent, snapshot: False,
+    )
+    receipt, state = _execute()
+    assert receipt.final_outcome is FinalOutcome.ROLLED_BACK
+    assert state["eu_ai_act_mode"] is False
+    assert state["safety_threshold"] == 0.8
+
+
+def test_compliance_config_bind_apply_failed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ComplianceConfigUpdateAdapter,
+        "apply",
+        lambda self, intent, snapshot: (_ for _ in ()).throw(ValueError("invalid")),
+    )
+    receipt, state = _execute()
+    assert receipt.final_outcome is FinalOutcome.APPLY_FAILED
+    assert state["eu_ai_act_mode"] is False
+
+
+def test_compliance_config_bind_persists_receipt_lineage(trustlog_env) -> None:
+    receipt, _state = _execute(
+        decision_id="dec-comp-persist",
+        request_id="req-comp-persist",
+        execution_intent_id="ei-comp-persist",
+        bind_receipt_id="br-comp-persist",
+        append_trustlog=True,
+    )
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+
+    by_decision = find_bind_receipts(decision_id="dec-comp-persist")
+    by_intent = find_bind_receipts(execution_intent_id="ei-comp-persist")
+    by_receipt = find_bind_receipts(bind_receipt_id="br-comp-persist")
+
+    assert len(by_decision) == 1
+    assert len(by_intent) == 1
+    assert len(by_receipt) == 1
+    assert by_receipt[0].bind_receipt_id == "br-comp-persist"
+
+
+def test_compliance_config_bind_backward_compatible_execute_call() -> None:
+    state = _config_store()
+    receipt = update_compliance_config_with_bind_boundary(
+        decision_id="dec-comp-legacy",
+        request_id="req-comp-legacy",
+        actor_identity="legacy",
+        policy_snapshot_id="compliance-config-v1",
+        decision_hash="d" * 64,
+        config_patch={"eu_ai_act_mode": True, "safety_threshold": 0.75},
+        config_reader=_reader_factory(state),
+        config_updater=_updater_factory(state),
+        append_trustlog=False,
+    )
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert state["eu_ai_act_mode"] is True

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -154,3 +154,22 @@ def test_openapi_decide_response_includes_bind_contract_fields() -> None:
     assert "constraint_check_result" in decide_schema
     assert "drift_check_result" in decide_schema
     assert "risk_check_result" in decide_schema
+
+
+def test_openapi_compliance_config_put_response_includes_bind_fields() -> None:
+    """Compliance config mutation route should document bind lineage fields."""
+    spec = _load_openapi_spec()
+    schema = (
+        spec["paths"]["/v1/compliance/config"]["put"]["responses"]["200"]["content"]
+        ["application/json"]["schema"]
+    )
+    if "$ref" in schema:
+        ref_name = str(schema["$ref"]).split("/")[-1]
+        schema = spec["components"]["schemas"][ref_name]
+    properties = schema["properties"]
+    assert "bind_outcome" in properties
+    assert "bind_failure_reason" in properties
+    assert "bind_reason_code" in properties
+    assert "bind_receipt_id" in properties
+    assert "execution_intent_id" in properties
+    assert "bind_receipt" in properties


### PR DESCRIPTION
### Motivation
- Expand the bind-boundary standard from two example paths to a third existing operator-governed effect path (`PUT /v1/compliance/config`) to show the pattern is reusable across domains.
- Reuse the existing bind core and adapter patterns (governance policy update / bundle promotion) to minimize risk and avoid redesigning bind adjudication.
- Provide operators with traceable `execution_intent` → `bind_receipt` lineage for runtime compliance config mutations while keeping current runtime semantics additive and backward-compatible where possible.

### Description
- Added a `ComplianceConfigUpdateAdapter` implementing the adapter contract (`snapshot`, `fingerprint_state`, `validate_authority`, `validate_constraints`, `assess_runtime_risk`, `apply`, `verify_postconditions`, `revert`, `describe_target`) in `veritas_os/policy/bind_boundary_adapters.py` to govern runtime compliance config mutations.
- Added the helper `update_compliance_config_with_bind_boundary` in `veritas_os/policy/compliance_config_update.py` that builds an `ExecutionIntent`, takes a pre-snapshot/fingerprint, and calls `execute_bind_adjudication` (same pattern as existing governance helpers).
- Routed `PUT /v1/compliance/config` in `veritas_os/api/routes_system.py` through the new helper and made the endpoint additive: it now returns bind lineage fields (`bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `execution_intent_id`, `bind_receipt_id`, `bind_receipt`) while preserving `ok`/`config`/`error` envelope semantics and mapping non-COMMITTED outcomes to HTTP status codes in a compatibility-preserving way.
- Synced runtime schemas and OpenAPI: added `ComplianceConfigResponse` to `veritas_os/api/schemas.py` and updated `openapi.yaml` to document that PUT response can include bind lineage fields when adjudication runs.
- Added tests and small docs updates: new adapter unit tests, integration path tests for the compliance-bind path (COMMITTED/BLOCKED/ESCALATED/PRECONDITION_FAILED/APPLY_FAILED/ROLLED_BACK), API route compatibility tests, OpenAPI spec test updates, and an operator note in `docs/en/guides/aml-kyc-operator-runbook.md`; README current-fact was updated to list the third bind-governed path.

### Testing
- Ran targeted pytest suite for the new/affected areas with: `pytest -q veritas_os/tests/test_bind_execution_compliance_config_adapter.py veritas_os/tests/test_compliance_config_bind_path.py veritas_os/tests/test_api_compliance_config.py veritas_os/tests/test_openapi_spec.py veritas_os/tests/test_bind_adapter_contract.py` and observed `26 passed`.
- Existing bind-core and governance bind tests exercised persistence and trustlog linkage via the new path (receipt persistence/retrieval assertions present and passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8977d09248326a65e8c0c56de33da)