### PR TITLE
Use Corepack to prepare pnpm in workflows and inject canonical participation_signal in real-pipeline E2E test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,8 +141,10 @@ jobs:
       - name: Block high/critical CVEs in Python dependencies
         run: pip-audit -r veritas_os/requirements.txt --desc
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup pnpm (Corepack)
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.32.1 --activate
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -603,8 +605,10 @@ jobs:
             exit 1
           fi
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup pnpm (Corepack)
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.32.1 --activate
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/sbom-nightly.yml
+++ b/.github/workflows/sbom-nightly.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Generate Python SBOM (CycloneDX)
         run: cyclonedx-py requirements veritas_os/requirements.txt --output-file security/sbom/python.cdx.json
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup pnpm (Corepack)
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.32.1 --activate
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -53,8 +53,10 @@ jobs:
       - name: Python dependency audit (pip-audit)
         run: pip-audit -r veritas_os/requirements.txt
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup pnpm (Corepack)
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.32.1 --activate
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/docs/en/proofs/pre_bind_canonical_cases_proof.md
+++ b/docs/en/proofs/pre_bind_canonical_cases_proof.md
@@ -86,4 +86,6 @@ pre-bind state combinations.
 - HTTP E2E tests protect `/v1/decide` endpoint wiring, response contract shape, additive optionality, and bind-field non-regression.
 - Real pipeline reliability E2E protects the non-stubbed HTTP → route → pipeline → response assembly path for canonical
   cases (including additive field optionality and bind-family field presence).
+- Real pipeline reliability E2E now injects canonical `participation_signal` at the core decide raw-extras boundary,
+  so governance-layer evaluation is exercised without monkeypatching response-layer evaluator calls.
 - Bind behavior is unchanged: pre-bind signals remain additive governance evidence only.

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -42,6 +42,26 @@ _PRE_BIND_FIXTURE_DIR = Path("veritas_os/tests/fixtures/pre_bind")
 _PRE_BIND_GOLDEN_DIR = Path("veritas_os/tests/golden/pre_bind")
 
 
+def _inject_canonical_participation_signal(
+    monkeypatch,
+    participation_signal: dict[str, Any],
+) -> None:
+    """Inject canonical participation_signal via core decide output extras."""
+    import veritas_os.core.pipeline as pipeline_module
+
+    original_call_core_decide = pipeline_module.call_core_decide
+
+    async def _patched_call_core_decide(*args: Any, **kwargs: Any) -> Any:
+        raw = await original_call_core_decide(*args, **kwargs)
+        if isinstance(raw, dict):
+            raw_extras = raw.setdefault("extras", {})
+            if isinstance(raw_extras, dict):
+                raw_extras["participation_signal"] = participation_signal
+        return raw
+
+    monkeypatch.setattr(pipeline_module, "call_core_decide", _patched_call_core_decide)
+
+
 def _load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -592,15 +612,9 @@ class TestCanonicalPreBindRealPipeline:
         client = _make_client(monkeypatch)
         fixture = _load_json(_PRE_BIND_FIXTURE_DIR / f"{case_id}.json")
         golden = _load_json(_PRE_BIND_GOLDEN_DIR / f"{case_id}_golden.json")
-        from veritas_os.core.pipeline import pipeline_response as pipeline_response_module
-        from veritas_os.core.pipeline.governance_layers import evaluate_governance_layers
-
-        monkeypatch.setattr(
-            pipeline_response_module,
-            "evaluate_governance_layers",
-            lambda participation_signal=None: evaluate_governance_layers(
-                participation_signal=fixture["participation_signal"],
-            ),
+        _inject_canonical_participation_signal(
+            monkeypatch,
+            fixture["participation_signal"],
         )
 
         response = _post_decide(


### PR DESCRIPTION
### Motivation

- Replace the external `pnpm/action-setup` action with Corepack to prepare a pinned `pnpm` runtime in CI workflows for more deterministic Node tooling setup.
- Keep SBOM, dependency-audit, and security-gate workflows consistent with the new `pnpm` setup.
- Improve the real `/v1/decide` pipeline E2E reliability test by injecting canonical `participation_signal` at the core decide output boundary so governance-layer evaluation is exercised without monkeypatching response-layer evaluator calls.

### Description

- Replace `uses: pnpm/action-setup@v4` with a Corepack-based setup that runs `corepack enable` and `corepack prepare pnpm@10.32.1 --activate` in `.github/workflows/main.yml`, `.github/workflows/sbom-nightly.yml`, and `.github/workflows/security-gates.yml`.
- Keep Node setup using `actions/setup-node@v4` with `node-version: '22'` and `cache: pnpm`, and retain `pnpm install --frozen-lockfile` steps.
- Add a short documentation note to `docs/en/proofs/pre_bind_canonical_cases_proof.md` documenting that the real pipeline reliability E2E now injects canonical `participation_signal` at the core decide raw-extras boundary.
- Add `_inject_canonical_participation_signal` helper to `veritas_os/tests/test_decide_e2e_reliability.py` and switch the `TestCanonicalPreBindRealPipeline` test to use this injection instead of monkeypatching `evaluate_governance_layers`.

### Testing

- Ran the modified test module with `pytest veritas_os/tests/test_decide_e2e_reliability.py` and the `TestCanonicalPreBindRealPipeline` tests succeeded.
- CI workflows that use the updated Corepack `pnpm` setup were validated locally for syntax and step sequence (install/build/audit) during testing and showed no configuration errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ef576c288326a99ca44d725adef2)