### PR TITLE
fix(security): require explicit compose credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,23 @@ VERITAS_API_BASE_URL=http://backend:8000
 # Keep this strict; only local development origins are included by default.
 VERITAS_CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
+# ──────────────────────────────────────────────────────────────
+# Docker Compose local credentials
+# ──────────────────────────────────────────────────────────────
+# docker-compose.yml intentionally does not provide default database or admin BFF credentials.
+# Copy this file to .env and replace every CHANGE_ME value before running:
+#   cp .env.example .env
+#   docker compose up --build
+#
+# Do not commit real secrets.
+# Do not use these example values in shared, staging, or production environments.
+VERITAS_DB_USER=veritas
+VERITAS_DB_PASSWORD=CHANGE_ME_generate_a_strong_local_password
+VERITAS_DB_NAME=veritas
+VERITAS_DATABASE_URL=postgresql://veritas:CHANGE_ME_generate_a_strong_local_password@postgres:5432/veritas
+VERITAS_BFF_SESSION_TOKEN=CHANGE_ME_generate_a_random_local_session_token
+VERITAS_BFF_AUTH_TOKENS_JSON={"CHANGE_ME_generate_a_random_local_session_token":"admin"}
+
 # Backend authentication secret (set a strong random value in real environments).
 # VERITAS_API_SECRET=change-me
 
@@ -75,7 +92,7 @@ VERITAS_CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 # PostgreSQL connection URL.
 # Required when any backend is set to "postgresql".
 # In production, inject from an external secret manager — never commit credentials.
-# VERITAS_DATABASE_URL=postgresql://veritas:veritas@localhost:5432/veritas
+# VERITAS_DATABASE_URL=postgresql://veritas:CHANGE_ME_generate_a_strong_local_password@postgres:5432/veritas
 
 # Connection pool tuning.
 #   Dev:     min=1, max=5

--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ VERITAS OS uses a **pluggable storage backend** pattern for MemoryOS and TrustLo
 # Use PostgreSQL for both backends
 VERITAS_MEMORY_BACKEND=postgresql
 VERITAS_TRUSTLOG_BACKEND=postgresql
-VERITAS_DATABASE_URL=postgresql://veritas:veritas@localhost:5432/veritas
+VERITAS_DATABASE_URL=postgresql://veritas:CHANGE_ME_generate_a_strong_local_password@localhost:5432/veritas
 
 # Apply schema
 make db-upgrade
@@ -1228,7 +1228,7 @@ Environment variables (set in `.env` or shell):
 | `VERITAS_API_BASE_URL` | `http://backend:8000` | Frontend BFF (server-only) → backend URL |
 | `VERITAS_MEMORY_BACKEND` | `postgresql` | Memory storage backend (`json` or `postgresql`) |
 | `VERITAS_TRUSTLOG_BACKEND` | `postgresql` | TrustLog storage backend (`jsonl` or `postgresql`) |
-| `VERITAS_DATABASE_URL` | `postgresql://veritas:veritas@postgres:5432/veritas` | PostgreSQL connection URL |
+| `VERITAS_DATABASE_URL` | required for PostgreSQL | PostgreSQL DSN; for Docker Compose set this in `.env` using a non-default password |
 | `LLM_PROVIDER` | `openai` | LLM provider |
 | `LLM_MODEL` | `gpt-4.1-mini` | LLM model name |
 

--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ VERITAS OS uses a **pluggable storage backend** pattern for MemoryOS and TrustLo
 | Environment | Recommended backend | Config source |
 |-------------|-------------------|---------------|
 | Local dev (no Docker) | JSON / JSONL | `.env` defaults |
-| Local dev (Docker Compose) | PostgreSQL | `docker-compose.yml` defaults |
+| Local dev (Docker Compose) | PostgreSQL | `.env` copied from `.env.example`; explicit compose credentials required |
 | Staging | PostgreSQL | Explicit env vars |
 | Secure / Prod | PostgreSQL | External secret manager |
 
@@ -1231,6 +1231,8 @@ Environment variables (set in `.env` or shell):
 | `VERITAS_DATABASE_URL` | `postgresql://veritas:veritas@postgres:5432/veritas` | PostgreSQL connection URL |
 | `LLM_PROVIDER` | `openai` | LLM provider |
 | `LLM_MODEL` | `gpt-4.1-mini` | LLM model name |
