### PR TITLE
docs(positioning): add enterprise value brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ For external reviewers, start with `docs/REVIEWER_ENTRYPOINT.md`.
 
 For a 10-minute implementation snapshot, start here:
 
+For a concise business-facing overview, see [Enterprise Value Brief](docs/en/positioning/enterprise-value-brief.md).
+日本語補助版: [企業向け価値説明ブリーフ](docs/ja/positioning/enterprise-value-brief.md)
+
 1. [Reviewer Entrypoint](docs/REVIEWER_ENTRYPOINT.md)
 2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
 3. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -54,6 +54,7 @@
 | PoC: Evidence packet schema | `schemas/poc/one_day_poc_evidence.v1.schema.json` | — | EN canonical / machine-readable | One-Day PoC evidence JSON schema |
 | Positioning: AML/KYC | `docs/en/positioning/aml-kyc-beachhead-short-positioning.md` | `docs/ja/positioning/aml-kyc-beachhead-short-positioning.md` | JA explanation / EN canonical | 公開向け短縮版 |
 | Positioning: Public positioning | `docs/en/positioning/public-positioning.md` | `docs/ja/positioning/public-positioning.md` | JA explanation / EN canonical | 内部再評価含む |
+| Positioning: Enterprise value brief | `docs/en/positioning/enterprise-value-brief.md` | `docs/ja/positioning/enterprise-value-brief.md` | JA explanation / EN canonical | One-page enterprise/investor value brief, proof assets, boundaries, and next-step review path |
 | UI docs | `docs/ui/README_UI.md` | `docs/ui/PREVIEW_PAGES_JP.md` | Mixed | UI本体は EN、プレビュー案内は JA |
 | Reviews | `docs/en/reviews/` | `docs/ja/reviews/` | Mixed | JAはレビュー蓄積多め |
 | Benchmarks | `docs/benchmarks/VERITAS_EVIDENCE_BENCHMARK_PLAN.md` | `docs/ja/validation/technical-proof-pack.md` | JA explanation / EN canonical | ベンチ証跡案内 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -53,6 +53,7 @@
 | Financial Governance Templates | [Financial governance templates (EN)](en/guides/financial-governance-templates.md) | [金融ガバナンステンプレート (JA)](ja/guides/financial-governance-templates.md) |
 | Governance Policy Bundle Promotion | [Policy bundle promotion (EN)](en/guides/governance-policy-bundle-promotion.md) | [ポリシーバンドル昇格 (JA)](ja/guides/governance-policy-bundle-promotion.md) |
 | AML/KYC Beachhead Positioning | [AML/KYC short positioning (EN)](en/positioning/aml-kyc-beachhead-short-positioning.md) | [AML/KYCポジショニング (JA)](ja/positioning/aml-kyc-beachhead-short-positioning.md) |
+| Positioning: Enterprise value brief | [Enterprise value brief (EN)](en/positioning/enterprise-value-brief.md) | [企業向け価値説明ブリーフ (JA)](ja/positioning/enterprise-value-brief.md) |
 | UI / Frontend | [UI Docs (EN)](ui/README_UI.md) | [UI preview (JA)](ui/PREVIEW_PAGES_JP.md) |
 | Benchmarks | [Benchmarks (EN)](benchmarks/) | [技術証明パック (JA解説)](ja/validation/technical-proof-pack.md) |
 | Reviews / Audits | [Reviews (EN)](en/reviews/) | [Reviews / Audits (JA)](ja/reviews/) |
@@ -120,6 +121,7 @@
 | 金融ガバナンステンプレート | [Financial governance templates（英語正本）](en/guides/financial-governance-templates.md) | [金融ガバナンステンプレート（日本語解説）](ja/guides/financial-governance-templates.md) |
 | ポリシーバンドル昇格 | [Policy bundle promotion（英語正本）](en/guides/governance-policy-bundle-promotion.md) | [ポリシーバンドル昇格（日本語解説）](ja/guides/governance-policy-bundle-promotion.md) |
 | AML/KYCポジショニング | [AML/KYC short positioning（英語正本）](en/positioning/aml-kyc-beachhead-short-positioning.md) | [AML/KYCポジショニング（日本語解説）](ja/positioning/aml-kyc-beachhead-short-positioning.md) |
