### PR TITLE
docs(poc): add schema for one-day PoC evidence packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ See full walkthroughs:
 - [One-Day VERITAS PoC Walkthrough (JA)](docs/ja/poc/one-day-poc-walkthrough.md)
 
 Sample sanitized evidence packets are available for reviewers who want to preview the deliverable format before running the smoke script.
+Evidence JSON follows `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 
 - [Sample One-Day PoC Evidence (JSON)](docs/en/poc/sample-one-day-poc-evidence.json)
 - [Sample One-Day PoC Evidence (Markdown, EN)](docs/en/poc/sample-one-day-poc-evidence.md)

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -46,6 +46,7 @@
 | Guides: PoC quickstart | `docs/en/guides/poc-pack-financial-quickstart.md` | `docs/ja/guides/poc-pack-financial-quickstart.md` | EN/JA fully paired | JAファースト導線 |
 | PoC: One-day walkthrough | `docs/en/poc/one-day-poc-walkthrough.md` | `docs/ja/poc/one-day-poc-walkthrough.md` | JA explanation / EN canonical | 外部レビュー向け1-dayデモ導線 + evidence packet生成 |
 | PoC: Sample evidence packet | `docs/en/poc/sample-one-day-poc-evidence.json` / `docs/en/poc/sample-one-day-poc-evidence.md` | `docs/ja/poc/sample-one-day-poc-evidence.md` | JA explanation / EN canonical | 外部レビュー向けサンプル証跡 |
+| PoC: Evidence packet schema | `schemas/poc/one_day_poc_evidence.v1.schema.json` | — | EN canonical / machine-readable | One-Day PoC evidence JSON schema |
 | Positioning: AML/KYC | `docs/en/positioning/aml-kyc-beachhead-short-positioning.md` | `docs/ja/positioning/aml-kyc-beachhead-short-positioning.md` | JA explanation / EN canonical | 公開向け短縮版 |
 | Positioning: Public positioning | `docs/en/positioning/public-positioning.md` | `docs/ja/positioning/public-positioning.md` | JA explanation / EN canonical | 内部再評価含む |
 | UI docs | `docs/ui/README_UI.md` | `docs/ui/PREVIEW_PAGES_JP.md` | Mixed | UI本体は EN、プレビュー案内は JA |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -40,6 +40,7 @@
 | Guides | [Guides (EN)](en/guides/) | [Guides (JA)](ja/guides/) |
 | One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough (EN)](en/poc/one-day-poc-walkthrough.md) — Includes sanitized JSON/Markdown evidence packet generation. | [One-Day VERITAS PoC Walkthrough (JA)](ja/poc/one-day-poc-walkthrough.md) — sanitized evidence packet（JSON/Markdown）生成を含む。 |
 | One-Day PoC Sample Evidence Packet | [Sample one-day PoC evidence (EN JSON/Markdown)](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（JA Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
+| One-Day PoC Evidence Schema | [One-day PoC evidence schema (JSON Schema)](../schemas/poc/one_day_poc_evidence.v1.schema.json) | — |
 | AI-Assisted Development | [AI-assisted development guardrails (EN)](en/development/ai-assisted-development.md) | [AI支援開発ガードレール (JA)](ja/development/ai-assisted-development.md) |
 | AI Review Matrix | [AI review matrix (EN)](en/development/ai-review-matrix.md) | [AIレビューマトリクス (JA)](ja/development/ai-review-matrix.md) |
 | Recent hardening notes | [Recent hardening notes (EN)](en/development/recent-hardening.md) | [直近のハードニング整理 (JA)](ja/development/recent-hardening.md) |
@@ -101,6 +102,7 @@
 | ガイド | [Guides（英語正本）](en/guides/) | [Guides（日本語）](ja/guides/) |
 | One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough（英語正本）](en/poc/one-day-poc-walkthrough.md) | [One-Day VERITAS PoC Walkthrough（日本語）](ja/poc/one-day-poc-walkthrough.md) |
 | One-Day PoC サンプル証跡パケット | [Sample one-day PoC evidence（英語 JSON/Markdown）](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（日本語 Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
+| One-Day PoC 証跡スキーマ | [One-day PoC evidence schema（JSON Schema）](../schemas/poc/one_day_poc_evidence.v1.schema.json) | — |
 | AI支援開発 | [AI-assisted development guardrails（英語正本）](en/development/ai-assisted-development.md) | [AI支援開発ガードレール（日本語）](ja/development/ai-assisted-development.md) |
 | AIレビューマトリクス | [AI review matrix（英語正本）](en/development/ai-review-matrix.md) | [AIレビューマトリクス（日本語）](ja/development/ai-review-matrix.md) |
 | 直近のハードニング整理 | [Recent hardening notes（英語正本）](en/development/recent-hardening.md) | [直近のハードニング整理（日本語）](ja/development/recent-hardening.md) |

--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -31,6 +31,7 @@ This walkthrough provides a one-day, external-reviewer-friendly PoC flow for dem
 This PoC is intended to show enforceable boundaries and auditable behavior, not final production packaging. The sanitized evidence packet is the recommended deliverable for external review.
 
 Before running the smoke script, reviewers can preview the final deliverable format using the sample packet fixtures: `docs/en/poc/sample-one-day-poc-evidence.json`, `docs/en/poc/sample-one-day-poc-evidence.md`, and `docs/ja/poc/sample-one-day-poc-evidence.md`. These samples are dummy/sanitized/fixture-based and are not live environment evidence.
+The evidence JSON follows the repo-local schema at `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 
 ## Prerequisites
 

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -33,6 +33,7 @@
 この PoC の目的は、最終パッケージではなく「強制可能な境界」と「監査可能性」を示すことです。外部レビュー提出用の推奨成果物は sanitized evidence packet です。
 
 スモークスクリプト実行前に、提出物の形式はサンプル証跡で事前確認できます: `docs/en/poc/sample-one-day-poc-evidence.json`、`docs/en/poc/sample-one-day-poc-evidence.md`、`docs/ja/poc/sample-one-day-poc-evidence.md`。これらは dummy / sanitized / fixture-based のサンプルであり、実環境の証跡ではありません。
