### PR TITLE
Align README/README_JP regulated-action governance framing and add bilingual-docs guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ VERITAS OS focuses on **decision governance and bind-boundary control**:
 This opening reflects current implemented fact: bind-governed adjudication is already active on at least five operator-governed effect paths,
 while broader effect-path coverage remains roadmap direction.
 
-VERITAS OS includes a Regulated Action Governance Kernel for selected AI-agent action paths. It uses Action Class Contracts, Authority Evidence, Runtime Authority Validation, Admissibility Predicates, and Irreversible Commit Boundary checks to determine whether an execution intent should commit, block, escalate, or refuse at the bind boundary.
+VERITAS OS includes a Regulated Action Governance Kernel for selected AI-agent action paths. It uses Action Class Contracts, Authority Evidence, Runtime Authority Validation, Admissibility Predicates, and Irreversible Commit Boundary checks to determine whether an execution intent should commit, block, escalate, or refuse at the bind boundary, including an AML/KYC customer risk escalation fixture path.
 
-This is not legal advice, regulatory approval, third-party certification, or a claim of compliance by itself.
+Audit Log records what happened. Authority Evidence records why an action was authorized and admissible at bind time; audit log records alone do not authorize commit.
+
+This is not legal advice, not regulatory approval, not third-party certification, or a claim of compliance by itself.
 
 ## What VERITAS OS is / is not
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -19,7 +19,7 @@
 **Author**: Takeshi Fujishita
 
 VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agents**（AIエージェント向け意思決定ガバナンス / bind-boundary 制御プレーン）です。
-エージェント実行の前段に **governance layer before execution** を置き、現実世界に影響する前に意思決定を制御します。
+エージェント実行の前段に **governance layer before execution** を置き、現実世界に影響する前に意思決定を制御します。これは、AIエージェントの意思決定と実行境界を統治するコントロールプレーンという現在のプロダクトポジショニングを示します。
 
 > メンタルモデル: **LLM = CPU**、**VERITAS OS = その上に載る Decision Governance OS**
 
@@ -75,6 +75,42 @@ VERITAS OS は次を実現します。
 - **将来方向（標準化）**: bind-boundary は複数の effect path を統治する標準枠組みへ拡張していく方針ですが、現時点で全経路完了を主張するものではありません
 - **ロードマップ**: IdP/JWT スコープ連携の深耕、分散障害モード検証の拡張
 
+VERITAS には、選択された AI エージェントの action path を bind boundary で reviewable にする **Regulated Action Governance Kernel** が含まれます。Action Class Contract、Authority Evidence、Runtime Authority Validation、Admissibility Predicate、Irreversible Commit Boundary を用いて、execution intent の `commit / block / escalate / refuse` を判定します。AML/KYC customer risk escalation fixture は、この regulated action path を決定論的に確認するための実装済み経路です。
+
+Authority Evidence と Audit Log の違いは明確です。
+- **Audit Log** = 何が起きたかの記録
+- **Authority Evidence** = bind time でその action が authorized / admissible だった理由の証跡
+- audit log 単体では commit を許可しない
+
+### Regulated action governance の事実（実装済み）
+
+- Action Class Contract
+- AML/KYC Customer Risk Escalation contract
+- Authority Evidence artifact
+- Runtime Authority Validation
+- Admissibility Predicate evaluation
+- Commit Boundary Evaluator
+- BindReceipt / BindSummary regulated-action fields
+- AML/KYC deterministic regulated action path
+- Mission Control / Bind Cockpit regulated action display
+- Proof Pack / Quality Gate docs
+
+### Regulated action governance のロードマップ（未実装）
+
+- Real external authority source integration
+- Real bank / sanctions / compliance system integration
+- Third-party review
+- Broader regulated action-class coverage
+- Production customer workflow validation
+
+### Disclaimer
+
+- 本READMEは法的助言ではありません。
+- 規制当局の承認を示すものではありません。
+- 第三者認証を示すものではありません。
+- それ自体で法令適合を保証するものではありません。
+- 外部ガバナンスフレームワークの実装または認証を主張するものではありません。
+
 ### Technical Maturity Snapshot（内部）
 
 > 本セクションは **self-assessment / internal re-evaluation**（内部再評価）であり、第三者認証ではありません。
