### PR TITLE
Add governance_observation fixture drift detection (root ↔ frontend)

### DIFF
--- a/docs/governance/observe_mode_mission_control_walkthrough.md
+++ b/docs/governance/observe_mode_mission_control_walkthrough.md
@@ -103,6 +103,25 @@ This route renders a static fixture through the Mission Control-style UI.
 - In production environments, the fixture viewer is disabled and does not render the static `governance_observation` fixture.
 - Runtime behavior is unchanged and production remains fail-closed.
 
+
+## Fixture copy integrity (root ↔ frontend)
+
+`frontend/fixtures/governance_observation_live_snapshot.json` is a frontend-local dev-only copy of `fixtures/governance_observation_live_snapshot.json` (used because frontend bundling cannot import the repository-root fixture directly).
+
+Drift detection is enforced with:
+
+- `pytest -q veritas_os/tests/test_governance_observation_fixture_drift.py`
+- `python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json`
+- `python scripts/check_governance_observation.py frontend/fixtures/governance_observation_live_snapshot.json`
+
+The drift test verifies alignment of:
+
+- `governance_layer_snapshot.governance_observation`
+- key artifact IDs (`decision_id`, `bind_receipt_id`, `execution_intent_id`)
+- key routing/context fields (`participation_state`, `pre_bind_source`, `bind_reason_code`, `bind_failure_reason`, `failure_category`, `target_path`, `target_type`, `target_label`, `operator_surface`, `relevant_ui_href`)
+
+This is fixture integrity validation only. Runtime behavior remains unchanged, Observe Mode runtime is not enabled, and production remains fail-closed.
+
 ## What this walkthrough proves
 
 - Generated payload shape is understandable.

--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -101,6 +101,9 @@ docker compose up --build
 - `governance_observation` が snapshot payload に含まれる場合、Mission Control は `policy_mode` / `environment` / `would_have_blocked` / `effective_outcome` などを read-only の operator context として表示します。これは observation fields の可視化であり、Observe Mode runtime を有効化する挙動ではありません。
 - Observe Mode governance observation rendering walkthrough: `docs/governance/observe_mode_mission_control_walkthrough.md`.
 - `fixtures/governance_observation_live_snapshot.json` は、Observe Mode runtime を有効化せずに Mission Control の read-only 表示を確認するための dev-only sample payload です。
+- `frontend/fixtures/governance_observation_live_snapshot.json` は frontend bundler 制約に対応するための frontend-local dev-only copy で、source-of-truth は root fixture (`fixtures/governance_observation_live_snapshot.json`) です。
+- Drift detection は `veritas_os/tests/test_governance_observation_fixture_drift.py` と `scripts/check_governance_observation.py`（root/frontend fixture 両方）で実行し、`governance_observation` / artifact IDs / key routing fields の整合性を検証します。
+- 上記 fixture integrity check は表示契約の一貫性を保証するものであり、runtime behavior は変更しません。production は fail-closed のままで Observe Mode runtime は有効化されません。
 - `/dev/mission-fixture` renders the dev-only `governance_observation` fixture in a Mission Control-style read-only view without enabling Observe Mode runtime or calling backend APIs.
 - `/dev/mission-fixture` is local/dev/test-only; in production environments it renders a disabled state and does not render the static `governance_observation` fixture.
 - This route hardening does not change runtime behavior: production remains fail-closed and Observe Mode runtime is not enabled.

--- a/scripts/validate_governance_observation_fixture.sh
+++ b/scripts/validate_governance_observation_fixture.sh
@@ -7,7 +7,9 @@ pytest -q veritas_os/tests/test_governance_observation_evaluator.py
 pytest -q veritas_os/tests/test_governance_observation_cli.py
 pytest -q veritas_os/tests/test_observe_mode_wrapper.py
 pytest -q veritas_os/tests/test_observe_mode_demo_snapshot_generator.py
+pytest -q veritas_os/tests/test_governance_observation_fixture_drift.py
 python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
+python scripts/check_governance_observation.py frontend/fixtures/governance_observation_live_snapshot.json
 pnpm --filter frontend test components/mission-governance-adapter.test.ts
 pnpm --filter frontend test components/mission-page.test.tsx
 

