### PR TITLE
docs: align README_JP fast-path with English README

### DIFF
--- a/README_JP.md
+++ b/README_JP.md
@@ -27,6 +27,24 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 
 外部レビュー担当者向けの入口は `docs/REVIEWER_ENTRYPOINT.md` を参照してください。
 
+
+## 外部レビュアー向け Fast Path
+
+10 分で実装スナップショットを確認する場合は、次の順で参照してください。
+
+1. [Reviewer Entrypoint](docs/REVIEWER_ENTRYPOINT.md)
+2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
+3. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+4. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+5. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
+
+境界条件:
+
+- 法的助言ではありません。
+- 規制当局の承認ではありません。
+- 第三者認証ではありません。
+- fixture ベースの PoC 証跡は、実銀行統合の証明として提示してはいけません。
+
 ## AML/KYC レビュアー向けウォークスルー Quickstart
 
 VERITAS には、決定論的に確認できる AML/KYC reviewer walkthrough が実装されています。外部レビュアー・企業担当者・投資家は 10 分以内で価値確認できます。


### PR DESCRIPTION
### Motivation
- Ensure the Japanese README mirrors the English README reviewer fast-path so external reviewers have a consistent quick-entry and bilingual documentation checks pass.

### Description
- Add a new "外部レビュアー向け Fast Path" section to `README_JP.md` with the five quick-reference links and boundary notes, and update the Quickstart link to `docs/ja/guides/poc-pack-financial-quickstart.md` to prefer the Japanese guide.

### Testing
- Ran `pytest -q tests/test_check_bilingual_docs.py` and the test suite passed (3 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80abc4030832699e62e6570dd762f)