### PR TITLE
fix(demo): harden one-day PoC evidence validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Evidence JSON follows `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 To print the repo-local schema path: `python scripts/demo/one_day_poc_smoke.py --print-schema-path`.
 To validate a generated evidence packet offline: `python scripts/demo/one_day_poc_smoke.py --validate-evidence /tmp/veritas_poc_evidence.json`.
 CLI validation is a lightweight stdlib contract check aligned with the v1 schema; it does not add a jsonschema dependency.
+The `generated_at` field uses fixed UTC Z format: `YYYY-MM-DDTHH:MM:SSZ`.
 To generate and self-validate JSON evidence in one run, add `--validate-generated-evidence` together with `--evidence-json`.
 
 - [Sample One-Day PoC Evidence (JSON)](docs/en/poc/sample-one-day-poc-evidence.json)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Sample sanitized evidence packets are available for reviewers who want to previe
 Evidence JSON follows `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 To print the repo-local schema path: `python scripts/demo/one_day_poc_smoke.py --print-schema-path`.
 To validate a generated evidence packet offline: `python scripts/demo/one_day_poc_smoke.py --validate-evidence /tmp/veritas_poc_evidence.json`.
+CLI validation is a lightweight stdlib contract check aligned with the v1 schema; it does not add a jsonschema dependency.
 To generate and self-validate JSON evidence in one run, add `--validate-generated-evidence` together with `--evidence-json`.
 
 - [Sample One-Day PoC Evidence (JSON)](docs/en/poc/sample-one-day-poc-evidence.json)

