### PR TITLE
Add v1 lineage promotability pre-bind formation invariant

### DIFF
--- a/docs/en/architecture/pre-bind-formation-invariants.md
+++ b/docs/en/architecture/pre-bind-formation-invariants.md
@@ -1,0 +1,45 @@
+# Pre-bind formation invariants
+
+This document introduces the v1 additive **lineage promotability** contract.
+
+Detection tells us what state formed.
+Preservation tells us whether intervention remains possible.
+Lineage promotability defines whether the formed artifact can ever become bind-eligible.
+Bind governance only commits already-eligible artifacts.
+
+A bind-eligible artifact cannot emerge from a non-promotable lineage.
+
+## Positioning
+
+Non-promotability is **not** a third downstream check alongside detection and preservation.
+It is a formation-space invariant that applies across artifact lineage.
+
+- Detection/preservation remain observational and evidential surfaces.
+- Lineage promotability defines whether that formation history can ever be eligible for bind commitment.
+- Bind does not generate legitimacy; it commits artifacts that are already eligible in lineage terms.
+
+## v1 canonical hard rule
+
+In v1, only one canonical combination is hard-coded as non-promotable:
+
+- `participation_state=decision_shaping`
+- `preservation_state=collapsed`
+
+For that pair, lineage promotability returns:
+
+- `promotability_status=non_promotable`
+- `reason_code=NON_PROMOTABLE_LINEAGE`
+- `invariant_id=BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE`
+- `transformation_stable=true`
+
+All other combinations (including missing/unknown summaries) are backward-compatible as `promotable` in v1.
+
+## Transformation stability expectation
+
+The invariant should be preserved across persistence, aggregation, replay, export, summarization, reinterpretation, and repackaging surfaces.
+
+This PR does **not** fully prove every transformation-stability path. It introduces the minimal additive contract needed as a foundation for future enforcement and transition-refusal behavior.
+
+## Roadmap note
+
+A centralized execution-intent refusal guard for non-promotable lineage is intentionally deferred to a follow-up PR to keep this change small and reviewable.

--- a/docs/en/architecture/pre-bind-participation-signals.md
+++ b/docs/en/architecture/pre-bind-participation-signals.md
@@ -122,3 +122,11 @@ To keep future governance layers reviewable without changing public contracts,
 This split keeps `decision`, `execution_intent`, `bind_receipt`, and
 `bind_summary` contracts stable while making additional governance layers easier
 to add without route bloat.
+
+## Related formation invariant
+
+Pre-bind detection and preservation classify and explain upstream state.
+Lineage promotability defines whether that formation history can ever become bind-eligible.
+See: `docs/en/architecture/pre-bind-formation-invariants.md`.
+
+Note: current support is a v1 additive contract, not full production enforcement.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1697,6 +1697,10 @@ components:
           $ref: '#/components/schemas/PreBindPreservationDetail'
           nullable: true
           description: Optional additive expanded pre-bind preservation diagnostics.
+        lineage_promotability:
+          $ref: '#/components/schemas/LineagePromotabilitySummary'
+          nullable: true
+          description: Optional additive formation-space lineage promotability invariant summary.
     ParticipationSignal:
       type: object
       additionalProperties: true
@@ -1802,6 +1806,39 @@ components:
         main_contributing_conditions:
           type: array
           items: {type: string}
+    LineagePromotabilitySummary:
+      type: object
+      additionalProperties: true
+      properties:
+        promotability_family:
+          type: string
+          enum: [lineage_promotability]
+          default: lineage_promotability
+        promotability_version:
+          type: string
+          default: v1
+        promotability_status:
+          type: string
+          enum: [promotable, restricted, non_promotable]
+          default: promotable
+        reason_code:
+          type: string
+          nullable: true
+        invariant_id:
+          type: string
+          default: BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE
+        source_participation_state:
+          type: string
+          nullable: true
+        source_preservation_state:
+          type: string
+          nullable: true
+        transformation_stable:
+          type: boolean
+          default: true
+        concise_rationale:
+          type: string
+          nullable: true
     PreBindPreservationDetail:
       type: object
       additionalProperties: true

--- a/veritas_os/api/schemas.py
+++ b/veritas_os/api/schemas.py
@@ -649,6 +649,36 @@ class PreBindPreservationDetail(BaseModel):
     )
 
 
