### PR TITLE
Refactor /v1/decide governance: separate route, evaluators, and operator assembly

### DIFF
--- a/docs/en/architecture/pre-bind-participation-signals.md
+++ b/docs/en/architecture/pre-bind-participation-signals.md
@@ -102,3 +102,23 @@ The schema is intentionally minimal but first-class so future PRs can add:
 - operator-facing detection timelines
 
 without redefining public vocabulary or breaking existing bind contracts.
+
+## Internal composition boundaries (non-breaking refactor)
+
+To keep future governance layers reviewable without changing public contracts,
+`/v1/decide` now follows a contract-centered split:
+
+- **Route orchestration:** `veritas_os.api.routes_decide`
+  - receives request, delegates orchestration, returns response.
+- **Operator/public assembly:** `veritas_os.api.decide_operator_assembly`
+  - assembles bind/WAT operator summary/detail and canonical drift vocabulary.
+- **Pre-bind evaluators:**
+  - detection: `veritas_os.core.participation_detection`
+  - preservation: `veritas_os.core.preservation_evaluator`
+- **Evaluation-to-assembly adapter:** `veritas_os.core.pipeline.governance_layers`
+  - computes typed governance snapshot and maps it into additive
+    `DecideResponse` fields.
+
+This split keeps `decision`, `execution_intent`, `bind_receipt`, and
+`bind_summary` contracts stable while making additional governance layers easier
+to add without route bloat.

