### PR TITLE
Verify Mission Control governance feed main path with page integration test and docs

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -59,6 +59,19 @@ pnpm -r test
 - `resolveMissionGovernanceSnapshot` は `governance_layer_snapshot`（主経路）→ `pre_bind_governance_snapshot`（互換経路）→ render safety fallback（安全経路）の順で解決します。fallback は render safety 専用であり、live verification 完了を示しません。
 - `frontend/components/mission-page.tsx` は adapter/container で解決済みの shared contract を受け取って render する責務に限定し、将来の server-side hydration・polling・streaming 追加時の接続点を固定します。
 
+### Mission Control governance feed main path (repo-verifiable)
+
+- Main path endpoint は `GET /api/veritas/v1/report/governance`（`frontend/app/api/veritas/v1/report/governance/route.ts`）です。
+- 経路は `frontend/app/page.tsx` → `frontend/app/mission-control-ingress.ts` → `frontend/components/mission-control-container.tsx` → `frontend/components/mission-page.tsx` です。
+- `MissionPage` は presentational component のまま維持し、data ingress は保持しません。
+- endpoint unavailable 時は fallback snapshot を使う safety path を維持します。
+- 回帰テストは以下で追跡できます。
+  - route contract: `frontend/app/api/veritas/v1/report/governance/route.test.ts`
+  - ingress mapping: `frontend/app/mission-control-ingress.test.ts`
+  - container fallback/main selection: `frontend/components/mission-control-container.test.tsx`
+  - page integration(main + fallback): `frontend/app/page.integration.test.tsx`
+  - shared vocabulary drift regression: `frontend/components/mission-governance-adapter.test.ts`
+
 
 ## Docker Compose で一括起動
 

--- a/frontend/app/page.integration.test.tsx
+++ b/frontend/app/page.integration.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import CommandDashboardPage from "./page";
+
+describe("CommandDashboardPage integration", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves endpoint -> ingress -> container -> page main path", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        governance_layer_snapshot: {
+          participation_state: "decision_shaping",
+          preservation_state: "degrading",
+          intervention_viability: "minimal",
+          bind_outcome: "ESCALATED",
+        },
+      }),
+    } as Response);
+
+    render(await CommandDashboardPage());
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/veritas/v1/report/governance", {
+      method: "GET",
+      cache: "no-store",
+    });
+    expect(screen.getByText("decision_shaping")).toBeInTheDocument();
+    expect(screen.getByText("degrading")).toBeInTheDocument();
+    expect(screen.getByText("ESCALATED")).toBeInTheDocument();
+  });
+
+  it("keeps endpoint-unavailable fallback as safety path", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+
+    render(await CommandDashboardPage());
+
+    expect(screen.getByText("participatory")).toBeInTheDocument();
+    expect(screen.getByText("open")).toBeInTheDocument();
+    expect(screen.getByText("BLOCKED")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the Mission Control governance feed main path (endpoint → ingress → container → page) explicitly repo-verifiable by adding minimal integration coverage and doc pointers while preserving existing responsibilities and vocabulary.

### Description
- Add `frontend/app/page.integration.test.tsx` to exercise the full main path from `GET /api/veritas/v1/report/governance` through `loadMissionControlIngressPayload` into `MissionControlContainer` and render verification in the page, plus a fallback-unavailable case.
- Update `docs/ui/README_UI.md` to add a "Mission Control governance feed main path (repo-verifiable)" section that documents the endpoint location, the `page.tsx` → `mission-control-ingress.ts` → `MissionControlContainer` → `MissionPage` chain, fallback semantics, and the specific tests to track regressions.
- No changes were made to shared vocabulary (`PreBindGovernanceSnapshot` / `PRE_BIND_GOVERNANCE_VOCABULARY_LABELS`), `MissionPage` (remains presentational), or `MissionControlContainer` responsibilities, and no backend-breaking API changes were introduced.

### Testing
- Ran the frontend vitest command for the target test set with `pnpm --filter frontend test -- frontend/app/api/veritas/v1/report/governance/route.test.ts frontend/app/mission-control-ingress.test.ts frontend/components/mission-control-container.test.tsx frontend/app/page.integration.test.tsx frontend/components/mission-governance-adapter.test.ts frontend/app/page.test.tsx` and the targeted tests passed (green) with non-blocking test warnings observed during the larger suite run.
- New integration test verifies that the page issues a fetch to `/api/veritas/v1/report/governance`, that a `governance_layer_snapshot` payload reaches the rendered timeline, and that endpoint-unavailable falls back to the safety snapshot.
- Existing unit tests covering route contract, ingress mapping, container selection, and shared vocabulary remain in place and were exercised as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e5a3ae508326af70cf67f7477f7e)