### PR TITLE
PR7: Add deterministic AML/KYC regulated action path fixture/demo

### DIFF
--- a/examples/aml_kyc_regulated_action_path.py
+++ b/examples/aml_kyc_regulated_action_path.py
@@ -1,0 +1,12 @@
+"""Example invocation for AML/KYC regulated action path fixture."""
+
+from __future__ import annotations
+
+import json
+
+from veritas_os.governance.regulated_action_path import run_all_regulated_action_scenarios
+
+
+if __name__ == "__main__":
+    output = [item.to_dict() for item in run_all_regulated_action_scenarios()]
+    print(json.dumps(output, ensure_ascii=False, indent=2))

--- a/scripts/run_aml_kyc_regulated_action_path.py
+++ b/scripts/run_aml_kyc_regulated_action_path.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CLI wrapper for AML/KYC regulated action path fixture runner."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from veritas_os.scripts.aml_kyc_regulated_action_path_runner import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/governance/test_aml_kyc_regulated_action_path.py
+++ b/tests/governance/test_aml_kyc_regulated_action_path.py
@@ -1,0 +1,60 @@
+"""Tests for deterministic AML/KYC regulated action path fixture."""
+
+from __future__ import annotations
+
+from veritas_os.governance.regulated_action_path import run_all_regulated_action_scenarios
+
+
+def _by_name() -> dict[str, object]:
+    return {item.scenario_name: item for item in run_all_regulated_action_scenarios()}
+
+
+def test_allowed_internal_escalation_commits() -> None:
+    scenario = _by_name()["scenario_a_allowed_internal_escalation"]
+    assert scenario.actual_outcome == "commit"
+
+
+def test_prohibited_account_freeze_blocks() -> None:
+    scenario = _by_name()["scenario_b_prohibited_account_freeze"]
+    assert scenario.actual_outcome == "block"
+
+
+def test_prohibited_customer_notification_blocks() -> None:
+    scenario = _by_name()["scenario_c_prohibited_customer_notification"]
+    assert scenario.actual_outcome == "block"
+
+
+def test_stale_sanctions_screening_escalates_deterministically() -> None:
+    scenario = _by_name()["scenario_d_stale_sanctions_screening"]
+    assert scenario.actual_outcome == "escalate"
+
+
+def test_missing_authority_blocks() -> None:
+    scenario = _by_name()["scenario_e_missing_authority"]
+    assert scenario.actual_outcome == "block"
+
+
+def test_high_irreversibility_without_human_approval_blocks() -> None:
+    scenario = _by_name()["scenario_f_high_irreversibility_without_human_approval"]
+    assert scenario.actual_outcome == "block"
+
+
+def test_unresolved_policy_snapshot_blocks_deterministically() -> None:
+    scenario = _by_name()["scenario_g_policy_uncertainty"]
+    assert scenario.actual_outcome == "block"
+
+
+def test_bind_receipt_contains_action_contract_id() -> None:
+    scenario = _by_name()["scenario_a_allowed_internal_escalation"]
+    assert scenario.action_contract_id == "aml_kyc_customer_risk_escalation"
+
+
+def test_commit_receipt_contains_authority_evidence_hash() -> None:
+    scenario = _by_name()["scenario_a_allowed_internal_escalation"]
+    assert scenario.metadata["authority_evidence_hash"] == "hash-a"
+
+
+def test_all_scenarios_are_deterministic() -> None:
+    first = [item.to_dict() for item in run_all_regulated_action_scenarios()]
+    second = [item.to_dict() for item in run_all_regulated_action_scenarios()]
+    assert first == second

