### PR TITLE
Add PR risk label guidance

### DIFF
--- a/docs/en/development/pr-risk-labels.md
+++ b/docs/en/development/pr-risk-labels.md
@@ -1,0 +1,104 @@
+# PR Risk Label Guidance
+
+## Purpose
+
+This document defines recommended PR risk labels for VERITAS OS development.
+
+It supports the auditable AI-assisted development workflow defined in:
+
+- `docs/en/development/ai-assisted-development.md`
+- `docs/en/development/ai-review-matrix.md`
+
+Risk labels are triage aids. They do not replace CI, review, or human maintainer approval.
+
+## Authority Model
+
+- AI reviews are advisory signals.
+- GitHub Actions / CI are objective checks.
+- Human maintainer approval is the final commit boundary.
+- Risk labels do not authorize merge.
+- Risk labels do not downgrade security, governance, release, or public-claim review requirements.
+
+## Recommended Labels
+
+| Label | Meaning | Typical examples | Human approval |
+|---|---|---|---|
+| `risk:low` | Small, low-impact change | typo fix, docs-only clarification, non-public wording cleanup | normal review |
+| `risk:medium` | Meaningful change with limited blast radius | focused runtime fix, focused test update, localized frontend behavior, non-sensitive docs restructure | maintainer review required |
+| `risk:high` | Change may affect governance, security, release, or public claims | bind/admissibility behavior, FUJI Gate behavior, TrustLog persistence, release gates, public claims | explicit human approval required |
+| `docs-only` | Documentation-only change | docs page, guide, review matrix, explanation page | normal review unless public claims change |
+| `tests-only` | Test-only change | unit test coverage, fixture update, regression test | maintainer review required if expectations change |
+| `runtime-change` | Runtime code behavior may change | backend logic, frontend behavior, API response behavior | maintainer review required |
+| `governance-sensitive` | Governance behavior or policy boundary may change | policy behavior, bind/admissibility logic, approval flow, enforcement behavior | explicit human approval required |
+| `security-sensitive` | Security posture may change | secrets handling, auth, RBAC, encryption, PII masking, CORS, deserialization | explicit human approval required |
+| `release-gate-change` | Release or CI gate behavior may change | GitHub Actions, quality gate scripts, release workflow, coverage gate | explicit human approval required |
+| `public-claim-change` | Public positioning or external claims may change | README, README_JP, website copy, investor/customer-facing docs, social-post source text | explicit human approval required |
+| `needs-human-approval` | Human approval is explicitly required before merge | any high-risk or authority-sensitive change | explicit human approval required |
+| `ai-assisted` | AI tools contributed to planning, implementation, review, or drafting | ChatGPT planning, Codex implementation, Claude Code review, external AI advisory review | does not change approval rules |
+
+## Risk Classification Rules
+
+Use the highest applicable risk level.
+
+A PR is `risk:high` if it touches any of the following:
+
+- bind/admissibility logic
+- governance policy behavior
+- FUJI Gate fail-closed behavior
+- TrustLog persistence or encryption behavior
+- release gates
+- secrets or credential handling
+- public claims
+- website positioning
+- private user/customer data handling
+
+A docs-only PR can still be `risk:high` if it changes public claims, regulatory positioning, production-readiness statements, or external-review evidence claims.
+
+A tests-only PR can still be `risk:medium` or `risk:high` if it changes expected behavior, removes coverage, weakens assertions, or changes governance/release gate assumptions.
+
+## Suggested Review Routing
+
+| Risk | Recommended review |
+|---|---|
+| `risk:low` | normal maintainer review |
+| `risk:medium` | maintainer review + relevant AI advisory review |
+| `risk:high` | explicit human approval + CI success + targeted architecture/security/governance review |
+
+## AI Review Use
+
+AI tools may suggest labels, but humans decide final labels.
+
+Codex may identify likely risk categories during implementation.
+Claude Code may review whether the assigned labels match the diff.
+External AI tools may provide advisory feedback only from non-sensitive excerpts.
+
+## Non-Goals
+
+This document does not introduce:
+
+- automatic label application
+- automatic merge approval
+- automatic release approval
+- bypass of CI
+- replacement of human maintainer judgment
+
+## Minimal PR Labeling Example
+
+For a docs-only typo fix:
+
+- `risk:low`
+- `docs-only`
+
+For a bind/admissibility behavior change:
+
+- `risk:high`
+- `runtime-change`
+- `governance-sensitive`
+- `needs-human-approval`
+
+For README positioning updates:
+
+- `risk:high`
+- `docs-only`
+- `public-claim-change`
+- `needs-human-approval`