--- a/veritas_os/api/decide_operator_assembly.py
+++ b/veritas_os/api/decide_operator_assembly.py
@@ -1,0 +1,168 @@
+"""Operator-facing governance assembly helpers for /v1/decide."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+from veritas_os.audit.wat_events import format_event_ts_utc
+
+OPERATOR_VERBOSITY_MINIMAL = "minimal"
+OPERATOR_VERBOSITY_EXPANDED = "expanded"
+DEFAULT_EXPANDED_ROLES: set[str] = {"admin"}
+
+
+def normalize_wat_drift_vector(raw_vector: Any) -> Dict[str, float]:
+    """Normalize WAT drift vector keys for the public DecideResponse contract."""
+    if not isinstance(raw_vector, dict):
+        raw_vector = {}
+    key_map = {
+        "policy": "policy",
+        "policy_drift": "policy",
+        "signature": "signature",
+        "signature_drift": "signature",
+        "observable": "observable",
+        "observable_drift": "observable",
+        "temporal": "temporal",
+        "temporal_drift": "temporal",
+    }
+    normalized: Dict[str, float] = {}
+    for source_key, target_key in key_map.items():
+        if target_key in normalized:
+            continue
+        value = raw_vector.get(source_key)
+        if isinstance(value, (int, float)):
+            normalized[target_key] = float(value)
+    for key in ("policy", "signature", "observable", "temporal"):
+        normalized.setdefault(key, 0.0)
+    return normalized
+
+
+def resolve_operator_verbosity(value: Any) -> str:
+    """Resolve canonical operator verbosity with minimal-default safety."""
+    verbosity = str(value or OPERATOR_VERBOSITY_MINIMAL)
+    if verbosity not in {OPERATOR_VERBOSITY_MINIMAL, OPERATOR_VERBOSITY_EXPANDED}:
+        return OPERATOR_VERBOSITY_MINIMAL
+    return verbosity
+
+
+def build_operator_surface(
+    *,
+    summary: Dict[str, Any],
+    detail: Optional[Dict[str, Any]],
+    operator_verbosity: str,
+    role: str,
+    expanded_roles: set[str],
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Build minimal-default operator surface with role-gated expanded detail."""
+    effective_verbosity = (
+        OPERATOR_VERBOSITY_EXPANDED
+        if operator_verbosity == OPERATOR_VERBOSITY_EXPANDED and role in expanded_roles
+        else OPERATOR_VERBOSITY_MINIMAL
+    )
+    summary["operator_verbosity"] = effective_verbosity
+    if effective_verbosity == OPERATOR_VERBOSITY_EXPANDED and isinstance(detail, dict):
+        return summary, detail
+    return summary, None
+
+
+def attach_wat_contract_fields(payload: Dict[str, Any], wat_shadow: Dict[str, Any]) -> None:
+    """Attach additive canonical WAT fields + operator summary/detail."""
+    integrity_state = (
+        "healthy" if str(wat_shadow.get("validation_status")) == "valid" else "warning"
+    )
+    if str(wat_shadow.get("admissibility_state")) in {"non_admissible", "blocked"}:
+        integrity_state = "critical"
+    payload["wat_integrity"] = {
+        "integrity_state": integrity_state,
+        "wat_id": wat_shadow.get("wat_id"),
+        "psid_display": wat_shadow.get("psid_display"),
+        "validation_status": wat_shadow.get("validation_status"),
+        "admissibility_state": wat_shadow.get("admissibility_state"),
+        "replay_status": wat_shadow.get("replay_status"),
+        "revocation_status": wat_shadow.get("revocation_status"),
+        "action_summary": "observer_only_validation",
+    }
+    payload["wat_drift_vector"] = normalize_wat_drift_vector(wat_shadow.get("drift_vector"))
+    verifier_output_raw = wat_shadow.get("verifier_output_raw")
+    expanded_verifier_output_raw = dict(verifier_output_raw) if isinstance(verifier_output_raw, dict) else {}
+    if isinstance(wat_shadow.get("event_lane_details"), dict):
+        expanded_verifier_output_raw["event_lane_details"] = dict(
+            wat_shadow["event_lane_details"]
+        )
+    summary, detail = build_operator_surface(
+        summary={
+            "integrity_severity": integrity_state,
+            "affected_lanes": list(wat_shadow.get("affected_lanes") or ["wat_shadow"]),
+            "event_ts": format_event_ts_utc(
+                wat_shadow.get("event_ts") or wat_shadow.get("ts")
+            ),
+            "correlation_id": str(
+                wat_shadow.get("correlation_id")
+                or payload.get("request_id")
+                or wat_shadow.get("wat_id")
+                or ""
+            ),
+            "warning_context": str(wat_shadow.get("warning_context") or ""),
+            "warning_correlation_id": str(
+                wat_shadow.get("warning_correlation_id")
+                or wat_shadow.get("correlation_id")
+                or payload.get("request_id")
+                or wat_shadow.get("wat_id")
+                or ""
+            ),
+        },
+        detail={
+            "drift_vector": normalize_wat_drift_vector(wat_shadow.get("drift_vector")),
+            "verifier_output_raw": expanded_verifier_output_raw,
+            "historical_drift_trend": wat_shadow.get("historical_drift_trend"),
+        },
+        operator_verbosity=resolve_operator_verbosity(wat_shadow.get("operator_verbosity")),
+        role="admin",
+        expanded_roles=DEFAULT_EXPANDED_ROLES,
+    )
+    payload["wat_operator_summary"] = summary
+    if detail is not None:
+        payload["wat_operator_detail"] = detail
+
+
+def attach_bind_operator_surface(
+    *,
+    payload: Dict[str, Any],
+    policy: Dict[str, Any],
+    role: str,
+) -> None:
+    """Attach reusable minimal/expanded operator surface for bind governance."""
+    bind_summary = payload.get("bind_summary")
+    if not isinstance(bind_summary, dict):
+        return
+    operator_verbosity = resolve_operator_verbosity(policy.get("operator_verbosity"))
+    bind_outcome = str(payload.get("bind_outcome") or bind_summary.get("outcome") or "")
+    summary, detail = build_operator_surface(
+        summary={
+            "bind_state": bind_outcome.lower() or "unknown",
+            "bind_outcome": bind_outcome,
+            "bind_reason_code": str(
+                payload.get("bind_reason_code") or bind_summary.get("reason_code") or ""
+            ),
+            "bind_receipt_id": str(
+                payload.get("bind_receipt_id") or bind_summary.get("bind_receipt_id") or ""
+            ),
+            "execution_intent_id": str(
+                payload.get("execution_intent_id")
+                or bind_summary.get("execution_intent_id")
+                or ""
+            ),
+        },
+        detail={
+            "authority_check_result": payload.get("authority_check_result"),
+            "constraint_check_result": payload.get("constraint_check_result"),
+            "drift_check_result": payload.get("drift_check_result"),
+            "risk_check_result": payload.get("risk_check_result"),
+        },
+        operator_verbosity=operator_verbosity,
+        role=role,
+        expanded_roles=DEFAULT_EXPANDED_ROLES,
+    )
+    payload["bind_operator_summary"] = summary
+    if detail is not None:
+        payload["bind_operator_detail"] = detail

