### PR TITLE
Move canonical pre-bind reliability tests to request-input deterministic seam

### DIFF
--- a/docs/en/proofs/pre_bind_canonical_cases_proof.md
+++ b/docs/en/proofs/pre_bind_canonical_cases_proof.md
@@ -75,7 +75,7 @@ pre-bind state combinations.
 - Canonical tests: `veritas_os/tests/test_pre_bind_canonical_golden.py`
 - HTTP endpoint E2E parity tests for `/v1/decide`: `veritas_os/tests/test_pre_bind_http_e2e.py`
 - Real pipeline `/v1/decide` reliability extension for canonical cases:
-  `veritas_os/tests/test_decide_e2e_reliability.py` (`TestCanonicalPreBindRealPipelineInputBoundaryInjection`)
+  `veritas_os/tests/test_decide_e2e_reliability.py` (`TestCanonicalPreBindRealPipelineRequestInputSeam`)
 - Vocabulary consistency + rationale-linked assertions: `test_canonical_case_naming_and_vocabulary_consistency` and
   `test_canonical_pre_bind_signals_and_rationales_are_explanatory` in the same test module.
 
@@ -86,6 +86,7 @@ pre-bind state combinations.
 - HTTP E2E tests protect `/v1/decide` endpoint wiring, response contract shape, additive optionality, and bind-field non-regression.
 - Real pipeline reliability E2E protects the non-stubbed HTTP → route → pipeline → response assembly path for canonical
   cases (including additive field optionality and bind-family field presence).
+- Migration note: canonical reliability deterministic control was moved from legacy raw-extras monkeypatch injection to the request-input seam (`context.pre_bind_participation_signal`) for the canonical main path.
 - Deterministic control in that layer is intentionally limited to request input shaping:
   canonical `participation_signal` is passed via `/v1/decide` request
   `context.pre_bind_participation_signal`.

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -584,12 +584,13 @@ class TestBackwardCompatibility:
         assert "risk" in fuji
 
 
-class TestCanonicalPreBindRealPipelineInputBoundaryInjection:
-    """Canonical pre-bind reproducibility on /v1/decide with input-boundary injection.
+class TestCanonicalPreBindRealPipelineRequestInputSeam:
+    """Canonical pre-bind reproducibility via request-input deterministic seam.
 
     Scope:
       - Real HTTP/route/pipeline/response assembly path is exercised.
-      - Deterministic control is limited to request context input shaping.
+      - Deterministic control uses context.pre_bind_participation_signal.
+      - Canonical main path does not patch raw extras injection.
       - Response-layer governance evaluator is not monkeypatched here.
     """
 
@@ -638,6 +639,7 @@ class TestCanonicalPreBindRealPipelineInputBoundaryInjection:
         assert body["extras"]["participation_signal"] == normalize_participation_signal_payload(
             fixture["participation_signal"]
         )
+        assert "pre_bind_participation_signal" not in body.get("context", {})
         assert (
             body["pre_bind_detection_summary"]["participation_state"]
             == golden["pre_bind_detection_summary"]["participation_state"]


### PR DESCRIPTION
### Motivation
- Move the deterministic control for canonical pre-bind reliability tests from ad-hoc `raw['extras']` monkeypatch injection to a more natural request-input seam (`context.pre_bind_participation_signal`) while keeping production semantics unchanged. 
- Keep the change minimal and reviewable by only updating test naming, assertions, and proof documentation so the canonical 3-case parity, optionality, and bind-family regression checks remain intact.

### Description
- Rename the canonical reliability test class from `TestCanonicalPreBindRealPipelineInputBoundaryInjection` to `TestCanonicalPreBindRealPipelineRequestInputSeam` and update its docstring to state that deterministic control uses `context.pre_bind_participation_signal`. 
- Add an assertion to the canonical test to verify the test-only key is not left in runtime response context: `assert "pre_bind_participation_signal" not in body.get("context", {})`. 
- Update `docs/en/proofs/pre_bind_canonical_cases_proof.md` to reference the new test class name and add a migration note that deterministic control moved from raw-extras monkeypatch injection to the request-input seam. 
- Make no changes to pipeline production code or golden assertions, and do not remove any existing canonical/golden/http tests.

### Testing
- Ran the targeted reliability tests with `pytest -q veritas_os/tests/test_decide_e2e_reliability.py -k 'CanonicalPreBindRealPipelineRequestInputSeam or pre_bind_additive_fields_remain_optional_on_real_pipeline'`, resulting in `4 passed, 22 deselected`.
- The run confirmed canonical parity assertions, additive-absence optionality, and that the request-input seam is exercised without monkeypatching `raw["extras"]`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2eb3c11408326abdffcdef96cf99e)