### PR TITLE
Harden file-backed Ed25519 private-key loading against symlink/TOCTOU risks

### DIFF
--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -14,11 +14,13 @@ Risk:
 
 Mitigations applied here:
     - Files are created with mode ``0o600`` (owner-read/write only).
-    - ``_load_private_key`` checks that the key file is not world-readable
-      and raises ``PermissionError`` when unsafe permissions are detected.
+    - ``_load_private_key`` verifies that the private-key path resolves to a
+      regular file and rejects group/other-readable permissions before using
+      key material.
     - Local private-key reads use descriptor-based permission checks,
-      ``O_NOFOLLOW`` when available, and close-on-exec flags when available
-      to reduce symlink/TOCTOU and descriptor-inheritance exposure.
+      ``O_NOFOLLOW`` when available, ``O_CLOEXEC`` when available, and
+      non-blocking open flags when available to reduce symlink/TOCTOU,
+      descriptor-inheritance, and non-regular-file blocking exposure.
 
 Recommended additional hardening for production:
     - Store the private key in a secrets manager (HashiCorp Vault, AWS Secrets
@@ -109,7 +111,12 @@ def _check_private_key_permissions(private_key_path: Path) -> None:
             group or others.
     """
     try:
-        _check_private_key_stat(private_key_path.stat(), private_key_path)
+        file_stat = private_key_path.lstat()
+        if stat.S_ISLNK(file_stat.st_mode):
+            raise PermissionError(
+                f"Private key file {private_key_path} must not be a symlink"
+            )
+        _check_private_key_stat(file_stat, private_key_path)
     except PermissionError:
         raise
     except OSError as exc:
@@ -119,7 +126,7 @@ def _check_private_key_permissions(private_key_path: Path) -> None:
 def _private_key_open_flags() -> int:
     """Return secure open flags for local private-key reads."""
     flags = os.O_RDONLY
-    for optional_flag in ("O_NOFOLLOW", "O_CLOEXEC"):
+    for optional_flag in ("O_NOFOLLOW", "O_CLOEXEC", "O_NONBLOCK"):
         flag_value = getattr(os, optional_flag, 0)
         if flag_value:
             flags |= flag_value

--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -16,6 +16,8 @@ Mitigations applied here:
     - Files are created with mode ``0o600`` (owner-read/write only).
     - ``_load_private_key`` checks that the key file is not world-readable
       and raises ``PermissionError`` when unsafe permissions are detected.
+    - Local private-key reads use descriptor-based permission checks and
+      ``O_NOFOLLOW`` when available to reduce symlink/TOCTOU exposure.
 
 Recommended additional hardening for production:
     - Store the private key in a secrets manager (HashiCorp Vault, AWS Secrets
@@ -104,23 +106,52 @@ def _check_private_key_permissions(private_key_path: Path) -> None:
         PermissionError: When the file is readable by group or others.
     """
     try:
-        file_stat = private_key_path.stat()
-        mode = stat.S_IMODE(file_stat.st_mode)
-        if mode & (stat.S_IRGRP | stat.S_IROTH):
-            raise PermissionError(
-                f"Private key file {private_key_path} has unsafe permissions "
-                f"({oct(mode)}). Expected 0o600 (owner-read/write only). "
-                "An attacker with file-system read access could forge TrustLog signatures."
-            )
+        _check_private_key_stat(private_key_path.stat(), private_key_path)
     except PermissionError:
         raise
     except OSError as exc:
         logger.warning("Could not stat private key file %s: %s", private_key_path, exc)
 
 
+def _private_key_open_flags() -> int:
+    """Return secure open flags for local private-key reads."""
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    return flags
+
+
+def _check_private_key_stat(file_stat: os.stat_result, private_key_path: Path) -> None:
+    """Validate private-key file type and permissions from a stat result."""
+    mode = stat.S_IMODE(file_stat.st_mode)
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise PermissionError(
+            f"Private key file {private_key_path} must be a regular file"
+        )
+    if mode & (stat.S_IRGRP | stat.S_IROTH):
+        raise PermissionError(
+            f"Private key file {private_key_path} has unsafe permissions "
+            f"({oct(mode)}). Expected 0o600 (owner-read/write only). "
+            "An attacker with file-system read access could forge TrustLog signatures."
+        )
+
+
+def _read_private_key_file_secure(private_key_path: Path) -> str:
+    """Read private-key text via an opened descriptor after fstat checks."""
+    fd = os.open(str(private_key_path), _private_key_open_flags())
+    try:
+        _check_private_key_stat(os.fstat(fd), private_key_path)
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            return handle.read()
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
 def _load_private_key(private_key_path: Path) -> Ed25519PrivateKey:
-    _check_private_key_permissions(private_key_path)
-    raw = base64.urlsafe_b64decode(private_key_path.read_text(encoding="utf-8"))
+    raw = base64.urlsafe_b64decode(_read_private_key_file_secure(private_key_path))
     return Ed25519PrivateKey.from_private_bytes(raw)
 
 

--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -16,8 +16,9 @@ Mitigations applied here:
     - Files are created with mode ``0o600`` (owner-read/write only).
     - ``_load_private_key`` checks that the key file is not world-readable
       and raises ``PermissionError`` when unsafe permissions are detected.
-    - Local private-key reads use descriptor-based permission checks and
-      ``O_NOFOLLOW`` when available to reduce symlink/TOCTOU exposure.
+    - Local private-key reads use descriptor-based permission checks,
+      ``O_NOFOLLOW`` when available, and close-on-exec flags when available
+      to reduce symlink/TOCTOU and descriptor-inheritance exposure.
 
 Recommended additional hardening for production:
     - Store the private key in a secrets manager (HashiCorp Vault, AWS Secrets
@@ -95,15 +96,17 @@ def store_keypair(private_key_path: Path, public_key_path: Path) -> Tuple[Path, 
 
 
 def _check_private_key_permissions(private_key_path: Path) -> None:
-    """Warn (or raise) when the private key file has unsafe permissions.
+    """Warn (or raise) when the private key file is not safe to read.
 
     Security:
-        A world-readable private key file undermines the audit trail integrity
-        guarantee. This check runs at load time so misconfigurations are caught
-        early rather than silently tolerated.
+        A world-readable or non-regular private key file undermines the audit
+        trail integrity guarantee. This path-based compatibility check runs
+        at load/setup validation time, while ``_load_private_key`` uses an
+        fd-based check to reduce TOCTOU exposure.
 
     Raises:
-        PermissionError: When the file is readable by group or others.
+        PermissionError: When the file is not a regular file or is readable by
+            group or others.
     """
     try:
         _check_private_key_stat(private_key_path.stat(), private_key_path)
@@ -116,13 +119,17 @@ def _check_private_key_permissions(private_key_path: Path) -> None:
 def _private_key_open_flags() -> int:
     """Return secure open flags for local private-key reads."""
     flags = os.O_RDONLY
-    nofollow = getattr(os, "O_NOFOLLOW", 0)
-    if nofollow:
-        flags |= nofollow
+    for optional_flag in ("O_NOFOLLOW", "O_CLOEXEC"):
+        flag_value = getattr(os, optional_flag, 0)
+        if flag_value:
+            flags |= flag_value
     return flags
 
 
-def _check_private_key_stat(file_stat: os.stat_result, private_key_path: Path) -> None:
+def _check_private_key_stat(
+    file_stat: os.stat_result,
+    private_key_path: Path,
+) -> None:
     """Validate private-key file type and permissions from a stat result."""
     mode = stat.S_IMODE(file_stat.st_mode)
     if not stat.S_ISREG(file_stat.st_mode):

--- a/veritas_os/tests/test_signing_key_file_hardening.py
+++ b/veritas_os/tests/test_signing_key_file_hardening.py
@@ -56,6 +56,24 @@ def test_private_key_open_flags_include_optional_hardening_flags() -> None:
         assert flags & os.O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         assert flags & os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        assert flags & os.O_NONBLOCK
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink not available")
+def test_check_private_key_permissions_rejects_symlink(tmp_path: Path) -> None:
+    private_raw, _ = signing.generate_ed25519_keypair()
+    real_key = tmp_path / "real.key"
+    _write_private_key_file(real_key, private_raw, mode=0o600)
+
+    symlink_key = tmp_path / "symlink.key"
+    try:
+        symlink_key.symlink_to(real_key)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    with pytest.raises(PermissionError, match="symlink"):
+        signing._check_private_key_permissions(symlink_key)
 
 
 def test_file_backed_signing_flow_remains_valid(tmp_path: Path) -> None:

--- a/veritas_os/tests/test_signing_key_file_hardening.py
+++ b/veritas_os/tests/test_signing_key_file_hardening.py
@@ -1,0 +1,59 @@
+"""Hardening tests for file-backed Ed25519 private-key loading."""
+
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+
+import pytest
+
+from veritas_os.security import signing
+
+
+def _write_private_key_file(path: Path, raw_private_key: bytes, mode: int = 0o600) -> None:
+    path.write_text(
+        base64.urlsafe_b64encode(raw_private_key).decode("ascii"),
+        encoding="utf-8",
+    )
+    path.chmod(mode)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW not available")
+def test_load_private_key_rejects_symlink(tmp_path: Path) -> None:
+    private_raw, _ = signing.generate_ed25519_keypair()
+    real_key = tmp_path / "real.key"
+    _write_private_key_file(real_key, private_raw, mode=0o600)
+
+    symlink_key = tmp_path / "symlink.key"
+    symlink_key.symlink_to(real_key)
+
+    with pytest.raises(OSError):
+        signing._load_private_key(symlink_key)
+
+
+def test_load_private_key_rejects_unsafe_permissions(tmp_path: Path) -> None:
+    private_raw, _ = signing.generate_ed25519_keypair()
+    private_key_path = tmp_path / "private_unsafe.key"
+    _write_private_key_file(private_key_path, private_raw, mode=0o644)
+
+    with pytest.raises(PermissionError, match="unsafe permissions"):
+        signing._load_private_key(private_key_path)
+
+
+def test_load_private_key_rejects_non_regular_file(tmp_path: Path) -> None:
+    with pytest.raises((PermissionError, OSError), match="regular file"):
+        signing._load_private_key(tmp_path)
+
+
+def test_file_backed_signing_flow_remains_valid(tmp_path: Path) -> None:
+    private_key_path = tmp_path / "private.key"
+    public_key_path = tmp_path / "public.key"
+    signing.store_keypair(private_key_path, public_key_path)
+
+    loaded_private_key = signing._load_private_key(private_key_path)
+    assert loaded_private_key is not None
+
+    payload_hash = "a" * 64
+    signature = signing.sign_payload_hash(payload_hash, private_key_path)
+    assert signing.verify_payload_signature(payload_hash, signature, public_key_path)

--- a/veritas_os/tests/test_signing_key_file_hardening.py
+++ b/veritas_os/tests/test_signing_key_file_hardening.py
@@ -11,7 +11,11 @@ import pytest
 from veritas_os.security import signing
 
 
-def _write_private_key_file(path: Path, raw_private_key: bytes, mode: int = 0o600) -> None:
+def _write_private_key_file(
+    path: Path,
+    raw_private_key: bytes,
+    mode: int = 0o600,
+) -> None:
     path.write_text(
         base64.urlsafe_b64encode(raw_private_key).decode("ascii"),
         encoding="utf-8",
@@ -42,8 +46,16 @@ def test_load_private_key_rejects_unsafe_permissions(tmp_path: Path) -> None:
 
 
 def test_load_private_key_rejects_non_regular_file(tmp_path: Path) -> None:
-    with pytest.raises((PermissionError, OSError), match="regular file"):
+    with pytest.raises(PermissionError, match="regular file"):
         signing._load_private_key(tmp_path)
+
+
+def test_private_key_open_flags_include_optional_hardening_flags() -> None:
+    flags = signing._private_key_open_flags()
+    if hasattr(os, "O_CLOEXEC"):
+        assert flags & os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        assert flags & os.O_NOFOLLOW
 
 
 def test_file_backed_signing_flow_remains_valid(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Reduce TOCTOU and symlink attack exposure when loading local Ed25519 private keys by avoiding a separate `stat` + `read` window on the filesystem.
- Make permission and file-type checks operate on the opened descriptor so checks and reads observe the same file instance.
- Keep existing signing behavior and public APIs unchanged while satisfying the Low #6 external security review item.

### Description
- Added descriptor-based helpers: `_private_key_open_flags()`, `_check_private_key_stat()`, and `_read_private_key_file_secure()` to open the private-key file with `os.open(...)`, use `os.fstat()` for checks, and read via `os.fdopen()`.
- Updated `_load_private_key()` to use `_read_private_key_file_secure()` instead of `Path.read_text()` so permission checks and reads occur on the same file descriptor.
- Reused `_check_private_key_stat()` from `_check_private_key_permissions()` to centralize permission and regular-file validation.
- Updated the module docstring mitigations to note descriptor-based checks and `O_NOFOLLOW` usage.
- Added unit tests in `veritas_os/tests/test_signing_key_file_hardening.py` that cover: symlink rejection (skipped when `os.O_NOFOLLOW` is unavailable), unsafe permission rejection (`0o644`), non-regular-file rejection (directory), and a normal file-backed signing/verify roundtrip.
- Preserves: runtime governance/bind/RBAC/TrustLog semantics, API contracts, evidence/benchmark shapes, provider tiers, dependencies, and CI workflows; no secret material is logged.

Key technical changes: uses `os.open(..., O_NOFOLLOW)` when available, checks `os.fstat(fd)` for `S_ISREG` and group/other readability, ensures FDs are closed and avoids double-close via `fd = -1` after `os.fdopen()`.

### Testing
- Added tests: `veritas_os/tests/test_signing_key_file_hardening.py` (symlink, unsafe-permissions, non-regular-file, normal signing flow).
- Attempted to run: `pytest -q veritas_os/tests/test_signing_key_file_hardening.py`, `pytest -q veritas_os/tests/*signing*.py`, and `pytest -q veritas_os/tests/*trustlog*.py`.
- Test run status: automated test execution could not be completed in this environment due to the local Python toolchain configuration (`.python-version` requests `3.12.12` which is not installed) and `pytest` not being available in the active interpreter; `python3.12 -m pytest` also failed because the `pytest` module is not installed, so tests were not executed here.

Notes: the new tests are present and ready to run in CI or a developer environment with the appropriate Python version and `pytest` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde470fbc0832681e1bb710e960b0d)