### PR TITLE
Add AI-assisted development guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# VERITAS OS — Codex Agent Instructions
+
+## Purpose
+
+Codex is the primary implementation assistant for focused PRs in VERITAS OS.
+
+This file defines how Codex should operate inside an auditable AI-assisted development workflow. It does not replace `CLAUDE.md`, `.github/copilot-instructions.md`, CI, or human maintainer approval.
+
+## Authority Model
+
+- AI reviews are advisory signals.
+- GitHub Actions / CI are objective checks.
+- Human maintainer approval is the final commit boundary.
+- Codex must not push directly to `main`.
+- Codex must not merge PRs.
+- Codex must not approve security-sensitive, governance-sensitive, release-sensitive, or public-claim changes on its own.
+
+## Scope Rules
+
+- Prefer 1 PR = 1 purpose.
+- Prefer small, reviewable diffs.
+- Do not mix runtime changes, docs changes, and public positioning changes unless explicitly requested.
+- If scope is unclear, reduce the change size instead of expanding it.
+- Do not perform broad refactors unless explicitly requested.
+
+## High-Risk Areas Requiring Human Approval
+
+Human approval is required for changes touching:
+
+- bind/admissibility logic
+- governance policy behavior
+- release gates
+- secrets or credential handling
+- TrustLog persistence or encryption behavior
+- FUJI Gate fail-closed behavior
+- public claims in README, docs, website, or social posts
+- private user/customer data handling
+
+## Priority Order
+
+1. CI/test failures
+2. Security or data exposure
+3. Runtime behavior mismatch
+4. Public documentation mismatch
+5. Missing tests for code changes
+6. Refactor or style suggestions
+
+## External AI Review Safety
+
+External/free-tier AI tools may be used only with non-sensitive excerpts.
+
+Do not paste:
+
+- secrets
+- credentials
+- API keys
+- `.env` content
+- private customer data
+- unpublished internal strategy
+- non-public security details
+
+## References
+
+- `CLAUDE.md` — project architecture, safety rules, testing, and quality gates
+- `.github/copilot-instructions.md` — GitHub Copilot coding instructions
+- `docs/en/development/ai-assisted-development.md` — canonical AI-assisted development guide
+- `docs/ja/development/ai-assisted-development.md` — Japanese explanatory guide

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,3 +274,62 @@ python scripts/reset_repo_runtime.py --dry-run  # Preview cleanup
 • 重大な変更は必ず docstring とテストを作る
 • Planner / Kernel / Fuji / MemoryOS の責務を越える変更は禁止
 • セキュリティリスクは必ず警告する
+
+## 13. AI-Assisted Development Authority Model
+
+VERITAS OS may use multiple AI tools during development, including ChatGPT, Codex, Claude Code, GitHub Copilot, Gemini, Grok, and Meta AI.
+
+This is an auditable AI-assisted development workflow, not autonomous development.
+
+### Claude Code Role
+
+Claude Code is primarily used for:
+
+- architecture consistency review
+- implementation support
+- edge-case review
+- terminology consistency review
+- security/governance-sensitive change review
+- identifying runtime behavior mismatches
+- identifying missing or weak tests
+
+### Feedback Classification
+
+Claude Code feedback should be classified as:
+
+- `blocker`: must address before merge
+- `recommended`: should address unless there is a clear reason not to
+- `optional`: style, readability, or alternative implementation suggestion
+
+### Authority Rules
+
+- AI reviews are advisory signals.
+- GitHub Actions / CI are objective checks.
+- Human maintainer approval is the final commit boundary.
+- Claude Code feedback does not override CI or human maintainer approval.
+- Claude Code must not independently approve security-sensitive, governance-sensitive, release-sensitive, or public-claim changes.
+
+### VERITAS Terminology Rules
+
+Do not rename or generalize VERITAS-specific concepts without explicit human approval, including:
+
+- Bind Boundary
+- Commit Boundary
+- Authority Evidence
+- Proof Pack
+- Quality Gate
+- Admissibility
+- Receipt
+- Audit Trace
+- FUJI Gate
+- TrustLog
+- Mission Control
+- ExecutionIntent
+- BindReceipt
+- BindSummary
+
+### Prohibited Without Explicit Approval
+
+Do not introduce broad refactors, new abstraction layers, or public positioning changes unless explicitly requested.
+
+Do not change fail-closed safety behavior, bind/admissibility semantics, release gates, secret handling, or TrustLog persistence semantics without explicit human approval.