--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -35,6 +35,7 @@ The evidence JSON follows the repo-local schema at `schemas/poc/one_day_poc_evid
 `python scripts/demo/one_day_poc_smoke.py --print-schema-path` prints the repo-local schema path without requiring an API key or network access.
 `python scripts/demo/one_day_poc_smoke.py --validate-evidence PATH` validates a generated evidence JSON offline without requiring an API key or network access.
 This validation mode is a lightweight stdlib contract check aligned with the v1 schema, not a full external jsonschema engine.
+`generated_at` uses fixed UTC Z format: `YYYY-MM-DDTHH:MM:SSZ`.
 `--validate-generated-evidence` validates the generated JSON evidence packet during the same smoke run when used with `--evidence-json`.
 
 ## Prerequisites

--- a/docs/en/poc/one-day-poc-walkthrough.md
+++ b/docs/en/poc/one-day-poc-walkthrough.md
@@ -34,6 +34,7 @@ Before running the smoke script, reviewers can preview the final deliverable for
 The evidence JSON follows the repo-local schema at `schemas/poc/one_day_poc_evidence.v1.schema.json`.
 `python scripts/demo/one_day_poc_smoke.py --print-schema-path` prints the repo-local schema path without requiring an API key or network access.
 `python scripts/demo/one_day_poc_smoke.py --validate-evidence PATH` validates a generated evidence JSON offline without requiring an API key or network access.
+This validation mode is a lightweight stdlib contract check aligned with the v1 schema, not a full external jsonschema engine.
 `--validate-generated-evidence` validates the generated JSON evidence packet during the same smoke run when used with `--evidence-json`.
 
 ## Prerequisites

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -37,6 +37,7 @@ evidence JSON は `schemas/poc/one_day_poc_evidence.v1.schema.json` に従いま
 `python scripts/demo/one_day_poc_smoke.py --print-schema-path` で、API key やネットワーク接続なしに repo-local schema path を確認できます。
 `python scripts/demo/one_day_poc_smoke.py --validate-evidence PATH` で、生成済み evidence JSON を API key / ネットワーク接続なしにオフライン検証できます。
 この validation は v1 schema に沿った stdlib ベースの軽量 contract check であり、外部 jsonschema engine を追加するものではありません。
+`generated_at` は `YYYY-MM-DDTHH:MM:SSZ` の UTC Z 固定形式を使います。
 `--validate-generated-evidence` を `--evidence-json` と併用すると、同一 smoke run 内で生成済み JSON evidence packet を検証できます。
 
 ## 前提条件

--- a/docs/ja/poc/one-day-poc-walkthrough.md
+++ b/docs/ja/poc/one-day-poc-walkthrough.md
@@ -36,6 +36,7 @@
 evidence JSON は `schemas/poc/one_day_poc_evidence.v1.schema.json` に従います。
 `python scripts/demo/one_day_poc_smoke.py --print-schema-path` で、API key やネットワーク接続なしに repo-local schema path を確認できます。
 `python scripts/demo/one_day_poc_smoke.py --validate-evidence PATH` で、生成済み evidence JSON を API key / ネットワーク接続なしにオフライン検証できます。
+この validation は v1 schema に沿った stdlib ベースの軽量 contract check であり、外部 jsonschema engine を追加するものではありません。
 `--validate-generated-evidence` を `--evidence-json` と併用すると、同一 smoke run 内で生成済み JSON evidence packet を検証できます。
 
 ## 前提条件

--- a/schemas/poc/one_day_poc_evidence.v1.schema.json
+++ b/schemas/poc/one_day_poc_evidence.v1.schema.json
@@ -24,7 +24,8 @@
     },
     "generated_at": {
       "type": "string",
-      "format": "date-time"
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+      "description": "UTC timestamp in fixed YYYY-MM-DDTHH:MM:SSZ format."
     },
     "read_only": {
       "const": true

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -216,24 +216,24 @@ def _validate_evidence_packet(payload: Any) -> list[str]:
     return errors
 
 
-def _load_and_validate_evidence_file(path: Path) -> tuple[list[str], str | None]:
+def _load_and_validate_evidence_file(path: Path) -> list[str]:
     """Load and validate an evidence JSON file without exposing raw content."""
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
-        return [f"failed to read evidence file: {exc}"], None
+        return [f"failed to read evidence file: {exc}"]
 
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
-        return ["evidence file is not valid JSON"], None
+        return ["evidence file is not valid JSON"]
 
-    return _validate_evidence_packet(payload), None
+    return _validate_evidence_packet(payload)
 
 
 def _run_evidence_validation(path: Path) -> int:
     """Validate evidence JSON file and print compact result lines."""
-    errors, _unused = _load_and_validate_evidence_file(path)
+    errors = _load_and_validate_evidence_file(path)
     if errors:
         print("INVALID one_day_poc_evidence.v1", file=sys.stderr)
         for item in errors:
@@ -492,7 +492,7 @@ def main(argv: list[str] | None = None) -> int:
             return 3
         print(f"Wrote sanitized evidence JSON: {args.evidence_json}")
         if args.validate_generated_evidence:
-            generated_errors, _unused = _load_and_validate_evidence_file(args.evidence_json)
+            generated_errors = _load_and_validate_evidence_file(args.evidence_json)
             if generated_errors:
                 print(
                     "Generated evidence validation: INVALID one_day_poc_evidence.v1",

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -33,6 +33,29 @@ def _is_repo_local_doc_path(value: Any) -> bool:
     lowered = value.lower()
     return not (lowered.startswith("http://") or lowered.startswith("https://"))
 
+def _append_unknown_fields_errors(
+    errors: list[str],
+    value: Any,
+    allowed: set[str],
+    path: str,
+) -> None:
+    """Append unknown-field errors for object values."""
+    if not isinstance(value, dict):
+        return
+    for field in sorted(set(value) - allowed):
+        errors.append(f"unknown field: {path}.{field}")
+
+
+def _is_utc_timestamp(value: Any) -> bool:
+    """Return True for UTC timestamps in YYYY-MM-DDTHH:MM:SSZ format."""
+    if not isinstance(value, str):
+        return False
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+        return True
+    except ValueError:
+        return False
+
 
 def _validate_evidence_packet(payload: Any) -> list[str]:
     """Validate one-day PoC evidence packet fields using lightweight stdlib checks."""
@@ -65,6 +88,8 @@ def _validate_evidence_packet(payload: Any) -> list[str]:
         errors.append("schema_version must equal one_day_poc_evidence.v1")
     if not isinstance(payload.get("generated_at"), str):
         errors.append("generated_at must be a string")
+    elif not _is_utc_timestamp(payload.get("generated_at")):
+        errors.append("generated_at must use UTC format YYYY-MM-DDTHH:MM:SSZ")
     if payload.get("read_only") is not True:
         errors.append("read_only must be true")
     if payload.get("mutation_allowed") is not False:
@@ -74,11 +99,23 @@ def _validate_evidence_packet(payload: Any) -> list[str]:
     if not isinstance(checks, dict):
         errors.append("checks must be an object")
         checks = {}
+    _append_unknown_fields_errors(
+        errors,
+        checks,
+        {"observability_capabilities", "governance_policy_read"},
+        "checks",
+    )
 
     observability = checks.get("observability_capabilities")
     if not isinstance(observability, dict):
         errors.append("checks.observability_capabilities must be an object")
         observability = {}
+    _append_unknown_fields_errors(
+        errors,
+        observability,
+        {"status_code", "ok", "summary"},
+        "checks.observability_capabilities",
+    )
     if not isinstance(observability.get("status_code"), int):
         errors.append("checks.observability_capabilities.status_code must be an integer")
     if not isinstance(observability.get("ok"), bool):
@@ -88,6 +125,18 @@ def _validate_evidence_packet(payload: Any) -> list[str]:
     if not isinstance(summary, dict):
         errors.append("checks.observability_capabilities.summary must be an object")
         summary = {}
+    _append_unknown_fields_errors(
+        errors,
+        summary,
+        {
+            "structured_logging_format",
+            "opentelemetry_importable",
+            "exporter_configured",
+            "governance_span_chain",
+            "rbac_denial_audit_append_visibility",
+        },
+        "checks.observability_capabilities.summary",
+    )
 
     summary_fields = [
         "structured_logging_format",
@@ -115,6 +164,12 @@ def _validate_evidence_packet(payload: Any) -> list[str]:
     if not isinstance(policy_read, dict):
         errors.append("checks.governance_policy_read must be an object")
         policy_read = {}
+    _append_unknown_fields_errors(
+        errors,
+        policy_read,
+        {"status_code", "required"},
+        "checks.governance_policy_read",
+    )
     if not isinstance(policy_read.get("status_code"), int):
         errors.append("checks.governance_policy_read.status_code must be an integer")
     if not isinstance(policy_read.get("required"), bool):
@@ -124,6 +179,17 @@ def _validate_evidence_packet(payload: Any) -> list[str]:
     if not isinstance(docs, dict):
         errors.append("docs must be an object")
         docs = {}
+    _append_unknown_fields_errors(
+        errors,
+        docs,
+        {
+            "walkthrough_en",
+            "walkthrough_ja",
+            "trace_span_chain_en",
+            "trace_span_chain_ja",
+        },
+        "docs",
+    )
     doc_fields = [
         "walkthrough_en",
         "walkthrough_ja",
@@ -150,23 +216,24 @@ def _validate_evidence_packet(payload: Any) -> list[str]:
     return errors
 
 
-def _run_evidence_validation(path: Path) -> int:
-    """Validate evidence JSON file and print compact result lines."""
+def _load_and_validate_evidence_file(path: Path) -> tuple[list[str], str | None]:
+    """Load and validate an evidence JSON file without exposing raw content."""
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
-        print("INVALID one_day_poc_evidence.v1", file=sys.stderr)
-        print(f"- failed to read evidence file: {exc}", file=sys.stderr)
-        return 1
+        return [f"failed to read evidence file: {exc}"], None
 
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
-        print("INVALID one_day_poc_evidence.v1", file=sys.stderr)
-        print("- evidence file is not valid JSON", file=sys.stderr)
-        return 1
+        return ["evidence file is not valid JSON"], None
 
-    errors = _validate_evidence_packet(payload)
+    return _validate_evidence_packet(payload), None
+
+
+def _run_evidence_validation(path: Path) -> int:
+    """Validate evidence JSON file and print compact result lines."""
+    errors, _unused = _load_and_validate_evidence_file(path)
     if errors:
         print("INVALID one_day_poc_evidence.v1", file=sys.stderr)
         for item in errors:
@@ -425,7 +492,7 @@ def main(argv: list[str] | None = None) -> int:
             return 3
         print(f"Wrote sanitized evidence JSON: {args.evidence_json}")
         if args.validate_generated_evidence:
-            generated_errors = _validate_evidence_packet(evidence)
+            generated_errors, _unused = _load_and_validate_evidence_file(args.evidence_json)
             if generated_errors:
                 print(
                     "Generated evidence validation: INVALID one_day_poc_evidence.v1",

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -481,6 +481,32 @@ def test_validate_evidence_generated_at_utc_sample_is_valid(tmp_path: Path) -> N
     assert "VALID one_day_poc_evidence.v1" in result.stdout
 
 
+def test_validate_evidence_generated_at_plus_offset_is_invalid(tmp_path: Path) -> None:
+    payload = _sample_evidence_payload()
+    payload["generated_at"] = "2026-01-01T00:00:00+00:00"
+    evidence_path = tmp_path / "invalid_generated_at_offset.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _run_script({"VERITAS_API_KEY": ""}, "--validate-evidence", str(evidence_path))
+
+    assert result.returncode != 0
+    assert "generated_at must use UTC format YYYY-MM-DDTHH:MM:SSZ" in result.stderr
+
+
+def test_validate_evidence_generated_at_fractional_seconds_is_invalid(
+    tmp_path: Path,
+) -> None:
+    payload = _sample_evidence_payload()
+    payload["generated_at"] = "2026-01-01T00:00:00.000Z"
+    evidence_path = tmp_path / "invalid_generated_at_fractional.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _run_script({"VERITAS_API_KEY": ""}, "--validate-evidence", str(evidence_path))
+
+    assert result.returncode != 0
+    assert "generated_at must use UTC format YYYY-MM-DDTHH:MM:SSZ" in result.stderr
+
+
 def test_load_and_validate_evidence_file_reads_actual_file(tmp_path: Path) -> None:
     import importlib.util
 
@@ -494,13 +520,13 @@ def test_load_and_validate_evidence_file_reads_actual_file(tmp_path: Path) -> No
     evidence_path = tmp_path / "module_validation.json"
     evidence_path.write_text(json.dumps(payload), encoding="utf-8")
 
-    errors, _raw = module._load_and_validate_evidence_file(evidence_path)
+    errors = module._load_and_validate_evidence_file(evidence_path)
     assert errors == []
 
     payload["checks"]["extra"] = True
     evidence_path.write_text(json.dumps(payload), encoding="utf-8")
 
-    errors, _raw = module._load_and_validate_evidence_file(evidence_path)
+    errors = module._load_and_validate_evidence_file(evidence_path)
     assert "unknown field: checks.extra" in errors
 
 

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -421,6 +421,88 @@ def test_validate_evidence_does_not_create_evidence_outputs(tmp_path: Path) -> N
     assert not evidence_json_path.exists()
     assert not evidence_md_path.exists()
 
+def test_validate_evidence_rejects_unknown_nested_fields(tmp_path: Path) -> None:
+    cases = [
+        ("checks", "unknown field: checks.extra"),
+        (
+            "checks.observability_capabilities",
+            "unknown field: checks.observability_capabilities.extra",
+        ),
+        (
+            "checks.observability_capabilities.summary",
+            "unknown field: checks.observability_capabilities.summary.extra",
+        ),
+        (
+            "checks.governance_policy_read",
+            "unknown field: checks.governance_policy_read.extra",
+        ),
+        ("docs", "unknown field: docs.extra"),
+    ]
+    for path_name, expected_error in cases:
+        payload = _sample_evidence_payload()
+        target = payload
+        for key in path_name.split("."):
+            target = target[key]
+        target["extra"] = True
+        evidence_path = tmp_path / f"{path_name.replace('.', '_')}.json"
+        evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        result = _run_script(
+            {"VERITAS_API_KEY": ""},
+            "--validate-evidence",
+            str(evidence_path),
+        )
+
+        assert result.returncode != 0
+        assert expected_error in result.stderr
+
+
+def test_validate_evidence_generated_at_must_be_utc_format(tmp_path: Path) -> None:
+    payload = _sample_evidence_payload()
+    payload["generated_at"] = "not-a-date"
+    evidence_path = tmp_path / "bad_generated_at.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _run_script({"VERITAS_API_KEY": ""}, "--validate-evidence", str(evidence_path))
+
+    assert result.returncode != 0
+    assert "generated_at must use UTC format YYYY-MM-DDTHH:MM:SSZ" in result.stderr
+
+
+def test_validate_evidence_generated_at_utc_sample_is_valid(tmp_path: Path) -> None:
+    payload = _sample_evidence_payload()
+    payload["generated_at"] = "2026-01-01T00:00:00Z"
+    evidence_path = tmp_path / "valid_generated_at.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _run_script({"VERITAS_API_KEY": ""}, "--validate-evidence", str(evidence_path))
+
+    assert result.returncode == 0
+    assert "VALID one_day_poc_evidence.v1" in result.stdout
+
+
+def test_load_and_validate_evidence_file_reads_actual_file(tmp_path: Path) -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("one_day_poc_smoke", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    payload = _sample_evidence_payload()
+    evidence_path = tmp_path / "module_validation.json"
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    errors, _raw = module._load_and_validate_evidence_file(evidence_path)
+    assert errors == []
+
+    payload["checks"]["extra"] = True
+    evidence_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    errors, _raw = module._load_and_validate_evidence_file(evidence_path)
+    assert "unknown field: checks.extra" in errors
+
 
 def test_validate_evidence_output_masks_secret_values(tmp_path: Path) -> None:
     evidence_path = tmp_path / "invalid_with_secret.json"


### PR DESCRIPTION
### Motivation
- Close validation gaps in the one-day PoC evidence CLI by rejecting nested unknown fields, tightening generated_at checks, and ensuring self-validation actually checks the written file to reduce external-review concerns. 
- Maintain the current lightweight, stdlib-based validator approach (no new dependencies or full jsonschema engine) and avoid changing runtime governance or API semantics. 

### Description
- Added helper functions `_append_unknown_fields_errors` and `_is_utc_timestamp`, and enforced nested unknown-field rejection for `checks`, `checks.observability_capabilities`, `checks.observability_capabilities.summary`, `checks.governance_policy_read`, and `docs`. 
- Added `_load_and_validate_evidence_file(path: Path)` to centralize file read/parse/validation without exposing raw body, and switched `--validate-generated-evidence` to re-read and validate the actual written `--evidence-json` file. 
- Added a lightweight UTC timestamp format check for `generated_at` accepting `YYYY-MM-DDTHH:MM:SSZ`. 
- Clarified in `README.md`, `docs/en/poc/one-day-poc-walkthrough.md`, and `docs/ja/poc/one-day-poc-walkthrough.md` that the CLI validation is a stdlib lightweight contract check aligned with the v1 schema and not a full jsonschema engine. 
- Added unit/CLI tests in `veritas_os/tests/test_one_day_poc_smoke.py` to cover nested unknown-field rejection, `generated_at` format validation (invalid/valid), and that `_load_and_validate_evidence_file` reads and validates the actual file. 

### Testing
- Ran the smoke tests suite with `PYENV_VERSION=3.11.15 python -m pytest -q veritas_os/tests/test_one_day_poc_smoke.py veritas_os/tests/test_docs_poc_samples.py` and observed `41 passed, 1 warning`. 
- Ran the bilingual docs quality check with `python3 -m scripts.quality.check_bilingual_docs` and observed it passed. 
- No new dependencies were added and the existing secret-safety and output-shaping tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf66a46988326ab5afff838dc5f3d)