### PR TITLE
Add performance evidence freshness checker, Makefile target, and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST_MARKEXPR ?= not slow
 COVERAGE_XML ?= coverage.xml
 COVERAGE_HTML_DIR ?= coverage-html
 
-.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence
+.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence
 
 # ── Setup & Development ──────────────────────────────────────────────────
 
@@ -283,3 +283,7 @@ check-bind-coverage-evidence:
 
 performance-evidence:
 	python -m scripts.performance.export_performance_evidence
+
+
+check-performance-evidence:
+	python -m scripts.performance.check_performance_evidence_freshness

--- a/scripts/performance/check_performance_evidence_freshness.py
+++ b/scripts/performance/check_performance_evidence_freshness.py
@@ -1,0 +1,225 @@
+"""Check freshness of committed performance evidence artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+import json
+
+from scripts.performance.export_performance_evidence import OUTPUT_JSON, OUTPUT_MD
+from scripts.performance.export_performance_evidence import write_performance_evidence
+
+REGENERATE_COMMAND = "python -m scripts.performance.export_performance_evidence"
+REQUIRED_JSON_FIELDS = (
+    "schema_version",
+    "generated_at",
+    "measurement_mode",
+    "sample_count",
+    "warmup_count",
+    "metrics",
+    "notes",
+)
+
+
+@dataclass(frozen=True)
+class FreshnessResult:
+    """Result of freshness verification."""
+
+    fresh: bool
+    stale_files: tuple[Path, ...]
+    reasons: tuple[str, ...]
+
+
+def _read_text_or_error(path: Path) -> tuple[str | None, str | None]:
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, exc.__class__.__name__
+
+
+def _load_json_or_error(path: Path) -> tuple[Any | None, str | None]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        return None, exc.__class__.__name__
+
+
+def _validate_json_payload(payload: Any, label: str) -> list[str]:
+    reasons: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{label} JSON payload is not an object"]
+
+    for field in REQUIRED_JSON_FIELDS:
+        if field not in payload:
+            reasons.append(f"{label} missing required field {field}")
+
+    if (
+        "schema_version" in payload
+        and payload["schema_version"] != "performance_evidence.v1"
+    ):
+        reasons.append(f"{label} schema_version must be performance_evidence.v1")
+    if "metrics" in payload and not isinstance(payload["metrics"], list):
+        reasons.append(f"{label} metrics must be a list")
+    if "notes" in payload and not isinstance(payload["notes"], list):
+        reasons.append(f"{label} notes must be a list")
+    if "sample_count" in payload and not isinstance(payload["sample_count"], int):
+        reasons.append(f"{label} sample_count must be an int")
+    if "warmup_count" in payload and not isinstance(payload["warmup_count"], int):
+        reasons.append(f"{label} warmup_count must be an int")
+    return reasons
+
+
+def _validate_markdown_text(text: str, label: str) -> list[str]:
+    reasons: list[str] = []
+    if not text.endswith("\n"):
+        reasons.append(f"{label} markdown trailing newline is invalid")
+    if text.endswith("\n\n"):
+        reasons.append(f"{label} markdown has double trailing newline")
+    if "# Performance Evidence" not in text:
+        reasons.append(f"{label} markdown missing '# Performance Evidence'")
+    if "## Interpretation boundaries" not in text:
+        reasons.append(f"{label} markdown missing '## Interpretation boundaries'")
+    if "not a production SLA" not in text:
+        reasons.append(f"{label} markdown missing 'not a production SLA'")
+    return reasons
+
+
+def check_performance_evidence_freshness(
+    committed_json_path: Path | None = None,
+    committed_markdown_path: Path | None = None,
+) -> FreshnessResult:
+    """Compare committed artifacts with regenerated exporter output."""
+    resolved_json = (
+        committed_json_path if committed_json_path is not None else OUTPUT_JSON
+    )
+    resolved_md = (
+        committed_markdown_path if committed_markdown_path is not None else OUTPUT_MD
+    )
+
+    stale_files: list[Path] = []
+    reasons: list[str] = []
+    committed_json_valid = False
+    generated_json_valid = False
+    committed_md_valid = False
+    generated_md_valid = False
+
+    committed_json, committed_json_error = _load_json_or_error(resolved_json)
+    if committed_json_error is not None:
+        stale_files.append(resolved_json)
+        reasons.append(f"{resolved_json}: failed to load JSON ({committed_json_error})")
+    else:
+        committed_json_reasons = _validate_json_payload(committed_json, "committed")
+        for reason in committed_json_reasons:
+            stale_files.append(resolved_json)
+            reasons.append(f"{resolved_json}: {reason}")
+        if not committed_json_reasons:
+            committed_json_valid = True
+
+    committed_md_text, committed_md_error = _read_text_or_error(resolved_md)
+    if committed_md_error is not None:
+        stale_files.append(resolved_md)
+        reasons.append(f"{resolved_md}: failed to read markdown ({committed_md_error})")
+    else:
+        committed_md_reasons = _validate_markdown_text(committed_md_text, "committed")
+        for reason in committed_md_reasons:
+            stale_files.append(resolved_md)
+            reasons.append(f"{resolved_md}: {reason}")
+        if not committed_md_reasons:
+            committed_md_valid = True
+
+    with TemporaryDirectory() as tmp_dir:
+        generated_json_path = Path(tmp_dir) / "performance-evidence.latest.json"
+        generated_md_path = Path(tmp_dir) / "performance-evidence.latest.md"
+
+        try:
+            write_performance_evidence(
+                json_path=generated_json_path,
+                markdown_path=generated_md_path,
+            )
+        except Exception as exc:  # noqa: BLE001
+            stale_files.append(resolved_json)
+            stale_files.append(resolved_md)
+            reasons.append(f"failed to generate artifacts ({exc.__class__.__name__})")
+            return FreshnessResult(
+                fresh=False,
+                stale_files=tuple(dict.fromkeys(stale_files)),
+                reasons=tuple(reasons),
+            )
+
+        generated_json, generated_json_error = _load_json_or_error(generated_json_path)
+        if generated_json_error is not None:
+            stale_files.append(resolved_json)
+            reasons.append(
+                f"{resolved_json}: generated JSON invalid ({generated_json_error})"
+            )
+        else:
+            generated_json_reasons = _validate_json_payload(generated_json, "generated")
+            for reason in generated_json_reasons:
+                stale_files.append(resolved_json)
+                reasons.append(f"{resolved_json}: {reason}")
+            if not generated_json_reasons:
+                generated_json_valid = True
+
+        generated_md_text, generated_md_error = _read_text_or_error(generated_md_path)
+        if generated_md_error is not None:
+            stale_files.append(resolved_md)
+            reasons.append(
+                f"{resolved_md}: generated markdown invalid ({generated_md_error})"
+            )
+        else:
+            generated_md_reasons = _validate_markdown_text(
+                generated_md_text,
+                "generated",
+            )
+            for reason in generated_md_reasons:
+                stale_files.append(resolved_md)
+                reasons.append(f"{resolved_md}: {reason}")
+            if not generated_md_reasons:
+                generated_md_valid = True
+
+        if (
+            committed_json_valid
+            and generated_json_valid
+            and committed_json != generated_json
+        ):
+            stale_files.append(resolved_json)
+            reasons.append(f"{resolved_json}: JSON payload mismatch")
+
+        if (
+            committed_md_valid
+            and generated_md_valid
+            and committed_md_text != generated_md_text
+        ):
+            stale_files.append(resolved_md)
+            reasons.append(f"{resolved_md}: Markdown text mismatch")
+
+    unique_files = tuple(dict.fromkeys(stale_files))
+    return FreshnessResult(
+        fresh=len(unique_files) == 0,
+        stale_files=unique_files,
+        reasons=tuple(reasons),
+    )
+
+
+def main() -> int:
+    """CLI entry point."""
+    result = check_performance_evidence_freshness()
+    if result.fresh:
+        print("Performance evidence artifacts are fresh.")
+        return 0
+
+    print("Performance evidence artifacts are stale.")
+    print("Changed files:")
+    for stale_file in result.stale_files:
+        print(f"- {stale_file.as_posix()}")
+    print("Reasons:")
+    for reason in result.reasons:
+        print(f"- {reason}")
+    print(f"Regenerate with: {REGENERATE_COMMAND}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/performance/check_performance_evidence_freshness.py
+++ b/scripts/performance/check_performance_evidence_freshness.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
-import json
 
-from scripts.performance.export_performance_evidence import OUTPUT_JSON, OUTPUT_MD
-from scripts.performance.export_performance_evidence import write_performance_evidence
+from scripts.performance.export_performance_evidence import (
+    OUTPUT_JSON,
+    OUTPUT_MD,
+    write_performance_evidence,
+)
 
 REGENERATE_COMMAND = "python -m scripts.performance.export_performance_evidence"
 REQUIRED_JSON_FIELDS = (
@@ -21,6 +25,7 @@ REQUIRED_JSON_FIELDS = (
     "metrics",
     "notes",
 )
+ALLOWED_MEASUREMENT_MODES = ("deterministic_fixture", "not_measured")
 
 
 @dataclass(frozen=True)
@@ -55,10 +60,11 @@ def _validate_json_payload(payload: Any, label: str) -> list[str]:
         if field not in payload:
             reasons.append(f"{label} missing required field {field}")
 
-    if (
-        "schema_version" in payload
-        and payload["schema_version"] != "performance_evidence.v1"
-    ):
+    if "generated_at" in payload:
+        reasons.extend(_validate_generated_at(payload["generated_at"], label))
+    if "measurement_mode" in payload:
+        reasons.extend(_validate_measurement_mode(payload["measurement_mode"], label))
+    if "schema_version" in payload and payload["schema_version"] != "performance_evidence.v1":
         reasons.append(f"{label} schema_version must be performance_evidence.v1")
     if "metrics" in payload and not isinstance(payload["metrics"], list):
         reasons.append(f"{label} metrics must be a list")
@@ -69,6 +75,28 @@ def _validate_json_payload(payload: Any, label: str) -> list[str]:
     if "warmup_count" in payload and not isinstance(payload["warmup_count"], int):
         reasons.append(f"{label} warmup_count must be an int")
     return reasons
+
+
+def _validate_generated_at(value: Any, label: str) -> list[str]:
+    if not isinstance(value, str):
+        return [f"{label} generated_at must be a string"]
+    stripped = value.strip()
+    if not stripped:
+        return [f"{label} generated_at must be a non-empty ISO-8601 string"]
+    try:
+        datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+    except ValueError:
+        return [f"{label} generated_at must be a valid ISO-8601 datetime"]
+    return []
+
+
+def _validate_measurement_mode(value: Any, label: str) -> list[str]:
+    if not isinstance(value, str):
+        return [f"{label} measurement_mode must be a string"]
+    if value not in ALLOWED_MEASUREMENT_MODES:
+        allowed_values = ", ".join(ALLOWED_MEASUREMENT_MODES)
+        return [f"{label} measurement_mode must be one of {allowed_values}"]
+    return []
 
 
 def _validate_markdown_text(text: str, label: str) -> list[str]:

--- a/veritas_os/tests/test_performance_evidence_freshness.py
+++ b/veritas_os/tests/test_performance_evidence_freshness.py
@@ -1,0 +1,249 @@
+"""Tests for performance evidence freshness checker."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.performance.check_performance_evidence_freshness import (
+    REGENERATE_COMMAND,
+    check_performance_evidence_freshness,
+    main,
+)
+from scripts.performance.export_performance_evidence import write_performance_evidence
+
+
+def _write_fresh_artifacts(tmp_path: Path) -> tuple[Path, Path]:
+    committed_json = tmp_path / "docs/en/validation/performance-evidence.latest.json"
+    committed_md = tmp_path / "docs/en/validation/performance-evidence.latest.md"
+    write_performance_evidence(json_path=committed_json, markdown_path=committed_md)
+    return committed_json, committed_md
+
+
+def test_fresh_artifacts_pass(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is True
+    assert result.stale_files == ()
+
+
+def test_missing_json_is_stale(tmp_path: Path) -> None:
+    committed_json = tmp_path / "docs/en/validation/performance-evidence.latest.json"
+    _, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_json.unlink()
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_json in result.stale_files
+    assert any("FileNotFoundError" in reason for reason in result.reasons)
+
+
+def test_missing_markdown_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_md.unlink()
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_md in result.stale_files
+
+
+def test_invalid_json_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_json.write_text("{bad json", encoding="utf-8")
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_json in result.stale_files
+    assert any(
+        "JSONDecodeError" in reason or "ValueError" in reason
+        for reason in result.reasons
+    )
+
+
+def test_invalid_utf8_json_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_json.write_bytes(b"\xff\xfe\x00")
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("UnicodeDecodeError" in reason for reason in result.reasons)
+
+
+def test_invalid_utf8_markdown_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_md.write_bytes(b"\xff\xfe\x00")
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("UnicodeDecodeError" in reason for reason in result.reasons)
+
+
+def test_json_drift_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["measurement_mode"] = "tampered"
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_json in result.stale_files
+    assert any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_markdown_drift_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_md.write_text(
+        committed_md.read_text(encoding="utf-8").replace(
+            "reviewer-facing deterministic fixture evidence",
+            "reviewer-facing deterministic fixture evidence updated",
+        ),
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert committed_md in result.stale_files
+    assert any("Markdown text mismatch" in reason for reason in result.reasons)
+
+
+def test_missing_required_field_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    del payload["metrics"]
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("missing required field metrics" in reason for reason in result.reasons)
+
+
+def test_missing_required_field_does_not_add_generic_json_mismatch(
+    tmp_path: Path,
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    del payload["metrics"]
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("missing required field metrics" in reason for reason in result.reasons)
+    assert not any("metrics must be a list" in reason for reason in result.reasons)
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_wrong_type_does_not_add_generic_json_mismatch(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["metrics"] = "not-a-list"
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("metrics must be a list" in reason for reason in result.reasons)
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_markdown_double_trailing_newline_is_stale(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+
+    committed_md.write_text(
+        committed_md.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any("trailing newline" in reason for reason in result.reasons)
+    assert not any("Markdown text mismatch" in reason for reason in result.reasons)
+
+
+def test_markdown_sanity_error_does_not_add_generic_text_mismatch(
+    tmp_path: Path,
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    committed_md.write_text("broken markdown\n", encoding="utf-8")
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert result.fresh is False
+    assert any(
+        "missing '# Performance Evidence'" in reason for reason in result.reasons
+    )
+    assert not any("Markdown text mismatch" in reason for reason in result.reasons)
+
+
+def test_cli_main_fresh_returns_0(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    checker_module = __import__(
+        "scripts.performance.check_performance_evidence_freshness",
+        fromlist=["dummy"],
+    )
+    monkeypatch.setattr(checker_module, "OUTPUT_JSON", committed_json)
+    monkeypatch.setattr(checker_module, "OUTPUT_MD", committed_md)
+
+    exit_code = main()
+
+    assert exit_code == 0
+    assert "Performance evidence artifacts are fresh." in capsys.readouterr().out
+
+
+def test_cli_main_stale_returns_1(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["sample_count"] = 999
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    checker_module = __import__(
+        "scripts.performance.check_performance_evidence_freshness",
+        fromlist=["dummy"],
+    )
+    monkeypatch.setattr(checker_module, "OUTPUT_JSON", committed_json)
+    monkeypatch.setattr(checker_module, "OUTPUT_MD", committed_md)
+
+    exit_code = main()
+
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert REGENERATE_COMMAND in output

--- a/veritas_os/tests/test_performance_evidence_freshness.py
+++ b/veritas_os/tests/test_performance_evidence_freshness.py
@@ -91,7 +91,7 @@ def test_json_drift_is_stale(tmp_path: Path) -> None:
     committed_json, committed_md = _write_fresh_artifacts(tmp_path)
 
     payload = json.loads(committed_json.read_text(encoding="utf-8"))
-    payload["measurement_mode"] = "tampered"
+    payload["sample_count"] = 999
     committed_json.write_text(
         json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
@@ -170,6 +170,93 @@ def test_wrong_type_does_not_add_generic_json_mismatch(tmp_path: Path) -> None:
 
     assert result.fresh is False
     assert any("metrics must be a list" in reason for reason in result.reasons)
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_generated_at_non_string_reports_validation_error(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["generated_at"] = 123
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert any("generated_at must be a string" in reason for reason in result.reasons)
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_generated_at_empty_string_reports_validation_error(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["generated_at"] = "   "
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert any(
+        "generated_at must be a non-empty ISO-8601 string" in reason
+        for reason in result.reasons
+    )
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_generated_at_invalid_iso_reports_validation_error(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["generated_at"] = "not-a-date"
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert any(
+        "generated_at must be a valid ISO-8601 datetime" in reason
+        for reason in result.reasons
+    )
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_measurement_mode_non_string_reports_validation_error(tmp_path: Path) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["measurement_mode"] = 123
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert any(
+        "measurement_mode must be a string" in reason for reason in result.reasons
+    )
+    assert not any("JSON payload mismatch" in reason for reason in result.reasons)
+
+
+def test_measurement_mode_invalid_value_reports_validation_error(
+    tmp_path: Path,
+) -> None:
+    committed_json, committed_md = _write_fresh_artifacts(tmp_path)
+    payload = json.loads(committed_json.read_text(encoding="utf-8"))
+    payload["measurement_mode"] = "tampered"
+    committed_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = check_performance_evidence_freshness(committed_json, committed_md)
+
+    assert any(
+        "measurement_mode must be one of" in reason for reason in result.reasons
+    )
     assert not any("JSON payload mismatch" in reason for reason in result.reasons)
 
 


### PR DESCRIPTION
### Motivation

- Ensure committed performance evidence artifacts are validated and kept up to date by detecting drift between committed artifacts and the regenerated outputs.
- Provide an automated check to surface invalid or stale JSON/Markdown artifacts in CI or local development.

### Description

- Add `scripts/performance/check_performance_evidence_freshness.py` which regenerates performance evidence with `python -m scripts.performance.export_performance_evidence`, validates JSON schema and Markdown sanity, compares committed vs regenerated artifacts, and returns a non-zero exit code when stale.
- Add a `check-performance-evidence` Makefile target and include it in `.PHONY` so the check can be invoked via `make check-performance-evidence`.
- Add unit tests in `veritas_os/tests/test_performance_evidence_freshness.py` that exercise fresh, missing, invalid, drift, and CLI behaviors for the checker and verify expected exit codes and messages.

### Testing

- Ran the new unit test module with `pytest veritas_os/tests/test_performance_evidence_freshness.py` and all tests passed.
- Verified the checker returns `0` for fresh artifacts and `1` when artifacts are stale and prints the `Regenerate` instruction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017d7935c083269cd1e714a644171a)