### PR TITLE
Add staged readiness subreport absence contract tests

### DIFF
--- a/veritas_os/tests/test_staged_readiness_report.py
+++ b/veritas_os/tests/test_staged_readiness_report.py
@@ -30,8 +30,6 @@ def _sample_governance_results() -> list[dict]:
     ]
 
 
-
-
 def _passing_blocking_governance_results() -> list[dict]:
     """Return minimal passing blocking governance checks for semantics tests."""
     return [
@@ -43,6 +41,7 @@ def _passing_blocking_governance_results() -> list[dict]:
             "output": "",
         }
     ]
+
 
 def _sample_report() -> dict:
     """Return a representative staged readiness report payload."""

--- a/veritas_os/tests/test_staged_readiness_report.py
+++ b/veritas_os/tests/test_staged_readiness_report.py
@@ -4,6 +4,7 @@ from scripts.generate_staged_readiness_report import (
     CHECK_ENV_OVERRIDES,
     GOVERNANCE_CHECKS,
     build_report,
+    load_json_report,
     run_check,
     render_text_report,
 )
@@ -28,6 +29,20 @@ def _sample_governance_results() -> list[dict]:
         },
     ]
 
+
+
+
+def _passing_blocking_governance_results() -> list[dict]:
+    """Return minimal passing blocking governance checks for semantics tests."""
+    return [
+        {
+            "label": "runtime-pickle-ban",
+            "tier": "Tier 1",
+            "blocking": True,
+            "passed": True,
+            "output": "",
+        }
+    ]
 
 def _sample_report() -> dict:
     """Return a representative staged readiness report payload."""
@@ -450,3 +465,156 @@ def test_staged_readiness_text_report_contract_contains_schema_and_advisory_summ
     assert "Advisory Issues:" in text
     assert "warning" in text
     assert "Note: advisory failures are non-blocking but require operator review." in text
+
+
+def test_load_json_report_returns_parsed_report(tmp_path) -> None:
+    """load_json_report should return parsed JSON when the report is valid."""
+    path = tmp_path / "compose-report.json"
+    path.write_text('{"summary": {"overall": "PASS"}}', encoding="utf-8")
+
+    assert load_json_report(str(path)) == {"summary": {"overall": "PASS"}}
+
+
+def test_load_json_report_none_path_returns_none() -> None:
+    """load_json_report should return None when the report path is omitted."""
+    assert load_json_report(None) is None
+
+
+def test_load_json_report_missing_file_warns_and_returns_none(
+    tmp_path,
+    caplog,
+) -> None:
+    """Missing report artifacts should warn and return None."""
+    with caplog.at_level("WARNING"):
+        result = load_json_report(str(tmp_path / "missing.json"))
+
+    assert result is None
+    assert "Report file not found" in caplog.text
+
+
+def test_load_json_report_invalid_json_warns_and_returns_none(
+    tmp_path,
+    caplog,
+) -> None:
+    """Invalid JSON reports should warn and return None."""
+    path = tmp_path / "compose-report.json"
+    path.write_text("{not-json", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        result = load_json_report(str(path))
+
+    assert result is None
+    assert "Failed to parse JSON" in caplog.text
+
+
+def test_load_json_report_read_error_warns_and_returns_none(
+    tmp_path,
+    caplog,
+    monkeypatch,
+) -> None:
+    """Read errors should warn and return None for report loading."""
+    path = tmp_path / "compose-report.json"
+    path.write_text("{}", encoding="utf-8")
+
+    def raise_oserror(self, encoding=None):
+        raise OSError("boom")
+
+    monkeypatch.setattr(
+        "scripts.generate_staged_readiness_report.Path.read_text",
+        raise_oserror,
+    )
+
+    with caplog.at_level("WARNING"):
+        result = load_json_report(str(path))
+
+    assert result is None
+    assert "Failed to read report file" in caplog.text
+
+
+def test_absent_compose_report_is_not_failed_but_not_evidence_of_validation() -> None:
+    """Absent compose reports are treated as not failed, not as proof of validation."""
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=_passing_blocking_governance_results(),
+        compose_report=None,
+        live_report=None,
+    )
+
+    assert report["compose_validation"] is None
+    assert report["overall_readiness"]["compose_validated"] is True
+    assert report["overall_readiness"]["deployment_ready"] is True
+
+
+def test_absent_live_report_is_not_failed_but_not_evidence_of_validation() -> None:
+    """Absent live reports are treated as not failed, not as proof of provider health."""
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=_passing_blocking_governance_results(),
+        compose_report=None,
+        live_report=None,
+    )
+
+    assert report["live_provider_validation"] is None
+    assert report["overall_readiness"]["live_provider_ok"] is True
+    assert report["overall_readiness"]["deployment_ready"] is True
+
+
+def test_missing_compose_artifact_results_in_absent_compose_validation_semantics(
+    tmp_path,
+) -> None:
+    """Missing compose artifacts should map to absent compose validation semantics."""
+    compose_report = load_json_report(str(tmp_path / "missing-compose.json"))
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=_passing_blocking_governance_results(),
+        compose_report=compose_report,
+        live_report=None,
+    )
+
+    assert compose_report is None
+    assert report["compose_validation"] is None
+    assert report["overall_readiness"]["compose_validated"] is True
+    assert report["overall_readiness"]["deployment_ready"] is True
+
+
+def test_invalid_live_artifact_results_in_absent_live_validation_semantics(
+    tmp_path,
+) -> None:
+    """Invalid live artifacts should map to absent live validation semantics."""
+    path = tmp_path / "live-report.json"
+    path.write_text("{not-json", encoding="utf-8")
+
+    live_report = load_json_report(str(path))
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=_passing_blocking_governance_results(),
+        compose_report=None,
+        live_report=live_report,
+    )
+
+    assert live_report is None
+    assert report["live_provider_validation"] is None
+    assert report["overall_readiness"]["live_provider_ok"] is True
+    assert report["overall_readiness"]["deployment_ready"] is True
+
+
+def test_text_report_marks_absent_compose_and_live_reports_as_not_included() -> None:
+    """Text report should mark absent compose/live reports as not included."""
+    report = build_report(
+        ref="test",
+        sha="abc",
+        governance_results=_passing_blocking_governance_results(),
+        compose_report=None,
+        live_report=None,
+    )
+
+    text = render_text_report(report)
+
+    assert "Compose Validation" in text
+    assert "Not included (run with --compose-report)" in text
+    assert "Live Provider Validation" in text
+    assert "Not included (run with --live-report)" in text


