### PR TITLE
feat(observability): add read-only capabilities endpoint

### DIFF
--- a/docs/en/operations/governance-trace-span-chain.md
+++ b/docs/en/operations/governance-trace-span-chain.md
@@ -134,3 +134,13 @@ Use this checklist during review:
 4. Confirm forbidden attributes are absent from span attributes/events.
 5. Confirm no-op fallback behavior is documented and tested.
 6. Confirm this scope does not include Jaeger/Grafana/OTLP deployment work.
+
+## Runtime observability capabilities endpoint
+
+Use `GET /v1/observability/capabilities` to inspect current runtime observability and auditability capabilities in a read-only form.
+
+Security boundary:
+- Exporter configuration is reported as a boolean only.
+- Raw endpoint URLs, tokens, API keys, and secrets are never returned.
+
+This endpoint may still report Jaeger/Grafana/OTLP-related items as non-goals or not configured in the current environment.

--- a/docs/ja/operations/governance-trace-span-chain.md
+++ b/docs/ja/operations/governance-trace-span-chain.md
@@ -133,3 +133,13 @@ tracing helper は fail-safe 設計です。
 4. 禁止 attributes が span attributes/events に含まれないことを確認する。
 5. no-op fallback の挙動が文書化され、テストで担保されていることを確認する。
 6. 本PRに Jaeger/Grafana/OTLP のデプロイ作業が含まれないことを確認する。
+
+## Runtime observability capabilities endpoint
+
+`GET /v1/observability/capabilities` を使うと、現在環境の observability / auditability capability を read-only で確認できます。
+
+セキュリティ境界:
+- exporter 設定は boolean のみ返します。
+- endpoint URL、token、API key、secret の生値は返しません。
+
+この endpoint では、環境によって Jaeger/Grafana/OTLP 関連項目が non-goal / not configured として返る場合があります。