@@ -115,6 +151,11 @@ VERITAS OS は次を実現します。
 - **Decision Semantics Contract**: [`docs/ja/architecture/decision-semantics.md`](docs/ja/architecture/decision-semantics.md)
 - **Bind-Boundary Governance Artifacts**: [`docs/ja/architecture/bind-boundary-governance-artifacts.md`](docs/ja/architecture/bind-boundary-governance-artifacts.md)
 - **Bind-Time Admissibility Evaluator**: [`docs/ja/architecture/bind_time_admissibility_evaluator.md`](docs/ja/architecture/bind_time_admissibility_evaluator.md)
+- **Regulated Action Governance Kernel（英語正本）**: [`docs/en/architecture/regulated-action-governance-kernel.md`](docs/en/architecture/regulated-action-governance-kernel.md)
+- **Authority Evidence vs Audit Log（英語正本）**: [`docs/en/architecture/authority-evidence-vs-audit-log.md`](docs/en/architecture/authority-evidence-vs-audit-log.md)
+- **AML/KYC Regulated Action Path（英語正本）**: [`docs/en/use-cases/aml-kyc-regulated-action-path.md`](docs/en/use-cases/aml-kyc-regulated-action-path.md)
+- **Regulated Action Governance Proof Pack（英語正本）**: [`docs/en/validation/regulated-action-governance-proof-pack.md`](docs/en/validation/regulated-action-governance-proof-pack.md)
+- **Regulated Action Governance Quality Gate（英語正本）**: [`docs/en/validation/regulated-action-governance-quality-gate.md`](docs/en/validation/regulated-action-governance-quality-gate.md)
 - **Required Evidence Taxonomy v0**: [`docs/ja/governance/required-evidence-taxonomy.md`](docs/ja/governance/required-evidence-taxonomy.md)
 - **AML/KYC contract hardening（canonical gate + evidence profile）**: [`docs/ja/guides/financial-governance-templates.md`](docs/ja/guides/financial-governance-templates.md)
 - **ドキュメント対応表**: [`docs/DOCUMENTATION_MAP.md`](docs/DOCUMENTATION_MAP.md)
@@ -312,7 +353,7 @@ VERITAS は **ガバナンス** を最適化します。
 - **エンタープライズガバナンス** — ポリシー変更の**4-eyes承認**、**RBAC/ABAC**アクセス制御、**SSEリアルタイムガバナンスアラート**、外部シークレットマネージャー強制
 - **MemoryOS**（ベクトル検索）+ **WorldModel**（因果遷移）を一次入力として扱う
 - フルスタック **Mission Controlダッシュボード**（Next.js）によるリアルタイムイベントストリーミング、リスク分析、ガバナンスポリシー管理
-- **EU AI Act準拠** — コンプライアンスレポート生成、監査エクスポート、デプロイメント準備チェック
+- **規制対応支援機能（実装）** — コンプライアンス向けレポート生成・監査エクスポート・デプロイメント準備チェックを提供（これ自体は法令適合保証を意味しない）
 
 **想定ユーザー**
 - AI safety / エージェント研究者