--- a/docs/ja/development/pr-risk-labels.md
+++ b/docs/ja/development/pr-risk-labels.md
@@ -1,0 +1,104 @@
+# PRリスクラベル運用ガイド
+
+## 目的
+
+この文書は、VERITAS OS の開発における推奨PRリスクラベルを定義します。
+
+以下の監査可能なAI支援開発ワークフローを補完します。
+
+- `docs/ja/development/ai-assisted-development.md`
+- `docs/ja/development/ai-review-matrix.md`
+
+リスクラベルはトリアージ補助です。CI、レビュー、人間メンテナの承認を置き換えるものではありません。
+
+## 権限モデル
+
+- AIレビューは参考シグナルです。
+- GitHub Actions / CI は客観的チェックです。
+- 人間メンテナの承認が最終的な Commit Boundary です。
+- リスクラベルはマージを許可するものではありません。
+- リスクラベルは、セキュリティ、ガバナンス、リリース、公開主張に関するレビュー要件を下げるものではありません。
+
+## 推奨ラベル
+
+| ラベル | 意味 | 典型例 | 人間承認 |
+|---|---|---|---|
+| `risk:low` | 小さく影響が低い変更 | typo修正、docs-onlyの補足、非公開表現の軽微な整理 | 通常レビュー |
+| `risk:medium` | 影響範囲が限定された意味のある変更 | 焦点を絞ったruntime修正、テスト更新、局所的なfrontend挙動、非機密docs整理 | メンテナレビュー必須 |
+| `risk:high` | ガバナンス、セキュリティ、リリース、公開主張に影響し得る変更 | bind/admissibility挙動、FUJI Gate挙動、TrustLog永続化、release gates、公開主張 | 明示的な人間承認必須 |
+| `docs-only` | ドキュメントのみの変更 | docsページ、ガイド、レビューマトリクス、解説ページ | 公開主張変更がなければ通常レビュー |
+| `tests-only` | テストのみの変更 | unit test coverage、fixture update、regression test | 期待値変更がある場合はメンテナレビュー必須 |
+| `runtime-change` | runtime挙動が変わる可能性がある変更 | backend logic、frontend behavior、API response behavior | メンテナレビュー必須 |
+| `governance-sensitive` | ガバナンス挙動またはポリシー境界に影響し得る変更 | policy behavior、bind/admissibility logic、approval flow、enforcement behavior | 明示的な人間承認必須 |
+| `security-sensitive` | セキュリティ姿勢に影響し得る変更 | secrets handling、auth、RBAC、encryption、PII masking、CORS、deserialization | 明示的な人間承認必須 |
+| `release-gate-change` | リリースまたはCIゲートに影響し得る変更 | GitHub Actions、quality gate scripts、release workflow、coverage gate | 明示的な人間承認必須 |
+| `public-claim-change` | 公開表現・外部向け主張に影響し得る変更 | README、README_JP、website文言、投資家/顧客向けdocs、SNS投稿元テキスト | 明示的な人間承認必須 |
+| `needs-human-approval` | マージ前に明示的な人間承認が必要 | 高リスクまたは権限に関わる変更 | 明示的な人間承認必須 |
+| `ai-assisted` | AIツールが計画、実装、レビュー、ドラフトに関与 | ChatGPT計画、Codex実装、Claude Codeレビュー、外部AI参考レビュー | 承認ルールは変わらない |
+
+## リスク分類ルール
+
+該当する中で最も高いリスクレベルを使います。
+
+以下に触れるPRは `risk:high` です。
+
+- bind/admissibility logic
+- governance policy behavior
+- FUJI Gate fail-closed behavior
+- TrustLog persistence or encryption behavior
+- release gates
+- secrets or credential handling
+- public claims
+- website positioning
+- private user/customer data handling
+
+docs-only PR でも、公開主張、規制対応の見せ方、本番準備性の記述、外部レビュー証跡の主張を変更する場合は `risk:high` になり得ます。
+
+tests-only PR でも、期待挙動、カバレッジ、assertion、governance/release gate の前提を弱める場合は `risk:medium` または `risk:high` になり得ます。
+
+## 推奨レビュー経路
+
+| リスク | 推奨レビュー |
+|---|---|
+| `risk:low` | 通常のメンテナレビュー |
+| `risk:medium` | メンテナレビュー + 関連するAI参考レビュー |
+| `risk:high` | 明示的な人間承認 + CI成功 + アーキテクチャ/セキュリティ/ガバナンス観点の targeted review |
+
+## AIレビューの使い方
+
+AIツールはラベル候補を提案できますが、最終ラベルは人間が決定します。
+
+Codex は実装中に想定リスクカテゴリを示すことができます。
+Claude Code は、付与ラベルが差分内容と一致しているかレビューできます。
+外部AIツールは、非機密の抜粋に限って参考意見を提供できます。
+
+## 非目的
+
+この文書は以下を導入しません。
+
+- 自動ラベル付け
+- 自動マージ承認
+- 自動リリース承認
+- CIの迂回
+- 人間メンテナ判断の置き換え
+
+## 最小PRラベル例
+
+docs-only typo修正:
+
+- `risk:low`
+- `docs-only`
+
+bind/admissibility挙動変更:
+
+- `risk:high`
+- `runtime-change`
+- `governance-sensitive`
+- `needs-human-approval`
+
+README positioning update:
+
+- `risk:high`
+- `docs-only`
+- `public-claim-change`
+- `needs-human-approval`


### PR DESCRIPTION
### Motivation

- Provide a clear, auditable mapping from existing AI-assisted development guardrails to operational PR triage by documenting recommended PR risk labels and their intended use. 
- Ensure humans and AI reviewers share a common, language-neutral criterion set for labeling without introducing automation or changing runtime behavior.

### Description

- Add two new documentation pages: `docs/en/development/pr-risk-labels.md` (English) and `docs/ja/development/pr-risk-labels.md` (Japanese) containing purpose, authority model, recommended labels, classification rules, review routing, AI review use, non-goals, and minimal examples. 
- Explicitly preserve the authority model that AI reviews are advisory, CI is an objective check, and human maintainer approval is the final commit boundary. 
- Restrict changes to docs only and do not add any GitHub Actions, automation, auto-labeling, runtime/front-end/back-end/test/CI/dependency changes, or public-claim edits. 

### Testing

- Verified the presence and contents of the new files by printing them with `nl -ba docs/en/development/pr-risk-labels.md | sed -n '1,220p'` and `nl -ba docs/ja/development/pr-risk-labels.md | sed -n '1,240p'`, and confirmed the files contain the expected sections. 
- Confirmed the repository contains the two new docs files and that the change is docs-only by checking repository status and file listings. 
- Executed `find .. -name AGENTS.md -print` to confirm referenced agent guidance remains available; all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b6ed6a408326b90c06a3766f6ea9)