### PR TITLE
docs: add Observe Mode proof pack index

### DIFF
--- a/docs/governance/observe_mode.md
+++ b/docs/governance/observe_mode.md
@@ -8,6 +8,7 @@ This document defines semantics, safety constraints, and schema foundations for 
 
 For a developer-oriented end-to-end walkthrough, see `docs/governance/observe_mode_developer_walkthrough.md`.
 For a Mission Control-focused payload-to-UI walkthrough, see `docs/governance/observe_mode_mission_control_walkthrough.md`.
+For a reviewer-oriented evidence index, see `docs/governance/observe_mode_proof_pack.md`.
 
 ## Core policy modes
 

--- a/docs/governance/observe_mode_developer_walkthrough.md
+++ b/docs/governance/observe_mode_developer_walkthrough.md
@@ -16,6 +16,8 @@ Observe Mode foundation is a semantics, schema, UI, fixture, and dry-run validat
 
 It is **not** a production bypass.
 
+For an evidence-oriented proof pack covering files, tests, commands, and safety boundaries, see `docs/governance/observe_mode_proof_pack.md`.
+
 ## Current foundation
 
 - Semantics doc: `docs/governance/observe_mode.md`

--- a/docs/governance/observe_mode_mission_control_walkthrough.md
+++ b/docs/governance/observe_mode_mission_control_walkthrough.md
@@ -6,6 +6,8 @@ This walkthrough explains how a dev-only `governance_observation` snapshot maps 
 
 It does **not** enable Observe Mode runtime.
 
