### PR TITLE
feat(governance): add Bind Cockpit cross-path operator surface

### DIFF
--- a/frontend/app/governance/components/BindCockpit.test.tsx
+++ b/frontend/app/governance/components/BindCockpit.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@veritas/design-system", () => ({
+  Card: ({ children, title }: { children: React.ReactNode; title?: string }) => (
+    <div>
+      {title ? <h3>{title}</h3> : null}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("../../../components/ui", () => ({
+  StatusBadge: ({ label, variant }: { label: string; variant: string }) => (
+    <span data-testid="status-badge" data-variant={variant}>{label}</span>
+  ),
+}));
+
+const mockFetch = vi.fn();
+vi.mock("../../../lib/api-client", () => ({
+  veritasFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
+import { BindCockpit } from "./BindCockpit";
+
+const LIST_PAYLOAD = {
+  ok: true,
+  items: [
+    {
+      bind_receipt_id: "br-committed",
+      target_path: "/v1/governance/policy",
+      final_outcome: "COMMITTED",
+      bind_reason_code: "OK",
+      decision_id: "decision-1",
+      execution_intent_id: "exec-1",
+      occurred_at: "2026-04-22T10:00:00Z",
+    },
+    {
+      bind_receipt_id: "br-blocked",
+      target_path: "/v1/compliance/config",
+      final_outcome: "BLOCKED",
+      bind_reason_code: "POLICY_DENY",
+      decision_id: "decision-2",
+      execution_intent_id: "exec-2",
+      occurred_at: "2026-04-22T11:00:00Z",
+    },
+  ],
+};
+
+const DETAIL_PAYLOAD = {
+  ok: true,
+  bind_receipt: {
+    bind_receipt_id: "br-blocked",
+    target_path: "/v1/compliance/config",
+    final_outcome: "BLOCKED",
+    bind_failure_reason: "policy denied",
+    bind_reason_code: "POLICY_DENY",
+    decision_id: "decision-2",
+    execution_intent_id: "exec-2",
+    authority_check_result: { passed: true },
+    constraint_check_result: { passed: false },
+    drift_check_result: { result: "ok" },
+    risk_check_result: { result: "deny" },
+  },
+};
+
+describe("BindCockpit", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("renders empty state when no receipts", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, items: [] }) });
+    render(<BindCockpit />);
+    expect(await screen.findByText(/No bind receipts matched filters/i)).toBeInTheDocument();
+  });
+
+  it("applies outcome and path filters", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
+      .mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+    render(<BindCockpit />);
+    await screen.findByText("br-blocked");
+
+    fireEvent.change(screen.getByLabelText("bind-path-type"), { target: { value: "compliance_config_update" } });
+    fireEvent.change(screen.getByLabelText("bind-outcome"), { target: { value: "BLOCKED" } });
+
+    expect(screen.getByText("br-blocked")).toBeInTheDocument();
+    expect(screen.queryByText("br-committed")).not.toBeInTheDocument();
+  });
+
+  it("supports drill-down and related lineage navigation", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
+      .mockResolvedValueOnce({ ok: true, json: async () => DETAIL_PAYLOAD });
+
+    render(<BindCockpit />);
+    await screen.findByText("br-blocked");
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/veritas/v1/governance/bind-receipts/br-blocked");
+    });
+
+    expect(await screen.findByText("Receipt Drill-down")).toBeInTheDocument();
+    expect(screen.getByText(/Next operator step/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "related decision" })).toHaveAttribute("href", "/audit?decision_id=decision-2");
+    expect(screen.getByRole("link", { name: "related execution intent" })).toHaveAttribute("href", "/audit?cross=exec-2");
+    expect(screen.getByRole("link", { name: "related bind receipt" })).toHaveAttribute("href", "/audit?bind_receipt_id=br-blocked");
+  });
+});

