### PR TITLE
Add One-Day PoC evidence/operator/handoff docs to reviewer entrypoint and validate with tests

### DIFF
--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -10,25 +10,30 @@ This entry point is organized around the current enterprise review path: busines
 
 ## 10-minute review path
 
-1. `docs/en/positioning/enterprise-value-brief.md` — one-page business/investor overview.
-2. `README.md` — core product definition and repository entry map.
-3. `docs/en/validation/current-implementation-matrix.md` — current implementation facts vs roadmap.
-4. `docs/en/poc/one-day-poc-reviewer-pack.md` — what can be reviewed in a short PoC window.
-5. `docs/en/operations/provider-support-matrix.md` — provider tiers, support boundaries, and non-claims.
-6. `docs/en/positioning/public-positioning.md` — conservative positioning and legal/compliance boundary statements.
+1. [Enterprise Value Brief](en/positioning/enterprise-value-brief.md) — one-page business/investor overview.
+2. [README](../README.md) — core product definition and repository entry map.
+3. [Current Implementation Matrix](en/validation/current-implementation-matrix.md) — current implementation facts vs roadmap.
+4. [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md) — what reviewers should inspect, collect, and treat as success/failure evidence in a One-Day PoC.
+5. [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md) — how operators prepare, collect, package, and hand off PoC evidence.
+6. [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md) — submit-ready handoff format for PoC results.
+7. [Provider Support Matrix](en/operations/provider-support-matrix.md) — provider tiers, support boundaries, and non-claims.
+8. [Public Positioning](en/positioning/public-positioning.md) — conservative positioning and legal/compliance boundary statements.
 
 ## 30-minute technical review path
 
