### PR TITLE
Add CI guard for Bind coverage evidence freshness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,9 @@ jobs:
           python -m pip install -r veritas_os/requirements.txt
           python -m pip install pytest httpx anyio
 
+      - name: "[Tier 1] Check bind coverage evidence freshness"
+        run: python scripts/governance/check_bind_coverage_evidence_freshness.py
+
       - name: "[Tier 1] Run governance smoke tests"
         run: |
           set -euxo pipefail

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST_MARKEXPR ?= not slow
 COVERAGE_XML ?= coverage.xml
 COVERAGE_HTML_DIR ?= coverage-html
 
-.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision
+.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence
 
 # ── Setup & Development ──────────────────────────────────────────────────
 
@@ -272,3 +272,10 @@ drill-recovery-ci:
 
 check-bilingual-docs:
 	@python scripts/quality/check_bilingual_docs.py
+
+
+bind-coverage-evidence:
+	python scripts/governance/export_bind_coverage_evidence.py
+
+check-bind-coverage-evidence:
+	python scripts/governance/check_bind_coverage_evidence_freshness.py

--- a/docs/en/validation/bind-coverage-evidence.latest.md
+++ b/docs/en/validation/bind-coverage-evidence.latest.md
@@ -50,6 +50,10 @@ This artifact summarizes FastAPI runtime route classification against the canoni
 - Bind-governed routes are the routes currently wired to the Bind target catalog.
 - Audited exemptions require periodic governance review.
 
