### PR TITLE
docs: add repository-level Reviewer Entry Point

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ It is about making AI decisions **reviewable, traceable, replayable, auditable, 
 
 > **Mental model:** LLM = CPU, VERITAS OS = Decision / Agent Governance OS on top
 
+For external reviewers, start with `docs/REVIEWER_ENTRYPOINT.md`.
+
 ## Governance Review Workflow
 
 VERITAS OS does not only record governance artifacts. It connects them into a Mission Control → Audit review workflow:

--- a/README_JP.md
+++ b/README_JP.md
@@ -23,6 +23,8 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 
 > メンタルモデル: **LLM = CPU**、**VERITAS OS = その上に載る Decision Governance OS**
 
+外部レビュー担当者向けの入口は `docs/REVIEWER_ENTRYPOINT.md` を参照してください。
+
 ## Governance Review Workflow（ガバナンスレビュー導線）
 
 VERITAS OS は、ガバナンス証跡を記録するだけではありません。Mission Control から Audit へ、証跡を辿って確認できるレビュー導線を提供します。

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -1,0 +1,122 @@
+# VERITAS OS Reviewer Entry Point
+
+## Purpose
+
+This document is the fastest entry point for external reviewers, enterprise evaluators, investors, and technical reviewers who want to understand VERITAS OS without reading the entire repository first.
+
+It summarizes what to review, what is implemented, what is foundation-only, which proof packs exist, how to validate key claims, and what is intentionally not enabled.
+
+## 30-minute review path
+
+1. `README.md` — product overview and implemented scope boundary.
+2. `docs/REVIEWER_ENTRYPOINT.md` — this repository-level reviewer guide.
+3. `docs/governance/observe_mode_proof_pack.md` — Observe Mode evidence index.
+4. `docs/ui/README_UI.md` — Mission Control and governance UI context.
+5. `/dev/mission-fixture` — local/dev-only fixture viewer route for read-only inspection.
+6. `bash scripts/validate_governance_observation_fixture.sh` — focused validation command for fixture integrity and rendering contract checks.
+
+## What VERITAS OS is
+
+VERITAS OS is an auditable decision operating system for LLM agents. It focuses on making AI decisions reviewable, traceable, reproducible, and governable through structured evidence, policy checks, decision artifacts, Mission Control visibility, and validation workflows.
+
+It is a governance/control plane for decision and bind boundaries before real-world effect. It is not a claim that every effect path is fully production-complete today.
+
+## Current implemented evidence areas
+
+| Area | Where to look | What to verify |
+|---|---|---|
+| Decision / governance pipeline | `README.md`, `docs/INDEX.md` | Decision artifacts, governance pipeline concepts, evidence-oriented execution, fail-closed posture language. |
+| Mission Control | `docs/ui/README_UI.md`, `frontend/components/mission-page.tsx`, `frontend/app/dev/mission-fixture/page.tsx` | Read-only operator visibility, governance artifact rendering, dev-only fixture viewer behavior. |
+| Observe Mode foundation | `docs/governance/observe_mode_proof_pack.md`, `docs/governance/observe_mode.md` | Semantics, dry-run evaluator, CLI checker, dev-only snapshot generator, Mission Control read-only display, production fail-closed unchanged, runtime not enabled. |
+| Fixture and validation integrity | `scripts/validate_governance_observation_fixture.sh`, `veritas_os/tests/test_governance_observation_fixture_drift.py`, `frontend/app/dev/mission-fixture/page.test.tsx` | Root/frontend fixture parity, CLI checker validity, Mission Control rendering tests for the fixture path. |
+| Quality / validation commands | `README.md`, `scripts/check_governance_observation.py`, `scripts/generate_observe_mode_demo_snapshot.py` | Reproducible local checks, focused validation commands, proof-pack validation paths. |
+
+## Production-ready vs foundation-only
+
+### Implemented / reviewable
+
+- Mission Control read-only governance artifact rendering.
+- `governance_observation` schema/type foundation and documentation.
+- Observe Mode dry-run validation tooling (evaluator + CLI checker).
+- Dev-only fixture viewer with production disabled state.
+- Fixture drift detection and focused validation scripts.
+- Observe Mode demo snapshot generation for local/dev inspection.
+
+### Foundation-only / not runtime-enabled
+
+- Observe Mode runtime behavior.
+- Production observe execution.
+- Live backend emission of `governance_observation`.
+- User-uploaded JSON loader for Mission Control.
+- Automatic policy generation.
+- Governance palette marketplace.
+- Any production bypass path.
+
+## Recommended validation commands
+
+```bash
+bash scripts/validate_governance_observation_fixture.sh
+python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
+python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json
+python scripts/check_governance_observation.py /tmp/observe_snapshot.json
+pnpm --filter frontend test app/dev/mission-fixture/page.test.tsx
+```
+
+Optional broader checks (already used in repository docs):
+
+```bash
+bash scripts/demo_mission_audit_workflow.sh
+pnpm -r test
+```
+
+## Demo / inspection surfaces
+
+### `/dev/mission-fixture`
+
+- Local/dev/test oriented route.
+- Production environment renders a disabled state.
+- No backend API calls.
+- No runtime Observe Mode activation.
+- Static fixture only.
+- Useful for reviewing Mission Control rendering contract.
+
+### Observe Mode generated snapshot
+
+```bash
+python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json
+python scripts/check_governance_observation.py /tmp/observe_snapshot.json
+```
+
+This is a dev/test evidence path. It is not production runtime evidence.
+
+## Safety boundaries
+
+- Production remains fail-closed.
+- Observe Mode runtime is not enabled.
+- No production bypass exists.
+- No backend mutation endpoint is added by the Observe Mode foundation.
+- Mission Control observation display is read-only.
+- `/dev/mission-fixture` is disabled in production environment.
+- Proof packs document evidence; they do not replace future runtime safety validation.
+
+## Reviewer checklist
+
+- [ ] Read `README.md` overview.
+- [ ] Read `docs/governance/observe_mode_proof_pack.md`.
+- [ ] Run focused validation script.
+- [ ] Generate and check demo snapshot.
+- [ ] Review `/dev/mission-fixture` locally.
+- [ ] Confirm production disabled-state behavior.
+- [ ] Confirm runtime non-goals.
+- [ ] Confirm production fail-closed boundary.
+- [ ] Identify foundation-only areas.
+- [ ] Record unresolved questions.
+
+## Open questions / limitations
+
+- Some systems are foundation-only and not runtime-enabled.
+- External security review is still needed before production claims beyond current scope.
+- Production deployment posture should be evaluated separately per environment.
+- Observe Mode runtime is not implemented.
+- Live backend emission of `governance_observation` is not implemented.
+- Demo routes are not substitutes for production runtime tests.

