### PR TITLE
docs(security): add external security remediation summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
 - **PostgreSQL Production Guide**: [`docs/en/operations/postgresql-production-guide.md`](docs/en/operations/postgresql-production-guide.md)
 - **PostgreSQL Drill Runbook**: [`docs/en/operations/postgresql-drill-runbook.md`](docs/en/operations/postgresql-drill-runbook.md)
 - **Security Hardening**: [`docs/en/operations/security-hardening.md`](docs/en/operations/security-hardening.md)
+- External security review remediation notes are tracked in `docs/en/security/external-security-remediation-summary.md`, with a Japanese companion in `docs/ja/security/external-security-remediation-summary.md`.
 - **Database Migrations**: [`docs/en/operations/database-migrations.md`](docs/en/operations/database-migrations.md)
 - **Backend Parity Coverage**: [`docs/en/validation/backend-parity-coverage.md`](docs/en/validation/backend-parity-coverage.md)
 - **PostgreSQL Production Proof Map (compact)**: [`docs/en/validation/postgresql-production-proof-map.md`](docs/en/validation/postgresql-production-proof-map.md)

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
 - **PostgreSQL Production Guide**: [`docs/en/operations/postgresql-production-guide.md`](docs/en/operations/postgresql-production-guide.md)
 - **PostgreSQL Drill Runbook**: [`docs/en/operations/postgresql-drill-runbook.md`](docs/en/operations/postgresql-drill-runbook.md)
 - **Security Hardening**: [`docs/en/operations/security-hardening.md`](docs/en/operations/security-hardening.md)
-- External security review remediation notes are tracked in `docs/en/security/external-security-remediation-summary.md`, with a Japanese companion in `docs/ja/security/external-security-remediation-summary.md`.
+- **External Security Review Remediation Summary**: [`docs/en/security/external-security-remediation-summary.md`](docs/en/security/external-security-remediation-summary.md) / [`docs/ja/security/external-security-remediation-summary.md`](docs/ja/security/external-security-remediation-summary.md)
 - **Database Migrations**: [`docs/en/operations/database-migrations.md`](docs/en/operations/database-migrations.md)
 - **Backend Parity Coverage**: [`docs/en/validation/backend-parity-coverage.md`](docs/en/validation/backend-parity-coverage.md)
 - **PostgreSQL Production Proof Map (compact)**: [`docs/en/validation/postgresql-production-proof-map.md`](docs/en/validation/postgresql-production-proof-map.md)

--- a/README_JP.md
+++ b/README_JP.md
@@ -258,6 +258,7 @@ Authority Evidence と Audit Log の違いは明確です。
 - **PostgreSQL本番運用ガイド**: [`docs/ja/operations/postgresql-production-guide.md`](docs/ja/operations/postgresql-production-guide.md)
 - **PostgreSQLドリルRunbook**: [`docs/ja/operations/postgresql-drill-runbook.md`](docs/ja/operations/postgresql-drill-runbook.md)
 - **セキュリティ強化チェックリスト**: [`docs/ja/operations/security-hardening.md`](docs/ja/operations/security-hardening.md)
+- **外部セキュリティレビュー対応サマリー**: [日本語補助](docs/ja/security/external-security-remediation-summary.md) / [英語正本](docs/en/security/external-security-remediation-summary.md)
 - **データベースマイグレーション**: [`docs/ja/operations/database-migrations.md`](docs/ja/operations/database-migrations.md)
 - **バックエンドパリティカバレッジ**: [`docs/ja/validation/backend-parity-coverage.md`](docs/ja/validation/backend-parity-coverage.md)
 - **ライブPostgreSQL検証エビデンス**: [`docs/live-postgresql-validation.md`](docs/live-postgresql-validation.md)

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -36,6 +36,7 @@
 | Operations: PostgreSQL drill | `docs/en/operations/postgresql-drill-runbook.md` | `docs/ja/operations/postgresql-drill-runbook.md` | JA explanation / EN canonical | 復旧ドリル |
 | Operations: Security hardening | `docs/en/operations/security-hardening.md` | `docs/ja/operations/security-hardening.md` | JA explanation / EN canonical | ハードニング観点 |
 | Operations: Docker Compose security notes | `docs/en/operations/docker-compose-security.md` | `docs/ja/operations/docker-compose-security.md` | JA explanation / EN canonical | Local compose credential requirements, .env setup, non-claims, and production boundary |
