### PR TITLE
Document TrustLog production posture checker

### DIFF
--- a/docs/en/operations/env-reference.md
+++ b/docs/en/operations/env-reference.md
@@ -70,6 +70,7 @@ Variables prefixed with `VERITAS_` are project-specific.
 | `VERITAS_TRUSTLOG_ANCHOR_BACKEND` | `local` | TrustLog anchor backend (`local` = local spool receipt, `noop` = explicitly skip anchoring) |
 | `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` | `""` | Local spool path used by `VERITAS_TRUSTLOG_ANCHOR_BACKEND=local` |
 | `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` | `0` | Require transparency log anchoring (`0` = optional, `1` = required) |
+| `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` | `false` | Checker-only flag to force production TrustLog posture validation outside production env. Runtime behavior is not changed by this flag unless the checker is invoked. |
 
 ### TrustLog transparency anchoring roadmap
 

--- a/docs/en/operations/postgresql-production-guide.md
+++ b/docs/en/operations/postgresql-production-guide.md
@@ -159,6 +159,11 @@ In production mode, the checker fails if:
 - `VERITAS_TRUSTLOG_SIGNER_BACKEND` is not `aws_kms`
 - `VERITAS_TRUSTLOG_KMS_KEY_ID` is unset
 
+> Note: `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` is not honored by
+> this production posture checker. In production posture, the checker requires
+> `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms` and fails for `file`, `local`,
+> `noop`, or missing signer backends even if the break-glass flag is set.
+
 ### Production warning conditions
 
 In production mode, the checker warns (non-fatal) if:

--- a/docs/en/operations/postgresql-production-guide.md
+++ b/docs/en/operations/postgresql-production-guide.md
@@ -118,6 +118,86 @@ in `veritas_os/storage/db.py`.
 
 ---
 
+## TrustLog production posture checker (operator-facing minimum posture check)
+
+`check-trustlog-production-posture` is an operator-facing CLI checker for
+minimum TrustLog production posture. It validates environment-variable presence
+and posture assumptions only.
+
+- It does **not** change runtime defaults.
+- It does **not** connect to real DB/KMS/WORM services.
+- It validates env presence / posture for expected production configuration.
+- In CI, production-path enforcement is exercised with a non-secret dummy
+  fixture env.
+- Passing this checker does **not** prove real production readiness.
+- Production deployments still require separate real configuration for DB, KMS,
+  WORM, and transparency anchoring.
+
+### How to run
+
+```bash
+make check-trustlog-production-posture
+# or
+python -m scripts.security.check_trustlog_production_posture
+```
+
+### When production checks are enforced
+
+Production posture validation is strict when any of the following is true:
+
+- `VERITAS_ENV=production`
+- `VERITAS_ENV=prod`
+- `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` is truthy (`1`, `true`, `yes`, `on`)
+
+### Production failure conditions
+
+In production mode, the checker fails if:
+
+- `VERITAS_TRUSTLOG_BACKEND` is not `postgresql`
+- `VERITAS_DATABASE_URL` and `DATABASE_URL` are both unset
+- `VERITAS_ENCRYPTION_KEY` is unset
+- `VERITAS_TRUSTLOG_SIGNER_BACKEND` is not `aws_kms`
+- `VERITAS_TRUSTLOG_KMS_KEY_ID` is unset
+
+### Production warning conditions
+
+In production mode, the checker warns (non-fatal) if:
+
+- `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` is unset
+- `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` is not enabled
+- `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` is unset
+- `VERITAS_TRUSTLOG_ANCHOR_BACKEND=noop`
+
+> Note: WORM and transparency are warning-level in this checker, not failure-level.
+
+### CI fixture semantics and limits
+
+In GitHub Actions `[Tier 1] governance-smoke`, a step-local dummy env is used
+to run `make check-trustlog-production-posture`.
+
+- This is a deterministic fixture to ensure the checker's production-enforcement
+  path keeps working.
+- Dummy `VERITAS_DATABASE_URL` and dummy `VERITAS_TRUSTLOG_KMS_KEY_ID` are not
+  real connection targets.
+- Repository secrets are not used for this fixture.
+- This CI path does not prove real production readiness.
+
+### Recommended production env sample (placeholders only)
+
+```bash
+VERITAS_ENV=production
+VERITAS_TRUSTLOG_BACKEND=postgresql
+VERITAS_DATABASE_URL=postgresql://<user>:<password>@<host>:5432/<database>
+VERITAS_ENCRYPTION_KEY=<base64-encoded-32-byte-key>
+VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms
+VERITAS_TRUSTLOG_KMS_KEY_ID=<aws-kms-ed25519-key-arn>
+VERITAS_TRUSTLOG_WORM_MIRROR_PATH=<worm-mirror-path>
+VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED=1
+VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH=<transparency-log-path>
+```
+
+---
+
 ## 3. SSL / TLS
 
 ### Environment variable

--- a/docs/en/operations/trustlog_observability.md
+++ b/docs/en/operations/trustlog_observability.md
@@ -2,6 +2,10 @@
 
 This document defines production-focused TrustLog metrics, alerting guidance, and SLO suggestions.
 
