### PR TITLE
Deduplicate WAT verifier post-validation checks

### DIFF
--- a/veritas_os/security/wat_verifier.py
+++ b/veritas_os/security/wat_verifier.py
@@ -187,9 +187,6 @@ def _is_partial_allowed(config: Mapping[str, Any], now_ts: int) -> bool:
         return False
     return now_ts <= warning_only_until
 
-
-
-
 @dataclass(frozen=True)
 class _PostCheckResult:
     """Result payload for shared post-validation checks."""

--- a/veritas_os/security/wat_verifier.py
+++ b/veritas_os/security/wat_verifier.py
@@ -188,6 +188,97 @@ def _is_partial_allowed(config: Mapping[str, Any], now_ts: int) -> bool:
     return now_ts <= warning_only_until
 
 
+
+
+@dataclass(frozen=True)
+class _PostCheckResult:
+    """Result payload for shared post-validation checks."""
+
+    drift_vector: DriftVector
+    status: str
+    failure_type: str | None
+
+
+def _resolve_post_validation_checks(
+    *,
+    cfg: Mapping[str, Any],
+    replay_cache: MutableSet[str] | None,
+    binding_key: str,
+    claim_expiry_ts: int | None,
+    current_ts: int,
+    revocation_status: str,
+    issuance_ts_local: int | None,
+    claim_issuance_ts: int | None,
+    expiry_ts_local: int | None,
+) -> _PostCheckResult:
+    """Resolve shared post-validation checks while preserving legacy order."""
+    if replay_cache is not None and binding_key in replay_cache:
+        return _PostCheckResult(
+            drift_vector=DriftVector(1.0, 0.0, 0.0, 0.0),
+            status="invalid",
+            failure_type="replay_detected",
+        )
+
+    if claim_expiry_ts is not None and current_ts > claim_expiry_ts:
+        return _PostCheckResult(
+            drift_vector=DriftVector(0.0, 0.0, 0.0, 1.0),
+            status="stale",
+            failure_type="expired_token",
+        )
+
+    if revocation_status == "revoked_pending":
+        return _PostCheckResult(
+            drift_vector=DriftVector(0.6, 0.0, 0.0, 0.0),
+            status="revoked_pending",
+            failure_type="revocation_pending",
+        )
+
+    if bool(cfg.get("allow_partial_validation", False)):
+        if bool(cfg.get("partial_validation_requires_confirmation", True)) and not bool(
+            cfg.get("partial_validation_confirmation", False)
+        ):
+            status = "invalid"
+            failure_type = "partial_validation_confirmation_required"
+            logger.warning(
+                "WAT partial-validation confirmation failure "
+                "status=%s failure_type=%s binding_key=%s",
+                status,
+                failure_type,
+                binding_key,
+            )
+            return _PostCheckResult(
+                drift_vector=DriftVector(0.6, 0.0, 0.0, 0.0),
+                status=status,
+                failure_type=failure_type,
+            )
+        return _PostCheckResult(
+            drift_vector=DriftVector(0.3, 0.0, 0.0, 0.0),
+            status="partial",
+            failure_type="partial_validation_mode",
+        )
+
+    temporal_drift = 0.0
+    failure_type = None
+    skew_tolerance = int(cfg.get("timestamp_skew_tolerance_seconds", 30))
+    if issuance_ts_local is not None and claim_issuance_ts is not None:
+        if abs(claim_issuance_ts - issuance_ts_local) > skew_tolerance:
+            temporal_drift = 1.0
+            failure_type = "timestamp_skew_exceeded"
+    if expiry_ts_local is not None and claim_expiry_ts is not None:
+        if abs(claim_expiry_ts - expiry_ts_local) > skew_tolerance:
+            temporal_drift = max(temporal_drift, 1.0)
+            failure_type = failure_type or "timestamp_skew_exceeded"
+    if temporal_drift == 0.0 and issuance_ts_local is not None and claim_issuance_ts is not None:
+        if claim_issuance_ts != issuance_ts_local:
+            temporal_drift = 0.4
+            failure_type = "timestamp_skew_within_tolerance"
+    return _PostCheckResult(
+        drift_vector=DriftVector(0.0, 0.0, 0.0, temporal_drift),
+        status="invalid" if failure_type == "timestamp_skew_exceeded" else "valid",
+        failure_type=failure_type,
+    )
+
+
 def _verify_signature_local(
     *,
     claims: Mapping[str, Any],
@@ -382,102 +473,36 @@ def validate_local(
                 drift_vector = DriftVector(0.0, 0.0, 1.0, 0.0)
                 status = "invalid"
                 failure_type = "observable_digest_list_mismatch"
-            elif replay_cache is not None and binding_key in replay_cache:
-                drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
-                status = "invalid"
-                failure_type = "replay_detected"
-            elif claim_expiry_ts is not None and current_ts > claim_expiry_ts:
-                drift_vector = DriftVector(0.0, 0.0, 0.0, 1.0)
-                status = "stale"
-                failure_type = "expired_token"
-            elif revocation_status == "revoked_pending":
-                drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
-                status = "revoked_pending"
-                failure_type = "revocation_pending"
-            elif bool(cfg.get("allow_partial_validation", False)):
-                if bool(cfg.get("partial_validation_requires_confirmation", True)) and not bool(
-                    cfg.get("partial_validation_confirmation", False)
-                ):
-                    drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
-                    status = "invalid"
-                    failure_type = "partial_validation_confirmation_required"
-                    logger.warning(
-                        "WAT partial-validation confirmation failure "
-                        "status=%s failure_type=%s binding_key=%s",
-                        status,
-                        failure_type,
-                        binding_key,
-                    )
-                else:
-                    drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
-                    status = "partial"
-                    failure_type = "partial_validation_mode"
             else:
-                temporal_drift = 0.0
-                failure_type = None
-                skew_tolerance = int(cfg.get("timestamp_skew_tolerance_seconds", 30))
-                if issuance_ts_local is not None and claim_issuance_ts is not None:
-                    if abs(claim_issuance_ts - issuance_ts_local) > skew_tolerance:
-                        temporal_drift = 1.0
-                        failure_type = "timestamp_skew_exceeded"
-                if expiry_ts_local is not None and claim_expiry_ts is not None:
-                    if abs(claim_expiry_ts - expiry_ts_local) > skew_tolerance:
-                        temporal_drift = max(temporal_drift, 1.0)
-                        failure_type = failure_type or "timestamp_skew_exceeded"
-                if temporal_drift == 0.0 and issuance_ts_local is not None and claim_issuance_ts is not None:
-                    if claim_issuance_ts != issuance_ts_local:
-                        temporal_drift = 0.4
-                        failure_type = "timestamp_skew_within_tolerance"
-                drift_vector = DriftVector(0.0, 0.0, 0.0, temporal_drift)
-                status = "invalid" if failure_type == "timestamp_skew_exceeded" else "valid"
-        elif replay_cache is not None and binding_key in replay_cache:
-            drift_vector = DriftVector(1.0, 0.0, 0.0, 0.0)
-            status = "invalid"
-            failure_type = "replay_detected"
-        elif claim_expiry_ts is not None and current_ts > claim_expiry_ts:
-            drift_vector = DriftVector(0.0, 0.0, 0.0, 1.0)
-            status = "stale"
-            failure_type = "expired_token"
-        elif revocation_status == "revoked_pending":
-            drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
-            status = "revoked_pending"
-            failure_type = "revocation_pending"
-        elif bool(cfg.get("allow_partial_validation", False)):
-            if bool(cfg.get("partial_validation_requires_confirmation", True)) and not bool(
-                cfg.get("partial_validation_confirmation", False)
-            ):
-                drift_vector = DriftVector(0.6, 0.0, 0.0, 0.0)
-                status = "invalid"
-                failure_type = "partial_validation_confirmation_required"
-                logger.warning(
-                    "WAT partial-validation confirmation failure "
-                    "status=%s failure_type=%s binding_key=%s",
-                    status,
-                    failure_type,
-                    binding_key,
+                post_check = _resolve_post_validation_checks(
+                    cfg=cfg,
+                    replay_cache=replay_cache,
+                    binding_key=binding_key,
+                    claim_expiry_ts=claim_expiry_ts,
+                    current_ts=current_ts,
+                    revocation_status=revocation_status,
+                    issuance_ts_local=issuance_ts_local,
+                    claim_issuance_ts=claim_issuance_ts,
+                    expiry_ts_local=expiry_ts_local,
                 )
-            else:
-                drift_vector = DriftVector(0.3, 0.0, 0.0, 0.0)
-                status = "partial"
-                failure_type = "partial_validation_mode"
+                drift_vector = post_check.drift_vector
+                status = post_check.status
+                failure_type = post_check.failure_type
         else:
-            temporal_drift = 0.0
-            failure_type = None
-            skew_tolerance = int(cfg.get("timestamp_skew_tolerance_seconds", 30))
-            if issuance_ts_local is not None and claim_issuance_ts is not None:
-                if abs(claim_issuance_ts - issuance_ts_local) > skew_tolerance:
-                    temporal_drift = 1.0
-                    failure_type = "timestamp_skew_exceeded"
-            if expiry_ts_local is not None and claim_expiry_ts is not None:
-                if abs(claim_expiry_ts - expiry_ts_local) > skew_tolerance:
-                    temporal_drift = max(temporal_drift, 1.0)
-                    failure_type = failure_type or "timestamp_skew_exceeded"
-            if temporal_drift == 0.0 and issuance_ts_local is not None and claim_issuance_ts is not None:
-                if claim_issuance_ts != issuance_ts_local:
-                    temporal_drift = 0.4
-                    failure_type = "timestamp_skew_within_tolerance"
-            drift_vector = DriftVector(0.0, 0.0, 0.0, temporal_drift)
-            status = "invalid" if failure_type == "timestamp_skew_exceeded" else "valid"
+            post_check = _resolve_post_validation_checks(
+                cfg=cfg,
+                replay_cache=replay_cache,
+                binding_key=binding_key,
+                claim_expiry_ts=claim_expiry_ts,
+                current_ts=current_ts,
+                revocation_status=revocation_status,
+                issuance_ts_local=issuance_ts_local,
+                claim_issuance_ts=claim_issuance_ts,
+                expiry_ts_local=expiry_ts_local,
+            )
+            drift_vector = post_check.drift_vector
+            status = post_check.status
+            failure_type = post_check.failure_type
 
     if replay_cache is not None and status in {"valid", "partial", "revoked_pending"}:
         replay_cache.add(binding_key)

--- a/veritas_os/tests/test_wat_verifier_post_checks.py
+++ b/veritas_os/tests/test_wat_verifier_post_checks.py
@@ -20,7 +20,12 @@ BASE_CLAIMS: dict[str, Any] = {
 }
 
 
-def _run_case(*, claims: dict[str, Any], observable_refs_local: list[dict[str, str]] | None, **kwargs: Any) -> dict[str, Any]:
+def _run_case(
+    *,
+    claims: dict[str, Any],
+    observable_refs_local: list[dict[str, str]] | None,
+    **kwargs: Any,
+) -> dict[str, Any]:
     config = {"signature_verifier": lambda _claims, _sig: True}
     config.update(kwargs.pop("config", {}))
     return validate_local(
@@ -49,28 +54,59 @@ def _paired_results(*, claims: dict[str, Any], **kwargs: Any) -> tuple[dict[str,
     return non_list, with_list
 
 
+def _assert_post_check_parity(
+    non_list: dict[str, Any],
+    with_list: dict[str, Any],
+    *,
+    expected_status: str,
+    expected_failure_type: str | None,
+) -> None:
+    assert (
+        non_list["validation_status"]
+        == with_list["validation_status"]
+        == expected_status
+    )
+    assert non_list["failure_type"] == with_list["failure_type"] == expected_failure_type
+    assert non_list["drift_vector"] == with_list["drift_vector"]
+    assert (
+        non_list["admissibility_state"] == with_list["admissibility_state"]
+    )
+
+
 def test_post_checks_parity_between_observable_paths() -> None:
     replay_cache = {"action:nonce:session"}
     replay_non_list, replay_with_list = _paired_results(
         claims=BASE_CLAIMS,
         replay_cache=replay_cache,
     )
-    assert replay_non_list["validation_status"] == replay_with_list["validation_status"] == "invalid"
-    assert replay_non_list["failure_type"] == replay_with_list["failure_type"] == "replay_detected"
+    _assert_post_check_parity(
+        replay_non_list,
+        replay_with_list,
+        expected_status="invalid",
+        expected_failure_type="replay_detected",
+    )
 
     expired_non_list, expired_with_list = _paired_results(
         claims=BASE_CLAIMS,
         now_ts=2100,
     )
-    assert expired_non_list["validation_status"] == expired_with_list["validation_status"] == "stale"
-    assert expired_non_list["failure_type"] == expired_with_list["failure_type"] == "expired_token"
+    _assert_post_check_parity(
+        expired_non_list,
+        expired_with_list,
+        expected_status="stale",
+        expected_failure_type="expired_token",
+    )
 
     revoked_non_list, revoked_with_list = _paired_results(
         claims=BASE_CLAIMS,
         revocation_state="revoked_pending",
     )
-    assert revoked_non_list["validation_status"] == revoked_with_list["validation_status"] == "revoked_pending"
-    assert revoked_non_list["failure_type"] == revoked_with_list["failure_type"] == "revocation_pending"
+    _assert_post_check_parity(
+        revoked_non_list,
+        revoked_with_list,
+        expected_status="revoked_pending",
+        expected_failure_type="revocation_pending",
+    )
 
     partial_non_list, partial_with_list = _paired_results(
         claims=BASE_CLAIMS,
@@ -80,35 +116,39 @@ def test_post_checks_parity_between_observable_paths() -> None:
             "partial_validation_confirmation": False,
         },
     )
-    assert partial_non_list["validation_status"] == partial_with_list["validation_status"] == "invalid"
-    assert (
-        partial_non_list["failure_type"]
-        == partial_with_list["failure_type"]
-        == "partial_validation_confirmation_required"
+    _assert_post_check_parity(
+        partial_non_list,
+        partial_with_list,
+        expected_status="invalid",
+        expected_failure_type="partial_validation_confirmation_required",
     )
 
     skew_exceeded_non_list, skew_exceeded_with_list = _paired_results(
         claims=BASE_CLAIMS,
         issuance_ts_local=1100,
     )
-    assert skew_exceeded_non_list["validation_status"] == skew_exceeded_with_list["validation_status"] == "invalid"
-    assert (
-        skew_exceeded_non_list["failure_type"]
-        == skew_exceeded_with_list["failure_type"]
-        == "timestamp_skew_exceeded"
+    _assert_post_check_parity(
+        skew_exceeded_non_list,
+        skew_exceeded_with_list,
+        expected_status="invalid",
+        expected_failure_type="timestamp_skew_exceeded",
     )
 
     skew_within_non_list, skew_within_with_list = _paired_results(
         claims=BASE_CLAIMS,
         issuance_ts_local=1010,
     )
-    assert skew_within_non_list["validation_status"] == skew_within_with_list["validation_status"] == "valid"
-    assert (
-        skew_within_non_list["failure_type"]
-        == skew_within_with_list["failure_type"]
-        == "timestamp_skew_within_tolerance"
+    _assert_post_check_parity(
+        skew_within_non_list,
+        skew_within_with_list,
+        expected_status="valid",
+        expected_failure_type="timestamp_skew_within_tolerance",
     )
 
     valid_non_list, valid_with_list = _paired_results(claims=BASE_CLAIMS)
-    assert valid_non_list["validation_status"] == valid_with_list["validation_status"] == "valid"
-    assert valid_non_list["failure_type"] == valid_with_list["failure_type"] is None
+    _assert_post_check_parity(
+        valid_non_list,
+        valid_with_list,
+        expected_status="valid",
+        expected_failure_type=None,
+    )

--- a/veritas_os/tests/test_wat_verifier_post_checks.py
+++ b/veritas_os/tests/test_wat_verifier_post_checks.py
@@ -1,0 +1,114 @@
+"""Regression tests for shared WAT verifier post-validation checks."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from veritas_os.security.wat_token import compute_observable_digests
+from veritas_os.security.wat_verifier import validate_local
+
+
+BASE_CLAIMS: dict[str, Any] = {
+    "psid_full": "psid",
+    "action_digest": "action",
+    "observable_digest": "obs",
+    "issuance_ts": 1000,
+    "expiry_ts": 2000,
+    "nonce": "nonce",
+    "session_id": "session",
+}
+
+
+def _run_case(*, claims: dict[str, Any], observable_refs_local: list[dict[str, str]] | None, **kwargs: Any) -> dict[str, Any]:
+    config = {"signature_verifier": lambda _claims, _sig: True}
+    config.update(kwargs.pop("config", {}))
+    return validate_local(
+        signed_wat={"claims": claims, "signature": "sig"},
+        psid_full_local="psid",
+        action_digest_local="action",
+        observable_refs_local=observable_refs_local,
+        observable_digest_local="obs",
+        issuance_ts_local=kwargs.pop("issuance_ts_local", 1000),
+        expiry_ts_local=kwargs.pop("expiry_ts_local", 2000),
+        execution_nonce="nonce",
+        session_id="session",
+        revocation_state=kwargs.pop("revocation_state", None),
+        now_ts=kwargs.pop("now_ts", 1500),
+        config=config,
+        replay_cache=kwargs.pop("replay_cache", set()),
+    )
+
+
+def _paired_results(*, claims: dict[str, Any], **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    non_list = _run_case(claims=deepcopy(claims), observable_refs_local=None, **kwargs)
+    observable_refs = [{"id": "obs-1", "value": "x"}]
+    list_claims = deepcopy(claims)
+    list_claims["observable_digest_list"] = compute_observable_digests(observable_refs)
+    with_list = _run_case(claims=list_claims, observable_refs_local=observable_refs, **kwargs)
+    return non_list, with_list
+
+
+def test_post_checks_parity_between_observable_paths() -> None:
+    replay_cache = {"action:nonce:session"}
+    replay_non_list, replay_with_list = _paired_results(
+        claims=BASE_CLAIMS,
+        replay_cache=replay_cache,
+    )
+    assert replay_non_list["validation_status"] == replay_with_list["validation_status"] == "invalid"
+    assert replay_non_list["failure_type"] == replay_with_list["failure_type"] == "replay_detected"
+
+    expired_non_list, expired_with_list = _paired_results(
+        claims=BASE_CLAIMS,
+        now_ts=2100,
+    )
+    assert expired_non_list["validation_status"] == expired_with_list["validation_status"] == "stale"
+    assert expired_non_list["failure_type"] == expired_with_list["failure_type"] == "expired_token"
+
+    revoked_non_list, revoked_with_list = _paired_results(
+        claims=BASE_CLAIMS,
+        revocation_state="revoked_pending",
+    )
+    assert revoked_non_list["validation_status"] == revoked_with_list["validation_status"] == "revoked_pending"
+    assert revoked_non_list["failure_type"] == revoked_with_list["failure_type"] == "revocation_pending"
+
+    partial_non_list, partial_with_list = _paired_results(
+        claims=BASE_CLAIMS,
+        config={
+            "allow_partial_validation": True,
+            "partial_validation_requires_confirmation": True,
+            "partial_validation_confirmation": False,
+        },
+    )
+    assert partial_non_list["validation_status"] == partial_with_list["validation_status"] == "invalid"
+    assert (
+        partial_non_list["failure_type"]
+        == partial_with_list["failure_type"]
+        == "partial_validation_confirmation_required"
+    )
+
+    skew_exceeded_non_list, skew_exceeded_with_list = _paired_results(
+        claims=BASE_CLAIMS,
+        issuance_ts_local=1100,
+    )
+    assert skew_exceeded_non_list["validation_status"] == skew_exceeded_with_list["validation_status"] == "invalid"
+    assert (
+        skew_exceeded_non_list["failure_type"]
+        == skew_exceeded_with_list["failure_type"]
+        == "timestamp_skew_exceeded"
+    )
+
+    skew_within_non_list, skew_within_with_list = _paired_results(
+        claims=BASE_CLAIMS,
+        issuance_ts_local=1010,
+    )
+    assert skew_within_non_list["validation_status"] == skew_within_with_list["validation_status"] == "valid"
+    assert (
+        skew_within_non_list["failure_type"]
+        == skew_within_with_list["failure_type"]
+        == "timestamp_skew_within_tolerance"
+    )
+
+    valid_non_list, valid_with_list = _paired_results(claims=BASE_CLAIMS)
+    assert valid_non_list["validation_status"] == valid_with_list["validation_status"] == "valid"
+    assert valid_non_list["failure_type"] == valid_with_list["failure_type"] is None


### PR DESCRIPTION
### Motivation

- Reduce duplicated post-validation logic in `validate_local()` to avoid future divergence in replay/expiry/revocation/partial/timestamp behavior while preserving current semantics.
- Keep runtime and public contracts unchanged (result shape, `validate_local` signature, `replay_cache.add` timing, warning message text, and validation ordering).

### Description

- Adds internal dataclass `_PostCheckResult` to carry `drift_vector`, `status`, and `failure_type` for post-check outcomes.
- Implements `_resolve_post_validation_checks(...)` that centralizes the post-validation sequence (replay detection, expired token, revoked pending, partial validation checks with preserved `logger.warning` semantics, timestamp skew checks) in the same order and with identical drift/status/failure mappings as before.
- Replaces the two duplicated post-check blocks inside `validate_local()` (both the observable-list branch and the non-list branch) with calls to the shared helper and assigns `drift_vector`, `status`, and `failure_type` from the returned `_PostCheckResult`.
- Adds regression tests `veritas_os/tests/test_wat_verifier_post_checks.py` that assert parity of post-check outcomes between observable-list and non-list code paths for replay_detected, expired_token, revocation_pending, partial_validation_confirmation_required, timestamp_skew_exceeded, timestamp_skew_within_tolerance, and valid.

### Testing

- Ran a static compile check with `python -m py_compile veritas_os/security/wat_verifier.py veritas_os/tests/test_wat_verifier_post_checks.py`, which succeeded.
- Attempted `pytest -q veritas_os/tests/test_wat_verifier_post_checks.py` and `pytest -q` but test collection failed due to missing runtime test dependencies in the environment (notably `cryptography`, `fastapi`, `pydantic`, `httpx`, `yaml`), so automated pytest runs could not complete here.
- The change preserves existing runtime logic (no new dependencies introduced) and the new tests are included to run in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe032772748326ab088e14b2c1c5ac)