+class LineagePromotabilitySummary(BaseModel):
+    """Compact formation-space invariant summary for lineage promotability."""
+
+    model_config = ConfigDict(extra="allow")
+
+    promotability_family: Literal["lineage_promotability"] = "lineage_promotability"
+    promotability_version: str = Field(default="v1", max_length=MAX_TITLE_LENGTH)
+    promotability_status: Literal[
+        "promotable", "restricted", "non_promotable"
+    ] = "promotable"
+    reason_code: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    invariant_id: str = Field(
+        default="BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE",
+        max_length=MAX_TITLE_LENGTH,
+    )
+    source_participation_state: Optional[str] = Field(
+        default=None,
+        max_length=MAX_TITLE_LENGTH,
+    )
+    source_preservation_state: Optional[str] = Field(
+        default=None,
+        max_length=MAX_TITLE_LENGTH,
+    )
+    transformation_stable: bool = True
+    concise_rationale: Optional[str] = Field(
+        default=None,
+        max_length=MAX_DESCRIPTION_LENGTH,
+    )
+
+
 # =========================
 # Response envelope — Trust Log
 # =========================
@@ -1171,6 +1201,14 @@ class DecideResponse(BaseModel):
             "Optional additive pre-bind preservation detail. "
             "Contains intervention viability, openness floor status, and "
             "counterfactual recovery context for operator review."