--- a/docs/governance/observe_mode_proof_pack.md
+++ b/docs/governance/observe_mode_proof_pack.md
@@ -6,6 +6,8 @@ This proof pack summarizes the current Observe Mode foundation, the evidence art
 
 It is intended for external reviewers, enterprise evaluators, investors, and developers.
 
+For the repository-level reviewer guide, see `docs/REVIEWER_ENTRYPOINT.md`.
+
 ## Status
 
 - Observe Mode runtime is not enabled.

--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -1,5 +1,7 @@
 # UI Monorepo Quickstart
 
+Repository-level reviewer guide: `docs/REVIEWER_ENTRYPOINT.md`.
+
 ## frontend だけをローカル起動
 
 ```bash


### PR DESCRIPTION
### Motivation

- Provide a concise, repository-level onboarding guide so external reviewers, enterprise evaluators, investors, and technical reviewers can understand VERITAS OS in ~30 minutes. 
- Surface implemented evidence (especially Observe Mode foundation), demo/inspection paths, concrete validation commands, and explicit safety boundaries without expanding or changing runtime/test code. 

### Description

- Added `docs/REVIEWER_ENTRYPOINT.md` containing purpose, a 30-minute review path, implemented-evidence map, production-ready vs foundation-only split, recommended validation commands, demo/inspection surfaces, safety boundaries, reviewer checklist, and open limitations. 
- Added short one-line links to the new entry point from `README.md` and `README_JP.md`, and a repository-level reference in `docs/governance/observe_mode_proof_pack.md` and `docs/ui/README_UI.md`. 
- All changes are documentation-only; no production code, test code, runtime behavior, API, or UI logic was modified. 

### Testing

- Verified the documentation diff with `git diff -- docs/REVIEWER_ENTRYPOINT.md README.md README_JP.md docs/governance/observe_mode_proof_pack.md docs/ui/README_UI.md` to ensure only intended files changed. 
- Ran the focused fixture/validation script `bash scripts/validate_governance_observation_fixture.sh`, which executed the Python CLI checks, `pytest` fixture tests, and frontend unit tests, and completed with all automated checks passing and sample fixtures validated. 
- Ran frontend unit tests used by the validation flow (Vitest) for Mission Control adapter/page rendering and observed all referenced tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d9a2f8e88326b3467b5a13862087)