### PR TITLE
docs(poc): add sanitized sample one-day PoC evidence packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ See full walkthroughs:
 - [One-Day VERITAS PoC Walkthrough (EN)](docs/en/poc/one-day-poc-walkthrough.md)
 - [One-Day VERITAS PoC Walkthrough (JA)](docs/ja/poc/one-day-poc-walkthrough.md)
 
+Sample sanitized evidence packets are available for reviewers who want to preview the deliverable format before running the smoke script.
+
+- [Sample One-Day PoC Evidence (JSON)](docs/en/poc/sample-one-day-poc-evidence.json)
+- [Sample One-Day PoC Evidence (Markdown, EN)](docs/en/poc/sample-one-day-poc-evidence.md)
+- [Sample One-Day PoC Evidence (Markdown, JA)](docs/ja/poc/sample-one-day-poc-evidence.md)
+
 ## AML/KYC Reviewer Walkthrough Quickstart
 
 VERITAS now includes a deterministic AML/KYC reviewer walkthrough for external reviewers, enterprise stakeholders, and investors who need to verify value in under 10 minutes.

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -45,6 +45,7 @@
 | Guides: Bundle promotion | `docs/en/guides/governance-policy-bundle-promotion.md` | `docs/ja/guides/governance-policy-bundle-promotion.md` | JA explanation / EN canonical | ポリシーバンドル昇格 |
 | Guides: PoC quickstart | `docs/en/guides/poc-pack-financial-quickstart.md` | `docs/ja/guides/poc-pack-financial-quickstart.md` | EN/JA fully paired | JAファースト導線 |
 | PoC: One-day walkthrough | `docs/en/poc/one-day-poc-walkthrough.md` | `docs/ja/poc/one-day-poc-walkthrough.md` | JA explanation / EN canonical | 外部レビュー向け1-dayデモ導線 + evidence packet生成 |
+| PoC: Sample evidence packet | `docs/en/poc/sample-one-day-poc-evidence.json` / `docs/en/poc/sample-one-day-poc-evidence.md` | `docs/ja/poc/sample-one-day-poc-evidence.md` | JA explanation / EN canonical | 外部レビュー向けサンプル証跡 |
 | Positioning: AML/KYC | `docs/en/positioning/aml-kyc-beachhead-short-positioning.md` | `docs/ja/positioning/aml-kyc-beachhead-short-positioning.md` | JA explanation / EN canonical | 公開向け短縮版 |
 | Positioning: Public positioning | `docs/en/positioning/public-positioning.md` | `docs/ja/positioning/public-positioning.md` | JA explanation / EN canonical | 内部再評価含む |
 | UI docs | `docs/ui/README_UI.md` | `docs/ui/PREVIEW_PAGES_JP.md` | Mixed | UI本体は EN、プレビュー案内は JA |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,6 +39,7 @@
 | Governance Artifact Lifecycle | [Governance artifact lifecycle (EN)](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle (JA)](ja/governance/governance-artifact-lifecycle.md) |
 | Guides | [Guides (EN)](en/guides/) | [Guides (JA)](ja/guides/) |
 | One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough (EN)](en/poc/one-day-poc-walkthrough.md) — Includes sanitized JSON/Markdown evidence packet generation. | [One-Day VERITAS PoC Walkthrough (JA)](ja/poc/one-day-poc-walkthrough.md) — sanitized evidence packet（JSON/Markdown）生成を含む。 |
+| One-Day PoC Sample Evidence Packet | [Sample one-day PoC evidence (EN JSON/Markdown)](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（JA Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
 | AI-Assisted Development | [AI-assisted development guardrails (EN)](en/development/ai-assisted-development.md) | [AI支援開発ガードレール (JA)](ja/development/ai-assisted-development.md) |
 | AI Review Matrix | [AI review matrix (EN)](en/development/ai-review-matrix.md) | [AIレビューマトリクス (JA)](ja/development/ai-review-matrix.md) |
 | Recent hardening notes | [Recent hardening notes (EN)](en/development/recent-hardening.md) | [直近のハードニング整理 (JA)](ja/development/recent-hardening.md) |
@@ -99,6 +100,7 @@
 | Governance Artifact Lifecycle | [Governance artifact lifecycle（英語正本）](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle（日本語解説）](ja/governance/governance-artifact-lifecycle.md) |
 | ガイド | [Guides（英語正本）](en/guides/) | [Guides（日本語）](ja/guides/) |
 | One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough（英語正本）](en/poc/one-day-poc-walkthrough.md) | [One-Day VERITAS PoC Walkthrough（日本語）](ja/poc/one-day-poc-walkthrough.md) |
