### PR TITLE
Cache Playwright browsers and set Playwright browser path for frontend e2e job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -766,7 +766,7 @@ jobs:
         if: matrix.gate == 'e2e'
         uses: actions/cache@v4
         with:
-          path: ${{ runner.temp }}/ms-playwright
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -730,6 +730,8 @@ jobs:
       fail-fast: false
       matrix:
         gate: ["lint", "test", "e2e"]
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/ms-playwright
 
     steps:
       - name: Checkout
@@ -760,7 +762,16 @@ jobs:
           node-version: "22"
           cache: pnpm
 
+      - name: Cache Playwright browsers
+        if: matrix.gate == 'e2e'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers


### PR DESCRIPTION
### Motivation

- Reduce e2e job time and make Playwright browser installs more reliable by caching downloaded browsers and configuring a reproducible browsers path.

### Description

- Add `PLAYWRIGHT_BROWSERS_PATH` environment variable to the `frontend-quality-gate` job so Playwright uses a runner-local browsers directory at `${{ runner.temp }}/ms-playwright`.
- Add a conditional `actions/cache` step to cache the Playwright browsers for the `e2e` matrix case with key `playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}`.
- Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` during `pnpm install` so the install step does not re-download browsers when the cache is present.
- Restrict the Playwright install step to only `chromium` and `chromium-headless-shell` and document avoiding `--with-deps` to reduce external apt mirror issues.

### Testing

- No automated tests were executed as part of this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee4dcd6dc8326b787722059f10c34)