### PR TITLE
Lock revocation semantics, require confirmation for confirmed revocations, and add shadow warning traceability

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -636,6 +636,14 @@ components:
         replay_binding_required:
           type: boolean
           default: false
+        replay_binding_escalation_threshold:
+          type: integer
+          default: 4
+          minimum: 1
+          maximum: 16
+        partial_validation_requires_confirmation:
+          type: boolean
+          default: true
     RevocationConfig:
       type: object
       description: 失効反映の整合性設定
@@ -661,6 +669,12 @@ components:
         degrade_on_pending:
           type: boolean
           default: true
+        revocation_confirmation_required:
+          type: boolean
+          default: true
+        auto_escalate_confirmed_revocations:
+          type: boolean
+          default: false
     DriftScoringConfig:
       type: object
       description: ドリフト評価スコア重み
@@ -1125,6 +1139,10 @@ components:
           nullable: true
         revocation_status:
           type: string
+          enum:
+          - active
+          - revoked_pending
+          - revoked_confirmed
           nullable: true
         action_summary:
           type: string
@@ -1171,12 +1189,18 @@ components:
           - minimal
           - expanded
           default: minimal
+        warning_context:
+          type: string
+        warning_correlation_id:
+          type: string
       required:
       - integrity_severity
       - affected_lanes
       - event_ts
       - correlation_id
       - operator_verbosity
+      - warning_context
+      - warning_correlation_id
       additionalProperties: false
     DecideResponse:
       type: object
@@ -1705,6 +1729,10 @@ components:
         confirmed:
           type: boolean
           default: true
+        confirmation:
+          type: string
+          default: ''
+          description: Must be CONFIRM_REVOKED_CONFIRMED for confirmed state changes.
         reason:
           type: string
         details:

--- a/tests/test_wat_api.py
+++ b/tests/test_wat_api.py
@@ -128,13 +128,41 @@ def test_revoke_path(monkeypatch, tmp_path: Path) -> None:
     response = client.post(
         f"/v1/wat/revocation/{issue['wat_id']}",
         headers=_headers("k-operator"),
-        json={"confirmed": True, "reason": "manual"},
+        json={
+            "confirmed": True,
+            "confirmation": "CONFIRM_REVOKED_CONFIRMED",
+            "reason": "manual",
+        },
     )
 
     assert response.status_code == 200
     data = response.json()
     assert data["pending"]["event_type"] == "wat_revocation_pending"
     assert data["confirmed"]["event_type"] == "wat_revoked_confirmed"
