### PR TITLE
Add cursor pagination, list metadata, and export parity to /v1/governance/bind-receipts

### DIFF
--- a/frontend/app/governance/components/BindCockpit.test.tsx
+++ b/frontend/app/governance/components/BindCockpit.test.tsx
@@ -26,6 +26,14 @@ import { BindCockpit } from "./BindCockpit";
 
 const LIST_PAYLOAD = {
   ok: true,
+  count: 2,
+  returned_count: 2,
+  has_more: false,
+  next_cursor: null,
+  sort: "newest",
+  limit: 50,
+  applied_filters: {},
+  total_count: 2,
   items: [
     {
       bind_receipt_id: "br-committed",
@@ -68,11 +76,11 @@ const DETAIL_PAYLOAD = {
 describe("BindCockpit", () => {
   beforeEach(() => {
     mockFetch.mockReset();
-    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true, items: [] }) });
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true, count: 0, returned_count: 0, has_more: false, next_cursor: null, sort: "newest", limit: 50, applied_filters: {}, total_count: 0, items: [] }) });
   });
 
   it("renders empty state when no receipts", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, items: [] }) });
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, count: 0, returned_count: 0, has_more: false, next_cursor: null, sort: "newest", limit: 50, applied_filters: {}, total_count: 0, items: [] }) });
     render(<BindCockpit />);
     expect(await screen.findByText(/No bind receipts matched filters/i)).toBeInTheDocument();
   });
@@ -80,7 +88,7 @@ describe("BindCockpit", () => {
   it("reflects filter state into server-side bind receipt query", async () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
-      .mockResolvedValue({ ok: true, json: async () => ({ ok: true, items: [LIST_PAYLOAD.items[1]] }) });
+      .mockResolvedValue({ ok: true, json: async () => ({ ok: true, count: 1, returned_count: 1, has_more: false, next_cursor: null, sort: "newest", limit: 50, applied_filters: {}, total_count: 1, items: [LIST_PAYLOAD.items[1]] }) });
 
     render(<BindCockpit />);
     await screen.findByText("br-blocked");
@@ -101,7 +109,7 @@ describe("BindCockpit", () => {
       expect(calledUrls.some((url) => url.includes("failed_only=true"))).toBe(true);
       expect(calledUrls.some((url) => url.includes("recent_only=true"))).toBe(true);
       expect(calledUrls.some((url) => url.includes("sort=newest"))).toBe(true);
-      expect(calledUrls.some((url) => url.includes("limit=200"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("limit=50"))).toBe(true);
     });
   });
 
@@ -109,7 +117,7 @@ describe("BindCockpit", () => {
   it("renders no match state for filtered server response", async () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, items: [] }) });
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, count: 0, returned_count: 0, has_more: false, next_cursor: null, sort: "newest", limit: 50, applied_filters: {}, total_count: 0, items: [] }) });
 
     render(<BindCockpit />);
     await screen.findByText("br-blocked");
