### PR TITLE
Add CLI dry-run checker for governance_observation fixtures

### DIFF
--- a/docs/governance/observe_mode.md
+++ b/docs/governance/observe_mode.md
@@ -92,6 +92,10 @@ Observe mode misuse can become a security and compliance risk if enabled in prod
   - `policy_mode=enforce` proceeding despite `would_have_blocked=true`
   - `policy_mode=off` without explicit audit requirement
 - Run `pytest -q veritas_os/tests/test_governance_observation_evaluator.py` before future runtime rollout work.
+- CLI-style dry-run checker for any JSON payload: `python scripts/check_governance_observation.py <path-to-json>`.
+- The checker reads `governance_layer_snapshot.governance_observation`, performs schema validation (`GovernanceObservation`) and semantic evaluation (`evaluate_governance_observation`).
+- Exit code behavior: valid or warning-only payloads return `0`; semantic errors, schema validation failures, missing field paths, and invalid JSON return non-zero.
+- This checker is dev/test tooling only and does **not** enable Observe Mode runtime behavior or change production fail-closed enforcement.
 
 Short excerpt:
 

--- a/scripts/check_governance_observation.py
+++ b/scripts/check_governance_observation.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""CLI dry-run checker for governance_observation fixture JSON.
+
+This script validates schema and semantic consistency for
+``governance_layer_snapshot.governance_observation`` payloads without
+changing runtime governance behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from pydantic import ValidationError
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from veritas_os.api.schemas import GovernanceObservation
+from veritas_os.governance.observation_evaluator import evaluate_governance_observation
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Dry-run validate governance_observation semantics from a JSON file."
+        )
+    )
+    parser.add_argument("json_file", type=Path, help="Path to fixture/payload JSON file")
+    return parser
+
+
+def _load_observation_payload(json_file: Path) -> dict:
+    try:
+        data = json.loads(json_file.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise ValueError(f"file not found: {json_file}") from None
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON: {exc}") from None
+
+    snapshot = data.get("governance_layer_snapshot")
+    if not isinstance(snapshot, dict):
+        raise ValueError("governance_layer_snapshot not found or is not an object")
+
+    observation = snapshot.get("governance_observation")
+    if not isinstance(observation, dict):
+        raise ValueError("governance_observation not found at governance_layer_snapshot")
+
+    return observation
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        observation_payload = _load_observation_payload(args.json_file)
+        observation = GovernanceObservation(**observation_payload)
+    except ValidationError as exc:
+        print("governance_observation dry-run check: invalid", file=sys.stderr)
+        print(f"file: {args.json_file}", file=sys.stderr)
+        print("ERROR SCHEMA_VALIDATION_FAILED:", file=sys.stderr)
+        print(exc, file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print("governance_observation dry-run check: invalid", file=sys.stderr)
+        print(f"file: {args.json_file}", file=sys.stderr)
+        print(f"ERROR INPUT: {exc}", file=sys.stderr)
+        return 1
+
+    result = evaluate_governance_observation(observation)
+    has_errors = any(issue.severity == "error" for issue in result.issues)
+
+    status = "invalid" if has_errors else "valid"
+    stream = sys.stderr if has_errors else sys.stdout
+    print(f"governance_observation dry-run check: {status}", file=stream)
+    print(f"file: {args.json_file}", file=stream)
+    print(f"issues: {len(result.issues)}", file=stream)
+
+    for issue in result.issues:
+        print(f"{issue.severity.upper()} {issue.code}: {issue.message}", file=stream)
+
+    return 1 if has_errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_governance_observation_fixture.sh
+++ b/scripts/validate_governance_observation_fixture.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 echo "Validating VERITAS governance_observation sample fixture..."
 
 pytest -q veritas_os/tests/test_governance_observation_evaluator.py
+pytest -q veritas_os/tests/test_governance_observation_cli.py
+python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
 pnpm --filter frontend test components/mission-governance-adapter.test.ts
 pnpm --filter frontend test components/mission-page.test.tsx
 

--- a/veritas_os/tests/test_governance_observation_cli.py
+++ b/veritas_os/tests/test_governance_observation_cli.py
@@ -1,0 +1,102 @@
+"""Tests for governance_observation CLI dry-run checker."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+CLI_PATH = Path("scripts/check_governance_observation.py")
+
+
+def _run_cli(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLI_PATH), str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_valid_fixture_returns_zero() -> None:
+    fixture_path = Path("fixtures/governance_observation_live_snapshot.json")
+
+    result = _run_cli(fixture_path)
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0
+    assert "valid" in output
+    assert "issues: 0" in output
+
+
+def test_missing_governance_observation_returns_non_zero(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "missing_observation.json"
+    fixture_path.write_text(
+        json.dumps({"governance_layer_snapshot": {}}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    result = _run_cli(fixture_path)
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "governance_observation not found" in output
+
+
+def test_invalid_semantic_combination_returns_non_zero(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "invalid_semantic.json"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "governance_layer_snapshot": {
+                    "governance_observation": {
+                        "policy_mode": "observe",
+                        "environment": "production",
+                        "would_have_blocked": True,
+                        "would_have_blocked_reason": "policy_violation:missing_authority_evidence",
+                        "effective_outcome": "proceed",
+                        "observed_outcome": "block",
+                        "operator_warning": True,
+                        "audit_required": True,
+                    }
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_cli(fixture_path)
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "OBSERVE_MODE_NOT_ALLOWED_IN_PRODUCTION" in output
+
+
+def test_schema_validation_error_returns_non_zero(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "schema_error.json"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "governance_layer_snapshot": {
+                    "governance_observation": {
+                        "policy_mode": "shadow",
+                        "environment": "development",
+                        "would_have_blocked": True,
+                        "effective_outcome": "proceed",
+                    }
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_cli(fixture_path)
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "SCHEMA_VALIDATION_FAILED" in output
+    assert "Traceback" not in output


### PR DESCRIPTION
### Motivation

- Provide a simple CLI entrypoint so developers can dry-run-validate any JSON containing `governance_layer_snapshot.governance_observation` without touching runtime behavior.
- Combine schema validation and the existing pure semantic evaluator into a single, easy-to-use developer tool that returns meaningful exit codes.
- Keep production runtime unchanged and avoid adding any Observe Mode runtime switches or bypasses.

### Description

- Add `scripts/check_governance_observation.py`, a CLI that accepts a JSON file path, reads `governance_layer_snapshot.governance_observation`, validates it with `GovernanceObservation`, runs `evaluate_governance_observation()`, prints issues, and returns `0` for valid (or warning-only) results and non-zero for semantic errors, schema failures, missing paths, invalid JSON, or missing file.
- Add CLI tests in `veritas_os/tests/test_governance_observation_cli.py` covering: valid fixture returns `0`, missing observation returns non-zero, semantic error returns non-zero with expected code, and schema validation error returns non-zero without a traceback.
- Update `scripts/validate_governance_observation_fixture.sh` to run the new CLI tests and to execute the checker against `fixtures/governance_observation_live_snapshot.json` as part of the fixture validation flow.
- Update `docs/governance/observe_mode.md` to document the CLI usage (`python scripts/check_governance_observation.py <path-to-json>`), explain that it performs schema + semantic checks, and state the exit-code semantics and that runtime behavior is unchanged.

### Testing

- Ran `pytest -q veritas_os/tests/test_governance_observation_evaluator.py` and all tests passed (`8 passed`).
- Ran `pytest -q veritas_os/tests/test_governance_observation_cli.py` and all CLI tests passed (`4 passed`).
- Executed `python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json` and the checker printed a valid result and exited with `0`.
- Ran the full fixture validator `bash scripts/validate_governance_observation_fixture.sh` and the integrated pipeline succeeded (evaluator tests, CLI tests, CLI run, and frontend component tests ran and completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48ed0e3f883268997d7d98a82113d)