### PR TITLE
Add dev-only Observe Mode demo snapshot generator and tests

### DIFF
--- a/docs/governance/observe_mode.md
+++ b/docs/governance/observe_mode.md
@@ -91,6 +91,7 @@ Observe mode misuse can become a security and compliance risk if enabled in prod
 - It preserves would-be blocking outcomes as `observed_outcome`.
 - It runs generated observations through the dry-run evaluator before returning them.
 - Wrapper tests include a memory-only snapshot fixture generation check proving generated observations can be embedded in Mission Control-style payloads without touching runtime paths.
+- `python scripts/generate_observe_mode_demo_snapshot.py` can generate a dev-only Mission Control-style snapshot from the test-only wrapper for local inspection; it does not enable Observe Mode runtime.
 - It is intended for tests/dev fixtures before any future runtime rollout.
 
 ## Dry-run observation evaluator

--- a/docs/governance/observe_mode_developer_walkthrough.md
+++ b/docs/governance/observe_mode_developer_walkthrough.md
@@ -42,6 +42,26 @@ It is **not** a production bypass.
 
 ## Try it locally
 
+Generate a dev-only snapshot (wrapper + dry-run evaluator):
+
+```bash
+python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json
+```
+
+Validate generated output with existing CLI checker:
+
+```bash
+python scripts/check_governance_observation.py /tmp/observe_snapshot.json
+```
+
+You can also emit to stdout:
+
+```bash
+python scripts/generate_observe_mode_demo_snapshot.py
+```
+
+This flow uses the test-only wrapper and dry-run evaluator, does not enable Observe Mode runtime, does not connect to production execution, and produces a Mission Control-style JSON payload for local inspection.
+
 Single fixture check:
 
 ```bash

--- a/scripts/generate_observe_mode_demo_snapshot.py
+++ b/scripts/generate_observe_mode_demo_snapshot.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Generate a dev-only Observe Mode governance snapshot for walkthroughs.
+
+This tooling script is intended for development/test/documentation workflows.
+It does not enable Observe Mode runtime behavior and does not modify
+production fail-closed enforcement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from veritas_os.governance.observation_evaluator import evaluate_governance_observation
+from veritas_os.governance.observe_mode_wrapper import (
+    ObserveModeDecisionInput,
+    build_governance_observation_for_dry_run,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a dev-only Mission Control-style snapshot containing "
+            "wrapper-generated governance_observation."
+        )
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="Write output JSON to a file path instead of stdout.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact JSON (default emits pretty JSON).",
+    )
+    return parser
+
+
+def _build_snapshot() -> dict:
+    observation = build_governance_observation_for_dry_run(
+        ObserveModeDecisionInput(
+            policy_mode="observe",
+            environment="development",
+            would_be_outcome="block",
+            reason="policy_violation:missing_authority_evidence",
+        )
+    )
+    evaluation = evaluate_governance_observation(observation)
+    if not evaluation.valid:
+        issues = ", ".join(
+            f"{issue.code}: {issue.message}" for issue in evaluation.issues
+        )
+        raise ValueError(
+            "generated governance_observation failed semantic validation: "
+            f"{issues}"
+        )
+
+    return {
+        "sample_kind": "dev_only_observe_mode_demo",
+        "governance_layer_snapshot": {
+            "participation_state": "decision_shaping",
+            "pre_bind_source": "trustlog_matching_decision",
+            "bind_reason_code": "AUTHORITY_MISSING",
+            "bind_failure_reason": "Authority evidence missing",
+            "failure_category": "policy_violation",
+            "target_path": "/governance/policies/authority",
+            "target_type": "policy",
+            "target_label": "Authority policy",
+            "operator_surface": "governance",
+            "relevant_ui_href": "/governance",
+            "decision_id": "dec_observe_generated_001",
+            "bind_receipt_id": "br_observe_generated_001",
+            "execution_intent_id": "ei_observe_generated_001",
+            "governance_observation": observation.model_dump(mode="json"),
+        },
+    }
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        snapshot = _build_snapshot()
+    except ValueError as exc:
+        print("observe mode demo snapshot generation: invalid", file=sys.stderr)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    indent = None if args.compact else 2
+    rendered = json.dumps(snapshot, ensure_ascii=False, indent=indent) + "\n"
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered, encoding="utf-8")
+        print(f"observe mode demo snapshot generation: wrote {args.out}")
+        return 0
+
+    sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_governance_observation_fixture.sh
+++ b/scripts/validate_governance_observation_fixture.sh
@@ -6,6 +6,7 @@ echo "Validating VERITAS governance_observation sample fixture..."
 pytest -q veritas_os/tests/test_governance_observation_evaluator.py
 pytest -q veritas_os/tests/test_governance_observation_cli.py
 pytest -q veritas_os/tests/test_observe_mode_wrapper.py
+pytest -q veritas_os/tests/test_observe_mode_demo_snapshot_generator.py
 python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
 pnpm --filter frontend test components/mission-governance-adapter.test.ts
 pnpm --filter frontend test components/mission-page.test.tsx

--- a/veritas_os/tests/test_observe_mode_demo_snapshot_generator.py
+++ b/veritas_os/tests/test_observe_mode_demo_snapshot_generator.py
@@ -1,0 +1,79 @@
+"""Tests for dev-only Observe Mode demo snapshot generator script."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+GENERATOR_CLI_PATH = Path("scripts/generate_observe_mode_demo_snapshot.py")
+CHECKER_CLI_PATH = Path("scripts/check_governance_observation.py")
+
+
+def _run_generator(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GENERATOR_CLI_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _run_checker(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER_CLI_PATH), str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_stdout_generation_returns_valid_json() -> None:
+    result = _run_generator()
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+
+    assert payload["sample_kind"] == "dev_only_observe_mode_demo"
+    observation = payload["governance_layer_snapshot"]["governance_observation"]
+    assert observation["policy_mode"] == "observe"
+    assert observation["environment"] == "development"
+    assert observation["would_have_blocked"] is True
+    assert observation["effective_outcome"] == "proceed"
+    assert observation["observed_outcome"] == "block"
+
+
+def test_generated_stdout_passes_cli_checker(tmp_path: Path) -> None:
+    generated_file = tmp_path / "generated_snapshot.json"
+
+    generate_result = _run_generator()
+    assert generate_result.returncode == 0
+    generated_file.write_text(generate_result.stdout, encoding="utf-8")
+
+    check_result = _run_checker(generated_file)
+    output = check_result.stdout + check_result.stderr
+
+    assert check_result.returncode == 0
+    assert "valid" in output
+    assert "issues: 0" in output
+
+
+def test_out_writes_file_and_passes_cli_checker(tmp_path: Path) -> None:
+    output_file = tmp_path / "observe_snapshot.json"
+
+    result = _run_generator("--out", str(output_file))
+
+    assert result.returncode == 0
+    assert output_file.exists()
+
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["sample_kind"] == "dev_only_observe_mode_demo"
+
+    check_result = _run_checker(output_file)
+    output = check_result.stdout + check_result.stderr
+
+    assert check_result.returncode == 0
+    assert "valid" in output
+    assert "issues: 0" in output


### PR DESCRIPTION
### Motivation

- Provide a single-command developer walkthrough to generate a Mission Control-style, dev-only `governance_observation` snapshot so developers can run the wrapper + evaluator flow without enabling any runtime Observe Mode behavior.
- Keep production safety unchanged by ensuring this is strictly test/dev tooling that validates with the existing dry-run evaluator and the CLI checker.

### Description

- Add `scripts/generate_observe_mode_demo_snapshot.py` which builds a wrapper-generated `GovernanceObservation` via `build_governance_observation_for_dry_run()`, re-runs `evaluate_governance_observation()` and emits a Mission Control-style snapshot to stdout or to a file via `--out`; also supports `--compact` for compact JSON and includes a `sample_kind: "dev_only_observe_mode_demo"` marker and artifact ids (`decision_id`, `bind_receipt_id`, `execution_intent_id`).
- Add CLI-focused tests in `veritas_os/tests/test_observe_mode_demo_snapshot_generator.py` that validate stdout generation, that generated payloads pass the existing `scripts/check_governance_observation.py` checker, and that `--out` writes a file which also passes the checker.
- Wire the new test into the fixture validation flow by adding it to `scripts/validate_governance_observation_fixture.sh` and update developer docs in `docs/governance/observe_mode_developer_walkthrough.md` and `docs/governance/observe_mode.md` with local usage and the explicit note that this is dev-only and does not enable Observe Mode runtime.
- No runtime paths, production behavior, policy engine logic, API endpoints, or UI toggles were added or modified; this is purely dev/test/demo tooling.

### Testing

- Ran `pytest -q veritas_os/tests/test_observe_mode_demo_snapshot_generator.py` and the test file passed (`3 passed`).
- Executed generator + checker integration: `python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json` followed by `python scripts/check_governance_observation.py /tmp/observe_snapshot.json`, which reported `valid` and `issues: 0`.
- Ran full fixture validation script `bash scripts/validate_governance_observation_fixture.sh` and observed the included test suites and frontend adapter tests complete successfully (all invoked tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a4f6a36083268cf002083b63ac9e)