### PR TITLE
Add RSA ↔ VERITAS AML/KYC sandbox receiver with docs and tests

### DIFF
--- a/docs/en/guides/rsa-veritas-aml-kyc-sandbox-interface.md
+++ b/docs/en/guides/rsa-veritas-aml-kyc-sandbox-interface.md
@@ -1,0 +1,107 @@
+# RSA ↔ VERITAS AML/KYC Sandbox Interface Contract
+
+## Status and scope
+
+This interface is a **sandbox fixture contract only**.
+
+- It is intended for deterministic testing and review workflows.
+- RSA remains an external upstream system.
+- VERITAS consumes RSA-style status flags as upstream signals.
+- VERITAS remains responsible for continuation admissibility, bind-boundary evaluation, final commit outcome, and audit logging.
+
+## Compliance posture
+
+This artifact is **not** production AML/KYC compliance logic.
+
+This artifact is **not** regulatory approval.
+This artifact is **not** third-party certification.
+This artifact is **not** legal advice.
+
+## Current sandbox mapping
+
+The receiver maps RSA upstream flags into VERITAS continuation behavior:
+
+- `SAFE_PROCEED` → `CONTINUE_TO_BIND_BOUNDARY`
+- `DENSITY_THROTTLED` → `CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED`
+- `ALGORITHMIC_HUMILITY_ENGAGED` → `PAUSE_FOR_HUMAN_REVIEW`
+- `DEFERRAL_ENGAGED` → `BLOCK_FINAL_COMMIT`
+
+## Input schema
+
+RSASandboxPayload requires all fields:
+
+- rsa_status
+- trigger_source
+- original_llm_intent
+- rsa_action_taken
+- timestamp
+
+timestamp must be a timezone-aware ISO-8601 string with either:
+
+- trailing `Z`, or
+- explicit timezone offset (for example `+00:00` or `+09:00`)
+
+## Output schema and allowed values
+
+evaluate_rsa_sandbox_signal() returns a dictionary with:
+
+- veritas_decision
+  - continuation_decision
+  - reason_code
+  - authority_evidence_status
+  - sandbox_bind_boundary_state
+  - sandbox_commit_state
+  - required_next_action
+- audit_entry
+  - upstream_signal_source
+  - rsa_status
+  - trigger_source
+  - original_llm_intent
+  - rsa_action_taken
+  - veritas_reason
+  - timestamp
+  - veritas_continuation_decision
+  - veritas_sandbox_commit_state
+- function option
+  - include_raw_upstream_fields (default: false)
+
+Allowed / fixture values:
+
+- rsa_status
+  - SAFE_PROCEED
+  - DENSITY_THROTTLED
+  - ALGORITHMIC_HUMILITY_ENGAGED
+  - DEFERRAL_ENGAGED
+- continuation_decision
+  - CONTINUE_TO_BIND_BOUNDARY
+  - CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED
+  - PAUSE_FOR_HUMAN_REVIEW
+  - BLOCK_FINAL_COMMIT
+- reason_code
+  - UPSTREAM_SAFE_PROCEED_SIGNAL
+  - UPSTREAM_INTERVENTION_DENSITY_THROTTLE
+  - UPSTREAM_INCOMPLETE_KYC_CONTEXT
+  - UPSTREAM_CRITICAL_DEFERRAL_SIGNAL
+- authority_evidence_status
+  - INSUFFICIENT (fixed fixture value in this sandbox)
+- sandbox_bind_boundary_state
+  - NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE
+  - fixed fixture value in this sandbox
+  - indicates production bind-boundary evaluation has not run
+- sandbox_commit_state
+  - SUSPENDED_NOT_COMMITTED
+  - BLOCKED_NOT_COMMITTED
+- required_next_action
+  - REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW (fixed fixture value)
+
+## Security note
+
+- original_llm_intent and rsa_action_taken are redacted as [REDACTED] by default.
+- Raw values are returned only when include_raw_upstream_fields=True.
+- include_raw_upstream_fields=True requires VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM=1.
+- include_raw_upstream_fields=True is forbidden in VERITAS_ENV values: prod, production, stg, staging.
+- VERITAS_ENV is normalized by trim + lowercase before this operational check.
+- This is limited masking for specific fields only, not generalized PII/secret detection.
+- Do not persist raw fields outside tests unless routed through the TrustLog redaction/sanitization pipeline.
+- Because this is sandbox-only behavior, production systems must not rely on this fixture as the sole AML/KYC gate.
+- Production deployments require independently validated policy controls, authority evidence checks, and audited legal/regulatory review.

