### PR TITLE
Add bind-coverage evidence freshness check, deterministic generator, and CI integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,9 @@ jobs:
           python -m pip install -r veritas_os/requirements.txt
           python -m pip install pytest httpx anyio
 
+      - name: "[Tier 1] Check bind coverage evidence freshness"
+        run: python scripts/governance/check_bind_coverage_evidence_freshness.py
+
       - name: "[Tier 1] Run governance smoke tests"
         run: |
           set -euxo pipefail

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST_MARKEXPR ?= not slow
 COVERAGE_XML ?= coverage.xml
 COVERAGE_HTML_DIR ?= coverage-html
 
-.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision
+.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence
 
 # ── Setup & Development ──────────────────────────────────────────────────
 
@@ -272,3 +272,10 @@ drill-recovery-ci:
 
 check-bilingual-docs:
 	@python scripts/quality/check_bilingual_docs.py
+
+
+bind-coverage-evidence:
+	python scripts/governance/export_bind_coverage_evidence.py
+
+check-bind-coverage-evidence:
+	python scripts/governance/check_bind_coverage_evidence_freshness.py

--- a/docs/en/validation/bind-coverage-evidence.latest.md
+++ b/docs/en/validation/bind-coverage-evidence.latest.md
@@ -50,6 +50,10 @@ This artifact summarizes FastAPI runtime route classification against the canoni
 - Bind-governed routes are the routes currently wired to the Bind target catalog.
 - Audited exemptions require periodic governance review.
 
