### PR TITLE
Add pre-boundary collapse scenario fixtures and walkthrough docs

### DIFF
--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -1,0 +1,83 @@
+# Pre-Boundary Collapse Demo Walkthrough
+
+## Why this scenario matters
+
+This demo fixes a representative pre-bind governance risk: options can remain
+formally visible (A/B/C/D) while iterative framing converges the practical
+decision path before bind. The result is a structural gap where bind can look
+formally valid even though upstream optionality has already collapsed.
+
+## Mapping to Andrzej's minimal scenario
+
+Andrzej's minimal scenario is:
+
+- "A/B/C/D choices formally remain"
+- "Iterative framing reinforces a narrow subset"
+- "Effective optionality collapses before bind"
+
+The fixture set in this PR encodes that exact sequence as four deterministic
+phases with explicit expected participation and preservation states.
+
+## VERITAS five-layer mapping
+
+1. **Participation signal**
+   - Each phase includes `participation_signal` with shared fields:
+     `interpretation_space_narrowing`, `counterfactual_availability`,
+     `intervention_headroom`, and `structural_openness`.
+2. **Pre-bind structural detection**
+   - `expected_participation_state` is fixed per phase to make structural drift
+     reviewable before UI implementation.
+3. **Preservation / intervention viability**
+   - `expected_preservation_state` and `intervention_viability` define whether
+     practical intervention capacity remains open, degrading, or collapsed.
+4. **Bind-time admissibility**
+   - `expected_bind_outcome` highlights that bind-time formality can remain
+     valid while upstream decision space is structurally narrowed.
+5. **Post-bind replay and lineage**
+   - `lineage_evidence` pins minimum evidence categories required for replay,
+     external review, and phase-by-phase provenance reconstruction.
+
+## Phase semantics
+
+- **Phase 1 — Participation / open framing**
+  - A/B/C/D all exposed; optionality is full.
+  - Participation is informational (`informative`), preservation is `open`.
+- **Phase 2 — Iterative shaping**
+  - A/B gain reinforcement; C/D exposure drops.
+  - Formal optionality remains, but divergence shrinks.
+  - Participation becomes `participatory`; preservation enters `degrading`.
+- **Phase 3 — Pre-boundary collapse**
+  - A/B converge to one trajectory; C/D lose viability.
+  - Effective optionality is near zero.
+  - Participation is `decision_shaping`; preservation is `collapsed`.
+- **Phase 4 — Bind**
+  - Bind can remain formally admissible.
+  - Upstream decision space is already collapsed.
+  - This phase encodes the governance-relevant gap explicitly.
+
+## Meaning of "formally valid, structurally collapsed"
+
+The phrase means syntax-level or contract-level validity at bind time does not
+prove that pre-bind decision formation preserved meaningful optionality.
+Accordingly, this demo treats pre-bind structure as a first-class review target,
+not a post-hoc UI concern.
+
+## Required lineage evidence
+
+Each phase requires the following evidence keys:
+
+- `framing_iteration_log`
+- `option_exposure_trace`
+- `counterfactual_probes`
+- `intervention_record`
+- `bind_context_snapshot`
+
+This minimum set supports replayability, reviewer traceability, and consistent
+cross-phase comparison.
+
+## Scope guardrails for this PR
+
+This PR intentionally does **not** implement UI, governance feed route changes,
+OpenAPI changes, or bind-contract changes. It only fixes scenario fixtures,
+walkthrough semantics, and validation tests so the demo is reviewable before
+surface implementation.

--- a/veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/pre_boundary_collapse_phase_1_open.json
+++ b/veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/pre_boundary_collapse_phase_1_open.json
@@ -1,0 +1,31 @@
+{
+  "phase_id": "pre_boundary_collapse_phase_1_open",
+  "phase_label": "Phase 1 — Participation / open framing",
+  "options": ["A", "B", "C", "D"],
+  "option_exposure": {
+    "A": "high",
+    "B": "high",
+    "C": "high",
+    "D": "high"
+  },
+  "reinforcement_asymmetry": "none",
+  "effective_optionality": "full",
+  "participation_signal": {
+    "interpretation_space_narrowing": "open",
+    "counterfactual_availability": "high",
+    "intervention_headroom": "high",
+    "structural_openness": "open"
+  },
+  "expected_participation_state": "informative",
+  "expected_preservation_state": "open",
+  "intervention_viability": "high",
+  "expected_bind_outcome": "FORMALLY_VALID_UPSTREAM_OPEN",
+  "concise_rationale": "All options remain visible and contestable, so effective optionality remains full before bind.",
+  "lineage_evidence": {
+    "framing_iteration_log": "phase_1_framing_log_ref",
+    "option_exposure_trace": "phase_1_exposure_trace_ref",
+    "counterfactual_probes": "phase_1_counterfactual_probe_ref",
+    "intervention_record": "phase_1_intervention_record_ref",
+    "bind_context_snapshot": "phase_1_bind_context_snapshot_ref"
+  }
+}

