### PR TITLE
Add dev-only Observe Mode snapshot fixture generation coverage

### DIFF
--- a/docs/governance/observe_mode.md
+++ b/docs/governance/observe_mode.md
@@ -90,6 +90,7 @@ Observe mode misuse can become a security and compliance risk if enabled in prod
 - It rejects production observe mode.
 - It preserves would-be blocking outcomes as `observed_outcome`.
 - It runs generated observations through the dry-run evaluator before returning them.
+- Wrapper tests include a memory-only snapshot fixture generation check proving generated observations can be embedded in Mission Control-style payloads without touching runtime paths.
 - It is intended for tests/dev fixtures before any future runtime rollout.
 
 ## Dry-run observation evaluator

--- a/docs/governance/observe_mode_developer_walkthrough.md
+++ b/docs/governance/observe_mode_developer_walkthrough.md
@@ -28,11 +28,12 @@ It is **not** a production bypass.
 - Test-only Observe Mode wrapper: `veritas_os/governance/observe_mode_wrapper.py`
 - CLI checker: `scripts/check_governance_observation.py`
 - Fixture validation script: `scripts/validate_governance_observation_fixture.sh`
+- Dev-only generated observation path coverage: would-be outcome → wrapper-generated `GovernanceObservation` → semantic evaluator → snapshot fixture shape → Mission Control adapter/rendering tests
 
 ## What it does not do
 
-- Does not enable Observe Mode runtime
-- Does not bypass production enforcement
+- Does not enable Observe Mode runtime (this flow is still dev/test-only fixture validation)
+- Does not connect the wrapper to production execution or bypass production enforcement
 - Does not change policy engine behavior
 - Does not add a UI toggle
 - Does not generate production observation payloads
@@ -62,7 +63,7 @@ pytest -q veritas_os/tests/test_observe_mode_wrapper.py
 bash scripts/validate_governance_observation_fixture.sh
 ```
 
-This script runs the Python evaluator tests, CLI tests, CLI fixture check, adapter tests, and Mission Control read-only rendering tests.
+This script runs the Python evaluator tests, CLI tests, wrapper fixture-generation tests, CLI fixture check, adapter tests, and Mission Control read-only rendering tests.
 
 ## Safety rules
 

--- a/veritas_os/tests/test_observe_mode_wrapper.py
+++ b/veritas_os/tests/test_observe_mode_wrapper.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from veritas_os.governance.observation_evaluator import evaluate_governance_observation
 from veritas_os.governance.observe_mode_wrapper import (
     ObserveModeDecisionInput,
     build_governance_observation_for_dry_run,
@@ -108,3 +111,47 @@ def test_block_without_reason_raises_error(reason: str | None) -> None:
                 reason=reason,
             )
         )
+
+
+def test_wrapper_generated_observation_can_be_embedded_in_snapshot_fixture() -> None:
+    observation = build_governance_observation_for_dry_run(
+        ObserveModeDecisionInput(
+            policy_mode="observe",
+            environment="development",
+            would_be_outcome="block",
+            reason="policy_violation:missing_authority_evidence",
+        )
+    )
+
+    governance_layer_snapshot = {
+        "decision_id": "dec_observe_generated_001",
+        "bind_receipt_id": "br_observe_generated_001",
+        "execution_intent_id": "ei_observe_generated_001",
+        "participation_state": "decision_shaping",
+        "preservation_state": "degrading",
+        "intervention_viability": "minimal",
+        "bind_outcome": "ESCALATED",
+        "governance_observation": observation.model_dump(mode="json"),
+    }
+
+    evaluation = evaluate_governance_observation(observation)
+
+    assert evaluation.valid is True
+    assert governance_layer_snapshot["governance_observation"]["policy_mode"] == "observe"
+    assert governance_layer_snapshot["governance_observation"]["environment"] == "development"
+    assert governance_layer_snapshot["governance_observation"]["would_have_blocked"] is True
+    assert (
+        governance_layer_snapshot["governance_observation"]["would_have_blocked_reason"]
+        == "policy_violation:missing_authority_evidence"
+    )
+    assert governance_layer_snapshot["governance_observation"]["effective_outcome"] == "proceed"
+    assert governance_layer_snapshot["governance_observation"]["observed_outcome"] == "block"
+    assert governance_layer_snapshot["governance_observation"]["operator_warning"] is True
+    assert governance_layer_snapshot["governance_observation"]["audit_required"] is True
+    assert governance_layer_snapshot["decision_id"] == "dec_observe_generated_001"
+    assert governance_layer_snapshot["bind_receipt_id"] == "br_observe_generated_001"
+    assert governance_layer_snapshot["execution_intent_id"] == "ei_observe_generated_001"
+
+    serialized_snapshot = json.dumps({"governance_layer_snapshot": governance_layer_snapshot})
+
+    assert isinstance(serialized_snapshot, str)


### PR DESCRIPTION
### Motivation

- Provide a dev/test-only end-to-end flow that proves a would-be enforcement outcome can be converted into a validated `GovernanceObservation` and embedded into a Mission Control-style snapshot without touching production runtime paths.
- Close the remaining gap in Observe Mode foundation by connecting the wrapper, evaluator, snapshot shape, and adapter/rendering validation into a single developer-facing test flow.

### Description

- Add `test_wrapper_generated_observation_can_be_embedded_in_snapshot_fixture` to `veritas_os/tests/test_observe_mode_wrapper.py` which builds a wrapper-generated observation (`policy_mode="observe"`, `environment="development"`, `would_be_outcome="block"`, `reason="policy_violation:missing_authority_evidence"`), validates it with `evaluate_governance_observation`, embeds it with artifact ids into an in-memory `governance_layer_snapshot`, and asserts JSON-serializability.
- Update `docs/governance/observe_mode_developer_walkthrough.md` to document the dev-only generated observation validation path: would-be outcome → wrapper-generated `GovernanceObservation` → semantic evaluator → snapshot fixture shape → Mission Control adapter/rendering tests.
- Add a single-sentence note to `docs/governance/observe_mode.md` clarifying that wrapper tests include a memory-only snapshot fixture generation check; no runtime path, toggles, or production changes are introduced.
- No production runtime behavior, policy engine behavior, API endpoints, or UI toggles were modified; all changes are tests/docs and are side-effect free.

### Testing

- Ran `pytest -q veritas_os/tests/test_observe_mode_wrapper.py` and observed the suite pass (`11 passed`).
- Ran frontend tests `pnpm --filter frontend test components/mission-governance-adapter.test.ts` and `pnpm --filter frontend test components/mission-page.test.tsx` and observed both pass (adapter: 7 tests passed; mission-page: 32 tests passed).
- Ran full validation `bash scripts/validate_governance_observation_fixture.sh` which executed the Python evaluator/CLI tests, wrapper tests, CLI fixture check, adapter tests, and Mission Control rendering tests and completed successfully with the fixture check reporting valid.
- All automated tests related to this change passed locally and the new test asserts the generated observation is semantically valid, embedded with artifact ids, and JSON-serializable in-memory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a07474e883268c8ec3d567fa164b)