### PR TITLE
feat(demo): validate one-day PoC evidence packets offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See full walkthroughs:
 Sample sanitized evidence packets are available for reviewers who want to preview the deliverable format before running the smoke script.
 Evidence JSON follows `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 To print the repo-local schema path: `python scripts/demo/one_day_poc_smoke.py --print-schema-path`.
+To validate a generated evidence packet offline: `python scripts/demo/one_day_poc_smoke.py --validate-evidence /tmp/veritas_poc_evidence.json`.
 
 - [Sample One-Day PoC Evidence (JSON)](docs/en/poc/sample-one-day-poc-evidence.json)
 - [Sample One-Day PoC Evidence (Markdown, EN)](docs/en/poc/sample-one-day-poc-evidence.md)

--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -33,6 +33,7 @@ This PoC is intended to show enforceable boundaries and auditable behavior, not 
 Before running the smoke script, reviewers can preview the final deliverable format using the sample packet fixtures: `docs/en/poc/sample-one-day-poc-evidence.json`, `docs/en/poc/sample-one-day-poc-evidence.md`, and `docs/ja/poc/sample-one-day-poc-evidence.md`. These samples are dummy/sanitized/fixture-based and are not live environment evidence.
 The evidence JSON follows the repo-local schema at `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 `python scripts/demo/one_day_poc_smoke.py --print-schema-path` prints the repo-local schema path without requiring an API key or network access.
+`python scripts/demo/one_day_poc_smoke.py --validate-evidence PATH` validates a generated evidence JSON offline without requiring an API key or network access.
 
 ## Prerequisites
 

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -35,6 +35,7 @@
 スモークスクリプト実行前に、提出物の形式はサンプル証跡で事前確認できます: `docs/en/poc/sample-one-day-poc-evidence.json`、`docs/en/poc/sample-one-day-poc-evidence.md`、`docs/ja/poc/sample-one-day-poc-evidence.md`。これらは dummy / sanitized / fixture-based のサンプルであり、実環境の証跡ではありません。
 evidence JSON は `schemas/poc/one_day_poc_evidence.v1.schema.json` に従います。
 `python scripts/demo/one_day_poc_smoke.py --print-schema-path` で、API key やネットワーク接続なしに repo-local schema path を確認できます。
+`python scripts/demo/one_day_poc_smoke.py --validate-evidence PATH` で、生成済み evidence JSON を API key / ネットワーク接続なしにオフライン検証できます。
 
 ## 前提条件
 

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -18,6 +18,163 @@ EVIDENCE_PACKET_TYPE = "veritas_one_day_poc_evidence"
 EVIDENCE_SCHEMA_VERSION = "one_day_poc_evidence.v1"
 EVIDENCE_SCHEMA_PATH = "schemas/poc/one_day_poc_evidence.v1.schema.json"
 
