### PR TITLE
feat(observability): add trace span chain for governance decision paths

### DIFF
--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -21,6 +21,7 @@ from fastapi.security.api_key import APIKeyHeader
 from veritas_os.api.utils import _errstr, redact
 from veritas_os.api.rbac import Permission, Role, ROLE_PERMISSIONS
 from veritas_os.audit.trustlog_signed import append_signed_decision
+from veritas_os.observability.tracing import add_span_event
 
 logger = logging.getLogger(__name__)
 
@@ -641,6 +642,18 @@ def _append_rbac_denial_audit_event_best_effort(
         "ts": datetime.now(timezone.utc).isoformat(),
         "audit_schema_version": "rbac_denial.v1",
     }
+    add_span_event(
+        "rbac.denied",
+        attributes={
+            "event_type": "rbac_denial",
+            "reason_code": reason_code,
+            "actor_role": role.value,
+            "requested_permission": permission.value,
+            "endpoint": endpoint,
+            "method": method,
+            "trace_id": trace_id,
+        },
+    )
     try:
         append_signed_decision(event_payload)
     except Exception as exc:

--- a/veritas_os/api/middleware.py
+++ b/veritas_os/api/middleware.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 
 from veritas_os.api.rate_limiting import _rate_lock, _rate_bucket, _RATE_LIMIT, _RATE_WINDOW
 from veritas_os.logging.structured import reset_trace_id, set_trace_id
+from veritas_os.observability.tracing import set_span_attribute, start_span
 
 import logging
 logger = logging.getLogger(__name__)
@@ -112,14 +113,26 @@ def _inflight_snapshot() -> dict:
 # ---------------------------------------------------------------------------
 
 async def attach_trace_id(request: Request, call_next):
-    """Attach a validated trace id to request state and response headers."""
+    """Attach trace id and root request span to request lifecycle."""
     trace_id = _resolve_trace_id_from_request(request)
     request.state.trace_id = trace_id
     token = set_trace_id(trace_id)
-    try:
-        response = await call_next(request)
-    finally:
-        reset_trace_id(token)
+    attributes = {
+        "trace_id": trace_id,
+        "http.method": request.method,
+        "http.route": request.url.path,
+        "veritas.component": "api",
+    }
+    with start_span("http.request", attributes=attributes):
+        try:
+            response = await call_next(request)
+            set_span_attribute("status_code", response.status_code)
+        except Exception as exc:
+            set_span_attribute("error", True)
+            set_span_attribute("error.message", str(exc))
+            raise
+        finally:
+            reset_trace_id(token)
     response.headers[TRACE_ID_HEADER_NAME] = trace_id
     response.headers.setdefault("X-Request-Id", trace_id)
     return response

