### PR TITLE
Add safe /audit query links for Mission Control Operator actions

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -111,5 +111,6 @@ docker compose up --build
 - unsafe input から fake internal link は生成しません。
 - `Governance artifacts` パネル内の `Operator actions` は artifact 由来 metadata を compact に表示します。
 - `Open target surface` は `normalizeSafeInternalHref()` で safe internal path と判定できる場合のみ Link 化します。
-- `bind_receipt_id` / `decision_id` / `execution_intent_id` は operator 向けに表示しますが、対応 route が repository で確認できない場合は Link 化せず `route unavailable` として扱います。
+- `bind_receipt_id` / `decision_id` / `execution_intent_id` は `/audit` route が repository で確認できる場合のみ、`buildAuditArtifactHref()` により `/audit?bind_receipt_id=...` などの safe query link を生成して Link 化します。
+- artifact ID は untrusted-ish input として conservative validation（string / trim 後 non-empty / 制御文字禁止 / `^[A-Za-z0-9._:-]+$`）を通過した場合のみ Link 化し、unsafe / malformed ID は Link 化せず `route unavailable` を維持します。
 - `pre_bind_source` は source state として表示し、TrustLog 含む未確認 route への fake navigation は生成しません。

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -278,7 +278,7 @@ describe("MissionPage", () => {
     expect(screen.getByText(/unsafe or external link not rendered/)).toBeInTheDocument();
   });
 