--- a/frontend/app/governance/components/BindCockpit.tsx
+++ b/frontend/app/governance/components/BindCockpit.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Card } from "@veritas/design-system";
+import { StatusBadge } from "../../../components/ui";
+import { veritasFetch } from "../../../lib/api-client";
+import {
+  type BindFilterState,
+  type CanonicalBindReceipt,
+  filterCanonicalReceipts,
+  normalizeBindReceipt,
+  parseBindReceiptDetailPayload,
+  parseBindReceiptListPayload,
+} from "./bind-cockpit-normalization";
+
+const DEFAULT_FILTERS: BindFilterState = {
+  pathType: "all",
+  outcome: "all",
+  reasonCode: "",
+  lineageQuery: "",
+  failedOnly: false,
+  recentOnly: false,
+};
+
+function resolveOutcomeVariant(
+  outcome: CanonicalBindReceipt["outcome"],
+): "success" | "warning" | "danger" | "muted" {
+  if (outcome === "COMMITTED") {
+    return "success";
+  }
+  if (outcome === "BLOCKED" || outcome === "ROLLED_BACK" || outcome === "PRECONDITION_FAILED") {
+    return "warning";
+  }
+  if (outcome === "ESCALATED" || outcome === "APPLY_FAILED" || outcome === "SNAPSHOT_FAILED") {
+    return "danger";
+  }
+  return "muted";
+}
+
+function formatPathType(pathType: BindFilterState["pathType"]): string {
+  if (pathType === "governance_policy_update") {
+    return "governance policy update";
+  }
+  if (pathType === "policy_bundle_promotion") {
+    return "policy bundle promotion";
+  }
+  if (pathType === "compliance_config_update") {
+    return "compliance config update";
+  }
+  if (pathType === "other") {
+    return "other";
+  }
+  return "all";
+}
+
+/**
+ * Bind Cockpit: operator-facing cross-path surface for bind lifecycle triage.
+ */
+export function BindCockpit(): JSX.Element {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<BindFilterState>(DEFAULT_FILTERS);
+  const [receipts, setReceipts] = useState<CanonicalBindReceipt[]>([]);
+  const [selectedReceiptId, setSelectedReceiptId] = useState<string | null>(null);
+  const [selectedDetail, setSelectedDetail] = useState<CanonicalBindReceipt | null>(null);
+
+  const loadReceipts = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await veritasFetch("/api/veritas/v1/governance/bind-receipts");
+      if (!response.ok) {
+        setError(`HTTP ${response.status}: Failed to load bind receipts.`);
+        setReceipts([]);
+        return;
+      }
+      const payload = parseBindReceiptListPayload(await response.json());
+      const normalized = payload
+        .map(normalizeBindReceipt)
+        .sort((a, b) => b.timestampMs - a.timestampMs);
+      setReceipts(normalized);
+    } catch (caught: unknown) {
+      console.error("loadReceipts failed", caught);
+      setError("Network error: failed to load bind receipts.");
+      setReceipts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadReceipts();
+  }, [loadReceipts]);
+
+  useEffect(() => {
+    if (receipts.length > 0 && !selectedReceiptId) {
+      setSelectedReceiptId(receipts[0].bindReceiptId);
+    }
+  }, [receipts, selectedReceiptId]);
+
+  useEffect(() => {
+    if (!selectedReceiptId) {
+      setSelectedDetail(null);
+      return;
+    }
+    setDetailError(null);
+    void (async () => {
+      try {
+        const response = await veritasFetch(`/api/veritas/v1/governance/bind-receipts/${selectedReceiptId}`);
+        if (!response.ok) {
+          setDetailError(`HTTP ${response.status}: Failed to load bind receipt detail.`);
+          setSelectedDetail(null);
+          return;
+        }
+        const payload = parseBindReceiptDetailPayload(await response.json());
+        if (!payload) {
+          setDetailError("Bind receipt detail payload is malformed.");
+          setSelectedDetail(null);
+          return;
+        }
+        setSelectedDetail(normalizeBindReceipt(payload));
+      } catch (caught: unknown) {
+        console.error("loadReceiptDetail failed", caught);
+        setDetailError("Network error: failed to load bind receipt detail.");
+        setSelectedDetail(null);
+      }
+    })();
+  }, [selectedReceiptId]);
+
+  const filteredReceipts = useMemo(
+    () => filterCanonicalReceipts(receipts, filters),
+    [receipts, filters],
+  );
+
+  return (
+    <Card
+      title="Bind Cockpit"
+      description="Cross-path operator surface for bind outcomes, lineage triage, and bind receipt drill-down."
+      titleSize="md"
+      variant="elevated"
+    >
+      <div className="space-y-4">
+        <div className="grid gap-2 md:grid-cols-4">
+          <label className="text-xs">
+            path type
+            <select
+              aria-label="bind-path-type"
+              className="mt-1 w-full rounded border px-2 py-1"
+              value={filters.pathType}
+              onChange={(event) => {
+                setFilters((prev) => ({
+                  ...prev,
+                  pathType: event.target.value as BindFilterState["pathType"],
+                }));
+              }}
+            >
+              <option value="all">all</option>
+              <option value="governance_policy_update">governance policy update</option>
+              <option value="policy_bundle_promotion">policy bundle promotion</option>
+              <option value="compliance_config_update">compliance config update</option>
+              <option value="other">other</option>
+            </select>
+          </label>
+          <label className="text-xs">
+            outcome
+            <select
+              aria-label="bind-outcome"
+              className="mt-1 w-full rounded border px-2 py-1"
+              value={filters.outcome}
+              onChange={(event) => {
+                setFilters((prev) => ({
+                  ...prev,
+                  outcome: event.target.value as BindFilterState["outcome"],
+                }));
+              }}
+            >
+              <option value="all">all</option>
+              <option value="COMMITTED">COMMITTED</option>
+              <option value="BLOCKED">BLOCKED</option>
+              <option value="ESCALATED">ESCALATED</option>
+              <option value="ROLLED_BACK">ROLLED_BACK</option>
+              <option value="APPLY_FAILED">APPLY_FAILED</option>
+              <option value="SNAPSHOT_FAILED">SNAPSHOT_FAILED</option>
+              <option value="PRECONDITION_FAILED">PRECONDITION_FAILED</option>
+            </select>
+          </label>
+          <label className="text-xs">
+            reason code
+            <input
+              aria-label="bind-reason-code"
+              className="mt-1 w-full rounded border px-2 py-1"
+              value={filters.reasonCode}
+              onChange={(event) => {
+                setFilters((prev) => ({ ...prev, reasonCode: event.target.value }));
+              }}
+            />
+          </label>
+          <label className="text-xs">
+            lineage id search
+            <input
+              aria-label="bind-lineage-search"
+              className="mt-1 w-full rounded border px-2 py-1"
+              placeholder="decision / execution_intent / bind_receipt"
+              value={filters.lineageQuery}
+              onChange={(event) => {
+                setFilters((prev) => ({ ...prev, lineageQuery: event.target.value }));
+              }}
+            />
+          </label>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 text-xs">
+          <label>
+            <input
+              aria-label="failed-only"
+              type="checkbox"
+              checked={filters.failedOnly}
+              onChange={(event) => {
+                setFilters((prev) => ({ ...prev, failedOnly: event.target.checked }));
+              }}
+            />
+            <span className="ml-1">failed only</span>
+          </label>
+          <label>
+            <input
+              aria-label="recent-only"
+              type="checkbox"
+              checked={filters.recentOnly}
+              onChange={(event) => {
+                setFilters((prev) => ({ ...prev, recentOnly: event.target.checked }));
+              }}
+            />
+            <span className="ml-1">recent only (24h)</span>
+          </label>
+          <button
+            type="button"
+            className="rounded border px-2 py-1"
+            onClick={() => void loadReceipts()}
+            disabled={loading}
+          >
+            {loading ? "loading..." : "refresh receipts"}
+          </button>
+          <span className="text-muted-foreground">{filteredReceipts.length} receipts</span>
+        </div>
+
+        {error ? <p className="rounded border border-danger/30 bg-danger/10 px-2 py-1 text-xs">{error}</p> : null}
+
+        <div className="overflow-x-auto rounded border">
+          <table className="w-full min-w-[980px] text-xs">
+            <thead className="bg-surface/50">
+              <tr>
+                <th className="px-2 py-2 text-left">timestamp</th>
+                <th className="px-2 py-2 text-left">target path / type</th>
+                <th className="px-2 py-2 text-left">bind_outcome</th>
+                <th className="px-2 py-2 text-left">bind_reason_code</th>
+                <th className="px-2 py-2 text-left">bind_receipt_id</th>
+                <th className="px-2 py-2 text-left">execution_intent_id</th>
+                <th className="px-2 py-2 text-left">decision_id</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredReceipts.map((receipt) => (
+                <tr
+                  key={receipt.bindReceiptId}
+                  className={[
+                    "cursor-pointer border-t",
+                    selectedReceiptId === receipt.bindReceiptId ? "bg-primary/5" : "hover:bg-surface/20",
+                  ].join(" ")}
+                  onClick={() => {
+                    setSelectedReceiptId(receipt.bindReceiptId);
+                  }}
+                >
+                  <td className="px-2 py-2 font-mono">{receipt.timestamp}</td>
+                  <td className="px-2 py-2">
+                    <div className="font-mono">{receipt.targetPath}</div>
+                    <div className="text-muted-foreground">{formatPathType(receipt.targetPathType)}</div>
+                  </td>
+                  <td className="px-2 py-2">
+                    <StatusBadge label={receipt.outcome} variant={resolveOutcomeVariant(receipt.outcome)} />
+                  </td>
+                  <td className="px-2 py-2 font-mono">{receipt.reasonCode}</td>
+                  <td className="px-2 py-2 font-mono">{receipt.bindReceiptId}</td>
+                  <td className="px-2 py-2 font-mono">{receipt.executionIntentId ?? "-"}</td>
+                  <td className="px-2 py-2 font-mono">{receipt.decisionId ?? "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {!loading && filteredReceipts.length === 0 ? (
+            <p className="px-3 py-4 text-xs text-muted-foreground">
+              No bind receipts matched filters. Check path/outcome filters or refresh.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="rounded border p-3">
+          <h4 className="text-sm font-semibold">Receipt Drill-down</h4>
+          {detailError ? <p className="mt-2 text-xs text-danger">{detailError}</p> : null}
+          {!selectedDetail && !detailError ? (
+            <p className="mt-2 text-xs text-muted-foreground">Select a bind receipt row to inspect detail.</p>
+          ) : null}
+          {selectedDetail ? (
+            <div className="mt-2 space-y-2 text-xs">
+              <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+                <dt>bind_outcome</dt>
+                <dd><StatusBadge label={selectedDetail.outcome} variant={resolveOutcomeVariant(selectedDetail.outcome)} /></dd>
+                <dt>bind_failure_reason</dt>
+                <dd>{selectedDetail.failureReason}</dd>
+                <dt>bind_reason_code</dt>
+                <dd className="font-mono">{selectedDetail.reasonCode}</dd>
+                <dt>governance lineage</dt>
+                <dd className="font-mono">
+                  decision:{selectedDetail.decisionId ?? "-"} / execution_intent:{selectedDetail.executionIntentId ?? "-"}
+                </dd>
+                <dt>check summary</dt>
+                <dd className="font-mono">
+                  authority {selectedDetail.checks.authority} / constraint {selectedDetail.checks.constraint} / drift {selectedDetail.checks.drift} / risk {selectedDetail.checks.risk}
+                </dd>
+              </dl>
+
+              <div className="rounded border border-warning/30 bg-warning/10 px-2 py-2">
+                <p className="font-semibold">Next operator step</p>
+                <p>{selectedDetail.nextOperatorStep}</p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {selectedDetail.decisionId ? (
+                  <a className="rounded border px-2 py-1" href={`/audit?decision_id=${encodeURIComponent(selectedDetail.decisionId)}`}>
+                    related decision
+                  </a>
+                ) : null}
+                {selectedDetail.executionIntentId ? (
+                  <a className="rounded border px-2 py-1" href={`/audit?cross=${encodeURIComponent(selectedDetail.executionIntentId)}`}>
+                    related execution intent
+                  </a>
+                ) : null}
+                <a className="rounded border px-2 py-1" href={`/audit?bind_receipt_id=${encodeURIComponent(selectedDetail.bindReceiptId)}`}>
+                  related bind receipt
+                </a>
+                <a className="rounded border px-2 py-1" href="/audit">
+                  trust / audit explorer
+                </a>
+                <a className="rounded border px-2 py-1" href={selectedDetail.targetPath.startsWith("/v1/compliance") ? "/system" : "/governance"}>
+                  relevant governance/compliance surface
+                </a>
+              </div>
+
+              <details>
+                <summary className="cursor-pointer text-muted-foreground">bind receipt raw payload</summary>
+                <pre className="mt-1 max-h-60 overflow-auto rounded border bg-surface/40 p-2 font-mono text-[10px]">
+                  {JSON.stringify(selectedDetail.raw, null, 2)}
+                </pre>
+              </details>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/app/governance/components/bind-cockpit-normalization.test.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  filterCanonicalReceipts,
+  normalizeBindReceipt,
+  normalizeBindOutcome,
+  parseBindReceiptDetailPayload,
+  parseBindReceiptListPayload,
+} from "./bind-cockpit-normalization";
+
+describe("bind-cockpit-normalization", () => {
+  it("normalizes canonical bind outcomes", () => {
+    expect(normalizeBindOutcome("committed")).toBe("COMMITTED");
+    expect(normalizeBindOutcome("SUCCESS")).toBe("COMMITTED");
+    expect(normalizeBindOutcome("unexpected")).toBe("UNKNOWN");
+  });
+
+  it("parses list/detail payload safely", () => {
+    expect(parseBindReceiptListPayload({ items: [{ bind_receipt_id: "br-1" }] })).toHaveLength(1);
+    expect(parseBindReceiptListPayload({ bad: [] })).toHaveLength(0);
+    expect(parseBindReceiptDetailPayload({ bind_receipt: { bind_receipt_id: "br-1" } })?.bind_receipt_id).toBe("br-1");
+    expect(parseBindReceiptDetailPayload({ bind_receipt: {} })).toBeNull();
+  });
+
+  it("normalizes path, checks, and operator step", () => {
+    const normalized = normalizeBindReceipt({
+      bind_receipt_id: "br-7",
+      target_path: "/v1/governance/policy-bundles/promote",
+      final_outcome: "blocked",
+      bind_reason_code: "APPROVAL_MISSING",
+      authority_check_result: { passed: true },
+      constraint_check_result: { result: "deny" },
+    });
+    expect(normalized.targetPathType).toBe("policy_bundle_promotion");
+    expect(normalized.outcome).toBe("BLOCKED");
+    expect(normalized.checks.authority).toBe("PASS");
+    expect(normalized.checks.constraint).toBe("FAIL");
+    expect(normalized.nextOperatorStep).toContain("Policy / approval / input assumptions");
+  });
+
+  it("filters by path/outcome/reason/lineage and recent", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T12:00:00Z"));
+
+    const committed = normalizeBindReceipt({
+      bind_receipt_id: "br-1",
+      target_path: "/v1/governance/policy",
+      final_outcome: "COMMITTED",
+      occurred_at: "2026-04-22T10:00:00Z",
+      bind_reason_code: "OK",
+      decision_id: "dec-1",
+    });
+    const blockedOld = normalizeBindReceipt({
+      bind_receipt_id: "br-2",
+      target_path: "/v1/compliance/config",
+      final_outcome: "BLOCKED",
+      occurred_at: "2026-04-20T10:00:00Z",
+      bind_reason_code: "DENY",
+      decision_id: "dec-2",
+    });
+
+    const filtered = filterCanonicalReceipts([committed, blockedOld], {
+      pathType: "compliance_config_update",
+      outcome: "BLOCKED",
+      reasonCode: "deny",
+      lineageQuery: "dec-2",
+      failedOnly: true,
+      recentOnly: false,
+    });
+    expect(filtered).toHaveLength(1);
+
+    const recentOnly = filterCanonicalReceipts([committed, blockedOld], {
+      pathType: "all",
+      outcome: "all",
+      reasonCode: "",
+      lineageQuery: "",
+      failedOnly: false,
+      recentOnly: true,
+    });
+    expect(recentOnly.map((item) => item.bindReceiptId)).toEqual(["br-1"]);
+    vi.useRealTimers();
+  });
+});

--- a/frontend/app/governance/components/bind-cockpit-normalization.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.ts
@@ -1,0 +1,270 @@
+export type CanonicalBindOutcome =
+  | "COMMITTED"
+  | "BLOCKED"
+  | "ESCALATED"
+  | "ROLLED_BACK"
+  | "APPLY_FAILED"
+  | "SNAPSHOT_FAILED"
+  | "PRECONDITION_FAILED";
+
+export type CanonicalTargetPathType =
+  | "governance_policy_update"
+  | "policy_bundle_promotion"
+  | "compliance_config_update"
+  | "other";
+
+export interface BindCheckPayload {
+  passed?: boolean;
+  result?: string;
+  reason_code?: string;
+}
+
+export interface BindCockpitReceipt {
+  bind_receipt_id: string;
+  execution_intent_id?: string;
+  decision_id?: string;
+  target_path?: string;
+  target_resource?: string;
+  target_type?: string;
+  final_outcome?: string;
+  bind_reason_code?: string;
+  bind_failure_reason?: string;
+  occurred_at?: string;
+  created_at?: string;
+  policy_snapshot_id?: string;
+  trust_log_id?: string;
+  authority_check_result?: BindCheckPayload;
+  constraint_check_result?: BindCheckPayload;
+  drift_check_result?: BindCheckPayload;
+  risk_check_result?: BindCheckPayload;
+  [key: string]: unknown;
+}
+
+export interface CanonicalBindReceipt {
+  bindReceiptId: string;
+  executionIntentId: string | null;
+  decisionId: string | null;
+  policySnapshotId: string | null;
+  trustLogId: string | null;
+  targetPath: string;
+  targetResource: string;
+  targetType: string;
+  targetPathType: CanonicalTargetPathType;
+  outcome: CanonicalBindOutcome | "UNKNOWN";
+  reasonCode: string;
+  failureReason: string;
+  timestamp: string;
+  timestampMs: number;
+  checks: {
+    authority: "PASS" | "FAIL" | "UNKNOWN";
+    constraint: "PASS" | "FAIL" | "UNKNOWN";
+    drift: "PASS" | "FAIL" | "UNKNOWN";
+    risk: "PASS" | "FAIL" | "UNKNOWN";
+  };
+  nextOperatorStep: string;
+  raw: BindCockpitReceipt;
+}
+
+export interface BindFilterState {
+  pathType: CanonicalTargetPathType | "all";
+  outcome: CanonicalBindOutcome | "all";
+  reasonCode: string;
+  lineageQuery: string;
+  failedOnly: boolean;
+  recentOnly: boolean;
+}
+
+const CANONICAL_BIND_OUTCOMES: ReadonlySet<CanonicalBindOutcome> = new Set([
+  "COMMITTED",
+  "BLOCKED",
+  "ESCALATED",
+  "ROLLED_BACK",
+  "APPLY_FAILED",
+  "SNAPSHOT_FAILED",
+  "PRECONDITION_FAILED",
+]);
+
+const TARGET_PATH_TYPE_MAP: Record<string, CanonicalTargetPathType> = {
+  "/v1/governance/policy": "governance_policy_update",
+  "/v1/governance/policy-bundles/promote": "policy_bundle_promotion",
+  "/v1/compliance/config": "compliance_config_update",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function normalizeBindOutcome(outcome: unknown): CanonicalBindOutcome | "UNKNOWN" {
+  if (typeof outcome !== "string") {
+    return "UNKNOWN";
+  }
+  const normalized = outcome.trim().toUpperCase();
+  if (normalized === "SUCCESS") {
+    return "COMMITTED";
+  }
+  if (CANONICAL_BIND_OUTCOMES.has(normalized as CanonicalBindOutcome)) {
+    return normalized as CanonicalBindOutcome;
+  }
+  return "UNKNOWN";
+}
+
+function normalizePathType(path: unknown): CanonicalTargetPathType {
+  if (typeof path !== "string") {
+    return "other";
+  }
+  return TARGET_PATH_TYPE_MAP[path] ?? "other";
+}
+
+function resolveCheck(value: unknown): "PASS" | "FAIL" | "UNKNOWN" {
+  if (!isRecord(value)) {
+    return "UNKNOWN";
+  }
+  if (typeof value.passed === "boolean") {
+    return value.passed ? "PASS" : "FAIL";
+  }
+  if (typeof value.result === "string") {
+    const normalized = value.result.trim().toUpperCase();
+    if (["PASS", "OK", "ALLOW"].includes(normalized)) {
+      return "PASS";
+    }
+    if (["FAIL", "DENY", "BLOCK"].includes(normalized)) {
+      return "FAIL";
+    }
+  }
+  return "UNKNOWN";
+}
+
+function pickString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function toTimestampMs(value: string): number {
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+export function resolveOperatorStep(
+  outcome: CanonicalBindOutcome | "UNKNOWN",
+  reasonCode: string,
+): string {
+  if (outcome === "COMMITTED") {
+    return "Post-bind audit verification を実施し、TrustLog / evidence export を確認。";
+  }
+  if (outcome === "BLOCKED" || outcome === "PRECONDITION_FAILED") {
+    return `Policy / approval / input assumptions を確認（reason_code: ${reasonCode || "-"}）。`;
+  }
+  if (outcome === "ESCALATED") {
+    return "Human handoff: governance approver に bind receipt と execution intent を引き継ぐ。";
+  }
+  if (outcome === "ROLLED_BACK") {
+    return "Rollback trigger と prior policy snapshot を確認し、再適用可否を判断。";
+  }
+  if (outcome === "APPLY_FAILED" || outcome === "SNAPSHOT_FAILED") {
+    return "Runtime / snapshot integrity を調査し、根因特定後に再試行可否を判断。";
+  }
+  return "Bind receipt raw payload と trust lineage を確認して次の運用手順を判断。";
+}
+
+export function normalizeBindReceipt(receipt: BindCockpitReceipt): CanonicalBindReceipt {
+  const outcome = normalizeBindOutcome(receipt.final_outcome);
+  const reasonCode = pickString(
+    receipt.bind_reason_code,
+    receipt.authority_check_result?.reason_code,
+    receipt.constraint_check_result?.reason_code,
+    receipt.drift_check_result?.reason_code,
+    receipt.risk_check_result?.reason_code,
+  ) ?? "-";
+  const failureReason = pickString(receipt.bind_failure_reason) ?? "-";
+  const timestamp =
+    pickString(receipt.occurred_at, receipt.created_at) ?? new Date(0).toISOString();
+
+  return {
+    bindReceiptId: pickString(receipt.bind_receipt_id) ?? "-",
+    executionIntentId: pickString(receipt.execution_intent_id),
+    decisionId: pickString(receipt.decision_id),
+    policySnapshotId: pickString(receipt.policy_snapshot_id),
+    trustLogId: pickString(receipt.trust_log_id),
+    targetPath: pickString(receipt.target_path) ?? "-",
+    targetResource: pickString(receipt.target_resource) ?? "-",
+    targetType: pickString(receipt.target_type) ?? "-",
+    targetPathType: normalizePathType(receipt.target_path),
+    outcome,
+    reasonCode,
+    failureReason,
+    timestamp,
+    timestampMs: toTimestampMs(timestamp),
+    checks: {
+      authority: resolveCheck(receipt.authority_check_result),
+      constraint: resolveCheck(receipt.constraint_check_result),
+      drift: resolveCheck(receipt.drift_check_result),
+      risk: resolveCheck(receipt.risk_check_result),
+    },
+    nextOperatorStep: resolveOperatorStep(outcome, reasonCode),
+    raw: receipt,
+  };
+}
+
+export function filterCanonicalReceipts(
+  receipts: CanonicalBindReceipt[],
+  filters: BindFilterState,
+): CanonicalBindReceipt[] {
+  const nowMs = Date.now();
+  const recentWindowMs = 24 * 60 * 60 * 1000;
+  const query = filters.lineageQuery.trim().toLowerCase();
+  const reasonQuery = filters.reasonCode.trim().toLowerCase();
+
+  return receipts.filter((receipt) => {
+    if (filters.pathType !== "all" && receipt.targetPathType !== filters.pathType) {
+      return false;
+    }
+    if (filters.outcome !== "all" && receipt.outcome !== filters.outcome) {
+      return false;
+    }
+    if (filters.failedOnly && receipt.outcome === "COMMITTED") {
+      return false;
+    }
+    if (filters.recentOnly && nowMs - receipt.timestampMs > recentWindowMs) {
+      return false;
+    }
+    if (reasonQuery && !receipt.reasonCode.toLowerCase().includes(reasonQuery)) {
+      return false;
+    }
+    if (query) {
+      const haystacks = [
+        receipt.bindReceiptId,
+        receipt.executionIntentId ?? "",
+        receipt.decisionId ?? "",
+        receipt.policySnapshotId ?? "",
+      ].map((value) => value.toLowerCase());
+      if (!haystacks.some((value) => value.includes(query))) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+export function parseBindReceiptListPayload(value: unknown): BindCockpitReceipt[] {
+  if (!isRecord(value) || !Array.isArray(value.items)) {
+    return [];
+  }
+  return value.items.filter((item): item is BindCockpitReceipt => {
+    return isRecord(item) && typeof item.bind_receipt_id === "string";
+  });
+}
+
+export function parseBindReceiptDetailPayload(value: unknown): BindCockpitReceipt | null {
+  if (!isRecord(value) || !isRecord(value.bind_receipt)) {
+    return null;
+  }
+  const payload = value.bind_receipt;
+  if (typeof payload.bind_receipt_id !== "string") {
+    return null;
+  }
+  return payload as BindCockpitReceipt;
+}

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -16,6 +16,7 @@ import { ApplyFlow } from "./components/ApplyFlow";
 import { TrustLogStream } from "./components/TrustLogStream";
 import { ChangeHistory } from "./components/ChangeHistory";
 import { PolicyBundlePromotionFlow } from "./components/PolicyBundlePromotionFlow";
+import { BindCockpit } from "./components/BindCockpit";
 import { ConfirmDialog } from "../../components/ui/confirm-dialog";
 
 /* ------------------------------------------------------------------ */
@@ -378,6 +379,8 @@ export default function GovernanceControlPage(): JSX.Element {
           />
 
           <PolicyBundlePromotionFlow canOperate={state.canOperate} />
+
+          <BindCockpit />
 
           <TrustLogStream entries={state.trustLog} />
           <ChangeHistory entries={state.history} />


### PR DESCRIPTION
### Motivation
- Operators need a single, path-agnostic surface to triage bind-boundary outcomes across multiple effect paths instead of separate path-oriented UIs. 
- Existing bind lineage and bind-receipt APIs already provide the artifacts; the UI should normalize these into a shared vocabulary for consistent operator workflows. 
- The change must be non-breaking and reuse existing backend endpoints while improving discoverability, filtering, and drill-down for operator triage.

### Description
- Added a Bind Cockpit operator surface implemented in `frontend/app/governance/components/BindCockpit.tsx` that lists recent bind receipts with row-click drill-down and links to related lineage. 
- Introduced a light normalization layer in `frontend/app/governance/components/bind-cockpit-normalization.ts` that produces a canonical vocabulary including `outcome`, `targetPathType`, `reasonCode`, `checks`, `nextOperatorStep`, and filter-friendly fields. 
- Integrated the Bind Cockpit into the Governance page by adding an import and rendering it in `frontend/app/governance/page.tsx` so operators can access it alongside existing flows without changing `PolicyBundlePromotionFlow`. 
- Added tests: `BindCockpit` component tests and normalization tests were added at `frontend/app/governance/components/BindCockpit.test.tsx` and `frontend/app/governance/components/bind-cockpit-normalization.test.ts`; no backend/API route changes were made and only existing endpoints are used (`GET /v1/governance/bind-receipts` and `GET /v1/governance/bind-receipts/{id}`).

### Testing
- Ran the new unit & component tests with `vitest` for the modified components and helpers: `BindCockpit.test.tsx`, `bind-cockpit-normalization.test.ts`, and `page.test.tsx`, and the tests passed. 
- Executed the frontend lint check (`eslint`) for the touched files which produced no errors (only existing unrelated warnings remain). 
- Verified the Bind Cockpit integrates without breaking existing promotion flow behavior by running relevant governance page tests and the targeted test subset, all of which passed.

Security note: the UI surfaces raw bind receipt payloads for operator triage which can contain sensitive metadata; ensure RBAC/audit controls remain in place when deploying this feature to production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89f1c1e6c8326b537e283a3b438ec)