### PR TITLE
Move canonical pre-bind deterministic seam to pipeline input shaping boundary

### DIFF
--- a/docs/en/proofs/pre_bind_canonical_cases_proof.md
+++ b/docs/en/proofs/pre_bind_canonical_cases_proof.md
@@ -75,7 +75,7 @@ pre-bind state combinations.
 - Canonical tests: `veritas_os/tests/test_pre_bind_canonical_golden.py`
 - HTTP endpoint E2E parity tests for `/v1/decide`: `veritas_os/tests/test_pre_bind_http_e2e.py`
 - Real pipeline `/v1/decide` reliability extension for canonical cases:
-  `veritas_os/tests/test_decide_e2e_reliability.py` (`TestCanonicalPreBindRealPipelineRawExtrasInjection`)
+  `veritas_os/tests/test_decide_e2e_reliability.py` (`TestCanonicalPreBindRealPipelineInputBoundaryInjection`)
 - Vocabulary consistency + rationale-linked assertions: `test_canonical_case_naming_and_vocabulary_consistency` and
   `test_canonical_pre_bind_signals_and_rationales_are_explanatory` in the same test module.
 
@@ -86,8 +86,12 @@ pre-bind state combinations.
 - HTTP E2E tests protect `/v1/decide` endpoint wiring, response contract shape, additive optionality, and bind-field non-regression.
 - Real pipeline reliability E2E protects the non-stubbed HTTP → route → pipeline → response assembly path for canonical
   cases (including additive field optionality and bind-family field presence).
-- Deterministic control in that layer is intentionally limited to injecting canonical `participation_signal` into
-  `core.pipeline.call_core_decide(...)->raw["extras"]` before response assembly.
+- Deterministic control in that layer is intentionally limited to request input shaping:
+  canonical `participation_signal` is passed via `/v1/decide` request
+  `context.pre_bind_participation_signal`.
+- Pipeline input normalization copies that value into response extras before governance-layer evaluation.
 - Response-layer governance evaluation is still executed through the normal implementation
   (`pipeline_response.evaluate_governance_layers`) without monkeypatch replacement in canonical reliability tests.
+- This boundary is more natural than patching `call_core_decide(...)->raw["extras"]`, while preserving deterministic
+  stability and avoiding flaky behavior.
 - Bind behavior is unchanged: pre-bind signals remain additive governance evidence only.

--- a/veritas_os/core/pipeline/pipeline_inputs.py
+++ b/veritas_os/core/pipeline/pipeline_inputs.py
@@ -28,6 +28,7 @@ _PIPELINE_PRIVATE_PREFIXES = (
     "_daily_plans_",
     "_world_sim_result",
 )
+_TEST_ONLY_PRE_BIND_SIGNAL_KEY = "pre_bind_participation_signal"
 
 
 def _to_bool(v: Any) -> bool:
