### PR TITLE
Add server-side bind-receipt filters and BindCockpit query integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ All protected endpoints require `X-API-Key`. The full list of endpoints:
 | GET | `/v1/governance/value-drift` | Monitor value weight EMA drift |
 | GET | `/v1/governance/decisions/export` | Export decisions for governance audit |
 | POST | `/v1/governance/policy-bundles/promote` | Execute policy bundle promotion as a bind-boundary governance workflow (returns bind receipt lineage; requires governance write permission) |
-| GET | `/v1/governance/bind-receipts` | List bind receipts (filter by decision or execution intent lineage) |
+| GET | `/v1/governance/bind-receipts` | List bind receipts (decision/execution lineage + target/outcome/reason/failed/recent/sort/limit filters) |
 | GET | `/v1/governance/bind-receipts/{bind_receipt_id}` | Retrieve a single bind receipt artifact |
 
 #### Operator workflow: promote a policy bundle

--- a/README_JP.md
+++ b/README_JP.md
@@ -600,7 +600,7 @@ VERITAS_MEMORY_BACKEND=postgresql VERITAS_TRUSTLOG_BACKEND=postgresql \
 | GET | `/v1/governance/value-drift` | 価値重みEMAドリフト監視 |
 | GET | `/v1/governance/decisions/export` | ガバナンス監査用意思決定エクスポート |
 | POST | `/v1/governance/policy-bundles/promote` | bind-boundaryガバナンスワークフローでポリシーバンドル昇格を実行（bind receipt系譜を返却。governance write権限が必要） |
-| GET | `/v1/governance/bind-receipts` | bind receipt一覧（decision / execution intent 系譜でフィルタ可） |
+| GET | `/v1/governance/bind-receipts` | bind receipt一覧（decision / execution intent 系譜 + target/outcome/reason/failed/recent/sort/limit でフィルタ可） |
 | GET | `/v1/governance/bind-receipts/{bind_receipt_id}` | 単一bind receipt成果物を取得 |
 
 > **署名付きガバナンス成果物** — secure/prodポスチャでは、ポリシーバンドルにEd25519署名が必須です。

