### PR TITLE
Summarize advisory governance failures in staged readiness report (JSON + text) and update docs/tests

### DIFF
--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -163,6 +163,11 @@ advisory check, and runs it with a subprocess-scoped
 `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE=1` override so the production
 posture path is evaluated even from a local/dev shell. The check remains
 non-blocking and does not connect to real DB/KMS/WORM services.
+The JSON report surfaces advisory issues in
+`overall_readiness.advisory_issues` and
+`overall_readiness.advisory_issue_count`. Advisory failures do not flip
+`deployment_ready` by themselves, but operators must review them before
+promotion.
 
 
 ### Governance Readiness Report (v1.0)

--- a/docs/en/validation/production-validation.md
+++ b/docs/en/validation/production-validation.md
@@ -527,6 +527,9 @@ python scripts/generate_staged_readiness_report.py \
 
 The v2.1 staged report includes `trustlog-production-posture` as advisory
 governance evidence.
+In v2.1, advisory failures are also summarized at
+`overall_readiness.advisory_issues` / `advisory_issue_count` so non-blocking
+issues are visible without changing `deployment_ready` semantics.
 
 See [`operational-readiness-runbook.md`](../operations/operational-readiness-runbook.md) for full usage and troubleshooting.
 

--- a/docs/ja/validation/production-validation.md
+++ b/docs/ja/validation/production-validation.md
@@ -16,6 +16,7 @@
 - `make quality-checks` と production/smoke 系テストを継続実行する。
 - PostgreSQL の live 検証導線と運用ドリルを定期確認する。
 - staged readiness report は v2.1 を利用し、`trustlog-production-posture` の advisory 証跡を含みます。
+- v2.1 では、注意・警告扱いの失敗も `overall_readiness.advisory_issues` / `overall_readiness.advisory_issue_count` に要約されます。これらは単独では `deployment_ready` を未達扱いにはしませんが、昇格・本番反映の前に運用者が確認する必要があります。
 - 詳細は英語正本または実装ファイルを確認してください。
 
 ## 現時点の制限

