### PR TITLE
docs(observability): document governance trace span chain verification

### DIFF
--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -37,6 +37,7 @@
 | Operations: Security hardening | `docs/en/operations/security-hardening.md` | `docs/ja/operations/security-hardening.md` | JA explanation / EN canonical | ハードニング観点 |
 | Operations: Database migrations | `docs/en/operations/database-migrations.md` | `docs/ja/operations/database-migrations.md` | JA explanation / EN canonical | 移行手順 |
 | Operations: Governance artifact signing | `docs/en/operations/governance-artifact-signing.md` | `docs/ja/operations/governance-artifact-signing.md` | JA explanation / EN canonical | 署名運用 |
+| Operations: Governance trace span chain | `docs/en/operations/governance-trace-span-chain.md` | `docs/ja/operations/governance-trace-span-chain.md` | JA explanation / EN canonical | observability検証導線 |
 | Operations: Legacy path cleanup | `docs/en/operations/legacy-path-cleanup.md` | `docs/ja/operations/legacy-path-cleanup.md` | JA explanation / EN canonical | 旧経路整理 |
 | Governance: Required evidence taxonomy | `docs/en/governance/required-evidence-taxonomy.md` | `docs/ja/governance/required-evidence-taxonomy.md` | JA explanation / EN canonical | taxonomy語彙 |
 | Governance: Artifact lifecycle | `docs/en/governance/governance-artifact-lifecycle.md` | `docs/ja/governance/governance-artifact-lifecycle.md` | JA explanation / EN canonical | lifecycle管理 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,7 @@
 | Security | [Security hardening (EN)](en/operations/security-hardening.md) | [セキュリティハードニング (JA)](ja/operations/security-hardening.md) |
 | Database | [Database migrations (EN)](en/operations/database-migrations.md) | [データベース移行 (JA)](ja/operations/database-migrations.md) |
 | Governance Artifact Signing | [Governance artifact signing (EN)](en/operations/governance-artifact-signing.md) | [ガバナンス成果物署名 (JA)](ja/operations/governance-artifact-signing.md) |
+| Governance Trace Span Chain | [Governance trace span chain (EN)](en/operations/governance-trace-span-chain.md) | [ガバナンストレース span chain (JA)](ja/operations/governance-trace-span-chain.md) |
 | Governance | [Governance (EN)](en/governance/) | [Governance (JA)](ja/governance/) |
 | Required Evidence Taxonomy | [Required evidence taxonomy (EN)](en/governance/required-evidence-taxonomy.md) | [Required evidence taxonomy (JA)](ja/governance/required-evidence-taxonomy.md) |
 | Governance Artifact Lifecycle | [Governance artifact lifecycle (EN)](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle (JA)](ja/governance/governance-artifact-lifecycle.md) |
@@ -91,6 +92,7 @@
 | セキュリティ | [Security hardening（英語正本）](en/operations/security-hardening.md) | [セキュリティハードニング（日本語）](ja/operations/security-hardening.md) |
 | データベース | [Database migrations（英語正本）](en/operations/database-migrations.md) | [データベース移行（日本語）](ja/operations/database-migrations.md) |
 | ガバナンス成果物署名 | [Governance artifact signing（英語正本）](en/operations/governance-artifact-signing.md) | [ガバナンス成果物署名（日本語解説）](ja/operations/governance-artifact-signing.md) |
+| ガバナンストレース span chain | [Governance trace span chain（英語正本）](en/operations/governance-trace-span-chain.md) | [ガバナンストレース span chain（日本語解説）](ja/operations/governance-trace-span-chain.md) |
 | ガバナンス | [Governance（英語正本）](en/governance/) | [Governance（日本語）](ja/governance/) |
 | Required Evidence Taxonomy | [Required evidence taxonomy（英語正本）](en/governance/required-evidence-taxonomy.md) | [Required evidence taxonomy（日本語解説）](ja/governance/required-evidence-taxonomy.md) |
 | Governance Artifact Lifecycle | [Governance artifact lifecycle（英語正本）](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle（日本語解説）](ja/governance/governance-artifact-lifecycle.md) |

