### PR TITLE
Wire performance evidence freshness check into CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,6 +206,9 @@ jobs:
       - name: "[Tier 1] Check bind coverage evidence freshness"
         run: python -m scripts.governance.check_bind_coverage_evidence_freshness
 
+      - name: "[Tier 1] Check performance evidence freshness"
+        run: make check-performance-evidence
+
       - name: "[Tier 1] Run governance smoke tests"
         run: |
           set -euxo pipefail


### PR DESCRIPTION
### Motivation
- Ensure CI detects performance evidence artifact drift by wiring the existing freshness checker into the repository CI pipeline. 
- Keep change minimal and reviewable by reusing the already-present `make check-performance-evidence` target and placing it next to the bind coverage freshness check.

### Description
- Added a single CI step to `.github/workflows/main.yml` in the `[Tier 1] governance-smoke` job that runs `make check-performance-evidence` immediately after the bind coverage freshness check. 
- Change is CI-wiring only and limited to `.github/workflows/main.yml`; no changes were made to `scripts/performance/*`, the exporter, or any performance-evidence JSON/MD artifacts. 
- The added step prints the checker output to the Actions log so stale-artifact messages (e.g. `Performance evidence artifacts are stale.` and regeneration hints) surface in CI.

### Testing
- Ran `make check-performance-evidence` locally and it succeeded with `Performance evidence artifacts are fresh.`. 
- Ran `python -m scripts.performance.check_performance_evidence_freshness` locally and it succeeded with `Performance evidence artifacts are fresh.`. 
- Ran the unit test `python -m pytest -q veritas_os/tests/test_performance_evidence_freshness.py` locally and it passed (`20 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0252705aa08326a3e20678286e8776)