### PR TITLE
Add CI-safe performance evidence exporter with markdown renderer and tests

### DIFF
--- a/scripts/performance/__init__.py
+++ b/scripts/performance/__init__.py
@@ -1,0 +1,15 @@
+"""Performance evidence exporter package."""
+
+from .export_performance_evidence import (
+    export_performance_evidence,
+    measure_latency,
+    percentile,
+    render_performance_markdown,
+)
+
+__all__ = [
+    "export_performance_evidence",
+    "measure_latency",
+    "percentile",
+    "render_performance_markdown",
+]

--- a/scripts/performance/export_performance_evidence.py
+++ b/scripts/performance/export_performance_evidence.py
@@ -22,14 +22,15 @@ class _HttpResult:
 def _parse_generated_at(generated_at: str | None) -> str:
     if generated_at is None:
         return datetime.now(timezone.utc).isoformat()
-    if generated_at.strip() == "":
+    value = str(generated_at).strip()
+    if value == "":
         raise ValueError("generated_at must be a non-empty ISO-8601 string")
-    candidate = generated_at.replace("Z", "+00:00")
+    candidate = value.replace("Z", "+00:00")
     try:
         datetime.fromisoformat(candidate)
     except ValueError as exc:
         raise ValueError("generated_at must be a valid ISO-8601 datetime") from exc
-    return generated_at
+    return value
 
 
 def percentile(values: list[float], pct: float) -> float:

