### PR TITLE
Fix Bind receipt target metadata persistence for governance policy updates

### DIFF
--- a/veritas_os/policy/bind_core/core.py
+++ b/veritas_os/policy/bind_core/core.py
@@ -976,6 +976,7 @@ def _finalize_receipt(
     append_trustlog: bool,
     receipt: BindReceipt,
 ) -> BindReceipt:
+    receipt = _apply_bind_target_metadata_from_lineage(receipt, execution_intent=execution_intent)
     if not receipt.bind_reason_code or not receipt.bind_failure_reason:
         reason_code, failure_reason = _resolve_receipt_failure_fields(receipt)
         receipt = _with_receipt(
@@ -994,6 +995,39 @@ def _finalize_receipt(
         return receipt
     append_execution_intent_trustlog(execution_intent)
     return append_bind_receipt_trustlog(receipt)
+
+
+def _apply_bind_target_metadata_from_lineage(
+    receipt: BindReceipt,
+    *,
+    execution_intent: ExecutionIntent,
+) -> BindReceipt:
+    """Backfill target metadata from execution intent lineage when missing."""
+    policy_lineage = execution_intent.policy_lineage
+    if not isinstance(policy_lineage, dict):
+        return receipt
+    metadata = policy_lineage.get("bind_target_metadata")
+    if not isinstance(metadata, dict):
+        return receipt
+
+    updates: dict[str, Any] = {}
+    for field in (
+        "target_path",
+        "target_type",
+        "target_path_type",
+        "target_label",
+        "operator_surface",
+        "relevant_ui_href",
+    ):
+        current_value = getattr(receipt, field, "")
+        if isinstance(current_value, str) and current_value.strip():
+            continue
+        value = metadata.get(field)
+        if isinstance(value, str) and value.strip():
+            updates[field] = value.strip()
+    if not updates:
+        return receipt
+    return _with_receipt(receipt, **updates)
 
 
 def _deep_copy_mapping(value: dict[str, Any]) -> dict[str, Any]:

--- a/veritas_os/policy/bind_core/core.py
+++ b/veritas_os/policy/bind_core/core.py
@@ -1011,7 +1011,7 @@ def _apply_bind_target_metadata_from_lineage(
         return receipt
 
     updates: dict[str, Any] = {}
-    for field in (
+    for metadata_field in (
         "target_path",
         "target_type",
         "target_path_type",
@@ -1019,12 +1019,12 @@ def _apply_bind_target_metadata_from_lineage(
         "operator_surface",
         "relevant_ui_href",
     ):
-        current_value = getattr(receipt, field, "")
+        current_value = getattr(receipt, metadata_field, "")
         if isinstance(current_value, str) and current_value.strip():
             continue
-        value = metadata.get(field)
+        value = metadata.get(metadata_field)
         if isinstance(value, str) and value.strip():
-            updates[field] = value.strip()
+            updates[metadata_field] = value.strip()
     if not updates:
         return receipt
     return _with_receipt(receipt, **updates)

--- a/veritas_os/policy/governance_policy_update.py
+++ b/veritas_os/policy/governance_policy_update.py
@@ -91,6 +91,17 @@ def _with_bind_policy_lineage(
 ) -> dict[str, Any]:
     """Merge governance bind policy surface into execution intent lineage."""
     merged: dict[str, Any] = dict(lineage or {})
+    merged.setdefault(
+        "bind_target_metadata",
+        {
+            "target_path": "/v1/governance/policy",
+            "target_type": "governance_policy",
+            "target_path_type": "governance_policy_update",
+            "target_label": "governance policy update",
+            "operator_surface": "governance",
+            "relevant_ui_href": "/governance",
+        },
+    )
     if not isinstance(governance_policy, dict):
         return merged
     bind_policy = governance_policy.get("bind_adjudication")

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -215,9 +215,18 @@ class TestPutPolicy:
         assert body["bind_receipt_id"]
         assert body["execution_intent_id"]
         assert body["bind_receipt"]["final_outcome"] == "COMMITTED"
-        assert body["bind_receipt"]["target_path_type"] in {"governance_policy_update", "other"}
-        assert body["bind_receipt"]["target_label"]
-        assert body["target_metadata"]["target_path_type"] == body["bind_receipt"]["target_path_type"]
+        assert body["bind_receipt"]["target_path"] == "/v1/governance/policy"
+        assert body["bind_receipt"]["target_type"] == "governance_policy"
+        assert body["bind_receipt"]["target_path_type"] == "governance_policy_update"
+        assert body["bind_receipt"]["target_label"] == "governance policy update"
+        assert body["bind_receipt"]["operator_surface"] == "governance"
+        assert body["bind_receipt"]["relevant_ui_href"] == "/governance"
+        assert body["target_metadata"]["target_path"] == "/v1/governance/policy"
+        assert body["target_metadata"]["target_type"] == "governance_policy"
+        assert body["target_metadata"]["target_path_type"] == "governance_policy_update"
+        assert body["target_metadata"]["label"] == "governance policy update"
+        assert body["target_metadata"]["operator_surface"] == "governance"
+        assert body["target_metadata"]["relevant_ui_href"] == "/governance"
 
     def test_put_preserves_backward_compatible_response_shape(self, monkeypatch):
         monkeypatch.setattr(
@@ -675,6 +684,50 @@ def test_governance_bind_receipts_list_endpoint(monkeypatch) -> None:
     assert isinstance(body["target_catalog"], list)
     assert any(item["target_path_type"] == "governance_policy_update" for item in body["target_catalog"])
 
+
+def test_governance_policy_bind_receipt_target_metadata_persists_across_list_detail_and_filter() -> None:
+    put_resp = client.put(
+        "/v1/governance/policy",
+        headers=HEADERS,
+        json=_approved({"risk_thresholds": {"warn_upper": 0.58}}),
+    )
+    assert put_resp.status_code == 200
+    put_body = put_resp.json()
+    bind_receipt_id = put_body["bind_receipt_id"]
+    assert put_body["bind_receipt"]["target_path"] == "/v1/governance/policy"
+    assert put_body["bind_receipt"]["target_type"] == "governance_policy"
+    assert put_body["bind_receipt"]["target_path_type"] == "governance_policy_update"
+    assert put_body["bind_receipt"]["target_label"] == "governance policy update"
+    assert put_body["bind_receipt"]["operator_surface"] == "governance"
+    assert put_body["bind_receipt"]["relevant_ui_href"] == "/governance"
+
+    list_resp = client.get(
+        "/v1/governance/bind-receipts?target_path=/v1/governance/policy",
+        headers=HEADERS,
+    )
+    assert list_resp.status_code == 200
+    list_body = list_resp.json()
+    listed = [item for item in list_body["items"] if item["bind_receipt_id"] == bind_receipt_id]
+    assert listed
+    listed_receipt = listed[0]
+    assert listed_receipt["target_path"] == "/v1/governance/policy"
+    assert listed_receipt["target_type"] == "governance_policy"
+    assert listed_receipt["target_path_type"] == "governance_policy_update"
+    assert listed_receipt["target_label"] == "governance policy update"
+    assert listed_receipt["operator_surface"] == "governance"
+    assert listed_receipt["relevant_ui_href"] == "/governance"
+    assert any(item["target_path_type"] == "governance_policy_update" for item in list_body["target_catalog"])
+
+    detail_resp = client.get(f"/v1/governance/bind-receipts/{bind_receipt_id}", headers=HEADERS)
+    assert detail_resp.status_code == 200
+    detail_body = detail_resp.json()
+    detail_receipt = detail_body["bind_receipt"]
+    assert detail_receipt["target_path"] == "/v1/governance/policy"
+    assert detail_receipt["target_type"] == "governance_policy"
+    assert detail_receipt["target_path_type"] == "governance_policy_update"
+    assert detail_receipt["target_label"] == "governance policy update"
+    assert detail_receipt["operator_surface"] == "governance"
+    assert detail_receipt["relevant_ui_href"] == "/governance"
 
 def test_governance_bind_receipts_list_extended_filters(monkeypatch) -> None:
     class _Receipt:


### PR DESCRIPTION
### Motivation

- Bind receipts generated by `PUT /v1/governance/policy` were being persisted without the canonical target metadata, leaving `target_path`, `target_type`, and related fields empty and making audit traces unclear.

### Description

- Ensure governance policy update execution intents include canonical `bind_target_metadata` by adding a default `bind_target_metadata` map into `ExecutionIntent.policy_lineage` in `veritas_os/policy/governance_policy_update.py`.
- Backfill receipt target fields from execution intent lineage just before finalizing/persisting the bind receipt by adding `_apply_bind_target_metadata_from_lineage` and calling it at the start of `_finalize_receipt` in `veritas_os/policy/bind_core/core.py` so persisted receipts retain correct metadata regardless of outcome.
- Update and extend integration tests in `veritas_os/tests/integration/test_governance_api.py` to assert target metadata correctness in the PUT response, list (`GET /v1/governance/bind-receipts`), detail (`GET /v1/governance/bind-receipts/{id}`), and `target_path` filter scenarios.
- Changes are limited to metadata enrichment and tests; no RBAC, bind-check, rollback, TrustLog protocol, or response-schema breaking changes were made.

### Testing

- Ran targeted integration tests with `pytest -q veritas_os/tests/integration/test_governance_api.py -k "put_returns_bind_lineage_fields or policy_bind_receipt_target_metadata_persists"` and observed `2 passed`.
- Verified the modified tests assert the before/after expectations for `target_path`, `target_type`, `target_path_type`, `target_label`/`label`, `operator_surface`, and `relevant_ui_href` across PUT/list/detail/filter flows and that `target_catalog` still contains `governance_policy_update`.
- No new security-sensitive behavior was introduced; the change only backfills display/triage metadata from execution intent lineage and preserves existing authorization and bind validation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f0832c108326bd0c8afc6e41e9a5)