### PR TITLE
Add sandbox RSA receiver for AML/KYC interface contract

### DIFF
--- a/docs/en/guides/rsa-veritas-aml-kyc-sandbox-interface.md
+++ b/docs/en/guides/rsa-veritas-aml-kyc-sandbox-interface.md
@@ -1,0 +1,29 @@
+# RSA ↔ VERITAS AML/KYC Sandbox Interface Contract
+
+## Status and scope
+
+This interface is a **sandbox fixture contract only**.
+
+- It is intended for deterministic testing and review workflows.
+- RSA remains an external upstream system.
+- VERITAS consumes RSA-style status flags as upstream signals.
+- VERITAS remains responsible for continuation admissibility, bind-boundary evaluation, final commit outcome, and audit logging.
+
+## Compliance posture
+
+This artifact is **not** production AML/KYC compliance logic.
+
+This artifact is **not** legal advice and is **not** a regulatory certification.
+
+## Current sandbox mapping
+
+The receiver maps RSA upstream flags into VERITAS continuation behavior:
+
+- `SAFE_PROCEED` → `CONTINUE_TO_BIND_BOUNDARY`
+- `DENSITY_THROTTLED` → `CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED`
+- `ALGORITHMIC_HUMILITY_ENGAGED` → `PAUSE_FOR_HUMAN_REVIEW`
+- `DEFERRAL_ENGAGED` → `BLOCK_FINAL_COMMIT`
+
+## Security note
+
+Because this is sandbox-only behavior, production systems must not rely on this fixture as a sole AML/KYC gate. Production deployments require independently validated policy controls, authority evidence checks, and audited legal/regulatory review.

--- a/tests/governance/test_rsa_sandbox_receiver.py
+++ b/tests/governance/test_rsa_sandbox_receiver.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from veritas_os.governance.rsa_sandbox_receiver import (
+    RSASandboxPayload,
+    evaluate_rsa_sandbox_signal,
+)
+
+
+def _payload(status: str) -> RSASandboxPayload:
+    return RSASandboxPayload(
+        rsa_status=status,
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008Z",
+    )
+
+
+def test_algorithmic_humility_pauses_human_review_without_hard_block() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("ALGORITHMIC_HUMILITY_ENGAGED"))
+
+    assert result["veritas_decision"]["continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["veritas_decision"]["final_commit_outcome"] == "SUSPENDED_NOT_COMMITTED"
+
+
+def test_deferral_engaged_hard_blocks_final_commit() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("DEFERRAL_ENGAGED"))
+
+    assert result["veritas_decision"]["continuation_decision"] == "BLOCK_FINAL_COMMIT"
+    assert result["veritas_decision"]["final_commit_outcome"] == "BLOCKED_NOT_COMMITTED"
+
+
+def test_density_throttled_logs_intervention_without_default_block() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("DENSITY_THROTTLED"))
+
+    assert (
+        result["veritas_decision"]["continuation_decision"]
+        == "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED"
+    )
+    assert result["veritas_decision"]["final_commit_outcome"] == "SUSPENDED_NOT_COMMITTED"
+
+
+def test_safe_proceed_continues_to_bind_boundary_evaluation() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("SAFE_PROCEED"))
+
+    assert result["veritas_decision"]["continuation_decision"] == "CONTINUE_TO_BIND_BOUNDARY"
+
+
+def test_audit_entry_preserves_upstream_and_downstream_decision() -> None:
+    payload = _payload("ALGORITHMIC_HUMILITY_ENGAGED")
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["audit_entry"]["upstream_signal_source"] == "RSA"
+    assert result["audit_entry"]["rsa_status"] == payload.rsa_status
+    assert (
+        result["audit_entry"]["veritas_continuation_decision"]
+        == result["veritas_decision"]["continuation_decision"]
+    )
+    assert (
+        result["audit_entry"]["veritas_final_commit_outcome"]
+        == result["veritas_decision"]["final_commit_outcome"]
+    )
+
+
+def test_contract_example_matches_expected_output_shape() -> None:
+    payload = _payload("ALGORITHMIC_HUMILITY_ENGAGED")
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["veritas_decision"] == {
+        "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+        "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+        "authority_evidence_status": "INSUFFICIENT",
+        "bind_boundary_result": "NOT_ADMISSIBLE_PENDING_EVIDENCE",
+        "final_commit_outcome": "SUSPENDED_NOT_COMMITTED",
+        "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW",
+    }
+    assert result["audit_entry"] == {
+        "upstream_signal_source": "RSA",
+        "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+        "trigger_source": "SRC_Incomplete_Context",
+        "original_llm_intent": "Recommend_Transaction_Approval",
+        "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+        "veritas_reason": (
+            "The workflow cannot continue toward final commit because required "
+            "KYC context is incomplete and authority evidence is insufficient."
+        ),
+        "timestamp": "2026-05-11T11:25:44.008Z",
+        "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+        "veritas_final_commit_outcome": "SUSPENDED_NOT_COMMITTED",
+    }

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -35,6 +35,10 @@ from veritas_os.governance.runtime_authority import (
     RuntimeAuthorityValidator,
     validate_runtime_authority,
 )
