### PR TITLE
Add Observe Mode semantics foundation and additive schema/types (docs + fixtures)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Running VERITAS Mission Control → Audit workflow demo checks...
 Mission Control → Audit workflow demo checks completed.
 ```
 
+
+### Development-time Observe Mode
+
+VERITAS distinguishes production enforcement from development observation. Production governance remains fail-closed. Observe Mode support is a **foundation semantics** (default off) for development/test/sandbox contexts that records `would_have_blocked` outcomes without hiding violations. See `docs/governance/observe_mode.md`.
+
 Covered by focused frontend tests:
 
 - `frontend/components/mission-page.test.tsx`

--- a/README_JP.md
+++ b/README_JP.md
@@ -63,6 +63,11 @@ Running VERITAS Mission Control → Audit workflow demo checks...
 Mission Control → Audit workflow demo checks completed.
 ```
 
+
+### Development-time Observe Mode（開発時の観測モード）
+
+VERITAS は、本番の enforce と開発時の observe を区別します。本番では fail-closed を維持します。Observe Mode は現時点では **foundation semantics（default off）** であり、開発・test・sandbox 文脈で `would_have_blocked` を記録し、違反を隠さない設計を定義します。詳細は `docs/governance/observe_mode.md` を参照してください。
+
 この導線は、次の focused frontend tests でカバーされています。
 
 - `frontend/components/mission-page.test.tsx`

