### PR TITLE
docs(review): refresh reviewer entrypoint around enterprise value path

### DIFF
--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -2,126 +2,164 @@
 
 ## Purpose
 
-This document is the fastest entry point for external reviewers, enterprise evaluators, investors, and technical reviewers who want to understand VERITAS OS without reading the entire repository first.
+This document is the first review entry point for external reviewers, enterprise evaluators, investors, and technical due diligence teams who want to understand VERITAS OS before reading the full repository.
 
-It summarizes what to review, what is implemented, what is foundation-only, which proof packs exist, how to validate key claims, and what is intentionally not enabled.
+It is designed to clarify current value, implemented scope, proof assets, validation flow, and explicit boundaries/non-claims.
 
-## 30-minute review path
+This entry point is organized around the current enterprise review path: business value, implemented scope, one-day evidence, provider/compliance boundaries, and technical appendices.
 
-1. `README.md` — product overview and implemented scope boundary.
-2. `docs/REVIEWER_ENTRYPOINT.md` — this repository-level reviewer guide.
-3. `docs/governance/observe_mode_proof_pack.md` — Observe Mode evidence index.
-4. `docs/ui/README_UI.md` — Mission Control and governance UI context.
-5. `/dev/mission-fixture` — local/dev-only fixture viewer route for read-only inspection.
-6. `bash scripts/validate_governance_observation_fixture.sh` — focused validation command for fixture integrity and rendering contract checks.
+## 10-minute review path
+
+1. `docs/en/positioning/enterprise-value-brief.md` — one-page business/investor overview.
+2. `README.md` — core product definition and repository entry map.
+3. `docs/en/validation/current-implementation-matrix.md` — current implementation facts vs roadmap.
+4. `docs/en/poc/one-day-poc-reviewer-pack.md` — what can be reviewed in a short PoC window.
+5. `docs/en/operations/provider-support-matrix.md` — provider tiers, support boundaries, and non-claims.
+6. `docs/en/positioning/public-positioning.md` — conservative positioning and legal/compliance boundary statements.
+
+## 30-minute technical review path
+
+1. `docs/en/positioning/enterprise-value-brief.md`
+2. `docs/en/validation/current-implementation-matrix.md`
+3. `docs/en/validation/regulated-action-governance-proof-pack.md`
+4. `docs/en/poc/one-day-poc-reviewer-pack.md`
+5. `docs/en/poc/one-day-poc-performance-report.md`
+6. `docs/en/operations/type-safety-baseline.md`
+7. `docs/en/operations/maintainer-handoff.md`
+8. `docs/en/operations/provider-support-matrix.md`
+9. `docs/en/architecture/regulated-action-governance-kernel.md`
+10. `docs/en/architecture/bind-boundary-governance-artifacts.md`
 
 ## What VERITAS OS is
 
-VERITAS OS is an auditable decision operating system for LLM agents. It focuses on making AI decisions reviewable, traceable, reproducible, and governable through structured evidence, policy checks, decision artifacts, Mission Control visibility, and validation workflows.
+VERITAS OS is a Decision Governance and Bind-Boundary Control Plane for AI agents. It is designed to make AI-agent decisions reviewable, traceable, replayable, auditable, and enforceable before real-world effect.
 
-It is a governance/control plane for decision and bind boundaries before real-world effect. It is not a claim that every effect path is fully production-complete today.
+Key reviewer concepts:
 
-## Current implemented evidence areas
+- Decision governance for regulated/high-impact action paths.
+- Bind-boundary control before real-world side effects.
+- Authority Evidence for operator and reviewer traceability.
+- BindReceipt / BindSummary artifacts for inspection and replay context.
+- Fail-closed behavior as the default safety posture.
+- Operator-facing review artifacts for governance and PoC validation.
 
-| Area | Where to look | What to verify |
+## What to verify first
+
+| Review question | Primary source | What to check |
 |---|---|---|
