### PR TITLE
Add Blocked / Escalated queue to Bind Cockpit for faster triage

### DIFF
--- a/frontend/app/governance/components/BindCockpit.test.tsx
+++ b/frontend/app/governance/components/BindCockpit.test.tsx
@@ -130,7 +130,7 @@ describe("BindCockpit", () => {
       .mockResolvedValue({ ok: true, json: async () => ({ ok: true, count: 1, returned_count: 1, has_more: false, next_cursor: null, sort: "newest", limit: 50, applied_filters: {}, total_count: 1, items: [LIST_PAYLOAD.items[1]] }) });
 
     render(<BindCockpit />);
-    await screen.findByText("br-blocked");
+    await screen.findAllByText("br-blocked");
     expect(screen.getByRole("option", { name: "compliance config update" })).toBeInTheDocument();
     expect(screen.getByText("governance policy update canonical")).toBeInTheDocument();
 
@@ -161,7 +161,7 @@ describe("BindCockpit", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, count: 0, returned_count: 0, has_more: false, next_cursor: null, sort: "newest", limit: 50, applied_filters: {}, total_count: 0, items: [] }) });
 
     render(<BindCockpit />);
-    await screen.findByText("br-blocked");
+    await screen.findAllByText("br-blocked");
 
     fireEvent.change(screen.getByLabelText("bind-outcome"), { target: { value: "SNAPSHOT_FAILED" } });
 
@@ -210,12 +210,12 @@ describe("BindCockpit", () => {
     });
 
     render(<BindCockpit />);
-    await screen.findByText("br-committed");
+    await screen.findAllByText("br-committed");
 
     expect(screen.getByText(/has more pages/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /load more receipts/i }));
 
-    await screen.findByText("br-blocked");
+    await screen.findAllByText("br-blocked");
     expect(screen.getByText(/no more pages/i)).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("bind-outcome"), { target: { value: "BLOCKED" } });
@@ -237,9 +237,10 @@ describe("BindCockpit", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => DETAIL_PAYLOAD });
 
     render(<BindCockpit />);
-    await screen.findByText("br-blocked");
+    await screen.findAllByText("br-blocked");
 
-    fireEvent.click(screen.getByText("br-blocked"));
+    const blockedReceiptCells = await screen.findAllByText("br-blocked");
+    fireEvent.click(blockedReceiptCells[blockedReceiptCells.length - 1]);
 
     await waitFor(() => {
       const calledUrls = mockFetch.mock.calls.map((call) => String(call[0]));
@@ -254,6 +255,25 @@ describe("BindCockpit", () => {
     expect(screen.getByRole("link", { name: "relevant governance/compliance surface" })).toHaveAttribute("href", "/system");
   });
 
+  it("surfaces blocked/escalated queue with direct reason inspection action", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
+      .mockResolvedValueOnce({ ok: true, json: async () => DETAIL_PAYLOAD })
+      .mockResolvedValueOnce({ ok: true, json: async () => DETAIL_PAYLOAD });
+
+    render(<BindCockpit />);
+    expect(await screen.findByText("Blocked / Escalated queue")).toBeInTheDocument();
+    expect(screen.getByText("policy denied")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "inspect blocked/escalated reason" }));
+
+    await waitFor(() => {
+      const calledUrls = mockFetch.mock.calls.map((call) => String(call[0]));
+      expect(calledUrls).toContain("/api/veritas/v1/governance/bind-receipts/br-blocked");
+    });
+    expect(screen.getByText("Next operator step")).toBeInTheDocument();
+  });
+
   it("derives minimal filter catalog from receipt-level canonical fields when target_catalog is absent", async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -266,7 +286,7 @@ describe("BindCockpit", () => {
       .mockResolvedValue({ ok: true, json: async () => ({ ok: true, count: 0, returned_count: 0, has_more: false, next_cursor: null, sort: "newest", limit: 50, applied_filters: {}, total_count: 0, target_catalog: [], items: [] }) });
 
     render(<BindCockpit />);
-    await screen.findByText("br-blocked");
+    await screen.findAllByText("br-blocked");
     expect(screen.getByRole("option", { name: "compliance config update" })).toBeInTheDocument();
   });
 });

