### PR TITLE
test: isolate file-mode governance repository regression

### DIFF
--- a/veritas_os/tests/test_governance_repository.py
+++ b/veritas_os/tests/test_governance_repository.py
@@ -149,6 +149,8 @@ def test_file_mode_behavior_unchanged_for_load_save(tmp_path, monkeypatch):
     """Backward-compatible helpers still read/write JSON file based policy."""
     policy_path = tmp_path / "governance.json"
     history_path = tmp_path / "governance_history.jsonl"
+    monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "file")
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
     monkeypatch.setattr(gov, "_DEFAULT_POLICY_PATH", policy_path)
     monkeypatch.setattr(gov, "_POLICY_HISTORY_PATH", history_path)
 


### PR DESCRIPTION
### Motivation
- A legacy test `test_file_mode_behavior_unchanged_for_load_save` failed in CI when the job environment enabled the PostgreSQL governance backend because the test expects on-disk JSON writes. 
- The intent is to keep the test deterministic by forcing the file backend for that test without altering production code or PostgreSQL tests.

### Description
- Updated `veritas_os/tests/test_governance_repository.py` to set `VERITAS_GOVERNANCE_BACKEND` to `file` inside `test_file_mode_behavior_unchanged_for_load_save` using `monkeypatch.setenv`.
- Removed any inherited database URL from the environment for that test with `monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)` so `_save()` and `_load()` operate on the file repository.
- Kept the existing monkeypatches for `gov._DEFAULT_POLICY_PATH` and `gov._POLICY_HISTORY_PATH` and preserved the direct on-disk assertion that reads `governance.json`.

### Testing
- Ran `pytest -q veritas_os/tests/test_governance_backend_selection.py veritas_os/tests/test_governance_repository.py veritas_os/tests/test_governance_postgresql_repository.py veritas_os/tests/test_governance_artifact_signing.py::TestGovernanceHistoryDigests veritas_os/tests/test_governance_artifact_signing.py::TestGovernedRollback --tb=short --durations=20`, and the suite passed.
- Verified the targeted reproduction under a PostgreSQL-configured environment with `VERITAS_GOVERNANCE_BACKEND=postgresql VERITAS_DATABASE_URL=postgresql+psycopg://veritas:veritas_test@localhost:5432/veritas_test pytest -q veritas_os/tests/test_governance_repository.py::test_file_mode_behavior_unchanged_for_load_save --tb=short`, and the single test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72ce88d8483269e582438342e4908)