--- a/docs/en/operations/governance-trace-span-chain.md
+++ b/docs/en/operations/governance-trace-span-chain.md
@@ -1,0 +1,132 @@
+# Governance Trace Span Chain
+
+## Purpose
+
+This document defines what VERITAS OS currently traces for the governance policy update path, what attributes are privacy-safe, and what remains out of scope. It is intended for external reviewers, HPAN reviewers, and enterprise audit teams validating observability boundaries.
+
+## What is implemented
+
+VERITAS OS currently implements:
+
+- OpenTelemetry-compatible tracing helpers with fail-safe no-op fallback.
+- Root request span in API middleware.
+- Governance policy update span chain.
+- RBAC denial span event emission.
+- Span attribute attachment after span activation.
+
+## Expected span chain for governance policy update
+
+For `PUT /v1/governance/policy`, the expected span chain is:
+
+1. `http.request` (middleware root span)
+2. `governance.policy_update.request`
+3. `governance.approval.validate`
+4. `governance.bind_boundary.evaluate`
+5. `bind.boundary.evaluate.start` (event)
+6. `bind.boundary.evaluate.end` (event)
+8. `governance.policy.persist`
+9. `governance.policy_update.response`
+
+Notes:
+
+- `bind.boundary.evaluate.start` and `bind.boundary.evaluate.end` are emitted as trace events in the bind evaluator path; they are listed here because reviewers expect to validate the full chain, including boundary evaluation lifecycle markers.
+- `governance.approval.validate` is a validation step span executed before bind boundary evaluation.
+
+## Expected event for RBAC denial
+
+When RBAC rejects a permission check, the active span receives the event:
+
+- `rbac.denied`
+
+This event records denial metadata only (for example, role, permission, endpoint, method, reason code, trace id) and must not include secrets.
+
+## Privacy-safe attribute policy
+
+Trace attributes and events must remain operationally useful while avoiding secret and personal data leakage.
+
+## Attributes currently expected
+
+Current implementation and tests rely on the following attribute keys:
+
+- `trace_id`
+- `http.method`
+- `http.route`
+- `veritas.component`
+- `status_code`
+- `decision_id`
+- `request_id`
+- `actor_identity`
+- `policy_snapshot_id`
+- `approval_count`
+- `bind_receipt_id`
+- `final_outcome`
+- `bind_reason_code`
+- `target_path`
+- `target_type`
+- `event_type`
+- `reason_code`
+- `actor_role`
+- `requested_permission`
+- `endpoint`
+- `method`
+
+## Attributes explicitly forbidden
+
+The following must never be written into span attributes or events:
+
+- `Authorization`
+- `X-API-Key`
+- `Cookie`
+- `token`
+- `secret`
+- `password`
+- raw request body
+- `query_string`
+- personally identifying free-text payloads
+- approval signature raw secret beyond existing v1 token string semantics
+- medical/financial record contents
+
+## No-op fallback behavior
+
+Tracing helpers are fail-safe by design:
+
+- If OpenTelemetry is unavailable, span helpers degrade to no-op behavior.
+- If tracing APIs fail at runtime, business logic continues without breaking request flow.
+- Therefore, missing OpenTelemetry dependencies or runtime tracer backend does not change governance, bind, or RBAC semantics.
+
+## Current non-goals / not implemented
+
+The following are explicitly out of scope for the current implementation:
+
+- Jaeger deployment
+- Grafana/Tempo dashboard
+- OTLP exporter configuration
+- production collector
+- cryptographic human approval signature
+- backend TrustLog append guarantee changes
+- full distributed tracing across external services
+- frontend visual trace viewer
+
+## How to verify locally
+
+Important:
+
+- In environments without an OpenTelemetry exporter, spans may be no-op or may not appear in external trace UIs.
+- Current verification primarily uses unit tests, fake tracer tests, and monkeypatch-based tracing tests.
+
+Run:
+
+- `pytest -q veritas_os/tests/test_trace_span_chain.py`
+- `pytest -q veritas_os/tests/unit/test_auth_rbac_audit.py`
+- `pytest -q veritas_os/tests/test_middleware_core.py`
+
+## External reviewer checklist
+
+Use this checklist during review:
+
+1. Confirm governance update path emits expected span names and boundary events.
+2. Confirm RBAC denial emits `rbac.denied` event with safe metadata.
+3. Confirm privacy-safe attributes are present and useful for auditing.
+4. Confirm forbidden attributes are absent from span attributes/events.
+5. Confirm no-op fallback behavior is documented and tested.
+6. Confirm this scope does not include Jaeger/Grafana/OTLP deployment work.

