### PR TITLE
Stabilize decide E2E reliability test isolation

### DIFF
--- a/veritas_os/api/utils.py
+++ b/veritas_os/api/utils.py
@@ -108,6 +108,23 @@ def _coerce_alt_list(v: Any) -> list:
     return out
 
 
+
+
+def _hydrate_bind_compat_fields(payload: Dict[str, Any]) -> None:
+    """Populate canonical bind compatibility fields from nested bind structures."""
+    bind_summary = payload.get("bind_summary")
+    bind_receipt = payload.get("bind_receipt")
+
+    summary = bind_summary if isinstance(bind_summary, dict) else {}
+    receipt = bind_receipt if isinstance(bind_receipt, dict) else {}
+
+    payload.setdefault("bind_outcome", summary.get("bind_outcome") or summary.get("outcome") or receipt.get("final_outcome"))
+    payload.setdefault("bind_reason_code", summary.get("bind_reason_code") or summary.get("reason_code") or receipt.get("bind_reason_code"))
+    payload.setdefault("bind_failure_reason", summary.get("bind_failure_reason") or summary.get("failure_reason") or receipt.get("bind_failure_reason"))
+    payload.setdefault("bind_receipt_id", summary.get("bind_receipt_id") or receipt.get("bind_receipt_id"))
+    payload.setdefault("execution_intent_id", summary.get("execution_intent_id") or receipt.get("execution_intent_id"))
+    payload.setdefault("bind_summary", bind_summary if isinstance(bind_summary, dict) else None)
+
 def _coerce_decide_payload(payload: Any, *, seed: str = "") -> Dict[str, Any]:
     """response_model を "効かせつつ" server を落とさないための最終整形。"""
     if not isinstance(payload, dict):
@@ -122,6 +139,8 @@ def _coerce_decide_payload(payload: Any, *, seed: str = "") -> Dict[str, Any]:
         return payload
 
     d = dict(payload)
+
+    _hydrate_bind_compat_fields(d)
 
     if "trust_log" not in d:
         d["trust_log"] = None


### PR DESCRIPTION
### Motivation
- Fix a pre-existing, reproducible failure in `veritas_os/tests/test_decide_e2e_reliability.py` where the `pre_bind_case_decision_shaping_collapsed` scenario sometimes produced a `/v1/decide` response that lacked top-level bind compatibility fields, causing combined/local runs to fail while CI passed.

### Description
- Add a helper `_hydrate_bind_compat_fields()` to `veritas_os/api/utils.py` that promotes canonical bind compatibility keys from nested `bind_summary` / `bind_receipt` into the top-level response (fields: `bind_outcome`, `bind_reason_code`, `bind_failure_reason`, `bind_receipt_id`, `execution_intent_id`, `bind_summary`).
- Call `_hydrate_bind_compat_fields()` at the start of `_coerce_decide_payload()` so response coercion always exposes the expected compatibility fields before further normalization.
- No tests or assertions were skipped or weakened; this change only ensures the API response preserves the compatibility contract expected by tests and clients.

### Testing
- Ran `pytest -q veritas_os/tests/test_decide_e2e_reliability.py --tb=short -vv` and observed `26 passed` (the previously failing case now passes). (passed)
- Ran combined targeted discovery `pytest -q veritas_os/tests tests --tb=short -k "decide_e2e_reliability or auth or middleware or continuation" -vv` and observed `453 passed, 7182 deselected` (no regressions in the targeted scope). (passed)
- Ran `ruff check veritas_os/api/utils.py` which passed; `ruff check veritas_os/tests/test_decide_e2e_reliability.py veritas_os tests` reported pre-existing `F841` unused-local warnings in the test module which were not changed by this PR. (tooling)

Known limitations: the ruff-reported unused-local warnings (`original_mem`, `original_fn`) in the test file are pre-existing and out of scope for this focused change; they remain unchanged to keep the PR minimal and reviewable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ce0892348326ab02859d6c1f6938)