--- a/scripts/quality/check_bilingual_docs.py
+++ b/scripts/quality/check_bilingual_docs.py
@@ -113,6 +113,55 @@ MARKDOWN_SHORT_FILE_MAX_LINES = 2
 MARKDOWN_SHORT_FILE_MIN_CHARS = 10_001
 
 LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+REQUIRED_REGULATED_ACTION_TERMS_EN = (
+    "Regulated Action Governance Kernel",
+    "Action Class Contract",
+    "Authority Evidence",
+    "Runtime Authority Validation",
+    "Admissibility Predicate",
+    "Irreversible Commit Boundary",
+)
+
+REQUIRED_REGULATED_ACTION_TERMS_JA = (
+    "Regulated Action Governance Kernel",
+    "Action Class Contract",
+    "Authority Evidence",
+    "Runtime Authority Validation",
+    "Admissibility Predicate",
+    "Irreversible Commit Boundary",
+    "commit / block / escalate / refuse",
+    "AML/KYC customer risk escalation fixture",
+)
+
+REQUIRED_DISCLAIMER_TERMS_EN = (
+    "not legal advice",
+    "not regulatory approval",
+    "not third-party certification",
+)
+
+REQUIRED_DISCLAIMER_TERMS_JA = (
+    "法的助言ではありません",
+    "規制当局の承認",
+    "第三者認証",
+)
+
+REQUIRED_REGULATED_ACTION_LINKS = (
+    "docs/en/architecture/regulated-action-governance-kernel.md",
+    "docs/en/architecture/authority-evidence-vs-audit-log.md",
+    "docs/en/use-cases/aml-kyc-regulated-action-path.md",
+    "docs/en/validation/regulated-action-governance-proof-pack.md",
+    "docs/en/validation/regulated-action-governance-quality-gate.md",
+)
+
+FORBIDDEN_OVERCLAIM_PATTERNS = (
+    "implements OTANIS",
+    "implements ISDAIRE",
+    "implements ARETABA",
+    "regulatory approval",
+    "third-party certification",
+    "legal compliance guaranteed",
+)
 CODE_PATH_PATTERN = re.compile(
     r"(?<![\w.-])(?:README(?:_JP)?\.md|docs/(?:en|ja)/[^\s`\)\]\(]+\.md)"
 )
@@ -236,6 +285,74 @@ def check_readme_japanese_first_links(errors: list[str]) -> None:
         )
 
 
+
+
+def _missing_terms(markdown: str, terms: tuple[str, ...]) -> list[str]:
+    lowered = markdown.lower()
+    return [term for term in terms if term.lower() not in lowered]
+
+
+def check_readme_regulated_action_and_disclaimer(errors: list[str]) -> None:
+    """Validate core regulated-action framing and disclaimer presence in README pair."""
+    readme_en = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    readme_ja = README_JA.read_text(encoding="utf-8")
+
+    missing_en = _missing_terms(readme_en, REQUIRED_REGULATED_ACTION_TERMS_EN)
+    if missing_en:
+        errors.append(
+            "README.md: missing regulated-action terms: " + ", ".join(missing_en)
+        )
+
+    missing_ja = _missing_terms(readme_ja, REQUIRED_REGULATED_ACTION_TERMS_JA)
+    if missing_ja:
+        errors.append(
+            "README_JP.md: missing regulated-action terms: " + ", ".join(missing_ja)
+        )
+
+    if "Audit Log" not in readme_ja or "Authority Evidence" not in readme_ja:
+        errors.append(
+            "README_JP.md: Authority Evidence vs Audit Log distinction is missing."
+        )
+
+    missing_disclaimer_en = _missing_terms(readme_en, REQUIRED_DISCLAIMER_TERMS_EN)
+    if missing_disclaimer_en:
+        errors.append(
+            "README.md: missing disclaimer terms: "
+            + ", ".join(missing_disclaimer_en)
+        )
+
+    missing_disclaimer_ja = _missing_terms(readme_ja, REQUIRED_DISCLAIMER_TERMS_JA)
+    if missing_disclaimer_ja:
+        errors.append(
+            "README_JP.md: missing disclaimer terms: "
+            + ", ".join(missing_disclaimer_ja)
+        )
+
+    for path in REQUIRED_REGULATED_ACTION_LINKS:
+        if path not in readme_en:
+            errors.append(f"README.md: missing link {path}.")
+        if path not in readme_ja:
+            errors.append(f"README_JP.md: missing link {path}.")
+
+
+def check_forbidden_framework_overclaims(errors: list[str]) -> None:
+    """Reject external-framework implementation/certification overclaims in READMEs."""
+    readme_en = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    readme_ja = README_JA.read_text(encoding="utf-8")
+
+    for marker in FORBIDDEN_OVERCLAIM_PATTERNS:
+        lower = marker.lower()
+        if lower in readme_en.lower() and "not " + lower not in readme_en.lower():
+            errors.append(f"README.md: potential overclaim phrase detected: {marker}")
+
+    forbidden_ja_terms = ("OTANIS", "ISDAIRE", "ARETABA", "法令適合を保証")
+    for marker in forbidden_ja_terms:
+        if marker.lower() in readme_ja.lower() and "ではありません" not in readme_ja:
+            errors.append(
+                f"README_JP.md: potential overclaim phrase detected: {marker}"
+            )
+
+
 def check_local_markdown_links(errors: list[str]) -> None:
     """Validate local markdown links in designated documentation files."""
     for source_file in LOCAL_LINK_CHECK_TARGETS:
