### PR TITLE
docs: add short demo transcript for Mission Control → Audit workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Local workflow check:
 
 `bash scripts/demo_mission_audit_workflow.sh`
 
+A successful run should complete the focused checks for Mission Control actions, Audit page tracing, Audit hook behavior, and safe link validation:
+
+```text
+Running VERITAS Mission Control → Audit workflow demo checks...
+✓ Mission Control artifact actions
+✓ Audit page decision / bind receipt tracing
+✓ Audit hook query workflow
+✓ Governance link safety validation
+Mission Control → Audit workflow demo checks completed.
+```
+
 Covered by focused frontend tests:
 
 - `frontend/components/mission-page.test.tsx`

--- a/README_JP.md
+++ b/README_JP.md
@@ -52,6 +52,17 @@ flowchart LR
 
 `bash scripts/demo_mission_audit_workflow.sh`
 
+正常に完了する場合、この script は Mission Control actions、Audit page tracing、Audit hook behavior、safe link validation の focused checks を完了します。
+
+```text
+Running VERITAS Mission Control → Audit workflow demo checks...
+✓ Mission Control artifact actions
+✓ Audit page decision / bind receipt tracing
+✓ Audit hook query workflow
+✓ Governance link safety validation
+Mission Control → Audit workflow demo checks completed.
+```
+
 この導線は、次の focused frontend tests でカバーされています。
 
 - `frontend/components/mission-page.test.tsx`


### PR DESCRIPTION
### Motivation
- Make it immediately clear to external readers what the `bash scripts/demo_mission_audit_workflow.sh` check verifies by adding a short, non-literal demo transcript to the Local workflow check sections in both READMEs.

### Description
- Inserted a concise expected-output style transcript block under `Local workflow check` in `README.md` and added the corresponding Japanese explanatory sentence plus the same transcript block in `README_JP.md`, while preserving the existing focused frontend test evidence list and without modifying production, test, or script behavior.

### Testing
- Ran docs validation steps: `git diff -- README.md README_JP.md` (showed the README changes) and attempted `python tools/check_bilingual_docs.py` which reported `bilingual docs checker not available in repo path`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45efc82f483269a154c70326114bc)