### PR TITLE
frontend: promote Mission Control pre-bind snapshot to shared vocabulary contract

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -48,6 +48,12 @@ pnpm -r test
 - Mission Control Console 用の金融サンプルは `frontend/features/console/fixtures/financial-case.ts` を利用してください。
 - 本フィクスチャは `financial.high_risk_wire_transfer` 想定で、`required_evidence` / `missing_evidence` / `next_action` / `human_review_required` の視認回帰をテストします。
 
+## Mission Control pre-bind governance vocabulary
+
+- Mission Control の pre-bind governance snapshot は `frontend/components/dashboard-types.ts` の shared frontend contract を参照してください。
+- `participation_state` / `preservation_state` / `intervention_viability` / `concise_rationale` / `bind_outcome` は backend vocabulary をそのまま表示する契約です。
+- Mission Control は bind outcome だけでなく pre-bind state を timeline で扱うため、component-local 型ではなく shared type (`PreBindGovernanceSnapshot`) を利用してください。
+
 
 ## Docker Compose で一括起動
 

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -68,3 +68,21 @@ export interface DecisionEvidenceRouteModel {
 }
 
 export type MissionUiState = "loading" | "empty" | "degraded" | "operational";
+
+export interface PreBindGovernanceSnapshot {
+  participation_state?: string;
+  preservation_state?: string;
+  intervention_viability?: string;
+  concise_rationale?: string;
+  bind_outcome?: string;
+}
+
+export const PRE_BIND_GOVERNANCE_VOCABULARY_LABELS = {
+  participation_state: "participation_state",
+  preservation_state: "preservation_state",
+  intervention_viability: "intervention_viability",
+  concise_rationale: "concise_rationale",
+  bind_outcome: "bind_outcome",
+  heading: "Governance layer timeline (pre-bind → bind)",
+  unavailable: "n/a",
+} as const;

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { PRE_BIND_GOVERNANCE_VOCABULARY_LABELS } from "./dashboard-types";
 import { I18nProvider } from "./i18n-provider";
 import { MissionPage } from "./mission-page";
 
