### PR TITLE
Align canonical pre-bind real-pipeline E2E wording with implementation

### DIFF
--- a/docs/en/proofs/pre_bind_canonical_cases_proof.md
+++ b/docs/en/proofs/pre_bind_canonical_cases_proof.md
@@ -75,7 +75,7 @@ pre-bind state combinations.
 - Canonical tests: `veritas_os/tests/test_pre_bind_canonical_golden.py`
 - HTTP endpoint E2E parity tests for `/v1/decide`: `veritas_os/tests/test_pre_bind_http_e2e.py`
 - Real pipeline `/v1/decide` reliability extension for canonical cases:
-  `veritas_os/tests/test_decide_e2e_reliability.py` (`TestCanonicalPreBindRealPipeline`)
+  `veritas_os/tests/test_decide_e2e_reliability.py` (`TestCanonicalPreBindRealPipelineRawExtrasInjection`)
 - Vocabulary consistency + rationale-linked assertions: `test_canonical_case_naming_and_vocabulary_consistency` and
   `test_canonical_pre_bind_signals_and_rationales_are_explanatory` in the same test module.
 
@@ -86,6 +86,8 @@ pre-bind state combinations.
 - HTTP E2E tests protect `/v1/decide` endpoint wiring, response contract shape, additive optionality, and bind-field non-regression.
 - Real pipeline reliability E2E protects the non-stubbed HTTP → route → pipeline → response assembly path for canonical
   cases (including additive field optionality and bind-family field presence).
-- Real pipeline reliability E2E now injects canonical `participation_signal` at the core decide raw-extras boundary,
-  so governance-layer evaluation is exercised without monkeypatching response-layer evaluator calls.
+- Deterministic control in that layer is intentionally limited to injecting canonical `participation_signal` into
+  `core.pipeline.call_core_decide(...)->raw["extras"]` before response assembly.
+- Response-layer governance evaluation is still executed through the normal implementation
+  (`pipeline_response.evaluate_governance_layers`) without monkeypatch replacement in canonical reliability tests.
 - Bind behavior is unchanged: pre-bind signals remain additive governance evidence only.

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -46,7 +46,11 @@ def _inject_canonical_participation_signal(
     monkeypatch,
     participation_signal: dict[str, Any],
 ) -> None:
-    """Inject canonical participation_signal via core decide output extras."""
+    """Inject canonical signal at the raw-extras boundary before response assembly.
+
+    This keeps the HTTP -> route -> pipeline -> response-layer governance evaluation
+    path real while making canonical case inputs deterministic.
+    """
     import veritas_os.core.pipeline as pipeline_module
 
     original_call_core_decide = pipeline_module.call_core_decide
@@ -590,8 +594,14 @@ class TestBackwardCompatibility:
         assert "risk" in fuji
 
 
-class TestCanonicalPreBindRealPipeline:
-    """Canonical pre-bind cases must stay reproducible on the real /v1/decide path."""
+class TestCanonicalPreBindRealPipelineRawExtrasInjection:
+    """Canonical pre-bind reproducibility on /v1/decide with raw-extras injection.
+
+    Scope:
+      - Real HTTP/route/pipeline/response assembly path is exercised.
+      - Deterministic control is limited to core decide raw extras injection.
+      - Response-layer governance evaluator is not monkeypatched here.
+    """
 
     @pytest.mark.parametrize(
         ("case_id", "expected_participation", "expected_preservation"),
@@ -608,10 +618,13 @@ class TestCanonicalPreBindRealPipeline:
         expected_participation: str,
         expected_preservation: str,
     ):
-        """Real pipeline response must preserve canonical state/rationale parity."""
+        """Real-path response preserves canonical state/rationale and bind parity."""
         client = _make_client(monkeypatch)
         fixture = _load_json(_PRE_BIND_FIXTURE_DIR / f"{case_id}.json")
         golden = _load_json(_PRE_BIND_GOLDEN_DIR / f"{case_id}_golden.json")
+        import veritas_os.core.pipeline.governance_layers as pipeline_response_module
+
+        evaluator_before = pipeline_response_module.evaluate_governance_layers
         _inject_canonical_participation_signal(
             monkeypatch,
             fixture["participation_signal"],
@@ -627,6 +640,7 @@ class TestCanonicalPreBindRealPipeline:
 
         assert response.status_code == 200
         body = response.json()
+        assert pipeline_response_module.evaluate_governance_layers is evaluator_before
 
         assert body["participation_signal"]["participation_admissibility"] in {
             "admissible",
@@ -664,7 +678,7 @@ class TestCanonicalPreBindRealPipeline:
             assert bind_key in body
 
     def test_pre_bind_additive_fields_remain_optional_on_real_pipeline(self, monkeypatch):
-        """Absence of participation_signal keeps pre-bind additive fields optional."""
+        """Without injected signal, pre-bind additive evidence fields stay optional."""
         client = _make_client(monkeypatch)
         response = _post_decide(
             client,


### PR DESCRIPTION
### Motivation
- Remove reviewer-facing mismatch between the proof docs and the canonical real-pipeline E2E tests by making the test boundary and deterministic control explicit.

### Description
- Updated the canonical reliability test class name and docstring in `veritas_os/tests/test_decide_e2e_reliability.py` to clarify that deterministic input is injected at the raw-extras boundary while exercising the real HTTP→route→pipeline→response assembly path.
- Limited code change to the test surface: enhanced `_inject_canonical_participation_signal` docstring and added a regression assertion that `evaluate_governance_layers` (the response-layer evaluator) remains the original implementation during the canonical reliability tests.
- Synchronized documentation in `docs/en/proofs/pre_bind_canonical_cases_proof.md` to state that deterministic control is via `core.pipeline.call_core_decide(...)->raw["extras"]` injection and that `pipeline_response.evaluate_governance_layers` is not monkeypatched in these tests.
- Changed files: `veritas_os/tests/test_decide_e2e_reliability.py` and `docs/en/proofs/pre_bind_canonical_cases_proof.md`.

### Testing
- Ran the targeted canonical reliability tests with `pytest -q veritas_os/tests/test_decide_e2e_reliability.py -k 'CanonicalPreBindRealPipelineRawExtrasInjection'` and observed `4 passed` (no failures after the import fix).
- Ran supporting suites `pytest -q veritas_os/tests/test_pre_bind_canonical_golden.py veritas_os/tests/test_pre_bind_http_e2e.py` and observed `10 passed` in total, confirming golden and HTTP E2E parity still pass.
- The changes are test-only and did not require codepath semantic changes, and all exercised automated tests passed in the local runs described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f203a43314832684a354b86479b2f7)