### PR TITLE
Add RSA ↔ VERITAS AML/KYC sandbox receiver, docs, and unit tests

### DIFF
--- a/docs/en/guides/rsa-veritas-aml-kyc-sandbox-interface.md
+++ b/docs/en/guides/rsa-veritas-aml-kyc-sandbox-interface.md
@@ -1,0 +1,108 @@
+# RSA ↔ VERITAS AML/KYC Sandbox Interface Contract
+
+## Status and scope
+
+This interface is a **sandbox fixture contract only**.
+
+- It is intended for deterministic testing and review workflows.
+- RSA remains an external upstream system.
+- VERITAS consumes RSA-style status flags as upstream signals.
+- VERITAS remains responsible for continuation admissibility, bind-boundary evaluation, final commit outcome, and audit logging.
+
+## Compliance posture
+
+This artifact is **not** production AML/KYC compliance logic.
+
+This artifact is **not** regulatory approval.
+This artifact is **not** third-party certification.
+This artifact is **not** legal advice.
+
+## Current sandbox mapping
+
+The receiver maps RSA upstream flags into VERITAS continuation behavior:
+
+- `SAFE_PROCEED` → `CONTINUE_TO_BIND_BOUNDARY`
+- `DENSITY_THROTTLED` → `CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED`
+- `ALGORITHMIC_HUMILITY_ENGAGED` → `PAUSE_FOR_HUMAN_REVIEW`
+- `DEFERRAL_ENGAGED` → `BLOCK_FINAL_COMMIT`
+
+## Input schema
+
+RSASandboxPayload fields are all required:
+
+- rsa_status
+  - required string
+  - must be one of: SAFE_PROCEED, DENSITY_THROTTLED, ALGORITHMIC_HUMILITY_ENGAGED, DEFERRAL_ENGAGED
+- trigger_source
+  - required non-empty string
+- original_llm_intent
+  - required non-empty string
+  - expected to be redacted by default before persistence outside tests
+- rsa_action_taken
+  - required non-empty string
+  - expected to be redacted by default before persistence outside tests
+- timestamp
+  - required non-empty ISO-8601 compatible string
+  - trailing Z is accepted (for example: 2026-05-11T11:25:44.008Z)
+
+Invalid payloads raise ValueError and are treated as sandbox interface contract violations.
+
+## Output schema and allowed values
+
+evaluate_rsa_sandbox_signal() returns a dictionary with:
+
+- veritas_decision
+  - continuation_decision
+  - reason_code
+  - authority_evidence_status
+  - sandbox_bind_boundary_state
+  - sandbox_commit_state
+  - required_next_action
+- audit_entry
+  - upstream_signal_source
+  - rsa_status
+  - trigger_source
+  - original_llm_intent
+  - rsa_action_taken
+  - veritas_reason
+  - timestamp
+  - veritas_continuation_decision
+  - veritas_sandbox_commit_state
+
+Allowed / fixture values:
+
+- rsa_status
+  - SAFE_PROCEED
+  - DENSITY_THROTTLED
+  - ALGORITHMIC_HUMILITY_ENGAGED
+  - DEFERRAL_ENGAGED
+- continuation_decision
+  - CONTINUE_TO_BIND_BOUNDARY
+  - CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED
+  - PAUSE_FOR_HUMAN_REVIEW
+  - BLOCK_FINAL_COMMIT
+- reason_code
+  - UPSTREAM_SAFE_PROCEED_SIGNAL
+  - UPSTREAM_INTERVENTION_DENSITY_THROTTLE
+  - UPSTREAM_INCOMPLETE_KYC_CONTEXT
+  - UPSTREAM_CRITICAL_DEFERRAL_SIGNAL
+- authority_evidence_status
+  - INSUFFICIENT (fixed fixture value in this sandbox)
+- sandbox_bind_boundary_state
+  - NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE
+  - fixed fixture value in this sandbox
+  - indicates production bind-boundary evaluation has not run
+- sandbox_commit_state
+  - SUSPENDED_NOT_COMMITTED
+  - BLOCKED_NOT_COMMITTED
+- required_next_action
+  - REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW (fixed fixture value)
+
+## Security note
+
+- The audit_entry includes upstream-provided fields such as original_llm_intent and rsa_action_taken.
+- These raw upstream fields may contain sensitive content.
+- Do not persist raw fields outside tests unless routed through the TrustLog redaction/sanitization pipeline.
+- This sandbox receiver does not perform PII redaction.
+- Because this is sandbox-only behavior, production systems must not rely on this fixture as the sole AML/KYC gate.
+- Production deployments require independently validated policy controls, authority evidence checks, and audited legal/regulatory review.

