### PR TITLE
test(frontend): preserve governance_observation through BFF and adapter fixtures

### DIFF
--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -119,6 +119,16 @@ describe("/api/veritas/v1/report/governance", () => {
             target_label: "Governance policy",
             operator_surface: "governance",
             relevant_ui_href: "/governance",
+            governance_observation: {
+              policy_mode: "observe",
+              environment: "development",
+              would_have_blocked: true,
+              would_have_blocked_reason: "policy_violation:missing_authority_evidence",
+              effective_outcome: "proceed",
+              observed_outcome: "block",
+              operator_warning: true,
+              audit_required: true,
+            },
           },
         }),
         { status: 200, headers: { "content-type": "application/json" } },
@@ -144,6 +154,16 @@ describe("/api/veritas/v1/report/governance", () => {
         target_label: "Governance policy",
         operator_surface: "governance",
         relevant_ui_href: "/governance",
+        governance_observation: {
+          policy_mode: "observe",
+          environment: "development",
+          would_have_blocked: true,
+          would_have_blocked_reason: "policy_violation:missing_authority_evidence",
+          effective_outcome: "proceed",
+          observed_outcome: "block",
+          operator_warning: true,
+          audit_required: true,
+        },
       },
     });
   });

--- a/frontend/components/mission-governance-adapter.test.ts
+++ b/frontend/components/mission-governance-adapter.test.ts
@@ -34,6 +34,45 @@ describe("resolveMissionGovernanceSnapshot", () => {
     expect(snapshot.intervention_viability).toBeUndefined();
   });
 
+
+
+  it("preserves governance_observation fields when present", () => {
+    const snapshot = resolveMissionGovernanceSnapshot({
+      governance_layer_snapshot: {
+        participation_state: "decision_shaping",
+        governance_observation: {
+          policy_mode: "observe",
+          environment: "development",
+          would_have_blocked: true,
+          would_have_blocked_reason: "policy_violation:missing_authority_evidence",
+          effective_outcome: "proceed",
+          observed_outcome: "block",
+          operator_warning: true,
+          audit_required: true,
+        },
+      },
+    });
+
+    expect(snapshot.governance_observation).toBeDefined();
+    expect(snapshot.governance_observation?.policy_mode).toBe("observe");
+    expect(snapshot.governance_observation?.environment).toBe("development");
+    expect(snapshot.governance_observation?.would_have_blocked).toBe(true);
+    expect(snapshot.governance_observation?.would_have_blocked_reason).toBe("policy_violation:missing_authority_evidence");
+    expect(snapshot.governance_observation?.effective_outcome).toBe("proceed");
+    expect(snapshot.governance_observation?.observed_outcome).toBe("block");
+    expect(snapshot.governance_observation?.operator_warning).toBe(true);
+    expect(snapshot.governance_observation?.audit_required).toBe(true);
+  });
+
+  it("keeps governance_observation undefined when absent", () => {
+    const snapshot = resolveMissionGovernanceSnapshot({
+      governance_layer_snapshot: {
+        participation_state: "decision_shaping",
+      },
+    });
+
+    expect(snapshot.governance_observation).toBeUndefined();
+  });
   it("falls back to render-safe snapshot when ingress data is absent", () => {
     const snapshot = resolveMissionGovernanceSnapshot(undefined);
 


### PR DESCRIPTION
### Motivation

- Close a contract gap by locking that an incoming `governance_observation` on a live snapshot is preserved through the Mission Control BFF → adapter path to the UI without changing runtime semantics. 
- Ensure this preservation is a regression-covered contract rather than a behavioral feature (no Observe Mode runtime enablement or production policy changes). 
- Provide lightweight tests to prevent accidental dropping of the optional nested observation fields in future refactors.

### Description

- Added assertions to `frontend/components/mission-governance-adapter.test.ts` that verify `governance_observation` is preserved when present and remains `undefined` when absent. 
- Extended the backend-fed fixture in `frontend/app/api/veritas/v1/report/governance/route.test.ts` so the mocked `governance_layer_snapshot` includes the full `governance_observation` object and the test asserts it is returned unchanged. 
- Only test/fixture changes were made (no runtime or API behavior changes); modified files are `frontend/components/mission-governance-adapter.test.ts` and `frontend/app/api/veritas/v1/report/governance/route.test.ts`.

### Testing

- Ran `pnpm --filter frontend test components/mission-governance-adapter.test.ts` and the test file passed (6 tests passed). 
- Ran `pnpm --filter frontend test app/api/veritas/v1/report/governance/route.test.ts` and the test file passed (9 tests passed). 
- All modified frontend tests passed locally and the changes are limited to fixtures/assertions only; runtime behavior including production fail-closed and Observe Mode remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47d39978083269e86b6499833b712)