### PR TITLE
Introduce TrustLog production posture validator and enforce checks at startup

### DIFF
--- a/docs/en/operations/postgresql-production-guide.md
+++ b/docs/en/operations/postgresql-production-guide.md
@@ -127,6 +127,8 @@ and posture assumptions only.
 - It does **not** change runtime defaults.
 - It does **not** connect to real DB/KMS/WORM services.
 - It validates env presence / posture for expected production configuration.
+- Runtime startup validation also enforces the same production-failure posture as fail-fast checks for `VERITAS_ENV=prod|production`.
+- Warning-only WORM/transparency findings remain non-fatal during startup and CLI checks.
 - In CI, production-path enforcement is exercised with a non-secret dummy
   fixture env.
 - Passing this checker does **not** prove real production readiness.
@@ -156,7 +158,7 @@ In production mode, the checker fails if:
 - `VERITAS_TRUSTLOG_BACKEND` is not `postgresql`
 - `VERITAS_DATABASE_URL` and `DATABASE_URL` are both unset
 - `VERITAS_ENCRYPTION_KEY` is unset
-- `VERITAS_TRUSTLOG_SIGNER_BACKEND` is not `aws_kms`
+- `VERITAS_TRUSTLOG_SIGNER_BACKEND` is not `aws_kms` (alias `aws_kms_ed25519` is treated as `aws_kms`)
 - `VERITAS_TRUSTLOG_KMS_KEY_ID` is unset
 
 > Note: `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` is not honored by
@@ -168,10 +170,11 @@ In production mode, the checker fails if:
 
 In production mode, the checker warns (non-fatal) if:
 
-- `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` is unset
-- `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` is not enabled
+- `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` is explicitly disabled (`0`/`false`/etc.); if unset in production posture it is treated as required by default
 - `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` is unset
-- `VERITAS_TRUSTLOG_ANCHOR_BACKEND=noop`
+- `VERITAS_TRUSTLOG_ANCHOR_BACKEND` resolves to `noop` (`noop`/`none`/`no_op`)
+- Local mirror backend is selected but `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` is unset
+- `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` without `VERITAS_TRUSTLOG_S3_BUCKET`/`VERITAS_TRUSTLOG_S3_PREFIX`
 
 > Note: WORM and transparency are warning-level in this checker, not failure-level.
 

--- a/scripts/security/check_trustlog_production_posture.py
+++ b/scripts/security/check_trustlog_production_posture.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from os import environ
 
-from veritas_os.security.trustlog_production_posture import _env_true
 from veritas_os.security.trustlog_production_posture import check_trustlog_production_posture
 
 

--- a/scripts/security/check_trustlog_production_posture.py
+++ b/scripts/security/check_trustlog_production_posture.py
@@ -3,88 +3,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from os import environ
-from typing import Mapping
 
