### PR TITLE
Add governance feed support for pre-boundary collapse demo

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -153,3 +153,11 @@ docker compose up --build
 - `/audit?bind_receipt_id=...` は dedicated bind receipt lookup を実行し、timeline match または fallback detail で trace を表示します。
 - You can run the focused workflow checks with: `bash scripts/demo_mission_audit_workflow.sh`.
 - fake routes（例: `/decisions/...`, `/execution-intents/...`, `/trustlog/...`）および unsafe/external links は生成しません。
+
+## Pre-Boundary Collapse demo scenario feed seam
+
+- `GET /api/veritas/v1/report/governance` は demo/test seam として `demo_scenario=pre_boundary_collapse`（query）または `x-veritas-demo-scenario: pre_boundary_collapse`（header）を受け付けます。
+- この seam は production governance source の置き換えではなく、PR1 fixture を Mission Control main path へ接続するための demo payload 注入です。
+- payload は `governance_layer_snapshot.phase_snapshots` に 4 phase（phase 1〜4）を返し、`participation_state` / `preservation_state` / `intervention_viability` / `bind_outcome` など既存 vocabulary を維持します。
+- invalid な `demo_scenario` は upstream fetch path にフォールバックし、既存の endpoint unavailable / invalid payload fallback behavior を変更しません。
+- Mission Control UI の phase progression 表示強化は次 PR で実施し、この PR では feed/payload 接続のみを担当します。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -220,4 +220,56 @@ describe("/api/veritas/v1/report/governance", () => {
     await expect(response.json()).resolves.toEqual({ error: "governance_feed_unavailable" });
   });
 
