### PR TITLE
docs(poc): add one-day PoC evidence pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Boundary:
 
 For external reviewers, HPAN, enterprise stakeholders, and investor diligence, use the one-day PoC smoke script to generate a sanitized evidence packet from a running VERITAS API server.
 
-- **One-Day PoC Evidence Pack**: [`docs/en/poc/one-day-poc-evidence-pack.md`](docs/en/poc/one-day-poc-evidence-pack.md)
+- **One-Day PoC Evidence Pack / Checklist**: reviewer-facing checklist and success/failure criteria (distinct from generated evidence packet output) — [`docs/en/poc/one-day-poc-evidence-pack.md`](docs/en/poc/one-day-poc-evidence-pack.md)
 
 Prerequisites:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Boundary:
 
 For external reviewers, HPAN, enterprise stakeholders, and investor diligence, use the one-day PoC smoke script to generate a sanitized evidence packet from a running VERITAS API server.
 
+- **One-Day PoC Evidence Pack**: [`docs/en/poc/one-day-poc-evidence-pack.md`](docs/en/poc/one-day-poc-evidence-pack.md)
+
 Prerequisites:
 
 - VERITAS API server is running.

--- a/README_JP.md
+++ b/README_JP.md
@@ -29,6 +29,7 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 
 - **性能メトリクス**: [日本語補助](docs/ja/benchmarks/performance-metrics.md) / [英語正本](docs/en/benchmarks/performance-metrics.md)
 - **最新ローカル性能メトリクスartifact**: [日本語補助](docs/ja/benchmarks/local-performance-metrics.latest.md) / [英語正本](docs/en/benchmarks/local-performance-metrics.latest.md) / [JSON](docs/en/benchmarks/local-performance-metrics.latest.json)
+- **One-Day PoC証跡パック**: [日本語補助](docs/ja/poc/one-day-poc-evidence-pack.md) / [英語正本](docs/en/poc/one-day-poc-evidence-pack.md)
 - 性能メトリクスおよびOne-Day PoC benchmarkは、local/reviewer-facingな測定であり、本番SLA・第三者認証・顧客環境測定ではありません。
 
 

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -64,5 +64,4 @@
 | Benchmarks | `docs/benchmarks/VERITAS_EVIDENCE_BENCHMARK_PLAN.md` | `docs/ja/validation/technical-proof-pack.md` | JA explanation / EN canonical | ベンチ証跡案内 |
 | JA manuals | — | `docs/ja/guides/user-manual.md` | JA primary | 日本語中心運用文書 |
 | EN notes | `docs/en/notes/chainlit.md` | — | EN canonical only | 補助ノート |
-
 | PoC: One-Day PoC evidence pack | `docs/en/poc/one-day-poc-evidence-pack.md` | `docs/ja/poc/one-day-poc-evidence-pack.md` | JA explanation / EN canonical | Reviewer-facing evidence checklist, walkthrough scenarios, success/failure criteria, and non-claim boundaries for One-Day PoC. |

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -64,3 +64,5 @@
 | Benchmarks | `docs/benchmarks/VERITAS_EVIDENCE_BENCHMARK_PLAN.md` | `docs/ja/validation/technical-proof-pack.md` | JA explanation / EN canonical | ベンチ証跡案内 |
 | JA manuals | — | `docs/ja/guides/user-manual.md` | JA primary | 日本語中心運用文書 |
 | EN notes | `docs/en/notes/chainlit.md` | — | EN canonical only | 補助ノート |
