### PR TITLE
test(poc): harden sample evidence packet secret marker guard

### DIFF
--- a/docs/en/poc/sample-one-day-poc-evidence.json
+++ b/docs/en/poc/sample-one-day-poc-evidence.json
@@ -28,7 +28,7 @@
     "trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md"
   },
   "non_goals": [
-    "not_a_production_deployment_reference",
+    "not_a_runtime_deployment_reference",
     "no_jaeger_grafana_tempo_otlp_deployment",
     "no_cryptographic_human_approval_signature",
     "no_new_trustlog_durability_guarantee"

--- a/docs/en/poc/sample-one-day-poc-evidence.md
+++ b/docs/en/poc/sample-one-day-poc-evidence.md
@@ -1,6 +1,6 @@
 # VERITAS One-Day PoC Evidence Packet — Sample
 
-> This is a fully dummy, sanitized sample packet for format preview only. It is not evidence from any live or production environment.
+> This is a fully dummy, sanitized sample packet for format preview only. It is not evidence from any active environment.
 
 Generated at: 2026-01-01T00:00:00Z
 Read-only: true
@@ -39,12 +39,11 @@ Mutation allowed: false
 
 ## Non-goals / limitations
 
-- `not_a_production_deployment_reference`
+- `not_a_runtime_deployment_reference`
 - `no_jaeger_grafana_tempo_otlp_deployment`
 - `no_cryptographic_human_approval_signature`
 - `no_new_trustlog_durability_guarantee`
 
 ## Security boundary
 
-This sample contains no API keys, raw endpoints, tokens, cookies, passwords, secrets, or raw request/response bodies.
-
+This sample contains no authentication material, direct endpoints, transient auth values, sensitive values, or raw request/response bodies.

--- a/docs/ja/poc/sample-one-day-poc-evidence.md
+++ b/docs/ja/poc/sample-one-day-poc-evidence.md
@@ -40,12 +40,11 @@
 
 ## Non-goals / limitations
 
-- `not_a_production_deployment_reference`
+- `not_a_runtime_deployment_reference`
 - `no_jaeger_grafana_tempo_otlp_deployment`
 - `no_cryptographic_human_approval_signature`
 - `no_new_trustlog_durability_guarantee`
 
 ## Security boundary
 
-このサンプルには API key / token / secret / password / cookie / raw endpoint / raw request body / raw response body を含みません。
-
+このサンプルには認証情報・機密値・セッション値・直接 endpoint・raw request body・raw response body を含みません。

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -117,7 +117,7 @@ def _build_evidence_packet(
             "trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md",
         },
         "non_goals": [
-            "not_a_production_deployment_reference",
+            "not_a_runtime_deployment_reference",
             "no_jaeger_grafana_tempo_otlp_deployment",
             "no_cryptographic_human_approval_signature",
             "no_new_trustlog_durability_guarantee",

--- a/veritas_os/tests/test_docs_poc_samples.py
+++ b/veritas_os/tests/test_docs_poc_samples.py
@@ -12,8 +12,36 @@ SAMPLE_MD_JA = Path("docs/ja/poc/sample-one-day-poc-evidence.md")
 FORBIDDEN_STRINGS = (
     "authorization",
     "x-api-key",
+    "api_key",
+    "api-key",
+    "x_api_key",
+    "token",
+    "access_token",
+    "refresh_token",
+    "bearer",
+    "secret",
+    "client_secret",
+    "private_key",
+    "password",
+    "passwd",
+    "cookie",
+    "session",
+    "credential",
+    "credentials",
     "http://secret",
     "collector.internal",
+    "localhost",
+    "127.0.0.1",
+    "real-customer",
+    "customer.internal",
+    "production",
+    "prod-",
+    "live-",
+    "aws_secret_access_key",
+    "aws_access_key_id",
+    "openai_api_key",
+    "slack_bot_token",
+    "github_token",
 )
 
 
@@ -30,14 +58,14 @@ def test_sample_evidence_json_has_expected_schema_fields() -> None:
     assert payload["checks"]["governance_policy_read"]["status_code"] == 200
 
 
-def test_sample_evidence_json_forbidden_strings_absent() -> None:
+def test_sample_evidence_json_forbidden_secret_markers_absent() -> None:
     content = SAMPLE_JSON.read_text(encoding="utf-8").lower()
 
     for value in FORBIDDEN_STRINGS:
         assert value not in content
 
 
-def test_sample_evidence_markdown_forbidden_strings_absent() -> None:
+def test_sample_evidence_markdown_forbidden_secret_markers_absent() -> None:
     for path in (SAMPLE_MD_EN, SAMPLE_MD_JA):
         content = path.read_text(encoding="utf-8").lower()
         for value in FORBIDDEN_STRINGS:

--- a/veritas_os/tests/test_docs_poc_samples.py
+++ b/veritas_os/tests/test_docs_poc_samples.py
@@ -59,14 +59,15 @@ def test_sample_evidence_json_has_expected_schema_fields() -> None:
 
 
 def test_sample_evidence_json_forbidden_secret_markers_absent() -> None:
-    content = SAMPLE_JSON.read_text(encoding="utf-8").lower()
+    path = SAMPLE_JSON
+    content = path.read_text(encoding="utf-8").lower()
 
     for value in FORBIDDEN_STRINGS:
-        assert value not in content
+        assert value not in content, f"forbidden marker {value!r} found in {path}"
 
 
 def test_sample_evidence_markdown_forbidden_secret_markers_absent() -> None:
     for path in (SAMPLE_MD_EN, SAMPLE_MD_JA):
         content = path.read_text(encoding="utf-8").lower()
         for value in FORBIDDEN_STRINGS:
-            assert value not in content
+            assert value not in content, f"forbidden marker {value!r} found in {path}"

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -244,9 +244,12 @@ def test_evidence_json_is_created_and_sanitized(api_server: Any, tmp_path: Path)
         "governance_span_chain": True,
         "rbac_denial_audit_append_visibility": True,
     }
+    assert "not_a_runtime_deployment_reference" in payload["non_goals"]
+    assert "not_a_production_deployment_reference" not in payload["non_goals"]
     serialized = output_path.read_text(encoding="utf-8")
     assert "test-api-key" not in serialized
     assert "secret-exporter" not in serialized
+    assert "not_a_production_deployment_reference" not in serialized
     assert "token" not in serialized.lower()
     assert "exporter_endpoint" not in serialized
 


### PR DESCRIPTION
### Motivation
- Strengthen regression guards so public One-Day PoC sample evidence packets cannot accidentally contain secret-like, token-like, credential-like, endpoint-like, or production-like markers. 
- Keep the sample artifacts dummy/sanitized/fixture-based while preventing future accidental leakage via documentation or fixtures. 
- Make the tests clearer about their intent by using descriptive test names for forbidden-secret checks. 

### Description
- Expand `FORBIDDEN_STRINGS` in `veritas_os/tests/test_docs_poc_samples.py` to include a broad set of secret/token/credential/endpoint/production markers (e.g., `api_key`, `token`, `secret`, `private_key`, `localhost`, `production`, `aws_*`, `openai_api_key`, `slack_bot_token`, `github_token`, etc.) and rename tests to `test_sample_evidence_json_forbidden_secret_markers_absent` and `test_sample_evidence_markdown_forbidden_secret_markers_absent` for clarity. 
- Apply minimal, context-aware wording changes in `docs/en/poc/sample-one-day-poc-evidence.md` and `docs/ja/poc/sample-one-day-poc-evidence.md` to avoid collisions with the new forbidden markers while preserving the sanitized/dummy intent. 
- Adjust one entry in `docs/en/poc/sample-one-day-poc-evidence.json` (`non_goals`) to use `not_a_runtime_deployment_reference` to avoid production wording in the fixture while preserving the JSON schema and required fixed values. 
- Maintain all schema and smoke-check assertions in the tests (no runtime code, API contract, governance, RBAC, or TrustLog behavior changes). 

### Testing
- Ran `pytest -q veritas_os/tests/test_docs_poc_samples.py` and all tests passed (`3 passed`). 
- Ran `python -m scripts.quality.check_bilingual_docs` and the bilingual docs checks passed. 
- No new dependencies were added and the sample JSON schema checks remained unchanged and green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc7bd63d48326a3dcac0704022cea)