+| Positioning: Enterprise value brief | [Enterprise value brief (EN)](en/positioning/enterprise-value-brief.md) | [企業向け価値説明ブリーフ (JA)](ja/positioning/enterprise-value-brief.md) |
 | UI / Frontend | [UI Docs（英語正本）](ui/README_UI.md) | [UIプレビュー（日本語）](ui/PREVIEW_PAGES_JP.md) |
 | ベンチマーク | [Benchmarks（英語正本）](benchmarks/) | [技術証明パック（日本語解説）](ja/validation/technical-proof-pack.md) |
 | レビュー / 監査 | [Reviews（英語正本）](en/reviews/) | [レビュー / 監査（日本語）](ja/reviews/) |

--- a/docs/en/positioning/enterprise-value-brief.md
+++ b/docs/en/positioning/enterprise-value-brief.md
@@ -1,0 +1,129 @@
+# VERITAS OS Enterprise Value Brief
+
+## One-sentence value
+
+VERITAS OS is a decision-governance and bind-boundary control plane that helps organizations make AI-agent decisions reviewable, traceable, replayable, auditable, and enforceable before real-world effect.
+
+## Who this is for
+
+- Enterprise AI governance teams
+- Regulated workflow owners
+- Risk / compliance / audit teams
+- AI platform teams
+- Investors and technical diligence reviewers
+- Healthcare / financial / public-sector AI evaluators
+
+## The problem
+
+AI adoption often stalls not because models are weak, but because organizations cannot explain, stop, review, or audit AI-agent decisions before execution.
+
+Common gaps in enterprise rollout:
+
+- Agent outputs move too quickly from recommendation to action.
+- Regulated teams need explicit evidence, approval boundaries, and replayable traces.
+- Logs alone are not enough: audit logs show what happened, but not why an action was authorized.
+
+## What VERITAS does
+
+VERITAS routes AI decisions through governance and bind boundaries before commit:
+
+- Produces reviewable decision and bind artifacts.
+- Blocks, escalates, refuses, or permits actions before commit.
+- Keeps evidence and audit boundaries explicit.
+- Gives operators reviewer-facing artifacts and one-day PoC evidence packets.
+
+## What VERITAS blocks before real-world effect
+
+VERITAS can block or refuse specific pre-commit risk paths such as:
+
+- Missing Authority Evidence
+- Non-admissible regulated actions
+- Unsafe or undefined bind paths
+- Non-promotable pre-bind formation lineage
+- Governance mutation paths without proper bind checks
+- Provider or compliance claims not backed by evidence
+
+This brief describes current implemented control patterns and boundaries; it does not claim that VERITAS blocks all unsafe AI actions.
+
+## What evidence VERITAS produces
+
+Current reviewer-facing outputs include:
+
+- Decision artifacts
+- Execution intent lineage
+- Bind receipts
+- Bind summaries
+- One-Day PoC evidence JSON / Markdown
+- Benchmark JSON / Markdown
+- Reviewer packs
+- Provider support matrix
+- Compliance positioning docs
+- Type safety baseline
+- Maintainer handoff runbook
+
+## What can be verified in one day
+
+A reviewer can execute a one-day verification pass to:
+
+- Run the One-Day PoC smoke path
+- Generate a sanitized evidence packet
+- Validate evidence schema
+- Run local benchmark
+- Inspect provider support boundaries
+- Confirm EU AI Act-aligned positioning boundaries
+- Confirm maintainer handoff and type baseline docs
+
+## Why this matters for enterprise AI adoption
+
+- Enterprises need control before action, not only logs after action.
+- Governance must be inspectable by non-model engineers.
+- Compliance and audit teams need evidence packets they can review.
+- Investors and technical reviewers need reproducible proof paths.
+- VERITAS turns AI-agent governance from slideware into an inspectable control plane.
+
+## Current proof assets
+
+- [One-Day PoC Reviewer Pack](../poc/one-day-poc-reviewer-pack.md)
+- [One-Day PoC Performance Report](../poc/one-day-poc-performance-report.md)
+- [Provider Support Matrix](../operations/provider-support-matrix.md)
+- [Type Safety Baseline](../operations/type-safety-baseline.md)
+- [Maintainer Handoff](../operations/maintainer-handoff.md)
+- [Current Implementation Matrix](../validation/current-implementation-matrix.md)
+- [Regulated Action Governance Proof Pack](../validation/regulated-action-governance-proof-pack.md)
+- [Public Positioning](public-positioning.md)
+
+## Current boundaries and non-claims
+
+VERITAS OS currently makes no claim of:
+
+- Not legal advice
+- Not regulatory approval
+- Not third-party certification
+- Not EU Declaration of Conformity
+- Not CE marking
+- Not production SLA
+- Not 24/7 support
+- Not proof of provider-neutral production readiness
+- Not proof of live bank/healthcare/government integration
+- Not full repository strict typing
+- Not elimination of bus-factor risk
+
+## Best-fit first use cases
+
+- AML/KYC regulated action review
+- AI-agent approval gates
+- Internal governance review before tool execution
+- Evidence-first AI workflow review
+- Enterprise AI pilot diligence
+- Healthcare policy / governance review sandbox
+- Audit-ready AI decision review packets
+
+## Next step for reviewers/customers
+
+- Run the One-Day PoC
+- Review the evidence packet
+- Review provider support matrix
+- Review compliance positioning
+- Identify one regulated decision/action path
+- Compare current workflow with VERITAS-governed workflow
+- Decide whether to proceed to a scoped pilot

