### PR TITLE
Complete Mission Control provenance coverage for top-level operational cards

### DIFF
--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -59,6 +59,14 @@ BindReceipt, and clearly states that the case is not bind-retryable.
 
 ## Mission Control pre-bind governance vocabulary
 
+### Mission Control provenance coverage (top-level cards)
+
+- Mission Control の主要トップレベルカードは `source-state` badge を表示し、表示 provenance を `live` / `fixture` / `demo` / `unavailable` で明示します。
+- page 上部に `Mission Control provenance: mixed` summary を表示し、画面内が混在 provenance（runtime + fixture + demo + unavailable fallback）であることを即時判別できるようにしています。
+- `live` は runtime snapshot / governance artifact lineage 由来、`fixture` は deterministic/static sample、`demo` は walkthrough scenario、`unavailable` は payload 欠落や connector unavailable を意味します。
+- `source-state` label は reviewer guidance であり、法規制上の認証・第三者認証・規制承認を意味しません。
+- fixture/demo surface は live runtime data として扱わず、UI で明示的に区別します。
+
 - Mission Control の pre-bind governance snapshot は `frontend/components/dashboard-types.ts` の shared frontend contract を参照してください。
 - `participation_state` / `preservation_state` / `intervention_viability` / `concise_rationale` / `bind_outcome` は backend vocabulary をそのまま表示する契約です。
 - Mission Control は bind outcome だけでなく pre-bind state を timeline で扱うため、component-local 型ではなく shared type (`PreBindGovernanceSnapshot`) を利用してください。

--- a/frontend/components/critical-rail.test.tsx
+++ b/frontend/components/critical-rail.test.tsx
@@ -53,4 +53,9 @@ describe("CriticalRail", () => {
     render(<CriticalRail items={items} />);
     expect(screen.getByRole("region", { name: "critical rail" })).toBeInTheDocument();
   });
+
+  it("renders source badge when sourceState is provided", () => {
+    render(<CriticalRail items={items} sourceState="fixture" sourceStateReason="deterministic_fixture" />);
+    expect(screen.getByText("fixture")).toBeInTheDocument();
+  });
 });

--- a/frontend/components/critical-rail.tsx
+++ b/frontend/components/critical-rail.tsx
@@ -1,7 +1,11 @@
 import { type CriticalRailMetric } from "./dashboard-types";
