### PR TITLE
Bind Cockpit: add minimal pre-bind participation/preservation visibility

### DIFF
--- a/docs/en/architecture/bind-boundary-governance-artifacts.md
+++ b/docs/en/architecture/bind-boundary-governance-artifacts.md
@@ -127,6 +127,21 @@ bind-phase as a lower-layer execution-governance outcome:
 This distinction prevents operators from misreading decision-phase approval as
 bind-phase commitment.
 
+Mission Control Bind Cockpit also provides an additive **pre-bind governance
+surface** in the receipt drill-down when optional payload fields are present:
+
+- `pre_bind_detection_summary.participation_state`
+- `pre_bind_detection_summary.concise_rationale`
+- `pre_bind_detection_summary.primary_contributing_signals`
+- `pre_bind_preservation_summary.preservation_state`
+- `pre_bind_preservation_summary.intervention_viability`
+- `pre_bind_preservation_summary.concise_rationale`
+- `pre_bind_preservation_summary.main_contributing_conditions`
+
+The UI renders these as an ordered pre-bind flow (`participation` →
+`preservation` → `bind gate`) and keeps them visually separate from
+`bind_outcome`/`bind_reason_code` to avoid vocabulary mixing.
+
 ## Minimal API example
 
 `GET /v1/governance/decisions/export?limit=1`

--- a/frontend/app/governance/components/BindCockpit.test.tsx
+++ b/frontend/app/governance/components/BindCockpit.test.tsx
@@ -120,6 +120,19 @@ const DETAIL_PAYLOAD = {
     refusal_basis: ["authority_indeterminate"],
     escalation_basis: ["manual_review_required"],
     irreversibility_boundary_id: "ib-9",
+    pre_bind_detection_summary: {
+      detection_family: "pre_bind_structural_detection",
+      participation_state: "decision_shaping",
+      concise_rationale: "Interpretation space is narrowing.",
+      primary_contributing_signals: ["interpretation_space_narrowing"],
+    },
+    pre_bind_preservation_summary: {
+      preservation_family: "pre_bind_preservation",
+      preservation_state: "degrading",
+      intervention_viability: "minimal",
+      concise_rationale: "Alternatives are materially constrained.",
+      main_contributing_conditions: ["structural_openness"],
+    },
   },
 };
 
@@ -259,6 +272,17 @@ describe("BindCockpit", () => {
     });
 
     expect(await screen.findByText("Receipt Drill-down")).toBeInTheDocument();
