### PR TITLE
docs(ops): add maintainer handoff runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ See full walkthroughs:
 - [One-Day PoC Performance Benchmark Report (EN)](docs/en/poc/one-day-poc-performance-report.md)
 - [One-Day PoC Performance Benchmark Report (JA)](docs/ja/poc/one-day-poc-performance-report.md)
 
-Maintainer handoff and support-continuity guidance is documented in `docs/en/operations/maintainer-handoff.md`. This runbook reduces handoff friction but does not claim to eliminate bus-factor risk or provide a staffed support organization/SLA.
+Maintainer handoff and support-continuity guidance is documented in [Maintainer Handoff and Support Continuity Runbook](docs/en/operations/maintainer-handoff.md). This runbook reduces handoff friction but does not claim to eliminate bus-factor risk or provide a staffed support organization/SLA.
 
-Maintainer handoff / support continuity は `docs/ja/operations/maintainer-handoff.md` に補助説明があります。
+Maintainer handoff / support continuity の日本語補助説明は [Maintainer Handoff（日本語補助）](docs/ja/operations/maintainer-handoff.md) にあります。
 
 For lightweight local performance measurements, run `python scripts/demo/one_day_poc_benchmark.py` and see the performance report docs above.
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ See full walkthroughs:
 - [One-Day PoC Performance Benchmark Report (EN)](docs/en/poc/one-day-poc-performance-report.md)
 - [One-Day PoC Performance Benchmark Report (JA)](docs/ja/poc/one-day-poc-performance-report.md)
 
+Maintainer handoff and support-continuity guidance is documented in `docs/en/operations/maintainer-handoff.md`. This runbook reduces handoff friction but does not claim to eliminate bus-factor risk or provide a staffed support organization/SLA.
+
+Maintainer handoff / support continuity は `docs/ja/operations/maintainer-handoff.md` に補助説明があります。
+
 For lightweight local performance measurements, run `python scripts/demo/one_day_poc_benchmark.py` and see the performance report docs above.
 
 Sample sanitized evidence packets are available for reviewers who want to preview the deliverable format before running the smoke script.

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -39,6 +39,7 @@
 | Operations: Governance artifact signing | `docs/en/operations/governance-artifact-signing.md` | `docs/ja/operations/governance-artifact-signing.md` | JA explanation / EN canonical | 署名運用 |
 | Operations: Governance trace span chain | `docs/en/operations/governance-trace-span-chain.md` | `docs/ja/operations/governance-trace-span-chain.md` | JA explanation / EN canonical | observability検証導線 |
 | Operations: Provider support matrix | `docs/en/operations/provider-support-matrix.md` | `docs/ja/operations/provider-support-matrix.md` | JA explanation / EN canonical | Current provider support tiers, limits, and enterprise review checklist. |
+| Operations: Maintainer handoff | `docs/en/operations/maintainer-handoff.md` | `docs/ja/operations/maintainer-handoff.md` | JA explanation / EN canonical | Maintainer onboarding, quality gates, PR review, incident triage, and support-continuity boundaries |
 | Operations: Type safety baseline | `docs/en/operations/type-safety-baseline.md` | `docs/ja/operations/type-safety-baseline.md` | JA explanation / EN canonical | Incremental typecheck baseline and roadmap |
 | Operations: Legacy path cleanup | `docs/en/operations/legacy-path-cleanup.md` | `docs/ja/operations/legacy-path-cleanup.md` | JA explanation / EN canonical | 旧経路整理 |
 | Governance: Required evidence taxonomy | `docs/en/governance/required-evidence-taxonomy.md` | `docs/ja/governance/required-evidence-taxonomy.md` | JA explanation / EN canonical | taxonomy語彙 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,6 +35,7 @@
 | Governance Artifact Signing | [Governance artifact signing (EN)](en/operations/governance-artifact-signing.md) | [ガバナンス成果物署名 (JA)](ja/operations/governance-artifact-signing.md) |
 | Governance Trace Span Chain | [Governance trace span chain (EN)](en/operations/governance-trace-span-chain.md) | [ガバナンストレース span chain (JA)](ja/operations/governance-trace-span-chain.md) |
 | Provider Support Matrix | [Provider support matrix (EN)](en/operations/provider-support-matrix.md) | [Provider support matrix (JA)](ja/operations/provider-support-matrix.md) |
