### PR TITLE
Lock in WAT retention boundary and enforce immutable retention policy version

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -562,6 +562,43 @@ components:
         signer_backend:
           type: string
           default: existing_signer
+        wat_metadata_retention_ttl_seconds:
+          type: integer
+          default: 7776000
+          minimum: 60
+          maximum: 315360000
+          description: Primary audit path metadata retention TTL (seconds).
+        wat_event_pointer_retention_ttl_seconds:
+          type: integer
+          default: 7776000
+          minimum: 60
+          maximum: 315360000
+          description: Primary audit path event-pointer retention TTL (seconds).
+        observable_digest_retention_ttl_seconds:
+          type: integer
+          default: 31536000
+          minimum: 60
+          maximum: 315360000
+          description: Separate-store full observable digest retention TTL (seconds).
+        observable_digest_access_class:
+          type: string
+          enum:
+          - restricted
+          - privileged
+          default: restricted
+          description: Access control class for separate-store digest payloads.
+        observable_digest_ref:
+          type: string
+          default: separate_store://wat_observables
+          description: Separate-store digest reference prefix.
+        retention_policy_version:
+          type: string
+          default: wat_retention_v1
+          description: Immutable once retention_enforced_at_write=true.
+        retention_enforced_at_write:
+          type: boolean
+          default: true
+          description: Enables write-time retention boundary enforcement.
     PsidConfig:
       type: object
       description: PSID 表示・適用設定
@@ -1619,6 +1656,7 @@ components:
         details:
           type: object
           additionalProperties: true
+          description: Lean primary audit payload; metadata + pointers only.
         trustlog_anchor_ref:
           type: object
           additionalProperties: true

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -113,6 +113,49 @@ class WatConfig(BaseModel):
     require_observable_digest: bool = True
     default_ttl_seconds: int = Field(default=300, ge=1, le=86_400)
     signer_backend: str = "existing_signer"
+    wat_metadata_retention_ttl_seconds: int = Field(
+        default=7_776_000,
+        ge=60,
+        le=315_360_000,
+        description="Retention TTL for lean WAT metadata in the primary audit path.",
+    )
+    wat_event_pointer_retention_ttl_seconds: int = Field(
+        default=7_776_000,
+        ge=60,
+        le=315_360_000,
+        description="Retention TTL for event-pointer records in the primary audit path.",
+    )
+    observable_digest_retention_ttl_seconds: int = Field(
+        default=31_536_000,
+        ge=60,
+        le=315_360_000,
+        description="Retention TTL for full observable digests in a separate store.",
+    )
+    observable_digest_access_class: Literal["restricted", "privileged"] = Field(
+        default="restricted",
+        description="Access class for full observable digest store linkage.",
+    )
+    observable_digest_ref: str = Field(
+        default="separate_store://wat_observables",
+        max_length=500,
+        description="Reference prefix for separate full-observable digest storage.",
+    )
+    retention_policy_version: str = Field(
+        default="wat_retention_v1",
+        min_length=1,
+        max_length=120,
+        description=(
+            "Immutable once retention_enforced_at_write=true; identifies retention"
+            " boundary policy revision used at write time."
+        ),
+    )
+    retention_enforced_at_write: bool = Field(
+        default=True,
+        description=(
+            "When true, write-time retention guards are active and "
+            "retention_policy_version becomes immutable."
+        ),
+    )
 
 
 class PsidConfig(BaseModel):
@@ -417,6 +460,8 @@ def update_policy(patch: Dict[str, Any]) -> Dict[str, Any]:
     previous = _load()
     current = deepcopy(previous)
 
+    previous_wat = current.get("wat") if isinstance(current.get("wat"), dict) else {}
+
     # Validate and deep-merge nested patches immediately.
     # This prevents silently skipping non-dict payloads and validates each
     # section before it is written into the in-memory aggregate state.
@@ -437,6 +482,20 @@ def update_policy(patch: Dict[str, Any]) -> Dict[str, Any]:
 
         validated_section = model_cls.model_validate(merged_section)
         current[key] = validated_section.model_dump()
