### PR TITLE
feat(audit): auto-load latest logs for decision_id & execution_intent_id query traces

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -121,5 +121,7 @@ docker compose up --build
 - 無効値（例: `../secret`, `javascript:...`, 改行を含む値）は拒否し、error 表示のみ行い、unsafe query による検索・遷移は行いません。
 - query priority は `bind_receipt_id` > `decision_id` > `execution_intent_id` です。複数指定時は最優先 query を workflow focus として consume します。
 - `bind_receipt_id` は従来どおり dedicated lookup（governance bind receipt API）を実行し、timeline match があれば select/focus、miss 時は fallback detail を表示します。
-- `decision_id` は loaded timeline 内で一致する item (`item.decision_id`) を探索し、見つかれば select/focus、見つからなければ not-found trace を表示します。
-- `execution_intent_id` は loaded timeline 内で `item.execution_intent_id` / `item.metadata.execution_intent_id` / `item.bind_receipt.execution_intent_id` を探索し、見つかれば select/focus、見つからなければ not-found trace を表示します。
+- `decision_id` は valid query の場合、timeline 未ロードなら latest logs を自動ロードし、loaded timeline 内で一致する item (`item.decision_id`) を探索します。見つかれば select/focus、見つからなければ not-found trace を表示します。
+- `execution_intent_id` は valid query の場合、timeline 未ロードなら latest logs を自動ロードし、loaded timeline 内で `item.execution_intent_id` / `item.metadata.execution_intent_id` / `item.bind_receipt.execution_intent_id` を探索します。見つかれば select/focus、見つからなければ not-found trace を表示します。
+- invalid `decision_id` / `execution_intent_id` は reject され、auto-load は実行されません。
+- query なしの `/audit` は従来どおり手動の `Load latest logs` 操作で読み込みます。

--- a/frontend/app/audit/hooks/useAuditData.test.ts
+++ b/frontend/app/audit/hooks/useAuditData.test.ts
@@ -28,6 +28,57 @@ vi.mock("@veritas/types", async () => {
       return "items" in payload;
     },
   };
+
+  it("auto-loads logs for decision_id query without manual trigger", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=42");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/veritas/v1/trust/logs?limit=50",
+        expect.any(Object),
+      );
+      expect(result.current.decisionIdFromQuery).toBe("42");
+      expect(result.current.selected?.decision_id).toBe("42");
+      expect(result.current.queryTraceStatus).toBe("decision:matched");
+    });
+  });
+
+  it("does not auto-load when decision_id query is invalid", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=../secret");
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(result.current.bindReceiptLookupError).toContain("Invalid decision_id");
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("prefers decision_id over execution_intent_id when both are present", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=42&execution_intent_id=ei-123");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        items: [{ ...MOCK_ITEMS[0], metadata: { execution_intent_id: "ei-123" } }],
+        next_cursor: null,
+        has_more: false,
+      }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(result.current.decisionIdFromQuery).toBe("42");
+      expect(result.current.executionIntentIdFromQuery).toBeNull();
+      expect(result.current.queryTraceStatus).toBe("decision:matched");
+    });
+  });
+
 });
 
 vi.mock("../audit-types", async () => {
@@ -44,6 +95,57 @@ vi.mock("../audit-types", async () => {
       policyVersions: [],
     }),
   };
+
+  it("auto-loads logs for decision_id query without manual trigger", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=42");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/veritas/v1/trust/logs?limit=50",
+        expect.any(Object),
+      );
+      expect(result.current.decisionIdFromQuery).toBe("42");
+      expect(result.current.selected?.decision_id).toBe("42");
+      expect(result.current.queryTraceStatus).toBe("decision:matched");
+    });
+  });
+
+  it("does not auto-load when decision_id query is invalid", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=../secret");
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(result.current.bindReceiptLookupError).toContain("Invalid decision_id");
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("prefers decision_id over execution_intent_id when both are present", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=42&execution_intent_id=ei-123");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        items: [{ ...MOCK_ITEMS[0], metadata: { execution_intent_id: "ei-123" } }],
+        next_cursor: null,
+        has_more: false,
+      }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(result.current.decisionIdFromQuery).toBe("42");
+      expect(result.current.executionIntentIdFromQuery).toBeNull();
+      expect(result.current.queryTraceStatus).toBe("decision:matched");
+    });
+  });
+
 });
 
 import { useAuditData } from "./useAuditData";
@@ -532,4 +634,55 @@ describe("useAuditData", () => {
       expect(result.current.selected?.request_id).toBe("req-001");
     });
   });
