### PR TITLE
PR5: Add deterministic irreversible CommitBoundaryEvaluator (commit/block/escalate/refuse)

### DIFF
--- a/tests/governance/test_commit_boundary.py
+++ b/tests/governance/test_commit_boundary.py
@@ -1,0 +1,204 @@
+"""Tests for irreversible CommitBoundaryEvaluator."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence import AuthorityEvidence, VerificationResult
+from veritas_os.governance.commit_boundary import CommitBoundaryEvaluator
+
+
+FIXED_NOW = datetime.fromisoformat("2026-04-26T00:00:00")
+
+
+def _contract(**overrides: object) -> ActionClassContract:
+    base = {
+        "id": "aml_kyc_customer_risk_escalation",
+        "version": "1.0.0",
+        "domain": "aml",
+        "action_class": "customer_risk_escalation",
+        "description": "Escalate customer risk decisions under AML/KYC policy.",
+        "declared_intent": "Escalate suspicious customer risk for review.",
+        "allowed_scope": ["customer:risk_escalation", "customer:case_note"],
+        "prohibited_scope": ["account:freeze", "customer:notification"],
+        "authority_sources": ["policy.register.aml"],
+        "required_evidence": ["kyc_status", "sanctions_screening"],
+        "evidence_freshness": {"kyc_status": "P30D", "sanctions_screening": "P1D"},
+        "irreversibility": {"boundary": "escalation_dispatch", "level": "medium"},
+        "human_approval_rules": {"minimum_approvals": 0},
+        "refusal_conditions": ["authority_indeterminate"],
+        "escalation_conditions": ["high_risk_flag"],
+        "default_failure_mode": "fail_closed",
+        "metadata": {"regulated": True},
+    }
+    base.update(overrides)
+    return ActionClassContract(**base)
+
+
+def _authority(**overrides: object) -> AuthorityEvidence:
+    base = {
+        "authority_evidence_id": "aev-001",
+        "action_contract_id": "aml_kyc_customer_risk_escalation",
+        "action_contract_version": "1.0.0",
+        "actor_identity": "operator:alice",
+        "actor_role": "aml_reviewer",
+        "authority_source_refs": ["policy.register.aml"],
+        "role_or_policy_basis": ["role:aml_reviewer"],
+        "scope_grants": ["customer:risk_escalation", "customer:case_note"],
+        "scope_limitations": ["account:freeze", "customer:notification"],
+        "validity_window": {
+            "issued_at": "2026-04-25T00:00:00",
+            "valid_from": "2026-04-25T00:00:00",
+            "valid_until": "2026-04-30T00:00:00",
+        },
+        "issued_at": "2026-04-25T00:00:00",
+        "valid_from": "2026-04-25T00:00:00",
+        "valid_until": "2026-04-30T00:00:00",
+        "revalidated_at": "2026-04-26T00:00:00",
+        "policy_snapshot_id": "policy-snapshot-001",
+        "evidence_hash": "hash-001",
+        "verification_result": VerificationResult.VALID,
+        "failure_reasons": [],
+        "metadata": {"issuer": "governance-control-plane"},
+    }
+    base.update(overrides)
+    return AuthorityEvidence(**base)
+
+
+def _required_evidence(present: bool = True) -> dict[str, dict[str, object]]:
+    return {
+        "kyc_status": {"present": present},
+        "sanctions_screening": {"present": present},
+    }
+
+
+def _freshness(fresh: object = True) -> dict[str, dict[str, object]]:
+    return {
+        "kyc_status": {"fresh": fresh},
+        "sanctions_screening": {"fresh": fresh},
+    }
+
+
+def _evaluate(**overrides: object):
+    evaluator = CommitBoundaryEvaluator()
+    payload = {
+        "execution_intent": {
+            "action_class": "customer_risk_escalation",
+            "admissible": True,
+        },
+        "action_contract": _contract(),
+        "authority_evidence": _authority(),
+        "requested_scope": ["customer:risk_escalation"],
+        "required_evidence_metadata": _required_evidence(),
+        "evidence_freshness_metadata": _freshness(),
+        "policy_snapshot_id": "policy-snapshot-001",
+        "actor_identity": "operator:alice",
+        "human_approval_state": {"approved": True},
+        "bind_context_metadata": {"session_id": "bind-001"},
+        "now": FIXED_NOW,
+    }
+    payload.update(overrides)
+    return evaluator.evaluate(**payload)
+
+
+def test_allowed_internal_escalation_commits() -> None:
+    result = _evaluate(human_approval_state={"approved": False})
+
+    assert result.commit_boundary_result == "commit"
+
+
+def test_missing_action_contract_blocks() -> None:
+    result = _evaluate(action_contract=None)
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_invalid_action_contract_blocks() -> None:
+    result = _evaluate(action_contract=_contract(id=""))
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_missing_authority_evidence_blocks() -> None:
+    result = _evaluate(authority_evidence=None)
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_expired_authority_blocks() -> None:
+    result = _evaluate(authority_evidence=_authority(valid_until="2026-04-01T00:00:00"))
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_indeterminate_authority_blocks() -> None:
+    result = _evaluate(
+        authority_evidence=_authority(verification_result=VerificationResult.INDETERMINATE)
+    )
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_prohibited_account_freeze_blocks() -> None:
+    result = _evaluate(requested_scope=["account:freeze"])
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_prohibited_customer_notification_blocks() -> None:
+    result = _evaluate(requested_scope=["customer:notification"])
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_missing_evidence_blocks() -> None:
+    result = _evaluate(required_evidence_metadata=_required_evidence(present=False))
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_stale_evidence_escalates_if_contract_permits() -> None:
+    result = _evaluate(
+        action_contract=_contract(escalation_conditions=["stale_evidence"]),
+        evidence_freshness_metadata=_freshness(fresh=False),
+    )
+
+    assert result.commit_boundary_result == "escalate"
+
+
+def test_stale_evidence_blocks_without_escalation_path() -> None:
+    result = _evaluate(evidence_freshness_metadata=_freshness(fresh=False))
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_missing_human_approval_blocks_high_irreversibility_action() -> None:
+    result = _evaluate(
+        action_contract=_contract(
+            irreversibility={"boundary": "funds_committed", "level": "high"},
+            human_approval_rules={"minimum_approvals": 1},
+        ),
+        human_approval_state={"approved": False},
+    )
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_undefined_irreversibility_boundary_blocks() -> None:
+    result = _evaluate(action_contract=_contract(irreversibility={"boundary": "", "level": "high"}))
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_validator_exception_blocks() -> None:
+    result = _evaluate(authority_evidence=_authority(valid_until="invalid-date"))
+
+    assert result.commit_boundary_result == "block"
+
+
+def test_repeated_evaluation_is_deterministic() -> None:
+    first = _evaluate()
+    second = _evaluate()
+
+    assert first == second

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -17,6 +17,12 @@ from veritas_os.governance.action_contracts import (
     load_action_class_contract,
     validate_action_class_contract,
 )
+from veritas_os.governance.commit_boundary import (
+    CommitBoundaryResult,
+    CommitBoundaryEvaluator,
+    evaluate_commit_boundary,
+)
+
 from veritas_os.governance.config import (
     get_governance_backend,
     validate_governance_backend,
@@ -43,6 +49,8 @@ __all__ = [
     "ActionClassContract",
     "ActionClassContractValidationError",
     "create_governance_repository",
+    "CommitBoundaryResult",
+    "CommitBoundaryEvaluator",
     "FileGovernanceRepository",
     "load_action_class_contract",
     "get_governance_backend",
@@ -60,6 +68,7 @@ __all__ = [
     "is_scope_granting",
     "is_valid",
     "validate_authority_evidence",
+    "evaluate_commit_boundary",
     "validate_governance_backend",
     "validate_runtime_authority",
 ]

--- a/veritas_os/governance/commit_boundary.py
+++ b/veritas_os/governance/commit_boundary.py
@@ -1,0 +1,195 @@
+"""Deterministic irreversible commit-boundary evaluator.
+
+This module evaluates whether an execution intent may cross a regulated commit
+boundary using Action Class Contract + Authority Evidence artifacts. The design
+is fail-closed and inspectable, and reuses RuntimeAuthorityValidator predicate
+results for compatibility with existing bind-boundary architecture.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence import AuthorityEvidence
+from veritas_os.governance.predicates import PredicateResult
+from veritas_os.governance.runtime_authority import RuntimeAuthorityValidator
+
+CommitBoundaryOutcome = Literal["commit", "block", "escalate", "refuse"]
+
+
+@dataclass(frozen=True)
+class CommitBoundaryResult:
+    """Inspectable commit-boundary decision record."""
+
+    commit_boundary_result: CommitBoundaryOutcome
+    action_contract_id: str
+    action_contract_version: str
+    authority_evidence_id: str
+    authority_evidence_hash: str
+    authority_validation_status: str
+    admissibility_predicates: list[PredicateResult] = field(default_factory=list)
+    failed_predicates: list[PredicateResult] = field(default_factory=list)
+    stale_predicates: list[PredicateResult] = field(default_factory=list)
+    missing_predicates: list[PredicateResult] = field(default_factory=list)
+    refusal_basis: list[str] = field(default_factory=list)
+    escalation_basis: list[str] = field(default_factory=list)
+    irreversibility_boundary_id: str = ""
+    evaluated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    reason_summary: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class CommitBoundaryEvaluator:
+    """Evaluate commit-boundary admissibility with deterministic fail-closed rules."""
+
+    def __init__(self, validator: RuntimeAuthorityValidator | None = None) -> None:
+        self._validator = validator or RuntimeAuthorityValidator()
+
+    def evaluate(
+        self,
+        *,
+        execution_intent: str | dict[str, Any],
+        action_contract: ActionClassContract | None,
+        authority_evidence: AuthorityEvidence | None,
+        requested_scope: list[str],
+        required_evidence_metadata: dict[str, Any],
+        evidence_freshness_metadata: dict[str, Any],
+        policy_snapshot_id: str | None,
+        actor_identity: str | None,
+        human_approval_state: dict[str, Any],
+        bind_context_metadata: dict[str, Any],
+        now: datetime | None = None,
+    ) -> CommitBoundaryResult:
+        """Return commit/block/escalate/refuse for irreversible commit boundary."""
+        evaluated_at = (now or datetime.now(UTC)).isoformat()
+        merged_evidence = self._merge_evidence_metadata(
+            required_evidence_metadata=required_evidence_metadata,
+            evidence_freshness_metadata=evidence_freshness_metadata,
+        )
+
+        authority_result = self._validator.validate(
+            action_contract=action_contract,
+            authority_evidence=authority_evidence,
+            requested_scope=requested_scope,
+            required_evidence_metadata=merged_evidence,
+            policy_snapshot_id=policy_snapshot_id,
+            actor_identity=actor_identity,
+            human_approval_state=human_approval_state,
+            bind_context_metadata=bind_context_metadata,
+            now=now,
+        )
+
+        predicates = self._sorted_predicates(
+            authority_result.passed_predicates
+            + authority_result.failed_predicates
+            + authority_result.stale_predicates
+            + authority_result.missing_predicates
+            + authority_result.indeterminate_predicates
+        )
+        failed = self._sorted_predicates(authority_result.failed_predicates)
+        stale = self._sorted_predicates(authority_result.stale_predicates)
+        missing = self._sorted_predicates(authority_result.missing_predicates)
+
+        refusal_basis = sorted(set(authority_result.refusal_basis))
+        escalation_basis = sorted(set(authority_result.escalation_basis))
+        outcome = self._resolve_outcome(
+            execution_intent=execution_intent,
+            action_contract=action_contract,
+            authority_result=authority_result,
+        )
+
+        return CommitBoundaryResult(
+            commit_boundary_result=outcome,
+            action_contract_id=action_contract.id if action_contract else "",
+            action_contract_version=action_contract.version if action_contract else "",
+            authority_evidence_id=(
+                authority_evidence.authority_evidence_id if authority_evidence else ""
+            ),
+            authority_evidence_hash=(
+                authority_evidence.evidence_hash if authority_evidence else ""
+            ),
+            authority_validation_status=authority_result.status,
+            admissibility_predicates=predicates,
+            failed_predicates=failed,
+            stale_predicates=stale,
+            missing_predicates=missing,
+            refusal_basis=refusal_basis,
+            escalation_basis=escalation_basis,
+            irreversibility_boundary_id=(
+                str(action_contract.irreversibility.get("boundary", ""))
+                if action_contract
+                else ""
+            ),
+            evaluated_at=evaluated_at,
+            reason_summary=authority_result.reason_summary,
+            metadata={"validator_metadata": authority_result.metadata},
+        )
+
+    def _resolve_outcome(
+        self,
+        *,
+        execution_intent: str | dict[str, Any],
+        action_contract: ActionClassContract | None,
+        authority_result: Any,
+    ) -> CommitBoundaryOutcome:
+        if authority_result.recommended_outcome == "escalate":
+            return "escalate"
+        if authority_result.recommended_outcome == "refuse":
+            return "refuse"
+        if authority_result.recommended_outcome == "block":
+            return "block"
+
+        if not self._is_action_admissible(execution_intent, action_contract):
+            return "refuse"
+        return "commit"
+
+    def _is_action_admissible(
+        self,
+        execution_intent: str | dict[str, Any],
+        action_contract: ActionClassContract | None,
+    ) -> bool:
+        if not action_contract:
+            return False
+
+        if isinstance(execution_intent, str):
+            return bool(execution_intent.strip())
+
+        intent_action_class = str(execution_intent.get("action_class", "")).strip()
+        if intent_action_class and intent_action_class != action_contract.action_class:
+            return False
+
+        admissible_flag = execution_intent.get("admissible")
+        if admissible_flag is False:
+            return False
+
+        return True
+
+    def _merge_evidence_metadata(
+        self,
+        *,
+        required_evidence_metadata: dict[str, Any],
+        evidence_freshness_metadata: dict[str, Any],
+    ) -> dict[str, dict[str, Any]]:
+        merged: dict[str, dict[str, Any]] = {}
+        keys = sorted(set(required_evidence_metadata) | set(evidence_freshness_metadata))
+        for key in keys:
+            required = dict(required_evidence_metadata.get(key, {}))
+            freshness = dict(evidence_freshness_metadata.get(key, {}))
+            present = bool(required.get("present", False))
+            fresh_value = freshness.get("fresh", required.get("fresh", False))
+            merged[key] = {"present": present, "fresh": fresh_value}
+        return merged
+
+    def _sorted_predicates(
+        self,
+        predicates: list[PredicateResult],
+    ) -> list[PredicateResult]:
+        return sorted(predicates, key=lambda item: item.predicate_id)
+
+
+def evaluate_commit_boundary(**kwargs: Any) -> CommitBoundaryResult:
+    """Helper for one-shot commit-boundary evaluation."""
+    return CommitBoundaryEvaluator().evaluate(**kwargs)


