### PR TITLE
docs: add compact third-party review readiness index and navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ while broader effect-path coverage remains roadmap direction.
 - **AML/KYC Governance Template Contract**: [`docs/en/guides/financial-governance-templates.md`](docs/en/guides/financial-governance-templates.md)
 - **External Audit / Evidence Bundle Readiness**: [`docs/en/validation/external-audit-readiness.md`](docs/en/validation/external-audit-readiness.md)
 - **External Technical Proof Pack (review/pilot/DD/audit)**: [`docs/en/validation/technical-proof-pack.md`](docs/en/validation/technical-proof-pack.md)
+- **Third-Party Review Readiness (compact index)**: [`docs/en/validation/third-party-review-readiness.md`](docs/en/validation/third-party-review-readiness.md)
 - **AML/KYC Short Positioning (customer / operator / investor)**: [`docs/en/positioning/aml-kyc-beachhead-short-positioning.md`](docs/en/positioning/aml-kyc-beachhead-short-positioning.md)
 - **GitHub**: https://github.com/veritasfuji-japan/veritas_os
 - **Zenodo paper (EN)**: https://doi.org/10.5281/zenodo.17838349

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@
 - [Bilingual Maintenance Rules](BILINGUAL_RULES.md)
 - [Path Migration Table](PATH_MIGRATION.md)
 - [Operator Guide: Policy Bundle Promotion (EN)](en/guides/governance-policy-bundle-promotion.md)
+- [Third-Party Review Readiness (EN, compact)](en/validation/third-party-review-readiness.md)
 - [金融 PoC パック（JA）](ja/guides/poc-pack-financial-quickstart.md)
 
 ## Directory Structure

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -42,6 +42,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [PostgreSQL Production Proof Map (compact)](validation/postgresql-production-proof-map.md)
 - [External Audit Readiness](validation/external-audit-readiness.md)
 - [Technical Proof Pack (external review)](validation/technical-proof-pack.md)
+- [Third-Party Review Readiness (compact index)](validation/third-party-review-readiness.md)
 
 ### Governance & Compliance
 - [Decision Semantics Contract](architecture/decision-semantics.md)

--- a/docs/en/validation/technical-proof-pack.md
+++ b/docs/en/validation/technical-proof-pack.md
@@ -21,13 +21,14 @@ Use this as the top-level entrypoint before reading detailed maps and checklists
 ## 2) Proof-pack document set (read in order)
 
 1. [Short DD Summary](short-dd-summary.md)
-2. [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md)
-3. [Governance Capability Matrix](governance-capability-matrix.md)
-4. [Validation Evidence Map](validation-evidence-map.md)
-5. [AML/KYC Pilot Evidence Map](aml-kyc-pilot-evidence-map.md)
-6. [External Reviewer Checklist](external-reviewer-checklist.md)
-7. [External Audit Readiness Pack](external-audit-readiness.md)
-8. Optional: [Benchmark / Reproducibility Appendix](benchmark-reproducibility-appendix.md)
+2. [Third-Party Review Readiness (compact index)](third-party-review-readiness.md)
+3. [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md)
+4. [Governance Capability Matrix](governance-capability-matrix.md)
+5. [Validation Evidence Map](validation-evidence-map.md)
+6. [AML/KYC Pilot Evidence Map](aml-kyc-pilot-evidence-map.md)
+7. [External Reviewer Checklist](external-reviewer-checklist.md)
+8. [External Audit Readiness Pack](external-audit-readiness.md)
+9. Optional: [Benchmark / Reproducibility Appendix](benchmark-reproducibility-appendix.md)
 
 ---
 
@@ -68,4 +69,3 @@ If you are an external reviewer, start with:
 1. `short-dd-summary.md` (5–10 minutes)
 2. `implemented-vs-pending-boundary.md` (boundary control)
 3. `external-reviewer-checklist.md` (evidence verification flow)
-

