### PR TITLE
Add human-readable release proof summary (release-proof-summary.md) for release-gate artifacts

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -577,13 +577,19 @@ jobs:
             --ref "${VERITAS_RELEASE_REF}" \
             --sha "${VERITAS_RELEASE_SHA}" \
             --output release-artifacts/governance-readiness-report.json \
-            --text-output release-artifacts/governance-readiness-report.txt
+            --text-output release-artifacts/governance-readiness-report.txt \
+            --proof-output release-artifacts/release-proof-summary.md
 
       - name: Print governance readiness report
         if: always()
         run: |
           if [ -f release-artifacts/governance-readiness-report.txt ]; then
             cat release-artifacts/governance-readiness-report.txt
+          fi
+          if [ -f release-artifacts/release-proof-summary.md ]; then
+            echo ""
+            echo "---- release-proof-summary.md ----"
+            cat release-artifacts/release-proof-summary.md
           fi
 
       - name: Upload governance readiness report

--- a/README.md
+++ b/README.md
@@ -1329,6 +1329,7 @@ Additional CI workflows:
 - Production-like test suite (`pytest -m "production or smoke"` + TLS + load)
 - Full-stack Docker Compose health check
 - Governance readiness report artifact generated and uploaded
+- Human-readable `release-proof-summary.md` generated for enterprise review / diligence handoff
 
 **Tier 3** (`production-validation.yml`) — weekly schedule + manual dispatch:
 - Long-running production tests, load tests, external live tests
