### PR TITLE
Add reviewer entrypoint validation smoke script and update docs

### DIFF
--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -55,6 +55,7 @@ It is a governance/control plane for decision and bind boundaries before real-wo
 ## Recommended validation commands
 
 ```bash
+bash scripts/validate_reviewer_entrypoint.sh
 bash scripts/validate_governance_observation_fixture.sh
 python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
 python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json
@@ -103,6 +104,7 @@ This is a dev/test evidence path. It is not production runtime evidence.
 
 - [ ] Read `README.md` overview.
 - [ ] Read `docs/governance/observe_mode_proof_pack.md`.
+- [ ] Run `bash scripts/validate_reviewer_entrypoint.sh` (lightweight link + evidence smoke validation).
 - [ ] Run focused validation script.
 - [ ] Generate and check demo snapshot.
 - [ ] Review `/dev/mission-fixture` locally.

--- a/docs/governance/observe_mode_proof_pack.md
+++ b/docs/governance/observe_mode_proof_pack.md
@@ -34,6 +34,12 @@ For the repository-level reviewer guide, see `docs/REVIEWER_ENTRYPOINT.md`.
 
 ## Validation commands
 
+Repository-level reviewer link/integrity smoke checks:
+
+```bash
+bash scripts/validate_reviewer_entrypoint.sh
+```
+
 ```bash
 python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
 python scripts/check_governance_observation.py frontend/fixtures/governance_observation_live_snapshot.json

--- a/scripts/validate_reviewer_entrypoint.sh
+++ b/scripts/validate_reviewer_entrypoint.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[reviewer-entrypoint] $*"
+}
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "Missing required file: $path" >&2
+    exit 1
+  fi
+}
+
+require_text() {
+  local file="$1"
+  local text="$2"
+  if ! grep -Fq "$text" "$file"; then
+    echo "Missing required text in $file: $text" >&2
+    exit 1
+  fi
+}
+
+log "Checking required files..."
+required_files=(
+  "docs/REVIEWER_ENTRYPOINT.md"
+  "README.md"
+  "README_JP.md"
+  "docs/governance/observe_mode_proof_pack.md"
+  "docs/governance/observe_mode.md"
+  "docs/governance/observe_mode_developer_walkthrough.md"
+  "docs/governance/observe_mode_mission_control_walkthrough.md"
+  "docs/ui/README_UI.md"
+  "scripts/validate_governance_observation_fixture.sh"
+  "scripts/check_governance_observation.py"
+  "scripts/generate_observe_mode_demo_snapshot.py"
+  "fixtures/governance_observation_live_snapshot.json"
+  "frontend/fixtures/governance_observation_live_snapshot.json"
+  "frontend/app/dev/mission-fixture/page.tsx"
+  "frontend/app/dev/mission-fixture/page.test.tsx"
+)
+
+for file_path in "${required_files[@]}"; do
+  require_file "$file_path"
+done
+
+log "Checking required links and safety text..."
+require_text "README.md" "docs/REVIEWER_ENTRYPOINT.md"
+require_text "README_JP.md" "docs/REVIEWER_ENTRYPOINT.md"
+require_text "docs/governance/observe_mode_proof_pack.md" "docs/REVIEWER_ENTRYPOINT.md"
+require_text "docs/ui/README_UI.md" "docs/REVIEWER_ENTRYPOINT.md"
+
+require_text "docs/REVIEWER_ENTRYPOINT.md" "docs/governance/observe_mode_proof_pack.md"
+require_text "docs/REVIEWER_ENTRYPOINT.md" "scripts/validate_governance_observation_fixture.sh"
+require_text "docs/REVIEWER_ENTRYPOINT.md" "/dev/mission-fixture"
+require_text "docs/REVIEWER_ENTRYPOINT.md" "Production remains fail-closed"
+require_text "docs/REVIEWER_ENTRYPOINT.md" "Observe Mode runtime is not enabled"
+
+log "Checking optional heavy command references (presence only)..."
+require_text "docs/REVIEWER_ENTRYPOINT.md" "bash scripts/validate_governance_observation_fixture.sh"
+require_text "docs/REVIEWER_ENTRYPOINT.md" "pnpm --filter frontend test app/dev/mission-fixture/page.test.tsx"
+
+log "Running lightweight smoke checks..."
+python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
+python scripts/check_governance_observation.py frontend/fixtures/governance_observation_live_snapshot.json
+python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/veritas_reviewer_entrypoint_observe_snapshot.json
+python scripts/check_governance_observation.py /tmp/veritas_reviewer_entrypoint_observe_snapshot.json
+pytest -q veritas_os/tests/test_governance_observation_fixture_drift.py
+
+log "Reviewer entry point validation completed successfully."


### PR DESCRIPTION
### Motivation
- Provide a lightweight, repository-level smoke check to detect drift in the external reviewer onboarding path without touching runtime or production behavior. 
- Ensure reviewer-facing links, referenced evidence files, and a set of safe validation commands remain discoverable and runnable over time. 
- Keep checks fast and offline-safe so maintainers and external reviewers can run them locally or as a small CI job. 

### Description
- Add `scripts/validate_reviewer_entrypoint.sh`, a `bash` script with `set -euo pipefail` that defines `require_file` and `require_text` helpers and verifies required files, links, and safety language, then runs lightweight smoke commands. 
- The script verifies existence of core reviewer docs/scripts/fixtures/UI files listed in the `required_files` array and checks that README/README_JP/proof-pack/UI docs reference the reviewer entrypoint and required safety text. 
- The script executes safe smoke commands only: `python scripts/check_governance_observation.py` (root and frontend fixtures and a generated demo snapshot), `python scripts/generate_observe_mode_demo_snapshot.py --out ...`, and `pytest -q veritas_os/tests/test_governance_observation_fixture_drift.py`. 
- Update `docs/REVIEWER_ENTRYPOINT.md` to recommend `bash scripts/validate_reviewer_entrypoint.sh` and add the script to the reviewer checklist, and add a repository-level smoke check mention to `docs/governance/observe_mode_proof_pack.md`. 

### Testing
- Run `bash scripts/validate_reviewer_entrypoint.sh` which completed successfully and returned a zero exit code. 
- The CLI checker runs completed with `governance_observation dry-run check: valid` for `fixtures/governance_observation_live_snapshot.json`, `frontend/fixtures/governance_observation_live_snapshot.json`, and the generated `/tmp/veritas_reviewer_entrypoint_observe_snapshot.json`. 
- The fixture-drift pytest executed via `pytest -q veritas_os/tests/test_governance_observation_fixture_drift.py` passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4de43743c8326a97fe90a3bbe6386)