### PR TITLE
Move canonical pre-bind deterministic control to normalized input seam

### DIFF
--- a/docs/en/proofs/pre_bind_canonical_cases_proof.md
+++ b/docs/en/proofs/pre_bind_canonical_cases_proof.md
@@ -89,7 +89,9 @@ pre-bind state combinations.
 - Deterministic control in that layer is intentionally limited to request input shaping:
   canonical `participation_signal` is passed via `/v1/decide` request
   `context.pre_bind_participation_signal`.
-- Pipeline input normalization copies that value into response extras before governance-layer evaluation.
+- Pipeline input normalization extracts that test-only context key, normalizes it as a canonical
+  `participation_signal`, and places it into response extras before governance-layer evaluation.
+- The test hook key is removed from runtime context after extraction to keep the seam isolated.
 - Response-layer governance evaluation is still executed through the normal implementation
   (`pipeline_response.evaluate_governance_layers`) without monkeypatch replacement in canonical reliability tests.
 - This boundary is more natural than patching `call_core_decide(...)->raw["extras"]`, while preserving deterministic

--- a/veritas_os/core/pipeline/pipeline_inputs.py
+++ b/veritas_os/core/pipeline/pipeline_inputs.py
@@ -16,6 +16,7 @@ from typing import Any, Dict
 from .pipeline_types import PipelineContext
 from .pipeline_helpers import _to_bool_local, _lazy_import, _now_iso, _warn
 from .pipeline_contracts import _ensure_full_contract
+from ..participation_semantics import normalize_participation_signal_payload
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,18 @@ _TEST_ONLY_PRE_BIND_SIGNAL_KEY = "pre_bind_participation_signal"
 
 def _to_bool(v: Any) -> bool:
     return _to_bool_local(v)
+
+
+def _extract_test_only_pre_bind_signal(context: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Extract and normalize test-only canonical pre-bind signal from request context.
+
+    This keeps deterministic canonical control at the request input seam while
+    isolating the hook from normal context propagation.
+    """
+    pre_bind_signal = context.pop(_TEST_ONLY_PRE_BIND_SIGNAL_KEY, None)
+    if not isinstance(pre_bind_signal, dict):
+        return None
+    return normalize_participation_signal_payload(pre_bind_signal)
 
 
 def normalize_pipeline_inputs(
@@ -157,9 +170,9 @@ def normalize_pipeline_inputs(
     # Keep production semantics unchanged (absent by default), while allowing
     # reliability tests to inject participation signal at the request-input
     # boundary instead of patching call_core_decide/raw extras.
-    pre_bind_signal = context.get(_TEST_ONLY_PRE_BIND_SIGNAL_KEY)
-    if isinstance(pre_bind_signal, dict):
-        response_extras["participation_signal"] = dict(pre_bind_signal)
+    pre_bind_signal = _extract_test_only_pre_bind_signal(context)
+    if pre_bind_signal is not None:
+        response_extras["participation_signal"] = pre_bind_signal
 
     # --- WorldOS: inject state ---
     world_model = (

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -613,6 +613,7 @@ class TestCanonicalPreBindRealPipelineInputBoundaryInjection:
         fixture = _load_json(_PRE_BIND_FIXTURE_DIR / f"{case_id}.json")
         golden = _load_json(_PRE_BIND_GOLDEN_DIR / f"{case_id}_golden.json")
         import veritas_os.core.pipeline.governance_layers as pipeline_response_module
+        from veritas_os.core.participation_semantics import normalize_participation_signal_payload
 
         evaluator_before = pipeline_response_module.evaluate_governance_layers
         response = _post_decide(
@@ -634,7 +635,9 @@ class TestCanonicalPreBindRealPipelineInputBoundaryInjection:
         }
         assert body["pre_bind_detection_summary"]["participation_state"] == expected_participation
         assert body["pre_bind_preservation_summary"]["preservation_state"] == expected_preservation
-        assert body["extras"]["participation_signal"] == fixture["participation_signal"]
+        assert body["extras"]["participation_signal"] == normalize_participation_signal_payload(
+            fixture["participation_signal"]
+        )
         assert (
             body["pre_bind_detection_summary"]["participation_state"]
             == golden["pre_bind_detection_summary"]["participation_state"]

--- a/veritas_os/tests/unit/test_pipeline_inputs_pre_bind_seam.py
+++ b/veritas_os/tests/unit/test_pipeline_inputs_pre_bind_seam.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Tests for canonical pre-bind deterministic seam in pipeline input normalization."""
+
+from __future__ import annotations
+
+from veritas_os.core.pipeline_inputs import normalize_pipeline_inputs
+
+
+class _DummyReq:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self):
+        return self._payload
+
+
+class _DummyRequest:
+    query_params = {}
+    params = {}
+
+
+def test_pre_bind_signal_is_normalized_from_context_input_seam():
+    payload = {
+        "query": "canonical seam test",
+        "context": {
+            "user_id": "u",
+            "pre_bind_participation_signal": {
+                "interpretation_space_narrowing": "open",
+                "counterfactual_availability": "high",
+                "intervention_headroom": "high",
+                "structural_openness": "open",
+            },
+        },
+    }
+    ctx = normalize_pipeline_inputs(_DummyReq(payload), _DummyRequest())
+    signal = ctx.response_extras["participation_signal"]
+    assert signal["signal_family"] == "participation_signal"
+    assert signal["interpretation_space_narrowing"] == "open"
+
+
+def test_pre_bind_signal_hook_is_isolated_from_runtime_context():
+    payload = {
+        "query": "canonical seam isolation test",
+        "context": {
+            "user_id": "u",
+            "pre_bind_participation_signal": {
+                "interpretation_space_narrowing": "closed",
+                "counterfactual_availability": "none",
+                "intervention_headroom": "low",
+                "structural_openness": "closed",
+            },
+        },
+    }
+    ctx = normalize_pipeline_inputs(_DummyReq(payload), _DummyRequest())
+    assert "pre_bind_participation_signal" not in ctx.context