+
+| PoC: One-Day PoC evidence pack | `docs/en/poc/one-day-poc-evidence-pack.md` | `docs/ja/poc/one-day-poc-evidence-pack.md` | JA explanation / EN canonical | Reviewer-facing evidence checklist, walkthrough scenarios, success/failure criteria, and non-claim boundaries for One-Day PoC. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -45,6 +45,7 @@
 | One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough (EN)](en/poc/one-day-poc-walkthrough.md) — Includes sanitized JSON/Markdown evidence packet generation. | [One-Day VERITAS PoC Walkthrough (JA)](ja/poc/one-day-poc-walkthrough.md) — sanitized evidence packet（JSON/Markdown）生成を含む。 |
 | One-Day PoC Reviewer Pack | [One-Day PoC Reviewer Pack (EN)](en/poc/one-day-poc-reviewer-pack.md) | [One-Day PoC Reviewer Pack (JA)](ja/poc/one-day-poc-reviewer-pack.md) |
 | One-Day PoC Performance Benchmark | [One-Day PoC Performance Benchmark (EN)](en/poc/one-day-poc-performance-report.md) | [One-Day PoC Performance Benchmark (JA)](ja/poc/one-day-poc-performance-report.md) |
+| One-Day PoC Evidence Pack | [One-Day PoC Evidence Pack (EN)](en/poc/one-day-poc-evidence-pack.md) | [One-Day PoC Evidence Pack (JA)](ja/poc/one-day-poc-evidence-pack.md) |
 | Performance Metrics | [Performance Metrics (EN)](en/benchmarks/performance-metrics.md) | [性能メトリクス (JA)](ja/benchmarks/performance-metrics.md) |
 | Local Performance Metrics Artifact | [Local Performance Metrics Artifact (EN)](en/benchmarks/local-performance-metrics.latest.md) / [JSON](en/benchmarks/local-performance-metrics.latest.json) | [ローカル性能メトリクス実測artifact (JA)](ja/benchmarks/local-performance-metrics.latest.md) |
 | One-Day PoC Sample Evidence Packet | [Sample one-day PoC evidence (EN JSON/Markdown)](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（JA Markdown）](ja/poc/sample-one-day-poc-evidence.md) |

