### PR TITLE
Add safe operator actions to Mission Control 'Governance artifacts' panel

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -109,3 +109,7 @@ docker compose up --build
 - Mission Control UI は `relevant_ui_href` が app 内部 path（例: `/governance`, `/audit?receipt=...`）の場合のみ Link として表示します。
 - external URL / protocol 付き URL / malformed href（`\\`, 改行, タブなど）は Link 化せず、plain text または `not available` として表示します。
 - unsafe input から fake internal link は生成しません。
+- `Governance artifacts` パネル内の `Operator actions` は artifact 由来 metadata を compact に表示します。
+- `Open target surface` は `normalizeSafeInternalHref()` で safe internal path と判定できる場合のみ Link 化します。
+- `bind_receipt_id` / `decision_id` / `execution_intent_id` は operator 向けに表示しますが、対応 route が repository で確認できない場合は Link 化せず `route unavailable` として扱います。
+- `pre_bind_source` は source state として表示し、TrustLog 含む未確認 route への fake navigation は生成しません。

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -81,6 +81,9 @@ export interface PreBindGovernanceSnapshot {
   pre_bind_detection_detail?: unknown | null;
   pre_bind_preservation_detail?: unknown | null;
   bind_summary?: unknown | null;
+  bind_receipt_id?: string | null;
+  execution_intent_id?: string | null;
+  decision_id?: string | null;
   bind_reason_code?: string | null;
   bind_failure_reason?: string | null;
   failure_category?: string | null;

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -148,11 +148,13 @@ describe("MissionPage", () => {
       </I18nProvider>,
     );
 
-    expect(screen.getByText("trustlog_matching_decision")).toBeInTheDocument();
+    expect(screen.getAllByText("trustlog_matching_decision").length).toBeGreaterThan(0);
     expect(screen.getByText("AUTHORITY_MISSING")).toBeInTheDocument();
     expect(screen.getByText("Authority evidence missing")).toBeInTheDocument();
     expect(screen.getByText("Governance policy")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "/governance" })).toHaveAttribute("href", "/governance");
+    expect(screen.getAllByRole("link", { name: "/governance" })[0]).toHaveAttribute("href", "/governance");
+    expect(screen.getByText("Operator actions")).toBeInTheDocument();
+    expect(screen.getByText(/Open target surface:/)).toBeInTheDocument();
   });
 
   it.each(["/governance", "/governance/receipts/br_123", "/audit?receipt=br_123"])("renders safe relevant_ui_href as link: %s", (href) => {
@@ -170,7 +172,7 @@ describe("MissionPage", () => {
       </I18nProvider>,
     );
 
-    expect(screen.getByRole("link", { name: href })).toHaveAttribute("href", href);
+    expect(screen.getAllByRole("link", { name: href })[0]).toHaveAttribute("href", href);
   });
 
   it.each([
@@ -236,6 +238,120 @@ describe("MissionPage", () => {
     expect(screen.getByText(/relevant_ui_href:/)).toBeInTheDocument();
     expect(screen.getAllByText("not available").length).toBeGreaterThan(0);
     expect(screen.queryByRole("link", { name: /relevant_ui_href/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/Open target surface:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/not available/).length).toBeGreaterThan(0);
+  });
+
+  it("renders target surface action as link only when relevant_ui_href is safe", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            target_label: "Governance policy",
+            relevant_ui_href: "/governance",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getAllByRole("link", { name: "/governance" })[0]).toHaveAttribute("href", "/governance");
+  });
+
+  it("does not render target surface action link when relevant_ui_href is unsafe", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            relevant_ui_href: "https://evil.example",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.queryByRole("link", { name: "https://evil.example" })).not.toBeInTheDocument();
+    expect(screen.getByText(/unsafe or external link not rendered/)).toBeInTheDocument();
+  });
+
+  it("shows bind receipt id without creating a fake route link", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            bind_receipt_id: "br_123",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("Review bind receipt:")).toBeInTheDocument();
+    expect(screen.getByText("br_123")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "br_123" })).not.toBeInTheDocument();
+  });
+
+  it("shows decision id without creating a fake route link", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            decision_id: "dec_123",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("View decision artifact:")).toBeInTheDocument();
+    expect(screen.getByText("dec_123")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "dec_123" })).not.toBeInTheDocument();
+  });
+
+  it("shows execution intent id without creating a fake route link", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            execution_intent_id: "ei_123",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("View execution intent:")).toBeInTheDocument();
+    expect(screen.getByText("ei_123")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "ei_123" })).not.toBeInTheDocument();
+  });
+
+  it("shows pre-bind source without creating a fake trustlog route", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            pre_bind_source: "trustlog_matching_decision",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("View pre-bind source:")).toBeInTheDocument();
+    expect(screen.getAllByText("trustlog_matching_decision").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("link", { name: /trustlog_matching_decision/i })).not.toBeInTheDocument();
   });
 
   it("renders fallback text for null pre-bind summaries", () => {
@@ -256,7 +372,7 @@ describe("MissionPage", () => {
       </I18nProvider>,
     );
 
-    expect(screen.getByText("none")).toBeInTheDocument();
+    expect(screen.getAllByText("none").length).toBeGreaterThan(0);
     expect(screen.getAllByText("No pre-bind summary available").length).toBeGreaterThan(0);
   });
 
@@ -275,7 +391,7 @@ describe("MissionPage", () => {
       </I18nProvider>,
     );
 
-    expect(screen.getByText("malformed_pre_bind_artifact")).toBeInTheDocument();
+    expect(screen.getAllByText("malformed_pre_bind_artifact").length).toBeGreaterThan(0);
     expect(screen.getByText(/classification: degraded/)).toBeInTheDocument();
   });
 });

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -362,6 +362,31 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
             <pre className="overflow-x-auto whitespace-pre-wrap font-mono">{stringifyValue(governanceSnapshot?.risk_check_result)}</pre>
           </div>
         </div>
