### PR TITLE
Centralize and enforce TrustLog production posture at startup; add posture module, tests, and docs

### DIFF
--- a/docs/en/operations/postgresql-production-guide.md
+++ b/docs/en/operations/postgresql-production-guide.md
@@ -127,6 +127,8 @@ and posture assumptions only.
 - It does **not** change runtime defaults.
 - It does **not** connect to real DB/KMS/WORM services.
 - It validates env presence / posture for expected production configuration.
+- Runtime startup validation also enforces the same production-failure posture whenever TrustLog production posture enforcement is active: strict legacy `VERITAS_ENV` values (`secure`, `hardened`, `prod`, `production`), strict `VERITAS_POSTURE` values (`secure`, `hardened`, `prod`, `production`), or truthy `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE`.
+- Warning-only WORM/transparency findings remain non-fatal during startup and CLI checks.
 - In CI, production-path enforcement is exercised with a non-secret dummy
   fixture env.
 - Passing this checker does **not** prove real production readiness.
@@ -147,6 +149,12 @@ Production posture validation is strict when any of the following is true:
 
 - `VERITAS_ENV=production`
 - `VERITAS_ENV=prod`
+- `VERITAS_ENV=secure`
+- `VERITAS_ENV=hardened`
+- `VERITAS_POSTURE=secure`
+- `VERITAS_POSTURE=hardened`
+- `VERITAS_POSTURE=prod`
+- `VERITAS_POSTURE=production`
 - `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` is truthy (`1`, `true`, `yes`, `on`)
 
 ### Production failure conditions
@@ -156,8 +164,8 @@ In production mode, the checker fails if:
 - `VERITAS_TRUSTLOG_BACKEND` is not `postgresql`
 - `VERITAS_DATABASE_URL` and `DATABASE_URL` are both unset
 - `VERITAS_ENCRYPTION_KEY` is unset
-- `VERITAS_TRUSTLOG_SIGNER_BACKEND` is not `aws_kms`
-- `VERITAS_TRUSTLOG_KMS_KEY_ID` is unset
+- `VERITAS_TRUSTLOG_SIGNER_BACKEND` is not `aws_kms` (alias `aws_kms_ed25519` is treated as `aws_kms`)
+- `VERITAS_TRUSTLOG_SIGNER_BACKEND` resolves to `aws_kms` but `VERITAS_TRUSTLOG_KMS_KEY_ID` is unset
 
 > Note: `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` is not honored by
 > this production posture checker. In production posture, the checker requires
@@ -168,10 +176,12 @@ In production mode, the checker fails if:
 
 In production mode, the checker warns (non-fatal) if:
 
-- `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` is unset
-- `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` is not enabled
-- `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` is unset
-- `VERITAS_TRUSTLOG_ANCHOR_BACKEND=noop`
+- `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` is explicitly disabled (`0`/`false`/etc.); if unset in production posture it is treated as required by default
+- Local anchor backend is selected, transparency is required, and `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` is unset
+- `VERITAS_TRUSTLOG_ANCHOR_BACKEND` resolves to `noop` (`noop`/`none`/`no_op`)
+- Local mirror backend is selected but `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` is unset
+- `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` without `VERITAS_TRUSTLOG_S3_BUCKET`/`VERITAS_TRUSTLOG_S3_PREFIX`
+- `VERITAS_TRUSTLOG_MIRROR_BACKEND` is unrecognized (warning includes normalized backend value)
 
 > Note: WORM and transparency are warning-level in this checker, not failure-level.
 

--- a/docs/ja/operations/postgresql-production-guide.md
+++ b/docs/ja/operations/postgresql-production-guide.md
@@ -20,7 +20,27 @@ PostgreSQL を本番で運用する際の確認観点を、日本語で短く整
 ## TrustLog production posture checker（最小姿勢チェック）
 - `check-trustlog-production-posture` は、TrustLog の本番姿勢に必要な環境変数の有無/設定姿勢を確認する operator-facing な最小チェックです（実行: `make check-trustlog-production-posture` または `python -m scripts.security.check_trustlog_production_posture`）。
 - runtime default は変更せず、実DB/実KMS/実WORMへ接続もしません。CI の `[Tier 1] governance-smoke` では非シークレットのダミー環境変数で production enforcement path を検証しますが、実運用 readiness の証明にはなりません。