+  it("returns pre-boundary collapse demo scenario payload from query seam", async () => {
+    const response = await GET(new Request("http://localhost/api/veritas/v1/report/governance?demo_scenario=pre_boundary_collapse"));
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as { governance_layer_snapshot: { phase_snapshots: Array<Record<string, unknown>> } };
+    expect(payload.governance_layer_snapshot.phase_snapshots).toHaveLength(4);
+    expect(payload.governance_layer_snapshot.phase_snapshots[0]).toMatchObject({
+      phase_id: "pre_boundary_collapse_phase_1_open",
+      phase_label: "Phase 1 — Participation / open framing",
+      participation_state: "informative",
+      preservation_state: "open",
+      intervention_viability: "high",
+      bind_outcome: "FORMALLY_VALID_UPSTREAM_OPEN",
+      concise_rationale: expect.any(String),
+      lineage_evidence: expect.any(Object),
+      effective_optionality: "full",
+      option_exposure_summary: "A:high, B:high, C:high, D:high",
+      reinforcement_asymmetry_summary: "none",
+    });
+  });
+
+  it("returns pre-boundary collapse demo scenario payload from header seam", async () => {
+    const response = await GET(new Request("http://localhost/api/veritas/v1/report/governance", {
+      headers: { "x-veritas-demo-scenario": "pre_boundary_collapse" },
+    }));
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as { governance_layer_snapshot: { phase_snapshots: Array<Record<string, unknown>> } };
+    expect(payload.governance_layer_snapshot.phase_snapshots.map((phase) => phase.phase_id)).toEqual([
+      "pre_boundary_collapse_phase_1_open",
+      "pre_boundary_collapse_phase_2_iterative_shaping",
+      "pre_boundary_collapse_phase_3_collapse",
+      "pre_boundary_collapse_phase_4_bind",
+    ]);
+  });
+
+  it("falls back to upstream path when demo scenario is invalid", async () => {
+    vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
+    vi.stubEnv("VERITAS_API_KEY", "test-key");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ governance_layer_snapshot: { bind_outcome: "UNKNOWN" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const response = await GET(new Request("http://localhost/api/veritas/v1/report/governance?demo_scenario=unknown"));
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
 });

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
 import { NextResponse } from "next/server";
 
 import { resolveApiBaseUrl } from "../../../[...path]/route-config";
@@ -6,6 +9,16 @@ import { areE2EScenariosEnabled } from "../../../../../e2e-scenarios";
 const GOVERNANCE_LIVE_SNAPSHOT_PATH = "/v1/governance/live-snapshot";
 const E2E_SCENARIO_HEADER = "x-veritas-e2e-governance-scenario";
 const E2E_SCENARIO_QUERY = "e2e_governance_scenario";
+const DEMO_SCENARIO_HEADER = "x-veritas-demo-scenario";
+const DEMO_SCENARIO_QUERY = "demo_scenario";
+const PRE_BOUNDARY_COLLAPSE_SCENARIO = "pre_boundary_collapse";
+
+const PRE_BOUNDARY_COLLAPSE_PHASE_FIXTURE_FILES = [
+  "pre_boundary_collapse_phase_1_open.json",
+  "pre_boundary_collapse_phase_2_iterative_shaping.json",
+  "pre_boundary_collapse_phase_3_collapse.json",
+  "pre_boundary_collapse_phase_4_bind.json",
+] as const;
 
 function resolveE2EScenarioPayload(request: Request): Record<string, unknown> | null {
   const scenarioFromQuery = new URL(request.url).searchParams.get(E2E_SCENARIO_QUERY)?.trim();
@@ -58,17 +71,66 @@ function normalizeGovernanceReportPayload(payload: unknown): Record<string, unkn
   return null;
 }
 
-/**
- * Mission Control backend-fed governance feed endpoint.
- *
- * Main path fetches backend governance live snapshot and keeps payload vocabulary stable.
- */
+function resolveDemoScenario(request: Request): string | null {
+  const requestUrl = new URL(request.url);
+  const scenarioFromQuery = requestUrl.searchParams.get(DEMO_SCENARIO_QUERY)?.trim();
+  return scenarioFromQuery || request.headers.get(DEMO_SCENARIO_HEADER)?.trim() || null;
+}
+
+function resolveFixturePath(filename: string): string {
+  return path.resolve(process.cwd(), "..", "veritas_os", "tests", "fixtures", "pre_bind", "pre_boundary_collapse", filename);
+}
+
+function mapPreBoundaryCollapsePhaseToSnapshot(phase: Record<string, unknown>): Record<string, unknown> {
+  const optionExposure = phase.option_exposure as Record<string, string>;
+  return {
+    phase_id: phase.phase_id,
+    phase_label: phase.phase_label,
+    participation_state: phase.expected_participation_state,
+    preservation_state: phase.expected_preservation_state,
+    intervention_viability: phase.intervention_viability,
+    bind_outcome: phase.expected_bind_outcome,
+    concise_rationale: phase.concise_rationale,
+    lineage_evidence: phase.lineage_evidence,
+    effective_optionality: phase.effective_optionality,
+    option_exposure_summary: Object.entries(optionExposure)
+      .map(([option, exposure]) => `${option}:${exposure}`)
+      .join(", "),
+    reinforcement_asymmetry_summary: phase.reinforcement_asymmetry,
+  };
+}
+
+async function resolveDemoScenarioPayload(request: Request): Promise<Record<string, unknown> | null> {
+  if (resolveDemoScenario(request) !== PRE_BOUNDARY_COLLAPSE_SCENARIO) {
+    return null;
+  }
+
+  const phases = await Promise.all(
+    PRE_BOUNDARY_COLLAPSE_PHASE_FIXTURE_FILES.map(async (filename) => {
+      const raw = await readFile(resolveFixturePath(filename), "utf-8");
+      return JSON.parse(raw) as Record<string, unknown>;
+    }),
+  );
+
+  return {
+    governance_layer_snapshot: {
+      demo_scenario: PRE_BOUNDARY_COLLAPSE_SCENARIO,
+      phase_snapshots: phases.map(mapPreBoundaryCollapsePhaseToSnapshot),
+    },
+  };
+}
+
 export async function GET(request: Request): Promise<Response> {
   if (areE2EScenariosEnabled()) {
     const e2ePayload = resolveE2EScenarioPayload(request);
     if (e2ePayload) {
       return NextResponse.json(e2ePayload, { status: 200 });
     }
+  }
+
+  const demoScenarioPayload = await resolveDemoScenarioPayload(request);
+  if (demoScenarioPayload) {
+    return NextResponse.json(demoScenarioPayload, { status: 200 });
   }
 
   const apiBaseUrl = resolveApiBaseUrl();

--- a/frontend/app/mission-control-ingress.test.ts
+++ b/frontend/app/mission-control-ingress.test.ts
@@ -46,6 +46,22 @@ describe("mapGovernanceFeedToIngressPayload", () => {
     });
   });
 
+
+
+  it("maps governance demo phase snapshots without breaking main vocabulary", () => {
+    const result = mapGovernanceFeedToIngressPayload({
+      governance_layer_snapshot: {
+        phase_snapshots: [{ phase_id: "pre_boundary_collapse_phase_1_open" }],
+      },
+    });
+
+    expect(result).toEqual({
+      governance_layer_snapshot: {
+        phase_snapshots: [{ phase_id: "pre_boundary_collapse_phase_1_open" }],
+      },
+    });
+  });
+
   it("returns null for unsupported payload shape", () => {
     expect(mapGovernanceFeedToIngressPayload({})).toBeNull();
   });
@@ -127,4 +143,20 @@ describe("loadMissionControlIngressPayload", () => {
       },
     );
   });
