### PR TITLE
Add E2E and README entrypoint for pre-boundary collapse demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
 - **Legacy Path Cleanup**: [`docs/en/operations/legacy-path-cleanup.md`](docs/en/operations/legacy-path-cleanup.md)
 - **Review Document Map**: [`docs/ja/reviews/code-review-document-map.md`](docs/ja/reviews/code-review-document-map.md)
 - **Documentation Hub (EN)**: [`docs/en/README.md`](docs/en/README.md)
+- **Pre-Boundary Collapse Demo**: [`docs/en/demos/pre_boundary_collapse_demo.md`](docs/en/demos/pre_boundary_collapse_demo.md)
 - **Documentation Hub (JA)**: [`docs/ja/README.md`](docs/ja/README.md)
 - **Public Positioning Guide (EN)**: [`docs/en/positioning/public-positioning.md`](docs/en/positioning/public-positioning.md)
 - **Public Positioning Guide (JA)**: [`docs/ja/positioning/public-positioning.md`](docs/ja/positioning/public-positioning.md)

--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -95,3 +95,30 @@ snapshot payload.
 
 This preserves vocabulary and backend contracts while making the paradox
 visible at first glance: **formally valid, structurally collapsed**.
+
+
+## Run and verification entrypoint
+
+1. Open Mission Control demo mode via query seam:
+   - `/?demo_scenario=pre_boundary_collapse`
+2. Confirm the dedicated panel appears:
+   - `Pre-Boundary Collapse Demo · 4 phase walkthrough`
+3. Confirm expected progression:
+   - Phase 1 → 2 → 3 → 4 labels
+   - Phase 3 shows `participation_state=decision_shaping` with preservation collapse/degrading signal
+   - Phase 4 keeps bind admissibility-visible while upstream collapse gap remains explicit
+4. Confirm explanatory sentence remains visible:
+   - `formally valid, structurally collapsed`
+
+## Reviewer framing (external)
+
+- This demo is **not** production certification evidence by itself.
+- This is a **controlled representative demo** for reviewer orientation.
+- It concretely demonstrates VERITAS pre-bind governance stack behavior prior to bind.
+- It does **not** replace bind-time governance; it complements bind-time checks by exposing upstream structural collapse.
+
+## Known limitations
+
+- Scenario is deterministic and fixture-backed; it is representative, not exhaustive.
+- It does not claim legal/regulatory approval or third-party certification.
+- It should be read together with bind-time evidence and operational controls for production-readiness assessment.

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -60,6 +60,15 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
 
 
   test("pre-boundary collapse demo renders 4-phase walkthrough without breaking default timeline", async ({ page }) => {
+    const demoApiResponse = await page.request.get("/api/veritas/v1/report/governance?demo_scenario=pre_boundary_collapse");
+    await expect(demoApiResponse).toBeOK();
+    await expect(demoApiResponse.json()).resolves.toMatchObject({
+      governance_layer_snapshot: {
+        demo_scenario: "pre_boundary_collapse",
+        phase_snapshots: expect.any(Array),
+      },
+    });
+
     await page.goto("/?demo_scenario=pre_boundary_collapse");
 
     await expect(

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -72,14 +72,17 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     const phasePanel = page.locator('section[aria-label="pre-boundary collapse demo walkthrough"]');
     await expect(phasePanel).toBeVisible();
 
-    await expect(phasePanel).toContainText("Phase 1 — Participation / open framing");
-    await expect(phasePanel).toContainText("Phase 2 — Iterative shaping");
-    await expect(phasePanel).toContainText("Phase 3 — Pre-boundary collapse");
-    await expect(phasePanel).toContainText("Phase 4 — Bind");
+    const phases = phasePanel.locator("ol > li");
+    await expect(phases).toHaveCount(4);
 
-    await expect(phasePanel).toContainText("participation_state: decision_shaping");
-    await expect(phasePanel).toContainText(/preservation_state: (collapsed|degrading)/);
-    await expect(phasePanel).toContainText("bind_outcome: FORMALLY_VALID_STRUCTURALLY_COLLAPSED");
+    await expect(phases.nth(0)).toContainText("Phase 1 — Participation / open framing");
+    await expect(phases.nth(1)).toContainText("Phase 2 — Iterative shaping");
+    await expect(phases.nth(2)).toContainText("Phase 3 — Pre-boundary collapse");
+    await expect(phases.nth(3)).toContainText("Phase 4 — Bind");
+
+    await expect(phases.nth(2)).toContainText("participation_state: decision_shaping");
+    await expect(phases.nth(2)).toContainText(/preservation_state: (collapsed|degrading)/);
+    await expect(phases.nth(3)).toContainText("bind_outcome: FORMALLY_VALID_STRUCTURALLY_COLLAPSED");
 
     await expect(phasePanel).toContainText("lineage evidence summary");
 

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -57,6 +57,36 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     await expect(timeline).toContainText("bind_outcome:");
   });
 
+
+
+  test("pre-boundary collapse demo renders 4-phase walkthrough without breaking default timeline", async ({ page }) => {
+    await page.goto("/?demo_scenario=pre_boundary_collapse");
+
+    await expect(
+      page.getByRole("heading", { name: /コマンドダッシュボード|Command Dashboard/i }),
+    ).toBeVisible();
+
+    await expect(page.getByText("Pre-Boundary Collapse Demo · 4 phase walkthrough")).toBeVisible();
+    await expect(page.getByText("formally valid, structurally collapsed")).toBeVisible();
+
+    const phasePanel = page.locator('section[aria-label="pre-boundary collapse demo walkthrough"]');
+    await expect(phasePanel).toBeVisible();
+
+    await expect(phasePanel).toContainText("Phase 1 — Participation / open framing");
+    await expect(phasePanel).toContainText("Phase 2 — Iterative shaping");
+    await expect(phasePanel).toContainText("Phase 3 — Pre-boundary collapse");
+    await expect(phasePanel).toContainText("Phase 4 — Bind");
+
+    await expect(phasePanel).toContainText("participation_state: decision_shaping");
+    await expect(phasePanel).toContainText(/preservation_state: (collapsed|degrading)/);
+    await expect(phasePanel).toContainText("bind_outcome: COMMITTED");
+
+    await expect(phasePanel).toContainText("lineage evidence summary");
+
+    const timeline = page.locator('section[aria-label="governance layer timeline"]');
+    await expect(timeline).toBeVisible();
+    await expect(timeline).toContainText("bind_outcome:");
+  });
   test("endpoint unavailable path renders fallback safety snapshot without breaking page", async ({ page }) => {
     await page.setExtraHTTPHeaders({ [E2E_SCENARIO_HEADER]: "fallback" });
     await page.goto("/?e2e_governance_scenario=fallback");

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -79,7 +79,7 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
 
     await expect(phasePanel).toContainText("participation_state: decision_shaping");
     await expect(phasePanel).toContainText(/preservation_state: (collapsed|degrading)/);
-    await expect(phasePanel).toContainText("bind_outcome: COMMITTED");
+    await expect(phasePanel).toContainText("bind_outcome: FORMALLY_VALID_STRUCTURALLY_COLLAPSED");
 
     await expect(phasePanel).toContainText("lineage evidence summary");
 


### PR DESCRIPTION
### Motivation
- Provide a reviewer-facing entrypoint for the Pre-Boundary Collapse demo so external reviewers can reach the walkthrough from `README.md` and verify the scenario in the frontend UI. 
- Stabilize the demo as a representative, controlled pattern by adding a browser-equivalent frontend E2E that asserts the phase progression and non-regression of existing timeline behavior. 
- Finalize the walkthrough doc so reviewers have an explicit run/verify checklist, reviewer framing, and known limitations without changing backend contracts or core features.

### Description
- Added a Playwright frontend E2E test in `frontend/e2e/mission-control-governance-feed.spec.ts` that navigates the demo (`?demo_scenario=pre_boundary_collapse`) and asserts the demo panel, Phase 1–4 labels, Phase 3 `decision_shaping`/collapsed or degrading signal, Phase 4 bind visibility, the phrase `formally valid, structurally collapsed`, and that the default governance timeline remains present. 
- Added a concise quick link in `README.md` pointing to the demo walkthrough at `docs/en/demos/pre_boundary_collapse_demo.md`. 
- Extended `docs/en/demos/pre_boundary_collapse_demo.md` with a `Run and verification entrypoint`, explicit `Reviewer framing (external)`, and `Known limitations` to guide reviewers and keep the scenario clearly framed as a controlled demo. 
- All changes are additive and confined to UI/tests/docs; no OpenAPI, bind contract, state family, or backend enforcement changes were made.

### Testing
- Ran frontend unit/integration tests with `pnpm -C frontend test -- mission-page.test.tsx mission-control-ingress.test.ts`, and the relevant mission/ingress UI tests passed in this environment. 
- Attempted to run Playwright E2E with `cd frontend && pnpm playwright test e2e/mission-control-governance-feed.spec.ts`, but Playwright failed to launch browsers in this environment with the error instructing `pnpm exec playwright install`, so the Playwright run did not complete here. 
- Existing E2E fallback and main-path checks remain present in the spec and were left unchanged so non-regression behavior is asserted when the Playwright environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7572d4558832692970bd57145ebb7)