### PR TITLE
feat(demo): generate sanitized one-day PoC evidence packets

### DIFF
--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -45,6 +45,8 @@ This PoC is intended to show enforceable boundaries and auditable behavior, not 
 
 1. Run:
    - `python scripts/demo/one_day_poc_smoke.py --json`
+   - `python scripts/demo/one_day_poc_smoke.py --json --evidence-json /tmp/veritas_poc_evidence.json`
+   - `python scripts/demo/one_day_poc_smoke.py --evidence-md /tmp/veritas_poc_evidence.md`
 2. Confirm `capabilities_ok: true`.
 3. Confirm summary includes:
    - structured logging format
@@ -82,6 +84,7 @@ This PoC is intended to show enforceable boundaries and auditable behavior, not 
 
 - [ ] `GET /v1/observability/capabilities` response captured.
 - [ ] Smoke script JSON summary captured.
+- [ ] Sanitized evidence packet (`--evidence-json` / `--evidence-md`) generated for external reviewers.
 - [ ] RBAC denial example with audit visibility.
 - [ ] Human approval evidence for governance update path.
 - [ ] Bind Boundary outcome + receipt sample.
@@ -102,6 +105,28 @@ This PoC is intended to show enforceable boundaries and auditable behavior, not 
 - No cryptographic human approval signatures.
 - TrustLog durability characteristics remain exactly as implemented today.
 - Optional mutation path is disabled by default in smoke tooling.
+- Evidence packet is PoC evidence only, not production certification.
+
+## Evidence packet contents and exclusions
+
+The one-day smoke script can generate a sanitized evidence packet for external sharing:
+
+- `--evidence-json PATH`: writes a structured JSON evidence packet.
+- `--evidence-md PATH`: writes a reviewer-friendly Markdown packet.
+
+Included in the packet:
+
+- Allowlisted summary signals for observability capabilities.
+- Read-only check status for observability and governance policy read.
+- Documentation links and explicit PoC non-goals.
+
+Not included in the packet:
+
+- API keys or any `X-API-Key` values.
+- Raw exporter endpoint URLs.
+- Raw environment values.
+- Raw request/response payload bodies.
+- Tokens, cookies, passwords, secrets, or authorization headers.
 
 ## Suggested talk track for external reviewers
 

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -47,6 +47,8 @@
 
 1. 実行:
    - `python scripts/demo/one_day_poc_smoke.py --json`
+   - `python scripts/demo/one_day_poc_smoke.py --json --evidence-json /tmp/veritas_poc_evidence.json`
+   - `python scripts/demo/one_day_poc_smoke.py --evidence-md /tmp/veritas_poc_evidence.md`
 2. `capabilities_ok: true` を確認。
 3. 要約に以下が含まれることを確認:
    - structured logging format
@@ -84,6 +86,7 @@
 
 - [ ] `GET /v1/observability/capabilities` のレスポンス取得
 - [ ] スモークスクリプト JSON 要約の取得
+- [ ] 外部レビュー提出用の sanitized evidence packet（`--evidence-json` / `--evidence-md`）生成
 - [ ] RBAC deny と監査可視性の例
 - [ ] governance update の human approval 証跡
 - [ ] Bind Boundary の結果と receipt サンプル
@@ -104,6 +107,28 @@
 - 暗号学的な human approval 署名は含まない。
 - TrustLog durability 特性は現行実装のままである。
 - スモークツールの mutation 経路は既定で無効。
+- evidence packet は PoC 証跡用であり、本番認証（production certification）ではない。
+
+## Evidence packet の内容と非包含項目
+
+one-day smoke script は、外部共有向けに sanitize 済み evidence packet を生成できます。
+
+- `--evidence-json PATH`: 構造化 JSON evidence packet を出力
+- `--evidence-md PATH`: レビュアー向け Markdown packet を出力
+
+含まれるもの:
+
+- observability capability の allowlist 要約シグナル
+- observability と governance policy read の read-only チェック結果
+- ドキュメント参照リンクと PoC 非目標の明示
+
+含まれないもの:
+
+- API キーおよび `X-API-Key` の値
+- raw exporter endpoint URL
+- raw 環境変数値
+- raw request/response payload 本文
+- token / cookie / password / secret / authorization header
 
 ## 外部レビュアー向け推奨トークトラック
 

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -7,11 +7,15 @@ import argparse
 import json
 import os
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from urllib import error, request
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8000"
 DEFAULT_TIMEOUT_SECONDS = 5.0
+EVIDENCE_PACKET_TYPE = "veritas_one_day_poc_evidence"
+EVIDENCE_SCHEMA_VERSION = "one_day_poc_evidence.v1"
 
 
 def _bool_env(name: str, *, default: bool = False) -> bool:
@@ -71,7 +75,114 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run VERITAS one-day PoC smoke checks")
     parser.add_argument("--json", action="store_true", dest="json_output")
     parser.add_argument("--base-url", default=os.getenv("VERITAS_BASE_URL", DEFAULT_BASE_URL))