--- a/docs/ja/guides/rsa-veritas-aml-kyc-sandbox-interface.md
+++ b/docs/ja/guides/rsa-veritas-aml-kyc-sandbox-interface.md
@@ -1,0 +1,102 @@
+# RSA ↔ VERITAS AML/KYC サンドボックス・インターフェース契約
+
+## 位置づけとスコープ
+
+このインターフェースは **サンドボックス専用のフィクスチャ契約** です。
+
+- 決定論的なテストとレビュー用途を目的とします。
+- RSA は外部の上流システムとして扱われ、VERITAS の中核ロジックには統合しません。
+- VERITAS は RSA 形式のフラグを上流シグナルとして受け取り、継続可否・bind-boundary 判定・最終コミット結果・監査記録を下流で決定します。
+
+## 英語正本
+
+- [English authoritative version](../../en/guides/rsa-veritas-aml-kyc-sandbox-interface.md)
+
+## 入力スキーマ
+
+RSASandboxPayload は全フィールド必須です。
+
+- rsa_status
+  - 必須の文字列
+  - 許容値: SAFE_PROCEED, DENSITY_THROTTLED, ALGORITHMIC_HUMILITY_ENGAGED, DEFERRAL_ENGAGED
+- trigger_source
+  - 必須の非空文字列（空文字・空白のみ不可）
+- original_llm_intent
+  - 必須の非空文字列（空文字・空白のみ不可）
+  - テスト外で永続化する前提では、既定でのredaction対象として扱ってください
+- rsa_action_taken
+  - 必須の非空文字列（空文字・空白のみ不可）
+  - テスト外で永続化する前提では、既定でのredaction対象として扱ってください
+- timestamp
+  - 必須の非空文字列（空文字・空白のみ不可）
+  - ISO-8601 互換文字列である必要があります
+  - 末尾 Z 形式を許容します（例: 2026-05-11T11:25:44.008Z）
+
+不正なpayloadは ValueError となり、sandbox interface contract violation として扱います。
+
+## 免責事項
+
+この成果物は **本番 AML/KYC コンプライアンス実装ではありません**。
+
+この成果物は **規制当局による承認ではありません**。
+この成果物は **第三者認証ではありません**。
+この成果物は **法的助言ではありません**。
+
+## 出力スキーマと許容値
+
+evaluate_rsa_sandbox_signal() は次の辞書を返します。
+
+- veritas_decision
+  - continuation_decision
+  - reason_code
+  - authority_evidence_status
+  - sandbox_bind_boundary_state
+  - sandbox_commit_state
+  - required_next_action
+- audit_entry
+  - upstream_signal_source
+  - rsa_status
+  - trigger_source
+  - original_llm_intent
+  - rsa_action_taken
+  - veritas_reason
+  - timestamp
+  - veritas_continuation_decision
+  - veritas_sandbox_commit_state
+
+許容値 / fixture 固定値:
+
+- rsa_status
+  - SAFE_PROCEED
+  - DENSITY_THROTTLED
+  - ALGORITHMIC_HUMILITY_ENGAGED
+  - DEFERRAL_ENGAGED
+- continuation_decision
+  - CONTINUE_TO_BIND_BOUNDARY
+  - CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED
+  - PAUSE_FOR_HUMAN_REVIEW
+  - BLOCK_FINAL_COMMIT
+- reason_code
+  - UPSTREAM_SAFE_PROCEED_SIGNAL
+  - UPSTREAM_INTERVENTION_DENSITY_THROTTLE
+  - UPSTREAM_INCOMPLETE_KYC_CONTEXT
+  - UPSTREAM_CRITICAL_DEFERRAL_SIGNAL
+- authority_evidence_status
+  - INSUFFICIENT（この sandbox では固定値）
+- sandbox_bind_boundary_state
+  - NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE
+  - この sandbox では固定値
+  - 本番の BindReceipt / FinalOutcome / CommitBoundaryOutcome ではありません
+  - production bind-boundary evaluation が実行されたことを意味しません
+- sandbox_commit_state
+  - SUSPENDED_NOT_COMMITTED
+  - BLOCKED_NOT_COMMITTED
+- required_next_action
+  - REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW（この sandbox では固定値）
+
+セキュリティ注意:
+
+- audit_entry には upstream 由来の raw fields が含まれます。
+- original_llm_intent と rsa_action_taken は PII/secret を含む可能性があります。
+- テスト外で保存する場合は TrustLog redaction/sanitization pipeline を必ず通してください。
+- この receiver 自体は PII redaction を行いません。