--- a/docs/ja/operations/governance-trace-span-chain.md
+++ b/docs/ja/operations/governance-trace-span-chain.md
@@ -1,0 +1,131 @@
+# Governance Trace Span Chain（ガバナンストレース span chain）
+
+> この文書は日本語の解説版です。仕様上の正本（canonical source）は英語版 `docs/en/operations/governance-trace-span-chain.md` です。
+
+## 目的
+
+本書は、VERITAS OS のガバナンスポリシー更新経路で現在どこまでトレースできるか、どの属性が安全に利用可能か、何が未実装かを明確にし、外部レビュアー・HPAN・企業監査担当の確認を容易にすることを目的とします。
+
+## 実装済みの範囲
+
+現時点で実装されている内容:
+
+- OpenTelemetry 互換の tracing helper（fail-safe な no-op fallback 付き）
+- API middleware の root span
+- governance policy update の span chain
+- RBAC denial の span event 出力
+- span 有効化後に属性を付与する実装
+
+## governance policy update で期待される span chain
+
+`PUT /v1/governance/policy` で確認すべき span / event は以下です。
+
+1. `http.request`（middleware root span）
+2. `governance.policy_update.request`
+3. `governance.approval.validate`
+4. `governance.bind_boundary.evaluate`
+5. `bind.boundary.evaluate.start`（event）
+6. `bind.boundary.evaluate.end`（event）
+7. `governance.policy.persist`
+8. `governance.policy_update.response`
+
+補足:
+
+- `bind.boundary.evaluate.start` / `bind.boundary.evaluate.end` は bind evaluator 側の event で、レビュー時には boundary 評価ライフサイクルの検証対象として扱います。
+
+## RBAC denial で期待される event
+
+RBAC が権限不足を拒否した場合、アクティブ span に次の event が付与されます。
+
+- `rbac.denied`
+
+この event には role / permission / endpoint / method / reason code / trace id などの拒否メタデータのみを記録し、秘密情報は含めません。
+
+## プライバシー安全属性ポリシー
+
+トレース情報は運用監査に必要な可観測性を維持しつつ、秘密情報や個人情報の漏えいを避ける必要があります。
+
+## 現在期待される attributes
+
+実装とテストで現在確認対象となるキー:
+
+- `trace_id`
+- `http.method`
+- `http.route`
+- `veritas.component`
+- `status_code`
+- `decision_id`
+- `request_id`
+- `actor_identity`
+- `policy_snapshot_id`
+- `approval_count`
+- `bind_receipt_id`
+- `final_outcome`
+- `bind_reason_code`
+- `target_path`
+- `target_type`
+- `event_type`
+- `reason_code`
+- `actor_role`
+- `requested_permission`
+- `endpoint`
+- `method`
+
+## 明示的に禁止される attributes
+
+次の項目は span attributes / events に**絶対に**含めてはいけません。
+
+- `Authorization`
+- `X-API-Key`
+- `Cookie`
+- `token`
+- `secret`
+- `password`
+- raw request body
+- `query_string`
+- personally identifying free-text payloads
+- approval signature raw secret beyond existing v1 token string semantics
+- medical/financial record contents
+
+## no-op fallback の挙動
+
+tracing helper は fail-safe 設計です。
+
+- OpenTelemetry が利用できない場合、helper は no-op として動作します。
+- tracing API で障害が起きても、業務ロジックは継続します。
+- そのため、OpenTelemetry や exporter 未設定は governance / bind / RBAC の意味論を変更しません。
+
+## 現在の非目標（未実装）
+
+本スコープ外（未実装）:
+
+- Jaeger deployment
+- Grafana/Tempo dashboard
+- OTLP exporter configuration
+- production collector
+- cryptographic human approval signature
+- backend TrustLog append guarantee changes
+- full distributed tracing across external services
+- frontend visual trace viewer
+
+## ローカル検証手順
+
+重要:
+
+- OpenTelemetry exporter がない環境では、span が no-op になるか、外部 trace UI に表示されない場合があります。
+- 現時点の検証は unit tests / fake tracer / monkeypatch tests が中心です。
+
+実行コマンド:
+
+- `pytest -q veritas_os/tests/test_trace_span_chain.py`
+- `pytest -q veritas_os/tests/unit/test_auth_rbac_audit.py`
+- `pytest -q veritas_os/tests/test_middleware_core.py`
+
+## 外部レビュアーチェックリスト
+
+1. governance update 経路で期待 span 名と boundary event が出ることを確認する。
+2. RBAC denial で `rbac.denied` event が安全な属性で出ることを確認する。
+3. 監査に必要な privacy-safe attributes が確認できることを確認する。
+4. 禁止 attributes が span attributes/events に含まれないことを確認する。
+5. no-op fallback の挙動が文書化され、テストで担保されていることを確認する。
+6. 本PRに Jaeger/Grafana/OTLP のデプロイ作業が含まれないことを確認する。

--- a/veritas_os/tests/test_trace_span_chain.py
+++ b/veritas_os/tests/test_trace_span_chain.py
@@ -12,6 +12,31 @@ from veritas_os.api.rbac import Permission, Role
 from veritas_os.observability import tracing
 from veritas_os.policy.bind_artifacts import FinalOutcome
 
