### PR TITLE
Add Mission Control source-state labels and AML/KYC evidence drilldown path

### DIFF
--- a/docs/en/validation/external-review-handoff-regulated-action-governance.md
+++ b/docs/en/validation/external-review-handoff-regulated-action-governance.md
@@ -69,6 +69,35 @@ BindReceipt / BindSummary enrichment
 commit / block / escalate / refuse
 ```
 
+### 4.1) 10-minute reviewer path (Mission Control → Audit)
+
+Use this quick path to separate implemented facts from fixture/demo data in about 10 minutes:
+
+1. Open Mission Control.
+2. Check source-state labels on key cards/panels:
+   - `live`: runtime-linked data.
+   - `fixture`: deterministic sample/fixture-backed data.
+   - `demo`: walkthrough/illustrative display path.
+   - `unavailable`: data not present or connector unavailable.
+3. Open the AML/KYC regulated-action panel and confirm the drilldown path:
+   - AI decision
+   - execution intent
+   - bind-boundary result
+   - authority evidence state
+   - bind receipt
+   - audit view
+4. Follow safe internal links from Mission Control operator actions to Audit/BindReceipt details.
+5. Validate authority-evidence failure behavior:
+   - missing authority evidence must be shown as blocked/fail-closed;
+   - no fake link should be rendered when drilldown identifiers are missing.
+
+Boundary reminder:
+
+- Implemented fact: deterministic AML/KYC governed path, bind artifacts, and Mission Control/Audit linkage are repository-implemented behavior.
+- Roadmap area: broader production integrations, external certification claims, and legal/regulatory sign-off are outside this implementation boundary.
+
+This reviewer path is technical evidence guidance only, and is not third-party certification, legal advice, or regulatory approval.
+
 ## 5) Scenario matrix
 
 | Scenario | Requested action | Expected outcome | Review focus |

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -143,6 +143,7 @@ describe("MissionPage", () => {
             target_label: "Governance policy",
             operator_surface: "governance",
             relevant_ui_href: "/governance",
+            bind_receipt_id: "br_123",
           }}
         />
       </I18nProvider>,
@@ -155,6 +156,20 @@ describe("MissionPage", () => {
     expect(screen.getAllByRole("link", { name: "/governance" })[0]).toHaveAttribute("href", "/governance");
     expect(screen.getByText("Operator actions")).toBeInTheDocument();
     expect(screen.getByText(/Open target surface:/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "open audit path" })).toBeInTheDocument();
+    expect(screen.getByText(/Authority evidence status:/)).toBeInTheDocument();
+  });
+
+  it("shows unavailable drilldown without fake links when ids are missing", () => {
+    render(
+      <I18nProvider>
+        <MissionPage title="Command Dashboard" subtitle="Mission overview" chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]} governanceLayerSnapshot={{ pre_bind_source: "none" }} />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText(/AML\/KYC evidence drilldown:/)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "open audit path" })).not.toBeInTheDocument();
+    expect(screen.getAllByText("unavailable").length).toBeGreaterThan(0);
   });
 
   it("renders pre-boundary collapse demo walkthrough with four phases", () => {
@@ -315,6 +330,7 @@ describe("MissionPage", () => {
           governanceLayerSnapshot={{
             target_label: "Governance policy",
             relevant_ui_href: "/governance",
+            bind_receipt_id: "br_123",
           }}
         />
       </I18nProvider>,

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -7,6 +7,7 @@ import { GlobalHealthSummary } from "./global-health-summary";
 import { OpsPriorityCard } from "./ops-priority-card";
 import { useI18n } from "./i18n-provider";
 import { buildAuditArtifactHref, normalizeSafeInternalHref } from "../lib/governance-link-utils";
+import { resolveGovernanceSourceState, resolveSourceState, type SourceState } from "../lib/source-state-utils";
 import {
   type CriticalRailMetric,
   type DecisionEvidenceRouteModel,
@@ -28,6 +29,10 @@ interface MissionPageProps {
 }
 
 const AUDIT_ROUTE_AVAILABLE = true;
+
+function SourceStateBadge({ state }: { state: SourceState }): JSX.Element {
+  return <span className="ml-2 rounded border border-border/60 bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide">{state}</span>;
+}
 
 const CRITICAL_RAIL_ITEMS: CriticalRailMetric[] = [
   {
@@ -248,6 +253,8 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
 
   const governanceObservation = governanceSnapshot?.governance_observation;
   const hasGovernanceObservation = governanceObservation != null;
+  const governanceState = resolveGovernanceSourceState(governanceSnapshot?.pre_bind_source, governanceSnapshot?.demo_scenario);
+  const actionDrilldownHref = bindReceiptAuditHref ?? decisionAuditHref ?? executionIntentAuditHref;
   const renderObservationValue = (value: unknown): string => {
     if (value === null || value === undefined) {
       return "not available";
@@ -287,7 +294,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
 
       {hasPreBindGovernance ? (
         <section aria-label="governance layer timeline" className="rounded-xl border border-info/40 bg-info/5 p-4">
-          <p className="text-xs font-semibold uppercase tracking-wide text-info">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.heading}</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-info">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.heading}<SourceStateBadge state={governanceState} /></p>
           <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs">
             <li>
               <span className="font-semibold">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.participation_state}:</span>{" "}
@@ -343,7 +350,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
       ) : null}
 
       <section aria-label="governance artifact details" className="rounded-xl border border-border/70 bg-background/70 p-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Governance artifacts</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Governance artifacts<SourceStateBadge state={governanceState} /></p>
         <div className="mt-2 grid gap-3 md:grid-cols-2">
           <div className="rounded-md border border-border/60 bg-muted/10 p-3 text-xs">
             <p className="font-semibold">Pre-bind source</p>
@@ -481,12 +488,19 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
               View pre-bind source: <span className="font-mono">{governanceSnapshot?.pre_bind_source ?? "unknown"}</span>{" "}
               <span className="text-muted-foreground">(route unavailable)</span>
             </li>
+            <li>
+              AML/KYC evidence drilldown: {actionDrilldownHref ? <Link className="underline" href={actionDrilldownHref}>open audit path</Link> : <span className="font-mono">unavailable</span>}
+            </li>
+            {governanceSnapshot?.bind_reason_code === "AUTHORITY_MISSING" ? (
+              <li>Authority evidence status: <span className="text-warning">missing (bind blocked)</span></li>
+            ) : null}
           </ul>
         </div>
       </section>
 
       <section className="grid gap-4 md:grid-cols-2" aria-label="trust and governance highlights">
         <Card title="Trust Chain Integrity" titleSize="sm" variant="elevated" accent="danger" className="border-danger/40">
+          <SourceStateBadge state={resolveSourceState(TRUST_CHAIN_INTEGRITY, { fixture: true })} />
           <div className="space-y-1 text-xs">
             <p>Verification: <span className="font-semibold text-danger">{TRUST_CHAIN_INTEGRITY.verificationStatus}</span></p>
             <p>Continuity ratio: {(TRUST_CHAIN_INTEGRITY.continuityRatio * 100).toFixed(1)}%</p>
@@ -497,6 +511,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
         </Card>
 
         <Card title="Governance approval risk" titleSize="sm" variant="elevated" accent="warning" className="border-warning/40">
+          <SourceStateBadge state={resolveSourceState(GOVERNANCE_APPROVAL, { fixture: true })} />
           <div className="space-y-1 text-xs">
             <p>Pending policy: <span className="font-semibold">{GOVERNANCE_APPROVAL.pendingVersion}</span></p>
             <p>Status: <span className="font-semibold text-warning">{GOVERNANCE_APPROVAL.status}</span></p>
@@ -523,6 +538,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
 
       <section className="grid gap-4 md:grid-cols-2" aria-label="replay and evidence routing">
         <Card title="Replay diff readability" titleSize="sm" variant="glass" className="border-border/70" accent="danger">
+          <SourceStateBadge state={resolveSourceState(REPLAY_DIFF_INSIGHT, { fixture: true })} />
           <div className="space-y-1 text-xs">
             <p>Status: <span className="font-semibold text-danger">{REPLAY_DIFF_INSIGHT.status}</span></p>
             <p>Changed fields: {REPLAY_DIFF_INSIGHT.changedFields.join(", ")}</p>
@@ -532,6 +548,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
         </Card>
 
         <Card title="Risk → Decision → Evidence → Report" titleSize="sm" variant="glass" className="border-border/70" accent="info">
+          <SourceStateBadge state={resolveSourceState(DECISION_EVIDENCE_ROUTE, { demo: true })} />
           <ol className="list-decimal space-y-1 pl-4 text-xs">
             <li><span className="font-semibold">Risk:</span> {DECISION_EVIDENCE_ROUTE.riskSignal}</li>
             <li><span className="font-semibold">Decision:</span> {DECISION_EVIDENCE_ROUTE.decisionTarget}</li>
@@ -541,6 +558,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
         </Card>
 
         <Card title="Policy diff / impact preview" titleSize="sm" variant="glass" className="border-border/70" accent="warning">
+          <SourceStateBadge state={resolveSourceState(POLICY_DIFF_IMPACT_PREVIEW, { demo: true })} />
           <div className="space-y-1 text-xs">
             <p>Status: <span className="font-semibold text-warning">{POLICY_DIFF_IMPACT_PREVIEW.status}</span></p>
             <p>{POLICY_DIFF_IMPACT_PREVIEW.summary}</p>

--- a/frontend/lib/source-state-utils.test.ts
+++ b/frontend/lib/source-state-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveGovernanceSourceState, resolveSourceState } from "./source-state-utils";
+
+describe("resolveSourceState", () => {
+  it("resolves live / fixture / demo / unavailable", () => {
+    expect(resolveSourceState({ ok: true })).toBe("live");
+    expect(resolveSourceState({ ok: true }, { fixture: true })).toBe("fixture");
+    expect(resolveSourceState({ ok: true }, { demo: true })).toBe("demo");
+    expect(resolveSourceState(null)).toBe("unavailable");
+  });
+});
+
+describe("resolveGovernanceSourceState", () => {
+  it("maps governance source into source-state", () => {
+    expect(resolveGovernanceSourceState("trustlog_matching_decision", null)).toBe("live");
+    expect(resolveGovernanceSourceState("sample_data", null)).toBe("fixture");
+    expect(resolveGovernanceSourceState("none", null)).toBe("unavailable");
+    expect(resolveGovernanceSourceState("trustlog_matching_decision", "pre_boundary_collapse")).toBe("demo");
+  });
+});

--- a/frontend/lib/source-state-utils.ts
+++ b/frontend/lib/source-state-utils.ts
@@ -1,0 +1,30 @@
+export type SourceState = "live" | "fixture" | "demo" | "unavailable";
+
+/**
+ * Resolve display provenance for Mission Control cards.
+ */
+export function resolveSourceState(value: unknown, options?: { demo?: boolean; fixture?: boolean }): SourceState {
+  if (options?.demo) {
+    return "demo";
+  }
+  if (options?.fixture) {
+    return "fixture";
+  }
+  if (value === null || value === undefined || value === "") {
+    return "unavailable";
+  }
+  return "live";
+}
+
+export function resolveGovernanceSourceState(source?: string | null, demoScenario?: string | null): SourceState {
+  if (demoScenario) {
+    return "demo";
+  }
+  if (!source || source === "none" || source === "pre_bind_artifact_retrieval_failed") {
+    return "unavailable";
+  }
+  if (source.includes("trustlog") || source.includes("latest_bind_receipt")) {
+    return "live";
+  }
+  return "fixture";
+}


### PR DESCRIPTION
### Motivation
- Mission Control and Audit UIs were ambiguous about whether displayed data is runtime, fixture, or demo, which makes external review and PoC evaluation harder. 
- The change clarifies provenance on Mission Control cards and provides a safe, discoverable AML/KYC drilldown path so reviewers can follow Decision → Execution Intent → BindReceipt → Authority Evidence → Audit in a few minutes.

### Description
- Add `frontend/lib/source-state-utils.ts` with `resolveSourceState` and `resolveGovernanceSourceState` to centralize `live | fixture | demo | unavailable` classification logic. 
- Add a compact `SourceStateBadge` and wire source-state labels into `frontend/components/mission-page.tsx` on governance artifacts and key Trust/Governance/Evidence cards without changing existing card contents or contracts. 
- Add an AML/KYC evidence drilldown operator action that safely links to `/audit` when `bind_receipt_id`, `decision_id`, or `execution_intent_id` exists (priority: bind_receipt → decision → execution_intent) using existing `buildAuditArtifactHref`/`normalizeSafeInternalHref`, and show a short operator message when `bind_reason_code === "AUTHORITY_MISSING"`. 
- Documentation: extend `docs/en/validation/external-review-handoff-regulated-action-governance.md` with a “10-minute reviewer path (Mission Control → Audit)”; tests: add `frontend/lib/source-state-utils.test.ts` and update `frontend/components/mission-page.test.tsx` to cover labels, safe-link behavior, and the drilldown/no-fake-link cases.

### Testing
- Ran `pnpm -C frontend exec vitest run components/mission-page.test.tsx lib/source-state-utils.test.ts lib/governance-link-utils.test.ts` and the included test set passed (`42` tests passed in the focused run). 
- Ran `pnpm -C frontend lint`, which returned only pre-existing warnings and no new lint errors from these changes. 
- The implementation reuses existing safe-href and artifact-id sanitization utilities to avoid generating external/unsafe links, and tests ensure that unsafe/malformed ids or URLs do not produce anchor links.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78ecf4268832685cc89ee5e4e24c8)