### PR TITLE
feat(observability): expose RBAC denial audit append status

### DIFF
--- a/docs/en/operations/governance-trace-span-chain.md
+++ b/docs/en/operations/governance-trace-span-chain.md
@@ -37,8 +37,10 @@ Notes:
 When RBAC rejects a permission check, the active span receives the event:
 
 - `rbac.denied`
+- `rbac.denial.audit_append`
 
 This event records denial metadata only (for example, role, permission, endpoint, method, reason code, trace id) and must not include secrets.
+For `rbac.denial.audit_append`, `audit_append_status = success | failed | deduped` tracks best-effort TrustLog append outcomes without changing RBAC deny semantics or API responses.
 
 ## Privacy-safe attribute policy
 
@@ -69,6 +71,8 @@ Current implementation and tests rely on the following attribute keys:
 - `requested_permission`
 - `endpoint`
 - `method`
+- `audit_append_status`
+- `error_type`
 
 ## Attributes explicitly forbidden
 

--- a/docs/ja/operations/governance-trace-span-chain.md
+++ b/docs/ja/operations/governance-trace-span-chain.md
@@ -38,8 +38,10 @@
 RBAC が権限不足を拒否した場合、アクティブ span に次の event が付与されます。
 
 - `rbac.denied`
+- `rbac.denial.audit_append`
 
 この event には role / permission / endpoint / method / reason code / trace id などの拒否メタデータのみを記録し、秘密情報は含めません。
+`rbac.denial.audit_append` では `audit_append_status = success | failed | deduped` により、best-effort な TrustLog 追記結果のみを可視化します（RBAC deny の意味論や API 応答は変更しません）。
 
 ## プライバシー安全属性ポリシー
 
@@ -70,6 +72,8 @@ RBAC が権限不足を拒否した場合、アクティブ span に次の event
 - `requested_permission`
 - `endpoint`
 - `method`
+- `audit_append_status`
+- `error_type`
 
 ## 明示的に禁止される attributes
 

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -627,7 +627,22 @@ def _append_rbac_denial_audit_event_best_effort(
         endpoint=endpoint,
         trace_id=trace_id,
     )
+
+    base_attrs = {
+        "event_type": "rbac_denial",
+        "reason_code": reason_code,
+        "actor_role": role.value,
+        "requested_permission": permission.value,
+        "endpoint": endpoint,
+        "method": method,
+        "trace_id": trace_id,
+    }
+
     if not _should_append_rbac_denial_event(dedupe_key=dedupe_key, now_ts=time.time()):
