### PR TITLE
docs(poc): add one-day PoC operator runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Boundary:
 For external reviewers, HPAN, enterprise stakeholders, and investor diligence, use the one-day PoC smoke script to generate a sanitized evidence packet from a running VERITAS API server.
 
 - **One-Day PoC Evidence Pack / Checklist**: reviewer-facing checklist and success/failure criteria (distinct from generated evidence packet output) — [`docs/en/poc/one-day-poc-evidence-pack.md`](docs/en/poc/one-day-poc-evidence-pack.md)
+- **One-Day PoC Operator Runbook**: [`docs/en/poc/one-day-poc-operator-runbook.md`](docs/en/poc/one-day-poc-operator-runbook.md)
 
 Prerequisites:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -30,6 +30,7 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 - **性能メトリクス**: [日本語補助](docs/ja/benchmarks/performance-metrics.md) / [英語正本](docs/en/benchmarks/performance-metrics.md)
 - **最新ローカル性能メトリクスartifact**: [日本語補助](docs/ja/benchmarks/local-performance-metrics.latest.md) / [英語正本](docs/en/benchmarks/local-performance-metrics.latest.md) / [JSON](docs/en/benchmarks/local-performance-metrics.latest.json)
 - **One-Day PoC証跡パック**: [日本語補助](docs/ja/poc/one-day-poc-evidence-pack.md) / [英語正本](docs/en/poc/one-day-poc-evidence-pack.md)
+- **One-Day PoC運用Runbook**: [日本語補助](docs/ja/poc/one-day-poc-operator-runbook.md) / [英語正本](docs/en/poc/one-day-poc-operator-runbook.md)
 - 性能メトリクスおよびOne-Day PoC benchmarkは、local/reviewer-facingな測定であり、本番SLA・第三者認証・顧客環境測定ではありません。
 
 

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -65,3 +65,4 @@
 | JA manuals | — | `docs/ja/guides/user-manual.md` | JA primary | 日本語中心運用文書 |
 | EN notes | `docs/en/notes/chainlit.md` | — | EN canonical only | 補助ノート |
 | PoC: One-Day PoC evidence pack | `docs/en/poc/one-day-poc-evidence-pack.md` | `docs/ja/poc/one-day-poc-evidence-pack.md` | JA explanation / EN canonical | Reviewer-facing evidence checklist, walkthrough scenarios, success/failure criteria, and non-claim boundaries for One-Day PoC. |
+| PoC: One-Day PoC operator runbook | `docs/en/poc/one-day-poc-operator-runbook.md` | `docs/ja/poc/one-day-poc-operator-runbook.md` | JA explanation / EN canonical | Operator-facing preparation, execution, evidence collection, packaging, and review handoff runbook for One-Day PoC. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,6 +46,7 @@
 | One-Day PoC Reviewer Pack | [One-Day PoC Reviewer Pack (EN)](en/poc/one-day-poc-reviewer-pack.md) | [One-Day PoC Reviewer Pack (JA)](ja/poc/one-day-poc-reviewer-pack.md) |
 | One-Day PoC Performance Benchmark | [One-Day PoC Performance Benchmark (EN)](en/poc/one-day-poc-performance-report.md) | [One-Day PoC Performance Benchmark (JA)](ja/poc/one-day-poc-performance-report.md) |
 | One-Day PoC Evidence Pack | [One-Day PoC Evidence Pack (EN)](en/poc/one-day-poc-evidence-pack.md) | [One-Day PoC Evidence Pack (JA)](ja/poc/one-day-poc-evidence-pack.md) |