--- a/docs/en/validation/third-party-review-readiness.md
+++ b/docs/en/validation/third-party-review-readiness.md
@@ -1,0 +1,92 @@
+# Third-Party Review Readiness (Compact Index)
+
+**Snapshot date:** 2026-04-24 (UTC)  
+**Audience:** External technical reviewers, enterprise diligence teams, and audit-oriented evaluators.  
+**Positioning boundary:** This is a repository navigation index for review readiness, **not** a third-party certification.
+
+---
+
+## 1) What this product currently claims
+
+VERITAS OS claims a governance-first control plane for AI decisions, with a bind boundary before real-world effect:
+
+- Decision Governance + bind-boundary control plane semantics.
+- Operator-facing governance workflows and APIs.
+- Reviewable / traceable / replayable / auditable / enforceable decision lifecycle.
+
+Primary claim sources:
+
+- [README (fact vs roadmap boundary)](../../../README.md)
+- [Public Positioning Guide](../positioning/public-positioning.md)
+- [Bind-Boundary Governance Artifacts](../architecture/bind-boundary-governance-artifacts.md)
+
+---
+
+## 2) What is implemented now (repository-verifiable)
+
+Use these as the shortest implementation entrypoints:
+
+1. **Public API contract and operator bind vocabulary**
+   - `openapi.yaml` (`bind_summary`, `bind_outcome`, governance/bind endpoints).
+2. **Bind artifact contract**
+   - `veritas_os/policy/bind_artifacts.py` (`ExecutionIntent`, `BindReceipt`).
+3. **Operator-facing API binding**
+   - `veritas_os/api/bind_summary.py`
+   - `veritas_os/api/routes_governance.py`
+   - `veritas_os/api/routes_system.py`
+4. **Scope boundary statement**
+   - [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md)
+
+Related documentation map:
+
+- [Technical Proof Pack](technical-proof-pack.md)
+- [Validation Evidence Map](validation-evidence-map.md)
+
+---
+
+## 3) Which automated checks exist
+
+For external reviewers, start with validation strategy + release-gate definitions:
+
+- [Production Validation Strategy](production-validation.md)
+- [Backend Parity Coverage](backend-parity-coverage.md)
+- `.github/workflows/main.yml` (PR/push blocking checks)
+- `.github/workflows/release-gate.yml` (release-blocking checks)
+- `.github/workflows/production-validation.yml` (scheduled/manual production-like checks)
+
+Representative bind/governance test surfaces:
+
+- `tests/test_bind_admissibility.py`
+- `tests/test_continuation_enforcement_integration.py`
+- `frontend/app/governance/control-plane.test.tsx`
+- `frontend/app/governance/components/PolicyBundlePromotionFlow.test.tsx`
+- `frontend/app/governance/components/BindCockpit.test.tsx`
+
+---
+
+## 4) What is roadmap or environment-specific
+
+Treat the following as explicitly out-of-scope for repository-only assurance:
+
+- Independent third-party certification completion.
+- Tenant-specific production controls (IdP, key custody, retention, HA/DR, ops execution quality).
+- Universal guarantee across all deployment environments.
+
+Primary boundary sources:
+
+- [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md)
+- [External Audit Readiness](external-audit-readiness.md)
+- [PostgreSQL Production Guide](../operations/postgresql-production-guide.md)
+- [Security Hardening Checklist](../operations/security-hardening.md)
+
+---
+
+## 5) 15-minute reviewer path (recommended)
+
+1. Read [Short DD Summary](short-dd-summary.md) (orientation).
+2. Read this compact index (claim/implementation/check/boundary split).
+3. Read [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md).
+4. Spot-check API contract in `openapi.yaml` and one bind mutation path.
+5. Confirm validation gates in [Production Validation Strategy](production-validation.md).
+
+If deeper verification is needed, continue with [External Reviewer Checklist](external-reviewer-checklist.md).


### PR DESCRIPTION
### Motivation

- Provide external technical reviewers and audit teams a single, conservative entrypoint that maps claims to repository-verifiable artifacts without implying third-party certification.  
- Reduce time-to-first-evidence for diligence by surfacing a compact index and clear navigation from the README and docs hubs.  

### Description

- Add a new compact index at `docs/en/validation/third-party-review-readiness.md` that summarizes current claims, repository-verifiable implementation entrypoints, automated checks, roadmap/environmental boundaries, and a 15-minute reviewer path.  
- Wire the new index into documentation navigation by adding links from `README.md`, `docs/en/README.md`, and `docs/INDEX.md`.  
- Insert the index into the reading order of `docs/en/validation/technical-proof-pack.md` so it appears early in the external review proof-pack flow.  
- This is a documentation-only change with conservative wording that explicitly separates self-assessment from any third-party certification and does not alter runtime, API schemas, or behavior.  

### Testing

- Ran the focused unit test `pytest -q tests/test_release_readiness_proof_summary.py` which passed (`2 passed`).  
- Verified that updated documentation files are present and link targets resolve in the repo (manual verification via test run environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf62ae99883268a5218ae7542bc22)