@@ -79,7 +80,7 @@ describe("MissionPage", () => {
       </I18nProvider>,
     );
 
-    expect(screen.getByText(/Governance layer timeline/)).toBeInTheDocument();
+    expect(screen.getByText(PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.heading)).toBeInTheDocument();
     expect(screen.getByText(/participation_state:/)).toBeInTheDocument();
     expect(screen.getByText("decision_shaping")).toBeInTheDocument();
     expect(screen.getByText(/preservation_state:/)).toBeInTheDocument();
@@ -89,6 +90,25 @@ describe("MissionPage", () => {
     expect(screen.getByText(/bind_outcome:/)).toBeInTheDocument();
     expect(screen.getByText("ESCALATED")).toBeInTheDocument();
     expect(screen.getByText(/concise_rationale:/)).toBeInTheDocument();
+  });
+
+  it("uses shared pre-bind governance vocabulary labels", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            participation_state: "participatory",
+            preservation_state: "open",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText(`${PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.participation_state}:`)).toBeInTheDocument();
+    expect(screen.getByText(`${PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.preservation_state}:`)).toBeInTheDocument();
   });
 
   it("omits governance timeline when additive pre-bind fields are absent", () => {

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -12,26 +12,20 @@ import {
   type GovernanceApprovalModel,
   type MissionUiState,
   type OpsPriorityItem,
+  type PreBindGovernanceSnapshot,
   type ReplayDiffInsightModel,
   type TrustChainIntegrityModel,
+  PRE_BIND_GOVERNANCE_VOCABULARY_LABELS,
 } from "./dashboard-types";
 
 interface MissionPageProps {
   title: string;
   subtitle: string;
   chips: [string, string, string];
-  governanceLayerSnapshot?: GovernanceLayerSnapshot;
+  governanceLayerSnapshot?: PreBindGovernanceSnapshot;
 }
 
-interface GovernanceLayerSnapshot {
-  participation_state?: string;
-  preservation_state?: string;
-  intervention_viability?: string;
-  concise_rationale?: string;
-  bind_outcome?: string;
-}
-
-const DEFAULT_GOVERNANCE_LAYER_SNAPSHOT: GovernanceLayerSnapshot = {
+const DEFAULT_GOVERNANCE_LAYER_SNAPSHOT: PreBindGovernanceSnapshot = {
   participation_state: "participatory",
   preservation_state: "open",
   intervention_viability: "high",
@@ -240,29 +234,29 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
 
       {hasPreBindGovernance ? (
         <section aria-label="governance layer timeline" className="rounded-xl border border-info/40 bg-info/5 p-4">
-          <p className="text-xs font-semibold uppercase tracking-wide text-info">Governance layer timeline (pre-bind → bind)</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-info">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.heading}</p>
           <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs">
             <li>
-              <span className="font-semibold">participation_state:</span>{" "}
-              <span className="font-mono">{governanceSnapshot.participation_state ?? "n/a"}</span>
+              <span className="font-semibold">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.participation_state}:</span>{" "}
+              <span className="font-mono">{governanceSnapshot.participation_state ?? PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.unavailable}</span>
             </li>
             <li>
-              <span className="font-semibold">preservation_state:</span>{" "}
-              <span className="font-mono">{governanceSnapshot.preservation_state ?? "n/a"}</span>
+              <span className="font-semibold">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.preservation_state}:</span>{" "}
+              <span className="font-mono">{governanceSnapshot.preservation_state ?? PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.unavailable}</span>
               {governanceSnapshot.intervention_viability ? (
-                <span className="text-muted-foreground"> (intervention_viability: <span className="font-mono">{governanceSnapshot.intervention_viability}</span>)</span>
+                <span className="text-muted-foreground"> ({PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.intervention_viability}: <span className="font-mono">{governanceSnapshot.intervention_viability}</span>)</span>
               ) : null}
             </li>
             {governanceSnapshot.bind_outcome ? (
               <li>
-                <span className="font-semibold">bind_outcome:</span>{" "}
+                <span className="font-semibold">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.bind_outcome}:</span>{" "}
                 <span className="font-mono">{governanceSnapshot.bind_outcome}</span>
               </li>
             ) : null}
           </ol>
           {governanceSnapshot.concise_rationale ? (
             <p className="mt-2 text-xs text-muted-foreground">
-              <span className="font-semibold">concise_rationale:</span> {governanceSnapshot.concise_rationale}
+              <span className="font-semibold">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.concise_rationale}:</span> {governanceSnapshot.concise_rationale}
             </p>
           ) : null}
         </section>


### PR DESCRIPTION
### Motivation
- Reduce vocabulary drift by promoting Mission Control's pre-bind snapshot from a component-local interface to a shared frontend contract.
- Centralize labels and fallbacks so multiple panels (panel/detail/audit) can consume the same source of truth.
- Preserve existing Mission Control rendering and avoid backend or bind/detection logic changes to keep this non-breaking.

### Description
- Add `PreBindGovernanceSnapshot` and `PRE_BIND_GOVERNANCE_VOCABULARY_LABELS` to `frontend/components/dashboard-types.ts` to provide a shared type and label source for pre-bind fields. 
- Replace the component-local governance snapshot interface in `frontend/components/mission-page.tsx` with the shared `PreBindGovernanceSnapshot` and switch labels/fallbacks to `PRE_BIND_GOVERNANCE_VOCABULARY_LABELS` while keeping existing render logic and conditional behavior. 
- Update `frontend/components/mission-page.test.tsx` to assert the shared vocabulary is used and to verify optional additive-field handling remains graceful. 
- Add a short note to `docs/ui/README_UI.md` documenting that Mission Control should reference the shared `PreBindGovernanceSnapshot` and display backend vocabulary as-is. 

### Testing
- Ran `cd frontend && pnpm vitest run components/mission-page.test.tsx`, which executed the mission-page tests and reported: `1 test file, 6 tests passed` (all passing). 
- The change is narrowly scoped and unit-tested for the Mission Control rendering and vocabulary behavior; no API/backend tests were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f174a8a19c8326a5608e32031d9060)