### PR TITLE
Fix broken Zenodo DOI badge image URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Reviewable, traceable, replayable, auditable, and enforceable AI decisions through decision and bind boundaries before real-world effect.**
 
-[![DOI](https://doi.org/10.5281/zenodo.17838349.svg)](https://doi.org/10.5281/zenodo.17838349)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17838349.svg)](https://doi.org/10.5281/zenodo.17838349)
 [![DOI (JP Paper)](https://zenodo.org/badge/DOI/10.5281/zenodo.17838456.svg)](https://doi.org/10.5281/zenodo.17838456)
 ![Python](https://img.shields.io/badge/python-3.11%2B-blue)
 ![Next.js](https://img.shields.io/badge/Next.js-16-black)


### PR DESCRIPTION
### Motivation
- 英語版 `README.md` の DOI バッジ画像が正しく表示されないため、Zenodo の公式バッジ URL に差し替えて表示を改善しました。日本語版 `README_JP.md` は既に正しい形式だったため変更していません。

### Description
- `README.md` の DOI バッジ画像ソースを `https://doi.org/10.5281/zenodo.17838349.svg` から `https://zenodo.org/badge/DOI/10.5281/zenodo.17838349.svg` に置換して修正し、元の DOI リンク先はそのまま維持しました（ファイル: `README.md`）。

### Testing
- 実行した自動コマンド: `git diff -- README.md README_JP.md`（差分確認）、`git diff --check`（空白・問題チェック）および `nl -ba README.md | sed -n '1,20p'`（修正行の確認）を実行し、いずれも問題なく期待どおりの差分が確認できました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97e6833d083268aec5a70fda24295)