-_TRUE_VALUES = {"1", "true", "yes", "on"}
-PRODUCTION_ENV_ALIASES = {"prod", "production"}
-
-
-@dataclass(frozen=True)
-class TrustLogPostureResult:
-    """Result payload for TrustLog production posture checks."""
-
-    passed: bool
-    failures: tuple[str, ...]
-    warnings: tuple[str, ...]
-
-
-def _env_true(value: str | None) -> bool:
-    """Return True when the provided environment value is explicitly truthy."""
-    if value is None:
-        return False
-    return value.strip().lower() in _TRUE_VALUES
-
-
-def _normalized(env: Mapping[str, str], key: str) -> str:
-    """Return normalized environment value for robust comparisons."""
-    return (env.get(key, "") or "").strip().lower()
-
-
-def _is_production_mode(env: Mapping[str, str]) -> bool:
-    """Return True when strict production posture must be enforced."""
-    return (
-        _normalized(env, "VERITAS_ENV") in PRODUCTION_ENV_ALIASES
-        or _env_true(env.get("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE"))
-    )
-
-
-def check_trustlog_production_posture(
-    env: Mapping[str, str] | None = None,
-) -> TrustLogPostureResult:
-    """Validate TrustLog posture using production defaults and required controls."""
-    current_env = env if env is not None else environ
-    failures: list[str] = []
-    warnings: list[str] = []
-
-    if not _is_production_mode(current_env):
-        return TrustLogPostureResult(True, tuple(failures), tuple(warnings))
-
-    if _normalized(current_env, "VERITAS_TRUSTLOG_BACKEND") != "postgresql":
-        failures.append("production TrustLog backend must be postgresql")
-
-    has_database_url = bool((current_env.get("VERITAS_DATABASE_URL", "") or "").strip())
-    has_fallback_database_url = bool((current_env.get("DATABASE_URL", "") or "").strip())
-    if not (has_database_url or has_fallback_database_url):
-        failures.append(
-            "production TrustLog PostgreSQL backend requires VERITAS_DATABASE_URL or DATABASE_URL"
-        )
-
-    if not (current_env.get("VERITAS_ENCRYPTION_KEY", "") or "").strip():
-        failures.append("production TrustLog encryption requires VERITAS_ENCRYPTION_KEY")
-
-    if _normalized(current_env, "VERITAS_TRUSTLOG_SIGNER_BACKEND") != "aws_kms":
-        failures.append("production TrustLog signer backend must be aws_kms")
-
-    if not (current_env.get("VERITAS_TRUSTLOG_KMS_KEY_ID", "") or "").strip():
-        failures.append(
-            "production TrustLog aws_kms signer requires VERITAS_TRUSTLOG_KMS_KEY_ID"
-        )
-
-    if not (current_env.get("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "") or "").strip():
-        warnings.append("production TrustLog WORM mirror path is not configured")
-
-    if not _env_true(current_env.get("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED")):
-        warnings.append("production TrustLog transparency anchoring is not required")
-
-    if not (current_env.get("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "") or "").strip():
-        warnings.append("production TrustLog transparency log path is not configured")
-
-    if _normalized(current_env, "VERITAS_TRUSTLOG_ANCHOR_BACKEND") == "noop":
-        warnings.append("production TrustLog anchor backend is noop")
-
-    return TrustLogPostureResult(not failures, tuple(failures), tuple(warnings))
+from veritas_os.security.trustlog_production_posture import _env_true
+from veritas_os.security.trustlog_production_posture import check_trustlog_production_posture
 
 
 def main() -> int:

--- a/veritas_os/api/startup_health.py
+++ b/veritas_os/api/startup_health.py
@@ -8,7 +8,6 @@ from typing import Callable, Optional
 
 from veritas_os.security.trustlog_production_posture import (
     check_trustlog_production_posture,
-    is_trustlog_production_posture_enforced,
 )
 
 
@@ -184,13 +183,10 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
 def validate_trustlog_production_posture_on_startup(*, logger: logging.Logger) -> None:
     """Validate TrustLog posture during startup with production fail-fast handling."""
     current_env = dict(os.environ)
-    enforced = is_trustlog_production_posture_enforced(current_env)
     result = check_trustlog_production_posture(current_env)
     if result.failures:
         failures = "; ".join(result.failures)
         message = f"[SECURITY] TrustLog production posture check failed: {failures}"
-        if not enforced:
-            return
         raise RuntimeError(
             f"{message}. Refusing startup because TrustLog production posture is "
             "enforced."

--- a/veritas_os/api/startup_health.py
+++ b/veritas_os/api/startup_health.py
@@ -6,6 +6,11 @@ import logging
 import os
 from typing import Callable, Optional
 
+from veritas_os.security.trustlog_production_posture import (
+    check_trustlog_production_posture,
+    is_trustlog_production_posture_enforced,
+)
+
 
 def _is_truthy_env(var_name: str) -> bool:
     """Return True when the named environment variable is explicitly truthy."""
@@ -172,6 +177,27 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
                 "templates to prevent production drift.",
                 message,
             )
+
+    validate_trustlog_production_posture_on_startup(logger=logger)
+
+
+def validate_trustlog_production_posture_on_startup(*, logger: logging.Logger) -> None:
+    """Validate TrustLog posture during startup with production fail-fast handling."""
+    current_env = dict(os.environ)
+    enforced = is_trustlog_production_posture_enforced(current_env)
+    result = check_trustlog_production_posture(current_env)
+    if result.failures:
+        failures = "; ".join(result.failures)
+        message = f"[SECURITY] TrustLog production posture check failed: {failures}"
+        if not enforced:
+            return
+        raise RuntimeError(
+            f"{message}. Refusing startup because TrustLog production posture is "
+            "enforced."
+        )
+
+    for warning in result.warnings:
+        logger.warning("[SECURITY] TrustLog production posture warning: %s", warning)
 
 
 def check_runtime_feature_health(

--- a/veritas_os/security/trustlog_production_posture.py
+++ b/veritas_os/security/trustlog_production_posture.py
@@ -8,6 +8,7 @@ from typing import Mapping
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 PRODUCTION_ENV_ALIASES = {"prod", "production"}
+STRICT_POSTURE_ALIASES = {"secure", "hardened", "prod", "production"}
 
 
 @dataclass(frozen=True)
@@ -35,6 +36,7 @@ def _is_production_mode(env: Mapping[str, str]) -> bool:
     """Return True when strict production posture must be enforced."""
     return (
         _normalized(env, "VERITAS_ENV") in PRODUCTION_ENV_ALIASES
+        or _normalized(env, "VERITAS_POSTURE") in STRICT_POSTURE_ALIASES
         or _env_true(env.get("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE"))
     )
 
@@ -79,10 +81,7 @@ def _effective_transparency_required(env: Mapping[str, str]) -> bool:
     raw = env.get("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED")
     if raw is not None:
         return _env_true(raw)
-    if _is_production_mode(env):
-        return True
-    posture = _normalized(env, "VERITAS_POSTURE")
-    return posture in {"secure", "hardened", "prod", "production"}
+    return _is_production_mode(env)
 
 
 def check_trustlog_production_posture(
@@ -102,7 +101,9 @@ def check_trustlog_production_posture(
     has_database_url = bool(
         (current_env.get("VERITAS_DATABASE_URL", "") or "").strip()
     )
-    has_fallback_database_url = bool((current_env.get("DATABASE_URL", "") or "").strip())
+    has_fallback_database_url = bool(
+        (current_env.get("DATABASE_URL", "") or "").strip()
+    )
     if not (has_database_url or has_fallback_database_url):
         failures.append(
             "production TrustLog PostgreSQL backend requires VERITAS_DATABASE_URL or DATABASE_URL"

--- a/veritas_os/security/trustlog_production_posture.py
+++ b/veritas_os/security/trustlog_production_posture.py
@@ -1,0 +1,146 @@
+"""Runtime-safe TrustLog production posture validation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import environ
+from typing import Mapping
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+PRODUCTION_ENV_ALIASES = {"prod", "production"}
+
+
+@dataclass(frozen=True)
+class TrustLogPostureResult:
+    """Result payload for TrustLog production posture checks."""
+
+    passed: bool
+    failures: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+def _env_true(value: str | None) -> bool:
+    """Return True when the provided environment value is explicitly truthy."""
+    if value is None:
+        return False
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def _normalized(env: Mapping[str, str], key: str) -> str:
+    """Return normalized environment value for robust comparisons."""
+    return (env.get(key, "") or "").strip().lower()
+
+
+def _is_production_mode(env: Mapping[str, str]) -> bool:
+    """Return True when strict production posture must be enforced."""
+    return (
+        _normalized(env, "VERITAS_ENV") in PRODUCTION_ENV_ALIASES
+        or _env_true(env.get("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE"))
+    )
+
+
+def is_trustlog_production_posture_enforced(env: Mapping[str, str]) -> bool:
+    """Return whether TrustLog production posture enforcement is active."""
+    return _is_production_mode(env)
+
+
+def _normalized_signer_backend(env: Mapping[str, str]) -> str:
+    """Normalize signer backend aliases to runtime posture canonical values."""
+    raw = _normalized(env, "VERITAS_TRUSTLOG_SIGNER_BACKEND")
+    if raw in {"", "file", "file_ed25519"}:
+        return "file"
+    if raw in {"aws_kms", "aws_kms_ed25519"}:
+        return "aws_kms"
+    return raw
+
+
+def _normalized_anchor_backend(env: Mapping[str, str]) -> str:
+    """Normalize anchor backend aliases to runtime posture canonical values."""
+    raw = _normalized(env, "VERITAS_TRUSTLOG_ANCHOR_BACKEND")
+    if raw in {"", "local", "file"}:
+        return "local"
+    if raw in {"none", "noop", "no_op"}:
+        return "noop"
+    return raw
+
+
+def _normalized_mirror_backend(env: Mapping[str, str]) -> str:
+    """Normalize mirror backend aliases to runtime posture canonical values."""
+    raw = _normalized(env, "VERITAS_TRUSTLOG_MIRROR_BACKEND")
+    if raw in {"", "local", "filesystem"}:
+        return "local"
+    if raw in {"s3_object_lock", "s3"}:
+        return "s3_object_lock"
+    return raw
+
+
+def _effective_transparency_required(env: Mapping[str, str]) -> bool:
+    """Return effective transparency-required state with posture defaults."""
+    raw = env.get("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED")
+    if raw is not None:
+        return _env_true(raw)
+    if _is_production_mode(env):
+        return True
+    posture = _normalized(env, "VERITAS_POSTURE")
+    return posture in {"secure", "hardened", "prod", "production"}
+
+
+def check_trustlog_production_posture(
+    env: Mapping[str, str] | None = None,
+) -> TrustLogPostureResult:
+    """Validate TrustLog posture using production defaults and required controls."""
+    current_env = env if env is not None else environ
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if not _is_production_mode(current_env):
+        return TrustLogPostureResult(True, tuple(failures), tuple(warnings))
+
+    if _normalized(current_env, "VERITAS_TRUSTLOG_BACKEND") != "postgresql":
+        failures.append("production TrustLog backend must be postgresql")
+
+    has_database_url = bool(
+        (current_env.get("VERITAS_DATABASE_URL", "") or "").strip()
+    )
+    has_fallback_database_url = bool((current_env.get("DATABASE_URL", "") or "").strip())
+    if not (has_database_url or has_fallback_database_url):
+        failures.append(
+            "production TrustLog PostgreSQL backend requires VERITAS_DATABASE_URL or DATABASE_URL"
+        )
+
+    if not (current_env.get("VERITAS_ENCRYPTION_KEY", "") or "").strip():
+        failures.append("production TrustLog encryption requires VERITAS_ENCRYPTION_KEY")
+
+    if _normalized_signer_backend(current_env) != "aws_kms":
+        failures.append("production TrustLog signer backend must be aws_kms")
+
+    if not (current_env.get("VERITAS_TRUSTLOG_KMS_KEY_ID", "") or "").strip():
+        failures.append(
+            "production TrustLog aws_kms signer requires VERITAS_TRUSTLOG_KMS_KEY_ID"
+        )
+
+    mirror_backend = _normalized_mirror_backend(current_env)
+    if mirror_backend == "local":
+        if not (current_env.get("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "") or "").strip():
+            warnings.append("production TrustLog local WORM mirror path is not configured")
+    elif mirror_backend == "s3_object_lock":
+        has_bucket = bool((current_env.get("VERITAS_TRUSTLOG_S3_BUCKET", "") or "").strip())
+        has_prefix = bool((current_env.get("VERITAS_TRUSTLOG_S3_PREFIX", "") or "").strip())
+        if not (has_bucket and has_prefix):
+            warnings.append(
+                "production TrustLog s3_object_lock mirror requires "
+                "VERITAS_TRUSTLOG_S3_BUCKET and VERITAS_TRUSTLOG_S3_PREFIX"
+            )
+    else:
+        warnings.append("production TrustLog mirror backend is unrecognized")
+
+    if not _effective_transparency_required(current_env):
+        warnings.append("production TrustLog transparency anchoring is not required")
+
+    if not (current_env.get("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "") or "").strip():
+        warnings.append("production TrustLog transparency log path is not configured")
+
+    if _normalized_anchor_backend(current_env) == "noop":
+        warnings.append("production TrustLog anchor backend is noop")
+
+    return TrustLogPostureResult(not failures, tuple(failures), tuple(warnings))

--- a/veritas_os/tests/test_api_startup_health.py
+++ b/veritas_os/tests/test_api_startup_health.py
@@ -267,3 +267,104 @@ def test_check_runtime_feature_health_rejects_missing_atomic_io_in_production(
             has_sanitize=True,
             has_atomic_io=False,
         )
+
+
+def _trustlog_production_env() -> dict[str, str]:
+    return {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+    }
+
+
+def test_validate_startup_security_flags_non_production_trustlog_insecure_does_not_raise(
+    monkeypatch,
+):
+    monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+    monkeypatch.setenv("VERITAS_ENV", "local")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "jsonl")
+
+    startup_health.validate_startup_security_flags(
+        logger=logging.getLogger("test.startup_health")
+    )
+
+
+def test_validate_startup_security_flags_rejects_production_insecure_trustlog(monkeypatch):
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.delenv("VERITAS_TRUSTLOG_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="TrustLog production posture check failed"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_validate_startup_security_flags_rejects_prod_alias_insecure_trustlog(monkeypatch):
+    monkeypatch.setenv("VERITAS_ENV", "prod")
+    monkeypatch.delenv("VERITAS_TRUSTLOG_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="TrustLog production posture check failed"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_validate_startup_security_flags_allows_fully_configured_production_trustlog(
+    monkeypatch,
+):
+    for key, value in {
+        **_trustlog_production_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "1",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    startup_health.validate_startup_security_flags(
+        logger=logging.getLogger("test.startup_health")
+    )
+
+
+def test_validate_startup_security_flags_trustlog_warning_only_does_not_raise(
+    monkeypatch,
+    caplog,
+):
+    for key, value in _trustlog_production_env().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", raising=False)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
+
+    with caplog.at_level(logging.WARNING):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+    assert "TrustLog production posture warning" in caplog.text
+
+
+def test_validate_startup_security_flags_rejects_production_file_signer_with_break_glass(
+    monkeypatch,
+):
+    for key, value in _trustlog_production_env().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD", "1")
+
+    with pytest.raises(RuntimeError, match="signer backend must be aws_kms"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )

--- a/veritas_os/tests/test_api_startup_health.py
+++ b/veritas_os/tests/test_api_startup_health.py
@@ -284,6 +284,7 @@ def test_validate_startup_security_flags_non_production_trustlog_insecure_does_n
     monkeypatch,
 ):
     monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+    monkeypatch.delenv("VERITAS_POSTURE", raising=False)
     monkeypatch.setenv("VERITAS_ENV", "local")
     monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "jsonl")
 
@@ -368,3 +369,34 @@ def test_validate_startup_security_flags_rejects_production_file_signer_with_bre
         startup_health.validate_startup_security_flags(
             logger=logging.getLogger("test.startup_health")
         )
+
+
+def test_validate_trustlog_production_posture_on_startup_raises_on_failures(monkeypatch):
+    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    monkeypatch.delenv("VERITAS_TRUSTLOG_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="TrustLog production posture check failed"):
+        startup_health.validate_trustlog_production_posture_on_startup(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_validate_trustlog_production_posture_on_startup_warns_only(monkeypatch, caplog):
+    for key, value in _trustlog_production_env().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("VERITAS_POSTURE", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", raising=False)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/tmp/transparency.jsonl")
+
+    with caplog.at_level(logging.WARNING):
+        startup_health.validate_trustlog_production_posture_on_startup(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+    assert "TrustLog production posture warning" in caplog.text

--- a/veritas_os/tests/test_trustlog_production_posture.py
+++ b/veritas_os/tests/test_trustlog_production_posture.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from scripts.security.check_trustlog_production_posture import _env_true
-from scripts.security.check_trustlog_production_posture import check_trustlog_production_posture
 from scripts.security.check_trustlog_production_posture import main
+from veritas_os.security.trustlog_production_posture import _env_true
+from veritas_os.security.trustlog_production_posture import check_trustlog_production_posture
 
 
 def _production_base_env() -> dict[str, str]:
@@ -83,6 +83,19 @@ def test_production_file_signer_fails_even_with_override() -> None:
     assert any("signer backend must be aws_kms" in item for item in result.failures)
 
 
+def test_production_file_ed25519_signer_fails() -> None:
+    env = {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "file_ed25519",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("signer backend must be aws_kms" in item for item in result.failures)
+
+
 def test_production_aws_kms_without_kms_key_fails() -> None:
     env = {
         "VERITAS_ENV": "production",
@@ -107,7 +120,19 @@ def test_production_fully_configured_passes() -> None:
     assert result.failures == ()
 
 
-def test_production_without_worm_emits_warning() -> None:
+def test_production_aws_kms_ed25519_signer_passes() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms_ed25519",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is True
+    assert result.failures == ()
+
+
+def test_production_local_mirror_without_worm_emits_warning() -> None:
     env = {
         **_production_base_env(),
         "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "1",
@@ -115,7 +140,41 @@ def test_production_without_worm_emits_warning() -> None:
     }
     result = check_trustlog_production_posture(env)
     assert result.passed is True
-    assert any("WORM mirror path" in item for item in result.warnings)
+    assert any("local WORM mirror path" in item for item in result.warnings)
+
+
+def test_production_s3_object_lock_without_worm_path_no_local_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+        "VERITAS_TRUSTLOG_S3_BUCKET": "bucket",
+        "VERITAS_TRUSTLOG_S3_PREFIX": "prefix",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("local WORM mirror path" in item for item in result.warnings)
+
+
+def test_production_s3_object_lock_missing_bucket_or_prefix_emits_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("s3_object_lock mirror requires" in item for item in result.warnings)
+
+
+def test_production_s3_object_lock_with_bucket_and_prefix_has_no_mirror_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+        "VERITAS_TRUSTLOG_S3_BUCKET": "bucket",
+        "VERITAS_TRUSTLOG_S3_PREFIX": "prefix",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("mirror" in item for item in result.warnings)
 
 
 def test_anchor_noop_emits_warning() -> None:
@@ -131,6 +190,38 @@ def test_anchor_noop_emits_warning() -> None:
     assert any("anchor backend is noop" in item for item in result.warnings)
 
 
+def test_anchor_no_op_emits_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "no_op",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("anchor backend is noop" in item for item in result.warnings)
+
+
+def test_anchor_none_emits_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "none",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("anchor backend is noop" in item for item in result.warnings)
+
+
+def test_anchor_default_local_does_not_emit_noop_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchor backend is noop" in item for item in result.warnings)
+
+
 def test_require_production_flag_enforces_check() -> None:
     env = {"VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": "1"}
     result = check_trustlog_production_posture(env)
@@ -141,6 +232,42 @@ def test_require_production_flag_truthy_alias_enforces_check() -> None:
     env = {"VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": "true"}
     result = check_trustlog_production_posture(env)
     assert result.passed is False
+
+
+def test_production_transparency_unset_does_not_warn_not_required() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_production_transparency_explicit_zero_warns_not_required() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "0",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_require_production_flag_with_transparency_unset_does_not_warn_not_required() -> None:
+    env = {
+        "VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": "1",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchoring is not required" in item for item in result.warnings)
 
 
 def test_boolean_parser_accepts_truthy_values() -> None:

--- a/veritas_os/tests/test_trustlog_production_posture.py
+++ b/veritas_os/tests/test_trustlog_production_posture.py
@@ -51,6 +51,21 @@ def test_prod_alias_enforces_production_posture() -> None:
     assert any("backend must be postgresql" in item for item in result.failures)
 
 
+def test_secure_posture_enforces_production_posture() -> None:
+    result = check_trustlog_production_posture({"VERITAS_POSTURE": "secure"})
+    assert result.passed is False
+
+
+def test_hardened_posture_enforces_production_posture() -> None:
+    result = check_trustlog_production_posture({"VERITAS_POSTURE": "hardened"})
+    assert result.passed is False
+
+
+def test_prod_posture_enforces_production_posture() -> None:
+    result = check_trustlog_production_posture({"VERITAS_POSTURE": "prod"})
+    assert result.passed is False
+
+
 def test_production_postgresql_without_database_url_fails() -> None:
     result = check_trustlog_production_posture(
         {"VERITAS_ENV": "production", "VERITAS_TRUSTLOG_BACKEND": "postgresql"}
@@ -242,6 +257,55 @@ def test_production_transparency_unset_does_not_warn_not_required() -> None:
     }
     result = check_trustlog_production_posture(env)
     assert not any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_secure_posture_transparency_unset_does_not_warn_not_required() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_ENV": "local",
+        "VERITAS_POSTURE": "secure",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_hardened_posture_transparency_unset_does_not_warn_not_required() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_ENV": "local",
+        "VERITAS_POSTURE": "hardened",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_prod_posture_transparency_unset_does_not_warn_not_required() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_ENV": "local",
+        "VERITAS_POSTURE": "prod",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_secure_posture_fully_configured_passes() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_ENV": "local",
+        "VERITAS_POSTURE": "secure",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is True
+    assert result.failures == ()
 
 
 def test_production_transparency_explicit_zero_warns_not_required() -> None:

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -2698,6 +2698,19 @@ def test_run_startup_config_validation_raises_in_production(monkeypatch):
         raising=False,
     )
     monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_S3_BUCKET", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_S3_PREFIX", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND", raising=False)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://example")
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", "dummy")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "dummy-kms-key")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/tmp/worm")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/tmp/transparency.jsonl")
 
     with pytest.raises(RuntimeError, match="config invalid"):
         server._run_startup_config_validation()


### PR DESCRIPTION
### Motivation

- Centralize and harden TrustLog production posture logic into a runtime-safe helper so CLI, CI, and app startup share the same rules. 
- Enforce stricter startup fail-fast behavior for TrustLog when running in production to prevent insecure configurations from booting.
- Expand normalization and posture defaults to accept aliases (e.g. `aws_kms_ed25519`) and normalize mirror/anchor backend semantics.

### Description

- Add new module `veritas_os.security.trustlog_production_posture` implementing `check_trustlog_production_posture`, `is_trustlog_production_posture_enforced`, and `_env_true` with canonical normalization for signer/anchor/mirror backends and transparency defaults. 
- Replace the standalone script implementation to import and delegate to the new module in `scripts/security/check_trustlog_production_posture.py` (CLI behavior unchanged). 
- Integrate posture validation into API startup via `veritas_os.api.startup_health`, adding `validate_trustlog_production_posture_on_startup` and invoking it from `validate_startup_security_flags` to raise on enforced production failures and log warnings otherwise. 
- Update documentation `docs/en/operations/postgresql-production-guide.md` to reflect new enforcement semantics, signer alias handling, and additional warning conditions for mirror/anchor/backends. 
- Expand and adjust unit tests in `veritas_os/tests/test_trustlog_production_posture.py` and `veritas_os/tests/test_api_startup_health.py` to cover normalization, mirror/backends, transparency defaults, CLI delegation, and startup integration.

### Testing

- Ran `pytest veritas_os/tests/test_trustlog_production_posture.py` which exercises signer aliases, mirror/anchor normalization, transparency defaults, and CLI behavior; all tests passed. 
- Ran `pytest veritas_os/tests/test_api_startup_health.py` to verify startup enforcement and warning behavior integration; tests passed. 
- Ran the repository unit test suite (`pytest`) to ensure no regressions; the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0462e9e49c8326a1b5eb87e2c2db31)