### PR TITLE
Introduce reusable minimal/expanded operator summary/detail surface and apply to bind output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ VERITAS OS focuses on **decision governance and bind-boundary control**:
 - FUJI gate behavior is **fail-closed by default** on unsafe/undefined paths.
 - TrustLog + governance identity create **audit-grade decision lineage**.
 - Mission Control + governance APIs provide an operator-facing governance surface with bind-phase outcomes, bind receipts, and compact bind summaries, not only developer telemetry.
+- `/v1/decide` now follows a shared operator-facing contract pattern: `*_operator_summary` is minimal-by-default, while `*_operator_detail` is only emitted when `operator_verbosity=expanded` and role policy permits.
 
 ### Why this fits regulated / enterprise use
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1261,6 +1261,34 @@ components:
       - warning_context
       - warning_correlation_id
       additionalProperties: false
+    BindOperatorSummary:
+      type: object
+      description: Compact operator-facing bind governance summary surface.
+      properties:
+        bind_state:
+          type: string
+        bind_outcome:
+          type: string
+        bind_reason_code:
+          type: string
+        bind_receipt_id:
+          type: string
+        execution_intent_id:
+          type: string
+        operator_verbosity:
+          type: string
+          enum:
+          - minimal
+          - expanded
+          default: minimal
+      required:
+      - bind_state
+      - bind_outcome
+      - bind_reason_code
+      - bind_receipt_id
+      - execution_intent_id
+      - operator_verbosity
+      additionalProperties: false
     DecideResponse:
       type: object
       properties:
@@ -1551,6 +1579,15 @@ components:
           nullable: true
           additionalProperties: true
           description: Expanded drill-down payload, emitted only when operator_verbosity=expanded.
+        bind_operator_summary:
+          $ref: '#/components/schemas/BindOperatorSummary'
+          nullable: true
+          description: Compact bind governance summary (minimal default surface).
+        bind_operator_detail:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Expanded bind drill-down payload emitted only for expanded verbosity and permitted roles.
         bind_summary:
           anyOf:
           - $ref: '#/components/schemas/BindSummary'

--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -569,6 +569,15 @@ export interface WatOperatorSummary {
   operator_verbosity: "minimal" | "expanded";
 }
 
