### PR TITLE
Add pre-bind canonical rationale and vocabulary regression checks

### DIFF
--- a/docs/en/proofs/pre_bind_canonical_cases_proof.md
+++ b/docs/en/proofs/pre_bind_canonical_cases_proof.md
@@ -73,3 +73,5 @@ pre-bind state combinations.
 - Fixtures: `veritas_os/tests/fixtures/pre_bind/`
 - Goldens: `veritas_os/tests/golden/pre_bind/`
 - Canonical tests: `veritas_os/tests/test_pre_bind_canonical_golden.py`
+- Vocabulary consistency + rationale-linked assertions: `test_canonical_case_naming_and_vocabulary_consistency` and
+  `test_canonical_pre_bind_signals_and_rationales_are_explanatory` in the same test module.

--- a/veritas_os/tests/test_pre_bind_canonical_golden.py
+++ b/veritas_os/tests/test_pre_bind_canonical_golden.py
@@ -67,6 +67,57 @@ def test_canonical_pre_bind_golden_snapshots_stay_stable() -> None:
         assert evaluated == golden
 
 
+
+
+def test_canonical_pre_bind_signals_and_rationales_are_explanatory() -> None:
+    """Snapshots must include rationale-linked state explanations, not raw enums only."""
+    required_signals = {
+        "interpretation_space_narrowing",
+        "counterfactual_availability",
+        "intervention_headroom",
+        "structural_openness",
+    }
+
+    for fixture_path in sorted(FIXTURE_DIR.glob("pre_bind_case_*.json")):
+        fixture = _load_json(fixture_path)
+        signal = fixture["participation_signal"]
+        result = _evaluate(signal)
+
+        assert required_signals.issubset(signal.keys())
+        assert result["pre_bind_detection_summary"]["concise_rationale"]
+        assert result["pre_bind_preservation_summary"]["concise_rationale"]
+        assert "primary_contributing_signals" in result["pre_bind_detection_summary"]
+        assert "main_contributing_conditions" in result["pre_bind_preservation_summary"]
+
+        if result["pre_bind_detection_summary"]["participation_state"] != "informative":
+            assert result["pre_bind_detection_summary"]["primary_contributing_signals"]
+
+        if result["pre_bind_preservation_summary"]["preservation_state"] != "open":
+            assert result["pre_bind_preservation_summary"]["main_contributing_conditions"]
+
+
+def test_canonical_case_naming_and_vocabulary_consistency() -> None:
+    """Fixture/golden naming and vocabulary must stay aligned with docs/OpenAPI terms."""
+    canonical_case_ids = [
+        "pre_bind_case_informative_open",
+        "pre_bind_case_participatory_degrading",
+        "pre_bind_case_decision_shaping_collapsed",
+    ]
+
+    for case_id in canonical_case_ids:
+        fixture_path = FIXTURE_DIR / f"{case_id}.json"
+        golden_path = GOLDEN_DIR / f"{case_id}_golden.json"
+
+        assert fixture_path.exists()
+        assert golden_path.exists()
+
+        fixture = _load_json(fixture_path)
+        golden = _load_json(golden_path)
+
+        assert fixture["case_id"] == case_id
+        assert golden["case_id"] == case_id
+        assert "pre_bind_detection_summary" in golden
+        assert "pre_bind_preservation_summary" in golden
 def test_additive_fields_remain_optional_for_legacy_clients() -> None:
     """Legacy clients remain valid when additive pre-bind fields are absent."""
     legacy = DecideResponse(request_id="req-pre-bind-legacy")


### PR DESCRIPTION
### Motivation
- Prevent semantics drift by making pre-bind canonical cases reproducible and by ensuring snapshots are explanatory evidence rather than raw enum dumps.
- Strengthen reviewer traceability by verifying fixture/golden naming and that rationale / contributing signals are present and linked to state judgments.
- Preserve additive, backward-compatible behavior and avoid any runtime/OpenAPI/UI/state changes.

### Description
- Add tests `test_canonical_pre_bind_signals_and_rationales_are_explanatory` and `test_canonical_case_naming_and_vocabulary_consistency` to `veritas_os/tests/test_pre_bind_canonical_golden.py` to assert presence of required signals, `concise_rationale`, and contributing-signal/condition keys, and to lock fixture/golden naming consistency.
- Keep existing golden-snapshot and state-equality tests intact so the three canonical cases still map to `informative/open`, `participatory/degrading`, and `decision_shaping/collapsed` without changing evaluation logic.
- Update proof doc `docs/en/proofs/pre_bind_canonical_cases_proof.md` to point reviewers to the new rationale-linked and vocabulary-consistency assertions.
- Changes are test and docs only; no codepath, OpenAPI, UI, or state semantics modifications were introduced.

### Testing
- Ran `pytest -q veritas_os/tests/test_pre_bind_canonical_golden.py veritas_os/tests/test_openapi_pre_bind_contract.py veritas_os/tests/test_pre_bind_participation_detection.py veritas_os/tests/test_pre_bind_preservation.py` and observed `28 passed`.
- During development an initial run of the updated canonical test failed (one explanatory assertion), the test was adjusted to allow informative/open edge cases and the failure was resolved.
- Re-ran `pytest -q veritas_os/tests/test_pre_bind_canonical_golden.py veritas_os/tests/test_openapi_pre_bind_contract.py` and observed `9 passed`, confirming the new assertions and naming checks succeed on the modified codebase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f195c165a48326a25345d2120e5ad0)