--- a/veritas_os/governance/regulated_action_path.py
+++ b/veritas_os/governance/regulated_action_path.py
@@ -1,0 +1,250 @@
+"""Deterministic AML/KYC regulated action path fixture orchestration.
+
+This module provides a fully synthetic, side-effect-free end-to-end fixture that
+walks the regulated action path from AI-assisted risk detection through commit
+boundary evaluation and bind-receipt enrichment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from veritas_os.governance.action_contracts import ActionClassContract, load_action_class_contract
+from veritas_os.governance.authority_evidence import AuthorityEvidence, VerificationResult
+from veritas_os.governance.commit_boundary import CommitBoundaryResult, evaluate_commit_boundary
+from veritas_os.security.hash import sha256_of_canonical_json
+
+DEFAULT_CONTRACT_PATH = Path("policies/action_contracts/aml_kyc_customer_risk_escalation.v1.yaml")
+DEFAULT_FIXTURE_PATH = Path(
+    "veritas_os/sample_data/governance/aml_kyc_regulated_action_path/scenarios.json"
+)
+FIXTURE_NOW = datetime.fromisoformat("2026-04-26T00:00:00")
+
+
+@dataclass(frozen=True)
+class RegulatedActionPathResult:
+    """Inspectable deterministic result of one regulated action scenario."""
+
+    scenario_name: str
+    expected_outcome: str
+    actual_outcome: str
+    action_contract_id: str
+    authority_evidence_id: str
+    bind_receipt_id: str
+    commit_boundary_result: str
+    failed_predicate_count: int
+    stale_predicate_count: int
+    missing_predicate_count: int
+    refusal_basis: list[str]
+    escalation_basis: list[str]
+    trustlog_lineage_ref: str
+    decision_artifact_id: str
+    risk_detection_summary: dict[str, Any]
+    metadata: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize result as JSON-ready mapping."""
+        return {
+            "scenario_name": self.scenario_name,
+            "expected_outcome": self.expected_outcome,
+            "actual_outcome": self.actual_outcome,
+            "action_contract_id": self.action_contract_id,
+            "authority_evidence_id": self.authority_evidence_id,
+            "bind_receipt_id": self.bind_receipt_id,
+            "commit_boundary_result": self.commit_boundary_result,
+            "failed_predicate_count": self.failed_predicate_count,
+            "stale_predicate_count": self.stale_predicate_count,
+            "missing_predicate_count": self.missing_predicate_count,
+            "refusal_basis": self.refusal_basis,
+            "escalation_basis": self.escalation_basis,
+            "trustlog_lineage_ref": self.trustlog_lineage_ref,
+            "decision_artifact_id": self.decision_artifact_id,
+            "risk_detection_summary": self.risk_detection_summary,
+            "metadata": self.metadata,
+        }
+
+
+def load_regulated_action_scenarios(path: Path = DEFAULT_FIXTURE_PATH) -> list[dict[str, Any]]:
+    """Load deterministic AML/KYC regulated action scenarios."""
+    import json
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    scenarios = payload.get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError("regulated action fixture must include non-empty 'scenarios'")
+    return scenarios
+
+
+def run_regulated_action_scenario(
+    scenario: dict[str, Any],
+    *,
+    action_contract: ActionClassContract,
+) -> RegulatedActionPathResult:
+    """Run one deterministic regulated-action scenario end to end."""
+    scenario_name = str(scenario["scenario_name"])
+    expected_outcome = str(scenario["expected_outcome"])
+    requested_scope = [str(item) for item in scenario.get("requested_scope", [])]
+    scenario_contract = _merge_contract_overrides(action_contract, scenario)
+
+    risk_detection_summary = _build_risk_detection_summary(scenario)
+    decision_artifact = _build_decision_artifact(scenario, risk_detection_summary)
+    execution_intent = {
+        "execution_intent_id": f"ei::{scenario_name}",
+        "action_class": action_contract.action_class,
+        "requested_scope": requested_scope,
+        "admissible": True,
+        "decision_artifact_id": decision_artifact["decision_artifact_id"],
+    }
+
+    authority_evidence = _build_authority_evidence(scenario, action_contract)
+    evaluation = evaluate_commit_boundary(
+        execution_intent=execution_intent,
+        action_contract=scenario_contract,
+        authority_evidence=authority_evidence,
+        requested_scope=requested_scope,
+        required_evidence_metadata=dict(scenario.get("required_evidence_metadata", {})),
+        evidence_freshness_metadata=dict(scenario.get("evidence_freshness_metadata", {})),
+        policy_snapshot_id=scenario.get("policy_snapshot_id"),
+        actor_identity=scenario.get("actor_identity"),
+        human_approval_state=dict(scenario.get("human_approval_state", {})),
+        bind_context_metadata=dict(scenario.get("bind_context_metadata", {})),
+        now=FIXTURE_NOW,
+    )
+
+    bind_receipt = _build_bind_receipt(scenario_name, evaluation)
+    trustlog_lineage_ref = f"trustlog://bind/{bind_receipt['bind_receipt_id']}"
+
+    return RegulatedActionPathResult(
+        scenario_name=scenario_name,
+        expected_outcome=expected_outcome,
+        actual_outcome=evaluation.commit_boundary_result,
+        action_contract_id=evaluation.action_contract_id,
+        authority_evidence_id=evaluation.authority_evidence_id,
+        bind_receipt_id=bind_receipt["bind_receipt_id"],
+        commit_boundary_result=evaluation.commit_boundary_result,
+        failed_predicate_count=len(evaluation.failed_predicates),
+        stale_predicate_count=len(evaluation.stale_predicates),
+        missing_predicate_count=len(evaluation.missing_predicates),
+        refusal_basis=evaluation.refusal_basis,
+        escalation_basis=evaluation.escalation_basis,
+        trustlog_lineage_ref=trustlog_lineage_ref,
+        decision_artifact_id=decision_artifact["decision_artifact_id"],
+        risk_detection_summary=risk_detection_summary,
+        metadata={
+            "authority_evidence_hash": bind_receipt["authority_evidence_hash"],
+            "refusal_or_escalation_basis": (
+                evaluation.refusal_basis or evaluation.escalation_basis
+            ),
+        },
+    )
+
+
+def run_all_regulated_action_scenarios(
+    *,
+    scenarios: list[dict[str, Any]] | None = None,
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> list[RegulatedActionPathResult]:
+    """Run all deterministic fixture scenarios with one shared action contract."""
+    contract = load_action_class_contract(contract_path)
+    scenario_list = scenarios or load_regulated_action_scenarios(fixture_path)
+    return [
+        run_regulated_action_scenario(scenario, action_contract=contract)
+        for scenario in scenario_list
+    ]
+
+
+def _build_risk_detection_summary(scenario: dict[str, Any]) -> dict[str, Any]:
+    risk_flags = dict(scenario.get("risk_flags", {}))
+    risk_score = int(scenario.get("risk_score", 0))
+    triggered_flags = sorted([key for key, enabled in risk_flags.items() if bool(enabled)])
+    return {
+        "risk_score": risk_score,
+        "risk_band": "high" if risk_score >= 80 else "medium" if risk_score >= 40 else "low",
+        "triggered_flags": triggered_flags,
+    }
+
+
+def _build_decision_artifact(
+    scenario: dict[str, Any],
+    risk_detection_summary: dict[str, Any],
+) -> dict[str, Any]:
+    scenario_name = str(scenario["scenario_name"])
+    artifact_id = f"decision::{scenario_name}"
+    return {
+        "decision_artifact_id": artifact_id,
+        "risk_detection_summary": risk_detection_summary,
+        "policy_snapshot_id": scenario.get("policy_snapshot_id", ""),
+    }
+
+
+def _build_authority_evidence(
+    scenario: dict[str, Any],
+    action_contract: ActionClassContract,
+) -> AuthorityEvidence | None:
+    authority_payload = scenario.get("authority_evidence")
+    if not isinstance(authority_payload, dict):
+        return None
+
+    verification = VerificationResult(str(authority_payload.get("verification_result", "valid")))
+    evidence = AuthorityEvidence(
+        authority_evidence_id=str(authority_payload["authority_evidence_id"]),
+        action_contract_id=action_contract.id,
+        action_contract_version=action_contract.version,
+        actor_identity=str(scenario.get("actor_identity", "")),
+        actor_role=str(authority_payload.get("actor_role", "aml_reviewer")),
+        authority_source_refs=list(authority_payload.get("authority_source_refs", [])),
+        role_or_policy_basis=list(authority_payload.get("role_or_policy_basis", [])),
+        scope_grants=list(authority_payload.get("scope_grants", [])),
+        scope_limitations=list(authority_payload.get("scope_limitations", [])),
+        validity_window=dict(authority_payload.get("validity_window", {})),
+        issued_at=str(authority_payload.get("issued_at", "")),
+        valid_from=str(authority_payload.get("valid_from", "")),
+        valid_until=str(authority_payload.get("valid_until", "")),
+        revalidated_at=authority_payload.get("revalidated_at"),
+        policy_snapshot_id=scenario.get("policy_snapshot_id"),
+        evidence_hash=str(authority_payload.get("evidence_hash", "")),
+        verification_result=verification,
+        failure_reasons=list(authority_payload.get("failure_reasons", [])),
+        metadata=dict(authority_payload.get("metadata", {})),
+    )
+    if not evidence.evidence_hash:
+        digest = evidence.deterministic_digest()
+        payload = evidence.to_dict()
+        payload["verification_result"] = verification
+        payload["evidence_hash"] = digest
+        return AuthorityEvidence(**payload)
+    return evidence
+
+
+def _build_bind_receipt(scenario_name: str, result: CommitBoundaryResult) -> dict[str, str]:
+    payload = {
+        "bind_receipt_id": f"bind::{scenario_name}",
+        "action_contract_id": result.action_contract_id,
+        "authority_evidence_id": result.authority_evidence_id,
+        "authority_evidence_hash": result.authority_evidence_hash,
+        "commit_boundary_result": result.commit_boundary_result,
+    }
+    payload["bind_receipt_hash"] = sha256_of_canonical_json(payload)
+    return payload
+
+
+def _merge_contract_overrides(
+    base: ActionClassContract,
+    scenario: dict[str, Any],
+) -> ActionClassContract:
+    overrides = scenario.get("contract_overrides")
+    payload = base.to_dict()
+    irreversibility = dict(payload.get("irreversibility", {}))
+    if not str(irreversibility.get("boundary", "")).strip():
+        irreversibility["boundary"] = "internal_escalation_dispatch"
+    if not str(irreversibility.get("level", "")).strip():
+        irreversibility["level"] = "medium"
+    payload["irreversibility"] = irreversibility
+    if not isinstance(overrides, dict) or not overrides:
+        return ActionClassContract(**payload)
+    payload.update(overrides)
+    return ActionClassContract(**payload)

--- a/veritas_os/sample_data/governance/aml_kyc_regulated_action_path/scenarios.json
+++ b/veritas_os/sample_data/governance/aml_kyc_regulated_action_path/scenarios.json
@@ -1,0 +1,145 @@
+{
+  "fixture_id": "aml_kyc_regulated_action_path_v1",
+  "scenarios": [
+    {
+      "scenario_name": "scenario_a_allowed_internal_escalation",
+      "expected_outcome": "commit",
+      "requested_scope": ["create_internal_risk_escalation"],
+      "risk_score": 88,
+      "risk_flags": {"high_risk_country_corridor": true, "velocity_spike": true},
+      "policy_snapshot_id": "policy-snapshot-001",
+      "actor_identity": "operator:alice",
+      "required_evidence_metadata": {
+        "kyc_profile": {"present": true},
+        "sanctions_screening_trace": {"present": true},
+        "transaction_pattern_summary": {"present": true},
+        "policy_snapshot_id": {"present": true},
+        "model_output_hash": {"present": true},
+        "actor_identity": {"present": true},
+        "approval_matrix": {"present": true},
+        "timestamped_evidence_freshness_metadata": {"present": true}
+      },
+      "evidence_freshness_metadata": {
+        "kyc_profile": {"fresh": true},
+        "sanctions_screening_trace": {"fresh": true},
+        "transaction_pattern_summary": {"fresh": true},
+        "policy_snapshot_id": {"fresh": true},
+        "model_output_hash": {"fresh": true},
+        "actor_identity": {"fresh": true},
+        "approval_matrix": {"fresh": true},
+        "timestamped_evidence_freshness_metadata": {"fresh": true}
+      },
+      "human_approval_state": {"approved": true},
+      "bind_context_metadata": {"session_id": "bind-a"},
+      "authority_evidence": {
+        "authority_evidence_id": "aev-a",
+        "actor_role": "aml_reviewer",
+        "authority_source_refs": ["policy_snapshot_id", "compliance_role_or_policy_basis"],
+        "role_or_policy_basis": ["role:aml_reviewer"],
+        "scope_grants": ["create_internal_risk_escalation"],
+        "scope_limitations": ["freeze_account", "notify_customer"],
+        "validity_window": {
+          "issued_at": "2026-04-25T00:00:00",
+          "valid_from": "2026-04-25T00:00:00",
+          "valid_until": "2026-04-30T00:00:00"
+        },
+        "issued_at": "2026-04-25T00:00:00",
+        "valid_from": "2026-04-25T00:00:00",
+        "valid_until": "2026-04-30T00:00:00",
+        "revalidated_at": "2026-04-26T00:00:00",
+        "verification_result": "valid",
+        "evidence_hash": "hash-a"
+      }
+    },
+    {
+      "scenario_name": "scenario_b_prohibited_account_freeze",
+      "expected_outcome": "block",
+      "requested_scope": ["freeze_account"],
+      "risk_score": 95,
+      "risk_flags": {"sanctions_partial_match": true},
+      "policy_snapshot_id": "policy-snapshot-001",
+      "actor_identity": "operator:alice",
+      "required_evidence_metadata": {"kyc_profile": {"present": true}, "sanctions_screening_trace": {"present": true}, "transaction_pattern_summary": {"present": true}, "policy_snapshot_id": {"present": true}, "model_output_hash": {"present": true}, "actor_identity": {"present": true}, "approval_matrix": {"present": true}, "timestamped_evidence_freshness_metadata": {"present": true}},
+      "evidence_freshness_metadata": {"kyc_profile": {"fresh": true}, "sanctions_screening_trace": {"fresh": true}, "transaction_pattern_summary": {"fresh": true}, "policy_snapshot_id": {"fresh": true}, "model_output_hash": {"fresh": true}, "actor_identity": {"fresh": true}, "approval_matrix": {"fresh": true}, "timestamped_evidence_freshness_metadata": {"fresh": true}},
+      "human_approval_state": {"approved": true},
+      "bind_context_metadata": {"session_id": "bind-b"},
+      "authority_evidence": {"authority_evidence_id": "aev-b", "actor_role": "aml_reviewer", "authority_source_refs": ["policy_snapshot_id"], "role_or_policy_basis": ["role:aml_reviewer"], "scope_grants": ["create_internal_risk_escalation"], "scope_limitations": ["freeze_account"], "validity_window": {"issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00"}, "issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00", "revalidated_at": "2026-04-26T00:00:00", "verification_result": "valid", "evidence_hash": "hash-b"}
+    },
+    {
+      "scenario_name": "scenario_c_prohibited_customer_notification",
+      "expected_outcome": "block",
+      "requested_scope": ["notify_customer"],
+      "risk_score": 78,
+      "risk_flags": {"pep_association": true},
+      "policy_snapshot_id": "policy-snapshot-001",
+      "actor_identity": "operator:alice",
+      "required_evidence_metadata": {"kyc_profile": {"present": true}, "sanctions_screening_trace": {"present": true}, "transaction_pattern_summary": {"present": true}, "policy_snapshot_id": {"present": true}, "model_output_hash": {"present": true}, "actor_identity": {"present": true}, "approval_matrix": {"present": true}, "timestamped_evidence_freshness_metadata": {"present": true}},
+      "evidence_freshness_metadata": {"kyc_profile": {"fresh": true}, "sanctions_screening_trace": {"fresh": true}, "transaction_pattern_summary": {"fresh": true}, "policy_snapshot_id": {"fresh": true}, "model_output_hash": {"fresh": true}, "actor_identity": {"fresh": true}, "approval_matrix": {"fresh": true}, "timestamped_evidence_freshness_metadata": {"fresh": true}},
+      "human_approval_state": {"approved": true},
+      "bind_context_metadata": {"session_id": "bind-c"},
+      "authority_evidence": {"authority_evidence_id": "aev-c", "actor_role": "aml_reviewer", "authority_source_refs": ["policy_snapshot_id"], "role_or_policy_basis": ["role:aml_reviewer"], "scope_grants": ["create_internal_risk_escalation"], "scope_limitations": ["notify_customer"], "validity_window": {"issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00"}, "issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00", "revalidated_at": "2026-04-26T00:00:00", "verification_result": "valid", "evidence_hash": "hash-c"}
+    },
+    {
+      "scenario_name": "scenario_d_stale_sanctions_screening",
+      "expected_outcome": "escalate",
+      "requested_scope": ["create_internal_risk_escalation"],
+      "risk_score": 90,
+      "risk_flags": {"sanctions_partial_match": true},
+      "policy_snapshot_id": "policy-snapshot-001",
+      "actor_identity": "operator:alice",
+      "required_evidence_metadata": {"kyc_profile": {"present": true}, "sanctions_screening_trace": {"present": true}, "transaction_pattern_summary": {"present": true}, "policy_snapshot_id": {"present": true}, "model_output_hash": {"present": true}, "actor_identity": {"present": true}, "approval_matrix": {"present": true}, "timestamped_evidence_freshness_metadata": {"present": true}},
+      "evidence_freshness_metadata": {"kyc_profile": {"fresh": true}, "sanctions_screening_trace": {"fresh": false}, "transaction_pattern_summary": {"fresh": true}, "policy_snapshot_id": {"fresh": true}, "model_output_hash": {"fresh": true}, "actor_identity": {"fresh": true}, "approval_matrix": {"fresh": true}, "timestamped_evidence_freshness_metadata": {"fresh": true}},
+      "human_approval_state": {"approved": true},
+      "bind_context_metadata": {"session_id": "bind-d"},
+      "contract_overrides": {
+        "escalation_conditions": ["stale_evidence"]
+      },
+      "authority_evidence": {"authority_evidence_id": "aev-d", "actor_role": "aml_reviewer", "authority_source_refs": ["policy_snapshot_id"], "role_or_policy_basis": ["role:aml_reviewer"], "scope_grants": ["create_internal_risk_escalation"], "scope_limitations": ["freeze_account"], "validity_window": {"issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00"}, "issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00", "revalidated_at": "2026-04-26T00:00:00", "verification_result": "valid", "evidence_hash": "hash-d"}
+    },
+    {
+      "scenario_name": "scenario_e_missing_authority",
+      "expected_outcome": "block",
+      "requested_scope": ["create_internal_risk_escalation"],
+      "risk_score": 85,
+      "risk_flags": {"velocity_spike": true},
+      "policy_snapshot_id": "policy-snapshot-001",
+      "actor_identity": "operator:alice",
+      "required_evidence_metadata": {"kyc_profile": {"present": true}, "sanctions_screening_trace": {"present": true}, "transaction_pattern_summary": {"present": true}, "policy_snapshot_id": {"present": true}, "model_output_hash": {"present": true}, "actor_identity": {"present": true}, "approval_matrix": {"present": true}, "timestamped_evidence_freshness_metadata": {"present": true}},
+      "evidence_freshness_metadata": {"kyc_profile": {"fresh": true}, "sanctions_screening_trace": {"fresh": true}, "transaction_pattern_summary": {"fresh": true}, "policy_snapshot_id": {"fresh": true}, "model_output_hash": {"fresh": true}, "actor_identity": {"fresh": true}, "approval_matrix": {"fresh": true}, "timestamped_evidence_freshness_metadata": {"fresh": true}},
+      "human_approval_state": {"approved": true},
+      "bind_context_metadata": {"session_id": "bind-e"}
+    },
+    {
+      "scenario_name": "scenario_f_high_irreversibility_without_human_approval",
+      "expected_outcome": "block",
+      "requested_scope": ["create_internal_risk_escalation"],
+      "risk_score": 92,
+      "risk_flags": {"high_risk_country_corridor": true},
+      "policy_snapshot_id": "policy-snapshot-001",
+      "actor_identity": "operator:alice",
+      "required_evidence_metadata": {"kyc_profile": {"present": true}, "sanctions_screening_trace": {"present": true}, "transaction_pattern_summary": {"present": true}, "policy_snapshot_id": {"present": true}, "model_output_hash": {"present": true}, "actor_identity": {"present": true}, "approval_matrix": {"present": true}, "timestamped_evidence_freshness_metadata": {"present": true}},
+      "evidence_freshness_metadata": {"kyc_profile": {"fresh": true}, "sanctions_screening_trace": {"fresh": true}, "transaction_pattern_summary": {"fresh": true}, "policy_snapshot_id": {"fresh": true}, "model_output_hash": {"fresh": true}, "actor_identity": {"fresh": true}, "approval_matrix": {"fresh": true}, "timestamped_evidence_freshness_metadata": {"fresh": true}},
+      "human_approval_state": {"approved": false},
+      "bind_context_metadata": {"session_id": "bind-f"},
+      "authority_evidence": {"authority_evidence_id": "aev-f", "actor_role": "aml_reviewer", "authority_source_refs": ["policy_snapshot_id"], "role_or_policy_basis": ["role:aml_reviewer"], "scope_grants": ["create_internal_risk_escalation"], "scope_limitations": ["freeze_account"], "validity_window": {"issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00"}, "issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00", "revalidated_at": "2026-04-26T00:00:00", "verification_result": "valid", "evidence_hash": "hash-f"},
+      "contract_overrides": {
+        "irreversibility": {"boundary": "account_restriction", "level": "high"},
+        "human_approval_rules": {"required": true, "minimum_approvals": 1}
+      }
+    },
+    {
+      "scenario_name": "scenario_g_policy_uncertainty",
+      "expected_outcome": "block",
+      "requested_scope": ["create_internal_risk_escalation"],
+      "risk_score": 83,
+      "risk_flags": {"policy_uncertainty": true},
+      "policy_snapshot_id": "",
+      "actor_identity": "operator:alice",
+      "required_evidence_metadata": {"kyc_profile": {"present": true}, "sanctions_screening_trace": {"present": true}, "transaction_pattern_summary": {"present": true}, "policy_snapshot_id": {"present": false}, "model_output_hash": {"present": true}, "actor_identity": {"present": true}, "approval_matrix": {"present": true}, "timestamped_evidence_freshness_metadata": {"present": true}},
+      "evidence_freshness_metadata": {"kyc_profile": {"fresh": true}, "sanctions_screening_trace": {"fresh": true}, "transaction_pattern_summary": {"fresh": true}, "policy_snapshot_id": {"fresh": false}, "model_output_hash": {"fresh": true}, "actor_identity": {"fresh": true}, "approval_matrix": {"fresh": true}, "timestamped_evidence_freshness_metadata": {"fresh": true}},
+      "human_approval_state": {"approved": true},
+      "bind_context_metadata": {"session_id": "bind-g"},
+      "authority_evidence": {"authority_evidence_id": "aev-g", "actor_role": "aml_reviewer", "authority_source_refs": ["policy_snapshot_id"], "role_or_policy_basis": ["role:aml_reviewer"], "scope_grants": ["create_internal_risk_escalation"], "scope_limitations": ["freeze_account"], "validity_window": {"issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00"}, "issued_at": "2026-04-25T00:00:00", "valid_from": "2026-04-25T00:00:00", "valid_until": "2026-04-30T00:00:00", "revalidated_at": "2026-04-26T00:00:00", "verification_result": "valid", "evidence_hash": "hash-g"}
+    }
+  ]
+}

--- a/veritas_os/scripts/aml_kyc_regulated_action_path_runner.py
+++ b/veritas_os/scripts/aml_kyc_regulated_action_path_runner.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CLI runner for deterministic AML/KYC regulated action path fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from veritas_os.governance.regulated_action_path import (
+    DEFAULT_FIXTURE_PATH,
+    run_all_regulated_action_scenarios,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run deterministic AML/KYC regulated action path scenarios."
+    )
+    parser.add_argument("--input", default=str(DEFAULT_FIXTURE_PATH))
+    parser.add_argument("--output-json", default="")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run fixture scenarios and print normalized deterministic outputs."""
+    args = _parse_args()
+    results = run_all_regulated_action_scenarios(fixture_path=Path(args.input))
+    payload = [item.to_dict() for item in results]
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"[aml-kyc-regulated-action-path] report saved: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a deterministic, side-effect-free end-to-end AML/KYC regulated action path fixture that demonstrates the full regulated flow from AI-assisted risk detection to commit-boundary decision and bind-receipt enrichment. 
- Support deterministic scenarios (commit / block / escalate / refuse basis) for testing, operator walkthroughs and audit-oriented demos while reusing existing governance primitives (action contracts, authority evidence, commit-boundary evaluator).

### Description
- Added `veritas_os/governance/regulated_action_path.py` which orchestrates scenario execution: builds a risk detection summary, decision artifact, execution intent, authority evidence, invokes `evaluate_commit_boundary`, and emits enriched bind-receipt metadata (including `authority_evidence_hash` and `bind_receipt_hash`) and a deterministic `trustlog://` lineage reference.
- Added deterministic fixture scenarios at `veritas_os/sample_data/governance/aml_kyc_regulated_action_path/scenarios.json` covering Scenarios A–G (allowed internal escalation, prohibited account freeze, prohibited customer notification, stale sanctions screening, missing authority, high irreversibility without human approval, policy uncertainty) and supporting contract overrides for scenario-specific behavior.
- Added CLI integration and examples: `veritas_os/scripts/aml_kyc_regulated_action_path_runner.py` (runner), `scripts/run_aml_kyc_regulated_action_path.py` (wrapper), and `examples/aml_kyc_regulated_action_path.py` (example invocation).
- Added tests in `tests/governance/test_aml_kyc_regulated_action_path.py` that assert each scenario outcome, check action contract id and authority evidence hash in the bind receipt, and verify determinism; implementation keeps all behavior synthetic and avoids external side effects.

### Testing
- Ran the new scenario tests: `python -m pytest tests/governance/test_aml_kyc_regulated_action_path.py` and they all passed (`10 passed`).
- Ran governing compatibility tests: `python -m pytest tests/governance/test_commit_boundary.py tests/governance/test_bind_receipt_regulated_action_fields.py tests/test_aml_kyc_poc_fixture_runner.py` and observed all tests passing (existing governance tests remained green).
- Exercised CLI: `python scripts/run_aml_kyc_regulated_action_path.py` to produce deterministic JSON output showing expected vs actual outcomes for A–G; output verified against test assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3796b09483269f91a6f85c265557)