+| Maintainer Handoff | [Maintainer handoff (EN)](en/operations/maintainer-handoff.md) | [Maintainer handoff (JA)](ja/operations/maintainer-handoff.md) |
 | Governance | [Governance (EN)](en/governance/) | [Governance (JA)](ja/governance/) |
 | Required Evidence Taxonomy | [Required evidence taxonomy (EN)](en/governance/required-evidence-taxonomy.md) | [Required evidence taxonomy (JA)](ja/governance/required-evidence-taxonomy.md) |
 | Governance Artifact Lifecycle | [Governance artifact lifecycle (EN)](en/governance/governance-artifact-lifecycle.md) | [Governance artifact lifecycle (JA)](ja/governance/governance-artifact-lifecycle.md) |
@@ -100,6 +101,7 @@
 | ガバナンス成果物署名 | [Governance artifact signing（英語正本）](en/operations/governance-artifact-signing.md) | [ガバナンス成果物署名（日本語解説）](ja/operations/governance-artifact-signing.md) |
 | ガバナンストレース span chain | [Governance trace span chain（英語正本）](en/operations/governance-trace-span-chain.md) | [ガバナンストレース span chain（日本語解説）](ja/operations/governance-trace-span-chain.md) |
 | Provider Support Matrix | [Provider support matrix（英語正本）](en/operations/provider-support-matrix.md) | [Provider support matrix（日本語）](ja/operations/provider-support-matrix.md) |
+| Maintainer Handoff | [Maintainer handoff（英語正本）](en/operations/maintainer-handoff.md) | [Maintainer handoff（日本語補助）](ja/operations/maintainer-handoff.md) |
 | Type Safety Baseline | [Type safety baseline (EN)](en/operations/type-safety-baseline.md) | [型安全性 baseline (JA)](ja/operations/type-safety-baseline.md) |
 | ガバナンス | [Governance（英語正本）](en/governance/) | [Governance（日本語）](ja/governance/) |
 | Required Evidence Taxonomy | [Required evidence taxonomy（英語正本）](en/governance/required-evidence-taxonomy.md) | [Required evidence taxonomy（日本語解説）](ja/governance/required-evidence-taxonomy.md) |

--- a/docs/en/operations/maintainer-handoff.md
+++ b/docs/en/operations/maintainer-handoff.md
@@ -213,7 +213,7 @@ When handing off to another maintainer, package at minimum:
 
 - Single primary maintainer risk remains.
 - No staffed 24/7 support organization is claimed.
-- no formal support SLA is claimed.
+- No formal support SLA is claimed.
 - Some operational knowledge may still be implicit.
 - External legal/security review remains outside this repository.
 - Production deployment ownership remains customer/operator responsibility.

