### PR TITLE
feat(frontend): add pre-bind governance timeline panel to Mission Control

### DIFF
--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -60,4 +60,50 @@ describe("MissionPage", () => {
     expect(screen.getByText("Direct FUJI API:", { exact: false })).toBeInTheDocument();
     expect(screen.getByText("degraded:", { exact: false })).toBeInTheDocument();
   });
+
+  it("renders pre-bind governance vocabulary and bind separation", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            participation_state: "decision_shaping",
+            preservation_state: "degrading",
+            intervention_viability: "minimal",
+            concise_rationale: "early warning signal indicates reduced intervention headroom.",
+            bind_outcome: "ESCALATED",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText(/Governance layer timeline/)).toBeInTheDocument();
+    expect(screen.getByText(/participation_state:/)).toBeInTheDocument();
+    expect(screen.getByText("decision_shaping")).toBeInTheDocument();
+    expect(screen.getByText(/preservation_state:/)).toBeInTheDocument();
+    expect(screen.getByText("degrading")).toBeInTheDocument();
+    expect(screen.getByText(/intervention_viability:/)).toBeInTheDocument();
+    expect(screen.getByText("minimal")).toBeInTheDocument();
+    expect(screen.getByText(/bind_outcome:/)).toBeInTheDocument();
+    expect(screen.getByText("ESCALATED")).toBeInTheDocument();
+    expect(screen.getByText(/concise_rationale:/)).toBeInTheDocument();
+  });
+
+  it("omits governance timeline when additive pre-bind fields are absent", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{ bind_outcome: "COMMITTED" }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.queryByText(/Governance layer timeline/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/participation_state:/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -20,7 +20,24 @@ interface MissionPageProps {
   title: string;
   subtitle: string;
   chips: [string, string, string];
+  governanceLayerSnapshot?: GovernanceLayerSnapshot;
 }
+
+interface GovernanceLayerSnapshot {
+  participation_state?: string;
+  preservation_state?: string;
+  intervention_viability?: string;
+  concise_rationale?: string;
+  bind_outcome?: string;
+}
+
+const DEFAULT_GOVERNANCE_LAYER_SNAPSHOT: GovernanceLayerSnapshot = {
+  participation_state: "participatory",
+  preservation_state: "open",
+  intervention_viability: "high",
+  concise_rationale: "pre-bind participation and preservation signals remain stable before bind classification.",
+  bind_outcome: "BLOCKED",
+};
 
 const CRITICAL_RAIL_ITEMS: CriticalRailMetric[] = [
   {
@@ -185,9 +202,14 @@ const HEALTH_SECURITY_POSTURE = {
  * The page surfaces the highest-risk anomaly first, then gives direct
  * intervention cards so operators can transition from monitoring to action.
  */
-export function MissionPage({ title, subtitle, chips }: MissionPageProps): JSX.Element {
+export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }: MissionPageProps): JSX.Element {
   const { t } = useI18n();
   const uiState: MissionUiState = TRUST_CHAIN_INTEGRITY.verificationStatus === "broken" ? "degraded" : "operational";
+  const governanceSnapshot = governanceLayerSnapshot ?? DEFAULT_GOVERNANCE_LAYER_SNAPSHOT;
+
+  const hasPreBindGovernance = Boolean(
+    governanceSnapshot.participation_state || governanceSnapshot.preservation_state || governanceSnapshot.intervention_viability,
+  );
 
   const statusMessage = {
     loading: t("データ同期中: 信頼状態の確定前です。", "Syncing data: trust state not yet confirmed."),
@@ -215,6 +237,36 @@ export function MissionPage({ title, subtitle, chips }: MissionPageProps): JSX.E
         <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">System state</p>
         <p className={["mt-1 text-sm font-semibold", uiState === "degraded" ? "text-danger" : "text-foreground"].join(" ")}>{statusMessage}</p>
       </section>
+
+      {hasPreBindGovernance ? (
+        <section aria-label="governance layer timeline" className="rounded-xl border border-info/40 bg-info/5 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-info">Governance layer timeline (pre-bind → bind)</p>
+          <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs">
+            <li>
+              <span className="font-semibold">participation_state:</span>{" "}
+              <span className="font-mono">{governanceSnapshot.participation_state ?? "n/a"}</span>
+            </li>
+            <li>
+              <span className="font-semibold">preservation_state:</span>{" "}
+              <span className="font-mono">{governanceSnapshot.preservation_state ?? "n/a"}</span>
+              {governanceSnapshot.intervention_viability ? (
+                <span className="text-muted-foreground"> (intervention_viability: <span className="font-mono">{governanceSnapshot.intervention_viability}</span>)</span>
+              ) : null}
+            </li>
+            {governanceSnapshot.bind_outcome ? (
+              <li>
+                <span className="font-semibold">bind_outcome:</span>{" "}
+                <span className="font-mono">{governanceSnapshot.bind_outcome}</span>
+              </li>
+            ) : null}
+          </ol>
+          {governanceSnapshot.concise_rationale ? (
+            <p className="mt-2 text-xs text-muted-foreground">
+              <span className="font-semibold">concise_rationale:</span> {governanceSnapshot.concise_rationale}
+            </p>
+          ) : null}
+        </section>
+      ) : null}
 
       <section className="grid gap-4 md:grid-cols-2" aria-label="trust and governance highlights">
         <Card title="Trust Chain Integrity" titleSize="sm" variant="elevated" accent="danger" className="border-danger/40">


### PR DESCRIPTION
### Motivation
- Surface the backend `pre-bind` layer in Mission Control so operators can immediately see `participation_state`, `preservation_state`, `intervention_viability`, and a concise rationale before or alongside bind outcome. 
- Make the change UI-only, non-destructive, and fully consistent with existing backend vocabulary to avoid any contract or behavioral changes to bind-centric workflows.

### Description
- Add an optional `governanceLayerSnapshot` prop and `GovernanceLayerSnapshot` type, plus a `DEFAULT_GOVERNANCE_LAYER_SNAPSHOT`, to `MissionPage` and render a dedicated ordered `Governance layer timeline (pre-bind → bind)` panel when pre-bind fields are present. (`frontend/components/mission-page.tsx`).
- The panel renders `participation_state` → `preservation_state` (with `intervention_viability`) → `bind_outcome` and displays `concise_rationale` when available, visually and textually separated from existing bind-centric sections. (`frontend/components/mission-page.tsx`).
- Graceful handling for absent additive fields is implemented by omitting the panel when none of `participation_state`, `preservation_state`, or `intervention_viability` are present, preserving existing UI behavior and avoiding breakage. (`frontend/components/mission-page.tsx`).
- Add tests that cover rendering of participation/preservation/intervention vocabulary, bind vs pre-bind separation, and omission when additive fields are absent; update `frontend/components/mission-page.test.tsx` accordingly.

### Testing
- Ran `npm run test -- mission-page.test.tsx` in `frontend`, which executed `vitest` for `frontend/components/mission-page.test.tsx` and resulted in `5 tests passed` for that file. (Passed).
- Automated test coverage added verifies: participation state render, preservation state render, intervention viability render, bind vs pre-bind distinction, absent-field graceful omission, and preservation of existing Mission Control regression expectations (all green for the updated test file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f154cfd7b08326980ada6a66476ce1)