### PR TITLE
fix(observability): attach tracing attributes after span activation

### DIFF
--- a/veritas_os/observability/tracing.py
+++ b/veritas_os/observability/tracing.py
@@ -39,6 +39,27 @@ class _NoOpContextManager:
         return False
 
 
+class _SafeSpanContextManager:
+    """Wrap a span context manager and set attributes on the activated span."""
+
+    def __init__(self, span_cm: Any, attributes: dict[str, Any] | None = None) -> None:
+        self._span_cm = span_cm
+        self._attributes = attributes or {}
+
+    def __enter__(self) -> Any:
+        span = self._span_cm.__enter__()
+        if self._attributes:
+            for key, value in self._attributes.items():
+                try:
+                    span.set_attribute(key, value)
+                except Exception:
+                    continue
+        return span
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        return self._span_cm.__exit__(exc_type, exc_val, exc_tb)
+
+
 def get_tracer():
     """Return OpenTelemetry tracer when available, otherwise a no-op tracer."""
     if otel_trace is None:
@@ -60,7 +81,11 @@ def _active_span() -> Any:
 
 
 def start_span(name: str, attributes: dict[str, Any] | None = None):
-    """Start a span context manager with optional privacy-safe attributes."""
+    """Start a span context manager with optional privacy-safe attributes.
+
+    Attributes are attached after span activation to avoid writing to a stale
+    current span in real OpenTelemetry runtimes.
+    """
     tracer = get_tracer()
     if tracer is None:
         return _NoOpContextManager()
@@ -69,14 +94,7 @@ def start_span(name: str, attributes: dict[str, Any] | None = None):
     except Exception:
         return _NoOpContextManager()
 
-    if attributes:
-        try:
-            current = _active_span()
-            for key, value in attributes.items():
-                current.set_attribute(key, value)
-        except Exception:
-            pass
-    return span_cm
+    return _SafeSpanContextManager(span_cm, attributes=attributes)
 
 
 def add_span_event(name: str, attributes: dict[str, Any] | None = None) -> None:

--- a/veritas_os/tests/test_trace_span_chain.py
+++ b/veritas_os/tests/test_trace_span_chain.py
@@ -35,6 +35,135 @@ def test_trace_step_handles_exception_and_reraises(monkeypatch):
     assert any(name == "step.exception" for name, _ in events)
 
 