+evidence JSON は `schemas/poc/one_day_poc_evidence.v1.schema.json` に従います。
 
 ## 前提条件
 

--- a/schemas/poc/one_day_poc_evidence.v1.schema.json
+++ b/schemas/poc/one_day_poc_evidence.v1.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/poc/one_day_poc_evidence.v1.schema.json",
+  "title": "VERITAS One-Day PoC Evidence Packet",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "packet_type",
+    "schema_version",
+    "generated_at",
+    "read_only",
+    "mutation_allowed",
+    "checks",
+    "docs",
+    "non_goals",
+    "warnings"
+  ],
+  "properties": {
+    "packet_type": {
+      "const": "veritas_one_day_poc_evidence"
+    },
+    "schema_version": {
+      "const": "one_day_poc_evidence.v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "read_only": {
+      "const": true
+    },
+    "mutation_allowed": {
+      "const": false
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observability_capabilities",
+        "governance_policy_read"
+      ],
+      "properties": {
+        "observability_capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status_code",
+            "ok",
+            "summary"
+          ],
+          "properties": {
+            "status_code": {
+              "type": "integer"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "summary": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "structured_logging_format",
+                "opentelemetry_importable",
+                "exporter_configured",
+                "governance_span_chain",
+                "rbac_denial_audit_append_visibility"
+              ],
+              "properties": {
+                "structured_logging_format": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "enum": [
+                    "json",
+                    "text",
+                    "unknown",
+                    null
+                  ]
+                },
+                "opentelemetry_importable": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "exporter_configured": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "governance_span_chain": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "rbac_denial_audit_append_visibility": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "governance_policy_read": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status_code",
+            "required"
+          ],
+          "properties": {
+            "status_code": {
+              "type": "integer"
+            },
+            "required": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "docs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "walkthrough_en",
+        "walkthrough_ja",
+        "trace_span_chain_en",
+        "trace_span_chain_ja"
+      ],
+      "properties": {
+        "walkthrough_en": {
+          "type": "string",
+          "pattern": "^(?!https?://).+"
+        },
+        "walkthrough_ja": {
+          "type": "string",
+          "pattern": "^(?!https?://).+"
+        },
+        "trace_span_chain_en": {
+          "type": "string",
+          "pattern": "^(?!https?://).+"
+        },
+        "trace_span_chain_ja": {
+          "type": "string",
+          "pattern": "^(?!https?://).+"
+        }
+      }
+    },
+    "non_goals": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/veritas_os/tests/test_docs_poc_samples.py
+++ b/veritas_os/tests/test_docs_poc_samples.py
@@ -9,6 +9,25 @@ from pathlib import Path
 SAMPLE_JSON = Path("docs/en/poc/sample-one-day-poc-evidence.json")
 SAMPLE_MD_EN = Path("docs/en/poc/sample-one-day-poc-evidence.md")
 SAMPLE_MD_JA = Path("docs/ja/poc/sample-one-day-poc-evidence.md")
