### PR TITLE
Add recent hardening link to Japanese docs index

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -97,6 +97,7 @@
 | ガイド | [Guides（英語正本）](en/guides/) | [Guides（日本語）](ja/guides/) |
 | AI支援開発 | [AI-assisted development guardrails（英語正本）](en/development/ai-assisted-development.md) | [AI支援開発ガードレール（日本語）](ja/development/ai-assisted-development.md) |
 | AIレビューマトリクス | [AI review matrix（英語正本）](en/development/ai-review-matrix.md) | [AIレビューマトリクス（日本語）](ja/development/ai-review-matrix.md) |
+| 直近のハードニング整理 | [Recent hardening notes（英語正本）](en/development/recent-hardening.md) | [直近のハードニング整理（日本語）](ja/development/recent-hardening.md) |
 | 金融 / AML-KYC | [AML/KYC quickstart（英語正本）](en/guides/poc-pack-financial-quickstart.md) | [AML/KYCクイックスタート（日本語）](ja/guides/poc-pack-financial-quickstart.md) |
 | AML/KYC Regulated Action Path | [AML/KYC Regulated Action Path（英語正本）](en/use-cases/aml-kyc-regulated-action-path.md) | — |
 | 金融ガバナンステンプレート | [Financial governance templates（英語正本）](en/guides/financial-governance-templates.md) | [金融ガバナンステンプレート（日本語解説）](ja/guides/financial-governance-templates.md) |


### PR DESCRIPTION
### Motivation
- Align Japanese quick navigation with the English section by exposing the Recent Hardening Notes route in the Japanese `docs/INDEX.md` so bilingual readers find the same resource from both language blocks.

### Description
- Updated `docs/INDEX.md` to add a single row labeled 「直近のハードニング整理」 beneath the AI review entries linking to `en/development/recent-hardening.md` and `ja/development/recent-hardening.md`.
- The change modifies only `docs/INDEX.md`, does not add any new documents, and introduces no runtime/CI/dependency changes.

### Testing
- Executed `make check-bilingual-docs`, `python scripts/quality/check_bilingual_docs.py`, and `ruff check docs scripts`, and all automated checks passed.
- Known limitations: this PR only updates documentation navigation and does not add hardening content or alter runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95f284e148326b6683c987a4e0cb7)