+## CI freshness guard
+- CI checks these artifacts for freshness against current API routes and bind coverage sources.
+- If this check fails, rerun the generator command below and commit both artifacts.
+
 ## How to regenerate
 ```bash
 python scripts/governance/export_bind_coverage_evidence.py

--- a/scripts/governance/check_bind_coverage_evidence_freshness.py
+++ b/scripts/governance/check_bind_coverage_evidence_freshness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from scripts.governance.export_bind_coverage_evidence import (
     OUTPUT_JSON,
@@ -16,6 +17,24 @@ FIXED_GENERATED_AT = "1970-01-01T00:00:00+00:00"
 REGENERATE_COMMAND = "python scripts/governance/export_bind_coverage_evidence.py"
 
 
+def _load_json_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Load JSON object from path, returning a user-safe error reason on failure."""
+
+    try:
+        raw_payload = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"missing or unreadable file: {exc}"
+
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON: {exc.msg}"
+
+    if not isinstance(payload, dict):
+        return None, "JSON payload is not an object"
+    return payload, None
+
+
 def compare_bind_coverage_evidence(
     committed_json: Path,
     committed_md: Path,
@@ -25,14 +44,43 @@ def compare_bind_coverage_evidence(
     """Return stale artifact filenames when committed and generated outputs differ."""
 
     stale_files: list[str] = []
-    committed_json_payload = json.loads(committed_json.read_text(encoding="utf-8"))
-    generated_json_payload = json.loads(generated_json.read_text(encoding="utf-8"))
-    committed_json_payload["generated_at"] = FIXED_GENERATED_AT
-    generated_json_payload["generated_at"] = FIXED_GENERATED_AT
-    if committed_json_payload != generated_json_payload:
+    committed_json_payload, committed_json_error = _load_json_object(committed_json)
+    generated_json_payload, generated_json_error = _load_json_object(generated_json)
+    if committed_json_error:
+        print(f"- {committed_json}: {committed_json_error}")
         stale_files.append(str(committed_json))
-    if committed_md.read_text(encoding="utf-8") != generated_md.read_text(encoding="utf-8"):
+    if generated_json_error:
+        print(f"- {generated_json}: {generated_json_error}")
+        stale_files.append(str(committed_json))
+
+    if committed_json_payload and generated_json_payload:
+        committed_json_payload["generated_at"] = FIXED_GENERATED_AT
+        generated_json_payload["generated_at"] = FIXED_GENERATED_AT
+        if committed_json_payload != generated_json_payload:
+            stale_files.append(str(committed_json))
+
+    try:
+        committed_md_payload = committed_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"- {committed_md}: missing or unreadable file: {exc}")
         stale_files.append(str(committed_md))
+        committed_md_payload = None
+
+    try:
+        generated_md_payload = generated_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"- {generated_md}: missing or unreadable file: {exc}")
+        stale_files.append(str(committed_md))
+        generated_md_payload = None
+
+    if (
+        committed_md_payload is not None
+        and generated_md_payload is not None
+        and committed_md_payload != generated_md_payload
+    ):
+        stale_files.append(str(committed_md))
+
+    stale_files = sorted(set(stale_files))
     return stale_files
 
 

--- a/scripts/governance/check_bind_coverage_evidence_freshness.py
+++ b/scripts/governance/check_bind_coverage_evidence_freshness.py
@@ -1,0 +1,80 @@
+"""Check bind coverage evidence artifacts are fresh against current sources."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from scripts.governance.export_bind_coverage_evidence import (
+    OUTPUT_JSON,
+    OUTPUT_MD,
+    write_bind_coverage_evidence,
+)
+
+FIXED_GENERATED_AT = "1970-01-01T00:00:00+00:00"
+REGENERATE_COMMAND = "python scripts/governance/export_bind_coverage_evidence.py"
+
+
+def compare_bind_coverage_evidence(
+    committed_json: Path,
+    committed_md: Path,
+    generated_json: Path,
+    generated_md: Path,
+) -> list[str]:
+    """Return stale artifact filenames when committed and generated outputs differ."""
+
+    stale_files: list[str] = []
+    committed_json_payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    generated_json_payload = json.loads(generated_json.read_text(encoding="utf-8"))
+    committed_json_payload["generated_at"] = FIXED_GENERATED_AT
+    generated_json_payload["generated_at"] = FIXED_GENERATED_AT
+    if committed_json_payload != generated_json_payload:
+        stale_files.append(str(committed_json))
+    if committed_md.read_text(encoding="utf-8") != generated_md.read_text(encoding="utf-8"):
+        stale_files.append(str(committed_md))
+    return stale_files
+
+
+def check_bind_coverage_evidence_freshness(
+    committed_json: Path = OUTPUT_JSON,
+    committed_md: Path = OUTPUT_MD,
+) -> int:
+    """Return process-compatible status code for bind coverage evidence freshness."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_root = Path(tmp_dir)
+        generated_json = tmp_root / committed_json.name
+        generated_md = tmp_root / committed_md.name
+        write_bind_coverage_evidence(
+            json_path=generated_json,
+            markdown_path=generated_md,
+            generated_at=FIXED_GENERATED_AT,
+        )
+        stale_files = compare_bind_coverage_evidence(
+            committed_json=committed_json,
+            committed_md=committed_md,
+            generated_json=generated_json,
+            generated_md=generated_md,
+        )
+
+    if stale_files:
+        print("Bind coverage evidence artifacts are stale.")
+        print("Changed files:")
+        for file_path in stale_files:
+            print(f"- {file_path}")
+        print(f"Regenerate with: {REGENERATE_COMMAND}")
+        return 1
+
+    print("Bind coverage evidence artifacts are fresh.")
+    return 0
+
+
+def main() -> None:
+    """CLI entrypoint for freshness checks."""
+
+    raise SystemExit(check_bind_coverage_evidence_freshness())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/governance/export_bind_coverage_evidence.py
+++ b/scripts/governance/export_bind_coverage_evidence.py
@@ -39,7 +39,7 @@ def _runtime_api_routes() -> list[tuple[str, str]]:
     return sorted(routes, key=lambda item: (item[0], item[1]))
 
 
-def generate_bind_coverage_evidence() -> dict[str, Any]:
+def generate_bind_coverage_evidence(generated_at: str | None = None) -> dict[str, Any]:
     """Build bind coverage evidence payload from runtime routes + registry."""
 
     runtime_routes = _runtime_api_routes()
@@ -107,7 +107,7 @@ def generate_bind_coverage_evidence() -> dict[str, Any]:
 
     return {
         "schema_version": "bind_coverage_evidence.v1",
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
         "total_runtime_routes": len(route_rows),
         "total_effect_bearing_routes": len(effect_routes),
         "classified_routes": len(route_rows) - len(unclassified),
@@ -135,7 +135,7 @@ def generate_bind_coverage_evidence() -> dict[str, Any]:
     }
 
 
-def _render_markdown(evidence: dict[str, Any]) -> str:
+def render_bind_coverage_markdown(evidence: dict[str, Any]) -> str:
     """Render markdown summary from evidence payload."""
 
     lines: list[str] = [
@@ -206,6 +206,10 @@ def _render_markdown(evidence: dict[str, Any]) -> str:
             "- Bind-governed routes are the routes currently wired to the Bind target catalog.",
             "- Audited exemptions require periodic governance review.",
             "",
+            "## CI freshness guard",
+            "- CI checks these artifacts for freshness against current API routes and bind coverage sources.",
+            "- If this check fails, rerun the generator command below and commit both artifacts.",
+            "",
             "## How to regenerate",
             "```bash",
             "python scripts/governance/export_bind_coverage_evidence.py",
