### PR TITLE
test(frontend): add demo-grade Mission Control → Audit workflow scenario tests

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -125,3 +125,11 @@ docker compose up --build
 - `execution_intent_id` は valid query の場合、timeline 未ロードなら latest logs を自動ロードし、loaded timeline 内で `item.execution_intent_id` / `item.metadata.execution_intent_id` / `item.bind_receipt.execution_intent_id` を探索します。見つかれば select/focus します。timeline miss 時に execution_intent 専用 direct lookup は current API semantics 上で厳密な artifact 一意取得が保証できないため実行せず、`direct lookup unavailable` を表示します（fake lookup を行いません）。
 - invalid `decision_id` / `execution_intent_id` は reject され、auto-load / direct lookup ともに実行されません。
 - query なしの `/audit` は従来どおり手動の `Load latest logs` 操作で読み込みます。
+
+## Demo-grade Mission Control → Audit review scenario
+
+- Mission Control は governance artifacts metadata（pre-bind source / bind reason / target metadata）を表示します。
+- Operator actions は safe internal path のみ Link 化し、`/audit?decision_id=...` / `/audit?bind_receipt_id=...` / `/audit?execution_intent_id=...` を生成します。
+- `/audit?decision_id=...` は query を consume し、latest logs の auto-load と timeline focus を行い、timeline miss 時は direct lookup fallback を表示します。
+- `/audit?bind_receipt_id=...` は dedicated bind receipt lookup を実行し、timeline match または fallback detail で trace を表示します。
+- fake routes（例: `/decisions/...`, `/execution-intents/...`, `/trustlog/...`）および unsafe/external links は生成しません。

--- a/frontend/app/audit/page.test.tsx
+++ b/frontend/app/audit/page.test.tsx
@@ -107,6 +107,37 @@ describe("TrustLogExplorerPage", () => {
     expect(screen.getByText(/Matched decision artifact in timeline|関連する decision artifact をタイムラインで選択しました/)).toBeInTheDocument();
   });
 
