### PR TITLE
Document staged readiness report interpretation semantics

### DIFF
--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -158,6 +158,30 @@ python scripts/generate_staged_readiness_report.py \
 ```
 
 ## Report Artifacts
+
+## Interpreting staged readiness v2.1
+
+`deployment_ready` is intentionally narrow in v2.1: it reflects blocking governance checks and compose validation. It does not certify that advisory findings are cleared or that live providers are healthy. Review `advisory_issues`, `advisory_issue_count`, `governance.advisory_failure_labels`, and `live_provider_ok` before promotion.
+
+Interpretation rules:
+- `deployment_ready=true` means blocking governance checks passed and compose validation did not fail.
+- `deployment_ready=true` does not mean all advisory issues are cleared.
+- `deployment_ready=true` does not mean live providers are healthy.
+- Operators must separately review:
+  - `overall_readiness.advisory_issues`
+  - `overall_readiness.advisory_issue_count`
+  - `governance.advisory_failure_labels`
+  - `overall_readiness.live_provider_ok`
+  - `live_provider_validation`
+- Compose validation is deployment-gating:
+  - compose `FAIL` sets `overall_readiness.compose_validated=false`
+  - compose `FAIL` makes `deployment_ready=false`
+- Live provider validation is reported but not deployment-gating in v2.1:
+  - live `FAIL` sets `overall_readiness.live_provider_ok=false`
+  - live `FAIL` does not by itself flip `deployment_ready=false`
+- Advisory failures are non-blocking but require operator review.
+- The report is evidence for release review, not production certification.
+
 The staged readiness report also records the `trustlog-production-posture`
 advisory check, and runs it with a subprocess-scoped
 `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE=1` override so the production

--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -139,7 +139,7 @@ make validate-live-report
 - Staging security headers (HSTS)
 - Web search external test suite
 
-### Staged Readiness Report (Full Certification)
+### Staged Readiness Report (Full Operational Evidence)
 
 ```bash
 # Generate the comprehensive readiness report
@@ -159,9 +159,9 @@ python scripts/generate_staged_readiness_report.py \
 
 ## Report Artifacts
 
-## Interpreting staged readiness v2.1
+### Interpreting staged readiness v2.1
 
-`deployment_ready` is intentionally narrow in v2.1: it reflects blocking governance checks and compose validation. It does not certify that advisory findings are cleared or that live providers are healthy. Review `advisory_issues`, `advisory_issue_count`, `governance.advisory_failure_labels`, and `live_provider_ok` before promotion.
+`deployment_ready` is intentionally narrow in v2.1: it reflects blocking governance checks and compose validation. It does not certify that advisory findings are cleared or that live providers are healthy. Review `overall_readiness.advisory_issues`, `overall_readiness.advisory_issue_count`, `governance.advisory_failure_labels`, `overall_readiness.live_provider_ok`, and `live_provider_validation` before promotion.
 
 Interpretation rules:
 - `deployment_ready=true` means blocking governance checks passed and compose validation did not fail.

--- a/docs/en/validation/production-validation.md
+++ b/docs/en/validation/production-validation.md
@@ -127,6 +127,9 @@ Memory/TrustLog backend posture:
 | **TLS** | `@pytest.mark.tls` | Tier 2 (release) + Tier 3 (weekly) | TLS/security-header posture verification |
 | **Load** | `@pytest.mark.load` | Tier 2 (release) + Tier 3 (weekly) | Lightweight burst/concurrency validation |
 
+
+In staged readiness report v2.1, `deployment_ready` is gated by blocking governance checks and compose validation. Advisory failures and live provider failures are surfaced separately through `overall_readiness.advisory_issues`, `overall_readiness.advisory_issue_count`, `governance.advisory_failure_labels`, and `overall_readiness.live_provider_ok`; they require review but do not independently change `deployment_ready` in v2.1.
+
 ## How to Tell If a Release Is Governance-Ready
 
 A VERITAS OS release is **governance-ready** when all of the following hold:

--- a/docs/ja/validation/production-validation.md
+++ b/docs/ja/validation/production-validation.md
@@ -13,10 +13,11 @@
 - operator-facing governance surface の信頼性を、テストと証跡で裏づけます。
 
 ## 実装上の確認ポイント
+
+- staged readiness report v2.1 では、`deployment_ready` は blocking governance checks と compose validation の結果に基づきます。注意・警告扱いの失敗や live provider の失敗は、`overall_readiness.advisory_issues`、`overall_readiness.advisory_issue_count`、`governance.advisory_failure_labels`、`overall_readiness.live_provider_ok` に分けて表示されます。これらは v2.1 では単独で `deployment_ready` を未達扱いにはしませんが、昇格・本番反映の前に運用者が確認する必要があります。
 - `make quality-checks` と production/smoke 系テストを継続実行する。
 - PostgreSQL の live 検証導線と運用ドリルを定期確認する。
 - staged readiness report は v2.1 を利用し、`trustlog-production-posture` の advisory 証跡を含みます。
-- v2.1 では、注意・警告扱いの失敗も `overall_readiness.advisory_issues` / `overall_readiness.advisory_issue_count` に要約されます。これらは単独では `deployment_ready` を未達扱いにはしませんが、昇格・本番反映の前に運用者が確認する必要があります。
 - 詳細は英語正本または実装ファイルを確認してください。
 
 ## 現時点の制限


### PR DESCRIPTION
### Motivation
- Clarify operator/auditor interpretation of staged readiness report v2.1 so `deployment_ready=true` is not over‑interpreted as a full production certification. 
- Ensure EN/JA docs present the same minimal, operational guidance about compose/live/advisory failure semantics introduced by recent report changes.

### Description
- Add `## Interpreting staged readiness v2.1` to `docs/en/operations/operational-readiness-runbook.md` that states `deployment_ready=true` is limited to blocking governance checks plus compose validation and documents compose FAIL / live FAIL / advisory handling and the exact fields to review (`overall_readiness.advisory_issues`, `overall_readiness.advisory_issue_count`, `governance.advisory_failure_labels`, `overall_readiness.live_provider_ok`, `live_provider_validation`).
- Insert a short clarification in `docs/en/validation/production-validation.md` next to the Staged Readiness Report guidance summarizing the same semantics for quick reference.
- Add an equivalent Japanese paragraph to `docs/ja/validation/production-validation.md` using the requested phrasing (terms: “注意・警告扱いの失敗”, “昇格・本番反映”, “未達扱い”) to keep EN/JA in sync; do not create `docs/ja/operations/operational-readiness-runbook.md` because it did not exist.
- This is a docs-only change; no runtime code, tests, report generator, Makefile, CI workflow, migration, health, storage, checker, or startup behaviour was modified.

### Testing
- Ran `python3 scripts/quality/check_operational_docs_consistency.py`, which passed. 
- Ran `python3 scripts/quality/check_bilingual_docs.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05211610948326b3dcb9093daf2eaa)