### PR TITLE
Add privacy-safe TrustLog audit events for RBAC denials

### DIFF
--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -10,6 +10,8 @@ import os
 import secrets
 import threading
 import time
+import uuid
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Any, Dict, Optional, Protocol, Tuple
 
@@ -18,6 +20,7 @@ from fastapi.security.api_key import APIKeyHeader
 
 from veritas_os.api.utils import _errstr, redact
 from veritas_os.api.rbac import Permission, Role, ROLE_PERMISSIONS
+from veritas_os.audit.trustlog_signed import append_signed_decision
 
 logger = logging.getLogger(__name__)
 
@@ -555,6 +558,95 @@ def _resolve_role_from_request(
         return Role.admin  # Fallback; auth check already validated the key
 
 
+
+_RBAC_DENIAL_DEDUPE_TTL_SEC = 60.0
+_RBAC_DENIAL_DEDUPE_MAX = 1024
+_rbac_denial_dedupe_cache: Dict[str, float] = {}
+_rbac_denial_dedupe_lock = threading.Lock()
+
+
+def _build_rbac_denial_dedupe_key(
+    *,
+    role: Role,
+    permission: Permission,
+    endpoint: str,
+    trace_id: Optional[str],
+) -> str:
+    """Build stable in-memory dedupe key for RBAC denial audit events."""
+    return "|".join([role.value, permission.value, endpoint, trace_id or "none"])
+
+
+def _should_append_rbac_denial_event(
+    *,
+    dedupe_key: str,
+    now_ts: float,
+) -> bool:
+    """Return True when RBAC denial event should be appended (TTL dedupe)."""
+    with _rbac_denial_dedupe_lock:
+        expired = [
+            key
+            for key, seen_at in _rbac_denial_dedupe_cache.items()
+            if now_ts - seen_at > _RBAC_DENIAL_DEDUPE_TTL_SEC
+        ]
+        for key in expired:
+            _rbac_denial_dedupe_cache.pop(key, None)
+
+        last_seen = _rbac_denial_dedupe_cache.get(dedupe_key)
+        if last_seen is not None and now_ts - last_seen <= _RBAC_DENIAL_DEDUPE_TTL_SEC:
+            return False
+
+        _rbac_denial_dedupe_cache[dedupe_key] = now_ts
+        if len(_rbac_denial_dedupe_cache) > _RBAC_DENIAL_DEDUPE_MAX:
+            overflow = len(_rbac_denial_dedupe_cache) - _RBAC_DENIAL_DEDUPE_MAX
+            oldest = sorted(_rbac_denial_dedupe_cache.items(), key=lambda item: item[1])[:overflow]
+            for key, _ in oldest:
+                _rbac_denial_dedupe_cache.pop(key, None)
+        return True
+
+
+def _append_rbac_denial_audit_event_best_effort(
+    *,
+    request: Optional[Request],
+    role: Role,
+    permission: Permission,
+    reason_code: str,
+) -> None:
+    """Append privacy-safe RBAC denial event to signed TrustLog on best-effort basis."""
+    endpoint = "unknown"
+    method = "unknown"
+    trace_id = None
+    if request is not None:
+        endpoint = getattr(getattr(request, "url", None), "path", None) or "unknown"
+        method = getattr(request, "method", None) or "unknown"
+        trace_id = getattr(getattr(request, "state", None), "trace_id", None)
+
+    dedupe_key = _build_rbac_denial_dedupe_key(
+        role=role,
+        permission=permission,
+        endpoint=endpoint,
+        trace_id=trace_id,
+    )
+    if not _should_append_rbac_denial_event(dedupe_key=dedupe_key, now_ts=time.time()):
+        return
+
+    event_payload = {
+        "event_type": "rbac_denial",
+        "decision_id": f"rbac-denial-{uuid.uuid4()}",
+        "actor_role": role.value,
+        "requested_permission": permission.value,
+        "endpoint": endpoint,
+        "method": method,
+        "reason_code": reason_code,
+        "trace_id": trace_id,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "audit_schema_version": "rbac_denial.v1",
+    }
+    try:
+        append_signed_decision(event_payload)
+    except Exception as exc:
+        logger.warning("RBAC denial audit append failed: %s", _errstr(exc))
+
+
 def require_permission(permission: Permission):
     """FastAPI dependency factory that enforces a specific RBAC permission.
 
@@ -588,6 +680,12 @@ def require_permission(permission: Permission):
         allowed = ROLE_PERMISSIONS.get(role, frozenset())
         if permission not in allowed:
             _record_auth_reject_reason("insufficient_permission")
+            _append_rbac_denial_audit_event_best_effort(
+                request=request,
+                role=role,
+                permission=permission,
+                reason_code="RBAC_INSUFFICIENT_PERMISSION",
+            )
             logger.warning(
                 "RBAC denied: role=%s permission=%s",
                 role.value,

--- a/veritas_os/tests/unit/test_auth_rbac_audit.py
+++ b/veritas_os/tests/unit/test_auth_rbac_audit.py
@@ -1,0 +1,135 @@
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from veritas_os.api import auth
+from veritas_os.api.rbac import Permission, Role
+
+
+def _build_request(path: str = "/v1/secure", method: str = "GET", query_string: bytes = b"") -> Request:
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": query_string,
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "scheme": "http",
+        "server": ("testserver", 80),
+    }
+    req = Request(scope)
+    req.state.trace_id = "trace-001"
+    return req
+
+
+def test_rbac_denial_appends_audit_event(monkeypatch):
+    captured = []
+    monkeypatch.setattr(auth, "resolve_role_for_key", lambda _key: Role.auditor)
+    monkeypatch.setattr(auth, "append_signed_decision", lambda payload: captured.append(payload))
+    auth._rbac_denial_dedupe_cache.clear()
+
+    checker = auth.require_permission(Permission.decide)
+    request = _build_request(path="/v1/decide", method="POST")
+
+    try:
+        checker(request=request, x_api_key="valid-key")
+        raise AssertionError("expected HTTPException")
+    except HTTPException as exc:
+        assert exc.status_code == 403
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event["event_type"] == "rbac_denial"
+    assert event["reason_code"] == "RBAC_INSUFFICIENT_PERMISSION"
+    assert event["actor_role"] == "auditor"
+    assert event["requested_permission"] == "decide"
+    assert event["endpoint"] == "/v1/decide"
+    assert event["method"] == "POST"
+    assert event["trace_id"] == "trace-001"
+
+
+def test_rbac_denial_append_failure_still_returns_403(monkeypatch):
+    monkeypatch.setattr(auth, "resolve_role_for_key", lambda _key: Role.auditor)
+
+    def _raise(_payload):
+        raise RuntimeError("append failed")
+
+    monkeypatch.setattr(auth, "append_signed_decision", _raise)
+    auth._rbac_denial_dedupe_cache.clear()
+
+    checker = auth.require_permission(Permission.decide)
+    request = _build_request()
+    try:
+        checker(request=request, x_api_key="valid-key")
+        raise AssertionError("expected HTTPException")
+    except HTTPException as exc:
+        assert exc.status_code == 403
+
+
+def test_rbac_denial_payload_excludes_secrets(monkeypatch):
+    captured = []
+    monkeypatch.setattr(auth, "resolve_role_for_key", lambda _key: Role.auditor)
+    monkeypatch.setattr(auth, "append_signed_decision", lambda payload: captured.append(payload))
+    auth._rbac_denial_dedupe_cache.clear()
+
+    checker = auth.require_permission(Permission.decide)
+    request = _build_request(path="/v1/private", query_string=b"token=secret")
+    try:
+        checker(request=request, x_api_key="valid-key")
+        raise AssertionError("expected HTTPException")
+    except HTTPException:
+        pass
+
+    event = captured[0]
+    dumped = str(event)
+    assert "Authorization" not in dumped
+    assert "X-API-Key" not in dumped
+    assert "Cookie" not in dumped
+    assert "token=secret" not in dumped
+    assert event["endpoint"] == "/v1/private"
+
+
+def test_rbac_denial_dedupe(monkeypatch):
+    captured = []
+    monkeypatch.setattr(auth, "resolve_role_for_key", lambda _key: Role.auditor)
+    monkeypatch.setattr(auth, "append_signed_decision", lambda payload: captured.append(payload))
+    auth._rbac_denial_dedupe_cache.clear()
+
+    checker = auth.require_permission(Permission.decide)
+    req1 = _build_request(path="/v1/decide")
+    req1.state.trace_id = "same"
+    req2 = _build_request(path="/v1/decide")
+    req2.state.trace_id = "same"
+
+    for request in (req1, req2):
+        try:
+            checker(request=request, x_api_key="valid-key")
+        except HTTPException:
+            pass
+
+    assert len(captured) == 1
+
+    req3 = _build_request(path="/v1/decide")
+    req3.state.trace_id = "different"
+    try:
+        checker(request=req3, x_api_key="valid-key")
+    except HTTPException:
+        pass
+    assert len(captured) == 2
+
+
+def test_rbac_denial_helper_handles_none_request(monkeypatch):
+    captured = []
+    monkeypatch.setattr(auth, "append_signed_decision", lambda payload: captured.append(payload))
+    auth._rbac_denial_dedupe_cache.clear()
+
+    auth._append_rbac_denial_audit_event_best_effort(
+        request=None,
+        role=Role.auditor,
+        permission=Permission.decide,
+        reason_code="RBAC_INSUFFICIENT_PERMISSION",
+    )
+
+    assert len(captured) == 1
+    assert captured[0]["endpoint"] == "unknown"
+    assert captured[0]["method"] == "unknown"


### PR DESCRIPTION
### Motivation
- Denied RBAC decisions were only logged to standard logs/metrics and need an append-only, auditable TrustLog entry so investigators can verify who, which role, which permission, which endpoint, and why a denial occurred. 
- The change ensures denied actions are captured in the signed TrustLog without changing authorization semantics or exposing secrets.

### Description
- Added a best-effort helper ` _append_rbac_denial_audit_event_best_effort` in `veritas_os/api/auth.py` that builds a minimal, privacy-safe denial summary and calls existing `append_signed_decision` to persist a signed TrustLog summary. 
- Integrated the helper into `require_permission` so that when `permission not in allowed` the helper is invoked before the existing `HTTPException(403)` path, preserving existing behavior. 
- Implemented a small in-memory dedupe cache (`_rbac_denial_dedupe_cache`) with a TTL of 60 seconds and a bounded max size to avoid repeated identical appends; dedupe key is `role + permission + endpoint + trace_id`. 
- Enforced privacy/security boundaries in the payload: only `role`, `requested_permission`, `endpoint` (only `request.url.path`), `method`, `reason_code`, `trace_id`, `ts`, `decision_id`, and `audit_schema_version` are recorded; API keys, `Authorization`, cookies, query string, body, IPs, and other secrets are never stored; append failures are logged and do not change authorization outcome. 

### Testing
- Unit tests added in `veritas_os/tests/unit/test_auth_rbac_audit.py` covering append-on-403, append failure safety, secret exclusion, dedupe behavior, and `request=None` handling, and all new tests passed. 
- Ran `pytest -q veritas_os/tests/unit/test_auth_rbac_audit.py --tb=short` which passed. 
- Ran `pytest -q veritas_os/tests -k "auth or rbac" --tb=short` which passed (`140 passed` selected tests). 
- Ran `ruff check veritas_os/` which succeeded with no issues. 

Known limitations: dedupe is process-local in-memory only (not shared across workers/nodes) and the helper is best-effort (mirror/anchor failures are logged and do not affect authorization).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8106823fc8326961595dcd23fc415)