### PR TITLE
Unify canonical bind vocabulary across API/detail surfaces

### DIFF
--- a/docs/en/architecture/bind-boundary-governance-artifacts.md
+++ b/docs/en/architecture/bind-boundary-governance-artifacts.md
@@ -76,6 +76,18 @@ full artifact (`/v1/governance/bind-receipts*`).
 This keeps full-artifact and summary-object semantics explicit rather than
 merging them into a single overloaded shape.
 
+Canonical vocabulary used across backend schema, OpenAPI, and frontend surfaces:
+
+- `bind_summary`: compact, shared operator-facing bind envelope.
+- `bind_receipt` / `bind_receipt_id`: full artifact and stable lineage pointer.
+- `execution_intent_id`: lineage pointer linking decision → execution intent → bind receipt.
+- target metadata fields (`target_path_type`, `target_label`, `operator_surface`, `relevant_ui_href`):
+  backend-owned canonical metadata for operator rendering.
+- bind outcome/reason fields (`bind_outcome`, `bind_reason_code`, `bind_failure_reason`):
+  compact triage vocabulary; full diagnostics remain in `BindReceipt` check payloads.
+
+Legacy flat bind fields remain intentionally additive for compatibility.
+
 ## Runtime behavior impact
 
 Additive to existing decision flows. Decision-phase semantics remain primary;

--- a/frontend/app/governance/components/bind-cockpit-normalization.test.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.test.ts
@@ -35,6 +35,24 @@ describe("bind-cockpit-normalization", () => {
     expect(parseBindReceiptDetailPayload({ bind_receipt: {} })).toBeNull();
   });
 
