### PR TITLE
Add performance evidence freshness checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST_MARKEXPR ?= not slow
 COVERAGE_XML ?= coverage.xml
 COVERAGE_HTML_DIR ?= coverage-html
 
-.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence
+.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence
 
 # ── Setup & Development ──────────────────────────────────────────────────
 
@@ -283,3 +283,7 @@ check-bind-coverage-evidence:
 
 performance-evidence:
 	python -m scripts.performance.export_performance_evidence
+
+
+check-performance-evidence:
+	python -m scripts.performance.check_performance_evidence_freshness

--- a/scripts/performance/check_performance_evidence_freshness.py
+++ b/scripts/performance/check_performance_evidence_freshness.py
@@ -95,24 +95,34 @@ def check_performance_evidence_freshness(
 
     stale_files: list[Path] = []
     reasons: list[str] = []
+    committed_json_valid = False
+    generated_json_valid = False
+    committed_md_valid = False
+    generated_md_valid = False
 
     committed_json, committed_json_error = _load_json_or_error(resolved_json)
     if committed_json_error is not None:
         stale_files.append(resolved_json)
         reasons.append(f"{resolved_json}: failed to load JSON ({committed_json_error})")
     else:
-        for reason in _validate_json_payload(committed_json, "committed"):
+        committed_json_reasons = _validate_json_payload(committed_json, "committed")
+        for reason in committed_json_reasons:
             stale_files.append(resolved_json)
             reasons.append(f"{resolved_json}: {reason}")
+        if not committed_json_reasons:
+            committed_json_valid = True
 
     committed_md_text, committed_md_error = _read_text_or_error(resolved_md)
     if committed_md_error is not None:
         stale_files.append(resolved_md)
         reasons.append(f"{resolved_md}: failed to read markdown ({committed_md_error})")
     else:
-        for reason in _validate_markdown_text(committed_md_text, "committed"):
+        committed_md_reasons = _validate_markdown_text(committed_md_text, "committed")
+        for reason in committed_md_reasons:
             stale_files.append(resolved_md)
             reasons.append(f"{resolved_md}: {reason}")
+        if not committed_md_reasons:
+            committed_md_valid = True
 
     with TemporaryDirectory() as tmp_dir:
         generated_json_path = Path(tmp_dir) / "performance-evidence.latest.json"
@@ -140,9 +150,12 @@ def check_performance_evidence_freshness(
                 f"{resolved_json}: generated JSON invalid ({generated_json_error})"
             )
         else:
-            for reason in _validate_json_payload(generated_json, "generated"):
+            generated_json_reasons = _validate_json_payload(generated_json, "generated")
+            for reason in generated_json_reasons:
                 stale_files.append(resolved_json)
                 reasons.append(f"{resolved_json}: {reason}")
+            if not generated_json_reasons:
+                generated_json_valid = True
 
         generated_md_text, generated_md_error = _read_text_or_error(generated_md_path)
         if generated_md_error is not None:
@@ -151,19 +164,31 @@ def check_performance_evidence_freshness(
                 f"{resolved_md}: generated markdown invalid ({generated_md_error})"
             )
         else:
-            for reason in _validate_markdown_text(generated_md_text, "generated"):
+            generated_md_reasons = _validate_markdown_text(
+                generated_md_text,
+                "generated",
+            )
+            for reason in generated_md_reasons:
                 stale_files.append(resolved_md)
                 reasons.append(f"{resolved_md}: {reason}")
+            if not generated_md_reasons:
+                generated_md_valid = True
 
-        if committed_json is not None and generated_json is not None:
-            if committed_json != generated_json:
-                stale_files.append(resolved_json)
-                reasons.append(f"{resolved_json}: JSON payload mismatch")
+        if (
+            committed_json_valid
+            and generated_json_valid
+            and committed_json != generated_json
+        ):
+            stale_files.append(resolved_json)
+            reasons.append(f"{resolved_json}: JSON payload mismatch")
 
-        if committed_md_text is not None and generated_md_text is not None:
-            if committed_md_text != generated_md_text:
-                stale_files.append(resolved_md)
-                reasons.append(f"{resolved_md}: Markdown text mismatch")
+        if (
+            committed_md_valid
+            and generated_md_valid
+            and committed_md_text != generated_md_text
+        ):
+            stale_files.append(resolved_md)
+            reasons.append(f"{resolved_md}: Markdown text mismatch")
 
     unique_files = tuple(dict.fromkeys(stale_files))
     return FreshnessResult(

--- a/scripts/performance/check_performance_evidence_freshness.py
+++ b/scripts/performance/check_performance_evidence_freshness.py
@@ -1,0 +1,195 @@
+"""Check freshness of committed performance evidence artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+import json
+
+from scripts.performance.export_performance_evidence import OUTPUT_JSON, OUTPUT_MD
+from scripts.performance.export_performance_evidence import write_performance_evidence
+
+REGENERATE_COMMAND = "python -m scripts.performance.export_performance_evidence"
+REQUIRED_JSON_FIELDS = (
+    "schema_version",
+    "generated_at",
+    "measurement_mode",
+    "sample_count",
+    "warmup_count",
+    "metrics",
+    "notes",
+)
+
+
+@dataclass(frozen=True)
+class FreshnessResult:
+    """Result of freshness verification."""
+
+    fresh: bool
+    stale_files: tuple[Path, ...]
+    reasons: tuple[str, ...]
+
+
+def _read_text_or_error(path: Path) -> tuple[str | None, str | None]:
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, exc.__class__.__name__
+
+
+def _load_json_or_error(path: Path) -> tuple[Any | None, str | None]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        return None, exc.__class__.__name__
+
+
+def _validate_json_payload(payload: Any, label: str) -> list[str]:
+    reasons: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{label} JSON payload is not an object"]
+
+    for field in REQUIRED_JSON_FIELDS:
+        if field not in payload:
+            reasons.append(f"{label} missing required field {field}")
+
+    if payload.get("schema_version") != "performance_evidence.v1":
+        reasons.append(f"{label} schema_version must be performance_evidence.v1")
+    if not isinstance(payload.get("metrics"), list):
+        reasons.append(f"{label} metrics must be a list")
+    if not isinstance(payload.get("notes"), list):
+        reasons.append(f"{label} notes must be a list")
+    if not isinstance(payload.get("sample_count"), int):
+        reasons.append(f"{label} sample_count must be an int")
+    if not isinstance(payload.get("warmup_count"), int):
+        reasons.append(f"{label} warmup_count must be an int")
+    return reasons
+
+
+def _validate_markdown_text(text: str, label: str) -> list[str]:
+    reasons: list[str] = []
+    if not text.endswith("\n"):
+        reasons.append(f"{label} markdown trailing newline is invalid")
+    if text.endswith("\n\n"):
+        reasons.append(f"{label} markdown has double trailing newline")
+    if "# Performance Evidence" not in text:
+        reasons.append(f"{label} markdown missing '# Performance Evidence'")
+    if "## Interpretation boundaries" not in text:
+        reasons.append(f"{label} markdown missing '## Interpretation boundaries'")
+    if "not a production SLA" not in text:
+        reasons.append(f"{label} markdown missing 'not a production SLA'")
+    return reasons
+
+
+def check_performance_evidence_freshness(
+    committed_json_path: Path | None = None,
+    committed_markdown_path: Path | None = None,
+) -> FreshnessResult:
+    """Compare committed artifacts with regenerated exporter output."""
+    resolved_json = committed_json_path if committed_json_path is not None else OUTPUT_JSON
+    resolved_md = (
+        committed_markdown_path if committed_markdown_path is not None else OUTPUT_MD
+    )
+
+    stale_files: list[Path] = []
+    reasons: list[str] = []
+
+    committed_json, committed_json_error = _load_json_or_error(resolved_json)
+    if committed_json_error is not None:
+        stale_files.append(resolved_json)
+        reasons.append(f"{resolved_json}: failed to load JSON ({committed_json_error})")
+    else:
+        for reason in _validate_json_payload(committed_json, "committed"):
+            stale_files.append(resolved_json)
+            reasons.append(f"{resolved_json}: {reason}")
+
+    committed_md_text, committed_md_error = _read_text_or_error(resolved_md)
+    if committed_md_error is not None:
+        stale_files.append(resolved_md)
+        reasons.append(f"{resolved_md}: failed to read markdown ({committed_md_error})")
+    else:
+        for reason in _validate_markdown_text(committed_md_text, "committed"):
+            stale_files.append(resolved_md)
+            reasons.append(f"{resolved_md}: {reason}")
+
+    with TemporaryDirectory() as tmp_dir:
+        generated_json_path = Path(tmp_dir) / "performance-evidence.latest.json"
+        generated_md_path = Path(tmp_dir) / "performance-evidence.latest.md"
+
+        try:
+            write_performance_evidence(
+                json_path=generated_json_path,
+                markdown_path=generated_md_path,
+            )
+        except Exception as exc:  # noqa: BLE001
+            stale_files.append(resolved_json)
+            stale_files.append(resolved_md)
+            reasons.append(f"failed to generate artifacts ({exc.__class__.__name__})")
+            return FreshnessResult(
+                fresh=False,
+                stale_files=tuple(dict.fromkeys(stale_files)),
+                reasons=tuple(reasons),
+            )
+
+        generated_json, generated_json_error = _load_json_or_error(generated_json_path)
+        if generated_json_error is not None:
+            stale_files.append(resolved_json)
+            reasons.append(
+                f"{resolved_json}: generated JSON invalid ({generated_json_error})"
+            )
+        else:
+            for reason in _validate_json_payload(generated_json, "generated"):
+                stale_files.append(resolved_json)
+                reasons.append(f"{resolved_json}: {reason}")
+
+        generated_md_text, generated_md_error = _read_text_or_error(generated_md_path)
+        if generated_md_error is not None:
+            stale_files.append(resolved_md)
+            reasons.append(
+                f"{resolved_md}: generated markdown invalid ({generated_md_error})"
+            )
+        else:
+            for reason in _validate_markdown_text(generated_md_text, "generated"):
+                stale_files.append(resolved_md)
+                reasons.append(f"{resolved_md}: {reason}")
+
+        if committed_json is not None and generated_json is not None:
+            if committed_json != generated_json:
+                stale_files.append(resolved_json)
+                reasons.append(f"{resolved_json}: JSON payload mismatch")
+
+        if committed_md_text is not None and generated_md_text is not None:
+            if committed_md_text != generated_md_text:
+                stale_files.append(resolved_md)
+                reasons.append(f"{resolved_md}: Markdown text mismatch")
+
+    unique_files = tuple(dict.fromkeys(stale_files))
+    return FreshnessResult(
+        fresh=len(unique_files) == 0,
+        stale_files=unique_files,
+        reasons=tuple(reasons),
+    )
+
+
+def main() -> int:
+    """CLI entry point."""
+    result = check_performance_evidence_freshness()
+    if result.fresh:
+        print("Performance evidence artifacts are fresh.")
+        return 0
+
+    print("Performance evidence artifacts are stale.")
+    print("Changed files:")
+    for stale_file in result.stale_files:
+        print(f"- {stale_file.as_posix()}")
+    print("Reasons:")
+    for reason in result.reasons:
+        print(f"- {reason}")
+    print(f"Regenerate with: {REGENERATE_COMMAND}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_performance_evidence_freshness.py
+++ b/veritas_os/tests/test_performance_evidence_freshness.py
@@ -108,7 +108,10 @@ def test_markdown_drift_is_stale(tmp_path: Path) -> None:
     committed_json, committed_md = _write_fresh_artifacts(tmp_path)
 
     committed_md.write_text(
-        committed_md.read_text(encoding="utf-8") + "extra line\n",
+        committed_md.read_text(encoding="utf-8").replace(
+            "reviewer-facing deterministic fixture evidence",
+            "reviewer-facing deterministic fixture evidence updated",
+        ),
         encoding="utf-8",
     )
 
@@ -135,6 +138,40 @@ def test_missing_required_field_is_stale(tmp_path: Path) -> None:
     assert any("missing required field metrics" in reason for reason in result.reasons)
 
 
+def test_missing_required_field_does_not_add_generic_json_mismatch(
+    tmp_path: Path,
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    del payload["metrics"]
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("missing required field metrics" in reason for reason in result.reasons)
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_wrong_type_does_not_add_generic_json_mismatch(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["metrics"] = "not-a-list"
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("metrics must be a list" in reason for reason in result.reasons)
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
 def test_markdown_double_trailing_newline_is_stale(tmp_path: Path) -> None:
     committed_json, committed_md = _write_fresh_artifacts(tmp_path)
 
@@ -147,6 +184,22 @@ def test_markdown_double_trailing_newline_is_stale(tmp_path: Path) -> None:
 
     assert result.fresh is False
     assert any("trailing newline" in reason for reason in result.reasons)
+    assert not any("Markdown text mismatch" in reason for reason in result.reasons)
+
+
+def test_markdown_sanity_error_does_not_add_generic_text_mismatch(
+    tmp_path: Path,
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    committed_md.write_text("broken markdown\n", encoding="utf-8")
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any(
+        "missing '# Performance Evidence'" in reason for reason in result.reasons
+    )
+    assert not any("Markdown text mismatch" in reason for reason in result.reasons)
 
 
 def test_cli_main_fresh_returns_0(

--- a/veritas_os/tests/test_performance_evidence_freshness.py
+++ b/veritas_os/tests/test_performance_evidence_freshness.py
@@ -1,0 +1,195 @@
+"""Tests for performance evidence freshness checker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+import pytest
+
+from scripts.performance.check_performance_evidence_freshness import (
+    REGENERATE_COMMAND,
+    check_performance_evidence_freshness,
+    main,
+)
+from scripts.performance.export_performance_evidence import write_performance_evidence
+
+
+def _write_fresh_artifacts(tmp_path: Path) -> tuple[Path, Path]:
+    committed_json = tmp_path / "docs/en/validation/performance-evidence.latest.json"
+    committed_md = tmp_path / "docs/en/validation/performance-evidence.latest.md"
+    write_performance_evidence(json_path=committed_json, markdown_path=committed_md)
+    return committed_json, committed_md
+
+
+def test_fresh_artifacts_pass(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is True
+    assert result.stale_files == ()
+
+
+def test_missing_json_is_stale(tmp_path: Path) -> None:
+    committed_json = tmp_path / "docs/en/validation/performance-evidence.latest.json"
+    _, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_json.unlink()
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_json in result.stale_files
+    assert any("FileNotFoundError" in reason for reason in result.reasons)
+
+
+def test_missing_markdown_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_md.unlink()
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_md in result.stale_files
+
+
+def test_invalid_json_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_json.write_text("{bad json", encoding="utf-8")
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_json in result.stale_files
+    assert any(
+        "JSONDecodeError" in reason or "ValueError" in reason
+        for reason in result.reasons
+    )
+
+
+def test_invalid_utf8_json_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_json.write_bytes(b"\xff\xfe\x00")
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("UnicodeDecodeError" in reason for reason in result.reasons)
+
+
+def test_invalid_utf8_markdown_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_md.write_bytes(b"\xff\xfe\x00")
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("UnicodeDecodeError" in reason for reason in result.reasons)
+
+
+def test_json_drift_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["measurement_mode"] = "tampered"
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_json in result.stale_files
+    assert any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_markdown_drift_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_md.write_text(
+        committed_md.read_text(encoding="utf-8") + "extra line\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_md in result.stale_files
+    assert any("Markdown text mismatch" in reason for reason in result.reasons)
+
+
+def test_missing_required_field_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    del payload["metrics"]
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("missing required field metrics" in reason for reason in result.reasons)
+
+
+def test_markdown_double_trailing_newline_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_md.write_text(
+        committed_md.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("trailing newline" in reason for reason in result.reasons)
+
+
+def test_cli_main_fresh_returns_0(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    checker_module = __import__(
+        "scripts.performance.check_performance_evidence_freshness",
+        fromlist=["dummy"],
+    )
+    monkeypatch.setattr(checker_module, "OUTPUT_JSON", committed_json)
+    monkeypatch.setattr(checker_module, "OUTPUT_MD", committed_md)
+
+    exit_code = main()
+
+    assert exit_code == 0
+    assert "Performance evidence artifacts are fresh." in capsys.readouterr().out
+
+
+def test_cli_main_stale_returns_1(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["sample_count"] = 999
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    checker_module = __import__(
+        "scripts.performance.check_performance_evidence_freshness",
+        fromlist=["dummy"],
+    )
+    monkeypatch.setattr(checker_module, "OUTPUT_JSON", committed_json)
+    monkeypatch.setattr(checker_module, "OUTPUT_MD", committed_md)
+
+    exit_code = main()
+
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert REGENERATE_COMMAND in output


### PR DESCRIPTION
### Motivation
- Ensure the committed performance evidence artifacts (`docs/en/validation/performance-evidence.latest.json` and `.md`) remain identical to outputs produced by the exporter, so reviewers can detect stale generated artifacts without changing CI gates.

### Description
- Added `scripts/performance/check_performance_evidence_freshness.py` which regenerates artifacts into a `TemporaryDirectory` via `write_performance_evidence` and compares them: JSON is compared semantically with `json.loads`, Markdown is compared as UTF-8 text with trailing-newline and section sanity checks.
- Introduced a frozen dataclass `FreshnessResult(fresh, stale_files, reasons)` and exported functions `check_performance_evidence_freshness(...)` (call-time resolution of default paths) and `main()` CLI that returns `0` when fresh and `1` when stale and prints a structured report including `REGENERATE_COMMAND`.
- Implemented robust error handling converting missing files, invalid UTF-8, invalid JSON, generation failures, payload/type mismatches, required-field absences, and Markdown sanity issues into readable stale reasons; `stale_files` reports only committed artifact paths (never temp paths).
- Added `Makefile` target `check-performance-evidence` that runs `python -m scripts.performance.check_performance_evidence_freshness` and added unit tests at `veritas_os/tests/test_performance_evidence_freshness.py` covering the required scenarios (fresh pass, missing/invalid artifacts, drift cases, required-field checks, trailing newline checks, and CLI return codes/output).

### Testing
- Ran `python3 -m scripts.performance.export_performance_evidence` which wrote the artifacts successfully and returned expected output. (succeeded)
- Ran `python3 -m scripts.performance.check_performance_evidence_freshness` which reported `Performance evidence artifacts are fresh.` (succeeded)
- Attempted to run `python3 -m pytest -q veritas_os/tests/test_performance_evidence_freshness.py` and `python3 -m pytest -q veritas_os/tests/test_performance_evidence_artifact.py`, but `pytest` was not available in the environment and dependency installation was blocked by network/PyPI access, so automated pytest runs could not be completed here (blocked by environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017d7935c083269cd1e714a644171a)