+> For the operator-facing **minimum posture check** (`check-trustlog-production-posture`),
+> including failure/warning semantics and CI dummy-fixture limitations, see
+> [`postgresql-production-guide.md`](postgresql-production-guide.md#trustlog-production-posture-checker-operator-facing-minimum-posture-check).
+
 ## Metrics
 
 ### Counters

--- a/docs/ja/operations/postgresql-production-guide.md
+++ b/docs/ja/operations/postgresql-production-guide.md
@@ -17,6 +17,11 @@ PostgreSQL を本番で運用する際の確認観点を、日本語で短く整
 - バックアップ/リストア手順とドリル結果を証跡化する。
 - Migration 手順とロールバック手順を運用Runbookに統合する。
 
+## TrustLog production posture checker（最小姿勢チェック）
+- `check-trustlog-production-posture` は、TrustLog の本番姿勢に必要な環境変数の有無/設定姿勢を確認する operator-facing な最小チェックです（実行: `make check-trustlog-production-posture` または `python -m scripts.security.check_trustlog_production_posture`）。
+- runtime default は変更せず、実DB/実KMS/実WORMへ接続もしません。CI の `[Tier 1] governance-smoke` では非シークレットのダミー環境変数で production enforcement path を検証しますが、実運用 readiness の証明にはなりません。
+- production mode（`VERITAS_ENV=production|prod` または `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` が truthy）の failure 条件は、`postgresql` backend / DB URL / `VERITAS_ENCRYPTION_KEY` / `aws_kms` signer / `VERITAS_TRUSTLOG_KMS_KEY_ID` の不足です。`VERITAS_TRUSTLOG_WORM_MIRROR_PATH` 未設定、transparency 未要求、`VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` 未設定、`VERITAS_TRUSTLOG_ANCHOR_BACKEND=noop` は warning 扱いです。
+
 ## 現時点の制限
 - ここで示す内容は一般指針で、各環境のHA/DR要件を代替しません。
 - 本番適用前に監査設計・鍵管理・アクセス統制を追加してください。

--- a/docs/ja/operations/postgresql-production-guide.md
+++ b/docs/ja/operations/postgresql-production-guide.md
@@ -21,6 +21,7 @@ PostgreSQL を本番で運用する際の確認観点を、日本語で短く整
 - `check-trustlog-production-posture` は、TrustLog の本番姿勢に必要な環境変数の有無/設定姿勢を確認する operator-facing な最小チェックです（実行: `make check-trustlog-production-posture` または `python -m scripts.security.check_trustlog_production_posture`）。
 - runtime default は変更せず、実DB/実KMS/実WORMへ接続もしません。CI の `[Tier 1] governance-smoke` では非シークレットのダミー環境変数で production enforcement path を検証しますが、実運用 readiness の証明にはなりません。
 - production mode（`VERITAS_ENV=production|prod` または `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` が truthy）の failure 条件は、`postgresql` backend / DB URL / `VERITAS_ENCRYPTION_KEY` / `aws_kms` signer / `VERITAS_TRUSTLOG_KMS_KEY_ID` の不足です。`VERITAS_TRUSTLOG_WORM_MIRROR_PATH` 未設定、transparency 未要求、`VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` 未設定、`VERITAS_TRUSTLOG_ANCHOR_BACKEND=noop` は warning 扱いです。
+- 注: `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` は、この production posture checker では考慮されません。本番姿勢チェックでは `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms` を要求し、`file` / `local` / `noop` / 未設定の signer は、break-glass フラグがあっても failure になります。
 
 ## 現時点の制限
 - ここで示す内容は一般指針で、各環境のHA/DR要件を代替しません。


### PR DESCRIPTION
### Motivation
- Align documentation with the TrustLog production posture checker implementation (introduced earlier) and the CI fixture that exercises its production path. 
- Reduce operator confusion by clearly stating the checker's purpose, how to run it, its enforcement conditions, failure vs warning semantics, CI fixture limits, and a safe placeholder production env sample. 
- Keep this PR docs-only and avoid touching code, tests, Makefile, or workflows. 

### Description
- Added `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` to `docs/en/operations/env-reference.md` with default `false` and a note that it is a checker-only flag that does not alter runtime behavior unless the checker is invoked. 
- Extended `docs/en/operations/postgresql-production-guide.md` with a new section `TrustLog production posture checker` documenting the checker's purpose, `make`/`python -m` invocation, production-mode detection (`VERITAS_ENV=production|prod` or `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` truthy), truthy examples, production failure conditions (`VERITAS_TRUSTLOG_BACKEND != postgresql`, missing `VERITAS_DATABASE_URL`/`DATABASE_URL`, missing `VERITAS_ENCRYPTION_KEY`, `VERITAS_TRUSTLOG_SIGNER_BACKEND != aws_kms`, missing `VERITAS_TRUSTLOG_KMS_KEY_ID`), production warning conditions (WORM/transparency-related vars and `anchor_backend=noop`), CI dummy-fixture semantics, and a placeholder-only recommended production env sample. 
- Added a cross-reference in `docs/en/operations/trustlog_observability.md` pointing operators to the new checker section for failure/warning semantics and CI limits. 
- Added a short, equivalent Japanese note to `docs/ja/operations/postgresql-production-guide.md` mirroring the English guidance. 
- Confirmed this change is documentation-only and does not modify the checker script, tests, Makefile, or CI workflows. 

### Testing
- Ran `python3 scripts/quality/check_operational_docs_consistency.py` and it passed (`Operational documentation consistency checks passed`). 
- Attempted `python scripts/quality/check_operational_docs_consistency.py` but the `python` shim failed because the repository `.python-version` pins `3.12.12` which is not installed in this environment. 
- Attempted to run `python3 scripts/quality/check_bilingual_docs_consistency.py` but the script is not present in the repository path, so the bilingual consistency check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045c7123e48326b4e94dc745794a69)