+export interface BindOperatorSummary {
+  bind_state: string;
+  bind_outcome: string;
+  bind_reason_code: string;
+  bind_receipt_id: string;
+  execution_intent_id: string;
+  operator_verbosity: "minimal" | "expanded";
+}
+
 export interface DecideResponse extends DecideResponseMeta {
   /* ------------------------------------------------------------------ */
   /* Core decision contract fields                                      */
@@ -669,6 +678,10 @@ export interface DecideResponse extends DecideResponseMeta {
   wat_operator_summary?: WatOperatorSummary | null;
   /** Expanded drill-down data emitted only when verbosity is expanded. */
   wat_operator_detail?: Record<string, unknown> | null;
+  /** Compact operator-facing bind summary surface. */
+  bind_operator_summary?: BindOperatorSummary | null;
+  /** Expanded bind drill-down data for permitted roles at expanded verbosity. */
+  bind_operator_detail?: Record<string, unknown> | null;
 
   /**
    * Continuation runtime output (shadow/observe — phase-1).
@@ -742,7 +755,9 @@ export function isDecideResponse(value: unknown): value is DecideResponse {
     (value.wat_integrity === null || value.wat_integrity === undefined || isRecord(value.wat_integrity)) &&
     (value.wat_drift_vector === null || value.wat_drift_vector === undefined || isRecord(value.wat_drift_vector)) &&
     (value.wat_operator_summary === null || value.wat_operator_summary === undefined || isRecord(value.wat_operator_summary)) &&
-    (value.wat_operator_detail === null || value.wat_operator_detail === undefined || isRecord(value.wat_operator_detail))
+    (value.wat_operator_detail === null || value.wat_operator_detail === undefined || isRecord(value.wat_operator_detail)) &&
+    (value.bind_operator_summary === null || value.bind_operator_summary === undefined || isRecord(value.bind_operator_summary)) &&
+    (value.bind_operator_detail === null || value.bind_operator_detail === undefined || isRecord(value.bind_operator_detail))
   );
 }
 

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -12,7 +12,7 @@ import hashlib
 import logging
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Request
@@ -452,6 +452,38 @@ def _normalize_wat_drift_vector(raw_vector: Any) -> Dict[str, float]:
     return normalized
 
 
+def _resolve_operator_verbosity(value: Any) -> str:
+    """Resolve canonical operator verbosity with minimal-default safety."""
+    verbosity = str(value or "minimal")
+    if verbosity not in {"minimal", "expanded"}:
+        return "minimal"
+    return verbosity
+
+
+def _resolve_operator_role(request: Request) -> str:
+    """Resolve request RBAC role for operator-facing detail controls."""
+    role = getattr(getattr(request, "state", None), "rbac_role", None)
+    if isinstance(role, str) and role.strip():
+        return role.strip().lower()
+    return "admin"
+
+
+def _build_operator_surface(
+    *,
+    summary: Dict[str, Any],
+    detail: Optional[Dict[str, Any]],
+    operator_verbosity: str,
+    role: str,
+    expanded_roles: set[str],
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Build minimal-default operator surface with role-gated expanded detail."""
+    effective_verbosity = "expanded" if operator_verbosity == "expanded" and role in expanded_roles else "minimal"
+    summary["operator_verbosity"] = effective_verbosity
+    if effective_verbosity == "expanded" and isinstance(detail, dict):
+        return summary, detail
+    return summary, None
+
+
 def _attach_wat_contract_fields(payload: Dict[str, Any], wat_shadow: Dict[str, Any]) -> None:
     """Attach additive canonical WAT fields to decide payload.
 
@@ -472,33 +504,74 @@ def _attach_wat_contract_fields(payload: Dict[str, Any], wat_shadow: Dict[str, A
         "action_summary": "observer_only_validation",
     }
     payload["wat_drift_vector"] = _normalize_wat_drift_vector(wat_shadow.get("drift_vector"))
-    operator_verbosity = str(wat_shadow.get("operator_verbosity") or "minimal")
-    if operator_verbosity not in {"minimal", "expanded"}:
-        operator_verbosity = "minimal"
-    payload["wat_operator_summary"] = {
+    operator_verbosity = _resolve_operator_verbosity(wat_shadow.get("operator_verbosity"))
+    summary, detail = _build_operator_surface(
+        summary={
         # v1 lock-in: intentionally minimal operator-facing default surface.
-        "integrity_severity": integrity_state,
-        "affected_lanes": list(wat_shadow.get("affected_lanes") or ["wat_shadow"]),
-        "event_ts": format_event_ts_utc(wat_shadow.get("event_ts") or wat_shadow.get("ts")),
-        "correlation_id": str(
-            wat_shadow.get("correlation_id") or payload.get("request_id") or wat_shadow.get("wat_id") or ""
-        ),
-        "operator_verbosity": operator_verbosity,
-        "warning_context": str(wat_shadow.get("warning_context") or ""),
-        "warning_correlation_id": str(
-            wat_shadow.get("warning_correlation_id")
-            or wat_shadow.get("correlation_id")
-            or payload.get("request_id")
-            or wat_shadow.get("wat_id")
-            or ""
-        ),
-    }
-    if operator_verbosity == "expanded":
-        payload["wat_operator_detail"] = {
+            "integrity_severity": integrity_state,
+            "affected_lanes": list(wat_shadow.get("affected_lanes") or ["wat_shadow"]),
+            "event_ts": format_event_ts_utc(wat_shadow.get("event_ts") or wat_shadow.get("ts")),
+            "correlation_id": str(
+                wat_shadow.get("correlation_id") or payload.get("request_id") or wat_shadow.get("wat_id") or ""
+            ),
+            "warning_context": str(wat_shadow.get("warning_context") or ""),
+            "warning_correlation_id": str(
+                wat_shadow.get("warning_correlation_id")
+                or wat_shadow.get("correlation_id")
+                or payload.get("request_id")
+                or wat_shadow.get("wat_id")
+                or ""
+            ),
+        },
+        detail={
             "drift_vector": _normalize_wat_drift_vector(wat_shadow.get("drift_vector")),
             "verifier_output_raw": wat_shadow.get("verifier_output_raw"),
             "historical_drift_trend": wat_shadow.get("historical_drift_trend"),
-        }
+        },
+        operator_verbosity=operator_verbosity,
+        role="admin",
+        expanded_roles={"admin"},
+    )
+    payload["wat_operator_summary"] = summary
+    if detail is not None:
+        payload["wat_operator_detail"] = detail
+
+
+def _attach_bind_operator_surface(
+    *,
+    payload: Dict[str, Any],
+    policy: Dict[str, Any],
+    role: str,
+) -> None:
+    """Attach reusable minimal/expanded operator surface for bind governance."""
+    bind_summary = payload.get("bind_summary")
+    if not isinstance(bind_summary, dict):
+        return
+    operator_verbosity = _resolve_operator_verbosity(policy.get("operator_verbosity"))
+    bind_outcome = str(payload.get("bind_outcome") or bind_summary.get("outcome") or "")
+    summary, detail = _build_operator_surface(
+        summary={
+            "bind_state": bind_outcome.lower() or "unknown",
+            "bind_outcome": bind_outcome,
+            "bind_reason_code": str(payload.get("bind_reason_code") or bind_summary.get("reason_code") or ""),
+            "bind_receipt_id": str(payload.get("bind_receipt_id") or bind_summary.get("bind_receipt_id") or ""),
+            "execution_intent_id": str(
+                payload.get("execution_intent_id") or bind_summary.get("execution_intent_id") or ""
+            ),
+        },
+        detail={
+            "authority_check_result": payload.get("authority_check_result"),
+            "constraint_check_result": payload.get("constraint_check_result"),
+            "drift_check_result": payload.get("drift_check_result"),
+            "risk_check_result": payload.get("risk_check_result"),
+        },
+        operator_verbosity=operator_verbosity,
+        role=role,
+        expanded_roles={"admin"},
+    )
+    payload["bind_operator_summary"] = summary
+    if detail is not None:
+        payload["bind_operator_detail"] = detail
 
 
 # ------------------------------------------------------------------
@@ -564,6 +637,9 @@ async def decide(req: DecideRequest, request: Request):
             logger.debug("stage event publish failed (best-effort)", exc_info=True)
 
     coerced = _coerce_decide_payload(payload, seed=getattr(req, "query", "") or "")
+    policy = get_policy()
+    operator_role = _resolve_operator_role(request)
+    _attach_bind_operator_surface(payload=coerced, policy=policy, role=operator_role)
 
     try:
         wat_shadow = _run_wat_shadow_observer(srv=srv, req=req, coerced=coerced)

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -901,6 +901,22 @@ class DecideResponse(BaseModel):
             "operator_verbosity=expanded."
         ),
     )
+    bind_operator_summary: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Compact operator-facing bind governance summary. "
+            "Minimal by default and includes only bind_state, bind_outcome, "
+            "bind_reason_code, bind_receipt_id, execution_intent_id, and "
+            "operator_verbosity."
+        ),
+    )
+    bind_operator_detail: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Expanded bind drill-down payload emitted only when "
+            "operator_verbosity=expanded for permitted roles."
+        ),
+    )
 
     # User-facing summary for simple_qa mode.
     # When present, frontends should display this instead of raw chosen/meta fields.

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -246,3 +246,20 @@ def test_openapi_wat_operator_summary_and_governance_defaults_locked() -> None:
 
     policy_props = spec["components"]["schemas"]["GovernancePolicy"]["properties"]
     assert policy_props["operator_verbosity"]["default"] == "minimal"
+
+
+def test_openapi_bind_operator_summary_surface_locked() -> None:
+    """Bind operator summary must preserve minimal-default contract semantics."""
+    spec = _load_openapi_spec()
+    bind_summary = spec["components"]["schemas"]["BindOperatorSummary"]
+    summary_props = bind_summary["properties"]
+    assert "bind_state" in summary_props
+    assert "bind_outcome" in summary_props
+    assert "bind_reason_code" in summary_props
+    assert "bind_receipt_id" in summary_props
+    assert "execution_intent_id" in summary_props
+    assert summary_props["operator_verbosity"]["default"] == "minimal"
+
+    decide_props = spec["components"]["schemas"]["DecideResponse"]["properties"]
+    assert "bind_operator_summary" in decide_props
+    assert "bind_operator_detail" in decide_props

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -1188,6 +1188,113 @@ def test_decide_wat_shadow_expanded_operator_verbosity_surfaces_detail(monkeypat
     assert "drift_vector" in detail
 
 
+def test_decide_bind_operator_surface_defaults_to_minimal_summary(monkeypatch):
+    """Bind operator surface must remain compact by default."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            return {
+                "ok": True,
+                "request_id": "rid-bind-min",
+                "query": req.query,
+                "decision": "allow",
+                "business_decision": "APPROVE",
+                "result": "ok",
+                "bind_outcome": "COMMITTED",
+                "bind_reason_code": "bind_ok",
+                "bind_receipt_id": "br-001",
+                "execution_intent_id": "ei-001",
+                "bind_summary": {
+                    "outcome": "COMMITTED",
+                    "reason_code": "bind_ok",
+                    "bind_receipt_id": "br-001",
+                    "execution_intent_id": "ei-001",
+                },
+                "authority_check_result": {"status": "ok"},
+            }
+
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: {"operator_verbosity": "minimal"})
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    summary = payload.get("bind_operator_summary", {})
+    assert summary == {
+        "bind_state": "committed",
+        "bind_outcome": "COMMITTED",
+        "bind_reason_code": "bind_ok",
+        "bind_receipt_id": "br-001",
+        "execution_intent_id": "ei-001",
+        "operator_verbosity": "minimal",
+    }
+    assert payload.get("bind_operator_detail") is None
+
+
+def test_decide_bind_operator_surface_expanded_is_role_gated(monkeypatch):
+    """Expanded bind detail is shown only for admin role."""
+
+    class DummyPipeline:
+        @staticmethod
+        async def run_decide_pipeline(req, request):
+            return {
+                "ok": True,
+                "request_id": "rid-bind-exp",
+                "query": req.query,
+                "decision": "allow",
+                "business_decision": "APPROVE",
+                "result": "ok",
+                "bind_outcome": "BLOCKED",
+                "bind_reason_code": "policy_block",
+                "bind_receipt_id": "br-002",
+                "execution_intent_id": "ei-002",
+                "bind_summary": {
+                    "outcome": "BLOCKED",
+                    "reason_code": "policy_block",
+                    "bind_receipt_id": "br-002",
+                    "execution_intent_id": "ei-002",
+                },
+                "authority_check_result": {"status": "denied"},
+                "constraint_check_result": {"status": "blocked"},
+                "drift_check_result": {"status": "stable"},
+                "risk_check_result": {"status": "high"},
+            }
+
+    monkeypatch.setattr(server, "get_decision_pipeline", lambda: DummyPipeline())
+    monkeypatch.setattr(routes_decide, "get_policy", lambda: {"operator_verbosity": "expanded"})
+    monkeypatch.setattr(routes_decide, "_resolve_operator_role", lambda request: "operator")
+
+    response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    summary = payload.get("bind_operator_summary", {})
+    assert summary.get("operator_verbosity") == "minimal"
+    assert payload.get("bind_operator_detail") is None
+
+    monkeypatch.setattr(routes_decide, "_resolve_operator_role", lambda request: "admin")
+    admin_response = client.post(
+        "/v1/decide",
+        json=server._decide_example(),
+        headers={"X-API-Key": "test-api-key"},
+    )
+    assert admin_response.status_code == 200
+    admin_payload = admin_response.json()
+    admin_summary = admin_payload.get("bind_operator_summary", {})
+    assert admin_summary.get("operator_verbosity") == "expanded"
+    admin_detail = admin_payload.get("bind_operator_detail", {})
+    assert admin_detail.get("authority_check_result") == {"status": "denied"}
+    assert admin_detail.get("risk_check_result") == {"status": "high"}
+
+
 def test_decide_wat_shadow_uses_sign_wat(monkeypatch):
     """Shadow lane must build/sign WAT instead of using placeholder signatures."""
 


### PR DESCRIPTION
### Motivation
- Reuse the existing WAT pattern (minimal operator-facing summary + optional expanded detail) as a small shared convention so it can be applied consistently to other operator-facing governance surfaces.
- Apply the pattern once to a neighboring bind-governance surface to provide a compact default operator view while allowing explicit, role-gated drill-down when requested.

### Description
- Add small shared helpers in `veritas_os/api/routes_decide.py`: `_resolve_operator_verbosity`, `_resolve_operator_role`, and `_build_operator_surface`, and use them to keep WAT v1 behavior but routed through the shared helper (`_attach_wat_contract_fields`).
- Add a single horizontal application of the pattern by introducing `bind_operator_summary` (compact default) and `bind_operator_detail` (expanded, role-gated) via `_attach_bind_operator_surface` and emit them from `/v1/decide` when `bind_summary` exists.
- Sync the backend schema and OpenAPI by adding `bind_operator_summary`/`bind_operator_detail` to `veritas_os/api/schemas.py` and `openapi.yaml`, and add a `BindOperatorSummary` component.
- Sync frontend types in `packages/types/src/decision.ts` with a new `BindOperatorSummary` interface and optional fields on `DecideResponse`; add regression tests and a README note about the shared operator-facing contract pattern.

### Testing
- Ran targeted unit tests: `pytest -q veritas_os/tests/unit/test_server_api.py -k "bind_operator_surface or wat_shadow_expanded_operator_verbosity_surfaces_detail"` which completed with the selected tests passing (`3 passed, 320 deselected`).
- Ran OpenAPI regression tests: `pytest -q veritas_os/tests/test_openapi_spec.py -k "wat_operator_summary_and_governance_defaults_locked or bind_operator_summary_surface_locked"` which passed (`2 passed, 10 deselected`).
- Ran frontend types tests: `pnpm --filter @veritas/types test -- --run packages/types/src/index.test.ts` which passed (`1 test file, 57 tests passed`).
- All automated checks listed above succeeded on the modified surface and contract.

Security note: `bind_operator_detail` can include authority/constraint/risk check results, so expanded detail exposure is intentionally role-gated (admin-only by default) and the default remains minimal to avoid inadvertent information leakage; please review RBAC / API key role mappings in deployments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea17189c8c8326bf94a746cf86e242)