--- a/veritas_os/api/routes_observability.py
+++ b/veritas_os/api/routes_observability.py
@@ -1,0 +1,78 @@
+"""Read-only observability capability endpoints."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends
+
+from veritas_os.api.auth import require_permission
+from veritas_os.api.rbac import Permission
+from veritas_os.observability import tracing
+
+router = APIRouter()
+
+
+def _resolve_log_format() -> str:
+    """Resolve structured logging format without exposing raw config values."""
+    desired = (os.getenv("VERITAS_LOG_FORMAT", "text") or "text").strip().lower()
+    if desired in {"json", "text"}:
+        return desired
+    if not desired:
+        return "unknown"
+    return "text"
+
+
+def _is_exporter_configured() -> bool:
+    """Return True when any safe exporter env signal is present."""
+    candidate_vars = (
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_SERVICE_NAME",
+        "OTEL_TRACES_EXPORTER",
+    )
+    return any(bool((os.getenv(name) or "").strip()) for name in candidate_vars)
+
+
+@router.get(
+    "/v1/observability/capabilities",
+    dependencies=[Depends(require_permission(Permission.governance_read))],
+)
+def observability_capabilities() -> Dict[str, Any]:
+    """Return runtime observability capabilities as a read-only snapshot."""
+    opentelemetry_importable = tracing.otel_trace is not None
+
+    return {
+        "ok": True,
+        "observability": {
+            "structured_logging": {
+                "available": True,
+                "format": _resolve_log_format(),
+                "trace_id_supported": True,
+            },
+            "tracing": {
+                "helper_available": True,
+                "opentelemetry_importable": opentelemetry_importable,
+                "exporter_configured": _is_exporter_configured(),
+                "no_op_fallback": True,
+                "governance_span_chain": True,
+                "rbac_denial_events": True,
+                "rbac_denial_audit_append_visibility": True,
+            },
+            "human_approval": {
+                "workbench_frontend_supported": True,
+                "post_approval_edit_invalidation": True,
+                "cryptographic_signature": False,
+            },
+            "docs": {
+                "governance_trace_span_chain_en": "docs/en/operations/governance-trace-span-chain.md",
+                "governance_trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md",
+            },
+            "non_goals_currently_not_configured": [
+                "jaeger_deployment",
+                "grafana_tempo_dashboard",
+                "otlp_exporter_configuration",
+                "production_collector",
+                "frontend_visual_trace_viewer",
+            ],
+        },
+    }

--- a/veritas_os/api/routes_observability.py
+++ b/veritas_os/api/routes_observability.py
@@ -15,11 +15,9 @@ router = APIRouter()
 
 def _resolve_log_format() -> str:
     """Resolve structured logging format without exposing raw config values."""
-    desired = (os.getenv("VERITAS_LOG_FORMAT", "text") or "text").strip().lower()
-    if desired in {"json", "text"}:
-        return desired
-    if not desired:
-        return "unknown"
+    desired = (os.getenv("VERITAS_LOG_FORMAT") or "text").strip().lower()
+    if desired == "json":
+        return "json"
     return "text"
 
 

--- a/veritas_os/api/server.py
+++ b/veritas_os/api/server.py
@@ -932,6 +932,7 @@ from veritas_os.api.routes_system import (  # noqa: E402,F401 -- backward compat
     compliance_deployment_readiness,
 )
 from veritas_os.api.routes_wat import router as _wat_router  # noqa: E402
+from veritas_os.api.routes_observability import router as _observability_router  # noqa: E402
 from veritas_os.api.routes_wat import (  # noqa: E402,F401 -- backward compat
     issue_shadow_wat,
     validate_shadow_wat,
@@ -952,6 +953,7 @@ app.include_router(_trust_router, dependencies=_auth_deps)
 app.include_router(_wat_router, dependencies=_auth_deps)
 app.include_router(_governance_router, dependencies=_gov_deps)
 app.include_router(_system_router, dependencies=[Depends(require_api_key)])
+app.include_router(_observability_router, dependencies=[Depends(require_api_key)])
 app.include_router(_events_router, dependencies=[Depends(require_api_key_header_or_query)])
 
 

--- a/veritas_os/policy/bind_coverage.py
+++ b/veritas_os/policy/bind_coverage.py
@@ -111,6 +111,7 @@ BIND_COVERAGE_REGISTRY: tuple[BindCoverageEntry, ...] = (
     BindCoverageEntry("/v1/system/resume", "POST", BindCoverageClass.BIND_GOVERNED),
     BindCoverageEntry("/v1/system/halt-status", "GET", BindCoverageClass.READ_ONLY),
     BindCoverageEntry("/v1/compliance/deployment-readiness", "GET", BindCoverageClass.READ_ONLY),
+    BindCoverageEntry("/v1/observability/capabilities", "GET", BindCoverageClass.READ_ONLY),
 )
 
 _REGISTRY_INDEX = {entry.key(): entry for entry in BIND_COVERAGE_REGISTRY}

--- a/veritas_os/tests/test_observability_capabilities.py
+++ b/veritas_os/tests/test_observability_capabilities.py
@@ -13,9 +13,18 @@ def _headers() -> dict[str, str]:
     return {"X-API-Key": "test-observability-key"}
 
 
+def _set_api_keys(monkeypatch, role: str = "auditor") -> None:
+    """Configure auth via VERITAS_API_KEYS and disable legacy single-key fallback."""
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_API_KEYS_JSON", raising=False)
+    monkeypatch.setenv(
+        "VERITAS_API_KEYS",
+        f'[{{"key":"test-observability-key","role":"{role}"}}]',
+    )
+
+
 def test_observability_capabilities_ok_true(monkeypatch):
-    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
-    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    _set_api_keys(monkeypatch, role="auditor")
 
     client = TestClient(server.app)
     response = client.get("/v1/observability/capabilities", headers=_headers())
@@ -27,8 +36,7 @@ def test_observability_capabilities_ok_true(monkeypatch):
 
 
 def test_opentelemetry_importable_false_does_not_crash(monkeypatch):
-    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
-    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    _set_api_keys(monkeypatch, role="auditor")
     monkeypatch.setattr(routes_observability.tracing, "otel_trace", None)
 
     client = TestClient(server.app)
@@ -39,8 +47,7 @@ def test_opentelemetry_importable_false_does_not_crash(monkeypatch):
 
 
 def test_exporter_configured_false_without_env(monkeypatch):
-    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
-    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    _set_api_keys(monkeypatch, role="auditor")
     for name in ("OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_SERVICE_NAME", "OTEL_TRACES_EXPORTER"):
         monkeypatch.delenv(name, raising=False)
 
@@ -52,8 +59,7 @@ def test_exporter_configured_false_without_env(monkeypatch):
 
 
 def test_exporter_configured_true_with_env(monkeypatch):
-    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
-    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    _set_api_keys(monkeypatch, role="auditor")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.internal.example")
 
     client = TestClient(server.app)
@@ -64,8 +70,7 @@ def test_exporter_configured_true_with_env(monkeypatch):
 
 
 def test_endpoint_never_leaks_raw_sensitive_env_values(monkeypatch):
-    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
-    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    _set_api_keys(monkeypatch, role="auditor")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.internal.example")
     monkeypatch.setenv("DUMMY_API_TOKEN", "raw-token-value")
     monkeypatch.setenv("DUMMY_SECRET", "raw-secret-value")
@@ -81,8 +86,7 @@ def test_endpoint_never_leaks_raw_sensitive_env_values(monkeypatch):
 
 
 def test_endpoint_is_read_only_and_no_audit_append(monkeypatch):
-    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
-    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    _set_api_keys(monkeypatch, role="auditor")
     called = []
 
     def _fail_append(_entry):
@@ -95,3 +99,56 @@ def test_endpoint_is_read_only_and_no_audit_append(monkeypatch):
 
     assert response.status_code == 200
     assert called == []
+
+
+def test_non_governance_read_role_gets_403(monkeypatch):
+    _set_api_keys(monkeypatch, role="operator")
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 403
+
+
+def test_log_format_json(monkeypatch):
+    _set_api_keys(monkeypatch, role="auditor")
+    monkeypatch.setenv("VERITAS_LOG_FORMAT", "json")
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    assert response.json()["observability"]["structured_logging"]["format"] == "json"
+
+
+def test_log_format_text(monkeypatch):
+    _set_api_keys(monkeypatch, role="auditor")
+    monkeypatch.setenv("VERITAS_LOG_FORMAT", "text")
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    assert response.json()["observability"]["structured_logging"]["format"] == "text"
+
+
+def test_log_format_whitespace_returns_text(monkeypatch):
+    _set_api_keys(monkeypatch, role="auditor")
+    monkeypatch.setenv("VERITAS_LOG_FORMAT", "   ")
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    assert response.json()["observability"]["structured_logging"]["format"] == "text"
+
+
+def test_log_format_invalid_returns_text(monkeypatch):
+    _set_api_keys(monkeypatch, role="auditor")
+    monkeypatch.setenv("VERITAS_LOG_FORMAT", "invalid")
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    assert response.json()["observability"]["structured_logging"]["format"] == "text"

--- a/veritas_os/tests/test_observability_capabilities.py
+++ b/veritas_os/tests/test_observability_capabilities.py
@@ -1,0 +1,97 @@
+"""Tests for read-only observability capabilities endpoint."""
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from veritas_os.api import server
+from veritas_os.api import routes_observability
+
+
+def _headers() -> dict[str, str]:
+    return {"X-API-Key": "test-observability-key"}
+
+
+def test_observability_capabilities_ok_true(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
+    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["observability"]["docs"]["governance_trace_span_chain_en"]
+
+
+def test_opentelemetry_importable_false_does_not_crash(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
+    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    monkeypatch.setattr(routes_observability.tracing, "otel_trace", None)
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    assert response.json()["observability"]["tracing"]["opentelemetry_importable"] is False
+
+
+def test_exporter_configured_false_without_env(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
+    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    for name in ("OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_SERVICE_NAME", "OTEL_TRACES_EXPORTER"):
+        monkeypatch.delenv(name, raising=False)
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    assert response.json()["observability"]["tracing"]["exporter_configured"] is False
+
+
+def test_exporter_configured_true_with_env(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
+    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.internal.example")
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    assert response.json()["observability"]["tracing"]["exporter_configured"] is True
+
+
+def test_endpoint_never_leaks_raw_sensitive_env_values(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
+    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.internal.example")
+    monkeypatch.setenv("DUMMY_API_TOKEN", "raw-token-value")
+    monkeypatch.setenv("DUMMY_SECRET", "raw-secret-value")
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    body_str = json.dumps(response.json())
+    assert "https://collector.internal.example" not in body_str
+    assert "raw-token-value" not in body_str
+    assert "raw-secret-value" not in body_str
+
+
+def test_endpoint_is_read_only_and_no_audit_append(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "test-observability-key")
+    monkeypatch.setenv("VERITAS_API_KEYS_JSON", '{"test-observability-key":"auditor"}')
+    called = []
+
+    def _fail_append(_entry):
+        called.append(True)
+
+    monkeypatch.setattr(server, "append_trust_log", _fail_append)
+
+    client = TestClient(server.app)
+    response = client.get("/v1/observability/capabilities", headers=_headers())
+
+    assert response.status_code == 200
+    assert called == []


### PR DESCRIPTION
### Motivation
- Provide a safe, read-only runtime API so auditors and reviewers can quickly verify which observability/audit features are present or configured without changing runtime semantics. 
- Surface structured-logging, tracing, exporter presence, RBAC denial audit-append visibility, and human-approval capabilities in a privacy-safe way. 
- Security warning: the endpoint intentionally does not return raw env values, endpoints, tokens, API keys, or secrets and reports exporter configuration as booleans only to avoid information leakage.

### Description
- Adds a new router and endpoint `GET /v1/observability/capabilities` implemented in `veritas_os/api/routes_observability.py` that returns a read-only snapshot of observability capabilities and documentation links. 
- Registers the observability router in `veritas_os/api/server.py` with existing API key authentication and enforces `governance_read` permission (auditor+ compatible) to match existing read access rules. 
- Detects `opentelemetry_importable` by checking the tracing helper state (`tracing.otel_trace is not None`) and computes `exporter_configured` from safe environment signals (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_TRACES_EXPORTER`) without exposing their values. 
- Adds bind coverage entry for the new read-only endpoint, updates EN/JA docs (`docs/en/...` and `docs/ja/...`) to mention the endpoint and its security boundary, and includes focused tests in `veritas_os/tests/test_observability_capabilities.py`.

### Testing
- Ran `pytest -q veritas_os/tests/test_observability_capabilities.py` and it passed (`6 passed`).
- Ran `pytest -q veritas_os/tests/test_trace_span_chain.py` and it passed (`11 passed`).
- Ran `pytest -q veritas_os/tests/test_middleware_core.py` and it passed (`9 passed`).
- Ran `pytest -q veritas_os/tests/unit/test_auth_rbac_audit.py` and it passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fafe119f048326b77379c8ed63bcf6)