--- a/veritas_os/api/routes_decide.py
+++ b/veritas_os/api/routes_decide.py
@@ -12,7 +12,7 @@ import hashlib
 import logging
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Request
@@ -55,6 +55,10 @@ from veritas_os.api.utils import (
 )
 from veritas_os.api.constants import DECISION_REJECTED
 from veritas_os.api import decide_service as _svc
+from veritas_os.api.decide_operator_assembly import (
+    attach_bind_operator_surface as _attach_bind_operator_surface,
+    attach_wat_contract_fields as _attach_wat_contract_fields,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +83,14 @@ def _get_server():
     """Late import to avoid circular dependency at module load time."""
     from veritas_os.api import server as srv
     return srv
+
+
+def _resolve_operator_role(request: Request) -> str:
+    """Resolve request RBAC role for operator-facing detail controls."""
+    role = getattr(getattr(request, "state", None), "rbac_role", None)
+    if isinstance(role, str) and role.strip():
+        return role.strip().lower()
+    return "admin"
 
 
 def _resolve_candidate_action(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -490,166 +502,8 @@ def _run_wat_shadow_observer(
     return summary
 
 
-def _normalize_wat_drift_vector(raw_vector: Any) -> Dict[str, float]:
-    """Normalize WAT drift vector keys for the public DecideResponse contract.
-
-    Canonical public keys are ``policy``, ``signature``, ``observable``,
-    and ``temporal``. Legacy backend keys (``*_drift``) are accepted and
-    mapped additively to preserve compatibility with existing producers.
-    """
-    if not isinstance(raw_vector, dict):
-        raw_vector = {}
-    key_map = {
-        "policy": "policy",
-        "policy_drift": "policy",
-        "signature": "signature",
-        "signature_drift": "signature",
-        "observable": "observable",
-        "observable_drift": "observable",
-        "temporal": "temporal",
-        "temporal_drift": "temporal",
-    }
-    normalized: Dict[str, float] = {}
-    for source_key, target_key in key_map.items():
-        if target_key in normalized:
-            continue
-        value = raw_vector.get(source_key)
-        if isinstance(value, (int, float)):
-            normalized[target_key] = float(value)
-    for key in ("policy", "signature", "observable", "temporal"):
-        normalized.setdefault(key, 0.0)
-    return normalized
 
 
-def _resolve_operator_verbosity(value: Any) -> str:
-    """Resolve canonical operator verbosity with minimal-default safety."""
-    verbosity = str(value or "minimal")
-    if verbosity not in {"minimal", "expanded"}:
-        return "minimal"
-    return verbosity
-
-
-def _resolve_operator_role(request: Request) -> str:
-    """Resolve request RBAC role for operator-facing detail controls."""
-    role = getattr(getattr(request, "state", None), "rbac_role", None)
-    if isinstance(role, str) and role.strip():
-        return role.strip().lower()
-    return "admin"
-
-
-def _build_operator_surface(
-    *,
-    summary: Dict[str, Any],
-    detail: Optional[Dict[str, Any]],
-    operator_verbosity: str,
-    role: str,
-    expanded_roles: set[str],
-) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
-    """Build minimal-default operator surface with role-gated expanded detail."""
-    effective_verbosity = "expanded" if operator_verbosity == "expanded" and role in expanded_roles else "minimal"
-    summary["operator_verbosity"] = effective_verbosity
-    if effective_verbosity == "expanded" and isinstance(detail, dict):
-        return summary, detail
-    return summary, None
-
-
-def _attach_wat_contract_fields(payload: Dict[str, Any], wat_shadow: Dict[str, Any]) -> None:
-    """Attach additive canonical WAT fields to decide payload.
-
-    This keeps legacy ``meta["wat_shadow"]`` intact while promoting stable,
-    frontend-consumable top-level fields.
-    """
-    integrity_state = "healthy" if str(wat_shadow.get("validation_status")) == "valid" else "warning"
-    if str(wat_shadow.get("admissibility_state")) in {"non_admissible", "blocked"}:
-        integrity_state = "critical"
-    payload["wat_integrity"] = {
-        "integrity_state": integrity_state,
-        "wat_id": wat_shadow.get("wat_id"),
-        "psid_display": wat_shadow.get("psid_display"),
-        "validation_status": wat_shadow.get("validation_status"),
-        "admissibility_state": wat_shadow.get("admissibility_state"),
-        "replay_status": wat_shadow.get("replay_status"),
-        "revocation_status": wat_shadow.get("revocation_status"),
-        "action_summary": "observer_only_validation",
-    }
-    payload["wat_drift_vector"] = _normalize_wat_drift_vector(wat_shadow.get("drift_vector"))
-    verifier_output_raw = wat_shadow.get("verifier_output_raw")
-    if isinstance(verifier_output_raw, dict):
-        expanded_verifier_output_raw = dict(verifier_output_raw)
-    else:
-        expanded_verifier_output_raw = {}
-    if isinstance(wat_shadow.get("event_lane_details"), dict):
-        expanded_verifier_output_raw["event_lane_details"] = dict(
-            wat_shadow["event_lane_details"]
-        )
-    operator_verbosity = _resolve_operator_verbosity(wat_shadow.get("operator_verbosity"))
-    summary, detail = _build_operator_surface(
-        summary={
-        # v1 lock-in: intentionally minimal operator-facing default surface.
-            "integrity_severity": integrity_state,
-            "affected_lanes": list(wat_shadow.get("affected_lanes") or ["wat_shadow"]),
-            "event_ts": format_event_ts_utc(wat_shadow.get("event_ts") or wat_shadow.get("ts")),
-            "correlation_id": str(
-                wat_shadow.get("correlation_id") or payload.get("request_id") or wat_shadow.get("wat_id") or ""
-            ),
-            "warning_context": str(wat_shadow.get("warning_context") or ""),
-            "warning_correlation_id": str(
-                wat_shadow.get("warning_correlation_id")
-                or wat_shadow.get("correlation_id")
-                or payload.get("request_id")
-                or wat_shadow.get("wat_id")
-                or ""
-            ),
-        },
-        detail={
-            "drift_vector": _normalize_wat_drift_vector(wat_shadow.get("drift_vector")),
-            "verifier_output_raw": expanded_verifier_output_raw,
-            "historical_drift_trend": wat_shadow.get("historical_drift_trend"),
-        },
-        operator_verbosity=operator_verbosity,
-        role="admin",
-        expanded_roles={"admin"},
-    )
-    payload["wat_operator_summary"] = summary
-    if detail is not None:
-        payload["wat_operator_detail"] = detail
-
-
-def _attach_bind_operator_surface(
-    *,
-    payload: Dict[str, Any],
-    policy: Dict[str, Any],
-    role: str,
-) -> None:
-    """Attach reusable minimal/expanded operator surface for bind governance."""
-    bind_summary = payload.get("bind_summary")
-    if not isinstance(bind_summary, dict):
-        return
-    operator_verbosity = _resolve_operator_verbosity(policy.get("operator_verbosity"))
-    bind_outcome = str(payload.get("bind_outcome") or bind_summary.get("outcome") or "")
-    summary, detail = _build_operator_surface(
-        summary={
-            "bind_state": bind_outcome.lower() or "unknown",
-            "bind_outcome": bind_outcome,
-            "bind_reason_code": str(payload.get("bind_reason_code") or bind_summary.get("reason_code") or ""),
-            "bind_receipt_id": str(payload.get("bind_receipt_id") or bind_summary.get("bind_receipt_id") or ""),
-            "execution_intent_id": str(
-                payload.get("execution_intent_id") or bind_summary.get("execution_intent_id") or ""
-            ),
-        },
-        detail={
-            "authority_check_result": payload.get("authority_check_result"),
-            "constraint_check_result": payload.get("constraint_check_result"),
-            "drift_check_result": payload.get("drift_check_result"),
-            "risk_check_result": payload.get("risk_check_result"),
-        },
-        operator_verbosity=operator_verbosity,
-        role=role,
-        expanded_roles={"admin"},
-    )
-    payload["bind_operator_summary"] = summary
-    if detail is not None:
-        payload["bind_operator_detail"] = detail
 
 
 # ------------------------------------------------------------------

--- a/veritas_os/core/pipeline/governance_layers.py
+++ b/veritas_os/core/pipeline/governance_layers.py
@@ -1,0 +1,73 @@
+"""Governance layer evaluation/assembly helpers for decide response payloads.
+
+This module keeps pre-bind governance concerns separated by responsibility:
+- evaluation: participation detection + preservation evaluation
+- assembly: stable public response field mapping
+
+It preserves the existing public DecideResponse contract shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from veritas_os.core.participation_detection import (
+    evaluate_pre_bind_structural_detection,
+)
+from veritas_os.core.preservation_evaluator import evaluate_pre_bind_preservation
+
+
+@dataclass(frozen=True)
+class GovernanceEvaluationSnapshot:
+    """Typed snapshot bridging evaluators and response assembly."""
+
+    participation_signal: Dict[str, Any] | None
+    pre_bind_detection: Dict[str, Any]
+    pre_bind_preservation: Dict[str, Any]
+
+
+def evaluate_governance_layers(
+    *,
+    participation_signal: Any,
+) -> GovernanceEvaluationSnapshot:
+    """Run pre-bind governance evaluators and return a typed snapshot."""
+    normalized_signal = participation_signal if isinstance(participation_signal, dict) else None
+    if normalized_signal is None:
+        return GovernanceEvaluationSnapshot(
+            participation_signal=None,
+            pre_bind_detection={},
+            pre_bind_preservation={},
+        )
+
+    detection = evaluate_pre_bind_structural_detection(normalized_signal)
+    preservation = evaluate_pre_bind_preservation(
+        normalized_signal,
+        pre_bind_detection_summary=detection.get("pre_bind_detection_summary"),
+    )
+    return GovernanceEvaluationSnapshot(
+        participation_signal=normalized_signal,
+        pre_bind_detection=detection,
+        pre_bind_preservation=preservation,
+    )
+
+
+def assemble_governance_public_fields(
+    snapshot: GovernanceEvaluationSnapshot,
+) -> Dict[str, Any]:
+    """Assemble additive public governance fields from evaluator snapshot."""
+    return {
+        "participation_signal": snapshot.participation_signal,
+        "pre_bind_detection_summary": snapshot.pre_bind_detection.get(
+            "pre_bind_detection_summary"
+        ),
+        "pre_bind_detection_detail": snapshot.pre_bind_detection.get(
+            "pre_bind_detection_detail"
+        ),
+        "pre_bind_preservation_summary": snapshot.pre_bind_preservation.get(
+            "pre_bind_preservation_summary"
+        ),
+        "pre_bind_preservation_detail": snapshot.pre_bind_preservation.get(
+            "pre_bind_preservation_detail"
+        ),
+    }

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -30,10 +30,10 @@ from veritas_os.core.decision_semantics import (
     unique_preserve_order,
     validate_gate_business_combination,
 )
-from veritas_os.core.participation_detection import (
-    evaluate_pre_bind_structural_detection,
+from veritas_os.core.pipeline.governance_layers import (
+    assemble_governance_public_fields,
+    evaluate_governance_layers,
 )
-from veritas_os.core.preservation_evaluator import evaluate_pre_bind_preservation
 from veritas_os.observability.metrics import record_required_evidence_telemetry
 
 logger = logging.getLogger(__name__)
@@ -829,17 +829,9 @@ def _build_response_layers(
 
     Layering is documentation-oriented: callers still receive one flat dict.
     """
-    participation_signal = ctx.response_extras.get("participation_signal")
-    pre_bind_detection: Dict[str, Any] = {}
-    pre_bind_preservation: Dict[str, Any] = {}
-    if isinstance(participation_signal, dict):
-        pre_bind_detection = evaluate_pre_bind_structural_detection(participation_signal)
-        pre_bind_preservation = evaluate_pre_bind_preservation(
-            participation_signal,
-            pre_bind_detection_summary=pre_bind_detection.get(
-                "pre_bind_detection_summary"
-            ),
-        )
+    governance_snapshot = evaluate_governance_layers(
+        participation_signal=ctx.response_extras.get("participation_signal")
+    )
 
     core = {
         "ok": True,
@@ -865,20 +857,8 @@ def _build_response_layers(
         "version": os.getenv("VERITAS_API_VERSION", "veritas-api 1.x"),
         "decision_status": ctx.decision_status,
         "rejection_reason": ctx.rejection_reason,
-        "participation_signal": participation_signal,
-        "pre_bind_detection_summary": pre_bind_detection.get(
-            "pre_bind_detection_summary"
-        ),
-        "pre_bind_detection_detail": pre_bind_detection.get(
-            "pre_bind_detection_detail"
-        ),
-        "pre_bind_preservation_summary": pre_bind_preservation.get(
-            "pre_bind_preservation_summary"
-        ),
-        "pre_bind_preservation_detail": pre_bind_preservation.get(
-            "pre_bind_preservation_detail"
-        ),
     }
+    core.update(assemble_governance_public_fields(governance_snapshot))
     core.update(_derive_business_fields(ctx))
 
     audit_debug_internal = {

--- a/veritas_os/tests/unit/test_decide_operator_assembly.py
+++ b/veritas_os/tests/unit/test_decide_operator_assembly.py
@@ -1,0 +1,69 @@
+"""Unit tests for /v1/decide operator assembly helpers."""
+
+from __future__ import annotations
+
+from veritas_os.api.decide_operator_assembly import (
+    attach_bind_operator_surface,
+    attach_wat_contract_fields,
+    normalize_wat_drift_vector,
+    resolve_operator_verbosity,
+)
+
+
+def test_resolve_operator_verbosity_falls_back_to_minimal() -> None:
+    assert resolve_operator_verbosity(None) == "minimal"
+    assert resolve_operator_verbosity("verbose") == "minimal"
+    assert resolve_operator_verbosity("expanded") == "expanded"
+
+
+def test_normalize_wat_drift_vector_maps_legacy_keys() -> None:
+    normalized = normalize_wat_drift_vector(
+        {"policy_drift": 0.4, "signature": 0.1, "observable_drift": 0.2}
+    )
+
+    assert normalized == {
+        "policy": 0.4,
+        "signature": 0.1,
+        "observable": 0.2,
+        "temporal": 0.0,
+    }
+
+
+def test_attach_bind_operator_surface_role_gates_detail() -> None:
+    payload = {
+        "bind_summary": {
+            "outcome": "BLOCKED",
+            "reason_code": "reason-x",
+            "bind_receipt_id": "br-1",
+            "execution_intent_id": "ei-1",
+        },
+        "authority_check_result": {"status": "denied"},
+    }
+
+    attach_bind_operator_surface(
+        payload=payload,
+        policy={"operator_verbosity": "expanded"},
+        role="operator",
+    )
+
+    assert payload["bind_operator_summary"]["operator_verbosity"] == "minimal"
+    assert "bind_operator_detail" not in payload
+
+
+def test_attach_wat_contract_fields_attaches_summary_and_optional_detail() -> None:
+    payload = {"request_id": "rid-1"}
+    attach_wat_contract_fields(
+        payload,
+        {
+            "wat_id": "wat-1",
+            "validation_status": "valid",
+            "admissibility_state": "admissible",
+            "operator_verbosity": "expanded",
+            "drift_vector": {"policy": 0.1},
+            "event_lane_details": {"validation_status": "valid"},
+        },
+    )
+
+    assert payload["wat_integrity"]["integrity_state"] == "healthy"
+    assert payload["wat_operator_summary"]["operator_verbosity"] == "expanded"
+    assert payload["wat_operator_detail"]["drift_vector"]["policy"] == 0.1

--- a/veritas_os/tests/unit/test_governance_layers.py
+++ b/veritas_os/tests/unit/test_governance_layers.py
@@ -1,0 +1,38 @@
+"""Tests for pre-bind governance evaluation/assembly composition."""
+
+from __future__ import annotations
+
+from veritas_os.core.pipeline.governance_layers import (
+    assemble_governance_public_fields,
+    evaluate_governance_layers,
+)
+
+
+def test_evaluate_governance_layers_returns_empty_snapshot_without_signal() -> None:
+    snapshot = evaluate_governance_layers(participation_signal=None)
+
+    assert snapshot.participation_signal is None
+    assert snapshot.pre_bind_detection == {}
+    assert snapshot.pre_bind_preservation == {}
+
+
+def test_assemble_governance_public_fields_preserves_contract_shape() -> None:
+    signal = {
+        "participation_signal_id": "ps-1",
+        "participation_admissibility": "admissible",
+        "structural_signal": "open_participation",
+        "source": "unit-test",
+    }
+
+    snapshot = evaluate_governance_layers(participation_signal=signal)
+    payload = assemble_governance_public_fields(snapshot)
+
+    assert payload["participation_signal"]["participation_signal_id"] == "ps-1"
+    assert payload["pre_bind_detection_summary"]["detection_family"] == (
+        "pre_bind_structural_detection"
+    )
+    assert payload["pre_bind_preservation_summary"]["preservation_family"] == (
+        "pre_bind_preservation"
+    )
+    assert "pre_bind_detection_detail" in payload
+    assert "pre_bind_preservation_detail" in payload


### PR DESCRIPTION
### Motivation
- Reduce route handler responsibility by moving operator-facing assembly and governance orchestration out of `routes_decide` so routes remain thin orchestration points.
- Make pre-bind governance (participation detection + preservation) composable and typed so future governance layers can be added without inflating routes.
- Preserve existing public contracts (`decision`, `execution_intent`, `bind_receipt`, `bind_summary`, `DecideResponse` shape) while clarifying internal responsibilities.

### Description
- Extracted operator-facing assembly into `veritas_os/api/decide_operator_assembly.py` which centralizes WAT contract field assembly, WAT drift normalization, operator verbosity vocabulary, and bind operator summary/detail assembly.
- Introduced `veritas_os/core/pipeline/governance_layers.py` with a typed `GovernanceEvaluationSnapshot` and two helpers: `evaluate_governance_layers` (runs participation detection + preservation evaluators) and `assemble_governance_public_fields` (maps evaluator outputs to additive `DecideResponse` fields).
- Updated `veritas_os/core/pipeline/pipeline_response.py` to delegate pre-bind evaluation and public-field assembly to the new composition layer using `evaluate_governance_layers` + `assemble_governance_public_fields` so the response assembly is decoupled from evaluator internals.
- Kept `routes_decide` behavior stable while importing the new assembly helpers with compatibility aliases and moving only assembly logic out, and added a small `request` role resolution helper to gate operator detail exposure.
- Added doc notes in `docs/en/architecture/pre-bind-participation-signals.md` describing the internal composition boundaries and created unit tests for the new modules: `veritas_os/tests/unit/test_decide_operator_assembly.py` and `veritas_os/tests/unit/test_governance_layers.py`.

### Testing
- Added unit tests: `veritas_os/tests/unit/test_decide_operator_assembly.py` and `veritas_os/tests/unit/test_governance_layers.py` which exercise verbosity normalization, drift mapping, operator surface gating, and snapshot→public-field mapping.
- Ran targeted test groups locally: `pytest -q tests/test_wat_observability_contract.py veritas_os/tests/unit/test_decide_operator_assembly.py veritas_os/tests/unit/test_governance_layers.py veritas_os/tests/unit/test_server_api.py -k "bind_operator_surface or wat_shadow_operator or wat_contract or governance_layers or decide_operator_assembly"` and observed all collected tests passed (`8 passed, 330 deselected`).
- Ran additional coverage for pre-bind flows: `pytest -q veritas_os/tests/test_pre_bind_participation_detection.py veritas_os/tests/test_pre_bind_preservation.py veritas_os/tests/unit/test_pipeline_coverage.py -k "assemble_response or pre_bind"` and observed successful results (`21 passed, 62 deselected`).
- Note / security: this refactor preserves WAT signing and RBAC use, but reviewers should validate the `rbac_role` resolution and WAT signing/verification call-sites to ensure operator-detail gating and signing remain enforced (no behavioral change intended, but these are sensitive surfaces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06e45bea08326bb50951df9e4d792)