### PR TITLE
Add staged readiness report target with compose/live subreports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST_MARKEXPR ?= not slow
 COVERAGE_XML ?= coverage.xml
 COVERAGE_HTML_DIR ?= coverage-html
 
-.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence check-trustlog-production-posture
+.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report validate-staged-report-with-subreports db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence check-trustlog-production-posture
 
 # ── Setup & Development ──────────────────────────────────────────────────
 
@@ -249,6 +249,19 @@ validate-staged-report:
 	@python scripts/generate_staged_readiness_report.py \
 		--ref $$(git describe --tags --always 2>/dev/null || echo "local") \
 		--sha $$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
+		--output release-artifacts/staged-readiness-report.json \
+		--text-output release-artifacts/staged-readiness-report.txt
+
+validate-staged-report-with-subreports:
+	@echo "[veritas] Generating compose/live validation reports and staged readiness report..."
+	@mkdir -p release-artifacts
+	@bash scripts/compose_validation.sh --json-report=release-artifacts/compose-validation-report.json
+	@bash scripts/live_provider_validation.sh --json-report=release-artifacts/live-provider-report.json
+	@python scripts/generate_staged_readiness_report.py \
+		--ref $$(git describe --tags --always 2>/dev/null || echo "local") \
+		--sha $$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
+		--compose-report release-artifacts/compose-validation-report.json \
+		--live-report release-artifacts/live-provider-report.json \
 		--output release-artifacts/staged-readiness-report.json \
 		--text-output release-artifacts/staged-readiness-report.txt
 

--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -17,7 +17,8 @@ simulated, and what requires environment-specific confirmation.
 | `make validate-compose-report` | Compose validation + JSON report | Release gate |
 | `make validate-live` | Live provider checks (secrets-required) | Nightly/manual |
 | `make validate-live-report` | Live provider + JSON report | Release certification |
-| `make validate-staged-report` | Full staged readiness report | Release certification |
+| `make validate-staged-report` | Staged readiness report | Release evidence report without attached compose/live subreports |
+| `make validate-staged-report-with-subreports` | Staged readiness report with compose/live subreports (secrets-required for live checks) | Release evidence report with attached subreports |
 | `make quality-checks` | Architecture + security scripts | Every PR (automatic) |
 
 ## Validation Tiers
@@ -200,11 +201,19 @@ Interpretation rules:
     prove live validation ran
 - Advisory failures are non-blocking but require operator review.
 - The report is evidence for release review, not production certification.
-- `make validate-staged-report` may run without `--compose-report` or
-  `--live-report`; attach both subreports separately for fuller release
-  review evidence.
+- `make validate-staged-report` keeps generating staged reports without
+  attached compose/live subreports.
+- Use `make validate-staged-report-with-subreports` when release review needs
+  attached `compose_validation` and `live_provider_validation` artifacts.
+- The with-subreports target runs compose validation and live provider
+  validation first, then passes their JSON reports to
+  `scripts/generate_staged_readiness_report.py`.
+- Live provider validation may require provider secrets and can fail when
+  those secrets are not configured.
+- Operators may still run the generator directly when custom report paths are
+  required.
 
-To attach those subreports, run the underlying generator directly:
+To attach those subreports with custom paths, run the underlying generator directly:
 
 ```bash
 python scripts/generate_staged_readiness_report.py \

--- a/docs/en/validation/production-validation.md
+++ b/docs/en/validation/production-validation.md
@@ -141,6 +141,8 @@ findings are surfaced separately through `overall_readiness.advisory_issues`,
 `overall_readiness.live_provider_ok=true` does not prove live providers were
 checked.
 
+Use `make validate-staged-report` for a staged report without attached compose/live subreports. Use `make validate-staged-report-with-subreports` when release review requires `compose_validation` and `live_provider_validation` artifacts to be attached to the staged report. The subreport target runs compose and live provider validation first; live provider validation may require secrets.
+
 ## How to Tell If a Release Is Governance-Ready
 
 A VERITAS OS release is **governance-ready** when all of the following hold:

--- a/docs/ja/validation/production-validation.md
+++ b/docs/ja/validation/production-validation.md
@@ -32,6 +32,7 @@
 - `live_provider_validation` が未添付の場合、
   `overall_readiness.live_provider_ok=true` は
   live provider 検証が実行済みであることを意味しません。
+- `make validate-staged-report` は、compose/live provider のサブレポートを添付しない staged report を生成します。昇格・本番反映前の確認で `compose_validation` と `live_provider_validation` を staged report に含めたい場合は、`make validate-staged-report-with-subreports` を使用します。この target は compose 検証と live provider 検証を先に実行し、その JSON レポートを `scripts/generate_staged_readiness_report.py` に渡します。live provider 検証には provider secrets が必要になる場合があります。
 - `make quality-checks` と production/smoke 系テストを継続実行する。
 - PostgreSQL の live 検証導線と運用ドリルを定期確認する。
 - staged readiness report は v2.1 を利用し、`trustlog-production-posture` の advisory 証跡を含みます。


### PR DESCRIPTION
### Motivation
- Provide an operator-facing Make target that generates and attaches `compose_validation` and `live_provider_validation` JSON subreports to a staged readiness report for fuller release review evidence. 
- Preserve the existing `make validate-staged-report` behavior that generates the staged report without attached subreports. 
- Minimize changes to runtime code and generator semantics while clarifying operator choices in docs. 

### Description
- Add `.PHONY` entry `validate-staged-report-with-subreports` to the `Makefile`. 
- Add new `make validate-staged-report-with-subreports` target that ensures `release-artifacts/` exists, runs `scripts/compose_validation.sh --json-report=...`, runs `scripts/live_provider_validation.sh --json-report=...`, and then invokes `scripts/generate_staged_readiness_report.py` with `--compose-report` and `--live-report`. 
- Update `docs/en/operations/operational-readiness-runbook.md` to list both the no-subreport and with-subreport Make targets and to document that the subreport target runs the compose and live checks first and that live checks may be secrets-required. 
- Update `docs/en/validation/production-validation.md` and `docs/ja/validation/production-validation.md` with minimal guidance distinguishing `make validate-staged-report` (no attached subreports) from `make validate-staged-report-with-subreports` (attached `compose_validation` and `live_provider_validation`). 
- Intentionally do not change `scripts/generate_staged_readiness_report.py`, report semantics, tests, CI workflows, or runtime code. 

### Testing
- Ran `make -n validate-staged-report` (dry-run) which showed the original staged report recipe and completed successfully. 
- Ran `make -n validate-staged-report-with-subreports` (dry-run) which printed the new recipe including `compose_validation.sh`, `live_provider_validation.sh`, and the generator invocation. 
- Ran `python3 scripts/quality/check_operational_docs_consistency.py` and `python3 scripts/quality/check_bilingual_docs.py`, and both checks passed. 
- Changes were committed; note that running `make validate-staged-report-with-subreports` for real may fail if required live provider secrets are not configured, which is expected behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05768e609c83269ffe2a43d86f1389)