### PR TITLE
Add TrustLog posture contract tests

### DIFF
--- a/veritas_os/tests/test_trustlog_posture_contract.py
+++ b/veritas_os/tests/test_trustlog_posture_contract.py
@@ -1,0 +1,224 @@
+"""Contract tests for TrustLog posture alignment between checker and core."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from veritas_os.core.posture import PostureLevel, derive_defaults, resolve_posture, validate_posture_startup
+from veritas_os.security.trustlog_production_posture import check_trustlog_production_posture
+
+
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    keys = [
+        "VERITAS_ENV",
+        "VERITAS_POSTURE",
+        "VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE",
+        "VERITAS_TRUSTLOG_BACKEND",
+        "VERITAS_DATABASE_URL",
+        "DATABASE_URL",
+        "VERITAS_ENCRYPTION_KEY",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID",
+        "VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD",
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND",
+        "VERITAS_TRUSTLOG_WORM_MIRROR_PATH",
+        "VERITAS_TRUSTLOG_S3_BUCKET",
+        "VERITAS_TRUSTLOG_S3_PREFIX",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH",
+        "VERITAS_SECRET_PROVIDER",
+        "VERITAS_API_SECRET_REF",
+        "VERITAS_POSTURE_OVERRIDE_POLICY_ENFORCE",
+        "VERITAS_POSTURE_OVERRIDE_EXTERNAL_SECRET_MGR",
+        "VERITAS_POSTURE_OVERRIDE_TRUSTLOG_TRANSPARENCY",
+        "VERITAS_POSTURE_OVERRIDE_TRUSTLOG_WORM",
+        "VERITAS_POSTURE_OVERRIDE_REPLAY_STRICT",
+    ]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _checker_full_env() -> dict[str, str]:
+    return {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_ENCRYPTION_KEY": "dummy",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+        "VERITAS_TRUSTLOG_MIRROR_BACKEND": "s3_object_lock",
+        "VERITAS_TRUSTLOG_S3_BUCKET": "bucket",
+        "VERITAS_TRUSTLOG_S3_PREFIX": "prefix",
+        "VERITAS_TRUSTLOG_ANCHOR_BACKEND": "local",
+        "VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH": "/tmp/transparency.jsonl",
+    }
+
+
+def _core_full_env() -> dict[str, str]:
+    return {
+        **_checker_full_env(),
+        "VERITAS_SECRET_PROVIDER": "vault",
+        "VERITAS_API_SECRET_REF": "secret/ref",
+    }
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clean_env(monkeypatch)
+
+
+def _apply_env(monkeypatch: pytest.MonkeyPatch, env: dict[str, str]) -> None:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_prod_full_trustlog_config_passes_checker_and_core_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    _apply_env(monkeypatch, _core_full_env())
+
+    checker_result = check_trustlog_production_posture(dict(os.environ))
+    assert checker_result.passed is True
+    assert checker_result.failures == ()
+
+    defaults = derive_defaults(PostureLevel.PROD)
+    assert validate_posture_startup(defaults) == []
+
+
+def test_aws_kms_ed25519_alias_passes_checker_and_core_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = _core_full_env()
+    env["VERITAS_TRUSTLOG_SIGNER_BACKEND"] = "aws_kms_ed25519"
+    _apply_env(monkeypatch, env)
+
+    checker_result = check_trustlog_production_posture(dict(os.environ))
+    assert checker_result.passed is True
+    assert checker_result.failures == ()
+
+    defaults = derive_defaults(PostureLevel.PROD)
+    assert validate_posture_startup(defaults) == []
+
+
+def test_file_ed25519_alias_fails_checker_and_core_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = _core_full_env()
+    env["VERITAS_TRUSTLOG_SIGNER_BACKEND"] = "file_ed25519"
+    _apply_env(monkeypatch, env)
+
+    checker_result = check_trustlog_production_posture(dict(os.environ))
+    assert any("signer backend must be aws_kms" in item for item in checker_result.failures)
+
+    defaults = derive_defaults(PostureLevel.PROD)
+    errors = validate_posture_startup(defaults)
+    assert any("managed_signing" in item for item in errors)
+
+
+def test_s3_mirror_alias_passes_checker_and_core_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = _core_full_env()
+    env["VERITAS_TRUSTLOG_MIRROR_BACKEND"] = "s3"
+    _apply_env(monkeypatch, env)
+
+    checker_result = check_trustlog_production_posture(dict(os.environ))
+    assert checker_result.passed is True
+    assert not any("s3_object_lock mirror requires" in item for item in checker_result.warnings)
+
+    defaults = derive_defaults(PostureLevel.PROD)
+    assert validate_posture_startup(defaults) == []
+
+
+def test_local_mirror_is_warning_in_checker_but_error_in_core_strict_posture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Intentional divergence: checker warns/non-critical, core strict posture hard-fails."""
+    env = _core_full_env()
+    env["VERITAS_TRUSTLOG_MIRROR_BACKEND"] = "filesystem"
+    env["VERITAS_TRUSTLOG_WORM_MIRROR_PATH"] = "/tmp/worm"
+    _apply_env(monkeypatch, env)
+
+    checker_result = check_trustlog_production_posture(dict(os.environ))
+    assert checker_result.passed is True
+    assert checker_result.failures == ()
+
+    defaults = derive_defaults(PostureLevel.PROD)
+    errors = validate_posture_startup(defaults)
+    assert any("immutable_retention" in item for item in errors)
+
+
+def test_noop_anchor_is_warning_in_checker_but_error_in_core_when_transparency_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Intentional divergence: checker warning-only vs core capability hard-fail."""
+    env = _core_full_env()
+    env["VERITAS_TRUSTLOG_ANCHOR_BACKEND"] = "none"
+    _apply_env(monkeypatch, env)
+
+    checker_result = check_trustlog_production_posture(dict(os.environ))
+    assert checker_result.passed is True
+    assert checker_result.failures == ()
+    assert any("anchor backend is noop" in item for item in checker_result.warnings)
+
+    defaults = derive_defaults(PostureLevel.PROD)
+    errors = validate_posture_startup(defaults)
+    assert any("transparency_anchoring" in item for item in errors)
+
+
+@pytest.mark.parametrize(
+    "alias, expected",
+    [
+        ("production", PostureLevel.PROD),
+        ("prod", PostureLevel.PROD),
+        ("secure", PostureLevel.SECURE),
+        ("hardened", PostureLevel.SECURE),
+    ],
+)
+def test_strict_env_aliases_enforce_checker_and_core_fail_fast_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    alias: str,
+    expected: PostureLevel,
+) -> None:
+    monkeypatch.setenv("VERITAS_ENV", alias)
+    result = check_trustlog_production_posture(dict(os.environ))
+    assert result.passed is False
+    assert any("backend must be postgresql" in item for item in result.failures)
+    assert resolve_posture(env_fallback=alias) == expected
+
+
+@pytest.mark.parametrize(
+    "alias, expected",
+    [
+        ("production", PostureLevel.PROD),
+        ("prod", PostureLevel.PROD),
+        ("secure", PostureLevel.SECURE),
+        ("hardened", PostureLevel.SECURE),
+    ],
+)
+def test_strict_veritas_posture_aliases_enforce_checker_and_core(
+    monkeypatch: pytest.MonkeyPatch,
+    alias: str,
+    expected: PostureLevel,
+) -> None:
+    monkeypatch.setenv("VERITAS_POSTURE", alias)
+    result = check_trustlog_production_posture(dict(os.environ))
+    assert result.passed is False
+    assert any("backend must be postgresql" in item for item in result.failures)
+    assert resolve_posture() == expected
+
+
+@pytest.mark.parametrize("alias", ["dev", "development", "local", "test", "staging", "stg"])
+def test_non_strict_env_aliases_do_not_enforce_checker_or_core_strict_posture(
+    monkeypatch: pytest.MonkeyPatch,
+    alias: str,
+) -> None:
+    monkeypatch.setenv("VERITAS_ENV", alias)
+
+    checker_result = check_trustlog_production_posture(dict(os.environ))
+    assert checker_result.passed is True
+    assert checker_result.failures == ()
+
+    resolved = resolve_posture()
+    if alias in {"staging", "stg"}:
+        assert resolved == PostureLevel.STAGING
+    else:
+        assert resolved == PostureLevel.DEV
+
+    defaults = derive_defaults(resolved)
+    assert defaults.is_strict is False


### PR DESCRIPTION
### Motivation
- Ensure the TrustLog production posture checker and core startup `validate_posture_startup` do not contradict each other for the same TrustLog env fixtures by codifying a contract in tests. 
- Lock alias/normalization semantics for signer/mirror/anchor backends and document intentional differences (warning-only vs hard error) between checker and core strict posture. 

### Description
- Adds a tests-only module `veritas_os/tests/test_trustlog_posture_contract.py` that contains isolated env helpers (`_clean_env`, `_checker_full_env`, `_core_full_env`), an autouse `clean_env` fixture, and an `_apply_env` helper. 
- Implements contract tests covering: full strict config acceptance by both checker and core, `aws_kms_ed25519` alias acceptance, `file_ed25519` rejection, `s3` mirror alias normalization, filesystem/local mirror intentional divergence (warning in checker, error in core), noop/none anchor intentional divergence (warning in checker, error in core), strict `VERITAS_ENV`/`VERITAS_POSTURE` alias enforcement, and non-strict env aliases behavior. 
- Verifies backend normalization is interpreted consistently by `check_trustlog_production_posture` and `validate_posture_startup` without changing any runtime code. 
- This PR contains only test additions and minimal in-test helper organization; no changes to runtime modules, docs, CI, Makefile, migrations, or health endpoints are included. 

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_trustlog_posture_contract.py` and the new contract tests passed (`20 passed, 1 warning`).
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_trustlog_backend_normalization.py` and it passed (`3 passed, 1 warning`).
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_trustlog_production_posture.py` and it passed (`41 passed, 1 warning`).
- Ran `PYENV_VERSION=3.12.13 python -m pytest -q veritas_os/tests/test_posture.py` and it passed (`95 passed, 1 warning`).
- Ran the project check script `PYENV_VERSION=3.12.13 make check-trustlog-production-posture` and `PYENV_VERSION=3.12.13 python -m scripts.security.check_trustlog_production_posture` and both reported the production posture check passed (script printed `TrustLog production posture check passed.` and `33 passed, 1 warning` for the script-run tests).
- One unrelated environment-specific test invocation (`python -m pytest ... veritas_os/tests/unit/test_server_api.py::test_run_startup_config_validation_raises_in_production`) failed in this environment due to a missing `fastapi` dependency, which is external to these changes; the failure is an environment dependency issue and not caused by the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b4d0db508326bf0453858effa498)