### PR TITLE
frontend: forward auth role to backend via X-Role and make governance GET admin-only

### DIFF
--- a/frontend/app/api/veritas/[...path]/route-auth.test.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.test.ts
@@ -81,10 +81,10 @@ describe("parseAuthTokensConfig", () => {
 });
 
 describe("matchPolicy", () => {
-  it("matches GET governance/policy for viewer", () => {
+  it("matches GET governance/policy for admin only", () => {
     const result = matchPolicy(["v1", "governance", "policy"], "GET");
     expect(result).not.toBeNull();
-    expect(result!.policy.roles).toContain("viewer");
+    expect(result!.policy.roles).toEqual(["admin"]);
   });
 
   it("matches PUT governance/policy for admin only", () => {

--- a/frontend/app/api/veritas/[...path]/route-auth.ts
+++ b/frontend/app/api/veritas/[...path]/route-auth.ts
@@ -28,7 +28,7 @@ const ROUTE_POLICIES: readonly RoutePolicy[] = [
   {
     pathPattern: /^v1\/governance\/policy$/,
     method: "GET",
-    roles: ["viewer", "operator", "admin"],
+    roles: ["admin"],
   },
   { pathPattern: /^v1\/governance\/policy$/, method: "PUT", roles: ["admin"] },
   {

--- a/frontend/app/api/veritas/[...path]/route.test.ts
+++ b/frontend/app/api/veritas/[...path]/route.test.ts
@@ -132,12 +132,14 @@ describe("veritas bff route auth and authorization", () => {
   });
 
   it("applies route policies for admin-only and operator endpoints", () => {
+    const governanceGet = matchPolicy(["v1", "governance", "policy"], "GET");
     const governancePut = matchPolicy(["v1", "governance", "policy"], "PUT");
     const decidePost = matchPolicy(["v1", "decide"], "POST");
     const compliancePut = matchPolicy(["v1", "compliance", "config"], "PUT");
     const complianceGet = matchPolicy(["v1", "compliance", "config"], "GET");
 
     expect(governancePut?.policy.roles).toEqual(["admin"]);
+    expect(governanceGet?.policy.roles).toEqual(["admin"]);
     expect(decidePost?.policy.roles).toEqual(["operator", "admin"]);
     expect(compliancePut?.policy.roles).toEqual(["admin"]);
     expect(complianceGet?.policy.roles).toEqual(["viewer", "operator", "admin"]);
@@ -362,6 +364,7 @@ describe("veritas bff route proxy - full request lifecycle", () => {
     const upstreamHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
     expect(upstreamHeaders.get("x-trace-id")).toBe("my-trace-123");
     expect(upstreamHeaders.get("X-Request-Id")).toBe("my-trace-123");
+    expect(upstreamHeaders.get("X-Role")).toBe("admin");
   });
 
   it("forwards upstream content-type to client response", async () => {

--- a/frontend/app/api/veritas/[...path]/route.ts
+++ b/frontend/app/api/veritas/[...path]/route.ts
@@ -103,6 +103,7 @@ async function handleProxy(request: NextRequest, pathSegments: string[]): Promis
   const targetUrl = buildTargetUrl(apiBaseUrl, pathSegments, request.nextUrl.searchParams);
   const upstreamHeaders = new Headers();
   upstreamHeaders.set("X-API-Key", apiKey);
+  upstreamHeaders.set("X-Role", authResult.role);
   upstreamHeaders.set(TRACE_ID_HEADER_NAME, traceId);
   upstreamHeaders.set("X-Request-Id", traceId);
 


### PR DESCRIPTION
### Motivation
- Governance reads failed with HTTP 403 because the BFF proxy did not forward the authenticated role to the backend as `X-Role`. 
- The backend enforces RBAC based on `X-Role`, so the BFF must forward the resolved role without weakening backend RBAC.

### Description
- Forward the authenticated role to upstream by setting `X-Role` from the resolved `authResult.role` when constructing `upstreamHeaders` in `frontend/app/api/veritas/[...path]/route.ts`.
- Tighten the BFF route policy for the governance read endpoint by making `GET /v1/governance/policy` `admin` only in `frontend/app/api/veritas/[...path]/route-auth.ts` to match backend governance RBAC.
- Update tests to assert the new behavior and policy: add an assertion that proxied upstream headers include `X-Role` in `frontend/app/api/veritas/[...path]/route.test.ts`, and change the policy expectation in `frontend/app/api/veritas/[...path]/route-auth.test.ts` to expect admin-only for the governance GET route.
- Files changed: `frontend/app/api/veritas/[...path]/route.ts`, `frontend/app/api/veritas/[...path]/route-auth.ts`, `frontend/app/api/veritas/[...path]/route.test.ts`, `frontend/app/api/veritas/[...path]/route-auth.test.ts`.

### Testing
- Ran `pnpm --filter frontend test app/api/veritas/[...path]/route.test.ts` and it passed locally (31/31 tests).
- Ran `pnpm --filter frontend test app/api/veritas/[...path]/route-auth.test.ts` and it passed locally (34/34 tests).
- No backend or UI manual verification performed in this CI run; automated tests confirm `X-Role` is forwarded for admin-authenticated requests and the BFF policy now rejects non-admins for governance GETs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5599b6e9083268507950092742935)