### PR TITLE
Add AI review matrix and AI-assisted PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai_implementation_task.md
+++ b/.github/ISSUE_TEMPLATE/ai_implementation_task.md
@@ -1,0 +1,65 @@
+---
+name: AI implementation task
+about: Define a focused task for AI-assisted implementation
+title: "[AI Task] "
+labels: ["ai-assisted", "needs-scope"]
+assignees: ""
+---
+
+# Goal
+
+<!-- What should be achieved? -->
+
+# Background
+
+<!-- Why is this needed? -->
+
+# Files likely involved
+
+<!-- List expected files or areas. Keep this tentative. -->
+
+# Non-goals
+
+<!-- What must not be changed? -->
+
+# Acceptance criteria
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+# Risk level
+
+- [ ] Low
+- [ ] Medium
+- [ ] High
+
+# AI role
+
+- [ ] ChatGPT planning
+- [ ] Codex implementation
+- [ ] Claude Code review
+- [ ] GitHub Copilot review
+- [ ] External advisory review
+- [ ] Other:
+
+# Must not change
+
+- [ ] Runtime behavior
+- [ ] API contract
+- [ ] Tests
+- [ ] CI workflow
+- [ ] Release gates
+- [ ] Governance policy behavior
+- [ ] Bind/admissibility logic
+- [ ] Secrets or credential handling
+- [ ] Public claims
+- [ ] Website positioning
+
+# Test expectations
+
+<!-- What tests/checks should be run? -->
+
+# Human approval requirements
+
+<!-- State whether this requires explicit human approval and why. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,81 @@
+# Summary
+
+<!-- What changed? Keep this concise. -->
+
+## Scope
+
+<!-- What is included in this PR? -->
+
+## Type of change
+
+- [ ] Runtime
+- [ ] Tests
+- [ ] Docs
+- [ ] CI
+- [ ] Frontend
+- [ ] Website / positioning
+- [ ] Governance / security-sensitive
+- [ ] Other:
+
+## Why this change matters
+
+<!-- Explain the value. -->
+
+## Market / developer / user value
+
+- Market value:
+- Developer value:
+- User/operator value:
+
+## Tests run
+
+- [ ] Not applicable, docs-only change
+- [ ] `make test`
+- [ ] `make test-cov`
+- [ ] `make quality-checks`
+- [ ] frontend tests
+- [ ] other:
+
+## AI assistance used
+
+- [ ] ChatGPT
+- [ ] Codex
+- [ ] Claude Code
+- [ ] GitHub Copilot
+- [ ] Gemini
+- [ ] Grok
+- [ ] Meta AI
+- [ ] Other:
+- [ ] No AI assistance
+
+## Review status
+
+- [ ] CI passed
+- [ ] Claude Code review completed
+- [ ] Codex review completed
+- [ ] External advisory review completed
+- [ ] Human maintainer reviewed
+
+## Risk checklist
+
+- [ ] Touches bind/admissibility logic
+- [ ] Touches governance policy behavior
+- [ ] Touches release gates
+- [ ] Touches secrets or credentials
+- [ ] Touches TrustLog persistence or encryption behavior
+- [ ] Touches FUJI Gate fail-closed behavior
+- [ ] Changes public claims
+- [ ] Changes website positioning
+- [ ] Involves private user/customer data
+- [ ] None of the above
+
+## Human approval required?
+
+- [ ] Yes
+- [ ] No
+
+Reason:
+
+## Notes for reviewer
+
+<!-- Anything reviewers should pay attention to? -->