-1. `docs/en/positioning/enterprise-value-brief.md`
-2. `docs/en/validation/current-implementation-matrix.md`
-3. `docs/en/validation/regulated-action-governance-proof-pack.md`
-4. `docs/en/poc/one-day-poc-reviewer-pack.md`
-5. `docs/en/poc/one-day-poc-performance-report.md`
-6. `docs/en/operations/type-safety-baseline.md`
-7. `docs/en/operations/maintainer-handoff.md`
-8. `docs/en/operations/provider-support-matrix.md`
-9. `docs/en/architecture/regulated-action-governance-kernel.md`
-10. `docs/en/architecture/bind-boundary-governance-artifacts.md`
+1. [Enterprise Value Brief](en/positioning/enterprise-value-brief.md)
+2. [Current Implementation Matrix](en/validation/current-implementation-matrix.md)
+3. [Regulated Action Governance Proof Pack](en/validation/regulated-action-governance-proof-pack.md)
+4. [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md)
+5. [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md)
+6. [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md)
+7. [One-Day PoC Reviewer Pack](en/poc/one-day-poc-reviewer-pack.md)
+8. [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
+9. [Type Safety Baseline](en/operations/type-safety-baseline.md)
+10. [Maintainer Handoff](en/operations/maintainer-handoff.md)
+11. [Provider Support Matrix](en/operations/provider-support-matrix.md)
+12. [Regulated Action Governance Kernel](en/architecture/regulated-action-governance-kernel.md)
+13. [Bind-Boundary Governance Artifacts](en/architecture/bind-boundary-governance-artifacts.md)
 
 ## What VERITAS OS is
 
@@ -49,7 +54,10 @@ Key reviewer concepts:
 |---|---|---|
 | What problem does VERITAS solve? | `docs/en/positioning/enterprise-value-brief.md` | Enterprise value, target users, and priority use cases. |
 | What is implemented today? | `docs/en/validation/current-implementation-matrix.md` | Clear separation between current facts and roadmap/foundation-only items. |
-| What can be verified in one day? | `docs/en/poc/one-day-poc-reviewer-pack.md` | Smoke path, generated evidence packet, and validation workflow. |
+| What should reviewers inspect in the One-Day PoC? | `en/poc/one-day-poc-evidence-pack.md` | Evidence checklist, walkthrough scenarios, success/failure criteria, and non-claim boundaries. |
+| How should operators prepare and package the PoC evidence? | `en/poc/one-day-poc-operator-runbook.md` | Pre-flight checklist, evidence folder layout, run sequence, redaction notes, and review handoff package. |
+| What should be handed to the reviewer after the PoC? | `en/poc/one-day-poc-reviewer-handoff-template.md` | Submit-ready summary of scope, environment, scenarios, evidence, results, limitations, and open questions. |
+| What can be verified in one day? | `en/poc/one-day-poc-reviewer-pack.md` | Smoke path, generated evidence packet, and validation workflow. |
 | Is there performance evidence? | `docs/en/poc/one-day-poc-performance-report.md` | Local benchmark method, measurement boundaries, and non-SLA language. |
 | What are provider boundaries? | `docs/en/operations/provider-support-matrix.md` | OpenAI production tier, Anthropic planned with offline contract coverage, and explicit boundaries. |
 | Are legal/compliance claims bounded? | `docs/en/positioning/public-positioning.md`, `docs/eu_ai_act/technical_documentation.md` | Positioning uses conservative non-certification language and bounded claims. |
@@ -60,6 +68,9 @@ Key reviewer concepts:
 
 - [Enterprise Value Brief](en/positioning/enterprise-value-brief.md)
 - [One-Day PoC Reviewer Pack](en/poc/one-day-poc-reviewer-pack.md)
+- [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md)
+- [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md)
+- [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md)
 - For the completed external security review remediation matrix, see [External Security Review Remediation Summary](en/security/external-security-remediation-summary.md).
 - [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
 - [Sample evidence JSON](en/poc/sample-one-day-poc-evidence.json)
@@ -81,6 +92,9 @@ Run docs and reviewer-path checks first:
 python -m scripts.quality.check_bilingual_docs
 pytest -q veritas_os/tests/test_enterprise_value_brief_docs.py
 pytest -q veritas_os/tests/test_docs_poc_samples.py
+pytest -q veritas_os/tests/test_one_day_poc_evidence_pack_docs.py
+pytest -q veritas_os/tests/test_one_day_poc_operator_runbook_docs.py
+pytest -q veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py
 pytest -q veritas_os/tests/test_provider_support_matrix_docs.py
 pytest -q veritas_os/tests/test_type_safety_baseline.py
 pytest -q veritas_os/tests/test_maintainer_handoff_docs.py
@@ -94,6 +108,11 @@ One-Day PoC command examples (API server required, API key required):
 VERITAS_API_KEY=... python scripts/demo/one_day_poc_smoke.py --json --evidence-json /tmp/veritas_poc_evidence.json --evidence-md /tmp/veritas_poc_evidence.md
 VERITAS_API_KEY=... python scripts/demo/one_day_poc_benchmark.py --runs 10 --warmup 2 --json --out-json /tmp/veritas_poc_benchmark.json --out-md /tmp/veritas_poc_benchmark.md
 ```
+
+Use the Evidence Pack to decide what to inspect.
+Use the Operator Runbook to collect and organize evidence.
+Use the Reviewer Handoff Template to summarize and submit the PoC outcome.
+These documents do not create a production SLA, third-party certification, customer-environment measurement, or EU AI Act certification.
 
 Boundary notes for PoC commands:
 
@@ -115,6 +134,10 @@ Boundary notes for PoC commands:
 - Not full repository strict typing.
 - Not elimination of bus-factor risk.
 - Fixture/demo evidence is not live customer integration.
+- One-Day PoC evidence is not production audit evidence.
+- One-Day PoC handoff is not customer-environment verification unless explicitly run and documented in that environment.
+- Local/configured PoC output is not proof of production latency, production availability, or third-party certification.
+- Provider latency/cost is not measured unless providers are intentionally enabled and separately recorded.
 
 ## Provider and model boundary
 
@@ -147,7 +170,11 @@ Observe Mode boundary reminders:
 - [ ] Read Enterprise Value Brief.
 - [ ] Read Current Implementation Matrix.
 - [ ] Review One-Day PoC Reviewer Pack.
+- [ ] Review One-Day PoC Evidence Pack.
+- [ ] Use Operator Runbook when preparing or auditing PoC evidence collection.
+- [ ] Review completed Reviewer Handoff Template if PoC results are being submitted.
 - [ ] Generate or inspect evidence packet.
+- [ ] Confirm Evidence Packet / Evidence Pack / Handoff Template are not being presented as production audit evidence or certification.
 - [ ] Review performance report boundaries.
 - [ ] Review provider matrix.
 - [ ] Review compliance positioning boundaries.

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -50,6 +50,9 @@ def test_reviewer_entrypoint_links_required_current_docs() -> None:
         "en/positioning/enterprise-value-brief.md",
         "en/validation/current-implementation-matrix.md",
         "en/poc/one-day-poc-reviewer-pack.md",
+        "en/poc/one-day-poc-evidence-pack.md",
+        "en/poc/one-day-poc-operator-runbook.md",
+        "en/poc/one-day-poc-reviewer-handoff-template.md",
         "en/poc/one-day-poc-performance-report.md",
         "en/operations/provider-support-matrix.md",
         "en/operations/type-safety-baseline.md",
@@ -96,6 +99,9 @@ def test_reviewer_entrypoint_has_required_non_claim_boundaries() -> None:
         "Not proof of provider-neutral production readiness",
         "Not full repository strict typing",
         "Not elimination of bus-factor risk",
+        "One-Day PoC evidence is not production audit evidence",
+        "One-Day PoC handoff is not customer-environment verification",
+        "Provider latency/cost is not measured unless providers are intentionally enabled",
     ]
     for boundary in required_boundaries:
         assert boundary in text
@@ -127,3 +133,37 @@ def test_reviewer_entrypoint_keeps_observe_mode_appendix() -> None:
     assert "observe_mode_proof_pack.md" in text
     assert "/dev/mission-fixture" in text
     assert "Observe Mode runtime is not enabled" in text
+
+
+def test_reviewer_entrypoint_includes_one_day_poc_evidence_suite() -> None:
+    text = _entrypoint_text()
+    for phrase in [
+        "One-Day PoC Evidence Pack",
+        "One-Day PoC Operator Runbook",
+        "One-Day PoC Reviewer Handoff Template",
+        "Evidence Pack",
+        "Operator Runbook",
+        "Reviewer Handoff Template",
+    ]:
+        assert phrase in text
+
+
+def test_reviewer_entrypoint_validation_commands_include_poc_doc_guardrails() -> None:
+    text = _entrypoint_text()
+    commands_and_paths = [
+        (
+            "pytest -q veritas_os/tests/test_one_day_poc_evidence_pack_docs.py",
+            REPO_ROOT / "veritas_os/tests/test_one_day_poc_evidence_pack_docs.py",
+        ),
+        (
+            "pytest -q veritas_os/tests/test_one_day_poc_operator_runbook_docs.py",
+            REPO_ROOT / "veritas_os/tests/test_one_day_poc_operator_runbook_docs.py",
+        ),
+        (
+            "pytest -q veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py",
+            REPO_ROOT / "veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py",
+        ),
+    ]
+    for command, path in commands_and_paths:
+        assert command in text
+        assert path.exists()


### PR DESCRIPTION
### Motivation

- Surface the One-Day PoC evidence checklist, operator runbook, and reviewer handoff template in the main reviewer entry point so reviewers know what to inspect and how to package PoC evidence. 
- Ensure the reviewer entrypoint enforces doc link formats and non-claim guardrails by adding automated checks that these new artifacts and recommended pytest commands are present. 

### Description

- Updated `docs/REVIEWER_ENTRYPOINT.md` to add links and guidance for the `en/poc/one-day-poc-evidence-pack.md`, `en/poc/one-day-poc-operator-runbook.md`, and `en/poc/one-day-poc-reviewer-handoff-template.md` resources, and adjusted several link formats for consistency. 
- Expanded the 10-minute and 30-minute reviewer paths, the "What to verify first" table, the "Current proof assets" list, the recommended validation commands block, and the reviewer checklist to reference the new PoC artifacts and doc guardrails. 
- Added assertions in `veritas_os/tests/test_reviewer_entrypoint_current_path.py` to require the new PoC doc links, non-claim boundary phrases, and the presence of the corresponding `pytest` command lines and files. 

### Testing

- Ran `pytest -q veritas_os/tests/test_reviewer_entrypoint_current_path.py`, which executed the updated link/phrase/command assertions and succeeded. 
- Existing reviewer entrypoint section presence checks were re-run as part of the same test and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff75b39c10832691e83ab1feeab9a8)