### PR TITLE
Lock v1 WAT boundary: `observable_digest_ref` as locator; revocation flag schema-only

### DIFF
--- a/tests/test_wat_api.py
+++ b/tests/test_wat_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from veritas_os.api import routes_wat
@@ -173,9 +174,11 @@ def test_revoke_confirmed_requires_explicit_confirmation(monkeypatch, tmp_path: 
     assert data["confirmed"] is None
 
 
+@pytest.mark.parametrize("auto_escalate_flag", [False, True])
 def test_revoke_auto_escalate_policy_flag_is_schema_only_in_v1(
     monkeypatch,
     tmp_path: Path,
+    auto_escalate_flag: bool,
 ) -> None:
     """Runtime must ignore auto_escalate_confirmed_revocations in v1."""
     _configure_auth(monkeypatch)
@@ -183,7 +186,7 @@ def test_revoke_auto_escalate_policy_flag_is_schema_only_in_v1(
     monkeypatch.setattr(
         routes_wat,
         "get_policy",
-        lambda: {"revocation": {"auto_escalate_confirmed_revocations": True}},
+        lambda: {"revocation": {"auto_escalate_confirmed_revocations": auto_escalate_flag}},
     )
     client = TestClient(app)
 
@@ -205,7 +208,7 @@ def test_revoke_auto_escalate_policy_flag_is_schema_only_in_v1(
     assert data["confirmed"] is None
     assert (
         routes_wat._auto_escalate_confirmed_revocations_runtime_active(
-            {"revocation": {"auto_escalate_confirmed_revocations": True}}
+            {"revocation": {"auto_escalate_confirmed_revocations": auto_escalate_flag}}
         )
         is False
     )

--- a/veritas_os/api/routes_wat.py
+++ b/veritas_os/api/routes_wat.py
@@ -29,8 +29,19 @@ class WatIssueShadowRequest(BaseModel):
 
     wat_id: Optional[str] = None
     psid: str = Field(min_length=1, max_length=500)
-    observable_digest_ref: Optional[str] = Field(default=None, max_length=500)
-    observable_digest: Optional[str] = Field(default=None, max_length=500)
+    observable_digest_ref: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Separate-store observable digest locator/reference.",
+    )
+    observable_digest: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description=(
+            "Legacy transitional field. v1 canonical contract is "
+            "observable_digest_ref locator/reference."
+        ),
+    )
     ttl_seconds: int = Field(default=300, ge=1, le=86_400)
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
@@ -41,8 +52,19 @@ class WatValidateShadowRequest(BaseModel):
     wat_id: str = Field(min_length=1, max_length=500)
     outcome_event: str = Field(default="wat_validated")
     psid: Optional[str] = Field(default=None, max_length=500)
-    observable_digest_ref: Optional[str] = Field(default=None, max_length=500)
-    observable_digest: Optional[str] = Field(default=None, max_length=500)
+    observable_digest_ref: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Separate-store observable digest locator/reference.",
+    )
+    observable_digest: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description=(
+            "Legacy transitional field. v1 canonical contract is "
+            "observable_digest_ref locator/reference."
+        ),
+    )
     details: Dict[str, Any] = Field(default_factory=dict)
 
 

--- a/veritas_os/audit/wat_events.py
+++ b/veritas_os/audit/wat_events.py
@@ -47,6 +47,37 @@ _ALLOWED_OBSERVABLE_DIGEST_ACCESS_CLASSES: frozenset[str] = frozenset({
 })
 
 
+def _looks_like_locator(value: str) -> bool:
+    """Return ``True`` only for values that look like external locators."""
+    return "://" in value
+
+
+def _resolve_observable_digest_ref(raw: Dict[str, Any]) -> tuple[str, list[str]]:
+    """Resolve ``observable_digest_ref`` as locator-first with v1-safe fallback.
+
+    Contract lock-in for v1:
+    - canonical ``observable_digest_ref`` is a separate-store locator/reference.
+    - digest payload text is never accepted as canonical reference content.
+    """
+    failed_reasons: list[str] = []
+    observable_digest_ref = str(raw.get("observable_digest_ref") or "").strip()
+    legacy_observable_digest = str(raw.get("observable_digest") or "").strip()
+
+    if observable_digest_ref and not _looks_like_locator(observable_digest_ref):
+        failed_reasons.append("observable_digest_ref_not_locator")
+        observable_digest_ref = ""
+
+    if not observable_digest_ref and legacy_observable_digest:
+        if _looks_like_locator(legacy_observable_digest):
+            failed_reasons.append("legacy_observable_digest_ref_fallback_used")
+            observable_digest_ref = legacy_observable_digest
+        else:
+            failed_reasons.append("observable_digest_ref_missing")
+            failed_reasons.append("observable_digest_payload_not_accepted_as_ref")
+
+    return observable_digest_ref, failed_reasons
+
+
 def _utc_now_iso_z() -> str:
     """Return current UTC timestamp in RFC3339-like ``Z`` format."""
     return format_event_ts_utc()
