### PR TITLE
Harden GCP KMS verify error handling to propagate AttributeError

### DIFF
--- a/veritas_os/security/signing.py
+++ b/veritas_os/security/signing.py
@@ -406,7 +406,11 @@ class GcpKmsEd25519Provider:
         try:
             public_key = self._load_public_key()
             public_key.verify(signature, payload_hash.encode("utf-8"))
-        except (InvalidSignature, ValueError, TypeError, AttributeError):
+        # Signature/key-shape failures return False; provider/client
+        # programming errors such as AttributeError are allowed to propagate
+        # so configuration problems are not reported as ordinary
+        # invalid signatures.
+        except (InvalidSignature, ValueError, TypeError):
             return False
         return True
 

--- a/veritas_os/tests/test_kms_verify_error_handling.py
+++ b/veritas_os/tests/test_kms_verify_error_handling.py
@@ -1,0 +1,128 @@
+"""Regression tests for KMS verify error handling boundaries."""
+
+import base64
+
+import pytest
+from cryptography.exceptions import InvalidSignature
+
+from veritas_os.security import signing
+
+
+class _InvalidPublicKey:
+    def verify(self, signature: bytes, message: bytes) -> None:
+        raise InvalidSignature
+
+
+class _ValueErrorPublicKey:
+    def verify(self, signature: bytes, message: bytes) -> None:
+        raise ValueError("invalid key material")
+
+
+class _TypeErrorPublicKey:
+    def verify(self, signature: bytes, message: bytes) -> None:
+        raise TypeError("wrong signature type")
+
+
+class _PassingProvider:
+    provider_name = "passing"
+
+    def __init__(self) -> None:
+        self.verify_called = False
+
+    def sign(self, payload_hash: str) -> bytes:
+        return b"signature"
+
+    def verify(self, payload_hash: str, signature: bytes) -> bool:
+        self.verify_called = True
+        return True
+
+    def key_id(self) -> str:
+        return "id"
+
+    def key_version(self) -> str:
+        return "v1"
+
+    def algorithm(self) -> str:
+        return "eddsa_ed25519"
+
+    def public_key_fingerprint(self) -> str:
+        return "fp"
+
+
+class _BrokenProvider(_PassingProvider):
+    provider_name = "broken"
+
+    def verify(self, payload_hash: str, signature: bytes) -> bool:
+        raise AttributeError("provider misconfigured")
+
+
+def test_gcp_kms_verify_propagates_attribute_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = signing.GcpKmsEd25519Provider(
+        kms_key_name="projects/p/locations/l/keyRings/r/cryptoKeys/k",
+        kms_client=object(),
+    )
+
+    def _broken_load_public_key() -> object:
+        raise AttributeError("broken kms client")
+
+    monkeypatch.setattr(provider, "_load_public_key", _broken_load_public_key)
+
+    with pytest.raises(AttributeError, match="broken kms client"):
+        provider.verify("a" * 64, b"signature")
+
+
+def test_gcp_kms_verify_returns_false_on_invalid_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = signing.GcpKmsEd25519Provider(
+        kms_key_name="projects/p/locations/l/keyRings/r/cryptoKeys/k",
+        kms_client=object(),
+    )
+    monkeypatch.setattr(provider, "_load_public_key", lambda: _InvalidPublicKey())
+
+    assert provider.verify("a" * 64, b"signature") is False
+
+
+@pytest.mark.parametrize("public_key", [_ValueErrorPublicKey(), _TypeErrorPublicKey()])
+def test_gcp_kms_verify_returns_false_for_value_and_type_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    public_key: object,
+) -> None:
+    provider = signing.GcpKmsEd25519Provider(
+        kms_key_name="projects/p/locations/l/keyRings/r/cryptoKeys/k",
+        kms_client=object(),
+    )
+    monkeypatch.setattr(provider, "_load_public_key", lambda: public_key)
+
+    assert provider.verify("a" * 64, b"signature") is False
+
+
+def test_aws_kms_verify_propagates_attribute_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = signing.AwsKmsEd25519Provider(
+        kms_key_id="arn:aws:kms:us-east-1:111122223333:key/example",
+        kms_client=object(),
+    )
+
+    def _broken_load_public_key() -> object:
+        raise AttributeError("broken aws kms client")
+
+    monkeypatch.setattr(provider, "_load_public_key", _broken_load_public_key)
+
+    with pytest.raises(AttributeError, match="broken aws kms client"):
+        provider.verify("a" * 64, b"signature")
+
+
+def test_kms_signer_verify_payload_signature_propagates_attribute_error() -> None:
+    signer = signing.KmsEd25519Signer(_BrokenProvider())
+    signature_b64 = base64.urlsafe_b64encode(b"signature").decode("ascii")
+
+    with pytest.raises(AttributeError, match="provider misconfigured"):
+        signer.verify_payload_signature("a" * 64, signature_b64)
+
+
+def test_kms_signer_verify_payload_signature_returns_false_on_malformed_base64() -> None:
+    provider = _PassingProvider()
+    signer = signing.KmsEd25519Signer(provider)
+
+    assert signer.verify_payload_signature("a" * 64, "not base64 ???") is False
+    assert provider.verify_called is False


### PR DESCRIPTION
### Motivation
- External security review Low #8 highlighted that `AttributeError` was being swallowed by the KMS verify path, causing configuration/implementation errors to be reported as ordinary invalid signatures and obscuring root causes.  
- Preserve backward compatibility for genuine signature/key-shape failures and malformed base64 handling while surfacing provider/client programming errors for operational debugging and auditing.

### Description
- Remove `AttributeError` from the except tuple in `GcpKmsEd25519Provider.verify()` and add a short comment explaining that signature/key-shape failures still return `False` while provider/client programming errors are allowed to propagate.  
- Leave `AwsKmsEd25519Provider.verify()` semantics unchanged and add tests to assert that `AttributeError` is not swallowed by the AWS provider.  
- Confirm `KmsEd25519Signer.verify_payload_signature()` behavior remains to return `False` for malformed base64 and to propagate provider-side `AttributeError`, and add tests that exercise those boundaries.  
- Add regression tests in `veritas_os/tests/test_kms_verify_error_handling.py` covering: GCP `AttributeError` propagation, GCP `InvalidSignature`/`ValueError`/`TypeError` returning `False`, AWS `AttributeError` propagation, signer propagation of provider `AttributeError`, and malformed base64 returning `False` without calling provider verification.  
- Key summary: Removes `AttributeError` from GCP KMS verify invalid-signature handling so provider/client configuration errors propagate instead of being reported as ordinary invalid signatures; preserves `False` returns for `InvalidSignature`, `ValueError`, and `TypeError`, and keeps malformed base64 signatures returning `False` in the signer adapter.

### Testing
- Added tests: `veritas_os/tests/test_kms_verify_error_handling.py` which implements the A–E regression cases described in the change.  
- Ran `pytest -q veritas_os/tests/test_kms_verify_error_handling.py` locally but test collection failed due to missing `cryptography` package in the environment, causing `ModuleNotFoundError: No module named 'cryptography'`.  
- Attempted broader runs (`PYENV_VERSION=3.12.13 pytest -q veritas_os/tests/*signing*.py` and `PYENV_VERSION=3.12.13 pytest -q veritas_os/tests/*trustlog*.py`) but these also aborted due to missing dependencies (`cryptography`, `pydantic`, `fastapi`) in the execution environment; the new tests are expected to pass in CI where the project dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfdc7eed883268d9123cb2f612940)