### PR TITLE
Fix broken DOI badges in English/Japanese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Reviewable, traceable, replayable, auditable, and enforceable AI decisions through decision and bind boundaries before real-world effect.**
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17838349.svg)](https://doi.org/10.5281/zenodo.17838349)
-[![DOI (JP Paper)](https://zenodo.org/badge/DOI/10.5281/zenodo.17838456.svg)](https://doi.org/10.5281/zenodo.17838456)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.17838349-0E76A8?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.17838349)
+[![DOI (JP Paper)](https://img.shields.io/badge/DOI%20(JP)-10.5281%2Fzenodo.17838456-0E76A8?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.17838456)
 ![Python](https://img.shields.io/badge/python-3.11%2B-blue)
 ![Next.js](https://img.shields.io/badge/Next.js-16-black)
 ![License](https://img.shields.io/badge/license-Multi--license%20(Core%20Proprietary%20%2B%20MIT)-purple)

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,7 +1,7 @@
 # VERITAS OS v2.0 — LLMエージェント向け意思決定ガバナンスOS
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17838349.svg)](https://doi.org/10.5281/zenodo.17838349)
-[![DOI（日本語論文）](https://zenodo.org/badge/DOI/10.5281/zenodo.17838456.svg)](https://doi.org/10.5281/zenodo.17838456)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.17838349-0E76A8?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.17838349)
+[![DOI（日本語論文）](https://img.shields.io/badge/DOI%20(JP)-10.5281%2Fzenodo.17838456-0E76A8?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.17838456)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black.svg)](https://nextjs.org/)
 [![License](https://img.shields.io/badge/license-Multi--license%20(Core%20Proprietary%20%2B%20MIT)-purple.svg)](LICENSE)


### PR DESCRIPTION
### Motivation
- Replace Zenodo-hosted DOI badge images that rendered poorly in some GitHub clients with Shields.io badges while preserving the original DOI target links.

### Description
- Replaced the DOI badge image URLs in `README.md` and `README_JP.md` with Shields.io badge URLs and left the `https://doi.org/...` destination links unchanged, making this a documentation-only change with no runtime or security impact.

### Testing
- Ran `git diff --check` and `git status --short` to verify a clean patch and that only `README.md` and `README_JP.md` were modified (passed), and an attempted external fetch of the original Zenodo badge via `python` (`requests.get`) failed due to an environment proxy `403 Forbidden` but did not affect the local documentation update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ccda7e908326a15673b4e449026a)