### PR TITLE
Add dry-run governance observation semantic evaluator and tests

### DIFF
--- a/docs/governance/observe_mode.md
+++ b/docs/governance/observe_mode.md
@@ -78,7 +78,20 @@ Observe mode misuse can become a security and compliance risk if enabled in prod
 - `would_have_blocked: true` indicates a violation that should block under production enforcement semantics.
 - `effective_outcome: "proceed"` demonstrates a non-production observe-context continuation example.
 - `observed_outcome: "block"` preserves the would-be blocking governance outcome for audit visibility.
-- `bash scripts/validate_governance_observation_fixture.sh` validates that this sample fixture is preserved by the Mission Control adapter and verified by Mission Control read-only rendering tests.
+- `bash scripts/validate_governance_observation_fixture.sh` validates that this sample fixture is preserved by the Mission Control adapter, Mission Control read-only rendering tests, and the Python dry-run semantic evaluator.
+
+## Dry-run observation evaluator
+
+- The evaluator validates `governance_observation` semantic consistency for fixtures/tests.
+- It does **not** enable Observe Mode runtime behavior.
+- It does **not** change production fail-closed behavior.
+- It rejects unsafe combinations such as:
+  - `environment=production` with `policy_mode=observe`
+  - `policy_mode=observe` without required audit/operator warning
+  - `would_have_blocked=true` without preserved reason/observed outcome
+  - `policy_mode=enforce` proceeding despite `would_have_blocked=true`
+  - `policy_mode=off` without explicit audit requirement
+- Run `pytest -q veritas_os/tests/test_governance_observation_evaluator.py` before future runtime rollout work.
 
 Short excerpt:
 

--- a/scripts/validate_governance_observation_fixture.sh
+++ b/scripts/validate_governance_observation_fixture.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 echo "Validating VERITAS governance_observation sample fixture..."
 
+pytest -q veritas_os/tests/test_governance_observation_evaluator.py
 pnpm --filter frontend test components/mission-governance-adapter.test.ts
 pnpm --filter frontend test components/mission-page.test.tsx
 