@@ -1344,6 +1345,7 @@ tier model and [`docs/RELEASE_PROCESS.md`](docs/en/operations/release-process.md
 1. Find the `Release Gate` workflow run for the target tag in the [Actions tab](https://github.com/veritasfuji-japan/veritas_os/actions/workflows/release-gate.yml)
 2. The `✅ Release Readiness Gate` job must show **🟢 RELEASE IS GOVERNANCE-READY**
 3. Download the `release-governance-readiness-report` artifact and verify `"governance_ready": true`
+4. Read `release-proof-summary.md` for check-class pass/fail/skipped counts and assurance-boundary wording for external technical review
 
 ### Production-like Validation
 

--- a/docs/en/operations/release-process.md
+++ b/docs/en/operations/release-process.md
@@ -79,6 +79,9 @@ gh run download --name release-governance-readiness-report \
 # View the text summary
 cat governance-readiness-report.txt
 
+# View the external-facing proof summary
+cat release-proof-summary.md
+
 # Check the JSON summary
 python3 -c "
 import json
@@ -114,6 +117,7 @@ Attach the governance readiness report as a release asset:
 ```bash
 gh release upload v2.1.0 governance-readiness-report.json
 gh release upload v2.1.0 governance-readiness-report.txt
+gh release upload v2.1.0 release-proof-summary.md
 ```
 
 Publish when ready:

--- a/scripts/generate_release_readiness_report.py
+++ b/scripts/generate_release_readiness_report.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Generate a governance readiness report for VERITAS OS releases.
+"""Generate release-gate governance artifacts for VERITAS OS releases.
 
 This script runs all governance-critical checks and produces a structured
-JSON report plus a human-readable text summary. It is called by the
+JSON report, a human-readable text summary, and an external-facing
+release proof summary. It is called by the
 release-gate.yml workflow during the Tier 2 governance-report job.
 
 Usage:
@@ -10,7 +11,8 @@ Usage:
         --ref v2.0.1 \
         --sha abc1234 \
         --output release-artifacts/governance-readiness-report.json \
-        --text-output release-artifacts/governance-readiness-report.txt
+        --text-output release-artifacts/governance-readiness-report.txt \
+        --proof-output release-artifacts/release-proof-summary.md
 
 Exit code:
     0  — all blocking checks passed (release is governance-ready)
@@ -130,6 +132,59 @@ CHECKS: list[tuple[str, str, list[str], bool]] = [
         False,
     ),
 ]
+
+CHECK_CLASSES: dict[str, tuple[str, ...]] = {
+    "security": (
+        "runtime-pickle-ban",
+        "bare-except-ban",
+        "subprocess-shell-ban",
+        "unsafe-dynamic-execution",
+        "httpx-raw-upload-ban",
+        "next-public-key-exposure",
+    ),
+    "architecture": (
+        "responsibility-boundaries",
+        "core-complexity-budget",
+    ),
+    "quality": (
+        "replay-pipeline-version-rate",
+        "deployment-env-defaults",
+        "requirements-sync",
+    ),
+    "documentation": (
+        "operational-docs-consistency",
+        "frontend-docs-consistency",
+    ),
+}
+
+
+def classify_check(label: str) -> str:
+    """Map a check label to its high-level class name."""
+    for class_name, labels in CHECK_CLASSES.items():
+        if label in labels:
+            return class_name
+    return "other"
+
+
+def summarize_check_classes(results: list[dict]) -> list[dict[str, object]]:
+    """Return status counts grouped by high-level check class."""
+    grouped: dict[str, dict[str, int | str]] = {}
+    for result in results:
+        class_name = classify_check(result["label"])
+        if class_name not in grouped:
+            grouped[class_name] = {
+                "class_name": class_name,
+                "total": 0,
+                "pass": 0,
+                "fail": 0,
+                "skipped": 0,
+            }
+        grouped[class_name]["total"] += 1
+        if result["passed"]:
+            grouped[class_name]["pass"] += 1
+        else:
+            grouped[class_name]["fail"] += 1
+    return sorted(grouped.values(), key=lambda item: str(item["class_name"]))
 
 
 def run_check(
@@ -261,6 +316,76 @@ def render_text_report(report: dict) -> str:
     return "\n".join(lines)
 
 
+def render_release_proof_summary(report: dict) -> str:
+    """Render an external-facing release proof summary in Markdown."""
+    summary = report["summary"]
+    readiness_state = "Ready" if summary["governance_ready"] else "Not Ready"
+    class_rows = summarize_check_classes(report["checks"])
+    sha_value = report["release_sha"]
+    sha_display = f"{sha_value[:12]}..." if len(sha_value) > 12 else sha_value
+
+    lines = [
+        "# VERITAS OS — Release Proof Summary",
+        "",
+        "## Snapshot",
+        f"- Release reference: `{report['release_ref']}`",
+        f"- Commit: `{sha_display}`",
+        f"- Generated at (UTC): `{report['generated_at']}`",
+        f"- Release readiness: **{readiness_state}**",
+        "",
+        "## Check classes executed",
+        "",
+        "| Check class | Pass | Fail | Skipped | Notes |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for class_row in class_rows:
+        notes = (
+            "Blocking for release readiness."
+            if class_row["class_name"] != "documentation"
+            else "Advisory only; does not block release readiness."
+        )
+        lines.append(
+            "| "
+            f"{class_row['class_name']} | "
+            f"{class_row['pass']} | "
+            f"{class_row['fail']} | "
+            f"{class_row['skipped']} | "
+            f"{notes} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## What release readiness means",
+            (
+                "- `release-readiness` means Tier 1 and Tier 2 blocking controls "
+                "completed without failures, and governance checks reported no "
+                "blocking failure."
+            ),
+            "- Advisory checks can still report warnings; those are visible in artifacts.",
+            "",
+            "## Assurance boundary (conservative statement)",
+            (
+                "- This summary is an **internal assurance artifact** based on "
+                "VERITAS OS release-gate evidence."
+            ),
+            (
+                "- It is **not an external certification** and must not be "
+                "represented as a regulatory, legal, or auditor-issued attestation."
+            ),
+            (
+                "- External certification requires independent scope definition, "
+                "evidence collection, and assessor judgment."
+            ),
+            "",
+            "## Canonical artifacts",
+            "- `governance-readiness-report.json` (machine-readable status + raw check outputs)",
+            "- `governance-readiness-report.txt` (operator-readable detailed report)",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
 def main() -> int:
     """Run all governance checks and emit a readiness report.
 
@@ -279,6 +404,11 @@ def main() -> int:
         "--text-output",
         default="governance-readiness-report.txt",
         help="Path for human-readable text report",
+    )
+    parser.add_argument(
+        "--proof-output",
+        default="release-proof-summary.md",
+        help="Path for human-readable release proof summary (Markdown)",
     )
     args = parser.parse_args()
 
@@ -314,6 +444,12 @@ def main() -> int:
     text_path.parent.mkdir(parents=True, exist_ok=True)
     text_path.write_text(text_report, encoding="utf-8")
     logger.info("Text report written: %s", text_path)
+
+    proof_summary = render_release_proof_summary(report)
+    proof_path = Path(args.proof_output)
+    proof_path.parent.mkdir(parents=True, exist_ok=True)
+    proof_path.write_text(proof_summary, encoding="utf-8")
+    logger.info("Release proof summary written: %s", proof_path)
 
     # Print text report to stdout
     print(text_report)

--- a/tests/test_release_readiness_proof_summary.py
+++ b/tests/test_release_readiness_proof_summary.py
@@ -1,0 +1,70 @@
+"""Tests for release proof summary generation."""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "generate_release_readiness_report.py"
+    )
+    spec = spec_from_file_location("generate_release_readiness_report", module_path)
+    assert spec is not None and spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+release_readiness_report = _load_module()
+
+
+def test_summarize_check_classes_counts_pass_fail() -> None:
+    """Check-class summary should aggregate pass/fail counts per class."""
+    results = [
+        {"label": "runtime-pickle-ban", "passed": True},
+        {"label": "bare-except-ban", "passed": False},
+        {"label": "responsibility-boundaries", "passed": True},
+        {"label": "deployment-env-defaults", "passed": True},
+    ]
+
+    summary_rows = release_readiness_report.summarize_check_classes(results)
+    rows_by_name = {row["class_name"]: row for row in summary_rows}
+
+    assert rows_by_name["security"]["pass"] == 1
+    assert rows_by_name["security"]["fail"] == 1
+    assert rows_by_name["architecture"]["pass"] == 1
+    assert rows_by_name["quality"]["pass"] == 1
+
+
+def test_render_release_proof_summary_contains_assurance_boundary() -> None:
+    """Rendered proof summary should include conservative assurance wording."""
+    report = {
+        "release_ref": "v2.2.0",
+        "release_sha": "1234567890abcdef",
+        "generated_at": "2026-04-24T00:00:00+00:00",
+        "summary": {"governance_ready": True},
+        "checks": [
+            {
+                "label": "runtime-pickle-ban",
+                "passed": True,
+                "blocking": True,
+            },
+            {
+                "label": "operational-docs-consistency",
+                "passed": False,
+                "blocking": False,
+            },
+        ],
+    }
+
+    rendered = release_readiness_report.render_release_proof_summary(report)
+
+    assert "Release Proof Summary" in rendered
+    assert "| security | 1 | 0 | 0 |" in rendered
+    assert "| documentation | 0 | 1 | 0 |" in rendered
+    assert "internal assurance artifact" in rendered
+    assert "not an external certification" in rendered