+        _emit_rbac_denial_audit_append_visibility(
+            audit_append_status="deduped",
+            attributes=base_attrs,
+        )
         return
 
     event_payload = {
@@ -644,20 +659,41 @@ def _append_rbac_denial_audit_event_best_effort(
     }
     add_span_event(
         "rbac.denied",
-        attributes={
-            "event_type": "rbac_denial",
-            "reason_code": reason_code,
-            "actor_role": role.value,
-            "requested_permission": permission.value,
-            "endpoint": endpoint,
-            "method": method,
-            "trace_id": trace_id,
-        },
+        attributes=base_attrs,
     )
     try:
         append_signed_decision(event_payload)
+        _emit_rbac_denial_audit_append_visibility(
+            audit_append_status="success",
+            attributes=base_attrs,
+        )
     except Exception as exc:
-        logger.warning("RBAC denial audit append failed: %s", _errstr(exc))
+        _emit_rbac_denial_audit_append_visibility(
+            audit_append_status="failed",
+            attributes=base_attrs,
+            error_type=type(exc).__name__,
+        )
+
+
+def _emit_rbac_denial_audit_append_visibility(
+    *,
+    audit_append_status: str,
+    attributes: Dict[str, Optional[str]],
+    error_type: Optional[str] = None,
+) -> None:
+    """Emit structured observability signals for RBAC denial audit append outcomes."""
+    event_attrs = dict(attributes)
+    event_attrs["audit_append_status"] = audit_append_status
+    if error_type:
+        event_attrs["error_type"] = error_type
+
+    add_span_event("rbac.denial.audit_append", attributes=event_attrs)
+
+    safe_log_payload = dict(event_attrs)
+    if audit_append_status == "failed":
+        logger.warning("RBAC denial audit append outcome", extra={"rbac_audit_append": safe_log_payload})
+    else:
+        logger.info("RBAC denial audit append outcome", extra={"rbac_audit_append": safe_log_payload})
 
 
 def require_permission(permission: Permission):

--- a/veritas_os/tests/test_trace_span_chain.py
+++ b/veritas_os/tests/test_trace_span_chain.py
@@ -22,6 +22,10 @@ EXPECTED_GOVERNANCE_TRACE_SPANS = (
     "governance.policy.persist",
     "governance.policy_update.response",
 )
+EXPECTED_RBAC_TRACE_EVENTS = (
+    "rbac.denied",
+    "rbac.denial.audit_append",
+)
 
 FORBIDDEN_TRACE_ATTRIBUTE_NAMES = {
     "authorization",
@@ -294,6 +298,9 @@ def test_trace_docs_include_expected_spans_and_forbidden_attributes(doc_path):
     content = open(doc_path, "r", encoding="utf-8").read()
     for span_name in EXPECTED_GOVERNANCE_TRACE_SPANS:
         assert span_name in content
+    for event_name in EXPECTED_RBAC_TRACE_EVENTS:
+        assert event_name in content
+    assert "audit_append_status = success | failed | deduped" in content
     content_lower = content.lower()
     for forbidden_name in FORBIDDEN_TRACE_ATTRIBUTE_NAMES:
         assert forbidden_name in content_lower

--- a/veritas_os/tests/unit/test_auth_rbac_audit.py
+++ b/veritas_os/tests/unit/test_auth_rbac_audit.py
@@ -50,7 +50,9 @@ def test_rbac_denial_appends_audit_event(monkeypatch):
 
 
 def test_rbac_denial_append_failure_still_returns_403(monkeypatch):
+    captured = []
     monkeypatch.setattr(auth, "resolve_role_for_key", lambda _key: Role.auditor)
+    monkeypatch.setattr(auth, "add_span_event", lambda name, attributes=None: captured.append((name, attributes)))
 
     def _raise(_payload):
         raise RuntimeError("append failed")
@@ -65,6 +67,12 @@ def test_rbac_denial_append_failure_still_returns_403(monkeypatch):
         raise AssertionError("expected HTTPException")
     except HTTPException as exc:
         assert exc.status_code == 403
+    assert any(
+        name == "rbac.denial.audit_append"
+        and attrs.get("audit_append_status") == "failed"
+        and "error_type" in attrs
+        for name, attrs in captured
+    )
 
 
 def test_rbac_denial_payload_excludes_secrets(monkeypatch):
@@ -92,8 +100,10 @@ def test_rbac_denial_payload_excludes_secrets(monkeypatch):
 
 def test_rbac_denial_dedupe(monkeypatch):
     captured = []
+    span_events = []
     monkeypatch.setattr(auth, "resolve_role_for_key", lambda _key: Role.auditor)
     monkeypatch.setattr(auth, "append_signed_decision", lambda payload: captured.append(payload))
+    monkeypatch.setattr(auth, "add_span_event", lambda name, attributes=None: span_events.append((name, attributes)))
     auth._rbac_denial_dedupe_cache.clear()
 
     checker = auth.require_permission(Permission.decide)
@@ -109,6 +119,10 @@ def test_rbac_denial_dedupe(monkeypatch):
             pass
 
     assert len(captured) == 1
+    assert any(
+        name == "rbac.denial.audit_append" and attrs.get("audit_append_status") == "deduped"
+        for name, attrs in span_events
+    )
 
     req3 = _build_request(path="/v1/decide")
     req3.state.trace_id = "different"
@@ -134,6 +148,47 @@ def test_rbac_denial_helper_handles_none_request(monkeypatch):
     assert len(captured) == 1
     assert captured[0]["endpoint"] == "unknown"
     assert captured[0]["method"] == "unknown"
+
+
+def test_rbac_denial_append_success_emits_audit_append_status(monkeypatch):
+    captured = []
+    monkeypatch.setattr(auth, "append_signed_decision", lambda payload: None)
+    monkeypatch.setattr(auth, "add_span_event", lambda name, attributes=None: captured.append((name, attributes)))
+    auth._rbac_denial_dedupe_cache.clear()
+
+    auth._append_rbac_denial_audit_event_best_effort(
+        request=_build_request(path="/v1/decide", method="POST"),
+        role=Role.auditor,
+        permission=Permission.decide,
+        reason_code="RBAC_INSUFFICIENT_PERMISSION",
+    )
+
+    assert any(
+        name == "rbac.denial.audit_append" and attrs.get("audit_append_status") == "success"
+        for name, attrs in captured
+    )
+
+
+def test_rbac_denial_visibility_excludes_forbidden_attributes_in_events_and_logs(monkeypatch, caplog):
+    span_events = []
+    monkeypatch.setattr(auth, "add_span_event", lambda name, attributes=None: span_events.append((name, attributes)))
+    auth._emit_rbac_denial_audit_append_visibility(
+        audit_append_status="failed",
+        attributes={
+            "event_type": "rbac_denial",
+            "reason_code": "RBAC_INSUFFICIENT_PERMISSION",
+            "actor_role": "auditor",
+            "requested_permission": "decide",
+            "endpoint": "/v1/private",
+            "method": "GET",
+            "trace_id": "trace-001",
+        },
+        error_type="RuntimeError",
+    )
+
+    dump = str(span_events) + str(caplog.records)
+    for forbidden in ("Authorization", "X-API-Key", "Cookie", "token=secret", "query_string", "password"):
+        assert forbidden not in dump
 
 
 def test_rbac_denial_fields_survive_signed_summary_compaction():


### PR DESCRIPTION
### Motivation
- RBAC denial events are best-effort appended to TrustLog but failures had poor audit visibility, making it hard to observe whether an append succeeded, failed, or was deduped. 
- The goal is to increase observability of TrustLog append outcomes without changing RBAC decision semantics, API responses, or fail-open/fail-closed behavior. 
- This change must not expose secrets or sensitive headers in logs or span events and must preserve existing `rbac.denied` semantics. 

### Description
- Adds a small helper ` _emit_rbac_denial_audit_append_visibility(...)` in `veritas_os/api/auth.py` to emit a structured span event `rbac.denial.audit_append` and safe structured logs for append outcomes. 
- `_append_rbac_denial_audit_event_best_effort(...)` now classifies append results as `success`, `failed`, or `deduped` and calls the new helper for visibility while preserving the existing `rbac.denied` event and TrustLog best-effort semantics. 
- On failure the code emits only `error_type` (no raw error message) and logs a structured warning; no forbidden attributes such as `Authorization`, `X-API-Key`, `Cookie`, `token`, `query_string`, or raw request body are included. 
- Documentation was updated in `docs/en/operations/governance-trace-span-chain.md` and `docs/ja/operations/governance-trace-span-chain.md` to list the new `rbac.denial.audit_append` event and `audit_append_status = success | failed | deduped`. 

### Testing
- Unit tests updated/added in `veritas_os/tests/unit/test_auth_rbac_audit.py` and `veritas_os/tests/test_trace_span_chain.py` exercise `success`, `failed`, and `deduped` visibility, ensure forbidden attributes are not present, and verify append failure still returns `403`. 
- Ran `pytest -q veritas_os/tests/unit/test_auth_rbac_audit.py` (9 passed), `pytest -q veritas_os/tests/test_trace_span_chain.py` (11 passed), and `pytest -q veritas_os/tests/test_middleware_core.py` (9 passed), all succeeding. 
- No new runtime dependencies were added and existing best-effort TrustLog append behavior and API response contracts were preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf66b80a483269fe54f75b59d7d6a)