### PR TITLE
Add direct lookup fallback for decision_id (decision-only) and mark execution_intent lookup unavailable

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -121,7 +121,7 @@ docker compose up --build
 - 無効値（例: `../secret`, `javascript:...`, 改行を含む値）は拒否し、error 表示のみ行い、unsafe query による検索・遷移は行いません。
 - query priority は `bind_receipt_id` > `decision_id` > `execution_intent_id` です。複数指定時は最優先 query を workflow focus として consume します。
 - `bind_receipt_id` は従来どおり dedicated lookup（governance bind receipt API）を実行し、timeline match があれば select/focus、miss 時は fallback detail を表示します。
-- `decision_id` は valid query の場合、timeline 未ロードなら latest logs を自動ロードし、loaded timeline 内で一致する item (`item.decision_id`) を探索します。見つかれば select/focus、見つからなければ not-found trace を表示します。
-- `execution_intent_id` は valid query の場合、timeline 未ロードなら latest logs を自動ロードし、loaded timeline 内で `item.execution_intent_id` / `item.metadata.execution_intent_id` / `item.bind_receipt.execution_intent_id` を探索します。見つかれば select/focus、見つからなければ not-found trace を表示します。
-- invalid `decision_id` / `execution_intent_id` は reject され、auto-load は実行されません。
+- `decision_id` は valid query の場合、timeline 未ロードなら latest logs を自動ロードし、loaded timeline 内で一致する item (`item.decision_id`) を探索します。見つかれば select/focus し direct lookup は実行しません。見つからない場合は既存 API surface (`/api/veritas/v1/governance/bind-receipts?decision_id=...`) で direct lookup fallback を1回だけ試行し、found / not-found / unavailable を trace card に明示します。
+- `execution_intent_id` は valid query の場合、timeline 未ロードなら latest logs を自動ロードし、loaded timeline 内で `item.execution_intent_id` / `item.metadata.execution_intent_id` / `item.bind_receipt.execution_intent_id` を探索します。見つかれば select/focus します。timeline miss 時に execution_intent 専用 direct lookup は current API semantics 上で厳密な artifact 一意取得が保証できないため実行せず、`direct lookup unavailable` を表示します（fake lookup を行いません）。
+- invalid `decision_id` / `execution_intent_id` は reject され、auto-load / direct lookup ともに実行されません。
 - query なしの `/audit` は従来どおり手動の `Load latest logs` 操作で読み込みます。

--- a/frontend/app/audit/hooks/useAuditData.ts
+++ b/frontend/app/audit/hooks/useAuditData.ts
@@ -43,6 +43,9 @@ export interface AuditDataState {
   decisionIdFromQuery: string | null;
   executionIntentIdFromQuery: string | null;
   queryTraceStatus: string | null;
+  directLookupStatus: string | null;
+  directLookupError: string | null;
+  directLookupDetail: Record<string, unknown> | null;
 
   /* selected */
   selected: TrustLogItem | null;
@@ -141,10 +144,14 @@ export function useAuditData(): AuditDataState {
   const [decisionIdFromQuery, setDecisionIdFromQuery] = useState<string | null>(null);
   const [executionIntentIdFromQuery, setExecutionIntentIdFromQuery] = useState<string | null>(null);
   const [queryTraceStatus, setQueryTraceStatus] = useState<string | null>(null);
+  const [directLookupStatus, setDirectLookupStatus] = useState<string | null>(null);
+  const [directLookupError, setDirectLookupError] = useState<string | null>(null);
+  const [directLookupDetail, setDirectLookupDetail] = useState<Record<string, unknown> | null>(null);
   const [bindReceiptLookupDetail, setBindReceiptLookupDetail] = useState<BindReceiptLookupDetail | null>(null);
 
   const bindReceiptBootstrappedRef = useRef(false);
   const queryAutoLoadStartedRef = useRef(false);
+  const directLookupStartedRef = useRef<string | null>(null);
 
   /* -- search state ------------------------------------------------ */
   const [requestId, setRequestId] = useState("");
@@ -704,6 +711,43 @@ export function useAuditData(): AuditDataState {
   }, [decisionIdFromQuery, sortedItems]);
 
   useEffect(() => {
+    if (!decisionIdFromQuery || queryTraceStatus !== "decision:not-found") {
+      return;
+    }
+    if (directLookupStartedRef.current === `decision:${decisionIdFromQuery}`) {
+      return;
+    }
+    directLookupStartedRef.current = `decision:${decisionIdFromQuery}`;
+    const lookupDecision = async (): Promise<void> => {
+      setDirectLookupStatus("decision:lookup-pending");
+      setDirectLookupError(null);
+      setDirectLookupDetail(null);
+      try {
+        const response = await veritasFetch(
+          `/api/veritas/v1/governance/bind-receipts?decision_id=${encodeURIComponent(decisionIdFromQuery)}&limit=1`,
+        );
+        if (!response.ok) {
+          setDirectLookupStatus("decision:lookup-unavailable");
+          setDirectLookupError(`HTTP ${response.status}`);
+          return;
+        }
+        const payload = (await response.json()) as { items?: unknown[] };
+        const first = Array.isArray(payload.items) ? payload.items[0] : null;
+        if (first && typeof first === "object") {
+          setDirectLookupDetail(first as Record<string, unknown>);
+          setDirectLookupStatus("decision:lookup-found");
+          return;
+        }
+        setDirectLookupStatus("decision:lookup-not-found");
+      } catch (caught: unknown) {
+        setDirectLookupStatus("decision:lookup-unavailable");
+        setDirectLookupError(caught instanceof Error ? caught.message : "direct lookup failed");
+      }
+    };
+    void lookupDecision();
+  }, [decisionIdFromQuery, queryTraceStatus]);
+
+  useEffect(() => {
     if (!executionIntentIdFromQuery || sortedItems.length === 0) {
       return;
     }
@@ -716,6 +760,13 @@ export function useAuditData(): AuditDataState {
     }
     setQueryTraceStatus("execution-intent:not-found");
   }, [executionIntentIdFromQuery, sortedItems]);
+
+  useEffect(() => {
+    if (!executionIntentIdFromQuery || queryTraceStatus !== "execution-intent:not-found") {
+      return;
+    }
+    setDirectLookupStatus("execution-intent:lookup-unavailable");
+  }, [executionIntentIdFromQuery, queryTraceStatus]);
 
   /* ---------------------------------------------------------------- */
   /*  Return                                                           */
@@ -738,6 +789,9 @@ export function useAuditData(): AuditDataState {
     decisionIdFromQuery,
     executionIntentIdFromQuery,
     queryTraceStatus,
+    directLookupStatus,
+    directLookupError,
+    directLookupDetail,
     selected,
     setSelected,
     requestId,

--- a/frontend/app/audit/page.tsx
+++ b/frontend/app/audit/page.tsx
@@ -260,6 +260,25 @@ export default function TrustLogExplorerPage(): JSX.Element {
                   ? t("関連する decision artifact をタイムラインで選択しました。", "Matched decision artifact in timeline.")
                   : t("decision artifact は現在読み込まれているタイムラインに見つかりません。", "Decision artifact was not found in the currently loaded timeline.")}
             </p>
+            {data.directLookupStatus?.startsWith("decision:") ? (
+              <p className="text-muted-foreground">
+                {data.directLookupStatus === "decision:lookup-pending"
+                  ? "Direct lookup pending..."
+                  : data.directLookupStatus === "decision:lookup-found"
+                    ? "Direct lookup found fallback detail."
+                    : data.directLookupStatus === "decision:lookup-not-found"
+                      ? "Direct lookup did not find this decision_id."
+                      : `Direct lookup unavailable with current API surface.${data.directLookupError ? ` ${data.directLookupError}` : ""}`}
+              </p>
+            ) : null}
+            {data.directLookupDetail && data.directLookupStatus === "decision:lookup-found" ? (
+              <details>
+                <summary className="cursor-pointer">Raw fallback detail</summary>
+                <pre className="mt-1 max-h-64 overflow-auto rounded border border-border/60 bg-background/70 p-2 font-mono text-[10px]">
+                  {JSON.stringify(data.directLookupDetail, null, 2)}
+                </pre>
+              </details>
+            ) : null}
           </div>
         </Card>
       ) : null}