@@ -159,19 +190,7 @@ def _normalize_retention_boundary_details(
     pointers = raw.get("event_pointers")
     normalized_pointers: Dict[str, Any] = dict(pointers) if isinstance(pointers, dict) else {}
 
-    observable_digest_ref = str(raw.get("observable_digest_ref") or "").strip()
-    legacy_observable_digest = str(raw.get("observable_digest") or "").strip()
-    legacy_ref_adopted = False
-    if (
-        not observable_digest_ref
-        and legacy_observable_digest
-        and "://" in legacy_observable_digest
-    ):
-        # Transitional compatibility path:
-        # Older callers overloaded ``observable_digest`` for locator strings.
-        # We only adopt that legacy value when it looks like a reference.
-        observable_digest_ref = legacy_observable_digest
-        legacy_ref_adopted = True
+    observable_digest_ref, observable_ref_failed_reasons = _resolve_observable_digest_ref(raw)
     if observable_digest_ref:
         normalized_pointers["observable_digest_ref"] = observable_digest_ref
 
@@ -207,15 +226,9 @@ def _normalize_retention_boundary_details(
         ).strip(),
         "retention_enforced_at_write": bool(raw.get("retention_enforced_at_write", True)),
     }
-    assertion_failed_reasons: list[str] = []
+    assertion_failed_reasons: list[str] = list(observable_ref_failed_reasons)
     if normalized_retention["retention_enforced_at_write"] and not normalized_retention["retention_policy_version"]:
         assertion_failed_reasons.append("missing_retention_policy_version")
-    if legacy_observable_digest and not normalized_retention["observable_digest_ref"]:
-        assertion_failed_reasons.append("observable_digest_ref_missing")
-    if legacy_observable_digest and not legacy_ref_adopted:
-        assertion_failed_reasons.append("observable_digest_payload_not_accepted_as_ref")
-    if legacy_ref_adopted:
-        assertion_failed_reasons.append("legacy_observable_digest_ref_fallback_used")
     normalized_retention["retention_boundary_assertion"] = {
         "outcome": "passed" if not assertion_failed_reasons else "failed",
         "failed_reasons": assertion_failed_reasons,

--- a/veritas_os/tests/test_wat_events.py
+++ b/veritas_os/tests/test_wat_events.py
@@ -79,6 +79,24 @@ def test_observable_digest_payload_not_accepted_as_ref(tmp_path: Path) -> None:
     assert "observable_digest_payload_not_accepted_as_ref" in assertion["failed_reasons"]
 
 
+def test_observable_digest_ref_must_be_locator_not_payload(tmp_path: Path) -> None:
+    path = tmp_path / "wat_events.jsonl"
+    event = persist_wat_issuance_event(
+        wat_id="wat-boundary-legacy-3",
+        actor="test",
+        details={
+            "observable_digest_ref": "sha256:deadbeef",
+        },
+        path=path,
+    )
+
+    assertion = event["details"]["retention_boundary_assertion"]
+    pointers = event["details"]["event_pointers"]
+    assert "observable_digest_ref" not in pointers
+    assert assertion["outcome"] == "failed"
+    assert "observable_digest_ref_not_locator" in assertion["failed_reasons"]
+
+
 def test_legacy_locator_fallback_is_transitional_and_flagged(tmp_path: Path) -> None:
     path = tmp_path / "wat_events.jsonl"
     event = persist_wat_issuance_event(


### PR DESCRIPTION
### Motivation
- Remove ambiguity around `observable_digest_ref` so v1 treats it unambiguously as a separate-store locator/reference and never as inline digest payload.  
- Make `auto_escalate_confirmed_revocations` explicitly a schema-only placeholder for v1 so runtime behavior cannot be misinterpreted as an active auto-escalation switch.  
- Preserve a minimal, well-scoped backward-compatibility bridge for legacy locator strings while clearly flagging any transitional acceptance to avoid silently widening the contract.  
- Keep the operator-facing surface unchanged (`operator_verbosity=minimal` and WAT summary shape unchanged).  

### Description
- Introduced `_looks_like_locator` and `_resolve_observable_digest_ref` in `veritas_os/audit/wat_events.py` to centralize and enforce a locator-first contract for `observable_digest_ref`, and added docstring commentary explaining the v1 lock-in.  
- Reworked the retention-normalization path in `veritas_os/audit/wat_events.py` to reject payload-like values as canonical refs, to preserve the lean primary audit path, and to append explicit `retention_boundary_assertion` failure reasons for any fallback or misuse.  
- Clarified Pydantic request model field descriptions in `veritas_os/api/routes_wat.py` so `observable_digest_ref` is described as a separate-store locator/reference and `observable_digest` is labeled as a legacy/transitional field.  
- Kept the `auto_escalate_confirmed_revocations` runtime gate in `veritas_os/api/routes_wat.py` as an intentional no-op for v1, with an explicit security-minded docstring explaining the schema-only status.  
- Added a negative test asserting `observable_digest_ref` must look like a locator and will be rejected if it appears to be a payload, and parameterized the revocation flag test so both `True` and `False` policy values demonstrate the runtime ignores the flag in v1.  
- Files changed: `veritas_os/audit/wat_events.py`, `veritas_os/api/routes_wat.py`, `veritas_os/tests/test_wat_events.py`, `tests/test_wat_api.py`.

### Testing
- Ran targeted test subset: `pytest -q veritas_os/tests/test_wat_events.py tests/test_wat_api.py veritas_os/tests/test_openapi_spec.py -k "wat or openapi_wat"` and observed `22 passed, 12 deselected`, indicating the new assertions and schema descriptions are validated.  
- Automated tests added/updated: new `test_observable_digest_ref_must_be_locator_not_payload` in `veritas_os/tests/test_wat_events.py` and parameterized `test_revoke_auto_escalate_policy_flag_is_schema_only_in_v1` in `tests/test_wat_api.py`, both passing.  
- No changes to operator-facing summary shape or default verbosity were introduced and relevant OpenAPI schema checks remain green in the exercised spec tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef97408fdc8326b4269283f8dfe23d)