### PR TITLE
docs: add Governance Review Workflow section to root READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ It is about making AI decisions **reviewable, traceable, replayable, auditable, 
 
 > **Mental model:** LLM = CPU, VERITAS OS = Decision / Agent Governance OS on top
 
+## Governance Review Workflow
+
+VERITAS OS does not only record governance artifacts. It connects them into a Mission Control → Audit review workflow:
+
+1. Mission Control receives a live governance snapshot from `/v1/governance/live-snapshot`.
+2. The UI surfaces governance artifact metadata, including pre-bind source, bind reason, target metadata, check results, and safe operator actions.
+3. Operator actions provide safe internal `/audit?...` links for supported artifacts (`bind_receipt_id`, `decision_id`, `execution_intent_id`).
+4. Audit consumes supported query parameters and applies query validation before lookup/navigation.
+5. Decision traces auto-load latest logs and focus matching timeline artifacts when available, with direct lookup fallback when timeline data does not contain the decision.
+6. Bind receipt traces use dedicated lookup and render fallback detail when timeline items do not contain the target receipt.
+7. Unsafe links, external/protocol URLs, malformed hrefs, and fake routes are not generated.
+
+Covered by focused frontend tests:
+
+- `frontend/components/mission-page.test.tsx`
+- `frontend/app/audit/page.test.tsx`
+- `frontend/app/audit/hooks/useAuditData.test.ts`
+- `frontend/lib/governance-link-utils.test.ts`
+
+See `docs/ui/README_UI.md` for implementation details.
+
 ## Version
 
 - **Version:** 2.0.0

--- a/README_JP.md
+++ b/README_JP.md
@@ -23,6 +23,27 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 
 > メンタルモデル: **LLM = CPU**、**VERITAS OS = その上に載る Decision Governance OS**
 
+## Governance Review Workflow（ガバナンスレビュー導線）
+
+VERITAS OS は、ガバナンス証跡を記録するだけではありません。Mission Control から Audit へ、証跡を辿って確認できるレビュー導線を提供します。
+
+1. Mission Control が `/v1/governance/live-snapshot` から live governance snapshot を受け取ります。
+2. UI が pre-bind source / bind reason / target metadata / check results / safe operator actions を表示します。
+3. Operator actions は、supported artifacts（`bind_receipt_id` / `decision_id` / `execution_intent_id`）向けに safe internal `/audit?...` links を提供します。
+4. Audit は supported query parameters を consume し、lookup / navigation 前に query validation を適用します。
+5. decision trace は latest logs を auto-load し、一致する timeline artifact がある場合は focus します。timeline に存在しない場合は direct lookup fallback を表示します。
+6. bind receipt trace は dedicated lookup を使い、timeline に一致項目がない場合も fallback detail を表示します。
+7. unsafe links、external/protocol URLs、malformed hrefs、fake routes は生成しません。
+
+この導線は、次の focused frontend tests でカバーされています。
+
+- `frontend/components/mission-page.test.tsx`
+- `frontend/app/audit/page.test.tsx`
+- `frontend/app/audit/hooks/useAuditData.test.ts`
+- `frontend/lib/governance-link-utils.test.ts`
+
+実装詳細は `docs/ui/README_UI.md` を参照してください。
+
 ## VERITAS OS は何か
 
 - 実行前に意思決定を評価し、`proceed / hold / block / human_review_required` を判定するガバナンス層


### PR DESCRIPTION
### Motivation

- Make the Mission Control → Audit review workflow visible at repository entry so external readers immediately understand the product value and safety design. 
- Keep English/Japanese documentation in sync and point readers to detailed implementation notes in `docs/ui/README_UI.md` without changing production code. 

### Description

- Added a new `## Governance Review Workflow` section to `README.md` that summarizes the Mission Control → Audit flow, safe `/audit?...` links, decision auto-load/focus behavior, bind-receipt dedicated lookup, and that unsafe/external/malformed/fake routes are not generated. 
- Added a matching `## Governance Review Workflow（ガバナンスレビュー導線）` section to `README_JP.md` with equivalent content in Japanese for bilingual consistency. 
- Listed focused frontend test files as evidence: `frontend/components/mission-page.test.tsx`, `frontend/app/audit/page.test.tsx`, `frontend/app/audit/hooks/useAuditData.test.ts`, and `frontend/lib/governance-link-utils.test.ts`. 
- This is docs-only and does not modify production code, tests, routes, or UI behavior. 

### Testing

- Ran repository validation diff with `git diff -- README.md README_JP.md docs/ui/README_UI.md` to confirm changes are limited to the two README files and visibility of the `docs/ui` reference. (succeeded) 
- Attempted `python tools/check_bilingual_docs.py` as requested but the script was not found in the repository path, so bilingual-check could not be executed in this environment. (failed) 
- No unit or frontend test suites were modified or executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43060a4148326addaccea9be0adf3)