### PR TITLE
rollback時の Bind receipt top-level reason を rollback 原因に揃える

### DIFF
--- a/veritas_os/api/bind_summary.py
+++ b/veritas_os/api/bind_summary.py
@@ -21,6 +21,19 @@ def _resolve_rollback_failure_reason(bind_receipt: dict[str, Any]) -> str | None
     return normalized_reason
 
 
+def _extract_rollback_reason_code(bind_receipt: dict[str, Any]) -> str | None:
+    """Extract rollback reason code only when rollback_reason is code-shaped."""
+    rollback_reason = bind_receipt.get("rollback_reason")
+    if not isinstance(rollback_reason, str) or not rollback_reason.strip():
+        return None
+    rollback_prefix = rollback_reason.strip().split(":", 1)[0].strip()
+    if not rollback_prefix:
+        return None
+    if rollback_prefix.startswith("BIND_"):
+        return rollback_prefix
+    return None
+
+
 def resolve_bind_failure_reason(bind_receipt: dict[str, Any]) -> str | None:
     """Resolve compact operator-facing bind failure reason from receipt fields."""
     final_outcome = str(bind_receipt.get("final_outcome") or "").strip().upper()
@@ -52,9 +65,10 @@ def resolve_bind_failure_reason(bind_receipt: dict[str, Any]) -> str | None:
 def resolve_bind_reason_code(bind_receipt: dict[str, Any]) -> str | None:
     """Extract a stable bind reason code from the receipt payload."""
     final_outcome = str(bind_receipt.get("final_outcome") or "").strip().upper()
-    rollback_reason = bind_receipt.get("rollback_reason")
-    if final_outcome == "ROLLED_BACK" and isinstance(rollback_reason, str) and rollback_reason.strip():
-        return rollback_reason.strip().split(":", 1)[0]
+    if final_outcome == "ROLLED_BACK":
+        rollback_reason_code = _extract_rollback_reason_code(bind_receipt)
+        if rollback_reason_code:
+            return rollback_reason_code
     direct_reason_code = bind_receipt.get("bind_reason_code")
     if isinstance(direct_reason_code, str) and direct_reason_code.strip():
         return direct_reason_code.strip()

--- a/veritas_os/api/bind_summary.py
+++ b/veritas_os/api/bind_summary.py
@@ -6,8 +6,27 @@ from typing import Any
 from veritas_os.api.bind_target_catalog import resolve_bind_target_metadata
 
 
+def _resolve_rollback_failure_reason(bind_receipt: dict[str, Any]) -> str | None:
+    """Resolve rollback-specific failure messaging for operator-facing summaries."""
+    rollback_reason = bind_receipt.get("rollback_reason")
+    if not isinstance(rollback_reason, str) or not rollback_reason.strip():
+        return None
+    normalized_reason = rollback_reason.strip()
+    reason_code = normalized_reason.split(":", 1)[0]
+    if reason_code == "BIND_POSTCONDITION_FAILED":
+        return (
+            "Postcondition failed after attempted governance policy update; "
+            "mutation was rolled back. Authority check remained valid."
+        )
+    return normalized_reason
+
+
 def resolve_bind_failure_reason(bind_receipt: dict[str, Any]) -> str | None:
     """Resolve compact operator-facing bind failure reason from receipt fields."""
+    final_outcome = str(bind_receipt.get("final_outcome") or "").strip().upper()
+    rollback_failure_reason = _resolve_rollback_failure_reason(bind_receipt)
+    if final_outcome == "ROLLED_BACK" and rollback_failure_reason:
+        return rollback_failure_reason
     direct_reason = bind_receipt.get("bind_failure_reason")
     if isinstance(direct_reason, str) and direct_reason.strip():
         return direct_reason.strip()
@@ -32,6 +51,10 @@ def resolve_bind_failure_reason(bind_receipt: dict[str, Any]) -> str | None:
 
 def resolve_bind_reason_code(bind_receipt: dict[str, Any]) -> str | None:
     """Extract a stable bind reason code from the receipt payload."""