--- a/docs/ja/guides/rsa-veritas-aml-kyc-sandbox-interface.md
+++ b/docs/ja/guides/rsa-veritas-aml-kyc-sandbox-interface.md
@@ -1,0 +1,101 @@
+# RSA ↔ VERITAS AML/KYC サンドボックス・インターフェース契約
+
+## 位置づけとスコープ
+
+このインターフェースは **サンドボックス専用のフィクスチャ契約** です。
+
+- 決定論的なテストとレビュー用途を目的とします。
+- RSA は外部の上流システムとして扱われ、VERITAS の中核ロジックには統合しません。
+- VERITAS は RSA 形式のフラグを上流シグナルとして受け取り、継続可否・bind-boundary 判定・最終コミット結果・監査記録を下流で決定します。
+
+## 英語正本
+
+- [English authoritative version](../../en/guides/rsa-veritas-aml-kyc-sandbox-interface.md)
+
+## 免責事項
+
+この成果物は **本番 AML/KYC コンプライアンス実装ではありません**。
+
+この成果物は **規制当局による承認ではありません**。
+この成果物は **第三者認証ではありません**。
+この成果物は **法的助言ではありません**。
+
+## 入力スキーマ
+
+RSASandboxPayload は次の全フィールドが必須です。
+
+- rsa_status
+- trigger_source
+- original_llm_intent
+- rsa_action_taken
+- timestamp
+
+timestamp は timezone 情報付き ISO-8601 互換文字列である必要があります。
+
+- 末尾 `Z`、または
+- 明示的な timezone offset（例: `+00:00`, `+09:00`）
+
+## 出力スキーマと許容値
+
+evaluate_rsa_sandbox_signal() は次の辞書を返します。
+
+- veritas_decision
+  - continuation_decision
+  - reason_code
+  - authority_evidence_status
+  - sandbox_bind_boundary_state
+  - sandbox_commit_state
+  - required_next_action
+- audit_entry
+  - upstream_signal_source
+  - rsa_status
+  - trigger_source
+  - original_llm_intent
+  - rsa_action_taken
+  - veritas_reason
+  - timestamp
+  - veritas_continuation_decision
+  - veritas_sandbox_commit_state
+- 関数オプション
+  - include_raw_upstream_fields（既定値: false）
+
+許容値 / fixture 固定値:
+
+- rsa_status
+  - SAFE_PROCEED
+  - DENSITY_THROTTLED
+  - ALGORITHMIC_HUMILITY_ENGAGED
+  - DEFERRAL_ENGAGED
+- continuation_decision
+  - CONTINUE_TO_BIND_BOUNDARY
+  - CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED
+  - PAUSE_FOR_HUMAN_REVIEW
+  - BLOCK_FINAL_COMMIT
+- reason_code
+  - UPSTREAM_SAFE_PROCEED_SIGNAL
+  - UPSTREAM_INTERVENTION_DENSITY_THROTTLE
+  - UPSTREAM_INCOMPLETE_KYC_CONTEXT
+  - UPSTREAM_CRITICAL_DEFERRAL_SIGNAL
+- authority_evidence_status
+  - INSUFFICIENT（この sandbox では固定値）
+- sandbox_bind_boundary_state
+  - NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE
+  - この sandbox では固定値
+  - 本番の BindReceipt / FinalOutcome / CommitBoundaryOutcome ではありません
+  - production bind-boundary evaluation が実行されたことを意味しません
+- sandbox_commit_state
+  - SUSPENDED_NOT_COMMITTED
+  - BLOCKED_NOT_COMMITTED
+- required_next_action
+  - REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW（この sandbox では固定値）
+
+セキュリティ注意:
+
+- original_llm_intent と rsa_action_taken は既定で [REDACTED] にマスクされます。
+- raw 値は include_raw_upstream_fields=True のときのみ返されます。
+- include_raw_upstream_fields=True には VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM=1 が必要です。
+- VERITAS_ENV が prod / production / stg / staging の場合、raw 出力は許可されません。
+- VERITAS_ENV 判定前に strip/lower 正規化を行います。
+- これは特定フィールドに限定したマスキングであり、汎用的な PII/secret 検知ではありません。
+- テスト外で保存する場合は TrustLog redaction/sanitization pipeline を必ず通してください。
+- この sandbox は本番 AML/KYC コンプライアンス実装ではありません。

