### PR TITLE
feat(demo): self-validate generated one-day PoC evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Sample sanitized evidence packets are available for reviewers who want to previe
 Evidence JSON follows `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 To print the repo-local schema path: `python scripts/demo/one_day_poc_smoke.py --print-schema-path`.
 To validate a generated evidence packet offline: `python scripts/demo/one_day_poc_smoke.py --validate-evidence /tmp/veritas_poc_evidence.json`.
+To generate and self-validate JSON evidence in one run, add `--validate-generated-evidence` together with `--evidence-json`.
 
 - [Sample One-Day PoC Evidence (JSON)](docs/en/poc/sample-one-day-poc-evidence.json)
 - [Sample One-Day PoC Evidence (Markdown, EN)](docs/en/poc/sample-one-day-poc-evidence.md)

--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -34,6 +34,7 @@ Before running the smoke script, reviewers can preview the final deliverable for
 The evidence JSON follows the repo-local schema at `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 `python scripts/demo/one_day_poc_smoke.py --print-schema-path` prints the repo-local schema path without requiring an API key or network access.
 `python scripts/demo/one_day_poc_smoke.py --validate-evidence PATH` validates a generated evidence JSON offline without requiring an API key or network access.
+`--validate-generated-evidence` validates the generated JSON evidence packet during the same smoke run when used with `--evidence-json`.
 
 ## Prerequisites
 

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -36,6 +36,7 @@
 evidence JSON は `schemas/poc/one_day_poc_evidence.v1.schema.json` に従います。
 `python scripts/demo/one_day_poc_smoke.py --print-schema-path` で、API key やネットワーク接続なしに repo-local schema path を確認できます。
 `python scripts/demo/one_day_poc_smoke.py --validate-evidence PATH` で、生成済み evidence JSON を API key / ネットワーク接続なしにオフライン検証できます。
+`--validate-generated-evidence` を `--evidence-json` と併用すると、同一 smoke run 内で生成済み JSON evidence packet を検証できます。
 
 ## 前提条件
 

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -238,6 +238,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--evidence-json", type=Path, dest="evidence_json")
     parser.add_argument("--evidence-md", type=Path, dest="evidence_md")
     parser.add_argument("--validate-evidence", type=Path, dest="validate_evidence")
+    parser.add_argument("--validate-generated-evidence", action="store_true")
     return parser
 
 
@@ -349,6 +350,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.validate_evidence:
         return _run_evidence_validation(args.validate_evidence)
+    if args.validate_generated_evidence and not args.evidence_json:
+        print(
+            "ERROR: --validate-generated-evidence requires --evidence-json PATH",
+            file=sys.stderr,
+        )
+        return 2
 
     api_key = os.getenv("VERITAS_API_KEY")
     if not api_key:
@@ -417,6 +424,17 @@ def main(argv: list[str] | None = None) -> int:
             print(f"ERROR: failed to write evidence JSON: {exc}", file=sys.stderr)
             return 3
         print(f"Wrote sanitized evidence JSON: {args.evidence_json}")
+        if args.validate_generated_evidence:
+            generated_errors = _validate_evidence_packet(evidence)
+            if generated_errors:
+                print(
+                    "Generated evidence validation: INVALID one_day_poc_evidence.v1",
+                    file=sys.stderr,
+                )
+                for item in generated_errors:
+                    print(f"- {item}", file=sys.stderr)
+                return 1
+            print("Generated evidence validation: VALID one_day_poc_evidence.v1")
 
     if args.evidence_md:
         try:

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -450,3 +450,119 @@ def test_print_schema_path_precedence_over_validate_evidence(tmp_path: Path) -> 
 
     assert result.returncode == 0
     assert result.stdout.strip() == "schemas/poc/one_day_poc_evidence.v1.schema.json"
