### PR TITLE
docs(observability): fix governance trace span chain numbering

### DIFF
--- a/docs/en/operations/governance-trace-span-chain.md
+++ b/docs/en/operations/governance-trace-span-chain.md
@@ -24,8 +24,8 @@ For `PUT /v1/governance/policy`, the expected span chain is:
 4. `governance.bind_boundary.evaluate`
 5. `bind.boundary.evaluate.start` (event)
 6. `bind.boundary.evaluate.end` (event)
-8. `governance.policy.persist`
-9. `governance.policy_update.response`
+7. `governance.policy.persist`
+8. `governance.policy_update.response`
 
 Notes:
 


### PR DESCRIPTION
### Motivation
- Fix a numbering inconsistency in the English operational document `docs/en/operations/governance-trace-span-chain.md` so the expected span chain entries are sequential for external reviewers while keeping semantics unchanged.

### Description
- Renumbered the last two items in the "Expected span chain for governance policy update" list in `docs/en/operations/governance-trace-span-chain.md` so `governance.policy.persist` is `7` and `governance.policy_update.response` is `8`, with no other edits to span names, attributes, runtime code, or the Japanese document.

### Testing
- Ran `pytest -q veritas_os/tests/test_trace_span_chain.py` and it succeeded (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faef0bc8708326a5679758f0c6a823)