--- a/veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/pre_boundary_collapse_phase_2_iterative_shaping.json
+++ b/veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/pre_boundary_collapse_phase_2_iterative_shaping.json
@@ -1,0 +1,31 @@
+{
+  "phase_id": "pre_boundary_collapse_phase_2_iterative_shaping",
+  "phase_label": "Phase 2 — Iterative shaping",
+  "options": ["A", "B", "C", "D"],
+  "option_exposure": {
+    "A": "high",
+    "B": "high",
+    "C": "low",
+    "D": "low"
+  },
+  "reinforcement_asymmetry": "moderate_ab_over_cd",
+  "effective_optionality": "shrinking",
+  "participation_signal": {
+    "interpretation_space_narrowing": "narrowing",
+    "counterfactual_availability": "low",
+    "intervention_headroom": "medium",
+    "structural_openness": "fragile"
+  },
+  "expected_participation_state": "participatory",
+  "expected_preservation_state": "degrading",
+  "intervention_viability": "medium",
+  "expected_bind_outcome": "FORMALLY_VALID_WITH_SHAPING_RISK",
+  "concise_rationale": "A/B are repeatedly amplified while C/D remain formally available but under-exposed, reducing effective divergence.",
+  "lineage_evidence": {
+    "framing_iteration_log": "phase_2_framing_log_ref",
+    "option_exposure_trace": "phase_2_exposure_trace_ref",
+    "counterfactual_probes": "phase_2_counterfactual_probe_ref",
+    "intervention_record": "phase_2_intervention_record_ref",
+    "bind_context_snapshot": "phase_2_bind_context_snapshot_ref"
+  }
+}

--- a/veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/pre_boundary_collapse_phase_3_collapse.json
+++ b/veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/pre_boundary_collapse_phase_3_collapse.json
@@ -1,0 +1,31 @@
+{
+  "phase_id": "pre_boundary_collapse_phase_3_collapse",
+  "phase_label": "Phase 3 — Pre-boundary collapse",
+  "options": ["A", "B", "C", "D"],
+  "option_exposure": {
+    "A": "high",
+    "B": "high",
+    "C": "minimal",
+    "D": "minimal"
+  },
+  "reinforcement_asymmetry": "high_ab_convergent",
+  "effective_optionality": "near_zero",
+  "participation_signal": {
+    "interpretation_space_narrowing": "closed",
+    "counterfactual_availability": "none",
+    "intervention_headroom": "low",
+    "structural_openness": "closed"
+  },
+  "expected_participation_state": "decision_shaping",
+  "expected_preservation_state": "collapsed",
+  "intervention_viability": "low",
+  "expected_bind_outcome": "FORMALLY_VALID_STRUCTURALLY_COLLAPSED",
+  "concise_rationale": "A/B converge into one trajectory and C/D lose practical viability, collapsing optionality before bind.",
+  "lineage_evidence": {
+    "framing_iteration_log": "phase_3_framing_log_ref",
+    "option_exposure_trace": "phase_3_exposure_trace_ref",
+    "counterfactual_probes": "phase_3_counterfactual_probe_ref",
+    "intervention_record": "phase_3_intervention_record_ref",
+    "bind_context_snapshot": "phase_3_bind_context_snapshot_ref"
+  }
+}

--- a/veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/pre_boundary_collapse_phase_4_bind.json
+++ b/veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/pre_boundary_collapse_phase_4_bind.json
@@ -1,0 +1,31 @@
+{
+  "phase_id": "pre_boundary_collapse_phase_4_bind",
+  "phase_label": "Phase 4 — Bind",
+  "options": ["A", "B", "C", "D"],
+  "option_exposure": {
+    "A": "high",
+    "B": "high",
+    "C": "minimal",
+    "D": "minimal"
+  },
+  "reinforcement_asymmetry": "high_ab_convergent",
+  "effective_optionality": "near_zero",
+  "participation_signal": {
+    "interpretation_space_narrowing": "closed",
+    "counterfactual_availability": "none",
+    "intervention_headroom": "low",
+    "structural_openness": "closed"
+  },
+  "expected_participation_state": "decision_shaping",
+  "expected_preservation_state": "collapsed",
+  "intervention_viability": "low",
+  "expected_bind_outcome": "FORMALLY_VALID_STRUCTURALLY_COLLAPSED",
+  "concise_rationale": "Bind can still look admissible in-form while upstream decision space has already collapsed.",
+  "lineage_evidence": {
+    "framing_iteration_log": "phase_4_framing_log_ref",
+    "option_exposure_trace": "phase_4_exposure_trace_ref",
+    "counterfactual_probes": "phase_4_counterfactual_probe_ref",
+    "intervention_record": "phase_4_intervention_record_ref",
+    "bind_context_snapshot": "phase_4_bind_context_snapshot_ref"
+  }
+}

