### PR TITLE
Add BFF allowlist entries for governance bind-receipts and policy promotion

### DIFF
--- a/frontend/app/api/veritas/[...path]/route-auth.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.ts
@@ -36,6 +36,21 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
     method: "GET",
     roles: ["viewer", "operator", "admin"],
   },
+  {
+    pathPattern: /^v1\/governance\/bind-receipts$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
+  {
+    pathPattern: /^v1\/governance\/bind-receipts\/[^/]+$/,
+    method: "GET",
+    roles: ["viewer", "operator", "admin"],
+  },
+  {
+    pathPattern: /^v1\/governance\/policy-bundles\/promote$/,
+    method: "POST",
+    roles: ["operator", "admin"],
+  },
 
   // Trust logs
   {


### PR DESCRIPTION
### Motivation
- `scripts/quality/check_frontend_api_contract_consistency.py` reported frontend usages of governance endpoints that existed in `openapi.yaml` but were missing from the BFF allowlist, causing `make quality-checks` to fail.
- The minimal correct fix is to register the existing backend/OpenAPI endpoints in the BFF route allowlist so frontend, BFF, and OpenAPI remain consistent without changing runtime or governance behavior.

### Description
- Added three route policies to `frontend/app/api/veritas/[...path]/route-auth.ts`: `GET /v1/governance/bind-receipts`, `GET /v1/governance/bind-receipts/{id}` (regex `[^/]+`), and `POST /v1/governance/policy-bundles/promote`.
- Role exposure follows existing governance patterns: read = `viewer/operator/admin` and promote = `operator/admin`.
- Only `frontend/app/api/veritas/[...path]/route-auth.ts` was changed and no OpenAPI, backend logic, frontend usage, or checker weakening was performed.

### Testing
- Reproduced original failure with `python scripts/quality/check_frontend_api_contract_consistency.py` which initially reported the three missing BFF allowlist entries (FAIL).
- After the change, `python scripts/quality/check_frontend_api_contract_consistency.py` passed (PASS) and `make quality-checks` passed (PASS).
- Documentation checks `python scripts/quality/check_bilingual_docs.py` and `make check-bilingual-docs` passed (PASS).
- Frontend tests `cd frontend && pnpm test` passed (PASS) and `cd frontend && pnpm lint` completed with warnings only and no errors (PASS with warnings).
- The checker was not weakened, no endpoints were removed, and auth/semantics were not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4984df108326bbdad6647583f5ae)