+EXPECTED_GOVERNANCE_TRACE_SPANS = (
+    "http.request",
+    "governance.policy_update.request",
+    "governance.approval.validate",
+    "governance.bind_boundary.evaluate",
+    "bind.boundary.evaluate.start",
+    "bind.boundary.evaluate.end",
+    "governance.policy.persist",
+    "governance.policy_update.response",
+)
+
+FORBIDDEN_TRACE_ATTRIBUTE_NAMES = {
+    "authorization",
+    "x-api-key",
+    "cookie",
+    "token",
+    "secret",
+    "password",
+    "raw request body",
+    "query_string",
+    "personally identifying free-text payloads",
+    "approval signature raw secret beyond existing v1 token string semantics",
+    "medical/financial record contents",
+}
+
 
 def test_tracing_noop_without_opentelemetry(monkeypatch):
     monkeypatch.setattr(tracing, "otel_trace", None)
@@ -208,6 +233,19 @@ def test_governance_put_span_chain_happy_path(monkeypatch):
     assert "governance.policy_update.request" in steps
     assert "governance.approval.validate" in steps
     assert "governance.bind_boundary.evaluate" in steps
+    assert "governance.policy.persist" in steps
+    assert "governance.policy_update.response" in steps
+
+
+def test_governance_trace_span_expectation_alignment():
+    implemented_steps = {
+        "governance.policy_update.request",
+        "governance.approval.validate",
+        "governance.bind_boundary.evaluate",
+        "governance.policy.persist",
+        "governance.policy_update.response",
+    }
+    assert implemented_steps.issubset(set(EXPECTED_GOVERNANCE_TRACE_SPANS))
 
 
 def test_governance_put_approval_failure_adds_event(monkeypatch):
@@ -241,3 +279,21 @@ def test_rbac_denial_adds_span_event(monkeypatch):
     assert captured
     assert captured[0][0] == "rbac.denied"
     assert "token" not in str(captured[0][1]).lower()
+    lowered_keys = {str(key).lower() for key in captured[0][1].keys()}
+    assert lowered_keys.isdisjoint(FORBIDDEN_TRACE_ATTRIBUTE_NAMES)
+
+
+@pytest.mark.parametrize(
+    "doc_path",
+    (
+        "docs/en/operations/governance-trace-span-chain.md",
+        "docs/ja/operations/governance-trace-span-chain.md",
+    ),
+)
+def test_trace_docs_include_expected_spans_and_forbidden_attributes(doc_path):
+    content = open(doc_path, "r", encoding="utf-8").read()
+    for span_name in EXPECTED_GOVERNANCE_TRACE_SPANS:
+        assert span_name in content
+    content_lower = content.lower()
+    for forbidden_name in FORBIDDEN_TRACE_ATTRIBUTE_NAMES:
+        assert forbidden_name in content_lower


### PR DESCRIPTION
### Motivation

- Provide an auditable, reviewer-friendly explanation of what the governance policy update path currently traces, which span names and attributes are expected, and which attributes are forbidden for privacy/security reasons.
- Make the no-op fallback semantics and the current non-goals (Jaeger/Grafana/OTLP/deployment) explicit so external reviewers and auditors understand verification boundaries.
- Add a minimal smoke-test guard so documentation and implementation do not drift regressing expected span names or accidentally exposing forbidden attributes.

### Description

- Added an English canonical operations document `docs/en/operations/governance-trace-span-chain.md` describing purpose, implemented behaviour, expected governance span chain, RBAC denial event, privacy-safe attribute policy, forbidden attributes, no-op fallback behaviour, non-goals, local verification commands, and an external reviewer checklist.
- Added a paired Japanese explanatory document `docs/ja/operations/governance-trace-span-chain.md` that explicitly marks the English version as the canonical source.
- Updated `docs/INDEX.md` and `docs/DOCUMENTATION_MAP.md` to include discoverable EN/JA links for the new document.
- Extended `veritas_os/tests/test_trace_span_chain.py` with `EXPECTED_GOVERNANCE_TRACE_SPANS` and `FORBIDDEN_TRACE_ATTRIBUTE_NAMES` constants plus tests that (a) assert implemented governance step spans are a subset of expected spans, (b) ensure RBAC denial events do not contain forbidden attribute keys, and (c) verify both EN/JA docs contain the expected spans and forbidden attribute names.
- This change is documentation and tests only; it does not change runtime governance, bind, RBAC, or API semantics, does not add OpenTelemetry as a required dependency, and does not add any exporter/collector/deployment artifacts.

### Testing

- Ran `pytest -q veritas_os/tests/test_trace_span_chain.py veritas_os/tests/unit/test_auth_rbac_audit.py veritas_os/tests/test_middleware_core.py` and all tests passed (27 passed locally).
- The new tests include doc-content checks and runtime monkeypatch/fake-tracer scenarios exercised by existing tracing tests, and they passed in CI-like local runs.
- No runtime behaviour changes were introduced, so existing CI guards remain applicable and unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faddc93bcc83268b8b2bfc9adea2a8)