@@ -220,10 +224,11 @@ def _render_markdown(evidence: dict[str, Any]) -> str:
 def write_bind_coverage_evidence(
     json_path: Path = OUTPUT_JSON,
     markdown_path: Path = OUTPUT_MD,
+    generated_at: str | None = None,
 ) -> dict[str, Any]:
     """Generate and write bind coverage evidence JSON and markdown artifacts."""
 
-    evidence = generate_bind_coverage_evidence()
+    evidence = generate_bind_coverage_evidence(generated_at=generated_at)
     json_path.parent.mkdir(parents=True, exist_ok=True)
     markdown_path.parent.mkdir(parents=True, exist_ok=True)
     json_payload = json.dumps(
@@ -231,7 +236,7 @@ def write_bind_coverage_evidence(
         indent=2,
         sort_keys=True,
     ) + "\n"
-    markdown_payload = _render_markdown(evidence) + "\n"
+    markdown_payload = render_bind_coverage_markdown(evidence) + "\n"
 
     json_path.write_text(json_payload, encoding="utf-8")
     markdown_path.write_text(markdown_payload, encoding="utf-8")
@@ -241,7 +246,7 @@ def write_bind_coverage_evidence(
 def main() -> None:
     """CLI entrypoint for artifact generation."""
 
-    write_bind_coverage_evidence()
+    write_bind_coverage_evidence(generated_at=None)
 
 
 if __name__ == "__main__":

--- a/scripts/governance/export_bind_coverage_evidence.py
+++ b/scripts/governance/export_bind_coverage_evidence.py
@@ -27,6 +27,18 @@ OUTPUT_JSON = REPO_ROOT / "docs/en/validation/bind-coverage-evidence.latest.json
 OUTPUT_MD = REPO_ROOT / "docs/en/validation/bind-coverage-evidence.latest.md"
 
 
+def _resolve_generated_at(generated_at: str | None) -> str:
+    """Resolve generated_at with explicit validation for deterministic workflows."""
+
+    if generated_at is None:
+        return datetime.now(timezone.utc).isoformat()
+    if not str(generated_at).strip():
+        raise ValueError(
+            "generated_at must be a non-empty ISO-8601 timestamp when provided"
+        )
+    return generated_at
+
+
 def _runtime_api_routes() -> list[tuple[str, str]]:
     routes: list[tuple[str, str]] = []
     for route in app.routes:
@@ -107,7 +119,7 @@ def generate_bind_coverage_evidence(generated_at: str | None = None) -> dict[str
 
     return {
         "schema_version": "bind_coverage_evidence.v1",
-        "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
+        "generated_at": _resolve_generated_at(generated_at),
         "total_runtime_routes": len(route_rows),
         "total_effect_bearing_routes": len(effect_routes),
         "classified_routes": len(route_rows) - len(unclassified),

--- a/veritas_os/tests/test_bind_coverage_evidence_artifact.py
+++ b/veritas_os/tests/test_bind_coverage_evidence_artifact.py
@@ -129,7 +129,7 @@ def test_non_catalog_registry_error_forces_failed_status(monkeypatch) -> None:
     )
 
     evidence = evidence_module.generate_bind_coverage_evidence()
-    markdown = evidence_module._render_markdown(evidence)
+    markdown = evidence_module.render_bind_coverage_markdown(evidence)
 
     assert evidence["registry_errors"] == ["duplicate bind coverage entry: POST /x"]
     assert evidence["status"] == "failed"
@@ -168,3 +168,18 @@ def test_effect_route_unclassified_forces_failed_status(monkeypatch) -> None:
 
     assert evidence["unclassified_routes"]
     assert evidence["status"] == "failed"
+
+
+def test_deterministic_generated_at_produces_stable_payloads() -> None:
+    """A fixed generated_at must produce stable JSON and markdown outputs."""
+    fixed_generated_at = "1970-01-01T00:00:00+00:00"
+
+    first = evidence_module.generate_bind_coverage_evidence(generated_at=fixed_generated_at)
+    second = evidence_module.generate_bind_coverage_evidence(generated_at=fixed_generated_at)
+
+    assert first == second
+    assert first["generated_at"] == fixed_generated_at
+
+    first_markdown = evidence_module.render_bind_coverage_markdown(first)
+    second_markdown = evidence_module.render_bind_coverage_markdown(second)
+    assert first_markdown == second_markdown

--- a/veritas_os/tests/test_bind_coverage_evidence_artifact.py
+++ b/veritas_os/tests/test_bind_coverage_evidence_artifact.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 import scripts.governance.export_bind_coverage_evidence as evidence_module
 from scripts.governance.export_bind_coverage_evidence import (
     EFFECT_BEARING_METHODS,
@@ -183,3 +185,15 @@ def test_deterministic_generated_at_produces_stable_payloads() -> None:
     first_markdown = evidence_module.render_bind_coverage_markdown(first)
     second_markdown = evidence_module.render_bind_coverage_markdown(second)
     assert first_markdown == second_markdown
+
+
+def test_generated_at_empty_string_raises_value_error() -> None:
+    """Empty generated_at should fail fast to avoid ambiguous timestamp fallback."""
+    with pytest.raises(ValueError, match="generated_at must be a non-empty"):
+        evidence_module.generate_bind_coverage_evidence(generated_at="")
+
+
+def test_generated_at_whitespace_raises_value_error() -> None:
+    """Whitespace-only generated_at should fail fast to preserve determinism."""
+    with pytest.raises(ValueError, match="generated_at must be a non-empty"):
+        evidence_module.generate_bind_coverage_evidence(generated_at="   ")

--- a/veritas_os/tests/test_bind_coverage_evidence_freshness.py
+++ b/veritas_os/tests/test_bind_coverage_evidence_freshness.py
@@ -1,0 +1,72 @@
+"""Tests for bind coverage evidence freshness guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.governance.check_bind_coverage_evidence_freshness import (
+    FIXED_GENERATED_AT,
+    REGENERATE_COMMAND,
+    check_bind_coverage_evidence_freshness,
+)
+from scripts.governance.export_bind_coverage_evidence import write_bind_coverage_evidence
+
+
+def _write_committed_artifacts(directory: Path, generated_at: str) -> tuple[Path, Path]:
+    committed_json = directory / "bind-coverage-evidence.latest.json"
+    committed_md = directory / "bind-coverage-evidence.latest.md"
+    write_bind_coverage_evidence(
+        json_path=committed_json,
+        markdown_path=committed_md,
+        generated_at=generated_at,
+    )
+    return committed_json, committed_md
+
+
+def test_fresh_artifacts_exit_zero(tmp_path: Path, capsys) -> None:
+    """Fresh artifacts should produce a success status."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 0
+    assert "Bind coverage evidence artifacts are fresh." in output
+
+
+def test_stale_json_fails_with_regenerate_message(tmp_path: Path, capsys) -> None:
+    """JSON drift should fail and print regenerate guidance."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_json.write_text('{"stale": true}\n', encoding="utf-8")
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert str(committed_json) in output
+    assert REGENERATE_COMMAND in output
+
+
+def test_stale_markdown_fails_with_regenerate_message(tmp_path: Path, capsys) -> None:
+    """Markdown drift should fail and print regenerate guidance."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_md.write_text("# stale\n", encoding="utf-8")
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert str(committed_md) in output
+    assert REGENERATE_COMMAND in output
+
+
+def test_generated_at_only_difference_is_not_stale(tmp_path: Path) -> None:
+    """Freshness check should normalize generated_at by deterministic regeneration."""
+    committed_json, committed_md = _write_committed_artifacts(
+        tmp_path,
+        "2026-01-01T00:00:00+00:00",
+    )
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    assert result == 0

--- a/veritas_os/tests/test_bind_coverage_evidence_freshness.py
+++ b/veritas_os/tests/test_bind_coverage_evidence_freshness.py
@@ -70,3 +70,55 @@ def test_generated_at_only_difference_is_not_stale(tmp_path: Path) -> None:
 
     result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
     assert result == 0
+
+
+def test_missing_committed_json_is_stale(tmp_path: Path, capsys) -> None:
+    """Missing committed JSON should be stale without traceback."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_json.unlink()
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert REGENERATE_COMMAND in output
+
+
+def test_missing_committed_markdown_is_stale(tmp_path: Path, capsys) -> None:
+    """Missing committed Markdown should be stale without traceback."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_md.unlink()
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert REGENERATE_COMMAND in output
+
+
+def test_invalid_committed_json_is_stale(tmp_path: Path, capsys) -> None:
+    """Invalid committed JSON should be stale without traceback."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_json.write_text("{invalid", encoding="utf-8")
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert REGENERATE_COMMAND in output
+
+
+def test_non_object_committed_json_is_stale(tmp_path: Path, capsys) -> None:
+    """Non-object committed JSON should be stale without traceback."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_json.write_text("[]\n", encoding="utf-8")
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert REGENERATE_COMMAND in output


### PR DESCRIPTION
### Motivation
- Prevent reviewer-facing bind coverage evidence artifacts from drifting when API routes, bind coverage registry, or bind target catalog change by adding a CI freshness guard. 
- Provide a deterministic regeneration path so CI can reliably detect stale committed artifacts without changing runtime behavior.

### Description
- Exposed generator APIs in `scripts/governance/export_bind_coverage_evidence.py`: `generate_bind_coverage_evidence(generated_at: str | None = None)`, `render_bind_coverage_markdown(evidence: dict)`, and `write_bind_coverage_evidence(..., generated_at: str | None = None)`, preserving the existing CLI `python scripts/governance/export_bind_coverage_evidence.py` behavior. 
- Added `scripts/governance/check_bind_coverage_evidence_freshness.py` which regenerates artifacts in a temporary directory using a fixed timestamp (`1970-01-01T00:00:00+00:00`), compares JSON (normalizing `generated_at`) and Markdown outputs, prints actionable guidance (`Regenerate with: python scripts/governance/export_bind_coverage_evidence.py`) and returns `0`/`1` for fresh/stale artifacts. 
- Wired the freshness check into CI by adding a step to the `governance-smoke` job in `.github/workflows/main.yml` to run `python scripts/governance/check_bind_coverage_evidence_freshness.py`. 
- Added Make targets `bind-coverage-evidence` and `check-bind-coverage-evidence` to keep local workflows consistent. 
- Added tests `veritas_os/tests/test_bind_coverage_evidence_freshness.py` and extended `veritas_os/tests/test_bind_coverage_evidence_artifact.py` to assert deterministic `generated_at` behavior, freshness pass/fail semantics, and presence of regenerate guidance. 
- Made a minimal docs update to `docs/en/validation/bind-coverage-evidence.latest.md` noting the CI freshness guard and how to regenerate.

### Testing
- Static syntax/bytecode check succeeded via `/root/.pyenv/versions/3.12.13/bin/python -m compileall` for modified scripts and tests. (success)
- Running the generator (`python scripts/governance/export_bind_coverage_evidence.py`) in this environment failed due to missing runtime dependency `fastapi` (ModuleNotFoundError), so runtime execution could not be validated here. (failed)
- Attempted to run `pytest` for the affected tests but dependency installation failed (pip could not fetch packages in this environment), so the new unit tests were added but not executed end-to-end in this environment. (not executed)
- New tests added: `veritas_os/tests/test_bind_coverage_evidence_freshness.py` and deterministic assertions in `veritas_os/tests/test_bind_coverage_evidence_artifact.py` that validate JSON/Markdown stability and freshness-check behavior (ready for CI execution where dependencies are available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000213e20c8326a9ec707b19541cbd)