### PR TITLE
Harden /v1/governance/live-snapshot enrichment failure handling

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -97,4 +97,4 @@ docker compose up --build
 - deterministic scenario は UI regression 用フィクスチャであり、production governance data source ではありません。
 - `/v1/report/governance` は date-range governance/compliance report 用であり、Mission Control live snapshot source とは役割を分離します。
 - backend `/v1/governance/live-snapshot` は latest BindReceipt 由来の bind metadata（`bind_receipt_id` / `execution_intent_id` / `decision_id`）、target metadata（`target_path` / `target_type` / `target_label` / `operator_surface` / `relevant_ui_href`）、reason fields（`bind_reason_code` / `bind_failure_reason` / `failure_category` など）を返し、`bind_summary` が存在する場合は operator-facing artifact summary として利用できます。
-- degraded fallback snapshot は fake success を示さず render safety path です。receipt 不在・取得失敗時は `source=degraded_no_recent_governance_artifact` を維持します。
+- degraded fallback snapshot は fake success を示さず render safety path です。latest BindReceipt enrichment に失敗しても `/v1/governance/live-snapshot` は 500 ではなく degraded snapshot を返し、`source` に `degraded_artifact_retrieval_failed` / `degraded_invalid_latest_bind_receipt` / `degraded_bind_summary_enrichment_failed` などの理由を載せます。

--- a/veritas_os/api/governance_live_snapshot.py
+++ b/veritas_os/api/governance_live_snapshot.py
@@ -50,33 +50,46 @@ def _normalize_bind_outcome(value: Any) -> str:
     return normalized if normalized in _ALLOWED_BIND_OUTCOMES else "UNKNOWN"
 
 
