### PR TITLE
docs(poc): add one-day VERITAS PoC walkthrough

### DIFF
--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -44,6 +44,7 @@
 | Guides: Financial templates | `docs/en/guides/financial-governance-templates.md` | `docs/ja/guides/financial-governance-templates.md` | JA explanation / EN canonical | AML/KYC導線 |
 | Guides: Bundle promotion | `docs/en/guides/governance-policy-bundle-promotion.md` | `docs/ja/guides/governance-policy-bundle-promotion.md` | JA explanation / EN canonical | ポリシーバンドル昇格 |
 | Guides: PoC quickstart | `docs/en/guides/poc-pack-financial-quickstart.md` | `docs/ja/guides/poc-pack-financial-quickstart.md` | EN/JA fully paired | JAファースト導線 |
+| PoC: One-day walkthrough | `docs/en/poc/one-day-poc-walkthrough.md` | `docs/ja/poc/one-day-poc-walkthrough.md` | JA explanation / EN canonical | 外部レビュー向け1-dayデモ導線 |
 | Positioning: AML/KYC | `docs/en/positioning/aml-kyc-beachhead-short-positioning.md` | `docs/ja/positioning/aml-kyc-beachhead-short-positioning.md` | JA explanation / EN canonical | 公開向け短縮版 |
 | Positioning: Public positioning | `docs/en/positioning/public-positioning.md` | `docs/ja/positioning/public-positioning.md` | JA explanation / EN canonical | 内部再評価含む |
 | UI docs | `docs/ui/README_UI.md` | `docs/ui/PREVIEW_PAGES_JP.md` | Mixed | UI本体は EN、プレビュー案内は JA |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -38,6 +38,7 @@
 | Required Evidence Taxonomy | [Required evidence taxonomy (EN)](en/governance/required-evidence-taxonomy.md) | [Required evidence taxonomy (JA)](ja/governance/required-evidence-taxonomy.md) |
 | Governance Artifact Lifecycle | [Governance artifact lifecycle (EN)](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle (JA)](ja/governance/governance-artifact-lifecycle.md) |
 | Guides | [Guides (EN)](en/guides/) | [Guides (JA)](ja/guides/) |
+| One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough (EN)](en/poc/one-day-poc-walkthrough.md) | [One-Day VERITAS PoC Walkthrough (JA)](ja/poc/one-day-poc-walkthrough.md) |
 | AI-Assisted Development | [AI-assisted development guardrails (EN)](en/development/ai-assisted-development.md) | [AI支援開発ガードレール (JA)](ja/development/ai-assisted-development.md) |
 | AI Review Matrix | [AI review matrix (EN)](en/development/ai-review-matrix.md) | [AIレビューマトリクス (JA)](ja/development/ai-review-matrix.md) |
 | Recent hardening notes | [Recent hardening notes (EN)](en/development/recent-hardening.md) | [直近のハードニング整理 (JA)](ja/development/recent-hardening.md) |
@@ -97,6 +98,7 @@
 | Required Evidence Taxonomy | [Required evidence taxonomy（英語正本）](en/governance/required-evidence-taxonomy.md) | [Required evidence taxonomy（日本語解説）](ja/governance/required-evidence-taxonomy.md) |
 | Governance Artifact Lifecycle | [Governance artifact lifecycle（英語正本）](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle（日本語解説）](ja/governance/governance-artifact-lifecycle.md) |
 | ガイド | [Guides（英語正本）](en/guides/) | [Guides（日本語）](ja/guides/) |
+| One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough（英語正本）](en/poc/one-day-poc-walkthrough.md) | [One-Day VERITAS PoC Walkthrough（日本語）](ja/poc/one-day-poc-walkthrough.md) |
 | AI支援開発 | [AI-assisted development guardrails（英語正本）](en/development/ai-assisted-development.md) | [AI支援開発ガードレール（日本語）](ja/development/ai-assisted-development.md) |
 | AIレビューマトリクス | [AI review matrix（英語正本）](en/development/ai-review-matrix.md) | [AIレビューマトリクス（日本語）](ja/development/ai-review-matrix.md) |
 | 直近のハードニング整理 | [Recent hardening notes（英語正本）](en/development/recent-hardening.md) | [直近のハードニング整理（日本語）](ja/development/recent-hardening.md) |