+
+Docker Compose no longer ships default database or admin BFF credentials. Copy `.env.example` to `.env` and replace every `CHANGE_ME` value before running compose. See `docs/en/operations/docker-compose-security.md`.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   # ─────────────────────────────────────────────────────────────────
   # PostgreSQL — Pluggable storage backend for MemoryOS and TrustLog.
   #
-  #   Dev/local:   Use as-is with default credentials below.
+  #   Dev/local:   Copy .env.example to .env and set explicit credentials before startup.
   #   Staging:     Override VERITAS_DB_USER/PASSWORD via .env or CI secrets.
   #   Prod:        Use a managed PostgreSQL service (RDS, Cloud SQL) instead
   #                of this container.  See docs/en/operations/postgresql-production-guide.md.
@@ -21,7 +21,7 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_USER: ${VERITAS_DB_USER:-veritas}
-      POSTGRES_PASSWORD: ${VERITAS_DB_PASSWORD:-veritas}
+      POSTGRES_PASSWORD: ${VERITAS_DB_PASSWORD:?Set VERITAS_DB_PASSWORD in .env before running docker compose}
       POSTGRES_DB: ${VERITAS_DB_NAME:-veritas}
     volumes:
       - pgdata:/var/lib/postgresql/data
@@ -52,7 +52,7 @@ services:
       VERITAS_CORS_ALLOW_ORIGINS: ${VERITAS_CORS_ALLOW_ORIGINS:-http://localhost:3000,http://127.0.0.1:3000}
       VERITAS_MEMORY_BACKEND: ${VERITAS_MEMORY_BACKEND:-postgresql}
       VERITAS_TRUSTLOG_BACKEND: ${VERITAS_TRUSTLOG_BACKEND:-postgresql}
-      VERITAS_DATABASE_URL: ${VERITAS_DATABASE_URL:-postgresql://veritas:veritas@postgres:5432/veritas}
+      VERITAS_DATABASE_URL: ${VERITAS_DATABASE_URL:?Set VERITAS_DATABASE_URL in .env before running docker compose}
       VERITAS_DB_AUTO_MIGRATE: ${VERITAS_DB_AUTO_MIGRATE:-true}
     depends_on:
       postgres:
@@ -90,11 +90,12 @@ services:
       - "3000:3000"
     environment:
       VERITAS_API_BASE_URL: ${VERITAS_API_BASE_URL:-http://backend:8000}
-      # BFF auth defaults for local Docker development.
-      # The session token is minted as an httpOnly cookie by middleware,
-      # and the tokens JSON maps it to an admin role for full access.
-      VERITAS_BFF_SESSION_TOKEN: ${VERITAS_BFF_SESSION_TOKEN:-veritas-dev-session}
-      VERITAS_BFF_AUTH_TOKENS_JSON: ${VERITAS_BFF_AUTH_TOKENS_JSON:-'{"veritas-dev-session":"admin"}'}
+      # Local Docker development still requires explicit secrets in .env.
+      # Do not commit real values.
+      # VERITAS_BFF_SESSION_TOKEN must match a key in VERITAS_BFF_AUTH_TOKENS_JSON.
+      # Admin token use is limited to controlled local review only.
+      VERITAS_BFF_SESSION_TOKEN: ${VERITAS_BFF_SESSION_TOKEN:?Set VERITAS_BFF_SESSION_TOKEN in .env before running docker compose}
+      VERITAS_BFF_AUTH_TOKENS_JSON: ${VERITAS_BFF_AUTH_TOKENS_JSON:?Set VERITAS_BFF_AUTH_TOKENS_JSON in .env before running docker compose}
     volumes:
       - ./frontend:/app/frontend
       - ./packages:/app/packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,8 @@ services:
       # Do not commit real values.
       # VERITAS_BFF_SESSION_TOKEN must match a key in VERITAS_BFF_AUTH_TOKENS_JSON.
       # Admin token use is limited to controlled local review only.
-      VERITAS_BFF_SESSION_TOKEN: ${VERITAS_BFF_SESSION_TOKEN:?Set VERITAS_BFF_SESSION_TOKEN in .env before running docker compose}
-      VERITAS_BFF_AUTH_TOKENS_JSON: ${VERITAS_BFF_AUTH_TOKENS_JSON:?Set VERITAS_BFF_AUTH_TOKENS_JSON in .env before running docker compose}
+      VERITAS_BFF_SESSION_TOKEN: '${VERITAS_BFF_SESSION_TOKEN:?Set VERITAS_BFF_SESSION_TOKEN in .env before running docker compose}'
+      VERITAS_BFF_AUTH_TOKENS_JSON: '${VERITAS_BFF_AUTH_TOKENS_JSON:?Set VERITAS_BFF_AUTH_TOKENS_JSON in .env before running docker compose}'
     volumes:
       - ./frontend:/app/frontend
       - ./packages:/app/packages

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -35,6 +35,7 @@
 | Operations: PostgreSQL production | `docs/en/operations/postgresql-production-guide.md` | `docs/ja/operations/postgresql-production-guide.md` | JA explanation / EN canonical | PostgreSQL本番運用 |
 | Operations: PostgreSQL drill | `docs/en/operations/postgresql-drill-runbook.md` | `docs/ja/operations/postgresql-drill-runbook.md` | JA explanation / EN canonical | 復旧ドリル |
 | Operations: Security hardening | `docs/en/operations/security-hardening.md` | `docs/ja/operations/security-hardening.md` | JA explanation / EN canonical | ハードニング観点 |
+| Operations: Docker Compose security notes | `docs/en/operations/docker-compose-security.md` | `docs/ja/operations/docker-compose-security.md` | JA explanation / EN canonical | Local compose credential requirements, .env setup, non-claims, and production boundary |
 | Operations: Database migrations | `docs/en/operations/database-migrations.md` | `docs/ja/operations/database-migrations.md` | JA explanation / EN canonical | 移行手順 |
 | Operations: Governance artifact signing | `docs/en/operations/governance-artifact-signing.md` | `docs/ja/operations/governance-artifact-signing.md` | JA explanation / EN canonical | 署名運用 |
 | Operations: Governance trace span chain | `docs/en/operations/governance-trace-span-chain.md` | `docs/ja/operations/governance-trace-span-chain.md` | JA explanation / EN canonical | observability検証導線 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,7 @@
 | PostgreSQL Production Guide | [PostgreSQL production guide (EN)](en/operations/postgresql-production-guide.md) | [PostgreSQL本番運用ガイド (JA)](ja/operations/postgresql-production-guide.md) |
 | PostgreSQL Drill Runbook | [PostgreSQL drill runbook (EN)](en/operations/postgresql-drill-runbook.md) | [PostgreSQLドリルRunbook (JA)](ja/operations/postgresql-drill-runbook.md) |
 | Security | [Security hardening (EN)](en/operations/security-hardening.md) | [セキュリティハードニング (JA)](ja/operations/security-hardening.md) |
+| Docker Compose Security Notes | [Docker Compose security notes (EN)](en/operations/docker-compose-security.md) | [Docker Composeセキュリティノート (JA)](ja/operations/docker-compose-security.md) |
 | Database | [Database migrations (EN)](en/operations/database-migrations.md) | [データベース移行 (JA)](ja/operations/database-migrations.md) |
 | Governance Artifact Signing | [Governance artifact signing (EN)](en/operations/governance-artifact-signing.md) | [ガバナンス成果物署名 (JA)](ja/operations/governance-artifact-signing.md) |
 | Governance Trace Span Chain | [Governance trace span chain (EN)](en/operations/governance-trace-span-chain.md) | [ガバナンストレース span chain (JA)](ja/operations/governance-trace-span-chain.md) |
@@ -98,6 +99,7 @@
 | PostgreSQL本番運用ガイド | [PostgreSQL production guide（英語正本）](en/operations/postgresql-production-guide.md) | [PostgreSQL本番運用ガイド（日本語解説）](ja/operations/postgresql-production-guide.md) |
 | PostgreSQLドリルRunbook | [PostgreSQL drill runbook（英語正本）](en/operations/postgresql-drill-runbook.md) | [PostgreSQLドリルRunbook（日本語解説）](ja/operations/postgresql-drill-runbook.md) |
 | セキュリティ | [Security hardening（英語正本）](en/operations/security-hardening.md) | [セキュリティハードニング（日本語）](ja/operations/security-hardening.md) |
+| Docker Compose Security Notes | [Docker Compose security notes（英語正本）](en/operations/docker-compose-security.md) | [Docker Composeセキュリティノート（日本語補助）](ja/operations/docker-compose-security.md) |
 | データベース | [Database migrations（英語正本）](en/operations/database-migrations.md) | [データベース移行（日本語）](ja/operations/database-migrations.md) |
 | ガバナンス成果物署名 | [Governance artifact signing（英語正本）](en/operations/governance-artifact-signing.md) | [ガバナンス成果物署名（日本語解説）](ja/operations/governance-artifact-signing.md) |
 | ガバナンストレース span chain | [Governance trace span chain（英語正本）](en/operations/governance-trace-span-chain.md) | [ガバナンストレース span chain（日本語解説）](ja/operations/governance-trace-span-chain.md) |

--- a/docs/en/operations/docker-compose-security.md
+++ b/docs/en/operations/docker-compose-security.md
@@ -1,0 +1,44 @@
+# Docker Compose Security Notes
+
+## Purpose
+
+This note explains local Docker Compose credential handling for VERITAS OS and sets clear non-production boundaries.
+
+## Why compose credentials are explicit
+
+docker-compose.yml intentionally does not provide default database or admin BFF credentials.
+This fail-fast behavior prevents accidental startup with known credentials during PoC or external review usage.
+
+## Required local `.env` values
+
+Copy `.env.example` to `.env`.
+Replace every `CHANGE_ME` value.
+At minimum, set:
+
+- `VERITAS_DB_PASSWORD`
+- `VERITAS_DATABASE_URL`
+- `VERITAS_BFF_SESSION_TOKEN`
+- `VERITAS_BFF_AUTH_TOKENS_JSON`
+
+Do not commit `.env`.
+
+## Generating local-only secrets
+
+Use locally generated random values for database passwords and BFF session tokens.
+Keep them machine-local and rotate when sharing demos between operators.
+
+## What not to do
+
+- Do not restore default DB passwords or fixed admin session tokens.
+- Do not use local compose secrets in shared, staging, or production environments.
+- Do not commit `.env` or real secret values.
+
+## Production boundary
+
+Production should use managed secrets and a managed database where appropriate.
+This is not production SLA and does not claim production hardening.
+
+## Troubleshooting
+
+If Compose fails before startup with `${VAR:?...}` errors, required variables are missing.
+Re-check `.env` and ensure every required key is present with non-placeholder values.

--- a/docs/ja/operations/docker-compose-security.md
+++ b/docs/ja/operations/docker-compose-security.md
@@ -1,0 +1,12 @@
+# Docker Compose セキュリティノート
+
+> 英語版が正本であり、日本語版は補助説明です。
+
+`docker-compose.yml` は DB password / admin BFF token のデフォルト値を提供しません。
+
+- `.env.example` を `.env` にコピーする
+- `CHANGE_ME` をすべて置き換える
+- `.env` をコミットしない
+- local compose secrets を staging / production で使い回さない
+- 本番では managed secrets / managed database を使う
+- これは本番SLAではない、また本番ハードニング完了を意味しない

--- a/veritas_os/tests/test_docker_compose_security.py
+++ b/veritas_os/tests/test_docker_compose_security.py
@@ -9,16 +9,17 @@ def test_docker_compose_exists() -> None:
 
 def test_docker_compose_has_no_unsafe_defaults() -> None:
     text = Path("docker-compose.yml").read_text(encoding="utf-8")
-    blocked = [
-        "POSTGRES_PASSWORD: ${VERITAS_DB_PASSWORD:-veritas}",
-        "postgresql://veritas:veritas@postgres:5432/veritas",
-        "postgresql://veritas:veritas@localhost:5432/veritas",
-        "VERITAS_BFF_SESSION_TOKEN: ${VERITAS_BFF_SESSION_TOKEN:-veritas-dev-session}",
-        "VERITAS_BFF_AUTH_TOKENS_JSON: ${VERITAS_BFF_AUTH_TOKENS_JSON:-'{\"veritas-dev-session\":\"admin\"}'}",
+    blocked_patterns = [
+        "${VERITAS_DB_PASSWORD:-",
+        "${VERITAS_DATABASE_URL:-",
+        "${VERITAS_BFF_SESSION_TOKEN:-",
+        "${VERITAS_BFF_AUTH_TOKENS_JSON:-",
         "veritas-dev-session",
+        "postgresql://veritas:veritas@",
+        "VERITAS_DB_PASSWORD=veritas",
     ]
-    for item in blocked:
-        assert item not in text
+    for pattern in blocked_patterns:
+        assert pattern not in text
 
 
 def test_docker_compose_requires_explicit_secrets() -> None:
@@ -31,6 +32,14 @@ def test_docker_compose_requires_explicit_secrets() -> None:
     ]
     for item in required:
         assert item in text
+
+
+def test_bff_auth_tokens_json_interpolation_is_quoted() -> None:
+    text = Path("docker-compose.yml").read_text(encoding="utf-8")
+    assert (
+        "VERITAS_BFF_AUTH_TOKENS_JSON: "
+        "'${VERITAS_BFF_AUTH_TOKENS_JSON:?"
+    ) in text
 
 
 def test_env_example_keeps_operator_template_tokens() -> None:
@@ -98,3 +107,14 @@ def test_docs_links_exist() -> None:
     assert "docs/en/operations/docker-compose-security.md" in readme
     assert "docker-compose-security.md" in index
     assert "docker-compose-security.md" in documentation_map
+
+
+def test_readme_has_no_known_compose_database_password_examples() -> None:
+    text = Path("README.md").read_text(encoding="utf-8")
+    blocked = [
+        "postgresql://veritas:veritas@postgres",
+        "postgresql://veritas:veritas@localhost",
+        "veritas:veritas@",
+    ]
+    for item in blocked:
+        assert item not in text

--- a/veritas_os/tests/test_docker_compose_security.py
+++ b/veritas_os/tests/test_docker_compose_security.py
@@ -1,0 +1,100 @@
+"""Regression tests for Docker Compose credential hardening docs/config."""
+
+from pathlib import Path
+
+
+def test_docker_compose_exists() -> None:
+    assert Path("docker-compose.yml").exists()
+
+
+def test_docker_compose_has_no_unsafe_defaults() -> None:
+    text = Path("docker-compose.yml").read_text(encoding="utf-8")
+    blocked = [
+        "POSTGRES_PASSWORD: ${VERITAS_DB_PASSWORD:-veritas}",
+        "postgresql://veritas:veritas@postgres:5432/veritas",
+        "postgresql://veritas:veritas@localhost:5432/veritas",
+        "VERITAS_BFF_SESSION_TOKEN: ${VERITAS_BFF_SESSION_TOKEN:-veritas-dev-session}",
+        "VERITAS_BFF_AUTH_TOKENS_JSON: ${VERITAS_BFF_AUTH_TOKENS_JSON:-'{\"veritas-dev-session\":\"admin\"}'}",
+        "veritas-dev-session",
+    ]
+    for item in blocked:
+        assert item not in text
+
+
+def test_docker_compose_requires_explicit_secrets() -> None:
+    text = Path("docker-compose.yml").read_text(encoding="utf-8")
+    required = [
+        "${VERITAS_DB_PASSWORD:?",
+        "${VERITAS_DATABASE_URL:?",
+        "${VERITAS_BFF_SESSION_TOKEN:?",
+        "${VERITAS_BFF_AUTH_TOKENS_JSON:?",
+    ]
+    for item in required:
+        assert item in text
+
+
+def test_env_example_keeps_operator_template_tokens() -> None:
+    text = Path(".env.example").read_text(encoding="utf-8")
+    required = [
+        "VERITAS_API_BASE_URL",
+        "VERITAS_ENV=production",
+        "VERITAS_ENCRYPTION_KEY",
+        "VERITAS_DATABASE_URL=",
+        "VERITAS_BFF_AUTH_TOKENS_JSON=",
+        "CHANGE_ME",
+    ]
+    assert (
+        "VERITAS_DB_PASSWORD=CHANGE_ME" in text
+        or "VERITAS_DB_PASSWORD=CHANGE_ME_generate_a_strong_local_password" in text
+    )
+    assert (
+        "VERITAS_BFF_SESSION_TOKEN=CHANGE_ME" in text
+        or "VERITAS_BFF_SESSION_TOKEN=CHANGE_ME_generate_a_random_local_session_token" in text
+    )
+    for item in required:
+        assert item in text
+
+
+def test_env_example_has_no_legacy_insecure_values() -> None:
+    text = Path(".env.example").read_text(encoding="utf-8")
+    blocked = [
+        "veritas-dev-session",
+        "postgresql://veritas:veritas@postgres:5432/veritas",
+        "postgresql://veritas:veritas@localhost:5432/veritas",
+        "VERITAS_DB_PASSWORD=veritas",
+    ]
+    for item in blocked:
+        assert item not in text
+
+
+def test_docs_exist_and_include_boundaries() -> None:
+    en_text = Path("docs/en/operations/docker-compose-security.md").read_text(
+        encoding="utf-8"
+    ).lower()
+    ja_text = Path("docs/ja/operations/docker-compose-security.md").read_text(
+        encoding="utf-8"
+    )
+
+    en_required = [
+        "does not provide default database or admin bff credentials",
+        "copy `.env.example` to `.env`",
+        "replace every `change_me` value",
+        "do not commit `.env`",
+        "not production sla",
+    ]
+    for item in en_required:
+        assert item in en_text
+
+    ja_required = [".env.example", "CHANGE_ME", "本番SLA", "コミットしない"]
+    for item in ja_required:
+        assert item in ja_text
+
+
+def test_docs_links_exist() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    index = Path("docs/INDEX.md").read_text(encoding="utf-8")
+    documentation_map = Path("docs/DOCUMENTATION_MAP.md").read_text(encoding="utf-8")
+
+    assert "docs/en/operations/docker-compose-security.md" in readme
+    assert "docker-compose-security.md" in index
+    assert "docker-compose-security.md" in documentation_map

--- a/veritas_os/tests/test_production_smoke.py
+++ b/veritas_os/tests/test_production_smoke.py
@@ -228,16 +228,18 @@ class TestComposePostgresqlBackend:
             f"VERITAS_TRUSTLOG_BACKEND should default to postgresql, got {tlog!r}"
         )
 
-    def test_compose_database_url_set(self):
+    def test_compose_database_url_requires_explicit_env(self):
         import yaml
 
         compose = _ROOT / "docker-compose.yml"
         cfg = yaml.safe_load(compose.read_text())
         backend_env = cfg["services"]["backend"]["environment"]
         db_url = backend_env.get("VERITAS_DATABASE_URL", "")
-        assert "postgres" in db_url, (
-            f"VERITAS_DATABASE_URL should point to postgres, got {db_url!r}"
+        assert "${VERITAS_DATABASE_URL:?" in db_url, (
+            "VERITAS_DATABASE_URL must require explicit .env value via "
+            f"compose fail-fast expansion, got {db_url!r}"
         )
+        assert "postgresql://veritas:veritas@" not in db_url
 
     def test_compose_backend_depends_on_postgres(self):
         import yaml


### PR DESCRIPTION
### Motivation

- Remove unsafe Docker Compose defaults (known DB password and fixed admin BFF token) to prevent accidental startup with well-known credentials during PoC or external review. 
- Preserve the operator-facing `.env.example` template while prompting operators to provide explicit local credentials before starting Compose. 
- Provide explicit guidance (EN/JA) and automated regression tests to prevent reintroduction of insecure defaults. 

### Description

- Replace unsafe defaults in `docker-compose.yml` by making `VERITAS_DB_PASSWORD`, `VERITAS_DATABASE_URL`, `VERITAS_BFF_SESSION_TOKEN`, and `VERITAS_BFF_AUTH_TOKENS_JSON` required via shell-style expansion (e.g. `${VAR:?message}`) and update related comments to require copying `.env.example` to `.env` before startup. 
- Preserve `.env.example` as the operator-facing template and add a new "Docker Compose local credentials" section with `CHANGE_ME` placeholders and sanitized example DSNs (no `veritas:veritas`), while keeping existing operator-relevant keys such as `VERITAS_API_BASE_URL`, `VERITAS_ENV=production`, and `VERITAS_ENCRYPTION_KEY`. 
- Update `README.md` environment matrix to reflect that Docker Compose requires explicit `.env` credentials and add a short note linking to the new docs. 
- Add new documentation files `docs/en/operations/docker-compose-security.md` and `docs/ja/operations/docker-compose-security.md`, and add links to them in `docs/INDEX.md` and `docs/DOCUMENTATION_MAP.md`. 
- Add regression tests `veritas_os/tests/test_docker_compose_security.py` which assert the absence of unsafe defaults, presence of required `${VAR:?` expansions, `.env.example` operator-template invariants, doc contents, and documentation links. 
- This change does not modify runtime application code, governance/bind/RBAC/TrustLog semantics, API contracts, provider tiers, evidence/benchmark JSON shapes, dependencies, or CI workflows. 

### Testing

- Ran `python3.12 scripts/quality/check_deployment_env_defaults.py` and it passed. 
- Ran `python3.12 -m scripts.quality.check_bilingual_docs` and it passed. 
- Ran pytest with a controlled interpreter (`PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_docker_compose_security.py veritas_os/tests/test_reviewer_entrypoint_current_path.py`) and all tests passed (`15 passed, 1 warning`). 
- Note: running `pytest` directly in the environment initially failed until the appropriate test interpreter was selected; the final test run above is the validated result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc890e14083269e0a7b8ca2e813c0)