### PR TITLE
Document TrustLog production readiness checklist

### DIFF
--- a/docs/en/operations/postgresql-production-guide.md
+++ b/docs/en/operations/postgresql-production-guide.md
@@ -120,6 +120,8 @@ in `veritas_os/storage/db.py`.
 
 ## TrustLog production posture checker (operator-facing minimum posture check)
 
+- For a compact operator checklist, see `trustlog-production-readiness-checklist.md`.
+
 `check-trustlog-production-posture` is an operator-facing CLI checker for
 minimum TrustLog production posture. It validates environment-variable presence
 and posture assumptions only.

--- a/docs/en/operations/postgresql-production-guide.md
+++ b/docs/en/operations/postgresql-production-guide.md
@@ -120,7 +120,7 @@ in `veritas_os/storage/db.py`.
 
 ## TrustLog production posture checker (operator-facing minimum posture check)
 
-- For a compact operator checklist, see `trustlog-production-readiness-checklist.md`.
+- For a compact operator checklist, see [TrustLog production readiness checklist](trustlog-production-readiness-checklist.md).
 
 `check-trustlog-production-posture` is an operator-facing CLI checker for
 minimum TrustLog production posture. It validates environment-variable presence

--- a/docs/en/operations/trustlog-production-readiness-checklist.md
+++ b/docs/en/operations/trustlog-production-readiness-checklist.md
@@ -1,0 +1,80 @@
+# TrustLog production readiness checklist
+
+This checklist is an operator-facing readiness checklist for TrustLog production posture.
+It summarizes what must be configured before treating a deployment as production-ready.
+It complements, but does not replace, the PostgreSQL production guide, runtime startup validation,
+CI checks, and live provider validation.
+Passing this checklist is not sufficient by itself and does not certify compliance.
+
+## Scope and non-scope
+
+### Scope
+
+- TrustLog production posture
+- PostgreSQL TrustLog backend
+- managed signing
+- WORM / immutable mirror
+- transparency anchoring
+- startup fail-fast
+- operator CLI check
+- evidence links / tests
+
+### Non-scope
+
+- real KMS connectivity proof
+- real DB connectivity proof
+- real WORM retention proof
+- legal/compliance certification
+- external audit attestation
+- end-to-end live provider validation
+
+## Readiness checklist
+
+| Area | Required check | How to verify | Expected result | Notes |
+| --- | --- | --- | --- | --- |
+| Runtime posture trigger | `VERITAS_ENV` or `VERITAS_POSTURE` is strict, or `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` is truthy | Inspect deployment env | One of `prod`/`production`/`secure`/`hardened` triggers is active | Strict aliases are shared with startup fail-fast semantics |
+| TrustLog backend | `VERITAS_TRUSTLOG_BACKEND=postgresql` | Run `make check-trustlog-production-posture` | No failure for backend | `jsonl` is dev/demo only |
+| Database URL | `VERITAS_DATABASE_URL` or `DATABASE_URL` set | Run checker / inspect secret injection | No database URL failure | Do not print secrets in logs |
+| Encryption key | `VERITAS_ENCRYPTION_KEY` set | Run checker / inspect secret source | No encryption key failure | Use external secret manager in production |
+| Managed signer | `VERITAS_TRUSTLOG_SIGNER_BACKEND` resolves to `aws_kms` | Run checker | No signer backend failure | `aws_kms_ed25519` is accepted; `file`/`file_ed25519` fail |
+| KMS key id | `VERITAS_TRUSTLOG_KMS_KEY_ID` set when signer resolves to `aws_kms` | Run checker / inspect KMS env | No `KMS_KEY_ID` failure | Checker does not call KMS |
+| Break-glass override | `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` must not be relied on | Inspect env | Checker still fails file signer even if override is set | Production posture checker ignores the flag |
+| WORM / immutable mirror | Use appropriate mirror backend/path | Run checker and core posture startup validation | Checker warning-free or documented warning; core strict posture rejects incapable mirror | Checker warning-only; core strict posture can hard-error on capability |
+| S3 Object Lock mirror | If `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock`, set bucket and prefix | Run checker | No `s3_object_lock` mirror warning | Checker does not verify S3 retention |
+| Transparency required | Transparency should be required in strict posture unless explicitly disabled | Run checker | No "transparency anchoring is not required" warning | Explicit disable is warning-level |
+| Transparency log path | If local anchor is selected and transparency is required, set `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` | Run checker | No local transparency log path warning | TSA-specific validation is not added here |
+| Noop anchor | Do not use `noop`/`none`/`no_op` anchor in production posture | Run checker | No noop anchor warning | Checker warning-only; core strict posture hard-errors when transparency required |
+| Startup fail-fast | Production posture failures stop startup | Start app with strict env and invalid TrustLog config in staging test | `RuntimeError` / startup refusal | Do not test by breaking production |
+| Contract tests | checker/core alignment tests pass | `python -m pytest -q veritas_os/tests/test_trustlog_posture_contract.py` | All pass | Guards drift between checker and core posture validation |
+| CLI checker | operator CLI passes or only expected warnings remain | `make check-trustlog-production-posture` | Exit 0; warnings reviewed | Exit 0 with warnings is not full readiness proof |
+| Live provider validation | Real DB/KMS/WORM/TSA connectivity and retention validated separately | Run deployment-specific validation / cloud-native checks | Documented evidence | Not covered by this checker |
+
+## Command quick reference
+
+- `make check-trustlog-production-posture`
+- `python -m scripts.security.check_trustlog_production_posture`
+- `python -m pytest -q veritas_os/tests/test_trustlog_posture_contract.py`
+- `python -m pytest -q veritas_os/tests/test_trustlog_production_posture.py`
+- `python -m pytest -q veritas_os/tests/test_posture.py`
+- `python -m pytest -q veritas_os/tests/test_trustlog_backend_normalization.py`
+
+## Interpreting results
+
+- Failures are blocking for production posture.
+- Warnings are non-fatal in the checker.
+- Some warning-only checker findings can still be hard failures in core strict posture validation.
+- The contract tests intentionally cover this warning-vs-hard-error divergence.
+- Passing the checker is necessary but not sufficient for production readiness.
+- Real DB/KMS/WORM/transparency anchoring must be validated separately.
+
+## Evidence map
+
+- Runtime startup fail-fast: `veritas_os/api/startup_health.py`
+- Production posture checker: `veritas_os/security/trustlog_production_posture.py`
+- Backend normalization: `veritas_os/security/trustlog_backend_normalization.py`
+- Core posture validation: `veritas_os/core/posture.py`
+- CLI wrapper: `scripts/security/check_trustlog_production_posture.py`
+- Checker tests: `veritas_os/tests/test_trustlog_production_posture.py`
+- Contract tests: `veritas_os/tests/test_trustlog_posture_contract.py`
+- Normalization tests: `veritas_os/tests/test_trustlog_backend_normalization.py`
+- Operational guide: `docs/en/operations/postgresql-production-guide.md`

