### PR TITLE
Inject canonical participation_signal in real pipeline E2E test and set pnpm action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -605,6 +607,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/sbom-nightly.yml
+++ b/.github/workflows/sbom-nightly.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/docs/en/proofs/pre_bind_canonical_cases_proof.md
+++ b/docs/en/proofs/pre_bind_canonical_cases_proof.md
@@ -86,4 +86,6 @@ pre-bind state combinations.
 - HTTP E2E tests protect `/v1/decide` endpoint wiring, response contract shape, additive optionality, and bind-field non-regression.
 - Real pipeline reliability E2E protects the non-stubbed HTTP → route → pipeline → response assembly path for canonical
   cases (including additive field optionality and bind-family field presence).
+- Real pipeline reliability E2E now injects canonical `participation_signal` at the core decide raw-extras boundary,
+  so governance-layer evaluation is exercised without monkeypatching response-layer evaluator calls.
 - Bind behavior is unchanged: pre-bind signals remain additive governance evidence only.

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -42,6 +42,26 @@ _PRE_BIND_FIXTURE_DIR = Path("veritas_os/tests/fixtures/pre_bind")
 _PRE_BIND_GOLDEN_DIR = Path("veritas_os/tests/golden/pre_bind")
 
 
+def _inject_canonical_participation_signal(
+    monkeypatch,
+    participation_signal: dict[str, Any],
+) -> None:
+    """Inject canonical participation_signal via core decide output extras."""
+    import veritas_os.core.pipeline as pipeline_module
+
+    original_call_core_decide = pipeline_module.call_core_decide
+
+    async def _patched_call_core_decide(*args: Any, **kwargs: Any) -> Any:
+        raw = await original_call_core_decide(*args, **kwargs)
+        if isinstance(raw, dict):
+            raw_extras = raw.setdefault("extras", {})
+            if isinstance(raw_extras, dict):
+                raw_extras["participation_signal"] = participation_signal
+        return raw
+
+    monkeypatch.setattr(pipeline_module, "call_core_decide", _patched_call_core_decide)
+
+
 def _load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -592,15 +612,9 @@ class TestCanonicalPreBindRealPipeline:
         client = _make_client(monkeypatch)
         fixture = _load_json(_PRE_BIND_FIXTURE_DIR / f"{case_id}.json")
         golden = _load_json(_PRE_BIND_GOLDEN_DIR / f"{case_id}_golden.json")
-        from veritas_os.core.pipeline import pipeline_response as pipeline_response_module
-        from veritas_os.core.pipeline.governance_layers import evaluate_governance_layers
-
-        monkeypatch.setattr(
-            pipeline_response_module,
-            "evaluate_governance_layers",
-            lambda participation_signal=None: evaluate_governance_layers(
-                participation_signal=fixture["participation_signal"],
-            ),
+        _inject_canonical_participation_signal(
+            monkeypatch,
+            fixture["participation_signal"],
         )
 
         response = _post_decide(


### PR DESCRIPTION
### Motivation
- Ensure real `/v1/decide` pipeline E2E tests exercise governance-layer evaluation by injecting canonical `participation_signal` at the core decide raw-extras boundary instead of monkeypatching evaluator calls.
- Make workflow `pnpm/action-setup` usage explicit and deterministic by specifying `version: 10` to avoid implicit version drift across CI runs.

### Description
- Added helper `_inject_canonical_participation_signal` in `veritas_os/tests/test_decide_e2e_reliability.py` to monkeypatch `veritas_os.core.pipeline.call_core_decide` and insert `participation_signal` into the returned `extras` payload.
- Replaced the previous monkeypatch of `evaluate_governance_layers` in `TestCanonicalPreBindRealPipeline` with a call to `_inject_canonical_participation_signal` that injects the fixture `participation_signal` before calling `/v1/decide`.
- Updated three GitHub Actions workflow files (`.github/workflows/main.yml`, `.github/workflows/sbom-nightly.yml`, and `.github/workflows/security-gates.yml`) to pass `version: 10` to `pnpm/action-setup@v4`.
- Added a small documentation note in `docs/en/proofs/pre_bind_canonical_cases_proof.md` explaining that the real pipeline reliability E2E now injects the canonical `participation_signal`.

### Testing
- Ran the modified E2E reliability test file with `pytest veritas_os/tests/test_decide_e2e_reliability.py` and the relevant canonical pre-bind tests; the tests completed successfully.
- Executed the repository test suite with `pytest` locally to validate no regressions; the full test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ef576c288326a99ca44d725adef2)