-- production mode（`VERITAS_ENV=production|prod` または `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` が truthy）の failure 条件は、`postgresql` backend / DB URL / `VERITAS_ENCRYPTION_KEY` / `aws_kms` signer / `VERITAS_TRUSTLOG_KMS_KEY_ID` の不足です。`VERITAS_TRUSTLOG_WORM_MIRROR_PATH` 未設定、transparency 未要求、`VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` 未設定、`VERITAS_TRUSTLOG_ANCHOR_BACKEND=noop` は warning 扱いです。
+- production posture validation が厳格化される条件は以下です。
+  - `VERITAS_ENV=production`
+  - `VERITAS_ENV=prod`
+  - `VERITAS_ENV=secure`
+  - `VERITAS_ENV=hardened`
+  - `VERITAS_POSTURE=secure|hardened|prod|production`
+  - `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` が truthy（`1`/`true`/`yes`/`on`）
+- runtime startup validation でも、上記 enforcement が active の場合は同じ production-failure posture を fail-fast で適用します（legacy strict `VERITAS_ENV`、strict `VERITAS_POSTURE`、truthy `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE`）。
+- failure 条件（起動拒否/CLI失敗）は以下です。
+  - `VERITAS_TRUSTLOG_BACKEND` が `postgresql` でない
+  - `VERITAS_DATABASE_URL` と `DATABASE_URL` が両方未設定
+  - `VERITAS_ENCRYPTION_KEY` が未設定
+  - `VERITAS_TRUSTLOG_SIGNER_BACKEND` が `aws_kms` に解決されない（`aws_kms_ed25519` は `aws_kms` 扱い）
+  - signer backend が `aws_kms` に解決されるのに `VERITAS_TRUSTLOG_KMS_KEY_ID` が未設定
+- warning 条件（startup/CLI とも non-fatal）は以下です。
+  - `VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED` が明示的に無効
+  - local anchor backend かつ transparency required で `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` が未設定
+  - `VERITAS_TRUSTLOG_ANCHOR_BACKEND` が `noop` に解決される（`noop`/`none`/`no_op`）
+  - local mirror backend で `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` が未設定
+  - `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` なのに `VERITAS_TRUSTLOG_S3_BUCKET`/`VERITAS_TRUSTLOG_S3_PREFIX` が不足
+  - `VERITAS_TRUSTLOG_MIRROR_BACKEND` が未知値（warning には正規化された backend 値を含む）
 - 注: `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` は、この production posture checker では考慮されません。本番姿勢チェックでは `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms` を要求し、`file` / `local` / `noop` / 未設定の signer は、break-glass フラグがあっても failure になります。
 
 ## 現時点の制限

--- a/scripts/security/check_trustlog_production_posture.py
+++ b/scripts/security/check_trustlog_production_posture.py
@@ -3,88 +3,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from os import environ
-from typing import Mapping
 
