### PR TITLE
README: add compact external reviewer fast path near opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ It is about making AI decisions **reviewable, traceable, replayable, auditable, 
 
 For external reviewers, start with `docs/REVIEWER_ENTRYPOINT.md`.
 
+## External reviewer fast path
+
+For a 10-minute implementation snapshot, start here:
+
+1. [Reviewer Entrypoint](docs/REVIEWER_ENTRYPOINT.md)
+2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
+3. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+4. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+5. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
+
+Boundary:
+
+- This is not legal advice.
+- This is not regulatory approval.
+- This is not third-party certification.
+- Fixture-backed PoC evidence should not be presented as live bank-side integration.
+
 ## AML/KYC Reviewer Walkthrough Quickstart
 
 VERITAS now includes a deterministic AML/KYC reviewer walkthrough for external reviewers, enterprise stakeholders, and investors who need to verify value in under 10 minutes.


### PR DESCRIPTION
### Motivation

- Helps external reviewers, enterprise stakeholders, and investors reach the most relevant verification artifacts quickly while keeping the README opening minimal and avoiding new product/regulatory claims.

### Description

- Added an `External reviewer fast path` block immediately under the existing `For external reviewers, start with docs/REVIEWER_ENTRYPOINT.md` line that lists five concise links (Reviewer Entrypoint `docs/REVIEWER_ENTRYPOINT.md`, Current Implementation Matrix `docs/en/validation/current-implementation-matrix.md`, Regulated Action Governance Proof Pack `docs/en/validation/regulated-action-governance-proof-pack.md`, AML/KYC Reviewer Handoff Pack `docs/en/validation/external-review-handoff-regulated-action-governance.md`, and AML/KYC 1-day PoC Quickstart `docs/en/guides/poc-pack-financial-quickstart.md`), includes a short boundary/disclaimer block, preserves the README heading structure, and keeps the change minimal and non‑promotional (no "production-ready"/certification claims).  Summary: added the compact fast path, linked the five key reviewer docs, and repeated the non-certification/non-regulatory boundary in short form.

### Testing

- Verified the target documents exist with `for f in docs/REVIEWER_ENTRYPOINT.md docs/en/validation/current-implementation-matrix.md docs/en/validation/regulated-action-governance-proof-pack.md docs/en/validation/external-review-handoff-regulated-action-governance.md docs/en/guides/poc-pack-financial-quickstart.md; do test -f "$f" && echo OK $f || echo MISSING $f; done` and committed the README change (`git commit`), all checks passed; Validation: confirmed all added relative links resolve, confirmed no new certification or regulatory compliance claims were added, and confirmed README heading structure remains valid; Known limitations: this PR only improves reviewer navigation and does not add runtime behavior, tests, or external integrations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f803a5d9dc832691c5762c4e8d0b64)