+
+    # Retention boundary lock-in:
+    # once retention_enforced_at_write=true, retention_policy_version must not
+    # change for this persisted policy path.
+    current_wat = current.get("wat") if isinstance(current.get("wat"), dict) else {}
+    previous_enforced = bool(previous_wat.get("retention_enforced_at_write"))
+    if previous_enforced:
+        previous_version = str(previous_wat.get("retention_policy_version", "")).strip()
+        current_version = str(current_wat.get("retention_policy_version", "")).strip()
+        if previous_version and current_version and current_version != previous_version:
+            raise ValueError(
+                "wat.retention_policy_version is immutable after "
+                "retention_enforced_at_write=true"
+            )
 
     # Scalar overrides
     for key in ("version",):

--- a/veritas_os/audit/wat_events.py
+++ b/veritas_os/audit/wat_events.py
@@ -37,6 +37,15 @@ SUPPORTED_WAT_EVENT_TYPES: frozenset[str] = frozenset({
     "wat_partial_validation_blocked",
 })
 
+_DEFAULT_WAT_METADATA_RETENTION_TTL_SECONDS = 7_776_000
+_DEFAULT_WAT_EVENT_POINTER_RETENTION_TTL_SECONDS = 7_776_000
+_DEFAULT_OBSERVABLE_DIGEST_RETENTION_TTL_SECONDS = 31_536_000
+_DEFAULT_RETENTION_POLICY_VERSION = "wat_retention_v1"
+_ALLOWED_OBSERVABLE_DIGEST_ACCESS_CLASSES: frozenset[str] = frozenset({
+    "restricted",
+    "privileged",
+})
+
 
 def _utc_now_iso_z() -> str:
     """Return current UTC timestamp in RFC3339-like ``Z`` format."""
@@ -116,6 +125,66 @@ def _build_anchor_reference(event_payload: Dict[str, Any]) -> Dict[str, Any]:
         return {"error": "anchor_append_failed"}
 
 