+    expect(screen.getByText("Pre-bind governance surface")).toBeInTheDocument();
+    expect(screen.getByText("Bind-time governance surface")).toBeInTheDocument();
+    expect(screen.getByText(/participation_state:/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/decision_shaping/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/preservation_state:/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/degrading/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/intervention_viability:/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/minimal/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/1. participation \(pre_bind_detection_summary\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/2. preservation \(pre_bind_preservation_summary\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/3. bind gate \(bind_outcome\)/i)).toBeInTheDocument();
     expect(screen.getByText("Action Contract")).toBeInTheDocument();
     expect(screen.getByText("Authority Evidence")).toBeInTheDocument();
     expect(screen.getByText("Runtime Authority")).toBeInTheDocument();
@@ -274,6 +298,31 @@ describe("BindCockpit", () => {
     expect(screen.getByRole("link", { name: "related execution intent" })).toHaveAttribute("href", "/audit?cross=exec-2");
     expect(screen.getByRole("link", { name: "related bind receipt" })).toHaveAttribute("href", "/audit?bind_receipt_id=br-blocked");
     expect(screen.getByRole("link", { name: "relevant governance/compliance surface" })).toHaveAttribute("href", "/system");
+  });
+
+  it("handles absent pre-bind governance summaries without breaking receipt drill-down", async () => {
+    const detailWithoutPreBind = {
+      ...DETAIL_PAYLOAD,
+      bind_receipt: {
+        ...DETAIL_PAYLOAD.bind_receipt,
+        pre_bind_detection_summary: undefined,
+        pre_bind_preservation_summary: undefined,
+      },
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => LIST_PAYLOAD })
+      .mockResolvedValueOnce({ ok: true, json: async () => detailWithoutPreBind })
+      .mockResolvedValueOnce({ ok: true, json: async () => detailWithoutPreBind });
+
+    render(<BindCockpit />);
+    await screen.findAllByText("br-blocked");
+    fireEvent.click((await screen.findByText("decision-2")).closest("tr") as HTMLElement);
+
+    expect(await screen.findByText("Pre-bind governance surface")).toBeInTheDocument();
+    expect(screen.getByText(/pre_bind_detection_summary \/ pre_bind_preservation_summary are absent/i)).toBeInTheDocument();
+    expect(screen.getByText("Bind-time governance surface")).toBeInTheDocument();
+    expect(screen.getByText("Action Contract")).toBeInTheDocument();
   });
 
   it("surfaces blocked/escalated queue with direct reason inspection action", async () => {

--- a/frontend/app/governance/components/BindCockpit.tsx
+++ b/frontend/app/governance/components/BindCockpit.tsx
@@ -138,6 +138,32 @@ function countPredicates(items: unknown): number {
   return items.filter((item) => typeof item === "object" && item !== null).length;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function formatStringList(items: unknown): string {
+  if (!Array.isArray(items)) {
+    return "-";
+  }
+  const values = items.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+  return values.length > 0 ? values.join(", ") : "-";
+}
+
+function pickStringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : "-";
+}
+
+function hasPreBindSurface(detail: CanonicalBindReceipt): boolean {
+  return (
+    isRecord(detail.raw.pre_bind_detection_summary)
+    || isRecord(detail.raw.pre_bind_preservation_summary)
+    || isRecord(detail.raw.pre_bind_detection_detail)
+    || isRecord(detail.raw.pre_bind_preservation_detail)
+  );
+}
+
 /**
  * Bind Cockpit: operator-facing cross-path surface for bind lifecycle triage.
  */
@@ -495,6 +521,57 @@ export function BindCockpit(): JSX.Element {
                 </dd>
               </dl>
 
+              <div className="rounded border border-border/70 bg-surface/20 px-2 py-2">
+                <p className="font-semibold">Pre-bind governance surface</p>
+                <p className="text-muted-foreground">
+                  Upstream state before bind gate. Keep separate from bind_outcome.
+                </p>
+                {hasPreBindSurface(selectedDetail) ? (
+                  <div className="mt-2 space-y-2">
+                    <ol className="space-y-2">
+                      <li className="rounded border border-border/60 bg-background/70 px-2 py-2">
+                        <p className="font-semibold">1. participation (pre_bind_detection_summary)</p>
+                        {isRecord(selectedDetail.raw.pre_bind_detection_summary) ? (
+                          <div className="mt-1 space-y-1">
+                            <p>participation_state: <span className="font-mono">{pickStringField(selectedDetail.raw.pre_bind_detection_summary, "participation_state")}</span></p>
+                            <p>concise_rationale: <span>{pickStringField(selectedDetail.raw.pre_bind_detection_summary, "concise_rationale")}</span></p>
+                            <p>primary_contributing_signals: <span>{formatStringList(selectedDetail.raw.pre_bind_detection_summary.primary_contributing_signals)}</span></p>
+                          </div>
+                        ) : (
+                          <p className="text-muted-foreground">pre_bind_detection_summary is not present.</p>
+                        )}
+                      </li>
+                      <li className="rounded border border-border/60 bg-background/70 px-2 py-2">
+                        <p className="font-semibold">2. preservation (pre_bind_preservation_summary)</p>
+                        {isRecord(selectedDetail.raw.pre_bind_preservation_summary) ? (
+                          <div className="mt-1 space-y-1">
+                            <p>preservation_state: <span className="font-mono">{pickStringField(selectedDetail.raw.pre_bind_preservation_summary, "preservation_state")}</span></p>
+                            <p>intervention_viability: <span className="font-mono">{pickStringField(selectedDetail.raw.pre_bind_preservation_summary, "intervention_viability")}</span></p>
+                            <p>concise_rationale: <span>{pickStringField(selectedDetail.raw.pre_bind_preservation_summary, "concise_rationale")}</span></p>
+                            <p>main_contributing_conditions: <span>{formatStringList(selectedDetail.raw.pre_bind_preservation_summary.main_contributing_conditions)}</span></p>
+                          </div>
+                        ) : (
+                          <p className="text-muted-foreground">pre_bind_preservation_summary is not present.</p>
+                        )}
+                      </li>
+                      <li className="rounded border border-border/60 bg-background/70 px-2 py-2">
+                        <p className="font-semibold">3. bind gate (bind_outcome)</p>
+                        <p>bind_outcome: <span className="font-mono">{selectedDetail.outcome}</span></p>
+                        <p>bind_reason_code: <span className="font-mono">{selectedDetail.reasonCode}</span></p>
+                      </li>
+                    </ol>
+                  </div>
+                ) : (
+                  <p className="mt-2 text-muted-foreground">
+                    pre_bind_detection_summary / pre_bind_preservation_summary are absent in this bind receipt payload.
+                  </p>
+                )}
+              </div>
+
+              <div className="rounded border border-border/70 bg-surface/40 px-2 py-2">
+                <p className="font-semibold">Bind-time governance surface</p>
+                <p className="text-muted-foreground">Bind checks and artifacts after gate adjudication.</p>
+              </div>
               <div className="rounded border border-border/70 bg-surface/40 px-2 py-2">
                 <p className="font-semibold">Action Contract</p>
                 <p className="font-mono">{String(selectedDetail.raw.action_contract_id ?? "-")}</p>

--- a/frontend/app/governance/components/bind-cockpit-normalization.test.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.test.ts
@@ -44,6 +44,17 @@ describe("bind-cockpit-normalization", () => {
         bind_failure_reason: "policy missing",
         execution_intent_id: "ei-2",
         target_path_type: "governance_policy_update",
+        pre_bind_detection_summary: {
+          participation_state: "participatory",
+          concise_rationale: "Interpretation space is still open.",
+          primary_contributing_signals: ["interpretation_space_narrowing"],
+        },
+        pre_bind_preservation_summary: {
+          preservation_state: "open",
+          intervention_viability: "high",
+          concise_rationale: "Meaningful intervention remains possible.",
+          main_contributing_conditions: ["structural_openness"],
+        },
       },
     });
     expect(parsed?.bind_receipt_id).toBe("br-2");
@@ -51,6 +62,8 @@ describe("bind-cockpit-normalization", () => {
     expect(parsed?.bind_reason_code).toBe("POLICY_MISSING");
     expect(parsed?.execution_intent_id).toBe("ei-2");
     expect(parsed?.target_path_type).toBe("governance_policy_update");
+    expect((parsed?.pre_bind_detection_summary as Record<string, unknown> | undefined)?.participation_state).toBe("participatory");
+    expect((parsed?.pre_bind_preservation_summary as Record<string, unknown> | undefined)?.intervention_viability).toBe("high");
   });
 
   it("normalizes path, checks, and operator step", () => {

--- a/frontend/app/governance/components/bind-cockpit-normalization.ts
+++ b/frontend/app/governance/components/bind-cockpit-normalization.ts
@@ -52,6 +52,10 @@ export interface BindCockpitReceipt {
   refusal_basis?: string[];
   escalation_basis?: string[];
   irreversibility_boundary_id?: string;
+  pre_bind_detection_summary?: Record<string, unknown>;
+  pre_bind_detection_detail?: Record<string, unknown>;
+  pre_bind_preservation_summary?: Record<string, unknown>;
+  pre_bind_preservation_detail?: Record<string, unknown>;
   [key: string]: unknown;
 }
 
@@ -81,6 +85,10 @@ export interface BindSummaryPayload {
   refusal_basis?: string[];
   escalation_basis?: string[];
   irreversibility_boundary_id?: string;
+  pre_bind_detection_summary?: Record<string, unknown>;
+  pre_bind_detection_detail?: Record<string, unknown>;
+  pre_bind_preservation_summary?: Record<string, unknown>;
+  pre_bind_preservation_detail?: Record<string, unknown>;
 }
 
 export interface CanonicalBindReceipt {
@@ -165,6 +173,15 @@ const TARGET_PATH_TYPE_MAP: Record<string, CanonicalTargetPathType> = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function pickRecord(...values: unknown[]): Record<string, unknown> | undefined {
+  for (const value of values) {
+    if (isRecord(value)) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 export function normalizeBindOutcome(outcome: unknown): CanonicalBindOutcome | "UNKNOWN" {
@@ -459,5 +476,21 @@ export function parseBindReceiptDetailPayload(value: unknown): BindCockpitReceip
       payload.irreversibility_boundary_id,
       bindSummary?.irreversibility_boundary_id,
     ) ?? undefined,
+    pre_bind_detection_summary: pickRecord(
+      payload.pre_bind_detection_summary,
+      bindSummary?.pre_bind_detection_summary,
+    ),
+    pre_bind_detection_detail: pickRecord(
+      payload.pre_bind_detection_detail,
+      bindSummary?.pre_bind_detection_detail,
+    ),
+    pre_bind_preservation_summary: pickRecord(
+      payload.pre_bind_preservation_summary,
+      bindSummary?.pre_bind_preservation_summary,
+    ),
+    pre_bind_preservation_detail: pickRecord(
+      payload.pre_bind_preservation_detail,
+      bindSummary?.pre_bind_preservation_detail,
+    ),
   } as BindCockpitReceipt;
 }


### PR DESCRIPTION
### Motivation
- Provide operators minimal, additive visibility of upstream pre-bind participation and preservation signals in Mission Control without changing bind-time contracts or altering existing bind-centric UX. 
- Keep the implementation minimal, vocabulary-consistent with backend fields (`pre_bind_detection_summary` / `pre_bind_preservation_summary`), and safely extensible for future timeline/detail expansion. 

### Description
- Added canonical pre-bind fields to normalization and parsing so `bind_receipt` or `bind_summary` can provide `pre_bind_detection_summary`, `pre_bind_detection_detail`, `pre_bind_preservation_summary`, and `pre_bind_preservation_detail` via hydration logic in `bind-cockpit-normalization.ts`. 
- Introduced a compact, ordered `Pre-bind governance surface` in the Bind Cockpit receipt drill-down (component `BindCockpit.tsx`) that renders the three-step flow `1. participation (pre_bind_detection_summary) -> 2. preservation (pre_bind_preservation_summary) -> 3. bind gate (bind_outcome)`, with explicit visual/text separation from the `Bind-time governance surface`. 
- Implemented small helper utilities (`pickRecord`, `isRecord`, `pickStringField`, `formatStringList`, `hasPreBindSurface`) and graceful absence handling so the new section is omitted or shows a compact absence message when optional pre-bind fields are not present. 
- Updated unit/integration tests and docs to validate the new surface and vocabulary: modified `frontend/app/governance/components/bind-cockpit-normalization.ts`, `frontend/app/governance/components/BindCockpit.tsx`, tests under `frontend/app/governance/components/*`, and `docs/en/architecture/bind-boundary-governance-artifacts.md`.

### Testing
- Ran component/tests: `pnpm --filter frontend test app/governance/components/bind-cockpit-normalization.test.ts app/governance/components/BindCockpit.test.tsx`, and all tests passed (13/13). 
- Ran static type check: `pnpm --filter frontend typecheck` completed successfully and reported no errors. 
- Attempted UI snapshot via Playwright with `bash scripts/take_frontend_snapshot.sh ...` and `pnpm exec playwright install chromium`, but browser binary download failed due to CDN 403 in this environment, so automated screenshot acquisition did not complete (network/CDN environment issue, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07c6415408326bf92349e9e67509a)