### PR TITLE
Clarify observable_digest_ref locator contract and isolate legacy fallback

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -591,7 +591,7 @@ components:
         observable_digest_ref:
           type: string
           default: separate_store://wat_observables
-          description: Separate-store digest reference prefix.
+          description: Reference/locator prefix for separate-store digest material (not digest payload content).
         retention_policy_version:
           type: string
           default: wat_retention_v1
@@ -1869,9 +1869,14 @@ components:
           type: string
         psid:
           type: string
+        observable_digest_ref:
+          type: string
+          nullable: true
+          description: Separate-store observable digest locator/reference.
         observable_digest:
           type: string
           nullable: true
+          description: Legacy transitional field; digest payloads are not treated as observable_digest_ref.
         ttl_seconds:
           type: integer
           minimum: 1
@@ -1893,9 +1898,14 @@ components:
         psid:
           type: string
           nullable: true
+        observable_digest_ref:
+          type: string
+          nullable: true
+          description: Separate-store observable digest locator/reference.
         observable_digest:
           type: string
           nullable: true
+          description: Legacy transitional field; digest payloads are not treated as observable_digest_ref.
         details:
           type: object
           additionalProperties: true

--- a/tests/test_wat_api.py
+++ b/tests/test_wat_api.py
@@ -44,13 +44,20 @@ def test_issue_shadow_success(monkeypatch, tmp_path: Path) -> None:
     response = client.post(
         "/v1/wat/issue-shadow",
         headers=_headers("k-operator"),
-        json={"psid": "psid-1", "observable_digest": "abc"},
+        json={
+            "psid": "psid-1",
+            "observable_digest_ref": "separate_store://digests/wat-api-1",
+        },
     )
 
     assert response.status_code == 200
     data = response.json()
     assert data["ok"] is True
     assert data["event"]["event_type"] == "wat_issued"