--- a/docs/en/poc/one-day-poc-evidence-pack.md
+++ b/docs/en/poc/one-day-poc-evidence-pack.md
@@ -1,0 +1,89 @@
+# One-Day PoC Evidence Pack
+
+- This is a reviewer-facing evidence pack for a One-Day PoC.
+- It summarizes what to inspect, what evidence to collect, and what counts as a successful local/configured PoC walkthrough.
+- It is not a production SLA.
+- It is not third-party certified.
+- It is not a customer environment measurement.
+- It does not certify EU AI Act compliance.
+- External LLM/provider latency and cost are not measured unless providers are intentionally enabled and separately recorded.
+
+## Purpose
+
+Provide a compact reviewer-facing checklist for One-Day PoC validation so customers, investors, and review teams can quickly assess governance behavior and evidence quality without over-claiming production readiness.
+
+## What this PoC demonstrates
+
+- A regulated or sensitive action can be stopped before commit when required authority/evidence is missing.
+- The decision path can remain reviewable through governance/audit traces.
+- Reviewer-facing docs distinguish deterministic local metrics from HTTP PoC benchmarks.
+- The system can present governance boundaries before claiming production readiness.
+
+## What this PoC does not prove
+
+- It does not prove production latency.
+- It does not prove production availability.
+- It does not prove customer-environment performance.
+- It does not prove legal compliance by itself.
+- It does not replace legal, security, or regulatory review.
+- It does not certify EU AI Act compliance.
+- It does not measure provider latency or cost unless providers are explicitly enabled and separately measured.
+
+## Evidence checklist
+
+| Evidence item | What to inspect | Expected result | Link |
+|---|---|---|---|
+| Local deterministic performance artifact | Latest deterministic local benchmark markdown snapshot | Local deterministic metrics are visible with explicit non-claim boundaries | [`docs/en/benchmarks/local-performance-metrics.latest.md`](../benchmarks/local-performance-metrics.latest.md) |
+| Local deterministic performance summary | Latest deterministic local benchmark JSON snapshot | Machine-readable deterministic metrics and notes are present | [`docs/en/benchmarks/local-performance-metrics.latest.json`](../benchmarks/local-performance-metrics.latest.json) |
+| One-Day PoC performance benchmark doc | Local/configured HTTP PoC benchmark guidance and boundaries | Reviewer can separate HTTP PoC benchmark data from deterministic local artifacts | [`docs/en/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md) |
+| Bind / governance boundary documentation | Governance boundary and bind admissibility explanation | Reviewer can identify pre-commit boundary and policy/evidence expectations | [`docs/en/architecture/bind-boundary-governance-artifacts.md`](../architecture/bind-boundary-governance-artifacts.md) |
+| TrustLog / audit trace documentation | Audit and traceability controls for review | Reviewer can trace decisions and audit linkage path | [`docs/en/architecture/authority-evidence-vs-audit-log.md`](../architecture/authority-evidence-vs-audit-log.md) |
+| README / README_JP entry points | Top-level reviewer entry points | Reviewer can discover EN/JA PoC evidence resources quickly | [`README.md`](../../../README.md) / [`README_JP.md`](../../../README_JP.md) |
+| Documentation map | EN/JA mapping and canonical-language guidance | Reviewer can confirm EN canonical and JA explanatory mapping | [`docs/DOCUMENTATION_MAP.md`](../../DOCUMENTATION_MAP.md) |
+| Any demo scenario docs already present in repo | Existing walkthrough and reviewer-pack documents | Reviewer can run scenario walkthrough and compare outcome/evidence paths | [`docs/en/poc/one-day-poc-walkthrough.md`](one-day-poc-walkthrough.md), [`docs/en/poc/one-day-poc-reviewer-pack.md`](one-day-poc-reviewer-pack.md), [`docs/en/poc/sample-one-day-poc-evidence.md`](sample-one-day-poc-evidence.md) |
+
+## Suggested walkthrough scenarios
+
+1. Missing authority/evidence blocks sensitive action before commit.
+2. Allowed action proceeds when required policy/evidence is present.
+3. Audit/TrustLog path remains reviewable.
+4. Reviewer compares deterministic local artifact vs HTTP PoC benchmark.
+5. Operator explains non-claim boundaries clearly.
+
+## Success criteria
+
+- The reviewer can identify the commit boundary.
+- The reviewer can identify why an action was blocked or allowed.
+- The reviewer can locate the relevant evidence/audit path.
+- The reviewer can distinguish local deterministic metrics from HTTP PoC benchmark output.
+- The reviewer does not leave with an unsupported SLA/compliance/certification claim.
+
+## Failure criteria
+
+- The system appears to claim production SLA from local metrics.
+- The system appears to claim third-party certification without evidence.
+- The reviewer cannot identify why an action was blocked or allowed.
+- The audit trail or evidence path is unclear.
+- Provider cost/latency is implied without explicit provider measurement.
+
+## Artifacts to collect
+
+- Screenshots of block/allow decision path.
+- Relevant JSON outputs where available.
+- Local deterministic metrics artifact.
+- One-Day PoC benchmark output if run locally.
+- Notes on environment, command, date, commit SHA.
+- Any exceptions or failed checks.
+
+## Reviewer notes
+
+Use this pack together with existing validation and walkthrough docs. Keep all conclusions constrained to local/configured PoC evidence and explicitly state non-claims in verbal and written summaries.
+
+## Related documents
+
+- [`docs/en/benchmarks/local-performance-metrics.latest.md`](../benchmarks/local-performance-metrics.latest.md)
+- [`docs/en/benchmarks/local-performance-metrics.latest.json`](../benchmarks/local-performance-metrics.latest.json)
+- [`docs/en/benchmarks/performance-metrics.md`](../benchmarks/performance-metrics.md)
+- [`docs/en/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md)
+- [`docs/INDEX.md`](../../INDEX.md)
+- [`docs/DOCUMENTATION_MAP.md`](../../DOCUMENTATION_MAP.md)