-_TRUE_VALUES = {"1", "true", "yes", "on"}
-PRODUCTION_ENV_ALIASES = {"prod", "production"}
-
-
-@dataclass(frozen=True)
-class TrustLogPostureResult:
-    """Result payload for TrustLog production posture checks."""
-
-    passed: bool
-    failures: tuple[str, ...]
-    warnings: tuple[str, ...]
-
-
-def _env_true(value: str | None) -> bool:
-    """Return True when the provided environment value is explicitly truthy."""
-    if value is None:
-        return False
-    return value.strip().lower() in _TRUE_VALUES
-
-
-def _normalized(env: Mapping[str, str], key: str) -> str:
-    """Return normalized environment value for robust comparisons."""
-    return (env.get(key, "") or "").strip().lower()
-
-
-def _is_production_mode(env: Mapping[str, str]) -> bool:
-    """Return True when strict production posture must be enforced."""
-    return (
-        _normalized(env, "VERITAS_ENV") in PRODUCTION_ENV_ALIASES
-        or _env_true(env.get("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE"))
-    )
-
-
-def check_trustlog_production_posture(
-    env: Mapping[str, str] | None = None,
-) -> TrustLogPostureResult:
-    """Validate TrustLog posture using production defaults and required controls."""
-    current_env = env if env is not None else environ
-    failures: list[str] = []
-    warnings: list[str] = []
-
-    if not _is_production_mode(current_env):
-        return TrustLogPostureResult(True, tuple(failures), tuple(warnings))
-
-    if _normalized(current_env, "VERITAS_TRUSTLOG_BACKEND") != "postgresql":
-        failures.append("production TrustLog backend must be postgresql")
-
-    has_database_url = bool((current_env.get("VERITAS_DATABASE_URL", "") or "").strip())
-    has_fallback_database_url = bool((current_env.get("DATABASE_URL", "") or "").strip())
-    if not (has_database_url or has_fallback_database_url):
-        failures.append(
-            "production TrustLog PostgreSQL backend requires VERITAS_DATABASE_URL or DATABASE_URL"
-        )
-
-    if not (current_env.get("VERITAS_ENCRYPTION_KEY", "") or "").strip():
-        failures.append("production TrustLog encryption requires VERITAS_ENCRYPTION_KEY")
-
-    if _normalized(current_env, "VERITAS_TRUSTLOG_SIGNER_BACKEND") != "aws_kms":
-        failures.append("production TrustLog signer backend must be aws_kms")
-
-    if not (current_env.get("VERITAS_TRUSTLOG_KMS_KEY_ID", "") or "").strip():
-        failures.append(
-            "production TrustLog aws_kms signer requires VERITAS_TRUSTLOG_KMS_KEY_ID"
-        )
-
-    if not (current_env.get("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "") or "").strip():
-        warnings.append("production TrustLog WORM mirror path is not configured")
-
-    if not _env_true(current_env.get("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED")):
-        warnings.append("production TrustLog transparency anchoring is not required")
-
-    if not (current_env.get("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "") or "").strip():
-        warnings.append("production TrustLog transparency log path is not configured")
-
-    if _normalized(current_env, "VERITAS_TRUSTLOG_ANCHOR_BACKEND") == "noop":
-        warnings.append("production TrustLog anchor backend is noop")
-
-    return TrustLogPostureResult(not failures, tuple(failures), tuple(warnings))
+from veritas_os.security.trustlog_production_posture import check_trustlog_production_posture
 
 
 def main() -> int:

--- a/veritas_os/api/startup_health.py
+++ b/veritas_os/api/startup_health.py
@@ -6,6 +6,10 @@ import logging
 import os
 from typing import Callable, Optional
 
+from veritas_os.security.trustlog_production_posture import (
+    check_trustlog_production_posture,
+)
+
 
 def _is_truthy_env(var_name: str) -> bool:
     """Return True when the named environment variable is explicitly truthy."""
@@ -25,14 +29,20 @@ def _is_env_key_present(var_name: str) -> bool:
 
 
 def should_fail_fast_startup(profile: Optional[str] = None) -> bool:
-    """Return whether startup validation failures should stop app boot.
+    """Return whether startup validation errors should fail the process.
 
-    Fail-fast is active for ``prod``/``production`` (legacy) and also
-    when the posture model resolves to *secure* or *prod*.
+    When profile is provided, it is authoritative and ambient environment or
+    posture flags do not override it. When profile is omitted, fail-fast is
+    enabled for prod/production VERITAS_ENV, strict resolved posture, or a
+    truthy VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE flag.
     """
     resolved_profile = profile if profile is not None else os.getenv("VERITAS_ENV", "")
     normalized_profile = resolved_profile.strip().lower()
     if normalized_profile in {"prod", "production"}:
+        return True
+    if profile is not None:
+        return False
+    if _is_truthy_env("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE"):
         return True
 
     # Delegate to canonical posture resolution to avoid alias drift.
@@ -172,6 +182,24 @@ def validate_startup_security_flags(*, logger: logging.Logger) -> None:
                 "templates to prevent production drift.",
                 message,
             )
+
+    validate_trustlog_production_posture_on_startup(logger=logger)
+
+
+def validate_trustlog_production_posture_on_startup(*, logger: logging.Logger) -> None:
+    """Validate TrustLog posture during startup with production fail-fast handling."""
+    current_env = dict(os.environ)
+    result = check_trustlog_production_posture(current_env)
+    if result.failures:
+        failures = "; ".join(result.failures)
+        message = f"[SECURITY] TrustLog production posture check failed: {failures}"
+        raise RuntimeError(
+            f"{message}. Refusing startup because TrustLog production posture is "
+            "enforced."
+        )
+
+    for warning in result.warnings:
+        logger.warning("[SECURITY] TrustLog production posture warning: %s", warning)
 
 
 def check_runtime_feature_health(

--- a/veritas_os/security/trustlog_production_posture.py
+++ b/veritas_os/security/trustlog_production_posture.py
@@ -1,0 +1,155 @@
+"""Runtime-safe TrustLog production posture validation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import environ
+from typing import Mapping
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+PRODUCTION_ENV_ALIASES = {"prod", "production", "secure", "hardened"}
+STRICT_POSTURE_ALIASES = {"secure", "hardened", "prod", "production"}
+
+
+@dataclass(frozen=True)
+class TrustLogPostureResult:
+    """Result payload for TrustLog production posture checks."""
+
+    passed: bool
+    failures: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+def _env_true(value: str | None) -> bool:
+    """Return True when the provided environment value is explicitly truthy."""
+    if value is None:
+        return False
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def _normalized(env: Mapping[str, str], key: str) -> str:
+    """Return normalized environment value for robust comparisons."""
+    return (env.get(key, "") or "").strip().lower()
+
+
+def _is_production_mode(env: Mapping[str, str]) -> bool:
+    """Return True when strict production posture must be enforced."""
+    return (
+        _normalized(env, "VERITAS_ENV") in PRODUCTION_ENV_ALIASES
+        or _normalized(env, "VERITAS_POSTURE") in STRICT_POSTURE_ALIASES
+        or _env_true(env.get("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE"))
+    )
+
+
+def is_trustlog_production_posture_enforced(env: Mapping[str, str]) -> bool:
+    """Return whether TrustLog production posture enforcement is active."""
+    return _is_production_mode(env)
+
+
+def _normalized_signer_backend(env: Mapping[str, str]) -> str:
+    """Normalize signer backend aliases to runtime posture canonical values."""
+    raw = _normalized(env, "VERITAS_TRUSTLOG_SIGNER_BACKEND")
+    if raw in {"", "file", "file_ed25519"}:
+        return "file"
+    if raw in {"aws_kms", "aws_kms_ed25519"}:
+        return "aws_kms"
+    return raw
+
+
+def _normalized_anchor_backend(env: Mapping[str, str]) -> str:
+    """Normalize anchor backend aliases to runtime posture canonical values."""
+    raw = _normalized(env, "VERITAS_TRUSTLOG_ANCHOR_BACKEND")
+    if raw in {"", "local", "file"}:
+        return "local"
+    if raw in {"none", "noop", "no_op"}:
+        return "noop"
+    return raw
+
+
+def _normalized_mirror_backend(env: Mapping[str, str]) -> str:
+    """Normalize mirror backend aliases to runtime posture canonical values."""
+    raw = _normalized(env, "VERITAS_TRUSTLOG_MIRROR_BACKEND")
+    if raw in {"", "local", "filesystem"}:
+        return "local"
+    if raw in {"s3_object_lock", "s3"}:
+        return "s3_object_lock"
+    return raw
+
+
+def _effective_transparency_required(env: Mapping[str, str]) -> bool:
+    """Return effective transparency-required state with posture defaults."""
+    raw = env.get("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED")
+    if raw is not None:
+        return _env_true(raw)
+    return _is_production_mode(env)
+
+
+def check_trustlog_production_posture(
+    env: Mapping[str, str] | None = None,
+) -> TrustLogPostureResult:
+    """Validate TrustLog posture using production defaults and required controls."""
+    current_env = env if env is not None else environ
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if not _is_production_mode(current_env):
+        return TrustLogPostureResult(True, tuple(failures), tuple(warnings))
+
+    if _normalized(current_env, "VERITAS_TRUSTLOG_BACKEND") != "postgresql":
+        failures.append("production TrustLog backend must be postgresql")
+
+    has_database_url = bool(
+        (current_env.get("VERITAS_DATABASE_URL", "") or "").strip()
+    )
+    has_fallback_database_url = bool((current_env.get("DATABASE_URL", "") or "").strip())
+    if not (has_database_url or has_fallback_database_url):
+        failures.append(
+            "production TrustLog PostgreSQL backend requires VERITAS_DATABASE_URL or DATABASE_URL"
+        )
+
+    if not (current_env.get("VERITAS_ENCRYPTION_KEY", "") or "").strip():
+        failures.append("production TrustLog encryption requires VERITAS_ENCRYPTION_KEY")
+
+    signer_backend = _normalized_signer_backend(current_env)
+    if signer_backend != "aws_kms":
+        failures.append("production TrustLog signer backend must be aws_kms")
+    elif not (current_env.get("VERITAS_TRUSTLOG_KMS_KEY_ID", "") or "").strip():
+        failures.append(
+            "production TrustLog aws_kms signer requires VERITAS_TRUSTLOG_KMS_KEY_ID"
+        )
+
+    mirror_backend = _normalized_mirror_backend(current_env)
+    if mirror_backend == "local":
+        if not (current_env.get("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "") or "").strip():
+            warnings.append("production TrustLog local WORM mirror path is not configured")
+    elif mirror_backend == "s3_object_lock":
+        has_bucket = bool((current_env.get("VERITAS_TRUSTLOG_S3_BUCKET", "") or "").strip())
+        has_prefix = bool((current_env.get("VERITAS_TRUSTLOG_S3_PREFIX", "") or "").strip())
+        if not (has_bucket and has_prefix):
+            warnings.append(
+                "production TrustLog s3_object_lock mirror requires "
+                "VERITAS_TRUSTLOG_S3_BUCKET and VERITAS_TRUSTLOG_S3_PREFIX"
+            )
+    else:
+        warnings.append(
+            f"production TrustLog mirror backend {mirror_backend!r} is unrecognized"
+        )
+
+    transparency_required = _effective_transparency_required(current_env)
+    if not transparency_required:
+        warnings.append("production TrustLog transparency anchoring is not required")
+
+    anchor_backend = _normalized_anchor_backend(current_env)
+    if (
+        transparency_required
+        and anchor_backend == "local"
+        and not (
+            current_env.get("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "") or ""
+        ).strip()
+    ):
+        warnings.append("production TrustLog local transparency log path is not configured")
+
+    if anchor_backend == "noop":
+        warnings.append("production TrustLog anchor backend is noop")
+
+    return TrustLogPostureResult(not failures, tuple(failures), tuple(warnings))

--- a/veritas_os/tests/test_api_startup_health.py
+++ b/veritas_os/tests/test_api_startup_health.py
@@ -22,6 +22,22 @@ def test_should_fail_fast_startup_reads_env(monkeypatch):
     assert startup_health.should_fail_fast_startup() is True
 
 
+def test_should_fail_fast_startup_honors_trustlog_posture_enforcement_flag(monkeypatch):
+    """Explicit TrustLog enforcement flag should force fail-fast startup behavior."""
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+    monkeypatch.delenv("VERITAS_POSTURE", raising=False)
+    monkeypatch.setenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", "1")
+    assert startup_health.should_fail_fast_startup() is True
+
+
+def test_should_fail_fast_startup_explicit_profile_is_deterministic(monkeypatch):
+    """Explicit profile should not be overridden by ambient strict env flags."""
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    monkeypatch.setenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", "1")
+    assert startup_health.should_fail_fast_startup("staging") is False
+
+
 def test_run_startup_config_validation_warn_only(caplog):
     """Validation errors should be logged and not raised when fail-fast is false."""
 
@@ -266,4 +282,163 @@ def test_check_runtime_feature_health_rejects_missing_atomic_io_in_production(
             logger=logging.getLogger("test.startup_health"),
             has_sanitize=True,
             has_atomic_io=False,
+        )
+
+
+def _trustlog_production_env() -> dict[str, str]:
+    return {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+    }
+
+
+def test_validate_startup_security_flags_non_production_trustlog_insecure_does_not_raise(
+    monkeypatch,
+):
+    monkeypatch.delenv("VERITAS_POSTURE", raising=False)
+    monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+    monkeypatch.setenv("VERITAS_ENV", "local")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "jsonl")
+
+    startup_health.validate_startup_security_flags(
+        logger=logging.getLogger("test.startup_health")
+    )
+
+
+def test_validate_startup_security_flags_rejects_production_insecure_trustlog(monkeypatch):
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.delenv("VERITAS_TRUSTLOG_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="TrustLog production posture check failed"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_validate_startup_security_flags_rejects_prod_alias_insecure_trustlog(monkeypatch):
+    monkeypatch.setenv("VERITAS_ENV", "prod")
+    monkeypatch.delenv("VERITAS_TRUSTLOG_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="TrustLog production posture check failed"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_validate_startup_security_flags_allows_fully_configured_production_trustlog(
+    monkeypatch,
+):
+    for key, value in {
+        **_trustlog_production_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "1",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    startup_health.validate_startup_security_flags(
+        logger=logging.getLogger("test.startup_health")
+    )
+
+
+def test_validate_startup_security_flags_trustlog_warning_only_does_not_raise(
+    monkeypatch,
+    caplog,
+):
+    for key, value in _trustlog_production_env().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", raising=False)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
+
+    with caplog.at_level(logging.WARNING):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+    assert "TrustLog production posture warning" in caplog.text
+
+
+def test_validate_startup_security_flags_rejects_production_file_signer_with_break_glass(
+    monkeypatch,
+):
+    for key, value in _trustlog_production_env().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "file")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD", "1")
+
+    with pytest.raises(RuntimeError, match="signer backend must be aws_kms"):
+        startup_health.validate_startup_security_flags(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_validate_trustlog_production_posture_rejects_secure_posture_insecure_env(
+    monkeypatch,
+):
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+    monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "jsonl")
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="TrustLog production posture check failed"):
+        startup_health.validate_trustlog_production_posture_on_startup(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_validate_trustlog_production_posture_rejects_secure_env_insecure_env(
+    monkeypatch,
+):
+    monkeypatch.setenv("VERITAS_ENV", "secure")
+    monkeypatch.delenv("VERITAS_POSTURE", raising=False)
+    monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "jsonl")
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="TrustLog production posture check failed"):
+        startup_health.validate_trustlog_production_posture_on_startup(
+            logger=logging.getLogger("test.startup_health")
+        )
+
+
+def test_run_startup_config_validation_raises_with_trustlog_enforcement_flag(
+    monkeypatch,
+):
+    monkeypatch.delenv("VERITAS_ENV", raising=False)
+    monkeypatch.delenv("VERITAS_POSTURE", raising=False)
+    monkeypatch.setenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", "1")
+    monkeypatch.delenv("VERITAS_TRUSTLOG_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_KMS_KEY_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="TrustLog production posture check failed"):
+        startup_health.run_startup_config_validation(
+            logger=logging.getLogger("test.startup_health")
         )

--- a/veritas_os/tests/test_trustlog_production_posture.py
+++ b/veritas_os/tests/test_trustlog_production_posture.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from scripts.security.check_trustlog_production_posture import _env_true
-from scripts.security.check_trustlog_production_posture import check_trustlog_production_posture
 from scripts.security.check_trustlog_production_posture import main
+from veritas_os.security.trustlog_production_posture import check_trustlog_production_posture
 
 
 def _production_base_env() -> dict[str, str]:
@@ -51,6 +50,24 @@ def test_prod_alias_enforces_production_posture() -> None:
     assert any("backend must be postgresql" in item for item in result.failures)
 
 
+def test_secure_env_alias_enforces_production_posture() -> None:
+    result = check_trustlog_production_posture({"VERITAS_ENV": "secure"})
+    assert result.passed is False
+    assert any("backend must be postgresql" in item for item in result.failures)
+
+
+def test_hardened_env_alias_enforces_production_posture() -> None:
+    result = check_trustlog_production_posture({"VERITAS_ENV": "hardened"})
+    assert result.passed is False
+    assert any("backend must be postgresql" in item for item in result.failures)
+
+
+def test_local_env_alias_does_not_enforce_production_posture() -> None:
+    result = check_trustlog_production_posture({"VERITAS_ENV": "local"})
+    assert result.passed is True
+    assert result.failures == ()
+
+
 def test_production_postgresql_without_database_url_fails() -> None:
     result = check_trustlog_production_posture(
         {"VERITAS_ENV": "production", "VERITAS_TRUSTLOG_BACKEND": "postgresql"}
@@ -81,6 +98,20 @@ def test_production_file_signer_fails_even_with_override() -> None:
     }
     result = check_trustlog_production_posture(env)
     assert any("signer backend must be aws_kms" in item for item in result.failures)
+    assert not any("KMS_KEY_ID" in item for item in result.failures)
+
+
+def test_production_file_ed25519_signer_fails() -> None:
+    env = {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "file_ed25519",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("signer backend must be aws_kms" in item for item in result.failures)
 
 
 def test_production_aws_kms_without_kms_key_fails() -> None:
@@ -90,6 +121,18 @@ def test_production_aws_kms_without_kms_key_fails() -> None:
         "VERITAS_DATABASE_URL": "postgresql://example",
         "VERITAS_ENCRYPTION_KEY": "dummy",
         "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("KMS_KEY_ID" in item for item in result.failures)
+
+
+def test_production_aws_kms_ed25519_without_kms_key_fails() -> None:
+    env = {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms_ed25519",
     }
     result = check_trustlog_production_posture(env)
     assert any("KMS_KEY_ID" in item for item in result.failures)
@@ -107,7 +150,31 @@ def test_production_fully_configured_passes() -> None:
     assert result.failures == ()
 
 
-def test_production_without_worm_emits_warning() -> None:
+def test_secure_env_fully_configured_passes() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_ENV": "secure",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is True
+    assert result.failures == ()
+
+
+def test_production_aws_kms_ed25519_signer_passes() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms_ed25519",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is True
+    assert result.failures == ()
+
+
+def test_production_local_mirror_without_worm_emits_warning() -> None:
     env = {
         **_production_base_env(),
         "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "1",
@@ -115,7 +182,52 @@ def test_production_without_worm_emits_warning() -> None:
     }
     result = check_trustlog_production_posture(env)
     assert result.passed is True
-    assert any("WORM mirror path" in item for item in result.warnings)
+    assert any("local WORM mirror path" in item for item in result.warnings)
+
+
+def test_production_s3_object_lock_without_worm_path_no_local_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+        "VERITAS_TRUSTLOG_S3_BUCKET": "bucket",
+        "VERITAS_TRUSTLOG_S3_PREFIX": "prefix",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("local WORM mirror path" in item for item in result.warnings)
+
+
+def test_production_s3_object_lock_missing_bucket_or_prefix_emits_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("s3_object_lock mirror requires" in item for item in result.warnings)
+
+
+def test_production_s3_object_lock_with_bucket_and_prefix_has_no_mirror_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+        "VERITAS_TRUSTLOG_S3_BUCKET": "bucket",
+        "VERITAS_TRUSTLOG_S3_PREFIX": "prefix",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("mirror" in item for item in result.warnings)
+
+
+def test_unrecognized_mirror_backend_warning_includes_backend_value() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND": "unknown_backend",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("unknown_backend" in item for item in result.warnings)
 
 
 def test_anchor_noop_emits_warning() -> None:
@@ -131,6 +243,79 @@ def test_anchor_noop_emits_warning() -> None:
     assert any("anchor backend is noop" in item for item in result.warnings)
 
 
+def test_anchor_no_op_emits_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "no_op",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("anchor backend is noop" in item for item in result.warnings)
+
+
+def test_anchor_none_emits_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "none",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("anchor backend is noop" in item for item in result.warnings)
+
+
+def test_anchor_default_local_does_not_emit_noop_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchor backend is noop" in item for item in result.warnings)
+
+
+def test_local_anchor_required_transparency_without_path_emits_local_path_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("local transparency log path is not configured" in item for item in result.warnings)
+
+
+def test_transparency_disabled_without_path_does_not_emit_local_path_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "0",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("anchoring is not required" in item for item in result.warnings)
+    assert not any("local transparency log path is not configured" in item for item in result.warnings)
+
+
+def test_tsa_anchor_missing_path_does_not_emit_local_path_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "tsa",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("local transparency log path is not configured" in item for item in result.warnings)
+
+
+def test_noop_anchor_missing_path_does_not_emit_local_path_warning() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "noop",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("anchor backend is noop" in item for item in result.warnings)
+    assert not any("local transparency log path is not configured" in item for item in result.warnings)
+
+
 def test_require_production_flag_enforces_check() -> None:
     env = {"VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": "1"}
     result = check_trustlog_production_posture(env)
@@ -143,11 +328,68 @@ def test_require_production_flag_truthy_alias_enforces_check() -> None:
     assert result.passed is False
 
 
-def test_boolean_parser_accepts_truthy_values() -> None:
-    assert _env_true("1")
-    assert _env_true("TrUe")
-    assert _env_true("YES")
-    assert _env_true(" on ")
+def test_production_transparency_unset_does_not_warn_not_required() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_secure_env_transparency_unset_does_not_warn_not_required() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_ENV": "secure",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_production_transparency_explicit_zero_warns_not_required() -> None:
+    env = {
+        **_production_base_env(),
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED": "0",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_require_production_flag_with_transparency_unset_does_not_warn_not_required() -> None:
+    env = {
+        "VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": "1",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH": "/tmp/worm",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+    result = check_trustlog_production_posture(env)
+    assert not any("anchoring is not required" in item for item in result.warnings)
+
+
+def test_trustlog_enforcement_flag_truthy_values_enable_production_posture() -> None:
+    for value in ("1", "true", "yes", "on"):
+        result = check_trustlog_production_posture(
+            {"VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": value}
+        )
+        assert result.passed is False
+        assert any("backend must be postgresql" in item for item in result.failures)
+
+
+def test_trustlog_enforcement_flag_falsy_values_do_not_enable_production_posture() -> None:
+    for value in ("0", "false", "no", "off", ""):
+        result = check_trustlog_production_posture(
+            {"VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE": value}
+        )
+        assert result.passed is True
+        assert result.failures == ()
 
 
 def test_cli_main_returns_zero_in_development(monkeypatch) -> None:

--- a/veritas_os/tests/unit/test_server_api.py
+++ b/veritas_os/tests/unit/test_server_api.py
@@ -2698,6 +2698,24 @@ def test_run_startup_config_validation_raises_in_production(monkeypatch):
         raising=False,
     )
     monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+    monkeypatch.delenv("VERITAS_POSTURE", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_S3_BUCKET", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_S3_PREFIX", raising=False)
+    monkeypatch.delenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND", raising=False)
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://example")
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", "dummy")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "dummy-kms-key")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/tmp/worm")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
+    monkeypatch.setenv(
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH",
+        "/tmp/transparency.jsonl",
+    )
 
     with pytest.raises(RuntimeError, match="config invalid"):
         server._run_startup_config_validation()


### PR DESCRIPTION
### Motivation

- Centralize TrustLog production posture logic into a runtime-safe library to avoid duplicate checks and alias drift. 
- Enforce production-grade TrustLog posture at process startup (fail-fast) when production-like profiles or explicit enforcement flags are present. 
- Clarify operator-facing documentation about which environment values trigger strict enforcement and which findings remain warning-only.

### Description

- Add `veritas_os/security/trustlog_production_posture.py` implementing normalized signer/anchor/mirror backends, posture resolution (including `VERITAS_POSTURE` and aliases `secure`/`hardened`), and a `check_trustlog_production_posture` API returning structured failures and warnings. 
- Refactor the CLI `scripts/security/check_trustlog_production_posture.py` to delegate to the new module and keep the same user-facing output. 
- Integrate posture validation into startup flow in `veritas_os/api/startup_health.py` via `validate_trustlog_production_posture_on_startup`, and extend `should_fail_fast_startup` to honor explicit enforcement flags and resolved posture; surface warnings via logger and raise on failures when enforcement is active. 
- Update English and Japanese docs (`docs/en/...` and `docs/ja/...`) to document the stricter enforcement conditions, expanded aliases, and warning vs failure semantics. 
- Add and expand unit tests (`veritas_os/tests/test_trustlog_production_posture.py`, `veritas_os/tests/test_api_startup_health.py`, and `veritas_os/tests/unit/test_server_api.py`) to cover aliases, normalization, enforcement flag behavior, startup integration, and CLI return codes.

### Testing

- Ran the updated unit tests for TrustLog posture (`veritas_os/tests/test_trustlog_production_posture.py`) and the modified startup-health tests (`veritas_os/tests/test_api_startup_health.py`), and they passed. 
- Ran the affected server API unit tests (`veritas_os/tests/unit/test_server_api.py`) exercising startup validation, and they passed. 
- Executed the CLI smoke path via the test coverage for `scripts/security/check_trustlog_production_posture.py` and confirmed expected exit codes for dev and production fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0462e9e49c8326a1b5eb87e2c2db31)