### PR TITLE
docs(poc): add one-day PoC reviewer handoff template

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For external reviewers, HPAN, enterprise stakeholders, and investor diligence, u
 
 - **One-Day PoC Evidence Pack / Checklist**: reviewer-facing checklist and success/failure criteria (distinct from generated evidence packet output) — [`docs/en/poc/one-day-poc-evidence-pack.md`](docs/en/poc/one-day-poc-evidence-pack.md)
 - **One-Day PoC Operator Runbook**: [`docs/en/poc/one-day-poc-operator-runbook.md`](docs/en/poc/one-day-poc-operator-runbook.md)
+- **One-Day PoC Reviewer Handoff Template**: [`docs/en/poc/one-day-poc-reviewer-handoff-template.md`](docs/en/poc/one-day-poc-reviewer-handoff-template.md)
 
 Prerequisites:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -31,6 +31,7 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 - **最新ローカル性能メトリクスartifact**: [日本語補助](docs/ja/benchmarks/local-performance-metrics.latest.md) / [英語正本](docs/en/benchmarks/local-performance-metrics.latest.md) / [JSON](docs/en/benchmarks/local-performance-metrics.latest.json)
 - **One-Day PoC証跡パック**: [日本語補助](docs/ja/poc/one-day-poc-evidence-pack.md) / [英語正本](docs/en/poc/one-day-poc-evidence-pack.md)
 - **One-Day PoC運用Runbook**: [日本語補助](docs/ja/poc/one-day-poc-operator-runbook.md) / [英語正本](docs/en/poc/one-day-poc-operator-runbook.md)
+- **One-Day PoCレビュー引き渡しテンプレート**: [日本語補助](docs/ja/poc/one-day-poc-reviewer-handoff-template.md) / [英語正本](docs/en/poc/one-day-poc-reviewer-handoff-template.md)
 - 性能メトリクスおよびOne-Day PoC benchmarkは、local/reviewer-facingな測定であり、本番SLA・第三者認証・顧客環境測定ではありません。
 
 

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -66,3 +66,4 @@
 | EN notes | `docs/en/notes/chainlit.md` | — | EN canonical only | 補助ノート |
 | PoC: One-Day PoC evidence pack | `docs/en/poc/one-day-poc-evidence-pack.md` | `docs/ja/poc/one-day-poc-evidence-pack.md` | JA explanation / EN canonical | Reviewer-facing evidence checklist, walkthrough scenarios, success/failure criteria, and non-claim boundaries for One-Day PoC. |
 | PoC: One-Day PoC operator runbook | `docs/en/poc/one-day-poc-operator-runbook.md` | `docs/ja/poc/one-day-poc-operator-runbook.md` | JA explanation / EN canonical | Operator-facing preparation, execution, evidence collection, packaging, and review handoff runbook for One-Day PoC. |
+| PoC: One-Day PoC reviewer handoff template | `docs/en/poc/one-day-poc-reviewer-handoff-template.md` | `docs/ja/poc/one-day-poc-reviewer-handoff-template.md` | JA explanation / EN canonical | Reviewer-facing handoff template for summarizing PoC scope, evidence, results, limitations, open questions, and acknowledgements. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -47,6 +47,7 @@
 | One-Day PoC Performance Benchmark | [One-Day PoC Performance Benchmark (EN)](en/poc/one-day-poc-performance-report.md) | [One-Day PoC Performance Benchmark (JA)](ja/poc/one-day-poc-performance-report.md) |
 | One-Day PoC Evidence Pack | [One-Day PoC Evidence Pack (EN)](en/poc/one-day-poc-evidence-pack.md) | [One-Day PoC Evidence Pack (JA)](ja/poc/one-day-poc-evidence-pack.md) |
 | One-Day PoC Operator Runbook | [One-Day PoC Operator Runbook (EN)](en/poc/one-day-poc-operator-runbook.md) | [One-Day PoC運用Runbook (JA)](ja/poc/one-day-poc-operator-runbook.md) |