@@ -284,6 +303,9 @@ export default function TrustLogExplorerPage(): JSX.Element {
                   ? t("関連する execution intent をタイムラインで選択しました。", "Matched execution intent in timeline.")
                   : t("execution intent は現在読み込まれているタイムラインに見つかりません。", "Execution intent was not found in the currently loaded timeline.")}
             </p>
+            {data.directLookupStatus === "execution-intent:lookup-unavailable" ? (
+              <p className="text-muted-foreground">Direct lookup unavailable with current API surface.</p>
+            ) : null}
           </div>
         </Card>
       ) : null}


### PR DESCRIPTION
### Motivation

- Improve Audit `/audit` query workflow so `decision_id` passed from Mission Control is discoverable even when not present in the currently loaded latest logs. 
- Use existing backend API surfaces only (no new endpoints, no fake data) and preserve existing query priority and `bind_receipt_id` behavior. 

### Description

- Added direct lookup state to `useAuditData` (`directLookupStatus`, `directLookupError`, `directLookupDetail`) and a `directLookupStartedRef` guard to avoid duplicate fetches. 
- Implemented a single fallback fetch for timeline misses of `decision_id` using the existing API `GET /api/veritas/v1/governance/bind-receipts?decision_id=...&limit=1`, and set status to one of `decision:lookup-pending|decision:lookup-found|decision:lookup-not-found|decision:lookup-unavailable`. 
- Marked `execution_intent_id` timeline-miss direct lookup as unavailable (no fake lookup), and surface `execution-intent:lookup-unavailable` in the UI when applicable. 
- Updated `frontend/app/audit/page.tsx` to render direct lookup status messages and show raw fallback detail when a decision fallback item is found. 
- Documented behavior and constraints in `docs/ui/README_UI.md` and preserved existing validation (`^[A-Za-z0-9._:-]{1,128}$`) and query priority (`bind_receipt_id` > `decision_id` > `execution_intent_id`). 
- No backend code or new endpoints were added and no fake data/routes were introduced. 

### Testing

- Ran `pnpm --filter frontend test app/audit/hooks/useAuditData.test.ts` and it passed (`26 tests` passed). 
- Ran `pnpm --filter frontend test app/audit/page.test.tsx` and it passed (`22 tests` passed). 
- Ran `pnpm --filter frontend test components/mission-page.test.tsx` and it passed (`28 tests` passed). 
- Ran `pnpm --filter frontend test lib/governance-link-utils.test.ts` and it passed (`6 tests` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f422768494832694599d0461305b90)