--- a/scripts/generate_staged_readiness_report.py
+++ b/scripts/generate_staged_readiness_report.py
@@ -238,6 +238,8 @@ def build_report(
             "compose_validated": compose_ok,
             "live_provider_ok": live_ok,
             "deployment_ready": governance_ready and compose_ok,
+            "advisory_issues": len(advisory_failures) > 0,
+            "advisory_issue_count": len(advisory_failures),
         },
         "governance": {
             "total_checks": len(governance_results),
@@ -329,6 +331,12 @@ def render_text_report(report: dict) -> str:
     lines.append(
         f"  Live Providers:    {'✅ OK' if readiness['live_provider_ok'] else '⚠️  Not OK'}"
     )
+    advisory_summary = (
+        f"⚠️  {readiness['advisory_issue_count']} warning(s)"
+        if readiness["advisory_issues"]
+        else "✅ None"
+    )
+    lines.append(f"  Advisory Issues:   {advisory_summary}")
     lines.append("")
 
     # Governance checks
@@ -386,6 +394,10 @@ def render_text_report(report: dict) -> str:
     lines.append(f"  Governance passed:    {gov['passed']}")
     lines.append(f"  Blocking failures:    {gov['blocking_failures']}")
     lines.append(f"  Advisory failures:    {gov['advisory_failures']}")
+    if gov["advisory_failures"] > 0:
+        lines.append(
+            "  Note: advisory failures are non-blocking but require operator review."
+        )
     lines.append("")
     lines.append("=" * 66)
 

--- a/veritas_os/tests/test_staged_readiness_report.py
+++ b/veritas_os/tests/test_staged_readiness_report.py
@@ -87,6 +87,90 @@ def test_build_report_schema_version_is_2_1() -> None:
     assert report["schema_version"] == "2.1"
 
 
+def test_build_report_surfaces_advisory_issues_in_overall_readiness() -> None:
+    """Advisory failures should be summarized in overall readiness metadata."""
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=[
+            {
+                "label": "trustlog-production-posture",
+                "tier": "Tier 2",
+                "blocking": False,
+                "passed": False,
+                "output": "TrustLog production posture check failed.",
+            }
+        ],
+        compose_report=None,
+        live_report=None,
+    )
+    assert report["overall_readiness"]["deployment_ready"] is True
+    assert report["overall_readiness"]["advisory_issues"] is True
+    assert report["overall_readiness"]["advisory_issue_count"] == 1
+    assert report["governance"]["advisory_failures"] == 1
+    assert report["governance"]["advisory_failure_labels"] == [
+        "trustlog-production-posture"
+    ]
+
+
+def test_build_report_marks_no_advisory_issues_when_none() -> None:
+    """Advisory issue summary should be empty when no advisory checks fail."""
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=[],
+        compose_report=None,
+        live_report=None,
+    )
+    assert report["overall_readiness"]["advisory_issues"] is False
+    assert report["overall_readiness"]["advisory_issue_count"] == 0
+
+
+def test_render_text_report_surfaces_advisory_issue_summary() -> None:
+    """Text report should surface advisory summary and non-blocking note."""
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=[
+            {
+                "label": "trustlog-production-posture",
+                "tier": "Tier 2",
+                "blocking": False,
+                "passed": False,
+                "output": "TrustLog production posture check failed.",
+            }
+        ],
+        compose_report=None,
+        live_report=None,
+    )
+    text = render_text_report(report)
+    assert "Advisory Issues" in text
+    assert "warning" in text
+    assert "trustlog-production-posture" in text
+    assert "advisory failures are non-blocking" in text.lower()
+
+
+def test_blocking_failure_still_blocks_deployment_ready() -> None:
+    """Blocking failures must still determine deployment readiness outcome."""
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=[
+            {
+                "label": "runtime-pickle-ban",
+                "tier": "Tier 1",
+                "blocking": True,
+                "passed": False,
+                "output": "failed",
+            }
+        ],
+        compose_report=None,
+        live_report=None,
+    )
+    assert report["overall_readiness"]["deployment_ready"] is False
+    assert report["overall_readiness"]["governance_ready"] is False
+
+
 def test_trustlog_posture_check_forces_enforcement_override() -> None:
     """TrustLog check should always set production posture enforcement."""
     assert CHECK_ENV_OVERRIDES["trustlog-production-posture"] == {


### PR DESCRIPTION
### Motivation
- Make non-blocking advisory governance failures visible in the staged operational readiness output so operators can review warnings prior to promotion.
- Surface advisory summaries in both machine-readable and human-readable report outputs while preserving existing `deployment_ready` semantics.

### Description
- Add `overall_readiness.advisory_issues` and `overall_readiness.advisory_issue_count` to the v2.1 JSON report in `scripts/generate_staged_readiness_report.py` and include `governance.advisory_failures` and `advisory_failure_labels` in the governance section.
- Render an advisory summary line in the human-readable report via `render_text_report`, and append a note when advisory failures exist indicating they are non-blocking but require operator review.
- Update documentation files `docs/en/operations/operational-readiness-runbook.md`, `docs/en/validation/production-validation.md`, and `docs/ja/validation/production-validation.md` to document the new advisory summary fields and semantics.
- Add unit tests in `veritas_os/tests/test_staged_readiness_report.py` to validate JSON fields, text rendering, and that blocking failures still gate `deployment_ready`.

### Testing
- Ran the new unit tests in `veritas_os/tests/test_staged_readiness_report.py`, which assert JSON `advisory_issues`/`advisory_issue_count`, text report contents, and blocking behavior, and they passed.
- Existing staged report rendering tests (including `test_render_text_report_includes_trustlog_posture_label` and schema version assertion) were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0507f1b7688326b748d6ab61e117e1)