### PR TITLE
Cache Playwright browsers and set PLAYWRIGHT_BROWSERS_PATH for frontend e2e job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -730,6 +730,8 @@ jobs:
       fail-fast: false
       matrix:
         gate: ["lint", "test", "e2e"]
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/ms-playwright
 
     steps:
       - name: Checkout
@@ -762,6 +764,13 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        if: matrix.gate == 'e2e'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'frontend/package.json') }}
 
       - name: Install Playwright browsers
         if: matrix.gate == 'e2e'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -732,6 +732,7 @@ jobs:
         gate: ["lint", "test", "e2e"]
     env:
       PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/ms-playwright
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
 
     steps:
       - name: Checkout
@@ -762,9 +763,6 @@ jobs:
           node-version: "22"
           cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Cache Playwright browsers
         if: matrix.gate == 'e2e'
         uses: actions/cache@v4
@@ -772,12 +770,17 @@ jobs:
           path: ${{ runner.temp }}/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'frontend/package.json') }}
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Install Playwright browsers
         if: matrix.gate == 'e2e'
         working-directory: frontend
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "0"
         run: |
           set -euo pipefail
-          # Avoid --with-deps: apt mirror stalls can cancel the e2e job.
+          # Keep this browser-only; --with-deps can stall on apt mirrors in PR CI.
           pnpm exec playwright install chromium chromium-headless-shell
 
       - name: Build frontend


### PR DESCRIPTION
### Motivation
- Reduce e2e job startup time and avoid re-downloading Playwright browser binaries by caching them between runs and directing Playwright to use a stable path via `PLAYWRIGHT_BROWSERS_PATH`.

### Description
- Add `PLAYWRIGHT_BROWSERS_PATH` env to the `frontend-quality-gate` job and a conditional `actions/cache@v4` step that caches `${{ runner.temp }}/ms-playwright` keyed by OS and lockfiles, applied only when `matrix.gate == 'e2e'`.

### Testing
- No automated tests were executed as part of this change since it only updates the GitHub Actions workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee4dcd6dc8326b787722059f10c34)