### PR TITLE
Align bind admissibility TTL semantics and regulated bind summary fields

### DIFF
--- a/tests/governance/test_bind_receipt_regulated_action_fields.py
+++ b/tests/governance/test_bind_receipt_regulated_action_fields.py
@@ -52,11 +52,11 @@ def _regulated_context() -> dict[str, object]:
             "validity_window": {
                 "issued_at": "2026-04-25T00:00:00",
                 "valid_from": "2026-04-25T00:00:00",
-                "valid_until": "2026-04-30T00:00:00",
+                "valid_until": "2026-12-30T00:00:00",
             },
             "issued_at": "2026-04-25T00:00:00",
             "valid_from": "2026-04-25T00:00:00",
-            "valid_until": "2026-04-30T00:00:00",
+            "valid_until": "2026-12-30T00:00:00",
             "revalidated_at": "2026-04-26T00:00:00",
             "policy_snapshot_id": "policy-snapshot-001",
             "evidence_hash": "hash-001",
@@ -89,10 +89,12 @@ def _intent_with_regulated_context() -> dict[str, object]:
 
 
 def _run_bind(intent: dict[str, object], adapter: ReferenceBindAdapter | None = None):
+    """Execute regulated bind flow with deterministic bind timestamp for tests."""
     return execute_bind_adjudication(
         execution_intent=intent,
         adapter=adapter
         or ReferenceBindAdapter(state={"mode": "safe"}, pending_changes={"mode": "strict"}),
+        bind_ts="2026-04-26T00:00:00+00:00",
         append_trustlog=False,
     )
 

--- a/veritas_os/core/continuation_runtime/bind_admissibility.py
+++ b/veritas_os/core/continuation_runtime/bind_admissibility.py
@@ -246,11 +246,13 @@ def _check_freshness(evaluation_input: BindAdmissibilityInput) -> CheckResult:
     if expired:
         labels = ", ".join(name for name, _ in expired)
         primary_reason = expired[0][1]
-        expired_status = _missing_signal_status(evaluation_input)
         return CheckResult(
-            status=expired_status,
+            status=CheckStatus.ESCALATE,
             reason_code=primary_reason,
-            message=f"Freshness window expired ({labels}); policy fallback applied.",
+            message=(
+                f"Freshness window expired ({labels}); "
+                "escalation required before bind."
+            ),
         )
 
     return CheckResult(


### PR DESCRIPTION
### Motivation
- Align TTL/approval freshness expired semantics with the expected bind-time behaviour so expiry yields an escalation (non-commit) instead of being folded into the missing-signal fail path. 
- Ensure the regulated-action commit-boundary result can be observed in BindReceipt -> `to_dict()` -> `bind_summary` so reviewers/audit surfaces can follow `commit_boundary_result`. 
- Make the minimal, backward-compatible changes without widening API surfaces or weakening fail-closed semantics for clear failures (authority invalid, constraints violated, runtime risk unacceptable).

### Description
- Treat freshness expiry as an escalation by returning `CheckStatus.ESCALATE` from `_check_freshness()` when TTL/approval timestamps are present but expired, preserving reason codes `BIND_TTL_EXPIRED` / `BIND_APPROVAL_STALE` and keeping the missing-signal fallback unchanged (file: `veritas_os/core/continuation_runtime/bind_admissibility.py`).
- Stabilize the regulated-action test fixture by updating synthetic authority evidence validity windows and making test bind execution time deterministic so the commit-path `commit_boundary_result` assertion is reliable (file: `tests/governance/test_bind_receipt_regulated_action_fields.py`).
- No structural changes were required to `BindReceipt` or normalizers because `commit_boundary_result` was already carried by `_regulated_receipt_updates` and serialized by `BindReceipt.to_dict()`; the fix focused on ensuring test fixtures and evaluation timing exercise the intended commit path.
- Changes are minimal diffs, PEP8-compatible, maintain legacy receipt compatibility and preserve fail-closed behaviour for definitive failures.

### Testing
- Ran `pytest -q tests/test_bind_admissibility.py::test_expired_ttl_escalates_fail_closed` and it passed with `freshness_check_result.status == CheckStatus.ESCALATE` and `recommended_outcome == AdmissibilityOutcome.ESCALATE`.
- Ran `pytest -q tests/governance/test_bind_receipt_regulated_action_fields.py::test_bind_summary_includes_compact_commit_boundary_result` and it passed with `bind_summary["commit_boundary_result"] == "commit"`.
- Ran the full focused suites `pytest -q tests/test_bind_admissibility.py` and `pytest -q tests/governance/test_bind_receipt_regulated_action_fields.py` and all tests in those files passed.

Security note: This change routes TTL expiry to `ESCALATE` (non-commit) rather than `FAIL`; ensure any downstream automation does not interpret `ESCALATE` as a permit to auto-commit, since this is intentionally conservative (requires human/regulated review).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7baa28bfc83268617d29967f1637c)