+| One-Day PoC サンプル証跡パケット | [Sample one-day PoC evidence（英語 JSON/Markdown）](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（日本語 Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
 | AI支援開発 | [AI-assisted development guardrails（英語正本）](en/development/ai-assisted-development.md) | [AI支援開発ガードレール（日本語）](ja/development/ai-assisted-development.md) |
 | AIレビューマトリクス | [AI review matrix（英語正本）](en/development/ai-review-matrix.md) | [AIレビューマトリクス（日本語）](ja/development/ai-review-matrix.md) |
 | 直近のハードニング整理 | [Recent hardening notes（英語正本）](en/development/recent-hardening.md) | [直近のハードニング整理（日本語）](ja/development/recent-hardening.md) |

--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -30,6 +30,8 @@ This walkthrough provides a one-day, external-reviewer-friendly PoC flow for dem
 
 This PoC is intended to show enforceable boundaries and auditable behavior, not final production packaging. The sanitized evidence packet is the recommended deliverable for external review.
 
+Before running the smoke script, reviewers can preview the final deliverable format using the sample packet fixtures: `docs/en/poc/sample-one-day-poc-evidence.json`, `docs/en/poc/sample-one-day-poc-evidence.md`, and `docs/ja/poc/sample-one-day-poc-evidence.md`. These samples are dummy/sanitized/fixture-based and are not live environment evidence.
+
 ## Prerequisites
 
 1. Running VERITAS API server.

--- a/docs/en/poc/sample-one-day-poc-evidence.json
+++ b/docs/en/poc/sample-one-day-poc-evidence.json
@@ -1,0 +1,37 @@
+{
+  "packet_type": "veritas_one_day_poc_evidence",
+  "schema_version": "one_day_poc_evidence.v1",
+  "generated_at": "2026-01-01T00:00:00Z",
+  "read_only": true,
+  "mutation_allowed": false,
+  "checks": {
+    "observability_capabilities": {
+      "status_code": 200,
+      "ok": true,
+      "summary": {
+        "structured_logging_format": "json",
+        "opentelemetry_importable": true,
+        "exporter_configured": false,
+        "governance_span_chain": true,
+        "rbac_denial_audit_append_visibility": true
+      }
+    },
+    "governance_policy_read": {
+      "status_code": 200,
+      "required": false
+    }
+  },
+  "docs": {
+    "walkthrough_en": "docs/en/poc/one-day-poc-walkthrough.md",
+    "walkthrough_ja": "docs/ja/poc/one-day-poc-walkthrough.md",
+    "trace_span_chain_en": "docs/en/operations/governance-trace-span-chain.md",
+    "trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md"
+  },
+  "non_goals": [
+    "not_a_production_deployment_reference",
+    "no_jaeger_grafana_tempo_otlp_deployment",
+    "no_cryptographic_human_approval_signature",
+    "no_new_trustlog_durability_guarantee"
+  ],
+  "warnings": []
+}

--- a/docs/en/poc/sample-one-day-poc-evidence.md
+++ b/docs/en/poc/sample-one-day-poc-evidence.md
@@ -1,0 +1,50 @@
+# VERITAS One-Day PoC Evidence Packet — Sample
+
+> This is a fully dummy, sanitized sample packet for format preview only. It is not evidence from any live or production environment.
+
+Generated at: 2026-01-01T00:00:00Z
+Read-only: true
+Mutation allowed: false
+
+## Summary
+
+- Packet type: `veritas_one_day_poc_evidence`
+- Schema version: `one_day_poc_evidence.v1`
+- Observability capabilities check result: PASS
+- Governance policy read check status: 200
+
+## Checks
+
+### Observability Capabilities
+
+- Status: 200
+- Result: PASS
+- Structured logging format: `json`
+- OpenTelemetry importable: `true`
+- Exporter configured: `false`
+- Governance span chain: `true`
+- RBAC denial audit append visibility: `true`
+
+### Governance Policy Read
+
+- Status: 200
+- Required: `false`
+
+## Evidence Links
+
+- One-day walkthrough EN: `docs/en/poc/one-day-poc-walkthrough.md`
+- One-day walkthrough JA: `docs/ja/poc/one-day-poc-walkthrough.md`
+- Governance trace span chain EN: `docs/en/operations/governance-trace-span-chain.md`
+- Governance trace span chain JA: `docs/ja/operations/governance-trace-span-chain.md`
+
+## Non-goals / limitations
+
+- `not_a_production_deployment_reference`
+- `no_jaeger_grafana_tempo_otlp_deployment`
+- `no_cryptographic_human_approval_signature`
+- `no_new_trustlog_durability_guarantee`
+
+## Security boundary
+
+This sample contains no API keys, raw endpoints, tokens, cookies, passwords, secrets, or raw request/response bodies.
+

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -32,6 +32,8 @@
 
 この PoC の目的は、最終パッケージではなく「強制可能な境界」と「監査可能性」を示すことです。外部レビュー提出用の推奨成果物は sanitized evidence packet です。
 
+スモークスクリプト実行前に、提出物の形式はサンプル証跡で事前確認できます: `docs/en/poc/sample-one-day-poc-evidence.json`、`docs/en/poc/sample-one-day-poc-evidence.md`、`docs/ja/poc/sample-one-day-poc-evidence.md`。これらは dummy / sanitized / fixture-based のサンプルであり、実環境の証跡ではありません。
+
 ## 前提条件
 
 1. VERITAS API サーバーが起動済みであること。

--- a/docs/ja/poc/sample-one-day-poc-evidence.md
+++ b/docs/ja/poc/sample-one-day-poc-evidence.md
@@ -1,0 +1,51 @@
+# VERITAS One-Day PoC Evidence Packet — Sample（日本語版）
+
+> この文書は英語版サンプル `docs/en/poc/sample-one-day-poc-evidence.md` に対応する日本語版です。
+> 実環境の証跡ではなく、完全なダミー / sanitized / fixture-based サンプルです。
+
+生成時刻: 2026-01-01T00:00:00Z
+読み取り専用: true
+変更許可: false
+
+## Summary（概要）
+
+- Packet type: `veritas_one_day_poc_evidence`
+- Schema version: `one_day_poc_evidence.v1`
+- 観測性チェック結果: PASS
+- Governance policy read チェックのステータス: 200
+
+## Checks
+
+### Observability Capabilities
+
+- Status: 200
+- Result: PASS
+- Structured logging format: `json`
+- OpenTelemetry importable: `true`
+- Exporter configured: `false`
+- Governance span chain: `true`
+- RBAC denial audit append visibility: `true`
+
+### Governance Policy Read
+
+- Status: 200
+- Required: `false`
+
+## Evidence Links
+
+- One-day walkthrough EN: `docs/en/poc/one-day-poc-walkthrough.md`
+- One-day walkthrough JA: `docs/ja/poc/one-day-poc-walkthrough.md`
+- Governance trace span chain EN: `docs/en/operations/governance-trace-span-chain.md`
+- Governance trace span chain JA: `docs/ja/operations/governance-trace-span-chain.md`
+
+## Non-goals / limitations
+
+- `not_a_production_deployment_reference`
+- `no_jaeger_grafana_tempo_otlp_deployment`
+- `no_cryptographic_human_approval_signature`
+- `no_new_trustlog_durability_guarantee`
+
+## Security boundary
+
+このサンプルには API key / token / secret / password / cookie / raw endpoint / raw request body / raw response body を含みません。
+

--- a/veritas_os/tests/test_docs_poc_samples.py
+++ b/veritas_os/tests/test_docs_poc_samples.py
@@ -1,0 +1,44 @@
+"""Docs checks for one-day PoC sample evidence packet fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+SAMPLE_JSON = Path("docs/en/poc/sample-one-day-poc-evidence.json")
+SAMPLE_MD_EN = Path("docs/en/poc/sample-one-day-poc-evidence.md")
+SAMPLE_MD_JA = Path("docs/ja/poc/sample-one-day-poc-evidence.md")
+FORBIDDEN_STRINGS = (
+    "authorization",
+    "x-api-key",
+    "http://secret",
+    "collector.internal",
+)
+
+
+def test_sample_evidence_json_has_expected_schema_fields() -> None:
+    payload = json.loads(SAMPLE_JSON.read_text(encoding="utf-8"))
+
+    assert payload["packet_type"] == "veritas_one_day_poc_evidence"
+    assert payload["schema_version"] == "one_day_poc_evidence.v1"
+    assert payload["generated_at"] == "2026-01-01T00:00:00Z"
+    assert payload["read_only"] is True
+    assert payload["mutation_allowed"] is False
+    assert payload["checks"]["observability_capabilities"]["status_code"] == 200
+    assert payload["checks"]["observability_capabilities"]["ok"] is True
+    assert payload["checks"]["governance_policy_read"]["status_code"] == 200
+
+
+def test_sample_evidence_json_forbidden_strings_absent() -> None:
+    content = SAMPLE_JSON.read_text(encoding="utf-8").lower()
+
+    for value in FORBIDDEN_STRINGS:
+        assert value not in content
+
+
+def test_sample_evidence_markdown_forbidden_strings_absent() -> None:
+    for path in (SAMPLE_MD_EN, SAMPLE_MD_JA):
+        content = path.read_text(encoding="utf-8").lower()
+        for value in FORBIDDEN_STRINGS:
+            assert value not in content


### PR DESCRIPTION
### Motivation

- Provide external reviewers and stakeholders a fully dummy, sanitized sample One-Day PoC evidence packet so they can preview the deliverable format before running the smoke script.
- Ensure the sample is safe for public inspection by forbidding any runtime secrets, keys, raw endpoints, raw request/response bodies, real hostnames, or real customer/personal names.
- Keep this change strictly documentation-only so runtime code, smoke script behavior, API contracts, and governance semantics remain unchanged.

### Description

- Added a fixture JSON evidence packet `docs/en/poc/sample-one-day-poc-evidence.json` that matches the smoke script schema and includes the required fields (`packet_type`, `schema_version`, `generated_at` set to `2026-01-01T00:00:00Z`, `read_only: true`, `mutation_allowed: false`, `checks`, `docs`, `non_goals`, `warnings`).
- Added reviewer-facing Markdown samples `docs/en/poc/sample-one-day-poc-evidence.md` and `docs/ja/poc/sample-one-day-poc-evidence.md` with explicit notices that these are dummy/sanitized/fixture-based and contain no secrets.
- Updated discoverability by inserting links to the new samples in `README.md`, the docs hub `docs/INDEX.md`, and `docs/DOCUMENTATION_MAP.md`, and added guidance to the EN/JA walkthroughs `docs/en/poc/one-day-poc-walkthrough.md` and `docs/ja/poc/one-day-poc-walkthrough.md` that reviewers may preview the sample packet before running the smoke script.
- Added a lightweight docs test `veritas_os/tests/test_docs_poc_samples.py` that validates JSON schema fields and asserts forbidden markers are absent from the sample JSON/Markdown; no runtime code or new dependencies were introduced.

### Testing

- Ran bilingual docs validation with `python -m scripts.quality.check_bilingual_docs` and it passed (`[check-bilingual-docs] all checks passed`).
- Ran the one-day smoke script tests with `pytest -q veritas_os/tests/test_one_day_poc_smoke.py` and they passed (`12 passed`).
- Ran the new docs tests with `pytest -q veritas_os/tests/test_docs_poc_samples.py` and they passed (`3 passed`).
- All automated checks above succeeded and no runtime behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbb73595708326a879394fedddd48b)