### PR TITLE
Add governance route policies and exempt single-URL lines from markdown length check

### DIFF
--- a/README_JP.md
+++ b/README_JP.md
@@ -544,7 +544,7 @@ VERITAS_MEMORY_BACKEND=postgresql VERITAS_TRUSTLOG_BACKEND=postgresql \
 - インシデントレスポンスプレイブック（破損、改ざん）
 - `make drill-backup`、`make drill-restore`、`make drill-recovery`、`make drill-recovery-ci`
 
-関連: [`docs/database-migrations.md`](docs/ja/operations/database-migrations.md) | [`docs/BACKEND_PARITY_COVERAGE.md`](docs/ja/validation/backend-parity-coverage.md) | [`docs/legacy-path-cleanup.md`](docs/ja/operations/legacy-path-cleanup.md)
+関連: [`docs/ja/operations/database-migrations.md`](docs/ja/operations/database-migrations.md) | [`docs/ja/validation/backend-parity-coverage.md`](docs/ja/validation/backend-parity-coverage.md) | [`docs/ja/operations/legacy-path-cleanup.md`](docs/ja/operations/legacy-path-cleanup.md)
 
 ---
 

--- a/docs/ja/architecture/bind-time-admissibility-evaluator.md
+++ b/docs/ja/architecture/bind-time-admissibility-evaluator.md
@@ -1,3 +1,9 @@
 # Bind-Time Admissibility Evaluator（互換リンク）
 
-- 新しい日本語解説: [bind_time_admissibility_evaluator.md](bind_time_admissibility_evaluator.md)
+このページは旧ファイル名（ハイフン区切り）からの互換入口です。
+
+## 日本語解説
+- [docs/ja/architecture/bind_time_admissibility_evaluator.md](bind_time_admissibility_evaluator.md)
+
+## 英語正本
+- [docs/en/architecture/bind_time_admissibility_evaluator.md](../../en/architecture/bind_time_admissibility_evaluator.md)

--- a/frontend/app/api/veritas/[...path]/route-auth.test.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.test.ts
@@ -93,6 +93,28 @@ describe("matchPolicy", () => {
     expect(result!.policy.roles).toEqual(["admin"]);
   });
 
+  it("matches POST governance policy bundle promotion for admin only", () => {
+    const result = matchPolicy(["v1", "governance", "policy-bundles", "promote"], "POST");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toEqual(["admin"]);
+  });
+
+  it("matches GET governance bind receipts list for viewer/operator/admin", () => {
+    const result = matchPolicy(["v1", "governance", "bind-receipts"], "GET");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toContain("viewer");
+    expect(result!.policy.roles).toContain("operator");
+    expect(result!.policy.roles).toContain("admin");
+  });
+
+  it("matches GET governance bind receipt detail for viewer/operator/admin", () => {
+    const result = matchPolicy(["v1", "governance", "bind-receipts", "br-123"], "GET");
+    expect(result).not.toBeNull();
+    expect(result!.policy.roles).toContain("viewer");
+    expect(result!.policy.roles).toContain("operator");
+    expect(result!.policy.roles).toContain("admin");
+  });
+
   it("matches POST decide for operator/admin", () => {
     const result = matchPolicy(["v1", "decide"], "POST");
     expect(result).not.toBeNull();

--- a/frontend/app/api/veritas/[...path]/route-auth.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.ts
@@ -36,6 +36,21 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
     method: "GET",
     roles: ["viewer", "operator", "admin"],
   },
+  {
+    pathPattern: /^v1\/governance\/policy-bundles\/promote$/,
+    method: "POST",
+    roles: ["admin"],
+  },
+  {
+    pathPattern: /^v1\/governance\/bind-receipts$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
+  {
+    pathPattern: /^v1\/governance\/bind-receipts\/[^/]+$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
 
   // Trust logs
   {

--- a/scripts/quality/check_bilingual_docs.py
+++ b/scripts/quality/check_bilingual_docs.py
@@ -173,12 +173,24 @@ def _is_shields_badge_url(url: str) -> bool:
     return parsed.hostname == "img.shields.io"
 
 
+def _is_external_url_only_line(line: str) -> bool:
+    """Return True when a markdown line is effectively just one URL."""
+    stripped = line.strip().lstrip("-*").strip()
+    if not stripped or " " in stripped:
+        return False
+    urls = _extract_urls(stripped)
+    if len(urls) != 1:
+        return False
+    return stripped == urls[0]
+
+
 def _is_long_url_or_generated_badge(line: str) -> bool:
+    """Return True when a long line should be exempted from readability checks."""
+    if _is_external_url_only_line(line):
+        return True
     urls = _extract_urls(line)
     if any(_is_shields_badge_url(url) for url in urls):
         return True
-    if urls:
-        return len(line.strip()) > MARKDOWN_LINE_HARD_LIMIT
     return False
 
 

--- a/tests/test_check_bilingual_docs.py
+++ b/tests/test_check_bilingual_docs.py
@@ -1,6 +1,7 @@
 """Tests for bilingual documentation consistency checks."""
 
 from scripts.quality.check_bilingual_docs import (
+    _is_external_url_only_line,
     _is_long_url_or_generated_badge,
     run,
 )
@@ -24,3 +25,9 @@ def test_non_badge_url_is_not_auto_ignored() -> None:
     """Normal URLs should not be ignored unless line length is excessive."""
     line = "Reference: https://example.com/docs/ja/guide"
     assert _is_long_url_or_generated_badge(line) is False
+
+
+def test_external_url_only_line_is_ignored() -> None:
+    """A single external URL line should be exempted from long-line checks."""
+    line = "https://example.com/docs/ja/very/long/path"
+    assert _is_external_url_only_line(line) is True


### PR DESCRIPTION
### Motivation
- Extend route-based auth to cover new governance endpoints for policy bundle promotion and bind-receipts list/detail.
- Allow readability checks to ignore lines that are effectively a single external URL (common for long external links and generated badges).
- Fix/normalize Japanese docs links and add a compatibility entry for the bind-time evaluator page.

### Description
- Added new route policies to `frontend/app/api/veritas/[...path]/route-auth.ts` for `v1/governance/policy-bundles/promote` and `v1/governance/bind-receipts` (list and item) and updated unit tests in `route-auth.test.ts` to cover them.
- Implemented `_is_external_url_only_line` in `scripts/quality/check_bilingual_docs.py` and updated `_is_long_url_or_generated_badge` to exempt single-URL-only lines from the long-line check.
- Added a unit test `test_external_url_only_line_is_ignored` and updated `tests/test_check_bilingual_docs.py` to validate the new exemption.
- Updated `README_JP.md` links to point at `docs/ja/...` and expanded `docs/ja/architecture/bind-time-admissibility-evaluator.md` to act as a compatibility entry linking to the Japanese and English pages.

### Testing
- Ran the bilingual docs checks via `pytest -q tests/test_check_bilingual_docs.py` and the tests passed.
- Ran updated frontend route auth unit tests with the frontend test runner (`vitest` / `pnpm --filter frontend run test`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb03768f083269826ca3815b3a65f)