--- a/tests/governance/test_rsa_sandbox_receiver.py
+++ b/tests/governance/test_rsa_sandbox_receiver.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import pytest
+
+from veritas_os.governance.rsa_sandbox_receiver import (
+    RSASandboxPayload,
+    evaluate_rsa_sandbox_signal,
+)
+
+
+def _payload(status: str) -> RSASandboxPayload:
+    return RSASandboxPayload(
+        rsa_status=status,
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008Z",
+    )
+
+
+def test_algorithmic_humility_pauses_human_review_without_hard_block() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("ALGORITHMIC_HUMILITY_ENGAGED"))
+
+    assert result["veritas_decision"]["continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["veritas_decision"]["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        result["audit_entry"]["veritas_reason"]
+        == "The workflow cannot continue toward final commit because required "
+        "KYC context is incomplete and authority evidence is insufficient."
+    )
+
+
+def test_deferral_engaged_hard_blocks_final_commit() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("DEFERRAL_ENGAGED"))
+
+    assert result["veritas_decision"]["continuation_decision"] == "BLOCK_FINAL_COMMIT"
+    assert result["veritas_decision"]["reason_code"] == "UPSTREAM_CRITICAL_DEFERRAL_SIGNAL"
+    assert result["veritas_decision"]["sandbox_commit_state"] == "BLOCKED_NOT_COMMITTED"
+    assert (
+        result["audit_entry"]["veritas_reason"]
+        == "RSA reported a critical upstream deferral condition; VERITAS "
+        "blocks final commit until human review or policy remediation occurs."
+    )
+
+
+def test_density_throttled_logs_intervention_without_default_block() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("DENSITY_THROTTLED"))
+
+    assert (
+        result["veritas_decision"]["continuation_decision"]
+        == "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED"
+    )
+    assert (
+        result["veritas_decision"]["reason_code"]
+        == "UPSTREAM_INTERVENTION_DENSITY_THROTTLE"
+    )
+    assert result["veritas_decision"]["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        result["audit_entry"]["veritas_reason"]
+        == "RSA modified the upstream output for cognitive density control; "
+        "VERITAS records the intervention without treating it as a default "
+        "hard block."
+    )
+
+
+def test_safe_proceed_continues_to_bind_boundary_evaluation() -> None:
+    payload = _payload("SAFE_PROCEED")
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["veritas_decision"]["continuation_decision"] == "CONTINUE_TO_BIND_BOUNDARY"
+    assert result["veritas_decision"]["reason_code"] == "UPSTREAM_SAFE_PROCEED_SIGNAL"
+    assert result["veritas_decision"]["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        result["veritas_decision"]["sandbox_bind_boundary_state"]
+        == "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE"
+    )
+    assert result["audit_entry"]["upstream_signal_source"] == "RSA"
+    assert result["audit_entry"]["rsa_status"] == payload.rsa_status
+    assert result["audit_entry"]["trigger_source"] == payload.trigger_source
+    assert (
+        result["audit_entry"]["veritas_reason"]
+        == "The upstream RSA signal indicates the workflow may continue "
+        "toward normal bind-boundary evaluation."
+    )
+
+
+def test_audit_entry_preserves_upstream_and_downstream_decision() -> None:
+    payload = _payload("ALGORITHMIC_HUMILITY_ENGAGED")
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["audit_entry"]["upstream_signal_source"] == "RSA"
+    assert result["audit_entry"]["rsa_status"] == payload.rsa_status
+    assert (
+        result["audit_entry"]["veritas_continuation_decision"]
+        == result["veritas_decision"]["continuation_decision"]
+    )
+    assert (
+        result["audit_entry"]["veritas_sandbox_commit_state"]
+        == result["veritas_decision"]["sandbox_commit_state"]
+    )
+
+
+def test_contract_example_matches_expected_output_shape() -> None:
+    payload = _payload("ALGORITHMIC_HUMILITY_ENGAGED")
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["veritas_decision"] == {
+        "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+        "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+        "authority_evidence_status": "INSUFFICIENT",
+        "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+        "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+        "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW",
+    }
+    assert result["audit_entry"] == {
+        "upstream_signal_source": "RSA",
+        "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+        "trigger_source": "SRC_Incomplete_Context",
+        "original_llm_intent": "[REDACTED]",
+        "rsa_action_taken": "[REDACTED]",
+        "veritas_reason": (
+            "The workflow cannot continue toward final commit because required "
+            "KYC context is incomplete and authority evidence is insufficient."
+        ),
+        "timestamp": "2026-05-11T11:25:44.008Z",
+        "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+        "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+    }
+
+
+def test_unknown_status_raises_contract_violation() -> None:
+    payload = _payload("UNKNOWN_STATUS")
+
+    with pytest.raises(
+        ValueError,
+        match="Unknown RSA sandbox status: UNKNOWN_STATUS",
+    ) as exc_info:
+        evaluate_rsa_sandbox_signal(payload)
+    message = str(exc_info.value)
+
+    assert "Unknown RSA sandbox status: UNKNOWN_STATUS" in message
+    assert "Supported:" in message
+    assert "SAFE_PROCEED" in message
+    assert "DENSITY_THROTTLED" in message
+    assert "ALGORITHMIC_HUMILITY_ENGAGED" in message
+    assert "DEFERRAL_ENGAGED" in message
+
+
+def test_legacy_bind_boundary_field_is_not_present() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("SAFE_PROCEED"))
+
+    assert "bind_boundary_result" not in result["veritas_decision"]
+
+
+def test_default_output_redacts_upstream_raw_fields() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("SAFE_PROCEED"))
+
+    assert result["audit_entry"]["original_llm_intent"] == "[REDACTED]"
+    assert result["audit_entry"]["rsa_action_taken"] == "[REDACTED]"
+
+
+def test_opt_in_output_includes_upstream_raw_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _payload("SAFE_PROCEED")
+    monkeypatch.setenv("VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM", "1")
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+
+    result = evaluate_rsa_sandbox_signal(payload, include_raw_upstream_fields=True)
+
+    assert result["audit_entry"]["original_llm_intent"] == payload.original_llm_intent
+    assert result["audit_entry"]["rsa_action_taken"] == payload.rsa_action_taken
+
+
+def test_timestamp_with_trailing_z_is_accepted() -> None:
+    result = evaluate_rsa_sandbox_signal(_payload("SAFE_PROCEED"))
+
+    assert result["audit_entry"]["timestamp"] == "2026-05-11T11:25:44.008Z"
+
+
+def test_invalid_timestamp_is_rejected() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008Z-invalid",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "RSASandboxPayload.timestamp must be timezone-aware ISO-8601 "
+            "with trailing Z or explicit offset"
+        ),
+    ):
+        evaluate_rsa_sandbox_signal(payload)
+
+
+def test_timestamp_global_z_replacement_is_not_applied() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44Znote",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "RSASandboxPayload.timestamp must be timezone-aware ISO-8601 "
+            "with trailing Z or explicit offset"
+        ),
+    ):
+        evaluate_rsa_sandbox_signal(payload)
+
+
+def test_timezone_offset_plus_00_is_accepted() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008+00:00",
+    )
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["audit_entry"]["timestamp"] == payload.timestamp
+
+
+def test_timezone_offset_plus_09_is_accepted() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008+09:00",
+    )
+
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    assert result["audit_entry"]["timestamp"] == payload.timestamp
+
+
+def test_naive_timestamp_is_rejected() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="SAFE_PROCEED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-05-11T11:25:44.008",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "RSASandboxPayload.timestamp must be timezone-aware ISO-8601 "
+            "with trailing Z or explicit offset"
+        ),
+    ):
+        evaluate_rsa_sandbox_signal(payload)
+
+
+def test_raw_opt_in_raises_in_production_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _payload("SAFE_PROCEED")
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM", "1")
+
+    with pytest.raises(
+        ValueError,
+        match="Raw upstream RSA sandbox fields are not allowed in operational environments",
+    ):
+        evaluate_rsa_sandbox_signal(payload, include_raw_upstream_fields=True)
+
+
+@pytest.mark.parametrize("veritas_env", ["stg", " production ", " stg "])
+def test_raw_opt_in_raises_for_operational_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+    veritas_env: str,
+) -> None:
+    payload = _payload("SAFE_PROCEED")
+    monkeypatch.setenv("VERITAS_ENV", veritas_env)
+    monkeypatch.setenv("VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM", "1")
+
+    with pytest.raises(
+        ValueError,
+        match="Raw upstream RSA sandbox fields are not allowed in operational environments",
+    ):
+        evaluate_rsa_sandbox_signal(payload, include_raw_upstream_fields=True)
+
+
+def test_raw_opt_in_requires_explicit_allow_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _payload("SAFE_PROCEED")
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+    monkeypatch.delenv("VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM", raising=False)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Raw upstream RSA sandbox fields require "
+            "VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM=1"
+        ),
+    ):
+        evaluate_rsa_sandbox_signal(payload, include_raw_upstream_fields=True)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("rsa_status", ""),
+        ("trigger_source", " "),
+        ("original_llm_intent", ""),
+        ("rsa_action_taken", " "),
+        ("timestamp", ""),
+    ],
+)
+def test_payload_fields_must_be_non_empty_strings(
+    field_name: str,
+    field_value: str,
+) -> None:
+    payload_kwargs = {
+        "rsa_status": "SAFE_PROCEED",
+        "trigger_source": "SRC_Incomplete_Context",
+        "original_llm_intent": "Recommend_Transaction_Approval",
+        "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+        "timestamp": "2026-05-11T11:25:44.008Z",
+    }
+    payload_kwargs[field_name] = field_value
+    payload = RSASandboxPayload(**payload_kwargs)
+
+    with pytest.raises(
+        ValueError,
+        match=f"RSASandboxPayload.{field_name} must be a non-empty string",
+    ):
+        evaluate_rsa_sandbox_signal(payload)

