### PR TITLE
Ensure bind-receipt filtering uses enriched metadata and preserve trustlog_hash across views

### DIFF
--- a/veritas_os/api/governance_live_snapshot.py
+++ b/veritas_os/api/governance_live_snapshot.py
@@ -287,6 +287,7 @@ def _build_enriched_snapshot_from_receipt_payload(payload: dict[str, Any]) -> di
         "bind_receipt_id": enriched_receipt.get("bind_receipt_id"),
         "execution_intent_id": enriched_receipt.get("execution_intent_id"),
         "decision_id": enriched_receipt.get("decision_id"),
+        "trustlog_hash": enriched_receipt.get("trustlog_hash"),
         "bind_reason_code": bind_reason_code,
         "bind_failure_reason": bind_summary.get("bind_failure_reason"),
         "failure_category": enriched_receipt.get("failure_category"),

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -155,7 +155,7 @@ def _apply_bind_receipt_filters(
 
     filtered: list[dict[str, Any]] = []
     for receipt in receipts:
-        payload = receipt.to_dict()
+        payload = enrich_bind_receipt_payload(receipt.to_dict())
 
         if canonical_target_path:
             payload_target_path = _canonical_path(payload.get("target_path"))

--- a/veritas_os/policy/bind_artifacts.py
+++ b/veritas_os/policy/bind_artifacts.py
@@ -270,6 +270,7 @@ def _extract_bind_receipt(entry: dict[str, Any]) -> BindReceipt | None:
     payload = entry.get("bind_receipt")
     if not isinstance(payload, dict):
         return None
+    trustlog_hash = str(payload.get("trustlog_hash") or entry.get("sha256") or "")
     try:
         return BindReceipt(
             bind_receipt_id=str(payload.get("bind_receipt_id") or ""),
@@ -286,7 +287,7 @@ def _extract_bind_receipt(entry: dict[str, Any]) -> BindReceipt | None:
             final_outcome=FinalOutcome(str(payload.get("final_outcome") or FinalOutcome.BLOCKED.value)),
             rollback_reason=payload.get("rollback_reason"),
             escalation_reason=payload.get("escalation_reason"),
-            trustlog_hash=str(payload.get("trustlog_hash") or ""),
+            trustlog_hash=trustlog_hash,
             prev_bind_hash=payload.get("prev_bind_hash"),
             bind_receipt_hash=str(payload.get("bind_receipt_hash") or ""),
             execution_intent_hash=str(payload.get("execution_intent_hash") or ""),

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -930,6 +930,78 @@ def test_governance_bind_receipts_cursor_pagination_and_export_parity(monkeypatc
     assert export_body["target_catalog"] == first_body["target_catalog"]
 
 
+def test_governance_bind_receipts_filters_use_enriched_target_metadata(monkeypatch) -> None:
+    class _Receipt:
+        def to_dict(self) -> dict:
+            return {
+                "bind_receipt_id": "br-legacy-governance",
+                "decision_id": "dec-legacy-governance",
+                "execution_intent_id": "ei-legacy-governance",
+                "target_path": "",
+                "target_type": "",
+                "final_outcome": "ROLLED_BACK",
+                "rollback_reason": "BIND_POSTCONDITION_FAILED",
+                "occurred_at": "2026-04-22T11:00:00Z",
+            }
+
+    monkeypatch.setattr("veritas_os.api.routes_governance.find_bind_receipts", lambda **_kwargs: [_Receipt()])
+
+    by_target_path = client.get(
+        "/v1/governance/bind-receipts?target_path=/v1/governance/policy",
+        headers=HEADERS,
+    )
+    assert by_target_path.status_code == 200
+    assert [item["bind_receipt_id"] for item in by_target_path.json()["items"]] == ["br-legacy-governance"]
+
+    by_target_type = client.get(
+        "/v1/governance/bind-receipts?target_type=governance_policy",
+        headers=HEADERS,
+    )
+    assert by_target_type.status_code == 200
+    assert [item["bind_receipt_id"] for item in by_target_type.json()["items"]] == ["br-legacy-governance"]
+
+    export_resp = client.get(
+        "/v1/governance/bind-receipts/export?target_path=/v1/governance/policy",
+        headers=HEADERS,
+    )
+    assert export_resp.status_code == 200
+    assert [item["bind_receipt_id"] for item in export_resp.json()["items"]] == ["br-legacy-governance"]
+
+
+def test_governance_bind_receipts_and_snapshot_preserve_trustlog_hash(monkeypatch) -> None:
+    class _Receipt:
+        def to_dict(self) -> dict:
+            return {
+                "bind_receipt_id": "br-hash-1",
+                "decision_id": "dec-hash-1",
+                "execution_intent_id": "ei-hash-1",
+                "target_path": "/v1/governance/policy",
+                "target_type": "governance_policy",
+                "final_outcome": "COMMITTED",
+                "trustlog_hash": "93afd07c1efa61b76f80bca15386911d21b98d733496a0bed867c8818846dd43",
+                "occurred_at": "2026-04-22T11:00:00Z",
+            }
+
+    monkeypatch.setattr("veritas_os.api.routes_governance.find_bind_receipts", lambda **_kwargs: [_Receipt()])
+    monkeypatch.setattr("veritas_os.api.governance_live_snapshot.find_bind_receipts", lambda: [_Receipt()])
+
+    list_resp = client.get("/v1/governance/bind-receipts", headers=HEADERS)
+    assert list_resp.status_code == 200
+    assert list_resp.json()["items"][0]["trustlog_hash"] == _Receipt().to_dict()["trustlog_hash"]
+
+    detail_resp = client.get("/v1/governance/bind-receipts/br-hash-1", headers=HEADERS)
+    assert detail_resp.status_code == 200
+    assert detail_resp.json()["bind_receipt"]["trustlog_hash"] == _Receipt().to_dict()["trustlog_hash"]
+
+    export_resp = client.get("/v1/governance/bind-receipts/export", headers=HEADERS)
+    assert export_resp.status_code == 200
+    assert export_resp.json()["items"][0]["trustlog_hash"] == _Receipt().to_dict()["trustlog_hash"]
+
+    snapshot_resp = client.get("/v1/governance/live-snapshot", headers=HEADERS)
+    assert snapshot_resp.status_code == 200
+    snapshot_payload = snapshot_resp.json()["governance_layer_snapshot"]
+    assert snapshot_payload["trustlog_hash"] == _Receipt().to_dict()["trustlog_hash"]
+
 
 def test_governance_bind_receipts_list_invalid_query_returns_400(monkeypatch) -> None:
     monkeypatch.setattr(
@@ -1933,4 +2005,3 @@ def test_bind_receipt_list_and_detail_use_rollback_cause_for_top_level_reason(mo
     assert "postcondition failed" in body["bind_failure_reason"].lower()
     assert body["bind_receipt"]["bind_reason_code"] == "BIND_POSTCONDITION_FAILED"
     assert body["bind_receipt"]["authority_check_result"]["reason_code"] == "BIND_AUTHORITY_VALID"
-

--- a/veritas_os/tests/test_bind_artifacts.py
+++ b/veritas_os/tests/test_bind_artifacts.py
@@ -250,6 +250,7 @@ def test_trustlog_append_and_lineage_linkage_for_bind_receipt(trustlog_env) -> N
     assert len(by_intent_id) == 1
     assert len(by_decision_id) == 1
     assert by_decision_id[0].execution_intent_id == "ei-100"
+    assert by_decision_id[0].trustlog_hash == stored_receipt.trustlog_hash
 
 
 def test_previous_bind_hash_chaining_uses_existing_trustlog(trustlog_env) -> None:


### PR DESCRIPTION
### Motivation
- Legacy or partially-populated BindReceipt payloads were being filtered against raw fields, causing receipts that could be enriched to canonical target metadata to be excluded from `/v1/governance/bind-receipts` and export queries. 
- `trustlog_hash` could be lost when deserializing persisted TrustLog entries into BindReceipt views, breaking linkage visibility across PUT response, list/detail/export and live snapshot surfaces.

### Description
- Apply `enrich_bind_receipt_payload()` before evaluating filters in `_apply_bind_receipt_filters()` so `target_path` / `target_type` queries use enriched metadata (file: `veritas_os/api/routes_governance.py`).
- Preserve TrustLog linkage by falling back to the TrustLog entry `sha256` when `bind_receipt.trustlog_hash` is missing during deserialization in `_extract_bind_receipt()` (file: `veritas_os/policy/bind_artifacts.py`).
- Surface the preserved `trustlog_hash` in the governance live snapshot payload so the live snapshot retains TrustLog linkage (file: `veritas_os/api/governance_live_snapshot.py`).
- Add integration tests validating enriched-target filtering parity across list/export and that `trustlog_hash` is retained in list/detail/export/live-snapshot, and assert `find_bind_receipts()` returns a stored receipt with the append-time `trustlog_hash` (files: `veritas_os/tests/integration/test_governance_api.py`, `veritas_os/tests/test_bind_artifacts.py`).
- Changes are minimal, do not fabricate hashes, and do not modify RBAC, approval, bind decision, or rollback semantics.

### Testing
- Ran the focused pytest selection for the new/modified tests with: `pytest -q veritas_os/tests/integration/test_governance_api.py::test_governance_bind_receipts_filters_use_enriched_target_metadata veritas_os/tests/integration/test_governance_api.py::test_governance_bind_receipts_and_snapshot_preserve_trustlog_hash veritas_os/tests/test_bind_artifacts.py::test_trustlog_append_and_lineage_linkage_for_bind_receipt` and all tests passed (`3 passed`).
- Also executed a broader run that exercised the integration file and the artifact test which reported the same green results for the modified assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f503d198f88326989bcff453907b41)