### PR TITLE
Connect Mission Control pre-bind timeline to backend-fed live ingress

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -53,9 +53,10 @@ pnpm -r test
 - Mission Control の pre-bind governance snapshot は `frontend/components/dashboard-types.ts` の shared frontend contract を参照してください。
 - `participation_state` / `preservation_state` / `intervention_viability` / `concise_rationale` / `bind_outcome` は backend vocabulary をそのまま表示する契約です。
 - Mission Control は bind outcome だけでなく pre-bind state を timeline で扱うため、component-local 型ではなく shared type (`PreBindGovernanceSnapshot`) を利用してください。
-- Mission Control の live ingress 層は `frontend/components/mission-control-container.tsx` です。container が dashboard / loader 由来 payload を受け取り、`frontend/components/mission-governance-adapter.ts` の `resolveMissionGovernanceSnapshot` を経由して shared contract に正規化します。
-- `resolveMissionGovernanceSnapshot` は `governance_layer_snapshot`（主経路）→ `pre_bind_governance_snapshot`（互換経路）→ render safety fallback（安全経路）の順で解決します。fallback は main path ではありません。
-- `frontend/components/mission-page.tsx` は adapter/container で解決済みの shared contract を受け取って render する責務に限定し、将来の real API fetch・server-side hydration・polling 追加時の接続点を固定します。
+- Mission Control の backend-fed main path は `frontend/app/mission-control-ingress.ts` の `loadMissionControlIngressPayload` です。`/api/veritas/v1/report/governance` から governance feed を取得し、`mapGovernanceFeedToIngressPayload` で ingress contract に明示マッピングします。
+- Mission Control の live ingress 層は `frontend/components/mission-control-container.tsx` です。container が page loader 由来 payload を受け取り、`frontend/components/mission-governance-adapter.ts` の `resolveMissionGovernanceSnapshot` を経由して shared contract に正規化します。
+- `resolveMissionGovernanceSnapshot` は `governance_layer_snapshot`（主経路）→ `pre_bind_governance_snapshot`（互換経路）→ render safety fallback（安全経路）の順で解決します。fallback は render safety 専用であり、live verification 完了を示しません。
+- `frontend/components/mission-page.tsx` は adapter/container で解決済みの shared contract を受け取って render する責務に限定し、将来の server-side hydration・polling・streaming 追加時の接続点を固定します。
 
 
 ## Docker Compose で一括起動

--- a/frontend/app/mission-control-ingress.test.ts
+++ b/frontend/app/mission-control-ingress.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  loadMissionControlIngressPayload,
+  mapGovernanceFeedToIngressPayload,
+} from "./mission-control-ingress";
+
+describe("mapGovernanceFeedToIngressPayload", () => {
+  it("maps governance_layer_snapshot as main backend-fed path", () => {
+    const result = mapGovernanceFeedToIngressPayload({
+      governance_layer_snapshot: {
+        participation_state: "decision_shaping",
+        preservation_state: "degrading",
+      },
+    });
+
+    expect(result).toEqual({
+      governance_layer_snapshot: {
+        participation_state: "decision_shaping",
+        preservation_state: "degrading",
+      },
+    });
+  });
+
+  it("maps pre_bind_governance_snapshot as compatibility path", () => {
+    const result = mapGovernanceFeedToIngressPayload({
+      pre_bind_governance_snapshot: {
+        participation_state: "participatory",
+        preservation_state: "open",
+      },
+    });
+
+    expect(result).toEqual({
+      pre_bind_governance_snapshot: {
+        participation_state: "participatory",
+        preservation_state: "open",
+      },
+    });
+  });
+
+  it("returns null for unsupported payload shape", () => {
+    expect(mapGovernanceFeedToIngressPayload({})).toBeNull();
+  });
+});
+
+describe("loadMissionControlIngressPayload", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns mapped payload when backend feed is available", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        governance_layer_snapshot: {
+          participation_state: "decision_shaping",
+          preservation_state: "degrading",
+        },
+      }),
+    } as Response);
+
+    await expect(loadMissionControlIngressPayload()).resolves.toEqual({
+      governance_layer_snapshot: {
+        participation_state: "decision_shaping",
+        preservation_state: "degrading",
+      },
+    });
+  });
+
+  it("returns null when backend feed is unavailable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+
+    await expect(loadMissionControlIngressPayload()).resolves.toBeNull();
+  });
+});