+import { SourceStateBadge } from "./source-state-badge";
+import { type SourceState } from "../lib/source-state-utils";
 
 interface CriticalRailProps {
   items: CriticalRailMetric[];
+  sourceState?: SourceState;
+  sourceStateReason?: string;
 }
 
 const SEVERITY_STYLE = {
@@ -10,10 +14,12 @@ const SEVERITY_STYLE = {
   critical: "text-danger border-danger/40",
 };
 
-export function CriticalRail({ items }: CriticalRailProps): JSX.Element {
+export function CriticalRail({ items, sourceState, sourceStateReason }: CriticalRailProps): JSX.Element {
   return (
     <section aria-label="critical rail" className="rounded-xl border border-danger/30 bg-danger/8 p-4">
-      <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-danger">Critical Rail</p>
+      <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-danger">
+        Critical Rail {sourceState ? <SourceStateBadge state={sourceState} reason={sourceStateReason} compact className="ml-2" /> : null}
+      </p>
       <div className="grid gap-2 md:grid-cols-5">
         {items.map((item) => (
           <a key={item.key} href={item.href} className="rounded-lg border border-border/60 bg-background/70 p-3 text-xs">

--- a/frontend/components/global-health-summary.test.tsx
+++ b/frontend/components/global-health-summary.test.tsx
@@ -30,4 +30,10 @@ describe("GlobalHealthSummary", () => {
     expect(screen.getByText("Policy drift: 0.02")).toBeInTheDocument();
     expect(screen.getByText("Decision anomalies: 1")).toBeInTheDocument();
   });
+
+  it("renders source badge when sourceState is provided", () => {
+    render(<GlobalHealthSummary summary={summary} sourceState="fixture" sourceStateReason="static_fixture" />);
+    expect(screen.getByText("fixture")).toBeInTheDocument();
+    expect(screen.getByLabelText("source state: fixture (static_fixture)")).toBeInTheDocument();
+  });
 });

--- a/frontend/components/global-health-summary.tsx
+++ b/frontend/components/global-health-summary.tsx
@@ -1,8 +1,12 @@
 import { Card } from "@veritas/design-system";
 import { type GlobalHealthSummaryModel } from "./dashboard-types";
+import { SourceStateBadge } from "./source-state-badge";
+import { type SourceState } from "../lib/source-state-utils";
 
 interface GlobalHealthSummaryProps {
   summary: GlobalHealthSummaryModel;
+  sourceState?: SourceState;
+  sourceStateReason?: string;
 }
 
 const BAND_STYLE = {
@@ -11,7 +15,7 @@ const BAND_STYLE = {
   critical: "text-danger",
 };
 
-export function GlobalHealthSummary({ summary }: GlobalHealthSummaryProps): JSX.Element {
+export function GlobalHealthSummary({ summary, sourceState, sourceStateReason }: GlobalHealthSummaryProps): JSX.Element {
   return (
     <Card
       title="Global Health Summary"
@@ -20,6 +24,7 @@ export function GlobalHealthSummary({ summary }: GlobalHealthSummaryProps): JSX.
       className="border-border/60"
       description="healthy / degraded / critical の3区分で司令塔の現状を要約"
     >
+      <div className="mb-2">{sourceState ? <SourceStateBadge state={sourceState} reason={sourceStateReason} compact /> : null}</div>
       <div className="grid gap-3 md:grid-cols-2">
         <div className="space-y-2 text-xs">
           <p>

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -22,6 +22,7 @@ describe("MissionPage", () => {
     expect(screen.getByText("Critical Rail")).toBeInTheDocument();
     expect(screen.getByText("FUJI reject")).toBeInTheDocument();
     expect(screen.getByText("Open incidents: 4")).toBeInTheDocument();
+    expect(screen.getByText("Mission Control provenance: mixed")).toBeInTheDocument();
   });
 
   it("renders action-oriented priority cards", () => {
@@ -167,9 +168,21 @@ describe("MissionPage", () => {
       </I18nProvider>,
     );
 
-    expect(screen.getByText(/AML\/KYC evidence drilldown:/)).toBeInTheDocument();
+    expect(screen.getByText(/AML\/KYC evidence drilldown/)).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "open audit path" })).not.toBeInTheDocument();
     expect(screen.getAllByText("unavailable").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("source state: unavailable (missing_payload)").length).toBeGreaterThan(0);
+  });
+
+  it("marks static and demo cards with source-state labels", () => {
+    render(
+      <I18nProvider>
+        <MissionPage title="Command Dashboard" subtitle="Mission overview" chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]} />
+      </I18nProvider>,
+    );
+
+    expect(screen.getAllByText("fixture").length).toBeGreaterThan(3);
+    expect(screen.getAllByText("demo").length).toBeGreaterThan(1);
   });
 
   it("renders pre-boundary collapse demo walkthrough with four phases", () => {

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -5,9 +5,16 @@ import Link from "next/link";
 import { CriticalRail } from "./critical-rail";
 import { GlobalHealthSummary } from "./global-health-summary";
 import { OpsPriorityCard } from "./ops-priority-card";
+import { SourceStateBadge } from "./source-state-badge";
 import { useI18n } from "./i18n-provider";
 import { buildAuditArtifactHref, normalizeSafeInternalHref } from "../lib/governance-link-utils";
-import { resolveGovernanceSourceState, resolveSourceState, type SourceState } from "../lib/source-state-utils";
+import {
+  resolveDemoSourceState,
+  resolveGovernanceSourceState,
+  resolveOperationalSourceState,
+  resolveStaticFixtureSourceState,
+  resolveUnavailableSourceState,
+} from "../lib/source-state-utils";
 import {
   type CriticalRailMetric,
   type DecisionEvidenceRouteModel,
@@ -29,10 +36,6 @@ interface MissionPageProps {
 }
 
 const AUDIT_ROUTE_AVAILABLE = true;
-
-function SourceStateBadge({ state }: { state: SourceState }): JSX.Element {
-  return <span className="ml-2 rounded border border-border/60 bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide">{state}</span>;
-}
 
 const CRITICAL_RAIL_ITEMS: CriticalRailMetric[] = [
   {
@@ -253,7 +256,6 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
 
   const governanceObservation = governanceSnapshot?.governance_observation;
   const hasGovernanceObservation = governanceObservation != null;
-  const governanceState = resolveGovernanceSourceState(governanceSnapshot?.pre_bind_source, governanceSnapshot?.demo_scenario);
   const actionDrilldownHref = bindReceiptAuditHref ?? decisionAuditHref ?? executionIntentAuditHref;
   const renderObservationValue = (value: unknown): string => {
     if (value === null || value === undefined) {
@@ -271,6 +273,24 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
     degraded: t("degraded: 監査連鎖が断続し、レポート確定を一部停止しています。", "Degraded: audit-chain continuity is broken and report finalization is partially blocked."),
     operational: t("operational: 信頼連鎖は検証済みです。", "Operational: trust chain is verified."),
   }[uiState];
+  const governanceState = resolveGovernanceSourceState(governanceSnapshot?.pre_bind_source, governanceSnapshot?.demo_scenario);
+  const governanceReason = governanceSnapshot?.demo_scenario
+    ? "demo_scenario"
+    : governanceState === "unavailable"
+      ? "missing_payload"
+      : "trustlog_matching_decision";
+  const globalHealthSource = resolveStaticFixtureSourceState(GLOBAL_HEALTH_SUMMARY);
+  const criticalRailSource = resolveStaticFixtureSourceState(CRITICAL_RAIL_ITEMS);
+  const systemStateSource = resolveStaticFixtureSourceState(statusMessage);
+  const healthPostureSource = resolveStaticFixtureSourceState(HEALTH_SECURITY_POSTURE);
+  const trustChainSource = resolveStaticFixtureSourceState(TRUST_CHAIN_INTEGRITY);
+  const approvalRiskSource = resolveStaticFixtureSourceState(GOVERNANCE_APPROVAL);
+  const replayDiffSource = resolveStaticFixtureSourceState(REPLAY_DIFF_INSIGHT);
+  const evidenceRouteSource = resolveDemoSourceState(DECISION_EVIDENCE_ROUTE, true);
+  const policyPreviewSource = resolveDemoSourceState(POLICY_DIFF_IMPACT_PREVIEW, true);
+  const amlDrilldownSource = actionDrilldownHref
+    ? resolveOperationalSourceState(actionDrilldownHref)
+    : resolveUnavailableSourceState("missing_payload");
 
   return (
     <div className="space-y-6">
@@ -285,16 +305,20 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
         </div>
       </Card>
 
-      <GlobalHealthSummary summary={GLOBAL_HEALTH_SUMMARY} />
-      <CriticalRail items={CRITICAL_RAIL_ITEMS} />
+      <section aria-label="mission control provenance summary" className="rounded-xl border border-border/70 bg-muted/10 p-4 text-xs">
+        <p className="font-semibold">Mission Control provenance: mixed</p>
+        <p className="text-muted-foreground">live: governance artifacts / AML-KYC drilldown · fixture: critical rail, trust chain · demo: evidence route, policy preview · unavailable: missing drilldown ids</p>
+      </section>
+      <GlobalHealthSummary summary={GLOBAL_HEALTH_SUMMARY} sourceState={globalHealthSource.state} sourceStateReason={globalHealthSource.reason} />
+      <CriticalRail items={CRITICAL_RAIL_ITEMS} sourceState={criticalRailSource.state} sourceStateReason={criticalRailSource.reason} />
       <section aria-label="mission control state" className="rounded-xl border border-border/70 bg-background/70 p-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">System state</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">System state <SourceStateBadge state={systemStateSource.state} reason={systemStateSource.reason} compact className="ml-2" /></p>
         <p className={["mt-1 text-sm font-semibold", uiState === "degraded" ? "text-danger" : "text-foreground"].join(" ")}>{statusMessage}</p>
       </section>
 
       {hasPreBindGovernance ? (
         <section aria-label="governance layer timeline" className="rounded-xl border border-info/40 bg-info/5 p-4">
-          <p className="text-xs font-semibold uppercase tracking-wide text-info">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.heading}<SourceStateBadge state={governanceState} /></p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-info">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.heading}<SourceStateBadge state={governanceState} reason={governanceReason} compact className="ml-2" /></p>
           <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs">
             <li>
               <span className="font-semibold">{PRE_BIND_GOVERNANCE_VOCABULARY_LABELS.participation_state}:</span>{" "}
@@ -350,7 +374,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
       ) : null}
 
       <section aria-label="governance artifact details" className="rounded-xl border border-border/70 bg-background/70 p-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Governance artifacts<SourceStateBadge state={governanceState} /></p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Governance artifacts<SourceStateBadge state={governanceState} reason={governanceReason} compact className="ml-2" /></p>
         <div className="mt-2 grid gap-3 md:grid-cols-2">
           <div className="rounded-md border border-border/60 bg-muted/10 p-3 text-xs">
             <p className="font-semibold">Pre-bind source</p>
@@ -489,7 +513,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
               <span className="text-muted-foreground">(route unavailable)</span>
             </li>
             <li>
-              AML/KYC evidence drilldown: {actionDrilldownHref ? <Link className="underline" href={actionDrilldownHref}>open audit path</Link> : <span className="font-mono">unavailable</span>}
+              AML/KYC evidence drilldown <SourceStateBadge state={amlDrilldownSource.state} reason={amlDrilldownSource.reason} compact className="ml-2" />: {actionDrilldownHref ? <Link className="underline" href={actionDrilldownHref}>open audit path</Link> : <span className="font-mono">unavailable</span>}
             </li>
             {governanceSnapshot?.bind_reason_code === "AUTHORITY_MISSING" ? (
               <li>Authority evidence status: <span className="text-warning">missing (bind blocked)</span></li>
@@ -500,7 +524,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
 
       <section className="grid gap-4 md:grid-cols-2" aria-label="trust and governance highlights">
         <Card title="Trust Chain Integrity" titleSize="sm" variant="elevated" accent="danger" className="border-danger/40">
-          <SourceStateBadge state={resolveSourceState(TRUST_CHAIN_INTEGRITY, { fixture: true })} />
+          <SourceStateBadge state={trustChainSource.state} reason={trustChainSource.reason} compact />
           <div className="space-y-1 text-xs">
             <p>Verification: <span className="font-semibold text-danger">{TRUST_CHAIN_INTEGRITY.verificationStatus}</span></p>
             <p>Continuity ratio: {(TRUST_CHAIN_INTEGRITY.continuityRatio * 100).toFixed(1)}%</p>
@@ -511,7 +535,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
         </Card>
 
         <Card title="Governance approval risk" titleSize="sm" variant="elevated" accent="warning" className="border-warning/40">
-          <SourceStateBadge state={resolveSourceState(GOVERNANCE_APPROVAL, { fixture: true })} />
+          <SourceStateBadge state={approvalRiskSource.state} reason={approvalRiskSource.reason} compact />
           <div className="space-y-1 text-xs">
             <p>Pending policy: <span className="font-semibold">{GOVERNANCE_APPROVAL.pendingVersion}</span></p>
             <p>Status: <span className="font-semibold text-warning">{GOVERNANCE_APPROVAL.status}</span></p>
@@ -522,7 +546,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
       </section>
 
       <section aria-label="health security posture" className="rounded-xl border border-warning/40 bg-warning/10 p-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-warning">/health security posture (mandatory)</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-warning">/health security posture (mandatory) <SourceStateBadge state={healthPostureSource.state} reason={healthPostureSource.reason} compact className="ml-2" /></p>
         <ul className="mt-2 space-y-1 text-xs">
           <li>Encryption algorithm: <span className="font-semibold">{HEALTH_SECURITY_POSTURE.encryptionAlgorithm}</span></li>
           <li>Authentication mode: <span className="font-semibold">{HEALTH_SECURITY_POSTURE.authenticationMode}</span></li>
@@ -532,13 +556,13 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
 
       <section aria-label={`${title} operational cards`} className="grid gap-4 md:grid-cols-3">
         {OPS_PRIORITY_ITEMS.map((item, index) => (
-          <OpsPriorityCard key={item.key} item={item} priority={index + 1} />
+          <OpsPriorityCard key={item.key} item={item} priority={index + 1} sourceState="fixture" sourceStateReason="deterministic_fixture" />
         ))}
       </section>
 
       <section className="grid gap-4 md:grid-cols-2" aria-label="replay and evidence routing">
         <Card title="Replay diff readability" titleSize="sm" variant="glass" className="border-border/70" accent="danger">
-          <SourceStateBadge state={resolveSourceState(REPLAY_DIFF_INSIGHT, { fixture: true })} />
+          <SourceStateBadge state={replayDiffSource.state} reason={replayDiffSource.reason} compact />
           <div className="space-y-1 text-xs">
             <p>Status: <span className="font-semibold text-danger">{REPLAY_DIFF_INSIGHT.status}</span></p>
             <p>Changed fields: {REPLAY_DIFF_INSIGHT.changedFields.join(", ")}</p>
@@ -548,7 +572,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
         </Card>
 
         <Card title="Risk → Decision → Evidence → Report" titleSize="sm" variant="glass" className="border-border/70" accent="info">
-          <SourceStateBadge state={resolveSourceState(DECISION_EVIDENCE_ROUTE, { demo: true })} />
+          <SourceStateBadge state={evidenceRouteSource.state} reason={evidenceRouteSource.reason} compact />
           <ol className="list-decimal space-y-1 pl-4 text-xs">
             <li><span className="font-semibold">Risk:</span> {DECISION_EVIDENCE_ROUTE.riskSignal}</li>
             <li><span className="font-semibold">Decision:</span> {DECISION_EVIDENCE_ROUTE.decisionTarget}</li>
@@ -558,7 +582,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
         </Card>
 
         <Card title="Policy diff / impact preview" titleSize="sm" variant="glass" className="border-border/70" accent="warning">
-          <SourceStateBadge state={resolveSourceState(POLICY_DIFF_IMPACT_PREVIEW, { demo: true })} />
+          <SourceStateBadge state={policyPreviewSource.state} reason={policyPreviewSource.reason} compact />
           <div className="space-y-1 text-xs">
             <p>Status: <span className="font-semibold text-warning">{POLICY_DIFF_IMPACT_PREVIEW.status}</span></p>
             <p>{POLICY_DIFF_IMPACT_PREVIEW.summary}</p>

--- a/frontend/components/ops-priority-card.test.tsx
+++ b/frontend/components/ops-priority-card.test.tsx
@@ -39,4 +39,13 @@ describe("OpsPriorityCard", () => {
     const link = screen.getByRole("link", { name: "確認する" });
     expect(link).toHaveAttribute("href", "/governance");
   });
+
+  it("renders source badge when sourceState is provided", () => {
+    render(
+      <I18nProvider>
+        <OpsPriorityCard item={item} priority={2} sourceState="fixture" sourceStateReason="deterministic_fixture" />
+      </I18nProvider>,
+    );
+    expect(screen.getByText("fixture")).toBeInTheDocument();
+  });
 });

--- a/frontend/components/ops-priority-card.tsx
+++ b/frontend/components/ops-priority-card.tsx
@@ -1,13 +1,17 @@
 import { Card } from "@veritas/design-system";
 import { useI18n } from "./i18n-provider";
 import { type OpsPriorityItem } from "./dashboard-types";
+import { SourceStateBadge } from "./source-state-badge";
+import { type SourceState } from "../lib/source-state-utils";
 
 interface OpsPriorityCardProps {
   item: OpsPriorityItem;
   priority: number;
+  sourceState?: SourceState;
+  sourceStateReason?: string;
 }
 
-export function OpsPriorityCard({ item, priority }: OpsPriorityCardProps): JSX.Element {
+export function OpsPriorityCard({ item, priority, sourceState, sourceStateReason }: OpsPriorityCardProps): JSX.Element {
   const { t } = useI18n();
 
   return (
@@ -18,6 +22,7 @@ export function OpsPriorityCard({ item, priority }: OpsPriorityCardProps): JSX.E
       accent={priority === 1 ? "danger" : priority === 2 ? "warning" : "info"}
       className="border-border/60"
     >
+      <div className="mb-2">{sourceState ? <SourceStateBadge state={sourceState} reason={sourceStateReason} compact /> : null}</div>
       <div className="space-y-2 text-sm">
         <p className="text-xs text-muted-foreground">Owner: {item.owner}</p>
         <p>

--- a/frontend/components/source-state-badge.test.tsx
+++ b/frontend/components/source-state-badge.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SourceStateBadge } from "./source-state-badge";
+
+describe("SourceStateBadge", () => {
+  it("renders state", () => {
+    render(<SourceStateBadge state="fixture" />);
+    expect(screen.getByText("fixture")).toBeInTheDocument();
+  });
+
+  it("includes reason in accessibility text", () => {
+    render(<SourceStateBadge state="demo" reason="demo_scenario" />);
+    expect(screen.getByLabelText("source state: demo (demo_scenario)")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/source-state-badge.tsx
+++ b/frontend/components/source-state-badge.tsx
@@ -1,0 +1,26 @@
+import { type SourceState } from "../lib/source-state-utils";
+
+interface SourceStateBadgeProps {
+  state: SourceState;
+  reason?: string;
+  compact?: boolean;
+  className?: string;
+}
+
+export function SourceStateBadge({ state, reason, compact = false, className }: SourceStateBadgeProps): JSX.Element {
+  const sizeClass = compact ? "px-1 py-0.5 text-[9px]" : "px-1.5 py-0.5 text-[10px]";
+  const accessibleLabel = reason ? `source state: ${state} (${reason})` : `source state: ${state}`;
+  return (
+    <span
+      className={[
+        "inline-flex rounded border border-border/60 bg-muted uppercase tracking-wide",
+        sizeClass,
+        className ?? "",
+      ].join(" ").trim()}
+      aria-label={accessibleLabel}
+      title={reason ? `reason: ${reason}` : undefined}
+    >
+      {state}
+    </span>
+  );
+}

--- a/frontend/lib/source-state-utils.test.ts
+++ b/frontend/lib/source-state-utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveGovernanceSourceState, resolveSourceState } from "./source-state-utils";
+import {
+  resolveDemoSourceState,
+  resolveGovernanceSourceState,
+  resolveSourceState,
+  resolveUnavailableSourceState,
+} from "./source-state-utils";
 
 describe("resolveSourceState", () => {
   it("resolves live / fixture / demo / unavailable", () => {
@@ -8,6 +13,24 @@ describe("resolveSourceState", () => {
     expect(resolveSourceState({ ok: true }, { fixture: true })).toBe("fixture");
     expect(resolveSourceState({ ok: true }, { demo: true })).toBe("demo");
     expect(resolveSourceState(null)).toBe("unavailable");
+  });
+});
+
+describe("extended source-state resolvers", () => {
+  it("resolves unavailable when governance source is none", () => {
+    expect(resolveGovernanceSourceState("none", null)).toBe("unavailable");
+  });
+
+  it("prioritizes demo when demo scenario exists", () => {
+    expect(resolveGovernanceSourceState("trustlog_matching_decision", "pre_boundary_collapse")).toBe("demo");
+    expect(resolveDemoSourceState({ ok: true }, true)).toEqual({ state: "demo", reason: "demo_scenario" });
+  });
+
+  it("resolves unavailable source reason", () => {
+    expect(resolveUnavailableSourceState("connector_unavailable")).toEqual({
+      state: "unavailable",
+      reason: "connector_unavailable",
+    });
   });
 });
 

--- a/frontend/lib/source-state-utils.ts
+++ b/frontend/lib/source-state-utils.ts
@@ -1,4 +1,19 @@
 export type SourceState = "live" | "fixture" | "demo" | "unavailable";
+export type SourceStateReason =
+  | "runtime_snapshot"
+  | "trustlog_matching_decision"
+  | "latest_bind_receipt"
+  | "deterministic_fixture"
+  | "static_fixture"
+  | "demo_scenario"
+  | "missing_payload"
+  | "connector_unavailable"
+  | "retrieval_failed"
+  | "unknown_source";
+export interface SourceStateResolution {
+  state: SourceState;
+  reason: SourceStateReason;
+}
 
 /**
  * Resolve display provenance for Mission Control cards.
@@ -27,4 +42,32 @@ export function resolveGovernanceSourceState(source?: string | null, demoScenari
     return "live";
   }
   return "fixture";
+}
+
+export function resolveOperationalSourceState(value: unknown): SourceStateResolution {
+  if (value === null || value === undefined || value === "") {
+    return { state: "unavailable", reason: "missing_payload" };
+  }
+  return { state: "live", reason: "runtime_snapshot" };
+}
+
+export function resolveStaticFixtureSourceState(value: unknown): SourceStateResolution {
+  if (value === null || value === undefined || value === "") {
+    return { state: "unavailable", reason: "missing_payload" };
+  }
+  return { state: "fixture", reason: "static_fixture" };
+}
+
+export function resolveDemoSourceState(value: unknown, hasScenario = true): SourceStateResolution {
+  if (!hasScenario) {
+    return resolveOperationalSourceState(value);
+  }
+  if (value === null || value === undefined || value === "") {
+    return { state: "unavailable", reason: "missing_payload" };
+  }
+  return { state: "demo", reason: "demo_scenario" };
+}
+
+export function resolveUnavailableSourceState(reason: SourceStateReason = "unknown_source"): SourceStateResolution {
+  return { state: "unavailable", reason };
 }


### PR DESCRIPTION
### Motivation
- Provide clear provenance (live / fixture / demo / unavailable) across Mission Control top-level operational cards so external reviewers can immediately trust the display provenance of each surface.
- Keep this as a small, frontend-only finish: reuse existing utils/components, do not change backend/OpenAPI/bind-receipt/governance contracts, and avoid large UI or architecture rewrites.

### Description
- Extracted a reusable `SourceStateBadge` component with props `state`, `reason`, `compact`, and `className`, and expose the reason via `aria-label`/`title` for accessibility (`frontend/components/source-state-badge.tsx`).
- Extended `frontend/lib/source-state-utils.ts` with `SourceStateReason`, `SourceStateResolution` and light-weight resolvers: `resolveOperationalSourceState`, `resolveStaticFixtureSourceState`, `resolveDemoSourceState`, and `resolveUnavailableSourceState`, preserving existing `resolveSourceState`/`resolveGovernanceSourceState` behavior.
- Added optional `sourceState`/`sourceStateReason` props to `GlobalHealthSummary`, `CriticalRail`, and `OpsPriorityCard` and wired provenance badges into `MissionPage`, including a compact page-level summary (`Mission Control provenance: mixed`) and explicit AML/KYC drilldown provenance while preserving safe-link behavior and existing on-screen data.
- Reviewer impact and scope boundary: reviewers can now distinguish provenance at a glance; this PR implements frontend provenance labeling only and does not change backend behavior or regulatory semantics (UI labels are reviewer guidance, not certification). Risks/limitations: lint warnings pre-existed and remain (no new lint errors introduced), provenance reasons are UI-facing only, and link-safety behavior (no fake internal links for missing/unsafe IDs) is preserved.

### Testing
- Ran targeted unit tests: `pnpm -C frontend exec vitest run components/mission-page.test.tsx lib/source-state-utils.test.ts components/source-state-badge.test.tsx components/global-health-summary.test.tsx components/critical-rail.test.tsx components/ops-priority-card.test.tsx`, and all targeted tests passed (54 tests across these files passed).
- Ran frontend lint: `pnpm -C frontend lint`, which completed successfully with existing repository warnings but no new ESLint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79692611483269fef920bc0a6b472)