--- a/veritas_os/governance/observation_evaluator.py
+++ b/veritas_os/governance/observation_evaluator.py
@@ -1,0 +1,132 @@
+"""Dry-run evaluator for governance observation semantic consistency.
+
+This module validates ``GovernanceObservation`` fixture/test payload semantics
+without changing runtime governance behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from veritas_os.api.schemas import GovernanceObservation
+
+
+ObservationIssueSeverity = Literal["error", "warning"]
+
+
+@dataclass(frozen=True)
+class ObservationEvaluationIssue:
+    """Single semantic issue produced by observation evaluation."""
+
+    code: str
+    message: str
+    severity: ObservationIssueSeverity
+
+
+@dataclass(frozen=True)
+class ObservationEvaluationResult:
+    """Result object for dry-run governance observation evaluation."""
+
+    valid: bool
+    issues: tuple[ObservationEvaluationIssue, ...]
+
+
+def _is_blank(value: str | None) -> bool:
+    return value is None or value.strip() == ""
+
+
+def evaluate_governance_observation(
+    observation: "GovernanceObservation",
+) -> ObservationEvaluationResult:
+    """Validate semantic consistency for ``GovernanceObservation``.
+
+    This is a pure function intended for fixture/tests and dry-run checks only.
+    It has no side effects and does not alter runtime enforcement behavior.
+    """
+
+    issues: list[ObservationEvaluationIssue] = []
+
+    if observation.environment == "production" and observation.policy_mode == "observe":
+        issues.append(
+            ObservationEvaluationIssue(
+                code="OBSERVE_MODE_NOT_ALLOWED_IN_PRODUCTION",
+                message="Observe mode is not allowed in production environment.",
+                severity="error",
+            )
+        )
+
+    if observation.policy_mode == "observe" and observation.audit_required is not True:
+        issues.append(
+            ObservationEvaluationIssue(
+                code="OBSERVE_MODE_REQUIRES_AUDIT",
+                message="Observe mode requires audit_required to be true.",
+                severity="error",
+            )
+        )
+
+    if observation.policy_mode == "observe" and observation.operator_warning is not True:
+        issues.append(
+            ObservationEvaluationIssue(
+                code="OBSERVE_MODE_REQUIRES_OPERATOR_WARNING",
+                message="Observe mode requires operator_warning to be true.",
+                severity="error",
+            )
+        )
+
+    if observation.would_have_blocked is True and _is_blank(observation.would_have_blocked_reason):
+        issues.append(
+            ObservationEvaluationIssue(
+                code="WOULD_HAVE_BLOCKED_REQUIRES_REASON",
+                message="would_have_blocked=true requires would_have_blocked_reason.",
+                severity="error",
+            )
+        )
+
+    if observation.would_have_blocked is True and _is_blank(observation.observed_outcome):
+        issues.append(
+            ObservationEvaluationIssue(
+                code="WOULD_HAVE_BLOCKED_REQUIRES_OBSERVED_OUTCOME",
+                message="would_have_blocked=true requires observed_outcome.",
+                severity="error",
+            )
+        )
+
+    if (
+        observation.policy_mode == "observe"
+        and observation.would_have_blocked is True
+        and observation.observed_outcome != "block"
+    ):
+        issues.append(
+            ObservationEvaluationIssue(
+                code="OBSERVED_OUTCOME_SHOULD_PRESERVE_BLOCK",
+                message="Observe mode should preserve blocked observed_outcome when would_have_blocked=true.",
+                severity="warning",
+            )
+        )
+
+    if (
+        observation.policy_mode == "enforce"
+        and observation.would_have_blocked is True
+        and observation.effective_outcome == "proceed"
+    ):
+        issues.append(
+            ObservationEvaluationIssue(
+                code="ENFORCE_MODE_CANNOT_PROCEED_WHEN_BLOCKED",
+                message="Enforce mode cannot proceed when would_have_blocked=true.",
+                severity="error",
+            )
+        )
+
+    if observation.policy_mode == "off" and observation.audit_required is not True:
+        issues.append(
+            ObservationEvaluationIssue(
+                code="OFF_MODE_REQUIRES_AUDIT",
+                message="Off mode requires audit_required to be true.",
+                severity="error",
+            )
+        )
+
+    has_errors = any(issue.severity == "error" for issue in issues)
+    return ObservationEvaluationResult(valid=not has_errors, issues=tuple(issues))

--- a/veritas_os/tests/test_governance_observation_evaluator.py
+++ b/veritas_os/tests/test_governance_observation_evaluator.py
@@ -1,0 +1,108 @@
+"""Dry-run evaluator tests for governance observation semantic consistency."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from veritas_os.api.schemas import GovernanceObservation
+from veritas_os.governance.observation_evaluator import evaluate_governance_observation
+
+
+def _base_observation(**overrides: object) -> GovernanceObservation:
+    payload = {
+        "policy_mode": "observe",
+        "environment": "development",
+        "would_have_blocked": True,
+        "would_have_blocked_reason": "policy_violation:missing_authority_evidence",
+        "effective_outcome": "proceed",
+        "observed_outcome": "block",
+        "operator_warning": True,
+        "audit_required": True,
+    }
+    payload.update(overrides)
+    return GovernanceObservation(**payload)
+
+
+def _codes(result: object) -> set[str]:
+    return {issue.code for issue in result.issues}
+
+
+def test_production_observe_is_invalid() -> None:
+    result = evaluate_governance_observation(
+        _base_observation(environment="production", policy_mode="observe")
+    )
+    assert result.valid is False
+    assert "OBSERVE_MODE_NOT_ALLOWED_IN_PRODUCTION" in _codes(result)
+
+
+def test_observe_requires_audit() -> None:
+    result = evaluate_governance_observation(
+        _base_observation(policy_mode="observe", audit_required=False)
+    )
+    assert result.valid is False
+    assert "OBSERVE_MODE_REQUIRES_AUDIT" in _codes(result)
+
+
+def test_observe_requires_operator_warning() -> None:
+    result = evaluate_governance_observation(
+        _base_observation(policy_mode="observe", operator_warning=False)
+    )
+    assert result.valid is False
+    assert "OBSERVE_MODE_REQUIRES_OPERATOR_WARNING" in _codes(result)
+
+
+def test_would_have_blocked_requires_reason() -> None:
+    result = evaluate_governance_observation(
+        _base_observation(would_have_blocked=True, would_have_blocked_reason="")
+    )
+    assert result.valid is False
+    assert "WOULD_HAVE_BLOCKED_REQUIRES_REASON" in _codes(result)
+
+
+def test_would_have_blocked_requires_observed_outcome() -> None:
+    result = evaluate_governance_observation(
+        _base_observation(would_have_blocked=True, observed_outcome=None)
+    )
+    assert result.valid is False
+    assert "WOULD_HAVE_BLOCKED_REQUIRES_OBSERVED_OUTCOME" in _codes(result)
+
+
+def test_enforce_cannot_proceed_when_would_have_blocked() -> None:
+    result = evaluate_governance_observation(
+        _base_observation(
+            policy_mode="enforce",
+            would_have_blocked=True,
+            effective_outcome="proceed",
+            observed_outcome="block",
+        )
+    )
+    assert result.valid is False
+    assert "ENFORCE_MODE_CANNOT_PROCEED_WHEN_BLOCKED" in _codes(result)
+
+
+def test_off_mode_requires_audit() -> None:
+    result = evaluate_governance_observation(
+        _base_observation(
+            policy_mode="off",
+            would_have_blocked=False,
+            audit_required=False,
+            effective_outcome="proceed",
+            observed_outcome=None,
+        )
+    )
+    assert result.valid is False
+    assert "OFF_MODE_REQUIRES_AUDIT" in _codes(result)
+
+
+def test_current_sample_fixture_is_semantically_valid() -> None:
+    fixture_path = Path("fixtures/governance_observation_live_snapshot.json")
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    observation = GovernanceObservation(
+        **data["governance_layer_snapshot"]["governance_observation"]
+    )
+
+    result = evaluate_governance_observation(observation)
+
+    assert result.valid is True
+    assert result.issues == ()