--- a/docs/ja/operations/postgresql-production-guide.md
+++ b/docs/ja/operations/postgresql-production-guide.md
@@ -19,7 +19,7 @@ PostgreSQL を本番で運用する際の確認観点を、日本語で短く整
 
 ## TrustLog production posture checker（最小姿勢チェック）
 
-- コンパクトな運用チェックリストは `trustlog-production-readiness-checklist.md` を参照してください。
+- コンパクトな運用チェックリストは [TrustLog 本番 readiness チェックリスト](trustlog-production-readiness-checklist.md) を参照してください。
 - `check-trustlog-production-posture` は、TrustLog の本番姿勢に必要な環境変数の有無/設定姿勢を確認する operator-facing な最小チェックです（実行: `make check-trustlog-production-posture` または `python -m scripts.security.check_trustlog_production_posture`）。
 - runtime default は変更せず、実DB/実KMS/実WORMへ接続もしません。CI の `[Tier 1] governance-smoke` では非シークレットのダミー環境変数で production enforcement path を検証しますが、実運用 readiness の証明にはなりません。
 - production posture validation が厳格化される条件は以下です。

--- a/docs/ja/operations/postgresql-production-guide.md
+++ b/docs/ja/operations/postgresql-production-guide.md
@@ -18,6 +18,8 @@ PostgreSQL を本番で運用する際の確認観点を、日本語で短く整
 - Migration 手順とロールバック手順を運用Runbookに統合する。
 
 ## TrustLog production posture checker（最小姿勢チェック）