-def build_governance_live_snapshot() -> dict[str, Any]:
-    """Build a lightweight governance snapshot for Mission Control.
-
-    Returns a degraded unknown snapshot when recent governance artifacts are
-    unavailable or cannot be loaded.
-    """
-    fallback = {
+def _build_degraded_snapshot(source: str) -> dict[str, Any]:
+    """Return a render-safe degraded snapshot with explicit failure source."""
+    return {
         "governance_layer_snapshot": {
             "participation_state": "unknown",
             "preservation_state": "unknown",
             "intervention_viability": "unknown",
             "bind_outcome": "UNKNOWN",
-            "source": "degraded_no_recent_governance_artifact",
+            "source": source,
             "updated_at": _utc_now_iso8601(),
         },
     }
-    try:
-        receipts = find_bind_receipts()
-    except Exception:
-        return fallback
 
+
+def _select_latest_receipt(receipts: list[Any]) -> Any | None:
+    """Select the latest receipt when artifacts exist."""
     if not receipts:
-        return fallback
+        return None
+    return receipts[-1]
 
-    latest = receipts[-1].to_dict()
-    enriched_receipt = enrich_bind_receipt_payload(latest)
-    bind_summary = build_bind_summary_from_receipt(enriched_receipt)
+
+def _safe_receipt_payload(receipt: Any) -> dict[str, Any] | None:
+    """Safely materialize a receipt payload as a dictionary."""
+    try:
+        payload = receipt.to_dict()
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _build_enriched_snapshot_from_receipt_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Build enriched live snapshot from a valid receipt payload."""
+    try:
+        enriched_receipt = enrich_bind_receipt_payload(payload)
+        bind_summary = build_bind_summary_from_receipt(enriched_receipt)
+        bind_reason_code = resolve_bind_reason_code(enriched_receipt)
+    except Exception:
+        return None
 
     snapshot = {
         "participation_state": _normalize_state(
@@ -101,7 +114,7 @@ def build_governance_live_snapshot() -> dict[str, Any]:
         "bind_receipt_id": enriched_receipt.get("bind_receipt_id"),
         "execution_intent_id": enriched_receipt.get("execution_intent_id"),
         "decision_id": enriched_receipt.get("decision_id"),
-        "bind_reason_code": resolve_bind_reason_code(enriched_receipt),
+        "bind_reason_code": bind_reason_code,
         "bind_failure_reason": bind_summary.get("bind_failure_reason"),
         "failure_category": enriched_receipt.get("failure_category"),
         "rollback_status": enriched_receipt.get("rollback_status"),
@@ -119,3 +132,29 @@ def build_governance_live_snapshot() -> dict[str, Any]:
         "bind_summary": bind_summary,
     }
     return {"governance_layer_snapshot": snapshot}
+
+
+def build_governance_live_snapshot() -> dict[str, Any]:
+    """Build a lightweight governance snapshot for Mission Control.
+
+    Returns a degraded unknown snapshot when recent governance artifacts are
+    unavailable, malformed, or cannot be enriched safely.
+    """
+    try:
+        receipts = find_bind_receipts()
+    except Exception:
+        return _build_degraded_snapshot("degraded_artifact_retrieval_failed")
+
+    latest_receipt = _select_latest_receipt(receipts)
+    if latest_receipt is None:
+        return _build_degraded_snapshot("degraded_no_recent_governance_artifact")
+
+    payload = _safe_receipt_payload(latest_receipt)
+    if payload is None:
+        return _build_degraded_snapshot("degraded_invalid_latest_bind_receipt")
+
+    snapshot = _build_enriched_snapshot_from_receipt_payload(payload)
+    if snapshot is None:
+        return _build_degraded_snapshot("degraded_bind_summary_enrichment_failed")
+
+    return snapshot

--- a/veritas_os/tests/test_governance_live_snapshot.py
+++ b/veritas_os/tests/test_governance_live_snapshot.py
@@ -164,7 +164,7 @@ def test_governance_live_snapshot_degraded_when_artifact_unavailable(monkeypatch
     response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
     assert response.status_code == 200
     snapshot = response.json()["governance_layer_snapshot"]
-    assert snapshot["source"] == "degraded_no_recent_governance_artifact"
+    assert snapshot["source"] == "degraded_artifact_retrieval_failed"
     assert snapshot["bind_outcome"] == "UNKNOWN"
 
 
@@ -210,7 +210,7 @@ def test_builder_degraded_on_exception(monkeypatch):
 
     monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", _raise)
     snapshot = build_governance_live_snapshot()["governance_layer_snapshot"]
-    assert snapshot["source"] == "degraded_no_recent_governance_artifact"
+    assert snapshot["source"] == "degraded_artifact_retrieval_failed"
     assert snapshot["bind_outcome"] == "UNKNOWN"
 
 
@@ -224,3 +224,135 @@ def test_normalizers_invalid_values():
 def test_governance_live_snapshot_requires_auth():
     response = client.get("/v1/governance/live-snapshot")
     assert response.status_code in {401, 403}
+
+
+def test_governance_live_snapshot_degraded_when_to_dict_raises(monkeypatch):
+    class BrokenReceipt:
+        def to_dict(self):
+            raise RuntimeError("broken receipt")
+
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [BrokenReceipt()],
+    )
+
+    response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
+    assert response.status_code == 200
+    snapshot = response.json()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_invalid_latest_bind_receipt"
+    assert snapshot["bind_outcome"] == "UNKNOWN"
+
+
+def test_governance_live_snapshot_degraded_when_to_dict_not_dict(monkeypatch):
+    class MalformedReceipt:
+        def to_dict(self):
+            return "not a dict"
+
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [MalformedReceipt()],
+    )
+
+    response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
+    assert response.status_code == 200
+    snapshot = response.json()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_invalid_latest_bind_receipt"
+    assert snapshot["bind_outcome"] == "UNKNOWN"
+
+
+def test_governance_live_snapshot_degraded_when_enrich_raises(monkeypatch):
+    receipt = BindReceipt(final_outcome=FinalOutcome.COMMITTED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [receipt],
+    )
+
+    def _raise(_payload):
+        raise RuntimeError("enrich failed")
+
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.enrich_bind_receipt_payload", _raise)
+
+    response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
+    assert response.status_code == 200
+    snapshot = response.json()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_bind_summary_enrichment_failed"
+    assert snapshot["bind_outcome"] == "UNKNOWN"
+
+
+def test_governance_live_snapshot_degraded_when_bind_summary_raises(monkeypatch):
+    receipt = BindReceipt(final_outcome=FinalOutcome.COMMITTED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [receipt],
+    )
+
+    def _raise(_payload):
+        raise RuntimeError("summary failed")
+
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.build_bind_summary_from_receipt", _raise)
+
+    response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
+    assert response.status_code == 200
+    snapshot = response.json()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_bind_summary_enrichment_failed"
+
+
+def test_governance_live_snapshot_degraded_when_reason_resolver_raises(monkeypatch):
+    receipt = BindReceipt(final_outcome=FinalOutcome.COMMITTED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [receipt],
+    )
+
+    def _raise(_payload):
+        raise RuntimeError("reason failed")
+
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.resolve_bind_reason_code", _raise)
+
+    response = client.get("/v1/governance/live-snapshot", headers=_AUTH)
+    assert response.status_code == 200
+    snapshot = response.json()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_bind_summary_enrichment_failed"
+
+
+def test_builder_degraded_for_broken_to_dict(monkeypatch):
+    class BrokenReceipt:
+        def to_dict(self):
+            raise RuntimeError("broken")
+
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [BrokenReceipt()],
+    )
+    snapshot = build_governance_live_snapshot()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_invalid_latest_bind_receipt"
+
+
+def test_builder_degraded_for_enrich_exception(monkeypatch):
+    receipt = BindReceipt(final_outcome=FinalOutcome.COMMITTED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [receipt],
+    )
+
+    def _raise(_payload):
+        raise RuntimeError("enrich failed")
+
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.enrich_bind_receipt_payload", _raise)
+    snapshot = build_governance_live_snapshot()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_bind_summary_enrichment_failed"
+
+
+def test_builder_degraded_for_bind_summary_exception(monkeypatch):
+    receipt = BindReceipt(final_outcome=FinalOutcome.COMMITTED, bind_ts="2026-04-30T00:00:00Z")
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [receipt],
+    )
+
+    def _raise(_payload):
+        raise RuntimeError("summary failed")
+
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.build_bind_summary_from_receipt", _raise)
+    snapshot = build_governance_live_snapshot()["governance_layer_snapshot"]
+    assert snapshot["source"] == "degraded_bind_summary_enrichment_failed"


### PR DESCRIPTION
### Motivation
- Prevent the Mission Control live snapshot endpoint from returning 500s when the latest BindReceipt is malformed or enrichment helpers raise exceptions. 
- Ensure the operator surface returns an explicit degraded snapshot (not a fake success) with a clear `source` reason when enrichment cannot be completed. 
- Make the builder easier to reason about and test by isolating failure points and preserving the existing positive path behavior.

### Description
- Add small helper functions to the builder: `_build_degraded_snapshot`, `_select_latest_receipt`, `_safe_receipt_payload`, and `_build_enriched_snapshot_from_receipt_payload` to isolate failure points and improve testability. 
- Return explicit degraded snapshots (no 500s) for distinct failure reasons with new `source` values: `degraded_artifact_retrieval_failed`, `degraded_no_recent_governance_artifact`, `degraded_invalid_latest_bind_receipt`, and `degraded_bind_summary_enrichment_failed`. 
- Keep the positive path intact so `source == "backend_live_snapshot"` and all existing bind/target/reason/check fields plus `bind_summary` are still returned when enrichment succeeds. 
- Add endpoint- and builder-level tests covering `to_dict()` exceptions, non-dict payloads, enrichment/helper exceptions, and positive path continuity, and update UI docs to document degraded render-safety behavior.

### Testing
- Ran `pytest -q veritas_os/tests/test_governance_live_snapshot.py` and it passed (`20 passed`).
- Ran `pytest -q veritas_os/tests -k "governance_live_snapshot or bind_receipts"` and it passed (`27 passed, 7082 deselected`).
- Ran `pytest -q veritas_os/tests/test_bind_coverage_registry.py` and it passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3270aa1e08326a9fada3217798ef1)