### PR TITLE
PR4: Admissibility Predicate と Runtime Authority Validation を追加

### DIFF
--- a/tests/governance/test_runtime_authority_validation.py
+++ b/tests/governance/test_runtime_authority_validation.py
@@ -1,0 +1,179 @@
+"""Tests for deterministic runtime authority validation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence import AuthorityEvidence, VerificationResult
+from veritas_os.governance.runtime_authority import RuntimeAuthorityValidator
+
+
+def _contract(**overrides: object) -> ActionClassContract:
+    base = {
+        "id": "aml_kyc_customer_risk_escalation",
+        "version": "1.0.0",
+        "domain": "aml",
+        "action_class": "customer_risk_escalation",
+        "description": "Escalate customer risk decisions under AML/KYC policy.",
+        "declared_intent": "Escalate suspicious customer risk for review.",
+        "allowed_scope": ["customer:risk_escalation", "customer:case_note"],
+        "prohibited_scope": ["customer:fund_transfer"],
+        "authority_sources": ["policy.register.aml"],
+        "required_evidence": ["kyc_status", "sanctions_screening"],
+        "evidence_freshness": {"kyc_status": "P30D", "sanctions_screening": "P1D"},
+        "irreversibility": {"boundary": "escalation_dispatch", "level": "medium"},
+        "human_approval_rules": {"minimum_approvals": 0},
+        "refusal_conditions": ["authority_indeterminate"],
+        "escalation_conditions": ["high_risk_flag"],
+        "default_failure_mode": "fail_closed",
+        "metadata": {"regulated": True},
+    }
+    base.update(overrides)
+    return ActionClassContract(**base)
+
+
+def _authority(**overrides: object) -> AuthorityEvidence:
+    base = {
+        "authority_evidence_id": "aev-001",
+        "action_contract_id": "aml_kyc_customer_risk_escalation",
+        "action_contract_version": "1.0.0",
+        "actor_identity": "operator:alice",
+        "actor_role": "aml_reviewer",
+        "authority_source_refs": ["policy.register.aml"],
+        "role_or_policy_basis": ["role:aml_reviewer"],
+        "scope_grants": ["customer:risk_escalation", "customer:case_note"],
+        "scope_limitations": ["customer:fund_transfer"],
+        "validity_window": {
+            "issued_at": "2026-04-25T00:00:00",
+            "valid_from": "2026-04-25T00:00:00",
+            "valid_until": "2026-04-30T00:00:00",
+        },
+        "issued_at": "2026-04-25T00:00:00",
+        "valid_from": "2026-04-25T00:00:00",
+        "valid_until": "2026-04-30T00:00:00",
+        "revalidated_at": "2026-04-26T00:00:00",
+        "policy_snapshot_id": "policy-snapshot-001",
+        "evidence_hash": "",
+        "verification_result": VerificationResult.VALID,
+        "failure_reasons": [],
+        "metadata": {"issuer": "governance-control-plane"},
+    }
+    base.update(overrides)
+    return AuthorityEvidence(**base)
+
+
+def _required_evidence(fresh: object = True, present: bool = True) -> dict[str, dict[str, object]]:
+    return {
+        "kyc_status": {"present": present, "fresh": fresh},
+        "sanctions_screening": {"present": present, "fresh": fresh},
+    }
+
+
+def _validate(**overrides: object):
+    validator = RuntimeAuthorityValidator()
+    payload = {
+        "action_contract": _contract(),
+        "authority_evidence": _authority(),
+        "requested_scope": ["customer:risk_escalation"],
+        "required_evidence_metadata": _required_evidence(),
+        "policy_snapshot_id": "policy-snapshot-001",
+        "actor_identity": "operator:alice",
+        "human_approval_state": {"approved": True},
+        "bind_context_metadata": {"session_id": "bind-001"},
+        "now": datetime.fromisoformat("2026-04-26T00:00:00"),
+    }
+    payload.update(overrides)
+    return validator.validate(**payload)
+
+
+def test_valid_internal_escalation_is_commit_recommendation() -> None:
+    result = _validate(human_approval_state={"approved": False})
+
+    assert result.status == "pass"
+    assert result.recommended_outcome == "commit"
+
+
+def test_missing_action_contract_is_block() -> None:
+    result = _validate(action_contract=None)
+
+    assert result.recommended_outcome == "block"
+
+
+def test_invalid_action_contract_is_block() -> None:
+    result = _validate(authority_evidence=_authority(action_contract_version="2.0.0"))
+
+    assert result.recommended_outcome == "block"
+
+
+def test_missing_authority_evidence_is_block() -> None:
+    result = _validate(authority_evidence=None)
+
+    assert result.recommended_outcome == "block"
+
+
+def test_expired_authority_is_block() -> None:
+    result = _validate(authority_evidence=_authority(valid_until="2026-04-01T00:00:00"))
+
+    assert result.recommended_outcome == "block"
+
+
+def test_prohibited_scope_is_block() -> None:
+    result = _validate(requested_scope=["customer:fund_transfer"])
+
+    assert result.recommended_outcome == "block"
+
+
+def test_scope_expansion_is_block() -> None:
+    result = _validate(requested_scope=["customer:unlisted_scope"])
+
+    assert result.recommended_outcome == "block"
+
+
+def test_missing_required_evidence_is_block() -> None:
+    result = _validate(required_evidence_metadata=_required_evidence(present=False))
+
+    assert result.recommended_outcome == "block"
+
+
+def test_stale_evidence_escalate_or_block_by_contract() -> None:
+    result_escalate = _validate(
+        action_contract=_contract(escalation_conditions=["stale_evidence"]),
+        required_evidence_metadata=_required_evidence(fresh=False),
+    )
+    result_block = _validate(required_evidence_metadata=_required_evidence(fresh=False))
+
+    assert result_escalate.recommended_outcome == "escalate"
+    assert result_block.recommended_outcome == "block"
+
+
+def test_unresolved_policy_snapshot_is_block() -> None:
+    result = _validate(policy_snapshot_id="")
+
+    assert result.recommended_outcome == "block"
+
+
+def test_missing_actor_identity_is_block() -> None:
+    result = _validate(actor_identity="")
+
+    assert result.recommended_outcome == "block"
+
+
+def test_high_irreversibility_missing_human_approval_is_block() -> None:
+    result = _validate(
+        action_contract=_contract(
+            irreversibility={"boundary": "funds_committed", "level": "high"},
+            human_approval_rules={"minimum_approvals": 1},
+        ),
+        human_approval_state={"approved": False},
+    )
+
+    assert result.recommended_outcome == "block"
+
+
+def test_validator_exception_is_fail_closed() -> None:
+    result = _validate(authority_evidence=_authority(valid_until="invalid-date"))
+
+    assert result.status == "fail"
+    assert result.recommended_outcome == "block"
+    assert "validator_exception" in result.refusal_basis

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -23,6 +23,12 @@ from veritas_os.governance.config import (
 )
 from veritas_os.governance.factory import create_governance_repository
 from veritas_os.governance.file_repository import FileGovernanceRepository
+from veritas_os.governance.predicates import PredicateResult
+from veritas_os.governance.runtime_authority import (
+    RuntimeAuthorityValidationResult,
+    RuntimeAuthorityValidator,
+    validate_runtime_authority,
+)
 from veritas_os.governance.models import (
     GovernancePolicyEventRecord,
     GovernancePolicyRecord,
@@ -43,6 +49,9 @@ __all__ = [
     "GovernancePolicyEventRecord",
     "GovernancePolicyRecord",
     "PostgresGovernanceRepository",
+    "PredicateResult",
+    "RuntimeAuthorityValidationResult",
+    "RuntimeAuthorityValidator",
     "GovernanceRepository",
     "validate_action_class_contract",
     "is_expired",
@@ -52,4 +61,5 @@ __all__ = [
     "is_valid",
     "validate_authority_evidence",
     "validate_governance_backend",
+    "validate_runtime_authority",
 ]

--- a/veritas_os/governance/predicates.py
+++ b/veritas_os/governance/predicates.py
@@ -1,0 +1,40 @@
+"""Predicate result model for deterministic runtime governance checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+PredicateStatus = Literal["pass", "fail", "stale", "missing", "indeterminate"]
+PredicateType = Literal[
+    "action_contract_present",
+    "action_contract_valid",
+    "authority_present",
+    "authority_valid",
+    "authority_not_expired",
+    "scope_allowed",
+    "prohibited_scope_absent",
+    "evidence_present",
+    "evidence_fresh",
+    "policy_snapshot_resolved",
+    "human_approval_present",
+    "irreversibility_boundary_defined",
+    "actor_identity_resolved",
+    "bind_context_valid",
+]
+PredicateSeverity = Literal["low", "medium", "high", "critical"]
+
+
+@dataclass(frozen=True)
+class PredicateResult:
+    """Structured result for one deterministic admissibility predicate."""
+
+    predicate_id: str
+    predicate_type: PredicateType
+    status: PredicateStatus
+    reason: str
+    evidence_ref: str | None = None
+    severity: PredicateSeverity = "critical"
+    evaluated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/veritas_os/governance/runtime_authority.py
+++ b/veritas_os/governance/runtime_authority.py
@@ -1,0 +1,368 @@
+"""Runtime authority validator for regulated action governance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence import (
+    AuthorityEvidence,
+    VerificationResult,
+    is_expired,
+)
+from veritas_os.governance.predicates import PredicateResult
+
+RuntimeValidationStatus = Literal["pass", "fail"]
+RecommendedOutcome = Literal["commit", "block", "escalate", "refuse"]
+
+
+@dataclass(frozen=True)
+class RuntimeAuthorityValidationResult:
+    """Aggregate result for runtime authority validation."""
+
+    status: RuntimeValidationStatus
+    recommended_outcome: RecommendedOutcome
+    passed_predicates: list[PredicateResult] = field(default_factory=list)
+    failed_predicates: list[PredicateResult] = field(default_factory=list)
+    stale_predicates: list[PredicateResult] = field(default_factory=list)
+    missing_predicates: list[PredicateResult] = field(default_factory=list)
+    indeterminate_predicates: list[PredicateResult] = field(default_factory=list)
+    refusal_basis: list[str] = field(default_factory=list)
+    escalation_basis: list[str] = field(default_factory=list)
+    evaluated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    reason_summary: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class RuntimeAuthorityValidator:
+    """Deterministic predicate-based runtime validator with fail-closed defaults."""
+
+    def validate(
+        self,
+        *,
+        action_contract: ActionClassContract | None,
+        authority_evidence: AuthorityEvidence | None,
+        requested_scope: list[str],
+        required_evidence_metadata: dict[str, Any],
+        policy_snapshot_id: str | None,
+        actor_identity: str | None,
+        human_approval_state: dict[str, Any],
+        bind_context_metadata: dict[str, Any],
+        now: datetime | None = None,
+    ) -> RuntimeAuthorityValidationResult:
+        """Validate runtime authority with explicit deterministic predicates."""
+        evaluated_at = (now or datetime.now(UTC)).isoformat()
+        predicates: list[PredicateResult] = []
+
+        try:
+            contract_present = action_contract is not None
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-action-contract-present",
+                    predicate_type="action_contract_present",
+                    status="pass" if contract_present else "missing",
+                    reason="action_contract_present" if contract_present else "action_contract_missing",
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            contract_valid = bool(action_contract and action_contract.id and action_contract.version)
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-action-contract-valid",
+                    predicate_type="action_contract_valid",
+                    status="pass" if contract_valid else "fail",
+                    reason="action_contract_valid" if contract_valid else "action_contract_invalid",
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            authority_present = authority_evidence is not None
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-authority-present",
+                    predicate_type="authority_present",
+                    status="pass" if authority_present else "missing",
+                    reason="authority_present" if authority_present else "authority_missing",
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            authority_valid = False
+            if authority_evidence and action_contract:
+                authority_valid = (
+                    authority_evidence.verification_result == VerificationResult.VALID
+                    and authority_evidence.action_contract_version == action_contract.version
+                    and bool(authority_evidence.actor_role.strip())
+                    and bool(authority_evidence.authority_source_refs)
+                )
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-authority-valid",
+                    predicate_type="authority_valid",
+                    status="pass" if authority_valid else "fail",
+                    reason="authority_valid" if authority_valid else "authority_invalid",
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            not_expired = False
+            expiration_reason = "authority_expired_or_missing"
+            if authority_evidence:
+                not_expired = not is_expired(authority_evidence, now=now)
+                expiration_reason = "authority_not_expired" if not_expired else "authority_expired"
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-authority-not-expired",
+                    predicate_type="authority_not_expired",
+                    status="pass" if not_expired else "fail",
+                    reason=expiration_reason,
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            actor_resolved = bool((actor_identity or "").strip())
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-actor-identity-resolved",
+                    predicate_type="actor_identity_resolved",
+                    status="pass" if actor_resolved else "missing",
+                    reason="actor_identity_resolved" if actor_resolved else "actor_identity_missing",
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            scope_allowed = bool(action_contract) and all(
+                scope in action_contract.allowed_scope for scope in requested_scope
+            )
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-scope-allowed",
+                    predicate_type="scope_allowed",
+                    status="pass" if scope_allowed else "fail",
+                    reason="scope_allowed" if scope_allowed else "scope_expansion_detected",
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            prohibited_absent = bool(action_contract) and all(
+                scope not in action_contract.prohibited_scope for scope in requested_scope
+            )
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-prohibited-scope-absent",
+                    predicate_type="prohibited_scope_absent",
+                    status="pass" if prohibited_absent else "fail",
+                    reason=(
+                        "prohibited_scope_absent"
+                        if prohibited_absent
+                        else "prohibited_scope_detected"
+                    ),
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            required_evidence = action_contract.required_evidence if action_contract else []
+            evidence_present = all(
+                bool(required_evidence_metadata.get(key, {}).get("present"))
+                for key in required_evidence
+            )
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-evidence-present",
+                    predicate_type="evidence_present",
+                    status="pass" if evidence_present else "missing",
+                    reason="evidence_present" if evidence_present else "required_evidence_missing",
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            freshness_states = [
+                required_evidence_metadata.get(key, {}).get("fresh", False)
+                for key in required_evidence
+            ]
+            if all(state is True for state in freshness_states):
+                evidence_fresh_status = "pass"
+                evidence_fresh_reason = "evidence_fresh"
+            elif any(state == "indeterminate" for state in freshness_states):
+                evidence_fresh_status = "indeterminate"
+                evidence_fresh_reason = "evidence_freshness_indeterminate"
+            else:
+                evidence_fresh_status = "stale"
+                evidence_fresh_reason = "evidence_stale"
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-evidence-fresh",
+                    predicate_type="evidence_fresh",
+                    status=evidence_fresh_status,
+                    reason=evidence_fresh_reason,
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            snapshot_resolved = bool((policy_snapshot_id or "").strip())
+            if authority_evidence and authority_evidence.policy_snapshot_id:
+                snapshot_resolved = (
+                    snapshot_resolved
+                    and authority_evidence.policy_snapshot_id == policy_snapshot_id
+                )
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-policy-snapshot-resolved",
+                    predicate_type="policy_snapshot_resolved",
+                    status="pass" if snapshot_resolved else "fail",
+                    reason=(
+                        "policy_snapshot_resolved"
+                        if snapshot_resolved
+                        else "policy_snapshot_unresolved"
+                    ),
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            boundary_defined = bool(
+                action_contract
+                and str(action_contract.irreversibility.get("boundary", "")).strip()
+            )
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-irreversibility-boundary-defined",
+                    predicate_type="irreversibility_boundary_defined",
+                    status="pass" if boundary_defined else "fail",
+                    reason=(
+                        "irreversibility_boundary_defined"
+                        if boundary_defined
+                        else "irreversibility_boundary_missing"
+                    ),
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            needs_approval = self._requires_human_approval(action_contract)
+            approved = bool(human_approval_state.get("approved"))
+            human_approval_ok = (not needs_approval) or approved
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-human-approval-present",
+                    predicate_type="human_approval_present",
+                    status="pass" if human_approval_ok else "missing",
+                    reason=(
+                        "human_approval_present"
+                        if human_approval_ok
+                        else "human_approval_missing"
+                    ),
+                    evaluated_at=evaluated_at,
+                )
+            )
+
+            bind_context_valid = bool(bind_context_metadata) and not bool(
+                bind_context_metadata.get("invalid", False)
+            )
+            predicates.append(
+                self._predicate(
+                    predicate_id="p-bind-context-valid",
+                    predicate_type="bind_context_valid",
+                    status="pass" if bind_context_valid else "fail",
+                    reason="bind_context_valid" if bind_context_valid else "bind_context_invalid",
+                    evaluated_at=evaluated_at,
+                )
+            )
+        except Exception as exc:  # fail closed by design
+            return RuntimeAuthorityValidationResult(
+                status="fail",
+                recommended_outcome="block",
+                reason_summary="validator_exception_fail_closed",
+                refusal_basis=["validator_exception"],
+                metadata={"exception": str(exc)},
+                evaluated_at=evaluated_at,
+            )
+
+        return self._build_result(predicates=predicates, action_contract=action_contract)
+
+    def _build_result(
+        self,
+        *,
+        predicates: list[PredicateResult],
+        action_contract: ActionClassContract | None,
+    ) -> RuntimeAuthorityValidationResult:
+        passed = [item for item in predicates if item.status == "pass"]
+        failed = [item for item in predicates if item.status == "fail"]
+        stale = [item for item in predicates if item.status == "stale"]
+        missing = [item for item in predicates if item.status == "missing"]
+        indeterminate = [item for item in predicates if item.status == "indeterminate"]
+
+        has_critical = bool(failed or stale or missing or indeterminate)
+        status: RuntimeValidationStatus = "fail" if has_critical else "pass"
+        recommended: RecommendedOutcome = "commit"
+        refusal_basis: list[str] = []
+        escalation_basis: list[str] = []
+
+        if indeterminate:
+            recommended = "refuse"
+            refusal_basis = sorted({item.reason for item in indeterminate})
+        elif stale:
+            if self._stale_should_escalate(action_contract):
+                recommended = "escalate"
+                escalation_basis = sorted({item.reason for item in stale})
+            else:
+                recommended = "block"
+        elif failed or missing:
+            recommended = "block"
+
+        reason_tokens = [item.reason for item in failed + stale + missing + indeterminate]
+        summary = ", ".join(reason_tokens) if reason_tokens else "all_predicates_passed"
+
+        return RuntimeAuthorityValidationResult(
+            status=status,
+            recommended_outcome=recommended,
+            passed_predicates=passed,
+            failed_predicates=failed,
+            stale_predicates=stale,
+            missing_predicates=missing,
+            indeterminate_predicates=indeterminate,
+            refusal_basis=refusal_basis,
+            escalation_basis=escalation_basis,
+            reason_summary=summary,
+        )
+
+    def _stale_should_escalate(self, action_contract: ActionClassContract | None) -> bool:
+        if not action_contract:
+            return False
+        conditions = {item.lower() for item in action_contract.escalation_conditions}
+        return "evidence_stale" in conditions or "stale_evidence" in conditions
+
+    def _requires_human_approval(self, action_contract: ActionClassContract | None) -> bool:
+        if not action_contract:
+            return False
+        rules = action_contract.human_approval_rules
+        minimum_approvals = int(rules.get("minimum_approvals", 0) or 0)
+        if bool(rules.get("required", False)):
+            return True
+        return (
+            action_contract.irreversibility.get("level") == "high"
+            and minimum_approvals > 0
+        )
+
+    def _predicate(
+        self,
+        *,
+        predicate_id: str,
+        predicate_type: Literal["action_contract_present", "action_contract_valid", "authority_present", "authority_valid", "authority_not_expired", "scope_allowed", "prohibited_scope_absent", "evidence_present", "evidence_fresh", "policy_snapshot_resolved", "human_approval_present", "irreversibility_boundary_defined", "actor_identity_resolved", "bind_context_valid"],
+        status: Literal["pass", "fail", "stale", "missing", "indeterminate"],
+        reason: str,
+        evaluated_at: str,
+    ) -> PredicateResult:
+        return PredicateResult(
+            predicate_id=predicate_id,
+            predicate_type=predicate_type,
+            status=status,
+            reason=reason,
+            evaluated_at=evaluated_at,
+        )
+
+
+def validate_runtime_authority(**kwargs: Any) -> RuntimeAuthorityValidationResult:
+    """Helper for one-shot runtime authority validation."""
+    return RuntimeAuthorityValidator().validate(**kwargs)


### PR DESCRIPTION
### Motivation
- 規制対象アクションの `predicate` ベースでの決定論的検証を導入し、requested action が契約・権限・スコープ・証拠・ポリシースナップショット・人間承認等の要件を満たすか評価するためのランタイムバリデータを実装しました。 
- 本実装は既存の `ActionClassContract` と `AuthorityEvidence` モデル（PR1/PR2/PR3 相当）を前提としており、欠如があれば実装を中止して dependency gap を報告する設計です。 
- 安全性方針に従い `fail-closed` を基本とし、欠落・期限切れ・stale・indeterminate・バリデータ例外の際は silent commit を許さず block/escalate/refuse で決着させます。

### Description
- 追加ファイルは `veritas_os/governance/predicates.py`（`PredicateResult` モデル）と `veritas_os/governance/runtime_authority.py`（`RuntimeAuthorityValidationResult` と `RuntimeAuthorityValidator`）およびそれらを公開するための `veritas_os/governance/__init__.py` 更新です。 
- `PredicateResult` は `predicate_id` / `predicate_type` / `status` / `reason` / `evidence_ref` / `severity` / `evaluated_at` / `metadata` を持ち、状態は `pass|fail|stale|missing|indeterminate`、タイプは実装要件に沿った一覧で定義しています。 
- `RuntimeAuthorityValidator.validate` は入力（`action_contract`・`authority_evidence`・`requested_scope`・`required_evidence_metadata`・`policy_snapshot_id`・`actor_identity`・`human_approval_state`・`bind_context_metadata`）を受け、predicate を列挙して集約結果として `RuntimeAuthorityValidationResult`（`status` / `recommended_outcome` / predicate 列集合 / `refusal_basis` / `escalation_basis` / `reason_summary`）を返します。 
- 制御ロジックは fail-closed を実現しており、`indeterminate` → `refuse`、`stale` → contract の `escalation_conditions` に応じて `escalate` または `block`、`failed|missing` → `block`、例外発生時は `block`（`validator_exception` により拒否）を返します; なお `required_evidence_metadata` と `human_approval_state` の真正性検証は本PR範囲外であり将来の強化が必要です（セキュリティ上の注意）。

### Testing
- 新規テスト `tests/governance/test_runtime_authority_validation.py` による 13 ケース（valid internal commit、missing/invalid contract、missing/expired authority、prohibited/expanded scope、missing/stale evidence、unresolved policy snapshot、missing actor、high-irreversibility/human approval、validator exception fail-closed）を実装し、`pytest` 実行で `13 passed` を確認しました。 
- 既存ガバナンス関連テスト（`tests/governance/test_action_class_contracts.py` と `tests/governance/test_authority_evidence.py`）と合わせて実行した結合実行では `36 passed` を確認しました。 
- いずれの自動テストも成功しており、追加の手動検証は行っていません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee23f73bc88326b3585df95c447da9)