### PR TITLE
docs: add WAT v1 tightening trade-offs memo

### DIFF
--- a/docs/en/validation/implemented-vs-pending-boundary.md
+++ b/docs/en/validation/implemented-vs-pending-boundary.md
@@ -32,4 +32,5 @@
 - [Decision Semantics Contract](../architecture/decision-semantics.md)
 - [Required Evidence Taxonomy](../governance/required-evidence-taxonomy.md)
 - [External Audit Readiness](external-audit-readiness.md)
+- [WAT v1 Tightening Trade-offs](wat-v1-tightening-trade-offs.md)
 - [AML/KYC Pilot Checklist](../guides/aml-kyc-pilot-checklist.md)

--- a/docs/en/validation/wat-v1-tightening-trade-offs.md
+++ b/docs/en/validation/wat-v1-tightening-trade-offs.md
@@ -1,0 +1,36 @@
+# WAT v1 Tightening Pass: Engineering Trade-offs
+
+**Purpose:** Capture intentional trade-offs introduced by tightening the WAT v1 boundary so operators and implementers understand expected friction and complexity.
+
+## Boundary-tightening trade-offs
+
+1. **Explicit confirmation for confirmed revocation increases operator friction**
+   - Tightening requires an explicit confirmation step after a confirmed revocation signal before boundary crossing.
+   - Consequence: slower operator flow and extra click/ack overhead in edge-path incidents.
+   - Why accepted: it reduces silent continuation risk on stale or ambiguous authority state.
+
+2. **Lean primary audit path increases dependence on drill-down linkage**
+   - v1 keeps the default audit path intentionally compact.
+   - Consequence: deep verification relies more on drill-down navigation and separate-store linkage correctness.
+   - Why accepted: keeps the top-level contract stable and reviewable while preserving depth off-path.
+
+3. **Minimal default summary reduces immediate detail for operators**
+   - The default summary returns only the fields required by the boundary contract.
+   - Consequence: frontline operators may need an extra fetch to see full adjudication context.
+   - Why accepted: minimizes accidental coupling between UI convenience fields and contract-critical semantics.
+
+4. **Stronger retention separation introduces verification indirection**
+   - Retention-critical records are separated more strictly from operator-facing summaries.
+   - Consequence: verification and incident reconstruction involve more pointer-following across stores.
+   - Why accepted: clearer data-lifecycle boundaries and lower risk of summary-path retention leakage.
+
+5. **Expanded observability behind the contract increases engineering complexity**
+   - Tightening pushes richer diagnostics behind the stable boundary contract rather than into default UI payloads.
+   - Consequence: additional instrumentation, correlation IDs, and internal schema/version management for engineering teams.
+   - Why accepted: observability can evolve without repeatedly reopening the v1 operator contract.
+
+## Implementation guidance
+
+- Treat these costs as **intentional consequences of boundary discipline**, not regressions.
+- Optimize with tooling (better drill-down UX, correlation helpers, runbook shortcuts) without weakening the v1 contract.
+- When proposing exceptions, require an explicit statement of which boundary guarantee would be relaxed.


### PR DESCRIPTION
### Motivation

- Surface intentional UX and engineering trade-offs introduced by tightening the WAT v1 boundary so operators and implementers understand expected friction and complexity. 
- Respond to the explicit request to surface places where tightening introduces operator-facing and implementation-facing costs (e.g., revocation confirmation, audit path, retention separation).

### Description

- Add a short engineering-facing memo at `docs/en/validation/wat-v1-tightening-trade-offs.md` with sections `Boundary-tightening trade-offs` and `Implementation guidance` describing five concrete trade-offs. 
- Link the new memo from the validation boundary index by updating `docs/en/validation/implemented-vs-pending-boundary.md` under `Evidence pointers` for discoverability.
- The change is documentation-only and does not modify runtime behavior or contracts.

### Testing

- No automated tests were required because this is a documentation-only change. 
- Repository updates were verified by inspecting the created file `docs/en/validation/wat-v1-tightening-trade-offs.md` and confirming the link was added in `docs/en/validation/implemented-vs-pending-boundary.md` via repository diff and commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef68c424108326ab3a078909ca3fe8)