### PR TITLE
docs(review): wire one-day PoC evidence suite into reviewer entrypoint

### DIFF
--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -13,22 +13,26 @@ This entry point is organized around the current enterprise review path: busines
 1. `docs/en/positioning/enterprise-value-brief.md` — one-page business/investor overview.
 2. `README.md` — core product definition and repository entry map.
 3. `docs/en/validation/current-implementation-matrix.md` — current implementation facts vs roadmap.
-4. `docs/en/poc/one-day-poc-reviewer-pack.md` — what can be reviewed in a short PoC window.
-5. `docs/en/operations/provider-support-matrix.md` — provider tiers, support boundaries, and non-claims.
-6. `docs/en/positioning/public-positioning.md` — conservative positioning and legal/compliance boundary statements.
+4. `en/poc/one-day-poc-evidence-pack.md` — what reviewers should inspect, collect, and treat as success/failure evidence in a One-Day PoC.
+5. `en/poc/one-day-poc-reviewer-handoff-template.md` — submit-ready handoff format for PoC results.
+6. `en/operations/provider-support-matrix.md` — provider tiers, support boundaries, and non-claims.
+7. `en/positioning/public-positioning.md` — conservative positioning and legal/compliance boundary statements.
 
 ## 30-minute technical review path
 
-1. `docs/en/positioning/enterprise-value-brief.md`
-2. `docs/en/validation/current-implementation-matrix.md`
-3. `docs/en/validation/regulated-action-governance-proof-pack.md`
-4. `docs/en/poc/one-day-poc-reviewer-pack.md`
-5. `docs/en/poc/one-day-poc-performance-report.md`
-6. `docs/en/operations/type-safety-baseline.md`
-7. `docs/en/operations/maintainer-handoff.md`
-8. `docs/en/operations/provider-support-matrix.md`
-9. `docs/en/architecture/regulated-action-governance-kernel.md`
-10. `docs/en/architecture/bind-boundary-governance-artifacts.md`
+1. `en/positioning/enterprise-value-brief.md`
+2. `en/validation/current-implementation-matrix.md`
+3. `en/validation/regulated-action-governance-proof-pack.md`
+4. `en/poc/one-day-poc-evidence-pack.md`
+5. `en/poc/one-day-poc-operator-runbook.md`
+6. `en/poc/one-day-poc-reviewer-handoff-template.md`
+7. `en/poc/one-day-poc-reviewer-pack.md`
+8. `en/poc/one-day-poc-performance-report.md`
+9. `en/operations/type-safety-baseline.md`
+10. `en/operations/maintainer-handoff.md`
+11. `en/operations/provider-support-matrix.md`
+12. `en/architecture/regulated-action-governance-kernel.md`
+13. `en/architecture/bind-boundary-governance-artifacts.md`
 
 ## What VERITAS OS is
 
@@ -49,7 +53,10 @@ Key reviewer concepts:
 |---|---|---|
 | What problem does VERITAS solve? | `docs/en/positioning/enterprise-value-brief.md` | Enterprise value, target users, and priority use cases. |
 | What is implemented today? | `docs/en/validation/current-implementation-matrix.md` | Clear separation between current facts and roadmap/foundation-only items. |
-| What can be verified in one day? | `docs/en/poc/one-day-poc-reviewer-pack.md` | Smoke path, generated evidence packet, and validation workflow. |
+| What should reviewers inspect in the One-Day PoC? | `en/poc/one-day-poc-evidence-pack.md` | Evidence checklist, walkthrough scenarios, success/failure criteria, and non-claim boundaries. |
+| How should operators prepare and package the PoC evidence? | `en/poc/one-day-poc-operator-runbook.md` | Pre-flight checklist, evidence folder layout, run sequence, redaction notes, and review handoff package. |
+| What should be handed to the reviewer after the PoC? | `en/poc/one-day-poc-reviewer-handoff-template.md` | Submit-ready summary of scope, environment, scenarios, evidence, results, limitations, and open questions. |
+| What can be verified in one day? | `en/poc/one-day-poc-reviewer-pack.md` | Smoke path, generated evidence packet, and validation workflow. |
 | Is there performance evidence? | `docs/en/poc/one-day-poc-performance-report.md` | Local benchmark method, measurement boundaries, and non-SLA language. |
 | What are provider boundaries? | `docs/en/operations/provider-support-matrix.md` | OpenAI production tier, Anthropic planned with offline contract coverage, and explicit boundaries. |
 | Are legal/compliance claims bounded? | `docs/en/positioning/public-positioning.md`, `docs/eu_ai_act/technical_documentation.md` | Positioning uses conservative non-certification language and bounded claims. |