+
+- コンパクトな運用チェックリストは `trustlog-production-readiness-checklist.md` を参照してください。
 - `check-trustlog-production-posture` は、TrustLog の本番姿勢に必要な環境変数の有無/設定姿勢を確認する operator-facing な最小チェックです（実行: `make check-trustlog-production-posture` または `python -m scripts.security.check_trustlog_production_posture`）。
 - runtime default は変更せず、実DB/実KMS/実WORMへ接続もしません。CI の `[Tier 1] governance-smoke` では非シークレットのダミー環境変数で production enforcement path を検証しますが、実運用 readiness の証明にはなりません。
 - production posture validation が厳格化される条件は以下です。

--- a/docs/ja/operations/trustlog-production-readiness-checklist.md
+++ b/docs/ja/operations/trustlog-production-readiness-checklist.md
@@ -5,9 +5,9 @@
 PostgreSQL production guide、runtime startup validation、CI checks、live provider validation を補完するものであり、置き換えるものではありません。
 このチェックリストの通過だけでは十分ではなく、compliance を保証するものでもありません。
 
-## Scope / non-scope
+## 対象範囲と対象外
 
-### Scope
+### 対象範囲
 
 - TrustLog production posture
 - PostgreSQL TrustLog backend
@@ -18,7 +18,7 @@ PostgreSQL production guide、runtime startup validation、CI checks、live prov
 - operator CLI check
 - evidence links / tests
 
-### Non-scope
+### 対象外
 
 - real KMS connectivity proof
 - real DB connectivity proof
@@ -27,28 +27,28 @@ PostgreSQL production guide、runtime startup validation、CI checks、live prov
 - external audit attestation
 - end-to-end live provider validation
 
-## Readiness checklist
+## Readiness チェックリスト
 
-| Area | Required check | How to verify | Expected result | Notes |
+| 領域 | 必須確認 | 確認方法 | 期待結果 | 補足 |
 | --- | --- | --- | --- | --- |