--- a/docs/en/development/ai-assisted-development.md
+++ b/docs/en/development/ai-assisted-development.md
@@ -1,0 +1,116 @@
+# AI-Assisted Development Guardrails
+
+## Purpose
+
+VERITAS OS may use multiple AI tools to accelerate implementation, review, documentation, and release preparation.
+
+This guide defines an auditable AI-assisted development workflow. It does not introduce autonomous development, automatic merging, or replacement of human maintainers.
+
+## Principle
+
+AI tools may propose, implement, review, and summarize changes.
+
+Only a human maintainer may approve:
+
+- security-sensitive changes
+- governance-boundary changes
+- release decisions
+- public claims
+- changes involving private user or customer data
+
+## Authority Model
+
+- AI reviews are advisory signals.
+- GitHub Actions / CI are objective checks.
+- Human maintainer approval is the final commit boundary.
+
+## Tool Roles
+
+| Tool | Primary role |
+|---|---|
+| ChatGPT | PR intent, scope, risk framing, architecture reasoning, market/value review |
+| Codex | Primary implementation, focused PR patching, test updates, CI failure fixes |
+| Claude Code | Architecture review, edge-case review, implementation support, terminology consistency |
+| GitHub Copilot | GitHub-native PR review, local coding assistance, small bug suggestions |
+| Gemini | External clarity review, documentation readability, product explanation review |
+| Grok | Adversarial review, unnecessary-complexity detection, market/message skepticism |
+| Meta AI | Lightweight secondary review, terminology clarity, readability review |
+| GitHub Actions | Objective CI checks, tests, quality gates, release gates |
+| Human maintainer | Final approval, merge decision, security/governance/release/public-claim authority |
+
+## Recommended Workflow
+
+1. ChatGPT defines PR intent, scope, risk, and non-goals.
+2. Codex implements the focused change.
+3. Claude Code reviews architecture, edge cases, terminology, and consistency.
+4. GitHub Actions verifies tests and quality gates.
+5. External AI tools may provide advisory review using non-sensitive excerpts.
+6. Human maintainer approves, rejects, or requests changes.
+
+## Prohibited Automation
+
+AI must not automatically merge or independently approve:
+
+- bind/admissibility logic changes
+- governance policy changes
+- release gate changes
+- secret handling changes
+- TrustLog persistence or encryption behavior changes
+- FUJI Gate fail-closed behavior changes
+- public claim changes
+- website positioning changes
+- changes involving private user or customer data
+
+## External AI Review Safety
+
+External/free-tier AI review may use only non-sensitive excerpts.
+
+Do not paste:
+
+- secrets
+- credentials
+- API keys
+- `.env` content
+- private customer data
+- unpublished internal strategy
+- non-public security details
+
+Use only:
+
+- public docs
+- sanitized diffs
+- limited file excerpts
+- error messages without secrets
+- abstracted design questions
+
+External AI feedback must not become a merge blocker by itself.
+
+## Review Priority
+
+1. CI/test failures
+2. Security or data exposure
+3. Runtime behavior mismatch
+4. Public documentation mismatch
+5. Missing tests for code changes
+6. Refactor or style suggestions
+
+## Non-Goals
+
+This guide does not introduce:
+
+- autonomous development
+- automatic PR approval
+- automatic merging
+- replacement of human maintainers
+- changes to runtime governance behavior
+- changes to CI/release gates
+
+## VERITAS Development Statement
+
+VERITAS OS is developed through an auditable AI-assisted workflow:
+
+- Codex may implement.
+- Claude Code may review.
+- GitHub Actions verifies.
+- External models may provide advisory review.
+- Human maintainer approval remains the final commit boundary.

