### PR TITLE
Wire TrustLog production posture check into CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,6 +208,20 @@ jobs:
       - name: "[Tier 1] Check performance evidence freshness"
         run: make check-performance-evidence
 
+      - name: "[Tier 1] Check TrustLog production posture"
+        env:
+          VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE: "1"
+          VERITAS_ENV: "production"
+          VERITAS_TRUSTLOG_BACKEND: "postgresql"
+          VERITAS_DATABASE_URL: "postgresql://veritas:veritas@localhost:5432/veritas_ci"
+          VERITAS_ENCRYPTION_KEY: "ci-dummy-encryption-key-not-a-real-secret"
+          VERITAS_TRUSTLOG_SIGNER_BACKEND: "aws_kms"
+          VERITAS_TRUSTLOG_KMS_KEY_ID: "arn:aws:kms:us-east-1:000000000000:key/ci-dummy"
+          VERITAS_TRUSTLOG_WORM_MIRROR_PATH: "/tmp/veritas-ci/worm"
+          VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED: "1"
+          VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH: "/tmp/veritas-ci/transparency.jsonl"
+        run: make check-trustlog-production-posture
+
       - name: "[Tier 1] Run governance smoke tests"
         run: |
           set -euxo pipefail


### PR DESCRIPTION
### Motivation
- Exercise the TrustLog production-enforcement path on every PR by wiring the existing checker into the Tier 1 CI smoke job without changing checker logic or runtime behavior.

### Description
- Added a new step to `.github/workflows/main.yml` in the `[Tier 1] governance-smoke` job that runs `make check-trustlog-production-posture` adjacent to the evidence freshness checks.
- The step sets step-local non-secret dummy fixture env (`VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE`, `VERITAS_ENV`, `VERITAS_TRUSTLOG_BACKEND`, `VERITAS_DATABASE_URL`, `VERITAS_ENCRYPTION_KEY`, `VERITAS_TRUSTLOG_SIGNER_BACKEND`, `VERITAS_TRUSTLOG_KMS_KEY_ID`, `VERITAS_TRUSTLOG_WORM_MIRROR_PATH`, `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED`, `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH`) and does not introduce repository secrets or change any other files, tests, Makefile, or TrustLog implementation.

### Testing
- A local run of the make target failed initially due to the environment requesting `python 3.12.12` which was not installed (pyenv error).
- Re-running locally with `PYENV_VERSION=3.12.13` and the same dummy env produced `TrustLog production posture check passed.` and exited successfully.
- GitHub Actions was not executed from this environment, so remote CI run results are not included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0457fe2b008326a77e63a951851e75)