### PR TITLE
Add explicit governance feed endpoint and tests for Mission Control ingress

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -54,6 +54,7 @@ pnpm -r test
 - `participation_state` / `preservation_state` / `intervention_viability` / `concise_rationale` / `bind_outcome` は backend vocabulary をそのまま表示する契約です。
 - Mission Control は bind outcome だけでなく pre-bind state を timeline で扱うため、component-local 型ではなく shared type (`PreBindGovernanceSnapshot`) を利用してください。
 - Mission Control の backend-fed main path は `frontend/app/mission-control-ingress.ts` の `loadMissionControlIngressPayload` です。`/api/veritas/v1/report/governance` から governance feed を取得し、`mapGovernanceFeedToIngressPayload` で ingress contract に明示マッピングします。
+- `frontend/app/api/veritas/v1/report/governance/route.ts` が governance feed endpoint の責務を持ち、backend の `/v1/report/governance` を server-side API key 付きで取得して shared vocabulary (`governance_layer_snapshot` / `pre_bind_governance_snapshot`) を保ったまま返します。
 - Mission Control の live ingress 層は `frontend/components/mission-control-container.tsx` です。container が page loader 由来 payload を受け取り、`frontend/components/mission-governance-adapter.ts` の `resolveMissionGovernanceSnapshot` を経由して shared contract に正規化します。
 - `resolveMissionGovernanceSnapshot` は `governance_layer_snapshot`（主経路）→ `pre_bind_governance_snapshot`（互換経路）→ render safety fallback（安全経路）の順で解決します。fallback は render safety 専用であり、live verification 完了を示しません。
 - `frontend/components/mission-page.tsx` は adapter/container で解決済みの shared contract を受け取って render する責務に限定し、将来の server-side hydration・polling・streaming 追加時の接続点を固定します。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("/api/veritas/v1/report/governance", () => {
+  it("returns governance_layer_snapshot as backend-fed main path", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          governance_layer_snapshot: {
+            participation_state: "decision_shaping",
+            preservation_state: "degrading",
+            bind_outcome: "ESCALATED",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      governance_layer_snapshot: {
+        participation_state: "decision_shaping",
+        preservation_state: "degrading",
+        bind_outcome: "ESCALATED",
+      },
+    });
+  });
+
+  it("keeps compatibility with pre_bind_governance_snapshot payloads", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          pre_bind_governance_snapshot: {
+            participation_state: "participatory",
+            preservation_state: "open",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      pre_bind_governance_snapshot: {
+        participation_state: "participatory",
+        preservation_state: "open",
+      },
+    });
+  });
+
+  it("returns 503 when upstream endpoint is unavailable", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: "governance_feed_unavailable" });
+  });
+});

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+
+import { resolveApiBaseUrl } from "../../../[...path]/route-config";
+
+const GOVERNANCE_REPORT_PATH = "/v1/report/governance";
+
+function resolveApiKey(): string {
+  return (process.env.VERITAS_API_KEY ?? "").trim();
+}
+
+function normalizeGovernanceReportPayload(payload: unknown): Record<string, unknown> | null {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+
+  const source = payload as Record<string, unknown>;
+  const governanceLayerSnapshot = source.governance_layer_snapshot;
+  if (typeof governanceLayerSnapshot === "object" && governanceLayerSnapshot !== null) {
+    return { governance_layer_snapshot: governanceLayerSnapshot };
+  }
+
+  const preBindGovernanceSnapshot = source.pre_bind_governance_snapshot;
+  if (typeof preBindGovernanceSnapshot === "object" && preBindGovernanceSnapshot !== null) {
+    return { pre_bind_governance_snapshot: preBindGovernanceSnapshot };
+  }
+
+  return null;
+}
+
+/**
+ * Mission Control backend-fed governance feed endpoint.
+ *
+ * Main path fetches backend governance report and keeps payload vocabulary stable.
+ */
+export async function GET(): Promise<Response> {
+  const apiBaseUrl = resolveApiBaseUrl();
+  if (!apiBaseUrl) {
+    return NextResponse.json({ error: "governance_feed_unavailable" }, { status: 503 });
+  }
+
+  const apiKey = resolveApiKey();
+  if (!apiKey) {
+    return NextResponse.json({ error: "governance_feed_unavailable" }, { status: 503 });
+  }
+
+  try {
+    const upstreamResponse = await fetch(`${apiBaseUrl.replace(/\/$/, "")}${GOVERNANCE_REPORT_PATH}`, {
+      method: "GET",
+      headers: {
+        "X-API-Key": apiKey,
+      },
+      cache: "no-store",
+    });
+
+    if (!upstreamResponse.ok) {
+      return NextResponse.json({ error: "governance_feed_unavailable" }, { status: upstreamResponse.status });
+    }
+
+    const payload = normalizeGovernanceReportPayload((await upstreamResponse.json()) as unknown);
+    if (!payload) {
+      return NextResponse.json({ error: "invalid_governance_feed_payload" }, { status: 502 });
+    }
+
+    return NextResponse.json(payload, { status: 200 });
+  } catch {
+    return NextResponse.json({ error: "governance_feed_unavailable" }, { status: 503 });
+  }
+}

--- a/frontend/app/mission-control-ingress.test.ts
+++ b/frontend/app/mission-control-ingress.test.ts
@@ -65,6 +65,11 @@ describe("loadMissionControlIngressPayload", () => {
         preservation_state: "degrading",
       },
     });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/veritas/v1/report/governance", {
+      method: "GET",
+      cache: "no-store",
+    });
   });
 
   it("returns null when backend feed is unavailable", async () => {


### PR DESCRIPTION
### Motivation
- Make Mission Control’s backend-fed governance feed path traceable and verifiable inside the repo by exposing an explicit endpoint for the ingress helper to call. 
- Preserve existing responsibilities so `MissionPage` remains purely presentational and the container/adapter flow is unchanged. 
- Keep the shared pre-bind vocabulary and the safety fallback path intact while enabling end-to-end verification of the live path.

### Description
- Add a minimal server-side endpoint at `frontend/app/api/veritas/v1/report/governance/route.ts` that proxies `VERITAS_API_BASE_URL + /v1/report/governance` using the server `VERITAS_API_KEY` and normalizes payloads to prefer `governance_layer_snapshot` then `pre_bind_governance_snapshot`.
- Add tests at `frontend/app/api/veritas/v1/report/governance/route.test.ts` and strengthen `frontend/app/mission-control-ingress.test.ts` to assert that `loadMissionControlIngressPayload()` calls the repo-local endpoint with `cache: "no-store"`.
- Update documentation `docs/ui/README_UI.md` to describe the endpoint responsibility and to clarify the endpoint → ingress → container → adapter → page boundaries and the fallback safety path.

### Testing
- Ran the focused frontend test command `pnpm --filter frontend test -- app/api/veritas/v1/report/governance/route.test.ts app/mission-control-ingress.test.ts` and the tests passed. 
- Ran the frontend test suite used during validation which completed successfully with all test files passing (`83` test files, `773` tests passed). 
- Endpoint unit tests cover the main `governance_layer_snapshot` path, `pre_bind_governance_snapshot` compatibility, and upstream-unavailable fallback (`503`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1db339a0083268b89a057f4f025ee)