### PR TITLE
Add staged readiness Make target contract tests

### DIFF
--- a/veritas_os/tests/test_staged_readiness_make_targets.py
+++ b/veritas_os/tests/test_staged_readiness_make_targets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -29,6 +30,12 @@ def _run_make_dry_run(target: str) -> str:
     return result.stdout + result.stderr
 
 
+def _mentions_make_command(text: str, target: str) -> bool:
+    """Return whether text references `make <target>` as an exact command."""
+    pattern = rf"(?<![\w-])make\s+{re.escape(target)}(?![\w-])"
+    return re.search(pattern, text) is not None
+
+
 def test_validate_staged_report_dry_run_keeps_no_subreport_path() -> None:
     """Existing staged report target must remain the no-subreport path."""
     output = _run_make_dry_run("validate-staged-report")
@@ -47,19 +54,29 @@ def test_validate_staged_report_with_subreports_dry_run_attaches_subreports() ->
     """Subreport target must generate and attach compose/live JSON reports."""
     output = _run_make_dry_run("validate-staged-report-with-subreports")
 
-    assert (
+    compose_cmd = (
         "scripts/compose_validation.sh "
         "--json-report=release-artifacts/compose-validation-report.json"
-    ) in output
-    assert (
+    )
+    live_cmd = (
         "scripts/live_provider_validation.sh "
         "--json-report=release-artifacts/live-provider-report.json"
-    ) in output
-    assert "scripts/generate_staged_readiness_report.py" in output
+    )
+    generator_cmd = "scripts/generate_staged_readiness_report.py"
+
+    assert compose_cmd in output
+    assert live_cmd in output
+    assert generator_cmd in output
     assert "--compose-report release-artifacts/compose-validation-report.json" in output
     assert "--live-report release-artifacts/live-provider-report.json" in output
     assert "--output release-artifacts/staged-readiness-report.json" in output
     assert "--text-output release-artifacts/staged-readiness-report.txt" in output
+
+    compose_index = output.index(compose_cmd)
+    live_index = output.index(live_cmd)
+    generator_index = output.index(generator_cmd)
+
+    assert compose_index < live_index < generator_index
 
 
 def test_staged_readiness_make_targets_are_phony() -> None:
@@ -69,9 +86,10 @@ def test_staged_readiness_make_targets_are_phony() -> None:
         line for line in makefile.splitlines()
         if line.startswith(".PHONY:")
     )
+    phony_tokens = set(phony_line.split()[1:])
 
-    assert "validate-staged-report" in phony_line
-    assert "validate-staged-report-with-subreports" in phony_line
+    assert "validate-staged-report" in phony_tokens
+    assert "validate-staged-report-with-subreports" in phony_tokens
 
 
 def test_docs_reference_staged_readiness_make_targets() -> None:
@@ -84,5 +102,5 @@ def test_docs_reference_staged_readiness_make_targets() -> None:
 
     for path in docs:
         text = path.read_text(encoding="utf-8")
-        assert "make validate-staged-report" in text
-        assert "make validate-staged-report-with-subreports" in text
+        assert _mentions_make_command(text, "validate-staged-report")
+        assert _mentions_make_command(text, "validate-staged-report-with-subreports")