--- a/docs/en/operations/maintainer-handoff.md
+++ b/docs/en/operations/maintainer-handoff.md
@@ -1,0 +1,230 @@
+# Maintainer Handoff and Support Continuity Runbook
+
+## 1. Purpose
+
+This runbook documents a minimum handoff path so a new maintainer can continue VERITAS OS technical operations and reviewer-facing support artifacts with lower onboarding friction.
+
+This runbook reduces handoff friction but does not eliminate bus-factor risk.
+
+## 2. Scope
+
+This runbook covers:
+
+- Maintainer onboarding references
+- Local setup and baseline checks
+- Quality gates used in repository operations
+- PR and release review checkpoints
+- One-Day PoC reviewer packet continuity checks
+- Security, incident triage, and responsibility boundaries
+
+This runbook does not change runtime semantics, API contracts, provider tiers, evidence schema shape, benchmark schema shape, or CI workflow contracts.
+
+## 3. What this runbook does not solve
+
+It is not a substitute for a staffed support organization, 24/7 operations team, legal counsel, security operations center, or formal vendor support agreement.
+
+It does not claim:
+
+- Bus-factor risk elimination
+- Formal support SLA coverage
+- Legal compliance certification
+- Security certification
+- Production operations staffing guarantees
+
+## 4. First 60 minutes for a new maintainer
+
+Read first:
+
+- `README.md`
+- `docs/en/operations/provider-support-matrix.md`
+- `docs/en/operations/type-safety-baseline.md`
+- `docs/en/poc/one-day-poc-reviewer-pack.md`
+- `docs/en/poc/one-day-poc-performance-report.md`
+
+Then execute baseline commands:
+
+    python -m pytest -q veritas_os/tests/test_one_day_poc_smoke.py
+    python -m pytest -q veritas_os/tests/test_one_day_poc_benchmark.py
+    python -m scripts.quality.check_type_baseline
+    python -m scripts.quality.check_bilingual_docs
+
+Then verify current operational state:
+
+- Review open PRs/issues for release blockers and security-relevant regressions.
+- Confirm no secrets or raw API keys are committed in active branches.
+- Confirm CI status for `main` is green for required checks.
+
+## 5. Repository orientation
+
+Primary entrypoints:
+
+- Repository overview: `README.md`
+- Documentation hub: `docs/INDEX.md`
+- Bilingual mapping: `docs/DOCUMENTATION_MAP.md`
+- AI-assisted development guardrails: `docs/en/development/ai-assisted-development.md`
+
+Core operations references:
+
+- Provider support boundaries: `docs/en/operations/provider-support-matrix.md`
+- Type safety baseline: `docs/en/operations/type-safety-baseline.md`
+- One-Day PoC reviewer handoff: `docs/en/poc/one-day-poc-reviewer-pack.md`
+- One-Day PoC benchmark report path: `docs/en/poc/one-day-poc-performance-report.md`
+
+## 6. Local setup checklist
+
+- Use supported Python version from repository configuration.
+- Install dependencies according to project standard setup.
+- Ensure test commands execute from repository root.
+- Verify local environment does not embed customer secrets in shell history, scripts, or checked-in files.
+- Confirm local changes remain scoped to the intended PR purpose.
+
+## 7. Quality gates checklist
+
+Minimum gates to run/check:
+
+- CI (main workflow)
+- Security Gates
+- CodeQL custom checks
+- Runtime Pickle Guard checks
+- requirements sync checks
+- bilingual docs check
+- one-day PoC smoke tests
+- one-day PoC benchmark tests
+- provider support matrix docs test
+- compliance positioning docs test
+- type safety baseline test
+
+Passing these gates does not certify production readiness, legal compliance, security certification, or SLA readiness.
+
+## 8. PR review checklist
+
+For each PR, check:
+
+- Does it change runtime governance semantics?
+- Does it change bind/RBAC/TrustLog behavior?
+- Does it change evidence packet shape?
+- Does it change benchmark packet shape?
+- Does it change provider tier?
+- Does it make stronger compliance claims?
+- Does it add runtime dependencies?
+- Does it expose secrets?
+- Does it require EN/JA docs synchronization?
+- Does it require One-Day PoC reviewer pack updates?
+- Does it affect One-Day PoC execution paths?
+- Does it affect CI/security gate expectations?
+
+## 9. Release readiness checklist
+
+Before release tagging or release handoff:
+
+- `main` branch CI is green.
+- release gate is green when applicable.
+- docs updates are merged for changed behavior/positioning.
+- provider support matrix is current.
+- compliance positioning docs are current.
+- benchmark path remains runnable.
+- no unreviewed provider tier change exists.
+- no stronger legal/compliance claim was introduced.
+- no new runtime dependency exists without explicit justification.
+- no secret-handling or sensitive logging regression exists.
+
+## 10. One-Day PoC reviewer packet checklist
+
+For external reviewer/investor handoff packets, confirm:
+
+- reviewer pack doc is current
+- evidence JSON is present and sanitized
+- evidence Markdown is present and sanitized
+- benchmark JSON is present when required
+- benchmark Markdown is present when required
+- provider support matrix link is included
+- EU AI Act positioning docs link is included
+- type safety baseline docs link is included
+- known limitations are explicitly stated
+
+## 11. Security and secret-handling rules
+
+- Do not commit API keys.
+- Do not paste raw secrets into issues, PRs, docs, or benchmark packets.
+- Do not include raw request/response bodies when they may contain secrets.
+- Use sanitized outputs for reviewer-facing artifacts.
+- Treat customer data as sensitive by default.
+- Evidence packets must remain secret-safe.
+- Logs should avoid raw provider payloads where unnecessary.
+
+## 12. Incident triage checklist
+
+Initial triage only:
+
+- Identify failing gate or failing path.
+- Link the failing CI run/job or local command output.
+- Reproduce with a targeted command.
+- Isolate whether runtime behavior changed or only docs/tooling changed.
+- Avoid broad refactor in incident fix PR.
+- Document root cause and mitigation in the PR description.
+
+Incident classes to cover:
+
+- CI failure
+- security gate failure
+- evidence validation failure
+- benchmark failure
+- provider failure
+- TrustLog/RBAC/bind behavior regression
+- docs compliance-claim regression
+
+## 13. Governance subsystem map
+
+| Area | Primary docs/tests | Maintainer concern |
+|---|---|---|
+| Bind / admissibility | `docs/en/architecture/bind_time_admissibility_evaluator.md`, `docs/en/architecture/bind-boundary-governance-artifacts.md` | Do not weaken fail-closed behavior. |
+| RBAC | `docs/en/architecture/decision-semantics.md`, `veritas_os/tests/test_role_guard_escalation.py` | Preserve denial visibility and escalation boundaries. |
+| TrustLog | `docs/en/architecture/authority-evidence-vs-audit-log.md`, `veritas_os/tests/test_audit_log_writer.py` | Preserve append/audit semantics. |
+| Evidence packets | `docs/en/poc/one-day-poc-reviewer-pack.md`, `veritas_os/tests/test_docs_poc_samples.py` | Preserve schema shape and sanitization guarantees. |
+| Provider support | `docs/en/operations/provider-support-matrix.md`, `veritas_os/tests/test_provider_support_matrix_docs.py` | Do not overstate non-production providers. |
+| Compliance positioning | `docs/en/positioning/public-positioning.md`, `veritas_os/tests/test_compliance_positioning_docs.py` | Do not claim legal certification. |
+| Type safety | `docs/en/operations/type-safety-baseline.md`, `veritas_os/tests/test_type_safety_baseline.py` | Baseline is incremental, not strict full-repo typing. |
+
+## 14. Provider dependency boundary
+
+Provider tiers are documented, and production support claims must remain aligned with `docs/en/operations/provider-support-matrix.md`.
+
+Do not imply provider-neutral production equivalence if not documented and tested.
+
+## 15. Compliance positioning boundary
+
+Compliance positioning documents communicate technical supportability and evidence boundaries. They must not be rewritten into legal guarantees, regulatory approval claims, or certification claims.
+
+## 16. Type safety baseline
+
+Type safety is maintained as a baseline strategy with incremental expansion. Passing baseline checks indicates maintained baseline quality, not universal strict typing across all modules.
+
+## 17. Escalation and handoff packet
+
+When handing off to another maintainer, package at minimum:
+
+- Current branch and PR status summary
+- Latest CI run links and unresolved failures
+- Open incident list and temporary mitigations
+- Reviewer-facing packet links used in current diligence cycle
+- Known risky areas touched in active work
+
+## 18. Current known continuity risks
+
+- Single primary maintainer risk remains.
+- No staffed 24/7 support organization is claimed.
+- no formal support SLA is claimed.
+- Some operational knowledge may still be implicit.
+- External legal/security review remains outside this repository.
+- Production deployment ownership remains customer/operator responsibility.
+
+## 19. Roadmap for reducing bus factor
+
+- Add maintainer onboarding issue template.
+- Add release manager checklist template.
+- Add incident report template.
+- Expand type baseline coverage for core modules.
+- Add provider contract tests where practical.
+- Add architecture decision records for major subsystems.
+- Add deployment profile separation for dev/full/runtime dependencies.
+- Add support SLA only if an actual support organization exists.