--- a/scripts/performance/export_performance_evidence.py
+++ b/scripts/performance/export_performance_evidence.py
@@ -1,0 +1,193 @@
+"""Exporter for reviewer-facing performance evidence payloads.
+
+This module is intentionally CI-safe and avoids external dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import math
+from statistics import mean
+from time import perf_counter
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class _HttpResult:
+    status_code: int
+    body: str = ""
+
+
+def _parse_generated_at(generated_at: str | None) -> str:
+    if generated_at is None:
+        return datetime.now(timezone.utc).isoformat()
+    if generated_at.strip() == "":
+        raise ValueError("generated_at must be a non-empty ISO-8601 string")
+    candidate = generated_at.replace("Z", "+00:00")
+    try:
+        datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise ValueError("generated_at must be a valid ISO-8601 datetime") from exc
+    return generated_at
+
+
+def percentile(values: list[float], pct: float) -> float:
+    """Return nearest-rank percentile for inclusive pct range [0.0, 1.0]."""
+    if not values:
+        raise ValueError("values must not be empty")
+    if pct < 0.0 or pct > 1.0:
+        raise ValueError("pct must be between 0.0 and 1.0")
+    ordered = sorted(values)
+    rank = math.ceil(pct * len(ordered))
+    index = max(0, rank - 1)
+    return ordered[index]
+
+
+def _assert_http_status(result: _HttpResult) -> None:
+    if result.status_code != 200:
+        raise RuntimeError(f"unexpected status code: {result.status_code}")
+
+
+def measure_latency(name: str, fn: Callable[[], Any], sample_count: int) -> dict[str, Any]:
+    """Measure latency and convert exceptions into failed metric records."""
+    if sample_count <= 0:
+        raise ValueError("sample_count must be positive")
+
+    samples: list[float] = []
+    try:
+        for _ in range(sample_count):
+            started = perf_counter()
+            fn()
+            duration_ms = (perf_counter() - started) * 1000
+            samples.append(round(duration_ms, 6))
+    except Exception as exc:  # noqa: BLE001 - exported as structured failure
+        return {
+            "name": name,
+            "status": "failed",
+            "samples": samples,
+            "summary": None,
+            "notes": f"error_type={exc.__class__.__name__}",
+        }
+
+    return {
+        "name": name,
+        "status": "ok",
+        "samples": samples,
+        "summary": {
+            "avg_ms": round(mean(samples), 6),
+            "p50_ms": round(percentile(samples, 0.50), 6),
+            "p95_ms": round(percentile(samples, 0.95), 6),
+            "p99_ms": round(percentile(samples, 0.99), 6),
+        },
+        "notes": "",
+    }
+
+
+def export_performance_evidence(
+    *,
+    deterministic_fixture: bool,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Build performance evidence artifact payload for reviewers.
+
+    With deterministic_fixture enabled, no external service is called.
+    """
+    timestamp = _parse_generated_at(generated_at)
+
+    if deterministic_fixture:
+        measurement_mode = "deterministic_fixture"
+        sample_count = 3
+        warmup_count = 0
+
+        fixtures = {
+            "api_health_route": [8.1, 8.3, 8.2],
+            "trustlog_append_local": [3.1, 3.3, 3.2],
+            "bind_eval_local": [4.2, 4.1, 4.3],
+        }
+        metrics = [
+            {
+                "name": key,
+                "status": "ok",
+                "samples": vals,
+                "summary": {
+                    "avg_ms": round(mean(vals), 6),
+                    "p50_ms": round(percentile(vals, 0.50), 6),
+                    "p95_ms": round(percentile(vals, 0.95), 6),
+                    "p99_ms": round(percentile(vals, 0.99), 6),
+                },
+                "notes": "deterministic fixture; not production SLA",
+            }
+            for key, vals in fixtures.items()
+        ]
+    else:
+        measurement_mode = "not_measured"
+        sample_count = 0
+        warmup_count = 0
+        metrics = []
+
+    return {
+        "schema_version": "performance_evidence.v1",
+        "generated_at": timestamp,
+        "measurement_mode": measurement_mode,
+        "sample_count": sample_count,
+        "warmup_count": warmup_count,
+        "metrics": metrics,
+        "notes": [
+            "Reviewer-facing operational evidence only.",
+            "Not a production SLA statement.",
+        ],
+    }
+
+
+def _markdown_table_cell(value: Any) -> str:
+    """Escape markdown table cell separators and newlines."""
+    return str(value).replace("\r", " ").replace("\n", " ").replace("|", "\\|")
+
+
+def render_performance_markdown(payload: dict[str, Any]) -> str:
+    """Render markdown report for reviewers from payload."""
+    lines = [
+        "# Performance Evidence",
+        "",
+        "## Summary table",
+        "| Key | Value |",
+        "| --- | --- |",
+        f"| schema_version | {payload['schema_version']} |",
+        f"| generated_at | {payload['generated_at']} |",
+        f"| measurement_mode | {payload['measurement_mode']} |",
+        f"| sample_count | {payload['sample_count']} |",
+        f"| warmup_count | {payload['warmup_count']} |",
+        "",
+        "## Metrics table",
+        "| Metric | Status | Samples | p95_ms | Notes |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for metric in payload["metrics"]:
+        p95 = ""
+        if metric["summary"] is not None:
+            p95 = str(metric["summary"]["p95_ms"])
+        name = _markdown_table_cell(metric["name"])
+        status = _markdown_table_cell(metric["status"])
+        p95_cell = _markdown_table_cell(p95)
+        notes = _markdown_table_cell(metric["notes"])
+        lines.append(
+            f"| {name} | {status} | {len(metric['samples'])} | {p95_cell} | {notes} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation boundaries",
+            "- This evidence is for reviewer context and CI-safe checks.",
+            "- Figures are not production SLA claims.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "export_performance_evidence",
+    "measure_latency",
+    "percentile",
+    "render_performance_markdown",
+]

--- a/veritas_os/tests/test_performance_evidence_artifact.py
+++ b/veritas_os/tests/test_performance_evidence_artifact.py
@@ -1,0 +1,124 @@
+"""Tests for performance evidence exporter core."""
+
+import pytest
+
+from scripts.performance.export_performance_evidence import (
+    _HttpResult,
+    _assert_http_status,
+    export_performance_evidence,
+    measure_latency,
+    percentile,
+    render_performance_markdown,
+)
+
+
+def test_schema_version_and_fixture_counts() -> None:
+    payload = export_performance_evidence(deterministic_fixture=True)
+
+    assert payload["schema_version"] == "performance_evidence.v1"
+    assert payload["sample_count"] == 3
+    assert payload["warmup_count"] == 0
+    assert payload["measurement_mode"] == "deterministic_fixture"
+    for metric in payload["metrics"]:
+        assert len(metric["samples"]) == payload["sample_count"]
+
+
+def test_fixture_percentiles_are_numeric_and_rounded() -> None:
+    payload = export_performance_evidence(deterministic_fixture=True)
+    for metric in payload["metrics"]:
+        summary = metric["summary"]
+        assert isinstance(summary["p50_ms"], (float, int))
+        assert isinstance(summary["p95_ms"], (float, int))
+        assert isinstance(summary["p99_ms"], (float, int))
+        assert round(summary["p50_ms"], 6) == summary["p50_ms"]
+        assert round(summary["p95_ms"], 6) == summary["p95_ms"]
+        assert round(summary["p99_ms"], 6) == summary["p99_ms"]
+
+
+def test_generated_at_fixed_timestamp_reflected() -> None:
+    payload = export_performance_evidence(
+        deterministic_fixture=True,
+        generated_at="1970-01-01T00:00:00+00:00",
+    )
+    assert payload["generated_at"] == "1970-01-01T00:00:00+00:00"
+
+    payload_z = export_performance_evidence(
+        deterministic_fixture=True,
+        generated_at="1970-01-01T00:00:00Z",
+    )
+    assert payload_z["generated_at"] == "1970-01-01T00:00:00Z"
+
+
+def test_invalid_generated_at_raises_value_error() -> None:
+    for bad in ["", "   ", "not-a-date"]:
+        with pytest.raises(ValueError):
+            export_performance_evidence(deterministic_fixture=True, generated_at=bad)
+
+
+def test_percentile_boundaries_and_out_of_range() -> None:
+    values = [1.0, 2.0, 3.0]
+    assert percentile(values, 0.0) == 1.0
+    assert percentile(values, 1.0) == 3.0
+
+    for bad in (-0.1, 1.1):
+        with pytest.raises(ValueError):
+            percentile(values, bad)
+
+
+def test_assert_http_status_validation() -> None:
+    _assert_http_status(_HttpResult(status_code=200, body="ok"))
+
+    with pytest.raises(RuntimeError):
+        _assert_http_status(_HttpResult(status_code=500, body="internal-error"))
+
+
+def test_measure_latency_rejects_non_positive_sample_count() -> None:
+    with pytest.raises(ValueError):
+        measure_latency("bad", lambda: None, sample_count=0)
+    with pytest.raises(ValueError):
+        measure_latency("bad", lambda: None, sample_count=-1)
+
+
+def test_measure_latency_converts_runtime_error_to_failed_metric() -> None:
+    def fail() -> None:
+        raise RuntimeError("raw-response-body=secret")
+
+    metric = measure_latency("api_health", fail, sample_count=3)
+    assert metric["status"] == "failed"
+    assert "error_type=RuntimeError" in metric["notes"]
+    assert "raw-response-body" not in metric["notes"]
+
+
+def test_markdown_renderer_sections_and_trailing_newline() -> None:
+    payload = export_performance_evidence(
+        deterministic_fixture=True,
+        generated_at="1970-01-01T00:00:00+00:00",
+    )
+    markdown = render_performance_markdown(payload)
+
+    assert "## Summary table" in markdown
+    assert "## Metrics table" in markdown
+    assert "## Interpretation boundaries" in markdown
+    assert markdown.endswith("\n")
+    assert not markdown.endswith("\n\n")
+
+
+def test_markdown_renderer_escapes_metric_cells() -> None:
+    payload = export_performance_evidence(deterministic_fixture=True)
+    payload["metrics"] = [
+        {
+            "name": "metric|with|pipe",
+            "status": "ok",
+            "samples": [1.0, 1.1, 1.2],
+            "summary": {"p95_ms": 1.2},
+            "notes": "line1\nline2|pipe",
+        }
+    ]
+
+    markdown = render_performance_markdown(payload)
+
+    assert "metric\\|with\\|pipe" in markdown
+    assert "line1 line2\\|pipe" in markdown
+    assert "line1\nline2|pipe" not in markdown
+    assert markdown.endswith("\n")
+    assert not markdown.endswith("\n\n")

--- a/veritas_os/tests/test_performance_evidence_artifact.py
+++ b/veritas_os/tests/test_performance_evidence_artifact.py
@@ -49,6 +49,16 @@ def test_generated_at_fixed_timestamp_reflected() -> None:
     assert payload_z["generated_at"] == "1970-01-01T00:00:00Z"
 
 
+
+
+def test_generated_at_trims_surrounding_whitespace() -> None:
+    payload = export_performance_evidence(
+        deterministic_fixture=True,
+        generated_at=" 1970-01-01T00:00:00+00:00 ",
+    )
+    assert payload["generated_at"] == "1970-01-01T00:00:00+00:00"
+
+
 def test_invalid_generated_at_raises_value_error() -> None:
     for bad in ["", "   ", "not-a-date"]:
         with pytest.raises(ValueError):
@@ -122,3 +132,17 @@ def test_markdown_renderer_escapes_metric_cells() -> None:
     assert "line1\nline2|pipe" not in markdown
     assert markdown.endswith("\n")
     assert not markdown.endswith("\n\n")
+
+
+def test_noop_mode_returns_not_measured_without_metrics() -> None:
+    payload = export_performance_evidence(
+        deterministic_fixture=False,
+        generated_at="1970-01-01T00:00:00+00:00",
+    )
+
+    assert payload["schema_version"] == "performance_evidence.v1"
+    assert payload["measurement_mode"] == "not_measured"
+    assert payload["sample_count"] == 0
+    assert payload["warmup_count"] == 0
+    assert payload["metrics"] == []
+    assert payload["generated_at"] == "1970-01-01T00:00:00+00:00"


### PR DESCRIPTION
### Motivation
- Introduce a reviewer-facing, CI-safe performance evidence exporter to produce deterministic or no-op measurements for review context without external dependencies.
- Provide a lightweight way to capture and present latency samples and summaries suitable for inclusion in reviewer artifacts.

### Description
- Add a new `scripts.performance` package with `export_performance_evidence`, `measure_latency`, `percentile`, and `render_performance_markdown` exported via `__init__.py`.
- Implement `_HttpResult` dataclass, `_assert_http_status`, and `_parse_generated_at` helpers to validate inputs and failure modes, with validation of ISO-8601 `generated_at` values.
- Provide a deterministic fixture mode that returns precomputed sample sets and summaries, and a CI-safe path that avoids external calls when `deterministic_fixture=True`.
- Add markdown rendering with cell escaping via `_markdown_table_cell` to produce reviewer-facing reports and include interpretation boundaries in the output.

### Testing
- Added `veritas_os/tests/test_performance_evidence_artifact.py` with unit tests for schema and fixture counts, percentile behavior, `generated_at` validation, HTTP status assertion, `measure_latency` error conversion, and markdown escaping.
- Ran the test suite for the new module with `pytest veritas_os/tests/test_performance_evidence_artifact.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ac1fbdf083269adaab882baba8eb)