+def _normalize_retention_boundary_details(
+    details: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Normalize event details to retention boundary-safe payloads.
+
+    Primary audit path remains lean: only metadata and event-pointer fields are
+    persisted. Full observable digests are represented by
+    ``observable_digest_ref`` linkage to a separate store.
+    """
+    raw = details if isinstance(details, dict) else {}
+
+    metadata = raw.get("metadata")
+    normalized_metadata: Dict[str, Any] = dict(metadata) if isinstance(metadata, dict) else {}
+    for key in ("psid", "ttl_seconds", "mode", "reason", "request_id"):
+        if key in raw:
+            normalized_metadata[key] = raw.get(key)
+
+    pointers = raw.get("event_pointers")
+    normalized_pointers: Dict[str, Any] = dict(pointers) if isinstance(pointers, dict) else {}
+
+    observable_digest_ref = str(
+        raw.get("observable_digest_ref") or raw.get("observable_digest") or ""
+    ).strip()
+    if observable_digest_ref:
+        normalized_pointers["observable_digest_ref"] = observable_digest_ref
+
+    access_class = str(raw.get("observable_digest_access_class") or "restricted").strip().lower()
+    if access_class not in _ALLOWED_OBSERVABLE_DIGEST_ACCESS_CLASSES:
+        raise ValueError(f"invalid_observable_digest_access_class: {access_class}")
+
+    def _coerce_ttl(value: Any, default_value: int) -> int:
+        try:
+            return max(60, int(value))
+        except (TypeError, ValueError):
+            return default_value
+
+    return {
+        "metadata": normalized_metadata,
+        "event_pointers": normalized_pointers,
+        "wat_metadata_retention_ttl_seconds": _coerce_ttl(
+            raw.get("wat_metadata_retention_ttl_seconds"),
+            _DEFAULT_WAT_METADATA_RETENTION_TTL_SECONDS,
+        ),
+        "wat_event_pointer_retention_ttl_seconds": _coerce_ttl(
+            raw.get("wat_event_pointer_retention_ttl_seconds"),
+            _DEFAULT_WAT_EVENT_POINTER_RETENTION_TTL_SECONDS,
+        ),
+        "observable_digest_retention_ttl_seconds": _coerce_ttl(
+            raw.get("observable_digest_retention_ttl_seconds"),
+            _DEFAULT_OBSERVABLE_DIGEST_RETENTION_TTL_SECONDS,
+        ),
+        "observable_digest_access_class": access_class,
+        "observable_digest_ref": observable_digest_ref,
+        "retention_policy_version": str(
+            raw.get("retention_policy_version") or _DEFAULT_RETENTION_POLICY_VERSION
+        ).strip(),
+        "retention_enforced_at_write": bool(raw.get("retention_enforced_at_write", True)),
+    }
+
+
 def _persist_wat_event(
     *,
     wat_id: str,
@@ -140,6 +209,7 @@ def _persist_wat_event(
         raise ValueError(f"unsupported_wat_event_type: {normalized_event_type}")
 
     now_event_ts = _utc_now_iso_z()
+    normalized_details = _normalize_retention_boundary_details(details)
     record: Dict[str, Any] = {
         "event_id": str(uuid.uuid4()),
         "ts": now_event_ts,
@@ -149,7 +219,7 @@ def _persist_wat_event(
         "event_type": normalized_event_type,
         "actor": str(actor or "system")[:500],
         "status": str(status or "ok")[:50],
-        "details": details or {},
+        "details": normalized_details,
     }
     record["trustlog_anchor_ref"] = _build_anchor_reference(record)
 
@@ -157,6 +227,31 @@ def _persist_wat_event(
     events_path.parent.mkdir(parents=True, exist_ok=True)
 
     with _WAT_LOCK:
+        existing_events = _load_wat_events(events_path)
+        previous_for_wat: Optional[Dict[str, Any]] = None
+        for existing in reversed(existing_events):
+            if str(existing.get("wat_id", "")).strip() == str(wat_id).strip():
+                previous_for_wat = existing
+                break
+
+        previous_details = (
+            previous_for_wat.get("details", {}) if isinstance(previous_for_wat, dict) else {}
+        )
+        if isinstance(previous_details, dict) and bool(previous_details.get("retention_enforced_at_write")):
+            previous_policy_version = str(previous_details.get("retention_policy_version", "")).strip()
+            current_policy_version = str(
+                record["details"].get("retention_policy_version", "")
+            ).strip()
+            if (
+                previous_policy_version
+                and current_policy_version
+                and previous_policy_version != current_policy_version
+            ):
+                raise ValueError(
+                    "retention_policy_version is immutable after "
+                    "retention_enforced_at_write=true"
+                )
+
         with events_path.open("a", encoding="utf-8") as file_obj:
             file_obj.write(json.dumps(record, ensure_ascii=False) + "\n")
             file_obj.flush()

--- a/veritas_os/security/wat_token.py
+++ b/veritas_os/security/wat_token.py
@@ -13,6 +13,10 @@ from veritas_os.security.hash import canonical_json_dumps, sha256_hex
 from veritas_os.security.signing import Signer
 
 WAT_VERSION_V1 = "1"
+ALLOWED_OBSERVABLE_DIGEST_ACCESS_CLASSES: frozenset[str] = frozenset({
+    "restricted",
+    "privileged",
+})
 
 
 def canonicalize_wat_claims(claims: Mapping[str, Any]) -> bytes:
@@ -74,8 +78,17 @@ def build_wat_claims(
     action_summary: str | None = None,
     resource_summary: str | None = None,
     psid_display_length: int = 12,
+    observable_digest_ref: str | None = None,
+    observable_digest_access_class: str = "restricted",
+    retention_policy_version: str = "wat_retention_v1",
+    retention_enforced_at_write: bool = True,
 ) -> dict[str, Any]:
     """Build immutable WAT claims with required fields for v1."""
+    normalized_access_class = str(observable_digest_access_class).strip().lower()
+    if normalized_access_class not in ALLOWED_OBSERVABLE_DIGEST_ACCESS_CLASSES:
+        raise ValueError(
+            f"invalid_observable_digest_access_class: {observable_digest_access_class}"
+        )
     observable_digest_list = compute_observable_digests(observable_refs)
     claims: dict[str, Any] = {
         "wat_id": wat_id or str(uuid4()),
@@ -91,6 +104,11 @@ def build_wat_claims(
         "session_id": session_id,
         "nonce": nonce,
         "signer": dict(signer_metadata),
+        "observable_digest_ref": str(observable_digest_ref or "").strip(),
+        "observable_digest_access_class": normalized_access_class,
+        "retention_policy_version": str(retention_policy_version).strip()
+        or "wat_retention_v1",
+        "retention_enforced_at_write": bool(retention_enforced_at_write),
     }
 
     if decision_reason is not None:

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -1329,6 +1329,29 @@ class TestUpdatePolicyValidation:
         result = gov_mod.update_policy({})
         assert result["updated_by"] == "api"
 
+    def test_wat_observable_digest_access_class_enum_validation(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            gov_mod.update_policy(
+                {"wat": {"observable_digest_access_class": "internal_only"}}
+            )
+
+    def test_wat_retention_policy_version_immutable_when_enforced(self):
+        gov_mod.update_policy(
+            {
+                "wat": {
+                    "retention_enforced_at_write": True,
+                    "retention_policy_version": "wat_retention_v1",
+                }
+            }
+        )
+
+        with pytest.raises(ValueError, match="immutable"):
+            gov_mod.update_policy(
+                {"wat": {"retention_policy_version": "wat_retention_v2"}}
+            )
+
 
 class TestUpdatedBySanitization:
     """Ensure updated_by is safe for persistence, display, and audit logging."""

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -177,3 +177,24 @@ def test_openapi_compliance_config_put_response_includes_bind_fields() -> None:
     assert "execution_intent_id" in properties
     assert "bind_receipt" in properties
     assert "bind_summary" in properties
+
+
+def test_openapi_wat_config_includes_retention_boundary_fields() -> None:
+    """WAT config schema must expose retention boundary lock-in controls."""
+    spec = _load_openapi_spec()
+    wat_props = spec["components"]["schemas"]["WatConfig"]["properties"]
+
+    expected = {
+        "wat_metadata_retention_ttl_seconds",
+        "wat_event_pointer_retention_ttl_seconds",
+        "observable_digest_retention_ttl_seconds",
+        "observable_digest_access_class",
+        "observable_digest_ref",
+        "retention_policy_version",
+        "retention_enforced_at_write",
+    }
+    assert expected.issubset(set(wat_props.keys()))
+    assert wat_props["observable_digest_access_class"]["enum"] == [
+        "restricted",
+        "privileged",
+    ]

--- a/veritas_os/tests/test_wat_events.py
+++ b/veritas_os/tests/test_wat_events.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from veritas_os.audit.wat_events import (
     derive_latest_revocation_state,
+    persist_wat_validation_event,
     persist_wat_issuance_event,
     persist_wat_revocation_event,
 )
@@ -34,3 +37,48 @@ def test_derive_latest_revocation_state_confirmed(tmp_path: Path) -> None:
     state = derive_latest_revocation_state("wat-2", path=path)
     assert state["status"] == "revoked_confirmed"
     assert state["source"] == "wat_events"
+
+
+def test_primary_audit_path_stores_metadata_and_pointers_only(tmp_path: Path) -> None:
+    path = tmp_path / "wat_events.jsonl"
+    event = persist_wat_issuance_event(
+        wat_id="wat-boundary-1",
+        actor="test",
+        details={
+            "psid": "psid-1",
+            "metadata": {"request_id": "rid-1"},
+            "observable_digest": "digest-ref-001",
+            "observable_digest_payload": {"raw": "must-not-persist"},
+        },
+        path=path,
+    )
+
+    details = event["details"]
+    assert "metadata" in details
+    assert "event_pointers" in details
+    assert details["event_pointers"]["observable_digest_ref"] == "digest-ref-001"
+    assert "observable_digest_payload" not in details
+
+
+def test_retention_policy_version_immutable_after_enforcement(tmp_path: Path) -> None:
+    path = tmp_path / "wat_events.jsonl"
+    persist_wat_issuance_event(
+        wat_id="wat-boundary-2",
+        actor="test",
+        details={
+            "retention_policy_version": "wat_retention_v1",
+            "retention_enforced_at_write": True,
+        },
+        path=path,
+    )
+
+    with pytest.raises(ValueError, match="immutable"):
+        persist_wat_validation_event(
+            wat_id="wat-boundary-2",
+            actor="test",
+            details={
+                "retention_policy_version": "wat_retention_v2",
+                "retention_enforced_at_write": True,
+            },
+            path=path,
+        )

--- a/veritas_os/tests/test_wat_token.py
+++ b/veritas_os/tests/test_wat_token.py
@@ -143,3 +143,21 @@ def test_canonicalization_contains_observable_digest_list_field() -> None:
     )
     canonical = canonicalize_wat_claims(claims).decode("utf-8")
     assert '"observable_digest_list"' in canonical
+
+
+def test_build_wat_claims_includes_observable_digest_ref_linkage() -> None:
+    claims = build_wat_claims(
+        version=WAT_VERSION_V1,
+        psid_full="psid-full-005",
+        action_payload={"action": "allow"},
+        observable_refs=[{"obs": "A"}],
+        issuance_ts=1_712_000_000,
+        expiry_ts=1_712_000_600,
+        session_id="s-5",
+        nonce="n-5",
+        signer_metadata={"source": "unit-test"},
+        observable_digest_ref="separate_store://digests/wat-5",
+        observable_digest_access_class="restricted",
+    )
+    assert claims["observable_digest_ref"] == "separate_store://digests/wat-5"
+    assert claims["observable_digest_access_class"] == "restricted"


### PR DESCRIPTION
### Motivation
- Explicitly separate the primary WAT audit path (lean metadata + event pointers) from full observable-digest storage to avoid accidental retention of large/sensitive payloads. 
- Surface retention controls in the governance schema so write-time behavior is auditable and enforceable. 
- Prevent silent policy drift by making the retention policy version immutable once enforcement is active. 

### Description
- Added retention boundary fields to `WatConfig` in `veritas_os/api/governance.py` and published them in `openapi.yaml`: `wat_metadata_retention_ttl_seconds`, `wat_event_pointer_retention_ttl_seconds`, `observable_digest_retention_ttl_seconds`, `observable_digest_access_class`, `observable_digest_ref`, `retention_policy_version`, and `retention_enforced_at_write`.
- Normalized WAT event persistence in `veritas_os/audit/wat_events.py` to store only lean `metadata` + `event_pointers` in the primary audit lane and represent full observable payloads via `observable_digest_ref`, with `observable_digest_access_class` validation and per-WAT write-time immutability checks on `retention_policy_version`.
- Extended claim construction in `veritas_os/security/wat_token.py` to include `observable_digest_ref`, `observable_digest_access_class`, `retention_policy_version`, and `retention_enforced_at_write`, and validated the digest access-class enum (`restricted|privileged`).
- Enforced governance-level write-time lock-in in `veritas_os/api/governance.py` so if `wat.retention_enforced_at_write` was previously true, attempts to change `wat.retention_policy_version` now raise a deterministic `ValueError`.
- Tests and OpenAPI schema updates: updated `openapi.yaml` schema descriptions and added unit/integration tests covering the primary/separate-store boundary, access-class validation, digest-ref linkage, and immutability behavior.

### Testing
- Ran targeted unit tests: `veritas_os/tests/test_wat_events.py`, `veritas_os/tests/test_wat_token.py`, and `veritas_os/tests/test_openapi_spec.py` with relevant retention-related test selection and all assertions passed (`8 passed, 137 deselected` for the focused run).
- Ran broader test suites covering WAT API flows: `tests/test_wat_api.py` plus the above WAT tests and observed full success (`22 passed`).
- Added new assertions in `veritas_os/tests/integration/test_governance_api.py` to validate schema enum coercion and retention-version immutability and new unit tests in `veritas_os/tests/test_wat_events.py` and `veritas_os/tests/test_wat_token.py` to exercise the boundary behavior, all of which passed.

Security note: `observable_digest_ref` models linkage to a separate, stronger-controlled store but does not itself implement that store's TTL/access enforcement; ensure the referenced storage backend enforces the stronger TTL and access controls to avoid residual sensitive-data exposure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9913373ac8326b797cad8c9ccbd26)