### PR TITLE
fix(demo): align one-day PoC smoke script with capabilities schema

### DIFF
--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -34,6 +34,7 @@ This PoC is intended to show enforceable boundaries and auditable behavior, not 
 
 1. Running VERITAS API server.
 2. API key with read permissions for observability endpoints.
+   - The API key must map to a role with `governance_read` permission, such as `auditor` or `admin`.
 3. Local environment variables:
    - `VERITAS_BASE_URL` (optional, default `http://127.0.0.1:8000`)
    - `VERITAS_API_KEY` (required)

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -36,6 +36,7 @@
 
 1. VERITAS API サーバーが起動済みであること。
 2. observability エンドポイントを読める API キーがあること。
+   - API キーは `governance_read` 権限を含む role（例: `auditor` / `admin`）に紐づいている必要があります。
 3. 環境変数:
    - `VERITAS_BASE_URL`（任意、既定値 `http://127.0.0.1:8000`）
    - `VERITAS_API_KEY`（必須）

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -44,12 +44,24 @@ def _http_get_json(base_url: str, path: str, api_key: str) -> tuple[int, dict[st
 
 
 def _extract_observability_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    observability = payload.get("observability")
+    if not isinstance(observability, dict):
+        observability = {}
+
+    structured = observability.get("structured_logging")
+    if not isinstance(structured, dict):
+        structured = {}
+
+    tracing = observability.get("tracing")
+    if not isinstance(tracing, dict):
+        tracing = {}
+
     return {
-        "structured_logging_format": payload.get("structured_logging_format"),
-        "opentelemetry_importable": payload.get("opentelemetry_importable"),
-        "exporter_configured": payload.get("exporter_configured"),
-        "governance_span_chain": payload.get("governance_span_chain"),
-        "rbac_denial_audit_append_visibility": payload.get(
+        "structured_logging_format": structured.get("format"),
+        "opentelemetry_importable": tracing.get("opentelemetry_importable"),
+        "exporter_configured": tracing.get("exporter_configured"),
+        "governance_span_chain": tracing.get("governance_span_chain"),
+        "rbac_denial_audit_append_visibility": tracing.get(
             "rbac_denial_audit_append_visibility"
         ),
     }

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -40,12 +40,31 @@ def api_server(monkeypatch: pytest.MonkeyPatch) -> Any:
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
                 payload = {
-                    "structured_logging_format": "json",
-                    "opentelemetry_importable": True,
-                    "exporter_configured": False,
-                    "exporter_endpoint": "http://secret-exporter:4317",
-                    "governance_span_chain": True,
-                    "rbac_denial_audit_append_visibility": True,
+                    "ok": True,
+                    "observability": {
+                        "structured_logging": {
+                            "available": True,
+                            "format": "json",
+                            "trace_id_supported": True,
+                        },
+                        "tracing": {
+                            "helper_available": True,
+                            "opentelemetry_importable": True,
+                            "exporter_configured": False,
+                            "no_op_fallback": True,
+                            "governance_span_chain": True,
+                            "rbac_denial_events": True,
+                            "rbac_denial_audit_append_visibility": True,
+                        },
+                        "docs": {
+                            "governance_trace_span_chain_en": (
+                                "docs/en/operations/governance-trace-span-chain.md"
+                            ),
+                            "governance_trace_span_chain_ja": (
+                                "docs/ja/operations/governance-trace-span-chain.md"
+                            ),
+                        },
+                    },
                 }
                 self.wfile.write(json.dumps(payload).encode("utf-8"))
                 return
@@ -74,6 +93,7 @@ def api_server(monkeypatch: pytest.MonkeyPatch) -> Any:
         yield url, state
     finally:
         server.shutdown()
+        server.server_close()
         thread.join(timeout=2)
 
 
@@ -122,8 +142,9 @@ def test_uses_x_api_key_header_only(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     assert status == 200
-    assert captured_headers.get("X-api-key") == "key-for-test"
-    assert "Authorization" not in captured_headers
+    lowered = {k.lower(): v for k, v in captured_headers.items()}
+    assert lowered.get("x-api-key") == "key-for-test"
+    assert "authorization" not in lowered
 
 
 def test_script_does_not_print_api_key(api_server: Any) -> None:
@@ -151,9 +172,12 @@ def test_capabilities_response_is_summarized(api_server: Any) -> None:
     assert payload["capabilities_ok"] is True
     assert payload["observability"]["structured_logging_format"] == "json"
     assert payload["observability"]["opentelemetry_importable"] is True
+    assert payload["observability"]["exporter_configured"] is False
+    assert payload["observability"]["governance_span_chain"] is True
+    assert payload["observability"]["rbac_denial_audit_append_visibility"] is True
 
 
-def test_exporter_endpoint_raw_value_is_not_printed(api_server: Any) -> None:
+def test_unexpected_exporter_endpoint_raw_value_is_not_printed(api_server: Any) -> None:
     base_url, _ = api_server
     result = _run_script(
         {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
@@ -162,6 +186,18 @@ def test_exporter_endpoint_raw_value_is_not_printed(api_server: Any) -> None:
 
     assert result.returncode == 0
     assert "secret-exporter" not in result.stdout
+
+
+def test_fixture_does_not_expose_exporter_endpoint_field(api_server: Any) -> None:
+    base_url, _ = api_server
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--json",
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert "exporter_endpoint" not in payload["observability"]
 
 
 def test_non_200_capabilities_fails_nonzero() -> None:


### PR DESCRIPTION
### Motivation
- Fix the mismatch between the demo smoke script and the real `/v1/observability/capabilities` nested response so the demo and tests validate actual API contracts.
- Ensure the smoke summary is an allowlist extraction (not a full payload copy) and that raw secrets/endpoint values are not leaked in output.
- Preserve runtime semantics (read-only demo, no governance/RBAC/TrustLog behavioral changes) while improving test fidelity and docs clarity.

### Description
- Update `scripts/demo/one_day_poc_smoke.py` `_extract_observability_summary()` to read `observability.structured_logging.format` and `observability.tracing.*` instead of flat keys and to only extract allowlisted fields. 
- Replace the test fixture in `veritas_os/tests/test_one_day_poc_smoke.py` with a nested `ok`/`observability` payload that matches the real endpoint and remove non-contract flat fields such as `exporter_endpoint`. 
- Make `test_uses_x_api_key_header_only` assertions case-insensitive and assert `Authorization` is not present, and add `server.server_close()` in the fixture teardown. 
- Add assertions that nested tracing fields (`opentelemetry_importable`, `exporter_configured`, `governance_span_chain`, `rbac_denial_audit_append_visibility`) are summarized and that the raw exporter endpoint is not exposed. 
- Clarify prerequisites in `docs/en/poc/one-day-poc-walkthrough.md` and `docs/ja/poc/one-day-poc-walkthrough.md` to require an API key mapped to a role with `governance_read` (e.g., `auditor`/`admin`).
- This change intentionally does not alter runtime governance, bind, RBAC, TrustLog, or API semantics.

### Testing
- Ran `pytest -q veritas_os/tests/test_one_day_poc_smoke.py` and all tests passed (`8 passed`).
- Ran `pytest -q veritas_os/tests/test_observability_capabilities.py` and all tests passed (`11 passed`).
- Ran `pytest -q veritas_os/tests/test_trace_span_chain.py` and all tests passed (`11 passed`).
- Ran `python -m scripts.quality.check_bilingual_docs` and the bilingual docs check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb527e59708326a32b76e0a56aca6e)