### PR TITLE
Add FormationTransitionRefusalCard to DecisionResultPanel

### DIFF
--- a/frontend/features/console/components/decision-result-panel.test.tsx
+++ b/frontend/features/console/components/decision-result-panel.test.tsx
@@ -195,4 +195,93 @@ describe("DecisionResultPanel", () => {
     expect(screen.getAllByText(/gate_decision/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/business_decision/i).length).toBeGreaterThan(0);
   });
+
+  it("renders formation transition refusal card", () => {
+    const refusedResult = {
+      ...baseResult,
+      transition_refusal: {
+        transition_status: "structurally_refused",
+        reason_code: "NON_PROMOTABLE_LINEAGE",
+        invariant_id: "BIND_ELIGIBLE_ARTIFACT_CANNOT_EMERGE_FROM_NON_PROMOTABLE_LINEAGE",
+        source_promotability_status: "non_promotable",
+        execution_intent_created: false,
+        bind_receipt_created: false,
+        concise_rationale: "ExecutionIntent cannot be constructed from a non-promotable pre-bind formation lineage.",
+      },
+      actionability_status: "formation_transition_refused",
+      actionability_block_reason: "FORMATION_TRANSITION_REFUSED",
+      actionability_refusal_type: "pre_bind_formation_transition_refusal",
+      recovery_action: "RECONSTRUCT_FROM_ELIGIBLE_FORMATION_LINEAGE",
+      recovery_reason: "The refused artifact is not bind-retryable; reconstruct the decision from an eligible formation lineage.",
+      execution_intent_id: null,
+      bound_execution_intent_id: null,
+      bind_receipt_id: null,
+      bind_receipt: null,
+      human_review_required: true,
+    };
+    render(<I18nProvider><DecisionResultPanel result={refusedResult as never} /></I18nProvider>);
+    expect(screen.getByText("Formation Transition Refused")).toBeInTheDocument();
+    expect(screen.getByText("NON_PROMOTABLE_LINEAGE")).toBeInTheDocument();
+    expect(screen.getByText("FORMATION_TRANSITION_REFUSED")).toBeInTheDocument();
+    expect(screen.getByText("pre_bind_formation_transition_refusal")).toBeInTheDocument();
+    expect(screen.getByText("RECONSTRUCT_FROM_ELIGIBLE_FORMATION_LINEAGE")).toBeInTheDocument();
+    expect(screen.getAllByText("not created").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("no")).toBeInTheDocument();
+  });
+
+  it("renders card when actionability_status alone indicates refusal", () => {
+    const refusedResult = {
+      ...baseResult,
+      transition_refusal: null,
+      actionability_status: "formation_transition_refused",
+      execution_intent_id: null,
+      bind_receipt_id: null,
+      human_review_required: true,
+    };
+    render(<I18nProvider><DecisionResultPanel result={refusedResult as never} /></I18nProvider>);
+    expect(screen.getByText("Formation Transition Refused")).toBeInTheDocument();
+    expect(screen.getByText("NON_PROMOTABLE_LINEAGE")).toBeInTheDocument();
+    expect(screen.getByText("RECONSTRUCT_FROM_ELIGIBLE_FORMATION_LINEAGE")).toBeInTheDocument();
+  });
+
+  it("does not render card when transition is allowed", () => {
+    const allowedResult = {
+      ...baseResult,
+      transition_refusal: null,
+      actionability_status: "reviewable_only",
+    };
+    render(<I18nProvider><DecisionResultPanel result={allowedResult as never} /></I18nProvider>);
+    expect(screen.queryByText("Formation Transition Refused")).not.toBeInTheDocument();
+  });
+
+  it("does not present bind retry wording in formation refusal card", () => {
+    const refusedResult = {
+      ...baseResult,
+      actionability_status: "formation_transition_refused",
+      transition_refusal: { transition_status: "structurally_refused" },
+    };
+    render(<I18nProvider><DecisionResultPanel result={refusedResult as never} /></I18nProvider>);
+    const refusalCard = screen.getByText("Formation Transition Refused").closest("article");
+    expect(refusalCard).toBeInTheDocument();
+    expect(refusalCard).not.toHaveTextContent("Retry bind");
+    expect(refusalCard).not.toHaveTextContent("Re-run bind");
+    expect(refusalCard).not.toHaveTextContent("Bind failed");
+    expect(refusalCard).not.toHaveTextContent("Bind blocked");
+  });
+
+  it("renders with partial transition_refusal payload without crashing", () => {
+    const partialResult = {
+      ...baseResult,
+      transition_refusal: {
+        transition_status: "structurally_refused",
+      },
+      actionability_status: "formation_transition_refused",
+      execution_intent_id: null,
+      bind_receipt_id: null,
+    };
+    render(<I18nProvider><DecisionResultPanel result={partialResult as never} /></I18nProvider>);
+    expect(screen.getByText("Formation Transition Refused")).toBeInTheDocument();
+    expect(screen.getByText("NON_PROMOTABLE_LINEAGE")).toBeInTheDocument();
+    expect(screen.getByText("RECONSTRUCT_FROM_ELIGIBLE_FORMATION_LINEAGE")).toBeInTheDocument();
+  });
 });

