### PR TITLE
Cache Playwright browsers and configure browser path in frontend CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -730,6 +730,8 @@ jobs:
       fail-fast: false
       matrix:
         gate: ["lint", "test", "e2e"]
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/ms-playwright
 
     steps:
       - name: Checkout
@@ -760,7 +762,16 @@ jobs:
           node-version: "22"
           cache: pnpm
 
+      - name: Cache Playwright browsers
+        if: matrix.gate == 'e2e'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'frontend/package.json') }}
+
       - name: Install dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -767,7 +767,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'frontend/package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         env:


### PR DESCRIPTION
### Motivation

- Reduce e2e job time and network churn by avoiding repeated Playwright browser downloads across matrix runs. 

### Description

- Set `PLAYWRIGHT_BROWSERS_PATH` to use a shared cache directory at `${{ runner.temp }}/ms-playwright` for the `frontend-quality-gate` job. 
- Add an `actions/cache` step (conditioned on `matrix.gate == 'e2e'`) that caches the Playwright browser files keyed by platform and lockfiles. 
- Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` during dependency installation and keep an explicit `pnpm exec playwright install chromium chromium-headless-shell` step to populate the cached browsers. 

### Testing

- Ran local dependency install with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and then `pnpm exec playwright install chromium chromium-headless-shell` to verify browsers install into the configured path, and the commands completed successfully.
- Exercised the `frontend-quality-gate` e2e flow in CI to validate the cache step and the e2e browser install step, and the CI run completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee4dcd6dc8326b787722059f10c34)