+| Security: External review remediation summary | `docs/en/security/external-security-remediation-summary.md` | `docs/ja/security/external-security-remediation-summary.md` | JA explanation / EN canonical | Maps external security findings #1–#8 to remediation PRs, controls, verification commands, and residual boundaries. |
 | Operations: Database migrations | `docs/en/operations/database-migrations.md` | `docs/ja/operations/database-migrations.md` | JA explanation / EN canonical | 移行手順 |
 | Operations: Governance artifact signing | `docs/en/operations/governance-artifact-signing.md` | `docs/ja/operations/governance-artifact-signing.md` | JA explanation / EN canonical | 署名運用 |
 | Operations: Governance trace span chain | `docs/en/operations/governance-trace-span-chain.md` | `docs/ja/operations/governance-trace-span-chain.md` | JA explanation / EN canonical | observability検証導線 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,7 @@
 | PostgreSQL Drill Runbook | [PostgreSQL drill runbook (EN)](en/operations/postgresql-drill-runbook.md) | [PostgreSQLドリルRunbook (JA)](ja/operations/postgresql-drill-runbook.md) |
 | Security | [Security hardening (EN)](en/operations/security-hardening.md) | [セキュリティハードニング (JA)](ja/operations/security-hardening.md) |
 | Docker Compose Security Notes | [Docker Compose security notes (EN)](en/operations/docker-compose-security.md) | [Docker Composeセキュリティノート (JA)](ja/operations/docker-compose-security.md) |
+| External Security Review Remediation Summary | [External Security Review Remediation Summary (EN)](en/security/external-security-remediation-summary.md) | [外部セキュリティレビュー対応サマリー (JA)](ja/security/external-security-remediation-summary.md) |
 | Database | [Database migrations (EN)](en/operations/database-migrations.md) | [データベース移行 (JA)](ja/operations/database-migrations.md) |
 | Governance Artifact Signing | [Governance artifact signing (EN)](en/operations/governance-artifact-signing.md) | [ガバナンス成果物署名 (JA)](ja/operations/governance-artifact-signing.md) |
 | Governance Trace Span Chain | [Governance trace span chain (EN)](en/operations/governance-trace-span-chain.md) | [ガバナンストレース span chain (JA)](ja/operations/governance-trace-span-chain.md) |
@@ -100,6 +101,7 @@
 | PostgreSQLドリルRunbook | [PostgreSQL drill runbook（英語正本）](en/operations/postgresql-drill-runbook.md) | [PostgreSQLドリルRunbook（日本語解説）](ja/operations/postgresql-drill-runbook.md) |
 | セキュリティ | [Security hardening（英語正本）](en/operations/security-hardening.md) | [セキュリティハードニング（日本語）](ja/operations/security-hardening.md) |
 | Docker Compose Security Notes | [Docker Compose security notes（英語正本）](en/operations/docker-compose-security.md) | [Docker Composeセキュリティノート（日本語補助）](ja/operations/docker-compose-security.md) |
+| 外部セキュリティレビュー対応サマリー | [External Security Review Remediation Summary（英語正本）](en/security/external-security-remediation-summary.md) | [外部セキュリティレビュー対応サマリー（日本語補助）](ja/security/external-security-remediation-summary.md) |
 | データベース | [Database migrations（英語正本）](en/operations/database-migrations.md) | [データベース移行（日本語）](ja/operations/database-migrations.md) |
 | ガバナンス成果物署名 | [Governance artifact signing（英語正本）](en/operations/governance-artifact-signing.md) | [ガバナンス成果物署名（日本語解説）](ja/operations/governance-artifact-signing.md) |
 | ガバナンストレース span chain | [Governance trace span chain（英語正本）](en/operations/governance-trace-span-chain.md) | [ガバナンストレース span chain（日本語解説）](ja/operations/governance-trace-span-chain.md) |

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -60,6 +60,7 @@ Key reviewer concepts:
 
 - [Enterprise Value Brief](en/positioning/enterprise-value-brief.md)
 - [One-Day PoC Reviewer Pack](en/poc/one-day-poc-reviewer-pack.md)