--- a/docs/en/development/ai-review-matrix.md
+++ b/docs/en/development/ai-review-matrix.md
@@ -1,0 +1,61 @@
+# AI Review Matrix
+
+## Purpose
+
+This matrix defines how different AI tools may be used during VERITAS OS development.
+
+It supports the auditable AI-assisted development workflow defined in `docs/en/development/ai-assisted-development.md`.
+
+AI reviews are advisory. GitHub Actions / CI are objective checks. Human maintainer approval is the final commit boundary.
+
+## Role Matrix
+
+| Tool | Primary role | Best used for | Not authority for |
+|---|---|---|---|
+| ChatGPT | Planning and strategic review | PR intent, scope, risk framing, market/developer/user value, public messaging review | merge approval, CI override, security/governance approval |
+| Codex | Primary implementation | focused patches, tests, CI failure fixes, small docs updates | independent merge, security-sensitive approval, public-claim approval |
+| Claude Code | Architecture and implementation review | architecture consistency, edge cases, terminology consistency, missing/weak tests, governance-sensitive review | CI override, final approval, autonomous refactor approval |
+| GitHub Copilot | GitHub-native review and local coding assistance | small bug suggestions, code readability, local implementation assistance | final approval, governance/security approval |
+| Gemini | External clarity review | documentation readability, product explanation, external reviewer perspective | merge blocker, confidential review |
+| Grok | Adversarial review | unnecessary-complexity detection, market/message skepticism, overengineering detection | final architecture authority |
+| Meta AI | Lightweight secondary review | terminology clarity, readability, second opinion | merge blocker, sensitive review |
+| GitHub Actions | Objective verification | tests, quality gates, release gates, CodeQL, automation checks | product strategy or public messaging |
+| Human maintainer | Final authority | final approval, merge decision, security/governance/release/public-claim approval | none |
+
+## Feedback Classification
+
+AI feedback should be classified as:
+
+- `blocker`: must be addressed before merge
+- `recommended`: should be addressed unless there is a clear reason not to
+- `optional`: style, readability, alternative implementation, or non-critical suggestion
+
+Only a human maintainer may decide whether advisory AI feedback becomes a merge blocker.
+
+## Review Priority
+
+1. CI/test failures
+2. Security or data exposure
+3. Runtime behavior mismatch
+4. Public documentation mismatch
+5. Missing tests for code changes
+6. Refactor or style suggestions
+
+## High-Risk Changes
+
+The following changes require explicit human approval:
+
+- bind/admissibility logic
+- governance policy behavior
+- release gates
+- secrets or credential handling
+- TrustLog persistence or encryption behavior
+- FUJI Gate fail-closed behavior
+- public claims in README, docs, website, or social posts
+- private user/customer data handling
+
+## External AI Review Safety
+
+External/free-tier tools must receive only non-sensitive excerpts.
+
+Do not paste secrets, credentials, API keys, `.env` content, private customer data, unpublished internal strategy, or non-public security details.