+    assert (
+        data["event"]["details"]["event_pointers"]["observable_digest_ref"]
+        == "separate_store://digests/wat-api-1"
+    )
 
 
 def test_validate_shadow_success(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_wat_observability_contract.py
+++ b/tests/test_wat_observability_contract.py
@@ -99,8 +99,9 @@ def test_retention_boundary_assertion_telemetry_recorded(monkeypatch, tmp_path: 
     )
 
     assertion = event["details"]["retention_boundary_assertion"]
-    assert assertion["outcome"] == "passed"
-    assert assertion["failed_reasons"] == []
+    assert assertion["outcome"] == "failed"
+    assert "observable_digest_ref_missing" in assertion["failed_reasons"]
+    assert "observable_digest_payload_not_accepted_as_ref" in assertion["failed_reasons"]
 
 
 def test_partial_validation_confirmation_failure_observable_in_logs_and_events(caplog) -> None:

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -138,7 +138,10 @@ class WatConfig(BaseModel):
     observable_digest_ref: str = Field(
         default="separate_store://wat_observables",
         max_length=500,
-        description="Reference prefix for separate full-observable digest storage.",
+        description=(
+            "Reference/locator prefix for separate-store observable digest material; "
+            "never an inline digest payload."
+        ),
     )
     retention_policy_version: str = Field(
         default="wat_retention_v1",

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -304,6 +304,15 @@ def _run_wat_shadow_observer(
     ttl = int(wat_cfg.get("default_ttl_seconds", 300))
     expiry_ts = now_ts + max(1, ttl)
     wat_id = f"wat_{uuid4().hex}"
+    observable_digest_ref_prefix = str(
+        wat_cfg.get("observable_digest_ref") or "separate_store://wat_observables"
+    ).strip()
+    normalized_observable_digest_ref_prefix = observable_digest_ref_prefix.rstrip("/")
+    observable_digest_ref = (
+        f"{normalized_observable_digest_ref_prefix}/{wat_id}"
+        if normalized_observable_digest_ref_prefix
+        else f"separate_store://wat_observables/{wat_id}"
+    )
 
     issue_event = persist_wat_issuance_event(
         wat_id=wat_id,
@@ -314,7 +323,7 @@ def _run_wat_shadow_observer(
             "psid": psid_full,
             "psid_display": psid_display,
             "action_digest": action_digest,
-            "observable_digest": aggregate_observable_digest,
+            "observable_digest_ref": observable_digest_ref,
             "observable_digest_list": observable_digest_list,
             "ttl_seconds": ttl,
         },

--- a/veritas_os/api/routes_wat.py
+++ b/veritas_os/api/routes_wat.py
@@ -28,6 +28,7 @@ class WatIssueShadowRequest(BaseModel):
 
     wat_id: Optional[str] = None
     psid: str = Field(min_length=1, max_length=500)
+    observable_digest_ref: Optional[str] = Field(default=None, max_length=500)
     observable_digest: Optional[str] = Field(default=None, max_length=500)
     ttl_seconds: int = Field(default=300, ge=1, le=86_400)
     metadata: Dict[str, Any] = Field(default_factory=dict)
@@ -39,6 +40,7 @@ class WatValidateShadowRequest(BaseModel):
     wat_id: str = Field(min_length=1, max_length=500)
     outcome_event: str = Field(default="wat_validated")
     psid: Optional[str] = Field(default=None, max_length=500)
+    observable_digest_ref: Optional[str] = Field(default=None, max_length=500)
     observable_digest: Optional[str] = Field(default=None, max_length=500)
     details: Dict[str, Any] = Field(default_factory=dict)
 
@@ -75,6 +77,7 @@ def issue_shadow_wat(body: WatIssueShadowRequest, request: Request) -> Dict[str,
         actor=_actor_from_request(request),
         details={
             "psid": body.psid,
+            "observable_digest_ref": body.observable_digest_ref,
             "observable_digest": body.observable_digest,
             "ttl_seconds": body.ttl_seconds,
             "metadata": body.metadata,
@@ -96,6 +99,7 @@ def validate_shadow_wat(body: WatValidateShadowRequest, request: Request) -> Dic
             actor=_actor_from_request(request),
             details={
                 "psid": body.psid,
+                "observable_digest_ref": body.observable_digest_ref,
                 "observable_digest": body.observable_digest,
                 "mode": "shadow",
                 **body.details,
@@ -117,6 +121,7 @@ def validate_shadow_wat(body: WatValidateShadowRequest, request: Request) -> Dic
         status=status,
         details={
             "psid": body.psid,
+            "observable_digest_ref": body.observable_digest_ref,
             "observable_digest": body.observable_digest,
             "mode": "shadow",
             **body.details,

--- a/veritas_os/audit/wat_events.py
+++ b/veritas_os/audit/wat_events.py
@@ -159,9 +159,19 @@ def _normalize_retention_boundary_details(
     pointers = raw.get("event_pointers")
     normalized_pointers: Dict[str, Any] = dict(pointers) if isinstance(pointers, dict) else {}
 
-    observable_digest_ref = str(
-        raw.get("observable_digest_ref") or raw.get("observable_digest") or ""
-    ).strip()
+    observable_digest_ref = str(raw.get("observable_digest_ref") or "").strip()
+    legacy_observable_digest = str(raw.get("observable_digest") or "").strip()
+    legacy_ref_adopted = False
+    if (
+        not observable_digest_ref
+        and legacy_observable_digest
+        and "://" in legacy_observable_digest
+    ):
+        # Transitional compatibility path:
+        # Older callers overloaded ``observable_digest`` for locator strings.
+        # We only adopt that legacy value when it looks like a reference.
+        observable_digest_ref = legacy_observable_digest
+        legacy_ref_adopted = True
     if observable_digest_ref:
         normalized_pointers["observable_digest_ref"] = observable_digest_ref
 
@@ -200,8 +210,12 @@ def _normalize_retention_boundary_details(
     assertion_failed_reasons: list[str] = []
     if normalized_retention["retention_enforced_at_write"] and not normalized_retention["retention_policy_version"]:
         assertion_failed_reasons.append("missing_retention_policy_version")
-    if raw.get("observable_digest") and not normalized_retention["observable_digest_ref"]:
+    if legacy_observable_digest and not normalized_retention["observable_digest_ref"]:
         assertion_failed_reasons.append("observable_digest_ref_missing")
+    if legacy_observable_digest and not legacy_ref_adopted:
+        assertion_failed_reasons.append("observable_digest_payload_not_accepted_as_ref")
+    if legacy_ref_adopted:
+        assertion_failed_reasons.append("legacy_observable_digest_ref_fallback_used")
     normalized_retention["retention_boundary_assertion"] = {
         "outcome": "passed" if not assertion_failed_reasons else "failed",
         "failed_reasons": assertion_failed_reasons,

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -286,6 +286,22 @@ def test_openapi_wat_config_includes_retention_boundary_fields() -> None:
         "restricted",
         "privileged",
     ]
+    assert "Reference/locator" in wat_props["observable_digest_ref"]["description"]
+
+
+def test_openapi_wat_shadow_requests_define_observable_digest_ref_contract() -> None:
+    """WAT shadow request schemas should expose locator-first digest linkage."""
+    spec = _load_openapi_spec()
+    issue_props = spec["components"]["schemas"]["WatIssueShadowRequest"]["properties"]
+    validate_props = spec["components"]["schemas"]["WatValidateShadowRequest"]["properties"]
+
+    assert "observable_digest_ref" in issue_props
+    assert "locator/reference" in issue_props["observable_digest_ref"]["description"]
+    assert "Legacy transitional field" in issue_props["observable_digest"]["description"]
+
+    assert "observable_digest_ref" in validate_props
+    assert "locator/reference" in validate_props["observable_digest_ref"]["description"]
+    assert "Legacy transitional field" in validate_props["observable_digest"]["description"]
 
 
 def test_openapi_wat_operator_summary_and_governance_defaults_locked() -> None:

--- a/veritas_os/tests/test_wat_events.py
+++ b/veritas_os/tests/test_wat_events.py
@@ -47,7 +47,7 @@ def test_primary_audit_path_stores_metadata_and_pointers_only(tmp_path: Path) ->
         details={
             "psid": "psid-1",
             "metadata": {"request_id": "rid-1"},
-            "observable_digest": "digest-ref-001",
+            "observable_digest_ref": "separate_store://digests/wat-boundary-1",
             "observable_digest_payload": {"raw": "must-not-persist"},
         },
         path=path,
@@ -56,8 +56,46 @@ def test_primary_audit_path_stores_metadata_and_pointers_only(tmp_path: Path) ->
     details = event["details"]
     assert "metadata" in details
     assert "event_pointers" in details
-    assert details["event_pointers"]["observable_digest_ref"] == "digest-ref-001"
+    assert (
+        details["event_pointers"]["observable_digest_ref"]
+        == "separate_store://digests/wat-boundary-1"
+    )
     assert "observable_digest_payload" not in details
+
+
+def test_observable_digest_payload_not_accepted_as_ref(tmp_path: Path) -> None:
+    path = tmp_path / "wat_events.jsonl"
+    event = persist_wat_issuance_event(
+        wat_id="wat-boundary-legacy-1",
+        actor="test",
+        details={
+            "observable_digest": "sha256:deadbeef",
+        },
+        path=path,
+    )
+
+    assertion = event["details"]["retention_boundary_assertion"]
+    assert assertion["outcome"] == "failed"
+    assert "observable_digest_payload_not_accepted_as_ref" in assertion["failed_reasons"]
+
+
+def test_legacy_locator_fallback_is_transitional_and_flagged(tmp_path: Path) -> None:
+    path = tmp_path / "wat_events.jsonl"
+    event = persist_wat_issuance_event(
+        wat_id="wat-boundary-legacy-2",
+        actor="test",
+        details={
+            "observable_digest": "separate_store://digests/wat-boundary-legacy-2",
+        },
+        path=path,
+    )
+
+    assertion = event["details"]["retention_boundary_assertion"]
+    assert event["details"]["event_pointers"]["observable_digest_ref"].startswith(
+        "separate_store://digests/"
+    )
+    assert assertion["outcome"] == "failed"
+    assert "legacy_observable_digest_ref_fallback_used" in assertion["failed_reasons"]
 
 
 def test_retention_policy_version_immutable_after_enforcement(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent mixing a separate-store locator with an inline digest payload by making the meaning of `observable_digest_ref` explicit as a reference/locator string. 
- Tighten retention-boundary behavior so the primary audit path stays lean (metadata + pointers) and does not silently accept payload values as refs. 
- Preserve verification flows while isolating any unavoidable compatibility fallback as a transitional, auditable behavior.

### Description
- Normalized retention-boundary normalization in `veritas_os/audit/wat_events.py` to prefer `observable_digest_ref` and to treat `observable_digest` as a payload only; a legacy fallback will adopt `observable_digest` as a ref only when it resembles a locator (contains `://`) and that fallback is explicitly flagged in `retention_boundary_assertion`.
- Tightened assertion reporting: added explicit failed reasons such as `observable_digest_ref_missing`, `observable_digest_payload_not_accepted_as_ref`, and `legacy_observable_digest_ref_fallback_used` to make contract violations visible.
- Emitted pointer-style refs from the decide shadow issuance path by constructing `observable_digest_ref` (configured prefix + `wat_id`) in `veritas_os/api/routes_decide.py` so audit events store locators rather than overloading digest payload fields.
- Exposed a locator-first API contract: added `observable_digest_ref` fields to request models and documented `observable_digest` as a legacy/transitional field in `veritas_os/api/routes_wat.py`, `veritas_os/api/governance.py`, and `openapi.yaml`.
- Tests and docs updated to reflect and lock the new contract; changed files: `veritas_os/audit/wat_events.py`, `veritas_os/api/routes_decide.py`, `veritas_os/api/routes_wat.py`, `veritas_os/api/governance.py`, `openapi.yaml`, and tests `veritas_os/tests/test_wat_events.py`, `tests/test_wat_observability_contract.py`, `tests/test_wat_api.py`, `veritas_os/tests/test_openapi_spec.py`.
- Compatibility behavior retained but narrowed: legacy `observable_digest` -> `observable_digest_ref` promotion is allowed only when the value looks like a locator, and the promotion is recorded as transitional in assertions.
- Security note: `observable_digest_ref` remains caller-supplied text; downstream dereferencing must enforce scheme/host allowlists and access controls to avoid unsafe reference injection or exfiltration.

### Testing
- Updated and added unit tests to validate the contract: pointer-only storage in the primary audit path, payload-not-ref rejection, legacy-locator fallback flagging, and OpenAPI schema/documentation changes; modified/added tests include `veritas_os/tests/test_wat_events.py`, `tests/test_wat_observability_contract.py`, `tests/test_wat_api.py`, and `veritas_os/tests/test_openapi_spec.py`.
- Ran targeted test suite: `pytest -q veritas_os/tests/test_wat_events.py tests/test_wat_observability_contract.py veritas_os/tests/test_openapi_spec.py tests/test_wat_api.py` and all tests passed (`36 passed`).
- Compatibility: verification paths that consume digest payloads were preserved (no change to WAT claims/verification logic), and the fallback behavior is isolated and covered by tests as transitional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef48ee1db88326928c5bcf184c6716)