+
+  it("forwards demo scenario override independently from e2e scenarios", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+
+    await loadMissionControlIngressPayload(null, "pre_boundary_collapse");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/veritas/v1/report/governance?demo_scenario=pre_boundary_collapse",
+      {
+        method: "GET",
+        cache: "no-store",
+        headers: { "x-veritas-demo-scenario": "pre_boundary_collapse" },
+      },
+    );
+  });
+
 });

--- a/frontend/app/mission-control-ingress.ts
+++ b/frontend/app/mission-control-ingress.ts
@@ -7,6 +7,8 @@ import { areE2EScenariosEnabled } from "./e2e-scenarios";
 const GOVERNANCE_REPORT_ENDPOINT = "/api/veritas/v1/report/governance";
 const E2E_SCENARIO_HEADER = "x-veritas-e2e-governance-scenario";
 const E2E_SCENARIO_QUERY = "e2e_governance_scenario";
+const DEMO_SCENARIO_HEADER = "x-veritas-demo-scenario";
+const DEMO_SCENARIO_QUERY = "demo_scenario";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -54,18 +56,32 @@ async function resolveE2EScenarioHeader(): Promise<string | null> {
 
 export async function loadMissionControlIngressPayload(
   scenarioOverride?: string | null,
+  demoScenarioOverride?: string | null,
 ): Promise<MissionGovernanceIngressPayload | null> {
   try {
     const scenario = areE2EScenariosEnabled()
       ? scenarioOverride?.trim() || (await resolveE2EScenarioHeader())
       : null;
-    const endpoint = scenario
-      ? `${GOVERNANCE_REPORT_ENDPOINT}?${E2E_SCENARIO_QUERY}=${encodeURIComponent(scenario)}`
+    const demoScenario = demoScenarioOverride?.trim() || null;
+    const endpointParams = new URLSearchParams();
+    if (scenario) {
+      endpointParams.set(E2E_SCENARIO_QUERY, scenario);
+    }
+    if (demoScenario) {
+      endpointParams.set(DEMO_SCENARIO_QUERY, demoScenario);
+    }
+    const endpoint = endpointParams.size > 0
+      ? `${GOVERNANCE_REPORT_ENDPOINT}?${endpointParams.toString()}`
       : GOVERNANCE_REPORT_ENDPOINT;
     const response = await fetch(endpoint, {
       method: "GET",
       cache: "no-store",
-      headers: scenario ? { [E2E_SCENARIO_HEADER]: scenario } : undefined,
+      headers: scenario || demoScenario
+        ? {
+          ...(scenario ? { [E2E_SCENARIO_HEADER]: scenario } : {}),
+          ...(demoScenario ? { [DEMO_SCENARIO_HEADER]: demoScenario } : {}),
+        }
+        : undefined,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
### Motivation
- Enable Mission Control to consume the PR1 "Pre-Boundary Collapse" 4-phase fixtures as a demo/test payload via the existing governance feed without changing production data flows. 
- Provide a clear demo/test seam (query/header) so demo data cannot be confused with the upstream live snapshot and preserve existing vocabulary and ingress contracts. 
- Implement the feature as a small, localized BFF + ingress change with no OpenAPI, bind contract, or new state-family modifications.

### Description
- Added a demo seam to `GET /api/veritas/v1/report/governance` accepting `demo_scenario=pre_boundary_collapse` (query) or `x-veritas-demo-scenario: pre_boundary_collapse` (header) and wired it to load the four PR1 fixture files. 
- Implemented fixture loading and mapping logic in `frontend/app/api/veritas/v1/report/governance/route.ts` to produce `governance_layer_snapshot.phase_snapshots` using existing vocabulary fields (`phase_id`, `phase_label`, `participation_state`, `preservation_state`, `intervention_viability`, `bind_outcome`, `concise_rationale`, `lineage_evidence`, `effective_optionality`, `option_exposure_summary`, `reinforcement_asymmetry_summary`). 
- Extended `frontend/app/mission-control-ingress.ts` to optionally forward a demo scenario override while preserving existing E2E gating behavior and compatibility with `governance_layer_snapshot` and `pre_bind_governance_snapshot` payload shapes. 
- Updated tests and docs in the following files: `frontend/app/api/veritas/v1/report/governance/route.test.ts`, `frontend/app/mission-control-ingress.test.ts`, and `docs/ui/README_UI.md` to document demo seam usage and ensure non-regression. 

### Testing
- Ran the focused frontend tests with `pnpm --filter frontend test -- mission-control-ingress.test.ts app/api/veritas/v1/report/governance/route.test.ts` and the updated route/ingress tests passed. 
- The new route tests verify demo query/header payloads, 4-phase snapshot shape and field mapping, and fallback to the upstream path for invalid demo scenarios. 
- The updated ingress tests verify mapping of demo `phase_snapshots` into the existing ingress contract and that demo scenario forwarding occurs as expected without breaking e2e gating.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f750204b308326a39ed56d586d77d0)