+  it("consumes decision_id demo link and auto-loads timeline without manual action", async () => {
+    window.history.replaceState({}, "", "/audit?decision_id=dec_demo_001");
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            ...MOCK_ITEMS_CHAINED[0],
+            decision_id: "dec_demo_001",
+            request_id: "req_demo_001",
+            stage: "DECIDE",
+          },
+        ],
+        cursor: "0",
+        next_cursor: null,
+        limit: 50,
+        has_more: false,
+      }),
+    } as Response);
+
+    render(<TrustLogExplorerPage />);
+    expect(screen.getByText("Decision Artifact Trace")).toBeInTheDocument();
+    expect(screen.getByText(/Loading audit logs for decision artifact|decision artifact のために監査ログを読み込み中です/)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Matched decision artifact in timeline|関連する decision artifact をタイムラインで選択しました/)).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("dec_demo_001").length).toBeGreaterThan(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("renders execution intent trace not-found status", async () => {
     window.history.replaceState({}, "", "/audit?execution_intent_id=ei-missing");
     mockFetchWithItems();
@@ -436,6 +467,47 @@ describe("TrustLogExplorerPage", () => {
       expect(screen.getByText("関連する監査ログをタイムラインで選択しました。")).toBeInTheDocument();
     });
     expect(screen.queryByText("Bind check summary")).not.toBeInTheDocument();
+  });
+
+  it("consumes bind_receipt_id demo link and renders bind receipt trace fallback detail", async () => {
+    window.history.replaceState({}, "", "/audit?bind_receipt_id=br_demo_001");
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          bind_receipt_id: "br_demo_001",
+          execution_intent_id: "ei_demo_001",
+          final_outcome: "BLOCKED",
+          bind_failure_reason: "Authority evidence missing",
+          authority_check_result: { passed: false },
+          constraint_check_result: { passed: true },
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: MOCK_ITEMS_CHAINED,
+          cursor: "0",
+          next_cursor: null,
+          limit: 50,
+          has_more: false,
+        }),
+      } as Response);
+
+    render(<TrustLogExplorerPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bind Receipt Trace")).toBeInTheDocument();
+      expect(screen.getAllByText("br_demo_001").length).toBeGreaterThan(0);
+      expect(screen.getByText("Authority evidence missing")).toBeInTheDocument();
+      expect(screen.getByText("execution_intent_id")).toBeInTheDocument();
+      expect(screen.getByText("ei_demo_001")).toBeInTheDocument();
+      expect(screen.getByText("BLOCKED")).toBeInTheDocument();
+      expect(screen.getByText("PASS")).toBeInTheDocument();
+      expect(screen.getByText("FAIL")).toBeInTheDocument();
+    });
   });
 
   it("renders compact bind receipt fallback detail when timeline misses the receipt", async () => {

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -335,7 +335,41 @@ describe("MissionPage", () => {
     expect(screen.getByRole("link", { name: "ei_123" })).toHaveAttribute("href", "/audit?execution_intent_id=ei_123");
   });
 
-  
+  it("covers demo-grade Mission Control artifact review actions with safe audit links only", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            decision_id: "dec_demo_001",
+            bind_receipt_id: "br_demo_001",
+            execution_intent_id: "ei_demo_001",
+            pre_bind_source: "trustlog_matching_decision",
+            bind_reason_code: "AUTHORITY_MISSING",
+            bind_failure_reason: "Authority evidence missing",
+            target_label: "Governance policy",
+            relevant_ui_href: "/governance",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("Governance artifacts")).toBeInTheDocument();
+    expect(screen.getAllByText("trustlog_matching_decision").length).toBeGreaterThan(0);
+    expect(screen.getByText("AUTHORITY_MISSING")).toBeInTheDocument();
+    expect(screen.getByText("Authority evidence missing")).toBeInTheDocument();
+    expect(screen.getByText("Governance policy")).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "/governance" })[0]).toHaveAttribute("href", "/governance");
+    expect(screen.getByRole("link", { name: "br_demo_001" })).toHaveAttribute("href", "/audit?bind_receipt_id=br_demo_001");
+    expect(screen.getByRole("link", { name: "dec_demo_001" })).toHaveAttribute("href", "/audit?decision_id=dec_demo_001");
+    expect(screen.getByRole("link", { name: "ei_demo_001" })).toHaveAttribute("href", "/audit?execution_intent_id=ei_demo_001");
+    expect(screen.queryByRole("link", { name: "/decisions/dec_demo_001" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "/execution-intents/ei_demo_001" })).not.toBeInTheDocument();
+    expect(document.querySelector('a[href^="/trustlog"]')).toBeNull();
+  });
+
 
   it("does not create audit links for invalid artifact ids", () => {
     render(


### PR DESCRIPTION
### Motivation

- Lock a demo-grade integrated review story that proves Mission Control surfaces governance artifacts and operators can follow safe `/audit?...` links into Audit where the artifact is traced. 
- Cover the key handoff paths (`decision_id` auto-load + timeline focus, `bind_receipt_id` dedicated lookup + trace/fallback) in a small focused test suite without changing production behavior or adding fake production data.
- Ensure fake internal routes and unsafe/external links are not generated as part of the operator experience.

### Description

- Added scenario assertions and fixtures to the frontend test suite to exercise Mission Control → Audit flows by updating `frontend/components/mission-page.test.tsx` and `frontend/app/audit/page.test.tsx`. 
- Added a concise doc section to `docs/ui/README_UI.md` documenting the "Demo-grade Mission Control → Audit review scenario" and the intended behaviors for `/audit?decision_id` and `/audit?bind_receipt_id`.
- Tests added/proved: Mission Control shows governance artifact metadata and only safe operator links; Audit consumes `decision_id` and auto-loads timeline to focus a matching item; Audit consumes `bind_receipt_id` and renders bind receipt trace or fallback detail. 
- This change is test-only: no runtime production code or backend endpoints were modified and no fake production data was introduced.

### Testing

- Ran the focused frontend tests: `pnpm --filter frontend test app/page.integration.test.tsx` which passed (3 tests), `pnpm --filter frontend test app/audit/page.test.tsx` which passed (24 tests), `pnpm --filter frontend test components/mission-page.test.tsx` which passed (29 tests), and `pnpm --filter frontend test lib/governance-link-utils.test.ts` which passed (6 tests).
- Observed a non-fatal `LiveEventStream` URL parse warning logged to stderr during `app/page.integration.test.tsx` runs, but the tests still completed successfully; this is unrelated to the added assertions.
- All modified test files currently pass in CI-local runs; no linting or backend tests were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f428550ea083268dbc721694a522a7)