--- a/frontend/app/governance/components/BindCockpit.test.tsx
+++ b/frontend/app/governance/components/BindCockpit.test.tsx
@@ -68,6 +68,7 @@ const DETAIL_PAYLOAD = {
 describe("BindCockpit", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true, items: [] }) });
   });
 
   it("renders empty state when no receipts", async () => {
@@ -76,31 +77,62 @@ describe("BindCockpit", () => {
     expect(await screen.findByText(/No bind receipts matched filters/i)).toBeInTheDocument();
   });
 
-  it("applies outcome and path filters", async () => {
+  it("reflects filter state into server-side bind receipt query", async () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
-      .mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+      .mockResolvedValue({ ok: true, json: async () => ({ ok: true, items: [LIST_PAYLOAD.items[1]] }) });
 
     render(<BindCockpit />);
     await screen.findByText("br-blocked");
 
     fireEvent.change(screen.getByLabelText("bind-path-type"), { target: { value: "compliance_config_update" } });
     fireEvent.change(screen.getByLabelText("bind-outcome"), { target: { value: "BLOCKED" } });
+    fireEvent.change(screen.getByLabelText("bind-reason-code"), { target: { value: "POLICY" } });
+    fireEvent.change(screen.getByLabelText("bind-lineage-search"), { target: { value: "decision-2" } });
+    fireEvent.click(screen.getByLabelText("failed-only"));
+    fireEvent.click(screen.getByLabelText("recent-only"));
 
-    expect(screen.getByText("br-blocked")).toBeInTheDocument();
-    expect(screen.queryByText("br-committed")).not.toBeInTheDocument();
+    await waitFor(() => {
+      const calledUrls = mockFetch.mock.calls.map((call) => String(call[0]));
+      expect(calledUrls.some((url) => url.includes("target_path=%2Fv1%2Fcompliance%2Fconfig"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("outcome=BLOCKED"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("reason_code=POLICY"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("lineage_query=decision-2"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("failed_only=true"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("recent_only=true"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("sort=newest"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("limit=200"))).toBe(true);
+    });
+  });
+
+
+  it("renders no match state for filtered server response", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, items: [] }) });
+
+    render(<BindCockpit />);
+    await screen.findByText("br-blocked");
+
+    fireEvent.change(screen.getByLabelText("bind-outcome"), { target: { value: "SNAPSHOT_FAILED" } });
+
+    expect(await screen.findByText(/No bind receipts matched filters/i)).toBeInTheDocument();
   });
 
   it("supports drill-down and related lineage navigation", async () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
+      .mockResolvedValueOnce({ ok: true, json: async () => DETAIL_PAYLOAD })
       .mockResolvedValueOnce({ ok: true, json: async () => DETAIL_PAYLOAD });
 
     render(<BindCockpit />);
     await screen.findByText("br-blocked");
 
+    fireEvent.click(screen.getByText("br-blocked"));
+
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith("/api/veritas/v1/governance/bind-receipts/br-blocked");
+      const calledUrls = mockFetch.mock.calls.map((call) => String(call[0]));
+      expect(calledUrls).toContain("/api/veritas/v1/governance/bind-receipts/br-blocked");
     });
 
     expect(await screen.findByText("Receipt Drill-down")).toBeInTheDocument();

--- a/frontend/app/governance/components/BindCockpit.tsx
+++ b/frontend/app/governance/components/BindCockpit.tsx
@@ -7,7 +7,6 @@ import { veritasFetch } from "../../../lib/api-client";
 import {
   type BindFilterState,
   type CanonicalBindReceipt,
-  filterCanonicalReceipts,
   normalizeBindReceipt,
   parseBindReceiptDetailPayload,
   parseBindReceiptListPayload,
@@ -21,6 +20,41 @@ const DEFAULT_FILTERS: BindFilterState = {
   failedOnly: false,
   recentOnly: false,
 };
+
+const PATH_TYPE_TO_TARGET_PATH: Record<Exclude<BindFilterState["pathType"], "all" | "other">, string> = {
+  governance_policy_update: "/v1/governance/policy",
+  policy_bundle_promotion: "/v1/governance/policy-bundles/promote",
+  compliance_config_update: "/v1/compliance/config",
+};
+
+const DEFAULT_LIST_LIMIT = 200;
+
+function buildBindReceiptListQuery(filters: BindFilterState): string {
+  const params = new URLSearchParams();
+  params.set("sort", "newest");
+  params.set("limit", String(DEFAULT_LIST_LIMIT));
+
+  if (filters.pathType !== "all" && filters.pathType !== "other") {
+    params.set("target_path", PATH_TYPE_TO_TARGET_PATH[filters.pathType]);
+  }
+  if (filters.outcome !== "all") {
+    params.set("outcome", filters.outcome);
+  }
+  if (filters.reasonCode.trim()) {
+    params.set("reason_code", filters.reasonCode.trim());
+  }
+  if (filters.lineageQuery.trim()) {
+    params.set("lineage_query", filters.lineageQuery.trim());
+  }
+  if (filters.failedOnly) {
+    params.set("failed_only", "true");
+  }
+  if (filters.recentOnly) {
+    params.set("recent_only", "true");
+  }
+
+  return params.toString();
+}
 
 function resolveOutcomeVariant(
   outcome: CanonicalBindReceipt["outcome"],
@@ -65,20 +99,20 @@ export function BindCockpit(): JSX.Element {
   const [selectedReceiptId, setSelectedReceiptId] = useState<string | null>(null);
   const [selectedDetail, setSelectedDetail] = useState<CanonicalBindReceipt | null>(null);
 
+  const listQuery = useMemo(() => buildBindReceiptListQuery(filters), [filters]);
+
   const loadReceipts = useCallback(async (): Promise<void> => {
     setLoading(true);
     setError(null);
     try {
-      const response = await veritasFetch("/api/veritas/v1/governance/bind-receipts");
+      const response = await veritasFetch(`/api/veritas/v1/governance/bind-receipts?${listQuery}`);
       if (!response.ok) {
         setError(`HTTP ${response.status}: Failed to load bind receipts.`);
         setReceipts([]);
         return;
       }
       const payload = parseBindReceiptListPayload(await response.json());
-      const normalized = payload
-        .map(normalizeBindReceipt)
-        .sort((a, b) => b.timestampMs - a.timestampMs);
+      const normalized = payload.map(normalizeBindReceipt);
       setReceipts(normalized);
     } catch (caught: unknown) {
       console.error("loadReceipts failed", caught);
@@ -87,7 +121,7 @@ export function BindCockpit(): JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [listQuery]);
 
   useEffect(() => {
     void loadReceipts();
@@ -128,10 +162,12 @@ export function BindCockpit(): JSX.Element {
     })();
   }, [selectedReceiptId]);
 
-  const filteredReceipts = useMemo(
-    () => filterCanonicalReceipts(receipts, filters),
-    [receipts, filters],
-  );
+  const filteredReceipts = useMemo(() => {
+    if (filters.pathType !== "other") {
+      return receipts;
+    }
+    return receipts.filter((receipt) => receipt.targetPathType === "other");
+  }, [receipts, filters.pathType]);
 
   return (
     <Card

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2139,18 +2139,85 @@ paths:
 
   /v1/governance/bind-receipts:
     get:
-      summary: Bind receipt search by lineage filters
+      summary: Bind receipt search with operator filters
+      description: |
+        Lists governance bind receipt artifacts with additive server-side filters.
+        Existing `decision_id` and `execution_intent_id` filters remain supported.
+        `failed_only=true` excludes `COMMITTED` outcomes.
+        `recent_only=true` returns only receipts within the last 24 hours from server clock.
+        Default sort is `newest`; `limit` defaults to unbounded when omitted and is capped at 200 when specified.
       parameters:
         - in: query
           name: decision_id
           required: false
+          description: Exact governance decision identifier filter.
           schema:
             type: string
         - in: query
           name: execution_intent_id
           required: false
+          description: Exact execution intent identifier filter.
           schema:
             type: string
+        - in: query
+          name: target_path
+          required: false
+          description: Canonical target API path filter (exact match).
+          schema:
+            type: string
+        - in: query
+          name: target_type
+          required: false
+          description: Exact target type filter.
+          schema:
+            type: string
+        - in: query
+          name: outcome
+          required: false
+          description: Bind final outcome filter.
+          schema:
+            type: string
+            enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
+        - in: query
+          name: reason_code
+          required: false
+          description: Case-insensitive contains filter for bind reason code.
+          schema:
+            type: string
+        - in: query
+          name: lineage_query
+          required: false
+          description: Case-insensitive contains search across decision_id, execution_intent_id, bind_receipt_id, and policy_snapshot_id.
+          schema:
+            type: string
+        - in: query
+          name: failed_only
+          required: false
+          description: When true, include only outcomes other than COMMITTED.
+          schema:
+            type: boolean
+        - in: query
+          name: recent_only
+          required: false
+          description: When true, include only receipts from the last 24 hours.
+          schema:
+            type: boolean
+        - in: query
+          name: limit
+          required: false
+          description: Maximum receipts to return (safe upper bound is 200).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: sort
+          required: false
+          description: Timestamp sort order; default is newest.
+          schema:
+            type: string
+            enum: ["newest", "oldest"]
+            default: "newest"
       responses:
         "200":
           description: Bind receipts by filter
@@ -2167,6 +2234,19 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/BindReceipt'
+        "400":
+          description: Invalid bind receipt query parameter
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: string
+                  detail:
+                    type: string
 
   /v1/governance/bind-receipts/{bind_receipt_id}:
     get:

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Dict, Optional
 from uuid import uuid4
 
@@ -22,7 +23,7 @@ from veritas_os.api.schemas import (
     GovernancePolicyResponse,
     GovernancePolicyHistoryResponse,
 )
-from veritas_os.policy.bind_artifacts import FinalOutcome, find_bind_receipts
+from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome, find_bind_receipts
 from veritas_os.policy.governance_policy_update import update_governance_policy_with_bind_boundary
 from veritas_os.policy.policy_bundle_promotion import promote_policy_bundle_with_bind_boundary
 from veritas_os.security.hash import sha256_of_canonical_json
@@ -84,6 +85,148 @@ def _resolve_bind_reason_code(bind_receipt: Dict[str, Any]) -> str | None:
             return raw.strip()
     return None
 
+
+
+
+class BindReceiptListSort(str):
+    """Canonical sort keys for bind receipt list endpoint."""
+
+    NEWEST = "newest"
+    OLDEST = "oldest"
+
+
+def _parse_bool_query(value: str | None, *, field_name: str) -> bool | None:
+    """Parse an optional query boolean with stable 400 semantics."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"invalid_{field_name}")
+
+
+def _parse_bind_receipt_sort(value: str | None) -> str:
+    """Resolve bind receipt list sort key with stable 400 semantics."""
+    if value is None:
+        return BindReceiptListSort.NEWEST
+    normalized = value.strip().lower()
+    if normalized not in {BindReceiptListSort.NEWEST, BindReceiptListSort.OLDEST}:
+        raise ValueError("invalid_sort")
+    return normalized
+
+
+def _parse_bind_receipt_outcome(value: str | None) -> str | None:
+    """Normalize bind outcome query for list endpoint filtering."""
+    if value is None:
+        return None
+    normalized = value.strip().upper()
+    if not normalized:
+        return None
+    valid = {item.value for item in FinalOutcome}
+    if normalized not in valid:
+        raise ValueError("invalid_outcome")
+    return normalized
+
+
+def _parse_bind_receipt_timestamp(bind_receipt: dict[str, Any]) -> datetime | None:
+    """Parse bind receipt timestamp from known fields as UTC datetime."""
+    for key in ("occurred_at", "created_at", "bind_ts"):
+        raw = bind_receipt.get(key)
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        candidate = raw.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return None
+
+
+def _canonical_path(value: Any) -> str:
+    """Normalize API path-like value for canonical matching."""
+    if not isinstance(value, str):
+        return ""
+    stripped = value.strip()
+    if not stripped:
+        return ""
+    return stripped.rstrip("/") or "/"
+
+
+def _receipt_matches_lineage_query(bind_receipt: dict[str, Any], lineage_query: str) -> bool:
+    """Return True when lineage query matches common bind lineage identifiers."""
+    query = lineage_query.strip().lower()
+    if not query:
+        return True
+    for key in ("decision_id", "execution_intent_id", "bind_receipt_id", "policy_snapshot_id"):
+        value = bind_receipt.get(key)
+        if isinstance(value, str) and query in value.lower():
+            return True
+    return False
+
+
+def _apply_bind_receipt_filters(
+    receipts: list[BindReceipt],
+    *,
+    target_path: str | None,
+    target_type: str | None,
+    outcome: str | None,
+    reason_code: str | None,
+    lineage_query: str | None,
+    failed_only: bool | None,
+    recent_only: bool | None,
+    sort: str,
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    """Apply additive bind receipt list query semantics deterministically."""
+    now_utc = datetime.now(timezone.utc)
+    recent_threshold = now_utc - timedelta(hours=24)
+    canonical_target_path = _canonical_path(target_path) if target_path else None
+    reason_query = (reason_code or "").strip().lower()
+    lineage_term = (lineage_query or "").strip()
+
+    filtered: list[dict[str, Any]] = []
+    for receipt in receipts:
+        payload = receipt.to_dict()
+
+        if canonical_target_path:
+            payload_target_path = _canonical_path(payload.get("target_path"))
+            if payload_target_path != canonical_target_path:
+                continue
+        if target_type and payload.get("target_type") != target_type:
+            continue
+        if outcome and str(payload.get("final_outcome") or "").upper() != outcome:
+            continue
+
+        resolved_reason_code = (_resolve_bind_reason_code(payload) or "").lower()
+        if reason_query and reason_query not in resolved_reason_code:
+            continue
+
+        if lineage_term and not _receipt_matches_lineage_query(payload, lineage_term):
+            continue
+
+        normalized_outcome = str(payload.get("final_outcome") or "").upper()
+        if failed_only is True and normalized_outcome == FinalOutcome.COMMITTED.value:
+            continue
+
+        if recent_only is True:
+            parsed_ts = _parse_bind_receipt_timestamp(payload)
+            if parsed_ts is None or parsed_ts < recent_threshold:
+                continue
+
+        filtered.append(payload)
+
+    filtered.sort(
+        key=lambda item: _parse_bind_receipt_timestamp(item) or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=sort == BindReceiptListSort.NEWEST,
+    )
+    if limit is not None:
+        return filtered[:limit]
+    return filtered
 
 def _resolve_policy_bundle_paths(bundle_name: str) -> tuple[Path, Path, Path]:
     """Resolve promotion paths from server config/env with traversal protection."""
@@ -410,19 +553,60 @@ def governance_decision_export(
     dependencies=[Depends(require_permission(Permission.governance_read))],
 )
 def governance_bind_receipts(
-    decision_id: str | None = Query(default=None),
-    execution_intent_id: str | None = Query(default=None),
+    decision_id: str | None = Query(default=None, description="Filter by exact governance decision_id."),
+    execution_intent_id: str | None = Query(default=None, description="Filter by exact execution_intent_id."),
+    target_path: str | None = Query(default=None, description="Filter by canonical target_path match."),
+    target_type: str | None = Query(default=None, description="Filter by exact target_type match."),
+    outcome: str | None = Query(default=None, description="Filter by final_outcome enum value."),
+    reason_code: str | None = Query(default=None, description="Case-insensitive contains match for bind reason_code."),
+    lineage_query: str | None = Query(
+        default=None,
+        description="Case-insensitive contains search across decision_id, execution_intent_id, bind_receipt_id, and policy_snapshot_id.",
+    ),
+    failed_only: str | None = Query(
+        default=None,
+        description="When true, include outcomes except COMMITTED.",
+    ),
+    recent_only: str | None = Query(
+        default=None,
+        description="When true, include only receipts from the last 24 hours based on server clock.",
+    ),
+    limit: int | None = Query(default=None, ge=1, le=200, description="Max receipts returned (safe upper bound: 200)."),
+    sort: str | None = Query(default=None, description="Sort order: newest (default) or oldest."),
 ):
-    """Return bind receipt artifacts filtered by decision/execution intent lineage."""
+    """Return bind receipt artifacts with additive operator-focused server-side filtering."""
+    try:
+        parsed_outcome = _parse_bind_receipt_outcome(outcome)
+        parsed_sort = _parse_bind_receipt_sort(sort)
+        parsed_failed_only = _parse_bool_query(failed_only, field_name="failed_only")
+        parsed_recent_only = _parse_bool_query(recent_only, field_name="recent_only")
+    except ValueError as exc:
+        return JSONResponse(
+            status_code=400,
+            content={"ok": False, "error": "invalid_bind_receipt_query", "detail": str(exc)},
+        )
+
     try:
         receipts = find_bind_receipts(
             decision_id=decision_id,
             execution_intent_id=execution_intent_id,
         )
+        filtered_items = _apply_bind_receipt_filters(
+            receipts,
+            target_path=target_path,
+            target_type=target_type,
+            outcome=parsed_outcome,
+            reason_code=reason_code,
+            lineage_query=lineage_query,
+            failed_only=parsed_failed_only,
+            recent_only=parsed_recent_only,
+            sort=parsed_sort,
+            limit=limit,
+        )
         return {
             "ok": True,
-            "count": len(receipts),
-            "items": [receipt.to_dict() for receipt in receipts],
+            "count": len(filtered_items),
+            "items": filtered_items,
         }
     except Exception as e:
         logger.error("governance_bind_receipts failed: %s", e, exc_info=True)

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -580,10 +580,14 @@ def governance_bind_receipts(
         parsed_sort = _parse_bind_receipt_sort(sort)
         parsed_failed_only = _parse_bool_query(failed_only, field_name="failed_only")
         parsed_recent_only = _parse_bool_query(recent_only, field_name="recent_only")
-    except ValueError as exc:
+    except ValueError:
         return JSONResponse(
             status_code=400,
-            content={"ok": False, "error": "invalid_bind_receipt_query", "detail": str(exc)},
+            content={
+                "ok": False,
+                "error": "invalid_bind_receipt_query",
+                "detail": "invalid_query_parameter",
+            },
         )
 
     try:

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -708,10 +708,12 @@ def test_governance_bind_receipts_list_invalid_query_returns_400(monkeypatch) ->
     invalid_outcome_resp = client.get("/v1/governance/bind-receipts?outcome=NOT_A_REAL_OUTCOME", headers=HEADERS)
     assert invalid_outcome_resp.status_code == 400
     assert invalid_outcome_resp.json()["error"] == "invalid_bind_receipt_query"
+    assert invalid_outcome_resp.json()["detail"] == "invalid_query_parameter"
 
     invalid_sort_resp = client.get("/v1/governance/bind-receipts?sort=sideways", headers=HEADERS)
     assert invalid_sort_resp.status_code == 400
     assert invalid_sort_resp.json()["error"] == "invalid_bind_receipt_query"
+    assert invalid_sort_resp.json()["detail"] == "invalid_query_parameter"
 
 
 def test_governance_policy_bundle_promote_success(monkeypatch, tmp_path: Path) -> None:

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -607,6 +607,113 @@ def test_governance_bind_receipts_list_endpoint(monkeypatch) -> None:
     assert body["items"][0]["execution_intent_id"] == "ei-list-1"
 
 
+def test_governance_bind_receipts_list_extended_filters(monkeypatch) -> None:
+    class _Receipt:
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def to_dict(self) -> dict:
+            return dict(self._payload)
+
+    receipts = [
+        _Receipt(
+            {
+                "bind_receipt_id": "br-1",
+                "decision_id": "dec-1",
+                "execution_intent_id": "ei-1",
+                "policy_snapshot_id": "ps-1",
+                "target_path": "/v1/governance/policy",
+                "target_type": "governance_policy",
+                "final_outcome": "COMMITTED",
+                "bind_reason_code": "OK",
+                "occurred_at": "2026-04-22T11:00:00Z",
+            }
+        ),
+        _Receipt(
+            {
+                "bind_receipt_id": "br-2",
+                "decision_id": "dec-2",
+                "execution_intent_id": "ei-2",
+                "policy_snapshot_id": "ps-2",
+                "target_path": "/v1/compliance/config",
+                "target_type": "compliance_config",
+                "final_outcome": "BLOCKED",
+                "bind_reason_code": "POLICY_DENY",
+                "occurred_at": "2026-04-22T10:00:00Z",
+            }
+        ),
+        _Receipt(
+            {
+                "bind_receipt_id": "br-3",
+                "decision_id": "dec-3",
+                "execution_intent_id": "ei-3",
+                "policy_snapshot_id": "ps-3",
+                "target_path": "/v1/governance/policy",
+                "target_type": "governance_policy",
+                "final_outcome": "ESCALATED",
+                "bind_reason_code": "APPROVAL_MISSING",
+                "occurred_at": "2026-04-20T10:00:00Z",
+            }
+        ),
+    ]
+
+    monkeypatch.setattr(
+        "veritas_os.api.routes_governance.find_bind_receipts",
+        lambda **_kwargs: receipts,
+    )
+
+    outcome_resp = client.get("/v1/governance/bind-receipts?outcome=BLOCKED", headers=HEADERS)
+    assert outcome_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in outcome_resp.json()["items"]] == ["br-2"]
+
+    target_path_resp = client.get(
+        "/v1/governance/bind-receipts?target_path=/v1/compliance/config",
+        headers=HEADERS,
+    )
+    assert target_path_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in target_path_resp.json()["items"]] == ["br-2"]
+
+    reason_resp = client.get("/v1/governance/bind-receipts?reason_code=policy", headers=HEADERS)
+    assert reason_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in reason_resp.json()["items"]] == ["br-2"]
+
+    lineage_resp = client.get("/v1/governance/bind-receipts?lineage_query=ps-2", headers=HEADERS)
+    assert lineage_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in lineage_resp.json()["items"]] == ["br-2"]
+
+    failed_only_resp = client.get("/v1/governance/bind-receipts?failed_only=true", headers=HEADERS)
+    assert failed_only_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in failed_only_resp.json()["items"]] == ["br-2", "br-3"]
+
+    recent_only_resp = client.get("/v1/governance/bind-receipts?recent_only=true", headers=HEADERS)
+    assert recent_only_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in recent_only_resp.json()["items"]] == ["br-1", "br-2"]
+
+    oldest_resp = client.get("/v1/governance/bind-receipts?sort=oldest", headers=HEADERS)
+    assert oldest_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in oldest_resp.json()["items"]] == ["br-3", "br-2", "br-1"]
+
+    limit_resp = client.get("/v1/governance/bind-receipts?sort=newest&limit=1", headers=HEADERS)
+    assert limit_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in limit_resp.json()["items"]] == ["br-1"]
+
+
+
+def test_governance_bind_receipts_list_invalid_query_returns_400(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "veritas_os.api.routes_governance.find_bind_receipts",
+        lambda **_kwargs: [],
+    )
+
+    invalid_outcome_resp = client.get("/v1/governance/bind-receipts?outcome=NOT_A_REAL_OUTCOME", headers=HEADERS)
+    assert invalid_outcome_resp.status_code == 400
+    assert invalid_outcome_resp.json()["error"] == "invalid_bind_receipt_query"
+
+    invalid_sort_resp = client.get("/v1/governance/bind-receipts?sort=sideways", headers=HEADERS)
+    assert invalid_sort_resp.status_code == 400
+    assert invalid_sort_resp.json()["error"] == "invalid_bind_receipt_query"
+
+
 def test_governance_policy_bundle_promote_success(monkeypatch, tmp_path: Path) -> None:
     bundles_root = tmp_path / "bundles"
     bundle_dir = bundles_root / "bundle-v2"


### PR DESCRIPTION
### Motivation
- Reduce client-side filtering load by moving BindCockpit's main operator filters to the backend list API so the UI can focus on canonical normalization and presentation.
- Support operator triage patterns (failed-only, recent-only, outcome, reason, lineage) server-side to improve scalability and form a foundation for future pagination/export.
- Keep the change additive and backward-compatible with existing `decision_id` / `execution_intent_id` usage and existing response shape.
- Provide deterministic semantics and stable 400 handling for malformed enum/bool/sort queries.

### Description
- Extended `GET /v1/governance/bind-receipts` in `veritas_os/api/routes_governance.py` to accept additive query params: `target_path`, `target_type`, `outcome`, `reason_code`, `lineage_query`, `failed_only`, `recent_only`, `limit`, and `sort`, and added deterministic parsing/helpers and a lightweight `_apply_bind_receipt_filters` helper that filters/sorts/limits receipts before returning them.
- Added robust query parsing and validation helpers (`_parse_bool_query`, `_parse_bind_receipt_outcome`, `_parse_bind_receipt_sort`, timestamp parsing, canonical path normalization) and return `400` with `invalid_bind_receipt_query` for invalid values.
- Updated OpenAPI (`openapi.yaml`) and README/README_JP to document the new query params, semantics (24h window for `recent_only`, `failed_only` semantics, `limit` cap, default `sort`), and added a 400 response schema for invalid queries.
- Modified `frontend/app/governance/components/BindCockpit.tsx` to build and send query strings from the UI filter state (including `sort=newest` and `limit=200`), retaining only a small client-side refinement for `pathType === 'other'` while otherwise relying on server-side filtering.
- Added/updated tests: integration backend tests in `veritas_os/tests/integration/test_governance_api.py` covering outcome/target_path/reason_code/lineage_query/failed_only/recent_only/limit/sort and invalid query handling, and frontend tests in `frontend/app/governance/components/BindCockpit.test.tsx` verifying query-string construction, no-match UX, and drill-down behavior.

### Testing
- Ran backend integration tests: `pytest -q veritas_os/tests/integration/test_governance_api.py -k "bind_receipts_list or bind_receipt_endpoint or backward_compat_bind_receipts_endpoint"` and `pytest -q veritas_os/tests/test_openapi_spec.py`, both suites passed.
- Ran frontend unit tests: `npm --prefix frontend run test -- BindCockpit.test.tsx bind-cockpit-normalization.test.ts`, and the frontend tests passed.
- Confirmed Python module compiles via `python -m compileall veritas_os/api/routes_governance.py` and test changes exercise both new filters and backward-compatible endpoints with successful results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a716939c8326a0ecca342827cc33)