@@ -117,6 +125,68 @@ describe("BindCockpit", () => {
     fireEvent.change(screen.getByLabelText("bind-outcome"), { target: { value: "SNAPSHOT_FAILED" } });
 
     expect(await screen.findByText(/No bind receipts matched filters/i)).toBeInTheDocument();
+  });
+
+  
+
+  it("supports load more and export parity with current filters", async () => {
+    const firstPage = {
+      ok: true,
+      count: 1,
+      returned_count: 1,
+      has_more: true,
+      next_cursor: "cursor-1",
+      sort: "newest",
+      limit: 50,
+      applied_filters: {},
+      total_count: 2,
+      items: [LIST_PAYLOAD.items[0]],
+    };
+    const secondPage = {
+      ok: true,
+      count: 1,
+      returned_count: 1,
+      has_more: false,
+      next_cursor: null,
+      sort: "newest",
+      limit: 50,
+      applied_filters: {},
+      total_count: 2,
+      items: [LIST_PAYLOAD.items[1]],
+    };
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/bind-receipts/export")) {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true, items: [] }) });
+      }
+      if (url.includes("/bind-receipts/br-")) {
+        return Promise.resolve({ ok: true, json: async () => DETAIL_PAYLOAD });
+      }
+      if (url.includes("cursor=cursor-1")) {
+        return Promise.resolve({ ok: true, json: async () => secondPage });
+      }
+      return Promise.resolve({ ok: true, json: async () => firstPage });
+    });
+
+    render(<BindCockpit />);
+    await screen.findByText("br-committed");
+
+    expect(screen.getByText(/has more pages/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /load more receipts/i }));
+
+    await screen.findByText("br-blocked");
+    expect(screen.getByText(/no more pages/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("bind-outcome"), { target: { value: "BLOCKED" } });
+
+    await waitFor(() => {
+      const exportLink = screen.getByRole("link", { name: /export current filtered set/i });
+      expect(exportLink.getAttribute("href")).toContain("/api/veritas/v1/governance/bind-receipts/export?");
+      expect(exportLink.getAttribute("href")).toContain("outcome=BLOCKED");
+    });
+
+    const calledUrls = mockFetch.mock.calls.map((call) => String(call[0]));
+    expect(calledUrls.some((url) => url.includes("cursor=cursor-1"))).toBe(true);
   });
 
   it("supports drill-down and related lineage navigation", async () => {

--- a/frontend/app/governance/components/BindCockpit.tsx
+++ b/frontend/app/governance/components/BindCockpit.tsx
@@ -27,9 +27,9 @@ const PATH_TYPE_TO_TARGET_PATH: Record<Exclude<BindFilterState["pathType"], "all
   compliance_config_update: "/v1/compliance/config",
 };
 
-const DEFAULT_LIST_LIMIT = 200;
+const DEFAULT_LIST_LIMIT = 50;
 
-function buildBindReceiptListQuery(filters: BindFilterState): string {
+function buildBindReceiptListQuery(filters: BindFilterState, cursor?: string | null): string {
   const params = new URLSearchParams();
   params.set("sort", "newest");
   params.set("limit", String(DEFAULT_LIST_LIMIT));
@@ -51,6 +51,9 @@ function buildBindReceiptListQuery(filters: BindFilterState): string {
   }
   if (filters.recentOnly) {
     params.set("recent_only", "true");
+  }
+  if (cursor) {
+    params.set("cursor", cursor);
   }
 
   return params.toString();
@@ -98,34 +101,50 @@ export function BindCockpit(): JSX.Element {
   const [receipts, setReceipts] = useState<CanonicalBindReceipt[]>([]);
   const [selectedReceiptId, setSelectedReceiptId] = useState<string | null>(null);
   const [selectedDetail, setSelectedDetail] = useState<CanonicalBindReceipt | null>(null);
+  const [returnedCount, setReturnedCount] = useState(0);
+  const [totalCount, setTotalCount] = useState<number | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [currentSort, setCurrentSort] = useState<"newest" | "oldest">("newest");
 
   const listQuery = useMemo(() => buildBindReceiptListQuery(filters), [filters]);
+  const exportUrl = useMemo(() => `/api/veritas/v1/governance/bind-receipts/export?${buildBindReceiptListQuery(filters)}`, [filters]);
 
-  const loadReceipts = useCallback(async (): Promise<void> => {
+  const loadReceipts = useCallback(async (cursor?: string | null, append = false): Promise<void> => {
     setLoading(true);
     setError(null);
     try {
-      const response = await veritasFetch(`/api/veritas/v1/governance/bind-receipts?${listQuery}`);
+      const query = buildBindReceiptListQuery(filters, cursor);
+      const response = await veritasFetch(`/api/veritas/v1/governance/bind-receipts?${query}`);
       if (!response.ok) {
         setError(`HTTP ${response.status}: Failed to load bind receipts.`);
-        setReceipts([]);
+        if (!append) {
+          setReceipts([]);
+        }
         return;
       }
       const payload = parseBindReceiptListPayload(await response.json());
-      const normalized = payload.map(normalizeBindReceipt);
-      setReceipts(normalized);
+      const normalized = payload.items.map(normalizeBindReceipt);
+      setReturnedCount(payload.meta.returnedCount);
+      setTotalCount(payload.meta.totalCount);
+      setHasMore(payload.meta.hasMore);
+      setNextCursor(payload.meta.nextCursor);
+      setCurrentSort(payload.meta.sort);
+      setReceipts((prev) => (append ? [...prev, ...normalized] : normalized));
     } catch (caught: unknown) {
       console.error("loadReceipts failed", caught);
       setError("Network error: failed to load bind receipts.");
-      setReceipts([]);
+      if (!append) {
+        setReceipts([]);
+      }
     } finally {
       setLoading(false);
     }
-  }, [listQuery]);
+  }, [filters]);
 
   useEffect(() => {
-    void loadReceipts();
-  }, [loadReceipts]);
+    void loadReceipts(null, false);
+  }, [loadReceipts, listQuery]);
 
   useEffect(() => {
     if (receipts.length > 0 && !selectedReceiptId) {
@@ -272,12 +291,16 @@ export function BindCockpit(): JSX.Element {
           <button
             type="button"
             className="rounded border px-2 py-1"
-            onClick={() => void loadReceipts()}
+            onClick={() => void loadReceipts(null, false)}
             disabled={loading}
           >
             {loading ? "loading..." : "refresh receipts"}
           </button>
-          <span className="text-muted-foreground">{filteredReceipts.length} receipts</span>
+          <span className="text-muted-foreground">returned {returnedCount} / total {totalCount ?? filteredReceipts.length} (sort: {currentSort})</span>
+          <span className="text-muted-foreground">{hasMore ? "more available" : "end of results"}</span>
+          <a className="rounded border px-2 py-1" href={exportUrl}>
+            export current filtered set (json)
+          </a>
         </div>
 
         {error ? <p className="rounded border border-danger/30 bg-danger/10 px-2 py-1 text-xs">{error}</p> : null}
@@ -328,6 +351,17 @@ export function BindCockpit(): JSX.Element {
               No bind receipts matched filters. Check path/outcome filters or refresh.
             </p>
           ) : null}
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <button
+            type="button"
+            className="rounded border px-2 py-1"
+            disabled={!hasMore || loading || !nextCursor}
+            onClick={() => void loadReceipts(nextCursor, true)}
+          >
+            load more receipts
+          </button>
+          <span className="text-muted-foreground">{hasMore ? "has more pages" : "no more pages"}</span>
         </div>
 
         <div className="rounded border p-3">

--- a/frontend/app/governance/components/bind-cockpit-normalization.test.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.test.ts
@@ -15,8 +15,8 @@ describe("bind-cockpit-normalization", () => {
   });
 
   it("parses list/detail payload safely", () => {
-    expect(parseBindReceiptListPayload({ items: [{ bind_receipt_id: "br-1" }] })).toHaveLength(1);
-    expect(parseBindReceiptListPayload({ bad: [] })).toHaveLength(0);
+    expect(parseBindReceiptListPayload({ items: [{ bind_receipt_id: "br-1" }], count: 1 }).items).toHaveLength(1);
+    expect(parseBindReceiptListPayload({ bad: [] }).items).toHaveLength(0);
     expect(parseBindReceiptDetailPayload({ bind_receipt: { bind_receipt_id: "br-1" } })?.bind_receipt_id).toBe("br-1");
     expect(parseBindReceiptDetailPayload({ bind_receipt: {} })).toBeNull();
   });

--- a/frontend/app/governance/components/bind-cockpit-normalization.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.ts
@@ -65,6 +65,22 @@ export interface CanonicalBindReceipt {
   raw: BindCockpitReceipt;
 }
 
+export interface BindReceiptListResponseMeta {
+  count: number;
+  returnedCount: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+  sort: "newest" | "oldest";
+  limit: number | null;
+  appliedFilters: Record<string, unknown>;
+  totalCount: number | null;
+}
+
+export interface BindReceiptListParsedPayload {
+  items: BindCockpitReceipt[];
+  meta: BindReceiptListResponseMeta;
+}
+
 export interface BindFilterState {
   pathType: CanonicalTargetPathType | "all";
   outcome: CanonicalBindOutcome | "all";
@@ -249,13 +265,43 @@ export function filterCanonicalReceipts(
   });
 }
 
-export function parseBindReceiptListPayload(value: unknown): BindCockpitReceipt[] {
+export function parseBindReceiptListPayload(value: unknown): BindReceiptListParsedPayload {
   if (!isRecord(value) || !Array.isArray(value.items)) {
-    return [];
+    return {
+      items: [],
+      meta: {
+        count: 0,
+        returnedCount: 0,
+        hasMore: false,
+        nextCursor: null,
+        sort: "newest",
+        limit: null,
+        appliedFilters: {},
+        totalCount: null,
+      },
+    };
   }
-  return value.items.filter((item): item is BindCockpitReceipt => {
+
+  const items = value.items.filter((item): item is BindCockpitReceipt => {
     return isRecord(item) && typeof item.bind_receipt_id === "string";
   });
+  const nextCursor = typeof value.next_cursor === "string" ? value.next_cursor : null;
+  const sort = value.sort === "oldest" ? "oldest" : "newest";
+  const appliedFilters = isRecord(value.applied_filters) ? value.applied_filters : {};
+
+  return {
+    items,
+    meta: {
+      count: typeof value.count === "number" ? value.count : items.length,
+      returnedCount: typeof value.returned_count === "number" ? value.returned_count : items.length,
+      hasMore: Boolean(value.has_more),
+      nextCursor,
+      sort,
+      limit: typeof value.limit === "number" ? value.limit : null,
+      appliedFilters,
+      totalCount: typeof value.total_count === "number" ? value.total_count : null,
+    },
+  };
 }
 
 export function parseBindReceiptDetailPayload(value: unknown): BindCockpitReceipt | null {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2145,7 +2145,7 @@ paths:
         Existing `decision_id` and `execution_intent_id` filters remain supported.
         `failed_only=true` excludes `COMMITTED` outcomes.
         `recent_only=true` returns only receipts within the last 24 hours from server clock.
-        Default sort is `newest`; `limit` defaults to unbounded when omitted and is capped at 200 when specified.
+        Cursor pagination is stable across equal timestamps by using timestamp + bind_receipt_id ordering.
       parameters:
         - in: query
           name: decision_id
@@ -2205,11 +2205,17 @@ paths:
         - in: query
           name: limit
           required: false
-          description: Maximum receipts to return (safe upper bound is 200).
+          description: Maximum receipts per page (safe upper bound is 200).
           schema:
             type: integer
             minimum: 1
             maximum: 200
+        - in: query
+          name: cursor
+          required: false
+          description: Opaque cursor from `next_cursor` to continue current filtered/sorted result set.
+          schema:
+            type: string
         - in: query
           name: sort
           required: false
@@ -2220,7 +2226,7 @@ paths:
             default: "newest"
       responses:
         "200":
-          description: Bind receipts by filter
+          description: Bind receipts by filter with cursor pagination metadata
           content:
             application/json:
               schema:
@@ -2230,12 +2236,32 @@ paths:
                     type: boolean
                   count:
                     type: integer
+                    description: Current page item count (backward-compatible field).
+                  returned_count:
+                    type: integer
+                  has_more:
+                    type: boolean
+                  next_cursor:
+                    type: string
+                    nullable: true
+                  sort:
+                    type: string
+                    enum: ["newest", "oldest"]
+                  limit:
+                    type: integer
+                    nullable: true
+                  total_count:
+                    type: integer
+                    nullable: true
+                  applied_filters:
+                    type: object
+                    additionalProperties: true
                   items:
                     type: array
                     items:
                       $ref: '#/components/schemas/BindReceipt'
         "400":
-          description: Invalid bind receipt query parameter
+          description: Invalid bind receipt query parameter or cursor
           content:
             application/json:
               schema:
@@ -2247,6 +2273,94 @@ paths:
                     type: string
                   detail:
                     type: string
+
+  /v1/governance/bind-receipts/export:
+    get:
+      summary: Bind receipt export with list-filter parity
+      description: |
+        Exports bind receipts using the same filter/sort semantics as `/v1/governance/bind-receipts`.
+        This guarantees operator UI filtered-set parity for audit handoff.
+      parameters:
+        - in: query
+          name: decision_id
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: execution_intent_id
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: target_path
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: target_type
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: outcome
+          required: false
+          schema:
+            type: string
+            enum: ["COMMITTED", "BLOCKED", "ROLLED_BACK", "ESCALATED", "APPLY_FAILED", "SNAPSHOT_FAILED", "PRECONDITION_FAILED"]
+        - in: query
+          name: reason_code
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: lineage_query
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: failed_only
+          required: false
+          schema:
+            type: boolean
+        - in: query
+          name: recent_only
+          required: false
+          schema:
+            type: boolean
+        - in: query
+          name: sort
+          required: false
+          schema:
+            type: string
+            enum: ["newest", "oldest"]
+            default: "newest"
+      responses:
+        "200":
+          description: Bind receipt export payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  count:
+                    type: integer
+                  sort:
+                    type: string
+                    enum: ["newest", "oldest"]
+                  total_count:
+                    type: integer
+                    nullable: true
+                  applied_filters:
+                    type: object
+                    additionalProperties: true
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BindReceipt'
+        "400":
+          description: Invalid bind receipt export parameter
 
   /v1/governance/bind-receipts/{bind_receipt_id}:
     get:

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -254,8 +254,8 @@ def _decode_bind_receipt_cursor(cursor: str, *, expected_sort: str) -> tuple[dat
     try:
         decoded = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
         payload = json.loads(decoded)
-    except (ValueError, TypeError, json.JSONDecodeError):
-        raise ValueError("invalid_cursor")
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid_cursor") from exc
 
     if not isinstance(payload, dict):
         raise ValueError("invalid_cursor")
@@ -269,8 +269,8 @@ def _decode_bind_receipt_cursor(cursor: str, *, expected_sort: str) -> tuple[dat
 
     try:
         timestamp = datetime.fromisoformat(raw_timestamp)
-    except ValueError:
-        raise ValueError("invalid_cursor")
+    except ValueError as exc:
+        raise ValueError("invalid_cursor") from exc
     if timestamp.tzinfo is None:
         timestamp = timestamp.replace(tzinfo=timezone.utc)
     return timestamp.astimezone(timezone.utc), raw_bind_receipt_id

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -2,6 +2,8 @@
 """Governance policy API endpoints with RBAC/ABAC support."""
 from __future__ import annotations
 
+import base64
+import json
 import logging
 import os
 from pathlib import Path
@@ -15,6 +17,7 @@ from fastapi.responses import JSONResponse
 from veritas_os.api.auth import require_permission
 from veritas_os.api.rbac import Permission
 from veritas_os.api.schemas import (
+    GovernanceBindReceiptExportResponse,
     GovernanceBindReceiptListResponse,
     GovernanceBindReceiptResponse,
     GovernanceDecisionExportResponse,
@@ -180,7 +183,6 @@ def _apply_bind_receipt_filters(
     failed_only: bool | None,
     recent_only: bool | None,
     sort: str,
-    limit: int | None,
 ) -> list[dict[str, Any]]:
     """Apply additive bind receipt list query semantics deterministically."""
     now_utc = datetime.now(timezone.utc)
@@ -221,12 +223,112 @@ def _apply_bind_receipt_filters(
         filtered.append(payload)
 
     filtered.sort(
-        key=lambda item: _parse_bind_receipt_timestamp(item) or datetime.min.replace(tzinfo=timezone.utc),
+        key=_bind_receipt_cursor_key,
         reverse=sort == BindReceiptListSort.NEWEST,
     )
-    if limit is not None:
-        return filtered[:limit]
     return filtered
+
+
+
+def _bind_receipt_cursor_key(bind_receipt: dict[str, Any]) -> tuple[datetime, str]:
+    """Return deterministic cursor key tuple for bind receipt pagination."""
+    return (
+        _parse_bind_receipt_timestamp(bind_receipt) or datetime.min.replace(tzinfo=timezone.utc),
+        str(bind_receipt.get("bind_receipt_id") or ""),
+    )
+
+
+def _encode_bind_receipt_cursor(*, sort: str, bind_receipt: dict[str, Any]) -> str:
+    """Encode opaque cursor payload for bind receipt pagination windowing."""
+    timestamp, bind_receipt_id = _bind_receipt_cursor_key(bind_receipt)
+    payload = {
+        "s": sort,
+        "t": timestamp.isoformat(),
+        "id": bind_receipt_id,
+    }
+    return base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8")).decode("ascii")
+
+
+def _decode_bind_receipt_cursor(cursor: str, *, expected_sort: str) -> tuple[datetime, str]:
+    """Decode and validate bind receipt cursor payload for stable paging."""
+    try:
+        decoded = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+        payload = json.loads(decoded)
+    except (ValueError, TypeError, json.JSONDecodeError):
+        raise ValueError("invalid_cursor")
+
+    if not isinstance(payload, dict):
+        raise ValueError("invalid_cursor")
+    if payload.get("s") != expected_sort:
+        raise ValueError("invalid_cursor")
+
+    raw_timestamp = payload.get("t")
+    raw_bind_receipt_id = payload.get("id")
+    if not isinstance(raw_timestamp, str) or not isinstance(raw_bind_receipt_id, str):
+        raise ValueError("invalid_cursor")
+
+    try:
+        timestamp = datetime.fromisoformat(raw_timestamp)
+    except ValueError:
+        raise ValueError("invalid_cursor")
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc), raw_bind_receipt_id
+
+
+def _paginate_bind_receipt_items(
+    *,
+    items: list[dict[str, Any]],
+    sort: str,
+    limit: int | None,
+    cursor: str | None,
+) -> tuple[list[dict[str, Any]], bool, str | None]:
+    """Return paged bind receipt items with has_more and next_cursor."""
+    start_index = 0
+    if cursor:
+        cursor_key = _decode_bind_receipt_cursor(cursor, expected_sort=sort)
+        for idx, item in enumerate(items):
+            if _bind_receipt_cursor_key(item) == cursor_key:
+                start_index = idx + 1
+                break
+        else:
+            raise ValueError("invalid_cursor")
+
+    if limit is None:
+        page_items = items[start_index:]
+        return page_items, False, None
+
+    page_items = items[start_index:start_index + limit]
+    has_more = (start_index + limit) < len(items)
+    next_cursor = _encode_bind_receipt_cursor(sort=sort, bind_receipt=page_items[-1]) if has_more and page_items else None
+    return page_items, has_more, next_cursor
+
+
+def _bind_receipt_applied_filters(
+    *,
+    decision_id: str | None,
+    execution_intent_id: str | None,
+    target_path: str | None,
+    target_type: str | None,
+    outcome: str | None,
+    reason_code: str | None,
+    lineage_query: str | None,
+    failed_only: bool | None,
+    recent_only: bool | None,
+) -> dict[str, Any]:
+    """Build operator-visible summary of applied bind receipt filters."""
+    return {
+        "decision_id": decision_id,
+        "execution_intent_id": execution_intent_id,
+        "target_path": target_path,
+        "target_type": target_type,
+        "outcome": outcome,
+        "reason_code": reason_code,
+        "lineage_query": lineage_query,
+        "failed_only": failed_only,
+        "recent_only": recent_only,
+    }
+
 
 def _resolve_policy_bundle_paths(bundle_name: str) -> tuple[Path, Path, Path]:
     """Resolve promotion paths from server config/env with traversal protection."""
@@ -572,9 +674,106 @@ def governance_bind_receipts(
         description="When true, include only receipts from the last 24 hours based on server clock.",
     ),
     limit: int | None = Query(default=None, ge=1, le=200, description="Max receipts returned (safe upper bound: 200)."),
+    cursor: str | None = Query(default=None, description="Opaque pagination cursor for continuing list results."),
     sort: str | None = Query(default=None, description="Sort order: newest (default) or oldest."),
 ):
     """Return bind receipt artifacts with additive operator-focused server-side filtering."""
+    try:
+        parsed_outcome = _parse_bind_receipt_outcome(outcome)
+        parsed_sort = _parse_bind_receipt_sort(sort)
+        parsed_failed_only = _parse_bool_query(failed_only, field_name="failed_only")
+        parsed_recent_only = _parse_bool_query(recent_only, field_name="recent_only")
+    except ValueError as exc:
+        detail = "invalid_cursor" if str(exc) == "invalid_cursor" else "invalid_query_parameter"
+        return JSONResponse(
+            status_code=400,
+            content={
+                "ok": False,
+                "error": "invalid_bind_receipt_query",
+                "detail": detail,
+            },
+        )
+
+    try:
+        receipts = find_bind_receipts(
+            decision_id=decision_id,
+            execution_intent_id=execution_intent_id,
+        )
+        filtered_items = _apply_bind_receipt_filters(
+            receipts,
+            target_path=target_path,
+            target_type=target_type,
+            outcome=parsed_outcome,
+            reason_code=reason_code,
+            lineage_query=lineage_query,
+            failed_only=parsed_failed_only,
+            recent_only=parsed_recent_only,
+            sort=parsed_sort,
+        )
+        page_items, has_more, next_cursor = _paginate_bind_receipt_items(
+            items=filtered_items,
+            sort=parsed_sort,
+            limit=limit,
+            cursor=cursor,
+        )
+        applied_filters = _bind_receipt_applied_filters(
+            decision_id=decision_id,
+            execution_intent_id=execution_intent_id,
+            target_path=target_path,
+            target_type=target_type,
+            outcome=parsed_outcome,
+            reason_code=reason_code,
+            lineage_query=lineage_query,
+            failed_only=parsed_failed_only,
+            recent_only=parsed_recent_only,
+        )
+        return {
+            "ok": True,
+            "count": len(page_items),
+            "returned_count": len(page_items),
+            "items": page_items,
+            "has_more": has_more,
+            "next_cursor": next_cursor,
+            "sort": parsed_sort,
+            "limit": limit,
+            "applied_filters": applied_filters,
+            "total_count": len(filtered_items),
+        }
+    except ValueError as exc:
+        if str(exc) == "invalid_cursor":
+            return JSONResponse(
+                status_code=400,
+                content={"ok": False, "error": "invalid_bind_receipt_query", "detail": "invalid_cursor"},
+            )
+        raise
+    except Exception as e:
+        logger.error("governance_bind_receipts failed: %s", e, exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": "Failed to load bind receipts"},
+        )
+
+
+
+
+@router.get(
+    "/v1/governance/bind-receipts/export",
+    response_model=GovernanceBindReceiptExportResponse,
+    dependencies=[Depends(require_permission(Permission.governance_read))],
+)
+def governance_bind_receipts_export(
+    decision_id: str | None = Query(default=None),
+    execution_intent_id: str | None = Query(default=None),
+    target_path: str | None = Query(default=None),
+    target_type: str | None = Query(default=None),
+    outcome: str | None = Query(default=None),
+    reason_code: str | None = Query(default=None),
+    lineage_query: str | None = Query(default=None),
+    failed_only: str | None = Query(default=None),
+    recent_only: str | None = Query(default=None),
+    sort: str | None = Query(default=None),
+):
+    """Export bind receipts with list-equivalent filter and sort semantics."""
     try:
         parsed_outcome = _parse_bind_receipt_outcome(outcome)
         parsed_sort = _parse_bind_receipt_sort(sort)
@@ -605,19 +804,29 @@ def governance_bind_receipts(
             failed_only=parsed_failed_only,
             recent_only=parsed_recent_only,
             sort=parsed_sort,
-            limit=limit,
+        )
+        applied_filters = _bind_receipt_applied_filters(
+            decision_id=decision_id,
+            execution_intent_id=execution_intent_id,
+            target_path=target_path,
+            target_type=target_type,
+            outcome=parsed_outcome,
+            reason_code=reason_code,
+            lineage_query=lineage_query,
+            failed_only=parsed_failed_only,
+            recent_only=parsed_recent_only,
         )
         return {
             "ok": True,
             "count": len(filtered_items),
             "items": filtered_items,
+            "sort": parsed_sort,
+            "applied_filters": applied_filters,
+            "total_count": len(filtered_items),
         }
-    except Exception as e:
-        logger.error("governance_bind_receipts failed: %s", e, exc_info=True)
-        return JSONResponse(
-            status_code=500,
-            content={"ok": False, "error": "Failed to load bind receipts"},
-        )
+    except Exception as exc:
+        logger.error("governance_bind_receipts_export failed: %s", exc, exc_info=True)
+        return JSONResponse(status_code=500, content={"ok": False, "error": "Failed to export bind receipts"})
 
 
 @router.get(

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1434,5 +1434,24 @@ class GovernanceBindReceiptListResponse(BaseModel):
 
     ok: bool = True
     count: int = 0
+    returned_count: int = 0
+    has_more: bool = False
+    next_cursor: Optional[str] = None
+    sort: Literal["newest", "oldest"] = "newest"
+    limit: Optional[int] = None
+    applied_filters: Dict[str, Any] = Field(default_factory=dict)
+    total_count: Optional[int] = None
+    items: List[BindReceipt] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class GovernanceBindReceiptExportResponse(BaseModel):
+    """Response envelope for GET /v1/governance/bind-receipts/export."""
+
+    ok: bool = True
+    count: int = 0
+    sort: Literal["newest", "oldest"] = "newest"
+    applied_filters: Dict[str, Any] = Field(default_factory=dict)
+    total_count: Optional[int] = None
     items: List[BindReceipt] = Field(default_factory=list)
     error: Optional[str] = None

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -602,6 +602,10 @@ def test_governance_bind_receipts_list_endpoint(monkeypatch) -> None:
     body = resp.json()
     assert body["ok"] is True
     assert body["count"] == 1
+    assert body["returned_count"] == 1
+    assert body["has_more"] is False
+    assert body["next_cursor"] is None
+    assert body["sort"] == "newest"
     assert body["items"][0]["bind_receipt_id"] == "br-list-1"
     assert body["items"][0]["decision_id"] == "dec-list-1"
     assert body["items"][0]["execution_intent_id"] == "ei-list-1"
@@ -698,6 +702,90 @@ def test_governance_bind_receipts_list_extended_filters(monkeypatch) -> None:
     assert [item["bind_receipt_id"] for item in limit_resp.json()["items"]] == ["br-1"]
 
 
+def test_governance_bind_receipts_cursor_pagination_and_export_parity(monkeypatch) -> None:
+    class _Receipt:
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def to_dict(self) -> dict:
+            return dict(self._payload)
+
+    receipts = [
+        _Receipt(
+            {
+                "bind_receipt_id": "br-a",
+                "decision_id": "dec-a",
+                "execution_intent_id": "ei-a",
+                "target_path": "/v1/governance/policy",
+                "target_type": "governance_policy",
+                "final_outcome": "COMMITTED",
+                "bind_reason_code": "OK",
+                "occurred_at": "2026-04-22T11:00:00Z",
+            }
+        ),
+        _Receipt(
+            {
+                "bind_receipt_id": "br-b",
+                "decision_id": "dec-b",
+                "execution_intent_id": "ei-b",
+                "target_path": "/v1/governance/policy",
+                "target_type": "governance_policy",
+                "final_outcome": "BLOCKED",
+                "bind_reason_code": "POLICY_DENY",
+                "occurred_at": "2026-04-22T11:00:00Z",
+            }
+        ),
+        _Receipt(
+            {
+                "bind_receipt_id": "br-c",
+                "decision_id": "dec-c",
+                "execution_intent_id": "ei-c",
+                "target_path": "/v1/compliance/config",
+                "target_type": "compliance_config",
+                "final_outcome": "ESCALATED",
+                "bind_reason_code": "APPROVAL_MISSING",
+                "occurred_at": "2026-04-22T10:00:00Z",
+            }
+        ),
+    ]
+
+    monkeypatch.setattr("veritas_os.api.routes_governance.find_bind_receipts", lambda **_kwargs: receipts)
+
+    first = client.get("/v1/governance/bind-receipts?sort=newest&limit=1", headers=HEADERS)
+    assert first.status_code == 200
+    first_body = first.json()
+    assert first_body["count"] == 1
+    assert first_body["returned_count"] == 1
+    assert first_body["has_more"] is True
+    assert first_body["sort"] == "newest"
+    assert first_body["total_count"] == 3
+    assert [item["bind_receipt_id"] for item in first_body["items"]] == ["br-b"]
+    assert isinstance(first_body["next_cursor"], str)
+
+    second = client.get(
+        f"/v1/governance/bind-receipts?sort=newest&limit=1&cursor={first_body['next_cursor']}",
+        headers=HEADERS,
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    assert [item["bind_receipt_id"] for item in second_body["items"]] == ["br-a"]
+
+    oldest = client.get("/v1/governance/bind-receipts?sort=oldest&limit=2", headers=HEADERS)
+    assert oldest.status_code == 200
+    oldest_body = oldest.json()
+    assert [item["bind_receipt_id"] for item in oldest_body["items"]] == ["br-c", "br-a"]
+
+    export_resp = client.get(
+        "/v1/governance/bind-receipts/export?target_path=/v1/governance/policy&sort=newest",
+        headers=HEADERS,
+    )
+    assert export_resp.status_code == 200
+    export_body = export_resp.json()
+    assert export_body["sort"] == "newest"
+    assert export_body["total_count"] == 2
+    assert [item["bind_receipt_id"] for item in export_body["items"]] == ["br-b", "br-a"]
+
+
 
 def test_governance_bind_receipts_list_invalid_query_returns_400(monkeypatch) -> None:
     monkeypatch.setattr(
@@ -714,6 +802,10 @@ def test_governance_bind_receipts_list_invalid_query_returns_400(monkeypatch) ->
     assert invalid_sort_resp.status_code == 400
     assert invalid_sort_resp.json()["error"] == "invalid_bind_receipt_query"
     assert invalid_sort_resp.json()["detail"] == "invalid_query_parameter"
+
+    invalid_cursor_resp = client.get("/v1/governance/bind-receipts?cursor=not-a-valid-cursor", headers=HEADERS)
+    assert invalid_cursor_resp.status_code == 400
+    assert invalid_cursor_resp.json()["detail"] == "invalid_cursor"
 
 
 def test_governance_policy_bundle_promote_success(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Make the bind-receipts list API and BindCockpit operator surface robust at operational scale by adding stable cursor pagination, page metadata and a matching export path. 
- Ensure the operator can page/continue/export the exact same filtered result set used in the UI without breaking existing clients.

### Description
- Backend: added stable cursor paging helpers (`_bind_receipt_cursor_key`, `_encode_bind_receipt_cursor`, `_decode_bind_receipt_cursor`, `_paginate_bind_receipt_items`) and applied deterministic timestamp+bind_receipt_id ordering to the existing filter pipeline; introduced `cursor`, preserved `limit` and `sort` semantics, and returnable metadata (`returned_count`, `has_more`, `next_cursor`, `sort`, `limit`, `applied_filters`, `total_count`) in the list response. 
- Export parity: added `GET /v1/governance/bind-receipts/export` that reuses the same filter/sort pipeline so exported JSON matches the UI filtered set. 
- Frontend: updated `BindCockpit` to request pages with `cursor`, show returned/total/has-more/sort metadata, support `load more receipts` and provide an export link that carries current filters. 
- Contracts/docs/tests: updated Pydantic response models and `openapi.yaml`, extended client normalization to parse meta, and added backend + frontend tests covering cursor flows, same-timestamp stability, has_more/next_cursor semantics, filter+pagination interaction, export parity and invalid cursor handling. 
- Security note: cursors are opaque base64 JSON with validation of sort and shape (invalid cursors return 400); for stronger tamper-resistance a signed/HMAC cursor could be introduced later.

### Testing
- Backend integration: ran `pytest veritas_os/tests/integration/test_governance_api.py -k "bind_receipts"` and added `test_governance_bind_receipts_cursor_pagination_and_export_parity` plus invalid-cursor assertions; all selected backend tests passed. 
- Frontend unit: ran the relevant Vitest suites for normalization and cockpit (`pnpm vitest run app/governance/components/bind-cockpit-normalization.test.ts app/governance/components/BindCockpit.test.tsx`) and updated tests to assert metadata parsing, load-more and export-link behavior; those tests passed. 
- Failure handling: invalid cursor cases produce 400/`invalid_cursor` and are exercised in tests and validated in the endpoint parsing logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8aef6c47483269eeed70faf9b6d12)