### PR TITLE
docs: clarify staged readiness v2.1 semantics and subreport guidance

### DIFF
--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -139,7 +139,7 @@ make validate-live-report
 - Staging security headers (HSTS)
 - Web search external test suite
 
-### Staged Readiness Report (Full Certification)
+### Staged Readiness Report (Full Operational Evidence)
 
 ```bash
 # Generate the comprehensive readiness report
@@ -158,17 +158,67 @@ python scripts/generate_staged_readiness_report.py \
 ```
 
 ## Report Artifacts
+
+### Interpreting staged readiness v2.1
+
+`deployment_ready` is intentionally narrow in v2.1: it reflects blocking
+governance checks and a compose report only when `compose_validation` is
+attached. If `compose_validation` is absent, the generator treats compose as
+not failed, so `overall_readiness.compose_validated=true` does not prove
+compose validation ran. Likewise, `overall_readiness.live_provider_ok=true`
+does not prove live providers were checked when `live_provider_validation` is
+absent. Review `compose_validation`, `live_provider_validation`,
+`overall_readiness.advisory_issues`,
+`overall_readiness.advisory_issue_count`, and
+`governance.advisory_failure_labels` before promotion.
+
+Interpretation rules:
+
+- `deployment_ready=true` means blocking governance checks passed and no
+  attached compose report failed.
+- `deployment_ready=true` does not mean a compose report was attached; check
+  `compose_validation`.
+- `deployment_ready=true` does not mean all advisory issues are cleared.
+- `deployment_ready=true` does not mean live providers are healthy or checked;
+  check `live_provider_validation`.
+- Operators must separately review:
+  - `compose_validation`
+  - `live_provider_validation`
+  - `overall_readiness.advisory_issues`
+  - `overall_readiness.advisory_issue_count`
+  - `governance.advisory_failure_labels`
+  - `overall_readiness.live_provider_ok`
+- Compose validation is deployment-gating only when attached:
+  - attached compose `FAIL` sets `overall_readiness.compose_validated=false`
+  - attached compose `FAIL` makes `deployment_ready=false`
+  - absent `compose_validation` is treated as not failed and does not prove
+    compose validation ran
+- Live provider validation is reported but not deployment-gating in v2.1:
+  - attached live `FAIL` sets `overall_readiness.live_provider_ok=false`
+  - attached live `FAIL` does not by itself flip `deployment_ready=false`
+  - absent `live_provider_validation` is treated as not failed and does not
+    prove live validation ran
+- Advisory failures are non-blocking but require operator review.
+- The report is evidence for release review, not production certification.
+- `make validate-staged-report` may run without `--compose-report` or
+  `--live-report`; attach both subreports separately for fuller release
+  review evidence.
+
+To attach those subreports, run the underlying generator directly:
+
+```bash
+python scripts/generate_staged_readiness_report.py \
+  --compose-report <compose-report.json> \
+  --live-report <live-report.json> \
+  --output release-artifacts/staged-readiness-report.json \
+  --text-output release-artifacts/staged-readiness-report.txt
+```
+
 The staged readiness report also records the `trustlog-production-posture`
 advisory check, and runs it with a subprocess-scoped
 `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE=1` override so the production
 posture path is evaluated even from a local/dev shell. The check remains
 non-blocking and does not connect to real DB/KMS/WORM services.
-The JSON report surfaces advisory issues in
-`overall_readiness.advisory_issues` and
-`overall_readiness.advisory_issue_count`. Advisory failures do not flip
-`deployment_ready` by themselves, but operators must review them before
-promotion.
-
 
 ### Governance Readiness Report (v1.0)
 

--- a/docs/en/validation/production-validation.md
+++ b/docs/en/validation/production-validation.md
@@ -127,6 +127,20 @@ Memory/TrustLog backend posture:
 | **TLS** | `@pytest.mark.tls` | Tier 2 (release) + Tier 3 (weekly) | TLS/security-header posture verification |
 | **Load** | `@pytest.mark.load` | Tier 2 (release) + Tier 3 (weekly) | Lightweight burst/concurrency validation |
 
