### PR TITLE
PR6: Add regulated action governance fields to BindReceipt / BindSummary and integrate CommitBoundaryEvaluator

### DIFF
--- a/tests/governance/test_bind_receipt_regulated_action_fields.py
+++ b/tests/governance/test_bind_receipt_regulated_action_fields.py
@@ -1,0 +1,221 @@
+"""Tests for additive regulated-action fields in bind receipts and summaries."""
+
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.api.bind_summary import build_bind_response_payload, build_bind_summary_from_receipt
+from veritas_os.governance.authority_evidence import VerificationResult
+from veritas_os.governance.commit_boundary import CommitBoundaryResult
+from veritas_os.policy.bind_core.core import (
+    ReferenceBindAdapter,
+    execute_bind_adjudication,
+)
+from veritas_os.policy.bind_core.normalizers import normalize_bind_receipt
+
+
+def _regulated_context() -> dict[str, object]:
+    return {
+        "regulated_action_path_id": "rap-001",
+        "action_class": "customer_risk_escalation",
+        "requested_scope": ["customer:risk_escalation"],
+        "action_contract_id": "aml_kyc_customer_risk_escalation",
+        "action_contract": {
+            "id": "aml_kyc_customer_risk_escalation",
+            "version": "1.0.0",
+            "domain": "aml",
+            "action_class": "customer_risk_escalation",
+            "description": "Escalate suspicious customer risk for review.",
+            "declared_intent": "Escalate suspicious customer risk for review.",
+            "allowed_scope": ["customer:risk_escalation"],
+            "prohibited_scope": ["account:freeze"],
+            "authority_sources": ["policy.register.aml"],
+            "required_evidence": ["kyc_status"],
+            "evidence_freshness": {"kyc_status": "P30D"},
+            "irreversibility": {"boundary": "escalation_dispatch", "level": "medium"},
+            "human_approval_rules": {"minimum_approvals": 0},
+            "refusal_conditions": [],
+            "escalation_conditions": ["stale_evidence"],
+            "default_failure_mode": "fail_closed",
+            "metadata": {"regulated": True},
+        },
+        "authority_evidence": {
+            "authority_evidence_id": "aev-001",
+            "action_contract_id": "aml_kyc_customer_risk_escalation",
+            "action_contract_version": "1.0.0",
+            "actor_identity": "operator:alice",
+            "actor_role": "aml_reviewer",
+            "authority_source_refs": ["policy.register.aml"],
+            "role_or_policy_basis": ["role:aml_reviewer"],
+            "scope_grants": ["customer:risk_escalation"],
+            "scope_limitations": ["account:freeze"],
+            "validity_window": {
+                "issued_at": "2026-04-25T00:00:00",
+                "valid_from": "2026-04-25T00:00:00",
+                "valid_until": "2026-04-30T00:00:00",
+            },
+            "issued_at": "2026-04-25T00:00:00",
+            "valid_from": "2026-04-25T00:00:00",
+            "valid_until": "2026-04-30T00:00:00",
+            "revalidated_at": "2026-04-26T00:00:00",
+            "policy_snapshot_id": "policy-snapshot-001",
+            "evidence_hash": "hash-001",
+            "verification_result": VerificationResult.VALID.value,
+            "failure_reasons": [],
+            "metadata": {"issuer": "governance-control-plane"},
+        },
+        "required_evidence_metadata": {"kyc_status": {"present": True}},
+        "evidence_freshness_metadata": {"kyc_status": {"fresh": True}},
+        "human_approval_state": {"approved": True},
+        "bind_context_metadata": {"session_id": "bind-001"},
+    }
+
+
+def _intent_with_regulated_context() -> dict[str, object]:
+    return {
+        "execution_intent_id": "ei-regulated-001",
+        "decision_id": "dec-regulated-001",
+        "policy_snapshot_id": "policy-snapshot-001",
+        "actor_identity": "operator:alice",
+        "target_system": "governance",
+        "target_resource": "/v1/governance/policy",
+        "intended_action": "escalate",
+        "decision_ts": "2026-04-26T00:00:00Z",
+        "policy_lineage": {"bind_adjudication": {"drift_required": False}},
+        "approval_context": {
+            "regulated_action_governance": _regulated_context(),
+        },
+    }
+
+
+def _run_bind(intent: dict[str, object]):
+    return execute_bind_adjudication(
+        execution_intent=intent,
+        adapter=ReferenceBindAdapter(state={"mode": "safe"}, pending_changes={"mode": "strict"}),
+        append_trustlog=False,
+    )
+
+
+def test_legacy_bind_receipt_deserializes_without_new_fields() -> None:
+    legacy = {
+        "bind_receipt_id": "br-legacy",
+        "execution_intent_id": "ei-legacy",
+        "decision_id": "dec-legacy",
+        "bind_ts": "2026-04-26T00:00:00Z",
+        "final_outcome": "COMMITTED",
+    }
+
+    normalized = normalize_bind_receipt(legacy)
+    payload = normalized.to_dict()
+
+    assert normalized.bind_receipt_id == "br-legacy"
+    assert "action_contract_id" not in payload
+
+
+def test_legacy_bind_summary_deserializes_without_new_fields() -> None:
+    summary = build_bind_summary_from_receipt(
+        {"bind_receipt_id": "br-old", "execution_intent_id": "ei-old", "final_outcome": "COMMITTED"}
+    )
+
+    assert summary["bind_outcome"] == "COMMITTED"
+    assert summary.get("commit_boundary_result") is None
+
+
+def test_evaluator_execution_includes_action_contract_id() -> None:
+    receipt = _run_bind(_intent_with_regulated_context())
+    assert receipt.action_contract_id == "aml_kyc_customer_risk_escalation"
+
+
+def test_evaluator_execution_includes_authority_evidence_hash() -> None:
+    receipt = _run_bind(_intent_with_regulated_context())
+    assert receipt.authority_evidence_hash == "hash-001"
+
+
+def test_bind_summary_includes_compact_commit_boundary_result() -> None:
+    receipt = _run_bind(_intent_with_regulated_context())
+    summary = build_bind_summary_from_receipt(receipt.to_dict())
+    assert summary["commit_boundary_result"] == "commit"
+
+
+def test_blocked_path_includes_failed_predicates(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_eval(**_: object) -> CommitBoundaryResult:
+        return CommitBoundaryResult(
+            commit_boundary_result="block",
+            action_contract_id="contract-1",
+            action_contract_version="1.0.0",
+            authority_evidence_id="aev-1",
+            authority_evidence_hash="hash-1",
+            authority_validation_status="fail",
+            failed_predicates=[{
+                "predicate_id": "p-failed",
+                "predicate_type": "authority_valid",
+                "status": "fail",
+                "reason": "authority_invalid",
+            }],
+            reason_summary="blocked",
+        )
+
+    monkeypatch.setattr("veritas_os.policy.bind_core.core.evaluate_commit_boundary", _fake_eval)
+    receipt = _run_bind(_intent_with_regulated_context())
+    assert receipt.final_outcome.value == "BLOCKED"
+    assert isinstance(receipt.failed_predicates, list)
+
+
+def test_escalated_path_includes_escalation_basis(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_eval(**_: object) -> CommitBoundaryResult:
+        return CommitBoundaryResult(
+            commit_boundary_result="escalate",
+            action_contract_id="contract-1",
+            action_contract_version="1.0.0",
+            authority_evidence_id="aev-1",
+            authority_evidence_hash="hash-1",
+            authority_validation_status="fail",
+            escalation_basis=["manual_review_required"],
+            reason_summary="escalated",
+        )
+
+    monkeypatch.setattr("veritas_os.policy.bind_core.core.evaluate_commit_boundary", _fake_eval)
+    receipt = _run_bind(_intent_with_regulated_context())
+    assert receipt.final_outcome.value == "ESCALATED"
+    assert receipt.escalation_basis == ["manual_review_required"]
+
+
+def test_refused_path_includes_refusal_basis(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_eval(**_: object) -> CommitBoundaryResult:
+        return CommitBoundaryResult(
+            commit_boundary_result="refuse",
+            action_contract_id="contract-1",
+            action_contract_version="1.0.0",
+            authority_evidence_id="aev-1",
+            authority_evidence_hash="hash-1",
+            authority_validation_status="fail",
+            refusal_basis=["authority_indeterminate"],
+            reason_summary="refused",
+        )
+
+    monkeypatch.setattr("veritas_os.policy.bind_core.core.evaluate_commit_boundary", _fake_eval)
+    receipt = _run_bind(_intent_with_regulated_context())
+    assert receipt.final_outcome.value == "BLOCKED"
+    assert receipt.refusal_basis == ["authority_indeterminate"]
+
+
+def test_evaluator_exception_does_not_silent_commit() -> None:
+    bad_intent = _intent_with_regulated_context()
+    regulated = bad_intent["approval_context"]["regulated_action_governance"]
+    regulated["action_contract"] = {"id": "broken"}
+
+    with pytest.raises(RuntimeError, match="BIND_COMMIT_BOUNDARY_EVALUATION_FAILED"):
+        _run_bind(bad_intent)
+
+
+def test_export_payload_remains_backward_compatible() -> None:
+    payload = build_bind_response_payload(
+        {
+            "bind_receipt_id": "br-export-1",
+            "execution_intent_id": "ei-export-1",
+            "final_outcome": "COMMITTED",
+        }
+    )
+    assert payload["bind_receipt_id"] == "br-export-1"
+    assert payload["execution_intent_id"] == "ei-export-1"
+    assert "bind_summary" in payload

--- a/veritas_os/api/bind_summary.py
+++ b/veritas_os/api/bind_summary.py
@@ -69,6 +69,9 @@ def enrich_bind_receipt_payload(bind_receipt: dict[str, Any]) -> dict[str, Any]:
 def build_bind_summary_from_receipt(bind_receipt: dict[str, Any]) -> dict[str, Any]:
     """Build shared compact bind summary from a bind receipt payload."""
     enriched_receipt = enrich_bind_receipt_payload(bind_receipt)
+    failed_predicates = enriched_receipt.get("failed_predicates")
+    stale_predicates = enriched_receipt.get("stale_predicates")
+    missing_predicates = enriched_receipt.get("missing_predicates")
     return {
         "bind_outcome": enriched_receipt.get("final_outcome"),
         "bind_failure_reason": resolve_bind_failure_reason(enriched_receipt),
@@ -85,6 +88,18 @@ def build_bind_summary_from_receipt(bind_receipt: dict[str, Any]) -> dict[str, A
         "target_label": enriched_receipt.get("target_label"),
         "operator_surface": enriched_receipt.get("operator_surface"),
         "relevant_ui_href": enriched_receipt.get("relevant_ui_href"),
+        "action_contract_id": enriched_receipt.get("action_contract_id"),
+        "authority_evidence_id": enriched_receipt.get("authority_evidence_id"),
+        "authority_validation_status": enriched_receipt.get("authority_validation_status"),
+        "commit_boundary_result": enriched_receipt.get("commit_boundary_result"),
+        "failed_predicate_count": len(failed_predicates) if isinstance(failed_predicates, list) else None,
+        "stale_predicate_count": len(stale_predicates) if isinstance(stale_predicates, list) else None,
+        "missing_predicate_count": (
+            len(missing_predicates) if isinstance(missing_predicates, list) else None
+        ),
+        "refusal_basis": enriched_receipt.get("refusal_basis"),
+        "escalation_basis": enriched_receipt.get("escalation_basis"),
+        "irreversibility_boundary_id": enriched_receipt.get("irreversibility_boundary_id"),
     }
 
 

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -393,6 +393,21 @@ class BindReceipt(BaseModel):
     target_label: str = Field(default="other", max_length=MAX_TITLE_LENGTH)
     operator_surface: str = Field(default="audit", max_length=MAX_TITLE_LENGTH)
     relevant_ui_href: str = Field(default="/audit", max_length=MAX_URI_LENGTH)
+    regulated_action_path_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    action_contract_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    action_contract_version: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    authority_evidence_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    authority_evidence_hash: Optional[str] = Field(default=None, max_length=256)
+    authority_validation_status: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    admissibility_predicates: Optional[List[Dict[str, Any]]] = None
+    failed_predicates: Optional[List[Dict[str, Any]]] = None
+    stale_predicates: Optional[List[Dict[str, Any]]] = None
+    missing_predicates: Optional[List[Dict[str, Any]]] = None
+    irreversibility_boundary_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    commit_boundary_result: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    refusal_basis: Optional[List[str]] = None
+    escalation_basis: Optional[List[str]] = None
+    authority_evidence_summary: Optional[Dict[str, Any]] = None
 
 
 class BindSummary(BaseModel):
@@ -420,6 +435,16 @@ class BindSummary(BaseModel):
     target_label: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
     operator_surface: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
     relevant_ui_href: Optional[str] = Field(default=None, max_length=MAX_URI_LENGTH)
+    action_contract_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    authority_evidence_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+    authority_validation_status: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    commit_boundary_result: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    failed_predicate_count: Optional[int] = Field(default=None, ge=0)
+    stale_predicate_count: Optional[int] = Field(default=None, ge=0)
+    missing_predicate_count: Optional[int] = Field(default=None, ge=0)
+    refusal_basis: Optional[List[str]] = None
+    escalation_basis: Optional[List[str]] = None
+    irreversibility_boundary_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
 
 
 # =========================

--- a/veritas_os/policy/bind_artifacts.py
+++ b/veritas_os/policy/bind_artifacts.py
@@ -131,6 +131,21 @@ class BindReceipt:
     target_label: str = "other"
     operator_surface: str = "audit"
     relevant_ui_href: str = "/audit"
+    regulated_action_path_id: str | None = None
+    action_contract_id: str | None = None
+    action_contract_version: str | None = None
+    authority_evidence_id: str | None = None
+    authority_evidence_hash: str | None = None
+    authority_validation_status: str | None = None
+    admissibility_predicates: list[dict[str, Any]] | None = None
+    failed_predicates: list[dict[str, Any]] | None = None
+    stale_predicates: list[dict[str, Any]] | None = None
+    missing_predicates: list[dict[str, Any]] | None = None
+    irreversibility_boundary_id: str | None = None
+    commit_boundary_result: str | None = None
+    refusal_basis: list[str] | None = None
+    escalation_basis: list[str] | None = None
+    authority_evidence_summary: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation."""
@@ -145,7 +160,7 @@ class BindReceipt:
         target_label = str(self.target_label or "").strip() or "other"
         operator_surface = str(self.operator_surface or "").strip() or "audit"
         relevant_ui_href = str(self.relevant_ui_href or "").strip() or "/audit"
-        return {
+        payload: dict[str, Any] = {
             "bind_receipt_id": self.bind_receipt_id,
             "execution_intent_id": self.execution_intent_id,
             "decision_id": self.decision_id,
@@ -183,6 +198,27 @@ class BindReceipt:
             "operator_surface": operator_surface,
             "relevant_ui_href": relevant_ui_href,
         }
+        optional_fields = {
+            "regulated_action_path_id": self.regulated_action_path_id,
+            "action_contract_id": self.action_contract_id,
+            "action_contract_version": self.action_contract_version,
+            "authority_evidence_id": self.authority_evidence_id,
+            "authority_evidence_hash": self.authority_evidence_hash,
+            "authority_validation_status": self.authority_validation_status,
+            "admissibility_predicates": self.admissibility_predicates,
+            "failed_predicates": self.failed_predicates,
+            "stale_predicates": self.stale_predicates,
+            "missing_predicates": self.missing_predicates,
+            "irreversibility_boundary_id": self.irreversibility_boundary_id,
+            "commit_boundary_result": self.commit_boundary_result,
+            "refusal_basis": self.refusal_basis,
+            "escalation_basis": self.escalation_basis,
+            "authority_evidence_summary": self.authority_evidence_summary,
+        }
+        for key, value in optional_fields.items():
+            if value is not None:
+                payload[key] = value
+        return payload
 
 
 
@@ -300,9 +336,78 @@ def _extract_bind_receipt(entry: dict[str, Any]) -> BindReceipt | None:
             target_label=str(payload.get("target_label") or "other"),
             operator_surface=str(payload.get("operator_surface") or "audit"),
             relevant_ui_href=str(payload.get("relevant_ui_href") or "/audit"),
+            regulated_action_path_id=(
+                str(payload.get("regulated_action_path_id"))
+                if payload.get("regulated_action_path_id")
+                else None
+            ),
+            action_contract_id=(
+                str(payload.get("action_contract_id"))
+                if payload.get("action_contract_id")
+                else None
+            ),
+            action_contract_version=(
+                str(payload.get("action_contract_version"))
+                if payload.get("action_contract_version")
+                else None
+            ),
+            authority_evidence_id=(
+                str(payload.get("authority_evidence_id"))
+                if payload.get("authority_evidence_id")
+                else None
+            ),
+            authority_evidence_hash=(
+                str(payload.get("authority_evidence_hash"))
+                if payload.get("authority_evidence_hash")
+                else None
+            ),
+            authority_validation_status=(
+                str(payload.get("authority_validation_status"))
+                if payload.get("authority_validation_status")
+                else None
+            ),
+            admissibility_predicates=_normalize_dict_list(payload.get("admissibility_predicates")),
+            failed_predicates=_normalize_dict_list(payload.get("failed_predicates")),
+            stale_predicates=_normalize_dict_list(payload.get("stale_predicates")),
+            missing_predicates=_normalize_dict_list(payload.get("missing_predicates")),
+            irreversibility_boundary_id=(
+                str(payload.get("irreversibility_boundary_id"))
+                if payload.get("irreversibility_boundary_id")
+                else None
+            ),
+            commit_boundary_result=(
+                str(payload.get("commit_boundary_result"))
+                if payload.get("commit_boundary_result")
+                else None
+            ),
+            refusal_basis=_normalize_string_list(payload.get("refusal_basis")),
+            escalation_basis=_normalize_string_list(payload.get("escalation_basis")),
+            authority_evidence_summary=(
+                dict(payload.get("authority_evidence_summary"))
+                if isinstance(payload.get("authority_evidence_summary"), dict)
+                else None
+            ),
         )
     except (TypeError, ValueError):
         return None
+
+
+def _normalize_string_list(raw_value: Any) -> list[str] | None:
+    """Normalize optional list payloads into a homogeneous string list."""
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, list):
+        return None
+    return [str(item) for item in raw_value]
+
+
+def _normalize_dict_list(raw_value: Any) -> list[dict[str, Any]] | None:
+    """Normalize optional list payloads into dictionary items."""
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, list):
+        return None
+    return [dict(item) for item in raw_value if isinstance(item, dict)]
 
 
 def get_previous_bind_hash(*, decision_id: str = "", execution_intent_id: str = "") -> str | None:

--- a/veritas_os/policy/bind_core/core.py
+++ b/veritas_os/policy/bind_core/core.py
@@ -12,6 +12,12 @@ from veritas_os.core.continuation_runtime.bind_admissibility import (
     CheckStatus,
     evaluate_bind_admissibility,
 )
+from veritas_os.governance.action_contracts import (
+    ActionClassContract,
+    validate_action_class_contract,
+)
+from veritas_os.governance.authority_evidence import AuthorityEvidence, VerificationResult
+from veritas_os.governance.commit_boundary import CommitBoundaryResult, evaluate_commit_boundary
 from veritas_os.policy.bind_artifacts import (
     BindReceipt,
     ExecutionIntent,
@@ -293,6 +299,7 @@ def execute_bind_adjudication(
     constraint_result = _check_from_runtime(admissibility.constraint_check_result)
     drift_result = _check_from_runtime(admissibility.drift_check_result)
     risk_result = _check_from_runtime(admissibility.risk_check_result)
+    regulated_context = _resolve_regulated_action_context(normalized_intent)
 
     if not admissibility.admissibility_result:
         blocked_outcome = FinalOutcome.BLOCKED
@@ -319,8 +326,79 @@ def execute_bind_adjudication(
                 },
                 final_outcome=blocked_outcome,
                 escalation_reason=escalation_reason,
+                **_regulated_receipt_updates(regulated_context, None),
             ),
         )
+
+    regulated_boundary_result = _evaluate_regulated_commit_boundary(
+        execution_intent=normalized_intent,
+        regulated_context=regulated_context,
+    )
+    if regulated_boundary_result is not None:
+        if regulated_boundary_result.commit_boundary_result == "block":
+            return _finalize_receipt(
+                execution_intent=normalized_intent,
+                append_trustlog=append_trustlog,
+                receipt=_with_receipt(
+                    base_receipt,
+                    live_state_fingerprint_before=pre_fingerprint,
+                    authority_check_result=authority_result,
+                    constraint_check_result=constraint_result,
+                    drift_check_result=drift_result,
+                    risk_check_result=risk_result,
+                    admissibility_result={
+                        "admissible": False,
+                        "recommended_outcome": "block",
+                        "reason_codes": ["BIND_COMMIT_BOUNDARY_BLOCKED"],
+                        "target": adapter.describe_target(),
+                    },
+                    final_outcome=FinalOutcome.BLOCKED,
+                    **_regulated_receipt_updates(regulated_context, regulated_boundary_result),
+                ),
+            )
+        if regulated_boundary_result.commit_boundary_result == "escalate":
+            return _finalize_receipt(
+                execution_intent=normalized_intent,
+                append_trustlog=append_trustlog,
+                receipt=_with_receipt(
+                    base_receipt,
+                    live_state_fingerprint_before=pre_fingerprint,
+                    authority_check_result=authority_result,
+                    constraint_check_result=constraint_result,
+                    drift_check_result=drift_result,
+                    risk_check_result=risk_result,
+                    admissibility_result={
+                        "admissible": False,
+                        "recommended_outcome": "escalate",
+                        "reason_codes": ["BIND_COMMIT_BOUNDARY_ESCALATED"],
+                        "target": adapter.describe_target(),
+                    },
+                    final_outcome=FinalOutcome.ESCALATED,
+                    escalation_reason="BIND_COMMIT_BOUNDARY_ESCALATED",
+                    **_regulated_receipt_updates(regulated_context, regulated_boundary_result),
+                ),
+            )
+        if regulated_boundary_result.commit_boundary_result == "refuse":
+            return _finalize_receipt(
+                execution_intent=normalized_intent,
+                append_trustlog=append_trustlog,
+                receipt=_with_receipt(
+                    base_receipt,
+                    live_state_fingerprint_before=pre_fingerprint,
+                    authority_check_result=authority_result,
+                    constraint_check_result=constraint_result,
+                    drift_check_result=drift_result,
+                    risk_check_result=risk_result,
+                    admissibility_result={
+                        "admissible": False,
+                        "recommended_outcome": "block",
+                        "reason_codes": ["BIND_COMMIT_BOUNDARY_REFUSED"],
+                        "target": adapter.describe_target(),
+                    },
+                    final_outcome=FinalOutcome.BLOCKED,
+                    **_regulated_receipt_updates(regulated_context, regulated_boundary_result),
+                ),
+            )
 
     try:
         adapter.apply(normalized_intent, pre_snapshot)
@@ -422,8 +500,133 @@ def execute_bind_adjudication(
                 "target": adapter.describe_target(),
             },
             final_outcome=FinalOutcome.COMMITTED,
+            **_regulated_receipt_updates(regulated_context, regulated_boundary_result),
         ),
     )
+
+
+def _resolve_regulated_action_context(execution_intent: ExecutionIntent) -> dict[str, Any]:
+    """Resolve regulated action governance context from intent lineage."""
+    for container in (execution_intent.approval_context, execution_intent.policy_lineage):
+        if not isinstance(container, dict):
+            continue
+        candidate = container.get("regulated_action_governance")
+        if isinstance(candidate, dict):
+            return dict(candidate)
+    return {}
+
+
+def _evaluate_regulated_commit_boundary(
+    *,
+    execution_intent: ExecutionIntent,
+    regulated_context: dict[str, Any],
+) -> CommitBoundaryResult | None:
+    """Evaluate commit boundary only when action-contract context is declared."""
+    action_contract_payload = regulated_context.get("action_contract")
+    action_contract_id = str(
+        regulated_context.get("action_contract_id")
+        or (action_contract_payload or {}).get("id")
+        or ""
+    ).strip()
+    if not action_contract_id:
+        return None
+
+    authority_evidence_payload = regulated_context.get("authority_evidence")
+    requested_scope = regulated_context.get("requested_scope")
+    if not isinstance(requested_scope, list):
+        requested_scope = []
+
+    try:
+        action_contract = (
+            validate_action_class_contract(action_contract_payload)
+            if isinstance(action_contract_payload, dict)
+            else None
+        )
+        authority_evidence = (
+            _build_authority_evidence(authority_evidence_payload)
+            if isinstance(authority_evidence_payload, dict)
+            else None
+        )
+        return evaluate_commit_boundary(
+            execution_intent={
+                "execution_intent_id": execution_intent.execution_intent_id,
+                "action_class": str(regulated_context.get("action_class") or "").strip(),
+                "admissible": True,
+            },
+            action_contract=action_contract,
+            authority_evidence=authority_evidence,
+            requested_scope=[str(item) for item in requested_scope],
+            required_evidence_metadata=dict(regulated_context.get("required_evidence_metadata") or {}),
+            evidence_freshness_metadata=dict(
+                regulated_context.get("evidence_freshness_metadata") or {}
+            ),
+            policy_snapshot_id=execution_intent.policy_snapshot_id,
+            actor_identity=execution_intent.actor_identity,
+            human_approval_state=dict(regulated_context.get("human_approval_state") or {}),
+            bind_context_metadata=dict(regulated_context.get("bind_context_metadata") or {}),
+        )
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"BIND_COMMIT_BOUNDARY_EVALUATION_FAILED:{exc}") from exc
+
+
+def _regulated_receipt_updates(
+    regulated_context: dict[str, Any],
+    result: CommitBoundaryResult | None,
+) -> dict[str, Any]:
+    """Build additive regulated-governance bind receipt fields."""
+    if not regulated_context:
+        return {}
+    updates: dict[str, Any] = {
+        "regulated_action_path_id": str(regulated_context.get("regulated_action_path_id") or "")
+        or None,
+    }
+    if result is None:
+        return {key: value for key, value in updates.items() if value is not None}
+
+    updates.update(
+        {
+            "action_contract_id": result.action_contract_id or None,
+            "action_contract_version": result.action_contract_version or None,
+            "authority_evidence_id": result.authority_evidence_id or None,
+            "authority_evidence_hash": result.authority_evidence_hash or None,
+            "authority_validation_status": result.authority_validation_status or None,
+            "admissibility_predicates": [_predicate_to_dict(item) for item in result.admissibility_predicates],
+            "failed_predicates": [_predicate_to_dict(item) for item in result.failed_predicates],
+            "stale_predicates": [_predicate_to_dict(item) for item in result.stale_predicates],
+            "missing_predicates": [_predicate_to_dict(item) for item in result.missing_predicates],
+            "irreversibility_boundary_id": result.irreversibility_boundary_id or None,
+            "commit_boundary_result": result.commit_boundary_result,
+            "refusal_basis": list(result.refusal_basis),
+            "escalation_basis": list(result.escalation_basis),
+            "authority_evidence_summary": {
+                "reason_summary": result.reason_summary,
+                "evaluated_at": result.evaluated_at,
+            },
+        }
+    )
+    return {key: value for key, value in updates.items() if value is not None}
+
+
+def _predicate_to_dict(predicate: Any) -> dict[str, Any]:
+    return {
+        "predicate_id": str(getattr(predicate, "predicate_id", "")),
+        "predicate_type": str(getattr(predicate, "predicate_type", "")),
+        "status": str(getattr(predicate, "status", "")),
+        "reason": str(getattr(predicate, "reason", "")),
+        "evidence_ref": getattr(predicate, "evidence_ref", None),
+        "severity": str(getattr(predicate, "severity", "")),
+        "evaluated_at": str(getattr(predicate, "evaluated_at", "")),
+        "metadata": dict(getattr(predicate, "metadata", {}) or {}),
+    }
+
+
+def _build_authority_evidence(payload: dict[str, Any]) -> AuthorityEvidence:
+    """Build AuthorityEvidence from mapping with enum normalization."""
+    normalized = dict(payload)
+    verification_result = normalized.get("verification_result")
+    if isinstance(verification_result, str):
+        normalized["verification_result"] = VerificationResult(verification_result)
+    return AuthorityEvidence(**normalized)
 
 
 def _validate_intent_preconditions(execution_intent: ExecutionIntent) -> str | None:

--- a/veritas_os/policy/bind_core/normalizers.py
+++ b/veritas_os/policy/bind_core/normalizers.py
@@ -99,4 +99,69 @@ def normalize_bind_receipt(payload: BindReceipt | dict[str, Any]) -> BindReceipt
         target_label=str(data.get("target_label") or "other"),
         operator_surface=str(data.get("operator_surface") or "audit"),
         relevant_ui_href=str(data.get("relevant_ui_href") or "/audit"),
+        regulated_action_path_id=(
+            str(data.get("regulated_action_path_id"))
+            if data.get("regulated_action_path_id")
+            else None
+        ),
+        action_contract_id=(
+            str(data.get("action_contract_id")) if data.get("action_contract_id") else None
+        ),
+        action_contract_version=(
+            str(data.get("action_contract_version"))
+            if data.get("action_contract_version")
+            else None
+        ),
+        authority_evidence_id=(
+            str(data.get("authority_evidence_id"))
+            if data.get("authority_evidence_id")
+            else None
+        ),
+        authority_evidence_hash=(
+            str(data.get("authority_evidence_hash"))
+            if data.get("authority_evidence_hash")
+            else None
+        ),
+        authority_validation_status=(
+            str(data.get("authority_validation_status"))
+            if data.get("authority_validation_status")
+            else None
+        ),
+        admissibility_predicates=_normalize_dict_list(data.get("admissibility_predicates")),
+        failed_predicates=_normalize_dict_list(data.get("failed_predicates")),
+        stale_predicates=_normalize_dict_list(data.get("stale_predicates")),
+        missing_predicates=_normalize_dict_list(data.get("missing_predicates")),
+        irreversibility_boundary_id=(
+            str(data.get("irreversibility_boundary_id"))
+            if data.get("irreversibility_boundary_id")
+            else None
+        ),
+        commit_boundary_result=(
+            str(data.get("commit_boundary_result"))
+            if data.get("commit_boundary_result")
+            else None
+        ),
+        refusal_basis=_normalize_string_list(data.get("refusal_basis")),
+        escalation_basis=_normalize_string_list(data.get("escalation_basis")),
+        authority_evidence_summary=(
+            dict(data.get("authority_evidence_summary"))
+            if isinstance(data.get("authority_evidence_summary"), dict)
+            else None
+        ),
     )
+
+
+def _normalize_string_list(raw_value: Any) -> list[str] | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, list):
+        return None
+    return [str(item) for item in raw_value]
+
+
+def _normalize_dict_list(raw_value: Any) -> list[dict[str, Any]] | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, list):
+        return None
+    return [dict(item) for item in raw_value if isinstance(item, dict)]


### PR DESCRIPTION
### Motivation
- Integrate regulated-action commit-boundary evaluation output into existing bind artifacts so regulated governance results are available to operators while preserving legacy JSON shape. 
- Keep the integration opt-in and safe so non-regulated (legacy) flows remain unchanged and new governance checks do not silently permit commits. 
- Provide compact summary surface for operator views while avoiding embedding large predicate arrays in `BindSummary`.

### Description
- Changed files: `veritas_os/policy/bind_artifacts.py`, `veritas_os/policy/bind_core/core.py`, `veritas_os/policy/bind_core/normalizers.py`, `veritas_os/api/bind_summary.py`, `veritas_os/api/schemas.py`, and added tests in `tests/governance/test_bind_receipt_regulated_action_fields.py`.
- Added additive optional `BindReceipt` fields (only emitted when populated): `regulated_action_path_id`, `action_contract_id`, `action_contract_version`, `authority_evidence_id`, `authority_evidence_hash`, `authority_validation_status`, `admissibility_predicates`, `failed_predicates`, `stale_predicates`, `missing_predicates`, `irreversibility_boundary_id`, `commit_boundary_result`, `refusal_basis`, `escalation_basis`, and `authority_evidence_summary` (serialization/deserialization and normalizers updated accordingly). 
- Added compact optional `BindSummary` fields: `action_contract_id`, `authority_evidence_id`, `authority_validation_status`, `commit_boundary_result`, `failed_predicate_count`, `stale_predicate_count`, `missing_predicate_count`, `refusal_basis`, `escalation_basis`, and `irreversibility_boundary_id`, keeping large predicate arrays out of the summary (counts used instead). 
- Integration path: bind adjudication resolves `regulated_action_governance` from `approval_context` or `policy_lineage` and only when an `action_contract_id` is declared the code runs `evaluate_commit_boundary` (CommitBoundaryEvaluator); evaluator outcomes map into bind outcomes (`block`->`BLOCKED`, `escalate`->`ESCALATED`, `refuse`->`BLOCKED`, `commit`->proceed), and evaluator validation/construction errors raise `RuntimeError` (`BIND_COMMIT_BOUNDARY_EVALUATION_FAILED:*`) to avoid silent commits; legacy path retains prior behavior when no regulated context is declared. 
- Known limitations and security note: the regulated governance context is taken from intent lineage, so untrusted/unsigned external inputs used to populate `regulated_action_governance` may lead to incorrect adjudication; deployers must ensure the regulated context is validated/trusted (e.g., signed policy/evidence) before evaluation.

### Testing
- Added tests in `tests/governance/test_bind_receipt_regulated_action_fields.py` covering legacy deserialization, summary compatibility, evaluator-run fields population, blocked/escalated/refused mappings and evaluator-exception behaviour. 
- Ran targeted pytest: `python -m pytest tests/governance/test_bind_receipt_regulated_action_fields.py veritas_os/tests/test_bind_summary.py veritas_os/tests/test_bind_artifacts.py` and all tests passed (`22 passed`). 
- Ran linter/quality check with `ruff` on modified files and it passed (`All checks passed!`). 
- Export/build/response compatibility validated via `build_bind_response_payload` tests and summary tests which remained backward compatible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee33d11a548326a86c186b70ff864a)