### PR TITLE
feat(demo): expose one-day PoC evidence schema path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ See full walkthroughs:
 
 Sample sanitized evidence packets are available for reviewers who want to preview the deliverable format before running the smoke script.
 Evidence JSON follows `schemas/poc/one_day_poc_evidence.v1.schema.json`.
+To print the repo-local schema path: `python scripts/demo/one_day_poc_smoke.py --print-schema-path`.
 
 - [Sample One-Day PoC Evidence (JSON)](docs/en/poc/sample-one-day-poc-evidence.json)
 - [Sample One-Day PoC Evidence (Markdown, EN)](docs/en/poc/sample-one-day-poc-evidence.md)

--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -32,6 +32,7 @@ This PoC is intended to show enforceable boundaries and auditable behavior, not 
 
 Before running the smoke script, reviewers can preview the final deliverable format using the sample packet fixtures: `docs/en/poc/sample-one-day-poc-evidence.json`, `docs/en/poc/sample-one-day-poc-evidence.md`, and `docs/ja/poc/sample-one-day-poc-evidence.md`. These samples are dummy/sanitized/fixture-based and are not live environment evidence.
 The evidence JSON follows the repo-local schema at `schemas/poc/one_day_poc_evidence.v1.schema.json`.
+`python scripts/demo/one_day_poc_smoke.py --print-schema-path` prints the repo-local schema path without requiring an API key or network access.
 
 ## Prerequisites
 

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -34,6 +34,7 @@
 
 スモークスクリプト実行前に、提出物の形式はサンプル証跡で事前確認できます: `docs/en/poc/sample-one-day-poc-evidence.json`、`docs/en/poc/sample-one-day-poc-evidence.md`、`docs/ja/poc/sample-one-day-poc-evidence.md`。これらは dummy / sanitized / fixture-based のサンプルであり、実環境の証跡ではありません。
 evidence JSON は `schemas/poc/one_day_poc_evidence.v1.schema.json` に従います。
+`python scripts/demo/one_day_poc_smoke.py --print-schema-path` で、API key やネットワーク接続なしに repo-local schema path を確認できます。
 
 ## 前提条件
 

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -16,6 +16,7 @@ DEFAULT_BASE_URL = "http://127.0.0.1:8000"
 DEFAULT_TIMEOUT_SECONDS = 5.0
 EVIDENCE_PACKET_TYPE = "veritas_one_day_poc_evidence"
 EVIDENCE_SCHEMA_VERSION = "one_day_poc_evidence.v1"
+EVIDENCE_SCHEMA_PATH = "schemas/poc/one_day_poc_evidence.v1.schema.json"
 
 
 def _bool_env(name: str, *, default: bool = False) -> bool:
@@ -73,6 +74,7 @@ def _extract_observability_summary(payload: dict[str, Any]) -> dict[str, Any]:
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run VERITAS one-day PoC smoke checks")
+    parser.add_argument("--print-schema-path", action="store_true")
     parser.add_argument("--json", action="store_true", dest="json_output")
     parser.add_argument("--base-url", default=os.getenv("VERITAS_BASE_URL", DEFAULT_BASE_URL))
     parser.add_argument("--evidence-json", type=Path, dest="evidence_json")
@@ -187,6 +189,10 @@ def _build_evidence_markdown(evidence: dict[str, Any]) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
+    if args.print_schema_path:
+        print(EVIDENCE_SCHEMA_PATH)
+        return 0
+
     api_key = os.getenv("VERITAS_API_KEY")
     if not api_key:
         print("ERROR: missing required API credentials", file=sys.stderr)

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -295,3 +295,35 @@ def test_evidence_write_failure_exits_nonzero(api_server: Any, tmp_path: Path) -
     )
     assert result.returncode != 0
     assert not output_path.exists()
+
+
+def test_print_schema_path_succeeds_without_api_key() -> None:
+    result = _run_script({"VERITAS_API_KEY": ""}, "--print-schema-path")
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "schemas/poc/one_day_poc_evidence.v1.schema.json"
+
+
+def test_print_schema_path_no_network_and_no_evidence_files(tmp_path: Path) -> None:
+    evidence_json_path = tmp_path / "should_not_exist.json"
+    evidence_md_path = tmp_path / "should_not_exist.md"
+    result = _run_script(
+        {
+            "VERITAS_API_KEY": "",
+            "VERITAS_BASE_URL": "http://127.0.0.1:9",
+        },
+        "--print-schema-path",
+        "--evidence-json",
+        str(evidence_json_path),
+        "--evidence-md",
+        str(evidence_md_path),
+        "--json",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "schemas/poc/one_day_poc_evidence.v1.schema.json"
+    assert not evidence_json_path.exists()
+    assert not evidence_md_path.exists()
+    assert "api_key" not in result.stdout.lower()
+    assert "token" not in result.stdout.lower()
+    assert "secret" not in result.stdout.lower()


### PR DESCRIPTION
### Motivation
- Provide a safe, offline way for reviewers to discover the repo-local One-Day PoC evidence JSON Schema from the CLI without searching docs or README.
- Keep runtime semantics, evidence packet shape, and security boundaries unchanged while making schema discovery easier for auditors and stakeholders.

### Description
- Add `EVIDENCE_SCHEMA_PATH = "schemas/poc/one_day_poc_evidence.v1.schema.json"` and a `--print-schema-path` CLI flag to `scripts/demo/one_day_poc_smoke.py` that prints the path and exits with code `0` before any API-key checks or network calls.
- Implement early-exit behavior so `--print-schema-path` never requires `VERITAS_API_KEY`, does not perform network I/O, and does not create evidence files even if `--evidence-json`/`--evidence-md` are passed.
- Update `README.md`, `docs/en/poc/one-day-poc-walkthrough.md`, and `docs/ja/poc/one-day-poc-walkthrough.md` to document the new command.
- Add tests in `veritas_os/tests/test_one_day_poc_smoke.py` verifying success without an API key, that output contains the expected schema path, that no network or file creation occurs, and that no secret-like strings are printed.
- Preserves evidence packet JSON shape and does not add `$schema` to generated packets, does not change governance/bind/RBAC/TrustLog semantics, and adds no new dependencies.

### Testing
- Ran `pytest -q veritas_os/tests/test_one_day_poc_smoke.py` which passed: `14 passed`.
- Ran `pytest -q veritas_os/tests/test_docs_poc_samples.py` which passed: `6 passed`.
- Ran `python -m scripts.quality.check_bilingual_docs` which passed all bilingual docs checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbdcb7ff788326a8df65340fb0a69e)