### PR DESCRIPTION
### Motivation
- Provide an enterprise-friendly, human-readable summary that transforms existing release-gate artifacts into a concise "release proof" for external review and diligence while keeping the governance control plane unchanged. 
- Keep changes minimal and conservative: derive the summary from existing readiness checks and explicitly avoid wording that could be misconstrued as external certification.

### Description
- Extend `scripts/generate_release_readiness_report.py` to classify checks into high-level classes (`security`, `architecture`, `quality`, `documentation`), aggregate pass/fail/skipped counts, and render a Markdown `release-proof-summary.md` via a new `render_release_proof_summary` function and `--proof-output` CLI argument. 
- Wire the release gate to produce and print the new artifact by adding `--proof-output release-artifacts/release-proof-summary.md` to the Tier 2 `governance-report` job and printing the file if present. 
- Document the new artifact in `README.md` and `docs/en/operations/release-process.md` and recommend attaching `release-proof-summary.md` to releases alongside existing readiness artifacts. 
- Add unit tests `tests/test_release_readiness_proof_summary.py` to validate check-class aggregation and presence of conservative assurance-boundary wording.

### Testing
- Ran `pytest -q tests/test_release_readiness_proof_summary.py` which passed (2 tests, all passed). 
- Executed the modified generator end-to-end with `python scripts/generate_release_readiness_report.py --ref test-ref --sha 1234567890abcdef --output /tmp/governance-readiness-report.json --text-output /tmp/governance-readiness-report.txt --proof-output /tmp/release-proof-summary.md` and confirmed JSON/TXT/Markdown artifacts were written and printed. 
- Ran `ruff check scripts/generate_release_readiness_report.py tests/test_release_readiness_proof_summary.py` with no issues. 
- Note: remote `origin/main` could not be fetched in this environment (HTTP 403), so changes were validated against the provided repository snapshot rather than a live remote branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaef706cb48326a108bf7584fcefe6)