### PR TITLE
Clarify pytest discovery across repository and package tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -349,7 +349,9 @@ jobs:
           set -euxo pipefail
           mkdir -p test-reports coverage-html
 
-          pytest -q veritas_os/tests \
+          # Full Python test discovery roots are explicit to avoid skipping
+          # either repository-level tests/ or package-level veritas_os/tests/.
+          pytest -q veritas_os/tests tests \
             --cov=veritas_os \
             --cov-config=veritas_os/tests/.coveragerc \
             --cov-report=term-missing \

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-cov:
 	@set -e; \
 	if [ -x .venv/bin/python ] && .venv/bin/python -c "import pytest" >/dev/null 2>&1; then \
 		echo "[veritas] Using existing .venv"; \
-		.venv/bin/python -m pytest -q veritas_os/tests \
+		.venv/bin/python -m pytest -q veritas_os/tests tests \
 			--cov=veritas_os \
 			--cov-config=veritas_os/tests/.coveragerc \
 			--cov-report=term-missing \
@@ -110,7 +110,7 @@ test-cov:
 		exit 0; \
 	fi; \
 	echo "[veritas] Running coverage tests with Python $(PYTHON_VERSION) via uv"; \
-	if UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_VERSION) --with pytest --with pytest-cov pytest -q veritas_os/tests \
+	if UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_VERSION) --with pytest --with pytest-cov pytest -q veritas_os/tests tests \
 		--cov=veritas_os \
 		--cov-config=veritas_os/tests/.coveragerc \
 		--cov-report=term-missing \
@@ -124,7 +124,7 @@ test-cov:
 		exit 0; \
 	fi; \
 	echo "[veritas] Falling back to Python $(PYTHON_FALLBACK) (local or managed)"; \
-	UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_FALLBACK) --with pytest --with pytest-cov pytest -q veritas_os/tests \
+	UV_PYTHON_DOWNLOADS=automatic $(UV) run --python $(PYTHON_FALLBACK) --with pytest --with pytest-cov pytest -q veritas_os/tests tests \
 		--cov=veritas_os \
 		--cov-config=veritas_os/tests/.coveragerc \
 		--cov-report=term-missing \
@@ -169,6 +169,7 @@ verify: verify-backend verify-frontend
 
 verify-backend:
 	@echo "[veritas] Running backend verification suite..."
+	@echo "[veritas] Note: verify-backend runs targeted backend smoke/invariant checks, not full pytest discovery."
 	@pytest -q tests/test_continuation_enforcement.py \
 		tests/test_continuation_integration.py \
 		tests/test_debate_safety_heuristics.py

--- a/README.md
+++ b/README.md
@@ -1432,7 +1432,8 @@ make test-cov
 These targets use `uv` with `PYTHON_VERSION=3.12.12` and automatically download the
 interpreter if it is not already installed. `make test-cov` now mirrors the CI
 coverage gate (`--cov-fail-under=85`, `veritas_os/tests/.coveragerc`, XML/HTML reports,
-and `-m "not slow"`).
+and `-m "not slow"`), and explicitly executes both Python test roots:
+`veritas_os/tests/` and top-level `tests/`.
 
 ```bash
 # Optional: override the local gate/marker to troubleshoot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,14 @@ veritas_os = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+testpaths = [
+  "veritas_os/tests",
+  "tests",
+]
+python_files = [
+  "test_*.py",
+  "*_test.py",
+]
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
   "ignore:invalid escape sequence.*:SyntaxWarning:sentence_transformers\\..*",


### PR DESCRIPTION
### Motivation
- The repository has two test roots (`veritas_os/tests/` and top-level `tests/`) and plain `pytest`/CI invocations risk running only one tree, so discovery roots are made explicit to reduce accidental skips. 
- Makefile/CI currently target `veritas_os/tests` in many places which can lead to incomplete local/CI coverage of repository-level tests, so execution targets were aligned to include both roots. 
- The change is intentionally minimal and non-invasive: it clarifies discovery and commands without moving tests or changing coverage source/threshold behavior.

### Description
- Added `testpaths` (``veritas_os/tests``, ``tests``) and explicit ``python_files`` patterns to `[tool.pytest.ini_options]` in `pyproject.toml` to make discovery deterministic. 
- Updated `Makefile` `test-cov` targets to run `pytest -q veritas_os/tests tests` (coverage source remains `--cov=veritas_os` and existing `.coveragerc`/threshold preserved) and added a clarifying note that `verify-backend` is a targeted smoke/invariant subset rather than full discovery. 
- Updated CI (`.github/workflows/main.yml`) coverage step to run `pytest -q veritas_os/tests tests` and added a short comment explaining the intent to avoid skipping either test root. 
- Small README update to document that `make test-cov` explicitly runs both `veritas_os/tests/` and top-level `tests/`.

### Testing
- Ran `pytest --collect-only -q` which completed collection without script errors. 
- Ran `pytest -q tests --tb=short` which returned `437 passed` for the top-level `tests/` tree. 
- Ran `pytest -q veritas_os/tests --tb=short` which revealed a pre-existing unrelated failure in `veritas_os/tests` (one failing test: `veritas_os/tests/test_decide_e2e_reliability.py`) with the remainder passing (`~7k passed`, some skipped). 
- Ran the combined `pytest -q veritas_os/tests tests --tb=short` to confirm combined discovery and observed the same pre-existing failing test (no new failures introduced by these config changes). 
- Ran `ruff check .github scripts veritas_os tests` which passed with no issues.

Known limitations: this PR does not merge or move test files between roots, and some targeted CI jobs intentionally still execute subsets for speed; an unrelated pre-existing test failure in `veritas_os/tests` was observed during combined runs and is out of scope for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c603835483268e22764077613d58)