### PR TITLE
Add official website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 VERITAS OS is a **Decision Governance and Bind-Boundary Control Plane** for AI agents.
 Instead of passing model output directly to execution, VERITAS routes each decision through a **reproducible, fail-closed, safety-gated, hash-chained governance pipeline** with an operator-facing governance surface in **Mission Control** and governance APIs.
 
+Official Website: https://veritas-website-navy.vercel.app/
+
 This project is not only about running agents.
 It is about making AI decisions **reviewable, traceable, replayable, auditable, and enforceable** inside real organizational workflows before they have real-world effect, with bind artifacts exposed as full bind receipts and compact bind summaries.
 
@@ -211,6 +213,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
 - **External Technical Proof Pack (review/pilot/DD/audit)**: [`docs/en/validation/technical-proof-pack.md`](docs/en/validation/technical-proof-pack.md)
 - **Third-Party Review Readiness (compact index)**: [`docs/en/validation/third-party-review-readiness.md`](docs/en/validation/third-party-review-readiness.md)
 - **AML/KYC Short Positioning (customer / operator / investor)**: [`docs/en/positioning/aml-kyc-beachhead-short-positioning.md`](docs/en/positioning/aml-kyc-beachhead-short-positioning.md)
+- **Official Website**: https://veritas-website-navy.vercel.app/
 - **GitHub**: https://github.com/veritasfuji-japan/veritas_os
 - **Zenodo paper (EN)**: https://doi.org/10.5281/zenodo.17838349
 - **Zenodo paper (JP)**: https://doi.org/10.5281/zenodo.17838456


### PR DESCRIPTION
### Motivation
- Make the newly published VERITAS OS public website discoverable from the core implementation repository by adding a direct link near the top of the README and into the Quick Links.

### Description
- Modified only `README.md` to insert the line `Official Website: https://veritas-website-navy.vercel.app/` after the opening description and added `- **Official Website**: https://veritas-website-navy.vercel.app/` to the **Quick Links**, with no changes to claims, metrics, source code, workflows, dependencies, or configuration; please verify the external URL points to the intended Vercel deployment.

### Testing
- Verified the edit with `git diff -- README.md`, committed the change with `git commit`, inspected the targeted lines with `nl`/`sed`, and created the PR metadata via `make_pr`; all verification commands completed successfully and no build was required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5be7ef588832680c5eecc911a32e1)