+
+  it("auto-loads logs for decision_id query without manual trigger", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=42");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ items: MOCK_ITEMS, next_cursor: null, has_more: false }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/veritas/v1/trust/logs?limit=50",
+        expect.any(Object),
+      );
+      expect(result.current.decisionIdFromQuery).toBe("42");
+      expect(result.current.selected?.decision_id).toBe("42");
+      expect(result.current.queryTraceStatus).toBe("decision:matched");
+    });
+  });
+
+  it("does not auto-load when decision_id query is invalid", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=../secret");
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(result.current.bindReceiptLookupError).toContain("Invalid decision_id");
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("prefers decision_id over execution_intent_id when both are present", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=42&execution_intent_id=ei-123");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        items: [{ ...MOCK_ITEMS[0], metadata: { execution_intent_id: "ei-123" } }],
+        next_cursor: null,
+        has_more: false,
+      }),
+    });
+
+    const { result } = renderHook(() => useAuditData());
+
+    await vi.waitFor(() => {
+      expect(result.current.decisionIdFromQuery).toBe("42");
+      expect(result.current.executionIntentIdFromQuery).toBeNull();
+      expect(result.current.queryTraceStatus).toBe("decision:matched");
+    });
+  });
+
 });

--- a/frontend/app/audit/hooks/useAuditData.ts
+++ b/frontend/app/audit/hooks/useAuditData.ts
@@ -144,6 +144,7 @@ export function useAuditData(): AuditDataState {
   const [bindReceiptLookupDetail, setBindReceiptLookupDetail] = useState<BindReceiptLookupDetail | null>(null);
 
   const bindReceiptBootstrappedRef = useRef(false);
+  const queryAutoLoadStartedRef = useRef(false);
 
   /* -- search state ------------------------------------------------ */
   const [requestId, setRequestId] = useState("");
@@ -649,6 +650,10 @@ export function useAuditData(): AuditDataState {
       setSelectedDecisionId(decisionId);
       setCrossSearch({ query: decisionId, field: "decision_id" });
       setQueryTraceStatus("pending");
+      if (!queryAutoLoadStartedRef.current && items.length === 0) {
+        queryAutoLoadStartedRef.current = true;
+        void loadLogs(null, true);
+      }
       return;
     }
 
@@ -665,8 +670,12 @@ export function useAuditData(): AuditDataState {
       setExecutionIntentIdFromQuery(executionIntentId);
       setCrossSearch({ query: executionIntentId, field: "all" });
       setQueryTraceStatus("pending");
+      if (!queryAutoLoadStartedRef.current && items.length === 0) {
+        queryAutoLoadStartedRef.current = true;
+        void loadLogs(null, true);
+      }
     }
-  }, [t]);
+  }, [items.length, loadLogs, t]);
 
   useEffect(() => {
     if (!bindReceiptIdFromQuery || sortedItems.length === 0) {

--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -63,11 +63,44 @@ async function loadLogs() {
 }
 
 describe("TrustLogExplorerPage", () => {
+  it("auto-loads decision trace and shows pending before fetch resolves", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=dec-100");
+    let resolveFetch: ((value: Response) => void) | null = null;
+    vi.spyOn(global, "fetch").mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve as (value: Response) => void;
+        }),
+    );
+
+    render(<TrustLogExplorerPage />);
+
+    expect(screen.getByText("Decision Artifact Trace")).toBeInTheDocument();
+    expect(screen.getByText(/Loading audit logs for decision artifact|decision artifact のために監査ログを読み込み中です/)).toBeInTheDocument();
+
+    resolveFetch?.({
+      ok: true,
+      json: async () => ({
+        items: MOCK_ITEMS_CHAINED,
+        cursor: "0",
+        next_cursor: null,
+        limit: 50,
+        has_more: false,
+      }),
+    } as Response);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Matched decision artifact in timeline|関連する decision artifact をタイムラインで選択しました/)).toBeInTheDocument();
+    });
+  });
+
   it("renders decision trace card and matched status from decision_id query", async () => {
     window.history.replaceState({}, "", "/audit?decision_id=dec-100");
     mockFetchWithItems();
     render(<TrustLogExplorerPage />);
-    await loadLogs();
+    await waitFor(() => {
+      expect(screen.getByText(/Matched decision artifact in timeline|関連する decision artifact をタイムラインで選択しました/)).toBeInTheDocument();
+    });
     expect(screen.getByText("Decision Artifact Trace")).toBeInTheDocument();
     expect(screen.getAllByText("decision_id:").length).toBeGreaterThan(0);
     expect(screen.getAllByText("dec-100").length).toBeGreaterThan(0);
@@ -78,7 +111,9 @@ describe("TrustLogExplorerPage", () => {
     window.history.replaceState({}, "", "/audit?execution_intent_id=ei-missing");
     mockFetchWithItems();
     render(<TrustLogExplorerPage />);
-    await loadLogs();
+    await waitFor(() => {
+      expect(screen.getByText(/Execution intent was not found in the currently loaded timeline|execution intent は現在読み込まれているタイムラインに見つかりません/)).toBeInTheDocument();
+    });
     expect(screen.getByText("Execution Intent Trace")).toBeInTheDocument();
     expect(screen.getAllByText("ei-missing").length).toBeGreaterThan(0);
     expect(screen.getByText(/Execution intent was not found in the currently loaded timeline|execution intent は現在読み込まれているタイムラインに見つかりません/)).toBeInTheDocument();

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -254,9 +254,11 @@ export default function TrustLogExplorerPage(): JSX.Element {
               decision_id: <span className="font-mono">{data.decisionIdFromQuery}</span>
             </p>
             <p className={data.queryTraceStatus === "decision:matched" ? "text-success" : "text-warning"}>
-              {data.queryTraceStatus === "decision:matched"
-                ? t("関連する decision artifact をタイムラインで選択しました。", "Matched decision artifact in timeline.")
-                : t("decision artifact は現在読み込まれているタイムラインに見つかりません。", "Decision artifact was not found in the currently loaded timeline.")}
+              {data.queryTraceStatus === "decision:pending" || data.queryTraceStatus === "pending"
+                ? t("decision artifact のために監査ログを読み込み中です...", "Loading audit logs for decision artifact...")
+                : data.queryTraceStatus === "decision:matched"
+                  ? t("関連する decision artifact をタイムラインで選択しました。", "Matched decision artifact in timeline.")
+                  : t("decision artifact は現在読み込まれているタイムラインに見つかりません。", "Decision artifact was not found in the currently loaded timeline.")}
             </p>
           </div>
         </Card>
@@ -276,9 +278,11 @@ export default function TrustLogExplorerPage(): JSX.Element {
               execution_intent_id: <span className="font-mono">{data.executionIntentIdFromQuery}</span>
             </p>
             <p className={data.queryTraceStatus === "execution-intent:matched" ? "text-success" : "text-warning"}>
-              {data.queryTraceStatus === "execution-intent:matched"
-                ? t("関連する execution intent をタイムラインで選択しました。", "Matched execution intent in timeline.")
-                : t("execution intent は現在読み込まれているタイムラインに見つかりません。", "Execution intent was not found in the currently loaded timeline.")}
+              {data.queryTraceStatus === "execution-intent:pending" || data.queryTraceStatus === "pending"
+                ? t("execution intent のために監査ログを読み込み中です...", "Loading audit logs for execution intent...")
+                : data.queryTraceStatus === "execution-intent:matched"
+                  ? t("関連する execution intent をタイムラインで選択しました。", "Matched execution intent in timeline.")
+                  : t("execution intent は現在読み込まれているタイムラインに見つかりません。", "Execution intent was not found in the currently loaded timeline.")}
             </p>
           </div>
         </Card>


### PR DESCRIPTION
### Motivation
- Mission Control `/audit?decision_id=...` and `/audit?execution_intent_id=...` links must act as direct review entry points by automatically loading the latest audit logs so operators don't have to click "Load latest logs" manually. 
- The change must be minimal, preserve existing `bind_receipt_id` flow and query priority, and treat query parameters as untrusted input.

### Description
- Added a one-shot auto-load guard `queryAutoLoadStartedRef` and wired automatic `loadLogs(null, true)` when a valid `decision_id` or `execution_intent_id` query is present and the timeline is empty, implemented in `useAuditData` (`frontend/app/audit/hooks/useAuditData.ts`).
- Preserved `bind_receipt_id` dedicated lookup and priority ordering (`bind_receipt_id` > `decision_id` > `execution_intent_id`) so the new auto-load does not run when a bind receipt query is present. 
- Updated `/audit` trace cards in `frontend/app/audit/page.tsx` to show a clear pending message during auto-load (`Loading audit logs for decision artifact...` / `Loading audit logs for execution intent...`) and then transition to `matched` / `not-found` as before. 
- Added and adjusted unit tests to cover auto-load behaviours, invalid-query rejection, and priority handling in `frontend/app/audit/hooks/useAuditData.test.ts` and `frontend/app/audit/page.test.tsx`, and updated UI docs in `docs/ui/README_UI.md` to document the new auto-load semantics.

### Testing
- Ran `pnpm --filter frontend test app/audit/hooks/useAuditData.test.ts` and the test suite passed. 
- Ran `pnpm --filter frontend test app/audit/page.test.tsx` and the test suite passed. 
- Also ran `pnpm --filter frontend test components/mission-page.test.tsx` and `pnpm --filter frontend test lib/governance-link-utils.test.ts` and both succeeded.
- All modified and related frontend tests listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3feddab948326b6a17850f65dc6ac)