### PR TITLE
Bind-govern POST /v1/system/resume to match halt mutation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ VERITAS OS focuses on **decision governance and bind-boundary control**:
 - Signed and hash-linked governance artifacts for accountability
 - Posture-based secure/prod startup checks to reduce permissive misconfiguration
 
-This opening reflects current implemented fact: bind-governed adjudication is already active on at least three operator-governed effect paths,
+This opening reflects current implemented fact: bind-governed adjudication is already active on at least five operator-governed effect paths,
 while broader effect-path coverage remains roadmap direction.
 
 ## What VERITAS OS is / is not
@@ -84,11 +84,12 @@ while broader effect-path coverage remains roadmap direction.
 ## Fact vs roadmap (read this first)
 
 - **Current fact (beta):** Core decision pipeline, bind artifact lineage (`decision -> execution_intent -> bind_receipt`), bind-time admissibility checks, FUJI fail-closed gating, TrustLog lineage, Mission Control workflows, and governance endpoints are implemented.
-- **Current fact (bind policy surface):** Bind-boundary adjudication is currently wired on at least four operator-governed effect paths:
+- **Current fact (bind policy surface):** Bind-boundary adjudication is currently wired on at least five operator-governed effect paths:
   1) `PUT /v1/governance/policy` (governance policy update path),
   2) `POST /v1/governance/policy-bundles/promote` (policy bundle promotion path), and
   3) `PUT /v1/compliance/config` (runtime compliance config mutation path), and
