### PR TITLE
docs: add compact Mermaid flow for Governance Review Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ It is about making AI decisions **reviewable, traceable, replayable, auditable, 
 
 VERITAS OS does not only record governance artifacts. It connects them into a Mission Control → Audit review workflow:
 
+```mermaid
+flowchart LR
+  A[Mission Control<br/>Live governance snapshot] --> B[Governance artifacts panel<br/>pre-bind source / bind reason / target metadata / check results]
+  B --> C[Safe operator actions<br/>internal /audit?... links]
+  C --> D[Audit<br/>query validation]
+  D --> E{Supported artifact}
+  E -->|decision_id| F[Auto-load latest logs<br/>focus matching timeline item]
+  E -->|bind_receipt_id| G[Dedicated bind receipt lookup<br/>fallback detail]
+  E -->|execution_intent_id| I[Execution intent trace lookup]
+  E -->|invalid or unsafe| H[Reject<br/>no fake route]
+```
+
+
 1. Mission Control receives a live governance snapshot from `/v1/governance/live-snapshot`.
 2. The UI surfaces governance artifact metadata, including pre-bind source, bind reason, target metadata, check results, and safe operator actions.
 3. Operator actions provide safe internal `/audit?...` links for supported artifacts (`bind_receipt_id`, `decision_id`, `execution_intent_id`).

--- a/README_JP.md
+++ b/README_JP.md
@@ -27,6 +27,19 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 
 VERITAS OS は、ガバナンス証跡を記録するだけではありません。Mission Control から Audit へ、証跡を辿って確認できるレビュー導線を提供します。
 
+```mermaid
+flowchart LR
+  A[Mission Control<br/>Live governance snapshot] --> B[Governance artifacts panel<br/>pre-bind source / bind reason / target metadata / check results]
+  B --> C[Safe operator actions<br/>internal /audit?... links]
+  C --> D[Audit<br/>query validation]
+  D --> E{Supported artifact}
+  E -->|decision_id| F[Auto-load latest logs<br/>focus matching timeline item]
+  E -->|bind_receipt_id| G[Dedicated bind receipt lookup<br/>fallback detail]
+  E -->|execution_intent_id| I[Execution intent trace lookup]
+  E -->|invalid or unsafe| H[Reject<br/>no fake route]
+```
+
+
 1. Mission Control が `/v1/governance/live-snapshot` から live governance snapshot を受け取ります。
 2. UI が pre-bind source / bind reason / target metadata / check results / safe operator actions を表示します。
 3. Operator actions は、supported artifacts（`bind_receipt_id` / `decision_id` / `execution_intent_id`）向けに safe internal `/audit?...` links を提供します。


### PR DESCRIPTION
### Motivation
- Add a compact visual representation to the existing Governance Review Workflow so external readers can quickly understand the Mission Control → Audit review flow and its fail-closed safety behavior without overstating implemented capabilities.

### Description
- Insert a compact Mermaid `flowchart LR` diagram into `README.md` and `README_JP.md` under the Governance Review Workflow section that shows Mission Control live snapshot → governance artifacts panel → safe operator `/audit?...` links → Audit query validation → per-artifact trace routing (`decision_id`, `bind_receipt_id`, `execution_intent_id`) and explicit rejection for invalid/unsafe links, with no production code or test changes.

### Testing
- No automated tests were run as part of this documentation-only change; the workflow is already covered by existing frontend tests `frontend/components/mission-page.test.tsx`, `frontend/app/audit/page.test.tsx`, `frontend/app/audit/hooks/useAuditData.test.ts`, and `frontend/lib/governance-link-utils.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4377714b48326a5ee0201dbbc78d4)