-| Decision / governance pipeline | `README.md`, `docs/INDEX.md` | Decision artifacts, governance pipeline concepts, evidence-oriented execution, fail-closed posture language. |
-| Mission Control | `docs/ui/README_UI.md`, `frontend/components/mission-page.tsx`, `frontend/app/dev/mission-fixture/page.tsx` | Read-only operator visibility, governance artifact rendering, dev-only fixture viewer behavior. |
-| Observe Mode foundation | `docs/governance/observe_mode_proof_pack.md`, `docs/governance/observe_mode.md` | Semantics, dry-run evaluator, CLI checker, dev-only snapshot generator, Mission Control read-only display, production fail-closed unchanged, runtime not enabled. |
-| Fixture and validation integrity | `scripts/validate_governance_observation_fixture.sh`, `veritas_os/tests/test_governance_observation_fixture_drift.py`, `frontend/app/dev/mission-fixture/page.test.tsx` | Root/frontend fixture parity, CLI checker validity, Mission Control rendering tests for the fixture path. |
-| Quality / validation commands | `README.md`, `scripts/check_governance_observation.py`, `scripts/generate_observe_mode_demo_snapshot.py` | Reproducible local checks, focused validation commands, proof-pack validation paths. |
+| What problem does VERITAS solve? | `docs/en/positioning/enterprise-value-brief.md` | Enterprise value, target users, and priority use cases. |
+| What is implemented today? | `docs/en/validation/current-implementation-matrix.md` | Clear separation between current facts and roadmap/foundation-only items. |
+| What can be verified in one day? | `docs/en/poc/one-day-poc-reviewer-pack.md` | Smoke path, generated evidence packet, and validation workflow. |
+| Is there performance evidence? | `docs/en/poc/one-day-poc-performance-report.md` | Local benchmark method, measurement boundaries, and non-SLA language. |
+| What are provider boundaries? | `docs/en/operations/provider-support-matrix.md` | OpenAI production tier, Anthropic planned with offline contract coverage, and explicit boundaries. |
+| Are legal/compliance claims bounded? | `docs/en/positioning/public-positioning.md`, `docs/eu_ai_act/technical_documentation.md` | Positioning uses conservative non-certification language and bounded claims. |
+| Is there type safety? | `docs/en/operations/type-safety-baseline.md` | Narrow, practical baseline rather than full-repository strict typing claims. |
+| Is handoff possible? | `docs/en/operations/maintainer-handoff.md` | Maintainer runbook exists; handoff path is documented but risk is not eliminated. |
 
-## Production-ready vs foundation-only
+## Current proof assets
 