-| Runtime posture trigger | `VERITAS_ENV` or `VERITAS_POSTURE` is strict, or `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` is truthy | Inspect deployment env | One of `prod`/`production`/`secure`/`hardened` triggers is active | Strict aliases are shared with startup fail-fast semantics |
-| TrustLog backend | `VERITAS_TRUSTLOG_BACKEND=postgresql` | Run `make check-trustlog-production-posture` | No failure for backend | `jsonl` is dev/demo only |
-| Database URL | `VERITAS_DATABASE_URL` or `DATABASE_URL` set | Run checker / inspect secret injection | No database URL failure | Do not print secrets in logs |
-| Encryption key | `VERITAS_ENCRYPTION_KEY` set | Run checker / inspect secret source | No encryption key failure | Use external secret manager in production |
-| Managed signer | `VERITAS_TRUSTLOG_SIGNER_BACKEND` resolves to `aws_kms` | Run checker | No signer backend failure | `aws_kms_ed25519` is accepted; `file`/`file_ed25519` fail |
-| KMS key id | `VERITAS_TRUSTLOG_KMS_KEY_ID` set when signer resolves to `aws_kms` | Run checker / inspect KMS env | No `KMS_KEY_ID` failure | Checker does not call KMS |
-| Break-glass override | `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` must not be relied on | Inspect env | Checker still fails file signer even if override is set | Production posture checker ignores the flag |
-| WORM / immutable mirror | Use appropriate mirror backend/path | Run checker and core posture startup validation | Checker warning-free or documented warning; core strict posture rejects incapable mirror | Checker warning-only; core strict posture can hard-error on capability |
-| S3 Object Lock mirror | If `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock`, set bucket and prefix | Run checker | No `s3_object_lock` mirror warning | Checker does not verify S3 retention |
-| Transparency required | Transparency should be required in strict posture unless explicitly disabled | Run checker | No "transparency anchoring is not required" warning | Explicit disable is warning-level |
-| Transparency log path | If local anchor is selected and transparency is required, set `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` | Run checker | No local transparency log path warning | TSA-specific validation is not added here |
-| Noop anchor | Do not use `noop`/`none`/`no_op` anchor in production posture | Run checker | No noop anchor warning | Checker warning-only; core strict posture hard-errors when transparency required |
-| Startup fail-fast | Production posture failures stop startup | Start app with strict env and invalid TrustLog config in staging test | `RuntimeError` / startup refusal | Do not test by breaking production |
-| Contract tests | checker/core alignment tests pass | `python -m pytest -q veritas_os/tests/test_trustlog_posture_contract.py` | All pass | Guards drift between checker and core posture validation |
-| CLI checker | operator CLI passes or only expected warnings remain | `make check-trustlog-production-posture` | Exit 0; warnings reviewed | Exit 0 with warnings is not full readiness proof |
-| Live provider validation | Real DB/KMS/WORM/TSA connectivity and retention validated separately | Run deployment-specific validation / cloud-native checks | Documented evidence | Not covered by this checker |
+| Runtime posture trigger | `VERITAS_ENV` または `VERITAS_POSTURE` が strict 値、または `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` が truthy | deployment env を確認 | `prod` / `production` / `secure` / `hardened` のいずれかが有効 | strict alias は startup fail-fast semantics と共有されます |
+| TrustLog backend | `VERITAS_TRUSTLOG_BACKEND=postgresql` | `make check-trustlog-production-posture` を実行 | backend failure が出ない | `jsonl` は dev/demo 用です |
+| Database URL | `VERITAS_DATABASE_URL` または `DATABASE_URL` が設定されている | checker 実行 / secret injection を確認 | database URL failure が出ない | secret 値をログに出さないでください |
+| Encryption key | `VERITAS_ENCRYPTION_KEY` が設定されている | checker 実行 / secret source を確認 | encryption key failure が出ない | production では外部 secret manager を使います |
+| Managed signer | `VERITAS_TRUSTLOG_SIGNER_BACKEND` が `aws_kms` に解決される | checker を実行 | signer backend failure が出ない | `aws_kms_ed25519` は許可、`file` / `file_ed25519` は failure です |
+| KMS key id | signer が `aws_kms` に解決される場合 `VERITAS_TRUSTLOG_KMS_KEY_ID` が設定されている | checker 実行 / KMS 関連 env を確認 | `KMS_KEY_ID` failure が出ない | checker は KMS へ接続しません |
+| Break-glass override | `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` に依存しない | env を確認 | override があっても file signer は failure | production posture checker はこのフラグを無視します |
+| WORM / immutable mirror | 適切な mirror backend/path を使う | checker と core posture startup validation を実行 | checker warning なし、または warning を記録済み。capability 不足なら core strict posture が拒否 | checker では warning-only、core strict posture では hard-error になり得ます |
+| S3 Object Lock mirror | `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` の場合は bucket/prefix を設定する | checker を実行 | `s3_object_lock` mirror warning が出ない | checker は S3 retention を検証しません |
+| Transparency required | strict posture では transparency required を基本とし、明示 disable は例外運用に限定する | checker を実行 | "transparency anchoring is not required" warning が出ない | 明示 disable は warning-level です |
+| Transparency log path | local anchor かつ transparency required の場合 `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` を設定する | checker を実行 | local transparency log path warning が出ない | TSA-specific validation はこの checker では未追加です |
+| Noop anchor | production posture で `noop` / `none` / `no_op` anchor を使わない | checker を実行 | noop anchor warning が出ない | checker では warning-only、core strict posture では hard-error になり得ます |
+| Startup fail-fast | production posture の failure で startup が停止する | strict env + 不正 TrustLog 設定で staging 検証を行う | `RuntimeError` / startup refusal になる | production 本番を壊して試験しないでください |
+| Contract tests | checker/core alignment tests が通る | `python -m pytest -q veritas_os/tests/test_trustlog_posture_contract.py` | 全件 pass | checker と core posture validation の drift 防止です |
+| CLI checker | operator CLI が pass、または expected warnings のみ | `make check-trustlog-production-posture` を実行 | Exit 0、warnings をレビュー済み | warnings 付き Exit 0 は readiness の証明ではありません |
+| Live provider validation | 実 DB/KMS/WORM/TSA の接続・retention を別途検証する | 環境固有の検証手順 / クラウド側チェックを実行 | 証跡が文書化されている | checker の対象外です |
 
