### PR TITLE
Harden OpenAPI generation for FastAPI/Pydantic deprecation compatibility

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -13,6 +13,7 @@ import re
 import secrets
 import threading
 import time
+import warnings
 from contextlib import asynccontextmanager
 from functools import lru_cache
 from datetime import datetime, timezone
@@ -39,6 +40,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.exceptions import RequestValidationError
+from fastapi.openapi.utils import get_openapi
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security.api_key import APIKeyHeader
@@ -653,6 +655,39 @@ async def _app_lifespan(_: FastAPI):
 
 
 app = FastAPI(title="VERITAS Public API", version="2.0.0-beta", lifespan=_app_lifespan)
+
+
+def _safe_openapi_schema() -> Dict[str, Any]:
+    """Build OpenAPI schema while suppressing known Pydantic v2 shim deprecations.
+
+    FastAPI may trigger a DeprecationWarning via an internal Pydantic v1
+    compatibility check (`__fields__`) during OpenAPI security schema encoding.
+    This warning originates in dependency internals and does not indicate
+    deprecated API usage in VERITAS application models.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=r".*__fields__.*deprecated.*model_fields.*",
+        )
+        return get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+        )
+
+
+def custom_openapi() -> Dict[str, Any]:
+    """Return cached OpenAPI schema with compatibility-safe generation."""
+    if app.openapi_schema:
+        return app.openapi_schema
+    app.openapi_schema = _safe_openapi_schema()
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi
 
 # ★ セキュリティ: allow_credentials は明示的なオリジンが設定されている場合のみ True
 def _resolve_cors_settings(origins: Any) -> tuple[list[str], bool]:

--- a/veritas_os/tests/test_openapi_no_deprecation_warnings.py
+++ b/veritas_os/tests/test_openapi_no_deprecation_warnings.py
@@ -1,0 +1,23 @@
+"""OpenAPI compatibility tests for Pydantic/FastAPI deprecation handling."""
+
+from __future__ import annotations
+
+import warnings
+
+from fastapi.testclient import TestClient
+
+from veritas_os.api.server import app
+
+
+def test_openapi_generation_has_no_deprecation_warnings() -> None:
+    """Ensure /openapi.json is generated under DeprecationWarning-as-error mode."""
+    client = TestClient(app)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "openapi" in payload
+    assert "paths" in payload
+    assert "/v1/decide" in payload["paths"]


### PR DESCRIPTION
### Motivation
- FastAPI's OpenAPI generation can trigger a DeprecationWarning from Pydantic's v1 compatibility shim (use of `__fields__`) which fails when `DeprecationWarning` is escalated to an error, disrupting `/openapi.json` generation.
- The goal is a minimal, local compatibility layer to suppress that specific dependency-internal warning without changing API contracts, decision logic, or persistence behavior.
- A quick scan showed no application code relying on the deprecated `__fields__` API (the warning originates in dependency internals), so a narrow suppression is preferred over broad refactors.

### Description
- Added a narrow compatibility wrapper in `veritas_os/api/server.py` that builds the OpenAPI schema via a `_safe_openapi_schema()` helper which suppresses the known `DeprecationWarning` pattern and uses `fastapi.openapi.utils.get_openapi` under the filter.
- Exposed a `custom_openapi()` that caches the schema and assigned it to `app.openapi` so FastAPI uses the compatibility-safe generator without changing schema semantics or caching behavior.
- Imported `warnings` and `get_openapi` and kept the warning filter targeted to the `__fields__` → `model_fields` deprecation message only.
- Added `veritas_os/tests/test_openapi_no_deprecation_warnings.py` which ensures `/openapi.json` returns `200` and contains `openapi`, `paths`, and `/v1/decide` when `DeprecationWarning` is treated as an error.

### Testing
- Ran the requirements sync check with `python scripts/quality/check_requirements_sync.py` and it reported `Dependency manifests are in sync (name-level)`.
- Ran the selected OpenAPI/schema test matrix with `pytest -W error::DeprecationWarning` against `veritas_os/tests/test_openapi_no_deprecation_warnings.py`, `veritas_os/tests/test_openapi_spec.py`, `veritas_os/tests/test_openapi_pre_bind_contract.py`, `veritas_os/tests/test_schemas_extra.py`, and `veritas_os/tests/test_schemas_extra_v2.py` and they all passed (`93 passed`).
- Verified that generating `/openapi.json` under `DeprecationWarning`-as-error no longer raises and returns a valid OpenAPI payload (covered by the new test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d2e3912c8326936197d4a46485c4)