### PR TITLE
Align WebSocket API-key fallback and narrow JSONL TrustLog process lock

### DIFF
--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -808,6 +808,7 @@ def _has_configured_api_key() -> bool:
 
     return bool((_get_expected_api_key() or "").strip())
 
+
 def _is_valid_api_key(candidate: str) -> bool:
     """Check if *candidate* matches any configured API key (multi or single)."""
     candidate = candidate.strip()

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -796,6 +796,18 @@ def _enforce_auth_failure_rate_limit(client_ip: str) -> None:
         raise HTTPException(status_code=429, detail="Too many auth failures")
 
 
+
+
+def _has_configured_api_key() -> bool:
+    """Return True when at least one valid API key configuration exists."""
+    try:
+        if _parse_api_keys_config():
+            return True
+    except ValueError:
+        pass
+
+    return bool((_get_expected_api_key() or "").strip())
+
 def _is_valid_api_key(candidate: str) -> bool:
     """Check if *candidate* matches any configured API key (multi or single)."""
     candidate = candidate.strip()
@@ -825,15 +837,7 @@ def require_api_key(
     x_forwarded_for: Optional[str] = Header(default=None, alias="X-Forwarded-For"),
 ):
     """テスト契約: サーバ側の API Key が未設定なら 500, ヘッダが無い/不一致なら 401"""
-    # Check if any key is configured (multi or single)
-    has_multi = False
-    try:
-        has_multi = bool(_parse_api_keys_config())
-    except ValueError:
-        pass
-    expected = (_get_expected_api_key() or "").strip()
-
-    if not expected and not has_multi:
+    if not _has_configured_api_key():
         _record_auth_reject_reason("api_key_server_unconfigured")
         raise HTTPException(status_code=500, detail="Server API key not configured")
 
@@ -958,8 +962,7 @@ def _allow_sse_query_api_key() -> bool:
 
 def _authenticate_websocket_api_key(websocket: WebSocket) -> bool:
     """Authenticate WebSocket API key with header-first policy."""
-    expected = (_get_expected_api_key() or "").strip()
-    if not expected:
+    if not _has_configured_api_key():
         return False
 
     header_candidate = (websocket.headers.get("X-API-Key") or "").strip()

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -27,11 +27,19 @@ import logging
 import os
 import threading
 import uuid
+from contextlib import contextmanager
+from functools import lru_cache
 from time import perf_counter
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Protocol
+from typing import Any, Dict, Iterator, List, Optional, Protocol
+
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX environments
+    fcntl = None
 
 from veritas_os.logging.paths import LOG_DIR
 from veritas_os.audit.storage_mirror import build_storage_mirror
@@ -66,6 +74,35 @@ TRUSTLOG_VERIFICATION_POLICY_VERSION = "trustlog_witness_v2"
 
 class SignedTrustLogWriteError(RuntimeError):
     """Raised when signed TrustLog append fails for expected runtime reasons."""
+
+
+@lru_cache(maxsize=1)
+def _warn_jsonl_trustlog_process_lock_unavailable_once() -> None:
+    """Emit one warning when process-level JSONL locking is unavailable."""
+    _logger.warning(
+        "[security-warning] JSONL TrustLog process-level file locking is unavailable "
+        "because fcntl is not available. Cross-process append serialization is not "
+        "enforced for the JSONL backend on this platform; use PostgreSQL backend for "
+        "production multi-worker deployments."
+    )
+
+
+@contextmanager
+def _jsonl_trustlog_process_lock(path: Path) -> Iterator[None]:
+    """Serialize JSONL append critical section across processes when available."""
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_path.open("a+", encoding="utf-8")
+    try:
+        if fcntl is None:
+            _warn_jsonl_trustlog_process_lock_unavailable_once()
+        else:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        if fcntl is not None:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        lock_file.close()
 
 
 def _worm_mirror_path() -> Optional[Path]:
