### PR TITLE
docs(poc): add one-day PoC reviewer pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ See full walkthroughs:
 
 - [One-Day VERITAS PoC Walkthrough (EN)](docs/en/poc/one-day-poc-walkthrough.md)
 - [One-Day VERITAS PoC Walkthrough (JA)](docs/ja/poc/one-day-poc-walkthrough.md)
+- [One-Day PoC Reviewer Pack (EN)](docs/en/poc/one-day-poc-reviewer-pack.md)
+- [One-Day PoC Reviewer Pack (JA)](docs/ja/poc/one-day-poc-reviewer-pack.md)
 
 Sample sanitized evidence packets are available for reviewers who want to preview the deliverable format before running the smoke script.
 Evidence JSON follows `schemas/poc/one_day_poc_evidence.v1.schema.json`.

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -45,6 +45,7 @@
 | Guides: Bundle promotion | `docs/en/guides/governance-policy-bundle-promotion.md` | `docs/ja/guides/governance-policy-bundle-promotion.md` | JA explanation / EN canonical | ポリシーバンドル昇格 |
 | Guides: PoC quickstart | `docs/en/guides/poc-pack-financial-quickstart.md` | `docs/ja/guides/poc-pack-financial-quickstart.md` | EN/JA fully paired | JAファースト導線 |
 | PoC: One-day walkthrough | `docs/en/poc/one-day-poc-walkthrough.md` | `docs/ja/poc/one-day-poc-walkthrough.md` | JA explanation / EN canonical | 外部レビュー向け1-dayデモ導線 + evidence packet生成 |
+| PoC: Reviewer pack | `docs/en/poc/one-day-poc-reviewer-pack.md` | `docs/ja/poc/one-day-poc-reviewer-pack.md` | JA explanation / EN canonical | 外部レビュアー向け提出・確認手順 |
 | PoC: Sample evidence packet | `docs/en/poc/sample-one-day-poc-evidence.json` / `docs/en/poc/sample-one-day-poc-evidence.md` | `docs/ja/poc/sample-one-day-poc-evidence.md` | JA explanation / EN canonical | 外部レビュー向けサンプル証跡 |
 | PoC: Evidence packet schema | `schemas/poc/one_day_poc_evidence.v1.schema.json` | — | EN canonical / machine-readable | One-Day PoC evidence JSON schema |
 | Positioning: AML/KYC | `docs/en/positioning/aml-kyc-beachhead-short-positioning.md` | `docs/ja/positioning/aml-kyc-beachhead-short-positioning.md` | JA explanation / EN canonical | 公開向け短縮版 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,6 +39,7 @@
 | Governance Artifact Lifecycle | [Governance artifact lifecycle (EN)](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle (JA)](ja/governance/governance-artifact-lifecycle.md) |
 | Guides | [Guides (EN)](en/guides/) | [Guides (JA)](ja/guides/) |
 | One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough (EN)](en/poc/one-day-poc-walkthrough.md) — Includes sanitized JSON/Markdown evidence packet generation. | [One-Day VERITAS PoC Walkthrough (JA)](ja/poc/one-day-poc-walkthrough.md) — sanitized evidence packet（JSON/Markdown）生成を含む。 |
+| One-Day PoC Reviewer Pack | [One-Day PoC Reviewer Pack (EN)](en/poc/one-day-poc-reviewer-pack.md) | [One-Day PoC Reviewer Pack (JA)](ja/poc/one-day-poc-reviewer-pack.md) |
 | One-Day PoC Sample Evidence Packet | [Sample one-day PoC evidence (EN JSON/Markdown)](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（JA Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
 | One-Day PoC Evidence Schema | [One-day PoC evidence schema (JSON Schema)](../schemas/poc/one_day_poc_evidence.v1.schema.json) | — |
 | AI-Assisted Development | [AI-assisted development guardrails (EN)](en/development/ai-assisted-development.md) | [AI支援開発ガードレール (JA)](ja/development/ai-assisted-development.md) |
@@ -101,6 +102,7 @@
 | Governance Artifact Lifecycle | [Governance artifact lifecycle（英語正本）](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle（日本語解説）](ja/governance/governance-artifact-lifecycle.md) |
 | ガイド | [Guides（英語正本）](en/guides/) | [Guides（日本語）](ja/guides/) |
 | One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough（英語正本）](en/poc/one-day-poc-walkthrough.md) | [One-Day VERITAS PoC Walkthrough（日本語）](ja/poc/one-day-poc-walkthrough.md) |