--- a/docs/ja/positioning/enterprise-value-brief.md
+++ b/docs/ja/positioning/enterprise-value-brief.md
@@ -1,0 +1,127 @@
+# VERITAS OS 企業向け価値説明ブリーフ
+
+> この文書は日本語の補助説明です。英語版の正本は `docs/en/positioning/enterprise-value-brief.md` です。
+
+## 1. 一文で示す価値
+
+VERITAS OS は、意思決定ガバナンスとバインド境界を提供するコントロールプレーンであり、AIエージェントの判断を実世界への作用前に、レビュー可能・追跡可能・再現可能・監査可能・強制可能な形で扱えるようにします。
+
+## 2. 想定読者
+
+- エンタープライズAIガバナンス担当
+- 規制対象ワークフローの責任者
+- リスク / コンプライアンス / 監査チーム
+- AIプラットフォームチーム
+- 投資家および技術デューデリジェンス担当
+- 医療 / 金融 / 公共領域のAI評価担当
+
+## 3. 解決したい問題
+
+AI導入が止まる主因は、モデル性能の不足よりも、実行前のAIエージェント判断を説明・停止・レビュー・監査できないことにあります。
+
+代表的なギャップ:
+
+- 推奨から実行への遷移が速すぎる
+- 規制領域では、明示的な証跡・承認境界・再現可能なトレースが必要
+- 監査ログだけでは不十分（何が起きたかは示せても、なぜ許可されたかまでは示しにくい）
+
+## 4. VERITAS が行うこと
+
+VERITAS は、AIの判断をコミット前にガバナンス境界とバインド境界へ通します。
+
+- レビュー可能な判断成果物・バインド成果物を生成
+- コミット前に block / escalate / refuse / permit を実施
+- 証跡境界と監査境界を明示
+- 運用担当・レビュアー向け成果物と One-Day PoC 証跡パケットを提供
+
+## 5. 実世界作用前にブロックできる対象
+
+現在の実装範囲で、以下のような経路をコミット前にブロックまたは拒否できます。
+
+- Authority Evidence の欠落
+- 規制アクションの非admissible判定
+- unsafe / 未定義の bind path
+- pre-bind formation lineage が昇格不可
+- bindチェックを欠いた governance mutation path
+- 証拠で裏付けられない provider/compliance 主張
+
+本ブリーフは「現在の実装済み制御パターン」を示すものであり、「すべての unsafe AI actions を防止する」とは主張しません。
+
+## 6. VERITAS が生成する証跡
+
+- Decision artifacts
+- Execution intent lineage
+- Bind receipts
+- Bind summaries
+- One-Day PoC evidence JSON / Markdown
+- Benchmark JSON / Markdown
+- Reviewer packs
+- Provider support matrix
+- Compliance positioning docs
+- Type safety baseline
+- Maintainer handoff runbook
+
+## 7. 1日で検証できること
+
+- One-Day PoC の smoke path 実行
+- サニタイズ済み evidence packet の生成
+- evidence schema の検証
+- ローカル benchmark の実行
+- provider support 境界の確認
+- EU AI Act-aligned positioning 境界の確認
+- maintainer handoff / type baseline 文書の確認
+
+## 8. エンタープライズAI導入で重要な理由
+
+- 企業には「実行後のログ」だけでなく「実行前の制御」が必要
+- ガバナンスはモデル実装者以外にも検査可能である必要がある
+- コンプライアンス / 監査チームには提出可能な証跡パケットが必要
+- 投資家・技術レビュアーには再現可能な検証経路が必要
+- VERITAS は、AIエージェントガバナンスを slideware から検査可能な control plane へ変換する
+
+## 9. 現在の proof assets
+
+- [One-Day PoC Reviewer Pack](../poc/one-day-poc-reviewer-pack.md)
+- [One-Day PoC Performance Report](../poc/one-day-poc-performance-report.md)
+- [Provider Support Matrix](../operations/provider-support-matrix.md)
+- [Type Safety Baseline](../operations/type-safety-baseline.md)
+- [Maintainer Handoff](../operations/maintainer-handoff.md)
+- [Current Implementation Matrix](../validation/current-implementation-matrix.md)
+- [Regulated Action Governance Proof Pack](../validation/regulated-action-governance-proof-pack.md)
+- [Public Positioning](public-positioning.md)
+
+## 10. 現時点の境界線（非主張）
+
+以下は現時点で主張しません。
+
+- 法的助言ではありません
+- 規制当局の承認ではありません
+- 第三者認証ではありません
+- EU適合宣言ではありません
+- CEマーキングではありません
+- 本番SLAではありません
+- 24/7サポートではありません
+- provider-neutral production readiness の証明ではありません
+- 銀行 / 医療 / 政府の本番統合実績の証明ではありません
+- リポジトリ全体 strict typing 完了の証明ではありません
+- バスファクターリスクの完全解消を示すものではありません
+
+## 11. 最初に適したユースケース
+
+- AML/KYC 規制アクションレビュー
+- AIエージェント承認ゲート
+- ツール実行前の内部ガバナンスレビュー
+- 証跡先行のAIワークフローレビュー
+- エンタープライズAIパイロットのデューデリジェンス
+- 医療ポリシー / ガバナンスレビューのサンドボックス
+- 監査提出可能なAI意思決定レビューパケット
+
+## 12. レビュアー / 顧客向けの次の一手
+
+- One-Day PoC を実行
+- evidence packet をレビュー
+- provider support matrix を確認
+- compliance positioning を確認
+- 規制対象の decision/action path を1つ特定
+- 現行ワークフローと VERITAS ガバナンス適用後を比較
+- スコープを絞った pilot へ進むか判断

