### PR TITLE
docs: clarify execution_intent_id Mermaid flow and add local workflow check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ flowchart LR
   D --> E{Supported artifact}
   E -->|decision_id| F[Auto-load latest logs<br/>focus matching timeline item]
   E -->|bind_receipt_id| G[Dedicated bind receipt lookup<br/>fallback detail]
-  E -->|execution_intent_id| I[Execution intent trace lookup]
+  E -->|execution_intent_id| I[Auto-load latest logs<br/>timeline focus or unavailable]
   E -->|invalid or unsafe| H[Reject<br/>no fake route]
 ```
 
@@ -48,6 +48,10 @@ flowchart LR
 5. Decision traces auto-load latest logs and focus matching timeline artifacts when available, with direct lookup fallback when timeline data does not contain the decision.
 6. Bind receipt traces use dedicated lookup and render fallback detail when timeline items do not contain the target receipt.
 7. Unsafe links, external/protocol URLs, malformed hrefs, and fake routes are not generated.
+
+Local workflow check:
+
+`pnpm --filter frontend test components/mission-page.test.tsx app/audit/page.test.tsx`
 
 Covered by focused frontend tests:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -35,7 +35,7 @@ flowchart LR
   D --> E{Supported artifact}
   E -->|decision_id| F[Auto-load latest logs<br/>focus matching timeline item]
   E -->|bind_receipt_id| G[Dedicated bind receipt lookup<br/>fallback detail]
-  E -->|execution_intent_id| I[Execution intent trace lookup]
+  E -->|execution_intent_id| I[Auto-load latest logs<br/>timeline focus or unavailable]
   E -->|invalid or unsafe| H[Reject<br/>no fake route]
 ```
 
@@ -47,6 +47,10 @@ flowchart LR
 5. decision trace は latest logs を auto-load し、一致する timeline artifact がある場合は focus します。timeline に存在しない場合は direct lookup fallback を表示します。
 6. bind receipt trace は dedicated lookup を使い、timeline に一致項目がない場合も fallback detail を表示します。
 7. unsafe links、external/protocol URLs、malformed hrefs、fake routes は生成しません。
+
+ローカルでの導線確認:
+
+`pnpm --filter frontend test components/mission-page.test.tsx app/audit/page.test.tsx`
 
 この導線は、次の focused frontend tests でカバーされています。
 


### PR DESCRIPTION
### Motivation
- Prevent readers from misreading the `execution_intent_id` branch as implying a dedicated direct lookup by aligning the diagram wording with the implemented behavior.
- Provide a one-line local verification hint so contributors can quickly validate the Mission Control → Audit workflow without running full test suites.

### Description
- Updated the Governance Review Workflow Mermaid node for `execution_intent_id` in `README.md` and `README_JP.md` to: `Auto-load latest logs<br/>timeline focus or unavailable` instead of `Execution intent trace lookup`.
- Inserted a one-line local workflow check command near the focused frontend test evidence list in both `README.md` and `README_JP.md`: `pnpm --filter frontend test components/mission-page.test.tsx app/audit/page.test.tsx`.
- Kept the existing focused frontend test evidence list intact and made no production or test-code changes (docs-only change to two files: `README.md`, `README_JP.md`).

### Testing
- Ran `git diff -- README.md README_JP.md` to review the textual diffs between versions and confirmed the intended changes are present.
- Attempted to run `python tools/check_bilingual_docs.py` but the checker is not present in the repo path (`bilingual docs checker not available in repo path`).
- Did not run frontend/backend test suites as this is a docs-only PR; the added local check command can be executed locally with `pnpm --filter frontend test components/mission-page.test.tsx app/audit/page.test.tsx` if verification is desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f447c6e6788326bc9cd6a029959dbd)