-### Implemented / reviewable
-
-- Mission Control read-only governance artifact rendering.
-- `governance_observation` schema/type foundation and documentation.
-- Observe Mode dry-run validation tooling (evaluator + CLI checker).
-- Dev-only fixture viewer with production disabled state.
-- Fixture drift detection and focused validation scripts.
-- Observe Mode demo snapshot generation for local/dev inspection.
-
-### Foundation-only / not runtime-enabled
-
-- Observe Mode runtime behavior.
-- Production observe execution.
-- Live backend emission of `governance_observation`.
-- User-uploaded JSON loader for Mission Control.
-- Automatic policy generation.
-- Governance palette marketplace.
-- Any production bypass path.
+- [Enterprise Value Brief](docs/en/positioning/enterprise-value-brief.md)
+- [One-Day PoC Reviewer Pack](docs/en/poc/one-day-poc-reviewer-pack.md)
+- [One-Day PoC Performance Report](docs/en/poc/one-day-poc-performance-report.md)
+- [Sample evidence JSON / Markdown](docs/en/poc/sample-one-day-poc-evidence.md)
+- [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
+- [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+- [Provider Support Matrix](docs/en/operations/provider-support-matrix.md)
+- [Type Safety Baseline](docs/en/operations/type-safety-baseline.md)
+- [Maintainer Handoff Runbook](docs/en/operations/maintainer-handoff.md)
+- [Public Positioning](docs/en/positioning/public-positioning.md)
+- [AML/KYC regulated action path](docs/en/validation/aml-kyc-regulated-action-path.md)
+- Anthropic provider contract test path: `veritas_os/tests/test_llm_client_anthropic_contract.py`
 
 ## Recommended validation commands
 
-```bash
-bash scripts/validate_reviewer_entrypoint.sh
-bash scripts/validate_governance_observation_fixture.sh
-python scripts/check_governance_observation.py fixtures/governance_observation_live_snapshot.json
-python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json
-python scripts/check_governance_observation.py /tmp/observe_snapshot.json
-pnpm --filter frontend test app/dev/mission-fixture/page.test.tsx
-```
-
-The reviewer entrypoint validation script prints a summary block that can be pasted into `docs/reviewer_validation_report_template.md`.
-
-Optional broader checks (already used in repository docs):
+Run docs and reviewer-path checks first:
 
 ```bash
-bash scripts/demo_mission_audit_workflow.sh
-pnpm -r test
+python -m scripts.quality.check_bilingual_docs
+pytest -q veritas_os/tests/test_enterprise_value_brief_docs.py
+pytest -q veritas_os/tests/test_docs_poc_samples.py
+pytest -q veritas_os/tests/test_provider_support_matrix_docs.py
+pytest -q veritas_os/tests/test_type_safety_baseline.py
+pytest -q veritas_os/tests/test_maintainer_handoff_docs.py
+pytest -q veritas_os/tests/test_llm_client_anthropic_contract.py
+pytest -q veritas_os/tests/test_reviewer_entrypoint_current_path.py
 ```
 
-## Demo / inspection surfaces
-
-### `/dev/mission-fixture`
-
-- Local/dev/test oriented route.
-- Production environment renders a disabled state.
-- No backend API calls.
-- No runtime Observe Mode activation.
-- Static fixture only.
-- Useful for reviewing Mission Control rendering contract.
-
-### Observe Mode generated snapshot
+One-Day PoC command examples (API server required, API key required):
 
 ```bash
-python scripts/generate_observe_mode_demo_snapshot.py --out /tmp/observe_snapshot.json
-python scripts/check_governance_observation.py /tmp/observe_snapshot.json
+VERITAS_API_KEY=... python scripts/demo/one_day_poc_smoke.py --json --evidence-json /tmp/veritas_poc_evidence.json --evidence-md /tmp/veritas_poc_evidence.md
+VERITAS_API_KEY=... python scripts/demo/one_day_poc_benchmark.py --runs 10 --warmup 2 --json --out-json /tmp/veritas_poc_benchmark.json --out-md /tmp/veritas_poc_benchmark.md
 ```
 
-This is a dev/test evidence path. It is not production runtime evidence.
+Boundary notes for PoC commands:
 
-## Safety boundaries
+- API server is required for end-to-end PoC execution.
+- `VERITAS_API_KEY` is required for authenticated runs.
+- Do not print or commit secrets/tokens into logs, docs, or evidence files.
 
-- Production remains fail-closed.
+## Current boundaries and non-claims
+
+- Not legal advice.
+- Not regulatory approval.
+- Not third-party certification.
+- Not EU Declaration of Conformity.
+- Not CE marking.
+- Not production SLA.
+- Not 24/7 support.
+- Not proof of provider-neutral production readiness.
+- Not proof of live bank/healthcare/government integration.
+- Not full repository strict typing.
+- Not elimination of bus-factor risk.
+- Fixture/demo evidence is not live customer integration.
+
+## Provider and model boundary
+
+OpenAI is the current production-tier provider. Anthropic and Google remain Planned. Ollama/OpenRouter-style paths remain Experimental unless code and docs state otherwise. Anthropic has offline contract coverage, but that coverage does not promote it to production.
+
+## Compliance positioning boundary
+
+VERITAS supports EU AI Act-aligned governance workflows by producing inspectable control and audit evidence. It is not legal certification, conformity assessment, EU Declaration of Conformity, CE marking, or regulatory approval.
+
+## Technical appendix: Observe Mode foundation
+
+Observe Mode material is retained as a foundation/technical appendix path, not the primary enterprise reviewer path.
+
+- `docs/governance/observe_mode_proof_pack.md`
+- `docs/governance/observe_mode.md`
+- `docs/ui/README_UI.md`
+- `/dev/mission-fixture`
+- `scripts/validate_governance_observation_fixture.sh`
+- `scripts/check_governance_observation.py`
+- `scripts/generate_observe_mode_demo_snapshot.py`
+
+Observe Mode boundary reminders:
+
 - Observe Mode runtime is not enabled.
-- No production bypass exists.
-- No backend mutation endpoint is added by the Observe Mode foundation.
-- Mission Control observation display is read-only.
-- `/dev/mission-fixture` is disabled in production environment.
-- Proof packs document evidence; they do not replace future runtime safety validation.
+- Production remains fail-closed.
+- Demo fixture evidence is not production runtime evidence.
 
 ## Reviewer checklist
 
-- [ ] Read `README.md` overview.
-- [ ] Read `docs/governance/observe_mode_proof_pack.md`.
-- [ ] Run `bash scripts/validate_reviewer_entrypoint.sh` (lightweight link + evidence smoke validation).
-- [ ] Run focused validation script.
-- [ ] Generate and check demo snapshot.
-- [ ] Review `/dev/mission-fixture` locally.
-- [ ] Confirm production disabled-state behavior.
-- [ ] Confirm runtime non-goals.
-- [ ] Confirm production fail-closed boundary.
-- [ ] Identify foundation-only areas.
+- [ ] Read Enterprise Value Brief.
+- [ ] Read Current Implementation Matrix.
+- [ ] Review One-Day PoC Reviewer Pack.
+- [ ] Generate or inspect evidence packet.
+- [ ] Review performance report boundaries.
+- [ ] Review provider matrix.
+- [ ] Review compliance positioning boundaries.
+- [ ] Review type safety baseline.
+- [ ] Review maintainer handoff runbook.
+- [ ] Confirm non-claims.
 - [ ] Record unresolved questions.
-- [ ] Record findings using `docs/reviewer_validation_report_template.md`.
 
 ## Open questions / limitations
 
-- Some systems are foundation-only and not runtime-enabled.
-- External security review is still needed before production claims beyond current scope.
-- Production deployment posture should be evaluated separately per environment.
-- Observe Mode runtime is not implemented.
-- Live backend emission of `governance_observation` is not implemented.
-- Demo routes are not substitutes for production runtime tests.
+- External security review is still needed.
+- Legal review and conformity assessment are not included.
+- Production deployment posture must be evaluated per customer environment.
+- Live customer integrations are not proven by fixture/demo evidence.
+- Provider-neutral production readiness is not proven.
+- Type safety is baseline-only, not full-repository strict typing.
+- Bus-factor risk remains.

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -58,17 +58,18 @@ Key reviewer concepts:
 
 ## Current proof assets
 
-- [Enterprise Value Brief](docs/en/positioning/enterprise-value-brief.md)
-- [One-Day PoC Reviewer Pack](docs/en/poc/one-day-poc-reviewer-pack.md)
-- [One-Day PoC Performance Report](docs/en/poc/one-day-poc-performance-report.md)
-- [Sample evidence JSON / Markdown](docs/en/poc/sample-one-day-poc-evidence.md)
-- [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
-- [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-- [Provider Support Matrix](docs/en/operations/provider-support-matrix.md)
-- [Type Safety Baseline](docs/en/operations/type-safety-baseline.md)
-- [Maintainer Handoff Runbook](docs/en/operations/maintainer-handoff.md)
-- [Public Positioning](docs/en/positioning/public-positioning.md)
-- [AML/KYC regulated action path](docs/en/validation/aml-kyc-regulated-action-path.md)
+- [Enterprise Value Brief](en/positioning/enterprise-value-brief.md)
+- [One-Day PoC Reviewer Pack](en/poc/one-day-poc-reviewer-pack.md)
+- [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
+- [Sample evidence JSON](en/poc/sample-one-day-poc-evidence.json)
+- [Sample evidence Markdown](en/poc/sample-one-day-poc-evidence.md)
+- [Current Implementation Matrix](en/validation/current-implementation-matrix.md)
+- [Regulated Action Governance Proof Pack](en/validation/regulated-action-governance-proof-pack.md)
+- [Provider Support Matrix](en/operations/provider-support-matrix.md)
+- [Type Safety Baseline](en/operations/type-safety-baseline.md)
+- [Maintainer Handoff Runbook](en/operations/maintainer-handoff.md)
+- [Public Positioning](en/positioning/public-positioning.md)
+- [AML/KYC regulated action path](en/use-cases/aml-kyc-regulated-action-path.md)
 - Anthropic provider contract test path: `veritas_os/tests/test_llm_client_anthropic_contract.py`
 
 ## Recommended validation commands

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -1,0 +1,94 @@
+"""Docs checks for reviewer entrypoint current enterprise review path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO_ROOT / "docs/REVIEWER_ENTRYPOINT.md"
+
+
+def _entrypoint_text() -> str:
+    return ENTRYPOINT.read_text(encoding="utf-8")
+
+
+def test_reviewer_entrypoint_exists() -> None:
+    assert ENTRYPOINT.exists()
+
+
+def test_reviewer_entrypoint_links_required_current_docs() -> None:
+    text = _entrypoint_text()
+    required_links = [
+        "docs/en/positioning/enterprise-value-brief.md",
+        "docs/en/validation/current-implementation-matrix.md",
+        "docs/en/poc/one-day-poc-reviewer-pack.md",
+        "docs/en/poc/one-day-poc-performance-report.md",
+        "docs/en/operations/provider-support-matrix.md",
+        "docs/en/operations/type-safety-baseline.md",
+        "docs/en/operations/maintainer-handoff.md",
+    ]
+    for link in required_links:
+        assert link in text
+
+
+def test_reviewer_entrypoint_has_required_sections() -> None:
+    text = _entrypoint_text()
+    required_sections = [
+        "## 10-minute review path",
+        "## 30-minute technical review path",
+        "## What to verify first",
+        "## Current proof assets",
+        "## Recommended validation commands",
+        "## Current boundaries and non-claims",
+        "## Provider and model boundary",
+        "## Compliance positioning boundary",
+        "## Technical appendix: Observe Mode foundation",
+        "## Reviewer checklist",
+        "## Open questions / limitations",
+    ]
+    for section in required_sections:
+        assert section in text
+
+
+def test_reviewer_entrypoint_has_required_non_claim_boundaries() -> None:
+    text = _entrypoint_text()
+    required_boundaries = [
+        "Not legal advice",
+        "Not regulatory approval",
+        "Not third-party certification",
+        "Not production SLA",
+        "Not 24/7 support",
+        "Not proof of provider-neutral production readiness",
+        "Not full repository strict typing",
+        "Not elimination of bus-factor risk",
+    ]
+    for boundary in required_boundaries:
+        assert boundary in text
+
+
+def test_reviewer_entrypoint_does_not_include_overclaim_phrases() -> None:
+    text = _entrypoint_text().lower()
+    banned_phrases = [
+        "guaranteed compliance",
+        "fully compliant",
+        "certified product",
+        "eu ai act compliant product",
+        "production sla guaranteed",
+        "24/7 support guaranteed",
+        "provider-neutral production-ready",
+        "fully eliminates bus-factor risk",
+        "完全準拠",
+        "認証済み製品",
+        "本番sla保証",
+        "24時間365日サポート保証",
+        "バスファクターリスクを完全に解消",
+    ]
+    for phrase in banned_phrases:
+        assert phrase not in text
+
+
+def test_reviewer_entrypoint_keeps_observe_mode_appendix() -> None:
+    text = _entrypoint_text()
+    assert "observe_mode_proof_pack.md" in text
+    assert "/dev/mission-fixture" in text
+    assert "Observe Mode runtime is not enabled" in text

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -35,11 +35,13 @@ def test_reviewer_entrypoint_markdown_links_are_relative_and_exist() -> None:
             continue
 
         file_part = _link_file_part(target)
+        if not file_part:
+            continue
+
         assert not file_part.startswith("docs/"), (
             f"broken docs-relative link from docs/: {target}"
         )
-        if file_part.endswith(".md"):
-            assert (ENTRYPOINT.parent / file_part).exists(), target
+        assert (ENTRYPOINT.parent / file_part).exists(), target
 
 
 def test_reviewer_entrypoint_links_required_current_docs() -> None:

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -2,33 +2,66 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ENTRYPOINT = REPO_ROOT / "docs/REVIEWER_ENTRYPOINT.md"
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
 
 def _entrypoint_text() -> str:
     return ENTRYPOINT.read_text(encoding="utf-8")
 
 
+def _markdown_link_targets() -> list[str]:
+    return MARKDOWN_LINK_RE.findall(_entrypoint_text())
+
+
+def _link_file_part(target: str) -> str:
+    return target.split("#", 1)[0].split("?", 1)[0]
+
+
 def test_reviewer_entrypoint_exists() -> None:
     assert ENTRYPOINT.exists()
 
 
+def test_reviewer_entrypoint_markdown_links_are_relative_and_exist() -> None:
+    targets = _markdown_link_targets()
+    assert targets
+
+    for target in targets:
+        if target.startswith(("http://", "https://", "#", "/")):
+            continue
+
+        file_part = _link_file_part(target)
+        assert not file_part.startswith("docs/"), (
+            f"broken docs-relative link from docs/: {target}"
+        )
+        if file_part.endswith(".md"):
+            assert (ENTRYPOINT.parent / file_part).exists(), target
+
+
 def test_reviewer_entrypoint_links_required_current_docs() -> None:
-    text = _entrypoint_text()
+    targets = set(_markdown_link_targets())
     required_links = [
-        "docs/en/positioning/enterprise-value-brief.md",
-        "docs/en/validation/current-implementation-matrix.md",
-        "docs/en/poc/one-day-poc-reviewer-pack.md",
-        "docs/en/poc/one-day-poc-performance-report.md",
-        "docs/en/operations/provider-support-matrix.md",
-        "docs/en/operations/type-safety-baseline.md",
-        "docs/en/operations/maintainer-handoff.md",
+        "en/positioning/enterprise-value-brief.md",
+        "en/validation/current-implementation-matrix.md",
+        "en/poc/one-day-poc-reviewer-pack.md",
+        "en/poc/one-day-poc-performance-report.md",
+        "en/operations/provider-support-matrix.md",
+        "en/operations/type-safety-baseline.md",
+        "en/operations/maintainer-handoff.md",
     ]
     for link in required_links:
-        assert link in text
+        assert link in targets
+
+
+def test_reviewer_entrypoint_links_aml_kyc_use_case() -> None:
+    targets = set(_markdown_link_targets())
+    aml_kyc_path = "en/use-cases/aml-kyc-regulated-action-path.md"
+    assert aml_kyc_path in targets
+    assert (ENTRYPOINT.parent / aml_kyc_path).exists()
 
 
 def test_reviewer_entrypoint_has_required_sections() -> None:


### PR DESCRIPTION
### Motivation

- The repo added an Enterprise Value Brief and the reviewer entry point needed to present a concise enterprise-oriented review path first.  
- The goal was to reorganize the entry point into a short business-value path followed by a technical PoC/evidence path while keeping legacy Observe Mode material as a technical appendix.  
- The change must be documentation-only and must not alter runtime, governance, API contracts, provider tiers, evidence shapes, dependencies, or CI workflows.

### Description

- Rewrote `docs/REVIEWER_ENTRYPOINT.md` to present a `10-minute review path` and a `30-minute technical review path` centered on `docs/en/positioning/enterprise-value-brief.md`, the implementation matrix, One-Day PoC artifacts, provider/compliance boundaries, type baseline, and maintainer handoff.  
- Updated the proof-assets list and PoC guidance (including replacing the sample evidence link with `docs/en/poc/sample-one-day-poc-evidence.md`) and added explicit PoC command examples and boundary notes about `VERITAS_API_KEY` and secrets handling.  
- Preserved Observe Mode content by moving it into a `Technical appendix: Observe Mode foundation` section and explicitly clarified that Observe Mode runtime is not enabled and production remains fail-closed.  
- Added `veritas_os/tests/test_reviewer_entrypoint_current_path.py` to automatically verify the presence of required links, sections, non-claim boundaries, banned overclaim phrases (including Japanese variants), and that the Observe Mode appendix remains.

### Testing

- Ran the new docs test with `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_reviewer_entrypoint_current_path.py`, which completed successfully (`6 passed`).  
- Ran the bilingual docs check with `PYENV_VERSION=3.12.13 python -m scripts.quality.check_bilingual_docs`, which reported `all checks passed`.  
- Ran the broader related docs tests with `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_enterprise_value_brief_docs.py veritas_os/tests/test_docs_poc_samples.py veritas_os/tests/test_provider_support_matrix_docs.py veritas_os/tests/test_compliance_positioning_docs.py veritas_os/tests/test_maintainer_handoff_docs.py veritas_os/tests/test_type_safety_baseline.py`, which completed successfully (`33 passed`, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd794635088326bb782a5af9643b34)