+
+In the staged readiness report v2.1, `deployment_ready` is gated by blocking
+governance checks and by an attached compose report only when
+`compose_validation` is present. If `compose_validation` is absent,
+`overall_readiness.compose_validated=true` only means no compose failure was
+attached; it does not prove compose validation ran. Advisory and live provider
+findings are surfaced separately through `overall_readiness.advisory_issues`,
+`overall_readiness.advisory_issue_count`,
+`governance.advisory_failure_labels`, `overall_readiness.live_provider_ok`, and
+`live_provider_validation`; they require review but do not independently change
+`deployment_ready` in v2.1. If `live_provider_validation` is absent,
+`overall_readiness.live_provider_ok=true` does not prove live providers were
+checked.
+
 ## How to Tell If a Release Is Governance-Ready
 
 A VERITAS OS release is **governance-ready** when all of the following hold:

--- a/docs/ja/validation/production-validation.md
+++ b/docs/ja/validation/production-validation.md
@@ -13,10 +13,28 @@
 - operator-facing governance surface の信頼性を、テストと証跡で裏づけます。
 
 ## 実装上の確認ポイント
+
+- staged readiness report v2.1 では、`deployment_ready` は
+  ブロッキング扱いのガバナンスチェック（blocking governance checks）と、
+  `compose_validation` が添付されている場合の compose 検証結果に基づきます。
+  `compose_validation` が未添付の場合、
+  `overall_readiness.compose_validated=true` は
+  「compose の失敗が添付されていない」ことを示すだけで、
+  compose 検証が実行された証明ではありません。
+- 注意・警告扱いの失敗や live provider 検証の結果は、
+  `overall_readiness.advisory_issues`、
+  `overall_readiness.advisory_issue_count`、
+  `governance.advisory_failure_labels`、
+  `overall_readiness.live_provider_ok`、
+  `live_provider_validation` に分けて表示されます。
+  これらは v2.1 では単独で `deployment_ready` を未達扱いにはしませんが、
+  昇格・本番反映の前に運用者が確認する必要があります。
+- `live_provider_validation` が未添付の場合、
+  `overall_readiness.live_provider_ok=true` は
+  live provider 検証が実行済みであることを意味しません。
 - `make quality-checks` と production/smoke 系テストを継続実行する。
 - PostgreSQL の live 検証導線と運用ドリルを定期確認する。
 - staged readiness report は v2.1 を利用し、`trustlog-production-posture` の advisory 証跡を含みます。
-- v2.1 では、注意・警告扱いの失敗も `overall_readiness.advisory_issues` / `overall_readiness.advisory_issue_count` に要約されます。これらは単独では `deployment_ready` を未達扱いにはしませんが、昇格・本番反映の前に運用者が確認する必要があります。
 - 詳細は英語正本または実装ファイルを確認してください。
 
 ## 現時点の制限


### PR DESCRIPTION
### Motivation

- Clarify how the staged readiness report (schema v2.1) should be interpreted with respect to `deployment_ready`, compose validation, live provider checks, and advisory issues.
- Make it explicit that attached compose/live subreports change gating semantics only when present and that advisory findings require operator review but are non-blocking.

### Description

- Expanded `docs/en/operations/operational-readiness-runbook.md` with a new "Interpreting staged readiness v2.1" section that documents interpretation rules for `deployment_ready`, `compose_validation`, `live_provider_validation`, and advisory fields, plus a usage example for attaching subreports via `scripts/generate_staged_readiness_report.py`.
- Reworded the "Staged Readiness Report" heading to "Full Operational Evidence" and consolidated advisory-note text previously duplicated in the file.
- Updated `docs/en/validation/production-validation.md` and `docs/ja/validation/production-validation.md` to mirror the new v2.1 interpretation guidance in English and Japanese.

### Testing

- No runtime code changes were made; only documentation was updated. 
- Built the documentation site locally with `mkdocs build` to confirm there were no build errors and link checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05211610948326b3dcb9093daf2eaa)