### PR TITLE
test: add fail-fast OpenAPI guard for BindSummary

### DIFF
--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -21,6 +21,44 @@ def _load_openapi_spec() -> dict:
         return yaml.safe_load(file_obj)
 
 
+def _extract_bind_summary_property_keys_from_yaml() -> list[str]:
+    """Extract BindSummary property keys from raw YAML to detect duplicate keys."""
+    repo_root = Path(__file__).resolve().parents[2]
+    spec_path = repo_root / "openapi.yaml"
+    lines = spec_path.read_text(encoding="utf-8").splitlines()
+
+    in_bind_summary = False
+    in_properties = False
+    keys: list[str] = []
+
+    for raw_line in lines:
+        if raw_line.startswith("    BindSummary:"):
+            in_bind_summary = True
+            in_properties = False
+            continue
+        if in_bind_summary and raw_line.startswith("    ") and not raw_line.startswith("      "):
+            break
+        if not in_bind_summary:
+            continue
+        if raw_line.startswith("      properties:"):
+            in_properties = True
+            continue
+        if in_properties and raw_line.startswith("      ") and not raw_line.startswith("        "):
+            break
+        if (
+            not in_properties
+            or not raw_line.startswith("        ")
+            or raw_line.startswith("          ")
+        ):
+            continue
+
+        stripped = raw_line.strip()
+        if stripped.endswith(":") and not stripped.startswith("- "):
+            keys.append(stripped[:-1])
+
+    return keys
+
+
 def test_openapi_yaml_is_parseable() -> None:
     """The OpenAPI document must be valid YAML."""
     spec = _load_openapi_spec()
@@ -263,3 +301,26 @@ def test_openapi_bind_operator_summary_surface_locked() -> None:
     decide_props = spec["components"]["schemas"]["DecideResponse"]["properties"]
     assert "bind_operator_summary" in decide_props
     assert "bind_operator_detail" in decide_props
+
+
+def test_openapi_bind_summary_surface_nullable_and_duplicate_free() -> None:
+    """BindSummary must preserve optional target fields without YAML key shadowing."""
+    spec = _load_openapi_spec()
+    bind_summary_props = spec["components"]["schemas"]["BindSummary"]["properties"]
+    expected_optional_target_fields = {
+        "target_path",
+        "target_type",
+        "target_path_type",
+        "target_label",
+        "operator_surface",
+        "relevant_ui_href",
+    }
+
+    for field in expected_optional_target_fields:
+        schema = bind_summary_props[field]
+        assert "anyOf" in schema
+        assert any(branch.get("type") == "null" for branch in schema["anyOf"])
+
+    raw_property_keys = _extract_bind_summary_property_keys_from_yaml()
+    assert len(raw_property_keys) == len(set(raw_property_keys))
+    assert expected_optional_target_fields.issubset(set(raw_property_keys))


### PR DESCRIPTION
### Motivation
- BindSummary is a compact operator-facing governance surface and accidental OpenAPI drift here can become governance drift, so it needs a stronger fail-fast guard.
- YAML key shadowing (duplicate keys) in `openapi.yaml` can silently change schema meaning and must be detected early with minimal CI noise.

### Description
- Add `_extract_bind_summary_property_keys_from_yaml()` helper to parse the raw `openapi.yaml` BindSummary properties block to detect duplicate YAML keys. 
- Add `test_openapi_bind_summary_surface_nullable_and_duplicate_free()` to assert that the BindSummary target/operator-facing fields (`target_path`, `target_type`, `target_path_type`, `target_label`, `operator_surface`, `relevant_ui_href`) are nullable via `anyOf` that includes `null`. 
- The same test verifies there are no duplicate property keys in the BindSummary block to prevent YAML key shadowing drift. 
- Change is test-only and scoped to governance/bind operator-facing contract checks without modifying runtime codepaths.

### Testing
- Ran `pytest -q veritas_os/tests/test_openapi_spec.py`, results: `13 passed` (including the new test).
- Ran `pytest -q veritas_os/tests/test_bind_summary.py`, results: `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2ad5cb088326bb081e6250a60a77)