--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -1,0 +1,111 @@
+# One-Day VERITAS PoC Walkthrough
+
+## Purpose
+
+This walkthrough provides a one-day, external-reviewer-friendly PoC flow for demonstrating VERITAS value through existing capabilities, without changing runtime semantics.
+
+## Target audience
+
+- HPAN reviewers
+- Enterprise stakeholders and solution owners
+- Audit and assurance reviewers
+- Investors and technical due-diligence reviewers
+
+## What this PoC demonstrates
+
+- Observability capability reporting via `GET /v1/observability/capabilities`
+- RBAC denial audit append visibility (as exposed by current observability/reporting surfaces)
+- Human Approval Workbench path for governance policy changes (review path and evidence)
+- Bind Boundary outcomes and receipts
+- Trace and span-chain continuity for governance-related flow
+- Existing TrustLog and auditability signals as implemented today
+
+## What this PoC does not demonstrate
+
+- Full production deployment hardening and operations
+- Deployment of Jaeger, Grafana, Tempo, or OTLP collector
+- Cryptographic human approval signatures
+- Any stronger TrustLog append durability guarantee beyond the current implementation
+- Final enterprise packaging, commercial SLA, or complete security certification
+
+This PoC is intended to show enforceable boundaries and auditable behavior, not final production packaging.
+
+## Prerequisites
+
+1. Running VERITAS API server.
+2. API key with read permissions for observability endpoints.
+3. Local environment variables:
+   - `VERITAS_BASE_URL` (optional, default `http://127.0.0.1:8000`)
+   - `VERITAS_API_KEY` (required)
+   - `VERITAS_DEMO_ALLOW_MUTATION` (optional, default `false`)
+4. Python runtime for the smoke script.
+
+## Scenario A: Observability capability check
+
+1. Run:
+   - `python scripts/demo/one_day_poc_smoke.py --json`
+2. Confirm `capabilities_ok: true`.
+3. Confirm summary includes:
+   - structured logging format
+   - OpenTelemetry importability signal
+   - exporter configured signal
+   - governance span chain signal
+   - RBAC denial audit append visibility signal
+
+## Scenario B: RBAC denial audit visibility
+
+1. Produce or retrieve an RBAC-denied event through your standard test flow.
+2. Show that denial evidence is visible through the existing audit/observability path.
+3. Cross-check summary output and operational logs for the same trace context when possible.
+
+## Scenario C: Governance policy update with human approval
+
+1. Walk through governance policy update process in Human Approval Workbench.
+2. Demonstrate that a 4-eyes approval path is required by current implementation.
+3. Show evidence trail (approval record + audit entries).
+4. Demonstrate post-approval edit invalidation behavior as currently implemented.
+
+## Scenario D: Bind Boundary outcome and receipt
+
+1. Execute a policy-governed action sample.
+2. Show Bind Boundary outcome (`allow` or `deny`) and produced receipt/evidence.
+3. Link outcome to policy context and audit entries.
+
+## Scenario E: Trace/span verification
+
+1. Select one end-to-end request from Scenarios B–D.
+2. Show `trace_id` propagation across request/audit logs.
+3. Show governance span chain continuity from decision to emitted evidence.
+
+## Evidence checklist
+
+- [ ] `GET /v1/observability/capabilities` response captured.
+- [ ] Smoke script JSON summary captured.
+- [ ] RBAC denial example with audit visibility.
+- [ ] Human approval evidence for governance update path.
+- [ ] Bind Boundary outcome + receipt sample.
+- [ ] Trace ID and governance span chain continuity proof.
+- [ ] Notes about limitations and non-goals included in reviewer packet.
+
+## Success criteria
+
+- External reviewers can follow the sequence without internal tribal knowledge.
+- Reviewers can independently verify observability capability signals.
+- Reviewers can inspect evidence for RBAC, human approval, bind boundary, and trace continuity.
+- No runtime governance/bind/RBAC/TrustLog semantics are changed for the demo.
+
+## Known limitations
+
+- Not a production deployment reference architecture.
+- No bundled Jaeger/Grafana/Tempo/OTLP collector deployment in this walkthrough.
+- No cryptographic human approval signatures.
+- TrustLog durability characteristics remain exactly as implemented today.
+- Optional mutation path is disabled by default in smoke tooling.
+
+## Suggested talk track for external reviewers
+
+1. "We are demonstrating enforceable governance boundaries and auditable outcomes, not a full production rollout."
+2. "First, we show capability surfaces and logging/trace controls as currently implemented."
+3. "Second, we show RBAC denial visibility and governance approval controls (including 4-eyes and post-approval edit invalidation)."
+4. "Third, we show bind outcomes and receipts tied to trace-linked evidence."
+5. "Finally, we highlight what is intentionally out-of-scope for this one-day PoC."

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -1,0 +1,113 @@
+# One-Day VERITAS PoC Walkthrough（日本語版）
+
+> この文書は英語正本 `docs/en/poc/one-day-poc-walkthrough.md` に対応する日本語版です。仕様判断が必要な場合は英語正本を優先してください。
+
+## 目的
+
+本ウォークスルーは、既存機能を使って VERITAS の価値を 1 日で外部レビュー担当者へ提示するための PoC 導線です。ランタイムの意味論は変更しません。
+
+## 対象読者
+
+- HPAN レビュアー
+- 企業側ステークホルダー／導入担当
+- 監査・保証担当
+- 投資家・技術 DD 担当
+
+## この PoC で実証すること
+
+- `GET /v1/observability/capabilities` による観測性 capability の確認
+- RBAC denial audit append visibility（既存の観測・監査導線で確認可能な範囲）
+- governance policy 変更に対する Human Approval Workbench の承認導線
+- Bind Boundary の結果と receipt（証跡）
+- governance 関連フローの trace / span chain 連続性
+- 既存実装における TrustLog と監査可能性シグナル
+
+## この PoC で実証しないこと
+
+- 本番運用の完全な構成・ハードニング
+- Jaeger / Grafana / Tempo / OTLP collector のデプロイ
+- 人手承認の暗号学的署名
+- 現行実装を超える TrustLog append durability 保証
+- 最終的なエンタープライズ向けパッケージングや商用 SLA
+
+この PoC の目的は、最終パッケージではなく「強制可能な境界」と「監査可能性」を示すことです。
+
+## 前提条件
+
+1. VERITAS API サーバーが起動済みであること。
+2. observability エンドポイントを読める API キーがあること。
+3. 環境変数:
+   - `VERITAS_BASE_URL`（任意、既定値 `http://127.0.0.1:8000`）
+   - `VERITAS_API_KEY`（必須）
+   - `VERITAS_DEMO_ALLOW_MUTATION`（任意、既定値 `false`）
+4. スモークスクリプトを実行できる Python 環境。
+
+## シナリオ A: Observability capability check
+
+1. 実行:
+   - `python scripts/demo/one_day_poc_smoke.py --json`
+2. `capabilities_ok: true` を確認。
+3. 要約に以下が含まれることを確認:
+   - structured logging format
+   - OpenTelemetry importability
+   - exporter configured
+   - governance span chain
+   - RBAC denial audit append visibility
+
+## シナリオ B: RBAC denial audit visibility
+
+1. 標準の検証手順で RBAC deny イベントを生成または取得。
+2. 既存の監査／観測導線で deny 証跡が見えることを示す。
+3. 可能であれば同一 trace context でログと突合する。
+
+## シナリオ C: Human Approval を伴う governance policy update
+
+1. Human Approval Workbench 上の policy update 導線を説明。
+2. 現行実装で 4-eyes 承認が必要であることを示す。
+3. 承認記録と監査エントリを提示。
+4. 承認後編集の失効（post-approval edit invalidation）挙動を示す。
+
+## シナリオ D: Bind Boundary の結果と receipt
+
+1. policy 適用下のアクション例を実行。
+2. Bind Boundary の結果（`allow` / `deny`）と receipt を提示。
+3. 結果と policy 文脈、監査証跡の対応関係を示す。
+
+## シナリオ E: Trace/span verification
+
+1. シナリオ B〜D のいずれか 1 リクエストを対象にする。
+2. `trace_id` 伝播をリクエスト／監査ログで確認する。
+3. decision から証跡出力まで governance span chain が連続していることを示す。
+
+## 証跡チェックリスト
+
+- [ ] `GET /v1/observability/capabilities` のレスポンス取得
+- [ ] スモークスクリプト JSON 要約の取得
+- [ ] RBAC deny と監査可視性の例
+- [ ] governance update の human approval 証跡
+- [ ] Bind Boundary の結果と receipt サンプル
+- [ ] trace_id と governance span chain 連続性の証明
+- [ ] 制約・非目標をレビューパケットに明記
+
+## 成功条件
+
+- 外部レビュアーが内部知識なしで順番に確認できる。
+- observability capability シグナルを第三者が検証できる。
+- RBAC / human approval / bind boundary / trace continuity の証跡を確認できる。
+- デモのために runtime の governance/bind/RBAC/TrustLog 意味論を変更しない。
+
+## 既知の制約
+
+- 本番参照アーキテクチャではない。
+- Jaeger/Grafana/Tempo/OTLP collector の構築は含まない。
+- 暗号学的な human approval 署名は含まない。
+- TrustLog durability 特性は現行実装のままである。
+- スモークツールの mutation 経路は既定で無効。
+
+## 外部レビュアー向け推奨トークトラック
+
+1. 「このデモは本番ローンチではなく、境界強制と監査可能性の提示です。」
+2. 「まず capability 面と logging/trace 制御面を確認します。」
+3. 「次に RBAC deny 可視性と、人手承認（4-eyes・承認後編集失効）を確認します。」
+4. 「続いて bind outcome と receipt を trace 証跡と結び付けて確認します。」
+5. 「最後に、1-day PoC の意図的な非対象範囲を明示します。」

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -24,7 +24,7 @@ def _bool_env(name: str, *, default: bool = False) -> bool:
 def _http_get_json(base_url: str, path: str, api_key: str) -> tuple[int, dict[str, Any]]:
     url = f"{base_url.rstrip('/')}{path}"
     req = request.Request(url=url, method="GET")
