### PR TITLE
Unify canonical bind target metadata for bind receipts (backend → BindCockpit)

### DIFF
--- a/frontend/app/governance/components/BindCockpit.test.tsx
+++ b/frontend/app/governance/components/BindCockpit.test.tsx
@@ -34,6 +34,35 @@ const LIST_PAYLOAD = {
   limit: 50,
   applied_filters: {},
   total_count: 2,
+  target_catalog: [
+    {
+      target_path: "/v1/governance/policy",
+      target_type: "governance_policy",
+      target_path_type: "governance_policy_update",
+      label: "governance policy update",
+      operator_surface: "governance",
+      relevant_ui_href: "/governance",
+      supports_filtering: true,
+    },
+    {
+      target_path: "/v1/governance/policy-bundles/promote",
+      target_type: "policy_bundle",
+      target_path_type: "policy_bundle_promotion",
+      label: "policy bundle promotion",
+      operator_surface: "governance",
+      relevant_ui_href: "/governance",
+      supports_filtering: true,
+    },
+    {
+      target_path: "/v1/compliance/config",
+      target_type: "compliance_config",
+      target_path_type: "compliance_config_update",
+      label: "compliance config update",
+      operator_surface: "compliance",
+      relevant_ui_href: "/system",
+      supports_filtering: true,
+    },
+  ],
   items: [
     {
       bind_receipt_id: "br-committed",
@@ -47,6 +76,9 @@ const LIST_PAYLOAD = {
     {
       bind_receipt_id: "br-blocked",
       target_path: "/v1/compliance/config",
+      target_path_type: "compliance_config_update",
+      target_label: "compliance config update",
+      relevant_ui_href: "/system",
       final_outcome: "BLOCKED",
       bind_reason_code: "POLICY_DENY",
       decision_id: "decision-2",
@@ -61,6 +93,9 @@ const DETAIL_PAYLOAD = {
   bind_receipt: {
     bind_receipt_id: "br-blocked",
     target_path: "/v1/compliance/config",
+    target_path_type: "compliance_config_update",
+    target_label: "compliance config update",
+    relevant_ui_href: "/system",
     final_outcome: "BLOCKED",
     bind_failure_reason: "policy denied",
     bind_reason_code: "POLICY_DENY",
@@ -92,6 +127,7 @@ describe("BindCockpit", () => {
 
     render(<BindCockpit />);
     await screen.findByText("br-blocked");
+    expect(screen.getByRole("option", { name: "compliance config update" })).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("bind-path-type"), { target: { value: "compliance_config_update" } });
     fireEvent.change(screen.getByLabelText("bind-outcome"), { target: { value: "BLOCKED" } });
@@ -210,5 +246,6 @@ describe("BindCockpit", () => {
     expect(screen.getByRole("link", { name: "related decision" })).toHaveAttribute("href", "/audit?decision_id=decision-2");
     expect(screen.getByRole("link", { name: "related execution intent" })).toHaveAttribute("href", "/audit?cross=exec-2");
     expect(screen.getByRole("link", { name: "related bind receipt" })).toHaveAttribute("href", "/audit?bind_receipt_id=br-blocked");
+    expect(screen.getByRole("link", { name: "relevant governance/compliance surface" })).toHaveAttribute("href", "/system");
   });
 });

--- a/frontend/app/governance/components/BindCockpit.tsx
+++ b/frontend/app/governance/components/BindCockpit.tsx
@@ -5,6 +5,7 @@ import { Card } from "@veritas/design-system";
 import { StatusBadge } from "../../../components/ui";
 import { veritasFetch } from "../../../lib/api-client";
 import {
+  type BindTargetCatalogEntry,
   type BindFilterState,
   type CanonicalBindReceipt,
   normalizeBindReceipt,
@@ -21,21 +22,52 @@ const DEFAULT_FILTERS: BindFilterState = {
   recentOnly: false,
 };
 
-const PATH_TYPE_TO_TARGET_PATH: Record<Exclude<BindFilterState["pathType"], "all" | "other">, string> = {
-  governance_policy_update: "/v1/governance/policy",
-  policy_bundle_promotion: "/v1/governance/policy-bundles/promote",
-  compliance_config_update: "/v1/compliance/config",
-};
-
 const DEFAULT_LIST_LIMIT = 50;
 
-function buildBindReceiptListQuery(filters: BindFilterState, cursor?: string | null): string {
+const FALLBACK_TARGET_CATALOG: BindTargetCatalogEntry[] = [
+  {
+    targetPath: "/v1/governance/policy",
+    targetType: "governance_policy",
+    targetPathType: "governance_policy_update",
+    label: "governance policy update",
+    operatorSurface: "governance",
+    relevantUiHref: "/governance",
+    supportsFiltering: true,
+  },
+  {
+    targetPath: "/v1/governance/policy-bundles/promote",
+    targetType: "policy_bundle",
+    targetPathType: "policy_bundle_promotion",
+    label: "policy bundle promotion",
+    operatorSurface: "governance",
+    relevantUiHref: "/governance",
+    supportsFiltering: true,
+  },
+  {
+    targetPath: "/v1/compliance/config",
+    targetType: "compliance_config",
+    targetPathType: "compliance_config_update",
+    label: "compliance config update",
+    operatorSurface: "compliance",
+    relevantUiHref: "/system",
+    supportsFiltering: true,
+  },
+];
+
+function buildBindReceiptListQuery(
+  filters: BindFilterState,
+  targetCatalog: BindTargetCatalogEntry[],
+  cursor?: string | null,
+): string {
   const params = new URLSearchParams();
   params.set("sort", "newest");
   params.set("limit", String(DEFAULT_LIST_LIMIT));
 
   if (filters.pathType !== "all" && filters.pathType !== "other") {
-    params.set("target_path", PATH_TYPE_TO_TARGET_PATH[filters.pathType]);
+    const matched = targetCatalog.find((entry) => entry.targetPathType === filters.pathType);
+    if (matched?.targetPath) {
+      params.set("target_path", matched.targetPath);
+    }
   }
   if (filters.outcome !== "all") {
     params.set("outcome", filters.outcome);
@@ -59,6 +91,24 @@ function buildBindReceiptListQuery(filters: BindFilterState, cursor?: string | n
   return params.toString();
 }
 
+function isSameCatalog(left: BindTargetCatalogEntry[], right: BindTargetCatalogEntry[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((entry, index) => {
+    const candidate = right[index];
+    return (
+      entry.targetPath === candidate?.targetPath
+      && entry.targetType === candidate?.targetType
+      && entry.targetPathType === candidate?.targetPathType
+      && entry.label === candidate?.label
+      && entry.operatorSurface === candidate?.operatorSurface
+      && entry.relevantUiHref === candidate?.relevantUiHref
+      && entry.supportsFiltering === candidate?.supportsFiltering
+    );
+  });
+}
+
 function resolveOutcomeVariant(
   outcome: CanonicalBindReceipt["outcome"],
 ): "success" | "warning" | "danger" | "muted" {
@@ -72,22 +122,6 @@ function resolveOutcomeVariant(
     return "danger";
   }
   return "muted";
-}
-
-function formatPathType(pathType: BindFilterState["pathType"]): string {
-  if (pathType === "governance_policy_update") {
-    return "governance policy update";
-  }
-  if (pathType === "policy_bundle_promotion") {
-    return "policy bundle promotion";
-  }
-  if (pathType === "compliance_config_update") {
-    return "compliance config update";
-  }
-  if (pathType === "other") {
-    return "other";
-  }
-  return "all";
 }
 
 /**
@@ -106,15 +140,19 @@ export function BindCockpit(): JSX.Element {
   const [hasMore, setHasMore] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [currentSort, setCurrentSort] = useState<"newest" | "oldest">("newest");
+  const [targetCatalog, setTargetCatalog] = useState<BindTargetCatalogEntry[]>(FALLBACK_TARGET_CATALOG);
 
-  const listQuery = useMemo(() => buildBindReceiptListQuery(filters), [filters]);
-  const exportUrl = useMemo(() => `/api/veritas/v1/governance/bind-receipts/export?${buildBindReceiptListQuery(filters)}`, [filters]);
+  const listQuery = useMemo(() => buildBindReceiptListQuery(filters, targetCatalog), [filters, targetCatalog]);
+  const exportUrl = useMemo(
+    () => `/api/veritas/v1/governance/bind-receipts/export?${buildBindReceiptListQuery(filters, targetCatalog)}`,
+    [filters, targetCatalog],
+  );
 
   const loadReceipts = useCallback(async (cursor?: string | null, append = false): Promise<void> => {
     setLoading(true);
     setError(null);
     try {
-      const query = buildBindReceiptListQuery(filters, cursor);
+      const query = buildBindReceiptListQuery(filters, targetCatalog, cursor);
       const response = await veritasFetch(`/api/veritas/v1/governance/bind-receipts?${query}`);
       if (!response.ok) {
         setError(`HTTP ${response.status}: Failed to load bind receipts.`);
@@ -125,6 +163,9 @@ export function BindCockpit(): JSX.Element {
       }
       const payload = parseBindReceiptListPayload(await response.json());
       const normalized = payload.items.map(normalizeBindReceipt);
+      if (payload.targetCatalog.length > 0 && !isSameCatalog(payload.targetCatalog, targetCatalog)) {
+        setTargetCatalog(payload.targetCatalog);
+      }
       setReturnedCount(payload.meta.returnedCount);
       setTotalCount(payload.meta.totalCount);
       setHasMore(payload.meta.hasMore);
@@ -140,7 +181,7 @@ export function BindCockpit(): JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, [filters]);
+  }, [filters, targetCatalog]);
 
   useEffect(() => {
     void loadReceipts(null, false);
@@ -181,6 +222,11 @@ export function BindCockpit(): JSX.Element {
     })();
   }, [selectedReceiptId]);
 
+  const filterableCatalog = useMemo(
+    () => targetCatalog.filter((entry) => entry.supportsFiltering && entry.targetPathType !== "other"),
+    [targetCatalog],
+  );
+
   const filteredReceipts = useMemo(() => {
     if (filters.pathType !== "other") {
       return receipts;
@@ -211,9 +257,11 @@ export function BindCockpit(): JSX.Element {
               }}
             >
               <option value="all">all</option>
-              <option value="governance_policy_update">governance policy update</option>
-              <option value="policy_bundle_promotion">policy bundle promotion</option>
-              <option value="compliance_config_update">compliance config update</option>
+              {filterableCatalog.map((entry) => (
+                <option key={entry.targetPathType} value={entry.targetPathType}>
+                  {entry.label}
+                </option>
+              ))}
               <option value="other">other</option>
             </select>
           </label>
@@ -333,7 +381,7 @@ export function BindCockpit(): JSX.Element {
                   <td className="px-2 py-2 font-mono">{receipt.timestamp}</td>
                   <td className="px-2 py-2">
                     <div className="font-mono">{receipt.targetPath}</div>
-                    <div className="text-muted-foreground">{formatPathType(receipt.targetPathType)}</div>
+                    <div className="text-muted-foreground">{receipt.targetLabel}</div>
                   </td>
                   <td className="px-2 py-2">
                     <StatusBadge label={receipt.outcome} variant={resolveOutcomeVariant(receipt.outcome)} />
@@ -411,7 +459,7 @@ export function BindCockpit(): JSX.Element {
                 <a className="rounded border px-2 py-1" href="/audit">
                   trust / audit explorer
                 </a>
-                <a className="rounded border px-2 py-1" href={selectedDetail.targetPath.startsWith("/v1/compliance") ? "/system" : "/governance"}>
+                <a className="rounded border px-2 py-1" href={selectedDetail.relevantUiHref}>
                   relevant governance/compliance surface
                 </a>
               </div>

--- a/frontend/app/governance/components/bind-cockpit-normalization.test.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.test.ts
@@ -15,7 +15,21 @@ describe("bind-cockpit-normalization", () => {
   });
 
   it("parses list/detail payload safely", () => {
-    expect(parseBindReceiptListPayload({ items: [{ bind_receipt_id: "br-1" }], count: 1 }).items).toHaveLength(1);
+    const parsed = parseBindReceiptListPayload({
+      items: [{ bind_receipt_id: "br-1" }],
+      count: 1,
+      target_catalog: [{
+        target_path: "/v1/governance/policy",
+        target_type: "governance_policy",
+        target_path_type: "governance_policy_update",
+        label: "governance policy update",
+        operator_surface: "governance",
+        relevant_ui_href: "/governance",
+        supports_filtering: true,
+      }],
+    });
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.targetCatalog[0]?.targetPathType).toBe("governance_policy_update");
     expect(parseBindReceiptListPayload({ bad: [] }).items).toHaveLength(0);
     expect(parseBindReceiptDetailPayload({ bind_receipt: { bind_receipt_id: "br-1" } })?.bind_receipt_id).toBe("br-1");
     expect(parseBindReceiptDetailPayload({ bind_receipt: {} })).toBeNull();
@@ -25,12 +39,17 @@ describe("bind-cockpit-normalization", () => {
     const normalized = normalizeBindReceipt({
       bind_receipt_id: "br-7",
       target_path: "/v1/governance/policy-bundles/promote",
+      target_path_type: "policy_bundle_promotion",
+      target_label: "policy bundle promotion",
+      relevant_ui_href: "/governance",
       final_outcome: "blocked",
       bind_reason_code: "APPROVAL_MISSING",
       authority_check_result: { passed: true },
       constraint_check_result: { result: "deny" },
     });
     expect(normalized.targetPathType).toBe("policy_bundle_promotion");
+    expect(normalized.targetLabel).toBe("policy bundle promotion");
+    expect(normalized.relevantUiHref).toBe("/governance");
     expect(normalized.outcome).toBe("BLOCKED");
     expect(normalized.checks.authority).toBe("PASS");
     expect(normalized.checks.constraint).toBe("FAIL");

--- a/frontend/app/governance/components/bind-cockpit-normalization.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.ts
@@ -26,6 +26,10 @@ export interface BindCockpitReceipt {
   target_path?: string;
   target_resource?: string;
   target_type?: string;
+  target_path_type?: string;
+  target_label?: string;
+  operator_surface?: string;
+  relevant_ui_href?: string;
   final_outcome?: string;
   bind_reason_code?: string;
   bind_failure_reason?: string;
@@ -50,6 +54,9 @@ export interface CanonicalBindReceipt {
   targetResource: string;
   targetType: string;
   targetPathType: CanonicalTargetPathType;
+  targetLabel: string;
+  operatorSurface: string;
+  relevantUiHref: string;
   outcome: CanonicalBindOutcome | "UNKNOWN";
   reasonCode: string;
   failureReason: string;
@@ -79,6 +86,17 @@ export interface BindReceiptListResponseMeta {
 export interface BindReceiptListParsedPayload {
   items: BindCockpitReceipt[];
   meta: BindReceiptListResponseMeta;
+  targetCatalog: BindTargetCatalogEntry[];
+}
+
+export interface BindTargetCatalogEntry {
+  targetPath: string;
+  targetType: string;
+  targetPathType: CanonicalTargetPathType;
+  label: string;
+  operatorSurface: string;
+  relevantUiHref: string;
+  supportsFiltering: boolean;
 }
 
 export interface BindFilterState {
@@ -129,6 +147,20 @@ function normalizePathType(path: unknown): CanonicalTargetPathType {
     return "other";
   }
   return TARGET_PATH_TYPE_MAP[path] ?? "other";
+}
+
+function normalizePathTypeValue(pathType: unknown): CanonicalTargetPathType {
+  if (typeof pathType !== "string") {
+    return "other";
+  }
+  if (
+    pathType === "governance_policy_update"
+    || pathType === "policy_bundle_promotion"
+    || pathType === "compliance_config_update"
+  ) {
+    return pathType;
+  }
+  return "other";
 }
 
 function resolveCheck(value: unknown): "PASS" | "FAIL" | "UNKNOWN" {
@@ -199,6 +231,10 @@ export function normalizeBindReceipt(receipt: BindCockpitReceipt): CanonicalBind
   const timestamp =
     pickString(receipt.occurred_at, receipt.created_at) ?? new Date(0).toISOString();
 
+  const normalizedPathType = normalizePathTypeValue(receipt.target_path_type);
+  const fallbackPathType = normalizePathType(receipt.target_path);
+  const targetPathType = normalizedPathType === "other" ? fallbackPathType : normalizedPathType;
+
   return {
     bindReceiptId: pickString(receipt.bind_receipt_id) ?? "-",
     executionIntentId: pickString(receipt.execution_intent_id),
@@ -208,7 +244,10 @@ export function normalizeBindReceipt(receipt: BindCockpitReceipt): CanonicalBind
     targetPath: pickString(receipt.target_path) ?? "-",
     targetResource: pickString(receipt.target_resource) ?? "-",
     targetType: pickString(receipt.target_type) ?? "-",
-    targetPathType: normalizePathType(receipt.target_path),
+    targetPathType,
+    targetLabel: pickString(receipt.target_label) ?? targetPathType.replaceAll("_", " "),
+    operatorSurface: pickString(receipt.operator_surface) ?? "audit",
+    relevantUiHref: pickString(receipt.relevant_ui_href) ?? "/audit",
     outcome,
     reasonCode,
     failureReason,
@@ -279,6 +318,7 @@ export function parseBindReceiptListPayload(value: unknown): BindReceiptListPars
         appliedFilters: {},
         totalCount: null,
       },
+      targetCatalog: [],
     };
   }
 
@@ -288,6 +328,19 @@ export function parseBindReceiptListPayload(value: unknown): BindReceiptListPars
   const nextCursor = typeof value.next_cursor === "string" ? value.next_cursor : null;
   const sort = value.sort === "oldest" ? "oldest" : "newest";
   const appliedFilters = isRecord(value.applied_filters) ? value.applied_filters : {};
+  const targetCatalog = Array.isArray(value.target_catalog)
+    ? value.target_catalog
+      .filter((entry): entry is Record<string, unknown> => isRecord(entry))
+      .map((entry) => ({
+        targetPath: typeof entry.target_path === "string" ? entry.target_path : "",
+        targetType: typeof entry.target_type === "string" ? entry.target_type : "",
+        targetPathType: normalizePathTypeValue(entry.target_path_type),
+        label: typeof entry.label === "string" ? entry.label : "other",
+        operatorSurface: typeof entry.operator_surface === "string" ? entry.operator_surface : "audit",
+        relevantUiHref: typeof entry.relevant_ui_href === "string" ? entry.relevant_ui_href : "/audit",
+        supportsFiltering: Boolean(entry.supports_filtering),
+      }))
+    : [];
 
   return {
     items,
@@ -301,6 +354,7 @@ export function parseBindReceiptListPayload(value: unknown): BindReceiptListPars
       appliedFilters,
       totalCount: typeof value.total_count === "number" ? value.total_count : null,
     },
+    targetCatalog,
   };
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2143,6 +2143,7 @@ paths:
       description: |
         Lists governance bind receipt artifacts with additive server-side filters.
         Existing `decision_id` and `execution_intent_id` filters remain supported.
+        `target_catalog` returns canonical backend-owned metadata for operator surfaces.
         `failed_only=true` excludes `COMMITTED` outcomes.
         `recent_only=true` returns only receipts within the last 24 hours from server clock.
         Cursor pagination is stable across equal timestamps by using timestamp + bind_receipt_id ordering.
@@ -2256,6 +2257,26 @@ paths:
                   applied_filters:
                     type: object
                     additionalProperties: true
+                  target_catalog:
+                    type: array
+                    description: Canonical backend metadata catalog used for path-type selectors, labels, and navigation links.
+                    items:
+                      type: object
+                      properties:
+                        target_path:
+                          type: string
+                        target_type:
+                          type: string
+                        target_path_type:
+                          type: string
+                        label:
+                          type: string
+                        operator_surface:
+                          type: string
+                        relevant_ui_href:
+                          type: string
+                        supports_filtering:
+                          type: boolean
                   items:
                     type: array
                     items:
@@ -2280,6 +2301,7 @@ paths:
       description: |
         Exports bind receipts using the same filter/sort semantics as `/v1/governance/bind-receipts`.
         This guarantees operator UI filtered-set parity for audit handoff.
+        `target_catalog` follows the same canonical semantics as the list endpoint.
       parameters:
         - in: query
           name: decision_id
@@ -2355,6 +2377,25 @@ paths:
                   applied_filters:
                     type: object
                     additionalProperties: true
+                  target_catalog:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        target_path:
+                          type: string
+                        target_type:
+                          type: string
+                        target_path_type:
+                          type: string
+                        label:
+                          type: string
+                        operator_surface:
+                          type: string
+                        relevant_ui_href:
+                          type: string
+                        supports_filtering:
+                          type: boolean
                   items:
                     type: array
                     items:
@@ -2414,6 +2455,11 @@ paths:
                   risk_check_result:
                     type: object
                     nullable: true
+                    additionalProperties: true
+                  target_metadata:
+                    type: object
+                    nullable: true
+                    description: Canonical backend-owned metadata for this receipt target. Unknown paths are returned as `target_path_type=other`.
                     additionalProperties: true
 
   /v1/governance/policy-bundles/promote:

--- a/veritas_os/api/bind_target_catalog.py
+++ b/veritas_os/api/bind_target_catalog.py
@@ -1,0 +1,89 @@
+"""Canonical bind target catalog for operator-facing governance surfaces."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BindTargetCatalogEntry:
+    """Canonical metadata for a bind-governed target path/type pair."""
+
+    target_path: str
+    target_type: str
+    target_path_type: str
+    label: str
+    operator_surface: str
+    relevant_ui_href: str
+    supports_filtering: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable catalog entry for API responses."""
+        return {
+            "target_path": self.target_path,
+            "target_type": self.target_type,
+            "target_path_type": self.target_path_type,
+            "label": self.label,
+            "operator_surface": self.operator_surface,
+            "relevant_ui_href": self.relevant_ui_href,
+            "supports_filtering": self.supports_filtering,
+        }
+
+
+CATALOG: tuple[BindTargetCatalogEntry, ...] = (
+    BindTargetCatalogEntry(
+        target_path="/v1/governance/policy",
+        target_type="governance_policy",
+        target_path_type="governance_policy_update",
+        label="governance policy update",
+        operator_surface="governance",
+        relevant_ui_href="/governance",
+    ),
+    BindTargetCatalogEntry(
+        target_path="/v1/governance/policy-bundles/promote",
+        target_type="policy_bundle",
+        target_path_type="policy_bundle_promotion",
+        label="policy bundle promotion",
+        operator_surface="governance",
+        relevant_ui_href="/governance",
+    ),
+    BindTargetCatalogEntry(
+        target_path="/v1/compliance/config",
+        target_type="compliance_config",
+        target_path_type="compliance_config_update",
+        label="compliance config update",
+        operator_surface="compliance",
+        relevant_ui_href="/system",
+    ),
+)
+
+_INDEX_BY_PATH_AND_TYPE = {
+    (entry.target_path, entry.target_type): entry for entry in CATALOG
+}
+_INDEX_BY_PATH = {entry.target_path: entry for entry in CATALOG}
+
+
+def get_target_catalog_payload() -> list[dict[str, Any]]:
+    """Return canonical catalog payload for list/export/detail responses."""
+    return [entry.to_dict() for entry in CATALOG]
+
+
+def resolve_bind_target_metadata(target_path: Any, target_type: Any) -> dict[str, Any]:
+    """Resolve canonical bind target metadata with safe unknown-path fallback."""
+    canonical_path = str(target_path).strip() if isinstance(target_path, str) else ""
+    canonical_type = str(target_type).strip() if isinstance(target_type, str) else ""
+    matched = (
+        _INDEX_BY_PATH_AND_TYPE.get((canonical_path, canonical_type))
+        or _INDEX_BY_PATH.get(canonical_path)
+    )
+    if matched:
+        return matched.to_dict()
+    return {
+        "target_path": canonical_path,
+        "target_type": canonical_type,
+        "target_path_type": "other",
+        "label": "other",
+        "operator_surface": "audit",
+        "relevant_ui_href": "/audit",
+        "supports_filtering": False,
+    }

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -15,6 +15,10 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
 
 from veritas_os.api.auth import require_permission
+from veritas_os.api.bind_target_catalog import (
+    get_target_catalog_payload,
+    resolve_bind_target_metadata,
+)
 from veritas_os.api.rbac import Permission
 from veritas_os.api.schemas import (
     GovernanceBindReceiptExportResponse,
@@ -348,14 +352,26 @@ def _resolve_policy_bundle_paths(bundle_name: str) -> tuple[Path, Path, Path]:
 
 def _bind_response_payload(bind_receipt: Dict[str, Any]) -> Dict[str, Any]:
     """Normalize bind receipt summary payload for governance API responses."""
+    target_metadata = resolve_bind_target_metadata(
+        bind_receipt.get("target_path"),
+        bind_receipt.get("target_type"),
+    )
+    enriched_receipt = {
+        **bind_receipt,
+        "target_path_type": target_metadata["target_path_type"],
+        "target_label": target_metadata["label"],
+        "operator_surface": target_metadata["operator_surface"],
+        "relevant_ui_href": target_metadata["relevant_ui_href"],
+    }
     return {
         "ok": True,
-        "bind_receipt": bind_receipt,
-        "bind_outcome": bind_receipt.get("final_outcome"),
-        "bind_failure_reason": _resolve_bind_failure_reason(bind_receipt),
-        "bind_reason_code": _resolve_bind_reason_code(bind_receipt),
-        "bind_receipt_id": bind_receipt.get("bind_receipt_id"),
-        "execution_intent_id": bind_receipt.get("execution_intent_id"),
+        "bind_receipt": enriched_receipt,
+        "bind_outcome": enriched_receipt.get("final_outcome"),
+        "bind_failure_reason": _resolve_bind_failure_reason(enriched_receipt),
+        "bind_reason_code": _resolve_bind_reason_code(enriched_receipt),
+        "bind_receipt_id": enriched_receipt.get("bind_receipt_id"),
+        "execution_intent_id": enriched_receipt.get("execution_intent_id"),
+        "target_metadata": target_metadata,
     }
 
 
@@ -710,8 +726,20 @@ def governance_bind_receipts(
             recent_only=parsed_recent_only,
             sort=parsed_sort,
         )
+        enriched_items: list[dict[str, Any]] = []
+        for item in filtered_items:
+            target_metadata = resolve_bind_target_metadata(item.get("target_path"), item.get("target_type"))
+            enriched_items.append(
+                {
+                    **item,
+                    "target_path_type": target_metadata["target_path_type"],
+                    "target_label": target_metadata["label"],
+                    "operator_surface": target_metadata["operator_surface"],
+                    "relevant_ui_href": target_metadata["relevant_ui_href"],
+                }
+            )
         page_items, has_more, next_cursor = _paginate_bind_receipt_items(
-            items=filtered_items,
+            items=enriched_items,
             sort=parsed_sort,
             limit=limit,
             cursor=cursor,
@@ -738,6 +766,7 @@ def governance_bind_receipts(
             "limit": limit,
             "applied_filters": applied_filters,
             "total_count": len(filtered_items),
+            "target_catalog": get_target_catalog_payload(),
         }
     except ValueError as exc:
         if str(exc) == "invalid_cursor":
@@ -805,6 +834,18 @@ def governance_bind_receipts_export(
             recent_only=parsed_recent_only,
             sort=parsed_sort,
         )
+        enriched_items: list[dict[str, Any]] = []
+        for item in filtered_items:
+            target_metadata = resolve_bind_target_metadata(item.get("target_path"), item.get("target_type"))
+            enriched_items.append(
+                {
+                    **item,
+                    "target_path_type": target_metadata["target_path_type"],
+                    "target_label": target_metadata["label"],
+                    "operator_surface": target_metadata["operator_surface"],
+                    "relevant_ui_href": target_metadata["relevant_ui_href"],
+                }
+            )
         applied_filters = _bind_receipt_applied_filters(
             decision_id=decision_id,
             execution_intent_id=execution_intent_id,
@@ -818,11 +859,12 @@ def governance_bind_receipts_export(
         )
         return {
             "ok": True,
-            "count": len(filtered_items),
-            "items": filtered_items,
+            "count": len(enriched_items),
+            "items": enriched_items,
             "sort": parsed_sort,
             "applied_filters": applied_filters,
-            "total_count": len(filtered_items),
+            "total_count": len(enriched_items),
+            "target_catalog": get_target_catalog_payload(),
         }
     except Exception as exc:
         logger.error("governance_bind_receipts_export failed: %s", exc, exc_info=True)
@@ -841,18 +883,27 @@ def governance_bind_receipt(bind_receipt_id: str):
         if not receipts:
             return JSONResponse(status_code=404, content={"ok": False, "error": "bind_receipt_not_found"})
         receipt = receipts[-1].to_dict()
+        target_metadata = resolve_bind_target_metadata(receipt.get("target_path"), receipt.get("target_type"))
+        enriched_receipt = {
+            **receipt,
+            "target_path_type": target_metadata["target_path_type"],
+            "target_label": target_metadata["label"],
+            "operator_surface": target_metadata["operator_surface"],
+            "relevant_ui_href": target_metadata["relevant_ui_href"],
+        }
         return {
             "ok": True,
-            "bind_receipt": receipt,
-            "bind_outcome": receipt.get("final_outcome"),
-            "bind_failure_reason": _resolve_bind_failure_reason(receipt),
-            "bind_reason_code": _resolve_bind_reason_code(receipt),
-            "bind_receipt_id": receipt.get("bind_receipt_id"),
-            "execution_intent_id": receipt.get("execution_intent_id"),
-            "authority_check_result": receipt.get("authority_check_result"),
-            "constraint_check_result": receipt.get("constraint_check_result"),
-            "drift_check_result": receipt.get("drift_check_result"),
-            "risk_check_result": receipt.get("risk_check_result"),
+            "bind_receipt": enriched_receipt,
+            "bind_outcome": enriched_receipt.get("final_outcome"),
+            "bind_failure_reason": _resolve_bind_failure_reason(enriched_receipt),
+            "bind_reason_code": _resolve_bind_reason_code(enriched_receipt),
+            "bind_receipt_id": enriched_receipt.get("bind_receipt_id"),
+            "execution_intent_id": enriched_receipt.get("execution_intent_id"),
+            "authority_check_result": enriched_receipt.get("authority_check_result"),
+            "constraint_check_result": enriched_receipt.get("constraint_check_result"),
+            "drift_check_result": enriched_receipt.get("drift_check_result"),
+            "risk_check_result": enriched_receipt.get("risk_check_result"),
+            "target_metadata": target_metadata,
         }
     except Exception as e:
         logger.error("governance_bind_receipt failed: %s", e, exc_info=True)

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1362,7 +1362,7 @@ class GovernanceBindReceiptResponse(BaseModel):
     """Response envelope for GET /v1/governance/bind-receipts/{bind_receipt_id}."""
 
     ok: bool = True
-    bind_receipt: Optional[BindReceipt] = None
+    bind_receipt: Optional[Dict[str, Any]] = None
     bind_outcome: Optional[FinalOutcome] = None
     bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
     bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
@@ -1372,6 +1372,7 @@ class GovernanceBindReceiptResponse(BaseModel):
     constraint_check_result: Optional[Dict[str, Any]] = None
     drift_check_result: Optional[Dict[str, Any]] = None
     risk_check_result: Optional[Dict[str, Any]] = None
+    target_metadata: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
 
 
@@ -1441,7 +1442,8 @@ class GovernanceBindReceiptListResponse(BaseModel):
     limit: Optional[int] = None
     applied_filters: Dict[str, Any] = Field(default_factory=dict)
     total_count: Optional[int] = None
-    items: List[BindReceipt] = Field(default_factory=list)
+    items: List[Dict[str, Any]] = Field(default_factory=list)
+    target_catalog: List[Dict[str, Any]] = Field(default_factory=list)
     error: Optional[str] = None
 
 
@@ -1453,5 +1455,6 @@ class GovernanceBindReceiptExportResponse(BaseModel):
     sort: Literal["newest", "oldest"] = "newest"
     applied_filters: Dict[str, Any] = Field(default_factory=dict)
     total_count: Optional[int] = None
-    items: List[BindReceipt] = Field(default_factory=list)
+    items: List[Dict[str, Any]] = Field(default_factory=list)
+    target_catalog: List[Dict[str, Any]] = Field(default_factory=list)
     error: Optional[str] = None

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -569,6 +569,8 @@ def test_governance_bind_receipt_endpoint(monkeypatch) -> None:
     assert ok_body["drift_check_result"] == {"passed": False}
     assert ok_body["risk_check_result"] == {"reason_code": "POSTCONDITION_FAIL"}
     assert ok_body["bind_receipt"]["bind_receipt_id"] == "br-501"
+    assert ok_body["bind_receipt"]["target_path_type"] in {"governance_policy_update", "other"}
+    assert "target_metadata" in ok_body
 
     missing_resp = client.get("/v1/governance/bind-receipts/br-missing", headers=HEADERS)
     assert missing_resp.status_code == 404
@@ -609,6 +611,8 @@ def test_governance_bind_receipts_list_endpoint(monkeypatch) -> None:
     assert body["items"][0]["bind_receipt_id"] == "br-list-1"
     assert body["items"][0]["decision_id"] == "dec-list-1"
     assert body["items"][0]["execution_intent_id"] == "ei-list-1"
+    assert isinstance(body["target_catalog"], list)
+    assert any(item["target_path_type"] == "governance_policy_update" for item in body["target_catalog"])
 
 
 def test_governance_bind_receipts_list_extended_filters(monkeypatch) -> None:
@@ -700,6 +704,30 @@ def test_governance_bind_receipts_list_extended_filters(monkeypatch) -> None:
     limit_resp = client.get("/v1/governance/bind-receipts?sort=newest&limit=1", headers=HEADERS)
     assert limit_resp.status_code == 200
     assert [item["bind_receipt_id"] for item in limit_resp.json()["items"]] == ["br-1"]
+    assert target_path_resp.json()["items"][0]["target_path_type"] == "compliance_config_update"
+    assert target_path_resp.json()["items"][0]["target_label"] == "compliance config update"
+
+
+def test_governance_bind_receipts_unknown_target_metadata_fallback(monkeypatch) -> None:
+    class _Receipt:
+        def to_dict(self) -> dict:
+            return {
+                "bind_receipt_id": "br-unknown",
+                "decision_id": "dec-unknown",
+                "execution_intent_id": "ei-unknown",
+                "target_path": "/v1/unknown/path",
+                "target_type": "mystery_target",
+                "final_outcome": "BLOCKED",
+                "bind_reason_code": "DENY",
+                "occurred_at": "2026-04-22T11:00:00Z",
+            }
+
+    monkeypatch.setattr("veritas_os.api.routes_governance.find_bind_receipts", lambda **_kwargs: [_Receipt()])
+    resp = client.get("/v1/governance/bind-receipts", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"][0]["target_path_type"] == "other"
+    assert body["items"][0]["target_label"] == "other"
 
 
 def test_governance_bind_receipts_cursor_pagination_and_export_parity(monkeypatch) -> None:
@@ -784,6 +812,7 @@ def test_governance_bind_receipts_cursor_pagination_and_export_parity(monkeypatc
     assert export_body["sort"] == "newest"
     assert export_body["total_count"] == 2
     assert [item["bind_receipt_id"] for item in export_body["items"]] == ["br-b", "br-a"]
+    assert export_body["target_catalog"] == first_body["target_catalog"]
 
 
 


### PR DESCRIPTION
### Motivation
- Centralize operator-facing canonical metadata for bind-governed targets in the backend to remove frontend hard-coded path maps and reduce drift when new bind paths appear. 
- Ensure `/v1/governance/bind-receipts` list/export/detail responses provide the same canonical semantics for selector options, labels, navigation links and export parity. 
- Keep the change additive and non-breaking so existing clients that read `items` continue to work. 

### Description
- Add a single source-of-truth catalog at `veritas_os/api/bind_target_catalog.py` that defines known bind targets and a safe `other` fallback. 
- Extend governance endpoints to enrich receipts and responses with canonical metadata by injecting `target_catalog` at the list/export top-level and adding receipt-level fields (`target_path_type`, `target_label`, `operator_surface`, `relevant_ui_href`) and a detail `target_metadata`. 
- Update Pydantic response shapes in `veritas_os/api/schemas.py` and the OpenAPI spec in `openapi.yaml` to document the new `target_catalog` and `target_metadata` fields. 
- Update the frontend `BindCockpit` and `bind-cockpit-normalization` to consume backend `target_catalog` as the primary source for selector options, query-building, labels and relevant-surface links while keeping a minimal local fallback catalog; remove the previous `PATH_TYPE_TO_TARGET_PATH` primary mapping. 
- Update unit/integration tests to assert catalog presence, known mappings, unknown-path fallback, list/export parity, selector/query behavior, and relevant UI link usage. 

### Testing
- Ran the governance bind-receipts integration tests with `pytest -q veritas_os/tests/integration/test_governance_api.py -k "bind_receipts"` and all related tests passed (`6 passed`). 
- Validated OpenAPI spec with `pytest -q veritas_os/tests/test_openapi_spec.py` and it passed (`8 passed`). 
- Ran frontend tests with `cd frontend && npm test -- BindCockpit.test.tsx bind-cockpit-normalization.test.ts` and the relevant vitest suites passed (`9 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c38913bc8326b4ef5d6d9dd704a0)