### PR TITLE
docs: add Release Gate recovery case study

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
 - **Database Migrations**: [`docs/en/operations/database-migrations.md`](docs/en/operations/database-migrations.md)
 - **Backend Parity Coverage**: [`docs/en/validation/backend-parity-coverage.md`](docs/en/validation/backend-parity-coverage.md)
 - **PostgreSQL Production Proof Map (compact)**: [`docs/en/validation/postgresql-production-proof-map.md`](docs/en/validation/postgresql-production-proof-map.md)
+- [Release Gate Recovery Case Study](docs/en/validation/release-gate-recovery-case-study.md) — a real failure-to-green example showing how VERITAS OS blocks release promotion until governance backend, Docker runtime, and test isolation failures are fixed.
 - **Live PostgreSQL Validation Evidence**: [`docs/live-postgresql-validation.md`](docs/live-postgresql-validation.md)
 - **Legacy Path Cleanup**: [`docs/en/operations/legacy-path-cleanup.md`](docs/en/operations/legacy-path-cleanup.md)
 - **Review Document Map**: [`docs/ja/reviews/code-review-document-map.md`](docs/ja/reviews/code-review-document-map.md)

--- a/README_JP.md
+++ b/README_JP.md
@@ -206,6 +206,7 @@ Authority Evidence と Audit Log の違いは明確です。
 - **データベースマイグレーション**: [`docs/ja/operations/database-migrations.md`](docs/ja/operations/database-migrations.md)
 - **バックエンドパリティカバレッジ**: [`docs/ja/validation/backend-parity-coverage.md`](docs/ja/validation/backend-parity-coverage.md)
 - **ライブPostgreSQL検証エビデンス**: [`docs/live-postgresql-validation.md`](docs/live-postgresql-validation.md)
+- [Release Gate Recovery Case Study](docs/en/validation/release-gate-recovery-case-study.md) — Release Gate が実際に失敗したリリースを止め、PostgreSQL governance backend、Docker runtime、file/PostgreSQL test isolation の問題を修正後に passing へ戻した実例。
 - **レガシーパスクリーンアップ**: [`docs/ja/operations/legacy-path-cleanup.md`](docs/ja/operations/legacy-path-cleanup.md)
 - **レビュー文書マップ**: [`docs/ja/reviews/code-review-document-map.md`](docs/ja/reviews/code-review-document-map.md)
 - **ドキュメント入口（英語）**: [`docs/en/README.md`](docs/en/README.md)

--- a/docs/en/validation/release-gate-recovery-case-study.md
+++ b/docs/en/validation/release-gate-recovery-case-study.md
@@ -1,0 +1,36 @@
+# Release Gate Recovery Case Study
+
+## Summary
+VERITAS OS Release Gate blocked release promotion after detecting multiple release-blocking failures across governance persistence, runtime startup, and backend-specific test behavior. The first failures surfaced a PostgreSQL governance write-path defect and a Docker runtime startup defect. After those were remediated, the gate failed again on a test-isolation issue where a file-mode test was running under a PostgreSQL backend configuration. The gate returned to passing only after each blocking issue was corrected. This sequence shows an actual failure-to-green path, not a simulated exercise.
+
+## Why this matters
+This case shows the Release Gate is enforceable, not cosmetic. Release-blocking checks failed in CI and prevented release promotion until remediation. Docker runtime startup was validated at execution time, not only at image build time. PostgreSQL governance persistence behavior was also validated on the release path. The recovery also required explicit file-backend and PostgreSQL-backend test isolation. The final passing state indicates governance-ready release status was reached only after correction.
+
+## Failure 1: PostgreSQL JSONB adaptation
+- **Symptom:** Release Gate failed with `psycopg.ProgrammingError: cannot adapt type 'dict' using placeholder '%s'` during governance persistence writes.
+- **Root cause:** Python `dict`/`list` payloads were sent to PostgreSQL JSONB columns without psycopg JSONB adaptation.
+- **Fix:** JSONB-bound payloads were wrapped with `Jsonb(...)` in the governance PostgreSQL repository write path.
+- **Governance significance:** Governance artifacts could not be reliably persisted to PostgreSQL until adaptation was corrected, so release promotion remained blocked.
+
+## Failure 2: Docker runtime startup
+- **Symptom:** Backend container startup failed with `exec: "uvicorn": executable file not found in $PATH`.
+- **Root cause:** Dependencies were installed under `/app/deps`, but `/app/deps/bin` was not on `PATH`.
+- **Fix:** `/app/deps/bin` was added to `PATH`, and backend startup was changed to `python -m uvicorn`.
+- **Runtime significance:** The gate validated runnable startup behavior, not only artifact creation, and blocked promotion until runtime entrypoint execution was corrected.
+
+## Failure 3: File/PostgreSQL test isolation
+- **Symptom:** `veritas_os/tests/test_governance_repository.py::test_file_mode_behavior_unchanged_for_load_save` failed with `FileNotFoundError` on `tmp_path / "governance.json"`.
+- **Root cause:** The Release Gate job intentionally ran with `VERITAS_GOVERNANCE_BACKEND=postgresql`, while the test asserted legacy file-mode behavior without forcing file backend.
+- **Fix:** The test was isolated to file backend by explicitly setting `VERITAS_GOVERNANCE_BACKEND=file` and unsetting `VERITAS_DATABASE_URL` in test setup.
+- **Test-governance significance:** Multi-backend repositories require explicit backend isolation in tests; otherwise, governance behavior can be validated against the wrong persistence mode.
+
+## Final outcome
+After remediating all three issues, Release Gate passed. This does not claim that all future releases are automatically safe. It shows the gate can detect concrete release risks, block release promotion, and validate remediation before a release is treated as governance-ready.
+
+## What this demonstrates about VERITAS OS
+- Governance checks are enforceable.
+- Release readiness is evidence-driven.
+- Backend persistence is part of the release contract.
+- Runtime health is part of the release contract.
+- Test isolation matters when multiple backends exist.
+- A release is not considered governance-ready until blocking checks pass.


### PR DESCRIPTION
### Motivation
- Provide an external-facing, concise case study that documents a real Release Gate failure-to-green sequence affecting governance persistence, runtime startup, and test isolation.
- Make the event readable to engineers, reviewers, investors, and governance stakeholders while keeping language restrained and factual.
- Record concrete remediation actions so future reviewers can see why the gate blocked promotion and how the release returned to passing.

### Description
- Added `docs/en/validation/release-gate-recovery-case-study.md` with the required structure (Summary, Why this matters, three failure sections, Final outcome, What this demonstrates). 
- Linked the new case study from `README.md` and `README_JP.md` near existing validation/proof/governance links. 
- The case study covers the three published failure modes: PostgreSQL JSONB adaptation, Docker runtime startup (`uvicorn`/`PATH`), and file/PostgreSQL test isolation, and describes the fixes applied. 
- This is a documentation-only change; no runtime code, tests, or CI workflows were modified.

### Testing
- Verified the new documentation file exists via `test -f docs/en/validation/release-gate-recovery-case-study.md` and the content is present. (succeeded)
- Verified the README updates by searching for the link with `rg -n "Release Gate Recovery Case Study" README.md README_JP.md` and confirming the entries. (succeeded)
- Verified that only documentation files were changed by inspecting `git diff --name-only` and `git status --short`, confirming no code files or workflows were modified. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7328f7f348326849c6ebace7d2b9c)