+  it("hydrates detail payload from bind_summary vocabulary when receipt fields are sparse", () => {
+    const parsed = parseBindReceiptDetailPayload({
+      bind_receipt: { bind_receipt_id: "br-2" },
+      bind_summary: {
+        bind_outcome: "BLOCKED",
+        bind_reason_code: "POLICY_MISSING",
+        bind_failure_reason: "policy missing",
+        execution_intent_id: "ei-2",
+        target_path_type: "governance_policy_update",
+      },
+    });
+    expect(parsed?.bind_receipt_id).toBe("br-2");
+    expect(parsed?.final_outcome).toBe("BLOCKED");
+    expect(parsed?.bind_reason_code).toBe("POLICY_MISSING");
+    expect(parsed?.execution_intent_id).toBe("ei-2");
+    expect(parsed?.target_path_type).toBe("governance_policy_update");
+  });
+
   it("normalizes path, checks, and operator step", () => {
     const normalized = normalizeBindReceipt({
       bind_receipt_id: "br-7",

--- a/frontend/app/governance/components/bind-cockpit-normalization.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.ts
@@ -44,6 +44,24 @@ export interface BindCockpitReceipt {
   [key: string]: unknown;
 }
 
+export interface BindSummaryPayload {
+  bind_outcome?: string;
+  bind_failure_reason?: string;
+  bind_reason_code?: string;
+  bind_receipt_id?: string;
+  execution_intent_id?: string;
+  authority_check_result?: BindCheckPayload;
+  constraint_check_result?: BindCheckPayload;
+  drift_check_result?: BindCheckPayload;
+  risk_check_result?: BindCheckPayload;
+  target_path?: string;
+  target_type?: string;
+  target_path_type?: string;
+  target_label?: string;
+  operator_surface?: string;
+  relevant_ui_href?: string;
+}
+
 export interface CanonicalBindReceipt {
   bindReceiptId: string;
   executionIntentId: string | null;
@@ -362,9 +380,28 @@ export function parseBindReceiptDetailPayload(value: unknown): BindCockpitReceip
   if (!isRecord(value) || !isRecord(value.bind_receipt)) {
     return null;
   }
+  const bindSummary = isRecord(value.bind_summary) ? (value.bind_summary as BindSummaryPayload) : null;
   const payload = value.bind_receipt;
-  if (typeof payload.bind_receipt_id !== "string") {
+  const resolvedBindReceiptId = pickString(payload.bind_receipt_id, bindSummary?.bind_receipt_id);
+  if (resolvedBindReceiptId === null) {
     return null;
   }
-  return payload as BindCockpitReceipt;
+  return {
+    ...payload,
+    bind_receipt_id: resolvedBindReceiptId,
+    execution_intent_id: pickString(payload.execution_intent_id, bindSummary?.execution_intent_id) ?? undefined,
+    final_outcome: pickString(payload.final_outcome, bindSummary?.bind_outcome) ?? undefined,
+    bind_failure_reason: pickString(payload.bind_failure_reason, bindSummary?.bind_failure_reason) ?? undefined,
+    bind_reason_code: pickString(payload.bind_reason_code, bindSummary?.bind_reason_code) ?? undefined,
+    authority_check_result: (payload.authority_check_result ?? bindSummary?.authority_check_result) as BindCheckPayload,
+    constraint_check_result: (payload.constraint_check_result ?? bindSummary?.constraint_check_result) as BindCheckPayload,
+    drift_check_result: (payload.drift_check_result ?? bindSummary?.drift_check_result) as BindCheckPayload,
+    risk_check_result: (payload.risk_check_result ?? bindSummary?.risk_check_result) as BindCheckPayload,
+    target_path: pickString(payload.target_path, bindSummary?.target_path) ?? undefined,
+    target_type: pickString(payload.target_type, bindSummary?.target_type) ?? undefined,
+    target_path_type: pickString(payload.target_path_type, bindSummary?.target_path_type) ?? undefined,
+    target_label: pickString(payload.target_label, bindSummary?.target_label) ?? undefined,
+    operator_surface: pickString(payload.operator_surface, bindSummary?.operator_surface) ?? undefined,
+    relevant_ui_href: pickString(payload.relevant_ui_href, bindSummary?.relevant_ui_href) ?? undefined,
+  } as BindCockpitReceipt;
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2774,6 +2774,11 @@ paths:
                     type: boolean
                   bind_receipt:
                     $ref: '#/components/schemas/BindReceipt'
+                  bind_summary:
+                    anyOf:
+                    - $ref: '#/components/schemas/BindSummary'
+                    - type: 'null'
+                    description: Shared compact bind summary object.
                   bind_outcome:
                     type: string
                     nullable: true
@@ -2884,6 +2889,11 @@ paths:
                     nullable: true
                   bind_receipt:
                     $ref: '#/components/schemas/BindReceipt'
+                  bind_summary:
+                    anyOf:
+                    - $ref: '#/components/schemas/BindSummary'
+                    - type: 'null'
+                    description: Shared compact bind summary object.
   /v1/compliance/config:
     get:
       summary: Compliance config read

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -389,7 +389,12 @@ class BindReceipt(BaseModel):
 
 
 class BindSummary(BaseModel):
-    """Compact bind artifact summary shared across mutation/export responses."""
+    """Compact canonical bind vocabulary shared across mutation/export responses.
+
+    Full bind artifact data remains in ``BindReceipt`` while this summary keeps
+    stable operator-facing lineage and triage fields. Legacy flat bind fields
+    remain additive compatibility mirrors in response envelopes.
+    """
 
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
### Motivation
- The repository exposes both full `BindReceipt` artifacts and a compact `bind_summary` used across mutation/export responses, and the same canonical vocabulary must be clear and consumable across backend schema, OpenAPI, frontend list/detail/export flows, and docs. 
- Small mismatches caused frontend detail parsing to miss canonical summary values when `bind_receipt` payloads were sparse, weakening cross-surface semantic consistency. 
- Changes must be additive and preserve legacy flat fields to avoid any breaking compatibility for operators and existing integrations. 

### Description
- Frontend: added `BindSummaryPayload` and updated `parseBindReceiptDetailPayload` in `frontend/app/governance/components/bind-cockpit-normalization.ts` to hydrate missing receipt fields from `bind_summary` (e.g. `bind_outcome`, `bind_reason_code`, `execution_intent_id`, and target metadata) so detail views remain consistent with list/export payloads. 
- Tests: added a unit test to `bind-cockpit-normalization.test.ts` to verify hydration from `bind_summary` when `bind_receipt` fields are sparse. 
- OpenAPI: added `bind_summary` to the path-level response schemas for bind receipt detail and related promotion/export responses in `openapi.yaml` so the contract explicitly documents the compact summary envelope. 
- Backend schema/docs: clarified `BindSummary` docstring in `veritas_os/api/schemas.py` and documented the canonical vocabulary in `docs/en/architecture/bind-boundary-governance-artifacts.md` (listing `bind_summary`, `bind_receipt_id`, `execution_intent_id`, canonical target metadata, and outcome/reason fields). 

### Testing
- Ran `pytest -q veritas_os/tests/test_bind_summary.py` and the test suite passed (`2 passed`). 
- Ran the frontend unit tests with `npm --prefix frontend run test -- bind-cockpit-normalization.test.ts` and the spec passed (`1 test file, 5 tests, 5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0443542c8326af28b3b86a5fb4cb)