--- a/docs/ja/operations/maintainer-handoff.md
+++ b/docs/ja/operations/maintainer-handoff.md
@@ -1,0 +1,164 @@
+# Maintainer Handoff and Support Continuity Runbook
+
+> 英語版（`docs/en/operations/maintainer-handoff.md`）が正本です。日本語版は補助説明です。
+
+## 1. 目的
+
+この文書は、VERITAS OS の保守引き継ぎ時に必要な最小限の運用知識を明文化し、属人化による引き継ぎ摩擦を下げることを目的とします。
+
+## 2. この文書で解決できること / できないこと
+
+解決できること:
+
+- 新しい maintainer が最初に参照すべき資料の明確化
+- ローカルセットアップと品質ゲートの確認手順
+- PR レビュー、リリース前確認、PoC 提出確認の観点
+- インシデント初動と責任境界の整理
+
+解決できないこと:
+
+- バスファクターリスクを完全に解消するものではありません。
+- 人員体制そのものを補うものではありません。
+- 24/7 support または正式なSLAを意味しない補助文書です。
+- 法務・規制・認証の保証を提供するものではありません。
+
+## 3. 新しい maintainer の最初の60分
+
+最初に読む:
+
+- `README.md`
+- `docs/en/operations/provider-support-matrix.md`
+- `docs/en/operations/type-safety-baseline.md`
+- `docs/en/poc/one-day-poc-reviewer-pack.md`
+- `docs/en/poc/one-day-poc-performance-report.md`
+
+次に実行:
+
+    python -m pytest -q veritas_os/tests/test_one_day_poc_smoke.py
+    python -m pytest -q veritas_os/tests/test_one_day_poc_benchmark.py
+    python -m scripts.quality.check_type_baseline
+    python -m scripts.quality.check_bilingual_docs
+
+状態確認:
+
+- オープン PR / Issue のうち、セキュリティ・リリース影響の高いものを把握
+- 秘密情報や API key の混入がないことを確認
+- `main` の CI 必須チェックがグリーンであることを確認
+
+## 4. 品質ゲート
+
+最低限確認するゲート:
+
+- CI（main workflow）
+- Security Gates
+- CodeQL custom
+- Runtime Pickle Guard
+- requirements sync
+- bilingual docs check
+- one-day PoC smoke tests
+- one-day PoC benchmark tests
+- provider support matrix docs test
+- compliance positioning docs test
+- type safety baseline test
+
+補足: これらに合格しても、本番運用適格性・法的適合性・セキュリティ認証・SLA準備完了を保証するものではありません。
+
+## 5. PRレビュー観点
+
+- runtime governance semantics を変更していないか
+- bind / RBAC / TrustLog の挙動を変更していないか
+- evidence packet shape を変更していないか
+- benchmark packet shape を変更していないか
+- provider tier を変更していないか
+- compliance claim を過度に強化していないか
+- runtime dependency を追加していないか
+- secrets を露出していないか
+- EN/JA ドキュメント同期が必要か
+- One-Day PoC reviewer pack の更新が必要か
+- CI ゲート前提を壊していないか
+
+## 6. リリース前確認
+
+- `main` の CI がグリーン
+- 必要時に release gate がグリーン
+- 変更内容に対応する docs 更新が反映済み
+- provider support matrix / compliance positioning が最新
+- benchmark 導線が実行可能
+- 未レビューの provider tier 変更がない
+- 法務・規制保証の過剰主張がない
+- runtime dependency 追加に正当化がある
+- secret handling / logging 退行がない
+
+## 7. PoC提出確認
+
+- reviewer pack
+- evidence JSON
+- evidence Markdown
+- benchmark JSON
+- benchmark Markdown
+- provider support matrix 参照
+- EU AI Act positioning 参照
+- type safety baseline 参照
+- known limitations 明記
+
+## 8. secret handling
+
+- API key をコミットしない
+- secret を Issue / PR / docs / benchmark へ生で貼らない
+- secret を含みうる raw request/response を安易に共有しない
+- reviewer 向け成果物は sanitize された出力のみ使う
+- customer data は機密として扱う
+- evidence packet は secret-safe を維持する
+
+## 9. incident triage
+
+初動では以下に限定:
+
+- failing gate / failing path の特定
+- failing run へのリンク
+- 対象コマンドで再現
+- runtime 変更か docs/tooling 変更か切り分け
+- incident fix で広範囲リファクタをしない
+- PR に root cause と mitigation を記録
+
+対象インシデント例:
+
+- CI failure
+- security gate failure
+- evidence validation failure
+- benchmark failure
+- provider failure
+- TrustLog / RBAC / bind behavior regression
+- docs compliance claim regression
+
+## 10. subsystem map
+
+| Area | Primary docs/tests | Maintainer concern |
+|---|---|---|
+| Bind / admissibility | `docs/en/architecture/bind_time_admissibility_evaluator.md`, `docs/en/architecture/bind-boundary-governance-artifacts.md` | fail-closed を弱めない。 |
+| RBAC | `docs/en/architecture/decision-semantics.md`, `veritas_os/tests/test_role_guard_escalation.py` | denial visibility と escalation 境界を維持。 |
+| TrustLog | `docs/en/architecture/authority-evidence-vs-audit-log.md`, `veritas_os/tests/test_audit_log_writer.py` | append/audit semantics を維持。 |
+| Evidence packets | `docs/en/poc/one-day-poc-reviewer-pack.md`, `veritas_os/tests/test_docs_poc_samples.py` | schema shape と sanitize 保証を維持。 |
+| Provider support | `docs/en/operations/provider-support-matrix.md`, `veritas_os/tests/test_provider_support_matrix_docs.py` | 非本番 provider の過剰主張をしない。 |
+| Compliance positioning | `docs/en/positioning/public-positioning.md`, `veritas_os/tests/test_compliance_positioning_docs.py` | legal certification を主張しない。 |
+| Type safety | `docs/en/operations/type-safety-baseline.md`, `veritas_os/tests/test_type_safety_baseline.py` | baseline は段階的運用であり、全域 strict typing ではない。 |
+
+## 11. 既知の継続性リスク
+
+- 単一 primary maintainer リスクは残存
+- staffed support organization は未整備
+- formal support SLA は未提供
+- 一部運用知識は暗黙知のまま残る可能性
+- 法務/セキュリティの第三者レビューはリポジトリ外の責務
+- 本番デプロイ責任は customer/operator 側
+
+## 12. 今後の roadmap
+
+- maintainer onboarding issue template を追加
+- release manager checklist template を追加
+- incident report template を追加
+- type baseline の core modules カバレッジを拡張
+- provider contract tests を段階的に追加
+- major subsystems の ADR を整備
+- dev/full/runtime dependency profile 分離を整備
+- 実体あるサポート体制が存在する場合のみ SLA を定義