+    final_outcome = str(bind_receipt.get("final_outcome") or "").strip().upper()
+    rollback_reason = bind_receipt.get("rollback_reason")
+    if final_outcome == "ROLLED_BACK" and isinstance(rollback_reason, str) and rollback_reason.strip():
+        return rollback_reason.strip().split(":", 1)[0]
     direct_reason_code = bind_receipt.get("bind_reason_code")
     if isinstance(direct_reason_code, str) and direct_reason_code.strip():
         return direct_reason_code.strip()
@@ -57,13 +80,20 @@ def enrich_bind_receipt_payload(bind_receipt: dict[str, Any]) -> dict[str, Any]:
         bind_receipt.get("target_path"),
         bind_receipt.get("target_type"),
     )
-    return {
+    enriched = {
         **bind_receipt,
         "target_path_type": target_metadata["target_path_type"],
         "target_label": target_metadata["label"],
         "operator_surface": target_metadata["operator_surface"],
         "relevant_ui_href": target_metadata["relevant_ui_href"],
     }
+    resolved_reason_code = resolve_bind_reason_code(enriched)
+    if resolved_reason_code:
+        enriched["bind_reason_code"] = resolved_reason_code
+    resolved_failure_reason = resolve_bind_failure_reason(enriched)
+    if resolved_failure_reason:
+        enriched["bind_failure_reason"] = resolved_failure_reason
+    return enriched
 
 
 def build_bind_summary_from_receipt(bind_receipt: dict[str, Any]) -> dict[str, Any]:

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -1895,3 +1895,42 @@ class TestRouteValidationResponses:
         body = resp.json()
         assert body["ok"] is True
         assert isinstance(body["history"], list)
+
+
+def test_bind_receipt_list_and_detail_use_rollback_cause_for_top_level_reason(monkeypatch) -> None:
+    class _Receipt:
+        def to_dict(self) -> dict:
+            return {
+                "bind_receipt_id": "br-rb",
+                "execution_intent_id": "ei-rb",
+                "final_outcome": "ROLLED_BACK",
+                "rollback_reason": "BIND_POSTCONDITION_FAILED",
+                "failure_category": "POSTCONDITION",
+                "bind_reason_code": "BIND_AUTHORITY_VALID",
+                "bind_failure_reason": "Authority remains valid.",
+                "authority_check_result": {
+                    "status": "pass",
+                    "reason_code": "BIND_AUTHORITY_VALID",
+                    "message": "Authority remains valid.",
+                },
+                "occurred_at": "2026-04-22T11:00:00Z",
+            }
+
+    monkeypatch.setattr("veritas_os.api.routes_governance.find_bind_receipts", lambda **_kwargs: [_Receipt()])
+
+    list_resp = client.get("/v1/governance/bind-receipts", headers=HEADERS)
+    assert list_resp.status_code == 200
+    list_item = list_resp.json()["items"][0]
+    assert list_item["bind_reason_code"] == "BIND_POSTCONDITION_FAILED"
+    assert "postcondition failed" in list_item["bind_failure_reason"].lower()
+    assert "rolled back" in list_item["bind_failure_reason"].lower()
+    assert list_item["authority_check_result"]["reason_code"] == "BIND_AUTHORITY_VALID"
+
+    detail_resp = client.get("/v1/governance/bind-receipts/br-rb", headers=HEADERS)
+    assert detail_resp.status_code == 200
+    body = detail_resp.json()
+    assert body["bind_reason_code"] == "BIND_POSTCONDITION_FAILED"
+    assert "postcondition failed" in body["bind_failure_reason"].lower()
+    assert body["bind_receipt"]["bind_reason_code"] == "BIND_POSTCONDITION_FAILED"
+    assert body["bind_receipt"]["authority_check_result"]["reason_code"] == "BIND_AUTHORITY_VALID"
+

--- a/veritas_os/tests/test_bind_summary.py
+++ b/veritas_os/tests/test_bind_summary.py
@@ -50,3 +50,44 @@ def test_build_bind_response_payload_keeps_flat_fields_compatible() -> None:
     assert payload["bind_reason_code"] == summary["bind_reason_code"]
     assert payload["bind_receipt_id"] == summary["bind_receipt_id"]
     assert payload["execution_intent_id"] == summary["execution_intent_id"]
+
+
+def test_rolled_back_receipt_uses_rollback_reason_for_top_level_reason_fields() -> None:
+    """Rolled-back receipts must report rollback cause in top-level reason fields."""
+    receipt = {
+        "bind_receipt_id": "br-rollback",
+        "execution_intent_id": "ei-rollback",
+        "final_outcome": "ROLLED_BACK",
+        "rollback_reason": "BIND_POSTCONDITION_FAILED",
+        "failure_category": "POSTCONDITION",
+        "bind_reason_code": "BIND_AUTHORITY_VALID",
+        "bind_failure_reason": "Authority remains valid.",
+        "authority_check_result": {
+            "status": "pass",
+            "reason_code": "BIND_AUTHORITY_VALID",
+            "message": "Authority remains valid.",
+        },
+    }
+
+    payload = build_bind_response_payload(receipt)
+
+    assert payload["bind_reason_code"] == "BIND_POSTCONDITION_FAILED"
+    assert "Postcondition failed" in (payload["bind_failure_reason"] or "")
+    assert "rolled back" in (payload["bind_failure_reason"] or "").lower()
+    assert payload["authority_check_result"]["reason_code"] == "BIND_AUTHORITY_VALID"
+
+
+def test_non_rollback_receipt_keeps_original_top_level_reason_fields() -> None:
+    """Non-rollback receipts should continue using explicit top-level reason fields."""
+    receipt = {
+        "bind_receipt_id": "br-allowed",
+        "execution_intent_id": "ei-allowed",
+        "final_outcome": "COMMITTED",
+        "bind_reason_code": "BIND_AUTHORITY_VALID",
+        "bind_failure_reason": "Authority remains valid.",
+    }
+
+    payload = build_bind_response_payload(receipt)
+
+    assert payload["bind_reason_code"] == "BIND_AUTHORITY_VALID"
+    assert payload["bind_failure_reason"] == "Authority remains valid."


### PR DESCRIPTION
### Motivation
- Bind receipt が `final_outcome == ROLLED_BACK` の場合、top-level の `bind_reason_code` / `bind_failure_reason` が権限チェックの成功理由を誤って示してしまい監査者を誤導していたため、表示を実際の rollback 原因に合わせる必要があった。

### Description
- `veritas_os/api/bind_summary.py` にて、`ROLLED_BACK` の場合は `rollback_reason` を優先して `bind_reason_code` を解決するよう `resolve_bind_reason_code` を修正し、`BIND_POSTCONDITION_FAILED` 用の operator-facing メッセージを追加した。
- `enrich_bind_receipt_payload` で正規化済みの `bind_reason_code` と `bind_failure_reason` を上書きして、list/ detail 両 API 出力で一貫した表示にした。
- 関連するテストを追加・更新し、挙動が非rollbackケースに影響を与えないことを保持した（ファイル変更: `veritas_os/api/bind_summary.py`, `veritas_os/tests/test_bind_summary.py`, `veritas_os/tests/integration/test_governance_api.py`）。

### Testing
- 実行コマンド `pytest -q veritas_os/tests/test_bind_summary.py veritas_os/tests/integration/test_governance_api.py -k "rollback_cause_for_top_level_reason or bind_summary"` を実行し `6 passed, 122 deselected` で成功した。
- 追加されたユニットテストは `final_outcome == ROLLED_BACK` かつ `rollback_reason == BIND_POSTCONDITION_FAILED` の場合に top-level `bind_reason_code` が `BIND_POSTCONDITION_FAILED` になることと、`bind_failure_reason` に postcondition/rollback を説明する文言が含まれることを検証している。
- 統合テストは Bind receipt の list API と detail API の両方で同様の表示が出ることと、`authority_check_result.reason_code` が `BIND_AUTHORITY_VALID` のままであることを検証している。
- 表示ロジックの変更のみで認可・権限境界の挙動は変更しておらず、今回の修正自体に新たなセキュリティリスクは確認されていない。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f74317c88326af91334890be9dd7)