--- a/docs/governance/observe_mode.md
+++ b/docs/governance/observe_mode.md
@@ -1,0 +1,69 @@
+# Observe Mode Semantics Foundation
+
+## Purpose
+
+Observe Mode is a **development-time governance mode semantics** that records what the bind boundary would have done, without weakening production fail-closed enforcement.
+
+This document defines semantics, safety constraints, and schema foundations for future implementation work.
+
+## Core policy modes
+
+- `enforce`
+  - Production default.
+  - Existing fail-closed behavior applies.
+  - Blocking checks stop execution.
+- `observe`
+  - Development / test / sandbox contexts only.
+  - Governance checks still run.
+  - Violations are recorded as `would_have_blocked`.
+  - Execution may continue only in explicitly configured non-production contexts.
+  - Audit records preserve the original blocking reason.
+- `off`
+  - Not recommended.
+  - Must never be default.
+  - If used, must be explicit and auditable.
+
+## Required observation fields
+
+- `policy_mode`
+- `environment`
+- `would_have_blocked`
+- `would_have_blocked_reason`
+- `effective_outcome`
+- `observed_outcome`
+- `operator_warning`
+- `audit_required`
+
+## Safety constraints
+
+- Observe mode must never be the implicit production default.
+- Production must remain fail-closed.
+- Observe mode must not erase violation evidence.
+- Observe mode must not rewrite blocked outcomes as clean success.
+- Observe mode must be visible to operators.
+- Observe mode is **default off**.
+- Observe mode is not an “allow everything” switch.
+
+## Scope in this PR
+
+### Implemented in this PR
+
+- Semantics definition for observe/enforce/off.
+- Explicit production safety constraints.
+- Additive schema/type foundation for governance observation fields.
+- Fixture tests for `enforce` and `observe` modes and invalid mode rejection.
+- README and README_JP short references.
+
+### Not implemented in this PR
+
+- Runtime enforcement switch.
+- Production bypass behavior.
+- UI toggle.
+- API mutation endpoint changes.
+- Policy engine behavior changes.
+- Automatic evidence generation.
+- Governance palette implementation.
+
+## Security note
+
+Observe mode misuse can become a security and compliance risk if enabled in production or if audit evidence is suppressed. Any future runtime rollout must include explicit environment guards and operator-visible warnings.

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -69,6 +69,19 @@ export interface DecisionEvidenceRouteModel {
 
 export type MissionUiState = "loading" | "empty" | "degraded" | "operational";
 
+export type PolicyMode = "enforce" | "observe" | "off";
+
+export interface GovernanceObservation {
+  policy_mode: PolicyMode;
+  environment: "development" | "test" | "staging" | "production" | string;
+  would_have_blocked: boolean;
+  would_have_blocked_reason?: string | null;
+  effective_outcome: string;
+  observed_outcome?: string | null;
+  operator_warning?: boolean;
+  audit_required?: boolean;
+}
+
 export interface PreBindGovernanceSnapshot {
   participation_state?: string;
   preservation_state?: string;
@@ -99,6 +112,7 @@ export interface PreBindGovernanceSnapshot {
   constraint_check_result?: unknown | null;
   drift_check_result?: unknown | null;
   risk_check_result?: unknown | null;
+  governance_observation?: GovernanceObservation | null;
 }
 
 export const PRE_BIND_GOVERNANCE_VOCABULARY_LABELS = {

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -108,6 +108,13 @@ PreBindParticipationStateLiteral = Literal[
 PreservationStateLiteral = Literal["open", "degrading", "collapsed"]
 InterventionViabilityLevelLiteral = Literal["high", "partial", "minimal", "none"]
 OpennessFloorStatusLiteral = Literal["met", "at_risk", "breached"]
+PolicyModeLiteral = Literal["enforce", "observe", "off"]
+GovernanceEnvironmentLiteral = Literal[
+    "development",
+    "test",
+    "staging",
+    "production",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +202,26 @@ class Context(BaseModel):
             raise ValueError(f"list exceeds maximum size of {MAX_LIST_ITEMS}")
         return v
 
+
+
+
+class GovernanceObservation(BaseModel):
+    """Optional Observe Mode governance observation contract foundation.
+
+    This model is additive and intended for documentation, fixtures, and future
+    UI/API integration. It does not change current runtime fail-closed behavior.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    policy_mode: PolicyModeLiteral
+    environment: Union[GovernanceEnvironmentLiteral, str]
+    would_have_blocked: bool
+    would_have_blocked_reason: Optional[str] = None
+    effective_outcome: str
+    observed_outcome: Optional[str] = None
+    operator_warning: bool = False
+    audit_required: bool = True
 
 class Option(BaseModel):
     model_config = ConfigDict(extra="allow")

--- a/veritas_os/tests/test_governance_observation_schema.py
+++ b/veritas_os/tests/test_governance_observation_schema.py
@@ -1,0 +1,49 @@
+"""Schema fixtures for Observe Mode governance observation foundation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from veritas_os.api.schemas import GovernanceObservation
+
+
+def test_governance_observation_enforce_fixture() -> None:
+    payload = GovernanceObservation(
+        policy_mode="enforce",
+        environment="production",
+        would_have_blocked=False,
+        effective_outcome="block",
+        observed_outcome="block",
+        operator_warning=False,
+        audit_required=True,
+    )
+    assert payload.policy_mode == "enforce"
+    assert payload.environment == "production"
+    assert payload.would_have_blocked is False
+
+
+def test_governance_observation_observe_fixture() -> None:
+    payload = GovernanceObservation(
+        policy_mode="observe",
+        environment="development",
+        would_have_blocked=True,
+        would_have_blocked_reason="policy_violation:missing_authority_evidence",
+        effective_outcome="proceed",
+        observed_outcome="block",
+        operator_warning=True,
+        audit_required=True,
+    )
+    assert payload.policy_mode == "observe"
+    assert payload.would_have_blocked is True
+    assert payload.observed_outcome == "block"
+
+
+def test_governance_observation_invalid_mode_rejected() -> None:
+    with pytest.raises(ValidationError):
+        GovernanceObservation(
+            policy_mode="shadow",
+            environment="test",
+            would_have_blocked=True,
+            effective_outcome="proceed",
+        )


### PR DESCRIPTION
### Motivation

- Improve developer experience by defining a safe Observe Mode semantics foundation so teams can iterate without weakening production safety. 
- Preserve VERITAS OS core guarantees: production remains fail-closed, audits remain traceable, and violations are never hidden. 
- Provide minimal, non-breaking schema and type foundations so UI/API/runtime work can be wired later without changing current runtime behavior.

### Description

- Add `docs/governance/observe_mode.md` to define `enforce | observe | off` semantics, required observation fields, safety constraints, implemented/non-implemented scope, and security notes. 
- Add additive Python types in `veritas_os/api/schemas.py`: `PolicyModeLiteral`, `GovernanceEnvironmentLiteral`, and `GovernanceObservation` (Pydantic, `extra="forbid"`) as an optional, non-breaking schema foundation. 
- Add TypeScript types in `frontend/components/dashboard-types.ts`: `PolicyMode`, `GovernanceObservation`, and an optional `governance_observation?: GovernanceObservation | null` on `PreBindGovernanceSnapshot` as a frontend contract extension. 
- Add fixture tests `veritas_os/tests/test_governance_observation_schema.py` and small README/README_JP short references; all changes are additive and do not change runtime enforcement or policy engine behavior.

### Testing

- Ran `pytest -q veritas_os/tests/test_governance_observation_schema.py`, which passed (`3 passed`), validating the Pydantic model and invalid-mode rejection. 
- Ran `pnpm --filter frontend test components/mission-governance-adapter.test.ts` which passed (`1 test file` with `4 tests` passing) to ensure frontend type extension did not break the adapter tests. 
- An earlier `pnpm` invocation with an incorrect filter returned no files, but the corrected filtered test run succeeded; no runtime or policy behavior tests were added because runtime changes are out of scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46c18e85083269ac1279b56cc8cfc)