### PR TITLE
Add /v1/governance/live-snapshot and wire Mission Control to backend live state

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -54,14 +54,14 @@ pnpm -r test
 - `participation_state` / `preservation_state` / `intervention_viability` / `concise_rationale` / `bind_outcome` は backend vocabulary をそのまま表示する契約です。
 - Mission Control は bind outcome だけでなく pre-bind state を timeline で扱うため、component-local 型ではなく shared type (`PreBindGovernanceSnapshot`) を利用してください。
 - Mission Control の backend-fed main path は `frontend/app/mission-control-ingress.ts` の `loadMissionControlIngressPayload` です。`/api/veritas/v1/report/governance` から governance feed を取得し、`mapGovernanceFeedToIngressPayload` で ingress contract に明示マッピングします。
-- `frontend/app/api/veritas/v1/report/governance/route.ts` が governance feed endpoint の責務を持ち、backend の `/v1/report/governance` を server-side API key 付きで取得して shared vocabulary (`governance_layer_snapshot` / `pre_bind_governance_snapshot`) を保ったまま返します。
+- `frontend/app/api/veritas/v1/report/governance/route.ts` が governance feed endpoint の責務を持ち、backend の `/v1/governance/live-snapshot` を server-side API key 付きで取得して shared vocabulary (`governance_layer_snapshot` / `pre_bind_governance_snapshot`) を保ったまま返します。
 - Mission Control の live ingress 層は `frontend/components/mission-control-container.tsx` です。container が page loader 由来 payload を受け取り、`frontend/components/mission-governance-adapter.ts` の `resolveMissionGovernanceSnapshot` を経由して shared contract に正規化します。
 - `resolveMissionGovernanceSnapshot` は `governance_layer_snapshot`（主経路）→ `pre_bind_governance_snapshot`（互換経路）→ render safety fallback（安全経路）の順で解決します。fallback は render safety 専用であり、live verification 完了を示しません。
 - `frontend/components/mission-page.tsx` は adapter/container で解決済みの shared contract を受け取って render する責務に限定し、将来の server-side hydration・polling・streaming 追加時の接続点を固定します。
 
 ### Mission Control governance feed main path (repo-verifiable)
 
-- Main path endpoint は `GET /api/veritas/v1/report/governance`（`frontend/app/api/veritas/v1/report/governance/route.ts`）です。
+- Main path endpoint は `GET /api/veritas/v1/report/governance`（BFF）→ backend `GET /v1/governance/live-snapshot`（`frontend/app/api/veritas/v1/report/governance/route.ts`）です。
 - 経路は `frontend/app/page.tsx` → `frontend/app/mission-control-ingress.ts` → `frontend/components/mission-control-container.tsx` → `frontend/components/mission-page.tsx` です。
 - `MissionPage` は presentational component のまま維持し、data ingress は保持しません。
 - endpoint unavailable 時は fallback snapshot を使う safety path を維持します。
@@ -95,3 +95,4 @@ docker compose up --build
 - 上記 scenario 注入は `NODE_ENV === "test"` または `VERITAS_ENABLE_E2E_SCENARIOS=1` の明示 opt-in 時のみ有効です。
 - production では query/header での scenario injection は無視され、Mission Control は backend-fed governance data を優先します。
 - deterministic scenario は UI regression 用フィクスチャであり、production governance data source ではありません。
+- `/v1/report/governance` は date-range governance/compliance report 用であり、Mission Control live snapshot source とは役割を分離します。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -122,4 +122,31 @@ describe("/api/veritas/v1/report/governance", () => {
       },
     });
   });