+## CI freshness guard
+- CI checks these artifacts for freshness against current API routes and bind coverage sources.
+- If this check fails, rerun the generator command below and commit both artifacts.
+
 ## How to regenerate
 ```bash
 python scripts/governance/export_bind_coverage_evidence.py

--- a/scripts/governance/check_bind_coverage_evidence_freshness.py
+++ b/scripts/governance/check_bind_coverage_evidence_freshness.py
@@ -1,0 +1,118 @@
+"""Check bind coverage evidence artifacts are fresh against current sources."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from scripts.governance.export_bind_coverage_evidence import (
+    OUTPUT_JSON,
+    OUTPUT_MD,
+    write_bind_coverage_evidence,
+)
+
+FIXED_GENERATED_AT = "1970-01-01T00:00:00+00:00"
+REGENERATE_COMMAND = "python scripts/governance/export_bind_coverage_evidence.py"
+
+
+def _normalize_generated_at_for_compare(
+    payload: dict[str, Any],
+    path: Path,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Normalize generated_at for comparison or return a structural drift reason."""
+
+    if "generated_at" not in payload:
+        return None, f"{path}: missing generated_at"
+
+    normalized = dict(payload)
+    normalized["generated_at"] = FIXED_GENERATED_AT
+    return normalized, None
+
+
+def compare_bind_coverage_evidence(
+    committed_json: Path,
+    committed_md: Path,
+    generated_json: Path,
+    generated_md: Path,
+) -> list[str]:
+    """Return stale artifact filenames when committed and generated outputs differ."""
+
+    stale_files: list[str] = []
+    try:
+        committed_json_payload = json.loads(committed_json.read_text(encoding="utf-8"))
+        generated_json_payload = json.loads(generated_json.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        stale_files.append(str(committed_json))
+        committed_json_payload = None
+        generated_json_payload = None
+
+    if not isinstance(committed_json_payload, dict):
+        stale_files.append(str(committed_json))
+        committed_json_payload = None
+    if not isinstance(generated_json_payload, dict):
+        stale_files.append(str(committed_json))
+        generated_json_payload = None
+
+    if committed_json_payload is not None and generated_json_payload is not None:
+        normalized_committed, committed_error = _normalize_generated_at_for_compare(
+            committed_json_payload,
+            committed_json,
+        )
+        normalized_generated, generated_error = _normalize_generated_at_for_compare(
+            generated_json_payload,
+            generated_json,
+        )
+        if committed_error or generated_error:
+            stale_files.append(str(committed_json))
+        elif normalized_committed != normalized_generated:
+            stale_files.append(str(committed_json))
+
+    if committed_md.read_text(encoding="utf-8") != generated_md.read_text(encoding="utf-8"):
+        stale_files.append(str(committed_md))
+    return sorted(set(stale_files))
+
+
+def check_bind_coverage_evidence_freshness(
+    committed_json: Path = OUTPUT_JSON,
+    committed_md: Path = OUTPUT_MD,
+) -> int:
+    """Return process-compatible status code for bind coverage evidence freshness."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_root = Path(tmp_dir)
+        generated_json = tmp_root / committed_json.name
+        generated_md = tmp_root / committed_md.name
+        write_bind_coverage_evidence(
+            json_path=generated_json,
+            markdown_path=generated_md,
+            generated_at=FIXED_GENERATED_AT,
+        )
+        stale_files = compare_bind_coverage_evidence(
+            committed_json=committed_json,
+            committed_md=committed_md,
+            generated_json=generated_json,
+            generated_md=generated_md,
+        )
+
+    if stale_files:
+        print("Bind coverage evidence artifacts are stale.")
+        print("Changed files:")
+        for file_path in stale_files:
+            print(f"- {file_path}")
+        print(f"Regenerate with: {REGENERATE_COMMAND}")
+        return 1
+
+    print("Bind coverage evidence artifacts are fresh.")
+    return 0
+
+
+def main() -> None:
+    """CLI entrypoint for freshness checks."""
+
+    raise SystemExit(check_bind_coverage_evidence_freshness())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/governance/check_bind_coverage_evidence_freshness.py
+++ b/scripts/governance/check_bind_coverage_evidence_freshness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,17 @@ def _normalize_generated_at_for_compare(
 
     if "generated_at" not in payload:
         return None, f"{path}: missing generated_at"
+
+    raw_generated_at = payload.get("generated_at")
+    if not isinstance(raw_generated_at, str):
+        return None, f"{path}: invalid generated_at"
+    normalized_generated_at = raw_generated_at.strip()
+    if not normalized_generated_at:
+        return None, f"{path}: invalid generated_at"
+    try:
+        datetime.fromisoformat(normalized_generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None, f"{path}: invalid generated_at"
 
     normalized = dict(payload)
     normalized["generated_at"] = FIXED_GENERATED_AT
@@ -83,7 +95,7 @@ def compare_bind_coverage_evidence(
     if committed_md_error:
         stale_files.append(str(committed_md))
     if generated_md_error:
-        stale_files.append(str(generated_md))
+        stale_files.append(str(committed_md))
     if (
         committed_md_text is not None
         and generated_md_text is not None

--- a/scripts/governance/check_bind_coverage_evidence_freshness.py
+++ b/scripts/governance/check_bind_coverage_evidence_freshness.py
@@ -31,6 +31,15 @@ def _normalize_generated_at_for_compare(
     return normalized, None
 
 
+def _read_text_or_error(path: Path) -> tuple[str | None, str | None]:
+    """Read UTF-8 text or return a compact error marker."""
+
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except OSError as exc:
+        return None, f"{path}: {exc.__class__.__name__}"
+
+
 def compare_bind_coverage_evidence(
     committed_json: Path,
     committed_md: Path,
@@ -69,7 +78,17 @@ def compare_bind_coverage_evidence(
         elif normalized_committed != normalized_generated:
             stale_files.append(str(committed_json))
 
-    if committed_md.read_text(encoding="utf-8") != generated_md.read_text(encoding="utf-8"):
+    committed_md_text, committed_md_error = _read_text_or_error(committed_md)
+    generated_md_text, generated_md_error = _read_text_or_error(generated_md)
+    if committed_md_error:
+        stale_files.append(str(committed_md))
+    if generated_md_error:
+        stale_files.append(str(generated_md))
+    if (
+        committed_md_text is not None
+        and generated_md_text is not None
+        and committed_md_text != generated_md_text
+    ):
         stale_files.append(str(committed_md))
     return sorted(set(stale_files))
 

--- a/scripts/governance/export_bind_coverage_evidence.py
+++ b/scripts/governance/export_bind_coverage_evidence.py
@@ -27,6 +27,27 @@ OUTPUT_JSON = REPO_ROOT / "docs/en/validation/bind-coverage-evidence.latest.json
 OUTPUT_MD = REPO_ROOT / "docs/en/validation/bind-coverage-evidence.latest.md"
 
 
+def _resolve_generated_at(generated_at: str | None) -> str:
+    """Resolve and validate generated_at for evidence generation."""
+
+    if generated_at is None:
+        return datetime.now(timezone.utc).isoformat()
+
+    value = str(generated_at).strip()
+    if not value:
+        raise ValueError(
+            "generated_at must be a non-empty ISO-8601 timestamp when provided"
+        )
+
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            "generated_at must be a non-empty ISO-8601 timestamp when provided"
+        ) from exc
+    return value
+
+
 def _runtime_api_routes() -> list[tuple[str, str]]:
     routes: list[tuple[str, str]] = []
     for route in app.routes:
@@ -39,7 +60,7 @@ def _runtime_api_routes() -> list[tuple[str, str]]:
     return sorted(routes, key=lambda item: (item[0], item[1]))
 
 
-def generate_bind_coverage_evidence() -> dict[str, Any]:
+def generate_bind_coverage_evidence(generated_at: str | None = None) -> dict[str, Any]:
     """Build bind coverage evidence payload from runtime routes + registry."""
 
     runtime_routes = _runtime_api_routes()
@@ -107,7 +128,7 @@ def generate_bind_coverage_evidence() -> dict[str, Any]:
 
     return {
         "schema_version": "bind_coverage_evidence.v1",
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": _resolve_generated_at(generated_at),
         "total_runtime_routes": len(route_rows),
         "total_effect_bearing_routes": len(effect_routes),
         "classified_routes": len(route_rows) - len(unclassified),
@@ -135,7 +156,7 @@ def generate_bind_coverage_evidence() -> dict[str, Any]:
     }
 
 
-def _render_markdown(evidence: dict[str, Any]) -> str:
+def render_bind_coverage_markdown(evidence: dict[str, Any]) -> str:
     """Render markdown summary from evidence payload."""
 
     lines: list[str] = [
@@ -206,6 +227,10 @@ def _render_markdown(evidence: dict[str, Any]) -> str:
             "- Bind-governed routes are the routes currently wired to the Bind target catalog.",
             "- Audited exemptions require periodic governance review.",
             "",
+            "## CI freshness guard",
+            "- CI checks these artifacts for freshness against current API routes and bind coverage sources.",
+            "- If this check fails, rerun the generator command below and commit both artifacts.",
+            "",
             "## How to regenerate",
             "```bash",
             "python scripts/governance/export_bind_coverage_evidence.py",