--- a/docs/ja/development/ai-review-matrix.md
+++ b/docs/ja/development/ai-review-matrix.md
@@ -1,0 +1,61 @@
+# AIレビューマトリクス
+
+## 目的
+
+この文書は、VERITAS OS の開発において複数のAIツールをどの役割で使うかを定義します。
+
+`docs/ja/development/ai-assisted-development.md` で定義した、監査可能なAI支援開発ワークフローを補完する文書です。
+
+AIレビューは参考シグナルです。GitHub Actions / CI は客観的チェックです。人間メンテナの承認が最終的な Commit Boundary です。
+
+## 役割マトリクス
+
+| ツール | 主な役割 | 向いている用途 | 権限を持たないもの |
+|---|---|---|---|
+| ChatGPT | 計画・戦略レビュー | PR目的、スコープ、リスク整理、市場/開発者/ユーザー価値、公開メッセージ確認 | マージ承認、CI上書き、セキュリティ/ガバナンス承認 |
+| Codex | 主実装 | 焦点を絞った修正、テスト、CI失敗修正、小さなdocs更新 | 単独マージ、セキュリティ重要変更の承認、公開主張の承認 |
+| Claude Code | アーキテクチャ・実装レビュー | 構造整合、エッジケース、用語一貫性、不足テスト、ガバナンス重要変更の確認 | CI上書き、最終承認、自律的な大規模リファクタ承認 |
+| GitHub Copilot | GitHub上のレビュー・ローカル補助 | 小さなバグ指摘、可読性、ローカル実装補助 | 最終承認、ガバナンス/セキュリティ承認 |
+| Gemini | 外部視点での明瞭性レビュー | ドキュメント可読性、プロダクト説明、外部レビュアー視点 | merge blocker、機密情報レビュー |
+| Grok | 辛口レビュー | 不要な複雑性の検出、市場/メッセージ面の違和感、過剰設計検出 | 最終アーキテクチャ権限 |
+| Meta AI | 軽量な二次レビュー | 用語の明瞭性、読みやすさ、セカンドオピニオン | merge blocker、機密レビュー |
+| GitHub Actions | 客観的検証 | テスト、品質ゲート、リリースゲート、CodeQL、自動チェック | プロダクト戦略や公開メッセージ判断 |
+| 人間メンテナ | 最終権限 | 最終承認、マージ判断、セキュリティ/ガバナンス/リリース/公開主張の承認 | なし |
+
+## フィードバック分類
+
+AIのフィードバックは以下に分類します。
+
+- `blocker`: マージ前に対応が必要
+- `recommended`: 明確な理由がない限り対応すべき
+- `optional`: スタイル、可読性、代替実装、非重大な提案
+
+AIの参考意見を merge blocker にするかどうかは、人間メンテナが判断します。
+
+## レビュー優先度
+
+1. CI/test failures
+2. Security or data exposure
+3. Runtime behavior mismatch
+4. Public documentation mismatch
+5. Missing tests for code changes
+6. Refactor or style suggestions
+
+## 高リスク変更
+
+以下の変更には明示的な人間承認が必要です。
+
+- bind/admissibility logic
+- governance policy behavior
+- release gates
+- secrets or credential handling
+- TrustLog persistence or encryption behavior
+- FUJI Gate fail-closed behavior
+- README、docs、website、SNS投稿における公開主張
+- 非公開のユーザー情報または顧客情報の取り扱い
+
+## 外部AIレビューの安全ルール
+
+外部AIまたは無料版AIツールには、非機密の抜粋のみを渡します。
+
+secrets、credentials、API keys、`.env` content、private customer data、unpublished internal strategy、non-public security details を貼り付けてはいけません。


### PR DESCRIPTION
### Motivation

- Operationalize the AI-assisted development guardrails by adding an English/Japanese AI review matrix and repository templates to standardize AI-assisted PRs and issues.
- Provide clear role, feedback classification, high-risk change guidance, and external-AI safety rules so AI reviews remain advisory while CI and human maintainers retain final authority.
- Ensure this is a docs-only change with no runtime, API, test, CI, dependency, or public-claim modifications.

### Description

- Added `docs/en/development/ai-review-matrix.md` containing the AI authority model, role matrix, feedback classification, review priorities, a high-risk changes list, and external-AI safety rules.
- Added `docs/ja/development/ai-review-matrix.md` as a Japanese translation/equivalent of the English matrix.
- Added `.github/PULL_REQUEST_TEMPLATE.md` to require scope, value, test evidence, AI-assistance disclosure, review status, risk checklist, and human approval fields for PRs.
- Added `.github/ISSUE_TEMPLATE/ai_implementation_task.md` to standardize focused AI implementation tasks with goal/background/non-goals/acceptance/must-not-change and human-approval guidance.

### Testing

- Verified the four new files exist at `docs/en/development/ai-review-matrix.md`, `docs/ja/development/ai-review-matrix.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `.github/ISSUE_TEMPLATE/ai_implementation_task.md` using repository status commands (`git status --short`).
- Confirmed the new files are staged/visible to the repository with `git show --name-only --pretty=format: --stat HEAD` which listed only the four expected paths.
- No unit/integration/CI tests were run because this is a docs-only change and no runtime/CI/test files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8aab3875083268c4d967872fe98b3)