### PR TITLE
Reflect corrected Bind receipt metadata in Governance Live Snapshot

### DIFF
--- a/veritas_os/api/bind_summary.py
+++ b/veritas_os/api/bind_summary.py
@@ -16,7 +16,7 @@ def _resolve_rollback_failure_reason(bind_receipt: dict[str, Any]) -> str | None
     if reason_code == "BIND_POSTCONDITION_FAILED":
         return (
             "Postcondition failed after attempted governance policy update; "
-            "mutation was rolled back. Authority check remained valid."
+            "mutation was rolled back."
         )
     return normalized_reason
 
@@ -90,12 +90,22 @@ def resolve_bind_reason_code(bind_receipt: dict[str, Any]) -> str | None:
 
 def enrich_bind_receipt_payload(bind_receipt: dict[str, Any]) -> dict[str, Any]:
     """Attach canonical bind target metadata to any bind receipt payload."""
-    target_metadata = resolve_bind_target_metadata(
-        bind_receipt.get("target_path"),
-        bind_receipt.get("target_type"),
-    )
+    target_path = bind_receipt.get("target_path")
+    target_type = bind_receipt.get("target_type")
+    rollback_reason_code = _extract_rollback_reason_code(bind_receipt)
+    if (
+        rollback_reason_code == "BIND_POSTCONDITION_FAILED"
+        and (not isinstance(target_path, str) or not target_path.strip())
+        and (not isinstance(target_type, str) or not target_type.strip())
+    ):
+        target_path = "/v1/governance/policy"
+        target_type = "governance_policy"
+
+    target_metadata = resolve_bind_target_metadata(target_path, target_type)
     enriched = {
         **bind_receipt,
+        "target_path": target_metadata["target_path"],
+        "target_type": target_metadata["target_type"],
         "target_path_type": target_metadata["target_path_type"],
         "target_label": target_metadata["label"],
         "operator_surface": target_metadata["operator_surface"],

--- a/veritas_os/api/governance_live_snapshot.py
+++ b/veritas_os/api/governance_live_snapshot.py
@@ -232,7 +232,7 @@ def _resolve_pre_bind_from_trustlog_recent_decision(
                 if matched_key != key:
                     continue
                 if fields.get("pre_bind_source") != "latest_bind_receipt":
-                    return _default_pre_bind_fields(pre_bind_source="malformed_pre_bind_artifact")
+                    return _default_pre_bind_fields(pre_bind_source="bind_receipt_only")
                 resolved = dict(fields)
                 resolved["pre_bind_source"] = source_by_key[key]
                 return resolved

--- a/veritas_os/tests/test_governance_live_snapshot.py
+++ b/veritas_os/tests/test_governance_live_snapshot.py
@@ -128,6 +128,46 @@ def test_governance_live_snapshot_includes_bind_metadata(monkeypatch):
     assert snapshot["bind_summary"]["bind_outcome"] == "ESCALATED"
 
 
+def test_governance_live_snapshot_rolled_back_uses_corrected_bind_metadata(monkeypatch):
+    receipt = BindReceipt(
+        bind_receipt_id="br_rb",
+        execution_intent_id="ei_rb",
+        decision_id="dec_rb",
+        final_outcome=FinalOutcome.ROLLED_BACK,
+        bind_ts="2026-04-30T00:00:00Z",
+        bind_reason_code="BIND_AUTHORITY_VALID",
+        bind_failure_reason="Authority remains valid.",
+        rollback_reason="BIND_POSTCONDITION_FAILED: postcondition mismatch",
+        target_path="",
+        target_type="",
+        failure_category="POSTCONDITION",
+        rollback_status="rolled_back",
+        retry_safety="SAFE",
+    )
+    monkeypatch.setattr(
+        "veritas_os.api.governance_live_snapshot.find_bind_receipts",
+        lambda: [receipt],
+    )
+
+    snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
+
+    assert snapshot["bind_outcome"] == "ROLLED_BACK"
+    assert snapshot["bind_reason_code"] == "BIND_POSTCONDITION_FAILED"
+    assert snapshot["bind_failure_reason"] == (
+        "Postcondition failed after attempted governance policy update; "
+        "mutation was rolled back."
+    )
+    assert snapshot["target_path"] == "/v1/governance/policy"
+    assert snapshot["target_type"] == "governance_policy"
+    assert snapshot["target_path_type"] == "governance_policy_update"
+    assert snapshot["target_label"] == "governance policy update"
+    assert snapshot["operator_surface"] == "governance"
+    assert snapshot["relevant_ui_href"] == "/governance"
+    assert snapshot["failure_category"] == "POSTCONDITION"
+    assert snapshot["rollback_status"] == "rolled_back"
+    assert snapshot["retry_safety"] == "SAFE"
+
+
 def test_governance_live_snapshot_optional_metadata_defaults_to_none(monkeypatch):
     receipt = BindReceipt(
         final_outcome=FinalOutcome.BLOCKED,
@@ -615,5 +655,5 @@ def test_pre_bind_matching_malformed_artifact_returns_unknown(monkeypatch):
     )
 
     snapshot = client.get("/v1/governance/live-snapshot", headers=_AUTH).json()["governance_layer_snapshot"]
-    assert snapshot["pre_bind_source"] == "malformed_pre_bind_artifact"
+    assert snapshot["pre_bind_source"] == "bind_receipt_only"
     assert snapshot["participation_state"] == "unknown"


### PR DESCRIPTION
### Motivation
- Live Snapshot was returning outdated or generic bind fields (reason code/message, target metadata, operator surface, relevant UI link) for the latest rolled-back BindReceipt and classifying some pre-bind cases as `malformed_pre_bind_artifact`, causing UI confusion for auditors.
- The intent is to ensure the backend emits corrected, operator-facing metadata and a less aggressive pre-bind source classification so a reviewer immediately understands what mutation was attempted and why it rolled back.

### Description
- Adjusted rollback failure messaging for `BIND_POSTCONDITION_FAILED` to return the concise operator-facing sentence that explains the mutation was rolled back. (`veritas_os/api/bind_summary.py`)
- When a rolled-back receipt has `BIND_POSTCONDITION_FAILED` but missing `target_path`/`target_type`, canonical governance policy target metadata are filled in so `target_path`, `target_type`, `target_path_type`, `target_label`, `operator_surface`, and `relevant_ui_href` reflect the governance policy surface. (`veritas_os/api/bind_summary.py`)
- Changed pre-bind TrustLog correlation fallback so identity-matched TrustLog entries that lack valid pre-bind fields produce `bind_receipt_only` instead of `malformed_pre_bind_artifact`, reducing false malformed classifications. (`veritas_os/api/governance_live_snapshot.py`)
- Added a test verifying a rolled-back latest BindReceipt yields corrected bind reason code, failure reason, and canonical target metadata, and updated an existing test to expect `bind_receipt_only` for the weak pre-bind case. (`veritas_os/tests/test_governance_live_snapshot.py`)

### Testing
- Ran `pytest -q veritas_os/tests/test_governance_live_snapshot.py veritas_os/tests/test_bind_summary.py` and the test run succeeded with `36 passed`.
- Existing governance live snapshot tests and the bind summary unit tests were executed and all passed, validating enrichment, reason resolution, and pre-bind fallback behavior.
- No new external interfaces or permission changes were introduced; changes are limited to presentation/enrichment logic and unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ff20f0848326bac3dd2cd562a5ac)