### PR TITLE
Add compact PostgreSQL production proof map and README navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ while broader effect-path coverage remains roadmap direction.
 - **Security Hardening**: [`docs/en/operations/security-hardening.md`](docs/en/operations/security-hardening.md)
 - **Database Migrations**: [`docs/en/operations/database-migrations.md`](docs/en/operations/database-migrations.md)
 - **Backend Parity Coverage**: [`docs/en/validation/backend-parity-coverage.md`](docs/en/validation/backend-parity-coverage.md)
+- **PostgreSQL Production Proof Map (compact)**: [`docs/en/validation/postgresql-production-proof-map.md`](docs/en/validation/postgresql-production-proof-map.md)
 - **Live PostgreSQL Validation Evidence**: [`docs/live-postgresql-validation.md`](docs/live-postgresql-validation.md)
 - **Legacy Path Cleanup**: [`docs/en/operations/legacy-path-cleanup.md`](docs/en/operations/legacy-path-cleanup.md)
 - **Review Document Map**: [`docs/ja/reviews/code-review-document-map.md`](docs/ja/reviews/code-review-document-map.md)
@@ -200,6 +201,7 @@ development and migration workflows, not as the recommended production baseline.
 
 Verification-oriented docs:
 
+- [`docs/en/validation/postgresql-production-proof-map.md` — compact reviewer entrypoint for production-path proof, automation evidence, and guarantee boundary](docs/en/validation/postgresql-production-proof-map.md)
 - [`docs/en/validation/backend-parity-coverage.md` — canonical parity/implementation verification source](docs/en/validation/backend-parity-coverage.md)
 - [`docs/en/validation/production-validation.md` — canonical tier/promotion/release-gate source](docs/en/validation/production-validation.md)
 - [`docs/en/operations/postgresql-production-guide.md` — canonical PostgreSQL operations/monitoring/recovery source](docs/en/operations/postgresql-production-guide.md)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -39,6 +39,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 ### Validation & Testing
 - [Production Validation Strategy](validation/production-validation.md)
 - [Backend Parity Coverage](validation/backend-parity-coverage.md)
+- [PostgreSQL Production Proof Map (compact)](validation/postgresql-production-proof-map.md)
 - [External Audit Readiness](validation/external-audit-readiness.md)
 - [Technical Proof Pack (external review)](validation/technical-proof-pack.md)
 

--- a/docs/en/validation/postgresql-production-proof-map.md
+++ b/docs/en/validation/postgresql-production-proof-map.md
@@ -1,0 +1,60 @@
+# PostgreSQL Production Path — Compact Proof Map
+
+> Purpose: give external reviewers a single, fast proof surface for the claim
+> that PostgreSQL is the formal production path in this repository.
+
+## 1) Why PostgreSQL is the production path
+
+| Production claim | Primary proof | What to verify quickly |
+|---|---|---|
+| PostgreSQL is the formal production backend posture | [README — PostgreSQL Production Path & Validation Status](../../../README.md#postgresql-production-path--validation-status) | The README explicitly positions PostgreSQL as the formal production path for MemoryOS + TrustLog. |
+| Default full-stack runtime path is PostgreSQL | [`docker-compose.yml`](../../../docker-compose.yml) | Confirm `VERITAS_MEMORY_BACKEND=postgresql`, `VERITAS_TRUSTLOG_BACKEND=postgresql`, and PostgreSQL service wiring. |
+| Runtime can prove active backend selection | `/health` contract + [`test_production_smoke.py`](../../../veritas_os/tests/test_production_smoke.py) | Verify `storage_backends.memory` and `storage_backends.trustlog` report `postgresql` in compose-backed runs. |
+| Operational runbook and migration posture are defined | [PostgreSQL Production Guide](../operations/postgresql-production-guide.md) | Confirm migration, monitoring, and recovery expectations for production-like operation. |
+
+## 2) Automated validation evidence (what runs automatically)
+
+| Evidence category | Automated path | Canonical source |
+|---|---|---|
+| Tier model and blocking semantics | CI / release / scheduled validation tiers | [`production-validation.md`](production-validation.md) |
+| Backend parity and PG implementation coverage | parity matrix + backend-specific tests + known differences | [`backend-parity-coverage.md`](backend-parity-coverage.md) |
+| Live PostgreSQL contention evidence | real PG advisory-lock contention subset (`-m "postgresql and contention"`) | [`../../live-postgresql-validation.md`](../../live-postgresql-validation.md) |
+| Local reproducibility entrypoints | `make validate-postgresql-live`, `make validate-live-postgresql` | [`../../../Makefile`](../../../Makefile) |
+
+## 3) Parity / contention / release evidence map
+
+- **Parity evidence (breadth):** `test_storage_backend_contract.py`,
+  `test_storage_backend_parity_matrix.py`, and related backend unit tests are
+  summarized in [`backend-parity-coverage.md`](backend-parity-coverage.md).
+- **Contention evidence (depth):** real PostgreSQL advisory-lock contention tests
+  are centered in `test_pg_trustlog_contention.py`, tracked in
+  [`../../live-postgresql-validation.md`](../../live-postgresql-validation.md).
+- **Release evidence (promotion posture):** blocking release posture and tier
+  semantics are maintained in [`production-validation.md`](production-validation.md),
+  with workflow definitions in `.github/workflows/main.yml`,
+  `.github/workflows/release-gate.yml`, and
+  `.github/workflows/production-validation.yml`.
+
+## 4) Guarantee boundary (explicit)
+
+### Guaranteed by repository evidence
+
+- PostgreSQL is documented as the formal production path (not only an optional backend).
+- Docker Compose default path is PostgreSQL for both MemoryOS and TrustLog.
+- Backend parity expectations and known non-parity areas are explicitly documented.
+- Real PostgreSQL contention evidence exists and is continuously exercised in CI/scheduled validation.
+
+### Not guaranteed by repository evidence alone
+
+- Environment-specific HA/DR correctness for managed PostgreSQL offerings
+  (for example, cloud failover/PITR posture).
+- Universal success of live `pg_dump` / `pg_restore` in every target environment.
+- Performance/lock behavior under every production-grade saturation pattern.
+
+## 5) Reviewer fast path (5–10 minutes)
+
+1. Read this page once.
+2. Open [`production-validation.md`](production-validation.md) and verify tier/blocking model.
+3. Open [`backend-parity-coverage.md`](backend-parity-coverage.md) and verify parity/non-parity boundary.
+4. Open [`../../live-postgresql-validation.md`](../../live-postgresql-validation.md) and verify real-PG contention evidence.
+5. Confirm README entrypoint: [README PostgreSQL section](../../../README.md#postgresql-production-path--validation-status).


### PR DESCRIPTION
### Motivation
- Provide external reviewers a single, compact proof surface that makes it quick to verify that PostgreSQL is the formal production backend and where the automated/parity/contention/release evidence lives. 

### Description
- Add `docs/en/validation/postgresql-production-proof-map.md`, a concise proof map that links to canonical sources (why PostgreSQL is production, automated validation paths, parity/contention/release evidence map, explicit guarantee boundaries, and a 5–10 minute reviewer fast path). 
- Add direct navigation links to the new proof map from `README.md` (Quick Links and PostgreSQL validation section) and `docs/en/README.md` (Validation & Testing index) to improve discoverability without duplicating existing docs. 

### Testing
- Ran `python scripts/quality/check_operational_docs_consistency.py`, which passed. 
- Ran `python scripts/quality/check_review_improvements_consistency.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea24a275e483269636e04c05fef9e1)