### PR TITLE
Share TrustLog backend normalization helpers

### DIFF
--- a/veritas_os/core/posture.py
+++ b/veritas_os/core/posture.py
@@ -24,6 +24,12 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from veritas_os.security.trustlog_backend_normalization import (
+    normalize_trustlog_anchor_backend,
+    normalize_trustlog_mirror_backend,
+    normalize_trustlog_signer_backend,
+)
+
 _logger = logging.getLogger(__name__)
 
 # ── Boolean parsing (mirrors config._parse_bool but self-contained) ─────
@@ -317,32 +323,23 @@ def _trustlog_signer_backend() -> str:
     Supported aliases are normalized so startup validation can apply posture
     policy consistently.
     """
-    raw = (os.getenv("VERITAS_TRUSTLOG_SIGNER_BACKEND") or "file").strip().lower()
-    if raw in {"", "file", "file_ed25519"}:
-        return "file"
-    if raw in {"aws_kms", "aws_kms_ed25519"}:
-        return "aws_kms"
-    return raw
+    return normalize_trustlog_signer_backend(
+        os.getenv("VERITAS_TRUSTLOG_SIGNER_BACKEND")
+    )
 
 
 def _trustlog_mirror_backend() -> str:
     """Return normalized TrustLog mirror backend name."""
-    raw = (os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND") or "local").strip().lower()
-    if raw in {"", "local", "filesystem"}:
-        return "local"
-    if raw in {"s3_object_lock", "s3"}:
-        return "s3_object_lock"
-    return raw
+    return normalize_trustlog_mirror_backend(
+        os.getenv("VERITAS_TRUSTLOG_MIRROR_BACKEND")
+    )
 
 
 def _trustlog_anchor_backend() -> str:
     """Return normalized TrustLog anchor backend name."""
-    raw = (os.getenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND") or "local").strip().lower()
-    if raw in {"", "local", "file"}:
-        return "local"
-    if raw in {"none", "noop", "no_op"}:
-        return "noop"
-    return raw
+    return normalize_trustlog_anchor_backend(
+        os.getenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND")
+    )
 
 
 def _allow_insecure_signer_override() -> bool:

--- a/veritas_os/security/trustlog_backend_normalization.py
+++ b/veritas_os/security/trustlog_backend_normalization.py
@@ -1,0 +1,38 @@
+"""Pure helpers to normalize TrustLog backend aliases."""
+
+from __future__ import annotations
+
+
+def _normalized_raw(raw: str | None) -> str:
+    """Return stripped lowercase backend value."""
+    return (raw or "").strip().lower()
+
+
+def normalize_trustlog_signer_backend(raw: str | None) -> str:
+    """Normalize TrustLog signer backend aliases to canonical names."""
+    normalized = _normalized_raw(raw)
+    if normalized in {"", "file", "file_ed25519"}:
+        return "file"
+    if normalized in {"aws_kms", "aws_kms_ed25519"}:
+        return "aws_kms"
+    return normalized
+
+
+def normalize_trustlog_mirror_backend(raw: str | None) -> str:
+    """Normalize TrustLog mirror backend aliases to canonical names."""
+    normalized = _normalized_raw(raw)
+    if normalized in {"", "local", "filesystem"}:
+        return "local"
+    if normalized in {"s3_object_lock", "s3"}:
+        return "s3_object_lock"
+    return normalized
+
+
+def normalize_trustlog_anchor_backend(raw: str | None) -> str:
+    """Normalize TrustLog anchor backend aliases to canonical names."""
+    normalized = _normalized_raw(raw)
+    if normalized in {"", "local", "file"}:
+        return "local"
+    if normalized in {"none", "noop", "no_op"}:
+        return "noop"
+    return normalized

--- a/veritas_os/security/trustlog_production_posture.py
+++ b/veritas_os/security/trustlog_production_posture.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from os import environ
 from typing import Mapping
 
+from veritas_os.security.trustlog_backend_normalization import (
+    normalize_trustlog_anchor_backend,
+    normalize_trustlog_mirror_backend,
+    normalize_trustlog_signer_backend,
+)
+
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 STRICT_PRODUCTION_POSTURE_ALIASES = frozenset(
     {"prod", "production", "secure", "hardened"}
@@ -49,36 +55,6 @@ def is_trustlog_production_posture_enforced(env: Mapping[str, str]) -> bool:
     return _is_production_mode(env)
 
 
-def _normalized_signer_backend(env: Mapping[str, str]) -> str:
-    """Normalize signer backend aliases to runtime posture canonical values."""
-    raw = _normalized(env, "VERITAS_TRUSTLOG_SIGNER_BACKEND")
-    if raw in {"", "file", "file_ed25519"}:
-        return "file"
-    if raw in {"aws_kms", "aws_kms_ed25519"}:
-        return "aws_kms"
-    return raw
-
-
-def _normalized_anchor_backend(env: Mapping[str, str]) -> str:
-    """Normalize anchor backend aliases to runtime posture canonical values."""
-    raw = _normalized(env, "VERITAS_TRUSTLOG_ANCHOR_BACKEND")
-    if raw in {"", "local", "file"}:
-        return "local"
-    if raw in {"none", "noop", "no_op"}:
-        return "noop"
-    return raw
-
-
-def _normalized_mirror_backend(env: Mapping[str, str]) -> str:
-    """Normalize mirror backend aliases to runtime posture canonical values."""
-    raw = _normalized(env, "VERITAS_TRUSTLOG_MIRROR_BACKEND")
-    if raw in {"", "local", "filesystem"}:
-        return "local"
-    if raw in {"s3_object_lock", "s3"}:
-        return "s3_object_lock"
-    return raw
-
-
 def _effective_transparency_required(env: Mapping[str, str]) -> bool:
     """Return effective transparency-required state with posture defaults."""
     raw = env.get("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED")
@@ -113,7 +89,9 @@ def check_trustlog_production_posture(
     if not (current_env.get("VERITAS_ENCRYPTION_KEY", "") or "").strip():
         failures.append("production TrustLog encryption requires VERITAS_ENCRYPTION_KEY")
 
-    signer_backend = _normalized_signer_backend(current_env)
+    signer_backend = normalize_trustlog_signer_backend(
+        current_env.get("VERITAS_TRUSTLOG_SIGNER_BACKEND")
+    )
     if signer_backend != "aws_kms":
         failures.append("production TrustLog signer backend must be aws_kms")
     elif not (current_env.get("VERITAS_TRUSTLOG_KMS_KEY_ID", "") or "").strip():
@@ -121,7 +99,9 @@ def check_trustlog_production_posture(
             "production TrustLog aws_kms signer requires VERITAS_TRUSTLOG_KMS_KEY_ID"
         )
 
-    mirror_backend = _normalized_mirror_backend(current_env)
+    mirror_backend = normalize_trustlog_mirror_backend(
+        current_env.get("VERITAS_TRUSTLOG_MIRROR_BACKEND")
+    )
     if mirror_backend == "local":
         if not (current_env.get("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "") or "").strip():
             warnings.append("production TrustLog local WORM mirror path is not configured")
@@ -142,7 +122,9 @@ def check_trustlog_production_posture(
     if not transparency_required:
         warnings.append("production TrustLog transparency anchoring is not required")
 
-    anchor_backend = _normalized_anchor_backend(current_env)
+    anchor_backend = normalize_trustlog_anchor_backend(
+        current_env.get("VERITAS_TRUSTLOG_ANCHOR_BACKEND")
+    )
     if (
         transparency_required
         and anchor_backend == "local"

--- a/veritas_os/tests/test_trustlog_backend_normalization.py
+++ b/veritas_os/tests/test_trustlog_backend_normalization.py
@@ -1,0 +1,39 @@
+"""Unit tests for TrustLog backend normalization helpers."""
+
+from veritas_os.security.trustlog_backend_normalization import (
+    normalize_trustlog_anchor_backend,
+    normalize_trustlog_mirror_backend,
+    normalize_trustlog_signer_backend,
+)
+
+
+def test_normalize_trustlog_signer_backend() -> None:
+    """Signer backend aliases normalize to canonical runtime values."""
+    assert normalize_trustlog_signer_backend(None) == "file"
+    assert normalize_trustlog_signer_backend("") == "file"
+    assert normalize_trustlog_signer_backend("file") == "file"
+    assert normalize_trustlog_signer_backend("file_ed25519") == "file"
+    assert normalize_trustlog_signer_backend("aws_kms") == "aws_kms"
+    assert normalize_trustlog_signer_backend("aws_kms_ed25519") == "aws_kms"
+    assert normalize_trustlog_signer_backend("CUSTOM") == "custom"
+
+
+def test_normalize_trustlog_mirror_backend() -> None:
+    """Mirror backend aliases normalize to canonical runtime values."""
+    assert normalize_trustlog_mirror_backend(None) == "local"
+    assert normalize_trustlog_mirror_backend("") == "local"
+    assert normalize_trustlog_mirror_backend("filesystem") == "local"
+    assert normalize_trustlog_mirror_backend("s3") == "s3_object_lock"
+    assert normalize_trustlog_mirror_backend("s3_object_lock") == "s3_object_lock"
+    assert normalize_trustlog_mirror_backend("unknown_backend") == "unknown_backend"
+
+
+def test_normalize_trustlog_anchor_backend() -> None:
+    """Anchor backend aliases normalize to canonical runtime values."""
+    assert normalize_trustlog_anchor_backend(None) == "local"
+    assert normalize_trustlog_anchor_backend("") == "local"
+    assert normalize_trustlog_anchor_backend("file") == "local"
+    assert normalize_trustlog_anchor_backend("none") == "noop"
+    assert normalize_trustlog_anchor_backend("noop") == "noop"
+    assert normalize_trustlog_anchor_backend("no_op") == "noop"
+    assert normalize_trustlog_anchor_backend("tsa") == "tsa"


### PR DESCRIPTION
### Motivation
- Duplicate TrustLog signer/mirror/anchor backend normalization logic existed in multiple places, which risks divergence between runtime startup validation and the production posture checker. 
- Consolidate alias normalization into a single pure helper module so both `core/posture.py` and `security/trustlog_production_posture.py` use the same source of truth. 
- Keep this change strictly behavior-preserving so failure/warning semantics and startup policy remain unchanged.

### Description
- Adds a pure helper module `veritas_os/security/trustlog_backend_normalization.py` exporting `normalize_trustlog_signer_backend`, `normalize_trustlog_mirror_backend`, and `normalize_trustlog_anchor_backend` that take `str | None` and return canonical backend names. 
- Updates `veritas_os/security/trustlog_production_posture.py` to call the shared `normalize_trustlog_*` helpers instead of its previous `_normalized_*` helpers, preserving all messages and control flow. 
- Updates `veritas_os/core/posture.py` so the existing private functions `_trustlog_signer_backend`, `_trustlog_mirror_backend`, and `_trustlog_anchor_backend` now delegate to the shared helpers while preserving the original function names and external semantics. 
- Adds unit tests `veritas_os/tests/test_trustlog_backend_normalization.py` that cover the required alias normalization cases (None/empty/aliases/case normalization). 
- The helpers are pure (no `os.environ` reads, no side effects), PEP8-compliant, and do not alter `STRICT_PRODUCTION_POSTURE_ALIASES`, failure messages, or startup behavior.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_trustlog_backend_normalization.py` and the new normalization tests passed (3 passed, 1 warning). 
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_trustlog_production_posture.py` and the production posture tests passed (41 passed, 1 warning). 
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_api_startup_health.py` and those tests passed (33 passed, 1 warning). 
- Attempted `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/unit/test_server_api.py::test_run_startup_config_validation_raises_in_production` which failed to collect in this environment due to a missing `fastapi` dependency (ModuleNotFoundError). 
- `make check-trustlog-production-posture` could not run under the repository `.python-version` in this environment, but `PYENV_VERSION=3.12.13 python -m scripts.security.check_trustlog_production_posture` completed successfully with the check passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b054f3108326a4d3be00a9878612)