### PR TITLE
Replace remaining release certification wording in operational docs

### DIFF
--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -16,7 +16,7 @@ simulated, and what requires environment-specific confirmation.
 | `make validate-compose` | Docker Compose governance smoke | After Docker changes |
 | `make validate-compose-report` | Compose validation + JSON report | Release gate |
 | `make validate-live` | Live provider checks (secrets-required) | Nightly/manual |
-| `make validate-live-report` | Live provider + JSON report | Release certification |
+| `make validate-live-report` | Live provider + JSON report | Release evidence report |
 | `make validate-staged-report` | Staged readiness report | Release evidence report without attached compose/live subreports |
 | `make validate-staged-report-with-subreports` | Staged readiness report with compose/live subreports (secrets-required for live checks) | Release evidence report with attached subreports |
 | `make quality-checks` | Architecture + security scripts | Every PR (automatic) |


### PR DESCRIPTION
### Motivation
- Align operational runbook wording with the staged readiness report policy by removing remaining positive “certification” phrasing that could be misread as an assurance and instead present live-provider reports as evidence for release review.

### Description
- Updated `docs/en/operations/operational-readiness-runbook.md` Quick Reference to replace `Release certification` with `Release evidence report` for the `make validate-live-report` entry.
- Preserved explicit non-certification boundary language elsewhere in the file (e.g. phrasing that the report is "evidence for release review, not production certification").
- Did not change any runtime code, Makefiles, tests, report generator scripts, CI workflows, migrations, health/storage/checker behavior, or other docs outside the intended wording change; `docs/en/validation/current-implementation-matrix.md` was intentionally left unchanged.

### Testing
- Ran `python3 scripts/quality/check_operational_docs_consistency.py` and it passed.
- Ran `python3 scripts/quality/check_bilingual_docs.py` and it passed.
- Searched with `grep` for over-certification phrases and confirmed the replaced phrase is no longer present in `docs/en`/`docs/ja`.

Replaced expressions: `Release certification` → `Release evidence report`.
Non-certification boundary expressions left intact: `not production certification`, `not full production certification`, `not third-party certification`, and similar boundary language.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a059dbc800c83268eeaedb3aa6e07b2)