--- a/veritas_os/tests/test_pre_boundary_collapse_demo_fixtures.py
+++ b/veritas_os/tests/test_pre_boundary_collapse_demo_fixtures.py
@@ -1,0 +1,78 @@
+"""Validation tests for pre-boundary collapse demo scenario fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path("veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse")
+EXPECTED_PHASE_FILES = [
+    "pre_boundary_collapse_phase_1_open.json",
+    "pre_boundary_collapse_phase_2_iterative_shaping.json",
+    "pre_boundary_collapse_phase_3_collapse.json",
+    "pre_boundary_collapse_phase_4_bind.json",
+]
+ALLOWED_PARTICIPATION_STATES = {"informative", "participatory", "decision_shaping"}
+ALLOWED_PRESERVATION_STATES = {"open", "degrading", "collapsed"}
+REQUIRED_TOP_LEVEL_KEYS = {
+    "phase_id",
+    "phase_label",
+    "options",
+    "option_exposure",
+    "reinforcement_asymmetry",
+    "effective_optionality",
+    "participation_signal",
+    "expected_participation_state",
+    "expected_preservation_state",
+    "intervention_viability",
+    "expected_bind_outcome",
+    "concise_rationale",
+    "lineage_evidence",
+}
+REQUIRED_LINEAGE_KEYS = {
+    "framing_iteration_log",
+    "option_exposure_trace",
+    "counterfactual_probes",
+    "intervention_record",
+    "bind_context_snapshot",
+}
+
+
+def _load_fixture(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_pre_boundary_collapse_fixture_files_are_present() -> None:
+    """The representative demo must include all four required phase fixtures."""
+    actual_names = sorted(path.name for path in FIXTURE_DIR.glob("*.json"))
+
+    assert actual_names == EXPECTED_PHASE_FILES
+
+
+def test_pre_boundary_collapse_fixture_payload_shape_is_valid() -> None:
+    """Each phase fixture must include the required canonical walkthrough fields."""
+    for fixture_name in EXPECTED_PHASE_FILES:
+        fixture = _load_fixture(FIXTURE_DIR / fixture_name)
+
+        assert REQUIRED_TOP_LEVEL_KEYS.issubset(fixture.keys())
+        assert fixture["options"] == ["A", "B", "C", "D"]
+        assert sorted(fixture["option_exposure"].keys()) == ["A", "B", "C", "D"]
+
+
+def test_pre_boundary_collapse_expected_state_vocabulary_is_consistent() -> None:
+    """Expected state labels must stay aligned with VERITAS shared vocabulary."""
+    for fixture_name in EXPECTED_PHASE_FILES:
+        fixture = _load_fixture(FIXTURE_DIR / fixture_name)
+
+        assert fixture["expected_participation_state"] in ALLOWED_PARTICIPATION_STATES
+        assert fixture["expected_preservation_state"] in ALLOWED_PRESERVATION_STATES
+
+
+def test_pre_boundary_collapse_lineage_evidence_contains_minimum_items() -> None:
+    """Lineage evidence must include minimum reviewable artifacts for each phase."""
+    for fixture_name in EXPECTED_PHASE_FILES:
+        fixture = _load_fixture(FIXTURE_DIR / fixture_name)
+        lineage_evidence = fixture["lineage_evidence"]
+
+        assert REQUIRED_LINEAGE_KEYS.issubset(lineage_evidence.keys())
+        assert all(lineage_evidence[key] for key in REQUIRED_LINEAGE_KEYS)


### PR DESCRIPTION
### Motivation

- Encode Andrzej’s minimal “pre-boundary collapse” scenario as a reviewable, deterministic demo for VERITAS without touching UI or runtime contracts.  
- Make the sequence of phases, expected participation/preservation states, and required lineage evidence explicit so reviewers can evaluate structural collapse before any surface implementation.  
- Preserve existing pre-bind semantics and test coverage while preventing vocabulary drift through machine-checkable fixtures and tests.

### Description

- Add four phase fixtures under `veritas_os/tests/fixtures/pre_bind/pre_boundary_collapse/`: `pre_boundary_collapse_phase_1_open.json`, `pre_boundary_collapse_phase_2_iterative_shaping.json`, `pre_boundary_collapse_phase_3_collapse.json`, and `pre_boundary_collapse_phase_4_bind.json`, each containing required keys such as `phase_id`, `participation_signal`, `expected_participation_state`, `expected_preservation_state`, `lineage_evidence`, and a concise rationale.  
- Add a walkthrough doc at `docs/en/demos/pre_boundary_collapse_demo.md` that explains the scenario importance, mapping to Andrzej’s minimal scenario, VERITAS 5-layer mapping, per-phase semantics, the meaning of “formally valid, structurally collapsed”, required lineage evidence, and non-goals.  
- Add validation tests `veritas_os/tests/test_pre_boundary_collapse_demo_fixtures.py` that assert the presence of all four phase files, fixture payload shape, `expected_*` vocabulary consistency, and minimum `lineage_evidence` keys.  
- Constrain scope: no UI, feed route, OpenAPI, bind contract, or production runtime changes were made.

### Testing

- Ran `pytest -q veritas_os/tests/test_pre_boundary_collapse_demo_fixtures.py veritas_os/tests/test_pre_bind_canonical_golden.py` and all tests passed (`10 passed`).  
- New tests validate the four-phase presence, canonical fixture shape, allowed participation/preservation vocabulary, and that each phase includes the minimal lineage evidence keys.  
- Existing canonical pre-bind golden tests were run to ensure no regressions in pre-bind semantics and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74b34d4d48326b42d0bc6efe36d3e)