### PR TITLE
Harden OpenAPI generation against Pydantic deprecation warnings

### DIFF
--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -13,6 +13,7 @@ import re
 import secrets
 import threading
 import time
+import warnings
 from contextlib import asynccontextmanager
 from functools import lru_cache
 from datetime import datetime, timezone
@@ -653,6 +654,31 @@ async def _app_lifespan(_: FastAPI):
 
 
 app = FastAPI(title="VERITAS Public API", version="2.0.0-beta", lifespan=_app_lifespan)
+
+
+def _install_openapi_deprecation_guard(fastapi_app: FastAPI) -> None:
+    """Guard OpenAPI generation from third-party Pydantic v2 deprecation noise.
+
+    FastAPI's OpenAPI path may call pydantic.v1 compatibility checks that touch
+    ``BaseModel.__fields__`` on v2 models. This emits a deprecation warning in
+    Pydantic v2 and becomes a hard error under ``-W error::DeprecationWarning``.
+    The filter is intentionally narrow and scoped only to OpenAPI generation.
+    """
+    original_openapi = fastapi_app.openapi
+
+    def _guarded_openapi() -> dict[str, Any]:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"The `__fields__` attribute is deprecated, use `model_fields` instead\.",
+                category=DeprecationWarning,
+            )
+            return original_openapi()
+
+    fastapi_app.openapi = _guarded_openapi
+
+
+_install_openapi_deprecation_guard(app)
 
 # ★ セキュリティ: allow_credentials は明示的なオリジンが設定されている場合のみ True
 def _resolve_cors_settings(origins: Any) -> tuple[list[str], bool]:

--- a/veritas_os/tests/test_openapi_no_deprecation_warnings.py
+++ b/veritas_os/tests/test_openapi_no_deprecation_warnings.py
@@ -1,0 +1,18 @@
+import warnings
+
+from fastapi.testclient import TestClient
+
+from veritas_os.api.server import app
+
+
+def test_openapi_generation_has_no_deprecation_warnings() -> None:
+    client = TestClient(app)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "openapi" in payload
+    assert "paths" in payload
+    assert "/v1/decide" in payload["paths"]


### PR DESCRIPTION
### Motivation
- FastAPI's OpenAPI code path triggers a Pydantic v2 deprecation warning (accessing `BaseModel.__fields__`) which becomes a hard failure under `-W error::DeprecationWarning`, so OpenAPI generation must be hardened without changing API contracts. 

### Description
- Add a narrowly-scoped runtime guard in `veritas_os/api/server.py` (`_install_openapi_deprecation_guard`) that wraps `app.openapi` and suppresses the specific `__fields__` deprecation warning during OpenAPI generation. 
- Add `veritas_os/tests/test_openapi_no_deprecation_warnings.py` which requests `/openapi.json` with `DeprecationWarning` promoted to errors and asserts a `200` response and presence of `openapi`, `paths`, and `"/v1/decide"`. 
- No dependency pins were changed in `pyproject.toml` / `veritas_os/requirements.txt` and no API/schema behavioral changes were made. 

### Testing
- Ran `python scripts/quality/check_requirements_sync.py` and it passed (manifests are in sync). 
- Ran the targeted pytest selection `pytest -q veritas_os/tests -k "openapi or schema or schemas or api or decide" --tb=short` and it passed. 
- Ran the new test `pytest -q veritas_os/tests/test_openapi_no_deprecation_warnings.py --tb=short` and it passed (`1 passed`). 
- Ran `ruff check veritas_os/ scripts/` and it passed. 

Known limitations: this PR does not upgrade `fastapi`/`pydantic` versions or migrate to Pydantic v3, and the guard is intentionally narrow (it only filters the specific `__fields__` deprecation message during OpenAPI generation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d6ade1b483269f8bf0a73c5696d6)