@@ -865,8 +902,6 @@ def append_signed_decision(
     try:
         with _lock:
             signer = _resolve_signer(ensure_local_keys=True)
-            last_entry = _read_last_entry(SIGNED_TRUSTLOG_JSONL)
-            previous_hash = _entry_chain_hash(last_entry) if last_entry else None
 
             # Compute hash of the *full* payload for cross-reference,
             # then compact to a lightweight summary for on-disk storage.
@@ -887,7 +922,7 @@ def append_signed_decision(
             entry = {
                 "decision_id": _uuid7(),
                 "timestamp": signed_at,
-                "previous_hash": previous_hash,
+                "previous_hash": None,
                 "decision_payload": compact_payload,
                 "payload_hash": payload_hash,
                 "full_payload_hash": full_payload_hash,
@@ -901,11 +936,13 @@ def append_signed_decision(
                 if artifact_ref is not None:
                     entry["artifact_ref"] = artifact_ref
 
-            # Enforce maximum entry size before writing
-            entry = _enforce_entry_size(entry, signer)
+            with _jsonl_trustlog_process_lock(SIGNED_TRUSTLOG_JSONL):
+                last_entry = _read_last_entry(SIGNED_TRUSTLOG_JSONL)
+                entry["previous_hash"] = _entry_chain_hash(last_entry) if last_entry else None
+                entry = _enforce_entry_size(entry, signer)
+                line = json.dumps(entry, ensure_ascii=False) + "\n"
+                _append_line(SIGNED_TRUSTLOG_JSONL, line)
 
-            line = json.dumps(entry, ensure_ascii=False) + "\n"
-            _append_line(SIGNED_TRUSTLOG_JSONL, line)
             mirror = _mirror_to_worm(line)
             if _worm_hard_fail_enabled() and mirror.get("configured") and not mirror.get("ok"):
                 raise SignedTrustLogWriteError("worm_mirror_write_failed")

--- a/veritas_os/audit/trustlog_signed.py
+++ b/veritas_os/audit/trustlog_signed.py
@@ -92,17 +92,25 @@ def _jsonl_trustlog_process_lock(path: Path) -> Iterator[None]:
     """Serialize JSONL append critical section across processes when available."""
     lock_path = path.with_suffix(path.suffix + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_file = lock_path.open("a+", encoding="utf-8")
-    try:
-        if fcntl is None:
-            _warn_jsonl_trustlog_process_lock_unavailable_once()
-        else:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        yield
-    finally:
-        if fcntl is not None:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-        lock_file.close()
+    lock_acquired = False
+
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        try:
+            if fcntl is None:
+                _warn_jsonl_trustlog_process_lock_unavailable_once()
+            else:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                lock_acquired = True
+            yield
+        finally:
+            if fcntl is not None and lock_acquired:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    _logger.warning(
+                        "[security-warning] Failed to release JSONL TrustLog process lock",
+                        exc_info=True,
+                    )
 
 
 def _worm_mirror_path() -> Optional[Path]:
@@ -940,8 +948,10 @@ def append_signed_decision(
                 last_entry = _read_last_entry(SIGNED_TRUSTLOG_JSONL)
                 entry["previous_hash"] = _entry_chain_hash(last_entry) if last_entry else None
                 entry = _enforce_entry_size(entry, signer)
-                line = json.dumps(entry, ensure_ascii=False) + "\n"
+                persisted_entry = json.loads(json.dumps(entry, ensure_ascii=False))
+                line = json.dumps(persisted_entry, ensure_ascii=False) + "\n"
                 _append_line(SIGNED_TRUSTLOG_JSONL, line)
+            entry_hash_for_anchor = _entry_chain_hash(persisted_entry)
 
             mirror = _mirror_to_worm(line)
             if _worm_hard_fail_enabled() and mirror.get("configured") and not mirror.get("ok"):
@@ -950,7 +960,7 @@ def append_signed_decision(
             entry["mirror_backend"] = mirror.get("backend")
             entry["mirror_receipt"] = _build_mirror_receipt(mirror) if mirror.get("ok") else None
 
-            transparency_anchor = _anchor_entry_hash(_entry_chain_hash(entry))
+            transparency_anchor = _anchor_entry_hash(entry_hash_for_anchor)
             if (
                 _transparency_required_enabled()
                 and transparency_anchor.get("configured")

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -2887,6 +2887,30 @@ def test_websocket_auth_rejects_query_api_key_in_production_even_with_dual_flags
     assert server._authenticate_websocket_api_key(ws) is False
 
 
+def test_websocket_auth_falls_back_to_legacy_key_when_multi_key_config_malformed(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-ws-key")
+    monkeypatch.setenv("VERITAS_API_KEYS", "{bad-json")
+
+    ws = SimpleNamespace(
+        headers={"X-API-Key": "legacy-ws-key"},
+        query_params={},
+    )
+
+    assert server._authenticate_websocket_api_key(ws) is True
+
+
+def test_websocket_auth_fail_closed_when_multi_key_config_malformed_without_legacy_key(monkeypatch):
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.setenv("VERITAS_API_KEYS", "{bad-json")
+
+    ws = SimpleNamespace(
+        headers={"X-API-Key": "anything"},
+        query_params={},
+    )
+
+    assert server._authenticate_websocket_api_key(ws) is False
+
+
 def test_websocket_auth_rejects_query_api_key_without_risk_ack(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
     monkeypatch.setenv("VERITAS_ALLOW_WS_QUERY_API_KEY", "1")

--- a/veritas_os/tests/unit/test_trustlog.py
+++ b/veritas_os/tests/unit/test_trustlog.py
@@ -1828,7 +1828,6 @@ from veritas_os.logging import trust_log
 def test_append_signed_decision_wraps_oserror(monkeypatch):
     """Expected runtime write failures are wrapped in domain error."""
 
-    monkeypatch.setattr(trustlog_signed, "_read_all_entries", lambda _path: [])
     _stub_signing(monkeypatch)
 
     def _raise_oserror(_path, _line):
@@ -1879,7 +1878,6 @@ def test_append_signed_decision_adds_transparency_anchor(monkeypatch, tmp_path):
     anchor_path = tmp_path / "transparency.jsonl"
 
     monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", trustlog_path)
-    monkeypatch.setattr(trustlog_signed, "_read_all_entries", lambda _path: [])
     _stub_signing(monkeypatch)
     monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", str(anchor_path))
 
@@ -1900,7 +1898,6 @@ def test_append_signed_decision_raises_when_transparency_required(monkeypatch, t
     trustlog_path = tmp_path / "trustlog.jsonl"
 
     monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", trustlog_path)
-    monkeypatch.setattr(trustlog_signed, "_read_all_entries", lambda _path: [])
     _stub_signing(monkeypatch)
     monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", str(tmp_path / "tp.jsonl"))
     monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
@@ -1916,3 +1913,67 @@ def test_append_signed_decision_raises_when_transparency_required(monkeypatch, t
 
     with pytest.raises(trustlog_signed.SignedTrustLogWriteError):
         trustlog_signed.append_signed_decision({"request_id": "req-anchor-hard-fail"})
+
+
+def test_jsonl_process_lock_fallback_without_fcntl_warns_once(monkeypatch, tmp_path, caplog):
+    trustlog_path = tmp_path / "trustlog.jsonl"
+    monkeypatch.setattr(trustlog_signed, "fcntl", None)
+    trustlog_signed._warn_jsonl_trustlog_process_lock_unavailable_once.cache_clear()
+
+    with caplog.at_level(logging.WARNING):
+        with trustlog_signed._jsonl_trustlog_process_lock(trustlog_path):
+            trustlog_path.write_text("ok", encoding="utf-8")
+        with trustlog_signed._jsonl_trustlog_process_lock(trustlog_path):
+            pass
+
+    assert trustlog_path.read_text(encoding="utf-8") == "ok"
+    warnings = [
+        record.message
+        for record in caplog.records
+        if "JSONL TrustLog process-level file locking is unavailable" in record.message
+    ]
+    assert len(warnings) == 1
+
+
+def test_append_signed_decision_releases_process_lock_before_side_effects(monkeypatch, tmp_path):
+    trustlog_path = tmp_path / "trustlog.jsonl"
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", trustlog_path)
+    _stub_signing(monkeypatch)
+
+    events = []
+
+    class _SpyLock:
+        def __enter__(self):
+            events.append("enter")
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            events.append("exit")
+            return False
+
+    def _spy_process_lock(_path):
+        return _SpyLock()
+
+    def _spy_append_line(path, line):
+        events.append(f"append:{path.name}")
+
+    def _spy_mirror(_line):
+        events.append("mirror")
+        return {"configured": False, "ok": False, "backend": "local"}
+
+    def _spy_anchor(_entry_hash):
+        events.append("anchor")
+        return {"configured": False, "ok": False, "backend": "local", "status": "disabled", "receipt": None}
+
+    monkeypatch.setattr(trustlog_signed, "_jsonl_trustlog_process_lock", _spy_process_lock)
+    monkeypatch.setattr(trustlog_signed, "_append_line", _spy_append_line)
+    monkeypatch.setattr(trustlog_signed, "_mirror_to_worm", _spy_mirror)
+    monkeypatch.setattr(trustlog_signed, "_anchor_entry_hash", _spy_anchor)
+
+    trustlog_signed.append_signed_decision({"request_id": "req-lock-scope"})
+
+    assert events.count("enter") == 1
+    assert events.count("exit") == 1
+    assert events.index("append:trustlog.jsonl") < events.index("exit")
+    assert events.index("exit") < events.index("mirror")
+    assert events.index("exit") < events.index("anchor")

--- a/veritas_os/tests/unit/test_trustlog.py
+++ b/veritas_os/tests/unit/test_trustlog.py
@@ -16,6 +16,8 @@ pytestmark = pytest.mark.unit
 
 
 import json
+import logging
+import logging
 import hashlib
 import re
 import builtins
@@ -1825,8 +1827,10 @@ from veritas_os.audit import trustlog_signed
 from veritas_os.logging import trust_log
 
 
-def test_append_signed_decision_wraps_oserror(monkeypatch):
+def test_append_signed_decision_wraps_oserror(monkeypatch, tmp_path):
     """Expected runtime write failures are wrapped in domain error."""
+    trustlog_path = tmp_path / "trustlog.jsonl"
+    monkeypatch.setattr(trustlog_signed, "SIGNED_TRUSTLOG_JSONL", trustlog_path)
 
     _stub_signing(monkeypatch)
 
@@ -1954,15 +1958,19 @@ def test_append_signed_decision_releases_process_lock_before_side_effects(monkey
     def _spy_process_lock(_path):
         return _SpyLock()
 
+    captured = {}
+
     def _spy_append_line(path, line):
         events.append(f"append:{path.name}")
+        captured["line"] = line
 
     def _spy_mirror(_line):
         events.append("mirror")
         return {"configured": False, "ok": False, "backend": "local"}
 
-    def _spy_anchor(_entry_hash):
+    def _spy_anchor(entry_hash):
         events.append("anchor")
+        captured["anchor_hash"] = entry_hash
         return {"configured": False, "ok": False, "backend": "local", "status": "disabled", "receipt": None}
 
     monkeypatch.setattr(trustlog_signed, "_jsonl_trustlog_process_lock", _spy_process_lock)
@@ -1977,3 +1985,28 @@ def test_append_signed_decision_releases_process_lock_before_side_effects(monkey
     assert events.index("append:trustlog.jsonl") < events.index("exit")
     assert events.index("exit") < events.index("mirror")
     assert events.index("exit") < events.index("anchor")
+    persisted_entry = json.loads(captured["line"])
+    assert captured["anchor_hash"] == trustlog_signed._entry_chain_hash(persisted_entry)
+
+
+def test_jsonl_process_lock_does_not_unlock_when_lock_acquire_fails(monkeypatch, tmp_path):
+    class _FailingFcntl:
+        LOCK_EX = 1
+        LOCK_UN = 2
+
+        def __init__(self):
+            self.calls = []
+
+        def flock(self, _fd, op):
+            self.calls.append(op)
+            if op == self.LOCK_EX:
+                raise OSError("lock failed")
+
+    fake_fcntl = _FailingFcntl()
+    monkeypatch.setattr(trustlog_signed, "fcntl", fake_fcntl)
+
+    with pytest.raises(OSError, match="lock failed"):
+        with trustlog_signed._jsonl_trustlog_process_lock(tmp_path / "trustlog.jsonl"):
+            pass
+
+    assert fake_fcntl.calls == [fake_fcntl.LOCK_EX]

--- a/veritas_os/tests/unit/test_trustlog.py
+++ b/veritas_os/tests/unit/test_trustlog.py
@@ -17,7 +17,6 @@ pytestmark = pytest.mark.unit
 
 import json
 import logging
-import logging
 import hashlib
 import re
 import builtins


### PR DESCRIPTION
### Motivation
- Ensure WebSocket API-key resolution behaves like HTTP auth so a malformed multi-key config does not disable a valid legacy single-key fallback.
- Prevent slow WORM/mirror/anchor side-effects from executing while a cross-process JSONL append lock is held to avoid unnecessary cross-process contention.
- Make operator-visible when POSIX `fcntl` locking is unavailable instead of silently degrading.
- Remove misleading test monkeypatches and add focused tests that assert the corrected behaviors.

### Description
- Added `_has_configured_api_key()` and use it from `require_api_key()` and `_authenticate_websocket_api_key()` to align WS and HTTP key-configuration semantics and preserve single-key fallback when `VERITAS_API_KEYS` is malformed (`veritas_os/api/auth.py`).
- Introduced `_jsonl_trustlog_process_lock()` context manager with `fcntl` support and a once-per-process warning `_warn_jsonl_trustlog_process_lock_unavailable_once()` when `fcntl` is not present (`veritas_os/audit/trustlog_signed.py`).
- Narrowed `append_signed_decision()` lock scope so the cross-process lock only covers the JSONL chain-critical section (read last entry, compute/set `previous_hash`, enforce entry size, serialize and `_append_line`), and moved WORM mirror / transparency anchor side-effects to execute after the lock is released (`veritas_os/audit/trustlog_signed.py`).
- Removed misleading `monkeypatch.setattr(..., "_read_all_entries", ...)` uses from TrustLog tests and added tests: WS fallback behavior when multi-key is malformed, once-per-process warning when `fcntl` is unavailable, and a lock-scope regression test that verifies mirror/anchor are called after lock exit (`veritas_os/tests/unit/test_server_api.py`, `veritas_os/tests/unit/test_trustlog.py`).
- Preserved existing error handling, entry shape, RBAC/nonce semantics, and did not add dependencies.

### Testing
- Added unit tests covering the WebSocket fallback semantics and TrustLog lock/warning behaviors (`veritas_os/tests/unit/test_server_api.py`, `veritas_os/tests/unit/test_trustlog.py`).
- Attempted to run `pytest -q veritas_os/tests/unit/test_server_api.py` and `pytest -q veritas_os/tests/unit/test_trustlog.py`, but test execution could not be completed in this environment because `pytest` is not available / the configured `pyenv` Python version could not be used; therefore tests were not executed locally here (CI will exercise them).
- Code changes were committed locally and a PR update summary was prepared; CI should run the new unit tests and validate behavior in the repository environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9749463c832698da32c8ce921adb)