+EXPECTED_NON_GOALS = [
+    "not_a_runtime_deployment_reference",
+    "no_jaeger_grafana_tempo_otlp_deployment",
+    "no_cryptographic_human_approval_signature",
+    "no_new_trustlog_durability_guarantee",
+]
+ALLOWED_STRUCTURED_LOGGING_FORMATS = {"json", "text", "unknown", None}
+
+
+def _is_repo_local_doc_path(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.lower()
+    return not (lowered.startswith("http://") or lowered.startswith("https://"))
+
+
+def _validate_evidence_packet(payload: Any) -> list[str]:
+    """Validate one-day PoC evidence packet fields using lightweight stdlib checks."""
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ["payload must be an object"]
+
+    required_top_level = {
+        "packet_type",
+        "schema_version",
+        "generated_at",
+        "read_only",
+        "mutation_allowed",
+        "checks",
+        "docs",
+        "non_goals",
+        "warnings",
+    }
+    unknown_fields = sorted(set(payload) - required_top_level)
+    for field in unknown_fields:
+        errors.append(f"unknown top-level field: {field}")
+
+    for field in sorted(required_top_level):
+        if field not in payload:
+            errors.append(f"missing required field: {field}")
+
+    if payload.get("packet_type") != EVIDENCE_PACKET_TYPE:
+        errors.append("packet_type must equal veritas_one_day_poc_evidence")
+    if payload.get("schema_version") != EVIDENCE_SCHEMA_VERSION:
+        errors.append("schema_version must equal one_day_poc_evidence.v1")
+    if not isinstance(payload.get("generated_at"), str):
+        errors.append("generated_at must be a string")
+    if payload.get("read_only") is not True:
+        errors.append("read_only must be true")
+    if payload.get("mutation_allowed") is not False:
+        errors.append("mutation_allowed must be false")
+
+    checks = payload.get("checks")
+    if not isinstance(checks, dict):
+        errors.append("checks must be an object")
+        checks = {}
+
+    observability = checks.get("observability_capabilities")
+    if not isinstance(observability, dict):
+        errors.append("checks.observability_capabilities must be an object")
+        observability = {}
+    if not isinstance(observability.get("status_code"), int):
+        errors.append("checks.observability_capabilities.status_code must be an integer")
+    if not isinstance(observability.get("ok"), bool):
+        errors.append("checks.observability_capabilities.ok must be a boolean")
+
+    summary = observability.get("summary")
+    if not isinstance(summary, dict):
+        errors.append("checks.observability_capabilities.summary must be an object")
+        summary = {}
+
+    summary_fields = [
+        "structured_logging_format",
+        "opentelemetry_importable",
+        "exporter_configured",
+        "governance_span_chain",
+        "rbac_denial_audit_append_visibility",
+    ]
+    for field in summary_fields:
+        if field not in summary:
+            errors.append(f"missing required field: checks.observability_capabilities.summary.{field}")
+
+    if summary.get("structured_logging_format") not in ALLOWED_STRUCTURED_LOGGING_FORMATS:
+        errors.append(
+            "checks.observability_capabilities.summary.structured_logging_format must be json, text, unknown, or null"
+        )
+    for field in summary_fields[1:]:
+        value = summary.get(field)
+        if value is not None and not isinstance(value, bool):
+            errors.append(
+                f"checks.observability_capabilities.summary.{field} must be boolean or null"
+            )
+
+    policy_read = checks.get("governance_policy_read")
+    if not isinstance(policy_read, dict):
+        errors.append("checks.governance_policy_read must be an object")
+        policy_read = {}
+    if not isinstance(policy_read.get("status_code"), int):
+        errors.append("checks.governance_policy_read.status_code must be an integer")
+    if not isinstance(policy_read.get("required"), bool):
+        errors.append("checks.governance_policy_read.required must be a boolean")
+
+    docs = payload.get("docs")
+    if not isinstance(docs, dict):
+        errors.append("docs must be an object")
+        docs = {}
+    doc_fields = [
+        "walkthrough_en",
+        "walkthrough_ja",
+        "trace_span_chain_en",
+        "trace_span_chain_ja",
+    ]
+    for field in doc_fields:
+        value = docs.get(field)
+        if not isinstance(value, str):
+            errors.append(f"docs.{field} must be a string")
+        elif not _is_repo_local_doc_path(value):
+            errors.append(f"docs.{field} must be a repo-local path")
+
+    non_goals = payload.get("non_goals")
+    if not isinstance(non_goals, list) or not all(isinstance(item, str) for item in non_goals):
+        errors.append("non_goals must be a list of strings")
+    elif non_goals != EXPECTED_NON_GOALS:
+        errors.append("non_goals must match the expected one-day PoC non-goals")
+
+    warnings = payload.get("warnings")
+    if not isinstance(warnings, list) or not all(isinstance(item, str) for item in warnings):
+        errors.append("warnings must be a list of strings")
+
+    return errors
+
+
+def _run_evidence_validation(path: Path) -> int:
+    """Validate evidence JSON file and print compact result lines."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print("INVALID one_day_poc_evidence.v1", file=sys.stderr)
+        print(f"- failed to read evidence file: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        print("INVALID one_day_poc_evidence.v1", file=sys.stderr)
+        print("- evidence file is not valid JSON", file=sys.stderr)
+        return 1
+
+    errors = _validate_evidence_packet(payload)
+    if errors:
+        print("INVALID one_day_poc_evidence.v1", file=sys.stderr)
+        for item in errors:
+            print(f"- {item}", file=sys.stderr)
+        return 1
+
+    print("VALID one_day_poc_evidence.v1")
+    return 0
 
 def _bool_env(name: str, *, default: bool = False) -> bool:
     value = os.getenv(name)
@@ -79,6 +236,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--base-url", default=os.getenv("VERITAS_BASE_URL", DEFAULT_BASE_URL))
     parser.add_argument("--evidence-json", type=Path, dest="evidence_json")
     parser.add_argument("--evidence-md", type=Path, dest="evidence_md")
+    parser.add_argument("--validate-evidence", type=Path, dest="validate_evidence")
     return parser
 
 
@@ -118,12 +276,7 @@ def _build_evidence_packet(
             "trace_span_chain_en": "docs/en/operations/governance-trace-span-chain.md",
             "trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md",
         },
-        "non_goals": [
-            "not_a_runtime_deployment_reference",
-            "no_jaeger_grafana_tempo_otlp_deployment",
-            "no_cryptographic_human_approval_signature",
-            "no_new_trustlog_durability_guarantee",
-        ],
+        "non_goals": EXPECTED_NON_GOALS,
         "warnings": warnings,
     }
 
@@ -192,6 +345,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.print_schema_path:
         print(EVIDENCE_SCHEMA_PATH)
         return 0
+
+    if args.validate_evidence:
+        return _run_evidence_validation(args.validate_evidence)
 
     api_key = os.getenv("VERITAS_API_KEY")
     if not api_key:

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -327,3 +327,126 @@ def test_print_schema_path_no_network_and_no_evidence_files(tmp_path: Path) -> N
     assert "api_key" not in result.stdout.lower()
     assert "token" not in result.stdout.lower()
     assert "secret" not in result.stdout.lower()
+
+
+
+def _sample_evidence_payload() -> dict[str, Any]:
+    return json.loads(
+        Path("docs/en/poc/sample-one-day-poc-evidence.json").read_text(encoding="utf-8")
+    )
+
+
+def test_validate_evidence_sample_passes_without_api_key() -> None:
+    result = _run_script(
+        {"VERITAS_API_KEY": "", "VERITAS_BASE_URL": "http://127.0.0.1:9"},
+        "--validate-evidence",
+        "docs/en/poc/sample-one-day-poc-evidence.json",
+    )
+
+    assert result.returncode == 0
+    assert "VALID one_day_poc_evidence.v1" in result.stdout
+
+
+def test_validate_evidence_invalid_json_fails(tmp_path: Path) -> None:
+    evidence_path = tmp_path / "invalid.json"
+    evidence_path.write_text("{invalid", encoding="utf-8")
+    result = _run_script(
+        {"VERITAS_API_KEY": ""},
+        "--validate-evidence",
+        str(evidence_path),
+    )
+
+    assert result.returncode != 0
+    assert "INVALID one_day_poc_evidence.v1" in result.stderr
+
+
+def test_validate_evidence_missing_required_field_fails(tmp_path: Path) -> None:
+    payload = _sample_evidence_payload()
+    del payload["checks"]
+    evidence_path = tmp_path / "missing_checks.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = _run_script({"VERITAS_API_KEY": ""}, "--validate-evidence", str(evidence_path))
+
+    assert result.returncode != 0
+    assert "missing required field: checks" in result.stderr
+
+
+def test_validate_evidence_unknown_top_level_field_fails(tmp_path: Path) -> None:
+    payload = _sample_evidence_payload()
+    payload["unknown_field"] = True
+    evidence_path = tmp_path / "unknown_field.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = _run_script({"VERITAS_API_KEY": ""}, "--validate-evidence", str(evidence_path))
+
+    assert result.returncode != 0
+    assert "unknown top-level field: unknown_field" in result.stderr
+
+
+def test_validate_evidence_wrong_packet_type_fails(tmp_path: Path) -> None:
+    payload = _sample_evidence_payload()
+    payload["packet_type"] = "wrong"
+    evidence_path = tmp_path / "wrong_packet_type.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = _run_script({"VERITAS_API_KEY": ""}, "--validate-evidence", str(evidence_path))
+
+    assert result.returncode != 0
+    assert "packet_type must equal veritas_one_day_poc_evidence" in result.stderr
+
+
+def test_validate_evidence_rejects_external_docs_url(tmp_path: Path) -> None:
+    payload = _sample_evidence_payload()
+    payload["docs"]["walkthrough_en"] = "https://example.com/walkthrough"
+    evidence_path = tmp_path / "external_docs_url.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = _run_script({"VERITAS_API_KEY": ""}, "--validate-evidence", str(evidence_path))
+
+    assert result.returncode != 0
+    assert "docs.walkthrough_en must be a repo-local path" in result.stderr
+
+
+def test_validate_evidence_does_not_create_evidence_outputs(tmp_path: Path) -> None:
+    evidence_json_path = tmp_path / "should_not_create.json"
+    evidence_md_path = tmp_path / "should_not_create.md"
+    result = _run_script(
+        {"VERITAS_API_KEY": ""},
+        "--validate-evidence",
+        "docs/en/poc/sample-one-day-poc-evidence.json",
+        "--evidence-json",
+        str(evidence_json_path),
+        "--evidence-md",
+        str(evidence_md_path),
+    )
+
+    assert result.returncode == 0
+    assert not evidence_json_path.exists()
+    assert not evidence_md_path.exists()
+
+
+def test_validate_evidence_output_masks_secret_values(tmp_path: Path) -> None:
+    evidence_path = tmp_path / "invalid_with_secret.json"
+    evidence_path.write_text("not-json", encoding="utf-8")
+    result = _run_script(
+        {"VERITAS_API_KEY": "super-secret-key", "VERITAS_TOKEN": "token-value"},
+        "--validate-evidence",
+        str(evidence_path),
+    )
+
+    assert result.returncode != 0
+    assert "super-secret-key" not in result.stdout
+    assert "super-secret-key" not in result.stderr
+    assert "token-value" not in result.stdout
+    assert "token-value" not in result.stderr
+
+
+def test_print_schema_path_precedence_over_validate_evidence(tmp_path: Path) -> None:
+    evidence_path = tmp_path / "invalid.json"
+    evidence_path.write_text("{invalid", encoding="utf-8")
+    result = _run_script(
+        {"VERITAS_API_KEY": ""},
+        "--print-schema-path",
+        "--validate-evidence",
+        str(evidence_path),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "schemas/poc/one_day_poc_evidence.v1.schema.json"


### PR DESCRIPTION
### Motivation
- Provide reviewers and stakeholders a simple, offline way to validate generated one-day PoC evidence JSON without requiring API credentials or network access. 
- Keep the smoke script's runtime semantics and outputs unchanged while adding a read-only validation mode for sample/generated evidence packets. 
- Avoid adding new dependencies by implementing lightweight stdlib-only checks consistent with prior PoC validation design. 

### Description
- Adds a `--validate-evidence PATH` CLI flag to `scripts/demo/one_day_poc_smoke.py` that runs offline validation and exits immediately before API-key or network logic. 
- Implements `_validate_evidence_packet(payload)` with lightweight stdlib checks (top-level keys, required fields, types, `packet_type`/`schema_version` identity, `read_only`/`mutation_allowed` values, `checks` shape, `docs` repo-local path requirement, and exact `non_goals` vocabulary). 
- Implements `_run_evidence_validation(path)` which safely reads/parses the file and prints compact results (`VALID one_day_poc_evidence.v1` on stdout or `INVALID one_day_poc_evidence.v1` with concise field-path error lines on stderr); the code does not emit raw evidence bodies or secret-like values. 
- Adds `EXPECTED_NON_GOALS` and helper checks, wires `--validate-evidence` into the existing parser with precedence rules so `--print-schema-path` still exits first and `--validate-evidence` runs before API/network calls; evidence generation remains unchanged when not in validation mode. 
- Updates `veritas_os/tests/test_one_day_poc_smoke.py` with validation-mode tests and adds single-line usage mentions to `README.md`, `docs/en/poc/one-day-poc-walkthrough.md`, and `docs/ja/poc/one-day-poc-walkthrough.md`. 

### Testing
- Ran `pytest -q veritas_os/tests/test_one_day_poc_smoke.py` and observed `23 passed`. 
- Ran `pytest -q veritas_os/tests/test_docs_poc_samples.py` and observed `6 passed`. 
- Ran `python -m scripts.quality.check_bilingual_docs` and observed all checks passed. 

Note: validation is intentionally lightweight and uses stdlib `json` checks only; it is not a replacement for a full JSON Schema engine (`jsonschema` was not added by design). This is a read-only, offline check and should not be treated as a security gate for runtime governance decisions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe0325948832696d9dd3939fd3e41)