### PR TITLE
Clarify auto_escalate_confirmed_revocations as schema-only in v1

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -673,9 +673,11 @@ components:
         revocation_confirmation_required:
           type: boolean
           default: true
+          description: Confirmed revocation state changes always require explicit confirmation in v1 runtime.
         auto_escalate_confirmed_revocations:
           type: boolean
           default: false
+          description: Schema-only v1 placeholder; accepted for forward-compatibility but intentionally ignored by runtime handlers.
     DriftScoringConfig:
       type: object
       description: ドリフト評価スコア重み

--- a/tests/test_wat_api.py
+++ b/tests/test_wat_api.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from veritas_os.api import routes_wat
 from veritas_os.api.server import app
 from veritas_os.audit import wat_events
 
@@ -170,6 +171,44 @@ def test_revoke_confirmed_requires_explicit_confirmation(monkeypatch, tmp_path: 
     data = response.json()
     assert data["pending"]["event_type"] == "wat_revocation_pending"
     assert data["confirmed"] is None
+
+
+def test_revoke_auto_escalate_policy_flag_is_schema_only_in_v1(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Runtime must ignore auto_escalate_confirmed_revocations in v1."""
+    _configure_auth(monkeypatch)
+    _configure_wat_store(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        routes_wat,
+        "get_policy",
+        lambda: {"revocation": {"auto_escalate_confirmed_revocations": True}},
+    )
+    client = TestClient(app)
+
+    issue = client.post(
+        "/v1/wat/issue-shadow",
+        headers=_headers("k-operator"),
+        json={"psid": "psid-r3"},
+    ).json()
+
+    response = client.post(
+        f"/v1/wat/revocation/{issue['wat_id']}",
+        headers=_headers("k-operator"),
+        json={"confirmed": True, "reason": "manual"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pending"]["event_type"] == "wat_revocation_pending"
+    assert data["confirmed"] is None
+    assert (
+        routes_wat._auto_escalate_confirmed_revocations_runtime_active(
+            {"revocation": {"auto_escalate_confirmed_revocations": True}}
+        )
+        is False
+    )
 
 
 def test_auth_rbac_read_vs_mutation(monkeypatch, tmp_path: Path) -> None:

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -188,8 +188,21 @@ class RevocationConfig(BaseModel):
     alert_target_seconds: int = Field(default=30, ge=1, le=86_400)
     convergence_target_p95_seconds: int = Field(default=60, ge=1, le=86_400)
     degrade_on_pending: bool = True
-    revocation_confirmation_required: bool = True
-    auto_escalate_confirmed_revocations: bool = False
+    revocation_confirmation_required: bool = Field(
+        default=True,
+        description=(
+            "Requires explicit confirmation phrase for confirmed revocation state "
+            "changes. Runtime behavior is always enforced in v1."
+        ),
+    )
+    auto_escalate_confirmed_revocations: bool = Field(
+        default=False,
+        description=(
+            "Schema-only v1 placeholder. Accepted and persisted for policy "
+            "forward-compatibility, but intentionally ignored by runtime "
+            "decision/revocation handlers."
+        ),
+    )
 
 
 class DriftScoringConfig(BaseModel):

--- a/veritas_os/api/routes_wat.py
+++ b/veritas_os/api/routes_wat.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from veritas_os.api.auth import require_permission
+from veritas_os.api.governance import get_policy
 from veritas_os.api.rbac import Permission
 from veritas_os.audit.wat_events import (
     SUPPORTED_WAT_EVENT_TYPES,
@@ -63,6 +64,25 @@ def _actor_from_request(request: Request) -> str:
     if isinstance(role, str) and role.strip():
         return f"api:{role.strip()}"
     return "api:unknown"
+
+
+def _auto_escalate_confirmed_revocations_runtime_active(policy: Dict[str, Any]) -> bool:
+    """Return v1 runtime activation state for auto escalation.
+
+    Security warning:
+        In v1 this policy flag is intentionally schema-only and MUST NOT
+        auto-transition any revocation to confirmed state. Explicit operator
+        confirmation remains mandatory for confirmed transitions.
+    """
+    revocation_cfg = policy.get("revocation")
+    configured = False
+    if isinstance(revocation_cfg, dict):
+        configured = bool(revocation_cfg.get("auto_escalate_confirmed_revocations", False))
+    if configured:
+        # Intentional no-op for v1 boundary lock-in; we retain visibility that
+        # the field was set while preserving explicit confirmation semantics.
+        return False
+    return False
 
 
 @router.post(
@@ -170,11 +190,23 @@ def get_wat_by_id(wat_id: str) -> Dict[str, Any]:
 def revoke_wat(wat_id: str, body: WatRevocationRequest, request: Request) -> Dict[str, Any]:
     """Persist shadow revocation events (pending + optional confirmed)."""
     actor = _actor_from_request(request)
+    try:
+        policy = get_policy()
+    except Exception:
+        policy = {}
+    if not isinstance(policy, dict):
+        policy = {}
+    auto_escalation_runtime_active = _auto_escalate_confirmed_revocations_runtime_active(policy)
     pending = persist_wat_revocation_event(
         wat_id=wat_id,
         actor=actor,
         confirmed=False,
-        details={"mode": "shadow", "reason": body.reason, **body.details},
+        details={
+            "mode": "shadow",
+            "reason": body.reason,
+            "auto_escalation_runtime_active": auto_escalation_runtime_active,
+            **body.details,
+        },
     )
 
     confirmed_event: Optional[Dict[str, Any]] = None
@@ -184,7 +216,12 @@ def revoke_wat(wat_id: str, body: WatRevocationRequest, request: Request) -> Dic
             wat_id=wat_id,
             actor=actor,
             confirmed=True,
-            details={"mode": "shadow", "reason": body.reason, **body.details},
+            details={
+                "mode": "shadow",
+                "reason": body.reason,
+                "auto_escalation_runtime_active": auto_escalation_runtime_active,
+                **body.details,
+            },
         )
 
     return {

--- a/veritas_os/tests/test_openapi_spec.py
+++ b/veritas_os/tests/test_openapi_spec.py
@@ -327,6 +327,8 @@ def test_openapi_wat_operator_summary_and_governance_defaults_locked() -> None:
     assert revocation_props["mode"]["enum"] == ["bounded_eventual_consistency"]
     assert revocation_props["revocation_confirmation_required"]["default"] is True
     assert revocation_props["auto_escalate_confirmed_revocations"]["default"] is False
+    assert "always require explicit confirmation" in revocation_props["revocation_confirmation_required"]["description"]
+    assert "Schema-only v1 placeholder" in revocation_props["auto_escalate_confirmed_revocations"]["description"]
 
     policy_props = spec["components"]["schemas"]["GovernancePolicy"]["properties"]
     assert policy_props["operator_verbosity"]["default"] == "minimal"


### PR DESCRIPTION
### Motivation
- The meaning of `revocation.auto_escalate_confirmed_revocations` in governance was ambiguous between schema and runtime semantics, risking accidental runtime behavior changes.  I chose Direction A: make it schema-only for v1 so runtime behavior remains strict and unambiguous. 
- Preserve existing safety: confirmed revocations must still require an explicit confirmation phrase (`CONFIRM_REVOKED_CONFIRMED`) and runtime must not auto-confirm revocations in v1. 
- Security warning: avoid allowing configuration to silently promote a `revoked_pending` to `revoked_confirmed` without explicit human confirmation; this PR locks that down in code and docs.

### Description
- Marked `RevocationConfig.auto_escalate_confirmed_revocations` as a schema-only, forward-compatibility field with an explicit description in `veritas_os/api/governance.py`. 
- Updated `openapi.yaml` to include clear descriptions: `revocation_confirmation_required` is explicitly enforced in v1, and `auto_escalate_confirmed_revocations` is documented as schema-only and ignored by v1 runtime. 
- Added a small runtime helper in `veritas_os/api/routes_wat.py` (`_auto_escalate_confirmed_revocations_runtime_active`) that documents and enforces the v1 decision to ignore the auto-escalation flag, and threads an `auto_escalation_runtime_active` boolean into persisted revocation event details (always `False` in v1). 
- Preserved existing explicit confirmation flow in the WAT revocation endpoint (`/v1/wat/revocation/{wat_id}`) and left the operator-facing surface unchanged. 
- Tests and docstrings added/updated; code comments explain the v1 lock-in and security rationale. All edits follow PEP8 formatting.

Changed files:
- `veritas_os/api/governance.py` (schema Field descriptions)
- `openapi.yaml` (OpenAPI descriptions)
- `veritas_os/api/routes_wat.py` (runtime helper + event detail field)
- `tests/test_wat_api.py` (new test asserting schema-only behavior)
- `veritas_os/tests/test_openapi_spec.py` (assert descriptions present)

### Testing
- Added test `test_revoke_auto_escalate_policy_flag_is_schema_only_in_v1` in `tests/test_wat_api.py` which asserts runtime ignores the `auto_escalate_confirmed_revocations` flag; the test passed. 
- Ran existing `test_revoke_confirmed_requires_explicit_confirmation` (ensures confirmed revocation still requires explicit confirmation) and it passed. 
- Ran `veritas_os/tests/test_openapi_spec.py::test_openapi_wat_operator_summary_and_governance_defaults_locked` to assert the OpenAPI docs contain the new descriptions and defaults; it passed. 
- Command used (subset): `pytest -q tests/test_wat_api.py::test_revoke_confirmed_requires_explicit_confirmation tests/test_wat_api.py::test_revoke_auto_escalate_policy_flag_is_schema_only_in_v1 veritas_os/tests/test_openapi_spec.py::test_openapi_wat_operator_summary_and_governance_defaults_locked` and all three tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef56f89ab88326ab133484a2dfa4e4)