### PR TITLE
ci(frontend): stabilize Playwright browser cache for e2e

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -725,6 +725,8 @@ jobs:
     needs: [lint, dependency-audit, governance-smoke, governance-backend-fast]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/ms-playwright
 
     strategy:
       fail-fast: false
@@ -760,7 +762,16 @@ jobs:
           node-version: "22"
           cache: pnpm
 
+      - name: Cache Playwright browsers
+        if: matrix.gate == 'e2e'
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers


### PR DESCRIPTION
### Motivation
- Stabilize frontend e2e CI by avoiding apt-dependent Playwright installs and reducing repeated browser downloads.

### Description
- Sets `PLAYWRIGHT_BROWSERS_PATH` to `${{ runner.temp }}/ms-playwright`.
- Restores/caches Playwright browsers before `pnpm install` for the e2e matrix leg using a `Cache Playwright browsers` step that runs only when `matrix.gate == 'e2e'`.
- Uses `path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}` so the cache path stays synchronized with the Playwright install path.
- Keys the browser cache by runner OS, runner architecture, and `pnpm-lock.yaml` via `playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}` and does not add `restore-keys`.
- Sets `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` only during dependency installation (`Install dependencies` step with `pnpm install --frozen-lockfile`).
- Keeps the explicit Playwright install step browser-only as `pnpm exec playwright install chromium chromium-headless-shell` and does not use `--with-deps`, apt installs, or include `frontend/package.json` in the cache key.

### Testing
- Verified workflow references using `rg` to confirm absence of `playwright install --with-deps` and apt commands, and presence of `PLAYWRIGHT_BROWSERS_PATH`, `Cache Playwright browsers`, the expected cache `path`, `key`, and `pnpm exec playwright install chromium chromium-headless-shell`.
- Confirmed only `.github/workflows/main.yml` was changed and produced a local commit `ci(frontend): stabilize Playwright browser cache for e2e`.
- No runtime code, frontend app code, dependency additions, lockfile, benchmark, or docs changes were made.
- Security note: no secrets, credentials, or security-sensitive governance/bind logic were modified by this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff52b3eef08326bbfb8ae313bece3e)