### PR TITLE
Add Playwright E2E for Mission Control governance feed main & fallback paths

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -72,6 +72,11 @@ pnpm -r test
   - page integration(main + fallback): `frontend/app/page.integration.test.tsx`
   - shared vocabulary drift regression: `frontend/components/mission-governance-adapter.test.ts`
 
+- full frontend E2E (browser 相当): `frontend/e2e/mission-control-governance-feed.spec.ts`
+  - main path: endpoint (`/api/veritas/v1/report/governance`) を Playwright route interception で deterministic に固定し、timeline vocabulary が UI まで到達することを検証
+  - fallback path: endpoint unavailable (503) を再現し、ページ非破壊・safety fallback snapshot・timeline vocabulary 維持を検証
+- 役割分担: 既存の route/ingress/container/page integration test は層ごとの契約を守り、full frontend E2E は route → ingress → container → page の接続がブラウザ実行で破綻しないことを守ります。
+
 
 ## Docker Compose で一括起動
 

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -20,18 +20,21 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     });
 
     await page.goto("/");
+    await page.waitForResponse((response) => response.url().includes("/api/veritas/v1/report/governance"));
+    const timeline = page.getByRole("region", { name: "governance layer timeline" });
 
     await expect(
       page.getByRole("heading", { name: /(コマンドダッシュボード|Command Dashboard)/ }),
     ).toBeVisible();
-    await expect(page.getByText("participation_state:", { exact: true })).toBeVisible();
-    await expect(page.getByText("decision_shaping", { exact: true })).toBeVisible();
-    await expect(page.getByText("preservation_state:", { exact: true })).toBeVisible();
-    await expect(page.getByText("degrading", { exact: true })).toBeVisible();
-    await expect(page.getByText("intervention_viability:", { exact: true })).toBeVisible();
-    await expect(page.getByText("minimal", { exact: true })).toBeVisible();
-    await expect(page.getByText("bind_outcome:", { exact: true })).toBeVisible();
-    await expect(page.getByText("ESCALATED", { exact: true })).toBeVisible();
+    await expect(timeline).toBeVisible();
+    await expect(timeline.getByText(/^participation_state:/)).toBeVisible();
+    await expect(timeline.getByText(/^decision_shaping$/)).toBeVisible();
+    await expect(timeline.getByText(/^preservation_state:/)).toBeVisible();
+    await expect(timeline.getByText(/^degrading$/)).toBeVisible();
+    await expect(timeline.getByText(/intervention_viability:/)).toBeVisible();
+    await expect(timeline.getByText(/^minimal$/)).toBeVisible();
+    await expect(timeline.getByText(/^bind_outcome:/)).toBeVisible();
+    await expect(timeline.getByText(/^ESCALATED$/)).toBeVisible();
 
     await expect(page.getByText("BLOCKED", { exact: true })).toHaveCount(0);
   });
@@ -46,18 +49,21 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     });
 
     await page.goto("/");
+    await page.waitForResponse((response) => response.url().includes("/api/veritas/v1/report/governance"));
+    const timeline = page.getByRole("region", { name: "governance layer timeline" });
 
     await expect(
       page.getByRole("heading", { name: /(コマンドダッシュボード|Command Dashboard)/ }),
     ).toBeVisible();