+from veritas_os.governance.rsa_sandbox_receiver import (
+    RSASandboxPayload,
+    evaluate_rsa_sandbox_signal,
+)
 from veritas_os.governance.models import (
     GovernancePolicyEventRecord,
     GovernancePolicyRecord,
@@ -60,6 +64,7 @@ __all__ = [
     "PredicateResult",
     "RuntimeAuthorityValidationResult",
     "RuntimeAuthorityValidator",
+    "RSASandboxPayload",
     "GovernanceRepository",
     "validate_action_class_contract",
     "is_expired",
@@ -71,4 +76,5 @@ __all__ = [
     "evaluate_commit_boundary",
     "validate_governance_backend",
     "validate_runtime_authority",
+    "evaluate_rsa_sandbox_signal",
 ]

--- a/veritas_os/governance/rsa_sandbox_receiver.py
+++ b/veritas_os/governance/rsa_sandbox_receiver.py
@@ -1,0 +1,103 @@
+"""Sandbox-only RSA upstream signal receiver for AML/KYC interface contract.
+
+This module is intentionally scoped to deterministic fixture behavior. It does
+not implement production AML/KYC compliance workflows and must not be treated
+as legal or regulatory certification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+RSA_CONTINUATION_DECISIONS: Final[dict[str, str]] = {
+    "SAFE_PROCEED": "CONTINUE_TO_BIND_BOUNDARY",
+    "DENSITY_THROTTLED": "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+    "ALGORITHMIC_HUMILITY_ENGAGED": "PAUSE_FOR_HUMAN_REVIEW",
+    "DEFERRAL_ENGAGED": "BLOCK_FINAL_COMMIT",
+}
+
+
+@dataclass(frozen=True)
+class RSASandboxPayload:
+    """External RSA upstream payload consumed by VERITAS sandbox fixtures."""
+
+    rsa_status: str
+    trigger_source: str
+    original_llm_intent: str
+    rsa_action_taken: str
+    timestamp: str
+
+
+@dataclass(frozen=True)
+class VeritasSandboxDecision:
+    """VERITAS downstream decision fields derived from RSA upstream status."""
+
+    continuation_decision: str
+    reason_code: str
+    authority_evidence_status: str
+    bind_boundary_result: str
+    final_commit_outcome: str
+    required_next_action: str
+
+
+def _reason_code_for_status(rsa_status: str) -> str:
+    if rsa_status == "ALGORITHMIC_HUMILITY_ENGAGED":
+        return "UPSTREAM_INCOMPLETE_KYC_CONTEXT"
+    return "UPSTREAM_RSA_SIGNAL_RECEIVED"
+
+
+def _build_veritas_decision(rsa_status: str) -> VeritasSandboxDecision:
+    """Translate a sandbox RSA status into a deterministic VERITAS decision."""
+    continuation_decision = RSA_CONTINUATION_DECISIONS.get(
+        rsa_status,
+        "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+    )
+    is_deferral = rsa_status == "DEFERRAL_ENGAGED"
+
+    return VeritasSandboxDecision(
+        continuation_decision=continuation_decision,
+        reason_code=_reason_code_for_status(rsa_status),
+        authority_evidence_status="INSUFFICIENT",
+        bind_boundary_result="NOT_ADMISSIBLE_PENDING_EVIDENCE",
+        final_commit_outcome=(
+            "BLOCKED_NOT_COMMITTED" if is_deferral else "SUSPENDED_NOT_COMMITTED"
+        ),
+        required_next_action="REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW",
+    )
+
+
+def evaluate_rsa_sandbox_signal(payload: RSASandboxPayload) -> dict[str, dict[str, str]]:
+    """Evaluate RSA upstream status as an external signal in sandbox mode.
+
+    RSA remains external upstream context. VERITAS owns continuation
+    admissibility, bind-boundary status, final commit outcome, and audit output.
+    """
+    decision = _build_veritas_decision(payload.rsa_status)
+    veritas_reason = (
+        "The workflow cannot continue toward final commit because required "
+        "KYC context is incomplete and authority evidence is insufficient."
+    )
+
+    return {
+        "veritas_decision": {
+            "continuation_decision": decision.continuation_decision,
+            "reason_code": decision.reason_code,
+            "authority_evidence_status": decision.authority_evidence_status,
+            "bind_boundary_result": decision.bind_boundary_result,
+            "final_commit_outcome": decision.final_commit_outcome,
+            "required_next_action": decision.required_next_action,
+        },
+        "audit_entry": {
+            "upstream_signal_source": "RSA",
+            "rsa_status": payload.rsa_status,
+            "trigger_source": payload.trigger_source,
+            "original_llm_intent": payload.original_llm_intent,
+            "rsa_action_taken": payload.rsa_action_taken,
+            "veritas_reason": veritas_reason,
+            "timestamp": payload.timestamp,
+            "veritas_continuation_decision": decision.continuation_decision,
+            "veritas_final_commit_outcome": decision.final_commit_outcome,
+        },
+    }


### PR DESCRIPTION
### Motivation
- Provide a deterministic, non-production sandbox receiver that accepts RSA upstream AML/KYC status flags and lets VERITAS decide admissibility, bind-boundary result, final commit outcome, and audit logging.
- Capture and preserve upstream RSA signal context while keeping RSA logic external and out of VERITAS production decision paths.

### Description
- Add a sandbox-only module `veritas_os.governance.rsa_sandbox_receiver` that defines `RSASandboxPayload`, maps RSA flags to VERITAS continuation decisions, and returns a deterministic `veritas_decision` plus an `audit_entry` preserving upstream fields and downstream decisions.
- Export `RSASandboxPayload` and `evaluate_rsa_sandbox_signal` from `veritas_os.governance.__init__` so the fixture is accessible to governance test harnesses without merging RSA logic into core runtime behavior.
- Add focused unit tests in `tests/governance/test_rsa_sandbox_receiver.py` that assert the mappings for `SAFE_PROCEED`, `DENSITY_THROTTLED`, `ALGORITHMIC_HUMILITY_ENGAGED`, and `DEFERRAL_ENGAGED`, and verify audit preservation and example contract shape.
- Add documentation `docs/en/guides/rsa-veritas-aml-kyc-sandbox-interface.md` that clearly states this is a sandbox fixture, that RSA is external, and that this is not production AML/KYC compliance nor legal/regulatory certification, with an explicit security note.

### Testing
- Added automated tests in `tests/governance/test_rsa_sandbox_receiver.py` covering all required mappings and audit preservation, but test execution in this environment failed during collection due to a missing `yaml` dependency (import error from unrelated governance modules).
- Attempted to install `pyyaml` via `python -m pip install pyyaml` but the install failed due to network/mirror restrictions (`403 Forbidden`), preventing completion of the test run here.
- The tests are deterministic and should pass in CI or a developer environment where `PyYAML` is available and standard test dependencies can be installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e5927158832695cb3aacb17fb97c)