### PR TITLE
Add non-blocking FastAPI/Pydantic future compatibility CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,6 +275,65 @@ jobs:
           path: test-reports/governance-backend-fast.xml
           if-no-files-found: warn
 
+  # Experimental non-blocking compatibility check.
+  # This job does not change pinned production dependencies.
+  # It previews future FastAPI/Pydantic upgrade risk in CI logs.
+  future-dependency-compat:
+    name: future-dependency-compat
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    continue-on-error: true
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      OPENAI_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_API_KEY: "DUMMY_FOR_CI"
+      VERITAS_PIPELINE_VERSION: "${{ github.sha }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install base dependencies and dry-run upgrades
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r veritas_os/requirements.txt
+          python -m pip install --upgrade "fastapi>=0.121,<0.123" "pydantic>=2.10,<2.12"
+
+      - name: Print resolved dependency versions
+        run: |
+          set -euxo pipefail
+          python - <<'PY'
+          import fastapi
+          import pydantic
+          import starlette
+
+          print("fastapi", fastapi.__version__)
+          print("pydantic", pydantic.__version__)
+          print("starlette", starlette.__version__)
+          PY
+          python -m pip check
+
+      - name: Run targeted compatibility smoke tests
+        run: |
+          set -euxo pipefail
+          pytest -q \
+            veritas_os/tests/test_openapi_no_deprecation_warnings.py \
+            veritas_os/tests/test_openapi_spec.py \
+            veritas_os/tests/test_openapi_pre_bind_contract.py \
+            veritas_os/tests/test_schemas_extra.py \
+            veritas_os/tests/test_schemas_extra_v2.py \
+            veritas_os/tests/test_decide_e2e_reliability.py \
+            --tb=short \
+            -W error::DeprecationWarning
+
   # ============================================================
   # [Tier 1] Test matrix
   # ============================================================


### PR DESCRIPTION
### Motivation
- Surface future FastAPI/Pydantic upgrade breakage early in CI without changing production pins. 
- Run a targeted, low-risk compatibility dry-run that exercises OpenAPI/schema/decide smoke paths. 
- Keep mainline dependency manifests unchanged and avoid blocking the primary test matrix while evaluating upgrade risk. 

### Description
- Add an experimental `future-dependency-compat` job to `.github/workflows/main.yml` that is marked `continue-on-error: true` and `timeout-minutes: 12` to make the check non-blocking and time-limited. 
- The job installs baseline pinned deps from `veritas_os/requirements.txt` and then in-job upgrades to the tested ranges `fastapi>=0.121,<0.123` and `pydantic>=2.10,<2.12` (only inside the job). 
- The job prints resolved versions for `fastapi`, `pydantic`, and `starlette`, runs `python -m pip check` for dependency problems, and executes targeted tests with `pytest` and `-W error::DeprecationWarning`. 
- No production dependency files are modified by this PR (`pyproject.toml` and `veritas_os/requirements.txt` remain unchanged). 

### Testing
- Ran `python scripts/quality/check_requirements_sync.py` locally and it succeeded. 
- Ran `pytest -q veritas_os/tests/test_openapi_no_deprecation_warnings.py --tb=short` locally and it passed (`1 passed`). 
- Ran `ruff check .github` locally and it completed successfully (no blocking failures). 
- The dry-run job will run these tests in CI: `test_openapi_no_deprecation_warnings.py`, `test_openapi_spec.py`, `test_openapi_pre_bind_contract.py`, `test_schemas_extra.py`, `test_schemas_extra_v2.py`, and `test_decide_e2e_reliability.py`, and failures in that job indicate potential incompatibilities to investigate but do not change production pins or block the main CI by design.

Known limitations: this PR does not upgrade production dependency pins, does not guarantee full compatibility with all future FastAPI/Pydantic versions, and the job is intentionally non-blocking at first so it only provides early warning signals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f92b634eb483268417b92412543ace)