--- a/frontend/app/governance/components/BindCockpit.tsx
+++ b/frontend/app/governance/components/BindCockpit.tsx
@@ -119,6 +119,10 @@ function resolveOutcomeVariant(
   return "muted";
 }
 
+function isActionRequiredOutcome(outcome: CanonicalBindReceipt["outcome"]): boolean {
+  return outcome === "BLOCKED" || outcome === "ESCALATED";
+}
+
 /**
  * Bind Cockpit: operator-facing cross-path surface for bind lifecycle triage.
  */
@@ -238,6 +242,11 @@ export function BindCockpit(): JSX.Element {
     return receipts.filter((receipt) => receipt.targetPathType === "other");
   }, [receipts, filters.pathType]);
 
+  const blockedOrEscalatedReceipts = useMemo(
+    () => filteredReceipts.filter((receipt) => isActionRequiredOutcome(receipt.outcome)).slice(0, 5),
+    [filteredReceipts],
+  );
+
   return (
     <Card
       title="Bind Cockpit"
@@ -356,6 +365,38 @@ export function BindCockpit(): JSX.Element {
         </div>
 
         {error ? <p className="rounded border border-danger/30 bg-danger/10 px-2 py-1 text-xs">{error}</p> : null}
+
+        {blockedOrEscalatedReceipts.length > 0 ? (
+          <div className="rounded border border-warning/40 bg-warning/10 p-3">
+            <h4 className="text-sm font-semibold">Blocked / Escalated queue</h4>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Why it is blocked and what to inspect next.
+            </p>
+            <ul className="mt-2 space-y-2 text-xs">
+              {blockedOrEscalatedReceipts.map((receipt) => (
+                <li key={`action-required-${receipt.bindReceiptId}`} className="rounded border border-warning/30 bg-background/80 px-2 py-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusBadge label={receipt.outcome} variant={resolveOutcomeVariant(receipt.outcome)} />
+                    <span className="font-mono">{receipt.bindReceiptId}</span>
+                    <span className="text-muted-foreground">reason_code: {receipt.reasonCode}</span>
+                  </div>
+                  <p className="mt-1">
+                    {receipt.failureReason !== "-" ? receipt.failureReason : "No bind_failure_reason; inspect detail checks."}
+                  </p>
+                  <button
+                    type="button"
+                    className="mt-2 rounded border px-2 py-1"
+                    onClick={() => {
+                      setSelectedReceiptId(receipt.bindReceiptId);
+                    }}
+                  >
+                    inspect blocked/escalated reason
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
 
         <div className="overflow-x-auto rounded border">
           <table className="w-full min-w-[980px] text-xs">


### PR DESCRIPTION
### Motivation
- Improve operator triage for the single high-friction workflow: making it easier to discover "why" a bind is `BLOCKED` or `ESCALATED` without a large UI redesign. 
- Keep the change minimal and reuse existing bind fields (`bind_outcome`, `bind_reason_code`, `bind_failure_reason`, `bind_receipt_id`) so contracts remain unchanged. 
- Security note: this only fetches and surfaces existing bind detail payloads (no mutations), but fetching detail can expose sensitive governance diagnostics so operator auth/audit controls must remain enforced by the backend.

### Description
- Added a small helper `isActionRequiredOutcome` and a derived `blockedOrEscalatedReceipts` list limited to the top 5 actionable items to the cockpit logic. 
- Introduced a compact "Blocked / Escalated queue" panel in `BindCockpit` that shows outcome, reason code, brief failure reason, and a one-click `inspect blocked/escalated reason` button that focuses drill-down on the chosen receipt. 
- Updated tests in `frontend/app/governance/components/BindCockpit.test.tsx` to cover the new queue rendering and the direct inspection flow, and made text selectors robust to duplicate receipt IDs shown in both the queue and the table. 
- Files changed: `frontend/app/governance/components/BindCockpit.tsx` and `frontend/app/governance/components/BindCockpit.test.tsx`.

### Testing
- Ran the updated frontend unit tests with `cd /workspace/veritas_os/frontend && pnpm exec vitest run app/governance/components/BindCockpit.test.tsx` and the test file completed successfully: all 7 tests passed. 
- No backend schema, OpenAPI, or frontend type changes were made, and no integration tests were required for the UI-only IA improvement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea200e6a9c8326881b63bd51dcee6b)