+    assert data["revocation_confirmation_required"] is True
+
+
+def test_revoke_confirmed_requires_explicit_confirmation(monkeypatch, tmp_path: Path) -> None:
+    _configure_auth(monkeypatch)
+    _configure_wat_store(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    issue = client.post(
+        "/v1/wat/issue-shadow",
+        headers=_headers("k-operator"),
+        json={"psid": "psid-r2"},
+    ).json()
+
+    response = client.post(
+        f"/v1/wat/revocation/{issue['wat_id']}",
+        headers=_headers("k-operator"),
+        json={"confirmed": True, "reason": "manual"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pending"]["event_type"] == "wat_revocation_pending"
+    assert data["confirmed"] is None
 
 
 def test_auth_rbac_read_vs_mutation(monkeypatch, tmp_path: Path) -> None:

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -173,6 +173,8 @@ class ShadowValidationConfig(BaseModel):
     warning_only_until: str = ""
     timestamp_skew_tolerance_seconds: int = Field(default=5, ge=0, le=3600)
     replay_binding_required: bool = False
+    replay_binding_escalation_threshold: int = Field(default=4, ge=1, le=16)
+    partial_validation_requires_confirmation: bool = True
 
 
 class RevocationConfig(BaseModel):
@@ -183,6 +185,8 @@ class RevocationConfig(BaseModel):
     alert_target_seconds: int = Field(default=30, ge=1, le=86_400)
     convergence_target_p95_seconds: int = Field(default=60, ge=1, le=86_400)
     degrade_on_pending: bool = True
+    revocation_confirmation_required: bool = True
+    auto_escalate_confirmed_revocations: bool = False
 
 
 class DriftScoringConfig(BaseModel):

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -297,6 +297,12 @@ def _run_wat_shadow_observer(
     revocation_state = _resolve_shadow_revocation_state(wat_id=wat_id)
     effective_revocation_status = str(revocation_state.get("status", "active"))
     degrade_on_pending = bool(revocation_cfg.get("degrade_on_pending", True))
+    replay_binding_escalation_threshold = int(
+        shadow_cfg.get("replay_binding_escalation_threshold", 4)
+    )
+    partial_validation_requires_confirmation = bool(
+        shadow_cfg.get("partial_validation_requires_confirmation", True)
+    )
 
     verifier_result = validate_local(
         signed_wat=signed_wat,
@@ -320,6 +326,8 @@ def _run_wat_shadow_observer(
                 shadow_cfg.get("warning_only_until")
             ),
             "replay_binding_required": shadow_cfg.get("replay_binding_required", False),
+            "replay_binding_escalation_threshold": replay_binding_escalation_threshold,
+            "partial_validation_requires_confirmation": partial_validation_requires_confirmation,
             "drift_weights": drift_runtime_cfg["drift_weights"],
             "drift_thresholds": drift_runtime_cfg["drift_thresholds"],
         },
@@ -353,6 +361,8 @@ def _run_wat_shadow_observer(
                 "validation_status": validation_status,
                 "failure_type": failure_type or None,
                 "observable_digest_list": observable_digest_list,
+                "warning_context": "wat_shadow_warning" if event_type != "wat_validated" else "",
+                "warning_correlation_id": request_id or str(issue_event.get("event_id") or wat_id),
             },
         )
         replay_status = "suspected" if failure_type == "replay_detected" else "clear"
@@ -371,6 +381,16 @@ def _run_wat_shadow_observer(
     if operator_verbosity not in {"minimal", "expanded"}:
         operator_verbosity = "minimal"
     correlation_id = request_id or str(issue_event.get("event_id") or wat_id)
+    warning_context = ""
+    if validation_status in {"revoked_pending", "partial"} or integrity_severity == "warning":
+        warning_context = "wat_shadow_warning"
+        logger.warning(
+            "WAT shadow warning context=%s correlation_id=%s status=%s failure_type=%s",
+            warning_context,
+            correlation_id,
+            validation_status,
+            failure_type or "",
+        )
     event_ts = format_event_ts_utc(
         persisted_validation.get("event_ts") or persisted_validation.get("ts")
     )
@@ -388,6 +408,8 @@ def _run_wat_shadow_observer(
         "drift_vector": drift_vector,
         "replay_status": replay_status,
         "revocation_status": effective_revocation_status,
+        "warning_context": warning_context,
+        "warning_correlation_id": correlation_id,
         "integrity_summary": integrity_summary,
         "issue_event_id": issue_event.get("event_id"),
         "validation_event_id": persisted_validation.get("event_id"),
@@ -462,6 +484,14 @@ def _attach_wat_contract_fields(payload: Dict[str, Any], wat_shadow: Dict[str, A
             wat_shadow.get("correlation_id") or payload.get("request_id") or wat_shadow.get("wat_id") or ""
         ),
         "operator_verbosity": operator_verbosity,
+        "warning_context": str(wat_shadow.get("warning_context") or ""),
+        "warning_correlation_id": str(
+            wat_shadow.get("warning_correlation_id")
+            or wat_shadow.get("correlation_id")
+            or payload.get("request_id")
+            or wat_shadow.get("wat_id")
+            or ""
+        ),
     }
     if operator_verbosity == "expanded":
         payload["wat_operator_detail"] = {

--- a/veritas_os/api/routes_wat.py
+++ b/veritas_os/api/routes_wat.py
@@ -47,6 +47,10 @@ class WatRevocationRequest(BaseModel):
     """Request body for WAT revocation transitions."""
 
     confirmed: bool = True
+    confirmation: str = Field(
+        default="",
+        description="Explicit confirmation phrase required for confirmed revocation state changes.",
+    )
     reason: str = Field(default="", max_length=2000)
     details: Dict[str, Any] = Field(default_factory=dict)
 
@@ -169,7 +173,8 @@ def revoke_wat(wat_id: str, body: WatRevocationRequest, request: Request) -> Dic
     )
 
     confirmed_event: Optional[Dict[str, Any]] = None
-    if body.confirmed:
+    explicit_confirmation = body.confirmation.strip() == "CONFIRM_REVOKED_CONFIRMED"
+    if body.confirmed and explicit_confirmation:
         confirmed_event = persist_wat_revocation_event(
             wat_id=wat_id,
             actor=actor,
@@ -182,4 +187,5 @@ def revoke_wat(wat_id: str, body: WatRevocationRequest, request: Request) -> Dic
         "wat_id": wat_id,
         "pending": pending,
         "confirmed": confirmed_event,
+        "revocation_confirmation_required": True,
     }

--- a/veritas_os/audit/wat_events.py
+++ b/veritas_os/audit/wat_events.py
@@ -138,7 +138,15 @@ def _normalize_retention_boundary_details(
 
     metadata = raw.get("metadata")
     normalized_metadata: Dict[str, Any] = dict(metadata) if isinstance(metadata, dict) else {}
-    for key in ("psid", "ttl_seconds", "mode", "reason", "request_id"):
+    for key in (
+        "psid",
+        "ttl_seconds",
+        "mode",
+        "reason",
+        "request_id",
+        "warning_context",
+        "warning_correlation_id",
+    ):
         if key in raw:
             normalized_metadata[key] = raw.get(key)
 
@@ -209,7 +217,11 @@ def _persist_wat_event(
         raise ValueError(f"unsupported_wat_event_type: {normalized_event_type}")
 
     now_event_ts = _utc_now_iso_z()
-    normalized_details = _normalize_retention_boundary_details(details)
+    raw_details = dict(details) if isinstance(details, dict) else {}
+    if str(status or "").strip().lower() == "warning":
+        raw_details.setdefault("warning_context", "wat_shadow_warning")
+        raw_details.setdefault("warning_correlation_id", str(uuid.uuid4()))
+    normalized_details = _normalize_retention_boundary_details(raw_details)
     record: Dict[str, Any] = {
         "event_id": str(uuid.uuid4()),
         "ts": now_event_ts,

--- a/veritas_os/security/wat_verifier.py
+++ b/veritas_os/security/wat_verifier.py
@@ -17,6 +17,7 @@ from veritas_os.security.wat_token import compute_observable_digests, verify_wat
 
 ValidationStatus = str
 AdmissibilityState = str
+_REVOCATION_STATUS_ENUM = {"active", "revoked_pending", "revoked_confirmed"}
 
 _DEFAULT_THRESHOLDS: dict[str, float] = {
     "healthy": 0.2,
@@ -60,6 +61,8 @@ class VerifierResult:
     audit_event_ref: str
     mission_control_event_name: str
     operator_message: str
+    warning_context: str
+    warning_correlation_id: str
 
     def to_dict(self) -> dict[str, Any]:
         """Return JSON-safe dictionary representation."""
@@ -149,14 +152,17 @@ def _to_epoch(ts: Any) -> int | None:
 
 
 def _derive_revocation_status(revocation_state: Any) -> str:
+    """Derive lock-in revocation enum from runtime state payload."""
     if revocation_state is None:
         return "active"
     if isinstance(revocation_state, str):
-        return revocation_state
-    if isinstance(revocation_state, Mapping):
+        value = revocation_state
+    elif isinstance(revocation_state, Mapping):
         value = revocation_state.get("status")
-        if isinstance(value, str):
-            return value
+    else:
+        value = None
+    if isinstance(value, str) and value in _REVOCATION_STATUS_ENUM:
+        return value
     return "active"
 
 
@@ -229,6 +235,7 @@ def _resolve_replay_binding_failure(
     execution_nonce: str,
     claim_session_id: str,
     session_id: str,
+    escalation_threshold: int,
 ) -> str | None:
     """Resolve replay-binding failures for strict and observer-only modes.
 
@@ -251,7 +258,11 @@ def _resolve_replay_binding_failure(
         missing_any = any(claim_missing.values()) or any(local_missing.values())
         if missing_any:
             missing_count = sum(claim_missing.values()) + sum(local_missing.values())
-            return "replay_binding_missing" if missing_count >= 4 else "replay_binding_incomplete"
+            return (
+                "replay_binding_missing"
+                if missing_count >= max(1, int(escalation_threshold))
+                else "replay_binding_incomplete"
+            )
 
     if claim_action_digest != action_digest_local:
         return "action_digest_mismatch"
@@ -304,6 +315,8 @@ def validate_local(
             mission_control_event_name="wat.local.invalid",
             operator_message="WAT local verification status=invalid; "
             "failure=malformed_signed_wat; admissibility=non_admissible.",
+            warning_context="",
+            warning_correlation_id="malformed",
         )
         return result.to_dict()
 
@@ -322,6 +335,7 @@ def validate_local(
     revocation_status = _derive_revocation_status(revocation_state)
     partial_allowed = _is_partial_allowed(cfg, current_ts)
     replay_binding_required = bool(cfg.get("replay_binding_required", False))
+    replay_binding_escalation_threshold = int(cfg.get("replay_binding_escalation_threshold", 4))
 
     if revocation_status == "revoked_confirmed":
         drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
@@ -349,6 +363,7 @@ def validate_local(
             execution_nonce=execution_nonce,
             claim_session_id=claim_session_id,
             session_id=session_id,
+            escalation_threshold=replay_binding_escalation_threshold,
         )
         if replay_binding_failure is not None:
             drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
@@ -377,9 +392,16 @@ def validate_local(
                 status = "revoked_pending"
                 failure_type = "revocation_pending"
             elif bool(cfg.get("allow_partial_validation", False)):
-                drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
-                status = "partial"
-                failure_type = "partial_validation_mode"
+                if bool(cfg.get("partial_validation_requires_confirmation", True)) and not bool(
+                    cfg.get("partial_validation_confirmation", False)
+                ):
+                    drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
+                    status = "invalid"
+                    failure_type = "partial_validation_confirmation_required"
+                else:
+                    drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
+                    status = "partial"
+                    failure_type = "partial_validation_mode"
             else:
                 temporal_drift = 0.0
                 failure_type = None
@@ -411,9 +433,16 @@ def validate_local(
             status = "revoked_pending"
             failure_type = "revocation_pending"
         elif bool(cfg.get("allow_partial_validation", False)):
-            drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
-            status = "partial"
-            failure_type = "partial_validation_mode"
+            if bool(cfg.get("partial_validation_requires_confirmation", True)) and not bool(
+                cfg.get("partial_validation_confirmation", False)
+            ):
+                drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
+                status = "invalid"
+                failure_type = "partial_validation_confirmation_required"
+            else:
+                drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
+                status = "partial"
+                failure_type = "partial_validation_mode"
         else:
             temporal_drift = 0.0
             failure_type = None
@@ -452,6 +481,10 @@ def validate_local(
         failure_type = "partial_validation_timebox_expired"
 
     event_name = f"wat.local.{status}"
+    warning_context = ""
+    if status in {"revoked_pending", "partial"} or admissibility_state == "warning_only_shadow":
+        warning_context = "wat_shadow_warning"
+    warning_correlation_id = binding_key
     result = VerifierResult(
         validation_status=status,
         admissibility_state=admissibility_state,
@@ -464,6 +497,8 @@ def validate_local(
         ),
         mission_control_event_name=event_name,
         operator_message="",
+        warning_context=warning_context,
+        warning_correlation_id=warning_correlation_id,
     )
     operator_message = build_operator_message(result)
     result = VerifierResult(
@@ -474,5 +509,7 @@ def validate_local(
         audit_event_ref=result.audit_event_ref,
         mission_control_event_name=result.mission_control_event_name,
         operator_message=operator_message,
+        warning_context=result.warning_context,
+        warning_correlation_id=result.warning_correlation_id,
     )
     return result.to_dict()

--- a/veritas_os/tests/test_wat_events.py
+++ b/veritas_os/tests/test_wat_events.py
@@ -82,3 +82,18 @@ def test_retention_policy_version_immutable_after_enforcement(tmp_path: Path) ->
             },
             path=path,
         )
+
+
+def test_warning_events_include_traceability_context_and_correlation(tmp_path: Path) -> None:
+    path = tmp_path / "wat_events.jsonl"
+    event = persist_wat_validation_event(
+        wat_id="wat-warning-1",
+        actor="test",
+        event_type="wat_validation_failed",
+        status="warning",
+        details={"reason": "revocation_pending"},
+        path=path,
+    )
+    metadata = event["details"]["metadata"]
+    assert metadata["warning_context"] == "wat_shadow_warning"
+    assert metadata["warning_correlation_id"]

--- a/veritas_os/tests/test_wat_verifier.py
+++ b/veritas_os/tests/test_wat_verifier.py
@@ -434,6 +434,8 @@ def test_validate_local_revoked_pending_is_warning_only(tmp_path: Path) -> None:
     )
     assert result["validation_status"] == "revoked_pending"
     assert result["admissibility_state"] == "warning_only_shadow"
+    assert result["warning_context"] == "wat_shadow_warning"
+    assert result["warning_correlation_id"]
 
 
 def test_validate_local_revoked_pending_blocks_when_degrade_disabled(tmp_path: Path) -> None:
@@ -478,6 +480,74 @@ def test_validate_local_revoked_confirmed_is_hard_fail(tmp_path: Path) -> None:
     assert result["admissibility_state"] == "non_admissible"
 
 
+def test_validate_local_unknown_revocation_status_defaults_to_active(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="legacy_unknown_status",
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["validation_status"] == "valid"
+
+
+def test_validate_local_replay_binding_escalation_threshold_exists_and_applies(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat_with_claim_overrides(tmp_path, remove_keys={"nonce"})
+    claims = signed_wat["claims"]
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(claims["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(claims["observable_digest"]),
+        issuance_ts_local=int(claims["issuance_ts"]),
+        expiry_ts_local=int(claims["expiry_ts"]),
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        config={
+            "replay_binding_required": True,
+            "replay_binding_escalation_threshold": 1,
+        },
+        signer=signer,
+        now_ts=1_712_000_100,
+    )
+    assert result["failure_type"] == "replay_binding_missing"
+
+
+def test_validate_local_partial_requires_confirmation_field_exists_and_applies(tmp_path: Path) -> None:
+    signer, signed_wat = _signed_wat(tmp_path)
+    result = validate_local(
+        signed_wat=signed_wat,
+        psid_full_local="psid-full-001",
+        action_digest_local=str(signed_wat["claims"]["action_digest"]),
+        observable_refs_local=[{"obs": "A"}],
+        observable_digest_local=str(signed_wat["claims"]["observable_digest"]),
+        issuance_ts_local=1_712_000_000,
+        expiry_ts_local=1_712_000_600,
+        execution_nonce="nonce-1",
+        session_id="session-1",
+        revocation_state="active",
+        signer=signer,
+        now_ts=1_712_000_100,
+        config={
+            "allow_partial_validation": True,
+            "partial_validation_requires_confirmation": True,
+            "partial_validation_confirmation": False,
+        },
+    )
+    assert result["validation_status"] == "invalid"
+    assert result["failure_type"] == "partial_validation_confirmation_required"
+
+
 def test_validate_local_partial_requires_timebox(tmp_path: Path) -> None:
     signer, signed_wat = _signed_wat(tmp_path)
     expired_timebox = validate_local(
@@ -497,6 +567,7 @@ def test_validate_local_partial_requires_timebox(tmp_path: Path) -> None:
             "allow_partial_validation": True,
             "observer_only_mode": True,
             "warning_only_until": 1_712_000_050,
+            "partial_validation_confirmation": True,
         },
     )
     active_timebox = validate_local(
@@ -516,6 +587,7 @@ def test_validate_local_partial_requires_timebox(tmp_path: Path) -> None:
             "allow_partial_validation": True,
             "observer_only_mode": True,
             "warning_only_until": 1_712_000_500,
+            "partial_validation_confirmation": True,
         },
     )
     assert expired_timebox["admissibility_state"] == "non_admissible"

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -1064,6 +1064,8 @@ def test_decide_wat_shadow_enabled_emits_events_without_mutating_action(monkeypa
         "event_ts",
         "correlation_id",
         "operator_verbosity",
+        "warning_context",
+        "warning_correlation_id",
     }
     assert summary.get("operator_verbosity") == "minimal"
     assert summary.get("affected_lanes") == ["wat_shadow"]
@@ -1179,6 +1181,8 @@ def test_decide_wat_shadow_expanded_operator_verbosity_surfaces_detail(monkeypat
         "event_ts",
         "correlation_id",
         "operator_verbosity",
+        "warning_context",
+        "warning_correlation_id",
     }
     detail = payload.get("wat_operator_detail", {})
     assert "drift_vector" in detail


### PR DESCRIPTION
### Motivation

- Lock the revocation-state boundary and shadow-overlay validation edge to Mark-approved semantics by enforcing a strict `revocation_status` enum and explicit confirmation behavior.  
- Make `revoked_pending` warning-only and `revoked_confirmed` enforcement-only, add replay/partial-validation escalation controls, and ensure warnings are traceable.  
- Reduce risk of implicit confirmed-state flips by requiring explicit confirmation for confirmed revocations; note that this relies on RBAC/audit to mitigate authorized-misuse risk.

### Description

- Add governance fields `replay_binding_escalation_threshold` and `partial_validation_requires_confirmation` to `ShadowValidationConfig` and `revocation_confirmation_required` and `auto_escalate_confirmed_revocations` to `RevocationConfig` in `veritas_os/api/governance.py` and reflect them in `openapi.yaml`.  
- Lock `revocation_status` to the enum `active | revoked_pending | revoked_confirmed` and normalize legacy/unknown statuses to `active` in `veritas_os/security/wat_verifier.py`, wire `replay_binding_escalation_threshold` and `partial_validation_requires_confirmation` into replay/partial-validation logic, and add `warning_context` / `warning_correlation_id` into verifier results.  
- Require explicit confirmation phrase to record confirmed revocations in `/v1/wat/revocation/{wat_id}` by adding a `confirmation` field and only persisting confirmed events when `confirmation == "CONFIRM_REVOKED_CONFIRMED"` in `veritas_os/api/routes_wat.py`.  
- Surface and log warning traceability (`warning_context`, `warning_correlation_id`) in the shadow observer, persist these into event details via `veritas_os/audit/wat_events.py`, and expose them in decide summaries via `veritas_os/api/routes_decide.py`; update `openapi.yaml` schemas accordingly.  
- Updated unit and API tests to exercise enum behavior, pending-vs-confirmed semantics, confirmation requirement, warning traceability, replay escalation, and partial-validation confirmation wiring; changed files: `veritas_os/api/governance.py`, `veritas_os/security/wat_verifier.py`, `veritas_os/api/routes_decide.py`, `veritas_os/audit/wat_events.py`, `veritas_os/api/routes_wat.py`, `openapi.yaml`, and related tests.

### Testing

- Ran targeted test suites with `pytest -q tests/test_wat_api.py veritas_os/tests/test_wat_verifier.py veritas_os/tests/test_wat_events.py veritas_os/tests/unit/test_server_api.py -q`, and all tests passed after updates.  
- Added/updated tests include checks for `revocation_status` enum handling, `revoked_pending` => `warning_only_shadow`, `revoked_confirmed` => enforcement / `non_admissible`, confirmed-state change requiring explicit confirmation, warning logs/events containing `warning_context` and `warning_correlation_id`, `replay_binding_escalation_threshold` wiring, and `partial_validation_requires_confirmation` behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b192e81c832685912611cd7cf104)