### PR TITLE
Add screenshot-free Observe Mode Mission Control walkthrough

### DIFF
--- a/docs/governance/observe_mode.md
+++ b/docs/governance/observe_mode.md
@@ -7,6 +7,7 @@ Observe Mode is a **development-time governance mode semantics** that records wh
 This document defines semantics, safety constraints, and schema foundations for future implementation work.
 
 For a developer-oriented end-to-end walkthrough, see `docs/governance/observe_mode_developer_walkthrough.md`.
+For a Mission Control-focused payload-to-UI walkthrough, see `docs/governance/observe_mode_mission_control_walkthrough.md`.
 
 ## Core policy modes
 

--- a/docs/governance/observe_mode_developer_walkthrough.md
+++ b/docs/governance/observe_mode_developer_walkthrough.md
@@ -62,6 +62,8 @@ python scripts/generate_observe_mode_demo_snapshot.py
 
 This flow uses the test-only wrapper and dry-run evaluator, does not enable Observe Mode runtime, does not connect to production execution, and produces a Mission Control-style JSON payload for local inspection.
 
+For how the generated snapshot maps to Mission Control read-only fields, see `docs/governance/observe_mode_mission_control_walkthrough.md`.
+
 Single fixture check:
 
 ```bash

--- a/docs/governance/observe_mode_mission_control_walkthrough.md
+++ b/docs/governance/observe_mode_mission_control_walkthrough.md
@@ -1,0 +1,107 @@
+# Observe Mode Mission Control Walkthrough
+
+## Purpose
+
+This walkthrough explains how a dev-only `governance_observation` snapshot maps to Mission Control read-only display fields.
+
+It does **not** enable Observe Mode runtime.
+
+## Generate a dev-only snapshot
+
+```bash
+python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json
+```
+
+## Validate the snapshot
+
+```bash
+python scripts/check_governance_observation.py /tmp/observe_snapshot.json
+```
+
+Expected output:
+
+```text
+governance_observation dry-run check: valid
+file: /tmp/observe_snapshot.json
+issues: 0
+```
+
+## Payload contract
+
+The generated snapshot contains:
+
+- `sample_kind`
+- `governance_layer_snapshot`
+- artifact ids:
+  - `decision_id`
+  - `bind_receipt_id`
+  - `execution_intent_id`
+- routing/context fields:
+  - `participation_state`
+  - `pre_bind_source`
+  - `bind_reason_code`
+  - `bind_failure_reason`
+  - `failure_category`
+  - `target_path`
+  - `target_type`
+  - `target_label`
+  - `operator_surface`
+  - `relevant_ui_href`
+- `governance_observation`
+
+## Governance observation fields
+
+| Field | Example | Meaning |
+|---|---|---|
+| `policy_mode` | `observe` | Development/test observation semantics |
+| `environment` | `development` | Non-production context |
+| `would_have_blocked` | `true` | The action would have been blocked under enforcement |
+| `would_have_blocked_reason` | `policy_violation:missing_authority_evidence` | Preserved would-be blocking reason |
+| `effective_outcome` | `proceed` | Dev-only observed execution result |
+| `observed_outcome` | `block` | Would-be enforcement outcome preserved for audit |
+| `operator_warning` | `true` | Operator should see that this is not clean success |
+| `audit_required` | `true` | Observation must remain auditable |
+
+## Mission Control rendering contract
+
+When `governance_observation` is present in the governance snapshot, Mission Control renders a read-only Governance observation section.
+
+It should show:
+
+- policy mode
+- environment
+- would-have-blocked status
+- reason
+- effective outcome
+- observed outcome
+- operator warning
+- audit required
+
+Important behavior:
+
+- This is display-only.
+- No runtime behavior changes.
+- No Observe Mode switch is enabled.
+- No production bypass is created.
+- Missing `governance_observation` means the section is hidden.
+
+## What this walkthrough proves
+
+- Generated payload shape is understandable.
+- CLI checker can validate the payload.
+- Mission Control has a read-only display contract for these fields.
+- Operators can distinguish dev-only observed proceed from would-be block.
+
+## What this walkthrough does not prove
+
+- It does not prove runtime Observe Mode is implemented.
+- It does not prove production execution can proceed when blocked.
+- It does not add an API endpoint.
+- It does not load generated JSON into a live UI session.
+- It does not replace runtime enforcement tests.
+
+## Safety boundary
+
+Development can move fast.
+Production still fails closed.
+Both modes remain auditable.

--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -99,6 +99,7 @@ docker compose up --build
 - backend `/v1/governance/live-snapshot` は latest BindReceipt 由来の bind metadata（`bind_receipt_id` / `execution_intent_id` / `decision_id`）、target metadata（`target_path` / `target_type` / `target_label` / `operator_surface` / `relevant_ui_href`）、reason fields（`bind_reason_code` / `bind_failure_reason` / `failure_category` など）を返し、`bind_summary` が存在する場合は operator-facing artifact summary として利用できます。
 - Mission Control UI は上記 live snapshot fields を operator-facing details として表示します（pre-bind source / pre-bind summaries / bind reason / target metadata / check results）。
 - `governance_observation` が snapshot payload に含まれる場合、Mission Control は `policy_mode` / `environment` / `would_have_blocked` / `effective_outcome` などを read-only の operator context として表示します。これは observation fields の可視化であり、Observe Mode runtime を有効化する挙動ではありません。
+- Observe Mode governance observation rendering walkthrough: `docs/governance/observe_mode_mission_control_walkthrough.md`.
 - `fixtures/governance_observation_live_snapshot.json` は、Observe Mode runtime を有効化せずに Mission Control の read-only 表示を確認するための dev-only sample payload です。
 - `bash scripts/validate_governance_observation_fixture.sh` は dev-only `governance_observation` sample 用の adapter / Mission Control focused tests を実行します。
 - `pre_bind_source` は artifact 取得元と fallback 状態を示し、`trustlog_matching_*` は matched、`trustlog_recent_decision` と `latest_bind_receipt` は fallback、`none` は unavailable、`malformed_pre_bind_artifact` と `pre_bind_artifact_retrieval_failed` は degraded source として扱います。


### PR DESCRIPTION
### Motivation

- Make it easy for external developers to understand how a generated dev-only `governance_observation` snapshot maps to Mission Control's read-only operator UI without using screenshots or images.
- Clarify the payload contract and the UI rendering contract for `governance_observation` fields while explicitly preserving the non-goals that affect runtime, production safety, and UI toggles.

### Description

- Added `docs/governance/observe_mode_mission_control_walkthrough.md` containing Purpose, Generate/Validate commands, Payload contract, a table of `governance_observation` fields and meanings, Mission Control rendering contract, hidden-section behavior, non-goals, and a safety boundary.
- Inserted single-line references to the new walkthrough from `docs/governance/observe_mode_developer_walkthrough.md`, `docs/governance/observe_mode.md`, and `docs/ui/README_UI.md` so the developer walkthrough and UI docs point to the Mission Control–focused page.
- The change is documentation-only and does not alter production code, test code, runtime behavior, or add any UI/runtime toggles or images.

### Testing

- Ran `python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json` and confirmed the generator wrote `/tmp/observe_snapshot.json` successfully.
- Ran `python scripts/check_governance_observation.py /tmp/observe_snapshot.json` and observed the CLI checker report `governance_observation dry-run check: valid` with `issues: 0`.
- Ran `bash scripts/validate_governance_observation_fixture.sh` and the invoked Python `pytest` suites and frontend `vitest` suites completed with all targeted tests passing during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4adeec6a88326bd459d39dbb767f1)