### PR TITLE
fix(security): harden RBAC fallback and HMAC nonce registration

### DIFF
--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -1103,6 +1103,14 @@ def _check_and_register_nonce(nonce: str) -> bool:
     return _auth_store_register_nonce(nonce=nonce, ttl_sec=_NONCE_TTL_SEC)
 
 
+def _is_nonce_shape_valid(nonce: str) -> bool:
+    """Validate nonce shape before body/HMAC work (registration happens later)."""
+    normalized = (nonce or "").strip()
+    if not normalized:
+        return False
+    return len(normalized) <= _NONCE_MAX_LENGTH
+
+
 async def verify_signature(
     request: Request,
     x_api_key: Optional[str] = Header(default=None, alias="X-API-Key"),
@@ -1142,6 +1150,9 @@ async def verify_signature(
     if abs(int(time.time()) - ts) > _NONCE_TTL_SEC:
         _record_auth_reject_reason("signature_timestamp_out_of_range")
         raise HTTPException(status_code=401, detail="Timestamp out of range")
+    if not _is_nonce_shape_valid(nonce):
+        _record_auth_reject_reason("signature_invalid_nonce")
+        raise HTTPException(status_code=401, detail="Invalid nonce")
     body_bytes = await request.body()
     try:
         body = body_bytes.decode("utf-8") if body_bytes else ""

--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -549,14 +549,19 @@ def resolve_role_for_key(api_key: str) -> Role:
 def _resolve_role_from_request(
     x_api_key: str | None,
 ) -> Role:
-    """Resolve role from the request API key, defaulting to admin for legacy keys."""
+    """Resolve role from request API key with least-privilege fallback.
+
+    Authentication should have already validated the API key before this helper
+    is used. If role resolution still fails here, default to least privilege
+    (auditor) rather than admin as a defense-in-depth control.
+    """
     key = (x_api_key or "").strip()
     if not key:
-        return Role.admin  # Will be caught by require_api_key first
+        return Role.auditor
     try:
         return resolve_role_for_key(key)
     except ValueError:
-        return Role.admin  # Fallback; auth check already validated the key
+        return Role.auditor
 
 
 
@@ -1137,10 +1142,6 @@ async def verify_signature(
     if abs(int(time.time()) - ts) > _NONCE_TTL_SEC:
         _record_auth_reject_reason("signature_timestamp_out_of_range")
         raise HTTPException(status_code=401, detail="Timestamp out of range")
-    if not _check_and_register_nonce(nonce):
-        _record_auth_reject_reason("signature_replay_detected")
-        raise HTTPException(status_code=401, detail="Replay detected")
-
     body_bytes = await request.body()
     try:
         body = body_bytes.decode("utf-8") if body_bytes else ""
@@ -1152,6 +1153,9 @@ async def verify_signature(
     if not hmac.compare_digest(mac, signature.lower()):
         _record_auth_reject_reason("signature_invalid")
         raise HTTPException(status_code=401, detail="Invalid signature")
+    if not _check_and_register_nonce(nonce):
+        _record_auth_reject_reason("signature_replay_detected")
+        raise HTTPException(status_code=401, detail="Replay detected")
     return True
 
 

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -2911,12 +2911,12 @@ def test_websocket_auth_fail_closed_when_multi_key_config_malformed_without_lega
     assert server._authenticate_websocket_api_key(ws) is False
 
 
-def test_resolve_role_from_request_empty_key_fallbacks_to_auditor():
+def test_resolve_role_from_request_empty_key_falls_back_to_auditor():
     assert server._resolve_role_from_request(None) == server.Role.auditor
     assert server._resolve_role_from_request("") == server.Role.auditor
 
 
-def test_resolve_role_from_request_invalid_key_fallbacks_to_auditor(monkeypatch):
+def test_resolve_role_from_request_invalid_key_falls_back_to_auditor(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
     monkeypatch.delenv("VERITAS_API_KEYS", raising=False)
 
@@ -2948,7 +2948,7 @@ def test_resolve_role_from_request_malformed_multi_key_valid_legacy_is_admin(mon
     assert server._resolve_role_from_request("legacy-admin-key") == server.Role.admin
 
 
-def test_resolve_role_from_request_malformed_multi_key_invalid_key_fallbacks_auditor(monkeypatch):
+def test_resolve_role_from_request_malformed_multi_key_invalid_key_falls_back_to_auditor(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEYS", "{bad-json")
     monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
 
@@ -4421,6 +4421,30 @@ def test_verify_signature_invalid_signature_does_not_consume_nonce(monkeypatch):
         )
     )
     assert ok is True
+
+
+def test_verify_signature_rejects_oversized_nonce_before_signature_and_does_not_register(
+    monkeypatch,
+):
+    secret = b"secret-for-test-1234567890abcdef"
+    monkeypatch.setattr(server, "API_SECRET", secret)
+    server._nonce_store.clear()
+    ts = str(int(time.time()))
+    nonce = "n" * (server._NONCE_MAX_LENGTH + 1)
+
+    with pytest.raises(HTTPException) as exc:
+        _run_async(
+            server.verify_signature(
+                _FakeRequest(b'{"hello":"world"}'),
+                x_api_key="k",
+                x_timestamp=ts,
+                x_nonce=nonce,
+                x_signature="bad-signature",
+            )
+        )
+    assert exc.value.status_code == 401
+    assert "nonce" in str(exc.value.detail).lower()
+    assert nonce not in server._nonce_store
 
 
 # ----------------------------------------------------------------

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -2911,6 +2911,50 @@ def test_websocket_auth_fail_closed_when_multi_key_config_malformed_without_lega
     assert server._authenticate_websocket_api_key(ws) is False
 
 
+def test_resolve_role_from_request_empty_key_fallbacks_to_auditor():
+    assert server._resolve_role_from_request(None) == server.Role.auditor
+    assert server._resolve_role_from_request("") == server.Role.auditor
+
+
+def test_resolve_role_from_request_invalid_key_fallbacks_to_auditor(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
+    monkeypatch.delenv("VERITAS_API_KEYS", raising=False)
+
+    assert server._resolve_role_from_request("wrong") == server.Role.auditor
+
+
+def test_resolve_role_from_request_valid_legacy_key_is_admin(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
+    monkeypatch.delenv("VERITAS_API_KEYS", raising=False)
+
+    assert server._resolve_role_from_request("legacy-admin-key") == server.Role.admin
+
+
+def test_resolve_role_from_request_multi_key_role_is_preserved(monkeypatch):
+    monkeypatch.setenv(
+        "VERITAS_API_KEYS",
+        '[{"key":"auditor-key","role":"auditor"},{"key":"operator-key","role":"operator"}]',
+    )
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+
+    assert server._resolve_role_from_request("auditor-key") == server.Role.auditor
+    assert server._resolve_role_from_request("operator-key") == server.Role.operator
+
+
+def test_resolve_role_from_request_malformed_multi_key_valid_legacy_is_admin(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEYS", "{bad-json")
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
+
+    assert server._resolve_role_from_request("legacy-admin-key") == server.Role.admin
+
+
+def test_resolve_role_from_request_malformed_multi_key_invalid_key_fallbacks_auditor(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEYS", "{bad-json")
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
+
+    assert server._resolve_role_from_request("wrong") == server.Role.auditor
+
+
 def test_websocket_auth_rejects_query_api_key_without_risk_ack(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
     monkeypatch.setenv("VERITAS_ALLOW_WS_QUERY_API_KEY", "1")
@@ -4342,6 +4386,41 @@ def test_verify_signature_replay(monkeypatch):
             x_nonce=nonce, x_signature=sig,
         ))
     assert exc.value.status_code == 401
+
+
+def test_verify_signature_invalid_signature_does_not_consume_nonce(monkeypatch):
+    secret = b"secret-for-test-1234567890abcdef"
+    monkeypatch.setattr(server, "API_SECRET", secret)
+    server._nonce_store.clear()
+    ts = str(int(time.time()))
+    nonce = "nonce-invalid-signature-not-consumed"
+    body = b'{"hello":"world"}'
+    payload = f"{ts}\n{nonce}\n{body.decode()}"
+    valid_sig = hmac.new(secret, payload.encode(), hashlib.sha256).hexdigest()
+
+    with pytest.raises(HTTPException) as exc:
+        _run_async(
+            server.verify_signature(
+                _FakeRequest(body),
+                x_api_key="k",
+                x_timestamp=ts,
+                x_nonce=nonce,
+                x_signature="bad-signature",
+            )
+        )
+    assert exc.value.status_code == 401
+    assert "Invalid signature" in exc.value.detail
+
+    ok = _run_async(
+        server.verify_signature(
+            _FakeRequest(body),
+            x_api_key="k",
+            x_timestamp=ts,
+            x_nonce=nonce,
+            x_signature=valid_sig,
+        )
+    )
+    assert ok is True
 
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent excessive privilege escalation by changing RBAC fallback from `Role.admin` to least-privilege `Role.auditor` when role resolution fails.
- Prevent nonce poisoning and denial-of-service by ensuring HMAC nonce registration only occurs after signature validation succeeds.
- Add regression tests to guard against these two security issues and retain backward compatibility for legacy single-key admin and multi-key role behavior.

### Description
- Change `_resolve_role_from_request(...)` to return `Role.auditor` on empty/failed role resolution and add a docstring clarifying the least-privilege fallback rationale.
- Move nonce registration from before signature validation to after successful `hmac.compare_digest(...)` in `verify_signature(...)`, so invalid signatures do not consume nonces.
- Add unit tests in `veritas_os/tests/unit/test_server_api.py` covering RBAC fallback cases: empty key, invalid key, legacy valid key (admin), multi-key role preservation, and malformed multi-key compatibility paths.
- Add an HMAC regression test `test_verify_signature_invalid_signature_does_not_consume_nonce` that asserts invalid signatures do not consume a nonce and a subsequent valid signature succeeds, while existing replay tests remain in place.

### Testing
- Added unit tests but running `pytest -q veritas_os/tests/unit/test_server_api.py` in this environment failed due to local toolchain issues: `pyenv` requested Python `3.12.12` which is not installed.
- Re-running with `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/unit/test_server_api.py` produced a test collection error due to missing runtime dependency `fastapi` in this sandbox (`ModuleNotFoundError: No module named 'fastapi'`).
- The new tests are committed and expected to run in CI where dependencies and configured Python versions are available; CI should validate that invalid signatures do not consume nonces and RBAC fallback behavior matches the specs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdab3ccbb48326aa57502429cece69)