--- a/veritas_os/tests/test_governance_observation_fixture_drift.py
+++ b/veritas_os/tests/test_governance_observation_fixture_drift.py
@@ -1,0 +1,80 @@
+"""Drift detection tests for governance observation sample fixtures.
+
+These tests ensure the frontend-local dev fixture copy remains semantically
+aligned with the root fixture used by CLI validation workflows.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT_FIXTURE_PATH = Path("fixtures/governance_observation_live_snapshot.json")
+FRONTEND_FIXTURE_PATH = Path("frontend/fixtures/governance_observation_live_snapshot.json")
+
+ARTIFACT_ID_FIELDS = (
+    "decision_id",
+    "bind_receipt_id",
+    "execution_intent_id",
+)
+
+ROUTING_CONTEXT_FIELDS = (
+    "participation_state",
+    "pre_bind_source",
+    "bind_reason_code",
+    "bind_failure_reason",
+    "failure_category",
+    "target_path",
+    "target_type",
+    "target_label",
+    "operator_surface",
+    "relevant_ui_href",
+)
+
+
+def _load_snapshot(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))["governance_layer_snapshot"]
+
+
+def test_governance_observation_matches_between_root_and_frontend_fixture_copy() -> None:
+    root_snapshot = _load_snapshot(ROOT_FIXTURE_PATH)
+    frontend_snapshot = _load_snapshot(FRONTEND_FIXTURE_PATH)
+
+    assert (
+        root_snapshot["governance_observation"]
+        == frontend_snapshot["governance_observation"]
+    )
+
+
+def test_artifact_ids_match_between_root_and_frontend_fixture_copy() -> None:
+    root_snapshot = _load_snapshot(ROOT_FIXTURE_PATH)
+    frontend_snapshot = _load_snapshot(FRONTEND_FIXTURE_PATH)
+
+    for field in ARTIFACT_ID_FIELDS:
+        assert root_snapshot[field] == frontend_snapshot[field]
+
+
+def test_routing_context_fields_match_between_root_and_frontend_fixture_copy() -> None:
+    root_snapshot = _load_snapshot(ROOT_FIXTURE_PATH)
+    frontend_snapshot = _load_snapshot(FRONTEND_FIXTURE_PATH)
+
+    for field in ROUTING_CONTEXT_FIELDS:
+        assert root_snapshot[field] == frontend_snapshot[field]
+
+
+def test_frontend_fixture_passes_cli_governance_observation_checker() -> None:
+    result = subprocess.run(
+        [
+            "python",
+            "scripts/check_governance_observation.py",
+            str(FRONTEND_FIXTURE_PATH),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "governance_observation dry-run check: valid" in result.stdout
+    assert "issues: 0" in result.stdout


### PR DESCRIPTION
### Motivation

- Frontend uses a bundler-friendly local copy of the root `governance_observation` fixture which creates a drift risk between CLI validation and the Mission Control dev viewer.  
- We need automated, developer-facing checks to ensure the `governance_layer_snapshot.governance_observation` payload, key artifact IDs, and routing/context fields stay aligned without changing runtime behavior.  
- This change is scoped to fixture integrity and documentation only and must not enable Observe Mode or alter production fail-closed behavior.

### Description

- Add `veritas_os/tests/test_governance_observation_fixture_drift.py` which asserts exact equality of `governance_layer_snapshot.governance_observation`, equality of artifact IDs (`decision_id`, `bind_receipt_id`, `execution_intent_id`), equality of routing/context fields (`participation_state`, `pre_bind_source`, `bind_reason_code`, `bind_failure_reason`, `failure_category`, `target_path`, `target_type`, `target_label`, `operator_surface`, `relevant_ui_href`), and runs the CLI checker on the frontend fixture via `scripts/check_governance_observation.py`.  
- Update `scripts/validate_governance_observation_fixture.sh` to run the new drift pytest and to validate both `fixtures/governance_observation_live_snapshot.json` and `frontend/fixtures/governance_observation_live_snapshot.json`.  
- Document the frontend-local copy purpose and the drift-detection guardrails in `docs/governance/observe_mode_mission_control_walkthrough.md` and `docs/ui/README_UI.md`.  
- No production/runtime code was modified and no fixture JSON content needed changes because the root and frontend fixtures were already aligned.

### Testing

- Ran `pytest -q veritas_os/tests/test_governance_observation_fixture_drift.py` which passed (`4 passed`).  
- Ran `python scripts/check_governance_observation.py frontend/fixtures/governance_observation_live_snapshot.json` which printed `governance_observation dry-run check: valid` and `issues: 0`.  
- Ran the full `bash scripts/validate_governance_observation_fixture.sh` which executed the existing evaluator/cli/wrapper/snapshot tests and frontend unit tests, all of which completed successfully.  
- No runtime changes were exercised; all tests are validation-only and confirm fixture parity and CLI/evaluator compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c6cca78c8326a31de0c5c6683a5b)