--- a/veritas_os/api/routes_governance.py
+++ b/veritas_os/api/routes_governance.py
@@ -37,6 +37,7 @@ from veritas_os.api.schemas import (
 from veritas_os.policy.bind_route_markers import requires_bind_boundary
 from veritas_os.policy.bind_artifacts import BindReceipt, FinalOutcome, find_bind_receipts
 from veritas_os.policy.governance_policy_update import update_governance_policy_with_bind_boundary
+from veritas_os.observability.tracing import add_span_event, set_span_attribute, trace_step
 from veritas_os.policy.policy_bundle_promotion import promote_policy_bundle_with_bind_boundary
 from veritas_os.security.hash import sha256_of_canonical_json
 
@@ -463,68 +464,94 @@ def governance_get():
 def governance_put(body: dict):
     """Update the governance policy (partial merge)."""
     srv = _get_server()
-    try:
-        srv.enforce_four_eyes_approval(body)
-        previous = srv.get_policy()
-        decision_id = str(body.get("decision_id") or uuid4().hex)
-        request_id = str(body.get("request_id") or decision_id)
-        policy_snapshot_id = str(previous.get("updated_at") or previous.get("version") or "governance_policy")
-        bind_receipt = update_governance_policy_with_bind_boundary(
-            decision_id=decision_id,
-            request_id=request_id,
-            actor_identity=str(body.get("updated_by") or "api"),
-            policy_snapshot_id=policy_snapshot_id,
-            decision_hash=sha256_of_canonical_json(_governance_decision_hash_payload(body)),
-            policy_patch=body,
-            policy_reader=srv.get_policy,
-            policy_updater=srv.update_policy,
-            policy_rollback=getattr(srv, "rollback_policy", None),
-            approval_context={"governance_policy_update_approved": True},
-            approval_records=body.get("approvals") if isinstance(body.get("approvals"), list) else None,
-            policy_lineage=body.get("policy_lineage")
-            if isinstance(body.get("policy_lineage"), dict)
-            else None,
-            governance_policy=previous if isinstance(previous, dict) else None,
-            execution_intent_id=str(body.get("execution_intent_id") or "") or None,
-            bind_receipt_id=str(body.get("bind_receipt_id") or "") or None,
-        ).to_dict()
-        updated = srv.get_policy()
-        bind_payload = build_bind_response_payload(bind_receipt)
-        if bind_receipt.get("final_outcome") != FinalOutcome.COMMITTED.value:
-            status_code, error_message = _bind_failure_status_and_error(bind_receipt)
-            return JSONResponse(
-                status_code=status_code,
-                content={
-                    **bind_payload,
-                    "ok": False,
-                    "error": error_message,
-                    "policy": updated,
-                },
+    with trace_step(
+        "governance.policy_update.request",
+        attributes={
+            "target_path": "/v1/governance/policy",
+            "target_type": "governance_policy",
+        },
+    ):
+        try:
+            with trace_step("governance.approval.validate"):
+                srv.enforce_four_eyes_approval(body)
+
+            previous = srv.get_policy()
+            decision_id = str(body.get("decision_id") or uuid4().hex)
+            request_id = str(body.get("request_id") or decision_id)
+            actor_identity = str(body.get("updated_by") or "api")
+            approval_count = len(body.get("approvals")) if isinstance(body.get("approvals"), list) else 0
+            policy_snapshot_id = str(previous.get("updated_at") or previous.get("version") or "governance_policy")
+            set_span_attribute("decision_id", decision_id)
+            set_span_attribute("request_id", request_id)
+            set_span_attribute("actor_identity", actor_identity)
+            set_span_attribute("policy_snapshot_id", policy_snapshot_id)
+            set_span_attribute("approval_count", approval_count)
+
+            with trace_step("governance.bind_boundary.evaluate"):
+                bind_receipt = update_governance_policy_with_bind_boundary(
+                    decision_id=decision_id,
+                    request_id=request_id,
+                    actor_identity=actor_identity,
+                    policy_snapshot_id=policy_snapshot_id,
+                    decision_hash=sha256_of_canonical_json(_governance_decision_hash_payload(body)),
+                    policy_patch=body,
+                    policy_reader=srv.get_policy,
+                    policy_updater=srv.update_policy,
+                    policy_rollback=getattr(srv, "rollback_policy", None),
+                    approval_context={"governance_policy_update_approved": True},
+                    approval_records=body.get("approvals") if isinstance(body.get("approvals"), list) else None,
+                    policy_lineage=body.get("policy_lineage")
+                    if isinstance(body.get("policy_lineage"), dict)
+                    else None,
+                    governance_policy=previous if isinstance(previous, dict) else None,
+                    execution_intent_id=str(body.get("execution_intent_id") or "") or None,
+                    bind_receipt_id=str(body.get("bind_receipt_id") or "") or None,
+                ).to_dict()
+
+            set_span_attribute("bind_receipt_id", bind_receipt.get("bind_receipt_id"))
+            set_span_attribute("final_outcome", bind_receipt.get("final_outcome"))
+            set_span_attribute("bind_reason_code", resolve_bind_reason_code(bind_receipt) or "")
+            with trace_step("governance.policy.persist"):
+                updated = srv.get_policy()
+            bind_payload = build_bind_response_payload(bind_receipt)
+            if bind_receipt.get("final_outcome") != FinalOutcome.COMMITTED.value:
+                with trace_step("governance.policy_update.response"):
+                    status_code, error_message = _bind_failure_status_and_error(bind_receipt)
+                    return JSONResponse(
+                        status_code=status_code,
+                        content={
+                            **bind_payload,
+                            "ok": False,
+                            "error": error_message,
+                            "policy": updated,
+                        },
+                    )
+            srv._publish_event(
+                "governance.updated",
+                {"updated_by": updated.get("updated_by", "api")},
             )
-        srv._publish_event(
-            "governance.updated",
-            {"updated_by": updated.get("updated_by", "api")},
-        )
-        _emit_governance_change_alert(previous=previous, updated=updated)
-        return {"ok": True, "policy": updated, **bind_payload}
-    except PermissionError as e:
-        logger.warning("governance_put rejected: %s", e)
-        return JSONResponse(
-            status_code=403,
-            content={"ok": False, "error": "governance approval validation failed"},
-        )
-    except (ValueError, TypeError) as e:
-        logger.warning("governance_put validation error: %s", e)
-        return JSONResponse(
-            status_code=400,
-            content={"ok": False, "error": "Governance policy validation failed"},
-        )
-    except Exception as e:
-        logger.error("governance_put failed: %s", e, exc_info=True)
-        return JSONResponse(
-            status_code=500,
-            content={"ok": False, "error": "Failed to update governance policy"},
-        )
+            _emit_governance_change_alert(previous=previous, updated=updated)
+            with trace_step("governance.policy_update.response"):
+                return {"ok": True, "policy": updated, **bind_payload}
+        except PermissionError as e:
+            add_span_event("governance.approval.failed", attributes={"error": str(e)})
+            logger.warning("governance_put rejected: %s", e)
+            return JSONResponse(
+                status_code=403,
+                content={"ok": False, "error": "governance approval validation failed"},
+            )
+        except (ValueError, TypeError) as e:
+            logger.warning("governance_put validation error: %s", e)
+            return JSONResponse(
+                status_code=400,
+                content={"ok": False, "error": "Governance policy validation failed"},
+            )
+        except Exception as e:
+            logger.error("governance_put failed: %s", e, exc_info=True)
+            return JSONResponse(
+                status_code=500,
+                content={"ok": False, "error": "Failed to update governance policy"},
+            )
 
 
 @router.get(

--- a/veritas_os/observability/tracing.py
+++ b/veritas_os/observability/tracing.py
@@ -1,0 +1,107 @@
+"""Privacy-safe tracing helpers with OpenTelemetry-compatible fallback.
+
+The helper APIs in this module are intentionally fail-safe:
+- If OpenTelemetry is unavailable, helpers become no-op.
+- If tracing operations fail at runtime, business logic continues.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+try:
+    from opentelemetry import trace as otel_trace
+except Exception:  # pragma: no cover - fallback behavior tested via monkeypatch
+    otel_trace = None
+
+
+class _NoOpSpan:
+    """No-op span implementation used when OpenTelemetry is unavailable."""
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        return None
+
+    def add_event(self, name: str, attributes: dict[str, Any] | None = None) -> None:
+        return None
+
+
+_NOOP_SPAN = _NoOpSpan()
+
+
+class _NoOpContextManager:
+    """Context manager that yields a no-op span."""
+
+    def __enter__(self) -> _NoOpSpan:
+        return _NOOP_SPAN
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        return False
+
+
+def get_tracer():
+    """Return OpenTelemetry tracer when available, otherwise a no-op tracer."""
+    if otel_trace is None:
+        return None
+    try:
+        return otel_trace.get_tracer("veritas_os")
+    except Exception:
+        return None
+
+
+def _active_span() -> Any:
+    """Return current active span or no-op span."""
+    if otel_trace is None:
+        return _NOOP_SPAN
+    try:
+        return otel_trace.get_current_span()
+    except Exception:
+        return _NOOP_SPAN
+
+
+def start_span(name: str, attributes: dict[str, Any] | None = None):
+    """Start a span context manager with optional privacy-safe attributes."""
+    tracer = get_tracer()
+    if tracer is None:
+        return _NoOpContextManager()
+    try:
+        span_cm = tracer.start_as_current_span(name)
+    except Exception:
+        return _NoOpContextManager()
+
+    if attributes:
+        try:
+            current = _active_span()
+            for key, value in attributes.items():
+                current.set_attribute(key, value)
+        except Exception:
+            pass
+    return span_cm
+
+
+def add_span_event(name: str, attributes: dict[str, Any] | None = None) -> None:
+    """Append event to current span; silently no-op on tracing failures."""
+    try:
+        _active_span().add_event(name, attributes=attributes)
+    except Exception:
+        return None
+
+
+def set_span_attribute(key: str, value: Any) -> None:
+    """Set attribute on current span; silently no-op on tracing failures."""
+    try:
+        _active_span().set_attribute(key, value)
+    except Exception:
+        return None
+
+
+@contextmanager
+def trace_step(name: str, attributes: dict[str, Any] | None = None):
+    """Wrap a governance/audit step in a child span without affecting runtime semantics."""
+    with start_span(name, attributes=attributes):
+        try:
+            yield
+        except Exception as exc:
+            add_span_event("step.exception", attributes={"error": str(exc), "step": name})
+            set_span_attribute("error", True)
+            raise

--- a/veritas_os/policy/governance_policy_update.py
+++ b/veritas_os/policy/governance_policy_update.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from veritas_os.policy.bind_artifacts import BindReceipt, ExecutionIntent
 from veritas_os.policy.bind_boundary_adapters import GovernancePolicyUpdateAdapter
 from veritas_os.policy.bind_core import execute_bind_adjudication
+from veritas_os.observability.tracing import add_span_event, set_span_attribute, trace_step
 
 
 def update_governance_policy_with_bind_boundary(
@@ -37,13 +38,14 @@ def update_governance_policy_with_bind_boundary(
     bind_receipt_id: str | None = None,
 ) -> BindReceipt:
     """Apply governance policy patch through bind-boundary adjudication."""
-    adapter = GovernancePolicyUpdateAdapter(
-        policy_reader=policy_reader,
-        policy_updater=policy_updater,
-        policy_patch=dict(policy_patch),
-        policy_rollback=policy_rollback,
-        approval_records=approval_records,
-    )
+    with trace_step("bind.boundary.evaluate.start"):
+        adapter = GovernancePolicyUpdateAdapter(
+            policy_reader=policy_reader,
+            policy_updater=policy_updater,
+            policy_patch=dict(policy_patch),
+            policy_rollback=policy_rollback,
+            approval_records=approval_records,
+        )
 
     pre_snapshot = adapter.snapshot()
     expected_fingerprint = adapter.fingerprint_state(pre_snapshot)
@@ -70,13 +72,23 @@ def update_governance_policy_with_bind_boundary(
         ),
     )
 
-    return execute_bind_adjudication(
+    receipt = execute_bind_adjudication(
         execution_intent=intent,
         adapter=adapter,
         bind_ts=bind_ts,
         bind_receipt_id=bind_receipt_id,
         append_trustlog=append_trustlog,
     )
+    set_span_attribute("final_outcome", receipt.final_outcome.value)
+    set_span_attribute("bind_receipt_id", receipt.bind_receipt_id)
+    add_span_event(
+        "bind.boundary.evaluate.end",
+        attributes={
+            "final_outcome": receipt.final_outcome.value,
+            "bind_receipt_id": receipt.bind_receipt_id,
+        },
+    )
+    return receipt
 
 
 def _utc_now_iso8601() -> str:

--- a/veritas_os/tests/test_trace_span_chain.py
+++ b/veritas_os/tests/test_trace_span_chain.py
@@ -1,0 +1,114 @@
+"""Tests for observability tracing span-chain helpers and hooks."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from veritas_os.api import auth
+from veritas_os.api import routes_governance
+from veritas_os.api.rbac import Permission, Role
+from veritas_os.observability import tracing
+from veritas_os.policy.bind_artifacts import FinalOutcome
+
+
+def test_tracing_noop_without_opentelemetry(monkeypatch):
+    monkeypatch.setattr(tracing, "otel_trace", None)
+    with tracing.start_span("noop.span", attributes={"trace_id": "abc"}):
+        tracing.set_span_attribute("k", "v")
+        tracing.add_span_event("evt", attributes={"a": 1})
+
+
+def test_trace_step_handles_exception_and_reraises(monkeypatch):
+    events = []
+
+    def _capture(name, attributes=None):
+        events.append((name, attributes))
+
+    monkeypatch.setattr(tracing, "add_span_event", _capture)
+
+    with pytest.raises(ValueError):
+        with tracing.trace_step("test.step"):
+            raise ValueError("boom")
+
+    assert any(name == "step.exception" for name, _ in events)
+
+
+def test_governance_put_span_chain_happy_path(monkeypatch):
+    steps = []
+
+    class _Step:
+        def __init__(self, name, attributes=None):
+            self.name = name
+
+        def __enter__(self):
+            steps.append(self.name)
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+    monkeypatch.setattr(routes_governance, "trace_step", lambda name, attributes=None: _Step(name, attributes))
+    monkeypatch.setattr(routes_governance, "set_span_attribute", lambda *a, **k: None)
+    monkeypatch.setattr(routes_governance, "add_span_event", lambda *a, **k: None)
+
+    class _Receipt:
+        def to_dict(self):
+            return {"final_outcome": FinalOutcome.COMMITTED.value, "bind_receipt_id": "br-1"}
+
+    monkeypatch.setattr(routes_governance, "update_governance_policy_with_bind_boundary", lambda **k: _Receipt())
+
+    class _Srv:
+        def enforce_four_eyes_approval(self, body):
+            return None
+
+        def get_policy(self):
+            return {"updated_at": "x", "updated_by": "api"}
+
+        def update_policy(self, patch):
+            return patch
+
+        def _publish_event(self, *_a, **_k):
+            return None
+
+    monkeypatch.setattr(routes_governance, "_get_server", lambda: _Srv())
+    monkeypatch.setattr(routes_governance, "_emit_governance_change_alert", lambda **k: None)
+
+    resp = routes_governance.governance_put({"updated_by": "alice", "approvals": [{}, {}]})
+    assert resp["ok"] is True
+    assert "governance.policy_update.request" in steps
+    assert "governance.approval.validate" in steps
+    assert "governance.bind_boundary.evaluate" in steps
+
+
+def test_governance_put_approval_failure_adds_event(monkeypatch):
+    events = []
+    monkeypatch.setattr(routes_governance, "trace_step", lambda n, attributes=None: tracing.trace_step(n, attributes))
+    monkeypatch.setattr(routes_governance, "add_span_event", lambda name, attributes=None: events.append((name, attributes)))
+
+    class _Srv:
+        def enforce_four_eyes_approval(self, _body):
+            raise PermissionError("approval missing")
+
+    monkeypatch.setattr(routes_governance, "_get_server", lambda: _Srv())
+    resp = routes_governance.governance_put({})
+    assert resp.status_code == 403
+    assert any(name == "governance.approval.failed" for name, _ in events)
+
+
+def test_rbac_denial_adds_span_event(monkeypatch):
+    captured = []
+    monkeypatch.setattr(auth, "resolve_role_for_key", lambda _key: Role.auditor)
+    monkeypatch.setattr(auth, "append_signed_decision", lambda payload: None)
+    monkeypatch.setattr(auth, "add_span_event", lambda name, attributes=None: captured.append((name, attributes)))
+    auth._rbac_denial_dedupe_cache.clear()
+
+    checker = auth.require_permission(Permission.decide)
+    request = SimpleNamespace(url=SimpleNamespace(path="/v1/decide"), method="POST", state=SimpleNamespace(trace_id="trace-1"))
+
+    with pytest.raises(Exception):
+        checker(request=request, x_api_key="valid-key")
+
+    assert captured
+    assert captured[0][0] == "rbac.denied"
+    assert "token" not in str(captured[0][1]).lower()


### PR DESCRIPTION
### Motivation
- Provide minimal Distributed Trace Span Chain so governance decisions can be traced end-to-end as spans (request → approval → bind → persist → response). 
- Offer an OpenTelemetry-compatible tracing helper that is fail-safe in environments without OpenTelemetry so existing CI and runtime continue to work. 
- Preserve privacy and runtime semantics by avoiding secrets in span attributes and keeping tracing failures from altering governance/bind/TrustLog behavior; tracing can expose sensitive data so attributes are intentionally privacy-safe and reviewers should validate attribute choices. 

### Description
- Adds a privacy-safe tracing helper with OpenTelemetry-compatible no-op fallback in `veritas_os/observability/tracing.py` implementing `get_tracer()`, `start_span()`, `add_span_event()`, `set_span_attribute()` and `trace_step()` context manager. 
- Wires a root `http.request` span into the API middleware in `veritas_os/api/middleware.py`, correlating with existing `trace_id` and tagging `http.method`, `http.route`, `veritas.component`, and `status_code` (and marking errors on exceptions). 
- Adds span chain coverage for governance policy update paths in `veritas_os/api/routes_governance.py` (`governance.policy_update.request`, `governance.approval.validate`, `governance.bind_boundary.evaluate`, `governance.policy.persist`, `governance.policy_update.response`) and records attributes such as `decision_id`, `request_id`, `actor_identity`, `policy_snapshot_id`, `bind_receipt_id`, `final_outcome`, `bind_reason_code`, and `approval_count`. 
- Adds bind-boundary end event/attributes in `veritas_os/policy/governance_policy_update.py` and emits an `rbac.denied` span event in `veritas_os/api/auth.py` on RBAC denials; TrustLog append behavior is unchanged. 
- Does not add a required OpenTelemetry dependency, does not implement Jaeger/Grafana/OTLP deployment, and does not change backend governance or bind semantics. 

### Testing
- Added `veritas_os/tests/test_trace_span_chain.py` which asserts no-op behavior without OpenTelemetry, `trace_step` exception safety, governance span chain happy/failure paths, RBAC denial span events, and secret-safety of span attributes. 
- Ran `pytest -q veritas_os/tests/test_trace_span_chain.py veritas_os/tests/unit/test_auth_rbac_audit.py` and the tests passed (`12 passed`). 
- Tracing helpers are exercised via monkeypatches so the OpenTelemetry optional-path and no-op fallback are covered by tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa2102db1c8326be774842b8246937)