+
+
+SCHEMA_JSON = Path("schemas/poc/one_day_poc_evidence.v1.schema.json")
+EXPECTED_NON_GOALS = [
+    "not_a_runtime_deployment_reference",
+    "no_jaeger_grafana_tempo_otlp_deployment",
+    "no_cryptographic_human_approval_signature",
+    "no_new_trustlog_durability_guarantee",
+]
+
+
+def _assert_required_fields(payload: dict[str, object], required: list[str]) -> None:
+    for field in required:
+        assert field in payload
+
+
+def _assert_no_unknown_fields(payload: dict[str, object], allowed: set[str]) -> None:
+    assert set(payload) == allowed
+
 FORBIDDEN_STRINGS = (
     "authorization",
     "x-api-key",
@@ -71,3 +90,66 @@ def test_sample_evidence_markdown_forbidden_secret_markers_absent() -> None:
         content = path.read_text(encoding="utf-8").lower()
         for value in FORBIDDEN_STRINGS:
             assert value not in content, f"forbidden marker {value!r} found in {path}"
+
+
+def test_one_day_poc_schema_json_parses_and_expected_consts() -> None:
+    schema = json.loads(SCHEMA_JSON.read_text(encoding="utf-8"))
+
+    assert schema["title"] == "VERITAS One-Day PoC Evidence Packet"
+    assert schema["properties"]["packet_type"]["const"] == "veritas_one_day_poc_evidence"
+    assert schema["properties"]["schema_version"]["const"] == "one_day_poc_evidence.v1"
+
+
+def test_sample_evidence_json_matches_schema_key_requirements() -> None:
+    schema = json.loads(SCHEMA_JSON.read_text(encoding="utf-8"))
+    payload = json.loads(SAMPLE_JSON.read_text(encoding="utf-8"))
+
+    required = schema["required"]
+    assert isinstance(required, list)
+    _assert_required_fields(payload, required)
+    _assert_no_unknown_fields(payload, set(required))
+
+    assert payload["packet_type"] == schema["properties"]["packet_type"]["const"]
+    assert payload["schema_version"] == schema["properties"]["schema_version"]["const"]
+    assert payload["read_only"] is schema["properties"]["read_only"]["const"]
+    assert payload["mutation_allowed"] is schema["properties"]["mutation_allowed"]["const"]
+    assert payload["non_goals"] == EXPECTED_NON_GOALS
+
+
+def test_generated_evidence_json_core_contract_matches_sample_non_goals(tmp_path: Path) -> None:
+    import os
+    import subprocess
+    import sys
+
+    from veritas_os.tests.test_one_day_poc_smoke import SCRIPT_PATH
+
+    out = tmp_path / "generated-evidence.json"
+    run_env = os.environ.copy()
+    run_env.update(
+        {
+            "VERITAS_API_KEY": "dummy-key",
+            "VERITAS_BASE_URL": "http://127.0.0.1:9",
+        }
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--json",
+            "--evidence-json",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=run_env,
+    )
+
+    assert out.exists()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+
+    assert payload["packet_type"] == "veritas_one_day_poc_evidence"
+    assert payload["schema_version"] == "one_day_poc_evidence.v1"
+    assert payload["read_only"] is True
+    assert payload["mutation_allowed"] is False
+    assert payload["non_goals"] == EXPECTED_NON_GOALS


### PR DESCRIPTION
### Motivation
- Provide a repo-local, machine-readable v1 JSON Schema so external reviewers and stakeholders can mechanically validate One-Day PoC evidence packets.
- Ensure the existing sample fixtures and smoke-script output are verifiable against a formal contract while leaving runtime semantics unchanged.
- Improve discoverability by documenting the schema location in the README and PoC walkthroughs so reviewers can find the canonical schema easily.

### Description
- Adds `schemas/poc/one_day_poc_evidence.v1.schema.json` which uses Draft 2020-12, enforces `additionalProperties: false`, required top-level fields, `packet_type`/`schema_version` consts, date-time formatting for `generated_at`, `read_only`/`mutation_allowed` consts, typed `warnings`, a strict `checks` object with the nested `observability_capabilities.summary` fields, and `docs` fields that must be repo-local paths (pattern disallowing HTTP URLs).
- Extends `veritas_os/tests/test_docs_poc_samples.py` with lightweight schema-contract checks (schema parses, expected title/consts, sample has required fields and no unknown top-level fields, sample/generated packets match core consts, and `non_goals` vocabulary alignment) and runs the smoke script to assert core contract fields without adding any new dependency.
- Updates `README.md`, `docs/en/poc/one-day-poc-walkthrough.md`, `docs/ja/poc/one-day-poc-walkthrough.md`, `docs/INDEX.md`, and `docs/DOCUMENTATION_MAP.md` to reference `schemas/poc/one_day_poc_evidence.v1.schema.json` while keeping the sample JSON unchanged (Option B: no `$schema` added to the sample file).
- No runtime code, smoke script behavior, API contracts, governance semantics, or new dependencies were changed or added, and all sample evidence remains sanitized/fixture-based.

### Testing
- Ran `PYENV_VERSION=3.12.13 pytest -q veritas_os/tests/test_docs_poc_samples.py` which passed (6 passed, 1 warning).
- Ran `PYENV_VERSION=3.12.13 pytest -q veritas_os/tests/test_one_day_poc_smoke.py` which passed (12 passed, 1 warning).
- Ran `PYENV_VERSION=3.12.13 python -m scripts.quality.check_bilingual_docs` which reported `all checks passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd6ba1228832699dbf1e6c74fae56)