+| One-Day PoC Operator Runbook | [One-Day PoC Operator Runbook (EN)](en/poc/one-day-poc-operator-runbook.md) | [One-Day PoC運用Runbook (JA)](ja/poc/one-day-poc-operator-runbook.md) |
 | Performance Metrics | [Performance Metrics (EN)](en/benchmarks/performance-metrics.md) | [性能メトリクス (JA)](ja/benchmarks/performance-metrics.md) |
 | Local Performance Metrics Artifact | [Local Performance Metrics Artifact (EN)](en/benchmarks/local-performance-metrics.latest.md) / [JSON](en/benchmarks/local-performance-metrics.latest.json) | [ローカル性能メトリクス実測artifact (JA)](ja/benchmarks/local-performance-metrics.latest.md) |
 | One-Day PoC Sample Evidence Packet | [Sample one-day PoC evidence (EN JSON/Markdown)](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（JA Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
@@ -118,6 +119,7 @@
 | One-Day PoC Walkthrough | [One-Day VERITAS PoC Walkthrough（英語正本）](en/poc/one-day-poc-walkthrough.md) | [One-Day VERITAS PoC Walkthrough（日本語）](ja/poc/one-day-poc-walkthrough.md) |
 | One-Day PoC Reviewer Pack | [One-Day PoC Reviewer Pack（英語正本）](en/poc/one-day-poc-reviewer-pack.md) | [One-Day PoC Reviewer Pack（日本語）](ja/poc/one-day-poc-reviewer-pack.md) |
 | One-Day PoC Performance Benchmark | [One-Day PoC Performance Benchmark（英語正本）](en/poc/one-day-poc-performance-report.md) | [One-Day PoC Performance Benchmark（日本語）](ja/poc/one-day-poc-performance-report.md) |
+| One-Day PoC Operator Runbook | [One-Day PoC Operator Runbook（英語正本）](en/poc/one-day-poc-operator-runbook.md) | [One-Day PoC運用Runbook（日本語補助）](ja/poc/one-day-poc-operator-runbook.md) |
 | 性能メトリクス | [Performance Metrics（英語正本）](en/benchmarks/performance-metrics.md) | [性能メトリクス（日本語）](ja/benchmarks/performance-metrics.md) |
 | One-Day PoC サンプル証跡パケット | [Sample one-day PoC evidence（英語 JSON/Markdown）](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（日本語 Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
 | One-Day PoC 証跡スキーマ | [One-day PoC evidence schema（JSON Schema）](../schemas/poc/one_day_poc_evidence.v1.schema.json) | — |

--- a/docs/en/poc/one-day-poc-evidence-pack.md
+++ b/docs/en/poc/one-day-poc-evidence-pack.md
@@ -81,6 +81,7 @@ Use this pack together with existing validation and walkthrough docs. Keep all c
 
 ## Related documents
 
+- [`docs/en/poc/one-day-poc-operator-runbook.md`](one-day-poc-operator-runbook.md) — Use the operator runbook when preparing and packaging reviewer-facing evidence.
 - [`docs/en/benchmarks/local-performance-metrics.latest.md`](../benchmarks/local-performance-metrics.latest.md)
 - [`docs/en/benchmarks/local-performance-metrics.latest.json`](../benchmarks/local-performance-metrics.latest.json)
 - [`docs/en/benchmarks/performance-metrics.md`](../benchmarks/performance-metrics.md)

--- a/docs/en/poc/one-day-poc-operator-runbook.md
+++ b/docs/en/poc/one-day-poc-operator-runbook.md
@@ -1,0 +1,139 @@
+# One-Day PoC Operator Runbook
+
+- This is an operator-facing runbook for conducting a One-Day PoC.
+- It explains how to prepare, run, collect, package, and hand off reviewer-facing PoC evidence.
+- It complements the One-Day PoC Evidence Pack.
+- It is not a production deployment guide.
+- It is not a production SLA.
+- It is not third-party certified.
+- It is not a customer environment measurement.
+- It does not certify EU AI Act compliance.
+- External LLM/provider latency and cost are not measured unless providers are intentionally enabled and separately recorded.
+
+## Purpose
+
+- Give operators a repeatable procedure for running a One-Day PoC.
+- Make the output reviewable by customers, investors, and technical reviewers.
+- Keep PoC claims bounded to local/configured evidence.
+
+## Operator responsibilities
+
+- Record commit SHA, date/time, operator name or role, and environment notes.
+- Avoid editing generated evidence after collection except for explicitly documented redaction.
+- Keep raw and sanitized artifacts separate when applicable.
+- State non-claim boundaries clearly during review.
+
+## Pre-flight checklist
+
+- [ ] Repository checked out at intended commit.
+- [ ] Dependencies installed according to existing setup docs.
+- [ ] VERITAS API server available if running HTTP PoC flow.
+- [ ] `VERITAS_API_KEY` configured where required.
+- [ ] Output directory created.
+- [ ] No production SLA / certification / customer-environment claim will be made.
+- [ ] If external providers are enabled, provider configuration and measurement scope are recorded separately.
+
+## Recommended evidence folder layout
+
+```text
+poc-evidence/
+  README.md
+  environment.md
+  commands.md
+  screenshots/
+  json/
+  markdown/
+  logs/
+  redactions.md
+  reviewer-notes.md
+```
+
+- `environment.md`: date, commit SHA, local/configured environment notes.
+- `commands.md`: exact commands run.
+- `screenshots/`: block/allow decision path screenshots.
+- `json/`: machine-readable outputs.
+- `markdown/`: human-readable reports.
+- `logs/`: optional local logs.
+- `redactions.md`: what was redacted and why.
+- `reviewer-notes.md`: summary for handoff.
+
+## Run sequence
+
+1. Capture environment and commit SHA.
+2. Start or confirm VERITAS API server if required.
+3. Run One-Day PoC walkthrough or smoke flow using existing docs/scripts.
+4. Optionally run One-Day PoC benchmark if local/configured HTTP benchmark is in scope.
+5. Collect JSON / Markdown / screenshots.
+6. Record failures and exceptions.
+7. Redact sensitive data if needed.
+8. Package reviewer handoff.
+
+For concrete commands, follow the existing walkthrough and benchmark documents rather than inventing new commands in this runbook.
+
+## Evidence collection checklist
+
+| Evidence | Required? | Where to save | Notes |
+|---|---|---|---|
+| Commit SHA and environment notes | Yes | `environment.md` | Include timestamp and local/configured scope. |
+| Commands run | Yes | `commands.md` | Keep command list exact and ordered. |
+| Blocked decision screenshot | Yes | `screenshots/` | Show scenario context and resulting decision. |
+| Allowed decision screenshot if scenario exists | Conditional | `screenshots/` | Include only when allow path is part of the run. |
+| JSON evidence packet if generated | Conditional | `json/` | Preserve raw generated output. |
+| Markdown evidence report if generated | Conditional | `markdown/` | Keep reviewer-readable output adjacent to JSON. |
+| Local deterministic metrics artifact reference | Recommended | `reviewer-notes.md` | Link deterministic local metrics artifact used in review. |
+| One-Day PoC benchmark output if run | Conditional | `markdown/` or `json/` | Record if benchmark scope is included. |
+| Redaction notes | Conditional | `redactions.md` | Describe what was redacted and why. |
+| Reviewer notes | Yes | `reviewer-notes.md` | Summarize outcomes, boundaries, and follow-up. |
+
+## What to record for each run
+
+- Date/time.
+- Commit SHA.
+- Operator role.
+- Environment type: local / configured / customer-managed if applicable.
+- Whether external providers were enabled.
+- Commands run.
+- Scenario names.
+- Result: pass / fail / inconclusive.
+- Exceptions or known limitations.
+
+## Review handoff package
+
+- One short README for the reviewer.
+- Evidence Pack link.
+- Operator Runbook link.
+- Evidence folder.
+- Known limitations.
+- Explicit non-claim boundaries.
+- Open questions / follow-up items.
+
+## Common failure modes
+
+- Required API server not running.
+- `VERITAS_API_KEY` missing.
+- Evidence generated but not linked in handoff.
+- Local deterministic metrics mistaken for production latency.
+- Provider cost/latency implied without provider measurement.
+- Screenshots lack context.
+- Redaction not documented.
+- Reviewer cannot identify why action was blocked or allowed.
+
+## Non-claim boundaries
+
+- Do not claim production SLA from local/configured PoC output.
+- Do not claim third-party certification.
+- Do not claim customer-environment measurement unless actually run and documented in that environment.
+- Do not claim EU AI Act compliance certification.
+- Do not claim provider cost/latency unless providers are explicitly enabled and separately measured.
+- Do not present demo screenshots as production audit evidence.
+
+## Related documents
+
+- [`docs/en/poc/one-day-poc-evidence-pack.md`](one-day-poc-evidence-pack.md)
+- [`docs/en/poc/one-day-poc-reviewer-pack.md`](one-day-poc-reviewer-pack.md)
+- [`docs/en/poc/one-day-poc-walkthrough.md`](one-day-poc-walkthrough.md)
+- [`docs/en/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md)
+- [`docs/en/benchmarks/local-performance-metrics.latest.md`](../benchmarks/local-performance-metrics.latest.md)
+- [`docs/en/benchmarks/performance-metrics.md`](../benchmarks/performance-metrics.md)
+- [`docs/INDEX.md`](../../INDEX.md)
+- [`docs/DOCUMENTATION_MAP.md`](../../DOCUMENTATION_MAP.md)

--- a/docs/ja/poc/one-day-poc-evidence-pack.md
+++ b/docs/ja/poc/one-day-poc-evidence-pack.md
@@ -86,6 +86,7 @@
 
 ## Related documents
 
+- [`docs/ja/poc/one-day-poc-operator-runbook.md`](one-day-poc-operator-runbook.md) — 証跡の準備・実行・提出手順はOperator Runbookを参照する。
 - [`docs/en/benchmarks/local-performance-metrics.latest.md`](../../en/benchmarks/local-performance-metrics.latest.md)
 - [`docs/en/benchmarks/local-performance-metrics.latest.json`](../../en/benchmarks/local-performance-metrics.latest.json)
 - [`docs/en/benchmarks/performance-metrics.md`](../../en/benchmarks/performance-metrics.md)

--- a/docs/ja/poc/one-day-poc-operator-runbook.md
+++ b/docs/ja/poc/one-day-poc-operator-runbook.md
@@ -1,0 +1,144 @@
+# One-Day PoC運用Runbook
+
+- 英語版が正本であり、日本語版は補助説明です。
+- これはOne-Day PoCを実施するoperator向けrunbookである。
+- PoCの準備、実行、証跡収集、整理、レビュー担当者への引き渡し方法を説明する。
+- One-Day PoC証跡パックを補完する。
+- 本番デプロイ手順ではない。
+- 本番SLAではない。
+- 第三者認証ではない。
+- 顧客環境測定ではない。
+- EU AI Act準拠を認証するものではない。
+- 外部LLM/provider latencyやcostは、明示的にproviderを有効化して別途記録しない限り測定対象ではない。
+
+## 英語正本
+
+- [One-Day PoC Operator Runbook](../../en/poc/one-day-poc-operator-runbook.md)
+
+## Purpose
+
+- One-Day PoCを実施するための再現可能な手順をoperatorに提供する。
+- 顧客・投資家・技術レビュー担当者が確認できる形で成果物を整理する。
+- PoCの主張をlocal/configured証跡の範囲に限定する。
+
+## Operator responsibilities
+
+- commit SHA、日時、operator名または役割、環境メモを記録する。
+- 明示的に記録したredaction以外、収集後に生成証跡を編集しない。
+- 必要に応じてraw成果物とsanitized成果物を分離する。
+- レビュー時に非主張境界を明確に伝える。
+
+## Pre-flight checklist
+
+- [ ] 意図したcommitでリポジトリをcheckoutしている。
+- [ ] 既存セットアップdocsに従って依存関係を導入済み。
+- [ ] HTTP PoCフローを実行する場合、VERITAS API serverが利用可能。
+- [ ] 必要箇所で`VERITAS_API_KEY`を設定済み。
+- [ ] 出力ディレクトリを作成済み。
+- [ ] 本番SLA / 認証 / 顧客環境測定の主張を行わない。
+- [ ] 外部providerを有効化する場合、設定内容と測定範囲を別途記録する。
+
+## Recommended evidence folder layout
+
+```text
+poc-evidence/
+  README.md
+  environment.md
+  commands.md
+  screenshots/
+  json/
+  markdown/
+  logs/
+  redactions.md
+  reviewer-notes.md
+```
+
+- `environment.md`: 日付、commit SHA、local/configured環境メモ。
+- `commands.md`: 実行したコマンドを正確に記録。
+- `screenshots/`: block/allow decision pathのスクリーンショット。
+- `json/`: 機械可読出力。
+- `markdown/`: 人間可読レポート。
+- `logs/`: 任意のローカルログ。
+- `redactions.md`: 何をなぜマスクしたか。
+- `reviewer-notes.md`: 引き渡し用サマリー。
+
+## Run sequence
+
+1. 環境情報とcommit SHAを記録する。
+2. 必要に応じてVERITAS API serverの起動または稼働確認を行う。
+3. 既存docs/scriptsを用いてOne-Day PoC walkthroughまたはsmoke flowを実行する。
+4. local/configured HTTP benchmarkを対象とする場合のみ、One-Day PoC benchmarkを任意実行する。
+5. JSON / Markdown / スクリーンショットを収集する。
+6. 失敗と例外を記録する。
+7. 必要に応じて機微情報をredactする。
+8. reviewer向けhandoffパッケージを作成する。
+
+具体コマンドは本runbookで新設せず、既存のwalkthrough/benchmark文書に従う。
+
+## Evidence collection checklist
+
+| Evidence | Required? | Where to save | Notes |
+|---|---|---|---|
+| Commit SHA and environment notes | Yes | `environment.md` | タイムスタンプとlocal/configured範囲を含める。 |
+| Commands run | Yes | `commands.md` | 実行順を維持して正確に記録する。 |
+| Blocked decision screenshot | Yes | `screenshots/` | シナリオ文脈と決定結果が分かる状態にする。 |
+| Allowed decision screenshot if scenario exists | Conditional | `screenshots/` | allow経路が対象シナリオの場合のみ収集。 |
+| JSON evidence packet if generated | Conditional | `json/` | 生成されたraw出力を保存する。 |
+| Markdown evidence report if generated | Conditional | `markdown/` | reviewer可読の要約をJSONと対応させる。 |
+| Local deterministic metrics artifact reference | Recommended | `reviewer-notes.md` | レビューで参照したdeterministic metricsを記載。 |
+| One-Day PoC benchmark output if run | Conditional | `markdown/` or `json/` | benchmarkを実施した場合のみ記録。 |
+| Redaction notes | Conditional | `redactions.md` | redaction対象と理由を明記。 |
+| Reviewer notes | Yes | `reviewer-notes.md` | 結果、境界、フォローアップを要約。 |
+
+## What to record for each run
+
+- Date/time。
+- Commit SHA。
+- Operator role。
+- Environment type: local / configured / customer-managed if applicable。
+- Whether external providers were enabled。
+- Commands run。
+- Scenario names。
+- Result: pass / fail / inconclusive。
+- Exceptions or known limitations。
+
+## Review handoff package
+
+- reviewer向けの短いREADME。
+- Evidence Packへのリンク。
+- Operator Runbookへのリンク。
+- Evidence folder。
+- 既知の制約事項。
+- 明示的な非主張境界。
+- 未解決事項 / follow-up項目。
+
+## Common failure modes
+
+- 必要なAPI serverが起動していない。
+- `VERITAS_API_KEY`が未設定。
+- 証跡は生成されたがhandoff資料から参照されていない。
+- local deterministic metricsを本番レイテンシと誤認する。
+- provider測定なしでprovider cost/latencyを示唆する。
+- スクリーンショットに文脈がない。
+- redaction記録がない。
+- reviewerがactionのblock/allow理由を特定できない。
+
+## Non-claim boundaries
+
+- local/configured PoC出力から本番SLAを主張しない。
+- 第三者認証を主張しない。
+- 実際にその環境で実行・記録した場合を除き、顧客環境測定を主張しない。
+- EU AI Act準拠認証を主張しない。
+- providerを明示的に有効化して別途測定しない限り、provider cost/latencyを主張しない。
+- デモ用スクリーンショットを本番監査証跡として提示しない。
+
+## Related documents
+
+- [`docs/ja/poc/one-day-poc-evidence-pack.md`](one-day-poc-evidence-pack.md)
+- [`docs/ja/poc/one-day-poc-reviewer-pack.md`](one-day-poc-reviewer-pack.md)
+- [`docs/ja/poc/one-day-poc-walkthrough.md`](one-day-poc-walkthrough.md)
+- [`docs/ja/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md)
+- [`docs/en/benchmarks/local-performance-metrics.latest.md`](../../en/benchmarks/local-performance-metrics.latest.md)
+- [`docs/en/benchmarks/performance-metrics.md`](../../en/benchmarks/performance-metrics.md)
+- [`docs/INDEX.md`](../../INDEX.md)
+- [`docs/DOCUMENTATION_MAP.md`](../../DOCUMENTATION_MAP.md)

--- a/veritas_os/tests/test_one_day_poc_operator_runbook_docs.py
+++ b/veritas_os/tests/test_one_day_poc_operator_runbook_docs.py
@@ -1,0 +1,120 @@
+"""Documentation guardrails for the One-Day PoC operator runbook."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EN_RUNBOOK = ROOT / "docs/en/poc/one-day-poc-operator-runbook.md"
+JA_RUNBOOK = ROOT / "docs/ja/poc/one-day-poc-operator-runbook.md"
+EN_EVIDENCE_PACK = ROOT / "docs/en/poc/one-day-poc-evidence-pack.md"
+JA_EVIDENCE_PACK = ROOT / "docs/ja/poc/one-day-poc-evidence-pack.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_runbook_files_exist() -> None:
+    assert EN_RUNBOOK.exists()
+    assert JA_RUNBOOK.exists()
+
+
+def test_en_runbook_contains_required_boundaries() -> None:
+    content = _read(EN_RUNBOOK)
+    required = [
+        "operator-facing runbook",
+        "not a production deployment guide",
+        "not a production SLA",
+        "not third-party certified",
+        "not a customer environment measurement",
+        "does not certify EU AI Act compliance",
+        "External LLM/provider latency and cost are not measured",
+    ]
+    for item in required:
+        assert item in content
+
+
+def test_ja_runbook_contains_required_boundaries() -> None:
+    content = _read(JA_RUNBOOK)
+    required = [
+        "英語版が正本",
+        "## 英語正本",
+        "../../en/poc/one-day-poc-operator-runbook.md",
+        "本番デプロイ手順ではない",
+        "本番SLAではない",
+        "第三者認証ではない",
+        "顧客環境測定ではない",
+        "EU AI Act準拠を認証するものではない",
+    ]
+    for item in required:
+        assert item in content
+
+
+def test_en_runbook_contains_key_sections() -> None:
+    content = _read(EN_RUNBOOK)
+    sections = [
+        "## Purpose",
+        "## Operator responsibilities",
+        "## Pre-flight checklist",
+        "## Recommended evidence folder layout",
+        "## Run sequence",
+        "## Evidence collection checklist",
+        "## What to record for each run",
+        "## Review handoff package",
+        "## Common failure modes",
+        "## Non-claim boundaries",
+        "## Related documents",
+    ]
+    for section in sections:
+        assert section in content
+
+
+def test_en_runbook_links_to_existing_docs() -> None:
+    content = _read(EN_RUNBOOK)
+    links = [
+        "one-day-poc-evidence-pack.md",
+        "one-day-poc-reviewer-pack.md",
+        "one-day-poc-walkthrough.md",
+        "one-day-poc-performance-report.md",
+        "../benchmarks/local-performance-metrics.latest.md",
+        "../benchmarks/performance-metrics.md",
+    ]
+    pack_path = EN_RUNBOOK
+    for link in links:
+        assert link in content
+        assert (pack_path.parent / link).resolve().exists()
+
+
+def test_evidence_pack_links_back_to_operator_runbook() -> None:
+    assert "one-day-poc-operator-runbook.md" in _read(EN_EVIDENCE_PACK)
+    assert "one-day-poc-operator-runbook.md" in _read(JA_EVIDENCE_PACK)
+
+
+def test_readme_and_index_links_present() -> None:
+    assert "docs/en/poc/one-day-poc-operator-runbook.md" in _read(ROOT / "README.md")
+    ja_readme = _read(ROOT / "README_JP.md")
+    assert "docs/ja/poc/one-day-poc-operator-runbook.md" in ja_readme
+    assert "docs/en/poc/one-day-poc-operator-runbook.md" in ja_readme
+    assert "one-day-poc-operator-runbook.md" in _read(ROOT / "docs/INDEX.md")
+    assert "one-day-poc-operator-runbook.md" in _read(
+        ROOT / "docs/DOCUMENTATION_MAP.md"
+    )
+
+
+def test_documentation_map_table_is_not_split() -> None:
+    content = _read(ROOT / "docs/DOCUMENTATION_MAP.md")
+    assert "\n\n| PoC: One-Day PoC operator runbook |" not in content
+
+
+def test_unsupported_claims_absent_from_runbooks() -> None:
+    combined = f"{_read(EN_RUNBOOK)}\n{_read(JA_RUNBOOK)}".casefold()
+    forbidden = [
+        "guaranteed compliance",
+        "certified eu ai act compliant",
+        "production sla certified",
+        "third-party certified benchmark",
+        "customer environment verified",
+        "cost per request measured",
+    ]
+    for claim in forbidden:
+        assert claim not in combined


### PR DESCRIPTION
### Motivation

- Provide operators a single, repeatable runbook for preparing, executing, collecting, packaging, and handing off One-Day PoC evidence that complements the reviewer-facing Evidence Pack.
- Make it straightforward for operators, sales, and technical staff to produce reviewer-ready artifacts while keeping PoC claims explicitly bounded and avoiding production/certification claims.

### Description

- Add an English operator runbook at `docs/en/poc/one-day-poc-operator-runbook.md` and a Japanese companion at `docs/ja/poc/one-day-poc-operator-runbook.md` containing required headings, pre-flight checklist, folder layout, run sequence, evidence checklist, non-claim boundaries, and related links.
- Link the new runbook from the existing Evidence Pack files by updating `docs/en/poc/one-day-poc-evidence-pack.md` and `docs/ja/poc/one-day-poc-evidence-pack.md` to point operators to the runbook when preparing reviewer evidence.
- Add navigation entries for the runbook in `docs/INDEX.md`, `docs/DOCUMENTATION_MAP.md`, `README.md`, and `README_JP.md` so EN/JA entrypoints can discover it, and ensure the documentation map table is not split.
- Add a guardrail test `veritas_os/tests/test_one_day_poc_operator_runbook_docs.py` that asserts the presence of both runbooks, required boundary language, required sections, linked files exist, Evidence Pack backlinking, README/INDEX/MAP wiring, and absence of forbidden unsupported-claim phrases; no runtime code, API contracts, provider tiers, dependencies, lockfiles, benchmark logic, or CI workflows were changed.

### Testing

- Ran `PYENV_VERSION=3.12.13 pytest -q veritas_os/tests/test_one_day_poc_operator_runbook_docs.py`, and the dedicated docs tests passed (9 passed).
- Ran the bilingual docs quality check with `PYENV_VERSION=3.12.13 python -m scripts.quality.check_bilingual_docs`, which completed successfully.
- A full test run (`PYENV_VERSION=3.12.13 pytest -q`) failed at collection in this environment due to missing optional test dependencies such as `fastapi`, `pydantic`, `cryptography`, `httpx`, and `yaml`, which are unrelated to these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff689026ec8326822717e31d53a29b)