### PR TITLE
Add test-only Observe Mode decision wrapper for safe GovernanceObservation generation

### DIFF
--- a/docs/governance/observe_mode.md
+++ b/docs/governance/observe_mode.md
@@ -82,6 +82,16 @@ Observe mode misuse can become a security and compliance risk if enabled in prod
 - `observed_outcome: "block"` preserves the would-be blocking governance outcome for audit visibility.
 - `bash scripts/validate_governance_observation_fixture.sh` validates that this sample fixture is preserved by the Mission Control adapter, Mission Control read-only rendering tests, and the Python dry-run semantic evaluator.
 
+
+## Test-only Observe Mode wrapper
+
+- `veritas_os/governance/observe_mode_wrapper.py` can build `GovernanceObservation` objects for tests and fixtures.
+- It does not enable Observe Mode runtime.
+- It rejects production observe mode.
+- It preserves would-be blocking outcomes as `observed_outcome`.
+- It runs generated observations through the dry-run evaluator before returning them.
+- It is intended for tests/dev fixtures before any future runtime rollout.
+
 ## Dry-run observation evaluator
 
 - The evaluator validates `governance_observation` semantic consistency for fixtures/tests.

--- a/docs/governance/observe_mode_developer_walkthrough.md
+++ b/docs/governance/observe_mode_developer_walkthrough.md
@@ -25,6 +25,7 @@ It is **not** a production bypass.
 - BFF / adapter preservation tests for `governance_observation`
 - Dev-only sample fixture: `fixtures/governance_observation_live_snapshot.json`
 - Dry-run semantic evaluator: `veritas_os/governance/observation_evaluator.py`
+- Test-only Observe Mode wrapper: `veritas_os/governance/observe_mode_wrapper.py`
 - CLI checker: `scripts/check_governance_observation.py`
 - Fixture validation script: `scripts/validate_governance_observation_fixture.sh`
 
@@ -35,6 +36,7 @@ It is **not** a production bypass.
 - Does not change policy engine behavior
 - Does not add a UI toggle
 - Does not generate production observation payloads
+- Does not let production proceed when it would block
 - Does not weaken fail-closed behavior
 
 ## Try it locally
@@ -56,6 +58,7 @@ issues: 0
 Full validation:
 
 ```bash
+pytest -q veritas_os/tests/test_observe_mode_wrapper.py
 bash scripts/validate_governance_observation_fixture.sh
 ```
 

--- a/scripts/validate_governance_observation_fixture.sh
+++ b/scripts/validate_governance_observation_fixture.sh
@@ -5,6 +5,7 @@ echo "Validating VERITAS governance_observation sample fixture..."
 
 pytest -q veritas_os/tests/test_governance_observation_evaluator.py
 pytest -q veritas_os/tests/test_governance_observation_cli.py
+pytest -q veritas_os/tests/test_observe_mode_wrapper.py
 python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
 pnpm --filter frontend test components/mission-governance-adapter.test.ts
 pnpm --filter frontend test components/mission-page.test.tsx