--- a/frontend/features/console/components/decision-result-panel.tsx
+++ b/frontend/features/console/components/decision-result-panel.tsx
@@ -64,13 +64,24 @@ function FormationTransitionRefusalCard({ result }: FormationTransitionRefusalCa
     return null;
   }
 
-  const status = result.actionability_status ?? "formation_transition_refused";
-  const reason = transitionRefusal?.reason_code ?? "NON_PROMOTABLE_LINEAGE";
-  const blockReason = result.actionability_block_reason ?? "FORMATION_TRANSITION_REFUSED";
-  const refusalType = result.actionability_refusal_type ?? "pre_bind_formation_transition_refusal";
-  const recoveryAction = result.recovery_action ?? "RECONSTRUCT_FROM_ELIGIBLE_FORMATION_LINEAGE";
-  const recoveryReason = result.recovery_reason
-    ?? "This artifact was refused before bind. It is not bind-retryable. Reconstruct the decision from an eligible formation lineage.";
+  const status = typeof result.actionability_status === "string"
+    ? result.actionability_status
+    : "formation_transition_refused";
+  const reason = typeof transitionRefusal?.reason_code === "string"
+    ? transitionRefusal.reason_code
+    : "NON_PROMOTABLE_LINEAGE";
+  const blockReason = typeof result.actionability_block_reason === "string"
+    ? result.actionability_block_reason
+    : "FORMATION_TRANSITION_REFUSED";
+  const refusalType = typeof result.actionability_refusal_type === "string"
+    ? result.actionability_refusal_type
+    : "pre_bind_formation_transition_refusal";
+  const recoveryAction = typeof result.recovery_action === "string"
+    ? result.recovery_action
+    : "RECONSTRUCT_FROM_ELIGIBLE_FORMATION_LINEAGE";
+  const recoveryReason = typeof result.recovery_reason === "string"
+    ? result.recovery_reason
+    : "This artifact was refused before bind. It is not bind-retryable. Reconstruct the decision from an eligible formation lineage.";
   const executionIntentStatus = result.execution_intent_id == null ? "not created" : result.execution_intent_id;
   const bindReceiptStatus = result.bind_receipt_id == null ? "not created" : result.bind_receipt_id;
   const humanReview = result.human_review_required === true ? "yes" : "unknown";

--- a/frontend/features/console/components/decision-result-panel.tsx
+++ b/frontend/features/console/components/decision-result-panel.tsx
@@ -51,6 +51,52 @@ function downloadEvidenceBundle(bundle: EvidenceBundleDraft): void {
   window.URL.revokeObjectURL(url);
 }
 
