### PR TITLE
Add bind coverage registry, route bind markers, and explicit decide actionability fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ while broader effect-path coverage remains roadmap direction.
   4) `POST /v1/system/halt` (operator emergency halt mutation path), and
   5) `POST /v1/system/resume` (operator system resume mutation path).
 - **Current fact (bind outcome public contract):** Governance bind responses expose legacy flat bind fields (`bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `execution_intent_id`, `bind_receipt_id`) and additive `bind_summary` objects as a shared compact bind vocabulary.
+- **Current fact (bind coverage registry):** VERITAS maintains a tested bind coverage registry for API effect paths. Effect-bearing routes must be classified as `bind_governed` or explicitly documented as `audited_exemption` with reason/risk metadata, reducing the risk that recorded decisions are treated as execution permission without a binding artifact.
 - **Current fact (bind artifact family):** `BindReceipt` is persisted as a full governance artifact and carries canonical target metadata as part of the artifact contract.
 - **Current fact (replay/operator flow):** Operator surfaces expose bind artifacts via list/export/detail endpoints (`/v1/governance/bind-receipts`, `/v1/governance/bind-receipts/export`, `/v1/governance/bind-receipts/{bind_receipt_id}`), with mutation/export responses reusing `bind_summary` for triage and audit workflows.
 - **Current fact (boundary):** Production readiness still depends on environment-specific hardening, integration, and operational controls.

--- a/README_JP.md
+++ b/README_JP.md
@@ -67,6 +67,7 @@ VERITAS OS は次を実現します。
   - `POST /v1/system/halt`
   - `POST /v1/system/resume`
 - **現時点の事実（bind outcome公開契約）**: ガバナンス系レスポンスでは従来のフラットな bind フィールド（`bind_outcome` / `bind_failure_reason` / `bind_reason_code` / `execution_intent_id` / `bind_receipt_id`）に加えて、共通のコンパクト語彙として加算的 `bind_summary` も返却されます
+- **現時点の事実（bind coverage registry）**: VERITAS は API 上の effect-bearing path に対して、テスト可能な bind coverage registry を持つ。現実世界に影響する route は `bind_governed` として分類されるか、明示的な `audited_exemption` として理由・リスク付きで記録されるため、記録済み意思決定が binding artifact なしで実行許可と誤認されるリスクを低減します。
 - **現時点の事実（bind artifact family）**: `BindReceipt` は完全なガバナンス成果物として永続化され、成果物契約に canonical target metadata を含みます
 - **現時点の事実（replay/運用フロー）**: 運用画面/API は bind 成果物の list/export/detail エンドポイント（`/v1/governance/bind-receipts` / `/v1/governance/bind-receipts/export` / `/v1/governance/bind-receipts/{bind_receipt_id}`）を提供し、mutation/export レスポンスでは監査トリアージ向けに `bind_summary` を再利用します
 - **現時点の境界**: これは現時点で全ての副作用経路が bind-governed であると主張するものではありません。  

--- a/docs/en/architecture/bind-boundary-governance-artifacts.md
+++ b/docs/en/architecture/bind-boundary-governance-artifacts.md
@@ -129,3 +129,5 @@ bind-phase commitment.
 
 `GET /v1/governance/bind-receipts/br-9001` returns the linked bind receipt
 artifact with authority/constraint/drift/risk check payloads.
+
+- VERITAS now keeps a tested bind coverage registry for API effect paths. Effect-bearing routes must be classified as `bind_governed` or documented as explicit `audited_exemption` entries (reason/risk/owner/review cadence), reducing the risk of TrustLog(recorded) being misread as execution permission without bind lineage.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1468,6 +1468,31 @@ components:
           default: REVISE_AND_RESUBMIT
           description: Operational guidance action; separate from business_decision
             state.
+        actionability_status:
+          type: string
+          enum:
+          - reviewable_only
+          - bind_required_before_execution
+          - actionable_after_bind
+          - blocked
+          - human_review_required
+          default: reviewable_only
+          description: Explicit execution boundary state. A recorded decision is reviewable
+            and does not grant execution permission without bind lineage.
+        requires_bind_before_execution:
+          type: boolean
+          default: true
+          description: True when execution requires bind before operational action.
+            This remains true unless a bind receipt is present and committed.
+        bound_execution_intent_id:
+          type: string
+          nullable: true
+          description: Execution intent identifier that is already bound, when available.
+        unbound_execution_warning:
+          type: string
+          nullable: true
+          description: Operator-facing warning that decision output is not executable
+            until bind receipt lineage is present.
         required_evidence:
           type: array
           default: []

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -33,6 +33,7 @@ from veritas_os.api.schemas import (
     GovernancePolicyResponse,
     GovernancePolicyHistoryResponse,
 )
+from veritas_os.policy.bind_route_markers import requires_bind_boundary
 from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome, find_bind_receipts
 from veritas_os.policy.governance_policy_update import update_governance_policy_with_bind_boundary
 from veritas_os.policy.policy_bundle_promotion import promote_policy_bundle_with_bind_boundary
@@ -453,6 +454,11 @@ def governance_get():
     response_model=GovernancePolicyResponse,
     dependencies=[Depends(require_permission(Permission.governance_write))],
 )
+@requires_bind_boundary(
+    target_path="/v1/governance/policy",
+    target_type="governance_policy",
+    target_path_type="governance_policy_update",
+)
 def governance_put(body: dict):
     """Update the governance policy (partial merge)."""
     srv = _get_server()
@@ -814,6 +820,11 @@ def governance_bind_receipt(bind_receipt_id: str):
     "/v1/governance/policy-bundles/promote",
     response_model=GovernancePolicyBundlePromoteResponse,
     dependencies=[Depends(require_permission(Permission.governance_write))],
+)
+@requires_bind_boundary(
+    target_path="/v1/governance/policy-bundles/promote",
+    target_type="policy_bundle",
+    target_path_type="policy_bundle_promotion",
 )
 def governance_promote_policy_bundle(
     body: GovernancePolicyBundlePromoteRequest,

--- a/veritas_os/api/routes_system.py
+++ b/veritas_os/api/routes_system.py
@@ -31,6 +31,7 @@ from veritas_os.api.pipeline_orchestrator import (
     update_runtime_config,
 )
 from veritas_os.logging.encryption import get_encryption_status
+from veritas_os.policy.bind_route_markers import requires_bind_boundary
 from veritas_os.policy.bind_artifacts import FinalOutcome
 from veritas_os.policy.compliance_config_update import (
     update_compliance_config_with_bind_boundary,
@@ -697,6 +698,11 @@ def compliance_get_config() -> Dict[str, Any]:
     response_model=ComplianceConfigResponse,
     dependencies=[Depends(require_permission(Permission.config_write))],
 )
+@requires_bind_boundary(
+    target_path="/v1/compliance/config",
+    target_type="compliance_config",
+    target_path_type="compliance_config_update",
+)
 def compliance_put_config(body: ComplianceConfigBody) -> Dict[str, Any]:
     """Update runtime compliance config via bind-boundary adjudication."""
     srv = _get_server()
@@ -789,6 +795,11 @@ def report_governance(from_: str = Query(alias="from"), to: str = Query(alias="t
     response_model=SystemHaltResponse,
     dependencies=[Depends(require_permission(Permission.config_write))],
 )
+@requires_bind_boundary(
+    target_path="/v1/system/halt",
+    target_type="system_halt",
+    target_path_type="system_halt",
+)
 def system_halt(body: SystemHaltRequest):
     """Halt the AI decision system (Art. 14(4) emergency stop)."""
     srv = _get_server()
@@ -840,6 +851,11 @@ def system_halt(body: SystemHaltRequest):
     "/v1/system/resume",
     response_model=SystemResumeResponse,
     dependencies=[Depends(require_permission(Permission.config_write))],
+)
+@requires_bind_boundary(
+    target_path="/v1/system/resume",
+    target_type="system_resume",
+    target_path_type="system_resume",
 )
 def system_resume(body: SystemResumeRequest):
     """Resume the AI decision system after a halt (Art. 14(4))."""

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -68,6 +68,13 @@ BusinessDecisionLiteral = Literal[
     "POLICY_DEFINITION_REQUIRED",
     "EVIDENCE_REQUIRED",
 ]
+ActionabilityStatusLiteral = Literal[
+    "reviewable_only",
+    "bind_required_before_execution",
+    "actionable_after_bind",
+    "blocked",
+    "human_review_required",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -771,6 +778,34 @@ class DecideResponse(BaseModel):
     )
     business_decision: BusinessDecisionLiteral = "HOLD"
     next_action: str = "REVISE_AND_RESUBMIT"
+    actionability_status: ActionabilityStatusLiteral = Field(
+        default="reviewable_only",
+        description=(
+            "Explicit execution boundary state. "
+            "A recorded decision is reviewable and does not grant execution "
+            "permission without bind lineage."
+        ),
+    )
+    requires_bind_before_execution: bool = Field(
+        default=True,
+        description=(
+            "True when execution requires bind before operational action. "
+            "This remains true unless a bind receipt is present and committed."
+        ),
+    )
+    bound_execution_intent_id: Optional[str] = Field(
+        default=None,
+        max_length=MAX_ID_LENGTH,
+        description="Execution intent identifier that is already bound, when available.",
+    )
+    unbound_execution_warning: Optional[str] = Field(
+        default=None,
+        max_length=MAX_DESCRIPTION_LENGTH,
+        description=(
+            "Operator-facing warning that decision output is not executable "
+            "until bind receipt lineage is present."
+        ),
+    )
     required_evidence: List[str] = Field(default_factory=list, max_length=MAX_LIST_ITEMS)
     missing_evidence: List[str] = Field(default_factory=list, max_length=MAX_LIST_ITEMS)
     satisfied_evidence: List[str] = Field(default_factory=list, max_length=MAX_LIST_ITEMS)

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -86,6 +86,63 @@ AML_KYC_PROFILE_ENFORCEMENT_KEYS = {
 }
 
 
+def _derive_actionability_fields(
+    *,
+    gate_decision: str,
+    business_decision: str,
+    human_review_required: bool,
+    next_action: str,
+    bind_outcome: Any,
+    bind_receipt_id: Any,
+    execution_intent_id: Any,
+) -> Dict[str, Any]:
+    """Derive explicit reviewable-vs-actionable boundary fields."""
+    normalized_outcome = str(bind_outcome or "").strip().upper()
+    normalized_bind_receipt_id = str(bind_receipt_id or "").strip() or None
+    normalized_execution_intent_id = str(execution_intent_id or "").strip() or None
+    has_bound_lineage = (
+        normalized_outcome == "COMMITTED"
+        and normalized_bind_receipt_id is not None
+        and normalized_execution_intent_id is not None
+    )
+    implies_execution = next_action in {
+        "EXECUTE_WITH_STANDARD_MONITORING",
+        "RUN_TARGETED_VALIDATION_CHECKS",
+    }
+
+    if gate_decision == "block" or business_decision == "DENY":
+        status = "blocked"
+        requires_bind = False
+    elif human_review_required or gate_decision == "human_review_required":
+        status = "human_review_required"
+        requires_bind = True
+    elif has_bound_lineage:
+        status = "actionable_after_bind"
+        requires_bind = False
+    elif implies_execution or business_decision == "APPROVE":
+        status = "bind_required_before_execution"
+        requires_bind = True
+    else:
+        status = "reviewable_only"
+        requires_bind = True
+
+    warning = None
+    if requires_bind:
+        warning = (
+            "Decision is reviewable only; bind receipt is required before "
+            "execution permission."
+        )
+
+    return {
+        "actionability_status": status,
+        "requires_bind_before_execution": requires_bind,
+        "bound_execution_intent_id": normalized_execution_intent_id if has_bound_lineage else None,
+        "bind_receipt_id": normalized_bind_receipt_id,
+        "execution_intent_id": normalized_execution_intent_id,
+        "unbound_execution_warning": warning,
+    }
+
+
 def _is_dev_mode_enabled(context: Dict[str, Any]) -> bool:
     """Return whether action-candidate diagnostics should be exposed."""
     explicit_flag = context.get("dev_mode") or context.get("debug")
@@ -688,6 +745,18 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
             "candidates_considered": len(action_candidates),
         },
     }
+    raw_payload = ctx.raw if isinstance(ctx.raw, dict) else {}
+    result.update(
+        _derive_actionability_fields(
+            gate_decision=gate_decision,
+            business_decision=business_decision,
+            human_review_required=human_review_required,
+            next_action=next_action,
+            bind_outcome=raw_payload.get("bind_outcome"),
+            bind_receipt_id=raw_payload.get("bind_receipt_id"),
+            execution_intent_id=raw_payload.get("execution_intent_id"),
+        )
+    )
     if structured_answer is not None:
         result["structured_answer"] = structured_answer
     if unknown_keys:

--- a/veritas_os/policy/bind_coverage.py
+++ b/veritas_os/policy/bind_coverage.py
@@ -1,0 +1,169 @@
+"""Canonical bind coverage registry for API paths.
+
+The registry makes route classification explicit so effect-bearing API paths are
+never silently added without governance review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from veritas_os.api.bind_target_catalog import CATALOG, resolve_bind_target_metadata
+
+
+class BindCoverageClass(str, Enum):
+    """Classification bucket for API route bind-boundary coverage."""
+
+    BIND_GOVERNED = "bind_governed"
+    READ_ONLY = "read_only"
+    NON_EFFECT = "non_effect"
+    AUDITED_EXEMPTION = "audited_exemption"
+
+
+@dataclass(frozen=True)
+class BindCoverageEntry:
+    """One canonical coverage row for an API method/path pair."""
+
+    path: str
+    method: str
+    coverage_class: BindCoverageClass
+    reason: str | None = None
+    risk_level: str | None = None
+    governance_owner: str | None = None
+    review_required_by: str | None = None
+
+    def key(self) -> tuple[str, str]:
+        """Return normalized key used by coverage lookup maps."""
+
+        return (self.path, self.method.upper())
+
+
+BIND_COVERAGE_REGISTRY: tuple[BindCoverageEntry, ...] = (
+    BindCoverageEntry("/", "GET", BindCoverageClass.NON_EFFECT),
+    BindCoverageEntry("/health", "GET", BindCoverageClass.NON_EFFECT),
+    BindCoverageEntry("/v1/health", "GET", BindCoverageClass.NON_EFFECT),
+    BindCoverageEntry("/status", "GET", BindCoverageClass.NON_EFFECT),
+    BindCoverageEntry("/v1/status", "GET", BindCoverageClass.NON_EFFECT),
+    BindCoverageEntry("/api/status", "GET", BindCoverageClass.NON_EFFECT),
+    BindCoverageEntry("/v1/metrics", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/events", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/decide", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Decision recording is reviewable output and not an execution permission path.",
+                      risk_level="medium", governance_owner="governance", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/replay/{decision_id}", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Replay endpoint reproduces prior decisions for audit and does not authorize execution.",
+                      risk_level="low", governance_owner="audit", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/decision/replay/{decision_id}", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Legacy replay alias is audit-only and has no external execution side effects.",
+                      risk_level="low", governance_owner="audit", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/fuji/validate", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Validation endpoint evaluates gate status but does not commit execution.",
+                      risk_level="medium", governance_owner="governance", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/memory/put", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Memory write persists internal context only; no governed external execution target.",
+                      risk_level="medium", governance_owner="memory", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/memory/search", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Search uses POST for payload size/shape but is read semantics only.",
+                      risk_level="low", governance_owner="memory", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/memory/get", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Lookup endpoint uses POST for typed request body; retrieval only.",
+                      risk_level="low", governance_owner="memory", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/memory/erase", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Memory erasure affects local memory store but is not a bind target catalog operation.",
+                      risk_level="high", governance_owner="memory", review_required_by="monthly"),
+    BindCoverageEntry("/v1/trust/logs", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/trust/stats", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/trust/{request_id}", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/trust/{request_id}/prov", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/trustlog/verify", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/trustlog/export", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/trust/feedback", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Trust feedback updates scoring telemetry only; no execution authorization.",
+                      risk_level="low", governance_owner="trust", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/wat/issue-shadow", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Shadow WAT issuance is observer-lane telemetry and non-enforcement.",
+                      risk_level="medium", governance_owner="governance", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/wat/validate-shadow", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Shadow validation checks signatures without granting execution privileges.",
+                      risk_level="medium", governance_owner="governance", review_required_by="quarterly"),
+    BindCoverageEntry("/v1/wat/events", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/wat/{wat_id}", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/wat/revocation/{wat_id}", "POST", BindCoverageClass.AUDITED_EXEMPTION,
+                      reason="Revocation mutates WAT lane state but is not a bind-governed execution path.",
+                      risk_level="high", governance_owner="governance", review_required_by="monthly"),
+    BindCoverageEntry("/v1/governance/value-drift", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/governance/policy", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/governance/policy", "PUT", BindCoverageClass.BIND_GOVERNED),
+    BindCoverageEntry("/v1/governance/policy/history", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/governance/decisions/export", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/governance/bind-receipts", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/governance/bind-receipts/export", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/governance/bind-receipts/{bind_receipt_id}", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/governance/policy-bundles/promote", "POST", BindCoverageClass.BIND_GOVERNED),
+    BindCoverageEntry("/v1/compliance/config", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/compliance/config", "PUT", BindCoverageClass.BIND_GOVERNED),
+    BindCoverageEntry("/v1/report/eu_ai_act/{decision_id}", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/report/governance", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/system/halt", "POST", BindCoverageClass.BIND_GOVERNED),
+    BindCoverageEntry("/v1/system/resume", "POST", BindCoverageClass.BIND_GOVERNED),
+    BindCoverageEntry("/v1/system/halt-status", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/compliance/deployment-readiness", "GET", BindCoverageClass.READ_ONLY),
+)
+
+_REGISTRY_INDEX = {entry.key(): entry for entry in BIND_COVERAGE_REGISTRY}
+
+
+def get_bind_coverage_registry() -> tuple[BindCoverageEntry, ...]:
+    """Return the immutable bind coverage registry."""
+
+    return BIND_COVERAGE_REGISTRY
+
+
+def classify_bind_coverage(path: str, method: str) -> BindCoverageEntry | None:
+    """Resolve a coverage entry for ``path`` + ``method`` when registered."""
+
+    return _REGISTRY_INDEX.get((str(path), str(method).upper()))
+
+
+def validate_bind_coverage_registry() -> list[str]:
+    """Validate registry integrity and catalog consistency.
+
+    Returns a list of error messages. Empty list means valid.
+    """
+
+    errors: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    bind_governed_paths = set()
+
+    for entry in BIND_COVERAGE_REGISTRY:
+        key = entry.key()
+        if key in seen:
+            errors.append(f"duplicate bind coverage entry: {key[1]} {key[0]}")
+        seen.add(key)
+
+        if entry.coverage_class == BindCoverageClass.AUDITED_EXEMPTION:
+            if not (entry.reason and entry.reason.strip()):
+                errors.append(f"audited exemption missing reason: {entry.method} {entry.path}")
+            if not (entry.risk_level and entry.risk_level.strip()):
+                errors.append(f"audited exemption missing risk_level: {entry.method} {entry.path}")
+
+        if entry.coverage_class == BindCoverageClass.BIND_GOVERNED:
+            bind_governed_paths.add(entry.path)
+            target = resolve_bind_target_metadata(entry.path, "")
+            if target.get("target_path_type") == "other":
+                errors.append(
+                    f"bind_governed route missing bind target metadata: {entry.method} {entry.path}"
+                )
+
+    catalog_paths = {entry.target_path for entry in CATALOG}
+    missing_in_catalog = bind_governed_paths - catalog_paths
+    for path in sorted(missing_in_catalog):
+        errors.append(f"bind_governed route missing from bind target catalog: {path}")
+
+    missing_in_registry = catalog_paths - bind_governed_paths
+    for path in sorted(missing_in_registry):
+        errors.append(f"bind target catalog route missing bind_governed registry entry: {path}")
+
+    return errors

--- a/veritas_os/policy/bind_route_markers.py
+++ b/veritas_os/policy/bind_route_markers.py
@@ -1,0 +1,50 @@
+"""Route-level metadata markers for bind-boundary governance coverage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class BindBoundaryRouteMetadata:
+    """Declarative metadata describing bind-boundary requirements."""
+
+    target_path: str
+    target_type: str
+    target_path_type: str
+
+
+def requires_bind_boundary(
+    *,
+    target_path: str,
+    target_type: str,
+    target_path_type: str,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Attach bind-boundary metadata to a route handler function.
+
+    This decorator is intentionally additive-only in this PR. It does not modify
+    runtime behavior and is used by tests to verify route/bind coverage drift.
+    """
+
+    metadata = BindBoundaryRouteMetadata(
+        target_path=target_path,
+        target_type=target_type,
+        target_path_type=target_path_type,
+    )
+
+    def _decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        setattr(func, "_requires_bind_boundary", True)
+        setattr(func, "_bind_boundary_metadata", metadata)
+        return func
+
+    return _decorator
+
+
+def get_bind_boundary_metadata(func: Callable[..., Any]) -> BindBoundaryRouteMetadata | None:
+    """Return bind-boundary metadata from a route handler when present."""
+
+    metadata = getattr(func, "_bind_boundary_metadata", None)
+    if isinstance(metadata, BindBoundaryRouteMetadata):
+        return metadata
+    return None

--- a/veritas_os/policy/bind_route_markers.py
+++ b/veritas_os/policy/bind_route_markers.py
@@ -34,8 +34,8 @@ def requires_bind_boundary(
     )
 
     def _decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        setattr(func, "_requires_bind_boundary", True)
-        setattr(func, "_bind_boundary_metadata", metadata)
+        func._requires_bind_boundary = True  # type: ignore[attr-defined]
+        func._bind_boundary_metadata = metadata  # type: ignore[attr-defined]
         return func
 
     return _decorator

--- a/veritas_os/tests/test_bind_coverage_registry.py
+++ b/veritas_os/tests/test_bind_coverage_registry.py
@@ -1,0 +1,60 @@
+"""Tests for canonical bind coverage registry and route classification."""
+
+from __future__ import annotations
+
+from fastapi.routing import APIRoute
+
+from veritas_os.api.server import app
+from veritas_os.policy.bind_coverage import (
+    BindCoverageClass,
+    classify_bind_coverage,
+    get_bind_coverage_registry,
+    validate_bind_coverage_registry,
+)
+
+
+def _runtime_api_routes() -> list[tuple[str, str]]:
+    routes: list[tuple[str, str]] = []
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        for method in sorted(route.methods):
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            routes.append((route.path, method))
+    return routes
+
+
+def test_bind_coverage_registry_is_valid() -> None:
+    """Registry must be internally consistent and catalog-aligned."""
+    assert validate_bind_coverage_registry() == []
+
+
+def test_all_effect_bearing_routes_are_classified() -> None:
+    """POST/PUT/PATCH/DELETE routes must be explicitly classified."""
+    missing: list[str] = []
+    for path, method in _runtime_api_routes():
+        if method not in {"POST", "PUT", "PATCH", "DELETE"}:
+            continue
+        if classify_bind_coverage(path, method) is None:
+            missing.append(f"{method} {path}")
+    assert not missing, f"Unclassified effect-bearing routes: {missing}"
+
+
+def test_audited_exemptions_include_reason_and_risk() -> None:
+    """Audited exemptions must carry explicit governance rationale."""
+    for entry in get_bind_coverage_registry():
+        if entry.coverage_class != BindCoverageClass.AUDITED_EXEMPTION:
+            continue
+        assert entry.reason is not None and entry.reason.strip()
+        assert entry.risk_level is not None and entry.risk_level.strip()
+
+
+def test_all_runtime_api_routes_are_classified() -> None:
+    """Every runtime API route should have a canonical coverage classification."""
+    missing = [
+        f"{method} {path}"
+        for path, method in _runtime_api_routes()
+        if classify_bind_coverage(path, method) is None
+    ]
+    assert not missing, f"Unclassified runtime API routes: {missing}"

--- a/veritas_os/tests/test_bind_target_catalog_consistency.py
+++ b/veritas_os/tests/test_bind_target_catalog_consistency.py
@@ -1,0 +1,57 @@
+"""Drift prevention tests for bind target catalog, coverage, and route markers."""
+
+from __future__ import annotations
+
+from fastapi.routing import APIRoute
+
+from veritas_os.api.bind_target_catalog import CATALOG
+from veritas_os.api.server import app
+from veritas_os.policy.bind_coverage import (
+    BindCoverageClass,
+    classify_bind_coverage,
+    get_bind_coverage_registry,
+)
+from veritas_os.policy.bind_route_markers import get_bind_boundary_metadata
+
+
+def test_bind_governed_registry_paths_match_catalog_paths() -> None:
+    """bind_governed coverage entries must match canonical catalog targets."""
+    governed_paths = {
+        entry.path
+        for entry in get_bind_coverage_registry()
+        if entry.coverage_class == BindCoverageClass.BIND_GOVERNED
+    }
+    catalog_paths = {entry.target_path for entry in CATALOG}
+    assert governed_paths == catalog_paths
+
+
+def test_bind_governed_routes_declare_marker_metadata() -> None:
+    """bind_governed runtime routes should declare bind marker metadata."""
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        for method in route.methods:
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            coverage = classify_bind_coverage(route.path, method)
+            if coverage is None or coverage.coverage_class != BindCoverageClass.BIND_GOVERNED:
+                continue
+            metadata = get_bind_boundary_metadata(route.endpoint)
+            assert metadata is not None, f"missing marker for {method} {route.path}"
+            assert metadata.target_path == route.path
+
+
+def test_bind_route_markers_align_with_catalog_metadata() -> None:
+    """Route marker metadata should align with catalog definitions."""
+    catalog_by_path = {entry.target_path: entry for entry in CATALOG}
+
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        metadata = get_bind_boundary_metadata(route.endpoint)
+        if metadata is None:
+            continue
+        catalog_entry = catalog_by_path.get(metadata.target_path)
+        assert catalog_entry is not None
+        assert catalog_entry.target_type == metadata.target_type
+        assert catalog_entry.target_path_type == metadata.target_path_type

--- a/veritas_os/tests/test_decide_actionability_boundary.py
+++ b/veritas_os/tests/test_decide_actionability_boundary.py
@@ -1,0 +1,93 @@
+"""Tests for reviewable vs actionable boundary semantics in decide responses."""
+
+from __future__ import annotations
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.core.pipeline.pipeline_response import assemble_response
+from veritas_os.core.pipeline.pipeline_types import PipelineContext
+
+
+def _build_payload(ctx: PipelineContext) -> dict:
+    return assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+
+def test_reviewable_decision_is_not_actionable_without_bind_receipt() -> None:
+    ctx = PipelineContext(
+        request_id="act-1",
+        query="can we proceed",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+    )
+    payload = _build_payload(ctx)
+
+    assert payload["actionability_status"] == "bind_required_before_execution"
+    assert payload["requires_bind_before_execution"] is True
+    assert payload["bind_receipt_id"] is None
+    assert payload["unbound_execution_warning"] is not None
+
+
+def test_blocked_decision_is_not_actionable() -> None:
+    ctx = PipelineContext(
+        request_id="act-2",
+        query="blocked",
+        fuji_dict={"decision_status": "deny", "status": "deny"},
+        decision_status="rejected",
+        rejection_reason="policy_violation",
+    )
+    payload = _build_payload(ctx)
+
+    assert payload["actionability_status"] == "blocked"
+    assert payload["requires_bind_before_execution"] is False
+
+
+def test_human_review_decision_is_not_actionable() -> None:
+    ctx = PipelineContext(
+        request_id="act-3",
+        query="human review",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+        context={"approval_boundary_defined": False},
+    )
+    payload = _build_payload(ctx)
+
+    assert payload["actionability_status"] == "human_review_required"
+    assert payload["requires_bind_before_execution"] is True
+
+
+def test_execution_like_next_action_still_requires_bind_when_unbound() -> None:
+    ctx = PipelineContext(
+        request_id="act-4",
+        query="execute",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        rejection_reason=None,
+    )
+    payload = _build_payload(ctx)
+
+    assert payload["next_action"] == "EXECUTE_WITH_STANDARD_MONITORING"
+    assert payload["actionability_status"] == "bind_required_before_execution"
+    assert payload["requires_bind_before_execution"] is True
+
+
+def test_decide_response_validation_accepts_new_actionability_fields() -> None:
+    payload = {
+        "ok": True,
+        "request_id": "act-5",
+        "chosen": {},
+        "actionability_status": "reviewable_only",
+        "requires_bind_before_execution": True,
+        "bound_execution_intent_id": None,
+        "bind_receipt_id": None,
+        "unbound_execution_warning": "bind needed",
+    }
+
+    parsed = DecideResponse.model_validate(payload)
+
+    assert parsed.actionability_status == "reviewable_only"
+    assert parsed.requires_bind_before_execution is True

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -141,6 +141,16 @@ def test_openapi_decide_response_decision_semantics_contract() -> None:
         "EVIDENCE_REQUIRED",
     ]
     assert decide_schema["next_action"]["type"] == "string"
+    assert decide_schema["actionability_status"]["enum"] == [
+        "reviewable_only",
+        "bind_required_before_execution",
+        "actionable_after_bind",
+        "blocked",
+        "human_review_required",
+    ]
+    assert decide_schema["requires_bind_before_execution"]["type"] == "boolean"
+    assert decide_schema["bound_execution_intent_id"]["nullable"] is True
+    assert decide_schema["unbound_execution_warning"]["nullable"] is True
     assert "governance_identity" in decide_schema
 
 


### PR DESCRIPTION
### Motivation
- Make bind-boundary coverage an explicit, testable contract so effect-bearing API paths cannot be added without governance review. 
- Make the decision → execution boundary explicit in responses so a recorded decision is not mistaken for execution permission without a committed bind lineage. 
- Keep backwards compatibility and avoid changing runtime behavior while making bind requirements visible and testable. 

### Description
- Add a canonical bind coverage registry with `BindCoverageClass`, `BindCoverageEntry`, `BIND_COVERAGE_REGISTRY`, `classify_bind_coverage`, `get_bind_coverage_registry`, and `validate_bind_coverage_registry` to `veritas_os/policy/bind_coverage.py`. 
- Add lightweight route-level marker decorator `@requires_bind_boundary` and metadata reader in `veritas_os/policy/bind_route_markers.py` and apply it to existing bind-governed handlers for governance/policy, policy-bundle promotion, compliance config, system halt and resume. 
- Wire a registry ↔ bind target catalog consistency check so every `bind_governed` registry entry must map to catalog metadata and vice-versa (validation logic included in the registry module). 
- Harden `/v1/decide` actionability semantics by adding `actionability_status`, `requires_bind_before_execution`, `bound_execution_intent_id`, and `unbound_execution_warning` to the `DecideResponse` schema and OpenAPI, and derive those fields in the pipeline response assembly so decisions are explicitly labelled reviewable vs actionable. 
- Update OpenAPI (`openapi.yaml`) and documentation/README text to describe the tested bind coverage guarantee without overclaiming. 
- Add tests that assert registry integrity, catalog consistency, runtime route classification presence, route marker alignment, and decide actionability semantics under representative pipeline contexts (`veritas_os/tests/test_bind_coverage_registry.py`, `veritas_os/tests/test_bind_target_catalog_consistency.py`, `veritas_os/tests/test_decide_actionability_boundary.py`), and extend OpenAPI assertions in `veritas_os/tests/test_openapi_spec.py`. 

### Testing
- Ran focused test subset covering new functionality with: `pytest -q veritas_os/tests/test_bind_coverage_registry.py veritas_os/tests/test_bind_target_catalog_consistency.py veritas_os/tests/test_decide_actionability_boundary.py veritas_os/tests/test_openapi_spec.py` which passed (final run reported `27 passed`). 
- Ran a targeted pipeline response unit test together with the new tests using: `pytest -q veritas_os/tests/unit/test_pipeline_stages_ext.py::TestAssembleResponse::test_contract_defaults_and_backward_compat_fields veritas_os/tests/test_decide_actionability_boundary.py veritas_os/tests/test_bind_coverage_registry.py veritas_os/tests/test_bind_target_catalog_consistency.py veritas_os/tests/test_openapi_spec.py` which passed for the modified parts. 
- A full test run (`pytest -q`) earlier surfaced an unrelated baseline failure in `tests/test_bind_admissibility.py::test_expired_ttl_escalates_fail_closed` (this was present during validation and is outside the files changed by this PR). 
- New/modified tests exercise: registry validation, route classification for all runtime POST/PUT/PATCH/DELETE paths, audited exemption metadata presence, bind-governed ↔ catalog alignment, route marker metadata presence, and decide actionability semantics including schema validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebaf5c637083269ed82c9573feefdd)