### PR TITLE
docs: align README_JP governance section with README

### DIFF
--- a/README_JP.md
+++ b/README_JP.md
@@ -744,6 +744,38 @@ VERITAS_MEMORY_BACKEND=postgresql VERITAS_TRUSTLOG_BACKEND=postgresql \
 | GET | `/v1/governance/bind-receipts/export` | list と同じフィルタ語彙で、運用/監査パイプライン向けに bind receipt をエクスポート |
 | GET | `/v1/governance/bind-receipts/{bind_receipt_id}` | 単一bind receipt成果物を取得 |
 
+#### Bind artifact family（運用者向けの意味）
+
+- `BindReceipt` は、reviewable/auditable な系譜確認と replay 調査に使う完全な bind 成果物です。
+- `bind_summary` は、bind-governed mutation/export レスポンス間で再利用されるコンパクトな共通語彙です。
+- この分離により、Mission Control + APIs での運用面において、decision approval と bind commitment の境界を明確に保ちます。
+
+#### 運用ワークフロー: policy bundle の昇格
+
+既存の bind-boundary パスで active policy bundle pointer を昇格する場合は、`POST /v1/governance/policy-bundles/promote` を使用します。
+
+- リクエストでは `bundle_id` **または** `bundle_dir_name` の **どちらか1つのみ** を指定できます。
+- 任意のファイルシステムパスは拒否されます（selector で `/`、`\`、`.`、`..` は受け付けません）。
+- レスポンスには bind 系譜フィールド（`bind_outcome` / `bind_receipt_id` / `execution_intent_id`）、加算的 `bind_summary`、完全な `bind_receipt` が含まれます。
+- 結果成果物の確認・エクスポートには、`GET /v1/governance/bind-receipts`、`GET /v1/governance/bind-receipts/export`、`GET /v1/governance/bind-receipts/{bind_receipt_id}` を利用します。
+
+```bash
+curl -X POST "http://127.0.0.1:8000/v1/governance/policy-bundles/promote" \
+  -H "X-API-Key: ${VERITAS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "bundle_id": "bundle-v2",
+    "decision_id": "dec-promote-1",
+    "request_id": "req-promote-1",
+    "policy_snapshot_id": "snap-promote-1",
+    "decision_hash": "hash-promote-1"
+  }'
+```
+
+運用ガイドと結果解釈は
+[`docs/en/guides/governance-policy-bundle-promotion.md`](docs/ja/guides/governance-policy-bundle-promotion.md)
+を参照してください。
+
 > **署名付きガバナンス成果物** — secure/prodポスチャでは、ポリシーバンドルにEd25519署名が必須です。
 > 意思決定成果物には、適用中のガバナンスポリシー（バージョン、ダイジェスト、署名検証結果、署名者ID）を
 > 示す `governance_identity` フィールドが含まれます。

--- a/README_JP.md
+++ b/README_JP.md
@@ -21,6 +21,8 @@
 VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agents**（AIエージェント向け意思決定ガバナンス / bind-boundary 制御プレーン）です。
 エージェント実行の前段に **governance layer before execution** を置き、現実世界に影響する前に意思決定を制御します。これは、AIエージェントの意思決定と実行境界を統治するコントロールプレーンという現在のプロダクトポジショニングを示します。
 
+公式Webサイト: https://veritas-website-navy.vercel.app/
+
 > メンタルモデル: **LLM = CPU**、**VERITAS OS = その上に載る Decision Governance OS**
 
 外部レビュー担当者向けの入口は `docs/REVIEWER_ENTRYPOINT.md` を参照してください。
@@ -188,6 +190,7 @@ Authority Evidence と Audit Log の違いは明確です。
 - **External Technical Proof Pack（review/pilot/DD/audit）**: [`docs/ja/validation/technical-proof-pack.md`](docs/ja/validation/technical-proof-pack.md)（英語正本あり）
 - **AML/KYC Short Positioning（customer / operator / investor）**: [`docs/ja/positioning/aml-kyc-beachhead-short-positioning.md`](docs/ja/positioning/aml-kyc-beachhead-short-positioning.md)（英語正本あり）
 - **GitHub**: https://github.com/veritasfuji-japan/veritas_os
+- **公式Webサイト**: https://veritas-website-navy.vercel.app/
 - **Zenodo論文（英語）**: https://doi.org/10.5281/zenodo.17838349
 - **Zenodo論文（日本語）**: https://doi.org/10.5281/zenodo.17838456
 - **英語README**: [`README.md`](README.md)


### PR DESCRIPTION
### Motivation
- Ensure the Japanese README matches the English README for governance documentation and operator guidance.
- Clarify operator-facing semantics for bind artifacts and the policy bundle promotion workflow to avoid misinterpretation during operations.
- Keep documentation parity so Mission Control / Audit workflows and API contract details are consistent across locales.

### Description
- Added a `Bind artifact family（運用者向けの意味）` section to `README_JP.md` describing the roles of `BindReceipt` and `bind_summary` and the separation between decision approval and bind commitment.
- Added an `運用ワークフロー: policy bundle の昇格` section documenting use of `POST /v1/governance/policy-bundles/promote`, the selector constraint that `bundle_id` **or** `bundle_dir_name` must be provided (exclusive), filesystem selector rejection rules (`/`, `\`, `.`, `..`), and the expected bind-lineage response fields (`bind_outcome`, `bind_receipt_id`, `execution_intent_id`).
- Included a sample `curl` request and linked to the Japanese policy bundle promotion guide for operator reference. 
- This change is documentation-only and does not modify runtime code paths or cross component responsibilities.

### Testing
- Committed the updated file with `git commit -m "docs: align README_JP governance section with README"`, which completed successfully. 
- Verified the localized additions with `diff -u README.md README_JP.md | head -n 200` and inspected the inserted lines with `nl -ba README_JP.md | sed -n '730,830p'`, both of which showed the expected content. 
- No automated unit or integration tests were required because this is a docs-only change and no runtime behavior was altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c2566ddc8326b884059de36b3cec)