--- a/docs/ja/development/ai-assisted-development.md
+++ b/docs/ja/development/ai-assisted-development.md
@@ -1,0 +1,118 @@
+# AI支援開発ガードレール
+
+## 目的
+
+VERITAS OS では、実装、レビュー、ドキュメント整理、リリース準備を加速するために複数のAIツールを利用することがあります。
+
+この文書は、AI支援開発を監査可能な形で運用するためのガードレールを定義します。
+
+これは完全自動開発、自動マージ、人間メンテナの置き換えを意味しません。
+
+## 基本原則
+
+AIツールは、変更の提案、実装、レビュー、要約を行うことができます。
+
+ただし、以下の承認は人間メンテナが行います。
+
+- セキュリティ上重要な変更
+- ガバナンス境界に関わる変更
+- リリース判断
+- 公開表現・公開主張
+- 非公開のユーザー情報または顧客情報に関わる変更
+
+## 権限モデル
+
+- AIレビューは参考シグナルです。
+- GitHub Actions / CI は客観的チェックです。
+- 人間メンテナの承認が最終的な Commit Boundary です。
+
+## ツールごとの役割
+
+| ツール | 主な役割 |
+|---|---|
+| ChatGPT | PR目的、スコープ、リスク整理、設計判断、市場価値レビュー |
+| Codex | 主実装、焦点を絞ったPR修正、テスト更新、CI失敗修正 |
+| Claude Code | アーキテクチャレビュー、エッジケース確認、実装補助、用語一貫性レビュー |
+| GitHub Copilot | GitHub上のPRレビュー、ローカル実装補助、小さなバグ指摘 |
+| Gemini | 外部視点での明瞭性レビュー、ドキュメント可読性、プロダクト説明レビュー |
+| Grok | 辛口レビュー、不要な複雑性の検出、市場・メッセージ面の違和感検出 |
+| Meta AI | 軽量な二次レビュー、用語の明瞭性、読みやすさ確認 |
+| GitHub Actions | CI、テスト、品質ゲート、リリースゲート |
+| 人間メンテナ | 最終承認、マージ判断、セキュリティ・ガバナンス・リリース・公開表現の権限 |
+
+## 推奨ワークフロー
+
+1. ChatGPT が PR の目的、スコープ、リスク、非目的を整理する。
+2. Codex が焦点を絞った変更を実装する。
+3. Claude Code がアーキテクチャ、エッジケース、用語、整合性をレビューする。
+4. GitHub Actions がテストと品質ゲートを検証する。
+5. 外部AIツールは、非機密の抜粋に限って参考レビューを行う。
+6. 人間メンテナが承認、却下、または修正依頼を行う。
+
+## 自動化してはいけないもの
+
+AIは以下を自動マージまたは単独承認してはいけません。
+
+- bind/admissibility logic の変更
+- governance policy の変更
+- release gate の変更
+- secret handling の変更
+- TrustLog の永続化または暗号化挙動の変更
+- FUJI Gate の fail-closed 挙動の変更
+- 公開主張の変更
+- website positioning の変更
+- 非公開のユーザー情報または顧客情報に関わる変更
+
+## 外部AIレビューの安全ルール
+
+外部AIまたは無料版AIレビューには、非機密の抜粋のみを使います。
+
+貼り付けてはいけないもの:
+
+- secrets
+- credentials
+- API keys
+- `.env` content
+- private customer data
+- unpublished internal strategy
+- non-public security details
+
+使ってよいもの:
+
+- 公開ドキュメント
+- サニタイズ済みdiff
+- 限定されたファイル抜粋
+- 秘密情報を含まないエラーメッセージ
+- 抽象化した設計相談
+
+外部AIのフィードバックは、それ単独では merge blocker になりません。
+
+## レビュー優先度
+
+1. CI/test failures
+2. Security or data exposure
+3. Runtime behavior mismatch
+4. Public documentation mismatch
+5. Missing tests for code changes
+6. Refactor or style suggestions
+
+## 非目的
+
+この文書は以下を導入しません。
+
+- 完全自動開発
+- 自動PR承認
+- 自動マージ
+- 人間メンテナの置き換え
+- runtime governance behavior の変更
+- CI/release gates の変更
+
+## VERITAS開発ステートメント
+
+VERITAS OS は、監査可能なAI支援ワークフローによって開発されます。
+
+- Codex は実装を支援できる。
+- Claude Code はレビューを支援できる。
+- GitHub Actions は検証する。
+- 外部モデルは参考レビューを提供できる。
+- 人間メンテナの承認が最終的な Commit Boundary である。


### PR DESCRIPTION
### Motivation

- Provide a minimal, auditable AI-assisted development policy that clarifies who implements, who reviews, and what requires human approval across multiple AI tools (Codex, Claude Code, ChatGPT, Copilot, Gemini, Grok, Meta AI) while preserving VERITAS-specific terminology and non-autonomous workflow constraints. 
- Keep changes small and documentation-only to match the existing repository structure and avoid touching runtime, frontend, backend, tests, CI, or dependency configuration.

### Description

- Add `AGENTS.md` with Codex-focused agent instructions including authority model, scope rules, high-risk areas requiring human approval, external-AI safety constraints, and references to existing documents. 
- Append a new section `## 13. AI-Assisted Development Authority Model` to the end of `CLAUDE.md` that describes Claude Code roles, feedback classification, authority rules, terminology protection, and prohibited changes without explicit human approval. 
- Add canonical English guide `docs/en/development/ai-assisted-development.md` and matching Japanese guide `docs/ja/development/ai-assisted-development.md` that define the auditable AI-assisted workflow, tool roles, recommended workflow, prohibited automation, external-AI safety, review priority, and non-goals. 
- Changes are limited to the four files requested and preserve existing VERITAS terms and the existing contents of `CLAUDE.md` (only appending a section); no code, tests, CI, README, or other docs were modified.

### Testing

- Repository-level validation: created and staged the four files and successfully committed them (`git status`, `git diff`, `git add`, `git commit` completed without error). 
- No unit/integration test suites were run locally because this is a documentation-only change and no runtime code was modified. 
- The normal CI pipeline (including `pytest --cov-fail-under=85` and the repository's security/architecture checks) will run on the PR and must pass before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f843b9a2388326add6c92fa94391a8)