-    req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("X-API-Key", api_key)
     req.add_header("Accept", "application/json")
     try:
         with request.urlopen(req, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
@@ -59,18 +59,14 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run VERITAS one-day PoC smoke checks")
     parser.add_argument("--json", action="store_true", dest="json_output")
     parser.add_argument("--base-url", default=os.getenv("VERITAS_BASE_URL", DEFAULT_BASE_URL))
-    parser.add_argument("--api-key-env", default="VERITAS_API_KEY")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    api_key = os.getenv(args.api_key_env)
+    api_key = os.getenv("VERITAS_API_KEY")
     if not api_key:
-        print(
-            f"ERROR: missing required environment variable {args.api_key_env}",
-            file=sys.stderr,
-        )
+        print("ERROR: missing required API credentials", file=sys.stderr)
         return 2
 
     allow_mutation = _bool_env("VERITAS_DEMO_ALLOW_MUTATION", default=False)

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Run a safe one-day VERITAS PoC smoke check against a running API server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+from urllib import error, request
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+
+def _bool_env(name: str, *, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _http_get_json(base_url: str, path: str, api_key: str) -> tuple[int, dict[str, Any]]:
+    url = f"{base_url.rstrip('/')}{path}"
+    req = request.Request(url=url, method="GET")
+    req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Accept", "application/json")
+    try:
+        with request.urlopen(req, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
+            status = response.getcode()
+            body = response.read().decode("utf-8")
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return exc.code, {"error": body[:300]}
+    except error.URLError as exc:
+        return 0, {"error": str(exc.reason)}
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        payload = {"raw": body[:300]}
+    return status, payload
+
+
+def _extract_observability_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "structured_logging_format": payload.get("structured_logging_format"),
+        "opentelemetry_importable": payload.get("opentelemetry_importable"),
+        "exporter_configured": payload.get("exporter_configured"),
+        "governance_span_chain": payload.get("governance_span_chain"),
+        "rbac_denial_audit_append_visibility": payload.get(
+            "rbac_denial_audit_append_visibility"
+        ),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run VERITAS one-day PoC smoke checks")
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    parser.add_argument("--base-url", default=os.getenv("VERITAS_BASE_URL", DEFAULT_BASE_URL))
+    parser.add_argument("--api-key-env", default="VERITAS_API_KEY")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    api_key = os.getenv(args.api_key_env)
+    if not api_key:
+        print(
+            f"ERROR: missing required environment variable {args.api_key_env}",
+            file=sys.stderr,
+        )
+        return 2
+
+    allow_mutation = _bool_env("VERITAS_DEMO_ALLOW_MUTATION", default=False)
+    warnings: list[str] = []
+    docs = {
+        "en": "docs/en/poc/one-day-poc-walkthrough.md",
+        "ja": "docs/ja/poc/one-day-poc-walkthrough.md",
+    }
+
+    capabilities_status, capabilities_payload = _http_get_json(
+        args.base_url,
+        "/v1/observability/capabilities",
+        api_key,
+    )
+    capabilities_ok = capabilities_status == 200
+
+    observability = _extract_observability_summary(
+        capabilities_payload if isinstance(capabilities_payload, dict) else {}
+    )
+
+    policy_status, _policy_payload = _http_get_json(
+        args.base_url,
+        "/v1/governance/policy",
+        api_key,
+    )
+    if policy_status not in (200, 401, 403, 404):
+        warnings.append(f"unexpected governance policy status: {policy_status}")
+
+    if allow_mutation:
+        warnings.append(
+            "VERITAS_DEMO_ALLOW_MUTATION=true is set, but this smoke script remains read-only."
+        )
+
+    ok = capabilities_ok
+    if not capabilities_ok:
+        warnings.append(
+            f"required check failed: GET /v1/observability/capabilities status={capabilities_status}"
+        )
+
+    summary = {
+        "ok": ok,
+        "capabilities_ok": capabilities_ok,
+        "observability": observability,
+        "docs": docs,
+        "warnings": warnings,
+    }
+
+    if args.json_output:
+        print(json.dumps(summary, ensure_ascii=False, separators=(",", ":")))
+    else:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -1,0 +1,145 @@
+"""Tests for one-day VERITAS PoC smoke script."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPT_PATH = Path("scripts/demo/one_day_poc_smoke.py")
+
+
+def _run_script(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    run_env = os.environ.copy()
+    run_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=run_env,
+    )
+
+
+@pytest.fixture()
+def api_server(monkeypatch: pytest.MonkeyPatch) -> Any:
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    import threading
+
+    state = {"mutation_called": False}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path == "/v1/observability/capabilities":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                payload = {
+                    "structured_logging_format": "json",
+                    "opentelemetry_importable": True,
+                    "exporter_configured": False,
+                    "exporter_endpoint": "http://secret-exporter:4317",
+                    "governance_span_chain": True,
+                    "rbac_denial_audit_append_visibility": True,
+                }
+                self.wfile.write(json.dumps(payload).encode("utf-8"))
+                return
+            if self.path == "/v1/governance/policy":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b"{}")
+                return
+            if self.path.startswith("/v1/governance/policy/update"):
+                state["mutation_called"] = True
+                self.send_response(405)
+                self.end_headers()
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        yield url, state
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_missing_api_key_fails_clearly() -> None:
+    result = _run_script({"VERITAS_API_KEY": ""})
+
+    assert result.returncode != 0
+    assert "missing required environment variable VERITAS_API_KEY" in result.stderr
+
+
+def test_script_does_not_print_api_key(api_server: Any) -> None:
+    base_url, _ = api_server
+    result = _run_script(
+        {"VERITAS_API_KEY": "super-secret-key", "VERITAS_BASE_URL": base_url},
+        "--json",
+    )
+
+    assert result.returncode == 0
+    assert "super-secret-key" not in result.stdout
+    assert "super-secret-key" not in result.stderr
+
+
+def test_capabilities_response_is_summarized(api_server: Any) -> None:
+    base_url, _ = api_server
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--json",
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["capabilities_ok"] is True
+    assert payload["observability"]["structured_logging_format"] == "json"
+    assert payload["observability"]["opentelemetry_importable"] is True
+
+
+def test_exporter_endpoint_raw_value_is_not_printed(api_server: Any) -> None:
+    base_url, _ = api_server
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--json",
+    )
+
+    assert result.returncode == 0
+    assert "secret-exporter" not in result.stdout
+
+
+def test_non_200_capabilities_fails_nonzero() -> None:
+    result = _run_script(
+        {
+            "VERITAS_API_KEY": "test-key",
+            "VERITAS_BASE_URL": "http://127.0.0.1:9",
+        },
+        "--json",
+    )
+
+    assert result.returncode != 0
+
+
+def test_default_mode_does_not_call_mutation_endpoints(api_server: Any) -> None:
+    base_url, state = api_server
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--json",
+    )
+
+    assert result.returncode == 0
+    assert state["mutation_called"] is False

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -81,7 +81,49 @@ def test_missing_api_key_fails_clearly() -> None:
     result = _run_script({"VERITAS_API_KEY": ""})
 
     assert result.returncode != 0
-    assert "missing required environment variable VERITAS_API_KEY" in result.stderr
+    assert "missing required API credentials" in result.stderr
+
+
+def test_uses_x_api_key_header_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("one_day_poc_smoke", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    captured_headers: dict[str, str] = {}
+
+    class DummyResponse:
+        def __enter__(self) -> "DummyResponse":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def getcode(self) -> int:
+            return 200
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    def _fake_urlopen(req: Any, timeout: float) -> DummyResponse:
+        del timeout
+        captured_headers.update(dict(req.header_items()))
+        return DummyResponse()
+
+    monkeypatch.setattr(module.request, "urlopen", _fake_urlopen)
+
+    status, _payload = module._http_get_json(
+        "http://127.0.0.1:8000",
+        "/v1/observability/capabilities",
+        "key-for-test",
+    )
+
+    assert status == 200
+    assert captured_headers.get("X-api-key") == "key-for-test"
+    assert "Authorization" not in captured_headers
 
 
 def test_script_does_not_print_api_key(api_server: Any) -> None:


### PR DESCRIPTION
### Motivation

- Provide an auditable, one-day PoC walkthrough that lets external reviewers (HPAN / enterprise / audit / investors) follow a short sequence to verify VERITAS observability, RBAC audit visibility, human-approval workbench, bind boundary receipts, and trace/span continuity without changing runtime semantics. 
- Make the walkthrough discoverable in the bilingual docs hub and supply a minimal, safe smoke script to confirm observable capability surfaces on a running server. 
- Security note: the smoke script is intentionally read-only by default and redacts sensitive configuration values from summaries, but running any checks against production systems with live credentials should be done with care. 

### Description

- Adds an English canonical walkthrough at `docs/en/poc/one-day-poc-walkthrough.md` and a natural Japanese counterpart at `docs/ja/poc/one-day-poc-walkthrough.md` that explicitly marks the English text as canonical. 
- Updates `docs/INDEX.md` and `docs/DOCUMENTATION_MAP.md` to make the One-Day PoC Walkthrough discoverable from the docs hub. 
- Adds a safe, read-only smoke script `scripts/demo/one_day_poc_smoke.py` which reads `VERITAS_BASE_URL`/`VERITAS_API_KEY` (env), enforces HTTP timeouts, checks `GET /v1/observability/capabilities` (required) and `GET /v1/governance/policy` (optional), provides a compact `--json` summary, never prints raw API keys or sensitive endpoints, and defaults to not mutating governance state (shows a warning if `VERITAS_DEMO_ALLOW_MUTATION=true`). 
- Adds tests `veritas_os/tests/test_one_day_poc_smoke.py` that validate missing API key handling, API key non-exposure, capabilities summarization, suppression of raw exporter endpoints, non-200 failure behavior, and that default mode does not call mutation endpoints; no runtime governance/bind/RBAC/TrustLog behavior was changed and no new required dependencies were introduced. 

### Testing

- Ran `pytest -q veritas_os/tests/test_one_day_poc_smoke.py` and the smoke-script unit tests passed. 
- Ran `pytest -q veritas_os/tests/test_observability_capabilities.py` and `pytest -q veritas_os/tests/test_trace_span_chain.py` and both suites passed. 
- Ran bilingual docs checks where direct `python scripts/check_bilingual_docs.py` initially failed due to module import resolution, and the module-invocation `python -m scripts.quality.check_bilingual_docs` was run and returned success, confirming docs consistency checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb44a341f08326a3e4e283adada38c)