--- a/frontend/app/mission-control-ingress.ts
+++ b/frontend/app/mission-control-ingress.ts
@@ -1,0 +1,55 @@
+import { type MissionGovernanceIngressPayload } from "../components/mission-governance-adapter";
+
+const GOVERNANCE_REPORT_ENDPOINT = "/api/veritas/v1/report/governance";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Maps backend governance feed payload into Mission Control ingress contract.
+ */
+export function mapGovernanceFeedToIngressPayload(
+  payload: unknown,
+): MissionGovernanceIngressPayload | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const governanceLayerSnapshot = payload.governance_layer_snapshot;
+  if (isRecord(governanceLayerSnapshot)) {
+    return {
+      governance_layer_snapshot: governanceLayerSnapshot,
+    };
+  }
+
+  const preBindGovernanceSnapshot = payload.pre_bind_governance_snapshot;
+  if (isRecord(preBindGovernanceSnapshot)) {
+    return {
+      pre_bind_governance_snapshot: preBindGovernanceSnapshot,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Main path: backend-fed governance feed. Fallback is adapter-level render safety.
+ */
+export async function loadMissionControlIngressPayload(): Promise<MissionGovernanceIngressPayload | null> {
+  try {
+    const response = await fetch(GOVERNANCE_REPORT_ENDPOINT, {
+      method: "GET",
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as unknown;
+    return mapGovernanceFeedToIngressPayload(payload);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1,11 +1,40 @@
 import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import CommandDashboardPage from "./page";
 
+const loadMissionControlIngressPayloadMock = vi.fn();
+
+vi.mock("./mission-control-ingress", () => ({
+  loadMissionControlIngressPayload: () => loadMissionControlIngressPayloadMock(),
+}));
+
 describe("CommandDashboardPage", () => {
-  it("renders dashboard skeleton content", () => {
-    render(<CommandDashboardPage />);
+  beforeEach(() => {
+    loadMissionControlIngressPayloadMock.mockReset();
+  });
+
+  it("renders dashboard content using backend-fed ingress payload", async () => {
+    loadMissionControlIngressPayloadMock.mockResolvedValue({
+      governance_layer_snapshot: {
+        participation_state: "decision_shaping",
+        preservation_state: "degrading",
+        bind_outcome: "ESCALATED",
+      },
+    });
+
+    render(await CommandDashboardPage());
 
     expect(screen.getByText("コマンドダッシュボード")).toBeInTheDocument();
-    expect(screen.getByText("稼働格子")).toBeInTheDocument();
+    expect(screen.getByText("decision_shaping")).toBeInTheDocument();
+  });
+
+  it("falls back to adapter render-safety snapshot when backend ingress is unavailable", async () => {
+    loadMissionControlIngressPayloadMock.mockResolvedValue(null);
+
+    render(await CommandDashboardPage());
+
+    expect(screen.getByText("participatory")).toBeInTheDocument();
+    expect(screen.getByText("BLOCKED")).toBeInTheDocument();
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,24 +1,15 @@
-"use client";
-
 import { LiveEventStream } from "../components/live-event-stream";
 import { MissionControlContainer } from "../components/mission-control-container";
 
-const DASHBOARD_LIVE_INGRESS = {
-  governance_layer_snapshot: {
-    participation_state: "participatory",
-    preservation_state: "open",
-    intervention_viability: "high",
-    concise_rationale:
-      "pre-bind participation and preservation signals remain stable before bind classification.",
-    bind_outcome: "BLOCKED",
-  },
-};
+import { loadMissionControlIngressPayload } from "./mission-control-ingress";
 
-export default function CommandDashboardPage(): JSX.Element {
+export default async function CommandDashboardPage(): Promise<JSX.Element> {
+  const ingressPayload = await loadMissionControlIngressPayload();
+
   return (
     <div className="space-y-6">
       <LiveEventStream />
-      <MissionControlContainer ingressPayload={DASHBOARD_LIVE_INGRESS} />
+      <MissionControlContainer ingressPayload={ingressPayload} />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Remove the hard-coded `DASHBOARD_LIVE_INGRESS` wiring so Mission Control receives a backend-fed live snapshot instead of a fixed payload. 
- Preserve existing `MissionControlContainer` / `resolveMissionGovernanceSnapshot` / `MissionPage` separation so presentation and shared vocabulary remain unchanged. 
- Keep a clear safety fallback path so UI never treats fallback data as live-verified state.

### Description
- Replace the fixed ingress in `frontend/app/page.tsx` with an async server-side loader `loadMissionControlIngressPayload` and pass its result into `MissionControlContainer`. 
- Add `frontend/app/mission-control-ingress.ts` implementing `mapGovernanceFeedToIngressPayload` to map backend feed shapes into `MissionGovernanceIngressPayload` and `loadMissionControlIngressPayload` which fetches `/api/veritas/v1/report/governance`. 
- Add tests `frontend/app/mission-control-ingress.test.ts` and update `frontend/app/page.test.tsx` to cover backend-present and backend-unavailable fallback cases. 
- Update `docs/ui/README_UI.md` to document the new backend-fed main path and to clarify the adapter fallback is render-safety only.

### Testing
- Ran the targeted test set with `cd frontend && pnpm vitest run app/mission-control-ingress.test.ts app/page.test.tsx components/mission-control-container.test.tsx components/mission-governance-adapter.test.ts components/mission-page.test.tsx`, and the run completed successfully. 
- The new mapping and loader tests passed and the updated page/container/adapter regression tests passed. 
- The broader test run emitted unrelated test warnings but the automated test suites for the modified areas succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c9d2a2e083268ae7871cc2a90cc3)