### PR TITLE
Default role fallback to auditor; validate nonce shape and avoid consuming nonce on bad signature

### DIFF
--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -549,14 +549,19 @@ def resolve_role_for_key(api_key: str) -> Role:
 def _resolve_role_from_request(
     x_api_key: str | None,
 ) -> Role:
-    """Resolve role from the request API key, defaulting to admin for legacy keys."""
+    """Resolve role from request API key with least-privilege fallback.
+
+    Authentication should have already validated the API key before this helper
+    is used. If role resolution still fails here, default to least privilege
+    (auditor) rather than admin as a defense-in-depth control.
+    """
     key = (x_api_key or "").strip()
     if not key:
-        return Role.admin  # Will be caught by require_api_key first
+        return Role.auditor
     try:
         return resolve_role_for_key(key)
     except ValueError:
-        return Role.admin  # Fallback; auth check already validated the key
+        return Role.auditor
 
 
 
@@ -1098,6 +1103,14 @@ def _check_and_register_nonce(nonce: str) -> bool:
     return _auth_store_register_nonce(nonce=nonce, ttl_sec=_NONCE_TTL_SEC)
 
 
+def _is_nonce_shape_valid(nonce: str) -> bool:
+    """Validate nonce shape before body/HMAC work (registration happens later)."""
+    normalized = (nonce or "").strip()
+    if not normalized:
+        return False
+    return len(normalized) <= _NONCE_MAX_LENGTH
+
+
 async def verify_signature(
     request: Request,
     x_api_key: Optional[str] = Header(default=None, alias="X-API-Key"),
@@ -1137,10 +1150,9 @@ async def verify_signature(
     if abs(int(time.time()) - ts) > _NONCE_TTL_SEC:
         _record_auth_reject_reason("signature_timestamp_out_of_range")
         raise HTTPException(status_code=401, detail="Timestamp out of range")
-    if not _check_and_register_nonce(nonce):
-        _record_auth_reject_reason("signature_replay_detected")
-        raise HTTPException(status_code=401, detail="Replay detected")
-
+    if not _is_nonce_shape_valid(nonce):
+        _record_auth_reject_reason("signature_invalid_nonce")
+        raise HTTPException(status_code=401, detail="Invalid nonce")
     body_bytes = await request.body()
     try:
         body = body_bytes.decode("utf-8") if body_bytes else ""
@@ -1152,6 +1164,9 @@ async def verify_signature(
     if not hmac.compare_digest(mac, signature.lower()):
         _record_auth_reject_reason("signature_invalid")
         raise HTTPException(status_code=401, detail="Invalid signature")
+    if not _check_and_register_nonce(nonce):
+        _record_auth_reject_reason("signature_replay_detected")
+        raise HTTPException(status_code=401, detail="Replay detected")
     return True
 
 

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -2911,6 +2911,50 @@ def test_websocket_auth_fail_closed_when_multi_key_config_malformed_without_lega
     assert server._authenticate_websocket_api_key(ws) is False
 
 
+def test_resolve_role_from_request_empty_key_falls_back_to_auditor():
+    assert server._resolve_role_from_request(None) == server.Role.auditor
+    assert server._resolve_role_from_request("") == server.Role.auditor
+
+
+def test_resolve_role_from_request_invalid_key_falls_back_to_auditor(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
+    monkeypatch.delenv("VERITAS_API_KEYS", raising=False)
+
+    assert server._resolve_role_from_request("wrong") == server.Role.auditor
+
+
+def test_resolve_role_from_request_valid_legacy_key_is_admin(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
+    monkeypatch.delenv("VERITAS_API_KEYS", raising=False)
+
+    assert server._resolve_role_from_request("legacy-admin-key") == server.Role.admin
+
+
+def test_resolve_role_from_request_multi_key_role_is_preserved(monkeypatch):
+    monkeypatch.setenv(
+        "VERITAS_API_KEYS",
+        '[{"key":"auditor-key","role":"auditor"},{"key":"operator-key","role":"operator"}]',
+    )
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+
+    assert server._resolve_role_from_request("auditor-key") == server.Role.auditor
+    assert server._resolve_role_from_request("operator-key") == server.Role.operator
+
+
+def test_resolve_role_from_request_malformed_multi_key_valid_legacy_is_admin(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEYS", "{bad-json")
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
+
+    assert server._resolve_role_from_request("legacy-admin-key") == server.Role.admin
+
+
+def test_resolve_role_from_request_malformed_multi_key_invalid_key_falls_back_to_auditor(monkeypatch):
+    monkeypatch.setenv("VERITAS_API_KEYS", "{bad-json")
+    monkeypatch.setenv("VERITAS_API_KEY", "legacy-admin-key")
+
+    assert server._resolve_role_from_request("wrong") == server.Role.auditor
+
+
 def test_websocket_auth_rejects_query_api_key_without_risk_ack(monkeypatch):
     monkeypatch.setenv("VERITAS_API_KEY", _TEST_API_KEY)
     monkeypatch.setenv("VERITAS_ALLOW_WS_QUERY_API_KEY", "1")
@@ -4342,6 +4386,65 @@ def test_verify_signature_replay(monkeypatch):
             x_nonce=nonce, x_signature=sig,
         ))
     assert exc.value.status_code == 401
+
+
+def test_verify_signature_invalid_signature_does_not_consume_nonce(monkeypatch):
+    secret = b"secret-for-test-1234567890abcdef"
+    monkeypatch.setattr(server, "API_SECRET", secret)
+    server._nonce_store.clear()
+    ts = str(int(time.time()))
+    nonce = "nonce-invalid-signature-not-consumed"
+    body = b'{"hello":"world"}'
+    payload = f"{ts}\n{nonce}\n{body.decode()}"
+    valid_sig = hmac.new(secret, payload.encode(), hashlib.sha256).hexdigest()
+
+    with pytest.raises(HTTPException) as exc:
+        _run_async(
+            server.verify_signature(
+                _FakeRequest(body),
+                x_api_key="k",
+                x_timestamp=ts,
+                x_nonce=nonce,
+                x_signature="bad-signature",
+            )
+        )
+    assert exc.value.status_code == 401
+    assert "Invalid signature" in exc.value.detail
+
+    ok = _run_async(
+        server.verify_signature(
+            _FakeRequest(body),
+            x_api_key="k",
+            x_timestamp=ts,
+            x_nonce=nonce,
+            x_signature=valid_sig,
+        )
+    )
+    assert ok is True
+
+
+def test_verify_signature_rejects_oversized_nonce_before_signature_and_does_not_register(
+    monkeypatch,
+):
+    secret = b"secret-for-test-1234567890abcdef"
+    monkeypatch.setattr(server, "API_SECRET", secret)
+    server._nonce_store.clear()
+    ts = str(int(time.time()))
+    nonce = "n" * (server._NONCE_MAX_LENGTH + 1)
+
+    with pytest.raises(HTTPException) as exc:
+        _run_async(
+            server.verify_signature(
+                _FakeRequest(b'{"hello":"world"}'),
+                x_api_key="k",
+                x_timestamp=ts,
+                x_nonce=nonce,
+                x_signature="bad-signature",
+            )
+        )
+    assert exc.value.status_code == 401
+    assert "nonce" in str(exc.value.detail).lower()
+    assert nonce not in server._nonce_store
 
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Reduce privilege escalation by changing the default role fallback to the least-privileged `auditor` as a defense-in-depth control.
- Prevent oversized or empty nonces from triggering expensive body/HMAC work and from being registered in the nonce store.
- Avoid consuming/locking a nonce when the provided signature is invalid to ensure replays are only detected for validly-signed requests.

### Description
- Change `_resolve_role_from_request` to return `Role.auditor` when no key is present or role resolution fails, and update the helper docstring to explain the least-privilege fallback.
- Add a helper `def _is_nonce_shape_valid(nonce: str) -> bool` to validate nonce presence and length before heavy processing.
- In `verify_signature`, validate nonce shape early and move the `_check_and_register_nonce(nonce)` call to after signature verification so invalid signatures do not register nonces.
- Add new unit tests in `veritas_os/tests/unit/test_server_api.py` covering role resolution behavior for legacy and multi-key configs and covering signature/nonce behavior including not consuming a nonce on invalid signature and rejecting oversized nonces before registration.

### Testing
- Ran the unit test module `veritas_os/tests/unit/test_server_api.py` which includes the new tests for `_resolve_role_from_request` and `verify_signature` behaviors.
- The new tests `test_resolve_role_from_request_*`, `test_verify_signature_invalid_signature_does_not_consume_nonce`, and `test_verify_signature_rejects_oversized_nonce_before_signature_and_does_not_register` were executed as part of the suite and passed.
- Full unit test suite run completed with no failures for the changed areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdab3ccbb48326aa57502429cece69)