### PR DESCRIPTION
### Motivation
- Ensure staged readiness report v2.1 semantics for compose/live subreport absence and load failures are pinned by focused, tests-only contract coverage.
- Prevent regressions around `load_json_report()` behavior for `None`, missing files, invalid JSON, and read errors, and fix the human-visible wording for absent subreports.

### Description
- Add `load_json_report` to the imports in `veritas_os/tests/test_staged_readiness_report.py` and introduce a small helper `_passing_blocking_governance_results()` for semantics tests.
- Add tests for `load_json_report` behaviors: `test_load_json_report_returns_parsed_report`, `test_load_json_report_none_path_returns_none`, `test_load_json_report_missing_file_warns_and_returns_none`, `test_load_json_report_invalid_json_warns_and_returns_none`, and `test_load_json_report_read_error_warns_and_returns_none`.
- Add contract tests fixing absent compose/live semantics in `build_report`: `test_absent_compose_report_is_not_failed_but_not_evidence_of_validation`, `test_absent_live_report_is_not_failed_but_not_evidence_of_validation`, `test_missing_compose_artifact_results_in_absent_compose_validation_semantics`, and `test_invalid_live_artifact_results_in_absent_live_validation_semantics`.
- Add a text-rendering contract test `test_text_report_marks_absent_compose_and_live_reports_as_not_included` to assert the human-readable "Not included (run with --compose-report)" / "Not included (run with --live-report)" messaging.
- Tests-only change; no runtime code, report generator, docs, CI workflows, Makefile, migrations, storage, or checker logic were modified.

### Testing
- Attempted to run unit tests: `python -m pytest -q veritas_os/tests/test_staged_readiness_report.py`, but the local `python` launcher failed due to a `pyenv` version mismatch in the environment; tests were not executed with that command.
- Attempted `python3 -m pytest -q veritas_os/tests/test_staged_readiness_report.py`, but `pytest` is not installed in the available `python3` environment; tests were not executed with that command.
- As a smoke validation, ran the report generator: `python3 scripts/generate_staged_readiness_report.py --ref test --sha test --output /tmp/staged-readiness-report.json --text-output /tmp/staged-readiness-report.txt`, which completed and wrote the JSON/text outputs, and produced governance check failures in this environment (expected given the environment); this run confirms the generator still executes but is not a substitute for the unit test run.

Note: All changes are tests-only and intended to pin current absent/failed-subreport semantics; CI should be used to execute the new pytest tests in the repository's standard test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055f6fe444832698134f63607d47d8)