--- a/veritas_os/governance/rsa_sandbox_receiver.py
+++ b/veritas_os/governance/rsa_sandbox_receiver.py
@@ -1,0 +1,212 @@
+"""Sandbox-only RSA upstream signal receiver for AML/KYC interface contract.
+
+This module is intentionally scoped to deterministic fixture behavior. It does
+not implement production AML/KYC compliance workflows and must not be treated
+as legal or regulatory certification.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Mapping
+
+
+@dataclass(frozen=True)
+class RSAStatusContract:
+    """Immutable RSA status contract used by this sandbox fixture."""
+
+    continuation_decision: str
+    reason_code: str
+
+
+_RSA_STATUS_CONTRACTS: Final[Mapping[str, RSAStatusContract]] = MappingProxyType(
+    {
+        "SAFE_PROCEED": RSAStatusContract(
+            continuation_decision="CONTINUE_TO_BIND_BOUNDARY",
+            reason_code="UPSTREAM_SAFE_PROCEED_SIGNAL",
+        ),
+        "DENSITY_THROTTLED": RSAStatusContract(
+            continuation_decision="CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+            reason_code="UPSTREAM_INTERVENTION_DENSITY_THROTTLE",
+        ),
+        "ALGORITHMIC_HUMILITY_ENGAGED": RSAStatusContract(
+            continuation_decision="PAUSE_FOR_HUMAN_REVIEW",
+            reason_code="UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+        ),
+        "DEFERRAL_ENGAGED": RSAStatusContract(
+            continuation_decision="BLOCK_FINAL_COMMIT",
+            reason_code="UPSTREAM_CRITICAL_DEFERRAL_SIGNAL",
+        ),
+    }
+)
+_TIMESTAMP_ERROR_MESSAGE = (
+    "RSASandboxPayload.timestamp must be timezone-aware ISO-8601 "
+    "with trailing Z or explicit offset"
+)
+
+
+@dataclass(frozen=True)
+class RSASandboxPayload:
+    """External RSA upstream payload consumed by VERITAS sandbox fixtures."""
+
+    rsa_status: str
+    trigger_source: str
+    original_llm_intent: str
+    rsa_action_taken: str
+    timestamp: str
+
+
+@dataclass(frozen=True)
+class VeritasSandboxDecision:
+    """VERITAS downstream decision fields derived from RSA upstream status."""
+
+    continuation_decision: str
+    reason_code: str
+    authority_evidence_status: str
+    sandbox_bind_boundary_state: str
+    sandbox_commit_state: str
+    required_next_action: str
+    audit_narrative: str
+
+
+def _veritas_reason_for_status(rsa_status: str) -> str:
+    """Return status-specific sandbox audit narrative for RSA upstream signals."""
+    if rsa_status == "SAFE_PROCEED":
+        return (
+            "The upstream RSA signal indicates the workflow may continue "
+            "toward normal bind-boundary evaluation."
+        )
+    if rsa_status == "DENSITY_THROTTLED":
+        return (
+            "RSA modified the upstream output for cognitive density control; "
+            "VERITAS records the intervention without treating it as a default "
+            "hard block."
+        )
+    if rsa_status == "DEFERRAL_ENGAGED":
+        return (
+            "RSA reported a critical upstream deferral condition; VERITAS "
+            "blocks final commit until human review or policy remediation occurs."
+        )
+    if rsa_status == "ALGORITHMIC_HUMILITY_ENGAGED":
+        return (
+            "The workflow cannot continue toward final commit because required "
+            "KYC context is incomplete and authority evidence is insufficient."
+        )
+    return (
+        "VERITAS received an upstream RSA signal and logged the intervention "
+        "for bind-boundary and commit evaluation."
+    )
+
+
+def _build_veritas_decision(rsa_status: str) -> VeritasSandboxDecision:
+    """Translate a sandbox RSA status into a deterministic VERITAS decision."""
+    contract = _contract_for_status(rsa_status)
+    is_deferral = rsa_status == "DEFERRAL_ENGAGED"
+
+    return VeritasSandboxDecision(
+        continuation_decision=contract.continuation_decision,
+        reason_code=contract.reason_code,
+        authority_evidence_status="INSUFFICIENT",
+        sandbox_bind_boundary_state="NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+        sandbox_commit_state=(
+            "BLOCKED_NOT_COMMITTED" if is_deferral else "SUSPENDED_NOT_COMMITTED"
+        ),
+        required_next_action="REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW",
+        audit_narrative=_veritas_reason_for_status(rsa_status),
+    )
+
+
+def _contract_for_status(rsa_status: str) -> RSAStatusContract:
+    """Return validated RSA contract metadata for one sandbox status."""
+    contract = _RSA_STATUS_CONTRACTS.get(rsa_status)
+    if contract is None:
+        supported = ", ".join(sorted(_RSA_STATUS_CONTRACTS))
+        raise ValueError(
+            f"Unknown RSA sandbox status: {rsa_status}. Supported: {supported}"
+        )
+    return contract
+
+
+def evaluate_rsa_sandbox_signal(
+    payload: RSASandboxPayload,
+    include_raw_upstream_fields: bool = False,
+) -> dict[str, dict[str, str]]:
+    """Evaluate RSA upstream status as an external signal in sandbox mode.
+
+    RSA remains external upstream context. VERITAS owns continuation
+    admissibility, sandbox bind-boundary state, sandbox commit state, and audit
+    output.
+
+    Security note:
+    By default, original_llm_intent and rsa_action_taken are redacted.
+    Set include_raw_upstream_fields=True only for sandbox tests that need raw
+    fixture values. This masking is limited to those fields and is not
+    generalized PII/secret detection. Do not persist raw values outside tests
+    unless they pass through the TrustLog redaction/sanitization pipeline.
+    """
+    for field_name, value in (
+        ("rsa_status", payload.rsa_status),
+        ("trigger_source", payload.trigger_source),
+        ("original_llm_intent", payload.original_llm_intent),
+        ("rsa_action_taken", payload.rsa_action_taken),
+        ("timestamp", payload.timestamp),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"RSASandboxPayload.{field_name} must be a non-empty string")
+
+    if include_raw_upstream_fields:
+        veritas_env = os.getenv("VERITAS_ENV", "").strip().lower()
+        if veritas_env in {"prod", "production", "stg", "staging"}:
+            raise ValueError(
+                "Raw upstream RSA sandbox fields are not allowed in operational environments"
+            )
+        if os.getenv("VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM") != "1":
+            raise ValueError(
+                "Raw upstream RSA sandbox fields require "
+                "VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM=1"
+            )
+
+    normalized_timestamp = (
+        payload.timestamp[:-1] + "+00:00"
+        if payload.timestamp.endswith("Z")
+        else payload.timestamp
+    )
+    try:
+        parsed = datetime.fromisoformat(normalized_timestamp)
+    except ValueError as exc:
+        raise ValueError(_TIMESTAMP_ERROR_MESSAGE) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(_TIMESTAMP_ERROR_MESSAGE)
+
+    decision = _build_veritas_decision(payload.rsa_status)
+    original_llm_intent = (
+        payload.original_llm_intent if include_raw_upstream_fields else "[REDACTED]"
+    )
+    rsa_action_taken = (
+        payload.rsa_action_taken if include_raw_upstream_fields else "[REDACTED]"
+    )
+
+    return {
+        "veritas_decision": {
+            "continuation_decision": decision.continuation_decision,
+            "reason_code": decision.reason_code,
+            "authority_evidence_status": decision.authority_evidence_status,
+            "sandbox_bind_boundary_state": decision.sandbox_bind_boundary_state,
+            "sandbox_commit_state": decision.sandbox_commit_state,
+            "required_next_action": decision.required_next_action,
+        },
+        "audit_entry": {
+            "upstream_signal_source": "RSA",
+            "rsa_status": payload.rsa_status,
+            "trigger_source": payload.trigger_source,
+            "original_llm_intent": original_llm_intent,
+            "rsa_action_taken": rsa_action_taken,
+            "veritas_reason": decision.audit_narrative,
+            "timestamp": payload.timestamp,
+            "veritas_continuation_decision": decision.continuation_decision,
+            "veritas_sandbox_commit_state": decision.sandbox_commit_state,
+        },
+    }


### PR DESCRIPTION
### Motivation

- Provide a deterministic sandbox fixture to translate RSA upstream AML/KYC signals into VERITAS continuation and audit decisions for testing and review workflows.
- Capture and document allowed input/output schemas and secure handling of raw upstream fields while preventing accidental use in production-like environments.

### Description

- Add `veritas_os.governance.rsa_sandbox_receiver` which implements `RSASandboxPayload`, deterministic translation of RSA statuses to a `VeritasSandboxDecision`, timestamp validation, and controlled redaction with `include_raw_upstream_fields` gated by environment variables.
- Introduce an immutable mapping of RSA statuses to VERITAS continuation and reason codes and explicit error handling for unknown statuses and invalid/empty payload fields.
- Implement audit output structure and sandbox-only commit/bind-boundary fixture states and narratives returned by `evaluate_rsa_sandbox_signal`.
- Add English and Japanese guide documents describing the sandbox contract and behavior.

### Testing

- Add unit tests at `tests/governance/test_rsa_sandbox_receiver.py` exercising all translation paths, timestamp validation, redaction gating, payload validation, and error messages.
- Run `pytest tests/governance/test_rsa_sandbox_receiver.py` and the new test suite passed (all assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e5927158832695cb3aacb17fb97c)