### PR TITLE
PR3: Add first-class AuthorityEvidence artifact separated from TrustLog

### DIFF
--- a/tests/governance/test_authority_evidence.py
+++ b/tests/governance/test_authority_evidence.py
@@ -1,0 +1,156 @@
+"""Tests for AuthorityEvidence first-class governance artifact."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from veritas_os.api.schemas import TrustLog
+from veritas_os.governance.authority_evidence import (
+    AuthorityEvidence,
+    VerificationResult,
+    is_scope_granting,
+    validate_authority_evidence,
+)
+
+
+def _build_valid_authority_evidence(**overrides: object) -> AuthorityEvidence:
+    base = {
+        "authority_evidence_id": "aev-001",
+        "action_contract_id": "aml_kyc_customer_risk_escalation",
+        "action_contract_version": "1.0.0",
+        "actor_identity": "operator:alice",
+        "actor_role": "aml_reviewer",
+        "authority_source_refs": ["contract:aml_kyc_customer_risk_escalation.v1"],
+        "role_or_policy_basis": ["role:aml_reviewer", "policy:customer_risk_escalation"],
+        "scope_grants": ["customer:risk_escalation", "customer:case_note"],
+        "scope_limitations": ["customer:fund_transfer"],
+        "validity_window": {
+            "issued_at": "2026-04-25T00:00:00",
+            "valid_from": "2026-04-25T00:00:00",
+            "valid_until": "2026-04-30T00:00:00",
+        },
+        "issued_at": "2026-04-25T00:00:00",
+        "valid_from": "2026-04-25T00:00:00",
+        "valid_until": "2026-04-30T00:00:00",
+        "revalidated_at": "2026-04-26T00:00:00",
+        "policy_snapshot_id": "policy-snapshot-001",
+        "evidence_hash": "",
+        "verification_result": VerificationResult.VALID,
+        "failure_reasons": [],
+        "metadata": {"issuer": "governance-control-plane", "tier": "high"},
+    }
+    base.update(overrides)
+    return AuthorityEvidence(**base)
+
+
+def test_valid_authority_evidence_is_validated() -> None:
+    artifact = _build_valid_authority_evidence()
+
+    result = validate_authority_evidence(
+        artifact,
+        policy_snapshot_required=True,
+        now=datetime.fromisoformat("2026-04-26T00:00:00"),
+    )
+
+    assert result.is_valid is True
+    assert result.failure_reasons == []
+
+
+def test_deterministic_hash_is_stable() -> None:
+    artifact_one = _build_valid_authority_evidence()
+    artifact_two = _build_valid_authority_evidence(
+        metadata={"tier": "high", "issuer": "governance-control-plane"}
+    )
+
+    assert artifact_one.deterministic_serialization() == artifact_two.deterministic_serialization()
+    assert artifact_one.deterministic_digest() == artifact_two.deterministic_digest()
+
+
+def test_expired_authority_is_invalid() -> None:
+    artifact = _build_valid_authority_evidence(valid_until="2026-04-20T00:00:00")
+
+    result = validate_authority_evidence(
+        artifact,
+        now=datetime.fromisoformat("2026-04-26T00:00:00"),
+    )
+
+    assert result.is_valid is False
+    assert "authority_expired" in result.failure_reasons
+
+
+def test_missing_authority_source_is_invalid() -> None:
+    artifact = _build_valid_authority_evidence(authority_source_refs=[])
+
+    result = validate_authority_evidence(artifact)
+
+    assert result.is_valid is False
+    assert "authority_source_refs_missing" in result.failure_reasons
+
+
+def test_missing_actor_identity_is_invalid() -> None:
+    artifact = _build_valid_authority_evidence(actor_identity="")
+
+    result = validate_authority_evidence(artifact)
+
+    assert result.is_valid is False
+    assert "actor_identity_missing" in result.failure_reasons
+
+
+def test_indeterminate_authority_is_invalid() -> None:
+    artifact = _build_valid_authority_evidence(
+        verification_result=VerificationResult.INDETERMINATE
+    )
+
+    result = validate_authority_evidence(artifact)
+
+    assert result.is_valid is False
+    assert "verification_result_indeterminate" in result.failure_reasons
+
+
+def test_missing_policy_snapshot_is_invalid_when_required() -> None:
+    artifact = _build_valid_authority_evidence(policy_snapshot_id="")
+
+    result = validate_authority_evidence(artifact, policy_snapshot_required=True)
+
+    assert result.is_valid is False
+    assert "policy_snapshot_id_missing" in result.failure_reasons
+
+
+def test_scope_grants_are_expressed() -> None:
+    artifact = _build_valid_authority_evidence()
+
+    assert is_scope_granting(artifact, "customer:risk_escalation") is True
+
+
+def test_scope_limitations_are_expressed() -> None:
+    artifact = _build_valid_authority_evidence()
+
+    assert is_scope_granting(artifact, "customer:fund_transfer") is False
+
+
+def test_audit_log_entry_alone_is_not_authority_evidence() -> None:
+    trust_log_entry = TrustLog(
+        request_id="req-001",
+        created_at="2026-04-26T00:00:00",
+        sources=["aml_case"],
+        critics=["fuji_gate"],
+        checks=["admissibility"],
+    )
+
+    assert isinstance(trust_log_entry, TrustLog)
+    assert not isinstance(trust_log_entry, AuthorityEvidence)
+
+    result = validate_authority_evidence(None)
+
+    assert result.is_valid is False
+    assert "authority_evidence_missing" in result.failure_reasons
+
+
+def test_authority_evidence_has_own_hash_and_verification_result() -> None:
+    artifact = _build_valid_authority_evidence(verification_result=VerificationResult.VALID)
+
+    digest = artifact.deterministic_digest()
+
+    assert digest
+    assert len(digest) == 64
+    assert artifact.verification_result == VerificationResult.VALID

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -1,5 +1,16 @@
 """Governance domain persistence abstractions."""
 
+from veritas_os.governance.authority_evidence import (
+    AuthorityEvidence,
+    AuthorityEvidenceValidationResult,
+    VerificationResult,
+    is_expired,
+    is_indeterminate,
+    is_present,
+    is_scope_granting,
+    is_valid,
+    validate_authority_evidence,
+)
 from veritas_os.governance.action_contracts import (
     ActionClassContract,
     ActionClassContractValidationError,
@@ -20,6 +31,9 @@ from veritas_os.governance.postgresql_repository import PostgresGovernanceReposi
 from veritas_os.governance.repository import GovernanceRepository
 
 __all__ = [
+    "AuthorityEvidence",
+    "AuthorityEvidenceValidationResult",
+    "VerificationResult",
     "ActionClassContract",
     "ActionClassContractValidationError",
     "create_governance_repository",
@@ -31,5 +45,11 @@ __all__ = [
     "PostgresGovernanceRepository",
     "GovernanceRepository",
     "validate_action_class_contract",
+    "is_expired",
+    "is_indeterminate",
+    "is_present",
+    "is_scope_granting",
+    "is_valid",
+    "validate_authority_evidence",
     "validate_governance_backend",
 ]

--- a/veritas_os/governance/authority_evidence.py
+++ b/veritas_os/governance/authority_evidence.py
@@ -1,0 +1,185 @@
+"""AuthorityEvidence artifact model and validation helpers.
+
+AuthorityEvidence is distinct from TrustLog/audit records. A TrustLog entry records
+what happened, while AuthorityEvidence captures bind-time proof that an action was
+authorized, admissible, in-scope, fresh, and valid.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from veritas_os.security.hash import canonical_json_dumps, sha256_of_canonical_json
+
+
+class VerificationResult(str, Enum):
+    """Verification outcome for authority evidence adjudication."""
+
+    VALID = "valid"
+    INVALID = "invalid"
+    EXPIRED = "expired"
+    MISSING = "missing"
+    STALE = "stale"
+    INDETERMINATE = "indeterminate"
+
+
+@dataclass(frozen=True)
+class AuthorityEvidence:
+    """First-class bind-time authority artifact.
+
+    The artifact is deterministic and hashable via canonical JSON serialization.
+    """
+
+    authority_evidence_id: str
+    action_contract_id: str
+    action_contract_version: str
+    actor_identity: str
+    actor_role: str
+    authority_source_refs: list[str]
+    role_or_policy_basis: list[str]
+    scope_grants: list[str]
+    scope_limitations: list[str]
+    validity_window: dict[str, str]
+    issued_at: str
+    valid_from: str
+    valid_until: str
+    revalidated_at: str | None = None
+    policy_snapshot_id: str | None = None
+    evidence_hash: str = ""
+    verification_result: VerificationResult = VerificationResult.INDETERMINATE
+    failure_reasons: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable authority evidence fields."""
+        return {
+            "authority_evidence_id": self.authority_evidence_id,
+            "action_contract_id": self.action_contract_id,
+            "action_contract_version": self.action_contract_version,
+            "actor_identity": self.actor_identity,
+            "actor_role": self.actor_role,
+            "authority_source_refs": list(self.authority_source_refs),
+            "role_or_policy_basis": list(self.role_or_policy_basis),
+            "scope_grants": list(self.scope_grants),
+            "scope_limitations": list(self.scope_limitations),
+            "validity_window": dict(self.validity_window),
+            "issued_at": self.issued_at,
+            "valid_from": self.valid_from,
+            "valid_until": self.valid_until,
+            "revalidated_at": self.revalidated_at,
+            "policy_snapshot_id": self.policy_snapshot_id,
+            "evidence_hash": self.evidence_hash,
+            "verification_result": self.verification_result.value,
+            "failure_reasons": list(self.failure_reasons),
+            "metadata": dict(self.metadata),
+        }
+
+    def deterministic_serialization(self) -> str:
+        """Serialize artifact with stable ordering using canonical JSON."""
+        return canonical_json_dumps(self.to_dict_for_hash())
+
+    def deterministic_digest(self) -> str:
+        """Compute deterministic SHA-256 digest with stable field ordering."""
+        return sha256_of_canonical_json(self.to_dict_for_hash())
+
+    def to_dict_for_hash(self) -> dict[str, Any]:
+        """Return canonical hash payload excluding self-referential evidence_hash."""
+        payload = self.to_dict()
+        payload["evidence_hash"] = ""
+        return payload
+
+
+@dataclass(frozen=True)
+class AuthorityEvidenceValidationResult:
+    """Validation result for authority evidence admissibility checks."""
+
+    is_valid: bool
+    failure_reasons: list[str] = field(default_factory=list)
+
+
+def is_present(authority_evidence: AuthorityEvidence | None) -> bool:
+    """Return True when AuthorityEvidence artifact exists."""
+    return authority_evidence is not None
+
+
+def is_expired(authority_evidence: AuthorityEvidence, *, now: datetime | None = None) -> bool:
+    """Return True when validity window has elapsed."""
+    now_dt = now or datetime.now()
+    valid_until_dt = datetime.fromisoformat(authority_evidence.valid_until)
+    return now_dt > valid_until_dt
+
+
+def is_indeterminate(authority_evidence: AuthorityEvidence) -> bool:
+    """Return True when verification result is indeterminate."""
+    return authority_evidence.verification_result == VerificationResult.INDETERMINATE
+
+
+def is_scope_granting(authority_evidence: AuthorityEvidence, scope: str) -> bool:
+    """Return True when scope is granted and not explicitly limited."""
+    return (
+        scope in authority_evidence.scope_grants
+        and scope not in authority_evidence.scope_limitations
+    )
+
+
+def is_valid(
+    authority_evidence: AuthorityEvidence | None,
+    *,
+    policy_snapshot_required: bool = False,
+    now: datetime | None = None,
+) -> bool:
+    """Return validation pass/fail for authority evidence artifact."""
+    return validate_authority_evidence(
+        authority_evidence,
+        policy_snapshot_required=policy_snapshot_required,
+        now=now,
+    ).is_valid
+
+
+def validate_authority_evidence(
+    authority_evidence: AuthorityEvidence | None,
+    *,
+    policy_snapshot_required: bool = False,
+    now: datetime | None = None,
+) -> AuthorityEvidenceValidationResult:
+    """Validate AuthorityEvidence according to fail-closed governance rules."""
+    failures: list[str] = []
+
+    if authority_evidence is None:
+        return AuthorityEvidenceValidationResult(
+            is_valid=False,
+            failure_reasons=["authority_evidence_missing"],
+        )
+
+    if not authority_evidence.actor_identity.strip():
+        failures.append("actor_identity_missing")
+
+    if not authority_evidence.authority_source_refs:
+        failures.append("authority_source_refs_missing")
+
+    if policy_snapshot_required and not (authority_evidence.policy_snapshot_id or "").strip():
+        failures.append("policy_snapshot_id_missing")
+
+    if authority_evidence.verification_result in {
+        VerificationResult.MISSING,
+        VerificationResult.INDETERMINATE,
+        VerificationResult.EXPIRED,
+        VerificationResult.INVALID,
+    }:
+        failures.append(
+            f"verification_result_{authority_evidence.verification_result.value}"
+        )
+
+    try:
+        if is_expired(authority_evidence, now=now):
+            failures.append("authority_expired")
+    except ValueError:
+        failures.append("validity_window_unparseable")
+
+    return AuthorityEvidenceValidationResult(
+        is_valid=len(failures) == 0,
+        failure_reasons=failures,
+    )


### PR DESCRIPTION
### Motivation
- Introduce AuthorityEvidence as a first-class governance artifact distinct from TrustLog so that audits (what happened) cannot be treated as proof of authority (that an action was admissible at bind time).
- Ensure authority artifacts are deterministic and tamper-evident by providing canonical serialization and a stable digest for artifact equality and chainability.
- Provide fail-closed validation helpers so bind-time decision paths can reject expired/missing/indeterminate authority evidence without embedding runtime enforcement in this change.

### Description
- Added `veritas_os/governance/authority_evidence.py` containing `AuthorityEvidence` dataclass, `VerificationResult` enum (`valid`, `invalid`, `expired`, `missing`, `stale`, `indeterminate`), deterministic serialization (`deterministic_serialization`), deterministic digest (`deterministic_digest`) and `to_dict_for_hash` which zeroes `evidence_hash` to avoid self-referential differences.
- Implemented validation helpers `is_present`, `is_valid`, `is_expired`, `is_indeterminate`, `is_scope_granting`, and `validate_authority_evidence` with fail-closed rules that reject expired, missing, indeterminate, or otherwise incomplete authority artifacts and require `policy_snapshot_id` when `policy_snapshot_required=True`.
- Exported AuthorityEvidence APIs from `veritas_os/governance/__init__.py` and added focused tests `tests/governance/test_authority_evidence.py` that cover the required acceptance cases and assert TrustLog audit entries are not treated as AuthorityEvidence unless explicitly materialized.
- Deterministic hashing follows existing repository canonicalization (`canonical_json_dumps`, `sha256_of_canonical_json`), uses stable field ordering, avoids injecting timestamps/random values, and ensures identical artifacts yield identical digests; TrustLog implementation was not modified.

### Testing
- Ran `pytest -q tests/governance/test_authority_evidence.py` and observed all tests in that file passed (11 passed) verifying validation logic, deterministic hash stability, scope grants/limitations, and audit-log separation.
- Ran `pytest -q tests/governance/test_authority_evidence.py tests/governance/test_action_class_contracts.py tests/governance/test_aml_kyc_action_contract.py` and observed the expanded governance test suite passed (33 passed in the run) confirming there are no regressions in the referenced contract tests.
- Quality checks: unit tests executed successfully and a small datetime deprecation warning was addressed (switched to `datetime.now()`), and no linting or external-framework claims were introduced.

Known limitations and security notes
- This PR implements only the artifact model, hashing, and validators and does not wire a runtime authority validator into commit/bind paths, so deploying this without integrating the validator into enforcement paths will not enforce authority checks.
- `is_expired` relies on ISO8601 parsing of `valid_until`, so callers should keep timezone semantics consistent; mismatched timezone handling may cause false expiry decisions.
- Security warning: treat AuthorityEvidence digests and metadata as sensitive when they contain PII and avoid persisting raw PII into TrustLog without appropriate redaction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd29ad4948326beeb3fd807ea9609)