+    parser.add_argument("--evidence-json", type=Path, dest="evidence_json")
+    parser.add_argument("--evidence-md", type=Path, dest="evidence_md")
     return parser
+
+
+def _write_text_file(path: Path, content: str) -> None:
+    """Write UTF-8 content to the target path."""
+    path.write_text(content, encoding="utf-8")
+
+
+def _build_evidence_packet(
+    observability: dict[str, Any],
+    capabilities_status: int,
+    capabilities_ok: bool,
+    policy_status: int,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Build a sanitized one-day PoC evidence packet."""
+    return {
+        "packet_type": EVIDENCE_PACKET_TYPE,
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "read_only": True,
+        "mutation_allowed": False,
+        "checks": {
+            "observability_capabilities": {
+                "status_code": capabilities_status,
+                "ok": capabilities_ok,
+                "summary": observability,
+            },
+            "governance_policy_read": {
+                "status_code": policy_status,
+                "required": False,
+            },
+        },
+        "docs": {
+            "walkthrough_en": "docs/en/poc/one-day-poc-walkthrough.md",
+            "walkthrough_ja": "docs/ja/poc/one-day-poc-walkthrough.md",
+            "trace_span_chain_en": "docs/en/operations/governance-trace-span-chain.md",
+            "trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md",
+        },
+        "non_goals": [
+            "not_a_production_deployment_reference",
+            "no_jaeger_grafana_tempo_otlp_deployment",
+            "no_cryptographic_human_approval_signature",
+            "no_new_trustlog_durability_guarantee",
+        ],
+        "warnings": warnings,
+    }
+
+
+def _build_evidence_markdown(evidence: dict[str, Any]) -> str:
+    """Render a sanitized evidence packet as Markdown."""
+    checks = evidence["checks"]
+    observability_check = checks["observability_capabilities"]
+    observability = observability_check["summary"]
+    observability_result = "PASS" if observability_check["ok"] else "FAIL"
+    docs = evidence["docs"]
+    lines = [
+        "# VERITAS One-Day PoC Evidence Packet",
+        "",
+        f"Generated at: {evidence['generated_at']}",
+        f"Read-only: {str(evidence['read_only']).lower()}",
+        f"Mutation allowed: {str(evidence['mutation_allowed']).lower()}",
+        "",
+        "## Summary",
+        f"- Observability capabilities: {observability_result}",
+        f"- Structured logging: {observability.get('structured_logging_format')}",
+        f"- OpenTelemetry importable: {observability.get('opentelemetry_importable')}",
+        f"- Exporter configured: {observability.get('exporter_configured')}",
+        f"- Governance span chain: {observability.get('governance_span_chain')}",
+        (
+            "- RBAC denial audit append visibility: "
+            f"{observability.get('rbac_denial_audit_append_visibility')}"
+        ),
+        "",
+        "## Checks",
+        "### Observability Capabilities",
+        f"- Status: {observability_check['status_code']}",
+        f"- Result: {observability_result}",
+        "",
+        "### Governance Policy Read",
+        f"- Status: {checks['governance_policy_read']['status_code']}",
+        f"- Required: {str(checks['governance_policy_read']['required']).lower()}",
+        "",
+        "## Evidence Links",
+        f"- One-day walkthrough EN: {docs['walkthrough_en']}",
+        f"- One-day walkthrough JA: {docs['walkthrough_ja']}",
+        f"- Governance trace span chain EN: {docs['trace_span_chain_en']}",
+        f"- Governance trace span chain JA: {docs['trace_span_chain_ja']}",
+        "",
+        "## Non-goals / limitations",
+    ]
+    lines.extend(f"- {item}" for item in evidence["non_goals"])
+    lines.extend(
+        [
+            "",
+            "## Security boundary",
+            "- API key not included.",
+            "- Raw exporter endpoint not included.",
+            "- Raw env values not included.",
+            "- Request/response raw bodies not included.",
+        ]
+    )
+    if evidence["warnings"]:
+        lines.extend(["", "## Warnings"])
+        lines.extend(f"- {warning}" for warning in evidence["warnings"])
+    return "\n".join(lines) + "\n"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -125,6 +236,32 @@ def main(argv: list[str] | None = None) -> int:
         "docs": docs,
         "warnings": warnings,
     }
+    evidence = _build_evidence_packet(
+        observability=observability,
+        capabilities_status=capabilities_status,
+        capabilities_ok=capabilities_ok,
+        policy_status=policy_status,
+        warnings=warnings,
+    )
+
+    if args.evidence_json:
+        try:
+            _write_text_file(
+                args.evidence_json,
+                json.dumps(evidence, ensure_ascii=False, indent=2) + "\n",
+            )
+        except OSError as exc:
+            print(f"ERROR: failed to write evidence JSON: {exc}", file=sys.stderr)
+            return 3
+        print(f"Wrote sanitized evidence JSON: {args.evidence_json}")
+
+    if args.evidence_md:
+        try:
+            _write_text_file(args.evidence_md, _build_evidence_markdown(evidence))
+        except OSError as exc:
+            print(f"ERROR: failed to write evidence Markdown: {exc}", file=sys.stderr)
+            return 3
+        print(f"Wrote sanitized evidence Markdown: {args.evidence_md}")
 
     if args.json_output:
         print(json.dumps(summary, ensure_ascii=False, separators=(",", ":")))

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -221,3 +221,74 @@ def test_default_mode_does_not_call_mutation_endpoints(api_server: Any) -> None:
 
     assert result.returncode == 0
     assert state["mutation_called"] is False
+
+
+def test_evidence_json_is_created_and_sanitized(api_server: Any, tmp_path: Path) -> None:
+    base_url, _ = api_server
+    output_path = tmp_path / "evidence.json"
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-api-key", "VERITAS_BASE_URL": base_url},
+        "--json",
+        "--evidence-json",
+        str(output_path),
+    )
+
+    assert result.returncode == 0
+    assert output_path.exists()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "one_day_poc_evidence.v1"
+    assert payload["checks"]["observability_capabilities"]["summary"] == {
+        "structured_logging_format": "json",
+        "opentelemetry_importable": True,
+        "exporter_configured": False,
+        "governance_span_chain": True,
+        "rbac_denial_audit_append_visibility": True,
+    }
+    serialized = output_path.read_text(encoding="utf-8")
+    assert "test-api-key" not in serialized
+    assert "secret-exporter" not in serialized
+    assert "token" not in serialized.lower()
+    assert "exporter_endpoint" not in serialized
+
+
+def test_evidence_markdown_is_created_and_sanitized(
+    api_server: Any, tmp_path: Path
+) -> None:
+    base_url, _ = api_server
+    output_path = tmp_path / "evidence.md"
+    result = _run_script(
+        {"VERITAS_API_KEY": "another-secret-key", "VERITAS_BASE_URL": base_url},
+        "--evidence-md",
+        str(output_path),
+    )
+
+    assert result.returncode == 0
+    assert output_path.exists()
+    content = output_path.read_text(encoding="utf-8")
+    assert "# VERITAS One-Day PoC Evidence Packet" in content
+    assert "another-secret-key" not in content
+    assert "secret-exporter" not in content
+    assert "token" not in content.lower()
+
+
+def test_missing_api_key_does_not_create_evidence_file(tmp_path: Path) -> None:
+    output_path = tmp_path / "evidence.json"
+    result = _run_script(
+        {"VERITAS_API_KEY": ""},
+        "--evidence-json",
+        str(output_path),
+    )
+    assert result.returncode != 0
+    assert not output_path.exists()
+
+
+def test_evidence_write_failure_exits_nonzero(api_server: Any, tmp_path: Path) -> None:
+    base_url, _ = api_server
+    output_path = tmp_path / "missing" / "dir" / "evidence.json"
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--evidence-json",
+        str(output_path),
+    )
+    assert result.returncode != 0
+    assert not output_path.exists()


### PR DESCRIPTION
### Motivation
- Extend the one-day PoC smoke script to produce an external-reviewer-friendly, sanitized evidence packet (JSON and Markdown) that can be submitted as a PoC deliverable.
- Preserve read-only behavior for demos and avoid any runtime mutation of governance, bind, RBAC, or TrustLog semantics while providing explicit warnings when mutation flags are present.
- Security-first: the evidence packet must never contain API keys, raw exporter endpoints, tokens, cookies, secrets, raw env values, or full raw request/response bodies and is explicitly a PoC artifact not production certification.

### Description
- Adds `--evidence-json PATH` and `--evidence-md PATH` to `scripts/demo/one_day_poc_smoke.py`, implements a sanitized JSON evidence schema (`packet_type`, `schema_version`, `generated_at`, read-only flags, allowlisted `checks` summary) and a Markdown renderer for human reviewers, while preserving existing `--json` stdout behavior.
- Evidence building uses stdlib only, `pathlib.Path` for safe file writes, returns nonzero on write errors, and prints only short messages to stdout when evidence files are written; raw capability responses are not copied and only allowlisted summaries are included.
- Adds tests in `veritas_os/tests/test_one_day_poc_smoke.py` covering evidence JSON/Markdown creation, `schema_version` presence, absence of API keys/secrets/exporter endpoints/tokens, missing-API-key behavior (no leftover file), file-write failure exit code, and non-mutation guarantees.
- Updates English and Japanese walkthrough docs to document the new evidence flags, what is included, and what is explicitly excluded; no new runtime dependencies were added and runtime governance semantics were not changed.

### Testing
- Ran `pytest -q veritas_os/tests/test_one_day_poc_smoke.py` and all tests passed (12 passed). 
- Ran `pytest -q veritas_os/tests/test_observability_capabilities.py` and `pytest -q veritas_os/tests/test_trace_span_chain.py` and both suites passed (11 passed each). 
- Ran the bilingual docs quality check with `python -m scripts.quality.check_bilingual_docs` and it passed. 
- The changes include added unit tests which were executed and validated the evidence packet creation and sanitization behavior described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb62cbd5948326b87cd8d170862e34)