+type FormationTransitionRefusalCardProps = {
+  result: DecideResponse;
+};
+
+function FormationTransitionRefusalCard({ result }: FormationTransitionRefusalCardProps): JSX.Element | null {
+  const transitionRefusal = result.transition_refusal ?? null;
+  const isFormationRefused = transitionRefusal?.transition_status === "structurally_refused"
+    || result.actionability_status === "formation_transition_refused";
+
+  if (!isFormationRefused) {
+    return null;
+  }
+
+  const status = result.actionability_status ?? "formation_transition_refused";
+  const reason = transitionRefusal?.reason_code ?? "NON_PROMOTABLE_LINEAGE";
+  const blockReason = result.actionability_block_reason ?? "FORMATION_TRANSITION_REFUSED";
+  const refusalType = result.actionability_refusal_type ?? "pre_bind_formation_transition_refusal";
+  const recoveryAction = result.recovery_action ?? "RECONSTRUCT_FROM_ELIGIBLE_FORMATION_LINEAGE";
+  const recoveryReason = result.recovery_reason
+    ?? "This artifact was refused before bind. It is not bind-retryable. Reconstruct the decision from an eligible formation lineage.";
+  const executionIntentStatus = result.execution_intent_id == null ? "not created" : result.execution_intent_id;
+  const bindReceiptStatus = result.bind_receipt_id == null ? "not created" : result.bind_receipt_id;
+  const humanReview = result.human_review_required === true ? "yes" : "unknown";
+
+  return (
+    <article className="space-y-2 rounded-md border border-orange-400/40 bg-orange-500/5 p-3">
+      <h4 className="font-semibold text-foreground">Formation Transition Refused</h4>
+      <p className="text-muted-foreground">
+        This artifact was refused before bind. It is not bind-retryable. Reconstruct the decision from an eligible formation lineage.
+      </p>
+      <div className="grid gap-1 md:grid-cols-2">
+        <p><span className="text-muted-foreground">Status:</span> <span className="font-mono text-[11px]">{status}</span></p>
+        <p><span className="text-muted-foreground">Reason:</span> <span className="font-mono text-[11px]">{reason}</span></p>
+        <p><span className="text-muted-foreground">Block reason:</span> <span className="font-mono text-[11px]">{blockReason}</span></p>
+        <p><span className="text-muted-foreground">Refusal type:</span> <span className="font-mono text-[11px]">{refusalType}</span></p>
+        <p><span className="text-muted-foreground">Recovery action:</span> <span className="font-mono text-[11px]">{recoveryAction}</span></p>
+        <p><span className="text-muted-foreground">ExecutionIntent:</span> <span className="font-mono text-[11px]">{executionIntentStatus}</span></p>
+        <p><span className="text-muted-foreground">BindReceipt:</span> <span className="font-mono text-[11px]">{bindReceiptStatus}</span></p>
+        <p><span className="text-muted-foreground">Bind retryable:</span> no</p>
+        <p><span className="text-muted-foreground">Human review required:</span> {humanReview}</p>
+      </div>
+      <p><span className="text-muted-foreground">Pre-bind formation refusal:</span> {recoveryReason}</p>
+    </article>
+  );
+}
+
 /**
  * Structured decision result panel for operator review.
  *
@@ -167,6 +213,8 @@ export function DecisionResultPanel({
               <p className="text-muted-foreground">{tk("decisionPanelNextActionHint")}</p>
             </article>
           </div>
+
+          <FormationTransitionRefusalCard result={result} />
 
           <article className="space-y-2 rounded-md border border-border/70 bg-background/70 p-3">
             <h4 className="font-semibold text-foreground">{tk("decisionPanelBindPhaseTitle")}</h4>

--- a/packages/types/src/decision.ts
+++ b/packages/types/src/decision.ts
@@ -681,6 +681,29 @@ export interface DecideResponse extends DecideResponseMeta {
   drift_check_result?: Record<string, unknown> | null;
   /** Runtime risk check summary from bind-phase adjudication. */
   risk_check_result?: Record<string, unknown> | null;
+  /**
+   * Pre-bind formation transition refusal payload.
+   *
+   * Additive optional object used by operator-facing surfaces to distinguish
+   * transition refusal from bind-phase failures.
+   */
+  transition_refusal?: {
+    transition_status?: "allowed" | "structurally_refused";
+    reason_code?: string | null;
+    invariant_id?: string | null;
+    source_promotability_status?: "promotable" | "restricted" | "non_promotable" | null;
+    execution_intent_created?: boolean;
+    bind_receipt_created?: boolean;
+    concise_rationale?: string | null;
+  } | null;
+  /** Machine-readable actionability block reason for pre-bind refusal states. */
+  actionability_block_reason?: string | null;
+  /** Actionability refusal type marker for pre-bind refusal states. */
+  actionability_refusal_type?: string | null;
+  /** Canonical recovery action for operator remediation guidance. */
+  recovery_action?: string | null;
+  /** Human-readable recovery guidance for operator remediation. */
+  recovery_reason?: string | null;
   /** Art. 13 — notification record for individuals affected by high-risk decisions. */
   affected_parties_notice?: Record<string, unknown> | null;
 


### PR DESCRIPTION
### Motivation

- Distinguish pre-bind formation transition refusals from bind-phase failures on the Console/Mission Control decision surface so operators are not misled that this is a bind retryable failure. 
- Provide an operator-facing, resilient card that explains the refusal semantics and canonical recovery action when a decision is refused before bind. 

### Description

- Added `FormationTransitionRefusalCard` to `frontend/features/console/components/decision-result-panel.tsx`, rendered when `transition_refusal?.transition_status === "structurally_refused"` or `result.actionability_status === "formation_transition_refused"`. 
- The card displays required fields and human-friendly fallbacks including `Status`, `Reason`, `Block reason`, `Refusal type`, `Recovery action`, `ExecutionIntent: not created`, `BindReceipt: not created`, `Bind retryable: no`, and `Human review required: yes|unknown`. 
- Placed the card immediately before the Bind Phase section so it is clearly presented as a pre-bind refusal and does not mix with bind-failure UI. 
- Added additive optional types to `DecideResponse` in `packages/types/src/decision.ts` for `transition_refusal`, `actionability_block_reason`, `actionability_refusal_type`, `recovery_action`, and `recovery_reason` to support the UI without making fields required. 

### Testing

- Added tests to `frontend/features/console/components/decision-result-panel.test.tsx` covering full-card rendering, fallback-only rendering (via `actionability_status`), non-rendering when allowed, absence of bind-retry wording, and resilience to partial `transition_refusal` payloads. 
- Ran the targeted test file with `pnpm --filter frontend exec vitest run features/console/components/decision-result-panel.test.tsx` and the file passed (22 tests, 0 failed). 
- No backend changes were made and existing successful/promotable UI flows remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fb468db48326a1d9e475dd23641b)