### PR TITLE
fix(security): avoid nonce consumption on invalid signatures

### DIFF
--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -1137,10 +1137,6 @@ async def verify_signature(
     if abs(int(time.time()) - ts) > _NONCE_TTL_SEC:
         _record_auth_reject_reason("signature_timestamp_out_of_range")
         raise HTTPException(status_code=401, detail="Timestamp out of range")
-    if not _check_and_register_nonce(nonce):
-        _record_auth_reject_reason("signature_replay_detected")
-        raise HTTPException(status_code=401, detail="Replay detected")
-
     body_bytes = await request.body()
     try:
         body = body_bytes.decode("utf-8") if body_bytes else ""
@@ -1152,6 +1148,9 @@ async def verify_signature(
     if not hmac.compare_digest(mac, signature.lower()):
         _record_auth_reject_reason("signature_invalid")
         raise HTTPException(status_code=401, detail="Invalid signature")
+    if not _check_and_register_nonce(nonce):
+        _record_auth_reject_reason("signature_replay_detected")
+        raise HTTPException(status_code=401, detail="Replay detected")
     return True
 
 

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -4344,6 +4344,33 @@ def test_verify_signature_replay(monkeypatch):
     assert exc.value.status_code == 401
 
 
+def test_verify_signature_invalid_signature_does_not_consume_nonce(monkeypatch):
+    secret = b"secret-for-test-1234567890abcdef"
+    monkeypatch.setattr(server, "API_SECRET", secret)
+    server._nonce_store.clear()
+    ts = str(int(time.time()))
+    nonce = "nonce-survives-invalid-signature"
+    body = b'{"check":"nonce"}'
+
+    invalid_signature = "0" * 64
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        _run_async(server.verify_signature(
+            _FakeRequest(body), x_api_key="k", x_timestamp=ts,
+            x_nonce=nonce, x_signature=invalid_signature,
+        ))
+    assert exc.value.status_code == 401
+
+    payload = f"{ts}\n{nonce}\n{body.decode()}"
+    valid_signature = hmac.new(secret, payload.encode(), hashlib.sha256).hexdigest()
+    result = _run_async(server.verify_signature(
+        _FakeRequest(body), x_api_key="k", x_timestamp=ts,
+        x_nonce=nonce, x_signature=valid_signature,
+    ))
+    assert result is True
+
+
 # ----------------------------------------------------------------
 # 30-32. _coerce_decide_payload
 # ----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent nonce poisoning and replay-window denial where an attacker could burn valid nonces by sending invalid signatures. 
- Make nonce registration in `verify_signature(...)` atomic with respect to successful signature verification to avoid consuming nonces on failed auth attempts.

### Description
- Move `_check_and_register_nonce(nonce)` in `veritas_os/api/auth.py` to run only after HMAC signature verification succeeds. 
- Add a focused regression test `test_verify_signature_invalid_signature_does_not_consume_nonce` in `veritas_os/tests/unit/test_server_api.py` that asserts an invalid signature returns `401` and does not prevent a subsequent valid signature with the same nonce from succeeding. 
- Change is minimal and scoped to auth nonce ordering to limit surface area and preserve existing component responsibilities.

### Testing
- Added unit test `test_verify_signature_invalid_signature_does_not_consume_nonce` to the test suite and verified it locally via test authoring. 
- Attempted to run `python -m pytest -q veritas_os/tests/unit/test_server_api.py -k "verify_signature_replay or invalid_signature_does_not_consume_nonce"` but the environment failed due to `pyenv` requesting `3.12.12` which is not installed. 
- Retried with `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/unit/test_server_api.py -k "verify_signature_replay or invalid_signature_does_not_consume_nonce"` and test collection failed with `ModuleNotFoundError: No module named 'fastapi'`, so automated execution was blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb86dabbc8326825c22e3a0eed507)