-## Command quick reference
+## コマンド早見表
 
 - `make check-trustlog-production-posture`
 - `python -m scripts.security.check_trustlog_production_posture`
@@ -57,23 +57,27 @@ PostgreSQL production guide、runtime startup validation、CI checks、live prov
 - `python -m pytest -q veritas_os/tests/test_posture.py`
 - `python -m pytest -q veritas_os/tests/test_trustlog_backend_normalization.py`
 
-## Interpreting results
+## 結果の読み方
 
 - failure は production posture では blocking です。
 - warning は checker では non-fatal です。
-- checker で warning-only の指摘でも、core strict posture validation では hard failure になるものがあります。
-- contract tests はこの warning と hard-error の差異を意図的にカバーしています。
-- checker 通過は必要条件ですが、本番 readiness の十分条件ではありません。
-- 実 DB/KMS/WORM/transparency anchoring の検証は別途必要です。
+- checker の warning-only 指摘でも、core strict posture validation では hard failure になり得ます。
+- contract tests は warning-vs-hard-error divergence を意図的にカバーしています。
+- checker 通過は必要条件ですが十分条件ではありません。
+- 実 DB/KMS/WORM/transparency anchoring は別途検証が必要です。
 
-## Evidence map
+## 証跡マップ
 
-- Runtime startup fail-fast: `veritas_os/api/startup_health.py`
-- Production posture checker: `veritas_os/security/trustlog_production_posture.py`
-- Backend normalization: `veritas_os/security/trustlog_backend_normalization.py`
-- Core posture validation: `veritas_os/core/posture.py`
+- Runtime startup fail-fast 実装: `veritas_os/api/startup_health.py`
+- Production posture checker 実装: `veritas_os/security/trustlog_production_posture.py`
+- Backend normalization 実装: `veritas_os/security/trustlog_backend_normalization.py`
+- Core posture validation 実装: `veritas_os/core/posture.py`
 - CLI wrapper: `scripts/security/check_trustlog_production_posture.py`
-- Checker tests: `veritas_os/tests/test_trustlog_production_posture.py`
-- Contract tests: `veritas_os/tests/test_trustlog_posture_contract.py`
-- Normalization tests: `veritas_os/tests/test_trustlog_backend_normalization.py`
+- Checker テスト: `veritas_os/tests/test_trustlog_production_posture.py`
+- Contract テスト: `veritas_os/tests/test_trustlog_posture_contract.py`
+- Normalization テスト: `veritas_os/tests/test_trustlog_backend_normalization.py`
 - Operational guide: `docs/en/operations/postgresql-production-guide.md`