@@ -220,10 +245,11 @@ def _render_markdown(evidence: dict[str, Any]) -> str:
 def write_bind_coverage_evidence(
     json_path: Path = OUTPUT_JSON,
     markdown_path: Path = OUTPUT_MD,
+    generated_at: str | None = None,
 ) -> dict[str, Any]:
     """Generate and write bind coverage evidence JSON and markdown artifacts."""
 
-    evidence = generate_bind_coverage_evidence()
+    evidence = generate_bind_coverage_evidence(generated_at=generated_at)
     json_path.parent.mkdir(parents=True, exist_ok=True)
     markdown_path.parent.mkdir(parents=True, exist_ok=True)
     json_payload = json.dumps(
@@ -231,7 +257,7 @@ def write_bind_coverage_evidence(
         indent=2,
         sort_keys=True,
     ) + "\n"
-    markdown_payload = _render_markdown(evidence) + "\n"
+    markdown_payload = render_bind_coverage_markdown(evidence) + "\n"
 
     json_path.write_text(json_payload, encoding="utf-8")
     markdown_path.write_text(markdown_payload, encoding="utf-8")
@@ -241,7 +267,7 @@ def write_bind_coverage_evidence(
 def main() -> None:
     """CLI entrypoint for artifact generation."""
 
-    write_bind_coverage_evidence()
+    write_bind_coverage_evidence(generated_at=None)
 
 
 if __name__ == "__main__":

--- a/scripts/governance/export_bind_coverage_evidence.py
+++ b/scripts/governance/export_bind_coverage_evidence.py
@@ -267,7 +267,7 @@ def write_bind_coverage_evidence(
 def main() -> None:
     """CLI entrypoint for artifact generation."""
 
-    write_bind_coverage_evidence(generated_at=None)
+    write_bind_coverage_evidence()
 
 
 if __name__ == "__main__":

--- a/veritas_os/tests/test_bind_coverage_evidence_artifact.py
+++ b/veritas_os/tests/test_bind_coverage_evidence_artifact.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 import scripts.governance.export_bind_coverage_evidence as evidence_module
 from scripts.governance.export_bind_coverage_evidence import (
     EFFECT_BEARING_METHODS,
@@ -129,7 +131,7 @@ def test_non_catalog_registry_error_forces_failed_status(monkeypatch) -> None:
     )
 
     evidence = evidence_module.generate_bind_coverage_evidence()
-    markdown = evidence_module._render_markdown(evidence)
+    markdown = evidence_module.render_bind_coverage_markdown(evidence)
 
     assert evidence["registry_errors"] == ["duplicate bind coverage entry: POST /x"]
     assert evidence["status"] == "failed"
@@ -168,3 +170,44 @@ def test_effect_route_unclassified_forces_failed_status(monkeypatch) -> None:
 
     assert evidence["unclassified_routes"]
     assert evidence["status"] == "failed"
+
+
+def test_deterministic_generated_at_produces_stable_payloads() -> None:
+    """A fixed generated_at must produce stable JSON and markdown outputs."""
+    fixed_generated_at = "1970-01-01T00:00:00+00:00"
+
+    first = evidence_module.generate_bind_coverage_evidence(generated_at=fixed_generated_at)
+    second = evidence_module.generate_bind_coverage_evidence(generated_at=fixed_generated_at)
+
+    assert first == second
+    assert first["generated_at"] == fixed_generated_at
+
+    first_markdown = evidence_module.render_bind_coverage_markdown(first)
+    second_markdown = evidence_module.render_bind_coverage_markdown(second)
+    assert first_markdown == second_markdown
+
+
+def test_generate_bind_coverage_evidence_rejects_empty_generated_at() -> None:
+    """Empty generated_at should raise ValueError."""
+    with pytest.raises(ValueError, match="ISO-8601"):
+        evidence_module.generate_bind_coverage_evidence(generated_at="")
+
+
+def test_generate_bind_coverage_evidence_rejects_whitespace_generated_at() -> None:
+    """Whitespace-only generated_at should raise ValueError."""
+    with pytest.raises(ValueError, match="ISO-8601"):
+        evidence_module.generate_bind_coverage_evidence(generated_at="   ")
+
+
+def test_generate_bind_coverage_evidence_rejects_invalid_generated_at() -> None:
+    """Non-ISO generated_at should raise ValueError."""
+    with pytest.raises(ValueError, match="ISO-8601"):
+        evidence_module.generate_bind_coverage_evidence(generated_at="not-a-date")
+
+
+def test_generate_bind_coverage_evidence_accepts_iso_z_generated_at() -> None:
+    """ISO timestamp with Z suffix should pass validation."""
+    evidence = evidence_module.generate_bind_coverage_evidence(
+        generated_at="1970-01-01T00:00:00Z"
+    )
+    assert evidence["generated_at"] == "1970-01-01T00:00:00Z"

--- a/veritas_os/tests/test_bind_coverage_evidence_freshness.py
+++ b/veritas_os/tests/test_bind_coverage_evidence_freshness.py
@@ -143,3 +143,33 @@ def test_non_dict_json_is_stale(tmp_path: Path) -> None:
         generated_md=generated_md,
     )
     assert str(committed_json) in stale_files
+
+
+def test_missing_committed_markdown_is_stale(tmp_path: Path, capsys) -> None:
+    """Missing committed markdown should be stale without traceback."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_md.unlink()
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert REGENERATE_COMMAND in output
+    assert "Traceback" not in output
+
+
+def test_missing_generated_markdown_is_stale(tmp_path: Path) -> None:
+    """Missing regenerated markdown should be treated as stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    generated_json = tmp_path / "generated.json"
+    generated_md = tmp_path / "generated.md"
+    generated_json.write_text(committed_json.read_text(encoding="utf-8"), encoding="utf-8")
+
+    stale_files = compare_bind_coverage_evidence(
+        committed_json=committed_json,
+        committed_md=committed_md,
+        generated_json=generated_json,
+        generated_md=generated_md,
+    )
+    assert str(generated_md) in stale_files

--- a/veritas_os/tests/test_bind_coverage_evidence_freshness.py
+++ b/veritas_os/tests/test_bind_coverage_evidence_freshness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from scripts.governance.check_bind_coverage_evidence_freshness import (
@@ -172,4 +173,88 @@ def test_missing_generated_markdown_is_stale(tmp_path: Path) -> None:
         generated_json=generated_json,
         generated_md=generated_md,
     )
-    assert str(generated_md) in stale_files
+    assert str(committed_md) in stale_files
+    assert str(generated_md) not in stale_files
+
+
+def test_empty_generated_at_in_committed_json_is_stale(tmp_path: Path, capsys) -> None:
+    """Empty generated_at in committed JSON should be stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["generated_at"] = ""
+    committed_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert REGENERATE_COMMAND in output
+    assert "Traceback" not in output
+
+
+def test_whitespace_generated_at_in_committed_json_is_stale(tmp_path: Path) -> None:
+    """Whitespace generated_at in committed JSON should be stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["generated_at"] = "   "
+    committed_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    assert result == 1
+
+
+def test_invalid_generated_at_in_committed_json_is_stale(tmp_path: Path) -> None:
+    """Invalid generated_at in committed JSON should be stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["generated_at"] = "not-a-date"
+    committed_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    assert result == 1
+
+
+def test_iso_z_generated_at_in_committed_json_is_not_stale(tmp_path: Path) -> None:
+    """Valid ISO Z generated_at should not be stale when content otherwise matches."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["generated_at"] = "1970-01-01T00:00:00Z"
+    committed_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    assert result == 0
+
+
+def test_invalid_generated_at_in_generated_json_is_stale(tmp_path: Path) -> None:
+    """Invalid generated_at in regenerated JSON should mark committed JSON stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    generated_json = tmp_path / "generated.json"
+    generated_md = tmp_path / "generated.md"
+    generated_payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    generated_payload["generated_at"] = "not-a-date"
+    generated_json.write_text(
+        json.dumps(generated_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    generated_md.write_text(committed_md.read_text(encoding="utf-8"), encoding="utf-8")
+
+    stale_files = compare_bind_coverage_evidence(
+        committed_json=committed_json,
+        committed_md=committed_md,
+        generated_json=generated_json,
+        generated_md=generated_md,
+    )
+    assert str(committed_json) in stale_files

--- a/veritas_os/tests/test_bind_coverage_evidence_freshness.py
+++ b/veritas_os/tests/test_bind_coverage_evidence_freshness.py
@@ -1,0 +1,145 @@
+"""Tests for bind coverage evidence freshness guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.governance.check_bind_coverage_evidence_freshness import (
+    FIXED_GENERATED_AT,
+    REGENERATE_COMMAND,
+    check_bind_coverage_evidence_freshness,
+    compare_bind_coverage_evidence,
+)
+from scripts.governance.export_bind_coverage_evidence import write_bind_coverage_evidence
+
+
+def _write_committed_artifacts(directory: Path, generated_at: str) -> tuple[Path, Path]:
+    committed_json = directory / "bind-coverage-evidence.latest.json"
+    committed_md = directory / "bind-coverage-evidence.latest.md"
+    write_bind_coverage_evidence(
+        json_path=committed_json,
+        markdown_path=committed_md,
+        generated_at=generated_at,
+    )
+    return committed_json, committed_md
+
+
+def test_fresh_artifacts_exit_zero(tmp_path: Path, capsys) -> None:
+    """Fresh artifacts should produce a success status."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 0
+    assert "Bind coverage evidence artifacts are fresh." in output
+
+
+def test_stale_json_fails_with_regenerate_message(tmp_path: Path, capsys) -> None:
+    """JSON drift should fail and print regenerate guidance."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_json.write_text('{"stale": true}\n', encoding="utf-8")
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert str(committed_json) in output
+    assert REGENERATE_COMMAND in output
+
+
+def test_stale_markdown_fails_with_regenerate_message(tmp_path: Path, capsys) -> None:
+    """Markdown drift should fail and print regenerate guidance."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_md.write_text("# stale\n", encoding="utf-8")
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert str(committed_md) in output
+    assert REGENERATE_COMMAND in output
+
+
+def test_generated_at_only_difference_is_not_stale(tmp_path: Path) -> None:
+    """Freshness check should normalize generated_at by deterministic regeneration."""
+    committed_json, committed_md = _write_committed_artifacts(
+        tmp_path,
+        "2026-01-01T00:00:00+00:00",
+    )
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    assert result == 0
+
+
+def test_missing_generated_at_in_committed_json_is_stale(
+    tmp_path: Path, capsys
+) -> None:
+    """Missing generated_at in committed JSON should be treated as stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    committed_json.write_text('{"schema_version": "bind_coverage_evidence.v1"}\n', encoding="utf-8")
+
+    result = check_bind_coverage_evidence_freshness(committed_json, committed_md)
+    output = capsys.readouterr().out
+
+    assert result == 1
+    assert "Bind coverage evidence artifacts are stale." in output
+    assert REGENERATE_COMMAND in output
+    assert "Traceback" not in output
+
+
+def test_missing_generated_at_in_generated_json_is_stale(tmp_path: Path) -> None:
+    """Missing generated_at in regenerated JSON should be stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    generated_json = tmp_path / "generated.json"
+    generated_md = tmp_path / "generated.md"
+    generated_json.write_text(
+        '{"schema_version": "bind_coverage_evidence.v1"}\n',
+        encoding="utf-8",
+    )
+    generated_md.write_text(committed_md.read_text(encoding="utf-8"), encoding="utf-8")
+
+    stale_files = compare_bind_coverage_evidence(
+        committed_json=committed_json,
+        committed_md=committed_md,
+        generated_json=generated_json,
+        generated_md=generated_md,
+    )
+    assert str(committed_json) in stale_files
+
+
+def test_invalid_committed_json_is_stale(tmp_path: Path) -> None:
+    """Invalid JSON should be treated as stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    generated_json = tmp_path / "generated.json"
+    generated_md = tmp_path / "generated.md"
+    committed_json.write_text("{invalid}\n", encoding="utf-8")
+    generated_json.write_text('{"generated_at":"1970-01-01T00:00:00+00:00"}\n', encoding="utf-8")
+    generated_md.write_text(committed_md.read_text(encoding="utf-8"), encoding="utf-8")
+
+    stale_files = compare_bind_coverage_evidence(
+        committed_json=committed_json,
+        committed_md=committed_md,
+        generated_json=generated_json,
+        generated_md=generated_md,
+    )
+    assert str(committed_json) in stale_files
+
+
+def test_non_dict_json_is_stale(tmp_path: Path) -> None:
+    """Non-dict JSON payload should be treated as stale."""
+    committed_json, committed_md = _write_committed_artifacts(tmp_path, FIXED_GENERATED_AT)
+    generated_json = tmp_path / "generated.json"
+    generated_md = tmp_path / "generated.md"
+    committed_json.write_text("[1, 2, 3]\n", encoding="utf-8")
+    generated_json.write_text("[1, 2, 3]\n", encoding="utf-8")
+    generated_md.write_text(committed_md.read_text(encoding="utf-8"), encoding="utf-8")
+
+    stale_files = compare_bind_coverage_evidence(
+        committed_json=committed_json,
+        committed_md=committed_md,
+        generated_json=generated_json,
+        generated_md=generated_md,
+    )
+    assert str(committed_json) in stale_files


### PR DESCRIPTION
### Motivation
- Ensure the committed bind coverage evidence artifacts in `docs/` remain fresh with respect to runtime routes and the bind target catalog to avoid undetected drift. 
- Make evidence generation deterministic for CI comparisons by allowing a fixed `generated_at` and validating provided timestamps. 
- Fail early in CI when evidence is stale so reviewers regenerate and commit authoritative artifacts.

### Description
- Add a freshness guard CLI `scripts/governance/check_bind_coverage_evidence_freshness.py` which regenerates artifacts with a fixed timestamp, compares JSON/Markdown outputs, and exits non-zero on differences while printing a `REGENERATE_COMMAND` hint. 
- Extend `scripts/governance/export_bind_coverage_evidence.py` to accept an optional `generated_at`, validate ISO-8601 timestamps, return deterministic payloads when fixed, and rename the markdown renderer to `render_bind_coverage_markdown`. 
- Add Makefile targets `bind-coverage-evidence` and `check-bind-coverage-evidence`, update CI workflow (`.github/workflows/main.yml`) to run the freshness check as a Tier 1 pre-smoke step, and add CI guidance to the evidence markdown documentation. 
- Add/adjust tests: update `veritas_os/tests/test_bind_coverage_evidence_artifact.py` to validate `generated_at` behavior and renderer rename, and add `veritas_os/tests/test_bind_coverage_evidence_freshness.py` to exercise the freshness-check logic and edge cases.

### Testing
- Ran the modified unit tests for bind coverage evidence: `pytest veritas_os/tests/test_bind_coverage_evidence_artifact.py` and the new freshness tests `pytest veritas_os/tests/test_bind_coverage_evidence_freshness.py`. 
- All added and modified tests completed successfully (assertions for deterministic `generated_at`, validation failure cases, and freshness detection passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000213e20c8326a9ec707b19541cbd)