@@ -319,6 +436,8 @@ def run() -> list[str]:
     check_readme_japanese_first_links(errors)
     check_local_markdown_links(errors)
     check_documentation_map_paths(errors)
+    check_readme_regulated_action_and_disclaimer(errors)
+    check_forbidden_framework_overclaims(errors)
     check_extreme_markdown_compression(errors)
     return errors
 


### PR DESCRIPTION
### Motivation

- Ensure `README.md` (source-of-truth) and `README_JP.md` present the same product positioning and implementation facts for the Regulated Action Governance Kernel. 
- Make the distinction between `Authority Evidence` and `Audit Log` explicit in both languages so readers understand why audit logs alone do not permit commit. 
- Prevent future doc drift and overclaiming by adding automated checks that assert presence of required regulated-action terms, docs links, and disclaimers. 
- Preserve README.md wording as the canonical truth while updating README_JP.md to reflect the same facts, roadmap separation, and disclaimers (no legal/regulatory guarantees). 

### Description

- Updated `README.md` to mention the AML/KYC regulated-action fixture path and to add a concise clarification that `Authority Evidence` explains why an action was authorized at bind time while `Audit Log` records what happened. 
- Extended `README_JP.md` with a clear Regulated Action Governance Kernel section covering: `Action Class Contract`, `Authority Evidence`, `Runtime Authority Validation`, `Admissibility Predicate`, `Irreversible Commit Boundary`, `commit / block / escalate / refuse`, and the `AML/KYC customer risk escalation fixture`; added an explicit `Authority Evidence vs Audit Log` explanation, Fact vs Roadmap separation, and a five-item disclaimer in Japanese. 
- Synchronized README_JP quick links by adding English-canonical links for the regulated-action docs: `regulated-action-governance-kernel`, `authority-evidence-vs-audit-log`, `aml-kyc-regulated-action-path`, `regulated-action-governance-proof-pack`, and `regulated-action-governance-quality-gate`. 
- Enhanced `scripts/quality/check_bilingual_docs.py` with new guards: required regulated-action term lists for EN/JA, required disclaimer terms, required regulated-action doc links, and detection of forbidden overclaim phrases; wired these checks into `run()`. 

### Testing

- Ran `pytest -q tests/test_check_bilingual_docs.py` and received `3 passed` (bilingual docs checks passed). 
- Ran the checker directly with `python scripts/quality/check_bilingual_docs.py` which printed `[check-bilingual-docs] all checks passed`. 
- Ran `ruff` on the modified checker and tests with `ruff check scripts/quality/check_bilingual_docs.py tests/test_check_bilingual_docs.py` and the lint passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef110fa788326b429162f1a4911dd)