### PR TITLE
Add lightweight Mission Control → Audit demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flowchart LR
 
 Local workflow check:
 
-`pnpm --filter frontend test components/mission-page.test.tsx app/audit/page.test.tsx`
+`bash scripts/demo_mission_audit_workflow.sh`
 
 Covered by focused frontend tests:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -50,7 +50,7 @@ flowchart LR
 
 ローカルでの導線確認:
 
-`pnpm --filter frontend test components/mission-page.test.tsx app/audit/page.test.tsx`
+`bash scripts/demo_mission_audit_workflow.sh`
 
 この導線は、次の focused frontend tests でカバーされています。
 

--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -132,4 +132,5 @@ docker compose up --build
 - Operator actions は safe internal path のみ Link 化し、`/audit?decision_id=...` / `/audit?bind_receipt_id=...` / `/audit?execution_intent_id=...` を生成します。
 - `/audit?decision_id=...` は query を consume し、latest logs の auto-load と timeline focus を行い、timeline miss 時は direct lookup fallback を表示します。
 - `/audit?bind_receipt_id=...` は dedicated bind receipt lookup を実行し、timeline match または fallback detail で trace を表示します。
+- You can run the focused workflow checks with: `bash scripts/demo_mission_audit_workflow.sh`.
 - fake routes（例: `/decisions/...`, `/execution-intents/...`, `/trustlog/...`）および unsafe/external links は生成しません。

--- a/scripts/demo_mission_audit_workflow.sh
+++ b/scripts/demo_mission_audit_workflow.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running VERITAS Mission Control → Audit workflow demo checks..."
+
+pnpm --filter frontend test components/mission-page.test.tsx
+pnpm --filter frontend test app/audit/page.test.tsx
+pnpm --filter frontend test app/audit/hooks/useAuditData.test.ts
+pnpm --filter frontend test lib/governance-link-utils.test.ts
+
+echo "Mission Control → Audit workflow demo checks completed."


### PR DESCRIPTION
### Motivation

- Provide a single, one-command developer/demo entrypoint that verifies the Mission Control → Audit review workflow by running the existing focused frontend tests.
- Improve external developer experience and documentation without changing production runtime code or adding heavy E2E frameworks.

### Description

- Add a lightweight shell wrapper `scripts/demo_mission_audit_workflow.sh` that runs the focused frontend tests with `set -euo pipefail` and preserves executable permission.
- Update `README.md` and `README_JP.md` to advertise the new local workflow check command `bash scripts/demo_mission_audit_workflow.sh` in place of the previous direct `pnpm` one-liner.
- Add a single-line note to `docs/ui/README_UI.md` pointing users to `bash scripts/demo_mission_audit_workflow.sh` for focused workflow checks.
- No changes were made to production code, routes, fixtures, or test contents; the script only invokes existing tests.

### Testing

- Ran `bash scripts/demo_mission_audit_workflow.sh`, which executed the following tests and completed successfully: `frontend/components/mission-page.test.tsx`, `frontend/app/audit/page.test.tsx`, `frontend/app/audit/hooks/useAuditData.test.ts`, and `frontend/lib/governance-link-utils.test.ts`.
- All targeted test files passed in this environment and the script exited with code 0, demonstrating the wrapper behaves as intended under `set -euo pipefail`.
- Existing React `act(...)` warnings are emitted by `useAuditData.test.ts` during the run but did not cause failures; these are pre-existing warnings outside the scope of this PR.
- The new script is executable (`chmod +x` applied) and suitable for CI/quick local validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44f0bd6988326bbd2aec9f0f1684e)