+| One-Day PoC Reviewer Pack | [One-Day PoC Reviewer Pack（英語正本）](en/poc/one-day-poc-reviewer-pack.md) | [One-Day PoC Reviewer Pack（日本語）](ja/poc/one-day-poc-reviewer-pack.md) |
 | One-Day PoC サンプル証跡パケット | [Sample one-day PoC evidence（英語 JSON/Markdown）](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（日本語 Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
 | One-Day PoC 証跡スキーマ | [One-day PoC evidence schema（JSON Schema）](../schemas/poc/one_day_poc_evidence.v1.schema.json) | — |
 | AI支援開発 | [AI-assisted development guardrails（英語正本）](en/development/ai-assisted-development.md) | [AI支援開発ガードレール（日本語）](ja/development/ai-assisted-development.md) |

--- a/docs/en/poc/one-day-poc-reviewer-pack.md
+++ b/docs/en/poc/one-day-poc-reviewer-pack.md
@@ -1,0 +1,141 @@
+# One-Day VERITAS PoC Reviewer Pack
+
+## 1. Purpose
+
+This pack helps external reviewers verify VERITAS PoC evidence quickly.
+It is intended for review, diligence, and technical evaluation.
+It is **not** production certification.
+
+## 2. Who this is for
+
+- HPAN reviewers
+- Enterprise AI governance teams
+- Security and audit reviewers
+- Investors and technical diligence reviewers
+- Integration partners
+
+## 3. What reviewers should verify
+
+- Observability capabilities endpoint can be checked.
+- JSON evidence packet can be generated.
+- Markdown evidence packet can be generated.
+- Generated evidence can be self-validated.
+- Evidence JSON follows the repo-local schema.
+- Sample evidence packet is available before running the script.
+- No API key, token, raw endpoint, raw env value, or raw request/response body is written into evidence.
+
+## 4. Minimum command
+
+Use this exact command:
+
+```bash
+VERITAS_API_KEY=... python scripts/demo/one_day_poc_smoke.py \
+  --json \
+  --evidence-json /tmp/veritas_poc_evidence.json \
+  --evidence-md /tmp/veritas_poc_evidence.md \
+  --validate-generated-evidence
+```
+
+## 5. Expected success output
+
+You should see output that includes the following lines:
+
+- `Wrote sanitized evidence JSON: ...`
+- `Generated evidence validation: VALID one_day_poc_evidence.v1`
+- `Wrote sanitized evidence Markdown: ...`
+- JSON summary output that includes `ok` and `capabilities_ok`
+
+Do not require an exact full stdout ordering; verify presence of the expected success signals.
+
+## 6. Optional offline validation command
+
+```bash
+python scripts/demo/one_day_poc_smoke.py \
+  --validate-evidence /tmp/veritas_poc_evidence.json
+```
+
+Expected output includes:
+
+- `VALID one_day_poc_evidence.v1`
+
+## 7. Optional schema discovery command
+
+```bash
+python scripts/demo/one_day_poc_smoke.py --print-schema-path
+```
+
+Expected output includes:
+
+- `schemas/poc/one_day_poc_evidence.v1.schema.json`
+
+## 8. Files reviewers should inspect
+
+- `/tmp/veritas_poc_evidence.json`
+- `/tmp/veritas_poc_evidence.md`
+- `schemas/poc/one_day_poc_evidence.v1.schema.json`
+- `docs/en/poc/sample-one-day-poc-evidence.json`
+- `docs/en/poc/sample-one-day-poc-evidence.md`
+- `docs/ja/poc/sample-one-day-poc-evidence.md`
+- `docs/en/poc/one-day-poc-walkthrough.md`
+- `docs/ja/poc/one-day-poc-walkthrough.md`
+
+## 9. Success criteria checklist
+
+- [ ] API server is running
+- [ ] API key is mapped to `governance_read` role, such as `auditor` or `admin`
+- [ ] Smoke script completes
+- [ ] JSON evidence file is created
+- [ ] Markdown evidence file is created
+- [ ] Generated evidence validation reports `VALID`
+- [ ] Offline validation reports `VALID`
+- [ ] Evidence does not contain API key
+- [ ] Evidence does not contain raw exporter endpoint
+- [ ] Evidence does not contain raw env values
+- [ ] Evidence does not copy raw request/response bodies
+- [ ] `generated_at` uses fixed UTC Z format: `YYYY-MM-DDTHH:MM:SSZ`
+- [ ] `non_goals` are present
+- [ ] `limitations` are understood
+
+## 10. Security boundary
+
+- API keys are not written.
+- Raw endpoints are not written.
+- Raw env values are not written.
+- Raw request/response bodies are not copied.
+- Validation output does not print raw evidence body.
+- CLI validation is a stdlib lightweight contract check aligned with v1 schema.
+- CLI validation is **not** a full external `jsonschema` engine.
+
+## 11. Non-goals / limitations
+
+- Not production certification.
+- Not final enterprise SLA.
+- No Jaeger, Grafana, Tempo, or OTLP deployment is included.
+- No cryptographic human approval signature is included.
+- No stronger TrustLog durability guarantee beyond current implementation.
+- Not a live customer integration proof by itself.
+
+## 12. Suggested reviewer notes
+
+- "The relevant question is not whether this is a full enterprise deployment, but whether VERITAS can produce reviewable, sanitized, schema-aligned evidence for governed AI action flows."
+- "The PoC should be evaluated as an auditable decision-boundary demonstration."
+- "Production hardening would require deployment architecture, operational controls, retention policy, identity integration, and customer-specific risk controls."
+
+## 13. Troubleshooting
+
+- Missing API key: set `VERITAS_API_KEY` and retry.
+- `401` / `403`: verify key validity and role mapping (`governance_read`, e.g. `auditor` or `admin`).
+- `capabilities_ok: false`: check API server status and capabilities endpoint availability.
+- Evidence validation invalid: re-run generation and inspect evidence JSON shape against the v1 schema path.
+- Write failure: ensure target path is writable (for example `/tmp`).
+- `generated_at` invalid: verify timestamp format is `YYYY-MM-DDTHH:MM:SSZ`.
+- Schema path not found: verify repo checkout includes `schemas/poc/one_day_poc_evidence.v1.schema.json`.
+
+## 14. What to send after the PoC
+
+- Generated JSON evidence packet
+- Generated Markdown evidence packet
+- Command used
+- VERITAS commit hash or release tag, if available
+- Reviewer notes
+- Known limitations

--- a/docs/ja/poc/one-day-poc-reviewer-pack.md
+++ b/docs/ja/poc/one-day-poc-reviewer-pack.md
@@ -1,0 +1,143 @@
+# One-Day VERITAS PoC Reviewer Pack（外部レビュアー向け）
+
+> 英語版（`docs/en/poc/one-day-poc-reviewer-pack.md`）が正本です。日本語版は補助説明です。
+
+## 1. 目的
+
+このパックは、外部レビュアーが VERITAS の PoC 証跡を短時間で確認するための手順です。
+用途はレビュー、デューデリジェンス、技術評価です。
+**本番認証を示すものではありません。**
+
+## 2. 想定読者
+
+- HPAN レビュアー
+- エンタープライズ AI ガバナンス担当
+- セキュリティ / 監査担当
+- 投資家 / 技術 DD 担当
+- 連携パートナー
+
+## 3. レビュアーが確認すべき点
+
+- Observability capabilities endpoint を確認できること
+- JSON 証跡パケットを生成できること
+- Markdown 証跡パケットを生成できること
+- 生成した証跡を self-validation できること
+- 証跡 JSON が repo-local schema に準拠すること
+- スクリプト実行前に sample evidence packet が参照できること
+- API key / token / raw endpoint / raw env 値 / raw request-response body が証跡に書き出されないこと
+
+## 4. 最小実行コマンド
+
+以下のコマンドをそのまま使用してください。
+
+```bash
+VERITAS_API_KEY=... python scripts/demo/one_day_poc_smoke.py \
+  --json \
+  --evidence-json /tmp/veritas_poc_evidence.json \
+  --evidence-md /tmp/veritas_poc_evidence.md \
+  --validate-generated-evidence
+```
+
+## 5. 成功時の期待出力
+
+以下の文字列を含むことを確認してください。
+
+- `Wrote sanitized evidence JSON: ...`
+- `Generated evidence validation: VALID one_day_poc_evidence.v1`
+- `Wrote sanitized evidence Markdown: ...`
+- `ok` と `capabilities_ok` を含む JSON summary
+
+stdout 全体の厳密な行順までは固定要件にしないでください（成功シグナルの有無を確認）。
+
+## 6. 任意: オフライン検証コマンド
+
+```bash
+python scripts/demo/one_day_poc_smoke.py \
+  --validate-evidence /tmp/veritas_poc_evidence.json
+```
+
+期待値:
+
+- `VALID one_day_poc_evidence.v1`
+
+## 7. 任意: スキーマパス確認コマンド
+
+```bash
+python scripts/demo/one_day_poc_smoke.py --print-schema-path
+```
+
+期待値:
+
+- `schemas/poc/one_day_poc_evidence.v1.schema.json`
+
+## 8. レビュアーが確認すべきファイル
+
+- `/tmp/veritas_poc_evidence.json`
+- `/tmp/veritas_poc_evidence.md`
+- `schemas/poc/one_day_poc_evidence.v1.schema.json`
+- `docs/en/poc/sample-one-day-poc-evidence.json`
+- `docs/en/poc/sample-one-day-poc-evidence.md`
+- `docs/ja/poc/sample-one-day-poc-evidence.md`
+- `docs/en/poc/one-day-poc-walkthrough.md`
+- `docs/ja/poc/one-day-poc-walkthrough.md`
+
+## 9. 成功条件チェックリスト
+
+- [ ] API server が起動している
+- [ ] API key が `governance_read` ロール（例: `auditor` / `admin`）にマップされている
+- [ ] Smoke script が完了する
+- [ ] JSON evidence file が生成される
+- [ ] Markdown evidence file が生成される
+- [ ] generated evidence validation が `VALID` を返す
+- [ ] offline validation が `VALID` を返す
+- [ ] 証跡に API key が含まれない
+- [ ] 証跡に raw exporter endpoint が含まれない
+- [ ] 証跡に raw env 値が含まれない
+- [ ] 証跡に raw request/response body がコピーされない
+- [ ] `generated_at` が固定 UTC Z 形式 `YYYY-MM-DDTHH:MM:SSZ` である
+- [ ] `non_goals` が存在する
+- [ ] `limitations` を理解している
+
+## 10. セキュリティ境界
+
+- API key は書き出されません。
+- Raw endpoint は書き出されません。
+- Raw env 値は書き出されません。
+- Raw request/response body はコピーされません。
+- validation 出力に raw evidence body は表示されません。
+- CLI validation は v1 schema に整合する stdlib ベースの軽量 contract check です。
+- CLI validation は外部 `jsonschema` エンジンの完全実装ではありません。
+
+## 11. 非目標 / 制約
+
+- 本番認証ではありません。
+- 最終的なエンタープライズ SLA ではありません。
+- Jaeger / Grafana / Tempo / OTLP の導入は含みません。
+- 暗号学的な human approval signature は含みません。
+- 現行実装を超える TrustLog durability 保証は含みません。
+- これ単体で live customer integration の証明にはなりません。
+
+## 12. レビューノート（推奨）
+
+- 「評価すべき論点は、これがフルのエンタープライズ配備かどうかではなく、VERITAS が governed AI action flow に対して reviewable かつ sanitized で schema-aligned な証跡を出力できるかどうかである。」
+- 「この PoC は、監査可能な decision-boundary の実証として評価すべきである。」
+- 「本番ハードニングには、デプロイ構成、運用統制、保持ポリシー、ID 連携、顧客固有のリスク統制が必要となる。」
+
+## 13. トラブルシューティング
+
+- API key がない: `VERITAS_API_KEY` を設定して再実行。
+- `401` / `403`: キーの有効性とロールマッピング（`governance_read`、例: `auditor` / `admin`）を確認。
+- `capabilities_ok: false`: API server の稼働状態と capabilities endpoint の可用性を確認。
+- Evidence validation invalid: 再生成し、v1 schema path と JSON shape の整合を確認。
+- 書き込み失敗: 出力先（例: `/tmp`）の書き込み権限を確認。
+- `generated_at` invalid: `YYYY-MM-DDTHH:MM:SSZ` 形式を確認。
+- Schema path not found: リポジトリに `schemas/poc/one_day_poc_evidence.v1.schema.json` が存在するか確認。
+
+## 14. PoC 後に送付すべきもの
+
+- 生成された JSON evidence packet
+- 生成された Markdown evidence packet
+- 実行コマンド
+- 可能であれば VERITAS の commit hash または release tag
+- レビューノート
+- 既知の制約


### PR DESCRIPTION
### Motivation

- Provide external reviewers (HPAN, enterprise governance, auditors, investors, integration partners) a single, concise Reviewer Pack that shows exactly what to run, what to inspect, and what success looks like for the One-Day PoC evidence packet.
- Make the Reviewer Pack discoverable from the existing docs hub, README, and documentation map while keeping all runtime, schema, and API behavior unchanged.

### Description

- Adds EN/JA One-Day PoC Reviewer Pack for external reviewers as `docs/en/poc/one-day-poc-reviewer-pack.md` and `docs/ja/poc/one-day-poc-reviewer-pack.md` and marks the English page as canonical with the Japanese page as a companion translation.
- Documents minimum command, expected outputs, validation flow, success checklist, security boundaries, and limitations in the new reviewer pack files.
- Links reviewer pack from `README.md`, `docs/INDEX.md`, and `docs/DOCUMENTATION_MAP.md` so reviewers can find the pack from existing PoC guidance.
- Does not change runtime code, smoke script behavior, API contracts, schema, or governance semantics.

### Testing

- Ran bilingual docs checker with `python3 -m scripts.quality.check_bilingual_docs` and it passed.
- Attempted to run the requested pytest commands (`pytest -q veritas_os/tests/test_one_day_poc_smoke.py` and `pytest -q veritas_os/tests/test_docs_poc_samples.py`) but the environment lacks the configured pyenv Python version and the `pytest` module, so those tests could not be executed here (see environment `pyenv` / `pytest` mismatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc078a1b1483269f0e535880c997bc)