--- a/veritas_os/tests/test_maintainer_handoff_docs.py
+++ b/veritas_os/tests/test_maintainer_handoff_docs.py
@@ -27,9 +27,10 @@ def test_readme_index_and_map_link_handoff_docs() -> None:
 def test_risk_boundary_phrases_exist() -> None:
     en = EN_DOC.read_text(encoding="utf-8")
     ja = JA_DOC.read_text(encoding="utf-8")
-    assert "does not eliminate bus-factor risk" in en
-    assert "not a substitute for a staffed support organization" in en
-    assert "no formal support SLA" in en
+    en_lower = en.lower()
+    assert "does not eliminate bus-factor risk" in en_lower
+    assert "not a substitute for a staffed support organization" in en_lower
+    assert "no formal support sla" in en_lower
     assert "バスファクターリスクを完全に解消するものではありません" in ja
     assert "24/7 support または正式なSLAを意味しない" in ja
 

--- a/veritas_os/tests/test_maintainer_handoff_docs.py
+++ b/veritas_os/tests/test_maintainer_handoff_docs.py
@@ -1,0 +1,68 @@
+"""Docs checks for maintainer handoff and support continuity runbook."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EN_DOC = REPO_ROOT / "docs/en/operations/maintainer-handoff.md"
+JA_DOC = REPO_ROOT / "docs/ja/operations/maintainer-handoff.md"
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_maintainer_handoff_docs_exist() -> None:
+    assert EN_DOC.exists()
+    assert JA_DOC.exists()
+
+
+def test_readme_index_and_map_link_handoff_docs() -> None:
+    assert "docs/en/operations/maintainer-handoff.md" in _read("README.md")
+    assert "maintainer-handoff.md" in _read("docs/INDEX.md")
+    assert "maintainer-handoff.md" in _read("docs/DOCUMENTATION_MAP.md")
+
+
+def test_risk_boundary_phrases_exist() -> None:
+    en = EN_DOC.read_text(encoding="utf-8")
+    ja = JA_DOC.read_text(encoding="utf-8")
+    assert "does not eliminate bus-factor risk" in en
+    assert "not a substitute for a staffed support organization" in en
+    assert "no formal support SLA" in en
+    assert "バスファクターリスクを完全に解消するものではありません" in ja
+    assert "24/7 support または正式なSLAを意味しない" in ja
+
+
+def test_required_sections_exist_in_english_doc() -> None:
+    text = EN_DOC.read_text(encoding="utf-8")
+    required = [
+        "First 60 minutes",
+        "Quality gates checklist",
+        "PR review checklist",
+        "Incident triage checklist",
+        "Current known continuity risks",
+    ]
+    for phrase in required:
+        assert phrase in text
+
+
+def test_no_overclaim_phrases() -> None:
+    targets = [
+        "docs/en/operations/maintainer-handoff.md",
+        "docs/ja/operations/maintainer-handoff.md",
+        "README.md",
+    ]
+    banned = [
+        "bus factor solved",
+        "eliminates bus-factor risk",
+        "24/7 support guaranteed",
+        "formal SLA included",
+        "バスファクター解決済み",
+        "24時間365日サポート保証",
+        "正式SLA提供済み",
+    ]
+    for path in targets:
+        text = _read(path)
+        for phrase in banned:
+            assert phrase not in text


### PR DESCRIPTION
### Motivation

- Reduce handoff friction and lower bus-factor risk by providing a concise Maintainer Handoff and Support Continuity Runbook that documents first-hour onboarding, repository orientation, quality gates, PR/release checklists, PoC reviewer packet checklists, secret handling, and incident triage.
- Provide an English canonical runbook plus a Japanese companion so external reviewers, investors, and incoming maintainers can verify operational continuity artifacts and boundaries without asserting staffing/SLA or legal/security certifications.

### Description

- Add `docs/en/operations/maintainer-handoff.md` (canonical EN runbook) with the requested 19 sections including "First 60 minutes", quality gates, PR review checklist, incident triage, governance subsystem map, known continuity risks, and roadmap items.
- Add Japanese companion `docs/ja/operations/maintainer-handoff.md` that clearly marks the English doc as canonical and provides the same guidance in natural Japanese.
- Link the runbook from `README.md`, add entries to `docs/INDEX.md` and `docs/DOCUMENTATION_MAP.md`, and add a lightweight docs test at `veritas_os/tests/test_maintainer_handoff_docs.py` to validate presence, risk-boundary phrases, required sections, and absence of overclaiming phrases.
- No runtime code, governance semantics, API contracts, evidence/benchmark shapes, provider tiers, CI workflows, or new dependencies were changed or added.

### Testing

- Ran the new docs test and related doc/quality checks and verification suites and they passed locally: `~/.pyenv/versions/3.12.13/bin/python -m pytest -q veritas_os/tests/test_maintainer_handoff_docs.py` (passed), `~/.pyenv/versions/3.12.13/bin/python -m scripts.quality.check_bilingual_docs` (passed), and additional repo doc/type/PoC tests (`test_docs_poc_samples.py`, `test_type_safety_baseline.py`, `test_provider_support_matrix_docs.py`, `test_compliance_positioning_docs.py`) all passed under the available interpreter.
- Note: a pyenv/default-interpreter mismatch was observed when invoking `pytest` with the repo default Python in this environment; all tests were executed successfully using an installed interpreter path instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd417e42288326b0a572f2beffb134)