### PR TITLE
fix(auth): align nonce shape validator type annotation

### DIFF
--- a/veritas_os/api/auth.py
+++ b/veritas_os/api/auth.py
@@ -1103,7 +1103,7 @@ def _check_and_register_nonce(nonce: str) -> bool:
     return _auth_store_register_nonce(nonce=nonce, ttl_sec=_NONCE_TTL_SEC)
 
 
-def _is_nonce_shape_valid(nonce: str) -> bool:
+def _is_nonce_shape_valid(nonce: str | None) -> bool:
     """Validate nonce shape before body/HMAC work (registration happens later)."""
     normalized = (nonce or "").strip()
     if not normalized:


### PR DESCRIPTION
### Motivation
- Ensure the type annotation matches the function's defensive runtime behavior so `_is_nonce_shape_valid` explicitly accepts `None` per the Copilot review comment. 

### Description
- Change the signature in `veritas_os/api/auth.py` from `def _is_nonce_shape_valid(nonce: str) -> bool:` to `def _is_nonce_shape_valid(nonce: str | None) -> bool:` while leaving the function body and runtime logic unchanged. 

### Testing
- Attempted to run `pytest -q veritas_os/tests/unit/test_server_api.py` and `pytest -q`, but both runs could not execute in this environment because the repository `.python-version` requests `3.12.12` which is not installed and `pytest` was not available, so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbab8f054832696e1904bc2d290c5)