### PR TITLE
Show future dependency pytest result in GitHub Actions summary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -323,7 +323,8 @@ jobs:
 
       - name: Run targeted compatibility smoke tests
         run: |
-          set -euxo pipefail
+          set -uo pipefail
+          status=0
           pytest -q \
             veritas_os/tests/test_openapi_no_deprecation_warnings.py \
             veritas_os/tests/test_openapi_spec.py \
@@ -332,7 +333,17 @@ jobs:
             veritas_os/tests/test_schemas_extra_v2.py \
             veritas_os/tests/test_decide_e2e_reliability.py \
             --tb=short \
-            -W error::DeprecationWarning
+            -W error::DeprecationWarning || status=$?
+
+          if [ "$status" -eq 0 ]; then
+            echo "passed" > future-dependency-pytest-result.txt
+            echo "0" > future-dependency-pytest-exit-code.txt
+          else
+            echo "failed" > future-dependency-pytest-result.txt
+            echo "$status" > future-dependency-pytest-exit-code.txt
+          fi
+
+          exit "$status"
 
       - name: Write compatibility summary
         if: always()
@@ -358,6 +369,27 @@ jobs:
               echo "Resolved versions were not captured; dependency install may have failed."
             fi
             echo "\`\`\`"
+            echo ""
+            echo "### Test result"
+            if [ -f future-dependency-pytest-result.txt ]; then
+              result="$(cat future-dependency-pytest-result.txt)"
+            else
+              result="unknown"
+            fi
+            if [ -f future-dependency-pytest-exit-code.txt ]; then
+              exit_code="$(cat future-dependency-pytest-exit-code.txt)"
+            else
+              exit_code="unavailable"
+            fi
+            echo "Result: \`$result\`"
+            echo "Exit code: \`$exit_code\`"
+            if [ "$result" = "unknown" ]; then
+              echo ""
+              echo "The pytest result file was not captured; dependency install or earlier setup may have failed."
+            elif [ "$result" != "passed" ]; then
+              echo ""
+              echo "Review the job log for failing tests and dependency resolver output."
+            fi
             echo ""
             echo "### Targeted tests"
             echo "- \`veritas_os/tests/test_openapi_no_deprecation_warnings.py\`"


### PR DESCRIPTION
### Motivation
- Improve CI visibility for the experimental `future-dependency-compat` job so reviewers can see whether the targeted compatibility smoke tests actually passed without opening raw logs. 
- Surface pytest pass/fail and numeric exit code in the GitHub Actions summary while keeping the lane non-blocking and not touching runtime code or production pins. 
- Keep the change small and reviewable: only the workflow is modified (no changes to `pyproject.toml`, `veritas_os/requirements.txt`, or runtime code). 

### Description
- Capture the `pytest` exit code in the `Run targeted compatibility smoke tests` step, write `future-dependency-pytest-result.txt` (`passed`/`failed`) and `future-dependency-pytest-exit-code.txt` (numeric), and exit the step with the same code. 
- Extend the `Write compatibility summary` step (kept `if: always()`) to add a `### Test result` section that prints `Result:  <passed|failed|unknown> ` and `Exit code:  <0|n|unavailable> `, with a clear hint to review logs when failures occur. 
- Add robust fallbacks so summary generation does not fail when the result files are missing and emit explanatory messages when files are absent. 
- Preserve job design: `continue-on-error: true`, `timeout-minutes: 12`, targeted test list, and dry-run ranges remain unchanged; no production dependency pins or runtime code were modified. 

### Testing
- Ran `python scripts/quality/check_requirements_sync.py` and it succeeded. 
- Ran `ruff check .github` and it succeeded (no blocking findings). 
- The change is limited to the workflow file and requires GitHub Actions execution to verify the rendered summary in the GitHub UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94015e1e8832681731cae4b81809a)