### PR TITLE
Preserve RBAC denial audit fields in signed TrustLog summaries

### DIFF
--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -693,6 +693,16 @@ _SUMMARY_ALLOWLIST: frozenset[str] = frozenset({
     "critique_ok",
     "critique_mode",
     "critique_reason",
+    # RBAC denial audit fields (scalar-only, no secrets)
+    "event_type",
+    "actor_role",
+    "requested_permission",
+    "endpoint",
+    "method",
+    "reason_code",
+    "trace_id",
+    "audit_schema_version",
+    "ts",
 })
 
 #: Keys inside the full payload whose *scalar* value is extracted for the

--- a/veritas_os/tests/unit/test_auth_rbac_audit.py
+++ b/veritas_os/tests/unit/test_auth_rbac_audit.py
@@ -3,6 +3,7 @@ from starlette.requests import Request
 
 from veritas_os.api import auth
 from veritas_os.api.rbac import Permission, Role
+from veritas_os.audit.trustlog_signed import build_trustlog_summary
 
 
 def _build_request(path: str = "/v1/secure", method: str = "GET", query_string: bytes = b"") -> Request:
@@ -133,3 +134,52 @@ def test_rbac_denial_helper_handles_none_request(monkeypatch):
     assert len(captured) == 1
     assert captured[0]["endpoint"] == "unknown"
     assert captured[0]["method"] == "unknown"
+
+
+def test_rbac_denial_fields_survive_signed_summary_compaction():
+    payload = {
+        "event_type": "rbac_denial",
+        "decision_id": "rbac-denial-test",
+        "actor_role": "auditor",
+        "requested_permission": "decide",
+        "endpoint": "/v1/decide",
+        "method": "POST",
+        "reason_code": "RBAC_INSUFFICIENT_PERMISSION",
+        "trace_id": "trace-001",
+        "ts": "2026-05-04T00:00:00+00:00",
+        "audit_schema_version": "rbac_denial.v1",
+        "Authorization": "Bearer secret",
+        "X-API-Key": "secret",
+        "query_string": "token=secret",
+    }
+
+    summary = build_trustlog_summary(payload)
+
+    assert summary["event_type"] == "rbac_denial"
+    assert summary["actor_role"] == "auditor"
+    assert summary["requested_permission"] == "decide"
+    assert summary["endpoint"] == "/v1/decide"
+    assert summary["method"] == "POST"
+    assert summary["reason_code"] == "RBAC_INSUFFICIENT_PERMISSION"
+    assert summary["trace_id"] == "trace-001"
+    assert summary["audit_schema_version"] == "rbac_denial.v1"
+    assert summary["ts"] == "2026-05-04T00:00:00+00:00"
+
+    assert "Authorization" not in summary
+    assert "X-API-Key" not in summary
+    assert "query_string" not in summary
+
+
+def test_normal_decision_summary_allowlist_unchanged():
+    payload = {
+        "decision_id": "decision-001",
+        "decision_status": "approved",
+        "chosen_title": "Allow",
+        "world_state": {"secret": "should-not-leak"},
+    }
+
+    summary = build_trustlog_summary(payload)
+    assert summary["decision_id"] == "decision-001"
+    assert summary["decision_status"] == "approved"
+    assert summary["chosen_title"] == "Allow"
+    assert "world_state" not in summary


### PR DESCRIPTION
### Motivation
- PR #1607 added RBAC denial TrustLog events via `append_signed_decision()`, but signed TrustLog compaction (`build_trustlog_summary`) uses a strict allowlist so RBAC-specific fields risked being dropped from the compact signed summary.
- I reviewed `veritas_os/api/auth.py`, `veritas_os/audit/trustlog_signed.py`, `veritas_os/tests/unit/test_auth_rbac_audit.py` and existing `trustlog_signed` tests to implement a minimal, safe fix. 
- The goal is to ensure denial context needed for external audit remains in the compact signed TrustLog without changing the overall compaction design or introducing large/secret fields.

### Description
- Extended `_SUMMARY_ALLOWLIST` in `veritas_os/audit/trustlog_signed.py` to include the RBAC denial scalar keys: `event_type`, `actor_role`, `requested_permission`, `endpoint`, `method`, `reason_code`, `trace_id`, `audit_schema_version`, and `ts`.
- Did not change `build_trustlog_summary()` logic or the signed TrustLog entry format beyond the small allowlist extension, preserving the allowlist-based compaction design and avoiding large nested structures.
- Added unit tests in `veritas_os/tests/unit/test_auth_rbac_audit.py` to assert that RBAC denial fields survive `build_trustlog_summary()`, that secret-like fields (`Authorization`, `X-API-Key`, `query_string`) remain excluded, and that normal decision summary behavior is unchanged.
- No DB/schema/auth logic/async/queue/batch/ OpenAPI changes were made; only a conservative allowlist extension and test coverage were added.

### Testing
- Ran `pytest -q veritas_os/tests/unit/test_auth_rbac_audit.py --tb=short`: 7 passed (all RBAC/audit helper tests, including the new ones).
- Ran `pytest -q veritas_os/tests -k "trustlog or auth or rbac" --tb=short`: observed the test subset exercising trustlog/auth/rbac passed (599 passed, 13 skipped for the selected patterns).
- Ran `ruff check veritas_os/`: All checks passed.
- Ran full test suite `pytest -q veritas_os/tests --tb=short`: observed one unrelated pre-existing failure in `veritas_os/tests/test_decide_e2e_reliability.py` that predates this change; all trustlog/auth/rbac tests relevant to this PR passed.

Preserved fields in compact signed TrustLog summary: `event_type`, `actor_role`, `requested_permission`, `endpoint`, `method`, `reason_code`, `trace_id`, `audit_schema_version`, `ts`.
Secret fields that remain excluded from signed summary: `X-API-Key`, `Authorization`, `Cookie`, request body, `query_string`, raw URL, IP address, nonce, signature, token, and other secrets.

Known limitation: process-local RBAC denial dedupe behavior remains unchanged (this PR does not add cross-process dedupe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f815a3448c8326bdf0529404e97e92)