### PR TITLE
Harden Mission Control relevant_ui_href link rendering

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -102,3 +102,10 @@ docker compose up --build
 - `pre_bind_detection_summary` / `pre_bind_preservation_summary` / detail fields / check result fields が `null` または `unknown` の場合、Mission Control UI は fake data を生成せず unavailable 表示を維持します。
 - 同 endpoint は optional enrichment として pre-bind detection / preservation fields（`pre_bind_source` / `pre_bind_detection_summary` / `pre_bind_preservation_summary` / `pre_bind_detection_detail` / `pre_bind_preservation_detail`）も返します。TrustLog pre-bind artifact 利用時は latest BindReceipt の `decision_id` / `request_id` / `execution_intent_id` と一致する artifact を優先し、`trustlog_matching_decision` → `trustlog_matching_request` → `trustlog_matching_execution_intent` の順で選択します。一致が無い場合のみ `trustlog_recent_decision` に fallback し、さらに TrustLog 側に signal が無い場合は latest BindReceipt payload fallback（`latest_bind_receipt`）を使います。どちらにも signal が無い場合は fake data を作らず `unknown` / `null` を返し、`pre_bind_source`（`trustlog_matching_decision` / `trustlog_matching_request` / `trustlog_matching_execution_intent` / `trustlog_recent_decision` / `latest_bind_receipt` / `none` / `pre_bind_artifact_retrieval_failed` / `malformed_pre_bind_artifact`）で取得元を明示します。
 - degraded fallback snapshot は fake success を示さず render safety path です。latest BindReceipt enrichment に失敗しても `/v1/governance/live-snapshot` は 500 ではなく degraded snapshot を返し、`source` に `degraded_artifact_retrieval_failed` / `degraded_invalid_latest_bind_receipt` / `degraded_bind_summary_enrichment_failed` などの理由を載せます。
+
+## Mission Control governance artifact link hardening
+
+- `relevant_ui_href` は backend artifact 由来の untrusted-ish display input として扱います。
+- Mission Control UI は `relevant_ui_href` が app 内部 path（例: `/governance`, `/audit?receipt=...`）の場合のみ Link として表示します。
+- external URL / protocol 付き URL / malformed href（`\\`, 改行, タブなど）は Link 化せず、plain text または `not available` として表示します。
+- unsafe input から fake internal link は生成しません。

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -155,6 +155,89 @@ describe("MissionPage", () => {
     expect(screen.getByRole("link", { name: "/governance" })).toHaveAttribute("href", "/governance");
   });
 
