### PR TITLE
Add first-class pre-bind ParticipationSignal schema (additive, backward-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ It is the governance layer from **decision adjudication through bind-time bounda
 it determines whether an AI decision may proceed and whether an approved decision
 can be committed, blocked, escalated, rolled back, or fail safely at bind time before
 real-world effect.
+It now also exposes an additive pre-bind schema surface for participation
+admissibility signals without changing the existing bind-time commitment contract.
 
 ### What problem it solves
 
@@ -102,6 +104,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
 - **Current fact (bind outcome public contract):** Governance bind responses expose legacy flat bind fields (`bind_outcome`, `bind_failure_reason`, `bind_reason_code`, `execution_intent_id`, `bind_receipt_id`) and additive `bind_summary` objects as a shared compact bind vocabulary.
 - **Current fact (bind coverage registry):** VERITAS maintains a tested bind coverage registry for API effect paths. Effect-bearing routes must be classified as `bind_governed` or explicitly documented as `audited_exemption` with reason/risk metadata, reducing the risk that recorded decisions are treated as execution permission without a binding artifact.
 - **Current fact (bind artifact family):** `BindReceipt` is persisted as a full governance artifact and carries canonical target metadata as part of the artifact contract.
+- **Current fact (pre-bind participation schema):** `/v1/decide` supports an optional additive `participation_signal` object as an upstream signal family (`participation_signal -> decision -> execution_intent -> bind_receipt`) for participation admissibility; bind-time commitment admissibility remains unchanged.
 - **Current fact (replay/operator flow):** Operator surfaces expose bind artifacts via list/export/detail endpoints (`/v1/governance/bind-receipts`, `/v1/governance/bind-receipts/export`, `/v1/governance/bind-receipts/{bind_receipt_id}`), with mutation/export responses reusing `bind_summary` for triage and audit workflows.
 - **Current fact (boundary):** Production readiness still depends on environment-specific hardening, integration, and operational controls.
 - **Roadmap / future direction:** Bind-boundary policy surface is expected to expand to more effect paths and become a broader standardization framework for multi-path effect governance; this is direction, not a claim of full completion today.
@@ -170,6 +173,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
 - **Decision Semantics Contract**: [`docs/en/architecture/decision-semantics.md`](docs/en/architecture/decision-semantics.md)
 - **Bind-Boundary Governance Artifacts**: [`docs/en/architecture/bind-boundary-governance-artifacts.md`](docs/en/architecture/bind-boundary-governance-artifacts.md)
 - **Bind-Time Admissibility Evaluator**: [`docs/en/architecture/bind_time_admissibility_evaluator.md`](docs/en/architecture/bind_time_admissibility_evaluator.md)
+- **Pre-Bind Participation Signals**: [`docs/en/architecture/pre-bind-participation-signals.md`](docs/en/architecture/pre-bind-participation-signals.md)
 - **Regulated Action Governance Kernel**: [`docs/en/architecture/regulated-action-governance-kernel.md`](docs/en/architecture/regulated-action-governance-kernel.md)
 - **Authority Evidence vs Audit Log**: [`docs/en/architecture/authority-evidence-vs-audit-log.md`](docs/en/architecture/authority-evidence-vs-audit-log.md)
 - **AML/KYC Regulated Action Path (Use Case)**: [`docs/en/use-cases/aml-kyc-regulated-action-path.md`](docs/en/use-cases/aml-kyc-regulated-action-path.md)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -52,6 +52,7 @@ For the bilingual correspondence table, see [../DOCUMENTATION_MAP.md](../DOCUMEN
 - [Decision Semantics Contract](architecture/decision-semantics.md)
 - [Bind-Boundary Governance Artifacts](architecture/bind-boundary-governance-artifacts.md)
 - [Bind-Time Admissibility Evaluator](architecture/bind_time_admissibility_evaluator.md)
+- [Pre-Bind Participation Signals](architecture/pre-bind-participation-signals.md)
 - [Regulated Action Governance Kernel](architecture/regulated-action-governance-kernel.md)
 - [Authority Evidence vs Audit Log](architecture/authority-evidence-vs-audit-log.md)
 - [Required Evidence Taxonomy v0](governance/required-evidence-taxonomy.md)

--- a/docs/en/architecture/bind-boundary-governance-artifacts.md
+++ b/docs/en/architecture/bind-boundary-governance-artifacts.md
@@ -63,6 +63,17 @@ Not guaranteed by this document alone:
 This keeps decision artifacts primary while extending native VERITAS governance
 lineage toward bind-boundary control.
 
+## Participation vs commitment admissibility
+
+Bind artifacts govern **admissibility of commitment** at the bind boundary.
+The additive pre-bind `participation_signal` family governs
+**admissibility of participation** during decision formation.
+
+The two layers are intentionally separate and composable:
+
+- participation layer (upstream): governability signals before commit
+- bind layer (boundary): commitment adjudication before real-world effect
+
 
 ## Companion summary vocabulary (`bind_summary`)
 

--- a/docs/en/architecture/pre-bind-participation-signals.md
+++ b/docs/en/architecture/pre-bind-participation-signals.md
@@ -1,0 +1,57 @@
+# Pre-Bind Participation Signals (First-Class Schema)
+
+This document defines the additive **participation admissibility** schema layer
+introduced upstream of the existing bind boundary.
+
+## Positioning
+
+VERITAS currently governs commitment at bind time via:
+
+`decision -> execution_intent -> bind_receipt`
+
+This remains unchanged.
+
+The participation layer is an upstream signal family:
+
+`participation_signal -> decision -> execution_intent -> bind_receipt`
+
+It does **not** replace bind governance and does not grant execution permission.
+
+## Admissibility distinction
+
+- **Admissibility of participation:** whether decision formation remains
+  governable before commitment (pre-bind).
+- **Admissibility of commitment:** whether an execution intent may cross the
+  bind boundary and commit real-world effect.
+
+These are intentionally separate contracts.
+
+## Schema vocabulary (frozen for this layer)
+
+`ParticipationSignal` carries:
+
+- `interpretation_space_narrowing`: `open|narrowing|constrained|closed`
+- `counterfactual_availability`: `high|medium|low|none`
+- `intervention_headroom`: `high|medium|low|none`
+- `structural_openness`: `open|partially_open|fragile|closed`
+- `participation_admissibility`: `admissible|review_required|inadmissible|unknown`
+
+The signal family name is fixed as `participation_signal`.
+
+## Current integration scope
+
+- `DecideResponse.participation_signal` is optional and additive.
+- Existing bind family contracts (`ExecutionIntent`, `BindReceipt`,
+  `BindSummary`, flat bind compatibility fields) remain backward-compatible.
+- Runtime behavior is unchanged unless producers explicitly attach a
+  `participation_signal` payload.
+
+## Why this shape
+
+The schema is intentionally minimal but first-class so future PRs can add:
+
+- pre-bind detection scoring
+- preservation safeguards
+- operator-facing detection timelines
+
+without redefining public vocabulary or breaking existing bind contracts.

--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -578,6 +578,26 @@ export interface BindOperatorSummary {
   operator_verbosity: "minimal" | "expanded";
 }
 
+/**
+ * Pre-bind participation admissibility signal.
+ *
+ * This is an additive upstream schema and does not replace bind-time
+ * commitment admissibility artifacts.
+ */
+export interface ParticipationSignal {
+  participation_signal_id: string;
+  signal_family: "participation_signal";
+  interpretation_space_narrowing: "open" | "narrowing" | "constrained" | "closed";
+  counterfactual_availability: "high" | "medium" | "low" | "none";
+  intervention_headroom: "high" | "medium" | "low" | "none";
+  structural_openness: "open" | "partially_open" | "fragile" | "closed";
+  participation_admissibility: "admissible" | "review_required" | "inadmissible" | "unknown";
+  rationale?: string | null;
+  evidence_refs?: string[];
+  observation_ts?: string | null;
+  [key: string]: unknown;
+}
+
 export interface DecideResponse extends DecideResponseMeta {
   /* ------------------------------------------------------------------ */
   /* Core decision contract fields                                      */
@@ -682,6 +702,8 @@ export interface DecideResponse extends DecideResponseMeta {
   bind_operator_summary?: BindOperatorSummary | null;
   /** Expanded bind drill-down data for permitted roles at expanded verbosity. */
   bind_operator_detail?: Record<string, unknown> | null;
+  /** Optional upstream participation admissibility signal (pre-bind). */
+  participation_signal?: ParticipationSignal | null;
 
   /**
    * Continuation runtime output (shadow/observe — phase-1).
@@ -757,7 +779,8 @@ export function isDecideResponse(value: unknown): value is DecideResponse {
     (value.wat_operator_summary === null || value.wat_operator_summary === undefined || isRecord(value.wat_operator_summary)) &&
     (value.wat_operator_detail === null || value.wat_operator_detail === undefined || isRecord(value.wat_operator_detail)) &&
     (value.bind_operator_summary === null || value.bind_operator_summary === undefined || isRecord(value.bind_operator_summary)) &&
-    (value.bind_operator_detail === null || value.bind_operator_detail === undefined || isRecord(value.bind_operator_detail))
+    (value.bind_operator_detail === null || value.bind_operator_detail === undefined || isRecord(value.bind_operator_detail)) &&
+    (value.participation_signal === null || value.participation_signal === undefined || isRecord(value.participation_signal))
   );
 }
 

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -22,6 +22,10 @@ from veritas_os.core.decision_semantics import (
     unique_preserve_order,
     validate_gate_business_combination,
 )
+from veritas_os.core.participation_semantics import (
+    PARTICIPATION_SIGNAL_FAMILY,
+    normalize_participation_signal_payload,
+)
 
 # =========================
 # Input Length Constraints (Security)
@@ -74,6 +78,21 @@ ActionabilityStatusLiteral = Literal[
     "actionable_after_bind",
     "blocked",
     "human_review_required",
+]
+InterpretationSpaceNarrowingLiteral = Literal[
+    "open",
+    "narrowing",
+    "constrained",
+    "closed",
+]
+CounterfactualAvailabilityLiteral = Literal["high", "medium", "low", "none"]
+InterventionHeadroomLiteral = Literal["high", "medium", "low", "none"]
+StructuralOpennessLiteral = Literal["open", "partially_open", "fragile", "closed"]
+ParticipationAdmissibilityLiteral = Literal[
+    "admissible",
+    "review_required",
+    "inadmissible",
+    "unknown",
 ]
 
 logger = logging.getLogger(__name__)
@@ -445,6 +464,47 @@ class BindSummary(BaseModel):
     refusal_basis: Optional[List[str]] = None
     escalation_basis: Optional[List[str]] = None
     irreversibility_boundary_id: Optional[str] = Field(default=None, max_length=MAX_ID_LENGTH)
+
+
+class ParticipationSignal(BaseModel):
+    """Upstream participation admissibility signal (pre-bind, additive).
+
+    This schema models whether decision formation remains governable before the
+    system reaches commitment admissibility at the bind boundary.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    participation_signal_id: str = Field(
+        default_factory=lambda: uuid4().hex,
+        max_length=MAX_ID_LENGTH,
+    )
+    signal_family: Literal["participation_signal"] = PARTICIPATION_SIGNAL_FAMILY
+    interpretation_space_narrowing: InterpretationSpaceNarrowingLiteral = "open"
+    counterfactual_availability: CounterfactualAvailabilityLiteral = "medium"
+    intervention_headroom: InterventionHeadroomLiteral = "medium"
+    structural_openness: StructuralOpennessLiteral = "open"
+    participation_admissibility: ParticipationAdmissibilityLiteral = "unknown"
+    rationale: Optional[str] = Field(default=None, max_length=MAX_DESCRIPTION_LENGTH)
+    evidence_refs: List[str] = Field(default_factory=list, max_length=MAX_LIST_ITEMS)
+    observation_ts: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _normalize_levels(self) -> "ParticipationSignal":
+        normalized = normalize_participation_signal_payload(self.model_dump())
+        self.signal_family = PARTICIPATION_SIGNAL_FAMILY
+        self.interpretation_space_narrowing = normalized[
+            "interpretation_space_narrowing"
+        ]
+        self.counterfactual_availability = normalized[
+            "counterfactual_availability"
+        ]
+        self.intervention_headroom = normalized["intervention_headroom"]
+        self.structural_openness = normalized["structural_openness"]
+        self.participation_admissibility = normalized[
+            "participation_admissibility"
+        ]
+        return self
 
 
 # =========================
@@ -930,6 +990,14 @@ class DecideResponse(BaseModel):
     bind_summary: Optional[BindSummary] = Field(
         default=None,
         description="Compact bind summary object; additive companion to flat bind compatibility fields.",
+    )
+    participation_signal: Optional[ParticipationSignal] = Field(
+        default=None,
+        description=(
+            "Optional pre-bind participation admissibility signal. "
+            "This is additive to bind-time commitment admissibility fields and "
+            "does not replace bind artifacts."
+        ),
     )
     wat_integrity: Optional[Dict[str, Any]] = Field(
         default=None,

--- a/veritas_os/core/participation_semantics.py
+++ b/veritas_os/core/participation_semantics.py
@@ -1,0 +1,87 @@
+"""Pre-bind participation admissibility vocabulary and normalization helpers.
+
+This module defines the first-class schema vocabulary for upstream
+``participation_signal`` artifacts. It is intentionally additive and does not
+modify bind-time commitment admissibility semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+PARTICIPATION_SIGNAL_FAMILY = "participation_signal"
+
+INTERPRETATION_SPACE_NARROWING_VALUES: tuple[str, ...] = (
+    "open",
+    "narrowing",
+    "constrained",
+    "closed",
+)
+COUNTERFACTUAL_AVAILABILITY_VALUES: tuple[str, ...] = (
+    "high",
+    "medium",
+    "low",
+    "none",
+)
+INTERVENTION_HEADROOM_VALUES: tuple[str, ...] = (
+    "high",
+    "medium",
+    "low",
+    "none",
+)
+STRUCTURAL_OPENNESS_VALUES: tuple[str, ...] = (
+    "open",
+    "partially_open",
+    "fragile",
+    "closed",
+)
+PARTICIPATION_ADMISSIBILITY_VALUES: tuple[str, ...] = (
+    "admissible",
+    "review_required",
+    "inadmissible",
+    "unknown",
+)
+
+
+def _canonicalize_level(value: Any, *, allowed: tuple[str, ...], fallback: str) -> str:
+    """Normalize level-like values to lowercase and clamp to known vocabulary."""
+    normalized = str(value or "").strip().lower()
+    if normalized in allowed:
+        return normalized
+    return fallback
+
+
+def normalize_participation_signal_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return normalized payload using fixed participation vocabulary.
+
+    Unknown values are normalized to conservative compatibility defaults so this
+    additive surface remains fail-soft for partial upstream producers.
+    """
+    normalized = dict(payload)
+    normalized["signal_family"] = PARTICIPATION_SIGNAL_FAMILY
+    normalized["interpretation_space_narrowing"] = _canonicalize_level(
+        payload.get("interpretation_space_narrowing"),
+        allowed=INTERPRETATION_SPACE_NARROWING_VALUES,
+        fallback="open",
+    )
+    normalized["counterfactual_availability"] = _canonicalize_level(
+        payload.get("counterfactual_availability"),
+        allowed=COUNTERFACTUAL_AVAILABILITY_VALUES,
+        fallback="medium",
+    )
+    normalized["intervention_headroom"] = _canonicalize_level(
+        payload.get("intervention_headroom"),
+        allowed=INTERVENTION_HEADROOM_VALUES,
+        fallback="medium",
+    )
+    normalized["structural_openness"] = _canonicalize_level(
+        payload.get("structural_openness"),
+        allowed=STRUCTURAL_OPENNESS_VALUES,
+        fallback="open",
+    )
+    normalized["participation_admissibility"] = _canonicalize_level(
+        payload.get("participation_admissibility"),
+        allowed=PARTICIPATION_ADMISSIBILITY_VALUES,
+        fallback="unknown",
+    )
+    return normalized

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -849,6 +849,7 @@ def _build_response_layers(
         "version": os.getenv("VERITAS_API_VERSION", "veritas-api 1.x"),
         "decision_status": ctx.decision_status,
         "rejection_reason": ctx.rejection_reason,
+        "participation_signal": ctx.response_extras.get("participation_signal"),
     }
     core.update(_derive_business_fields(ctx))
 

--- a/veritas_os/tests/test_participation_signal_schema.py
+++ b/veritas_os/tests/test_participation_signal_schema.py
@@ -1,0 +1,98 @@
+"""Schema tests for additive pre-bind participation signals."""
+
+from __future__ import annotations
+
+from veritas_os.api.schemas import DecideResponse
+from veritas_os.api.schemas import ParticipationSignal
+from veritas_os.core.pipeline.pipeline_response import assemble_response
+from veritas_os.core.pipeline.pipeline_types import PipelineContext
+
+
+def test_participation_signal_serialization_roundtrip() -> None:
+    """ParticipationSignal should serialize/deserialize with canonical vocabulary."""
+    signal = ParticipationSignal(
+        interpretation_space_narrowing="narrowing",
+        counterfactual_availability="high",
+        intervention_headroom="medium",
+        structural_openness="partially_open",
+        participation_admissibility="review_required",
+        evidence_refs=["ev-1"],
+    )
+    payload = signal.model_dump()
+    restored = ParticipationSignal.model_validate(payload)
+
+    assert restored.signal_family == "participation_signal"
+    assert restored.interpretation_space_narrowing == "narrowing"
+    assert restored.counterfactual_availability == "high"
+    assert restored.evidence_refs == ["ev-1"]
+
+
+def test_participation_signal_is_optional_and_additive_on_decide_response() -> None:
+    """Existing DecideResponse contract remains valid without participation signal."""
+    legacy = DecideResponse(request_id="req-legacy")
+    assert legacy.participation_signal is None
+    assert legacy.bind_summary is None
+
+    enriched = DecideResponse(
+        request_id="req-enriched",
+        participation_signal={
+            "interpretation_space_narrowing": "constrained",
+            "counterfactual_availability": "low",
+            "intervention_headroom": "low",
+            "structural_openness": "fragile",
+            "participation_admissibility": "review_required",
+        },
+    )
+    assert enriched.participation_signal is not None
+    assert enriched.participation_signal.signal_family == "participation_signal"
+
+
+def test_participation_signal_schema_name_integrity() -> None:
+    """Schema should keep explicit first-class naming and not generic signal labels."""
+    signal = ParticipationSignal()
+    dumped = signal.model_dump()
+    assert "participation_signal_id" in dumped
+    assert dumped["signal_family"] == "participation_signal"
+    assert "interpretation_space_narrowing" in dumped
+    assert "counterfactual_availability" in dumped
+    assert "intervention_headroom" in dumped
+    assert "structural_openness" in dumped
+
+
+def test_pipeline_response_accepts_optional_participation_signal_hook() -> None:
+    """Response assembly should pass through additive participation signal hook."""
+    ctx = PipelineContext(
+        request_id="req-hook",
+        query="test",
+        response_extras={
+            "participation_signal": {
+                "interpretation_space_narrowing": "open",
+                "counterfactual_availability": "medium",
+                "intervention_headroom": "medium",
+                "structural_openness": "open",
+                "participation_admissibility": "admissible",
+            }
+        },
+    )
+
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+    assert "participation_signal" in payload
+    assert payload["participation_signal"]["participation_admissibility"] == "admissible"
+
+
+def test_bind_contract_fields_remain_unchanged_with_participation_signal() -> None:
+    """Additive participation signal must not mutate existing bind contract fields."""
+    resp = DecideResponse(
+        request_id="req-bind-compat",
+        bind_outcome="BLOCKED",
+        bind_reason_code="CONSTRAINT_MISMATCH",
+        bind_failure_reason="constraint mismatch",
+        participation_signal={"participation_admissibility": "unknown"},
+    )
+    assert resp.bind_outcome == "BLOCKED"
+    assert resp.bind_reason_code == "CONSTRAINT_MISMATCH"
+    assert resp.bind_failure_reason == "constraint mismatch"


### PR DESCRIPTION
### Motivation
- Introduce a minimal, first-class participation admissibility layer upstream of bind-time governance to enable future pre-bind detection and preservation without changing bind-time commitment semantics.
- Fix vocabulary and schema for participation signals so the repository has a stable contract for `interpretation_space_narrowing`, `counterfactual_availability`, `intervention_headroom`, `structural_openness`, and `participation_admissibility`.
- Keep the change strictly additive and backward-compatible so existing `decision / execution_intent / bind_receipt / bind_summary` public contracts are preserved.
- Security note: new upstream signals may carry untrusted producer data; authorization, signature, and audit boundaries must be defined before enabling producers to write these fields in production.

### Description
- Added `veritas_os/core/participation_semantics.py` implementing the fixed vocabulary and `normalize_participation_signal_payload` helper for conservative canonicalization of participation signal values.
- Introduced `ParticipationSignal` Pydantic model into `veritas_os/api/schemas.py` and an optional `DecideResponse.participation_signal` field; preserved all existing bind-related fields and validation behavior.
- Added a lightweight integration hook in `veritas_os/core/pipeline/pipeline_response.py` to pass through an optional `ctx.response_extras["participation_signal"]` into the assembled response without changing runtime decision or bind logic.
- Synchronized TypeScript types in `packages/types/src/decision.ts` with a `ParticipationSignal` interface and `DecideResponse.participation_signal?` entry.
- Documentation: new architecture doc `docs/en/architecture/pre-bind-participation-signals.md`, plus README/docs index and `bind-boundary-governance-artifacts.md` updates clarifying the separation between "admissibility of participation" (pre-bind) and "admissibility of commitment" (bind).
- Tests: added `veritas_os/tests/test_participation_signal_schema.py` covering serialization/deserialization, optional/additive behavior, naming integrity, response hook pass-through, and bind-contract non-regression.

### Testing
- Run targeted pytest: `pytest -q veritas_os/tests/test_participation_signal_schema.py veritas_os/tests/test_bind_artifacts.py::test_backward_compatibility_existing_decide_response_unchanged veritas_os/tests/unit/test_pipeline_response_public_decision_fields.py::test_assemble_response_includes_public_decision_semantics` — result: all tests passed (7 passed, 0 failed).
- Static checks: `python -m ruff check veritas_os/core/participation_semantics.py veritas_os/api/schemas.py veritas_os/core/pipeline/pipeline_response.py veritas_os/tests/test_participation_signal_schema.py` — result: no issues reported.
- The changes are intentionally schema-only and additive; no behavioral bind-time changes were introduced and existing public responses remain valid when `participation_signal` is absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efae7fa6748326bfeeaeb62704b70d)