### PR TITLE
Audit: consume decision_id and execution_intent_id query targets

### DIFF
--- a/frontend/app/audit/hooks/useAuditData.test.ts
+++ b/frontend/app/audit/hooks/useAuditData.test.ts
@@ -443,7 +443,7 @@ describe("useAuditData", () => {
     const { result } = renderHook(() => useAuditData());
 
     await vi.waitFor(() => {
-      expect(result.current.bindReceiptLookupError).toContain("Invalid bind_receipt_id");
+      expect(result.current.queryTargetInvalidError).toContain("Invalid artifact ID");
     });
     expect(result.current.bindReceiptLookupDetail).toBeNull();
     expect(result.current.showBindReceiptFallback).toBe(false);
@@ -474,5 +474,85 @@ describe("useAuditData", () => {
     });
     expect(result.current.bindReceiptLookupDetail).toBeNull();
     expect(result.current.showBindReceiptFallback).toBe(false);
+  });
+
+  it("consumes decision_id query and focuses matched timeline item", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=43");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    await vi.waitFor(() => {
+      expect(result.current.queryTarget?.kind).toBe("decision_id");
+      expect(result.current.queryTarget?.value).toBe("43");
+      expect(result.current.queryTargetFoundInTimeline).toBe(true);
+      expect(result.current.selected?.decision_id).toBe("43");
+      expect(result.current.detailTab).toBe("related");
+    });
+  });
+
+  it("consumes execution_intent_id query from metadata and focuses item", async () => {
+    window.history.replaceState({}, "", "/audit?execution_intent_id=ei-002");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          items: [
+            MOCK_ITEMS[0],
+            {
+              ...MOCK_ITEMS[1],
+              metadata: { execution_intent_id: "ei-002" },
+            },
+          ],
+          next_cursor: null,
+          has_more: false,
+        }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    await vi.waitFor(() => {
+      expect(result.current.queryTarget?.kind).toBe("execution_intent_id");
+      expect(result.current.queryTargetFoundInTimeline).toBe(true);
+      expect(result.current.selected?.request_id).toBe("req-002");
+    });
+  });
+
+  it("marks timeline miss for decision_id when not loaded", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=missing-dec");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+    await act(async () => {
+      await result.current.loadLogs(null, true);
+    });
+
+    await vi.waitFor(() => {
+      expect(result.current.queryTarget?.kind).toBe("decision_id");
+      expect(result.current.queryTargetTimelineMiss).toBe(true);
+      expect(result.current.queryTargetFoundInTimeline).toBe(false);
+    });
+  });
+
+  it("rejects invalid decision_id query", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=bad%20value");
+
+    const { result } = renderHook(() => useAuditData());
+    await vi.waitFor(() => {
+      expect(result.current.queryTargetInvalidError).toContain("Invalid artifact ID");
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/audit/hooks/useAuditData.ts
+++ b/frontend/app/audit/hooks/useAuditData.ts
@@ -40,6 +40,10 @@ export interface AuditDataState {
   bindReceiptLookupSucceeded: boolean;
   bindReceiptTimelineMiss: boolean;
   showBindReceiptFallback: boolean;
+  queryTarget: AuditQueryTarget | null;
+  queryTargetInvalidError: string | null;
+  queryTargetFoundInTimeline: boolean;
+  queryTargetTimelineMiss: boolean;
 
   /* selected */
   selected: TrustLogItem | null;
@@ -118,6 +122,15 @@ interface BindReceiptLookupDetail {
   riskCheckResult: Record<string, unknown> | null;
 }
 
+type AuditQueryTargetKind = "bind_receipt_id" | "decision_id" | "execution_intent_id";
+
+interface AuditQueryTarget {
+  kind: AuditQueryTargetKind;
+  value: string;
+}
+
+const AUDIT_ARTIFACT_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
 /* ------------------------------------------------------------------ */
 /*  Hook                                                               */
 /* ------------------------------------------------------------------ */
@@ -136,6 +149,8 @@ export function useAuditData(): AuditDataState {
   const [bindReceiptLookupLoading, setBindReceiptLookupLoading] = useState(false);
   const [bindReceiptIdFromQuery, setBindReceiptIdFromQuery] = useState<string | null>(null);
   const [bindReceiptLookupDetail, setBindReceiptLookupDetail] = useState<BindReceiptLookupDetail | null>(null);
+  const [queryTarget, setQueryTarget] = useState<AuditQueryTarget | null>(null);
+  const [queryTargetInvalidError, setQueryTargetInvalidError] = useState<string | null>(null);
 
   const bindReceiptBootstrappedRef = useRef(false);
 
@@ -186,6 +201,32 @@ export function useAuditData(): AuditDataState {
       return true;
     }
 
+    return false;
+  };
+
+  const matchesDecisionId = (item: TrustLogItem, decisionId: string): boolean =>
+    String(item.decision_id ?? "") === decisionId;
+
+  const matchesExecutionIntentId = (item: TrustLogItem, executionIntentId: string): boolean => {
+    if (String((item as Record<string, unknown>).execution_intent_id ?? "") === executionIntentId) {
+      return true;
+    }
+    if (
+      item.metadata &&
+      typeof item.metadata === "object" &&
+      item.metadata !== null &&
+      String((item.metadata as Record<string, unknown>).execution_intent_id ?? "") === executionIntentId
+    ) {
+      return true;
+    }
+    if (
+      item.bind_receipt &&
+      typeof item.bind_receipt === "object" &&
+      item.bind_receipt !== null &&
+      String((item.bind_receipt as Record<string, unknown>).execution_intent_id ?? "") === executionIntentId
+    ) {
+      return true;
+    }
     return false;
   };
 
@@ -403,6 +444,23 @@ export function useAuditData(): AuditDataState {
     () => bindReceiptTimelineMiss && bindReceiptLookupDetail !== null,
     [bindReceiptLookupDetail, bindReceiptTimelineMiss],
   );
+  const queryTargetFoundInTimeline = useMemo(() => {
+    if (!queryTarget) {
+      return false;
+    }
+    if (queryTarget.kind === "bind_receipt_id") {
+      return sortedItems.some((item) => matchesBindReceiptId(item, queryTarget.value));
+    }
+    if (queryTarget.kind === "decision_id") {
+      return sortedItems.some((item) => matchesDecisionId(item, queryTarget.value));
+    }
+    return sortedItems.some((item) => matchesExecutionIntentId(item, queryTarget.value));
+  }, [queryTarget, sortedItems]);
+
+  const queryTargetTimelineMiss = useMemo(
+    () => Boolean(queryTarget) && !queryTargetFoundInTimeline,
+    [queryTarget, queryTargetFoundInTimeline],
+  );
 
   /* ---------------------------------------------------------------- */
   /*  Actions                                                          */
@@ -542,23 +600,34 @@ export function useAuditData(): AuditDataState {
 
     const params = new URLSearchParams(window.location.search);
     const bindReceiptId = params.get("bind_receipt_id")?.trim() ?? "";
-    if (!bindReceiptId) {
-      return;
+    const decisionId = params.get("decision_id")?.trim() ?? "";
+    const executionIntentId = params.get("execution_intent_id")?.trim() ?? "";
+    const queryTargets: AuditQueryTarget[] = [];
+    if (bindReceiptId) queryTargets.push({ kind: "bind_receipt_id", value: bindReceiptId });
+    if (decisionId) queryTargets.push({ kind: "decision_id", value: decisionId });
+    if (executionIntentId) queryTargets.push({ kind: "execution_intent_id", value: executionIntentId });
+    const prioritizedTarget = queryTargets[0] ?? null;
+    if (prioritizedTarget) {
+      setQueryTarget(prioritizedTarget);
+      setCrossSearch({ query: prioritizedTarget.value, field: "all" });
     }
 
-    if (!/^[A-Za-z0-9._:-]{1,128}$/.test(bindReceiptId)) {
+    if (queryTargets.some((target) => !AUDIT_ARTIFACT_ID_PATTERN.test(target.value))) {
       setBindReceiptLookupDetail(null);
-      setBindReceiptLookupError(
+      setQueryTargetInvalidError(
         t(
-          "無効な bind_receipt_id が指定されました。",
-          "Invalid bind_receipt_id query parameter.",
+          "無効な artifact ID query parameter が指定されました。",
+          "Invalid artifact ID query parameter.",
         ),
       );
       return;
     }
 
+    if (!bindReceiptId) {
+      return;
+    }
+
     setBindReceiptIdFromQuery(bindReceiptId);
-    setCrossSearch({ query: bindReceiptId, field: "all" });
 
     const loadFromQuery = async (): Promise<void> => {
       setBindReceiptLookupLoading(true);
@@ -605,16 +674,20 @@ export function useAuditData(): AuditDataState {
   }, [t]);
 
   useEffect(() => {
-    if (!bindReceiptIdFromQuery || sortedItems.length === 0) {
+    if (!queryTarget || sortedItems.length === 0) {
       return;
     }
 
-    const matched = sortedItems.find((item) => matchesBindReceiptId(item, bindReceiptIdFromQuery));
+    const matched = sortedItems.find((item) => {
+      if (queryTarget.kind === "bind_receipt_id") return matchesBindReceiptId(item, queryTarget.value);
+      if (queryTarget.kind === "decision_id") return matchesDecisionId(item, queryTarget.value);
+      return matchesExecutionIntentId(item, queryTarget.value);
+    });
     if (matched) {
       setSelected(matched);
       setDetailTab("related");
     }
-  }, [bindReceiptIdFromQuery, sortedItems]);
+  }, [queryTarget, sortedItems]);
 
   /* ---------------------------------------------------------------- */
   /*  Return                                                           */
@@ -634,6 +707,10 @@ export function useAuditData(): AuditDataState {
     bindReceiptLookupSucceeded,
     bindReceiptTimelineMiss,
     showBindReceiptFallback,
+    queryTarget,
+    queryTargetInvalidError,
+    queryTargetFoundInTimeline,
+    queryTargetTimelineMiss,
     selected,
     setSelected,
     requestId,

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -241,6 +241,34 @@ export default function TrustLogExplorerPage(): JSX.Element {
         </Card>
       ) : null}
 
+      {data.queryTarget && data.queryTarget.kind !== "bind_receipt_id" ? (
+        <Card
+          title="Artifact Trace"
+          description={t(
+            "Governance から指定された artifact ID を追跡中です。",
+            "Tracing artifact ID specified from Governance.",
+          )}
+          variant="elevated"
+        >
+          <div className="space-y-2 text-xs">
+            <p>
+              {data.queryTarget.kind}: <span className="font-mono">{data.queryTarget.value}</span>
+            </p>
+            <p className={data.queryTargetFoundInTimeline ? "text-success" : "text-warning"}>
+              {data.queryTargetFoundInTimeline
+                ? t(
+                    "関連する監査ログをタイムラインで選択しました。",
+                    "Matched audit log has been focused in the timeline.",
+                  )
+                : t(
+                    "指定された artifact ID は現在読み込まれているタイムラインでは未検出です。",
+                    "Specified artifact ID was not found in loaded timeline.",
+                  )}
+            </p>
+          </div>
+        </Card>
+      ) : null}
+
       {data.error ? (
         <ErrorBanner
           message={data.error}
@@ -251,6 +279,9 @@ export default function TrustLogExplorerPage(): JSX.Element {
 
       {data.bindReceiptLookupError ? (
         <ErrorBanner message={data.bindReceiptLookupError} />
+      ) : null}
+      {data.queryTargetInvalidError ? (
+        <ErrorBanner message={data.queryTargetInvalidError} />
       ) : null}
 
       {/* Summary */}


### PR DESCRIPTION
### Motivation

- Make the `/audit` workflow navigable from Mission Control operator actions by having the Audit page explicitly consume `decision_id` and `execution_intent_id` query parameters and turn them into review actions. 
- Preserve existing `bind_receipt_id` behavior while treating query parameters as untrusted input that must be validated before use. 
- Surface timeline focus / miss state and clear UI feedback when an artifact ID is found or not found in the currently loaded timeline.

### Description

- Extend the bootstrap logic in `useAuditData` to parse `decision_id` and `execution_intent_id` in addition to `bind_receipt_id` and introduce a unified `AuditQueryTarget` (`queryTarget`) concept. 
- Add conservative validation with `AUDIT_ARTIFACT_ID_PATTERN` (`/^[A-Za-z0-9._:-]{1,128}$/`) and expose `queryTargetInvalidError` when validation fails to reject invalid inputs early. 
- Implement matching helpers (`matchesDecisionId`, `matchesExecutionIntentId`) that inspect top-level fields, nested `metadata`, and nested `bind_receipt` for `execution_intent_id`, and generalize the existing bind-receipt focus logic to select/focus timeline items for any supported artifact target. 
- Expose derived flags `queryTargetFoundInTimeline` and `queryTargetTimelineMiss` and add a small UI card in `frontend/app/audit/page.tsx` to show artifact trace status for non-`bind_receipt_id` targets and surface validation errors through `ErrorBanner`. 
- No backend shape changes, no new routes, and existing `bind_receipt` lookup/fallback behavior is preserved.

### Testing

- Added and updated unit tests in `frontend/app/audit/hooks/useAuditData.test.ts` to cover `decision_id` consumption and focus, `execution_intent_id` matching (including metadata), timeline-miss signaling, and invalid-artifact rejection, and updated the invalid `bind_receipt_id` expectation to the new rejection flow. 
- Ran frontend package tests with `cd frontend && pnpm test app/audit/hooks/useAuditData.test.ts app/audit/page.test.tsx` and the test suite passed (all added and existing assertions green; total tests run: 43). 
- Note: an attempted `vitest` invocation at the monorepo root failed because the `vitest` binary is not exposed there, but the frontend package tests above were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f387d7aab0832694023f1f560253e6)