+        <div className="mt-3 rounded-md border border-border/60 bg-muted/10 p-3 text-xs">
+          <p className="font-semibold">Operator actions</p>
+          <ul className="mt-2 space-y-1">
+            <li>
+              Open target surface:{" "}
+              {relevantUiHref ? <Link className="underline" href={relevantUiHref}>{relevantUiHref}</Link> : <span className="font-mono">not available</span>}
+            </li>
+            <li>
+              Review bind receipt: <span className="font-mono">{governanceSnapshot?.bind_receipt_id ?? "not available"}</span>{" "}
+              <span className="text-muted-foreground">(route unavailable)</span>
+            </li>
+            <li>
+              View decision artifact: <span className="font-mono">{governanceSnapshot?.decision_id ?? "not available"}</span>{" "}
+              <span className="text-muted-foreground">(route unavailable)</span>
+            </li>
+            <li>
+              View execution intent: <span className="font-mono">{governanceSnapshot?.execution_intent_id ?? "not available"}</span>{" "}
+              <span className="text-muted-foreground">(route unavailable)</span>
+            </li>
+            <li>
+              View pre-bind source: <span className="font-mono">{governanceSnapshot?.pre_bind_source ?? "unknown"}</span>{" "}
+              <span className="text-muted-foreground">(route unavailable)</span>
+            </li>
+          </ul>
+        </div>
       </section>
 
       <section className="grid gap-4 md:grid-cols-2" aria-label="trust and governance highlights">


### PR DESCRIPTION
### Motivation
- Operators need quick, safe access to bind/decision/execution/trustlog/target artifacts from the Mission Control UI without introducing navigation security risks. 
- The UI must not synthesize or surface fake/internal routes from untrusted artifact IDs or metadata, and must reuse the existing safe-link hardening.

### Description
- Added a compact `Operator actions` section to `MissionPage` that shows five actions: `Open target surface`, `Review bind receipt`, `View decision artifact`, `View execution intent`, and `View pre-bind source` (file changed: `frontend/components/mission-page.tsx`).
- `Open target surface` is linkified only when the existing normalized `relevantUiHref` (via the existing `normalizeSafeInternalHref()` flow) is present and safe; all other actions display IDs/text with a `route unavailable` note and are not linkified.
- Updated/added tests in `frontend/components/mission-page.test.tsx` to assert the safe-link behavior for `relevant_ui_href` and to verify that `bind_receipt_id` / `decision_id` / `execution_intent_id` / `pre_bind_source` are rendered but do not produce fake routes.
- Documented the operator-action policy and the no-fake-navigation rule in `docs/ui/README_UI.md` and kept all existing relevant link-hardening logic intact.

### Testing
- Ran `pnpm --filter frontend test components/mission-page.test.tsx` and the updated test file passed (`27` tests passed).
- Ran `pnpm --filter frontend test app/api/veritas/v1/report/governance/route.test.ts` and those tests passed (`9` tests passed).
- Ran `pnpm --filter frontend lint` which completed with existing warnings only and no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36bc2d4848326b6625392c49e851e)