@@ -60,6 +67,9 @@ Key reviewer concepts:
 
 - [Enterprise Value Brief](en/positioning/enterprise-value-brief.md)
 - [One-Day PoC Reviewer Pack](en/poc/one-day-poc-reviewer-pack.md)
+- [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md)
+- [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md)
+- [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md)
 - For the completed external security review remediation matrix, see [External Security Review Remediation Summary](en/security/external-security-remediation-summary.md).
 - [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
 - [Sample evidence JSON](en/poc/sample-one-day-poc-evidence.json)
@@ -81,6 +91,9 @@ Run docs and reviewer-path checks first:
 python -m scripts.quality.check_bilingual_docs
 pytest -q veritas_os/tests/test_enterprise_value_brief_docs.py
 pytest -q veritas_os/tests/test_docs_poc_samples.py
+pytest -q veritas_os/tests/test_one_day_poc_evidence_pack_docs.py
+pytest -q veritas_os/tests/test_one_day_poc_operator_runbook_docs.py
+pytest -q veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py
 pytest -q veritas_os/tests/test_provider_support_matrix_docs.py
 pytest -q veritas_os/tests/test_type_safety_baseline.py
 pytest -q veritas_os/tests/test_maintainer_handoff_docs.py
@@ -94,6 +107,11 @@ One-Day PoC command examples (API server required, API key required):
 VERITAS_API_KEY=... python scripts/demo/one_day_poc_smoke.py --json --evidence-json /tmp/veritas_poc_evidence.json --evidence-md /tmp/veritas_poc_evidence.md
 VERITAS_API_KEY=... python scripts/demo/one_day_poc_benchmark.py --runs 10 --warmup 2 --json --out-json /tmp/veritas_poc_benchmark.json --out-md /tmp/veritas_poc_benchmark.md
 ```
+
+Use the Evidence Pack to decide what to inspect.
+Use the Operator Runbook to collect and organize evidence.
+Use the Reviewer Handoff Template to summarize and submit the PoC outcome.
+These documents do not create a production SLA, third-party certification, customer-environment measurement, or EU AI Act certification.
 
 Boundary notes for PoC commands:
 
@@ -115,6 +133,10 @@ Boundary notes for PoC commands:
 - Not full repository strict typing.
 - Not elimination of bus-factor risk.
 - Fixture/demo evidence is not live customer integration.
+- One-Day PoC evidence is not production audit evidence.
+- One-Day PoC handoff is not customer-environment verification unless explicitly run and documented in that environment.
+- Local/configured PoC output is not proof of production latency, production availability, or third-party certification.
+- Provider latency/cost is not measured unless providers are intentionally enabled and separately recorded.
 
 ## Provider and model boundary
 
@@ -147,7 +169,11 @@ Observe Mode boundary reminders:
 - [ ] Read Enterprise Value Brief.
 - [ ] Read Current Implementation Matrix.
 - [ ] Review One-Day PoC Reviewer Pack.
+- [ ] Review One-Day PoC Evidence Pack.
+- [ ] Use Operator Runbook when preparing or auditing PoC evidence collection.
+- [ ] Review completed Reviewer Handoff Template if PoC results are being submitted.
 - [ ] Generate or inspect evidence packet.
+- [ ] Confirm Evidence Packet / Evidence Pack / Handoff Template are not being presented as production audit evidence or certification.
 - [ ] Review performance report boundaries.
 - [ ] Review provider matrix.
 - [ ] Review compliance positioning boundaries.

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -10,13 +10,14 @@ This entry point is organized around the current enterprise review path: busines
 
 ## 10-minute review path
 
-1. `docs/en/positioning/enterprise-value-brief.md` — one-page business/investor overview.
+1. `en/positioning/enterprise-value-brief.md` — one-page business/investor overview.
 2. `README.md` — core product definition and repository entry map.
-3. `docs/en/validation/current-implementation-matrix.md` — current implementation facts vs roadmap.
+3. `en/validation/current-implementation-matrix.md` — current implementation facts vs roadmap.
 4. `en/poc/one-day-poc-evidence-pack.md` — what reviewers should inspect, collect, and treat as success/failure evidence in a One-Day PoC.
-5. `en/poc/one-day-poc-reviewer-handoff-template.md` — submit-ready handoff format for PoC results.
-6. `en/operations/provider-support-matrix.md` — provider tiers, support boundaries, and non-claims.
-7. `en/positioning/public-positioning.md` — conservative positioning and legal/compliance boundary statements.
+5. `en/poc/one-day-poc-operator-runbook.md` — how operators prepare, collect, package, and hand off PoC evidence.
+6. `en/poc/one-day-poc-reviewer-handoff-template.md` — submit-ready handoff format for PoC results.
+7. `en/operations/provider-support-matrix.md` — provider tiers, support boundaries, and non-claims.
+8. `en/positioning/public-positioning.md` — conservative positioning and legal/compliance boundary statements.
 
 ## 30-minute technical review path
 
@@ -51,17 +52,17 @@ Key reviewer concepts:
 
 | Review question | Primary source | What to check |
 |---|---|---|
-| What problem does VERITAS solve? | `docs/en/positioning/enterprise-value-brief.md` | Enterprise value, target users, and priority use cases. |
-| What is implemented today? | `docs/en/validation/current-implementation-matrix.md` | Clear separation between current facts and roadmap/foundation-only items. |
+| What problem does VERITAS solve? | `en/positioning/enterprise-value-brief.md` | Enterprise value, target users, and priority use cases. |
+| What is implemented today? | `en/validation/current-implementation-matrix.md` | Clear separation between current facts and roadmap/foundation-only items. |
 | What should reviewers inspect in the One-Day PoC? | `en/poc/one-day-poc-evidence-pack.md` | Evidence checklist, walkthrough scenarios, success/failure criteria, and non-claim boundaries. |
 | How should operators prepare and package the PoC evidence? | `en/poc/one-day-poc-operator-runbook.md` | Pre-flight checklist, evidence folder layout, run sequence, redaction notes, and review handoff package. |
 | What should be handed to the reviewer after the PoC? | `en/poc/one-day-poc-reviewer-handoff-template.md` | Submit-ready summary of scope, environment, scenarios, evidence, results, limitations, and open questions. |
 | What can be verified in one day? | `en/poc/one-day-poc-reviewer-pack.md` | Smoke path, generated evidence packet, and validation workflow. |
-| Is there performance evidence? | `docs/en/poc/one-day-poc-performance-report.md` | Local benchmark method, measurement boundaries, and non-SLA language. |
-| What are provider boundaries? | `docs/en/operations/provider-support-matrix.md` | OpenAI production tier, Anthropic planned with offline contract coverage, and explicit boundaries. |
-| Are legal/compliance claims bounded? | `docs/en/positioning/public-positioning.md`, `docs/eu_ai_act/technical_documentation.md` | Positioning uses conservative non-certification language and bounded claims. |
-| Is there type safety? | `docs/en/operations/type-safety-baseline.md` | Narrow, practical baseline rather than full-repository strict typing claims. |
-| Is handoff possible? | `docs/en/operations/maintainer-handoff.md` | Maintainer runbook exists; handoff path is documented but risk is not eliminated. |
+| Is there performance evidence? | `en/poc/one-day-poc-performance-report.md` | Local benchmark method, measurement boundaries, and non-SLA language. |
+| What are provider boundaries? | `en/operations/provider-support-matrix.md` | OpenAI production tier, Anthropic planned with offline contract coverage, and explicit boundaries. |
+| Are legal/compliance claims bounded? | `en/positioning/public-positioning.md`, `eu_ai_act/technical_documentation.md` | Positioning uses conservative non-certification language and bounded claims. |
+| Is there type safety? | `en/operations/type-safety-baseline.md` | Narrow, practical baseline rather than full-repository strict typing claims. |
+| Is handoff possible? | `en/operations/maintainer-handoff.md` | Maintainer runbook exists; handoff path is documented but risk is not eliminated. |
 
 ## Current proof assets
 

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -50,6 +50,9 @@ def test_reviewer_entrypoint_links_required_current_docs() -> None:
         "en/positioning/enterprise-value-brief.md",
         "en/validation/current-implementation-matrix.md",
         "en/poc/one-day-poc-reviewer-pack.md",
+        "en/poc/one-day-poc-evidence-pack.md",
+        "en/poc/one-day-poc-operator-runbook.md",
+        "en/poc/one-day-poc-reviewer-handoff-template.md",
         "en/poc/one-day-poc-performance-report.md",
         "en/operations/provider-support-matrix.md",
         "en/operations/type-safety-baseline.md",
@@ -96,6 +99,9 @@ def test_reviewer_entrypoint_has_required_non_claim_boundaries() -> None:
         "Not proof of provider-neutral production readiness",
         "Not full repository strict typing",
         "Not elimination of bus-factor risk",
+        "One-Day PoC evidence is not production audit evidence",
+        "One-Day PoC handoff is not customer-environment verification",
+        "Provider latency/cost is not measured unless providers are intentionally enabled",
     ]
     for boundary in required_boundaries:
         assert boundary in text
@@ -127,3 +133,26 @@ def test_reviewer_entrypoint_keeps_observe_mode_appendix() -> None:
     assert "observe_mode_proof_pack.md" in text
     assert "/dev/mission-fixture" in text
     assert "Observe Mode runtime is not enabled" in text
+
+
+def test_reviewer_entrypoint_includes_one_day_poc_evidence_suite() -> None:
+    text = _entrypoint_text()
+    for phrase in [
+        "One-Day PoC Evidence Pack",
+        "One-Day PoC Operator Runbook",
+        "One-Day PoC Reviewer Handoff Template",
+        "Evidence Pack",
+        "Operator Runbook",
+        "Reviewer Handoff Template",
+    ]:
+        assert phrase in text
+
+
+def test_reviewer_entrypoint_validation_commands_include_poc_doc_guardrails() -> None:
+    text = _entrypoint_text()
+    for command in [
+        "pytest -q veritas_os/tests/test_one_day_poc_evidence_pack_docs.py",
+        "pytest -q veritas_os/tests/test_one_day_poc_operator_runbook_docs.py",
+        "pytest -q veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py",
+    ]:
+        assert command in text

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -141,11 +141,16 @@ def test_reviewer_entrypoint_includes_one_day_poc_evidence_suite() -> None:
         "One-Day PoC Evidence Pack",
         "One-Day PoC Operator Runbook",
         "One-Day PoC Reviewer Handoff Template",
-        "Evidence Pack",
-        "Operator Runbook",
-        "Reviewer Handoff Template",
     ]:
         assert phrase in text
+
+    targets = set(_markdown_link_targets())
+    for link in [
+        "en/poc/one-day-poc-evidence-pack.md",
+        "en/poc/one-day-poc-operator-runbook.md",
+        "en/poc/one-day-poc-reviewer-handoff-template.md",
+    ]:
+        assert link in targets
 
 
 def test_reviewer_entrypoint_validation_commands_include_poc_doc_guardrails() -> None:


### PR DESCRIPTION
### Motivation

- Integrate the newly authored One-Day PoC artifacts so external reviewers can quickly reach the Evidence Pack, Operator Runbook, and Reviewer Handoff Template from the primary entrypoint. 
- Ensure the 10-minute and 30-minute review flows, proof-assets list, verification checklist, recommended validation commands, and non-claim boundaries reflect the One-Day PoC suite. 
- Keep this change documentation-only to avoid any runtime, API, dependency, benchmark, or CI workflow modifications.

### Description

- Updated `docs/REVIEWER_ENTRYPOINT.md` to wire the One-Day PoC Evidence Pack, One-Day PoC Operator Runbook, and One-Day PoC Reviewer Handoff Template into the `## 10-minute review path` and `## 30-minute technical review path`, and to add the three items into `## What to verify first`, `## Current proof assets`, `## Recommended validation commands`, `## Reviewer checklist`, and `## Current boundaries and non-claims` as requested. 
- Standardized docs-relative links to use `en/...` form from inside `docs/` to satisfy existing link checks (examples: `en/poc/one-day-poc-evidence-pack.md`, `en/poc/one-day-poc-operator-runbook.md`, `en/poc/one-day-poc-reviewer-handoff-template.md`). 
- Added new docs-test guardrails to `veritas_os/tests/test_reviewer_entrypoint_current_path.py` by including the three required PoC links in `required_links`, appending non-claim boundary strings, and adding two tests: `test_reviewer_entrypoint_includes_one_day_poc_evidence_suite` and `test_reviewer_entrypoint_validation_commands_include_poc_doc_guardrails`. 
- This is strictly a docs + tests change and does not alter runtime governance, API contracts, provider tiers, dependencies, benchmarks, or CI workflow.

### Testing

- Attempted to run the requested validation commands including `pytest -q veritas_os/tests/test_reviewer_entrypoint_current_path.py` and the three PoC docs tests, and `python -m scripts.quality.check_bilingual_docs`, but execution failed in this environment due to the repo `pyenv` pin (`3.12.12`) not being provisioned and `pytest` not being available in the available Python interpreters, so automated tests were not executed here. 
- The `docs/REVIEWER_ENTRYPOINT.md` and `veritas_os/tests/test_reviewer_entrypoint_current_path.py` files were edited and validated locally (text replacements and file writes completed), and the updated tests are present for CI to run in the project environment. 
- No runtime or other automated test suites were modified; CI should run the new docs tests and report pass/fail in the repository CI environment where the pinned Python toolchain and `pytest` are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff75b39c10832691e83ab1feeab9a8)