+        ),
+    )
+    lineage_promotability: Optional[LineagePromotabilitySummary] = Field(
+        default=None,
+        description=(
+            "Optional additive formation-space invariant summary. "
+            "Defines whether the current pre-bind formation lineage can ever "
+            "become bind-eligible under the active invariant set."
         ),
     )
     wat_integrity: Optional[Dict[str, Any]] = Field(

--- a/veritas_os/core/lineage_promotability.py
+++ b/veritas_os/core/lineage_promotability.py
@@ -1,0 +1,81 @@
+"""Pre-bind formation-space lineage promotability invariant evaluator."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal, Mapping
+
+PromotabilityStatus = Literal["promotable", "restricted", "non_promotable"]
+
+LINEAGE_PROMOTABILITY_FAMILY = "lineage_promotability"
+LINEAGE_PROMOTABILITY_VERSION = "v1"
+NON_PROMOTABLE_INVARIANT_ID = (
+    "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE"
+)
+
+
+@dataclass(frozen=True)
+class LineagePromotability:
+    """Typed summary for lineage promotability invariant evaluation."""
+
+    promotability_family: str
+    promotability_version: str
+    promotability_status: PromotabilityStatus
+    reason_code: str | None
+    invariant_id: str
+    source_participation_state: str | None
+    source_preservation_state: str | None
+    transformation_stable: bool
+    concise_rationale: str
+
+
+def evaluate_lineage_promotability(
+    *,
+    pre_bind_detection_summary: Mapping[str, Any] | None,
+    pre_bind_preservation_summary: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Evaluate whether current pre-bind formation lineage can be bind-eligible."""
+    participation_state = None
+    preservation_state = None
+    if isinstance(pre_bind_detection_summary, Mapping):
+        participation_state = pre_bind_detection_summary.get("participation_state")
+    if isinstance(pre_bind_preservation_summary, Mapping):
+        preservation_state = pre_bind_preservation_summary.get("preservation_state")
+
+    if (
+        participation_state == "decision_shaping"
+        and preservation_state == "collapsed"
+    ):
+        return asdict(
+            LineagePromotability(
+                promotability_family=LINEAGE_PROMOTABILITY_FAMILY,
+                promotability_version=LINEAGE_PROMOTABILITY_VERSION,
+                promotability_status="non_promotable",
+                reason_code="NON_PROMOTABLE_LINEAGE",
+                invariant_id=NON_PROMOTABLE_INVARIANT_ID,
+                source_participation_state="decision_shaping",
+                source_preservation_state="collapsed",
+                transformation_stable=True,
+                concise_rationale=(
+                    "A bind-eligible artifact cannot be constructed from a "
+                    "non-promotable pre-bind formation lineage."
+                ),
+            )
+        )
+
+    return asdict(
+        LineagePromotability(
+            promotability_family=LINEAGE_PROMOTABILITY_FAMILY,
+            promotability_version=LINEAGE_PROMOTABILITY_VERSION,
+            promotability_status="promotable",
+            reason_code=None,
+            invariant_id=NON_PROMOTABLE_INVARIANT_ID,
+            source_participation_state=None,
+            source_preservation_state=None,
+            transformation_stable=True,
+            concise_rationale=(
+                "No non-promotable formation lineage was detected in the "
+                "current v1 invariant set."
+            ),
+        )
+    )

--- a/veritas_os/core/pipeline/governance_layers.py
+++ b/veritas_os/core/pipeline/governance_layers.py
@@ -15,6 +15,7 @@ from typing import Any, Dict
 from veritas_os.core.participation_detection import (
     evaluate_pre_bind_structural_detection,
 )
+from veritas_os.core.lineage_promotability import evaluate_lineage_promotability
 from veritas_os.core.preservation_evaluator import evaluate_pre_bind_preservation
 
 
@@ -25,6 +26,7 @@ class GovernanceEvaluationSnapshot:
     participation_signal: Dict[str, Any] | None
     pre_bind_detection: Dict[str, Any]
     pre_bind_preservation: Dict[str, Any]
+    lineage_promotability: Dict[str, Any]
 
 
 def evaluate_governance_layers(
@@ -38,6 +40,10 @@ def evaluate_governance_layers(
             participation_signal=None,
             pre_bind_detection={},
             pre_bind_preservation={},
+            lineage_promotability=evaluate_lineage_promotability(
+                pre_bind_detection_summary=None,
+                pre_bind_preservation_summary=None,
+            ),
         )
 
     detection = evaluate_pre_bind_structural_detection(normalized_signal)
@@ -49,6 +55,12 @@ def evaluate_governance_layers(
         participation_signal=normalized_signal,
         pre_bind_detection=detection,
         pre_bind_preservation=preservation,
+        lineage_promotability=evaluate_lineage_promotability(
+            pre_bind_detection_summary=detection.get("pre_bind_detection_summary"),
+            pre_bind_preservation_summary=preservation.get(
+                "pre_bind_preservation_summary"
+            ),
+        ),
     )
 
 
@@ -70,4 +82,5 @@ def assemble_governance_public_fields(
         "pre_bind_preservation_detail": snapshot.pre_bind_preservation.get(
             "pre_bind_preservation_detail"
         ),
+        "lineage_promotability": snapshot.lineage_promotability,
     }

--- a/veritas_os/tests/test_lineage_promotability.py
+++ b/veritas_os/tests/test_lineage_promotability.py
@@ -1,0 +1,37 @@
+"""Tests for lineage promotability invariant evaluation and assembly."""
+
+from __future__ import annotations
+
+from veritas_os.core.lineage_promotability import evaluate_lineage_promotability
+
+
+def test_lineage_promotability_non_promotable_canonical_case() -> None:
+    result = evaluate_lineage_promotability(
+        pre_bind_detection_summary={"participation_state": "decision_shaping"},
+        pre_bind_preservation_summary={"preservation_state": "collapsed"},
+    )
+    assert result["promotability_status"] == "non_promotable"
+    assert result["reason_code"] == "NON_PROMOTABLE_LINEAGE"
+    assert result["transformation_stable"] is True
+    assert (
+        result["invariant_id"]
+        == "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE"
+    )
+
+
+def test_lineage_promotability_informative_open_remains_promotable() -> None:
+    result = evaluate_lineage_promotability(
+        pre_bind_detection_summary={"participation_state": "informative"},
+        pre_bind_preservation_summary={"preservation_state": "open"},
+    )
+    assert result["promotability_status"] == "promotable"
+    assert result["reason_code"] is None
+
+
+def test_lineage_promotability_missing_summaries_remains_promotable() -> None:
+    result = evaluate_lineage_promotability(
+        pre_bind_detection_summary=None,
+        pre_bind_preservation_summary=None,
+    )
+    assert result["promotability_status"] == "promotable"
+    assert result["reason_code"] is None

--- a/veritas_os/tests/test_pre_bind_http_e2e.py
+++ b/veritas_os/tests/test_pre_bind_http_e2e.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from veritas_os.core.pipeline.governance_layers import assemble_governance_public_fields
+from veritas_os.core.lineage_promotability import evaluate_lineage_promotability
 
 _BIND_SENTINEL = {
     "bind_outcome": "ESCALATED",
@@ -63,6 +64,12 @@ def _build_payload(case_id: str, include_pre_bind: bool = True) -> dict[str, Any
                     "pre_bind_preservation_summary": golden["pre_bind_preservation_summary"],
                     "pre_bind_preservation_detail": golden["pre_bind_preservation_detail"],
                 },
+                lineage_promotability=evaluate_lineage_promotability(
+                    pre_bind_detection_summary=golden["pre_bind_detection_summary"],
+                    pre_bind_preservation_summary=golden[
+                        "pre_bind_preservation_summary"
+                    ],
+                ),
             )
         )
         payload.update(snapshot)
@@ -145,6 +152,8 @@ def test_decide_http_canonical_case_c_decision_shaping_collapsed(monkeypatch) ->
     assert "aggregate_index" in body["pre_bind_detection_detail"]
     assert body["pre_bind_preservation_detail"]["detection_context"]["participation_state"] == "decision_shaping"
     assert body["pre_bind_preservation_detail"]["detection_context"]["participation_state"] == "decision_shaping"
+    assert body["lineage_promotability"]["promotability_status"] == "non_promotable"
+    assert body["lineage_promotability"]["reason_code"] == "NON_PROMOTABLE_LINEAGE"
     _assert_bind_family_regression_guard(body)
 
 
@@ -162,3 +171,4 @@ def test_decide_http_pre_bind_optionality_absent_is_backward_compatible(monkeypa
     assert body["pre_bind_detection_detail"] is None
     assert body["pre_bind_preservation_summary"] is None
     assert body["pre_bind_preservation_detail"] is None
+    assert body["lineage_promotability"] is None

--- a/veritas_os/tests/unit/test_governance_layers.py
+++ b/veritas_os/tests/unit/test_governance_layers.py
@@ -14,6 +14,7 @@ def test_evaluate_governance_layers_returns_empty_snapshot_without_signal() -> N
     assert snapshot.participation_signal is None
     assert snapshot.pre_bind_detection == {}
     assert snapshot.pre_bind_preservation == {}
+    assert snapshot.lineage_promotability["promotability_status"] == "promotable"
 
 
 def test_assemble_governance_public_fields_preserves_contract_shape() -> None:
@@ -36,3 +37,4 @@ def test_assemble_governance_public_fields_preserves_contract_shape() -> None:
     )
     assert "pre_bind_detection_detail" in payload
     assert "pre_bind_preservation_detail" in payload
+    assert "lineage_promotability" in payload


### PR DESCRIPTION
### Motivation

- Introduce a minimal, additive formation-space invariant (`lineage_promotability`) that encodes the rule that "A bind-eligible artifact cannot emerge from a non-promotable lineage." 
- Provide a small, backward-compatible contract to surface whether a decision lineage can ever become bind-eligible, without treating this as a downstream detection/preservation check or changing bind-time behavior. 
- Keep the change reviewable and low-risk by making it additive (no required fields, no bind enforcement) and deferring execution-intent refusal to a later PR.

### Description

- Added `veritas_os/core/lineage_promotability.py` with `evaluate_lineage_promotability(...)` and a small typed `LineagePromotability` dataclass implementing v1 semantics where `participation_state == "decision_shaping"` and `preservation_state == "collapsed"` => `promotability_status = "non_promotable"` (with `reason_code` and `invariant_id`), and all other or missing summaries default to `promotable`.
- Wired the evaluator into `veritas_os/core/pipeline/governance_layers.py` so the `GovernanceEvaluationSnapshot` contains a `lineage_promotability` entry and `assemble_governance_public_fields(...)` emits an optional `lineage_promotability` field without re-running detection/preservation.
- Extended API models in `veritas_os/api/schemas.py` with `LineagePromotabilitySummary` and added optional `lineage_promotability` to `DecideResponse` to preserve schema/back-compat.
- Updated `openapi.yaml` to include the optional `lineage_promotability` response field and the `LineagePromotabilitySummary` component (enum for `promotability_status` set to `promotable|restricted|non_promotable`).
- Added focused tests `veritas_os/tests/test_lineage_promotability.py`, updated governance/HTTP tests to assert presence/absence and canonical behavior, and added documentation `docs/en/architecture/pre-bind-formation-invariants.md` with a short link added to `pre-bind-participation-signals.md`.

### Testing

- Ran the focused test set: `pytest -q veritas_os/tests/test_lineage_promotability.py veritas_os/tests/unit/test_governance_layers.py veritas_os/tests/test_pre_bind_http_e2e.py veritas_os/tests/test_openapi_pre_bind_contract.py` and all tests passed (`12 passed`).
- Unit tests verify the canonical non-promotable case (`decision_shaping + collapsed`) and that `informative + open` and missing summaries remain `promotable`.
- Assembly and HTTP-level tests validate that `lineage_promotability` is emitted as an optional additive field and that existing pre-bind and bind fields are unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52146a2e48326baff029f6b1c00d3)