### PR TITLE
Fix governance live snapshot bind receipt retrieval and tests

### DIFF
--- a/veritas_os/api/governance_live_snapshot.py
+++ b/veritas_os/api/governance_live_snapshot.py
@@ -62,14 +62,14 @@ def build_governance_live_snapshot() -> dict[str, Any]:
         },
     }
     try:
-        receipts = find_bind_receipts(limit=1)
+        receipts = find_bind_receipts()
     except Exception:
         return fallback
 
     if not receipts:
         return fallback
 
-    latest = receipts[0].to_dict()
+    latest = receipts[-1].to_dict()
     snapshot = {
         "participation_state": _normalize_state(
             latest.get("participation_state"),

--- a/veritas_os/tests/test_governance_live_snapshot.py
+++ b/veritas_os/tests/test_governance_live_snapshot.py
@@ -1,4 +1,4 @@
-"""Tests for governance live snapshot endpoint."""
+"""Tests for governance live snapshot endpoint and builder behavior."""
 from __future__ import annotations
 
 import os
@@ -7,6 +7,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 import veritas_os.api.server as server
+from veritas_os.api.governance_live_snapshot import (
+    _normalize_bind_outcome,
+    _normalize_state,
+    build_governance_live_snapshot,
+)
 from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome
 
 _TEST_KEY = "gov-live-snapshot-test-key"
@@ -22,12 +27,11 @@ def _reset_auth(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEYS", "[{\"key\":\"gov-live-snapshot-test-key\",\"role\":\"auditor\"}]")
 
 
-
 def test_governance_live_snapshot_returns_200(monkeypatch):
     receipt = BindReceipt(final_outcome=FinalOutcome.COMMITTED, bind_ts="2026-04-30T00:00:00Z")
     monkeypatch.setattr(
         "veritas_os.api.governance_live_snapshot.find_bind_receipts",
-        lambda limit=1: [receipt],
+        lambda: [receipt],
     )
 
     response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
@@ -40,7 +44,7 @@ def test_governance_live_snapshot_has_required_fields(monkeypatch):
     receipt = BindReceipt(final_outcome=FinalOutcome.ESCALATED, bind_ts="2026-04-30T00:00:00Z")
     monkeypatch.setattr(
         "veritas_os.api.governance_live_snapshot.find_bind_receipts",
-        lambda limit=1: [receipt],
+        lambda: [receipt],
     )
 
     snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
@@ -55,8 +59,30 @@ def test_governance_live_snapshot_has_required_fields(monkeypatch):
         assert key in snapshot
 
 
+def test_governance_live_snapshot_uses_latest_receipt(monkeypatch):
+    old = BindReceipt(final_outcome=FinalOutcome.BLOCKED, bind_ts="2026-04-29T00:00:00Z")
+    latest = BindReceipt(final_outcome=FinalOutcome.COMMITTED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [old, latest],
+    )
+
+    snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
+    assert snapshot["source"] == "backend_live_snapshot"
+    assert snapshot["bind_outcome"] == "COMMITTED"
+    assert snapshot["updated_at"] == "2026-04-30T00:00:00Z"
+
+
+def test_governance_live_snapshot_degraded_when_no_receipts(monkeypatch):
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", lambda: [])
+
+    snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_no_recent_governance_artifact"
+    assert snapshot["bind_outcome"] == "UNKNOWN"
+
+
 def test_governance_live_snapshot_degraded_when_artifact_unavailable(monkeypatch):
-    def _raise(limit=1):
+    def _raise():
         raise RuntimeError("no storage")
 
     monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", _raise)
@@ -68,21 +94,56 @@ def test_governance_live_snapshot_degraded_when_artifact_unavailable(monkeypatch
 
 
 def test_governance_live_snapshot_vocabulary(monkeypatch):
-    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", lambda limit=1: [])
+    class _FakeReceipt:
+        def to_dict(self):
+            return {
+                "participation_state": "INVALID",
+                "preservation_state": "",
+                "intervention_viability": "NOT_A_STATE",
+                "final_outcome": "not_real",
+                "bind_ts": "2026-04-30T00:00:00Z",
+            }
+
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [_FakeReceipt()],
+    )
     snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
-    assert snapshot["participation_state"] in {"informative", "participatory", "decision_shaping", "unknown"}
-    assert snapshot["preservation_state"] in {"open", "degrading", "collapsed", "unknown"}
-    assert snapshot["intervention_viability"] in {"high", "medium", "minimal", "unknown"}
-    assert snapshot["bind_outcome"] in {
-        "COMMITTED",
-        "BLOCKED",
-        "ESCALATED",
-        "ROLLED_BACK",
-        "APPLY_FAILED",
-        "SNAPSHOT_FAILED",
-        "PRECONDITION_FAILED",
-        "UNKNOWN",
-    }
+    assert snapshot["participation_state"] == "unknown"
+    assert snapshot["preservation_state"] == "unknown"
+    assert snapshot["intervention_viability"] == "unknown"
+    assert snapshot["bind_outcome"] == "UNKNOWN"
+
+
+def test_builder_uses_latest_receipt(monkeypatch):
+    old = BindReceipt(final_outcome=FinalOutcome.BLOCKED, bind_ts="2026-04-29T00:00:00Z")
+    latest = BindReceipt(final_outcome=FinalOutcome.ESCALATED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [old, latest],
+    )
+
+    snapshot = build_governance_live_snapshot()["governance_layer_snapshot"]
+    assert snapshot["source"] == "backend_live_snapshot"
+    assert snapshot["bind_outcome"] == "ESCALATED"
+    assert snapshot["updated_at"] == "2026-04-30T00:00:00Z"
+
+
+def test_builder_degraded_on_exception(monkeypatch):
+    def _raise():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", _raise)
+    snapshot = build_governance_live_snapshot()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_no_recent_governance_artifact"
+    assert snapshot["bind_outcome"] == "UNKNOWN"
+
+
+def test_normalizers_invalid_values():
+    assert _normalize_state("invalid", allowed={"known", "unknown"}) == "unknown"
+    assert _normalize_state(None, allowed={"known", "unknown"}) == "unknown"
+    assert _normalize_bind_outcome("not_real") == "UNKNOWN"
+    assert _normalize_bind_outcome(None) == "UNKNOWN"
 
 
 def test_governance_live_snapshot_requires_auth():


### PR DESCRIPTION
### Motivation
- Prevent `build_governance_live_snapshot()` from passing a non-existent `limit` kwarg to `find_bind_receipts()` which caused `TypeError` and produced fallback-only behavior. 
- Ensure Mission Control can read the real latest `BindReceipt` artifact and return a positive `backend_live_snapshot` path when receipts exist. 
- Keep degraded fallback behavior (no receipts / exceptions) but make the real retrieval path testable and reliable.

### Description
- Call `find_bind_receipts()` using the real signature and select the newest receipt with `receipts[-1]` instead of `receipts[0]` to pick the latest artifact. (`veritas_os/api/governance_live_snapshot.py`).
- Preserve existing degraded fallback when `find_bind_receipts()` returns empty or raises an exception, and ensure successful branch sets `"source": "backend_live_snapshot"` and maps `final_outcome` → `bind_outcome` and `bind_ts` → `updated_at` via existing normalizers. (`veritas_os/api/governance_live_snapshot.py`).
- Update tests to use signature-compatible monkeypatches (remove `lambda limit=1` fakes), add builder-level assertions, and strengthen positive/fallback path coverage and normalization checks. (`veritas_os/tests/test_governance_live_snapshot.py`).
- Files changed: `veritas_os/api/governance_live_snapshot.py`, `veritas_os/tests/test_governance_live_snapshot.py`.

### Testing
- Ran `pytest -q veritas_os/tests/test_governance_live_snapshot.py` and it passed (`10 passed`).
- Ran `pytest -q veritas_os/tests -k "governance_live_snapshot or bind_receipts"` and it passed (`17 passed, 7082 deselected`).
- Ran `pytest -q veritas_os/tests/test_bind_coverage_registry.py` and it passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30fcadfb88326ae88c3dc4b2f7e88)