+
+## 英語正本
+
+この日本語版は運用者向けの説明補助です。厳密な仕様・英語正本は [TrustLog production readiness checklist](../../en/operations/trustlog-production-readiness-checklist.md) を参照してください。

--- a/docs/ja/operations/trustlog-production-readiness-checklist.md
+++ b/docs/ja/operations/trustlog-production-readiness-checklist.md
@@ -1,0 +1,79 @@
+# TrustLog 本番 readiness チェックリスト
+
+このチェックリストは、TrustLog の本番 posture を短時間で確認するための operator-facing な文書です。
+本番相当として扱う前に必要な設定項目を要約します。
+PostgreSQL production guide、runtime startup validation、CI checks、live provider validation を補完するものであり、置き換えるものではありません。
+このチェックリストの通過だけでは十分ではなく、compliance を保証するものでもありません。
+
+## Scope / non-scope
+
+### Scope
+
+- TrustLog production posture
+- PostgreSQL TrustLog backend
+- managed signing
+- WORM / immutable mirror
+- transparency anchoring
+- startup fail-fast
+- operator CLI check
+- evidence links / tests
+
+### Non-scope
+
+- real KMS connectivity proof
+- real DB connectivity proof
+- real WORM retention proof
+- legal/compliance certification
+- external audit attestation
+- end-to-end live provider validation
+
+## Readiness checklist
+
+| Area | Required check | How to verify | Expected result | Notes |
+| --- | --- | --- | --- | --- |
+| Runtime posture trigger | `VERITAS_ENV` or `VERITAS_POSTURE` is strict, or `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE` is truthy | Inspect deployment env | One of `prod`/`production`/`secure`/`hardened` triggers is active | Strict aliases are shared with startup fail-fast semantics |
+| TrustLog backend | `VERITAS_TRUSTLOG_BACKEND=postgresql` | Run `make check-trustlog-production-posture` | No failure for backend | `jsonl` is dev/demo only |
+| Database URL | `VERITAS_DATABASE_URL` or `DATABASE_URL` set | Run checker / inspect secret injection | No database URL failure | Do not print secrets in logs |
+| Encryption key | `VERITAS_ENCRYPTION_KEY` set | Run checker / inspect secret source | No encryption key failure | Use external secret manager in production |
+| Managed signer | `VERITAS_TRUSTLOG_SIGNER_BACKEND` resolves to `aws_kms` | Run checker | No signer backend failure | `aws_kms_ed25519` is accepted; `file`/`file_ed25519` fail |
+| KMS key id | `VERITAS_TRUSTLOG_KMS_KEY_ID` set when signer resolves to `aws_kms` | Run checker / inspect KMS env | No `KMS_KEY_ID` failure | Checker does not call KMS |
+| Break-glass override | `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` must not be relied on | Inspect env | Checker still fails file signer even if override is set | Production posture checker ignores the flag |
+| WORM / immutable mirror | Use appropriate mirror backend/path | Run checker and core posture startup validation | Checker warning-free or documented warning; core strict posture rejects incapable mirror | Checker warning-only; core strict posture can hard-error on capability |
+| S3 Object Lock mirror | If `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock`, set bucket and prefix | Run checker | No `s3_object_lock` mirror warning | Checker does not verify S3 retention |
+| Transparency required | Transparency should be required in strict posture unless explicitly disabled | Run checker | No "transparency anchoring is not required" warning | Explicit disable is warning-level |
+| Transparency log path | If local anchor is selected and transparency is required, set `VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH` | Run checker | No local transparency log path warning | TSA-specific validation is not added here |
+| Noop anchor | Do not use `noop`/`none`/`no_op` anchor in production posture | Run checker | No noop anchor warning | Checker warning-only; core strict posture hard-errors when transparency required |
+| Startup fail-fast | Production posture failures stop startup | Start app with strict env and invalid TrustLog config in staging test | `RuntimeError` / startup refusal | Do not test by breaking production |
+| Contract tests | checker/core alignment tests pass | `python -m pytest -q veritas_os/tests/test_trustlog_posture_contract.py` | All pass | Guards drift between checker and core posture validation |
+| CLI checker | operator CLI passes or only expected warnings remain | `make check-trustlog-production-posture` | Exit 0; warnings reviewed | Exit 0 with warnings is not full readiness proof |
+| Live provider validation | Real DB/KMS/WORM/TSA connectivity and retention validated separately | Run deployment-specific validation / cloud-native checks | Documented evidence | Not covered by this checker |
+
+## Command quick reference
+
+- `make check-trustlog-production-posture`
+- `python -m scripts.security.check_trustlog_production_posture`
+- `python -m pytest -q veritas_os/tests/test_trustlog_posture_contract.py`
+- `python -m pytest -q veritas_os/tests/test_trustlog_production_posture.py`
+- `python -m pytest -q veritas_os/tests/test_posture.py`
+- `python -m pytest -q veritas_os/tests/test_trustlog_backend_normalization.py`
+
+## Interpreting results
+
+- failure は production posture では blocking です。
+- warning は checker では non-fatal です。
+- checker で warning-only の指摘でも、core strict posture validation では hard failure になるものがあります。
+- contract tests はこの warning と hard-error の差異を意図的にカバーしています。
+- checker 通過は必要条件ですが、本番 readiness の十分条件ではありません。
+- 実 DB/KMS/WORM/transparency anchoring の検証は別途必要です。
+
+## Evidence map
+
+- Runtime startup fail-fast: `veritas_os/api/startup_health.py`
+- Production posture checker: `veritas_os/security/trustlog_production_posture.py`
+- Backend normalization: `veritas_os/security/trustlog_backend_normalization.py`
+- Core posture validation: `veritas_os/core/posture.py`
+- CLI wrapper: `scripts/security/check_trustlog_production_posture.py`
+- Checker tests: `veritas_os/tests/test_trustlog_production_posture.py`
+- Contract tests: `veritas_os/tests/test_trustlog_posture_contract.py`
+- Normalization tests: `veritas_os/tests/test_trustlog_backend_normalization.py`
+- Operational guide: `docs/en/operations/postgresql-production-guide.md`


