### PR TITLE
Add runnable AML/KYC deterministic PoC fixture pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ pack is documented as an executable path, not only positioning text:
 
 Start here:
 - [1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
+- Deterministic fixture scenario: `scripts/run_aml_kyc_poc_fixture.py` with `veritas_os/sample_data/governance/aml_kyc_poc_pack/`
 - [Financial Governance Templates](docs/en/guides/financial-governance-templates.md)
 - [External Audit Readiness](docs/en/validation/external-audit-readiness.md)
 - [Short Positioning by audience](docs/en/positioning/aml-kyc-beachhead-short-positioning.md)

--- a/docs/en/guides/poc-pack-financial-quickstart.md
+++ b/docs/en/guides/poc-pack-financial-quickstart.md
@@ -59,23 +59,29 @@ Reference semantics and taxonomy:
 
 - `veritas_os/sample_data/governance/aml_kyc_pilot_cases.json`
 
-### 4) Expected evidence bundle examples
+### 4) Deterministic runnable scenario fixture (bind/compliance output)
+
+- Runner: `scripts/run_aml_kyc_poc_fixture.py`
+- Fixture: `veritas_os/sample_data/governance/aml_kyc_poc_pack/scenario_high_risk_manual_review.json`
+- Expected output: `veritas_os/sample_data/governance/aml_kyc_poc_pack/expected_high_risk_manual_review_output.json`
+
+### 5) Expected evidence bundle examples
 
 - `veritas_os/sample_data/governance/aml_kyc_expected_evidence_bundle_examples.json`
 
-### 5) Red-team / failure scenarios
+### 6) Red-team / failure scenarios
 
 - `veritas_os/sample_data/governance/aml_kyc_failure_scenarios.json`
 
-### 6) Acceptance criteria summary
+### 7) Acceptance criteria summary
 
 - [Financial PoC Success Criteria](financial-poc-success-criteria.md)
 
-### 7) Customer handoff path
+### 8) Customer handoff path
 
 - [AML/KYC Customer Handoff Path](aml-kyc-customer-handoff-path.md)
 
-### 8) Security / privacy boundaries
+### 9) Security / privacy boundaries
 
 - [AML/KYC Pilot Checklist](aml-kyc-pilot-checklist.md#security-and-privacy-boundaries-must-not-cross)
 
@@ -117,6 +123,25 @@ python scripts/run_financial_poc.py \
   --dry-run \
   --output-json veritas_os/scripts/logs/aml_kyc_pilot_dry_run_report.json
 ```
+
+
+### Step 1b — Deterministic governance-output check (10 min)
+
+Run one executable AML/KYC fixture and verify expected governance outcome,
+bind result, and compliance-oriented output:
+
+```bash
+python scripts/run_aml_kyc_poc_fixture.py \
+  --input veritas_os/sample_data/governance/aml_kyc_poc_pack/scenario_high_risk_manual_review.json \
+  --verify-expected veritas_os/sample_data/governance/aml_kyc_poc_pack/expected_high_risk_manual_review_output.json \
+  --output-json veritas_os/scripts/logs/aml_kyc_poc_fixture_output.json
+```
+
+Expected fixture behavior:
+
+- `governance_outcome.gate_decision = human_review_required`
+- `bind_result.admissible = false` (bind-boundary hold path)
+- `compliance_view.status = conformant` for synthetic expected evidence coverage
 
 ### Step 2 — Live governance run (30-60 min)
 

--- a/scripts/run_aml_kyc_poc_fixture.py
+++ b/scripts/run_aml_kyc_poc_fixture.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CLI wrapper for deterministic AML/KYC PoC fixture runner."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from veritas_os.scripts.aml_kyc_poc_fixture_runner import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aml_kyc_poc_fixture_runner.py
+++ b/tests/test_aml_kyc_poc_fixture_runner.py
@@ -1,0 +1,36 @@
+"""Focused tests for deterministic AML/KYC PoC fixture runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from veritas_os.scripts.aml_kyc_poc_fixture_runner import evaluate_fixture, load_scenario
+
+SCENARIO_PATH = Path(
+    "veritas_os/sample_data/governance/aml_kyc_poc_pack/"
+    "scenario_high_risk_manual_review.json"
+)
+EXPECTED_PATH = Path(
+    "veritas_os/sample_data/governance/aml_kyc_poc_pack/"
+    "expected_high_risk_manual_review_output.json"
+)
+
+
+def test_aml_kyc_poc_fixture_matches_expected_output() -> None:
+    """Scenario evaluation must remain deterministic against expected output."""
+    scenario = load_scenario(SCENARIO_PATH)
+    actual = evaluate_fixture(scenario)
+    expected = json.loads(EXPECTED_PATH.read_text(encoding="utf-8"))
+
+    assert actual == expected
+
+
+def test_aml_kyc_poc_fixture_keeps_bind_closed_for_high_risk_flags() -> None:
+    """High-risk fixture should remain non-admissible at bind boundary."""
+    scenario = load_scenario(SCENARIO_PATH)
+    actual = evaluate_fixture(scenario)
+
+    assert actual["governance_outcome"]["gate_decision"] == "human_review_required"
+    assert actual["bind_result"]["admissible"] is False
+    assert actual["compliance_view"]["control_plane"] == "bind-boundary"

--- a/veritas_os/sample_data/governance/aml_kyc_poc_pack/expected_high_risk_manual_review_output.json
+++ b/veritas_os/sample_data/governance/aml_kyc_poc_pack/expected_high_risk_manual_review_output.json
@@ -1,0 +1,30 @@
+{
+  "scenario_id": "aml_kyc_high_risk_wire_manual_review_fixture",
+  "domain": "aml_kyc",
+  "governance_outcome": {
+    "gate_decision": "human_review_required",
+    "business_decision": "REVIEW_REQUIRED",
+    "next_action": "PREPARE_HUMAN_REVIEW_PACKET",
+    "human_review_required": true
+  },
+  "evidence_summary": {
+    "required_count": 8,
+    "provided_count": 8,
+    "missing_count": 0,
+    "missing_evidence": [],
+    "evidence_coverage_ratio": 1.0
+  },
+  "bind_result": {
+    "execution_intent": "bind:hold_wire_transfer",
+    "admissible": false,
+    "bind_receipt_id": "bind_receipt::aml_kyc_high_risk_wire_manual_review_fixture",
+    "reason": "risk-triggered-manual-review"
+  },
+  "compliance_view": {
+    "control_plane": "bind-boundary",
+    "policy_pack": "aml_kyc_poc_pack_v1",
+    "policy_hash": "sha256:6d5f5ad8fae0e58d463f2ea3d32fa948f24b7d2e5be5f6541a9f0fdd8a15c6ec",
+    "status": "conformant",
+    "scope": "synthetic_poc"
+  }
+}

--- a/veritas_os/sample_data/governance/aml_kyc_poc_pack/scenario_high_risk_manual_review.json
+++ b/veritas_os/sample_data/governance/aml_kyc_poc_pack/scenario_high_risk_manual_review.json
@@ -1,0 +1,35 @@
+{
+  "scenario_id": "aml_kyc_high_risk_wire_manual_review_fixture",
+  "domain": "aml_kyc",
+  "execution_intent": "bind:hold_wire_transfer",
+  "risk_flags": {
+    "pep_association": true,
+    "sanctions_partial_match": true,
+    "high_risk_country_corridor": true
+  },
+  "required_evidence": [
+    "kyc_profile",
+    "sanctions_screening_trace",
+    "pep_screening_result",
+    "source_of_funds_record",
+    "approval_matrix",
+    "audit_trail_export",
+    "secure_controls_attestation",
+    "policy_definition_record"
+  ],
+  "provided_evidence": [
+    "kyc_profile",
+    "sanctions_screening_trace",
+    "pep_screening_result",
+    "source_of_funds_record",
+    "approval_matrix",
+    "audit_trail_export",
+    "secure_controls_attestation",
+    "policy_definition_record"
+  ],
+  "governance_identity": {
+    "tenant_id": "tenant-synthetic-poc",
+    "policy_pack": "aml_kyc_poc_pack_v1",
+    "policy_hash": "sha256:6d5f5ad8fae0e58d463f2ea3d32fa948f24b7d2e5be5f6541a9f0fdd8a15c6ec"
+  }
+}

--- a/veritas_os/scripts/aml_kyc_poc_fixture_runner.py
+++ b/veritas_os/scripts/aml_kyc_poc_fixture_runner.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Deterministic AML/KYC PoC fixture runner.
+
+This runner provides one lightweight, repo-native executable scenario for the
+AML/KYC beachhead. It evaluates a single synthetic fixture and emits a
+bind-boundary governance result suitable for operator/audit walkthroughs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SCENARIO_PATH = Path(
+    "veritas_os/sample_data/governance/aml_kyc_poc_pack/"
+    "scenario_high_risk_manual_review.json"
+)
+
+
+def load_scenario(path: Path) -> dict[str, Any]:
+    """Load and parse one AML/KYC PoC scenario fixture."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalized_list(value: Any) -> list[str]:
+    """Normalize a JSON value into a sorted string list without duplicates."""
+    if not isinstance(value, list):
+        return []
+    normalized = {str(item).strip() for item in value if str(item).strip()}
+    return sorted(normalized)
+
+
+def evaluate_fixture(scenario: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate fixture inputs and build deterministic governance output."""
+    required_evidence = _normalized_list(scenario.get("required_evidence"))
+    provided_evidence = _normalized_list(scenario.get("provided_evidence"))
+
+    missing_evidence = sorted(set(required_evidence) - set(provided_evidence))
+    risk_flags = scenario.get("risk_flags") or {}
+
+    risk_triggered = bool(
+        risk_flags.get("pep_association")
+        or risk_flags.get("sanctions_partial_match")
+        or risk_flags.get("high_risk_country_corridor")
+    )
+
+    if missing_evidence:
+        gate_decision = "hold"
+        business_decision = "EVIDENCE_REQUIRED"
+        next_action = "COLLECT_REQUIRED_EVIDENCE"
+        bind_admissible = False
+    elif risk_triggered:
+        gate_decision = "human_review_required"
+        business_decision = "REVIEW_REQUIRED"
+        next_action = "PREPARE_HUMAN_REVIEW_PACKET"
+        bind_admissible = False
+    else:
+        gate_decision = "proceed"
+        business_decision = "APPROVE"
+        next_action = "EXECUTE_WITH_STANDARD_MONITORING"
+        bind_admissible = True
+
+    scenario_id = str(scenario.get("scenario_id", "")).strip()
+    bind_receipt_id = f"bind_receipt::{scenario_id}"
+
+    return {
+        "scenario_id": scenario_id,
+        "domain": str(scenario.get("domain", "")).strip(),
+        "governance_outcome": {
+            "gate_decision": gate_decision,
+            "business_decision": business_decision,
+            "next_action": next_action,
+            "human_review_required": gate_decision == "human_review_required",
+        },
+        "evidence_summary": {
+            "required_count": len(required_evidence),
+            "provided_count": len(provided_evidence),
+            "missing_count": len(missing_evidence),
+            "missing_evidence": missing_evidence,
+            "evidence_coverage_ratio": (
+                round(len(provided_evidence) / len(required_evidence), 4)
+                if required_evidence
+                else 1.0
+            ),
+        },
+        "bind_result": {
+            "execution_intent": str(scenario.get("execution_intent", "")).strip(),
+            "admissible": bind_admissible,
+            "bind_receipt_id": bind_receipt_id,
+            "reason": (
+                "risk-triggered-manual-review" if risk_triggered and not missing_evidence
+                else "missing-required-evidence" if missing_evidence
+                else "controls-and-evidence-sufficient"
+            ),
+        },
+        "compliance_view": {
+            "control_plane": "bind-boundary",
+            "policy_pack": str((scenario.get("governance_identity") or {}).get("policy_pack", "")).strip(),
+            "policy_hash": str((scenario.get("governance_identity") or {}).get("policy_hash", "")).strip(),
+            "status": "conformant" if not missing_evidence else "evidence-gap",
+            "scope": "synthetic_poc",
+        },
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for AML/KYC PoC fixture runner."""
+    parser = argparse.ArgumentParser(
+        description="Run deterministic AML/KYC PoC fixture and emit governance outputs."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_SCENARIO_PATH),
+        help="Path to AML/KYC scenario fixture JSON.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional path for output JSON.",
+    )
+    parser.add_argument(
+        "--verify-expected",
+        default="",
+        help="Optional expected-output JSON path for deterministic verification.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI entrypoint for deterministic AML/KYC PoC fixture execution."""
+    args = _parse_args()
+    input_path = Path(args.input)
+
+    if not input_path.exists():
+        raise SystemExit(f"[aml-kyc-poc] input file not found: {input_path}")
+
+    scenario = load_scenario(input_path)
+    output = evaluate_fixture(scenario)
+
+    if args.verify_expected:
+        expected_path = Path(args.verify_expected)
+        if not expected_path.exists():
+            raise SystemExit(f"[aml-kyc-poc] expected file not found: {expected_path}")
+        expected_payload = json.loads(expected_path.read_text(encoding="utf-8"))
+        if expected_payload != output:
+            raise SystemExit("[aml-kyc-poc] expected output mismatch")
+        print("[aml-kyc-poc] expected output verification: pass")
+
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"[aml-kyc-poc] report saved: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Turn the AML/KYC beachhead docs into a minimal, runnable PoC pack that produces deterministic governance / bind / compliance outputs. 
- Provide a single lightweight scenario to demonstrate fail-closed bind-boundary behavior without adding external SaaS dependencies.

### Description
- Add a deterministic fixture runner `veritas_os/scripts/aml_kyc_poc_fixture_runner.py` that evaluates one synthetic AML/KYC scenario and emits a machine-readable governance outcome, evidence summary, bind result, and compliance view. 
- Add a CLI wrapper `scripts/run_aml_kyc_poc_fixture.py` for repo-native execution. 
- Add one executable scenario fixture and its expected snapshot under `veritas_os/sample_data/governance/aml_kyc_poc_pack/` (`scenario_high_risk_manual_review.json` and `expected_high_risk_manual_review_output.json`).
- Add focused regression tests `tests/test_aml_kyc_poc_fixture_runner.py` and update the quickstart docs (`docs/en/guides/poc-pack-financial-quickstart.md`) and top-level `README.md` to link the runnable fixture and show the verification command.

### Testing
- Verified deterministic output with `python scripts/run_aml_kyc_poc_fixture.py --input veritas_os/sample_data/governance/aml_kyc_poc_pack/scenario_high_risk_manual_review.json --verify-expected veritas_os/sample_data/governance/aml_kyc_poc_pack/expected_high_risk_manual_review_output.json`, which printed `expected output verification: pass` and saved the report. 
- Ran unit tests with `pytest -q tests/test_aml_kyc_poc_fixture_runner.py`, which passed (`2 passed`). 
- No OpenAPI/backend schema/frontend types were changed; this is an additive, repo-native demo fixture and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadaba83e08326b53cb6582377eaa5)