### PR DESCRIPTION
### Motivation
- Provide a pure, non-runtime validator to catch unsafe `governance_observation` combinations in fixtures/tests before any runtime rollout without changing production behavior.  
- Strengthen safety foundation for Observe Mode semantics (detect production observe, missing audit/warning, missing would-have-blocked evidence, contradictory outcomes) for documentation and CI gating.  
- Keep the evaluator side-effect free, isolated from runtime code paths, and suitable for CI/manual fixture validation.

### Description
- Add a pure evaluator at `veritas_os/governance/observation_evaluator.py` exposing `evaluate_governance_observation()` and result types `ObservationEvaluationIssue` / `ObservationEvaluationResult`.  
- Implement semantic rules A–G as machine-checkable issues with codes: `OBSERVE_MODE_NOT_ALLOWED_IN_PRODUCTION`, `OBSERVE_MODE_REQUIRES_AUDIT`, `OBSERVE_MODE_REQUIRES_OPERATOR_WARNING`, `WOULD_HAVE_BLOCKED_REQUIRES_REASON`, `WOULD_HAVE_BLOCKED_REQUIRES_OBSERVED_OUTCOME`, `OBSERVED_OUTCOME_SHOULD_PRESERVE_BLOCK`, `ENFORCE_MODE_CANNOT_PROCEED_WHEN_BLOCKED`, and `OFF_MODE_REQUIRES_AUDIT`.  
- Add unit tests at `veritas_os/tests/test_governance_observation_evaluator.py` covering the eight required invalid/valid cases (production+observe, observe without audit, observe without operator warning, would_have_blocked without reason, would_have_blocked without observed_outcome, enforce+would_have_blocked with proceed, off without audit, and the sample fixture).  
- Update `docs/governance/observe_mode.md` with a Dry-run observation evaluator section clarifying non-runtime constraints and add the evaluator to the fixture validation script `scripts/validate_governance_observation_fixture.sh`.

### Testing
- Ran `pytest -q veritas_os/tests/test_governance_observation_evaluator.py` and it passed (8 tests, all passed).  
- Ran `pytest -q veritas_os/tests/test_governance_observation_schema.py` and it passed (3 tests, all passed).  
- Ran the fixture validation script `bash scripts/validate_governance_observation_fixture.sh`, which executed the new Python evaluator tests plus the frontend adapter/page tests via `pnpm`/`vitest`, and completed successfully (Python tests passed and frontend tests passed).  
- All automated tests added/modified in this change passed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48abc531c8326af2f6a1d6e17ee43)