### PR DESCRIPTION
### Motivation

- Provide an operator-facing, compact checklist that extracts TrustLog production readiness steps from the longer PostgreSQL guide so operators/SREs/auditors can quickly verify minimum posture. 
- Surface the relationship between the CLI checker, runtime startup fail-fast, and contract tests, and provide an evidence map to the implemented code and tests. 
- Offer a Japanese counterpart and link the checklist from both English and Japanese PostgreSQL production guides to make the guidance easy to find.

### Description

- Add `docs/en/operations/trustlog-production-readiness-checklist.md` containing scope, a tabular readiness checklist (16 rows), command quick reference, interpreting-results guidance, and an evidence map linking to repo-relative implementation and tests. 
- Add `docs/ja/operations/trustlog-production-readiness-checklist.md` providing the same operator-facing checklist in Japanese with matching failure/warning interpretation and limits. 
- Insert a short pointer to the checklist in the TrustLog production posture checker section of `docs/en/operations/postgresql-production-guide.md` and `docs/ja/operations/postgresql-production-guide.md`. 
- Docs-only change; no runtime code, tests, Makefile, CI, health endpoint, storage defaults, or migration changes were made; edits were applied on the current checked-out branch (no upstream `origin/main` was available in this environment).

### Testing

- Executed `python3 scripts/quality/check_operational_docs_consistency.py` and it passed. 
- Executed `python3 scripts/quality/check_bilingual_docs.py` and it passed. 
- Note: this environment could not fetch or inspect a remote `origin/main` (no remote configured), so edits were based on the current branch contents instead of verifying against a remote `main` head.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04baf980c4832693120d8de0381591)