### PR TITLE
Enrich /v1/governance/live-snapshot with bind metadata, target info, and bind_summary

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -96,3 +96,5 @@ docker compose up --build
 - production では query/header での scenario injection は無視され、Mission Control は backend-fed governance data を優先します。
 - deterministic scenario は UI regression 用フィクスチャであり、production governance data source ではありません。
 - `/v1/report/governance` は date-range governance/compliance report 用であり、Mission Control live snapshot source とは役割を分離します。
+- backend `/v1/governance/live-snapshot` は latest BindReceipt 由来の bind metadata（`bind_receipt_id` / `execution_intent_id` / `decision_id`）、target metadata（`target_path` / `target_type` / `target_label` / `operator_surface` / `relevant_ui_href`）、reason fields（`bind_reason_code` / `bind_failure_reason` / `failure_category` など）を返し、`bind_summary` が存在する場合は operator-facing artifact summary として利用できます。
+- degraded fallback snapshot は fake success を示さず render safety path です。receipt 不在・取得失敗時は `source=degraded_no_recent_governance_artifact` を維持します。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -97,6 +97,37 @@ describe("/api/veritas/v1/report/governance", () => {
     });
   });
 
+
+  it("preserves enriched governance_layer_snapshot metadata fields", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          governance_layer_snapshot: {
+            bind_outcome: "ESCALATED",
+            bind_receipt_id: "br_123",
+            execution_intent_id: "ei_123",
+            bind_summary: { bind_outcome: "ESCALATED" },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const response = await GET(new Request("http://localhost/api/veritas/v1/report/governance"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      governance_layer_snapshot: {
+        bind_outcome: "ESCALATED",
+        bind_receipt_id: "br_123",
+        execution_intent_id: "ei_123",
+        bind_summary: { bind_outcome: "ESCALATED" },
+      },
+    });
+  });
+
   it("keeps compatibility with pre_bind_governance_snapshot payloads", async () => {
     vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
     vi.stubEnv("VERITAS_API_KEY", "test-key");

--- a/veritas_os/api/governance_live_snapshot.py
+++ b/veritas_os/api/governance_live_snapshot.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from veritas_os.api.bind_summary import (
+    build_bind_summary_from_receipt,
+    enrich_bind_receipt_payload,
+    resolve_bind_reason_code,
+)
 from veritas_os.policy.bind_artifacts import FinalOutcome, find_bind_receipts
 
 _ALLOWED_PARTICIPATION_STATES = {
@@ -70,21 +75,47 @@ def build_governance_live_snapshot() -> dict[str, Any]:
         return fallback
 
     latest = receipts[-1].to_dict()
+    enriched_receipt = enrich_bind_receipt_payload(latest)
+    bind_summary = build_bind_summary_from_receipt(enriched_receipt)
+
     snapshot = {
         "participation_state": _normalize_state(
-            latest.get("participation_state"),
+            enriched_receipt.get("participation_state"),
             allowed=_ALLOWED_PARTICIPATION_STATES,
         ),
         "preservation_state": _normalize_state(
-            latest.get("preservation_state"),
+            enriched_receipt.get("preservation_state"),
             allowed=_ALLOWED_PRESERVATION_STATES,
         ),
         "intervention_viability": _normalize_state(
-            latest.get("intervention_viability"),
+            enriched_receipt.get("intervention_viability"),
             allowed=_ALLOWED_INTERVENTION_VIABILITY,
         ),
-        "bind_outcome": _normalize_bind_outcome(latest.get("final_outcome")),
+        "bind_outcome": _normalize_bind_outcome(enriched_receipt.get("final_outcome")),
         "source": "backend_live_snapshot",
-        "updated_at": latest.get("bind_ts") if isinstance(latest.get("bind_ts"), str) else _utc_now_iso8601(),
+        "updated_at": (
+            enriched_receipt.get("bind_ts")
+            if isinstance(enriched_receipt.get("bind_ts"), str)
+            else _utc_now_iso8601()
+        ),
+        "bind_receipt_id": enriched_receipt.get("bind_receipt_id"),
+        "execution_intent_id": enriched_receipt.get("execution_intent_id"),
+        "decision_id": enriched_receipt.get("decision_id"),
+        "bind_reason_code": resolve_bind_reason_code(enriched_receipt),
+        "bind_failure_reason": bind_summary.get("bind_failure_reason"),
+        "failure_category": enriched_receipt.get("failure_category"),
+        "rollback_status": enriched_receipt.get("rollback_status"),
+        "retry_safety": enriched_receipt.get("retry_safety"),
+        "target_path": enriched_receipt.get("target_path"),
+        "target_type": enriched_receipt.get("target_type"),
+        "target_path_type": enriched_receipt.get("target_path_type"),
+        "target_label": enriched_receipt.get("target_label"),
+        "operator_surface": enriched_receipt.get("operator_surface"),
+        "relevant_ui_href": enriched_receipt.get("relevant_ui_href"),
+        "authority_check_result": enriched_receipt.get("authority_check_result"),
+        "constraint_check_result": enriched_receipt.get("constraint_check_result"),
+        "drift_check_result": enriched_receipt.get("drift_check_result"),
+        "risk_check_result": enriched_receipt.get("risk_check_result"),
+        "bind_summary": bind_summary,
     }
     return {"governance_layer_snapshot": snapshot}

--- a/veritas_os/tests/test_governance_live_snapshot.py
+++ b/veritas_os/tests/test_governance_live_snapshot.py
@@ -73,6 +73,81 @@ def test_governance_live_snapshot_uses_latest_receipt(monkeypatch):
     assert snapshot["updated_at"] == "2026-04-30T00:00:00Z"
 
 
+
+
+def test_governance_live_snapshot_includes_bind_metadata(monkeypatch):
+    receipt = BindReceipt(
+        bind_receipt_id="br_1",
+        execution_intent_id="ei_1",
+        decision_id="dec_1",
+        final_outcome=FinalOutcome.ESCALATED,
+        bind_ts="2026-04-30T00:00:00Z",
+        bind_reason_code="AUTHORITY_MISSING",
+        bind_failure_reason="Authority evidence missing",
+        target_path="/v1/governance/policy",
+        target_type="governance_policy",
+        target_path_type="governance_policy_update",
+        target_label="Governance policy",
+        operator_surface="governance",
+        relevant_ui_href="/governance",
+        authority_check_result={"status": "fail"},
+        constraint_check_result={"status": "pass"},
+        drift_check_result={"status": "pass"},
+        risk_check_result={"status": "escalate"},
+        failure_category="authority",
+        rollback_status="not_started",
+        retry_safety="manual_review_required",
+    )
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [receipt],
+    )
+
+    snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
+
+    assert snapshot["source"] == "backend_live_snapshot"
+    assert snapshot["bind_outcome"] == "ESCALATED"
+    assert snapshot["bind_receipt_id"] == "br_1"
+    assert snapshot["execution_intent_id"] == "ei_1"
+    assert snapshot["decision_id"] == "dec_1"
+    assert snapshot["target_path"] == "/v1/governance/policy"
+    assert snapshot["target_type"] == "governance_policy"
+    assert isinstance(snapshot["target_label"], str)
+    assert snapshot["target_label"]
+    assert snapshot["operator_surface"] == "governance"
+    assert snapshot["relevant_ui_href"] == "/governance"
+    assert snapshot["bind_reason_code"] == "AUTHORITY_MISSING"
+    assert snapshot["bind_failure_reason"] == "Authority evidence missing"
+    assert snapshot["failure_category"] == "authority"
+    assert snapshot["rollback_status"] == "not_started"
+    assert snapshot["retry_safety"] == "manual_review_required"
+    assert snapshot["authority_check_result"] == {"status": "fail"}
+    assert snapshot["constraint_check_result"] == {"status": "pass"}
+    assert snapshot["drift_check_result"] == {"status": "pass"}
+    assert snapshot["risk_check_result"] == {"status": "escalate"}
+    assert snapshot["bind_summary"]["bind_outcome"] == "ESCALATED"
+
+
+def test_governance_live_snapshot_optional_metadata_defaults_to_none(monkeypatch):
+    receipt = BindReceipt(
+        final_outcome=FinalOutcome.BLOCKED,
+        bind_ts="2026-04-30T00:00:00Z",
+    )
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [receipt],
+    )
+
+    snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
+
+    assert snapshot["source"] == "backend_live_snapshot"
+    assert snapshot["bind_outcome"] == "BLOCKED"
+    assert isinstance(snapshot["bind_receipt_id"], str)
+    assert snapshot["execution_intent_id"] in (None, "")
+    assert snapshot["decision_id"] in (None, "")
+    assert snapshot["bind_failure_reason"] is None
+    assert snapshot["failure_category"] is None
+
 def test_governance_live_snapshot_degraded_when_no_receipts(monkeypatch):
     monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", lambda: [])
 


### PR DESCRIPTION
### Motivation
- Make the live governance snapshot a usable operator-facing artifact for Mission Control by surfacing which receipt/intents/decision/target caused the bind and why it failed or escalated. 
- Provide frontend-ready flat metadata (IDs, target fields, failure/reason/check results) so UI can route operators to the right surface without additional lookups. 
- Preserve existing vocabulary and degraded fallback behavior to remain backward-compatible and safe for render-fallbacks.

### Description
- Reused existing helpers by importing `enrich_bind_receipt_payload`, `build_bind_summary_from_receipt`, and `resolve_bind_reason_code` and applied them to the latest receipt in `build_governance_live_snapshot()` in `veritas_os/api/governance_live_snapshot.py`. 
- Enriched snapshot with IDs, reason fields, failure/category/rollback/retry, target metadata, check results, and `bind_summary` while keeping original fields (`participation_state`, `preservation_state`, `intervention_viability`, `bind_outcome`, `source`, `updated_at`). 
- Adjusted builder to call `to_dict()` on latest receipt, run `enrich_bind_receipt_payload()`, generate `bind_summary`, and flat-export selected fields for frontend convenience. 
- Added/updated tests in `veritas_os/tests/test_governance_live_snapshot.py` to cover positive enrichment and optional/default behavior, and extended `frontend/app/api/veritas/v1/report/governance/route.test.ts` to assert the BFF preserves additional metadata. 
- Updated `docs/ui/README_UI.md` to document the expanded live-snapshot vocabulary and that degraded fallback remains a render-safety path.

### Testing
- Ran `pytest -q veritas_os/tests/test_governance_live_snapshot.py` and related selection `pytest -q veritas_os/tests -k "governance_live_snapshot or bind_receipts"`, and all assertions in those tests passed (backend snapshot tests exercised enrichment and fallback). 
- Ran `pytest -q veritas_os/tests/test_bind_coverage_registry.py` and it passed (`4 passed`). 
- Ran frontend BFF route tests with `pnpm --filter frontend test app/api/veritas/v1/report/governance/route.test.ts` and the route test passed (all assertions in that file passed). 
- The degraded/fallback path is explicitly tested and remains unchanged (`source = "degraded_no_recent_governance_artifact"`, `bind_outcome = "UNKNOWN"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31e7e44dc8326909c926c95abcd11)