--- a/veritas_os/governance/observe_mode_wrapper.py
+++ b/veritas_os/governance/observe_mode_wrapper.py
@@ -1,0 +1,85 @@
+"""Test-only Observe Mode decision wrapper for fixture generation.
+
+This module provides a pure helper that converts a would-be governance
+enforcement outcome into a semantically validated ``GovernanceObservation``.
+It is intentionally scoped to development/test tooling and does not modify
+runtime policy behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from veritas_os.api.schemas import GovernanceObservation
+from veritas_os.governance.observation_evaluator import evaluate_governance_observation
+
+WouldBeOutcome = Literal["proceed", "block", "human_review"]
+
+
+@dataclass(frozen=True)
+class ObserveModeDecisionInput:
+    """Input contract for test-only observation payload generation."""
+
+    policy_mode: str
+    environment: str
+    would_be_outcome: WouldBeOutcome
+    reason: str | None = None
+
+
+def _normalized_reason(reason: str | None) -> str | None:
+    if reason is None:
+        return None
+    stripped = reason.strip()
+    return stripped if stripped else None
+
+
+def build_governance_observation_for_dry_run(
+    decision: ObserveModeDecisionInput,
+) -> GovernanceObservation:
+    """Build and validate a test-only governance observation payload.
+
+    The function is pure and side-effect free. It performs no runtime mutation,
+    no IO, and no policy engine integration.
+    """
+
+    if decision.policy_mode == "observe" and decision.environment == "production":
+        raise ValueError("observe mode in production is not allowed")
+
+    normalized_reason = _normalized_reason(decision.reason)
+    would_have_blocked = decision.would_be_outcome == "block"
+
+    if would_have_blocked and normalized_reason is None:
+        raise ValueError("would_be_outcome='block' requires a non-empty reason")
+
+    observed_outcome = (
+        "block" if decision.would_be_outcome == "block" else decision.would_be_outcome
+    )
+
+    if decision.policy_mode == "observe":
+        effective_outcome = "proceed"
+        operator_warning = True
+    elif decision.policy_mode == "enforce":
+        effective_outcome = "block" if would_have_blocked else "proceed"
+        operator_warning = would_have_blocked
+    else:
+        effective_outcome = decision.would_be_outcome
+        operator_warning = False
+
+    observation = GovernanceObservation(
+        policy_mode=decision.policy_mode,
+        environment=decision.environment,
+        would_have_blocked=would_have_blocked,
+        would_have_blocked_reason=normalized_reason if would_have_blocked else None,
+        effective_outcome=effective_outcome,
+        observed_outcome=observed_outcome,
+        operator_warning=operator_warning,
+        audit_required=True,
+    )
+
+    evaluation = evaluate_governance_observation(observation)
+    if not evaluation.valid:
+        issues = ", ".join(f"{issue.code}: {issue.message}" for issue in evaluation.issues)
+        raise ValueError(f"generated governance_observation is semantically invalid: {issues}")
+
+    return observation

--- a/veritas_os/tests/test_observe_mode_wrapper.py
+++ b/veritas_os/tests/test_observe_mode_wrapper.py
@@ -1,0 +1,110 @@
+"""Tests for test-only Observe Mode decision wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.governance.observe_mode_wrapper import (
+    ObserveModeDecisionInput,
+    build_governance_observation_for_dry_run,
+)
+
+
+@pytest.mark.parametrize("environment", ["development", "test", "sandbox"])
+def test_observe_block_creates_valid_observation(environment: str) -> None:
+    observation = build_governance_observation_for_dry_run(
+        ObserveModeDecisionInput(
+            policy_mode="observe",
+            environment=environment,
+            would_be_outcome="block",
+            reason="policy_violation:missing_authority_evidence",
+        )
+    )
+
+    assert observation.policy_mode == "observe"
+    assert observation.environment == environment
+    assert observation.would_have_blocked is True
+    assert observation.would_have_blocked_reason == "policy_violation:missing_authority_evidence"
+    assert observation.effective_outcome == "proceed"
+    assert observation.observed_outcome == "block"
+    assert observation.operator_warning is True
+    assert observation.audit_required is True
+
+
+def test_enforce_production_block_creates_valid_observation() -> None:
+    observation = build_governance_observation_for_dry_run(
+        ObserveModeDecisionInput(
+            policy_mode="enforce",
+            environment="production",
+            would_be_outcome="block",
+            reason="policy_violation:missing_authority_evidence",
+        )
+    )
+
+    assert observation.policy_mode == "enforce"
+    assert observation.environment == "production"
+    assert observation.would_have_blocked is True
+    assert observation.would_have_blocked_reason == "policy_violation:missing_authority_evidence"
+    assert observation.effective_outcome == "block"
+    assert observation.observed_outcome == "block"
+    assert observation.operator_warning is True
+    assert observation.audit_required is True
+
+
+def test_observe_production_raises_error() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        build_governance_observation_for_dry_run(
+            ObserveModeDecisionInput(
+                policy_mode="observe",
+                environment="production",
+                would_be_outcome="block",
+                reason="policy_violation:missing_authority_evidence",
+            )
+        )
+
+
+def test_observe_proceed_creates_valid_observation() -> None:
+    observation = build_governance_observation_for_dry_run(
+        ObserveModeDecisionInput(
+            policy_mode="observe",
+            environment="development",
+            would_be_outcome="proceed",
+        )
+    )
+
+    assert observation.would_have_blocked is False
+    assert observation.would_have_blocked_reason is None
+    assert observation.effective_outcome == "proceed"
+    assert observation.observed_outcome == "proceed"
+    assert observation.operator_warning is True
+    assert observation.audit_required is True
+
+
+def test_enforce_proceed_creates_valid_observation() -> None:
+    observation = build_governance_observation_for_dry_run(
+        ObserveModeDecisionInput(
+            policy_mode="enforce",
+            environment="production",
+            would_be_outcome="proceed",
+        )
+    )
+
+    assert observation.would_have_blocked is False
+    assert observation.would_have_blocked_reason is None
+    assert observation.effective_outcome == "proceed"
+    assert observation.observed_outcome == "proceed"
+    assert observation.operator_warning is False
+    assert observation.audit_required is True
+
+
+@pytest.mark.parametrize("reason", [None, "", "   "])
+def test_block_without_reason_raises_error(reason: str | None) -> None:
+    with pytest.raises(ValueError, match="requires a non-empty reason"):
+        build_governance_observation_for_dry_run(
+            ObserveModeDecisionInput(
+                policy_mode="observe",
+                environment="development",
+                would_be_outcome="block",
+                reason=reason,
+            )
+        )


### PR DESCRIPTION
### Motivation
- Provide a pure, test/dev-only helper to build semantically valid `GovernanceObservation` fixtures from a would-be enforcement outcome without touching runtime policy behavior. 
- Ensure developers can record `would_have_blocked` outcomes for non-production testing while preserving production fail-closed semantics. 
- Prevent accidental enabling of observe semantics in production and ensure generated payloads pass the dry-run evaluator. 

### Description
- Add `veritas_os/governance/observe_mode_wrapper.py` which defines `ObserveModeDecisionInput` and `build_governance_observation_for_dry_run()` as a pure, side-effect-free builder that maps would-be outcomes to `GovernanceObservation` and runs `evaluate_governance_observation()` before returning. 
- Implement guardrails that reject `policy_mode="observe"` with `environment="production"` and require a non-empty reason when `would_be_outcome == "block"`. 
- Add tests in `veritas_os/tests/test_observe_mode_wrapper.py` covering observe/enforce combinations, production rejection, proceed/block semantics, and missing-reason rejection. 
- Update `docs/governance/observe_mode.md`, `docs/governance/observe_mode_developer_walkthrough.md`, and `scripts/validate_governance_observation_fixture.sh` to document the wrapper and include the new tests in validation. 

### Testing
- Ran `pytest -q veritas_os/tests/test_observe_mode_wrapper.py` which completed successfully (`10 passed`).
- Ran `pytest -q veritas_os/tests/test_governance_observation_evaluator.py` which completed successfully (`8 passed`).
- Ran full fixture validation via `bash scripts/validate_governance_observation_fixture.sh` which executed the evaluator, CLI checks and frontend adapter/page tests and completed without errors (all invoked tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4999c62d483269711eb3f832cd094)