-    await expect(page.getByText("participation_state:", { exact: true })).toBeVisible();
-    await expect(page.getByText("participatory", { exact: true })).toBeVisible();
-    await expect(page.getByText("preservation_state:", { exact: true })).toBeVisible();
-    await expect(page.getByText("open", { exact: true })).toBeVisible();
-    await expect(page.getByText("intervention_viability:", { exact: true })).toBeVisible();
-    await expect(page.getByText("high", { exact: true })).toBeVisible();
-    await expect(page.getByText("bind_outcome:", { exact: true })).toBeVisible();
-    await expect(page.getByText("BLOCKED", { exact: true })).toBeVisible();
+    await expect(timeline).toBeVisible();
+    await expect(timeline.getByText(/^participation_state:/)).toBeVisible();
+    await expect(timeline.getByText(/^participatory$/)).toBeVisible();
+    await expect(timeline.getByText(/^preservation_state:/)).toBeVisible();
+    await expect(timeline.getByText(/^open$/)).toBeVisible();
+    await expect(timeline.getByText(/intervention_viability:/)).toBeVisible();
+    await expect(timeline.getByText(/^high$/)).toBeVisible();
+    await expect(timeline.getByText(/^bind_outcome:/)).toBeVisible();
+    await expect(timeline.getByText(/^BLOCKED$/)).toBeVisible();
 
     await expect(page.getByText("decision_shaping", { exact: true })).toHaveCount(0);
     await expect(page.getByText("ESCALATED", { exact: true })).toHaveCount(0);

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+const GOVERNANCE_ENDPOINT = "**/api/veritas/v1/report/governance";
+
+test.describe("Mission Control: governance feed frontend E2E", () => {
+  test("main path reaches UI from /api/veritas/v1/report/governance", async ({ page }) => {
+    await page.route(GOVERNANCE_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          governance_layer_snapshot: {
+            participation_state: "decision_shaping",
+            preservation_state: "degrading",
+            intervention_viability: "minimal",
+            bind_outcome: "ESCALATED",
+          },
+        }),
+      });
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: /(コマンドダッシュボード|Command Dashboard)/ }),
+    ).toBeVisible();
+    await expect(page.getByText("participation_state:", { exact: true })).toBeVisible();
+    await expect(page.getByText("decision_shaping", { exact: true })).toBeVisible();
+    await expect(page.getByText("preservation_state:", { exact: true })).toBeVisible();
+    await expect(page.getByText("degrading", { exact: true })).toBeVisible();
+    await expect(page.getByText("intervention_viability:", { exact: true })).toBeVisible();
+    await expect(page.getByText("minimal", { exact: true })).toBeVisible();
+    await expect(page.getByText("bind_outcome:", { exact: true })).toBeVisible();
+    await expect(page.getByText("ESCALATED", { exact: true })).toBeVisible();
+
+    await expect(page.getByText("BLOCKED", { exact: true })).toHaveCount(0);
+  });
+
+  test("endpoint unavailable path renders fallback safety snapshot without breaking page", async ({ page }) => {
+    await page.route(GOVERNANCE_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "service_unavailable" }),
+      });
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: /(コマンドダッシュボード|Command Dashboard)/ }),
+    ).toBeVisible();
+    await expect(page.getByText("participation_state:", { exact: true })).toBeVisible();
+    await expect(page.getByText("participatory", { exact: true })).toBeVisible();
+    await expect(page.getByText("preservation_state:", { exact: true })).toBeVisible();
+    await expect(page.getByText("open", { exact: true })).toBeVisible();
+    await expect(page.getByText("intervention_viability:", { exact: true })).toBeVisible();
+    await expect(page.getByText("high", { exact: true })).toBeVisible();
+    await expect(page.getByText("bind_outcome:", { exact: true })).toBeVisible();
+    await expect(page.getByText("BLOCKED", { exact: true })).toBeVisible();
+
+    await expect(page.getByText("decision_shaping", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("ESCALATED", { exact: true })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure the Mission Control governance feed main path is verified end-to-end in a browser-equivalent run from endpoint to UI without changing backend contracts or shared vocabulary. 
- Complement existing split tests (route / ingress / container / page) with a minimal deterministic full frontend E2E to catch integration surface regressions that unit/integration tests may miss. 
- Keep `MissionPage` presentational and avoid UI/design changes while providing a safety-path verification for endpoint unavailability.

### Description
- Add a Playwright spec `frontend/e2e/mission-control-governance-feed.spec.ts` that intercepts `GET /api/veritas/v1/report/governance` and verifies both the main path (200 payload) and fallback path (503) render timeline vocabulary through `page -> ingress -> container -> MissionPage`. 
- Update `docs/ui/README_UI.md` to document the new full frontend E2E file and clarify role separation between existing layer tests and the new browser-equivalent checks. 
- Maintain constraints: no changes to `PreBindGovernanceSnapshot`, shared vocabulary, backend API contracts, or `MissionPage` responsibilities; the tests use deterministic route interception to avoid flaky network dependence.

### Testing
- Added automated E2E test: `frontend/e2e/mission-control-governance-feed.spec.ts` which performs deterministic Playwright route interception for main (200) and fallback (503) paths; the test is designed to be stable and non-flaky. 
- Attempted to run the new spec with `cd frontend && pnpm playwright test e2e/mission-control-governance-feed.spec.ts`, but execution failed in this environment due to missing Playwright browser binaries and reported the required action `pnpm exec playwright install`. 
- No existing unit/integration tests were removed or modified; those tests remain the authoritative layer checks and were not re-run here as part of this PR validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f242837d808326bff12b648cb60a8c)