### PR TITLE
refactor(poc): share one-day PoC evidence helpers

### DIFF
--- a/scripts/demo/one_day_poc_benchmark.py
+++ b/scripts/demo/one_day_poc_benchmark.py
@@ -21,7 +21,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.demo import one_day_poc_smoke
+from scripts.demo import one_day_poc_shared
 
 SCHEMA_VERSION = "one_day_poc_benchmark.v1"
 PACKET_TYPE = "performance_benchmark"
@@ -297,7 +297,7 @@ def main(argv: list[str] | None = None) -> int:
             timeout=args.timeout,
             require_ok=True,
         )
-        observability_summary = one_day_poc_smoke._extract_observability_summary(obs_payload)
+        observability_summary = one_day_poc_shared.extract_observability_summary(obs_payload)
         policy_status, _policy_payload = _checked_http_get_json(
             args.base_url,
             "/v1/governance/policy",
@@ -307,9 +307,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         capabilities_ok = status == 200 and bool(obs_payload.get("ok", True))
         warnings: list[str] = []
-        # Reuses smoke-script helpers for contract parity in this PR.
-        # Follow-up refactor can extract shared public helpers.
-        one_day_poc_smoke._build_evidence_packet(
+        one_day_poc_shared.build_evidence_packet(
             observability=observability_summary,
             capabilities_status=status,
             capabilities_ok=capabilities_ok,

--- a/scripts/demo/one_day_poc_shared.py
+++ b/scripts/demo/one_day_poc_shared.py
@@ -7,12 +7,12 @@ from typing import Any
 
 EVIDENCE_PACKET_TYPE = "veritas_one_day_poc_evidence"
 EVIDENCE_SCHEMA_VERSION = "one_day_poc_evidence.v1"
-EXPECTED_NON_GOALS = [
+EXPECTED_NON_GOALS: tuple[str, ...] = (
     "not_a_runtime_deployment_reference",
     "no_jaeger_grafana_tempo_otlp_deployment",
     "no_cryptographic_human_approval_signature",
     "no_new_trustlog_durability_guarantee",
-]
+)
 
 
 def extract_observability_summary(payload: dict[str, Any]) -> dict[str, Any]:
@@ -71,6 +71,6 @@ def build_evidence_packet(
             "trace_span_chain_en": "docs/en/operations/governance-trace-span-chain.md",
             "trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md",
         },
-        "non_goals": EXPECTED_NON_GOALS,
+        "non_goals": list(EXPECTED_NON_GOALS),
         "warnings": warnings,
     }

--- a/scripts/demo/one_day_poc_shared.py
+++ b/scripts/demo/one_day_poc_shared.py
@@ -1,0 +1,76 @@
+"""Shared helper utilities for One-Day PoC smoke/benchmark evidence packets."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+EVIDENCE_PACKET_TYPE = "veritas_one_day_poc_evidence"
+EVIDENCE_SCHEMA_VERSION = "one_day_poc_evidence.v1"
+EXPECTED_NON_GOALS = [
+    "not_a_runtime_deployment_reference",
+    "no_jaeger_grafana_tempo_otlp_deployment",
+    "no_cryptographic_human_approval_signature",
+    "no_new_trustlog_durability_guarantee",
+]
+
+
+def extract_observability_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract a sanitized observability summary from API payloads."""
+    observability = payload.get("observability")
+    if not isinstance(observability, dict):
+        observability = {}
+
+    structured = observability.get("structured_logging")
+    if not isinstance(structured, dict):
+        structured = {}
+
+    tracing = observability.get("tracing")
+    if not isinstance(tracing, dict):
+        tracing = {}
+
+    return {
+        "structured_logging_format": structured.get("format"),
+        "opentelemetry_importable": tracing.get("opentelemetry_importable"),
+        "exporter_configured": tracing.get("exporter_configured"),
+        "governance_span_chain": tracing.get("governance_span_chain"),
+        "rbac_denial_audit_append_visibility": tracing.get(
+            "rbac_denial_audit_append_visibility"
+        ),
+    }
+
+
+def build_evidence_packet(
+    observability: dict[str, Any],
+    capabilities_status: int,
+    capabilities_ok: bool,
+    policy_status: int,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Build a sanitized one-day PoC evidence packet."""
+    return {
+        "packet_type": EVIDENCE_PACKET_TYPE,
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "read_only": True,
+        "mutation_allowed": False,
+        "checks": {
+            "observability_capabilities": {
+                "status_code": capabilities_status,
+                "ok": capabilities_ok,
+                "summary": observability,
+            },
+            "governance_policy_read": {
+                "status_code": policy_status,
+                "required": False,
+            },
+        },
+        "docs": {
+            "walkthrough_en": "docs/en/poc/one-day-poc-walkthrough.md",
+            "walkthrough_ja": "docs/ja/poc/one-day-poc-walkthrough.md",
+            "trace_span_chain_en": "docs/en/operations/governance-trace-span-chain.md",
+            "trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md",
+        },
+        "non_goals": EXPECTED_NON_GOALS,
+        "warnings": warnings,
+    }

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -8,18 +8,22 @@ import json
 import os
 import sys
 from datetime import datetime
-from pathlib import Path
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib import error, request
 from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.demo import one_day_poc_shared
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8000"
 DEFAULT_TIMEOUT_SECONDS = 5.0
-EVIDENCE_PACKET_TYPE = "veritas_one_day_poc_evidence"
-EVIDENCE_SCHEMA_VERSION = "one_day_poc_evidence.v1"
+EVIDENCE_PACKET_TYPE = one_day_poc_shared.EVIDENCE_PACKET_TYPE
+EVIDENCE_SCHEMA_VERSION = one_day_poc_shared.EVIDENCE_SCHEMA_VERSION
+EXPECTED_NON_GOALS = one_day_poc_shared.EXPECTED_NON_GOALS
 EVIDENCE_SCHEMA_PATH = "schemas/poc/one_day_poc_evidence.v1.schema.json"
 
 ALLOWED_STRUCTURED_LOGGING_FORMATS = {"json", "text", "unknown", None}
@@ -54,6 +58,7 @@ def _emit_status(message: str, *, json_output: bool, error: bool = False) -> Non
     """Emit status messages to stdout, or stderr when JSON mode/error is active."""
     stream = sys.stderr if json_output or error else sys.stdout
     print(message, file=stream)
+
 
 def _append_unknown_fields_errors(
     errors: list[str],

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -7,12 +7,14 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Any
 from urllib import error, request
 from urllib.parse import urlparse
+
+from scripts.demo import one_day_poc_shared
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8000"
 DEFAULT_TIMEOUT_SECONDS = 5.0
@@ -20,12 +22,6 @@ EVIDENCE_PACKET_TYPE = "veritas_one_day_poc_evidence"
 EVIDENCE_SCHEMA_VERSION = "one_day_poc_evidence.v1"
 EVIDENCE_SCHEMA_PATH = "schemas/poc/one_day_poc_evidence.v1.schema.json"
 
-EXPECTED_NON_GOALS = [
-    "not_a_runtime_deployment_reference",
-    "no_jaeger_grafana_tempo_otlp_deployment",
-    "no_cryptographic_human_approval_signature",
-    "no_new_trustlog_durability_guarantee",
-]
 ALLOWED_STRUCTURED_LOGGING_FORMATS = {"json", "text", "unknown", None}
 
 
@@ -300,27 +296,8 @@ def _http_get_json(base_url: str, path: str, api_key: str) -> tuple[int, dict[st
 
 
 def _extract_observability_summary(payload: dict[str, Any]) -> dict[str, Any]:
-    observability = payload.get("observability")
-    if not isinstance(observability, dict):
-        observability = {}
-
-    structured = observability.get("structured_logging")
-    if not isinstance(structured, dict):
-        structured = {}
-
-    tracing = observability.get("tracing")
-    if not isinstance(tracing, dict):
-        tracing = {}
-
-    return {
-        "structured_logging_format": structured.get("format"),
-        "opentelemetry_importable": tracing.get("opentelemetry_importable"),
-        "exporter_configured": tracing.get("exporter_configured"),
-        "governance_span_chain": tracing.get("governance_span_chain"),
-        "rbac_denial_audit_append_visibility": tracing.get(
-            "rbac_denial_audit_append_visibility"
-        ),
-    }
+    """Backward-compatible wrapper for older tests/internal callers."""
+    return one_day_poc_shared.extract_observability_summary(payload)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -347,33 +324,14 @@ def _build_evidence_packet(
     policy_status: int,
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Build a sanitized one-day PoC evidence packet."""
-    return {
-        "packet_type": EVIDENCE_PACKET_TYPE,
-        "schema_version": EVIDENCE_SCHEMA_VERSION,
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "read_only": True,
-        "mutation_allowed": False,
-        "checks": {
-            "observability_capabilities": {
-                "status_code": capabilities_status,
-                "ok": capabilities_ok,
-                "summary": observability,
-            },
-            "governance_policy_read": {
-                "status_code": policy_status,
-                "required": False,
-            },
-        },
-        "docs": {
-            "walkthrough_en": "docs/en/poc/one-day-poc-walkthrough.md",
-            "walkthrough_ja": "docs/ja/poc/one-day-poc-walkthrough.md",
-            "trace_span_chain_en": "docs/en/operations/governance-trace-span-chain.md",
-            "trace_span_chain_ja": "docs/ja/operations/governance-trace-span-chain.md",
-        },
-        "non_goals": EXPECTED_NON_GOALS,
-        "warnings": warnings,
-    }
+    """Backward-compatible wrapper for older tests/internal callers."""
+    return one_day_poc_shared.build_evidence_packet(
+        observability=observability,
+        capabilities_status=capabilities_status,
+        capabilities_ok=capabilities_ok,
+        policy_status=policy_status,
+        warnings=warnings,
+    )
 
 
 def _build_evidence_markdown(evidence: dict[str, Any]) -> str:

--- a/scripts/demo/one_day_poc_smoke.py
+++ b/scripts/demo/one_day_poc_smoke.py
@@ -233,7 +233,7 @@ def _validate_evidence_packet(payload: Any) -> list[str]:
     non_goals = payload.get("non_goals")
     if not isinstance(non_goals, list) or not all(isinstance(item, str) for item in non_goals):
         errors.append("non_goals must be a list of strings")
-    elif non_goals != EXPECTED_NON_GOALS:
+    elif non_goals != list(EXPECTED_NON_GOALS):
         errors.append("non_goals must match the expected one-day PoC non-goals")
 
     warnings = payload.get("warnings")

--- a/veritas_os/tests/test_one_day_poc_benchmark.py
+++ b/veritas_os/tests/test_one_day_poc_benchmark.py
@@ -372,3 +372,9 @@ def test_timeout_validation(timeout_value: str) -> None:
 def test_runs_validation(args: tuple[str, str]) -> None:
     result = _run_script({"VERITAS_API_KEY": "test-key"}, *args)
     assert result.returncode != 0
+
+
+def test_benchmark_no_private_smoke_helper_dependency() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert "one_day_poc_smoke._build_evidence_packet" not in source
+    assert "one_day_poc_smoke._extract_observability_summary" not in source

--- a/veritas_os/tests/test_one_day_poc_benchmark.py
+++ b/veritas_os/tests/test_one_day_poc_benchmark.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import subprocess
@@ -375,6 +376,24 @@ def test_runs_validation(args: tuple[str, str]) -> None:
 
 
 def test_benchmark_no_private_smoke_helper_dependency() -> None:
-    source = SCRIPT_PATH.read_text(encoding="utf-8")
-    assert "one_day_poc_smoke._build_evidence_packet" not in source
-    assert "one_day_poc_smoke._extract_observability_summary" not in source
+    tree = ast.parse(SCRIPT_PATH.read_text(encoding="utf-8"))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "scripts.demo.one_day_poc_smoke"
+                assert alias.name != "one_day_poc_smoke"
+
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            assert module != "scripts.demo.one_day_poc_smoke"
+            for alias in node.names:
+                assert alias.name != "one_day_poc_smoke"
+
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr in {"_build_evidence_packet", "_extract_observability_summary"}
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "one_day_poc_smoke"
+        ):
+            raise AssertionError("benchmark must not reference smoke private helpers")

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -762,3 +762,46 @@ def test_normal_run_without_validate_generated_evidence_unchanged(api_server: An
 
     assert result.returncode == 0
     assert "Generated evidence validation: VALID one_day_poc_evidence.v1" not in result.stdout
+
+
+def test_shared_helper_import_and_contract() -> None:
+    from scripts.demo import one_day_poc_shared
+
+    summary = one_day_poc_shared.extract_observability_summary({"observability": {}})
+    assert isinstance(summary, dict)
+
+    packet = one_day_poc_shared.build_evidence_packet(
+        observability=summary,
+        capabilities_status=200,
+        capabilities_ok=True,
+        policy_status=200,
+        warnings=[],
+    )
+    assert packet["schema_version"] == "one_day_poc_evidence.v1"
+    assert packet["packet_type"] == "veritas_one_day_poc_evidence"
+
+
+def test_smoke_wrapper_build_evidence_packet_compatibility() -> None:
+    from scripts.demo import one_day_poc_shared
+    from scripts.demo import one_day_poc_smoke
+
+    shared_packet = one_day_poc_shared.build_evidence_packet(
+        observability={"structured_logging_format": "json"},
+        capabilities_status=200,
+        capabilities_ok=True,
+        policy_status=403,
+        warnings=["w"],
+    )
+    wrapper_packet = one_day_poc_smoke._build_evidence_packet(
+        observability={"structured_logging_format": "json"},
+        capabilities_status=200,
+        capabilities_ok=True,
+        policy_status=403,
+        warnings=["w"],
+    )
+
+    assert set(wrapper_packet.keys()) == set(shared_packet.keys())
+    assert wrapper_packet["schema_version"] == shared_packet["schema_version"]
+    assert wrapper_packet["packet_type"] == shared_packet["packet_type"]
+    assert wrapper_packet["docs"] == shared_packet["docs"]
+    assert wrapper_packet["non_goals"] == shared_packet["non_goals"]

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -104,6 +104,14 @@ def test_missing_api_key_fails_clearly() -> None:
     assert "missing required API credentials" in result.stderr
 
 
+def test_smoke_script_standalone_import_bootstrap_works() -> None:
+    result = _run_script({}, "--print-schema-path")
+
+    assert result.returncode == 0
+    assert "schemas/poc/one_day_poc_evidence.v1.schema.json" in result.stdout
+    assert "ModuleNotFoundError" not in result.stderr
+
+
 def test_uses_x_api_key_header_only(monkeypatch: pytest.MonkeyPatch) -> None:
     import importlib.util
 

--- a/veritas_os/tests/test_one_day_poc_smoke.py
+++ b/veritas_os/tests/test_one_day_poc_smoke.py
@@ -789,6 +789,25 @@ def test_shared_helper_import_and_contract() -> None:
     assert packet["packet_type"] == "veritas_one_day_poc_evidence"
 
 
+def test_shared_evidence_packet_non_goals_is_defensive_copy() -> None:
+    from scripts.demo import one_day_poc_shared
+
+    packet = one_day_poc_shared.build_evidence_packet(
+        observability={},
+        capabilities_status=200,
+        capabilities_ok=True,
+        policy_status=403,
+        warnings=[],
+    )
+    original = list(one_day_poc_shared.EXPECTED_NON_GOALS)
+    assert isinstance(packet["non_goals"], list)
+
+    packet["non_goals"].append("mutated")
+
+    assert list(one_day_poc_shared.EXPECTED_NON_GOALS) == original
+    assert "mutated" not in one_day_poc_shared.EXPECTED_NON_GOALS
+
+
 def test_smoke_wrapper_build_evidence_packet_compatibility() -> None:
     from scripts.demo import one_day_poc_shared
     from scripts.demo import one_day_poc_smoke


### PR DESCRIPTION
### Motivation

- The benchmark script reused private helpers from the smoke script which creates a fragile cross-script dependency that can break if the smoke script internals change.  
- Extract a small public helper surface so both smoke and benchmark can rely on the same stable API without changing evidence/benchmark shapes or runtime semantics.

### Description

- Add a new public shared module `scripts/demo/one_day_poc_shared.py` providing `extract_observability_summary(payload: dict[str, Any])` and `build_evidence_packet(...)` plus evidence constants (`EVIDENCE_PACKET_TYPE`, `EVIDENCE_SCHEMA_VERSION`, `EXPECTED_NON_GOALS`) and preserve the existing `generated_at` UTC `Z` formatting.  
- Update `scripts/demo/one_day_poc_smoke.py` to import and delegate to the shared helpers via thin backward-compatible wrappers (`_extract_observability_summary` and `_build_evidence_packet`) and keep existing CLI/evidence contracts unchanged.  
- Update `scripts/demo/one_day_poc_benchmark.py` to stop importing smoke internals and instead call `one_day_poc_shared.extract_observability_summary` and `one_day_poc_shared.build_evidence_packet`, removing the benchmark dependency on smoke private helpers.  
- Add tests to `veritas_os/tests/` to verify `one_day_poc_shared` import/contract, wrapper compatibility in the smoke script, and a source-level check that the benchmark no longer references `one_day_poc_smoke._*` private helpers.

### Testing

- Added unit tests: `test_shared_helper_import_and_contract` and `test_smoke_wrapper_build_evidence_packet_compatibility` in `veritas_os/tests/test_one_day_poc_smoke.py`, and `test_benchmark_no_private_smoke_helper_dependency` in `veritas_os/tests/test_one_day_poc_benchmark.py`.  
- Ran documentation quality check with `python3 -m scripts.quality.check_bilingual_docs`, which passed.  
- `pytest -q veritas_os/tests/test_one_day_poc_smoke.py` and `pytest -q veritas_os/tests/test_one_day_poc_benchmark.py` were attempted in this environment but could not be executed due to the runner's Python/pyenv/`pytest` availability (environment limitation), so full test execution is blocked here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7aa015f48326946d5f0ad28ccf98)