### PR TITLE
fix: JSONB adaptation for governance Postgres writes and ensure uvicorn found in Docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ FROM python:3.11.12-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app/deps
+    PYTHONPATH=/app/deps \
+    PATH="/app/deps/bin:${PATH}"
 
 WORKDIR /app
 
@@ -52,4 +53,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python -c "from http.client import HTTPConnection; c = HTTPConnection('localhost', 8000, timeout=3); c.request('GET', '/health'); exit(0 if c.getresponse().status == 200 else 1)" || exit 1
 
 STOPSIGNAL SIGTERM
-CMD ["uvicorn", "veritas_os.api.server:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "uvicorn", "veritas_os.api.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/veritas_os/governance/postgresql_repository.py
+++ b/veritas_os/governance/postgresql_repository.py
@@ -12,6 +12,8 @@ from datetime import datetime, timezone
 from time import monotonic
 from typing import Any, Callable, Iterator
 
+from psycopg.types.json import Jsonb
+
 from veritas_os.governance.repository import (
     GovernanceRepository,
     GovernanceWriteConflictError,
@@ -75,6 +77,8 @@ class PostgresGovernanceRepository(GovernanceRepository):
                         conn.rollback()
                         return default_factory()
                     payload = row[0]
+                    if isinstance(payload, Jsonb):
+                        payload = payload.obj
                     conn.rollback()
                     return payload if isinstance(payload, dict) else default_factory()
         except Exception:
@@ -129,10 +133,10 @@ class PostgresGovernanceRepository(GovernanceRepository):
                             event.changed_by,
                             self._parse_timestamp(event.changed_at),
                             "",
-                            {
+                            Jsonb({
                                 "previous_version": event.previous_version,
                                 "new_version": event.new_version,
-                            },
+                            }),
                         ),
                     )
                 conn.commit()
@@ -349,12 +353,12 @@ class PostgresGovernanceRepository(GovernanceRepository):
                         """,
                         (
                             str(updated.get("version", "")),
-                            updated,
+                            Jsonb(updated),
                             new_digest,
                             changed_at,
                             changed_by,
                             next_revision,
-                            {"expected_previous_digest": expected_digest},
+                            Jsonb({"expected_previous_digest": expected_digest}),
                         ),
                     )
                     new_policy_id = cur.fetchone()[0]
@@ -385,12 +389,12 @@ class PostgresGovernanceRepository(GovernanceRepository):
                             changed_by,
                             changed_at,
                             reason,
-                            {
+                            Jsonb({
                                 "previous_version": previous.get("version"),
                                 "new_version": updated.get("version"),
                                 "previous_revision": current_revision,
                                 "new_revision": next_revision,
-                            },
+                            }),
                         ),
                     )
                     event_id = cur.fetchone()[0]
@@ -409,7 +413,7 @@ class PostgresGovernanceRepository(GovernanceRepository):
                                 event_id,
                                 approval["reviewer"],
                                 approval["signature"],
-                                {},
+                                Jsonb({}),
                             ),
                         )
                 conn.commit()


### PR DESCRIPTION
### Motivation
- Fix a release-blocking `psycopg.ProgrammingError: cannot adapt type 'dict'` by ensuring Python dict/list objects are adapted to Postgres `jsonb` when written by the governance PostgreSQL repository.
- Fix the backend container startup failure `exec: "uvicorn": executable file not found in $PATH` by ensuring console scripts installed to `/app/deps/bin` are discoverable at runtime.
- Keep runtime semantics and JSONB column types unchanged while preserving test coverage and not weakening any Release Gate checks.

### Description
- Import `Jsonb` from `psycopg.types.json` and wrap all JSONB-bound Python values with `Jsonb(...)` when writing `policy_payload`, `metadata_json` on `governance_policies`, `governance_policy_events`, and `governance_approvals` in `veritas_os/governance/postgresql_repository.py`.
- Unwrap `Jsonb` objects on read in `get_current_policy` by converting `Jsonb` -> `.obj` so callers receive dict-compatible objects as before.
- Update `Dockerfile` to add `PATH="/app/deps/bin:${PATH}"` to the runtime `ENV` and change the runtime `CMD` to the robust module form `CMD ["python", "-m", "uvicorn", "veritas_os.api.server:app", "--host", "0.0.0.0", "--port", "8000"]` so `uvicorn` provided by installed dependencies is found and executed.
- Changes are limited to `veritas_os/governance/postgresql_repository.py` and `Dockerfile`, follow PEP8, and do not change governance persistence semantics or JSONB column types.
- Security note: adding `/app/deps/bin` to `PATH` exposes installed dependency console scripts at runtime, so only vetted dependencies should be present in `requirements.txt` (no secrets added or gate relaxations were introduced).

### Testing
- Ran governance tests with `pytest -q veritas_os/tests/test_governance_backend_selection.py veritas_os/tests/test_governance_repository.py veritas_os/tests/test_governance_postgresql_repository.py veritas_os/tests/test_governance_artifact_signing.py::TestGovernanceHistoryDigests veritas_os/tests/test_governance_artifact_signing.py::TestGovernedRollback --tb=short` and received `24 passed`.
- Attempted Docker smoke with `docker compose up -d --build --wait --timeout 120` and health probe `curl -sf http://localhost:8000/health`, but could not run locally because `docker` is not available in the environment (`/bin/bash: line 1: docker: command not found`), so runtime container verification must be validated by CI/GitHub Actions or a runner with Docker available.
- No automated tests were skipped or modified; all governance Postgres backend tests targeted by this fix passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e53f00f88326a6f20ce936fec6d7)