### PR DESCRIPTION
### Motivation
- Move the canonical pre-bind deterministic control one step upstream from raw extras injection to a more natural pipeline input boundary so reliability tests exercise a more realistic input seam while staying deterministic. 
- Keep pre-bind semantics, bind-family behavior, golden parity and existing proofs/tests unchanged while making the test seam explicit and isolated. 

### Description
- Introduced `_extract_test_only_pre_bind_signal(context)` in `veritas_os/core/pipeline/pipeline_inputs.py` to pop `context.pre_bind_participation_signal`, normalize it via `normalize_participation_signal_payload`, and place the normalized artifact into `response_extras["participation_signal"]` while removing the hook key from runtime context. 
- Updated the canonical real-pipeline reliability assertions in `veritas_os/tests/test_decide_e2e_reliability.py` to compare against the normalized canonical payload instead of raw fixture dicts. 
- Added focused unit tests `veritas_os/tests/unit/test_pipeline_inputs_pre_bind_seam.py` that verify (1) the signal is normalized at the input seam and (2) the test-only hook does not leak into `ctx.context`. 
- Synchronized the proof document `docs/en/proofs/pre_bind_canonical_cases_proof.md` to describe the new deterministic seam and its isolation semantics. 

Changed files: `veritas_os/core/pipeline/pipeline_inputs.py`, `veritas_os/tests/test_decide_e2e_reliability.py`, `veritas_os/tests/unit/test_pipeline_inputs_pre_bind_seam.py`, `docs/en/proofs/pre_bind_canonical_cases_proof.md`.

### Testing
- Ran the focused test selection: `pytest -q veritas_os/tests/unit/test_pipeline_inputs_pre_bind_seam.py veritas_os/tests/test_decide_e2e_reliability.py -k "CanonicalPreBindRealPipelineInputBoundaryInjection or pre_bind_signal"` and observed all tests pass (`6 passed, 22 deselected`). 
- The new unit tests exercise the normalization/isolation behavior and passed. 
- The canonical reliability E2E assertions for the three canonical cases (A/B/C) and the absent/minimal additive case remain passing and preserved golden parity through the updated assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dfa2047c8326a67d81a600f8ad94)