+def test_start_span_attaches_attributes_to_activated_span(monkeypatch):
+    class _FakeSpan:
+        def __init__(self):
+            self.attributes = {}
+
+        def set_attribute(self, key, value):
+            self.attributes[key] = value
+
+    class _FakeContextManager:
+        def __init__(self, span):
+            self._span = span
+
+        def __enter__(self):
+            return self._span
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+    class _FakeTracer:
+        def __init__(self, span):
+            self._span = span
+
+        def start_as_current_span(self, _name):
+            return _FakeContextManager(self._span)
+
+    stale_span = _FakeSpan()
+    active_span = _FakeSpan()
+    monkeypatch.setattr(tracing, "get_tracer", lambda: _FakeTracer(active_span))
+    monkeypatch.setattr(tracing, "_active_span", lambda: stale_span)
+
+    with tracing.start_span("x", attributes={"a": "b"}):
+        pass
+
+    assert active_span.attributes == {"a": "b"}
+    assert stale_span.attributes == {}
+
+
+def test_start_span_attribute_failure_does_not_break_context(monkeypatch):
+    events = []
+
+    class _FlakySpan:
+        def set_attribute(self, _key, _value):
+            raise RuntimeError("cannot set")
+
+        def add_event(self, name, attributes=None):
+            events.append((name, attributes))
+
+    class _FakeContextManager:
+        def __init__(self, span):
+            self._span = span
+
+        def __enter__(self):
+            return self._span
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+    class _FakeTracer:
+        def __init__(self, span):
+            self._span = span
+
+        def start_as_current_span(self, _name):
+            return _FakeContextManager(self._span)
+
+    monkeypatch.setattr(tracing, "get_tracer", lambda: _FakeTracer(_FlakySpan()))
+
+    with tracing.start_span("x", attributes={"a": "b"}):
+        tracing.add_span_event("inside")
+
+
+def test_trace_step_exception_marks_active_span(monkeypatch):
+    class _FakeSpan:
+        def __init__(self):
+            self.attributes = {}
+            self.events = []
+
+        def set_attribute(self, key, value):
+            self.attributes[key] = value
+
+        def add_event(self, name, attributes=None):
+            self.events.append((name, attributes or {}))
+
+    class _FakeContextManager:
+        def __init__(self, trace_api, span):
+            self._trace_api = trace_api
+            self._span = span
+
+        def __enter__(self):
+            self._trace_api._current = self._span
+            return self._span
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            self._trace_api._current = self._trace_api._stale
+            return False
+
+    class _FakeTracer:
+        def __init__(self, trace_api):
+            self._trace_api = trace_api
+
+        def start_as_current_span(self, _name):
+            span = _FakeSpan()
+            self._trace_api._started.append(span)
+            return _FakeContextManager(self._trace_api, span)
+
+    class _FakeTraceAPI:
+        def __init__(self):
+            self._stale = _FakeSpan()
+            self._current = self._stale
+            self._started = []
+
+        def get_tracer(self, _name):
+            return _FakeTracer(self)
+
+        def get_current_span(self):
+            return self._current
+
+    fake_api = _FakeTraceAPI()
+    monkeypatch.setattr(tracing, "otel_trace", fake_api)
+
+    with pytest.raises(ValueError):
+        with tracing.trace_step("test.step", attributes={"k": "v"}):
+            raise ValueError("boom")
+
+    step_span = fake_api._started[0]
+    assert step_span.attributes["k"] == "v"
+    assert step_span.attributes["error"] is True
+    assert any(name == "step.exception" for name, _attrs in step_span.events)
+
+
 def test_governance_put_span_chain_happy_path(monkeypatch):
     steps = []
 


### PR DESCRIPTION
### Motivation
- Prevent attributes intended for a newly-started span from being written to a stale current span in real OpenTelemetry runtimes by attaching attributes only after the span is activated.  
- Maintain the existing fail-open, no-op fallback when OpenTelemetry is absent so runtime semantics and CI behavior remain unchanged.  
- Avoid exposing sensitive data via tracing and keep existing privacy constraints (no Authorization/X-API-Key/Cookie/token/query_string additions); this change does not add new sensitive attributes.  

### Description
- Replace in-place pre-activation attribute-setting with a `_SafeSpanContextManager` that wraps the tracer's context manager and sets attributes in `__enter__` on the activated span, swallowing attribute-setting exceptions.  
- Update `start_span()` to return `_SafeSpanContextManager` instead of setting attributes via `_active_span()` before entering the context, and expand the docstring to explain the activation ordering intent.  
- Preserve `_NoOpContextManager` behavior when OpenTelemetry is unavailable and keep `trace_step()`, `set_span_attribute()`, and `add_span_event()` semantics unchanged.  
- Add tests with fake tracer/span/context-manager implementations validating that attributes are attached to the activated span, stale spans are not written, attribute-setting failures do not break the context, and `trace_step` exception path records `error` + `step.exception` on the target span.  
- Files changed: `veritas_os/observability/tracing.py` and `veritas_os/tests/test_trace_span_chain.py`.  

### Testing
- Ran `pytest -q veritas_os/tests/test_trace_span_chain.py` and all tests passed (`8 passed`).  
- Ran `pytest -q veritas_os/tests/unit/test_auth_rbac_audit.py` and all tests passed (`7 passed`).  
- Ran `pytest -q veritas_os/tests/test_middleware_core.py` and all tests passed (`9 passed`).  
- New/updated tests include `test_start_span_attaches_attributes_to_activated_span`, `test_start_span_attribute_failure_does_not_break_context`, and `test_trace_step_exception_marks_active_span`, and they passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa295bbaac832685a453a1544f8222)