--- a/tests/governance/test_rsa_sandbox_receiver.py
+++ b/tests/governance/test_rsa_sandbox_receiver.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.governance import RSASandboxPayload as ExportedRSASandboxPayload
+from veritas_os.governance import evaluate_rsa_sandbox_signal as exported_evaluator
+from veritas_os.governance.rsa_sandbox_receiver import (
+    RSASandboxPayload,
+    evaluate_rsa_sandbox_signal,
+)
+
+
+def _payload(status: str) -> RSASandboxPayload:
+    return RSASandboxPayload(
+        rsa_status=status,
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008Z",
+    )
+
+
+def test_algorithmic_humility_pauses_human_review_without_hard_block() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("ALGORITHMIC_HUMILITY_ENGAGED"))
+
+    assert result["veritas_decision"]["continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["veritas_decision"]["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        result["audit_entry"]["veritas_reason"]
+        == "The workflow cannot continue toward final commit because required "
+        "KYC context is incomplete and authority evidence is insufficient."
+    )
+
+
+def test_deferral_engaged_hard_blocks_final_commit() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("DEFERRAL_ENGAGED"))
+
+    assert result["veritas_decision"]["continuation_decision"] == "BLOCK_FINAL_COMMIT"
+    assert result["veritas_decision"]["reason_code"] == "UPSTREAM_CRITICAL_DEFERRAL_SIGNAL"
+    assert result["veritas_decision"]["sandbox_commit_state"] == "BLOCKED_NOT_COMMITTED"
+    assert (
+        result["audit_entry"]["veritas_reason"]
+        == "RSA reported a critical upstream deferral condition; VERITAS "
+        "blocks final commit until human review or policy remediation occurs."
+    )
+
+
+def test_density_throttled_logs_intervention_without_default_block() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("DENSITY_THROTTLED"))
+
+    assert (
+        result["veritas_decision"]["continuation_decision"]
+        == "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED"
+    )
+    assert (
+        result["veritas_decision"]["reason_code"]
+        == "UPSTREAM_INTERVENTION_DENSITY_THROTTLE"
+    )
+    assert result["veritas_decision"]["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        result["audit_entry"]["veritas_reason"]
+        == "RSA modified the upstream output for cognitive density control; "
+        "VERITAS records the intervention without treating it as a default "
+        "hard block."
+    )
+
+
+def test_safe_proceed_continues_to_bind_boundary_evaluation() -> None:
+    payload = _payload("SAFE_PROCEED")
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["veritas_decision"]["continuation_decision"] == "CONTINUE_TO_BIND_BOUNDARY"
+    assert result["veritas_decision"]["reason_code"] == "UPSTREAM_SAFE_PROCEED_SIGNAL"
+    assert result["veritas_decision"]["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        result["veritas_decision"]["sandbox_bind_boundary_state"]
+        == "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE"
+    )
+    assert result["audit_entry"]["upstream_signal_source"] == "RSA"
+    assert result["audit_entry"]["rsa_status"] == payload.rsa_status
+    assert result["audit_entry"]["trigger_source"] == payload.trigger_source
+    assert (
+        result["audit_entry"]["veritas_reason"]
+        == "The upstream RSA signal indicates the workflow may continue "
+        "toward normal bind-boundary evaluation."
+    )
+
+
+def test_audit_entry_preserves_upstream_and_downstream_decision() -> None:
+    payload = _payload("ALGORITHMIC_HUMILITY_ENGAGED")
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["audit_entry"]["upstream_signal_source"] == "RSA"
+    assert result["audit_entry"]["rsa_status"] == payload.rsa_status
+    assert (
+        result["audit_entry"]["veritas_continuation_decision"]
+        == result["veritas_decision"]["continuation_decision"]
+    )
+    assert (
+        result["audit_entry"]["veritas_sandbox_commit_state"]
+        == result["veritas_decision"]["sandbox_commit_state"]
+    )
+
+
+def test_contract_example_matches_expected_output_shape() -> None:
+    payload = _payload("ALGORITHMIC_HUMILITY_ENGAGED")
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["veritas_decision"] == {
+        "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+        "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+        "authority_evidence_status": "INSUFFICIENT",
+        "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+        "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+        "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW",
+    }
+    assert result["audit_entry"] == {
+        "upstream_signal_source": "RSA",
+        "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+        "trigger_source": "SRC_Incomplete_Context",
+        "original_llm_intent": "Recommend_Transaction_Approval",
+        "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+        "veritas_reason": (
+            "The workflow cannot continue toward final commit because required "
+            "KYC context is incomplete and authority evidence is insufficient."
+        ),
+        "timestamp": "2026-05-11T11:25:44.008Z",
+        "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+        "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+    }
+
+
+def test_public_exports_support_safe_proceed_evaluation() -> None:
+    payload = ExportedRSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008Z",
+    )
+
+    result = exported_evaluator(payload)
+
+    assert result["veritas_decision"]["continuation_decision"] == "CONTINUE_TO_BIND_BOUNDARY"
+
+
+def test_unknown_status_raises_contract_violation() -> None:
+    payload = _payload("UNKNOWN_STATUS")
+
+    with pytest.raises(ValueError, match="Unknown RSA sandbox status: UNKNOWN_STATUS") as exc_info:
+        evaluate_rsa_sandbox_signal(payload)
+    message = str(exc_info.value)
+
+    assert "Unknown RSA sandbox status: UNKNOWN_STATUS" in message
+    assert "Supported:" in message
+    assert "SAFE_PROCEED" in message
+    assert "DENSITY_THROTTLED" in message
+    assert "ALGORITHMIC_HUMILITY_ENGAGED" in message
+    assert "DEFERRAL_ENGAGED" in message
+
+
+def test_legacy_bind_boundary_field_is_not_present() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("SAFE_PROCEED"))
+
+    assert "bind_boundary_result" not in result["veritas_decision"]
+
+
+def test_empty_trigger_source_raises_validation_error() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008Z",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="RSASandboxPayload.trigger_source must be a non-empty string",
+    ):
+        evaluate_rsa_sandbox_signal(payload)
+
+
+def test_whitespace_original_llm_intent_raises_validation_error() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="   ",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008Z",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="RSASandboxPayload.original_llm_intent must be a non-empty string",
+    ):
+        evaluate_rsa_sandbox_signal(payload)
+
+
+def test_non_string_rsa_action_taken_raises_validation_error() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken=123,  # type: ignore[arg-type]
+        timestamp="2026-05-11T11:25:44.008Z",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="RSASandboxPayload.rsa_action_taken must be a non-empty string",
+    ):
+        evaluate_rsa_sandbox_signal(payload)
+
+
+def test_invalid_timestamp_raises_validation_error() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="not-a-timestamp",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="RSASandboxPayload.timestamp must be ISO-8601 compatible",
+    ):
+        evaluate_rsa_sandbox_signal(payload)
+
+
+def test_timestamp_with_trailing_z_is_accepted() -> None:
+    payload = _payload("SAFE_PROCEED")
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["audit_entry"]["timestamp"] == "2026-05-11T11:25:44.008Z"

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -35,6 +35,10 @@ from veritas_os.governance.runtime_authority import (
     RuntimeAuthorityValidator,
     validate_runtime_authority,
 )
