### PR TITLE
Add AML/KYC missing-authority reviewer walkthrough to Mission Control

### DIFF
--- a/docs/en/validation/external-review-handoff-regulated-action-governance.md
+++ b/docs/en/validation/external-review-handoff-regulated-action-governance.md
@@ -201,3 +201,13 @@ Snapshot status from documented ledger (updated **2026-04-27 UTC**):
 - [Regulated Action Governance Quality Gate](regulated-action-governance-quality-gate.md)
 - [Regulated Action Governance Proof Pack 日本語要約](../../ja/validation/regulated-action-governance-proof-pack-summary.md)
 - [Regulated Action Governance Quality Gate 日本語要約](../../ja/validation/regulated-action-governance-quality-gate-summary.md)
+
+
+## AML/KYC missing-authority reviewer walkthrough (fixture/demo)
+
+- Open Mission Control with `/?demo_scenario=aml_kyc_reviewer_walkthrough`.
+- Review panel fields: scenario id/name, requested scope, authority evidence status (`missing`), bind outcome (`block`), reason code, deterministic audit IDs, audit safe link, evidence bundle summary, and reviewer expected steps.
+- Expected behavior: missing authority evidence must fail-closed before commit and must not be represented as live production behavior.
+- Implemented fact: deterministic fixture payload + Mission Control panel + safe audit links + reviewer evidence summary.
+- Roadmap (not implemented here): real bank integration, real sanctions API, real customer data, third-party certification, regulatory approval.
+- Not legal advice, regulatory approval, third-party certification, or production customer validation.

--- a/docs/en/validation/regulated-action-governance-proof-pack.md
+++ b/docs/en/validation/regulated-action-governance-proof-pack.md
@@ -107,3 +107,13 @@ Recommended checks for this proof pack:
 - It does not establish full enterprise deployment correctness by itself.
 - It does not provide legal interpretation or external certification evidence.
 - Additional domain contracts and effect-path coverage are roadmap items.
+
+
+## AML/KYC missing-authority reviewer walkthrough (fixture/demo)
+
+- Open Mission Control with `/?demo_scenario=aml_kyc_reviewer_walkthrough`.
+- Review panel fields: scenario id/name, requested scope, authority evidence status (`missing`), bind outcome (`block`), reason code, deterministic audit IDs, audit safe link, evidence bundle summary, and reviewer expected steps.
+- Expected behavior: missing authority evidence must fail-closed before commit and must not be represented as live production behavior.
+- Implemented fact: deterministic fixture payload + Mission Control panel + safe audit links + reviewer evidence summary.
+- Roadmap (not implemented here): real bank integration, real sanctions API, real customer data, third-party certification, regulatory approval.
+- Not legal advice, regulatory approval, third-party certification, or production customer validation.

--- a/docs/ui/README_UI.md
+++ b/docs/ui/README_UI.md
@@ -182,3 +182,10 @@ docker compose up --build
 - 各 phase で `participation_state` / `preservation_state` / `intervention_viability` / `bind_outcome` / `concise_rationale` を表示します。
 - 追加で `effective optionality` / `option exposure summary` / `reinforcement asymmetry summary` / `lineage evidence summary` を表示し、`formally valid, structurally collapsed` の explanatory copy を固定表示します。
 - この UI は demo surface であり、normal Mission Control mode（live governance snapshot）を置き換えません。fallback behavior・shared vocabulary・backend contract は変更しません。
+
+
+## AML/KYC missing-authority reviewer walkthrough (fixture/demo)
+
+- Open: `/?demo_scenario=aml_kyc_reviewer_walkthrough`
+- Mission Control shows `AML/KYC Reviewer Walkthrough` panel with explicit `Authority Evidence: missing` and `Bind result: block`.
+- This path is deterministic fixture/demo evidence only; it is not live banking, sanctions API, customer data, legal advice, certification, or regulatory approval.

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -271,6 +271,36 @@ describe("/api/veritas/v1/report/governance", () => {
     ]);
   });
 
