### PR TITLE
ci: increase GHCR publish job timeout from 20 to 40 minutes

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - name: Prepare image tags
         id: image


### PR DESCRIPTION
### Motivation
- 20分の `build-and-push` ジョブがイメージのビルド／プッシュや Trivy スキャン中にキャンセルされる事象を防ぐため、ジョブの実行時間枠を延長しました。

### Description
- `.github/workflows/publish-ghcr.yml` の `build-and-push` ジョブで `timeout-minutes` を `20` から `40` に変更しました。

### Testing
- ワークフロー YAML を `yaml.safe_load` で検証して構文チェックが成功しました（コマンド: `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/publish-ghcr.yml').read_text()); print('ok')"`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d5eda7608326874caa129cddbbcd)