+  it.each(["/governance", "/governance/receipts/br_123", "/audit?receipt=br_123"])("renders safe relevant_ui_href as link: %s", (href) => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            pre_bind_source: "trustlog_matching_decision",
+            relevant_ui_href: href,
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByRole("link", { name: href })).toHaveAttribute("href", href);
+  });
+
+  it.each([
+    "https://evil.example",
+    "http://evil.example",
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "//evil.example",
+  ])("does not render external or protocol relevant_ui_href as a link: %s", (href) => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            pre_bind_source: "trustlog_matching_decision",
+            relevant_ui_href: href,
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.queryByRole("link", { name: href })).not.toBeInTheDocument();
+    expect(screen.getByText(href)).toBeInTheDocument();
+    expect(screen.getByText(/unsafe or external link not rendered/)).toBeInTheDocument();
+  });
+
+  it.each(["/foo\\bar", "/foo\nbar", "/foo\tbar"])("does not render malformed relevant_ui_href as a link: %s", (href) => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            pre_bind_source: "trustlog_matching_decision",
+            relevant_ui_href: href,
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.queryByRole("link", { name: href })).not.toBeInTheDocument();
+    expect(screen.getByText(/unsafe or external link not rendered/)).toBeInTheDocument();
+  });
+
+  it("renders not available when relevant_ui_href is null", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            pre_bind_source: "none",
+            relevant_ui_href: null,
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText(/relevant_ui_href:/)).toBeInTheDocument();
+    expect(screen.getAllByText("not available").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("link", { name: /relevant_ui_href/i })).not.toBeInTheDocument();
+  });
+
   it("renders fallback text for null pre-bind summaries", () => {
     render(
       <I18nProvider>

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -6,6 +6,7 @@ import { CriticalRail } from "./critical-rail";
 import { GlobalHealthSummary } from "./global-health-summary";
 import { OpsPriorityCard } from "./ops-priority-card";
 import { useI18n } from "./i18n-provider";
+import { normalizeSafeInternalHref } from "../lib/governance-link-utils";
 import {
   type CriticalRailMetric,
   type DecisionEvidenceRouteModel,
@@ -222,6 +223,8 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
     return "unknown";
   };
 
+  const relevantUiHref = normalizeSafeInternalHref(governanceSnapshot?.relevant_ui_href);
+
   const hasPreBindGovernance = Boolean(
     governanceSnapshot?.participation_state ||
       governanceSnapshot?.preservation_state ||
@@ -336,7 +339,16 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
             <p>type: <span className="font-mono">{governanceSnapshot?.target_type ?? "not available"}</span></p>
             <p>path_type: <span className="font-mono">{governanceSnapshot?.target_path_type ?? "not available"}</span></p>
             <p>operator_surface: <span className="font-mono">{governanceSnapshot?.operator_surface ?? "not available"}</span></p>
-            {governanceSnapshot?.relevant_ui_href ? <p>relevant_ui_href: <Link className="underline" href={governanceSnapshot.relevant_ui_href}>{governanceSnapshot.relevant_ui_href}</Link></p> : <p>relevant_ui_href: <span className="font-mono">not available</span></p>}
+            {relevantUiHref ? (
+              <p>
+                relevant_ui_href: <Link className="underline" href={relevantUiHref}>{relevantUiHref}</Link>
+              </p>
+            ) : governanceSnapshot?.relevant_ui_href != null ? (
+              <p>
+                relevant_ui_href: <span className="font-mono">{stringifyValue(governanceSnapshot.relevant_ui_href)}</span>{" "}
+                <span className="text-muted-foreground">unsafe or external link not rendered</span>
+              </p>
+            ) : <p>relevant_ui_href: <span className="font-mono">not available</span></p>}
           </div>
           <div className="rounded-md border border-border/60 bg-muted/10 p-3 text-xs">
             <p className="font-semibold">Check results</p>

--- a/frontend/lib/governance-link-utils.test.ts
+++ b/frontend/lib/governance-link-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSafeInternalHref } from "./governance-link-utils";
+
+describe("normalizeSafeInternalHref", () => {
+  it("returns trimmed safe internal paths", () => {
+    expect(normalizeSafeInternalHref("/governance")).toBe("/governance");
+    expect(normalizeSafeInternalHref("/governance/receipts/br_123")).toBe("/governance/receipts/br_123");
+    expect(normalizeSafeInternalHref(" /audit?receipt=br_123 ")).toBe("/audit?receipt=br_123");
+  });
+
+  it("rejects non-string or empty values", () => {
+    expect(normalizeSafeInternalHref(null)).toBeNull();
+    expect(normalizeSafeInternalHref(undefined)).toBeNull();
+    expect(normalizeSafeInternalHref({ href: "/governance" })).toBeNull();
+    expect(normalizeSafeInternalHref("   ")).toBeNull();
+  });
+
+  it("rejects external or protocol-based URLs", () => {
+    expect(normalizeSafeInternalHref("https://evil.example")).toBeNull();
+    expect(normalizeSafeInternalHref("http://evil.example")).toBeNull();
+    expect(normalizeSafeInternalHref("javascript:alert(1)")).toBeNull();
+    expect(normalizeSafeInternalHref("data:text/html,<script>alert(1)</script>")).toBeNull();
+    expect(normalizeSafeInternalHref("//evil.example")).toBeNull();
+  });
+
+  it("rejects malformed internal paths", () => {
+    expect(normalizeSafeInternalHref("/foo\\bar")).toBeNull();
+    expect(normalizeSafeInternalHref("/foo\nbar")).toBeNull();
+    expect(normalizeSafeInternalHref("/foo\tbar")).toBeNull();
+    expect(normalizeSafeInternalHref("/foo\rbar")).toBeNull();
+  });
+});

--- a/frontend/lib/governance-link-utils.ts
+++ b/frontend/lib/governance-link-utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Normalize backend-provided navigation metadata into a safe in-app href.
+ *
+ * Mission Control treats governance artifact link fields as untrusted-ish
+ * display input. Only internal app paths are linkable.
+ */
+export function normalizeSafeInternalHref(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const href = value.trim();
+  if (!href) {
+    return null;
+  }
+
+  if (!href.startsWith("/")) {
+    return null;
+  }
+
+  if (href.startsWith("//")) {
+    return null;
+  }
+
+  if (href.includes("\\") || href.includes("\n") || href.includes("\r") || href.includes("\t")) {
+    return null;
+  }
+
+  return href;
+}


### PR DESCRIPTION
### Motivation
- `relevant_ui_href` is backend-provided navigation metadata and must be treated as untrusted display input to avoid operator navigation to external or dangerous destinations. 
- The UI should only create navigable links for safe in-app paths (e.g. `/governance`, `/governance/receipts/...`, `/audit?receipt=...`) and must not synthesize fake internal links from unsafe input. 
- This change aims to harden Mission Control link rendering without touching backend contracts or generating fake data. 

### Description
- Add `normalizeSafeInternalHref(value: unknown): string | null` in `frontend/lib/governance-link-utils.ts` to validate and normalize only safe internal hrefs (string, trimmed, starts with `/`, not `//`, and contains no backslash or control characters). 
- Update `frontend/components/mission-page.tsx` to call the helper and render a `next/link` Link only when the helper returns a non-null safe path, otherwise show the raw value as plain text with the message `unsafe or external link not rendered`, and keep `null`/`undefined` as `not available`. 
- Add unit tests for the helper in `frontend/lib/governance-link-utils.test.ts` covering safe, non-string/empty, external/protocol, and malformed cases. 
- Extend `frontend/components/mission-page.test.tsx` to assert safe internal paths are links, and that external/protocol/malformed values are not links and show the unsafe-not-rendered hint, while preserving existing governance artifact UI regression tests. 
- Update `docs/ui/README_UI.md` with the Mission Control governance artifact link-hardening policy. 

### Testing
- Ran the focused component tests with `pnpm --filter frontend test components/mission-page.test.tsx` and they passed. 
- Ran the helper unit tests with `pnpm --filter frontend test lib/governance-link-utils.test.ts` and they passed. 
- Ran `pnpm --filter frontend lint` and lint completed successfully with pre-existing unrelated warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f363aad01c832694f714d1c91c3661)