### PR TITLE
fix(frontend): align human approval state with governance apply flow

### DIFF
--- a/frontend/app/governance/components/HumanApprovalWorkbench.tsx
+++ b/frontend/app/governance/components/HumanApprovalWorkbench.tsx
@@ -6,12 +6,14 @@ import type { HumanApprovalRecord } from "../governance-types";
 
 interface HumanApprovalWorkbenchProps {
   approvals: HumanApprovalRecord[];
+  approvalStatus: "approved" | "pending" | "rejected" | "draft";
   validationError: string | null;
   onUpdateApproval: (index: number, patch: Partial<HumanApprovalRecord>) => void;
 }
 
 export function HumanApprovalWorkbench({
   approvals,
+  approvalStatus,
   validationError,
   onUpdateApproval,
 }: HumanApprovalWorkbenchProps): JSX.Element {
@@ -24,6 +26,9 @@ export function HumanApprovalWorkbench({
           "Governance Policy の適用前に、2名の外部レビュアー承認情報を入力してください。",
           "Before applying governance policy changes, input approval records from two human reviewers.",
         )}
+      </p>
+      <p className="mb-3 text-xs font-semibold">
+        Overall approval status: <span className="uppercase">{approvalStatus}</span>
       </p>
       <div className="grid gap-3 md:grid-cols-2">
         {approvals.slice(0, 2).map((approval, index) => (

--- a/frontend/app/governance/hooks/useGovernanceState.test.ts
+++ b/frontend/app/governance/hooks/useGovernanceState.test.ts
@@ -103,6 +103,11 @@ const setValidApprovals = (result: { current: ReturnType<typeof useGovernanceSta
   });
 };
 
+const approveDraft = (result: { current: ReturnType<typeof useGovernanceState> }): void => {
+  act(() => { result.current.approveChanges(); });
+  act(() => { result.current.pendingConfirm?.onConfirm(); });
+};
+
 describe("useGovernanceState", () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -294,7 +299,11 @@ describe("useGovernanceState", () => {
     await act(async () => {
       await result.current.fetchPolicy();
     });
+    act(() => {
+      result.current.updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, pii_check: false } }));
+    });
     setValidApprovals(result);
+    approveDraft(result);
 
     const updatedPolicy = { ...MOCK_POLICY, version: "v2.0" };
     mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: updatedPolicy }) });
@@ -328,7 +337,11 @@ describe("useGovernanceState", () => {
     await act(async () => {
       await result.current.fetchPolicy();
     });
+    act(() => {
+      result.current.updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, pii_check: false } }));
+    });
     setValidApprovals(result);
+    approveDraft(result);
 
     mockFetch.mockResolvedValue({ ok: false, status: 500 });
 
@@ -346,7 +359,11 @@ describe("useGovernanceState", () => {
     await act(async () => {
       await result.current.fetchPolicy();
     });
+    act(() => {
+      result.current.updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, pii_check: false } }));
+    });
     setValidApprovals(result);
+    approveDraft(result);
 
     mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
     mockValidate.mockReturnValue({ ok: false });
@@ -365,7 +382,11 @@ describe("useGovernanceState", () => {
     await act(async () => {
       await result.current.fetchPolicy();
     });
+    act(() => {
+      result.current.updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, pii_check: false } }));
+    });
     setValidApprovals(result);
+    approveDraft(result);
 
     mockFetch.mockRejectedValue(new Error("Network failure"));
 
@@ -399,6 +420,8 @@ describe("useGovernanceState", () => {
     act(() => { result.current.pendingConfirm!.onConfirm(); });
 
     expect(result.current.draft!.approval_status).toBe("approved");
+    expect(result.current.approvalRecords[0].decision).toBe("approved");
+    expect(result.current.approvalRecords[1].decision).toBe("approved");
     expect(result.current.success).toContain("approved");
   });
 
@@ -424,6 +447,8 @@ describe("useGovernanceState", () => {
     act(() => { result.current.pendingConfirm!.onConfirm(); });
 
     expect(result.current.draft!.approval_status).toBe("rejected");
+    expect(result.current.approvalRecords[0].decision).toBe("rejected");
+    expect(result.current.approvalRecords[1].decision).toBe("rejected");
     expect(result.current.success).toContain("rejected");
   });
 
@@ -483,8 +508,13 @@ describe("useGovernanceState", () => {
 
     act(() => {
       result.current.updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, pii_check: false } }));
-      result.current.updateApprovalRecord(0, { reviewer: "dup", signature: "sig-A" });
-      result.current.updateApprovalRecord(1, { reviewer: "dup", signature: "sig-B" });
+      result.current.updateApprovalRecord(0, { reviewer: "reviewerA", signature: "sig-A" });
+      result.current.updateApprovalRecord(1, { reviewer: "reviewerB", signature: "sig-B" });
+    });
+    approveDraft(result);
+    act(() => {
+      result.current.updateApprovalRecord(0, { reviewer: "dup" });
+      result.current.updateApprovalRecord(1, { reviewer: "dup" });
     });
     act(() => { result.current.applyPolicy("apply"); });
     await act(async () => { result.current.pendingConfirm?.onConfirm(); });
