### PR TITLE
Harden /dev/mission-fixture with explicit production gating

### DIFF
--- a/docs/governance/observe_mode_mission_control_walkthrough.md
+++ b/docs/governance/observe_mode_mission_control_walkthrough.md
@@ -99,7 +99,9 @@ This route renders a static fixture through the Mission Control-style UI.
 - It does not enable Observe Mode runtime.
 - It does not call backend APIs.
 - It does not create a production bypass.
-- It is for local/dev inspection only.
+- It is for local/dev/test inspection only.
+- In production environments, the fixture viewer is disabled and does not render the static `governance_observation` fixture.
+- Runtime behavior is unchanged and production remains fail-closed.
 
 ## What this walkthrough proves
 

--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -102,6 +102,8 @@ docker compose up --build
 - Observe Mode governance observation rendering walkthrough: `docs/governance/observe_mode_mission_control_walkthrough.md`.
 - `fixtures/governance_observation_live_snapshot.json` は、Observe Mode runtime を有効化せずに Mission Control の read-only 表示を確認するための dev-only sample payload です。
 - `/dev/mission-fixture` renders the dev-only `governance_observation` fixture in a Mission Control-style read-only view without enabling Observe Mode runtime or calling backend APIs.
+- `/dev/mission-fixture` is local/dev/test-only; in production environments it renders a disabled state and does not render the static `governance_observation` fixture.
+- This route hardening does not change runtime behavior: production remains fail-closed and Observe Mode runtime is not enabled.
 - `bash scripts/validate_governance_observation_fixture.sh` は dev-only `governance_observation` sample 用の adapter / Mission Control focused tests を実行します。
 - `pre_bind_source` は artifact 取得元と fallback 状態を示し、`trustlog_matching_*` は matched、`trustlog_recent_decision` と `latest_bind_receipt` は fallback、`none` は unavailable、`malformed_pre_bind_artifact` と `pre_bind_artifact_retrieval_failed` は degraded source として扱います。
 - `pre_bind_detection_summary` / `pre_bind_preservation_summary` / detail fields / check result fields が `null` または `unknown` の場合、Mission Control UI は fake data を生成せず unavailable 表示を維持します。