-  it("shows bind receipt id without creating a fake route link", () => {
+  it("renders bind receipt id as audit link when id is valid", () => {
     render(
       <I18nProvider>
         <MissionPage
@@ -294,10 +294,10 @@ describe("MissionPage", () => {
 
     expect(screen.getByText("Review bind receipt:")).toBeInTheDocument();
     expect(screen.getByText("br_123")).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "br_123" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "br_123" })).toHaveAttribute("href", "/audit?bind_receipt_id=br_123");
   });
 
-  it("shows decision id without creating a fake route link", () => {
+  it("renders decision id as audit link when id is valid", () => {
     render(
       <I18nProvider>
         <MissionPage
@@ -313,10 +313,10 @@ describe("MissionPage", () => {
 
     expect(screen.getByText("View decision artifact:")).toBeInTheDocument();
     expect(screen.getByText("dec_123")).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "dec_123" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "dec_123" })).toHaveAttribute("href", "/audit?decision_id=dec_123");
   });
 
-  it("shows execution intent id without creating a fake route link", () => {
+  it("renders execution intent id as audit link when id is valid", () => {
     render(
       <I18nProvider>
         <MissionPage
@@ -332,10 +332,33 @@ describe("MissionPage", () => {
 
     expect(screen.getByText("View execution intent:")).toBeInTheDocument();
     expect(screen.getByText("ei_123")).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "ei_123" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "ei_123" })).toHaveAttribute("href", "/audit?execution_intent_id=ei_123");
   });
 
-  it("shows pre-bind source without creating a fake trustlog route", () => {
+  
+
+  it("does not create audit links for invalid artifact ids", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            bind_receipt_id: "../secret",
+            decision_id: "javascript:alert(1)",
+            execution_intent_id: "ei\n123",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.queryByRole("link", { name: "../secret" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "javascript:alert(1)" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /ei/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText(/route unavailable/).length).toBeGreaterThan(0);
+  });
+it("shows pre-bind source without creating a fake trustlog route", () => {
     render(
       <I18nProvider>
         <MissionPage

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -6,7 +6,7 @@ import { CriticalRail } from "./critical-rail";
 import { GlobalHealthSummary } from "./global-health-summary";
 import { OpsPriorityCard } from "./ops-priority-card";
 import { useI18n } from "./i18n-provider";
-import { normalizeSafeInternalHref } from "../lib/governance-link-utils";
+import { buildAuditArtifactHref, normalizeSafeInternalHref } from "../lib/governance-link-utils";
 import {
   type CriticalRailMetric,
   type DecisionEvidenceRouteModel,
@@ -26,6 +26,8 @@ interface MissionPageProps {
   chips: [string, string, string];
   governanceLayerSnapshot?: PreBindGovernanceSnapshot;
 }
+
+const AUDIT_ROUTE_AVAILABLE = true;
 
 const CRITICAL_RAIL_ITEMS: CriticalRailMetric[] = [
   {
@@ -224,6 +226,15 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
   };
 
   const relevantUiHref = normalizeSafeInternalHref(governanceSnapshot?.relevant_ui_href);
+  const bindReceiptAuditHref = AUDIT_ROUTE_AVAILABLE
+    ? buildAuditArtifactHref("bind_receipt_id", governanceSnapshot?.bind_receipt_id)
+    : null;
+  const decisionAuditHref = AUDIT_ROUTE_AVAILABLE
+    ? buildAuditArtifactHref("decision_id", governanceSnapshot?.decision_id)
+    : null;
+  const executionIntentAuditHref = AUDIT_ROUTE_AVAILABLE
+    ? buildAuditArtifactHref("execution_intent_id", governanceSnapshot?.execution_intent_id)
+    : null;
 
   const hasPreBindGovernance = Boolean(
     governanceSnapshot?.participation_state ||
@@ -370,16 +381,31 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
               {relevantUiHref ? <Link className="underline" href={relevantUiHref}>{relevantUiHref}</Link> : <span className="font-mono">not available</span>}
             </li>
             <li>
-              Review bind receipt: <span className="font-mono">{governanceSnapshot?.bind_receipt_id ?? "not available"}</span>{" "}
-              <span className="text-muted-foreground">(route unavailable)</span>
+              Review bind receipt:{" "}
+              {bindReceiptAuditHref ? <Link className="underline font-mono" href={bindReceiptAuditHref}>{governanceSnapshot?.bind_receipt_id}</Link> : (
+                <>
+                  <span className="font-mono">{governanceSnapshot?.bind_receipt_id ?? "not available"}</span>{" "}
+                  {governanceSnapshot?.bind_receipt_id ? <span className="text-muted-foreground">(route unavailable)</span> : null}
+                </>
+              )}
             </li>
             <li>
-              View decision artifact: <span className="font-mono">{governanceSnapshot?.decision_id ?? "not available"}</span>{" "}
-              <span className="text-muted-foreground">(route unavailable)</span>
+              View decision artifact:{" "}
+              {decisionAuditHref ? <Link className="underline font-mono" href={decisionAuditHref}>{governanceSnapshot?.decision_id}</Link> : (
+                <>
+                  <span className="font-mono">{governanceSnapshot?.decision_id ?? "not available"}</span>{" "}
+                  {governanceSnapshot?.decision_id ? <span className="text-muted-foreground">(route unavailable)</span> : null}
+                </>
+              )}
             </li>
             <li>
-              View execution intent: <span className="font-mono">{governanceSnapshot?.execution_intent_id ?? "not available"}</span>{" "}
-              <span className="text-muted-foreground">(route unavailable)</span>
+              View execution intent:{" "}
+              {executionIntentAuditHref ? <Link className="underline font-mono" href={executionIntentAuditHref}>{governanceSnapshot?.execution_intent_id}</Link> : (
+                <>
+                  <span className="font-mono">{governanceSnapshot?.execution_intent_id ?? "not available"}</span>{" "}
+                  {governanceSnapshot?.execution_intent_id ? <span className="text-muted-foreground">(route unavailable)</span> : null}
+                </>
+              )}
             </li>
             <li>
               View pre-bind source: <span className="font-mono">{governanceSnapshot?.pre_bind_source ?? "unknown"}</span>{" "}

--- a/frontend/lib/governance-link-utils.test.ts
+++ b/frontend/lib/governance-link-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeSafeInternalHref } from "./governance-link-utils";
+import { buildAuditArtifactHref, normalizeSafeInternalHref } from "./governance-link-utils";
 
 describe("normalizeSafeInternalHref", () => {
   it("returns trimmed safe internal paths", () => {
@@ -29,5 +29,35 @@ describe("normalizeSafeInternalHref", () => {
     expect(normalizeSafeInternalHref("/foo\nbar")).toBeNull();
     expect(normalizeSafeInternalHref("/foo\tbar")).toBeNull();
     expect(normalizeSafeInternalHref("/foo\rbar")).toBeNull();
+  });
+});
+
+
+describe("buildAuditArtifactHref", () => {
+  it("builds safe audit query links for supported artifact keys", () => {
+    expect(buildAuditArtifactHref("bind_receipt_id", "br_123")).toBe("/audit?bind_receipt_id=br_123");
+    expect(buildAuditArtifactHref("decision_id", "dec_123")).toBe("/audit?decision_id=dec_123");
+    expect(buildAuditArtifactHref("execution_intent_id", "ei_123")).toBe("/audit?execution_intent_id=ei_123");
+  });
+
+  it("rejects unsafe or malformed artifact ids", () => {
+    const unsafeValues: unknown[] = [
+      null,
+      undefined,
+      {},
+      "",
+      "   ",
+      "br\n123",
+      "br\t123",
+      "br\\123",
+      "../secret",
+      "/audit?x=1",
+      "https://evil.example",
+      "javascript:alert(1)",
+    ];
+
+    unsafeValues.forEach((value) => {
+      expect(buildAuditArtifactHref("bind_receipt_id", value)).toBeNull();
+    });
   });
 });

--- a/frontend/lib/governance-link-utils.ts
+++ b/frontend/lib/governance-link-utils.ts
@@ -28,3 +28,31 @@ export function normalizeSafeInternalHref(value: unknown): string | null {
 
   return href;
 }
+
+
+const AUDIT_ARTIFACT_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
+export function buildAuditArtifactHref(
+  key: "bind_receipt_id" | "decision_id" | "execution_intent_id",
+  value: unknown,
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const id = value.trim();
+  if (!id) {
+    return null;
+  }
+
+  if (id.includes("\\") || id.includes("\n") || id.includes("\r") || id.includes("\t")) {
+    return null;
+  }
+
+  if (!AUDIT_ARTIFACT_ID_PATTERN.test(id)) {
+    return null;
+  }
+
+  const params = new URLSearchParams({ [key]: id });
+  return normalizeSafeInternalHref(`/audit?${params.toString()}`);
+}


### PR DESCRIPTION
### Motivation
- Provide operators a safe navigation path from Mission Control "Operator actions" to the existing Audit UI when corresponding artifact IDs exist.  
- Ensure navigation is only created for an existing `/audit` route and only for conservatively-validated artifact IDs to avoid fake routes or injection/XSS risks.  

### Description
- Added `buildAuditArtifactHref()` to `frontend/lib/governance-link-utils.ts` to construct `/audit?…` query links for `bind_receipt_id`, `decision_id`, and `execution_intent_id` using `URLSearchParams` and `normalizeSafeInternalHref()`.  
- Enforced conservative artifact ID validation: must be a string, trimmed non-empty, no backslash/newline/carriage/tab, and match `^[A-Za-z0-9._:-]+$`.  
- Updated `frontend/components/mission-page.tsx` to gate audit-link generation behind a local `AUDIT_ROUTE_AVAILABLE` flag and render Link only when `buildAuditArtifactHref()` returns a non-null safe href; otherwise preserve `route unavailable` / `not available` fallbacks and keep `pre_bind_source` text-only.  
- Updated unit tests (`frontend/lib/governance-link-utils.test.ts`, `frontend/components/mission-page.test.tsx`) and docs (`docs/ui/README_UI.md`) to reflect behavior and validation policy.  

### Testing
- Ran `pnpm --filter frontend test lib/governance-link-utils.test.ts`, and the suite passed (helper tests succeeded).  
- Ran `pnpm --filter frontend test components/mission-page.test.tsx`, and the suite passed (MissionPage link behavior tests succeeded).  
- Both targeted test files passed locally and verify safe-link generation, rejection of unsafe IDs, unchanged `Open target surface` behavior, and that no fake routes are created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37cbf3f6c83268f5fa5527fa79a2f)