@@ -151,6 +152,14 @@ def normalize_pipeline_inputs(
     response_extras["fast_mode"] = fast_mode
     response_extras["metrics"]["fast_mode"] = fast_mode
     response_extras["memory_meta"] = {"context": dict(context)}
+
+    # Canonical pre-bind deterministic seam:
+    # Keep production semantics unchanged (absent by default), while allowing
+    # reliability tests to inject participation signal at the request-input
+    # boundary instead of patching call_core_decide/raw extras.
+    pre_bind_signal = context.get(_TEST_ONLY_PRE_BIND_SIGNAL_KEY)
+    if isinstance(pre_bind_signal, dict):
+        response_extras["participation_signal"] = dict(pre_bind_signal)
 
     # --- WorldOS: inject state ---
     world_model = (

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -42,28 +42,18 @@ _PRE_BIND_FIXTURE_DIR = Path("veritas_os/tests/fixtures/pre_bind")
 _PRE_BIND_GOLDEN_DIR = Path("veritas_os/tests/golden/pre_bind")
 
 
-def _inject_canonical_participation_signal(
-    monkeypatch,
+def _build_pre_bind_real_pipeline_payload(
+    case_id: str,
     participation_signal: dict[str, Any],
-) -> None:
-    """Inject canonical signal at the raw-extras boundary before response assembly.
-
-    This keeps the HTTP -> route -> pipeline -> response-layer governance evaluation
-    path real while making canonical case inputs deterministic.
-    """
-    import veritas_os.core.pipeline as pipeline_module
-
-    original_call_core_decide = pipeline_module.call_core_decide
-
-    async def _patched_call_core_decide(*args: Any, **kwargs: Any) -> Any:
-        raw = await original_call_core_decide(*args, **kwargs)
-        if isinstance(raw, dict):
-            raw_extras = raw.setdefault("extras", {})
-            if isinstance(raw_extras, dict):
-                raw_extras["participation_signal"] = participation_signal
-        return raw
-
-    monkeypatch.setattr(pipeline_module, "call_core_decide", _patched_call_core_decide)
+) -> dict[str, Any]:
+    """Build deterministic canonical payload at the pipeline-input boundary."""
+    return {
+        "query": f"canonical pre-bind real pipeline: {case_id}",
+        "context": {
+            "user_id": f"real_pipeline_{case_id}",
+            "pre_bind_participation_signal": participation_signal,
+        },
+    }
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -594,12 +584,12 @@ class TestBackwardCompatibility:
         assert "risk" in fuji
 
 
-class TestCanonicalPreBindRealPipelineRawExtrasInjection:
-    """Canonical pre-bind reproducibility on /v1/decide with raw-extras injection.
+class TestCanonicalPreBindRealPipelineInputBoundaryInjection:
+    """Canonical pre-bind reproducibility on /v1/decide with input-boundary injection.
 
     Scope:
       - Real HTTP/route/pipeline/response assembly path is exercised.
-      - Deterministic control is limited to core decide raw extras injection.
+      - Deterministic control is limited to request context input shaping.
       - Response-layer governance evaluator is not monkeypatched here.
     """
 
@@ -625,17 +615,12 @@ class TestCanonicalPreBindRealPipelineRawExtrasInjection:
         import veritas_os.core.pipeline.governance_layers as pipeline_response_module
 
         evaluator_before = pipeline_response_module.evaluate_governance_layers
-        _inject_canonical_participation_signal(
-            monkeypatch,
-            fixture["participation_signal"],
-        )
-
         response = _post_decide(
             client,
-            {
-                "query": f"canonical pre-bind real pipeline: {case_id}",
-                "context": {"user_id": f"real_pipeline_{case_id}"},
-            },
+            _build_pre_bind_real_pipeline_payload(
+                case_id=case_id,
+                participation_signal=fixture["participation_signal"],
+            ),
         )
 
         assert response.status_code == 200
@@ -649,6 +634,7 @@ class TestCanonicalPreBindRealPipelineRawExtrasInjection:
         }
         assert body["pre_bind_detection_summary"]["participation_state"] == expected_participation
         assert body["pre_bind_preservation_summary"]["preservation_state"] == expected_preservation
+        assert body["extras"]["participation_signal"] == fixture["participation_signal"]
         assert (
             body["pre_bind_detection_summary"]["participation_state"]
             == golden["pre_bind_detection_summary"]["participation_state"]


### PR DESCRIPTION
### Motivation
- Move the deterministic control used by canonical real-pipeline E2E tests from a test-only patch of `call_core_decide(...)->raw["extras"]` to a more natural upstream input boundary so the tests exercise a closer-to-production request→pipeline path while preserving semantics.
- Keep canonical 3 cases, golden parity, bind-family regression, additive optionality, and non-flakiness unchanged.
- Avoid API/schema/vocabulary changes and avoid adding external dependencies or broader pipeline semantics changes.

### Description
- Added a small, test-only seam key `pre_bind_participation_signal` that `normalize_pipeline_inputs()` copies into `response_extras["participation_signal"]` when present, preserving default absent behavior otherwise.
- Updated the real-pipeline reliability tests to build `/v1/decide` payloads that place canonical fixtures into `context.pre_bind_participation_signal` and to assert the injected value flows through into `extras` and preserves golden/evaluator parity.
- Updated the proof document to reflect the new deterministic boundary, rationale why it is more natural, and that evaluator/bind semantics remain unchanged.
- Files changed: `veritas_os/core/pipeline/pipeline_inputs.py`, `veritas_os/tests/test_decide_e2e_reliability.py`, `docs/en/proofs/pre_bind_canonical_cases_proof.md`.
- Security note: this PR introduces a test-only input seam; operational guidance is required to restrict usage of `context.pre_bind_participation_signal` to proof/reliability scenarios to avoid accidental production injection.

### Testing
- Ran targeted reliability tests: `pytest -q veritas_os/tests/test_decide_e2e_reliability.py -k "CanonicalPreBindRealPipelineInputBoundaryInjection or pre_bind_additive_fields_remain_optional_on_real_pipeline"` and observed all selected tests passed (`4 passed, 22 deselected`).
- Ran golden and HTTP parity tests: `pytest -q veritas_os/tests/test_pre_bind_canonical_golden.py veritas_os/tests/test_pre_bind_http_e2e.py` and observed all tests passed (`10 passed`).
- These automated runs confirm canonical 3 cases, absent/additive optional behavior, and golden parity are preserved under the new input-boundary seam.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d38ea3e083269f035528afafd8c9)