+
+  it("calls /v1/governance/live-snapshot when scenarios are not used", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ governance_layer_snapshot: { bind_outcome: "UNKNOWN" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await GET(new Request("http://localhost/api/veritas/v1/report/governance"));
+
+    expect(fetchSpy).toHaveBeenCalledWith("http://internal-api:8000/v1/governance/live-snapshot", expect.any(Object));
+  });
+
+  it("returns unavailable when upstream live snapshot is unavailable", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 503 }));
+
+    const response = await GET(new Request("http://localhost/api/veritas/v1/report/governance"));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: "governance_feed_unavailable" });
+  });
+
 });

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { resolveApiBaseUrl } from "../../../[...path]/route-config";
 import { areE2EScenariosEnabled } from "../../../../../e2e-scenarios";
 
-const GOVERNANCE_REPORT_PATH = "/v1/report/governance";
+const GOVERNANCE_LIVE_SNAPSHOT_PATH = "/v1/governance/live-snapshot";
 const E2E_SCENARIO_HEADER = "x-veritas-e2e-governance-scenario";
 const E2E_SCENARIO_QUERY = "e2e_governance_scenario";
 
@@ -61,7 +61,7 @@ function normalizeGovernanceReportPayload(payload: unknown): Record<string, unkn
 /**
  * Mission Control backend-fed governance feed endpoint.
  *
- * Main path fetches backend governance report and keeps payload vocabulary stable.
+ * Main path fetches backend governance live snapshot and keeps payload vocabulary stable.
  */
 export async function GET(request: Request): Promise<Response> {
   if (areE2EScenariosEnabled()) {
@@ -82,7 +82,7 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   try {
-    const upstreamResponse = await fetch(`${apiBaseUrl.replace(/\/$/, "")}${GOVERNANCE_REPORT_PATH}`, {
+    const upstreamResponse = await fetch(`${apiBaseUrl.replace(/\/$/, "")}${GOVERNANCE_LIVE_SNAPSHOT_PATH}`, {
       method: "GET",
       headers: {
         "X-API-Key": apiKey,

--- a/veritas_os/api/governance_live_snapshot.py
+++ b/veritas_os/api/governance_live_snapshot.py
@@ -1,0 +1,90 @@
+"""Mission Control governance live snapshot builder."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from veritas_os.policy.bind_artifacts import FinalOutcome, find_bind_receipts
+
+_ALLOWED_PARTICIPATION_STATES = {
+    "informative",
+    "participatory",
+    "decision_shaping",
+    "unknown",
+}
+_ALLOWED_PRESERVATION_STATES = {
+    "open",
+    "degrading",
+    "collapsed",
+    "unknown",
+}
+_ALLOWED_INTERVENTION_VIABILITY = {
+    "high",
+    "medium",
+    "minimal",
+    "unknown",
+}
+_ALLOWED_BIND_OUTCOMES = {item.value for item in FinalOutcome} | {"UNKNOWN"}
+
+
+def _utc_now_iso8601() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _normalize_state(value: Any, *, allowed: set[str]) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    normalized = value.strip().lower()
+    return normalized if normalized in allowed else "unknown"
+
+
+def _normalize_bind_outcome(value: Any) -> str:
+    if not isinstance(value, str):
+        return "UNKNOWN"
+    normalized = value.strip().upper()
+    return normalized if normalized in _ALLOWED_BIND_OUTCOMES else "UNKNOWN"
+
+
+def build_governance_live_snapshot() -> dict[str, Any]:
+    """Build a lightweight governance snapshot for Mission Control.
+
+    Returns a degraded unknown snapshot when recent governance artifacts are
+    unavailable or cannot be loaded.
+    """
+    fallback = {
+        "governance_layer_snapshot": {
+            "participation_state": "unknown",
+            "preservation_state": "unknown",
+            "intervention_viability": "unknown",
+            "bind_outcome": "UNKNOWN",
+            "source": "degraded_no_recent_governance_artifact",
+            "updated_at": _utc_now_iso8601(),
+        },
+    }
+    try:
+        receipts = find_bind_receipts(limit=1)
+    except Exception:
+        return fallback
+
+    if not receipts:
+        return fallback
+
+    latest = receipts[0].to_dict()
+    snapshot = {
+        "participation_state": _normalize_state(
+            latest.get("participation_state"),
+            allowed=_ALLOWED_PARTICIPATION_STATES,
+        ),
+        "preservation_state": _normalize_state(
+            latest.get("preservation_state"),
+            allowed=_ALLOWED_PRESERVATION_STATES,
+        ),
+        "intervention_viability": _normalize_state(
+            latest.get("intervention_viability"),
+            allowed=_ALLOWED_INTERVENTION_VIABILITY,
+        ),
+        "bind_outcome": _normalize_bind_outcome(latest.get("final_outcome")),
+        "source": "backend_live_snapshot",
+        "updated_at": latest.get("bind_ts") if isinstance(latest.get("bind_ts"), str) else _utc_now_iso8601(),
+    }
+    return {"governance_layer_snapshot": snapshot}

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -23,6 +23,7 @@ from veritas_os.api.bind_summary import (
 )
 from veritas_os.api.bind_target_catalog import get_target_catalog_payload
 from veritas_os.api.rbac import Permission
+from veritas_os.api.governance_live_snapshot import build_governance_live_snapshot
 from veritas_os.api.schemas import (
     GovernanceBindReceiptExportResponse,
     GovernanceBindReceiptListResponse,
@@ -862,3 +863,9 @@ def governance_promote_policy_bundle(
             status_code=500,
             content={"ok": False, "error": "Failed to promote policy bundle"},
         )
+
+
+@router.get("/v1/governance/live-snapshot", dependencies=[Depends(require_permission(Permission.governance_read))])
+def governance_live_snapshot() -> dict[str, Any]:
+    """Return Mission Control governance live snapshot from backend artifacts."""
+    return build_governance_live_snapshot()

--- a/veritas_os/policy/bind_coverage.py
+++ b/veritas_os/policy/bind_coverage.py
@@ -101,6 +101,7 @@ BIND_COVERAGE_REGISTRY: tuple[BindCoverageEntry, ...] = (
     BindCoverageEntry("/v1/governance/bind-receipts", "GET", BindCoverageClass.READ_ONLY),
     BindCoverageEntry("/v1/governance/bind-receipts/export", "GET", BindCoverageClass.READ_ONLY),
     BindCoverageEntry("/v1/governance/bind-receipts/{bind_receipt_id}", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/governance/live-snapshot", "GET", BindCoverageClass.READ_ONLY),
     BindCoverageEntry("/v1/governance/policy-bundles/promote", "POST", BindCoverageClass.BIND_GOVERNED),
     BindCoverageEntry("/v1/compliance/config", "GET", BindCoverageClass.READ_ONLY),
     BindCoverageEntry("/v1/compliance/config", "PUT", BindCoverageClass.BIND_GOVERNED),

--- a/veritas_os/tests/test_governance_live_snapshot.py
+++ b/veritas_os/tests/test_governance_live_snapshot.py
@@ -1,0 +1,90 @@
+"""Tests for governance live snapshot endpoint."""
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+import veritas_os.api.server as server
+from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome
+
+_TEST_KEY = "gov-live-snapshot-test-key"
+os.environ["VERITAS_API_KEY"] = _TEST_KEY
+_AUTH = {"X-API-Key": _TEST_KEY, "X-Role": "admin"}
+
+client = TestClient(server.app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", _TEST_KEY)
+    monkeypatch.setenv("VERITAS_API_KEYS", "[{\"key\":\"gov-live-snapshot-test-key\",\"role\":\"auditor\"}]")
+
+
+
+def test_governance_live_snapshot_returns_200(monkeypatch):
+    receipt = BindReceipt(final_outcome=FinalOutcome.COMMITTED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda limit=1: [receipt],
+    )
+
+    response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
+    assert response.status_code == 200
+    payload = response.json()
+    assert "governance_layer_snapshot" in payload
+
+
+def test_governance_live_snapshot_has_required_fields(monkeypatch):
+    receipt = BindReceipt(final_outcome=FinalOutcome.ESCALATED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda limit=1: [receipt],
+    )
+
+    snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
+    for key in (
+        "participation_state",
+        "preservation_state",
+        "intervention_viability",
+        "bind_outcome",
+        "source",
+        "updated_at",
+    ):
+        assert key in snapshot
+
+
+def test_governance_live_snapshot_degraded_when_artifact_unavailable(monkeypatch):
+    def _raise(limit=1):
+        raise RuntimeError("no storage")
+
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", _raise)
+    response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
+    assert response.status_code == 200
+    snapshot = response.json()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_no_recent_governance_artifact"
+    assert snapshot["bind_outcome"] == "UNKNOWN"
+
+
+def test_governance_live_snapshot_vocabulary(monkeypatch):
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", lambda limit=1: [])
+    snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
+    assert snapshot["participation_state"] in {"informative", "participatory", "decision_shaping", "unknown"}
+    assert snapshot["preservation_state"] in {"open", "degrading", "collapsed", "unknown"}
+    assert snapshot["intervention_viability"] in {"high", "medium", "minimal", "unknown"}
+    assert snapshot["bind_outcome"] in {
+        "COMMITTED",
+        "BLOCKED",
+        "ESCALATED",
+        "ROLLED_BACK",
+        "APPLY_FAILED",
+        "SNAPSHOT_FAILED",
+        "PRECONDITION_FAILED",
+        "UNKNOWN",
+    }
+
+
+def test_governance_live_snapshot_requires_auth():
+    response = client.get("/v1/governance/live-snapshot")
+    assert response.status_code in {401, 403}


### PR DESCRIPTION
### Motivation
- Mission Control should consume a lightweight backend-fed live governance snapshot rather than the date-range report endpoint, avoiding misuse of `/v1/report/governance` for live UI state.
- Provide a minimal, explicit degraded/unknown fallback when real governance artifacts are unavailable so the UI never receives a fake success or throws a 500.
- Preserve deterministic E2E scenario injection as test-only / opt-in and maintain existing RBAC/ABAC protections for governance-sensitive endpoints.

### Description
- Added a standalone snapshot builder `build_governance_live_snapshot()` in `veritas_os/api/governance_live_snapshot.py` that normalizes vocabulary, prefers the latest bind receipt when available, and falls back to an explicit degraded/unknown snapshot; `updated_at` is returned as UTC ISO8601.
- Exposed a new backend endpoint `GET /v1/governance/live-snapshot` in `veritas_os/api/routes_governance.py` that returns the builder output and remains guarded by the existing `governance_read` permission and governance access guard.
- Wired the frontend BFF route `frontend/app/api/veritas/v1/report/governance/route.ts` to call backend `/v1/governance/live-snapshot` (keeps existing E2E scenario gating and payload normalization behavior).
- Added backend tests `veritas_os/tests/test_governance_live_snapshot.py` and updated frontend route tests `frontend/app/api/veritas/v1/report/governance/route.test.ts`, and updated `docs/ui/README_UI.md` to document role separation between live snapshot and report endpoints.
- Security: endpoint remains under RBAC/ABAC and the implementation intentionally fails to an explicit degraded snapshot instead of returning fake data; ensure API secret and governance role config are correctly set in deployment.

### Testing
- Ran `pytest -q veritas_os/tests/test_governance_live_snapshot.py` and all tests passed (`5 passed`).
- Ran `pnpm --filter frontend test app/api/veritas/v1/report/governance/route.test.ts` and the updated route tests passed (`1 file, 8 tests passed`).
- Ran `pnpm --filter frontend test app/mission-control-ingress.test.ts app/page.integration.test.tsx` and the tests passed (noting transient LiveEventStream URL parse warnings emitted to stderr but not failing tests).
- Playwright E2E was not executed in this rollout; Playwright browser install/execution can be run separately if full browser E2E validation is required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30526e9288326842d248be97d5a15)