@@ -503,8 +533,13 @@ describe("useGovernanceState", () => {
 
     act(() => {
       result.current.updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, pii_check: false } }));
-      result.current.updateApprovalRecord(0, { reviewer: "reviewerA", signature: "same" });
-      result.current.updateApprovalRecord(1, { reviewer: "reviewerB", signature: "same" });
+      result.current.updateApprovalRecord(0, { reviewer: "reviewerA", signature: "sig-A" });
+      result.current.updateApprovalRecord(1, { reviewer: "reviewerB", signature: "sig-B" });
+    });
+    approveDraft(result);
+    act(() => {
+      result.current.updateApprovalRecord(0, { signature: "same" });
+      result.current.updateApprovalRecord(1, { signature: "same" });
     });
     act(() => { result.current.applyPolicy("apply"); });
     await act(async () => { result.current.pendingConfirm?.onConfirm(); });
@@ -538,6 +573,52 @@ describe("useGovernanceState", () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(result.current.draft?.approval_status).toBe("rejected");
+  });
+
+  it("blocks apply when draft approval_status is pending", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    act(() => {
+      result.current.updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, pii_check: false } }));
+    });
+    setValidApprovals(result);
+    mockFetch.mockClear();
+
+    act(() => { result.current.applyPolicy("apply"); });
+    await act(async () => { result.current.pendingConfirm?.onConfirm(); });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.error).toContain("must be approved by two reviewers");
+  });
+
+  it("apply payload includes only approved records and blocks with fewer than two approvals", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ policy: MOCK_POLICY }) });
+    mockValidate.mockReturnValue({ ok: true, data: { policy: MOCK_POLICY } });
+
+    const { result } = renderHook(() => useGovernanceState());
+    await act(async () => {
+      await result.current.fetchPolicy();
+    });
+
+    act(() => {
+      result.current.updateDraft((prev) => ({ ...prev, fuji_rules: { ...prev.fuji_rules, pii_check: false } }));
+    });
+    setValidApprovals(result);
+    approveDraft(result);
+    act(() => {
+      result.current.updateApprovalRecord(1, { decision: "pending" });
+    });
+    mockFetch.mockClear();
+    act(() => { result.current.applyPolicy("apply"); });
+    await act(async () => { result.current.pendingConfirm?.onConfirm(); });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.error).toContain("two approved human approval records");
   });
 
   it("draftApprovalStatus returns draft when no draft loaded", () => {

--- a/frontend/app/governance/hooks/useGovernanceState.ts
+++ b/frontend/app/governance/hooks/useGovernanceState.ts
@@ -49,6 +49,18 @@ export function useGovernanceState() {
     setApprovalRecords((prev) => prev.map((item, itemIndex) => (itemIndex === index ? { ...item, ...patch } : item)));
   }, []);
 
+  const updateApprovalDecisions = useCallback((decision: HumanApprovalRecord["decision"]) => {
+    const reviewedAt = new Date().toISOString();
+    setApprovalRecords((prev) => prev.map((item, itemIndex) => {
+      if (itemIndex > 1) return item;
+      return {
+        ...item,
+        decision,
+        reviewed_at: item.reviewed_at ?? reviewedAt,
+      };
+    }));
+  }, []);
+
   const validateApprovalRecords = useCallback((): { ok: boolean; message?: string } => {
     if (approvalRecords.length < 2) return { ok: false, message: "Two approvals are required before apply." };
     const relevant = approvalRecords.slice(0, 2);
@@ -173,6 +185,13 @@ export function useGovernanceState() {
               setError(blocked);
               return;
             }
+            if (draft.approval_status !== "approved") {
+              const blocked = "Apply blocked: draft must be approved by two reviewers before apply.";
+              setApprovalValidationError(blocked);
+              appendLog(blocked, "warning");
+              setError(blocked);
+              return;
+            }
             const validation = validateApprovalRecords();
             if (!validation.ok) {
               const blocked = `apply blocked: ${validation.message}`;
@@ -181,8 +200,18 @@ export function useGovernanceState() {
               setError(validation.message ?? "Approval validation failed.");
               return;
             }
-            appendLog(`approval records prepared by ${approvalRecords[0].reviewer.trim()} and ${approvalRecords[1].reviewer.trim()}`, "policy");
-            const approvals = approvalRecords.slice(0, 2).map((item) => ({
+            const approvedApprovals = approvalRecords
+              .slice(0, 2)
+              .filter((item) => item.decision === "approved");
+            if (approvedApprovals.length < 2) {
+              const blocked = "Apply blocked: two approved human approval records are required before apply.";
+              setApprovalValidationError(blocked);
+              appendLog(blocked, "warning");
+              setError(blocked);
+              return;
+            }
+            appendLog(`approval records prepared by ${approvedApprovals[0].reviewer.trim()} and ${approvedApprovals[1].reviewer.trim()}`, "policy");
+            const approvals = approvedApprovals.map((item) => ({
               reviewer: item.reviewer.trim(),
               signature: item.signature.trim(),
               ...(item.reason?.trim() ? { reason: item.reason.trim() } : {}),
@@ -250,26 +279,28 @@ export function useGovernanceState() {
           setError(validation.message ?? "Approval validation failed.");
           return;
         }
+        updateApprovalDecisions("approved");
         setDraft((prev) => prev ? { ...prev, approval_status: "approved" } : prev);
         appendHistory("approve", "draft approved by two reviewers");
         appendLog("draft approved by two reviewers", "policy");
         setSuccess(t("ドラフトを承認しました。apply で本番適用できます。", "Draft approved. Apply to push to production."));
       },
     );
-  }, [appendHistory, appendLog, draft, hasChanges, requestConfirm, t, validateApprovalRecords]);
+  }, [appendHistory, appendLog, draft, hasChanges, requestConfirm, t, updateApprovalDecisions, validateApprovalRecords]);
 
   const rejectChanges = useCallback(() => {
     if (!draft || !hasChanges) return;
     requestConfirm(
       t("ドラフト変更を却下しますか？", "Reject draft changes?"),
       () => {
+        updateApprovalDecisions("rejected");
         setDraft((prev) => prev ? { ...prev, approval_status: "rejected" } : prev);
         appendHistory("reject", `draft changes rejected by ${selectedRole}`);
         appendLog(`draft rejected by ${selectedRole}`, "warning");
         setSuccess(t("ドラフトを却下しました。", "Draft rejected."));
       },
     );
-  }, [appendHistory, appendLog, draft, hasChanges, requestConfirm, t, validateApprovalRecords]);
+  }, [appendHistory, appendLog, draft, hasChanges, requestConfirm, selectedRole, t, updateApprovalDecisions]);
 
   const currentRisk = savedPolicy ? Math.round(((savedPolicy.risk_thresholds.deny_upper + savedPolicy.auto_stop.max_risk_score) / 2) * 100) : 0;
   const pendingRisk = draft ? Math.round(((draft.risk_thresholds.deny_upper + draft.auto_stop.max_risk_score) / 2) * 100) : 0;

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -502,6 +502,7 @@ export default function GovernanceControlPage(): JSX.Element {
 
           <HumanApprovalWorkbench
             approvals={state.approvalRecords}
+            approvalStatus={state.draftApprovalStatus}
             validationError={state.approvalValidationError}
             onUpdateApproval={state.updateApprovalRecord}
           />


### PR DESCRIPTION
### Motivation
- Fix inconsistent Human Approval Workbench UX where `draft.approval_status` could be `approved` while individual `approvalRecords` remained `pending`, and where a draft could be `pending` but still `apply`-able, which is confusing for auditors and external reviewers. 
- Ensure the frontend enforces the same human-approval preconditions expected by audit and governance UI (two explicit approved reviewer records required before apply). 
- Keep backend `enforce_four_eyes_approval` semantics unchanged and avoid implementing cryptographic signatures or distributed tracing in this PR. 

### Description
- Added `updateApprovalDecisions()` in `useGovernanceState` to mark the first two `approvalRecords` as `approved` or `rejected` and to stamp `reviewed_at` when missing. 
- Updated `approveChanges()` to call `updateApprovalDecisions("approved")` and `rejectChanges()` to call `updateApprovalDecisions("rejected")`, preserving `reviewer`/`signature`/`reason` and appending `History`/`TrustLog` entries (`draft approved by two reviewers`). 
- Hardened `applyPolicy("apply")` to block if `draft.approval_status !== "approved"` (with clear error: `Apply blocked: draft must be approved by two reviewers before apply.`) and to only include `approvalRecords` with `decision === "approved"` in the apply payload, blocking apply when fewer than two approved records exist. 
- Improved `HumanApprovalWorkbench` UI to show the overall `draftApprovalStatus` and ensured each reviewer card displays the `decision` state and validation errors clearly. 
- Tests added/updated to assert that `approveChanges()` sets both `approvalRecords` to `approved`, `rejectChanges()` sets both to `rejected`, `pending` drafts cannot be applied, only two `approved` records are included in the apply payload, and duplicate reviewer/signature validation remains enforced. 
- Does not change backend four-eyes approval semantics and does not implement cryptographic signatures or distributed tracing. 

### Testing
- Ran the frontend unit tests with Vitest for the governance hooks and components using `pnpm --dir frontend test -- app/governance/hooks/useGovernanceState.test.ts` and `pnpm --dir frontend test -- app/governance/components/components.test.tsx`, and the targeted governance tests passed. 
- Verified new assertions: two `approvalRecords` updated to `approved` after `approveChanges()`, two `rejected` after `rejectChanges()`, `applyPolicy("apply")` blocks when `draft.approval_status` is not `approved`, and apply payload contains only the two approved approvals. 
- Note: this PR tightens client-side gating (fail-closed) which reduces audit ambiguity; reviewers should be aware of UX impact and that backend enforcement semantics were intentionally not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa118ece7c83268808649ba189ecd5)