--- a/veritas_os/tests/test_staged_readiness_make_targets.py
+++ b/veritas_os/tests/test_staged_readiness_make_targets.py
@@ -1,0 +1,88 @@
+"""Dry-run contract tests for staged readiness Makefile targets."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_make_dry_run(target: str) -> str:
+    """Run `make -n` for a target and return combined process output."""
+    if shutil.which("make") is None:
+        pytest.skip("make is not available in this environment")
+
+    result = subprocess.run(
+        ["make", "-n", target],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout + result.stderr
+
+
+def test_validate_staged_report_dry_run_keeps_no_subreport_path() -> None:
+    """Existing staged report target must remain the no-subreport path."""
+    output = _run_make_dry_run("validate-staged-report")
+
+    assert "scripts/generate_staged_readiness_report.py" in output
+    assert "--output release-artifacts/staged-readiness-report.json" in output
+    assert "--text-output release-artifacts/staged-readiness-report.txt" in output
+
+    assert "--compose-report" not in output
+    assert "--live-report" not in output
+    assert "compose_validation.sh" not in output
+    assert "live_provider_validation.sh" not in output
+
+
+def test_validate_staged_report_with_subreports_dry_run_attaches_subreports() -> None:
+    """Subreport target must generate and attach compose/live JSON reports."""
+    output = _run_make_dry_run("validate-staged-report-with-subreports")
+
+    assert (
+        "scripts/compose_validation.sh "
+        "--json-report=release-artifacts/compose-validation-report.json"
+    ) in output
+    assert (
+        "scripts/live_provider_validation.sh "
+        "--json-report=release-artifacts/live-provider-report.json"
+    ) in output
+    assert "scripts/generate_staged_readiness_report.py" in output
+    assert "--compose-report release-artifacts/compose-validation-report.json" in output
+    assert "--live-report release-artifacts/live-provider-report.json" in output
+    assert "--output release-artifacts/staged-readiness-report.json" in output
+    assert "--text-output release-artifacts/staged-readiness-report.txt" in output
+
+
+def test_staged_readiness_make_targets_are_phony() -> None:
+    """Makefile should mark both staged readiness targets as phony."""
+    makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    phony_line = next(
+        line for line in makefile.splitlines()
+        if line.startswith(".PHONY:")
+    )
+
+    assert "validate-staged-report" in phony_line
+    assert "validate-staged-report-with-subreports" in phony_line
+
+
+def test_docs_reference_staged_readiness_make_targets() -> None:
+    """Docs should reference both staged readiness Make targets by name."""
+    docs = [
+        REPO_ROOT / "docs/en/operations/operational-readiness-runbook.md",
+        REPO_ROOT / "docs/en/validation/production-validation.md",
+        REPO_ROOT / "docs/ja/validation/production-validation.md",
+    ]
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert "make validate-staged-report" in text
+        assert "make validate-staged-report-with-subreports" in text


### PR DESCRIPTION
### Motivation
- Provide focused, automated dry-run contract checks for the staged readiness `make` targets so future regressions in target names, recipes, or subreport attachment paths are detected early.
- Preserve the existing semantics that `validate-staged-report` is the no-subreport path and that `validate-staged-report-with-subreports` attaches compose/live JSON subreports.
- Avoid running secrets-required validation by using `make -n` dry-run only.

### Description
- Adds a new tests-only file `veritas_os/tests/test_staged_readiness_make_targets.py` that implements a `_run_make_dry_run` helper and four focused tests.
- Adds `test_validate_staged_report_dry_run_keeps_no_subreport_path` to assert the existing `validate-staged-report` target invokes the report generator with `--output`/`--text-output` and does not reference `--compose-report`, `--live-report`, or compose/live validation scripts.
- Adds `test_validate_staged_report_with_subreports_dry_run_attaches_subreports` to assert `validate-staged-report-with-subreports` runs the compose and live validation commands generating JSON reports and passes those JSON paths to the report generator.
- Adds `test_staged_readiness_make_targets_are_phony` to check `.PHONY` includes both targets and `test_docs_reference_staged_readiness_make_targets` to ensure docs mention both `make validate-staged-report` and `make validate-staged-report-with-subreports` in the specified files; no Makefile, docs, scripts, runtime, or CI workflows were modified.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_staged_readiness_make_targets.py` in the environment, but the pinned pyenv Python (`3.12.12`) was not available so the `python` shim failed; this prevented running tests with the project `python` shim.
- Attempted `python3.12 -m pytest -q veritas_os/tests/test_staged_readiness_make_targets.py`, but the `pytest` module was not installed for that interpreter, so tests could not be executed in this environment.
- The tests are implemented to `skip` when `make` is not available, and they use `make -n` (dry-run) to avoid executing secrets-required live validations; these checks should run in CI where the correct Python and `pytest` are available.

Security note: This PR is tests-only and verifies `make -n` command strings only, avoiding execution of secrets-required operations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05884a9d2883269b14093ed458acbc)