### PR TITLE
Add TrustLog production-posture checker with Makefile target and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST_MARKEXPR ?= not slow
 COVERAGE_XML ?= coverage.xml
 COVERAGE_HTML_DIR ?= coverage-html
 
-.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence
+.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence check-trustlog-production-posture
 
 # ── Setup & Development ──────────────────────────────────────────────────
 
@@ -287,3 +287,7 @@ performance-evidence:
 
 check-performance-evidence:
 	python -m scripts.performance.check_performance_evidence_freshness
+
+
+check-trustlog-production-posture:
+	python -m scripts.security.check_trustlog_production_posture

--- a/scripts/security/check_trustlog_production_posture.py
+++ b/scripts/security/check_trustlog_production_posture.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Check TrustLog production security posture from environment variables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import environ
+from typing import Mapping
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+PRODUCTION_ENV_ALIASES = {"prod", "production"}
+
+
+@dataclass(frozen=True)
+class TrustLogPostureResult:
+    """Result payload for TrustLog production posture checks."""
+
+    passed: bool
+    failures: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+def _env_true(value: str | None) -> bool:
+    """Return True when the provided environment value is explicitly truthy."""
+    if value is None:
+        return False
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def _normalized(env: Mapping[str, str], key: str) -> str:
+    """Return normalized environment value for robust comparisons."""
+    return (env.get(key, "") or "").strip().lower()
+
+
+def _is_production_mode(env: Mapping[str, str]) -> bool:
+    """Return True when strict production posture must be enforced."""
+    return (
+        _normalized(env, "VERITAS_ENV") in PRODUCTION_ENV_ALIASES
+        or _env_true(env.get("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE"))
+    )
+
+
+def check_trustlog_production_posture(
+    env: Mapping[str, str] | None = None,
+) -> TrustLogPostureResult:
+    """Validate TrustLog posture using production defaults and required controls."""
+    current_env = env if env is not None else environ
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if not _is_production_mode(current_env):
+        return TrustLogPostureResult(True, tuple(failures), tuple(warnings))
+
+    if _normalized(current_env, "VERITAS_TRUSTLOG_BACKEND") != "postgresql":
+        failures.append("production TrustLog backend must be postgresql")
+
+    has_database_url = bool((current_env.get("VERITAS_DATABASE_URL", "") or "").strip())
+    has_fallback_database_url = bool((current_env.get("DATABASE_URL", "") or "").strip())
+    if not (has_database_url or has_fallback_database_url):
+        failures.append(
+            "production TrustLog PostgreSQL backend requires VERITAS_DATABASE_URL or DATABASE_URL"
+        )
+
+    if not (current_env.get("VERITAS_ENCRYPTION_KEY", "") or "").strip():
+        failures.append("production TrustLog encryption requires VERITAS_ENCRYPTION_KEY")
+
+    if _normalized(current_env, "VERITAS_TRUSTLOG_SIGNER_BACKEND") != "aws_kms":
+        failures.append("production TrustLog signer backend must be aws_kms")
+
+    if not (current_env.get("VERITAS_TRUSTLOG_KMS_KEY_ID", "") or "").strip():
+        failures.append(
+            "production TrustLog aws_kms signer requires VERITAS_TRUSTLOG_KMS_KEY_ID"
+        )
+
+    if not (current_env.get("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "") or "").strip():
+        warnings.append("production TrustLog WORM mirror path is not configured")
+
+    if not _env_true(current_env.get("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED")):
+        warnings.append("production TrustLog transparency anchoring is not required")
+
+    if not (current_env.get("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "") or "").strip():
+        warnings.append("production TrustLog transparency log path is not configured")
+
+    if _normalized(current_env, "VERITAS_TRUSTLOG_ANCHOR_BACKEND") == "noop":
+        warnings.append("production TrustLog anchor backend is noop")
+
+    return TrustLogPostureResult(not failures, tuple(failures), tuple(warnings))
+
+
+def main() -> int:
+    """Run the TrustLog production posture checker as a CLI."""
+    result = check_trustlog_production_posture(dict(environ))
+
+    if result.passed and not result.warnings:
+        print("TrustLog production posture check passed.")
+        return 0
+
+    if result.passed and result.warnings:
+        print("TrustLog production posture check passed with warnings.")
+        print("Warnings:")
+        for warning in result.warnings:
+            print(f"- {warning}")
+        return 0
+
+    print("TrustLog production posture check failed.")
+    print("Failures:")
+    for failure in result.failures:
+        print(f"- {failure}")
+    if result.warnings:
+        print("Warnings:")
+        for warning in result.warnings:
+            print(f"- {warning}")
+    print("Remediation:")
+    print("- Set VERITAS_TRUSTLOG_BACKEND=postgresql")
+    print("- Configure VERITAS_DATABASE_URL or DATABASE_URL")
+    print("- Configure VERITAS_ENCRYPTION_KEY")
+    print("- Set VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms")
+    print("- Configure VERITAS_TRUSTLOG_KMS_KEY_ID")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veritas_os/tests/test_trustlog_production_posture.py
+++ b/veritas_os/tests/test_trustlog_production_posture.py
@@ -1,0 +1,180 @@
+"""Tests for TrustLog production posture security checker."""
+
+from __future__ import annotations
+
+from scripts.security.check_trustlog_production_posture import _env_true
+from scripts.security.check_trustlog_production_posture import check_trustlog_production_posture
+from scripts.security.check_trustlog_production_posture import main
+
+
+def _production_base_env() -> dict[str, str]:
+    return {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+    }
+
+
+def test_development_env_passes() -> None:
+    result = check_trustlog_production_posture({})
+    assert result.passed is True
+    assert result.failures == ()
+
+
+def test_development_insecure_defaults_do_not_fail() -> None:
+    env = {
+        "VERITAS_TRUSTLOG_BACKEND": "jsonl",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "file",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is True
+
+
+def test_production_missing_backend_fails() -> None:
+    result = check_trustlog_production_posture({"VERITAS_ENV": "production"})
+    assert any("backend must be postgresql" in item for item in result.failures)
+
+
+def test_production_jsonl_backend_fails() -> None:
+    result = check_trustlog_production_posture(
+        {"VERITAS_ENV": "production", "VERITAS_TRUSTLOG_BACKEND": "jsonl"}
+    )
+    assert any("backend must be postgresql" in item for item in result.failures)
+
+
+def test_prod_alias_enforces_production_posture() -> None:
+    result = check_trustlog_production_posture({"VERITAS_ENV": "prod"})
+    assert result.passed is False
+    assert any("backend must be postgresql" in item for item in result.failures)
+
+
+def test_production_postgresql_without_database_url_fails() -> None:
+    result = check_trustlog_production_posture(
+        {"VERITAS_ENV": "production", "VERITAS_TRUSTLOG_BACKEND": "postgresql"}
+    )
+    assert any("requires VERITAS_DATABASE_URL or DATABASE_URL" in item for item in result.failures)
+
+
+def test_production_missing_encryption_key_fails() -> None:
+    env = {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("VERITAS_ENCRYPTION_KEY" in item for item in result.failures)
+
+
+def test_production_file_signer_fails_even_with_override() -> None:
+    env = {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "file",
+        "VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD": "1",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("signer backend must be aws_kms" in item for item in result.failures)
+
+
+def test_production_aws_kms_without_kms_key_fails() -> None:
+    env = {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("KMS_KEY_ID" in item for item in result.failures)
+
+
+def test_production_fully_configured_passes() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "1",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is True
+    assert result.failures == ()
+
+
+def test_production_without_worm_emits_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "1",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is True
+    assert any("WORM mirror path" in item for item in result.warnings)
+
+
+def test_anchor_noop_emits_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "1",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "noop",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is True
+    assert any("anchor backend is noop" in item for item in result.warnings)
+
+
+def test_require_production_flag_enforces_check() -> None:
+    env = {"VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": "1"}
+    result = check_trustlog_production_posture(env)
+    assert result.passed is False
+
+
+def test_require_production_flag_truthy_alias_enforces_check() -> None:
+    env = {"VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": "true"}
+    result = check_trustlog_production_posture(env)
+    assert result.passed is False
+
+
+def test_boolean_parser_accepts_truthy_values() -> None:
+    assert _env_true("1")
+    assert _env_true("TrUe")
+    assert _env_true("YES")
+    assert _env_true(" on ")
+
+
+def test_cli_main_returns_zero_in_development(monkeypatch) -> None:
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+    monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+    assert main() == 0
+
+
+def test_cli_main_returns_one_in_production_insecure(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.delenv("VERITAS_TRUSTLOG_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+    assert main() == 1
+
+
+def test_cli_main_returns_zero_in_production_fully_configured(monkeypatch) -> None:
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://example")
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", "dummy")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "dummy-kms-key")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/tmp/worm")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/tmp/transparency.jsonl")
+    assert main() == 0


### PR DESCRIPTION
### Motivation

- Provide an automated check to ensure TrustLog is configured with secure production defaults and to catch misconfigurations early.

### Description

- Add `scripts/security/check_trustlog_production_posture.py` which implements `check_trustlog_production_posture`, `_env_true`, `TrustLogPostureResult`, and a `main` CLI that validates production requirements and emits failures or warnings.
- Enforce production posture when `VERITAS_ENV` is `prod`/`production` or `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` is truthy, including checks for `VERITAS_TRUSTLOG_BACKEND=postgresql`, `VERITAS_DATABASE_URL`/`DATABASE_URL`, `VERITAS_ENCRYPTION_KEY`, `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms`, and `VERITAS_TRUSTLOG_KMS_KEY_ID`, and emit warnings for missing WORM mirror, transparency settings, or noop anchoring.
- Add a Makefile phony target `check-trustlog-production-posture` that runs `python -m scripts.security.check_trustlog_production_posture`.
- Add unit tests in `veritas_os/tests/test_trustlog_production_posture.py` covering development vs production behavior, failure and warning cases, boolean parsing, and CLI exit codes.

### Testing

- Executed `pytest veritas_os/tests/test_trustlog_production_posture.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03341642908326812690168fea1cc9)