--- a/veritas_os/tests/test_enterprise_value_brief_docs.py
+++ b/veritas_os/tests/test_enterprise_value_brief_docs.py
@@ -67,7 +67,8 @@ def test_non_claim_boundaries_exist() -> None:
 
 
 def test_no_overclaim_expressions() -> None:
-    combined_lower = f"{EN_BRIEF.read_text(encoding='utf-8')}\n{JA_BRIEF.read_text(encoding='utf-8')}".lower()
+    combined = f"{EN_BRIEF.read_text(encoding='utf-8')}\n{JA_BRIEF.read_text(encoding='utf-8')}"
+    combined_lower = combined.lower()
     banned_case_insensitive = [
         "guaranteed compliance",
         "fully compliant",
@@ -78,7 +79,7 @@ def test_no_overclaim_expressions() -> None:
         "provider-neutral production-ready",
         "fully eliminates bus-factor risk",
     ]
-    banned_ja = [
+    banned_ja_case_insensitive = [
         "完全準拠",
         "認証済み製品",
         "本番sla保証",
@@ -89,6 +90,7 @@ def test_no_overclaim_expressions() -> None:
     for phrase in banned_case_insensitive:
         assert phrase not in combined_lower
 
-    combined_text = f"{EN_BRIEF.read_text(encoding='utf-8')}\n{JA_BRIEF.read_text(encoding='utf-8')}"
-    for phrase in banned_ja:
-        assert phrase not in combined_text
+    # Use lowercased combined text so mixed Japanese/Latin phrases such as
+    # "本番SLA保証" are caught consistently.
+    for phrase in banned_ja_case_insensitive:
+        assert phrase.lower() not in combined_lower

--- a/veritas_os/tests/test_enterprise_value_brief_docs.py
+++ b/veritas_os/tests/test_enterprise_value_brief_docs.py
@@ -1,0 +1,94 @@
+"""Docs checks for enterprise value brief positioning boundaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EN_BRIEF = REPO_ROOT / "docs/en/positioning/enterprise-value-brief.md"
+JA_BRIEF = REPO_ROOT / "docs/ja/positioning/enterprise-value-brief.md"
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_enterprise_value_brief_docs_exist() -> None:
+    assert EN_BRIEF.exists()
+    assert JA_BRIEF.exists()
+
+
+def test_links_exist_in_readme_index_and_map() -> None:
+    assert "docs/en/positioning/enterprise-value-brief.md" in _read("README.md")
+    assert "enterprise-value-brief.md" in _read("docs/INDEX.md")
+    assert "enterprise-value-brief.md" in _read("docs/DOCUMENTATION_MAP.md")
+
+
+def test_required_sections_exist_in_en_brief() -> None:
+    text = EN_BRIEF.read_text(encoding="utf-8")
+    required_phrases = [
+        "One-sentence value",
+        "Who this is for",
+        "The problem",
+        "What VERITAS does",
+        "What evidence VERITAS produces",
+        "What can be verified in one day",
+        "Current boundaries and non-claims",
+        "Best-fit first use cases",
+        "Next step",
+    ]
+    for phrase in required_phrases:
+        assert phrase in text
+
+
+def test_non_claim_boundaries_exist() -> None:
+    en_text = EN_BRIEF.read_text(encoding="utf-8")
+    ja_text = JA_BRIEF.read_text(encoding="utf-8")
+
+    en_required = [
+        "Not legal advice",
+        "Not regulatory approval",
+        "Not third-party certification",
+        "Not production SLA",
+        "Not 24/7 support",
+        "Not proof of provider-neutral production readiness",
+    ]
+    ja_required = [
+        "法的助言ではありません",
+        "規制当局の承認ではありません",
+        "第三者認証ではありません",
+        "本番SLAではありません",
+        "24/7サポートではありません",
+    ]
+    for phrase in en_required:
+        assert phrase in en_text
+    for phrase in ja_required:
+        assert phrase in ja_text
+
+
+def test_no_overclaim_expressions() -> None:
+    combined_lower = f"{EN_BRIEF.read_text(encoding='utf-8')}\n{JA_BRIEF.read_text(encoding='utf-8')}".lower()
+    banned_case_insensitive = [
+        "guaranteed compliance",
+        "fully compliant",
+        "certified product",
+        "eu ai act compliant product",
+        "production sla guaranteed",
+        "24/7 support guaranteed",
+        "provider-neutral production-ready",
+        "fully eliminates bus-factor risk",
+    ]
+    banned_ja = [
+        "完全準拠",
+        "認証済み製品",
+        "本番sla保証",
+        "24時間365日サポート保証",
+        "バスファクターリスクを完全に解消",
+    ]
+
+    for phrase in banned_case_insensitive:
+        assert phrase not in combined_lower
+
+    combined_text = f"{EN_BRIEF.read_text(encoding='utf-8')}\n{JA_BRIEF.read_text(encoding='utf-8')}"
+    for phrase in banned_ja:
+        assert phrase not in combined_text


### PR DESCRIPTION
### Motivation

- External reviewers, enterprise stakeholders, and investors need a concise, one-page business-facing summary that explains VERITAS OS value, evidence outputs, boundaries, and a one-day verification path. 
- Existing README/docs are comprehensive but dense for a fast external review; a canonical EN brief with a JA supplement reduces onboarding friction without changing runtime behavior or claims.

### Description

- Adds canonical English brief at `docs/en/positioning/enterprise-value-brief.md` and a Japanese supplemental brief at `docs/ja/positioning/enterprise-value-brief.md` with the 12 requested sections and an explicit note that the English doc is canonical. 
- Links the brief from `README.md`, inserts entries into `docs/INDEX.md`, and updates `docs/DOCUMENTATION_MAP.md` so the brief is discoverable from main doc indexes. 
- Adds a docs test `veritas_os/tests/test_enterprise_value_brief_docs.py` that verifies files exist, README/INDEX/DOCUMENTATION_MAP links, required EN sections, required non-claim boundaries in EN/JA, and banned overclaim expressions. 
- No runtime code changes, no governance/bind/RBAC/TrustLog semantics changes, no API/evidence/benchmark shape changes, no dependency or CI workflow changes, and no legal/regulatory/SLA claims are added.

### Testing

- Ran `PYENV_VERSION=3.11.15 pytest -q veritas_os/tests/test_enterprise_value_brief_docs.py`, which passed. 
- Ran `/usr/bin/python3 -m scripts.quality.check_bilingual_docs`, which passed. 
- Ran other docs-focused tests such as `PYENV_VERSION=3.11.15 pytest -q veritas_os/tests/test_docs_poc_samples.py`, `pytest -q veritas_os/tests/test_provider_support_matrix_docs.py`, `pytest -q veritas_os/tests/test_compliance_positioning_docs.py`, `pytest -q veritas_os/tests/test_maintainer_handoff_docs.py`, and `pytest -q veritas_os/tests/test_type_safety_baseline.py`, all of which passed in this environment. 
- Running the full test suite with `PYENV_VERSION=3.11.15 pytest -q` failed during collection in this ephemeral environment due to missing optional packages (`fastapi`, `pydantic`, `cryptography`, `httpx`, `yaml`) unrelated to these docs changes; this is an environment dependency limitation rather than a problem introduced by the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6460c50c8326a4b39361d31e57e6)