+- For the completed external security review remediation matrix, see `docs/en/security/external-security-remediation-summary.md`.
 - [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
 - [Sample evidence JSON](en/poc/sample-one-day-poc-evidence.json)
 - [Sample evidence Markdown](en/poc/sample-one-day-poc-evidence.md)

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -60,7 +60,7 @@ Key reviewer concepts:
 
 - [Enterprise Value Brief](en/positioning/enterprise-value-brief.md)
 - [One-Day PoC Reviewer Pack](en/poc/one-day-poc-reviewer-pack.md)
-- For the completed external security review remediation matrix, see `docs/en/security/external-security-remediation-summary.md`.
+- For the completed external security review remediation matrix, see [External Security Review Remediation Summary](en/security/external-security-remediation-summary.md).
 - [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
 - [Sample evidence JSON](en/poc/sample-one-day-poc-evidence.json)
 - [Sample evidence Markdown](en/poc/sample-one-day-poc-evidence.md)

--- a/docs/en/security/external-security-remediation-summary.md
+++ b/docs/en/security/external-security-remediation-summary.md
@@ -1,0 +1,60 @@
+# External Security Review Remediation Summary
+
+This document summarizes remediation work completed after an external security review.
+It is an engineering remediation summary, not a third-party certification.
+It does not claim production SLA, legal certification, or absence of all vulnerabilities.
+It is intended to help reviewers trace security findings to concrete PRs, controls, and verification commands.
+
+## 1. Scope
+
+This summary covers review findings #1 through #8.
+
+Focus areas:
+
+- WebSocket API key auth
+- TrustLog JSONL append integrity
+- RBAC fallback
+- HMAC nonce registration
+- Docker Compose credentials
+- local signing key file hardening
+- WAT verifier post-check duplication
+- KMS verify error handling
+
+## 2. Remediation Matrix
+
+| Finding | Severity | Original risk | Remediation | PR | Verification |
+| --- | --- | --- | --- | --- | --- |
+| #1 WebSocket multi-key auth | High | WebSocket auth did not honor VERITAS_API_KEYS multi-key config consistently with HTTP auth. | Aligned WebSocket API key validation with multi-key/single-key semantics and fail-closed behavior. | #1660 | WebSocket multi-key / malformed multi-key / legacy fallback tests. |
+| #2 TrustLog JSONL multi-worker race | High | JSONL TrustLog append could race across workers and fork the hash chain. | Added process-level JSONL lock around read-last-entry / prev_hash / serialization / append critical section; kept mirror/anchor side effects outside the lock; anchored persisted JSONL snapshot. | #1660 | TrustLog JSONL lock tests, persisted-entry anchor hash tests. |
+| #3 RBAC fallback admin | Medium | Role resolution failure could fall back to admin. | Changed fallback to least-privilege auditor while preserving valid legacy admin and multi-key roles. | #1661 | RBAC fallback tests. |
+| #4 HMAC nonce poisoning | Medium | Invalid signatures could consume nonces before HMAC verification. | Separated nonce shape validation from nonce registration; registration now happens only after valid signature. | #1661, #1664 | Invalid signature does not consume nonce, oversized nonce rejected early, replay still rejected. |
+| #5 Docker Compose default credentials | Medium | Default DB password and default admin BFF token could be used accidentally. | Removed unsafe defaults, required explicit .env credentials, added .env.example placeholders and compose security docs. | #1666 | Docker Compose security tests and deployment env default checks. |
+| #6 Local signing key TOCTOU / symlink | Low | Private key load used path stat/read flow with symlink/TOCTOU exposure. | Moved to fd-based read, fstat checks, O_NOFOLLOW, O_CLOEXEC, O_NONBLOCK, lstat symlink rejection, regular-file and permission checks. | #1667 | Signing key file hardening tests. |
+| #7 WAT verifier duplicated post-checks | Low | Replay/expiry/revocation/partial/timestamp checks were duplicated across observable-list and non-list paths. | Centralized post-validation checks into shared helper while preserving output contract. | #1669 | Observable-list and non-list parity tests for validation_status, failure_type, drift_vector, admissibility_state. |
+| #8 KMS AttributeError swallowed | Low | Provider/client AttributeError could be reported as ordinary invalid signature. | Stopped swallowing AttributeError in GCP KMS verify path; preserved False for InvalidSignature / ValueError / TypeError. | #1668 | KMS verify error handling tests. |
+
+## 3. Verification Commands
+
+- `pytest -q veritas_os/tests/test_docker_compose_security.py`
+- `pytest -q veritas_os/tests/test_signing_key_file_hardening.py`
+- `pytest -q veritas_os/tests/test_kms_verify_error_handling.py`
+- `pytest -q veritas_os/tests/test_wat_verifier_post_checks.py`
+- `pytest -q veritas_os/tests/unit/test_server_api.py`
+- `pytest -q veritas_os/tests/unit/test_trustlog.py`
+- `python scripts/quality/check_deployment_env_defaults.py`
+- `python -m scripts.quality.check_bilingual_docs`
+
+CI, Security Gates, CodeQL custom, and Runtime Pickle Guard should be green.
+
+## 4. Residual Boundaries
+
+- This is not a substitute for a formal penetration test.
+- This is not legal certification for EU AI Act or other regulatory frameworks.
+- Production deployments should use managed secrets, durable storage, PostgreSQL TrustLog backend, and deployment-specific review.
+- JSONL TrustLog backend is hardened for local/file-backed usage, but PostgreSQL remains the recommended production backend.
+- KMS/Vault integrations still require provider-specific operational validation.
+
+## 5. Reviewer Notes
+
+- These remediations reduce obvious DD blockers from the prior review.
+- The project still needs empirical performance metrics, operational support planning, and third-party legal/security review for enterprise production procurement.

--- a/docs/ja/security/external-security-remediation-summary.md
+++ b/docs/ja/security/external-security-remediation-summary.md
@@ -1,0 +1,60 @@
+# 外部セキュリティレビュー対応サマリー
+
+本資料は、外部セキュリティレビューで指摘された項目に対する実装修正の整理である。
+第三者認証、法的認証、本番SLA、脆弱性ゼロを意味しない。
+DD・監査・PoC担当者が、指摘内容・対応PR・確認方法を追えるようにするための資料である。
+英語版が正本、日本語版は補助説明である。
+
+## 1. スコープ
+
+本サマリーは、レビュー指摘 #1 から #8 を対象とする。
+
+重点領域:
+
+- WebSocket API key auth
+- TrustLog JSONL append integrity
+- RBAC fallback
+- HMAC nonce registration
+- Docker Compose credentials
+- local signing key file hardening
+- WAT verifier post-check duplication
+- KMS verify error handling
+
+## 2. 対応マトリクス
+
+| Finding | Severity | Original risk | Remediation | PR | Verification |
+| --- | --- | --- | --- | --- | --- |
+| #1 WebSocket multi-key auth | High | WebSocket auth did not honor VERITAS_API_KEYS multi-key config consistently with HTTP auth. | Aligned WebSocket API key validation with multi-key/single-key semantics and fail-closed behavior. | #1660 | WebSocket multi-key / malformed multi-key / legacy fallback tests. |
+| #2 TrustLog JSONL multi-worker race | High | JSONL TrustLog append could race across workers and fork the hash chain. | Added process-level JSONL lock around read-last-entry / prev_hash / serialization / append critical section; kept mirror/anchor side effects outside the lock; anchored persisted JSONL snapshot. | #1660 | TrustLog JSONL lock tests, persisted-entry anchor hash tests. |
+| #3 RBAC fallback admin | Medium | Role resolution failure could fall back to admin. | Changed fallback to least-privilege auditor while preserving valid legacy admin and multi-key roles. | #1661 | RBAC fallback tests. |
+| #4 HMAC nonce poisoning | Medium | Invalid signatures could consume nonces before HMAC verification. | Separated nonce shape validation from nonce registration; registration now happens only after valid signature. | #1661, #1664 | Invalid signature does not consume nonce, oversized nonce rejected early, replay still rejected. |
+| #5 Docker Compose default credentials | Medium | Default DB password and default admin BFF token could be used accidentally. | Removed unsafe defaults, required explicit .env credentials, added .env.example placeholders and compose security docs. | #1666 | Docker Compose security tests and deployment env default checks. |
+| #6 Local signing key TOCTOU / symlink | Low | Private key load used path stat/read flow with symlink/TOCTOU exposure. | Moved to fd-based read, fstat checks, O_NOFOLLOW, O_CLOEXEC, O_NONBLOCK, lstat symlink rejection, regular-file and permission checks. | #1667 | Signing key file hardening tests. |
+| #7 WAT verifier duplicated post-checks | Low | Replay/expiry/revocation/partial/timestamp checks were duplicated across observable-list and non-list paths. | Centralized post-validation checks into shared helper while preserving output contract. | #1669 | Observable-list and non-list parity tests for validation_status, failure_type, drift_vector, admissibility_state. |
+| #8 KMS AttributeError swallowed | Low | Provider/client AttributeError could be reported as ordinary invalid signature. | Stopped swallowing AttributeError in GCP KMS verify path; preserved False for InvalidSignature / ValueError / TypeError. | #1668 | KMS verify error handling tests. |
+
+## 3. 確認コマンド
+
+- `pytest -q veritas_os/tests/test_docker_compose_security.py`
+- `pytest -q veritas_os/tests/test_signing_key_file_hardening.py`
+- `pytest -q veritas_os/tests/test_kms_verify_error_handling.py`
+- `pytest -q veritas_os/tests/test_wat_verifier_post_checks.py`
+- `pytest -q veritas_os/tests/unit/test_server_api.py`
+- `pytest -q veritas_os/tests/unit/test_trustlog.py`
+- `python scripts/quality/check_deployment_env_defaults.py`
+- `python -m scripts.quality.check_bilingual_docs`
+
+CI, Security Gates, CodeQL custom, and Runtime Pickle Guard が green であることを確認する。
+
+## 4. 残存境界
+
+- 正式なペネトレーションテストの代替ではない。
+- EU AI Act等の法的認証ではない。
+- 本番導入では managed secrets / durable storage / PostgreSQL TrustLog backend / deployment-specific review が必要。
+- JSONL TrustLog backend は local/file-backed 向けに hardening 済みだが、本番では PostgreSQL backend を推奨。
+- KMS/Vault統合は provider ごとの運用検証が必要。
+
+## 5. レビュアーノート
+
+- これらの対応により、前回レビュー時点の明確なDD阻害要因は縮小された。
+- 一方で、エンタープライズ本番調達に向けては、実測性能指標・運用体制計画・第三者の法務/セキュリティレビューが引き続き必要である。

--- a/veritas_os/tests/test_external_security_remediation_docs.py
+++ b/veritas_os/tests/test_external_security_remediation_docs.py
@@ -1,0 +1,63 @@
+"""Documentation coverage checks for external security remediation summary."""
+
+from pathlib import Path
+
+
+def _read(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_external_security_remediation_docs_exist() -> None:
+    assert Path("docs/en/security/external-security-remediation-summary.md").exists()
+    assert Path("docs/ja/security/external-security-remediation-summary.md").exists()
+
+
+def test_en_doc_contains_findings() -> None:
+    content = _read("docs/en/security/external-security-remediation-summary.md")
+    for finding in ["#1", "#2", "#3", "#4", "#5", "#6", "#7", "#8"]:
+        assert finding in content
+
+
+def test_en_doc_contains_pr_refs() -> None:
+    content = _read("docs/en/security/external-security-remediation-summary.md")
+    for pr_ref in ["#1660", "#1661", "#1664", "#1666", "#1667", "#1668", "#1669"]:
+        assert pr_ref in content
+
+
+def test_en_doc_contains_non_claim_boundaries() -> None:
+    content = _read("docs/en/security/external-security-remediation-summary.md")
+    required = [
+        "not a third-party certification",
+        "does not claim production SLA",
+        "does not claim",
+        "formal penetration test",
+        "legal certification",
+    ]
+    for phrase in required:
+        assert phrase in content
+
+
+def test_en_doc_contains_verification_commands() -> None:
+    content = _read("docs/en/security/external-security-remediation-summary.md")
+    commands = [
+        "pytest -q veritas_os/tests/test_docker_compose_security.py",
+        "pytest -q veritas_os/tests/test_signing_key_file_hardening.py",
+        "pytest -q veritas_os/tests/test_kms_verify_error_handling.py",
+        "pytest -q veritas_os/tests/test_wat_verifier_post_checks.py",
+        "python scripts/quality/check_deployment_env_defaults.py",
+    ]
+    for command in commands:
+        assert command in content
+
+
+def test_ja_doc_contains_required_phrases() -> None:
+    content = _read("docs/ja/security/external-security-remediation-summary.md")
+    required = ["第三者認証", "本番SLA", "脆弱性ゼロ", "英語版が正本", "#1660", "#1669"]
+    for phrase in required:
+        assert phrase in content
+
+
+def test_index_links_exist() -> None:
+    assert "external-security-remediation-summary.md" in _read("README.md")
+    assert "external-security-remediation-summary.md" in _read("docs/INDEX.md")
+    assert "external-security-remediation-summary.md" in _read("docs/DOCUMENTATION_MAP.md")

--- a/veritas_os/tests/test_external_security_remediation_docs.py
+++ b/veritas_os/tests/test_external_security_remediation_docs.py
@@ -59,5 +59,30 @@ def test_ja_doc_contains_required_phrases() -> None:
 
 def test_index_links_exist() -> None:
     assert "external-security-remediation-summary.md" in _read("README.md")
+    assert "docs/en/security/external-security-remediation-summary.md" in _read(
+        "README.md"
+    )
+    assert "docs/ja/security/external-security-remediation-summary.md" in _read(
+        "README.md"
+    )
+    assert "external-security-remediation-summary.md" in _read("README_JP.md")
+    assert "docs/ja/security/external-security-remediation-summary.md" in _read(
+        "README_JP.md"
+    )
+    assert "docs/en/security/external-security-remediation-summary.md" in _read(
+        "README_JP.md"
+    )
+    assert "英語正本" in _read("README_JP.md")
     assert "external-security-remediation-summary.md" in _read("docs/INDEX.md")
     assert "external-security-remediation-summary.md" in _read("docs/DOCUMENTATION_MAP.md")
+
+
+def test_remediation_matrix_tables_do_not_start_with_double_pipe() -> None:
+    for path in [
+        "docs/en/security/external-security-remediation-summary.md",
+        "docs/ja/security/external-security-remediation-summary.md",
+    ]:
+        for line in _read(path).splitlines():
+            assert not line.startswith("||"), (
+                f"{path} contains malformed table row: {line}"
+            )


### PR DESCRIPTION
### Motivation

- Provide an auditable remediation summary that maps external security review findings #1–#8 to concrete remediations, PRs, verification commands, and residual boundaries so DD/assessment/PoC reviewers can trace fixes. 
- Produce only documentation and trace artifacts; do not change runtime behavior, governance, or public-certification claims.

### Description

- Add the English remediation summary at `docs/en/security/external-security-remediation-summary.md` containing scope, a remediation matrix for findings #1–#8, verification commands, residual boundaries, and reviewer notes. 
- Add the Japanese companion at `docs/ja/security/external-security-remediation-summary.md` that mirrors the English structure and includes the required non-claim language and Japanese phrases. 
- Wire the new docs into navigation and discoverability by updating `docs/INDEX.md`, `docs/DOCUMENTATION_MAP.md`, `README.md`, and `docs/REVIEWER_ENTRYPOINT.md`, and add a regression test at `veritas_os/tests/test_external_security_remediation_docs.py` that asserts doc existence and required contents. 
- Preserve all runtime guarantees and constraints: no changes to governance/bind/RBAC/TrustLog/WAT semantics, API contracts, provider tiers, evidence/benchmark JSON shapes, dependencies, or CI workflows, and no claims of third-party/legal certification or production SLA.

### Testing

- Ran `python3 -m scripts.quality.check_bilingual_docs`, which passed in this environment. 
- Added `veritas_os/tests/test_external_security_remediation_docs.py`; an attempt to run it with `pytest` in this environment failed because `pytest` is not available here (`No module named pytest`), so the test could not be executed locally but will run in CI. 
- The documentation itself enumerates verification commands (e.g. `pytest -q veritas_os/tests/test_docker_compose_security.py`, `pytest -q veritas_os/tests/test_signing_key_file_hardening.py`, etc.) that are expected to be executed in CI/security gates; CI/Security Gates/CodeQL/Runtime Pickle Guard should be green as part of merge validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0e0509a08326879c04978e47e7bf)