### PR DESCRIPTION
### Motivation
- Implement a core deterministic, inspectable, fail-closed evaluator to decide whether an execution intent may cross a regulated irreversible commit boundary. 
- Reuse the existing runtime predicate pipeline so this evaluator is compatible with the bind-boundary architecture and existing authority validation logic. 
- Provide a single authoritative decision (one of `commit`, `block`, `escalate`, `refuse`) and rich, auditable metadata for downstream enforcement and auditing. 

### Description
- Added `veritas_os/governance/commit_boundary.py` introducing `CommitBoundaryEvaluator` and `CommitBoundaryResult` which consume `execution_intent`, `action_contract`, `authority_evidence`, `requested_scope`, `required_evidence_metadata`, `evidence_freshness_metadata`, `policy_snapshot_id`, `actor_identity`, `human_approval_state`, `bind_context_metadata`, and optional `now`, and return a deterministic `commit|block|escalate|refuse` result and inspectable predicates/metadata. 
- The evaluator reuses `RuntimeAuthorityValidator` predicate results, merges required/freshness evidence metadata deterministically, enforces stable predicate ordering, and maps validator outcomes into commit-boundary outcomes with `refuse` used for action-admissibility mismatches. 
- Exported `CommitBoundaryResult`, `CommitBoundaryEvaluator`, and helper `evaluate_commit_boundary` from `veritas_os.governance.__init__` and added deterministic helper `evaluate_commit_boundary`. 
- Added tests in `tests/governance/test_commit_boundary.py` covering required fail-closed cases and deterministic behavior, and included module-level docstring and deterministic behavior notes. 

### Testing
- Ran the new governance tests with `pytest -q tests/governance/test_commit_boundary.py tests/governance/test_runtime_authority_validation.py` and all tests passed (`28 passed`).
- Ran style checks with `ruff check veritas_os/governance/commit_boundary.py tests/governance/test_commit_boundary.py` and checks passed. 
- Tests added cover missing/invalid contract, missing/expired/indeterminate authority, prohibited scope cases, missing evidence, stale-evidence escalation vs block, missing human approval for high irreversibility, undefined irreversibility boundary, validator exception fail-closed, and deterministic repeated evaluation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2fa9b82883268146affd786df9be)