### PR TITLE
Link recent hardening notes from existing reviewer paths

### DIFF
--- a/docs/en/validation/current-implementation-matrix.md
+++ b/docs/en/validation/current-implementation-matrix.md
@@ -59,6 +59,7 @@ and non-certification boundaries for external reviewers.
 1. `README.md`
 2. `docs/REVIEWER_ENTRYPOINT.md`
 3. `docs/en/validation/current-implementation-matrix.md`
-4. `docs/en/validation/regulated-action-governance-proof-pack.md`
-5. `docs/en/guides/poc-pack-financial-quickstart.md`
-6. `docs/en/validation/external-review-handoff-regulated-action-governance.md`
+4. `docs/en/development/recent-hardening.md`
+5. `docs/en/validation/regulated-action-governance-proof-pack.md`
+6. `docs/en/guides/poc-pack-financial-quickstart.md`
+7. `docs/en/validation/external-review-handoff-regulated-action-governance.md`

--- a/docs/en/validation/third-party-review-readiness.md
+++ b/docs/en/validation/third-party-review-readiness.md
@@ -86,7 +86,8 @@ Primary boundary sources:
 1. Read [Short DD Summary](short-dd-summary.md) (orientation).
 2. Read this compact index (claim/implementation/check/boundary split).
 3. Read [Implemented vs Pending Boundary](implemented-vs-pending-boundary.md).
-4. Spot-check API contract in `openapi.yaml` and one bind mutation path.
-5. Confirm validation gates in [Production Validation Strategy](production-validation.md).
+4. Read [Recent Hardening Notes](../development/recent-hardening.md) for recent auditability, observability, CI gate, API compatibility, and dependency-risk visibility updates.
+5. Spot-check API contract in `openapi.yaml` and one bind mutation path.
+6. Confirm validation gates in [Production Validation Strategy](production-validation.md).
 
 If deeper verification is needed, continue with [External Reviewer Checklist](external-reviewer-checklist.md).

--- a/docs/ja/validation/third-party-review-readiness.md
+++ b/docs/ja/validation/third-party-review-readiness.md
@@ -15,6 +15,7 @@
 ## 実装上の確認ポイント
 - レビュー向けに evidence bundle と手順書が再現可能か。
 - bind-governed effect path の範囲が README と一致しているか。
+- [直近のハードニング整理](../development/recent-hardening.md) で、監査性・観測性・CI品質ゲート・API互換性・依存関係リスク可視化に関する最近の強化内容を確認してください。
 - 詳細は英語正本または実装ファイルを確認してください。
 
 ## 現時点の制限


### PR DESCRIPTION
### Motivation
- Surface the Recent Hardening Notes from existing external-review entrypoints so reviewers can quickly find recent auditability, observability, CI-gate, API-compatibility, and dependency-risk updates without adding a new reviewer guide.

### Description
- Inserted a link to `docs/en/development/recent-hardening.md` into the **15-minute reviewer path** in `docs/en/validation/third-party-review-readiness.md`.
- Added `docs/en/development/recent-hardening.md` into the **Recommended reviewer path** in `docs/en/validation/current-implementation-matrix.md`.
- Added a matching Japanese-side reference to `docs/ja/development/recent-hardening.md` in `docs/ja/validation/third-party-review-readiness.md` and did not create any new JA pages where none existed.
- No runtime code, CI workflow, dependency pin, or test behavior changes were made and `docs/INDEX.md` / `docs/DOCUMENTATION_MAP.md` were not modified beyond existing mappings.

### Testing
- Ran `make check-bilingual-docs`, `python scripts/quality/check_bilingual_docs.py`, and `ruff check docs scripts`, and all checks passed.
- Known limitations: this is a documentation-navigation improvement only, not a compliance certification, and it does not change runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95509fb14832688847670e54b5b45)