--- a/docs/en/poc/one-day-poc-performance-report.md
+++ b/docs/en/poc/one-day-poc-performance-report.md
@@ -34,3 +34,9 @@ The script emits a stable benchmark packet shape (`one_day_poc_benchmark.v1`) in
 - latency summaries (`min`, `p50`, `p95`, `p99`, `max`, `mean`, `stdev`)
 - per-target success/failure counts
 - limitations and sanitized failure metadata
+
+## Related evidence pack
+
+- For reviewer-facing PoC evidence collection and success/failure criteria, see `docs/en/poc/one-day-poc-evidence-pack.md`.
+- This benchmark report is only one input into the evidence pack.
+- It is not a production SLA, third-party certification, or customer environment measurement.

--- a/docs/ja/poc/one-day-poc-evidence-pack.md
+++ b/docs/ja/poc/one-day-poc-evidence-pack.md
@@ -1,0 +1,94 @@
+# One-Day PoC証跡パック
+
+- 英語版が正本であり、日本語版は補助説明です。
+- これはOne-Day PoCをレビューするための証跡パックである。
+- 何を確認し、どの証跡を集め、何を成功条件とするかを整理する。
+- 本番SLAではない。
+- 第三者認証ではない。
+- 顧客環境測定ではない。
+- EU AI Act準拠を認証するものではない。
+- 外部LLM/provider latencyやcostは、明示的にproviderを有効化して別途記録しない限り測定対象ではない。
+
+## 英語正本
+
+- [One-Day PoC Evidence Pack](../../en/poc/one-day-poc-evidence-pack.md)
+
+## Purpose
+
+顧客・投資家・レビュー担当者が、One-Day PoC のガバナンス挙動と証跡品質を短時間で確認できるように、レビュー観点をコンパクトに整理する。
+
+## What this PoC demonstrates
+
+- 必要な authority/evidence が不足している場合、規制対象または高感度 action は commit 前に停止できる。
+- 意思決定経路は governance/audit trace を通じてレビュー可能性を維持できる。
+- reviewer-facing docs により deterministic local metrics と HTTP PoC benchmark を区別できる。
+- 本番準備完了を主張する前に governance boundary を明示できる。
+
+## What this PoC does not prove
+
+- 本番レイテンシを証明するものではない。
+- 本番可用性を証明するものではない。
+- 顧客環境での性能を証明するものではない。
+- これ単体で法的コンプライアンスを証明するものではない。
+- 法務・セキュリティ・規制レビューを代替するものではない。
+- EU AI Act準拠を認証するものではない。
+- provider を明示的に有効化して別途測定しない限り、provider latency/cost を測定するものではない。
+
+## Evidence checklist
+
+| Evidence item | What to inspect | Expected result | Link |
+|---|---|---|---|
+| Local deterministic performance artifact | 最新の deterministic local benchmark markdown | deterministic metrics と非主張境界を確認できる | [`docs/en/benchmarks/local-performance-metrics.latest.md`](../../en/benchmarks/local-performance-metrics.latest.md) |
+| Local deterministic performance summary | 最新の deterministic local benchmark JSON | 機械可読な metrics と注記を確認できる | [`docs/en/benchmarks/local-performance-metrics.latest.json`](../../en/benchmarks/local-performance-metrics.latest.json) |
+| One-Day PoC performance benchmark doc | local/configured HTTP PoC benchmark の説明と境界 | HTTP benchmark と deterministic artifact を区別できる | [`docs/ja/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md) |
+| Bind / governance boundary documentation | bind admissibility と governance boundary の説明 | commit 前境界と必要証跡条件を特定できる | [`docs/ja/architecture/bind-boundary-governance-artifacts.md`](../architecture/bind-boundary-governance-artifacts.md) |
+| TrustLog / audit trace documentation | 監査・追跡導線の設計 | 意思決定根拠と監査導線を辿れる | [`docs/ja/architecture/authority-evidence-vs-audit-log.md`](../architecture/authority-evidence-vs-audit-log.md) |
+| README / README_JP entry points | トップレベルの案内導線 | EN/JA の入口をすぐ辿れる | [`README.md`](../../../README.md) / [`README_JP.md`](../../../README_JP.md) |
+| Documentation map | EN/JA 対応表と正本ルール | EN正本/JA補助の対応関係を確認できる | [`docs/DOCUMENTATION_MAP.md`](../../DOCUMENTATION_MAP.md) |
+| Any demo scenario docs already present in repo | 既存 walkthrough/reviewer pack/sample evidence docs | シナリオ実行と証跡比較の導線を確認できる | [`docs/ja/poc/one-day-poc-walkthrough.md`](one-day-poc-walkthrough.md), [`docs/ja/poc/one-day-poc-reviewer-pack.md`](one-day-poc-reviewer-pack.md), [`docs/ja/poc/sample-one-day-poc-evidence.md`](sample-one-day-poc-evidence.md) |
+
+## Suggested walkthrough scenarios
+
+1. authority/evidence 不足により sensitive action が commit 前に block される。
+2. 必要 policy/evidence が揃うと許可された action が proceed する。
+3. audit/TrustLog の経路がレビュー可能な状態で維持される。
+4. deterministic local artifact と HTTP PoC benchmark を比較できる。
+5. operator が non-claim boundary を明確に説明できる。
+
+## Success criteria
+
+- reviewer が commit boundary を特定できる。
+- reviewer が action の block/allow 理由を特定できる。
+- reviewer が relevant evidence/audit path を特定できる。
+- reviewer が deterministic local metrics と HTTP PoC benchmark output を区別できる。
+- reviewer が unsupported な SLA/compliance/certification claim を持ち帰らない。
+
+## Failure criteria
+
+- local metrics から本番SLAを主張しているように見える。
+- 根拠なしに第三者認証を主張しているように見える。
+- reviewer が action の block/allow 理由を特定できない。
+- audit trail または evidence path が不明瞭である。
+- 明示的な provider 測定なしに provider cost/latency を示唆している。
+
+## Artifacts to collect
+
+- block/allow decision path のスクリーンショット
+- 取得可能な関連 JSON 出力
+- deterministic local metrics artifact
+- 実行した場合の One-Day PoC benchmark output
+- environment / command / date / commit SHA の記録
+- 例外または failed checks の記録
+
+## Reviewer notes
+
+本パックは既存の validation/walkthrough docs と併用する。結論は local/configured PoC の証跡範囲に限定し、非主張境界を口頭・文書の双方で明示する。
+
+## Related documents
+
+- [`docs/en/benchmarks/local-performance-metrics.latest.md`](../../en/benchmarks/local-performance-metrics.latest.md)
+- [`docs/en/benchmarks/local-performance-metrics.latest.json`](../../en/benchmarks/local-performance-metrics.latest.json)
+- [`docs/en/benchmarks/performance-metrics.md`](../../en/benchmarks/performance-metrics.md)
+- [`docs/en/poc/one-day-poc-performance-report.md`](../../en/poc/one-day-poc-performance-report.md)
+- [`docs/INDEX.md`](../../INDEX.md)
+- [`docs/DOCUMENTATION_MAP.md`](../../DOCUMENTATION_MAP.md)

--- a/docs/ja/poc/one-day-poc-performance-report.md
+++ b/docs/ja/poc/one-day-poc-performance-report.md
@@ -26,3 +26,8 @@ VERITAS_API_KEY=... python scripts/demo/one_day_poc_benchmark.py --runs 5 --warm
 - 第三者認証ではない。
 - 顧客環境測定ではない。
 - 外部LLM/provider latency は、configured local server が明示的にproviderを呼ぶ場合を除き測定対象ではありません。
+
+## 関連する証跡パック
+
+- One-Day PoCの証跡収集、成功条件、失敗条件は `docs/ja/poc/one-day-poc-evidence-pack.md` を参照
+- このbenchmark reportは証跡パックの一部であり、本番SLA・第三者認証・顧客環境測定ではない

--- a/veritas_os/tests/test_one_day_poc_evidence_pack_docs.py
+++ b/veritas_os/tests/test_one_day_poc_evidence_pack_docs.py
@@ -1,0 +1,111 @@
+"""Documentation checks for One-Day PoC evidence pack docs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_evidence_pack_files_exist() -> None:
+    assert Path("docs/en/poc/one-day-poc-evidence-pack.md").exists()
+    assert Path("docs/ja/poc/one-day-poc-evidence-pack.md").exists()
+
+
+def test_en_evidence_pack_boundaries() -> None:
+    content = Path("docs/en/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8")
+    for needle in [
+        "reviewer-facing evidence pack",
+        "not a production SLA",
+        "not third-party certified",
+        "not a customer environment measurement",
+        "does not certify EU AI Act compliance",
+        "External LLM/provider latency and cost are not measured",
+    ]:
+        assert needle in content
+
+
+def test_ja_evidence_pack_boundaries() -> None:
+    content = Path("docs/ja/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8")
+    for needle in [
+        "英語版が正本",
+        "## 英語正本",
+        "../../en/poc/one-day-poc-evidence-pack.md",
+        "本番SLAではない",
+        "第三者認証ではない",
+        "顧客環境測定ではない",
+        "EU AI Act準拠を認証するものではない",
+    ]:
+        assert needle in content
+
+
+def test_en_evidence_pack_sections() -> None:
+    content = Path("docs/en/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8")
+    for needle in [
+        "## Purpose",
+        "## What this PoC demonstrates",
+        "## What this PoC does not prove",
+        "## Evidence checklist",
+        "## Suggested walkthrough scenarios",
+        "## Success criteria",
+        "## Failure criteria",
+        "## Artifacts to collect",
+        "## Related documents",
+    ]:
+        assert needle in content
+
+
+def test_en_evidence_pack_links() -> None:
+    content = Path("docs/en/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8")
+    for needle in [
+        "../benchmarks/local-performance-metrics.latest.md",
+        "../benchmarks/local-performance-metrics.latest.json",
+        "../benchmarks/performance-metrics.md",
+        "one-day-poc-performance-report.md",
+    ]:
+        assert needle in content
+
+
+def test_link_surfaces_updated() -> None:
+    checks = {
+        "README.md": ["docs/en/poc/one-day-poc-evidence-pack.md"],
+        "README_JP.md": [
+            "docs/ja/poc/one-day-poc-evidence-pack.md",
+            "docs/en/poc/one-day-poc-evidence-pack.md",
+        ],
+        "docs/INDEX.md": ["one-day-poc-evidence-pack.md"],
+        "docs/DOCUMENTATION_MAP.md": ["one-day-poc-evidence-pack.md"],
+    }
+    for path, needles in checks.items():
+        content = Path(path).read_text(encoding="utf-8")
+        for needle in needles:
+            assert needle in content
+
+
+def test_performance_report_related_links() -> None:
+    en_content = Path("docs/en/poc/one-day-poc-performance-report.md").read_text(
+        encoding="utf-8"
+    )
+    ja_content = Path("docs/ja/poc/one-day-poc-performance-report.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Related evidence pack" in en_content
+    assert "one-day-poc-evidence-pack.md" in en_content
+    assert "関連する証跡パック" in ja_content
+    assert "one-day-poc-evidence-pack.md" in ja_content
+
+
+def test_forbidden_claims_absent() -> None:
+    combined = "\n".join(
+        [
+            Path("docs/en/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8"),
+            Path("docs/ja/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8"),
+        ]
+    )
+    for needle in [
+        "guaranteed compliance",
+        "certified EU AI Act compliant",
+        "production SLA certified",
+        "third-party certified benchmark",
+        "customer environment verified",
+        "cost per request measured",
+    ]:
+        assert needle not in combined

--- a/veritas_os/tests/test_one_day_poc_evidence_pack_docs.py
+++ b/veritas_os/tests/test_one_day_poc_evidence_pack_docs.py
@@ -54,14 +54,17 @@ def test_en_evidence_pack_sections() -> None:
 
 
 def test_en_evidence_pack_links() -> None:
-    content = Path("docs/en/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8")
-    for needle in [
+    pack_path = Path("docs/en/poc/one-day-poc-evidence-pack.md")
+    content = pack_path.read_text(encoding="utf-8")
+    expected_links = [
         "../benchmarks/local-performance-metrics.latest.md",
         "../benchmarks/local-performance-metrics.latest.json",
         "../benchmarks/performance-metrics.md",
         "one-day-poc-performance-report.md",
-    ]:
-        assert needle in content
+    ]
+    for link in expected_links:
+        assert link in content
+        assert (pack_path.parent / link).resolve().exists()
 
 
 def test_link_surfaces_updated() -> None:
@@ -99,7 +102,7 @@ def test_forbidden_claims_absent() -> None:
             Path("docs/en/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8"),
             Path("docs/ja/poc/one-day-poc-evidence-pack.md").read_text(encoding="utf-8"),
         ]
-    )
+    ).casefold()
     for needle in [
         "guaranteed compliance",
         "certified EU AI Act compliant",
@@ -108,4 +111,11 @@ def test_forbidden_claims_absent() -> None:
         "customer environment verified",
         "cost per request measured",
     ]:
-        assert needle not in combined
+        assert needle.casefold() not in combined
+
+
+def test_documentation_map_table_not_split() -> None:
+    content = Path("docs/DOCUMENTATION_MAP.md").read_text(encoding="utf-8")
+    assert "| EN notes |" in content
+    assert "| PoC: One-Day PoC evidence pack |" in content
+    assert "\n\n| PoC: One-Day PoC evidence pack |" not in content


### PR DESCRIPTION
### Motivation

- Provide a compact, reviewer-facing One-Day PoC evidence pack so customers, investors, and reviewers can rapidly inspect PoC behavior and collected artifacts without over-claiming production readiness. 
- Make explicit non-claim boundaries (SLA, third-party certification, EU AI Act, customer-environment measurements, provider latency/cost) to avoid misleading statements. 
- Surface the evidence pack across docs (README, INDEX, DOCUMENTATION_MAP, PoC benchmark reports) so it is discoverable from existing reviewer workflows.

### Description

- Added `docs/en/poc/one-day-poc-evidence-pack.md` (EN canonical reviewer-facing evidence pack) and `docs/ja/poc/one-day-poc-evidence-pack.md` (JA explanatory supplement with `## 英語正本` link). 
- Updated PoC performance reports to reference the evidence pack by adding a `Related evidence pack` / `関連する証跡パック` section to `docs/en/poc/one-day-poc-performance-report.md` and `docs/ja/poc/one-day-poc-performance-report.md`. 
- Added discovery links: `README.md`, `README_JP.md`, `docs/INDEX.md`, and `docs/DOCUMENTATION_MAP.md` now include the One-Day PoC Evidence Pack entries. 
- Added a focused doc test `veritas_os/tests/test_one_day_poc_evidence_pack_docs.py` that enforces file presence, required non-claim boundaries, required sections, relative links to existing benchmark artifacts, and absence of forbidden over-claims; no runtime code, API, governance, or dependency changes were made.

### Testing

- Ran `pytest -q veritas_os/tests/test_one_day_poc_evidence_pack_docs.py` (passed).
- Ran `python -m scripts.quality.check_bilingual_docs` (bilingual doc checks passed).
- Ran a full `pytest -q` in the environment; collection failed in this environment due to missing optional test dependencies (examples: `fastapi`, `pydantic`, `cryptography`, `httpx`, `yaml`, `numpy`, `requests`, `starlette`), so full test-suite execution is environment-dependent and not caused by these doc changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5dcb65bc83268966b21325d8f539)