+| One-Day PoC Reviewer Handoff Template | [One-Day PoC Reviewer Handoff Template (EN)](en/poc/one-day-poc-reviewer-handoff-template.md) | [One-Day PoCレビュー引き渡しテンプレート (JA)](ja/poc/one-day-poc-reviewer-handoff-template.md) |
 | Performance Metrics | [Performance Metrics (EN)](en/benchmarks/performance-metrics.md) | [性能メトリクス (JA)](ja/benchmarks/performance-metrics.md) |
 | Local Performance Metrics Artifact | [Local Performance Metrics Artifact (EN)](en/benchmarks/local-performance-metrics.latest.md) / [JSON](en/benchmarks/local-performance-metrics.latest.json) | [ローカル性能メトリクス実測artifact (JA)](ja/benchmarks/local-performance-metrics.latest.md) |
 | One-Day PoC Sample Evidence Packet | [Sample one-day PoC evidence (EN JSON/Markdown)](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（JA Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
@@ -120,6 +121,7 @@
 | One-Day PoC Reviewer Pack | [One-Day PoC Reviewer Pack（英語正本）](en/poc/one-day-poc-reviewer-pack.md) | [One-Day PoC Reviewer Pack（日本語）](ja/poc/one-day-poc-reviewer-pack.md) |
 | One-Day PoC Performance Benchmark | [One-Day PoC Performance Benchmark（英語正本）](en/poc/one-day-poc-performance-report.md) | [One-Day PoC Performance Benchmark（日本語）](ja/poc/one-day-poc-performance-report.md) |
 | One-Day PoC Operator Runbook | [One-Day PoC Operator Runbook（英語正本）](en/poc/one-day-poc-operator-runbook.md) | [One-Day PoC運用Runbook（日本語補助）](ja/poc/one-day-poc-operator-runbook.md) |
+| One-Day PoC Reviewer Handoff Template | [One-Day PoC Reviewer Handoff Template（英語正本）](en/poc/one-day-poc-reviewer-handoff-template.md) | [One-Day PoCレビュー引き渡しテンプレート（日本語補助）](ja/poc/one-day-poc-reviewer-handoff-template.md) |
 | 性能メトリクス | [Performance Metrics（英語正本）](en/benchmarks/performance-metrics.md) | [性能メトリクス（日本語）](ja/benchmarks/performance-metrics.md) |
 | One-Day PoC サンプル証跡パケット | [Sample one-day PoC evidence（英語 JSON/Markdown）](en/poc/sample-one-day-poc-evidence.json) / [Markdown](en/poc/sample-one-day-poc-evidence.md) | [Sample one-day PoC evidence（日本語 Markdown）](ja/poc/sample-one-day-poc-evidence.md) |
 | One-Day PoC 証跡スキーマ | [One-day PoC evidence schema（JSON Schema）](../schemas/poc/one_day_poc_evidence.v1.schema.json) | — |

--- a/docs/en/poc/one-day-poc-evidence-pack.md
+++ b/docs/en/poc/one-day-poc-evidence-pack.md
@@ -81,6 +81,7 @@ Use this pack together with existing validation and walkthrough docs. Keep all c
 
 ## Related documents
 
+- [`docs/en/poc/one-day-poc-reviewer-handoff-template.md`](one-day-poc-reviewer-handoff-template.md)
 - [`docs/en/poc/one-day-poc-operator-runbook.md`](one-day-poc-operator-runbook.md) — Use the operator runbook when preparing and packaging reviewer-facing evidence.
 - [`docs/en/benchmarks/local-performance-metrics.latest.md`](../benchmarks/local-performance-metrics.latest.md)
 - [`docs/en/benchmarks/local-performance-metrics.latest.json`](../benchmarks/local-performance-metrics.latest.json)

--- a/docs/en/poc/one-day-poc-operator-runbook.md
+++ b/docs/en/poc/one-day-poc-operator-runbook.md
@@ -130,6 +130,7 @@ For concrete commands, follow the existing walkthrough and benchmark documents r
 ## Related documents
 
 - [`docs/en/poc/one-day-poc-evidence-pack.md`](one-day-poc-evidence-pack.md)
+- [`docs/en/poc/one-day-poc-reviewer-handoff-template.md`](one-day-poc-reviewer-handoff-template.md) — Use this template when packaging and handing off reviewer-facing PoC results.
 - [`docs/en/poc/one-day-poc-reviewer-pack.md`](one-day-poc-reviewer-pack.md)
 - [`docs/en/poc/one-day-poc-walkthrough.md`](one-day-poc-walkthrough.md)
 - [`docs/en/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md)

--- a/docs/en/poc/one-day-poc-reviewer-handoff-template.md
+++ b/docs/en/poc/one-day-poc-reviewer-handoff-template.md
@@ -1,0 +1,130 @@
+# One-Day PoC Reviewer Handoff Template
+
+- This is a reviewer-facing handoff template for a One-Day PoC.
+- It is intended to summarize what was run, what evidence was collected, what passed, what failed, and what remains open.
+- It complements the One-Day PoC Evidence Pack and Operator Runbook.
+- It is not a production SLA.
+- It is not third-party certified.
+- It is not a customer environment measurement unless explicitly stated and separately documented.
+- It does not certify EU AI Act compliance.
+- External LLM/provider latency and cost are not measured unless providers were intentionally enabled and separately recorded.
+
+## Purpose
+
+- Provide a standard reviewer handoff format after a One-Day PoC.
+- Make PoC evidence easier to inspect.
+- Keep claims bounded to collected evidence.
+
+## Handoff summary
+
+- PoC date:
+- Operator:
+- Reviewer / organization:
+- Repository:
+- Commit SHA:
+- Environment type: local / configured / customer-managed
+- External providers enabled: yes / no / unknown
+- Evidence folder:
+- Overall result: pass / fail / inconclusive
+
+## PoC scope
+
+- [ ] Missing authority/evidence block path reviewed
+- [ ] Allowed path reviewed where applicable
+- [ ] Audit/TrustLog path reviewed
+- [ ] Local deterministic metrics referenced
+- [ ] HTTP PoC benchmark run if in scope
+- [ ] Non-claim boundaries explained
+- [ ] Open questions documented
+
+## Environment and commit
+
+- Date/time:
+- Commit SHA:
+- Branch or tag:
+- Local/configured/customer-managed environment note:
+- API server status if HTTP flow was used:
+- Whether external providers were enabled:
+- Whether secrets or customer data were used:
+- Redaction status:
+
+## Scenarios reviewed
+
+| Scenario | Expected behavior | Observed result | Evidence link | Status |
+|---|---|---|---|---|
+| Missing authority/evidence blocks sensitive action before commit | | | | |
+| Allowed action proceeds when required evidence is present | | | | |
+| Audit/TrustLog path remains reviewable | | | | |
+| Deterministic local metrics reviewed | | | | |
+| HTTP PoC benchmark reviewed if run | | | | |
+| Non-claim boundaries explained | | | | |
+
+## Evidence provided
+
+| Evidence item | File/path | Required? | Notes |
+|---|---|---|---|
+| Environment notes | | Yes | |
+| Commands run | | Yes | |
+| Screenshots | | Conditional | |
+| JSON evidence output | | Conditional | |
+| Markdown evidence report | | Conditional | |
+| Local deterministic metrics artifact | | Recommended | |
+| One-Day PoC benchmark output if run | | Conditional | |
+| Redaction notes | | Conditional | |
+| Reviewer notes | | Yes | |
+
+## Results summary
+
+- Overall status: pass / fail / inconclusive
+- Block path status:
+- Allow path status:
+- Audit path status:
+- Evidence completeness:
+- Reviewer confidence:
+- Follow-up required:
+
+## Known limitations
+
+- Local/configured PoC output is not production latency.
+- Local/configured PoC output is not production availability.
+- Local deterministic metrics are not customer-environment measurements.
+- Benchmark output is only one input into the evidence package.
+- Legal, security, and regulatory review remain separate.
+- Provider latency/cost is out of scope unless explicitly enabled and separately recorded.
+
+## Non-claim boundaries
+
+- Do not claim production SLA from this handoff.
+- Do not claim third-party certification.
+- Do not claim customer-environment measurement unless the PoC was actually run in that environment and documented.
+- Do not claim EU AI Act compliance certification.
+- Do not claim provider cost/latency unless providers were explicitly enabled and separately measured.
+- Do not present demo screenshots as production audit evidence.
+
+## Open questions and follow-up
+
+| Question / follow-up | Owner | Due date | Status |
+|---|---|---|---|
+| | | | |
+
+## Reviewer acknowledgement
+
+- Reviewer name:
+- Organization:
+- Date:
+- Acknowledgement:
+  - [ ] I reviewed the provided evidence.
+  - [ ] I understand the stated non-claim boundaries.
+  - [ ] I understand this handoff does not certify production readiness or legal compliance.
+
+## Related documents
+
+- [`docs/en/poc/one-day-poc-evidence-pack.md`](one-day-poc-evidence-pack.md)
+- [`docs/en/poc/one-day-poc-operator-runbook.md`](one-day-poc-operator-runbook.md)
+- [`docs/en/poc/one-day-poc-reviewer-pack.md`](one-day-poc-reviewer-pack.md)
+- [`docs/en/poc/one-day-poc-walkthrough.md`](one-day-poc-walkthrough.md)
+- [`docs/en/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md)
+- [`docs/en/benchmarks/local-performance-metrics.latest.md`](../benchmarks/local-performance-metrics.latest.md)
+- [`docs/en/benchmarks/performance-metrics.md`](../benchmarks/performance-metrics.md)
+- [`docs/INDEX.md`](../../INDEX.md)
+- [`docs/DOCUMENTATION_MAP.md`](../../DOCUMENTATION_MAP.md)

--- a/docs/ja/poc/one-day-poc-evidence-pack.md
+++ b/docs/ja/poc/one-day-poc-evidence-pack.md
@@ -86,6 +86,7 @@
 
 ## Related documents
 
+- [`docs/ja/poc/one-day-poc-reviewer-handoff-template.md`](one-day-poc-reviewer-handoff-template.md)
 - [`docs/ja/poc/one-day-poc-operator-runbook.md`](one-day-poc-operator-runbook.md) — 証跡の準備・実行・提出手順はOperator Runbookを参照する。
 - [`docs/en/benchmarks/local-performance-metrics.latest.md`](../../en/benchmarks/local-performance-metrics.latest.md)
 - [`docs/en/benchmarks/local-performance-metrics.latest.json`](../../en/benchmarks/local-performance-metrics.latest.json)

--- a/docs/ja/poc/one-day-poc-operator-runbook.md
+++ b/docs/ja/poc/one-day-poc-operator-runbook.md
@@ -135,6 +135,7 @@ poc-evidence/
 ## Related documents
 
 - [`docs/ja/poc/one-day-poc-evidence-pack.md`](one-day-poc-evidence-pack.md)
+- [`docs/ja/poc/one-day-poc-reviewer-handoff-template.md`](one-day-poc-reviewer-handoff-template.md) — PoC結果をレビュー担当者へ提出する際は、このテンプレートを使用する。
 - [`docs/ja/poc/one-day-poc-reviewer-pack.md`](one-day-poc-reviewer-pack.md)
 - [`docs/ja/poc/one-day-poc-walkthrough.md`](one-day-poc-walkthrough.md)
 - [`docs/ja/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md)

--- a/docs/ja/poc/one-day-poc-reviewer-handoff-template.md
+++ b/docs/ja/poc/one-day-poc-reviewer-handoff-template.md
@@ -1,0 +1,135 @@
+# One-Day PoCレビュー引き渡しテンプレート
+
+- 英語版が正本であり、日本語版は補助説明です。
+- これはOne-Day PoC後にレビュー担当者へ渡すためのhandoff templateである。
+- 何を実行し、どの証跡を収集し、何が成功し、何が失敗し、何が未解決かを整理する。
+- One-Day PoC証跡パックおよびOne-Day PoC運用Runbookを補完する。
+- 本番SLAではない。
+- 第三者認証ではない。
+- 明示的に別途記録しない限り、顧客環境測定ではない。
+- EU AI Act準拠を認証するものではない。
+- 外部LLM/provider latencyやcostは、明示的にproviderを有効化して別途記録しない限り測定対象ではない。
+
+## 英語正本
+
+- [One-Day PoC Reviewer Handoff Template](../../en/poc/one-day-poc-reviewer-handoff-template.md)
+
+## Purpose
+
+- One-Day PoC後のレビュー引き渡し形式を標準化する。
+- PoC証跡を点検しやすくする。
+- 収集済み証跡に基づく範囲に主張を限定する。
+
+## Handoff summary
+
+- PoC date:
+- Operator:
+- Reviewer / organization:
+- Repository:
+- Commit SHA:
+- Environment type: local / configured / customer-managed
+- External providers enabled: yes / no / unknown
+- Evidence folder:
+- Overall result: pass / fail / inconclusive
+
+## PoC scope
+
+- [ ] Missing authority/evidence block path reviewed
+- [ ] Allowed path reviewed where applicable
+- [ ] Audit/TrustLog path reviewed
+- [ ] Local deterministic metrics referenced
+- [ ] HTTP PoC benchmark run if in scope
+- [ ] Non-claim boundaries explained
+- [ ] Open questions documented
+
+## Environment and commit
+
+- Date/time:
+- Commit SHA:
+- Branch or tag:
+- Local/configured/customer-managed environment note:
+- API server status if HTTP flow was used:
+- Whether external providers were enabled:
+- Whether secrets or customer data were used:
+- Redaction status:
+
+## Scenarios reviewed
+
+| Scenario | Expected behavior | Observed result | Evidence link | Status |
+|---|---|---|---|---|
+| Missing authority/evidence blocks sensitive action before commit | | | | |
+| Allowed action proceeds when required evidence is present | | | | |
+| Audit/TrustLog path remains reviewable | | | | |
+| Deterministic local metrics reviewed | | | | |
+| HTTP PoC benchmark reviewed if run | | | | |
+| Non-claim boundaries explained | | | | |
+
+## Evidence provided
+
+| Evidence item | File/path | Required? | Notes |
+|---|---|---|---|
+| Environment notes | | Yes | |
+| Commands run | | Yes | |
+| Screenshots | | Conditional | |
+| JSON evidence output | | Conditional | |
+| Markdown evidence report | | Conditional | |
+| Local deterministic metrics artifact | | Recommended | |
+| One-Day PoC benchmark output if run | | Conditional | |
+| Redaction notes | | Conditional | |
+| Reviewer notes | | Yes | |
+
+## Results summary
+
+- Overall status: pass / fail / inconclusive
+- Block path status:
+- Allow path status:
+- Audit path status:
+- Evidence completeness:
+- Reviewer confidence:
+- Follow-up required:
+
+## Known limitations
+
+- Local/configured PoC output is not production latency.
+- Local/configured PoC output is not production availability.
+- Local deterministic metrics are not customer-environment measurements.
+- Benchmark output is only one input into the evidence package.
+- Legal, security, and regulatory review remain separate.
+- Provider latency/cost is out of scope unless explicitly enabled and separately recorded.
+
+## Non-claim boundaries
+
+- Do not claim production SLA from this handoff.
+- Do not claim third-party certification.
+- Do not claim customer-environment measurement unless the PoC was actually run in that environment and documented.
+- Do not claim EU AI Act compliance certification.
+- Do not claim provider cost/latency unless providers were explicitly enabled and separately measured.
+- Do not present demo screenshots as production audit evidence.
+
+## Open questions and follow-up
+
+| Question / follow-up | Owner | Due date | Status |
+|---|---|---|---|
+| | | | |
+
+## Reviewer acknowledgement
+
+- Reviewer name:
+- Organization:
+- Date:
+- Acknowledgement:
+  - [ ] I reviewed the provided evidence.
+  - [ ] I understand the stated non-claim boundaries.
+  - [ ] I understand this handoff does not certify production readiness or legal compliance.
+
+## Related documents
+
+- [`docs/ja/poc/one-day-poc-evidence-pack.md`](one-day-poc-evidence-pack.md)
+- [`docs/ja/poc/one-day-poc-operator-runbook.md`](one-day-poc-operator-runbook.md)
+- [`docs/ja/poc/one-day-poc-reviewer-pack.md`](one-day-poc-reviewer-pack.md)
+- [`docs/ja/poc/one-day-poc-walkthrough.md`](one-day-poc-walkthrough.md)
+- [`docs/ja/poc/one-day-poc-performance-report.md`](one-day-poc-performance-report.md)
+- [`docs/en/benchmarks/local-performance-metrics.latest.md`](../../en/benchmarks/local-performance-metrics.latest.md)
+- [`docs/en/benchmarks/performance-metrics.md`](../../en/benchmarks/performance-metrics.md)
+- [`docs/INDEX.md`](../../INDEX.md)
+- [`docs/DOCUMENTATION_MAP.md`](../../DOCUMENTATION_MAP.md)

--- a/veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py
+++ b/veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py
@@ -1,28 +1,41 @@
 from pathlib import Path
 
 
-def test_one_day_poc_reviewer_handoff_template_docs() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[2]
+EN_TEMPLATE = ROOT / "docs/en/poc/one-day-poc-reviewer-handoff-template.md"
+JA_TEMPLATE = ROOT / "docs/ja/poc/one-day-poc-reviewer-handoff-template.md"
+EN_EVIDENCE_PACK = ROOT / "docs/en/poc/one-day-poc-evidence-pack.md"
+JA_EVIDENCE_PACK = ROOT / "docs/ja/poc/one-day-poc-evidence-pack.md"
+EN_OPERATOR_RUNBOOK = ROOT / "docs/en/poc/one-day-poc-operator-runbook.md"
+JA_OPERATOR_RUNBOOK = ROOT / "docs/ja/poc/one-day-poc-operator-runbook.md"
 
-    en_path = repo_root / "docs/en/poc/one-day-poc-reviewer-handoff-template.md"
-    ja_path = repo_root / "docs/ja/poc/one-day-poc-reviewer-handoff-template.md"
-    assert en_path.exists()
-    assert ja_path.exists()
 
-    en_text = en_path.read_text(encoding="utf-8")
-    ja_text = ja_path.read_text(encoding="utf-8")
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
 
-    for boundary in [
+
+def test_handoff_template_files_exist() -> None:
+    assert EN_TEMPLATE.exists()
+    assert JA_TEMPLATE.exists()
+
+
+def test_en_handoff_template_contains_required_boundaries() -> None:
+    content = _read(EN_TEMPLATE)
+    required = [
         "reviewer-facing handoff template",
         "not a production SLA",
         "not third-party certified",
         "not a customer environment measurement unless explicitly stated",
         "does not certify EU AI Act compliance",
         "External LLM/provider latency and cost are not measured",
-    ]:
-        assert boundary in en_text
+    ]
+    for item in required:
+        assert item in content
 
-    for boundary in [
+
+def test_ja_handoff_template_contains_required_boundaries() -> None:
+    content = _read(JA_TEMPLATE)
+    required = [
         "英語版が正本",
         "## 英語正本",
         "../../en/poc/one-day-poc-reviewer-handoff-template.md",
@@ -30,10 +43,14 @@ def test_one_day_poc_reviewer_handoff_template_docs() -> None:
         "第三者認証ではない",
         "顧客環境測定ではない",
         "EU AI Act準拠を認証するものではない",
-    ]:
-        assert boundary in ja_text
+    ]
+    for item in required:
+        assert item in content
 
-    for section in [
+
+def test_en_handoff_template_contains_key_sections() -> None:
+    content = _read(EN_TEMPLATE)
+    sections = [
         "## Purpose",
         "## Handoff summary",
         "## PoC scope",
@@ -46,10 +63,14 @@ def test_one_day_poc_reviewer_handoff_template_docs() -> None:
         "## Open questions and follow-up",
         "## Reviewer acknowledgement",
         "## Related documents",
-    ]:
-        assert section in en_text
+    ]
+    for section in sections:
+        assert section in content
 
-    linked_tokens = [
+
+def test_en_handoff_template_links_to_existing_docs() -> None:
+    content = _read(EN_TEMPLATE)
+    links = [
         "one-day-poc-evidence-pack.md",
         "one-day-poc-operator-runbook.md",
         "one-day-poc-reviewer-pack.md",
@@ -58,51 +79,48 @@ def test_one_day_poc_reviewer_handoff_template_docs() -> None:
         "../benchmarks/local-performance-metrics.latest.md",
         "../benchmarks/performance-metrics.md",
     ]
-    for token in linked_tokens:
-        assert token in en_text
+    for link in links:
+        assert link in content
+        assert (EN_TEMPLATE.parent / link).resolve().exists()
 
-    for link in [
-        "one-day-poc-evidence-pack.md",
-        "one-day-poc-operator-runbook.md",
-        "one-day-poc-reviewer-pack.md",
-        "one-day-poc-walkthrough.md",
-        "one-day-poc-performance-report.md",
-        "../benchmarks/local-performance-metrics.latest.md",
-        "../benchmarks/performance-metrics.md",
-    ]:
-        assert (en_path.parent / link).resolve().exists()
 
+def test_evidence_pack_and_operator_runbook_link_to_handoff_template() -> None:
     for path in [
-        repo_root / "docs/en/poc/one-day-poc-evidence-pack.md",
-        repo_root / "docs/ja/poc/one-day-poc-evidence-pack.md",
-        repo_root / "docs/en/poc/one-day-poc-operator-runbook.md",
-        repo_root / "docs/ja/poc/one-day-poc-operator-runbook.md",
+        EN_EVIDENCE_PACK,
+        JA_EVIDENCE_PACK,
+        EN_OPERATOR_RUNBOOK,
+        JA_OPERATOR_RUNBOOK,
     ]:
-        assert "one-day-poc-reviewer-handoff-template.md" in path.read_text(
-            encoding="utf-8"
-        )
+        assert "one-day-poc-reviewer-handoff-template.md" in _read(path)
 
-    assert (
-        "docs/en/poc/one-day-poc-reviewer-handoff-template.md"
-        in (repo_root / "README.md").read_text(encoding="utf-8")
+
+def test_readme_and_index_links_present() -> None:
+    assert "docs/en/poc/one-day-poc-reviewer-handoff-template.md" in _read(
+        ROOT / "README.md"
     )
-    readme_jp = (repo_root / "README_JP.md").read_text(encoding="utf-8")
+    readme_jp = _read(ROOT / "README_JP.md")
     assert "docs/ja/poc/one-day-poc-reviewer-handoff-template.md" in readme_jp
     assert "docs/en/poc/one-day-poc-reviewer-handoff-template.md" in readme_jp
-    assert "one-day-poc-reviewer-handoff-template.md" in (
-        repo_root / "docs/INDEX.md"
-    ).read_text(encoding="utf-8")
-    doc_map = (repo_root / "docs/DOCUMENTATION_MAP.md").read_text(encoding="utf-8")
-    assert "one-day-poc-reviewer-handoff-template.md" in doc_map
-    assert "\n\n| PoC: One-Day PoC reviewer handoff template |" not in doc_map
+    assert "one-day-poc-reviewer-handoff-template.md" in _read(ROOT / "docs/INDEX.md")
+    assert "one-day-poc-reviewer-handoff-template.md" in _read(
+        ROOT / "docs/DOCUMENTATION_MAP.md"
+    )
 
-    combined = f"{en_text}\n{ja_text}".casefold()
-    for forbidden in [
+
+def test_documentation_map_table_is_not_split() -> None:
+    content = _read(ROOT / "docs/DOCUMENTATION_MAP.md")
+    assert "\n\n| PoC: One-Day PoC reviewer handoff template |" not in content
+
+
+def test_unsupported_claims_absent_from_handoff_templates() -> None:
+    combined = f"{_read(EN_TEMPLATE)}\n{_read(JA_TEMPLATE)}".casefold()
+    forbidden = [
         "guaranteed compliance",
-        "certified eu ai act compliant",
-        "production sla certified",
+        "certified EU AI Act compliant",
+        "production SLA certified",
         "third-party certified benchmark",
         "customer environment verified",
         "cost per request measured",
-    ]:
-        assert forbidden not in combined
+    ]
+    for claim in forbidden:
+        assert claim.casefold() not in combined

--- a/veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py
+++ b/veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+
+def test_one_day_poc_reviewer_handoff_template_docs() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+
+    en_path = repo_root / "docs/en/poc/one-day-poc-reviewer-handoff-template.md"
+    ja_path = repo_root / "docs/ja/poc/one-day-poc-reviewer-handoff-template.md"
+    assert en_path.exists()
+    assert ja_path.exists()
+
+    en_text = en_path.read_text(encoding="utf-8")
+    ja_text = ja_path.read_text(encoding="utf-8")
+
+    for boundary in [
+        "reviewer-facing handoff template",
+        "not a production SLA",
+        "not third-party certified",
+        "not a customer environment measurement unless explicitly stated",
+        "does not certify EU AI Act compliance",
+        "External LLM/provider latency and cost are not measured",
+    ]:
+        assert boundary in en_text
+
+    for boundary in [
+        "英語版が正本",
+        "## 英語正本",
+        "../../en/poc/one-day-poc-reviewer-handoff-template.md",
+        "本番SLAではない",
+        "第三者認証ではない",
+        "顧客環境測定ではない",
+        "EU AI Act準拠を認証するものではない",
+    ]:
+        assert boundary in ja_text
+
+    for section in [
+        "## Purpose",
+        "## Handoff summary",
+        "## PoC scope",
+        "## Environment and commit",
+        "## Scenarios reviewed",
+        "## Evidence provided",
+        "## Results summary",
+        "## Known limitations",
+        "## Non-claim boundaries",
+        "## Open questions and follow-up",
+        "## Reviewer acknowledgement",
+        "## Related documents",
+    ]:
+        assert section in en_text
+
+    linked_tokens = [
+        "one-day-poc-evidence-pack.md",
+        "one-day-poc-operator-runbook.md",
+        "one-day-poc-reviewer-pack.md",
+        "one-day-poc-walkthrough.md",
+        "one-day-poc-performance-report.md",
+        "../benchmarks/local-performance-metrics.latest.md",
+        "../benchmarks/performance-metrics.md",
+    ]
+    for token in linked_tokens:
+        assert token in en_text
+
+    for link in [
+        "one-day-poc-evidence-pack.md",
+        "one-day-poc-operator-runbook.md",
+        "one-day-poc-reviewer-pack.md",
+        "one-day-poc-walkthrough.md",
+        "one-day-poc-performance-report.md",
+        "../benchmarks/local-performance-metrics.latest.md",
+        "../benchmarks/performance-metrics.md",
+    ]:
+        assert (en_path.parent / link).resolve().exists()
+
+    for path in [
+        repo_root / "docs/en/poc/one-day-poc-evidence-pack.md",
+        repo_root / "docs/ja/poc/one-day-poc-evidence-pack.md",
+        repo_root / "docs/en/poc/one-day-poc-operator-runbook.md",
+        repo_root / "docs/ja/poc/one-day-poc-operator-runbook.md",
+    ]:
+        assert "one-day-poc-reviewer-handoff-template.md" in path.read_text(
+            encoding="utf-8"
+        )
+
+    assert (
+        "docs/en/poc/one-day-poc-reviewer-handoff-template.md"
+        in (repo_root / "README.md").read_text(encoding="utf-8")
+    )
+    readme_jp = (repo_root / "README_JP.md").read_text(encoding="utf-8")
+    assert "docs/ja/poc/one-day-poc-reviewer-handoff-template.md" in readme_jp
+    assert "docs/en/poc/one-day-poc-reviewer-handoff-template.md" in readme_jp
+    assert "one-day-poc-reviewer-handoff-template.md" in (
+        repo_root / "docs/INDEX.md"
+    ).read_text(encoding="utf-8")
+    doc_map = (repo_root / "docs/DOCUMENTATION_MAP.md").read_text(encoding="utf-8")
+    assert "one-day-poc-reviewer-handoff-template.md" in doc_map
+    assert "\n\n| PoC: One-Day PoC reviewer handoff template |" not in doc_map
+
+    combined = f"{en_text}\n{ja_text}".casefold()
+    for forbidden in [
+        "guaranteed compliance",
+        "certified eu ai act compliant",
+        "production sla certified",
+        "third-party certified benchmark",
+        "customer environment verified",
+        "cost per request measured",
+    ]:
+        assert forbidden not in combined


### PR DESCRIPTION
### Motivation

- Standardize a reviewer-facing, submit-ready One-Day PoC handoff so reviewers can quickly see what was run, what evidence exists, what passed/failed, and what remains open.
- Provide a compact single-page template that complements the existing One-Day PoC Evidence Pack and Operator Runbook while explicitly bounding non-claim statements.
- Improve discoverability by adding clear cross-links from Evidence Pack / Operator Runbook and top-level documentation indices so reviewers can find the handoff easily.
- Keep this change documentation-only and avoid any runtime, API, or governance semantic modifications.

### Description

- Add English canonical handoff template at `docs/en/poc/one-day-poc-reviewer-handoff-template.md` containing the required 12 sections, tables for scenarios/evidence/open questions, and non-claim language.
- Add Japanese explanatory counterpart at `docs/ja/poc/one-day-poc-reviewer-handoff-template.md` with an explicit `## 英語正本` link to the EN canonical file.
- Insert cross-links to the new template from `docs/en/poc/one-day-poc-operator-runbook.md`, `docs/ja/poc/one-day-poc-operator-runbook.md`, `docs/en/poc/one-day-poc-evidence-pack.md`, and `docs/ja/poc/one-day-poc-evidence-pack.md` with short guidance notes.
- Update discoverability entries in `docs/INDEX.md`, `docs/DOCUMENTATION_MAP.md`, `README.md`, and `README_JP.md`, and add a focused test at `veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py` that verifies files, required wording, sections, cross-links, and absence of forbidden over-claim phrases.

### Testing

- Ran the focused pytest: `PYENV_VERSION=3.11.15 pytest -q veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py`, and the test passed.
- Ran the bilingual quality check: `PYENV_VERSION=3.11.15 python -m scripts.quality.check_bilingual_docs`, and the check passed.
- No runtime or API tests were required because this is a documentation-only change and all CI-relevant doc checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6cabeee08326aa7636b0edb34f40)