+For the full proof pack index, see `docs/governance/observe_mode_proof_pack.md`.
+
 ## Generate a dev-only snapshot
 
 ```bash

--- a/docs/governance/observe_mode_proof_pack.md
+++ b/docs/governance/observe_mode_proof_pack.md
@@ -1,0 +1,79 @@
+# Observe Mode Proof Pack
+
+## Purpose
+
+This proof pack summarizes the current Observe Mode foundation, the evidence artifacts that support it, the validation commands, and the safety boundaries.
+
+It is intended for external reviewers, enterprise evaluators, investors, and developers.
+
+## Status
+
+- Observe Mode runtime is not enabled.
+- Production remains fail-closed.
+- There is no production bypass.
+- There is no UI toggle that changes runtime behavior.
+- Current work is foundation / dry-run validation / dev-only tooling / read-only Mission Control visibility.
+
+## What is implemented
+
+| Area | Evidence | What it proves | What it does not prove |
+|---|---|---|---|
+| Semantics | `docs/governance/observe_mode.md` | Policy mode semantics are documented, production observe is not allowed, and Observe Mode is dev/test/sandbox oriented. | Runtime Observe Mode is active. |
+| Developer walkthrough | `docs/governance/observe_mode_developer_walkthrough.md` | Developers can understand end-to-end foundation and local commands. | Live runtime integration. |
+| Mission Control walkthrough | `docs/governance/observe_mode_mission_control_walkthrough.md` | Payload-to-UI rendering contract is documented. | Generated JSON can be loaded into production UI. |
+| Sample fixtures | `fixtures/governance_observation_live_snapshot.json`<br>`frontend/fixtures/governance_observation_live_snapshot.json` | Stable sample payload exists and frontend viewer has a static payload. | Runtime emits this payload. |
+| Fixture drift detection | `veritas_os/tests/test_governance_observation_fixture_drift.py`<br>`scripts/validate_governance_observation_fixture.sh` | Root and frontend fixture copy stay aligned; `governance_observation`, artifact IDs, and routing fields are checked. | Runtime source will never drift. |
+| Dry-run evaluator | `veritas_os/governance/observation_evaluator.py`<br>`veritas_os/tests/test_governance_observation_evaluator.py` | Unsafe semantic combinations are detected; production + observe is invalid; observe without audit/warning is invalid; `would_have_blocked` requires reason/outcome. | Policy engine is enforcing these rules at runtime. |
+| CLI checker | `scripts/check_governance_observation.py`<br>`veritas_os/tests/test_governance_observation_cli.py` | Arbitrary observation JSON can be dry-run checked. | Runtime endpoint validates all observations. |
+| Test-only wrapper | `veritas_os/governance/observe_mode_wrapper.py`<br>`veritas_os/tests/test_observe_mode_wrapper.py` | Dev/test fixtures can safely generate `GovernanceObservation`; generated observations pass evaluator. | Runtime decisions are wrapped. |
+| Demo snapshot generator | `scripts/generate_observe_mode_demo_snapshot.py`<br>`veritas_os/tests/test_observe_mode_demo_snapshot_generator.py` | Developers can generate a dev-only Mission Control-style snapshot; generated output passes CLI checker. | Generator is connected to live backend. |
+| Mission Control read-only display | `frontend/components/mission-page.tsx`<br>`frontend/components/mission-page.test.tsx` | Mission Control can render `governance_observation` as read-only context. | Mission Control changes runtime behavior. |
+| Dev-only fixture viewer | `frontend/app/dev/mission-fixture/page.tsx`<br>`frontend/app/dev/mission-fixture/page.test.tsx` | Developers can view the static fixture in Mission Control-like UI; production environment renders disabled state. | Production UI exposes this route as active; runtime Observe Mode is enabled. |
+
+## Validation commands
+
+```bash
+python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
+python scripts/check_governance_observation.py frontend/fixtures/governance_observation_live_snapshot.json
+python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json
+python scripts/check_governance_observation.py /tmp/observe_snapshot.json
+pytest -q veritas_os/tests/test_governance_observation_evaluator.py
+pytest -q veritas_os/tests/test_governance_observation_cli.py
+pytest -q veritas_os/tests/test_observe_mode_wrapper.py
+pytest -q veritas_os/tests/test_observe_mode_demo_snapshot_generator.py
+pytest -q veritas_os/tests/test_governance_observation_fixture_drift.py
+pnpm --filter frontend test app/dev/mission-fixture/page.test.tsx
+bash scripts/validate_governance_observation_fixture.sh
+```
+
+## Safety boundaries
+
+- No production runtime behavior is changed.
+- No Observe Mode runtime switch exists.
+- No production bypass exists.
+- No backend mutation endpoint is added.
+- No policy engine behavior is changed.
+- `/dev/mission-fixture` is local/dev/test oriented and disabled in production environment.
+- `governance_observation` display is read-only operator context.
+
+## Reviewer checklist
+
+- [ ] Semantics reviewed.
+- [ ] Runtime non-goals understood.
+- [ ] Sample fixtures validated.
+- [ ] Drift detection passed.
+- [ ] CLI checker passed.
+- [ ] Demo snapshot generated and validated.
+- [ ] Mission Control display behavior reviewed.
+- [ ] Production disabled route behavior reviewed.
+- [ ] Confirmed production remains fail-closed.
+- [ ] Confirmed Observe Mode runtime is not enabled.
+
+## Current limitations
+
+- Observe Mode runtime is not implemented.
+- There is no live backend endpoint emitting `governance_observation`.
+- There is no user-uploaded JSON loader.
+- `/dev/mission-fixture` uses static fixture data.
+- Mission Control visibility is read-only.
+- The proof pack does not replace future runtime enforcement tests.


### PR DESCRIPTION
### Motivation
- Provide a single, reviewer-oriented evidence index that consolidates Observe Mode foundation artifacts spread across docs, fixtures, scripts, tests, and frontend routes.  
- Make explicit what is implemented vs. what is intentionally not implemented (runtime not enabled / production remains fail-closed / no bypass) so external reviewers can quickly assess safety boundaries.  

### Description
- Add `docs/governance/observe_mode_proof_pack.md` that contains Purpose, Status, an evidence matrix (Area / Evidence / What it proves / What it does not prove), Validation commands, Safety boundaries, Reviewer checklist, and Current limitations.  
- Add cross-links from `docs/governance/observe_mode.md`, `docs/governance/observe_mode_developer_walkthrough.md`, and `docs/governance/observe_mode_mission_control_walkthrough.md` to the new proof pack.  
- This is a documentation-only change and does not modify production code, tests, runtime behavior, policy engine behavior, backend routes, or add any Observe Mode runtime switch.  

### Testing
- Ran the proof-pack validation commands and test suites: `python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json`, `python scripts/check_governance_observation.py frontend/fixtures/governance_observation_live_snapshot.json`, and `bash scripts/validate_governance_observation_fixture.sh`.  
- Executed the frontend tests for the Mission Control adapter and page with `vitest`, and multiple Python `pytest` suites referenced by the validation script.  
- All invoked validation commands and tests completed successfully with passing results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d4212e508326b9cd4743949f6b9d)