+from veritas_os.governance.rsa_sandbox_receiver import (
+    RSASandboxPayload,
+    evaluate_rsa_sandbox_signal,
+)
 from veritas_os.governance.models import (
     GovernancePolicyEventRecord,
     GovernancePolicyRecord,
@@ -60,6 +64,7 @@ __all__ = [
     "PredicateResult",
     "RuntimeAuthorityValidationResult",
     "RuntimeAuthorityValidator",
+    "RSASandboxPayload",
     "GovernanceRepository",
     "validate_action_class_contract",
     "is_expired",
@@ -71,4 +76,5 @@ __all__ = [
     "evaluate_commit_boundary",
     "validate_governance_backend",
     "validate_runtime_authority",
+    "evaluate_rsa_sandbox_signal",
 ]

--- a/veritas_os/governance/rsa_sandbox_receiver.py
+++ b/veritas_os/governance/rsa_sandbox_receiver.py
@@ -1,0 +1,186 @@
+"""Sandbox-only RSA upstream signal receiver for AML/KYC interface contract.
+
+This module is intentionally scoped to deterministic fixture behavior. It does
+not implement production AML/KYC compliance workflows and must not be treated
+as legal or regulatory certification.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Mapping
+
+
+RSA_CONTINUATION_DECISIONS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "SAFE_PROCEED": "CONTINUE_TO_BIND_BOUNDARY",
+        "DENSITY_THROTTLED": "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+        "ALGORITHMIC_HUMILITY_ENGAGED": "PAUSE_FOR_HUMAN_REVIEW",
+        "DEFERRAL_ENGAGED": "BLOCK_FINAL_COMMIT",
+    }
+)
+_REASON_CODES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "SAFE_PROCEED": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+        "DENSITY_THROTTLED": "UPSTREAM_INTERVENTION_DENSITY_THROTTLE",
+        "ALGORITHMIC_HUMILITY_ENGAGED": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+        "DEFERRAL_ENGAGED": "UPSTREAM_CRITICAL_DEFERRAL_SIGNAL",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RSASandboxPayload:
+    """External RSA upstream payload consumed by VERITAS sandbox fixtures."""
+
+    rsa_status: str
+    trigger_source: str
+    original_llm_intent: str
+    rsa_action_taken: str
+    timestamp: str
+
+
+@dataclass(frozen=True)
+class VeritasSandboxDecision:
+    """VERITAS downstream decision fields derived from RSA upstream status."""
+
+    continuation_decision: str
+    reason_code: str
+    authority_evidence_status: str
+    sandbox_bind_boundary_state: str
+    sandbox_commit_state: str
+    required_next_action: str
+
+
+def _reason_code_for_status(rsa_status: str) -> str:
+    try:
+        return _REASON_CODES[rsa_status]
+    except KeyError as exc:
+        raise AssertionError(
+            f"Unsupported RSA status reached reason-code mapping: {rsa_status}"
+        ) from exc
+
+
+def _veritas_reason_for_status(rsa_status: str, reason_code: str) -> str:
+    """Return status-specific sandbox audit narrative for RSA upstream signals."""
+    if rsa_status == "SAFE_PROCEED":
+        return (
+            "The upstream RSA signal indicates the workflow may continue "
+            "toward normal bind-boundary evaluation."
+        )
+    if rsa_status == "DENSITY_THROTTLED":
+        return (
+            "RSA modified the upstream output for cognitive density control; "
+            "VERITAS records the intervention without treating it as a default "
+            "hard block."
+        )
+    if rsa_status == "DEFERRAL_ENGAGED":
+        return (
+            "RSA reported a critical upstream deferral condition; VERITAS "
+            "blocks final commit until human review or policy remediation occurs."
+        )
+    if reason_code == "UPSTREAM_INCOMPLETE_KYC_CONTEXT":
+        return (
+            "The workflow cannot continue toward final commit because required "
+            "KYC context is incomplete and authority evidence is insufficient."
+        )
+    raise ValueError(f"Unknown RSA sandbox reason status: {rsa_status}")
+
+
+def _validate_non_empty_string(value: object, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+
+def _validate_payload(payload: RSASandboxPayload) -> None:
+    """Validate sandbox payload shape and timestamp contract."""
+    _validate_non_empty_string(payload.rsa_status, "RSASandboxPayload.rsa_status")
+    _validate_non_empty_string(
+        payload.trigger_source,
+        "RSASandboxPayload.trigger_source",
+    )
+    _validate_non_empty_string(
+        payload.original_llm_intent,
+        "RSASandboxPayload.original_llm_intent",
+    )
+    _validate_non_empty_string(
+        payload.rsa_action_taken,
+        "RSASandboxPayload.rsa_action_taken",
+    )
+    _validate_non_empty_string(payload.timestamp, "RSASandboxPayload.timestamp")
+
+    normalized_timestamp = payload.timestamp.replace("Z", "+00:00")
+    try:
+        datetime.fromisoformat(normalized_timestamp)
+    except ValueError as exc:
+        raise ValueError(
+            "RSASandboxPayload.timestamp must be ISO-8601 compatible"
+        ) from exc
+
+
+def _build_veritas_decision(rsa_status: str) -> VeritasSandboxDecision:
+    """Translate a sandbox RSA status into a deterministic VERITAS decision."""
+    continuation_decision = RSA_CONTINUATION_DECISIONS.get(rsa_status)
+    if continuation_decision is None:
+        supported = ", ".join(sorted(RSA_CONTINUATION_DECISIONS))
+        raise ValueError(
+            f"Unknown RSA sandbox status: {rsa_status}. Supported: {supported}"
+        )
+    is_deferral = rsa_status == "DEFERRAL_ENGAGED"
+
+    return VeritasSandboxDecision(
+        continuation_decision=continuation_decision,
+        reason_code=_reason_code_for_status(rsa_status),
+        authority_evidence_status="INSUFFICIENT",
+        sandbox_bind_boundary_state="NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+        sandbox_commit_state=(
+            "BLOCKED_NOT_COMMITTED" if is_deferral else "SUSPENDED_NOT_COMMITTED"
+        ),
+        required_next_action="REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW",
+    )
+
+
+def evaluate_rsa_sandbox_signal(payload: RSASandboxPayload) -> dict[str, dict[str, str]]:
+    """Evaluate RSA upstream status as an external signal in sandbox mode.
+
+    RSA remains external upstream context. VERITAS owns continuation
+    admissibility, sandbox bind-boundary state, sandbox commit state, and audit
+    output.
+
+    Security note:
+    The returned audit_entry includes upstream-provided sandbox fields such as
+    original_llm_intent and rsa_action_taken. Treat them as potentially
+    sensitive. Do not persist them outside tests unless they pass through the
+    TrustLog redaction/sanitization pipeline. This fixture does not perform PII
+    redaction.
+    """
+    _validate_payload(payload)
+    decision = _build_veritas_decision(payload.rsa_status)
+    veritas_reason = _veritas_reason_for_status(
+        payload.rsa_status,
+        decision.reason_code,
+    )
+
+    return {
+        "veritas_decision": {
+            "continuation_decision": decision.continuation_decision,
+            "reason_code": decision.reason_code,
+            "authority_evidence_status": decision.authority_evidence_status,
+            "sandbox_bind_boundary_state": decision.sandbox_bind_boundary_state,
+            "sandbox_commit_state": decision.sandbox_commit_state,
+            "required_next_action": decision.required_next_action,
+        },
+        "audit_entry": {
+            "upstream_signal_source": "RSA",
+            "rsa_status": payload.rsa_status,
+            "trigger_source": payload.trigger_source,
+            "original_llm_intent": payload.original_llm_intent,
+            "rsa_action_taken": payload.rsa_action_taken,
+            "veritas_reason": veritas_reason,
+            "timestamp": payload.timestamp,
+            "veritas_continuation_decision": decision.continuation_decision,
+            "veritas_sandbox_commit_state": decision.sandbox_commit_state,
+        },
+    }


### PR DESCRIPTION
### Motivation

- Provide a deterministic sandbox fixture for translating RSA upstream AML/KYC status flags into VERITAS continuation decisions for testing and review workflows.
- Surface a simple, auditable contract that preserves upstream fields for sandbox audits while warning about PII and non-production use.

### Description

- Add a new sandbox receiver module `veritas_os.governance.rsa_sandbox_receiver` that defines `RSASandboxPayload`, deterministic mappings from RSA statuses to VERITAS decisions, payload validation, and `evaluate_rsa_sandbox_signal` to produce `veritas_decision` and `audit_entry` outputs.
- Export `RSASandboxPayload` and `evaluate_rsa_sandbox_signal` from `veritas_os.governance.__init__` so consumers can use the public API.
- Add English and Japanese documentation files `docs/en/guides/rsa-veritas-aml-kyc-sandbox-interface.md` and `docs/ja/guides/rsa-veritas-aml-kyc-sandbox-interface.md` describing scope, schemas, allowed values, and security notes.
- Add comprehensive unit tests in `tests/governance/test_rsa_sandbox_receiver.py` covering mapping behavior, validation errors, audit shape, and exported public API usage.

### Testing

- Added unit tests in `tests/governance/test_rsa_sandbox_receiver.py` and executed them with `pytest tests/governance/test_rsa_sandbox_receiver.py`, which completed successfully.
- The tests assert valid decision mappings for `SAFE_PROCEED`, `DENSITY_THROTTLED`, `ALGORITHMIC_HUMILITY_ENGAGED`, and `DEFERRAL_ENGAGED` and also validate payload error conditions such as empty strings and invalid timestamps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e5927158832695cb3aacb17fb97c)