+
+  it("returns AML/KYC reviewer walkthrough payload from query seam", async () => {
+    const response = await GET(new Request("http://localhost/api/veritas/v1/report/governance?demo_scenario=aml_kyc_reviewer_walkthrough"));
+    expect(response.status).toBe(200);
+    const payload = await response.json() as { governance_layer_snapshot: Record<string, unknown> };
+    expect(payload.governance_layer_snapshot).toMatchObject({
+      demo_scenario: "aml_kyc_reviewer_walkthrough",
+      source_state: "fixture",
+      scenario_id: "scenario_e_missing_authority",
+      authority_evidence_status: "missing",
+      bind_outcome: "block",
+      bind_reason_code: "AUTHORITY_MISSING",
+    });
+  });
+
+  it("returns AML/KYC reviewer walkthrough payload from header seam", async () => {
+    const response = await GET(new Request("http://localhost/api/veritas/v1/report/governance", {
+      headers: { "x-veritas-demo-scenario": "aml_kyc_reviewer_walkthrough" },
+    }));
+    expect(response.status).toBe(200);
+    const payload = await response.json() as { governance_layer_snapshot: { audit_trace: Array<{ event: string }> } };
+    expect(payload.governance_layer_snapshot.audit_trace.map((item) => item.event)).toEqual([
+      "decision_created",
+      "execution_intent_requested",
+      "authority_evidence_validation_failed",
+      "bind_boundary_blocked",
+      "bind_receipt_recorded",
+    ]);
+  });
+
   it("falls back to upstream path when demo scenario is invalid", async () => {
     vi.stubEnv("VERITAS_API_BASE_URL", "http://internal-api:8000");
     vi.stubEnv("VERITAS_API_KEY", "test-key");

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { NextResponse } from "next/server";
 
 import { resolveApiBaseUrl } from "../../../[...path]/route-config";
+import { buildAmlKycReviewerWalkthroughPayload } from "../../../../../../lib/aml-kyc-reviewer-walkthrough";
 import { areE2EScenariosEnabled } from "../../../../../e2e-scenarios";
 
 const GOVERNANCE_LIVE_SNAPSHOT_PATH = "/v1/governance/live-snapshot";
@@ -12,6 +13,7 @@ const E2E_SCENARIO_QUERY = "e2e_governance_scenario";
 const DEMO_SCENARIO_HEADER = "x-veritas-demo-scenario";
 const DEMO_SCENARIO_QUERY = "demo_scenario";
 const PRE_BOUNDARY_COLLAPSE_SCENARIO = "pre_boundary_collapse";
+const AML_KYC_REVIEWER_WALKTHROUGH_SCENARIO = "aml_kyc_reviewer_walkthrough";
 
 const PRE_BOUNDARY_COLLAPSE_PHASE_FIXTURE_FILES = [
   "pre_boundary_collapse_phase_1_open.json",
@@ -101,7 +103,12 @@ function mapPreBoundaryCollapsePhaseToSnapshot(phase: Record<string, unknown>): 
 }
 
 async function resolveDemoScenarioPayload(request: Request): Promise<Record<string, unknown> | null> {
-  if (resolveDemoScenario(request) !== PRE_BOUNDARY_COLLAPSE_SCENARIO) {
+  const demoScenario = resolveDemoScenario(request);
+  if (demoScenario === AML_KYC_REVIEWER_WALKTHROUGH_SCENARIO) {
+    return buildAmlKycReviewerWalkthroughPayload();
+  }
+
+  if (demoScenario !== PRE_BOUNDARY_COLLAPSE_SCENARIO) {
     return null;
   }
 

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -84,6 +84,20 @@ export interface GovernanceObservation {
 
 export interface PreBindGovernanceSnapshot {
   demo_scenario?: string;
+  source_state?: string | null;
+  scenario_id?: string | null;
+  scenario_name?: string | null;
+  scenario_title?: string | null;
+  action_class?: string | null;
+  requested_action?: string | null;
+  requested_scope?: string[] | string | null;
+  customer_risk_context?: unknown | null;
+  authority_evidence?: unknown | null;
+  authority_evidence_status?: string | null;
+  admissibility_result?: unknown | null;
+  audit_trace?: Array<Record<string, unknown>> | null;
+  evidence_bundle_summary?: unknown | null;
+  reviewer_expected_steps?: Array<string | Record<string, unknown>> | null;
   phase_snapshots?: Array<Record<string, unknown>>;
   participation_state?: string;
   preservation_state?: string;

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -151,7 +151,7 @@ describe("MissionPage", () => {
     );
 
     expect(screen.getAllByText("trustlog_matching_decision").length).toBeGreaterThan(0);
-    expect(screen.getByText("AUTHORITY_MISSING")).toBeInTheDocument();
+    expect(screen.getAllByText("AUTHORITY_MISSING").length).toBeGreaterThan(0);
     expect(screen.getByText("Authority evidence missing")).toBeInTheDocument();
     expect(screen.getByText("Governance policy")).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: "/governance" })[0]).toHaveAttribute("href", "/governance");
@@ -290,6 +290,40 @@ describe("MissionPage", () => {
     expect(screen.queryByRole("link", { name: href })).not.toBeInTheDocument();
     expect(screen.getByText(href)).toBeInTheDocument();
     expect(screen.getByText(/unsafe or external link not rendered/)).toBeInTheDocument();
+  });
+
+
+  it("renders AML/KYC reviewer walkthrough panel with safe links and fail-closed labels", () => {
+    render(
+      <I18nProvider>
+        <MissionPage
+          title="Command Dashboard"
+          subtitle="Mission overview"
+          chips={["Uptime Lattice", "Signal Watch", "Anomaly Queue"]}
+          governanceLayerSnapshot={{
+            demo_scenario: "aml_kyc_reviewer_walkthrough",
+            source_state: "fixture",
+            scenario_id: "scenario_e_missing_authority",
+            scenario_name: "scenario_e_missing_authority",
+            action_class: "aml_kyc_customer_risk_escalation",
+            requested_action: "create_internal_risk_escalation",
+            requested_scope: "create_internal_risk_escalation",
+            authority_evidence_status: "missing",
+            bind_outcome: "block",
+            bind_reason_code: "AUTHORITY_MISSING",
+            bind_failure_reason: "authority evidence missing",
+            decision_id: "fixture.decision.aml_kyc.scenario_e_missing_authority",
+            execution_intent_id: "fixture.execution_intent.aml_kyc.scenario_e_missing_authority",
+            bind_receipt_id: "fixture.bind_receipt.aml_kyc.scenario_e_missing_authority",
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("AML/KYC Reviewer Walkthrough")).toBeInTheDocument();
+    expect(screen.getByText(/Authority Evidence:/)).toBeInTheDocument();
+    expect(screen.getAllByText("AUTHORITY_MISSING").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "open audit path" }).length).toBeGreaterThan(0);
   });
 
   it.each(["/foo\\bar", "/foo\nbar", "/foo\tbar"])("does not render malformed relevant_ui_href as a link: %s", (href) => {
@@ -450,7 +484,7 @@ describe("MissionPage", () => {
 
     expect(screen.getByText("Governance artifacts")).toBeInTheDocument();
     expect(screen.getAllByText("trustlog_matching_decision").length).toBeGreaterThan(0);
-    expect(screen.getByText("AUTHORITY_MISSING")).toBeInTheDocument();
+    expect(screen.getAllByText("AUTHORITY_MISSING").length).toBeGreaterThan(0);
     expect(screen.getByText("Authority evidence missing")).toBeInTheDocument();
     expect(screen.getByText("Governance policy")).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: "/governance" })[0]).toHaveAttribute("href", "/governance");

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -253,6 +253,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
     ? governanceSnapshot.phase_snapshots
     : [];
   const hasPreBoundaryCollapseDemo = governanceSnapshot?.demo_scenario === "pre_boundary_collapse" && phaseSnapshots.length > 0;
+  const hasAmlKycReviewerWalkthrough = governanceSnapshot?.demo_scenario === "aml_kyc_reviewer_walkthrough";
 
   const governanceObservation = governanceSnapshot?.governance_observation;
   const hasGovernanceObservation = governanceObservation != null;
@@ -345,6 +346,29 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
           ) : null}
         </section>
       ) : null}
+
+      {hasAmlKycReviewerWalkthrough ? (
+        <section aria-label="aml kyc reviewer walkthrough" className="rounded-xl border border-warning/40 bg-warning/5 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-warning">AML/KYC Reviewer Walkthrough <SourceStateBadge state={resolveGovernanceSourceState("none", governanceSnapshot?.demo_scenario)} reason="demo_scenario" compact className="ml-2" /></p>
+          <p className="mt-1 text-xs font-semibold">Authority Evidence: <span className="text-warning">missing</span> · Bind result: <span className="text-danger">block</span></p>
+          <ul className="mt-2 space-y-1 text-xs">
+            <li>scenario_id: <span className="font-mono">{stringifyValue(governanceSnapshot?.scenario_id)}</span></li>
+            <li>scenario_name: <span className="font-mono">{stringifyValue(governanceSnapshot?.scenario_name)}</span></li>
+            <li>action_class: <span className="font-mono">{stringifyValue(governanceSnapshot?.action_class)}</span></li>
+            <li>requested_action / requested_scope: <span className="font-mono">{stringifyValue(governanceSnapshot?.requested_action)} / {stringifyValue(governanceSnapshot?.requested_scope)}</span></li>
+            <li>customer_risk_context: <span className="font-mono">{stringifyValue(governanceSnapshot?.customer_risk_context)}</span></li>
+            <li>bind_reason_code: <span className="font-mono">{stringifyValue(governanceSnapshot?.bind_reason_code)}</span></li>
+            <li>bind_failure_reason: <span className="font-mono">{stringifyValue(governanceSnapshot?.bind_failure_reason)}</span></li>
+            <li>decision_id: {decisionAuditHref ? <Link className="underline font-mono" href={decisionAuditHref}>{governanceSnapshot?.decision_id}</Link> : <span className="font-mono">unavailable</span>}</li>
+            <li>execution_intent_id: {executionIntentAuditHref ? <Link className="underline font-mono" href={executionIntentAuditHref}>{governanceSnapshot?.execution_intent_id}</Link> : <span className="font-mono">unavailable</span>}</li>
+            <li>bind_receipt_id: {bindReceiptAuditHref ? <Link className="underline font-mono" href={bindReceiptAuditHref}>{governanceSnapshot?.bind_receipt_id}</Link> : <span className="font-mono">unavailable</span>}</li>
+            <li>audit path: {actionDrilldownHref ? <Link className="underline" href={actionDrilldownHref}>open audit path</Link> : <span className="font-mono">unavailable</span>}</li>
+            <li>evidence_bundle_summary: <span className="font-mono">{stringifyValue(governanceSnapshot?.evidence_bundle_summary)}</span></li>
+            <li>reviewer_expected_steps: <span className="font-mono">{stringifyValue(governanceSnapshot?.reviewer_expected_steps)}</span></li>
+          </ul>
+        </section>
+      ) : null}
+
       {hasPreBoundaryCollapseDemo ? (
         <section aria-label="pre-boundary collapse demo walkthrough" className="rounded-xl border border-warning/40 bg-warning/5 p-4">
           <p className="text-xs font-semibold uppercase tracking-wide text-warning">Pre-Boundary Collapse Demo · 4 phase walkthrough</p>

--- a/frontend/lib/aml-kyc-reviewer-walkthrough.ts
+++ b/frontend/lib/aml-kyc-reviewer-walkthrough.ts
@@ -1,0 +1,73 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const SCENARIO_FILE_PATH = path.resolve(
+  process.cwd(),
+  "..",
+  "veritas_os",
+  "sample_data",
+  "governance",
+  "aml_kyc_regulated_action_path",
+  "scenarios.json",
+);
+
+const REVIEWER_SCENARIO_NAME = "scenario_e_missing_authority";
+
+/**
+ * Build deterministic reviewer walkthrough payload for missing-authority behavior.
+ */
+export async function buildAmlKycReviewerWalkthroughPayload(): Promise<Record<string, unknown>> {
+  const raw = await readFile(SCENARIO_FILE_PATH, "utf-8");
+  const parsed = JSON.parse(raw) as { scenarios?: Array<Record<string, unknown>> };
+  const scenarios = Array.isArray(parsed.scenarios) ? parsed.scenarios : [];
+  const scenario = scenarios.find((item) => item.scenario_name === REVIEWER_SCENARIO_NAME);
+  if (!scenario) {
+    throw new Error("missing reviewer walkthrough scenario");
+  }
+
+  const riskFlags = typeof scenario.risk_flags === "object" && scenario.risk_flags !== null ? scenario.risk_flags : {};
+  const requestedScope = Array.isArray(scenario.requested_scope) && scenario.requested_scope.length > 0
+    ? String(scenario.requested_scope[0])
+    : "create_internal_risk_escalation";
+
+  return {
+    governance_layer_snapshot: {
+      demo_scenario: "aml_kyc_reviewer_walkthrough",
+      source_state: "fixture",
+      scenario_id: REVIEWER_SCENARIO_NAME,
+      scenario_name: REVIEWER_SCENARIO_NAME,
+      scenario_title: "AML/KYC Missing Authority Evidence Walkthrough",
+      decision_id: "fixture.decision.aml_kyc.scenario_e_missing_authority",
+      execution_intent_id: "fixture.execution_intent.aml_kyc.scenario_e_missing_authority",
+      bind_receipt_id: "fixture.bind_receipt.aml_kyc.scenario_e_missing_authority",
+      action_class: "aml_kyc_customer_risk_escalation",
+      requested_action: requestedScope,
+      requested_scope: requestedScope,
+      customer_risk_context: {
+        risk_score: scenario.risk_score,
+        risk_flags: riskFlags,
+        actor_identity: scenario.actor_identity,
+      },
+      authority_evidence_status: "missing",
+      authority_check_result: "fail_closed_missing_authority_evidence",
+      bind_outcome: "block",
+      bind_reason_code: "AUTHORITY_MISSING",
+      bind_failure_reason: "authority evidence missing",
+      bind_summary: "missing authority evidence triggers fail-closed block before commit",
+      audit_trace: [
+        { event: "decision_created", source_state: "fixture" },
+        { event: "execution_intent_requested", source_state: "fixture" },
+        { event: "authority_evidence_validation_failed", source_state: "fixture" },
+        { event: "bind_boundary_blocked", source_state: "fixture" },
+        { event: "bind_receipt_recorded", source_state: "fixture" },
+      ],
+      evidence_bundle_summary: "fixture-only AML/KYC packet: policy snapshot, risk flags, and missing authority evidence marker; no live customer or sanctions data.",
+      reviewer_expected_steps: [
+        "Open Mission Control reviewer panel",
+        "Confirm Authority Evidence is missing",
+        "Confirm bind outcome is block before commit",
+        "Open safe audit link and inspect trace ordering",
+      ],
+    },
+  };
+}

--- a/tests/governance/test_aml_kyc_regulated_action_path.py
+++ b/tests/governance/test_aml_kyc_regulated_action_path.py
@@ -58,3 +58,11 @@ def test_all_scenarios_are_deterministic() -> None:
     first = [item.to_dict() for item in run_all_regulated_action_scenarios()]
     second = [item.to_dict() for item in run_all_regulated_action_scenarios()]
     assert first == second
+
+
+def test_missing_authority_fixture_metadata_shape() -> None:
+    scenario = _by_name()["scenario_e_missing_authority"]
+    assert scenario.expected_outcome == "block"
+    assert scenario.actual_outcome == "block"
+    assert scenario.authority_evidence_id == ""
+    assert scenario.missing_predicate_count >= 1


### PR DESCRIPTION
### Motivation
- Provide a deterministic, reviewer-facing walkthrough that demonstrates the fail-closed behavior when Authority Evidence is missing for the existing `scenario_e_missing_authority` without introducing any live external integrations. 
- Make it easy for external reviewers to confirm that missing authority evidence blocks an AI-driven regulated action at the bind boundary while explicitly marking the data as `fixture`/`demo` to avoid live-data misrepresentation.

### Description
- Added a deterministic demo payload builder `frontend/lib/aml-kyc-reviewer-walkthrough.ts` that maps `scenario_e_missing_authority` into a `governance_layer_snapshot` payload containing safe deterministic IDs, `authority_evidence_status: "missing"`, ordered `audit_trace`, `bind_outcome: "block"`, `bind_reason_code: "AUTHORITY_MISSING"`, and reviewer guidance fields.  
- Extended the governance demo seam in `frontend/app/api/veritas/v1/report/governance/route.ts` to accept `demo_scenario=aml_kyc_reviewer_walkthrough` (query or `x-veritas-demo-scenario` header) and return the fixture payload while preserving the existing `pre_boundary_collapse` demo and invalid-demo fallback to upstream.  
- Added a Mission Control panel in `frontend/components/mission-page.tsx` that conditionally renders when `governance_layer_snapshot.demo_scenario === "aml_kyc_reviewer_walkthrough"`, highlights `Authority Evidence: missing` and `Bind result: block`, displays safe audit links for validated artifact IDs, and omits links when IDs are unsafe or missing.  
- Updated tests and docs: added/updated frontend tests (`route.test.ts`, `components/mission-page.test.tsx`), backend fixture assertions (`tests/governance/test_aml_kyc_regulated_action_path.py`), and documentation pages to describe the reviewer walkthrough and the implemented vs roadmap boundary; backend runtime contract and OpenAPI were not changed.  
- Reviewer walkthrough path: open `/?demo_scenario=aml_kyc_reviewer_walkthrough`, inspect the `AML/KYC Reviewer Walkthrough` panel, confirm `Authority Evidence: missing` → `Bind result: block`, open the safe `open audit path` link, and verify ordered `audit_trace` events.

### Testing
- Ran fixture and governance tests: `pytest -q tests/governance/test_aml_kyc_regulated_action_path.py` — passed.  
- Ran frontend unit tests: `pnpm -C frontend exec vitest run app/api/veritas/v1/report/governance/route.test.ts components/mission-page.test.tsx lib/source-state-utils.test.ts components/source-state-badge.test.tsx` — all tests passed.  
- Ran frontend lint: `pnpm -C frontend lint` — completed with existing repository warnings but no new errors introduced.  
- Playwright / full E2E was not executed in this environment (CI/browser drivers not available); this PR focuses on deterministic fixture payload, UI panel, and unit tests only.  

Risks / limitations
- This is a fixture/demo reviewer walkthrough only and intentionally does not connect to real banking, sanctions, or customer data; all payloads are labeled `fixture`/`demo` in UI and docs.  
- No backend runtime contract or OpenAPI changes were made; production behavior is unchanged.  
- Security: safe-link generation remains conservative (artifact IDs validated by `^[A-Za-z0-9._:-]+$` and control-character checks) so unsafe/malformed IDs will not produce navigable links; reviewers should still avoid treating fixture IDs as live artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79cf847f8832688e929d78fa63f5f)