+
+
+def test_validate_generated_evidence_succeeds_and_creates_file(
+    api_server: Any, tmp_path: Path
+) -> None:
+    base_url, _ = api_server
+    output_path = tmp_path / "generated_evidence.json"
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--evidence-json",
+        str(output_path),
+        "--validate-generated-evidence",
+    )
+
+    assert result.returncode == 0
+    assert "Generated evidence validation: VALID one_day_poc_evidence.v1" in result.stdout
+    assert output_path.exists()
+
+
+def test_validate_generated_evidence_output_revalidates_offline(
+    api_server: Any, tmp_path: Path
+) -> None:
+    base_url, _ = api_server
+    output_path = tmp_path / "generated_evidence.json"
+    generate_result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--evidence-json",
+        str(output_path),
+        "--validate-generated-evidence",
+    )
+    validate_result = _run_script(
+        {"VERITAS_API_KEY": "", "VERITAS_BASE_URL": "http://127.0.0.1:9"},
+        "--validate-evidence",
+        str(output_path),
+    )
+
+    assert generate_result.returncode == 0
+    assert validate_result.returncode == 0
+    assert "VALID one_day_poc_evidence.v1" in validate_result.stdout
+
+
+def test_validate_generated_evidence_requires_evidence_json() -> None:
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": "http://127.0.0.1:9"},
+        "--validate-generated-evidence",
+    )
+
+    assert result.returncode != 0
+    assert "ERROR: --validate-generated-evidence requires --evidence-json PATH" in result.stderr
+
+
+def test_validate_generated_evidence_requires_evidence_json_no_network() -> None:
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": "http://127.0.0.1:9"},
+        "--validate-generated-evidence",
+    )
+
+    assert result.returncode != 0
+    assert "required check failed" not in result.stdout
+    assert "urlopen error" not in result.stdout
+    assert "urlopen error" not in result.stderr
+
+
+def test_print_schema_path_precedence_over_validate_generated_evidence() -> None:
+    result = _run_script(
+        {"VERITAS_API_KEY": "", "VERITAS_BASE_URL": "http://127.0.0.1:9"},
+        "--print-schema-path",
+        "--validate-generated-evidence",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "schemas/poc/one_day_poc_evidence.v1.schema.json"
+
+
+def test_validate_evidence_precedence_over_validate_generated_evidence(
+    tmp_path: Path,
+) -> None:
+    evidence_path = tmp_path / "invalid.json"
+    evidence_path.write_text("{invalid", encoding="utf-8")
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": "http://127.0.0.1:9"},
+        "--validate-evidence",
+        str(evidence_path),
+        "--validate-generated-evidence",
+    )
+
+    assert result.returncode != 0
+    assert "INVALID one_day_poc_evidence.v1" in result.stderr
+    assert "Generated evidence validation: VALID one_day_poc_evidence.v1" not in result.stdout
+
+
+def test_validate_generated_evidence_write_failure_no_success_line(
+    api_server: Any, tmp_path: Path
+) -> None:
+    base_url, _ = api_server
+    output_path = tmp_path / "missing" / "dir" / "evidence.json"
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--evidence-json",
+        str(output_path),
+        "--validate-generated-evidence",
+    )
+
+    assert result.returncode != 0
+    assert "Generated evidence validation: VALID one_day_poc_evidence.v1" not in result.stdout
+
+
+def test_normal_run_without_validate_generated_evidence_unchanged(api_server: Any) -> None:
+    base_url, _ = api_server
+    result = _run_script(
+        {"VERITAS_API_KEY": "test-key", "VERITAS_BASE_URL": base_url},
+        "--json",
+    )
+
+    assert result.returncode == 0
+    assert "Generated evidence validation: VALID one_day_poc_evidence.v1" not in result.stdout


### PR DESCRIPTION
### Motivation
- Reduce reviewer/operator mistakes by validating a generated evidence JSON packet in the same smoke-run that creates it so callers don't forget to run a separate validation step.
- Build on the existing offline validation added earlier by providing an in-process, in-memory assertion of the generated packet shape while preserving security boundaries and not leaking secrets.

### Description
- Adds a new CLI flag `--validate-generated-evidence` to `scripts/demo/one_day_poc_smoke.py` that requires `--evidence-json` and performs in-memory validation of the just-built evidence dict via `_validate_evidence_packet` after the JSON file is written, printing a compact success/failure line and exiting nonzero on validation failure.
- Maintains existing option precedence: `--print-schema-path` and `--validate-evidence PATH` remain immediate-exit behaviors and take priority over the new flag; if both `--validate-evidence` and `--validate-generated-evidence` are given, `--validate-evidence` is honored and the normal smoke run is not executed.
- Preserves evidence packet JSON top-level shape and existing security constraints (no addition of fields, no `$schema` injection, no printing of API keys/secrets or raw evidence bodies), and uses only the lightweight stdlib validation already present.
- Updates tests (`veritas_os/tests/test_one_day_poc_smoke.py`) and docs (`README.md`, `docs/en/poc/one-day-poc-walkthrough.md`, `docs/ja/poc/one-day-poc-walkthrough.md`) to cover the new flag, required pairing with `--evidence-json`, precedence rules, write-failure behavior, and offline re-validation of the generated file.

### Testing
- Ran `pytest -q veritas_os/tests/test_one_day_poc_smoke.py` and all tests passed.
- Ran `pytest -q veritas_os/tests/test_docs_poc_samples.py` and it passed.
- Ran `python -m scripts.quality.check_bilingual_docs` and bilingual docs checks passed.
- Note: validation output intentionally omits raw evidence bodies and secret-like values to avoid exposing API keys/tokens; write failures stop before in-memory validation and return an error code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbee4534d083269398fb9249c9198a)