### PR TITLE
docs: align Regulated Action Governance Kernel positioning, quality gate, and bilingual docs checker (PR11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ VERITAS OS focuses on **decision governance and bind-boundary control**:
 This opening reflects current implemented fact: bind-governed adjudication is already active on at least five operator-governed effect paths,
 while broader effect-path coverage remains roadmap direction.
 
-VERITAS OS includes a Regulated Action Governance Kernel that makes selected AI-agent action paths reviewable at the bind boundary. It uses action-class contracts, runtime authority validation, authority evidence, admissibility predicates, and irreversible commit-boundary checks to determine whether an execution intent may commit, block, escalate, or refuse.
+VERITAS OS includes a Regulated Action Governance Kernel for selected AI-agent action paths. It uses Action Class Contracts, Authority Evidence, Runtime Authority Validation, Admissibility Predicates, and Irreversible Commit Boundary checks to determine whether an execution intent should commit, block, escalate, or refuse at the bind boundary.
 
 This is not legal advice, regulatory approval, third-party certification, or a claim of compliance by itself.
 
@@ -101,6 +101,27 @@ This is not legal advice, regulatory approval, third-party certification, or a c
 - **Current fact (boundary):** Production readiness still depends on environment-specific hardening, integration, and operational controls.
 - **Roadmap / future direction:** Bind-boundary policy surface is expected to expand to more effect paths and become a broader standardization framework for multi-path effect governance; this is direction, not a claim of full completion today.
 - **Roadmap:** Expanded enterprise integrations (for example deeper IdP/JWT scope models and broader distributed failure-mode validation).
+
+### Regulated action governance fact (implemented)
+
+- Action Class Contract
+- AML/KYC Customer Risk Escalation contract
+- Authority Evidence artifact
+- Runtime Authority Validation
+- Admissibility Predicate evaluation
+- Commit Boundary Evaluator
+- BindReceipt / BindSummary regulated-action fields
+- AML/KYC deterministic regulated action path
+- Mission Control / Bind Cockpit regulated action display
+- Proof Pack / Quality Gate docs
+
+### Regulated action governance roadmap (not yet implemented)
+
+- Real external authority source integration
+- Real bank / sanctions / compliance system integration
+- Third-party review
+- Broader regulated action-class coverage
+- Production customer workflow validation
 
 ### Technical Maturity Snapshot (internal)
 
@@ -148,6 +169,7 @@ This is not legal advice, regulatory approval, third-party certification, or a c
 - **Authority Evidence vs Audit Log**: [`docs/en/architecture/authority-evidence-vs-audit-log.md`](docs/en/architecture/authority-evidence-vs-audit-log.md)
 - **AML/KYC Regulated Action Path (Use Case)**: [`docs/en/use-cases/aml-kyc-regulated-action-path.md`](docs/en/use-cases/aml-kyc-regulated-action-path.md)
 - **Regulated Action Governance Proof Pack**: [`docs/en/validation/regulated-action-governance-proof-pack.md`](docs/en/validation/regulated-action-governance-proof-pack.md)
+- **Regulated Action Governance Quality Gate**: [`docs/en/validation/regulated-action-governance-quality-gate.md`](docs/en/validation/regulated-action-governance-quality-gate.md)
 - **Required Evidence Taxonomy v0**: [`docs/en/governance/required-evidence-taxonomy.md`](docs/en/governance/required-evidence-taxonomy.md)
 - **AML/KYC contract hardening (canonical gate + evidence profile)**: [`docs/en/guides/financial-governance-templates.md`](docs/en/guides/financial-governance-templates.md)
 - **Documentation Map**: [`docs/DOCUMENTATION_MAP.md`](docs/DOCUMENTATION_MAP.md)

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -19,6 +19,7 @@
 | Architecture: Authority evidence vs audit log | `docs/en/architecture/authority-evidence-vs-audit-log.md` | — | EN canonical only | 役割分離の明確化 |
 | Use case: AML/KYC regulated action path | `docs/en/use-cases/aml-kyc-regulated-action-path.md` | — | EN canonical only | 決定論fixture実行手順 |
 | Validation: Regulated action governance proof pack | `docs/en/validation/regulated-action-governance-proof-pack.md` | — | EN canonical only | レビュー証跡パック |
+| Validation: Regulated action governance quality gate | `docs/en/validation/regulated-action-governance-quality-gate.md` | — | EN canonical only | 品質ゲートと実行証跡 |
 | Validation: External audit readiness | `docs/en/validation/external-audit-readiness.md` | `docs/ja/validation/external-audit-readiness.md` | JA explanation / EN canonical | 外部監査準備性 |
 | Validation: Technical proof pack | `docs/en/validation/technical-proof-pack.md` | `docs/ja/validation/technical-proof-pack.md` | JA explanation / EN canonical | DD/監査前の提出導線 |
 | Validation: Third-party review readiness | `docs/en/validation/third-party-review-readiness.md` | `docs/ja/validation/third-party-review-readiness.md` | JA explanation / EN canonical | 省略版レビュー入口 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,6 +18,7 @@
 | External Audit | [External audit readiness (EN)](en/validation/external-audit-readiness.md) | [外部監査準備性 (JA)](ja/validation/external-audit-readiness.md) |
 | Technical Proof Pack | [Technical proof pack (EN)](en/validation/technical-proof-pack.md) | [技術証明パック (JA)](ja/validation/technical-proof-pack.md) |
 | Regulated Action Governance Proof Pack | [Regulated action governance proof pack (EN)](en/validation/regulated-action-governance-proof-pack.md) | — |
+| Regulated Action Governance Quality Gate | [Regulated action governance quality gate (EN)](en/validation/regulated-action-governance-quality-gate.md) | — |
 | Third-Party Review Readiness | [Third-party review readiness (EN)](en/validation/third-party-review-readiness.md) | [第三者レビュー準備性 (JA)](ja/validation/third-party-review-readiness.md) |
 | Backend Parity Coverage | [Backend parity coverage (EN)](en/validation/backend-parity-coverage.md) | [バックエンドパリティカバレッジ (JA)](ja/validation/backend-parity-coverage.md) |
 | Production Validation | [Production validation (EN)](en/validation/production-validation.md) | [本番検証 (JA)](ja/validation/production-validation.md) |
@@ -70,6 +71,7 @@
 | 外部監査 | [External audit readiness（英語正本）](en/validation/external-audit-readiness.md) | [外部監査準備性（日本語）](ja/validation/external-audit-readiness.md) |
 | 技術証明パック | [Technical proof pack（英語正本）](en/validation/technical-proof-pack.md) | [技術証明パック（日本語解説）](ja/validation/technical-proof-pack.md) |
 | Regulated Action Governance Proof Pack | [Regulated Action Governance Proof Pack（英語正本）](en/validation/regulated-action-governance-proof-pack.md) | — |
+| Regulated Action Governance Quality Gate | [Regulated Action Governance Quality Gate（英語正本）](en/validation/regulated-action-governance-quality-gate.md) | — |
 | 第三者レビュー準備性 | [Third-party review readiness（英語正本）](en/validation/third-party-review-readiness.md) | [第三者レビュー準備性（日本語解説）](ja/validation/third-party-review-readiness.md) |
 | バックエンドパリティカバレッジ | [Backend parity coverage（英語正本）](en/validation/backend-parity-coverage.md) | [バックエンドパリティカバレッジ（日本語解説）](ja/validation/backend-parity-coverage.md) |
 | 本番検証 | [Production validation（英語正本）](en/validation/production-validation.md) | [本番検証（日本語解説）](ja/validation/production-validation.md) |

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -43,6 +43,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [External Audit Readiness](validation/external-audit-readiness.md)
 - [Technical Proof Pack (external review)](validation/technical-proof-pack.md)
 - [Regulated Action Governance Proof Pack](validation/regulated-action-governance-proof-pack.md)
+- [Regulated Action Governance Quality Gate](validation/regulated-action-governance-quality-gate.md)
 - [Third-Party Review Readiness (compact index)](validation/third-party-review-readiness.md)
 
 ### Governance & Compliance

--- a/docs/en/validation/regulated-action-governance-proof-pack.md
+++ b/docs/en/validation/regulated-action-governance-proof-pack.md
@@ -82,6 +82,16 @@ For regulated-action paths, reviewers should inspect availability/values of:
 - `refusal_basis`
 - `escalation_basis`
 
+## Validation status (PR11 refresh)
+
+- Validation snapshot date: **2026-04-27 (UTC)**
+- Regulated action governance tests: `84 passed`
+- AML/KYC deterministic fixture runner tests: `2 passed`
+- Bilingual docs checker script: `PASS`
+- Frontend regulated-action compatibility tests: `12 passed`
+
+See the detailed command/result ledger in: `docs/en/validation/regulated-action-governance-quality-gate.md`.
+
 ## Quality checks
 
 Recommended checks for this proof pack:
@@ -89,6 +99,7 @@ Recommended checks for this proof pack:
 1. Run deterministic fixture runner and confirm expected outcomes.
 2. Run governance tests covering authority evidence, runtime predicates, commit boundary, and bind receipt enrichment.
 3. Run docs consistency checks available in repository quality tooling.
+4. Run frontend bind cockpit compatibility tests and build checks.
 
 ## Known limitations
 

--- a/docs/en/validation/regulated-action-governance-quality-gate.md
+++ b/docs/en/validation/regulated-action-governance-quality-gate.md
@@ -1,97 +1,94 @@
-# Regulated Action Governance Quality Gate (PR10)
+# Regulated Action Governance Quality Gate (PR11)
 
 ## Scope
 
-This note records the PR10 hardening validation run for the regulated-action governance kernel implementation.
+This note records the PR11 validation pass for README/public positioning alignment, regulated-action governance documentation integrity, and quality-gate evidence.
+
+- Updated at: **2026-04-27 (UTC)**
+- Reviewer intent: confirm implemented facts, avoid over-claim language, and preserve backward-compatible contracts.
 
 > Non-certification disclaimer: this document is implementation validation evidence only. It is **not** legal advice, regulatory approval, formal compliance certification, or a third-party attestation.
 
 ## Backward compatibility statement
 
-- Legacy bind receipt payloads deserialize without regulated-action additive fields.
-- Legacy bind summary payloads deserialize without regulated-action additive fields.
+- Legacy bind receipt payloads still deserialize without regulated-action additive fields.
+- Legacy bind summary payloads still deserialize without regulated-action additive fields.
 - Bind response export shape preserves legacy top-level compatibility fields.
-- Governance/UI normalization paths continue handling sparse and legacy bind artifacts without crashing.
-
-## Hardening changes in this PR
-
-1. Added explicit fail-closed handling for unknown critical runtime predicates.
-2. Added explicit fail-closed handling for commit-boundary receipt serialization failures so no side effect is applied before serialization-safe receipt enrichment.
-3. Added deterministic predicate-order assertion coverage.
+- Mission Control / Bind Cockpit normalization remains compatible with sparse and legacy bind artifacts.
 
 ## Checks run
 
-### Python governance checks
-
-Command:
+### Regulated action governance tests
 
 ```bash
-pytest -q tests/governance/test_action_class_contracts.py \
-  tests/governance/test_authority_evidence.py \
-  tests/governance/test_runtime_authority_validation.py \
-  tests/governance/test_commit_boundary.py \
-  tests/governance/test_aml_kyc_regulated_action_path.py \
-  tests/governance/test_bind_receipt_regulated_action_fields.py \
-  tests/test_aml_kyc_poc_fixture_runner.py
+pytest -q tests/governance/test_action_class_contracts.py tests/governance/test_aml_kyc_action_contract.py tests/governance/test_authority_evidence.py tests/governance/test_runtime_authority_validation.py tests/governance/test_commit_boundary.py tests/governance/test_aml_kyc_regulated_action_path.py tests/governance/test_bind_receipt_regulated_action_fields.py
 ```
 
-Result: **PASS** (`76 passed`).
+Result: **PASS** (`84 passed`).
 
-### Python lint checks
-
-Command:
+### AML/KYC deterministic fixture runner tests
 
 ```bash
-ruff check veritas_os/governance tests/governance tests/test_aml_kyc_poc_fixture_runner.py
+pytest -q tests/test_aml_kyc_poc_fixture_runner.py
+```
+
+Result: **PASS** (`2 passed`).
+
+### Bilingual docs checker (script)
+
+```bash
+python scripts/quality/check_bilingual_docs.py
 ```
 
 Result: **PASS**.
 
-### Frontend governance compatibility checks
-
-Command:
+### Bilingual docs checker (pytest)
 
 ```bash
-npm --prefix frontend test -- --run \
-  app/governance/components/bind-cockpit-normalization.test.ts \
-  app/governance/components/BindCockpit.test.tsx
+pytest -q tests/test_check_bilingual_docs.py
+```
+
+Result: **PASS** (`3 passed`) after fixing stale import usage in the test module.
+
+### Frontend governance compatibility tests
+
+```bash
+npm --prefix frontend test -- --run app/governance/components/bind-cockpit-normalization.test.ts app/governance/components/BindCockpit.test.tsx
 ```
 
 Result: **PASS** (`12 passed`).
 
-### Frontend lint and build checks
-
-Commands:
+### Frontend lint
 
 ```bash
 npm --prefix frontend run lint
+```
+
+Result: **PASS with warnings** (pre-existing warnings outside PR11 scope; zero lint errors).
+
+### Frontend build
+
+```bash
 npm --prefix frontend run build
 ```
 
-Results:
+Result: **PASS**.
 
-- `lint`: **PASS with warnings** (pre-existing warnings outside this PR scope).
-- `build`: **PASS**.
+## Not run / not verified
 
-## Not run / limitations
+- `pytest -q` (full repository suite): **not run** in this pass to keep cycle bounded to regulated-action governance and documentation quality scope.
+- `ruff check`: **not run for markdown/docs files**, because Ruff is Python-focused and reports markdown as invalid syntax when passed `.md` inputs.
+- `mypy`: **not run**, no mypy configuration is present in `pyproject.toml`.
+- GitHub Actions latest workflow status: **not verified locally** (`gh` CLI unavailable in this environment).
 
-- `mypy`: not run (no project mypy configuration present in `pyproject.toml`).
-- Full `pytest` suite: not run in this PR validation pass to keep cycle focused on regulated-action governance kernel hardening scope.
-- `tests/test_check_bilingual_docs.py`: currently fails at collection due to an existing import mismatch unrelated to this PR.
+## Known limitations
 
-## Security & privacy validation notes
+- Regulated-action fixture coverage remains centered on deterministic AML/KYC scenarios.
+- External authority systems (bank, sanctions, compliance, and production identity integrations) are still roadmap items.
+- This quality gate documents repository-level checks and does not by itself establish legal/regulatory compliance.
 
-- No real customer records were introduced in fixtures.
-- No live sanctions API integration was introduced in this hardening PR.
-- No real bank-side effect integration was introduced in this hardening PR.
-- Authority evidence summary remains compact (`reason_summary`, `evaluated_at`) and does not expose raw authority evidence material by default.
+## Security and control notes
 
-## Evidence map (updated / relevant tests)
-
-- `tests/governance/test_action_class_contracts.py`
-- `tests/governance/test_authority_evidence.py`
-- `tests/governance/test_runtime_authority_validation.py`
-- `tests/governance/test_commit_boundary.py`
-- `tests/governance/test_aml_kyc_regulated_action_path.py`
-- `tests/governance/test_bind_receipt_regulated_action_fields.py`
-- `tests/test_aml_kyc_poc_fixture_runner.py`
+- No real customer records were introduced.
+- No live sanctions API or bank-side effect integration was introduced.
+- Fail-closed bind adjudication remains the enforcement posture for missing/invalid/indeterminate authority and inadmissible scope.

--- a/tests/test_check_bilingual_docs.py
+++ b/tests/test_check_bilingual_docs.py
@@ -1,26 +1,41 @@
 """Tests for bilingual documentation consistency checks."""
 
-from scripts.quality.check_bilingual_docs import (
-    _is_long_url_or_generated_badge,
-    run,
-)
+from scripts.quality import check_bilingual_docs
 
 
 def test_bilingual_docs_checks_pass() -> None:
     """Repository documentation entrypoints should satisfy bilingual checks."""
-    assert run() == []
+    assert check_bilingual_docs.run() == []
 
 
-def test_badge_url_is_ignored_for_length_check() -> None:
-    """Shields badge URLs should be ignored by markdown readability guard."""
-    line = (
-        "[![CI](https://img.shields.io/badge/ci-passing-brightgreen.svg)]"
-        "(https://github.com/example/repo/actions)"
+def test_markdown_compression_guard_detects_overlong_line() -> None:
+    """Compression guard should flag excessive non-fenced line length."""
+    temp = check_bilingual_docs.REPO_ROOT / "tmp_bilingual_guard.md"
+    temp.write_text(
+        "x" * (check_bilingual_docs.MARKDOWN_LINE_HARD_LIMIT + 1),
+        encoding="utf-8",
     )
-    assert _is_long_url_or_generated_badge(line) is True
+
+    errors: list[str] = []
+    check_bilingual_docs._check_markdown_compression_guard(temp, errors)
+    temp.unlink()
+
+    assert errors
+    assert ("exceeds" in errors[0]) or ("likely compressed" in errors[0])
 
 
-def test_non_badge_url_is_not_auto_ignored() -> None:
-    """Normal URLs should not be ignored unless line length is excessive."""
-    line = "Reference: https://example.com/docs/ja/guide"
-    assert _is_long_url_or_generated_badge(line) is False
+def test_markdown_compression_guard_ignores_long_fenced_line() -> None:
+    """Compression guard should ignore long lines inside fenced code blocks."""
+    temp = check_bilingual_docs.REPO_ROOT / "tmp_bilingual_guard_fenced.md"
+    temp.write_text(
+        "```\n"
+        + "x" * (check_bilingual_docs.MARKDOWN_LINE_HARD_LIMIT + 5)
+        + "\n```\n",
+        encoding="utf-8",
+    )
+
+    errors: list[str] = []
+    check_bilingual_docs._check_markdown_compression_guard(temp, errors)
+    temp.unlink()
+
+    assert errors == []


### PR DESCRIPTION
### Motivation
- Bring public-facing README and supporting docs into alignment with the current implemented Regulated Action Governance Kernel behavior while avoiding over-claiming certification or legal status. 
- Make the regulated-action proof pack and quality-gate documentation self-contained reviewer evidence with an explicit validation ledger and transparent not-run rationale. 
- Fix a bilingual docs checker collection issue so docs quality checks run reliably in CI and provide reproducible evidence. 

### Description
- Update `README.md` wording to reflect the implemented Regulated Action Governance Kernel (Action Class Contracts, Authority Evidence, Runtime Authority Validation, Admissibility Predicates, Irreversible Commit Boundary) and add a short non-certification disclaimer plus a clear Fact vs Roadmap split. 
- Add links and index entries for the Regulated Action Governance Quality Gate in `docs/en/README.md`, `docs/INDEX.md`, and `docs/DOCUMENTATION_MAP.md`. 
- Replace `docs/en/validation/regulated-action-governance-quality-gate.md` with a PR11-focused ledger that records executed checks, timestamps, not-run items with reasons, backward-compatibility notes, known limitations, and a non-certification statement. 
- Refresh `docs/en/validation/regulated-action-governance-proof-pack.md` with a PR11 validation snapshot and a link to the quality-gate ledger. 
- Fix `tests/test_check_bilingual_docs.py` to use the public `scripts.quality.check_bilingual_docs` API and add compression-guard regression tests so the bilingual checker no longer fails collection. 

### Testing
- Ran governance unit tests: `pytest -q tests/governance/test_*` plus `tests/test_aml_kyc_poc_fixture_runner.py` and observed all relevant governance tests pass (`84 passed`) and the AML/KYC fixture runner pass (`2 passed`). 
- Verified bilingual docs checks: `python scripts/quality/check_bilingual_docs.py` returned PASS and `pytest -q tests/test_check_bilingual_docs.py` passed (`3 passed`). 
- Frontend checks: `npm --prefix frontend test` passed the targeted governance component tests (`12 passed`), `npm --prefix frontend run lint` passed with pre-existing warnings only, and `npm --prefix frontend run build` succeeded. 
- Not run / not verified locally: full repository `pytest -q` (scope-limited PR run), `mypy` (no project mypy config), and GitHub Actions workflow status (local environment lacks `gh` CLI); these are documented in the quality-gate file with reasons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeec51b9788326961180a690f15d0b)