-  4) `POST /v1/system/halt` (operator emergency halt mutation path).
+  4) `POST /v1/system/halt` (operator emergency halt mutation path), and
+  5) `POST /v1/system/resume` (operator system resume mutation path).
 - **Current fact (bind outcome public contract):** Governance bind responses expose legacy flat bind fields (`bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `execution_intent_id`, `bind_receipt_id`) and additive `bind_summary` objects as a shared compact bind vocabulary.
 - **Current fact (bind artifact family):** `BindReceipt` is persisted as a full governance artifact and carries canonical target metadata as part of the artifact contract.
 - **Current fact (replay/operator flow):** Operator surfaces expose bind artifacts via list/export/detail endpoints (`/v1/governance/bind-receipts`, `/v1/governance/bind-receipts/export`, `/v1/governance/bind-receipts/{bind_receipt_id}`), with mutation/export responses reusing `bind_summary` for triage and audit workflows.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -902,6 +902,61 @@ components:
           - $ref: '#/components/schemas/BindSummary'
           - type: 'null'
           description: Shared compact bind summary object.
+    SystemResumeResponse:
+      type: object
+      description: System resume response with bind lineage fields.
+      properties:
+        ok:
+          type: boolean
+        halted:
+          type: boolean
+        halted_by:
+          type: string
+          nullable: true
+        halted_at:
+          type: string
+          nullable: true
+        reason:
+          type: string
+          nullable: true
+        bind_outcome:
+          type: string
+          nullable: true
+          description: Present when bind adjudication runs for system resume mutation.
+          enum:
+          - COMMITTED
+          - BLOCKED
+          - ROLLED_BACK
+          - ESCALATED
+          - APPLY_FAILED
+          - SNAPSHOT_FAILED
+          - PRECONDITION_FAILED
+        bind_failure_reason:
+          type: string
+          nullable: true
+          description: Compact bind failure reason resolved from receipt checks.
+        bind_reason_code:
+          type: string
+          nullable: true
+          description: Stable bind reason code when available.
+        bind_receipt_id:
+          type: string
+          nullable: true
+        execution_intent_id:
+          type: string
+          nullable: true
+        bind_receipt:
+          allOf:
+          - $ref: '#/components/schemas/BindReceipt'
+          nullable: true
+        error:
+          type: string
+          nullable: true
+        bind_summary:
+          anyOf:
+          - $ref: '#/components/schemas/BindSummary'
+          - type: 'null'
+          description: Shared compact bind summary object.
     ExecutionIntent:
       type: object
       description: Decision-linked execution attempt descriptor.
@@ -3090,12 +3145,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  ok:
-                    type: boolean
-                  halted:
-                    type: boolean
+                $ref: '#/components/schemas/SystemResumeResponse'
   /v1/system/halt-status:
     get:
       summary: Halt status check

--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -1324,6 +1324,18 @@ export interface SystemHaltResponse {
 export interface SystemResumeResponse {
   ok: boolean;
   halted: boolean;
+  halted_by?: string | null;
+  halted_at?: string | null;
+  reason?: string | null;
+  bind_outcome?: FinalOutcomeStatus | null;
+  bind_failure_reason?: string | null;
+  bind_reason_code?: string | null;
+  bind_receipt_id?: string | null;
+  execution_intent_id?: string | null;
+  bind_receipt?: Record<string, unknown> | null;
+  bind_summary?: Record<string, unknown> | null;
+  target_metadata?: Record<string, unknown> | null;
+  error?: string | null;
   [key: string]: unknown;
 }
 

--- a/veritas_os/api/bind_target_catalog.py
+++ b/veritas_os/api/bind_target_catalog.py
@@ -63,6 +63,14 @@ CATALOG: tuple[BindTargetCatalogEntry, ...] = (
         operator_surface="compliance",
         relevant_ui_href="/system",
     ),
+    BindTargetCatalogEntry(
+        target_path="/v1/system/resume",
+        target_type="system_resume",
+        target_path_type="system_resume",
+        label="system resume",
+        operator_surface="compliance",
+        relevant_ui_href="/system",
+    ),
 )
 
 _INDEX_BY_PATH_AND_TYPE = {

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -20,7 +20,11 @@ from pydantic import BaseModel, Field
 from veritas_os.api.auth import require_permission
 from veritas_os.api.bind_summary import build_bind_response_payload
 from veritas_os.api.rbac import Permission
-from veritas_os.api.schemas import ComplianceConfigResponse, SystemHaltResponse
+from veritas_os.api.schemas import (
+    ComplianceConfigResponse,
+    SystemHaltResponse,
+    SystemResumeResponse,
+)
 from veritas_os.api.utils import _is_direct_fuji_api_enabled
 from veritas_os.api.pipeline_orchestrator import (
     get_runtime_config,
@@ -31,7 +35,10 @@ from veritas_os.policy.bind_artifacts import FinalOutcome
 from veritas_os.policy.compliance_config_update import (
     update_compliance_config_with_bind_boundary,
 )
-from veritas_os.policy.system_halt_update import halt_system_with_bind_boundary
+from veritas_os.policy.system_halt_update import (
+    halt_system_with_bind_boundary,
+    resume_system_with_bind_boundary,
+)
 from veritas_os.security.hash import sha256_of_canonical_json
 from veritas_os.storage.factory import get_backend_info
 # Note: report/compliance functions accessed via _get_server() to support
@@ -829,15 +836,50 @@ def system_halt(body: SystemHaltRequest):
         )
 
 
-@router.post("/v1/system/resume", dependencies=[Depends(require_permission(Permission.config_write))])
+@router.post(
+    "/v1/system/resume",
+    response_model=SystemResumeResponse,
+    dependencies=[Depends(require_permission(Permission.config_write))],
+)
 def system_resume(body: SystemResumeRequest):
     """Resume the AI decision system after a halt (Art. 14(4))."""
     srv = _get_server()
     try:
-        result = srv.SystemHaltController.resume(
-            operator=body.operator, comment=body.comment,
-        )
-        return {"ok": True, **result}
+        current_policy = srv.get_policy()
+        payload = {"operator": body.operator, "comment": body.comment}
+        decision_id = uuid4().hex
+        bind_receipt = resume_system_with_bind_boundary(
+            decision_id=decision_id,
+            request_id=decision_id,
+            actor_identity=body.operator,
+            policy_snapshot_id=str(
+                current_policy.get("updated_at")
+                or current_policy.get("version")
+                or "system_resume"
+            ),
+            decision_hash=sha256_of_canonical_json(payload),
+            operator=body.operator,
+            comment=body.comment,
+            status_reader=srv.SystemHaltController.status,
+            resume_executor=srv.SystemHaltController.resume,
+            approval_context={"system_resume_approved": True},
+            governance_policy=current_policy if isinstance(current_policy, dict) else None,
+        ).to_dict()
+        bind_receipt.setdefault("target_path", "/v1/system/resume")
+        bind_receipt.setdefault("target_type", "system_resume")
+        bind_payload = build_bind_response_payload(bind_receipt)
+        status = srv.SystemHaltController.status()
+        if bind_receipt.get("final_outcome") != FinalOutcome.COMMITTED.value:
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "ok": False,
+                    "error": "system resume bind approval validation failed",
+                    **status,
+                    **bind_payload,
+                },
+            )
+        return {"ok": True, **status, **bind_payload}
     except Exception as e:
         logger.error("system_resume failed: %s", e)
         return JSONResponse(

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -1534,6 +1534,25 @@ class SystemHaltResponse(BaseModel):
     error: Optional[str] = None
 
 
+class SystemResumeResponse(BaseModel):
+    """Response envelope for POST /v1/system/resume."""
+
+    ok: bool = True
+    halted: bool = False
+    halted_by: Optional[str] = None
+    halted_at: Optional[str] = None
+    reason: Optional[str] = None
+    bind_receipt: Optional[BindReceipt] = None
+    bind_outcome: Optional[FinalOutcome] = None
+    bind_failure_reason: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    bind_reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    bind_receipt_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    execution_intent_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    bind_summary: Optional[BindSummary] = None
+    target_metadata: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
 class GovernanceBindReceiptListResponse(BaseModel):
     """Response envelope for GET /v1/governance/bind-receipts."""
 

--- a/veritas_os/policy/bind_boundary_adapters.py
+++ b/veritas_os/policy/bind_boundary_adapters.py
@@ -503,3 +503,78 @@ class SystemHaltAdapter(BindAdapterContract):
     def describe_target(self) -> str:
         """Return human-readable target descriptor."""
         return self.target_description
+
+
+@dataclass
+class SystemResumeAdapter(BindAdapterContract):
+    """Bind adapter for operator-governed system resume."""
+
+    status_reader: Callable[[], dict[str, Any]]
+    resume_executor: Callable[..., dict[str, Any]]
+    operator: str
+    comment: str = ""
+    target_description: str = "system/resume"
+
+    def __post_init__(self) -> None:
+        self._last_resume_result: dict[str, Any] | None = None
+
+    def snapshot(self) -> dict[str, Any]:
+        """Capture deterministic pre-resume status snapshot."""
+        return {"status": dict(self.status_reader())}
+
+    def fingerprint_state(self, snapshot: Any) -> str:
+        """Return deterministic fingerprint for resume status snapshot."""
+        if not isinstance(snapshot, dict):
+            raise ValueError("BIND_STATE_SNAPSHOT_INVALID")
+        status = snapshot.get("status")
+        if not isinstance(status, dict):
+            raise ValueError("BIND_SYSTEM_RESUME_SNAPSHOT_INVALID")
+        return sha256_of_canonical_json(status)
+
+    def validate_authority(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        """Require explicit authority flag in bind approval context."""
+        del snapshot
+        if not isinstance(intent.approval_context, dict):
+            return False
+        return bool(intent.approval_context.get("system_resume_approved"))
+
+    def validate_constraints(self, intent: ExecutionIntent, snapshot: Any) -> dict[str, bool] | None:
+        """Validate input constraints and snapshot shape."""
+        del intent
+        status = snapshot.get("status") if isinstance(snapshot, dict) else None
+        return {
+            "snapshot_has_status": isinstance(status, dict),
+            "operator_present": bool(self.operator.strip()),
+            "comment_present": isinstance(self.comment, str),
+        }
+
+    def assess_runtime_risk(self, intent: ExecutionIntent, snapshot: Any) -> bool | None:
+        """System resume is admissible from runtime risk perspective."""
+        del intent, snapshot
+        return True
+
+    def apply(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Execute system resume through existing oversight controller."""
+        del intent, snapshot
+        result = self.resume_executor(operator=self.operator, comment=self.comment)
+        if not isinstance(result, dict):
+            raise ValueError("BIND_SYSTEM_RESUME_RESULT_INVALID")
+        self._last_resume_result = result
+        return True
+
+    def verify_postconditions(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """Verify system is no longer halted after apply execution."""
+        del intent, snapshot
+        status = self.status_reader()
+        if not isinstance(status, dict):
+            return False
+        return not bool(status.get("halted"))
+
+    def revert(self, intent: ExecutionIntent, snapshot: Any) -> bool:
+        """No-op revert: resume action is operator-controlled."""
+        del intent, snapshot
+        return True
+
+    def describe_target(self) -> str:
+        """Return human-readable target descriptor."""
+        return self.target_description

--- a/veritas_os/policy/system_halt_update.py
+++ b/veritas_os/policy/system_halt_update.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 from uuid import uuid4
 
 from veritas_os.policy.bind_artifacts import BindReceipt, ExecutionIntent
-from veritas_os.policy.bind_boundary_adapters import SystemHaltAdapter
+from veritas_os.policy.bind_boundary_adapters import SystemHaltAdapter, SystemResumeAdapter
 from veritas_os.policy.bind_core import execute_bind_adjudication
 
 
@@ -53,6 +53,67 @@ def halt_system_with_bind_boundary(
         target_system="system",
         target_resource="system/halt",
         intended_action="halt_system",
+        decision_hash=decision_hash,
+        decision_ts=decision_ts or _utc_now_iso8601(),
+        expected_state_fingerprint=expected_fingerprint,
+        approval_context=merged_approval_context,
+        policy_lineage=_with_bind_policy_lineage(
+            lineage=policy_lineage,
+            governance_policy=governance_policy,
+        ),
+    )
+
+    return execute_bind_adjudication(
+        execution_intent=intent,
+        adapter=adapter,
+        bind_ts=bind_ts,
+        bind_receipt_id=bind_receipt_id,
+        append_trustlog=append_trustlog,
+    )
+
+
+def resume_system_with_bind_boundary(
+    *,
+    decision_id: str,
+    request_id: str,
+    actor_identity: str,
+    policy_snapshot_id: str,
+    decision_hash: str,
+    operator: str,
+    comment: str,
+    status_reader: Callable[[], dict[str, Any]],
+    resume_executor: Callable[..., dict[str, Any]],
+    approval_context: dict[str, Any] | None = None,
+    policy_lineage: dict[str, Any] | None = None,
+    governance_policy: dict[str, Any] | None = None,
+    decision_ts: str | None = None,
+    append_trustlog: bool = True,
+    bind_ts: str | None = None,
+    execution_intent_id: str | None = None,
+    bind_receipt_id: str | None = None,
+) -> BindReceipt:
+    """Execute operator system resume through bind-boundary adjudication."""
+    adapter = SystemResumeAdapter(
+        status_reader=status_reader,
+        resume_executor=resume_executor,
+        operator=operator,
+        comment=comment,
+    )
+    pre_snapshot = adapter.snapshot()
+    expected_fingerprint = adapter.fingerprint_state(pre_snapshot)
+
+    merged_approval_context: dict[str, Any] = dict(approval_context or {})
+    merged_approval_context.setdefault("system_resume_approved", True)
+
+    intent = ExecutionIntent(
+        execution_intent_id=execution_intent_id or uuid4().hex,
+        decision_id=decision_id,
+        request_id=request_id,
+        policy_snapshot_id=policy_snapshot_id,
+        actor_identity=actor_identity,
+        target_system="system",
+        target_resource="system/resume",
+        intended_action="resume_system",
         decision_hash=decision_hash,
         decision_ts=decision_ts or _utc_now_iso8601(),
         expected_state_fingerprint=expected_fingerprint,

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -237,6 +237,26 @@ def test_openapi_system_halt_response_includes_bind_fields() -> None:
     assert "bind_summary" in properties
 
 
+def test_openapi_system_resume_response_includes_bind_fields() -> None:
+    """System resume mutation route should document bind lineage fields."""
+    spec = _load_openapi_spec()
+    schema = (
+        spec["paths"]["/v1/system/resume"]["post"]["responses"]["200"]["content"]
+        ["application/json"]["schema"]
+    )
+    if "$ref" in schema:
+        ref_name = str(schema["$ref"]).split("/")[-1]
+        schema = spec["components"]["schemas"][ref_name]
+    properties = schema["properties"]
+    assert "bind_outcome" in properties
+    assert "bind_failure_reason" in properties
+    assert "bind_reason_code" in properties
+    assert "bind_receipt_id" in properties
+    assert "execution_intent_id" in properties
+    assert "bind_receipt" in properties
+    assert "bind_summary" in properties
+
+
 def test_openapi_wat_config_includes_retention_boundary_fields() -> None:
     """WAT config schema must expose retention boundary lock-in controls."""
     spec = _load_openapi_spec()

--- a/veritas_os/tests/test_routes_system.py
+++ b/veritas_os/tests/test_routes_system.py
@@ -158,14 +158,73 @@ def test_system_halt_error(monkeypatch):
 
 
 def test_system_resume(monkeypatch):
-    monkeypatch.setattr(server, "SystemHaltController", _FakeHaltController)
+    class _ResumeCommittedController:
+        @staticmethod
+        def resume(operator, comment=""):
+            del operator, comment
+            return {"halted": False}
+
+        @staticmethod
+        def status():
+            return {"halted": False, "halted_by": None, "reason": None}
+
+    monkeypatch.setattr(server, "SystemHaltController", _ResumeCommittedController)
+    monkeypatch.setattr(
+        server,
+        "get_policy",
+        lambda: {"version": "test-policy", "updated_at": "2026-04-01T00:00:00Z"},
+    )
     resp = client.post(
         "/v1/system/resume",
         json={"operator": "tester", "comment": "all clear"},
         headers=_AUTH,
     )
     assert resp.status_code == 200
-    assert resp.json()["ok"] is True
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["halted"] is False
+    assert body["bind_outcome"] == "COMMITTED"
+    assert body["bind_summary"]["bind_outcome"] == "COMMITTED"
+    assert body["bind_receipt_id"]
+    assert body["execution_intent_id"]
+
+
+def test_system_resume_blocked_returns_bind_lineage(monkeypatch):
+    monkeypatch.setattr(server, "SystemHaltController", _FakeHaltController)
+    monkeypatch.setattr(
+        server,
+        "get_policy",
+        lambda: {"version": "test-policy", "updated_at": "2026-04-01T00:00:00Z"},
+    )
+
+    def _blocked(*args, **kwargs):
+        from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome
+
+        del args, kwargs
+        return BindReceipt(
+            bind_receipt_id="br-resume-blocked-1",
+            execution_intent_id="ei-resume-blocked-1",
+            decision_id="dec-resume-blocked-1",
+            final_outcome=FinalOutcome.BLOCKED,
+            target_path="/v1/system/resume",
+            target_type="system_resume",
+            bind_reason_code="authority_denied",
+            bind_failure_reason="approval denied",
+        )
+
+    monkeypatch.setattr("veritas_os.api.routes_system.resume_system_with_bind_boundary", _blocked)
+    resp = client.post(
+        "/v1/system/resume",
+        json={"operator": "tester", "comment": "all clear"},
+        headers=_AUTH,
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["bind_outcome"] == "BLOCKED"
+    assert body["bind_summary"]["bind_outcome"] == "BLOCKED"
+    assert body["bind_receipt_id"] == "br-resume-blocked-1"
+    assert body["execution_intent_id"] == "ei-resume-blocked-1"
 
 
 def test_system_resume_error(monkeypatch):


### PR DESCRIPTION
### Motivation
- Make `POST /v1/system/resume` symmetric with `POST /v1/system/halt` by applying the same bind-boundary adjudication pattern so resume becomes an operator-governed high-risk mutation. 
- Preserve the existing operator-facing bind contract vocabulary (`bind_receipt_id`, `execution_intent_id`, legacy flat bind fields and additive `bind_summary`) so operator surfaces and exports remain compatible. 
- Treat this as a minimal, backwards-compatible change limited to the resume path, OpenAPI/schema/types, bind target catalog, and focused tests, while calling out the operational risk of automatic approval context usage.

### Description
- Added `SystemResumeAdapter` (in `veritas_os/policy/bind_boundary_adapters.py`) to implement snapshot/fingerprint/authority/constraint/verify logic for resume operations. 
- Added `resume_system_with_bind_boundary` (in `veritas_os/policy/system_halt_update.py`) which constructs an `ExecutionIntent` for `target_resource="system/resume"` and executes bind adjudication via the new adapter. 
- Updated the route handler in `veritas_os/api/routes_system.py` to call `resume_system_with_bind_boundary`, return the same bind-aware payload as halt (flat bind fields + `bind_summary` + `bind_receipt` + `target_metadata`), use `response_model=SystemResumeResponse`, and return `403` when the bind outcome is not `COMMITTED`. 
- Extended the bind target catalog with `/v1/system/resume` (`system_resume`) and synchronized backend schema, OpenAPI (`openapi.yaml`), and frontend shared types (`packages/types/src/decision.ts`) by adding `SystemResumeResponse` with the canonical bind vocabulary. 
- Added and updated focused tests in `veritas_os/tests/test_routes_system.py` and `veritas_os/tests/test_openapi_spec.py` to cover a committed resume, blocked resume (bind-blocked), and OpenAPI contract regression.

### Testing
- Ran `pytest -q veritas_os/tests/test_routes_system.py::test_system_resume veritas_os/tests/test_routes_system.py::test_system_resume_blocked_returns_bind_lineage veritas_os/tests/test_openapi_spec.py::test_openapi_system_resume_response_includes_bind_fields veritas_os/tests/test_routes_system.py::test_system_halt veritas_os/tests/test_routes_system.py::test_system_halt_blocked_returns_bind_lineage` and all targeted tests passed (5 passed). 
- Ran `pytest -q veritas_os/tests/test_openapi_spec.py::test_openapi_system_halt_response_includes_bind_fields veritas_os/tests/test_openapi_spec.py::test_openapi_system_resume_response_includes_bind_fields` and both tests passed (2 passed). 
- Ran `pytest -q veritas_os/tests/test_routes_system.py -k "system_halt or system_resume"` which executed the combined halt/resume coverage and passed (8 passed, 13 deselected). 
- No other unrelated tests were modified; the change is focused to the resume mutation path and its contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1fc46e2c8326adce2d678e8588cc)