--- a/frontend/app/dev/mission-fixture/page.test.tsx
+++ b/frontend/app/dev/mission-fixture/page.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import DevMissionFixturePage from "./page";
+import DevMissionFixturePage, { isDevMissionFixtureEnabled } from "./page";
 
 describe("DevMissionFixturePage", () => {
-  it("renders a dev-only static mission fixture with governance observation fields", () => {
-    render(<DevMissionFixturePage />);
+  it("renders a dev-only static mission fixture with governance observation fields", async () => {
+    render(await DevMissionFixturePage({ nodeEnv: "test" }));
 
     expect(screen.getAllByText("DEV-ONLY FIXTURE").length).toBeGreaterThan(0);
     expect(screen.getByText("Runtime behavior is unchanged")).toBeInTheDocument();
@@ -22,5 +22,22 @@ describe("DevMissionFixturePage", () => {
     expect(screen.getByText("proceed")).toBeInTheDocument();
     expect(screen.getByText("observed_outcome")).toBeInTheDocument();
     expect(screen.getByText("block")).toBeInTheDocument();
+  });
+
+  it("disables the fixture viewer in production", async () => {
+    render(await DevMissionFixturePage({ nodeEnv: "production" }));
+
+    expect(screen.getByTestId("dev-mission-fixture-disabled")).toBeInTheDocument();
+    expect(screen.getByText("DEV-ONLY FIXTURE DISABLED")).toBeInTheDocument();
+    expect(screen.getByText("This route is disabled in production.")).toBeInTheDocument();
+    expect(screen.queryByText("Governance observation")).not.toBeInTheDocument();
+  });
+});
+
+describe("isDevMissionFixtureEnabled", () => {
+  it("returns true for development and test, false for production", () => {
+    expect(isDevMissionFixtureEnabled("development")).toBe(true);
+    expect(isDevMissionFixtureEnabled("test")).toBe(true);
+    expect(isDevMissionFixtureEnabled("production")).toBe(false);
   });
 });

--- a/frontend/app/dev/mission-fixture/page.tsx
+++ b/frontend/app/dev/mission-fixture/page.tsx
@@ -9,8 +9,10 @@ export function isDevMissionFixtureEnabled(nodeEnv = process.env.NODE_ENV): bool
   return nodeEnv !== "production";
 }
 
+type NodeEnv = "production" | "development" | "test" | undefined;
+
 type DevMissionFixturePageProps = {
-  nodeEnv?: string;
+  nodeEnv?: NodeEnv;
 };
 
 export default async function DevMissionFixturePage({ nodeEnv }: DevMissionFixturePageProps = {}): Promise<JSX.Element> {

--- a/frontend/app/dev/mission-fixture/page.tsx
+++ b/frontend/app/dev/mission-fixture/page.tsx
@@ -4,11 +4,35 @@ import {
   type MissionGovernanceIngressPayload,
   resolveMissionGovernanceSnapshot,
 } from "../../../components/mission-governance-adapter";
-import rawFixturePayload from "../../../fixtures/governance_observation_live_snapshot.json";
 
-const fixturePayload = rawFixturePayload as MissionGovernanceIngressPayload;
+export function isDevMissionFixtureEnabled(nodeEnv = process.env.NODE_ENV): boolean {
+  return nodeEnv !== "production";
+}
 
-export default function DevMissionFixturePage(): JSX.Element {
+type DevMissionFixturePageProps = {
+  nodeEnv?: string;
+};
+
+export default async function DevMissionFixturePage({ nodeEnv }: DevMissionFixturePageProps = {}): Promise<JSX.Element> {
+  if (!isDevMissionFixtureEnabled(nodeEnv)) {
+    return (
+      <I18nProvider>
+        <section
+          className="rounded-md border border-warning/60 bg-warning/5 p-4"
+          data-testid="dev-mission-fixture-disabled"
+        >
+          <h1 className="font-semibold">DEV-ONLY FIXTURE DISABLED</h1>
+          <p className="mt-2 text-sm">This route is disabled in production.</p>
+          <p className="text-sm">Runtime behavior is unchanged.</p>
+          <p className="text-sm">Production still fails closed.</p>
+          <p className="text-sm">Observe Mode runtime is not enabled.</p>
+        </section>
+      </I18nProvider>
+    );
+  }
+
+  const { default: rawFixturePayload } = await import("../../../fixtures/governance_observation_live_snapshot.json");
+  const fixturePayload = rawFixturePayload as MissionGovernanceIngressPayload;
   const governanceLayerSnapshot = resolveMissionGovernanceSnapshot(fixturePayload);
 
   return (


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of the dev-only `/dev/mission-fixture` viewer in production by adding an explicit environment gate. 
- Ensure fixture resolution and adapter logic are not executed in production to avoid bundling/execution surprises while keeping runtime behavior unchanged. 
- Provide a clear, testable safety boundary and document it in the governance/UI walkthroughs. 

### Description
- Add `isDevMissionFixtureEnabled(nodeEnv)` helper and gate the page on `nodeEnv !== "production"`, returning a clear disabled safety UI when disabled. 
- Turn the page into an async component and move fixture loading into a non-production branch using `await import(...)` so fixture resolution is not executed in the production branch. 
- Add tests that render the page in non-production and production modes and add unit coverage for the helper; update `page.test.tsx` accordingly. 
- Update `docs/governance/observe_mode_mission_control_walkthrough.md` and `docs/ui/README_UI.md` to state the route is local/dev/test-only and disabled in production while explicitly noting runtime behavior is unchanged and production remains fail-closed. 

### Testing
- Ran the route unit tests with `pnpm --filter frontend test app/dev/mission-fixture/page.test.tsx`, which passed (3 tests passed). 
- Ran related frontend tests `pnpm --filter frontend test components/mission-page.test.tsx` and `pnpm --filter frontend test components/mission-governance-adapter.test.ts`, both of which passed. 
- Executed fixture validation with `bash scripts/validate_governance_observation_fixture.sh`, which completed successfully (fixture validation passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4bdebc38883269ed704ba3017eddd)