### PR TITLE
Guard against positive certification wording in docs

### DIFF
--- a/scripts/quality/check_operational_docs_consistency.py
+++ b/scripts/quality/check_operational_docs_consistency.py
@@ -57,6 +57,26 @@ DOC_MAP_REQUIRED_TOKENS = (
     "`veritas_os/README_JP.md` は補助説明",
 )
 
+FORBIDDEN_POSITIVE_CERTIFICATION_PHRASES = (
+    "Release certification",
+    "Full Certification",
+    "production certified",
+    "certified for production",
+    "compliance guaranteed",
+    "guarantees compliance",
+    "proves production readiness",
+    "proves readiness",
+    "certifies readiness",
+    "certifies production readiness",
+)
+
+OVER_CERTIFICATION_DOC_PATHS = (
+    REPO_ROOT / "docs/en/operations/operational-readiness-runbook.md",
+    REPO_ROOT / "docs/en/validation/production-validation.md",
+    REPO_ROOT / "docs/ja/validation/production-validation.md",
+    REPO_ROOT / "docs/en/validation/current-implementation-matrix.md",
+)
+
 
 def collect_missing_tokens(content: str, required_tokens: tuple[str, ...]) -> list[str]:
     """Return required markers missing from a documentation file."""
@@ -75,6 +95,22 @@ def _validate_file(path: pathlib.Path, required_tokens: tuple[str, ...]) -> list
     ]
 
 
+def _find_forbidden_positive_certification_phrases(path: pathlib.Path) -> list[str]:
+    """Return forbidden over-certification wording errors for a file."""
+    if not path.exists():
+        return [f"Missing file: {path}"]
+    content = path.read_text(encoding="utf-8")
+    lowered = content.lower()
+    problems = []
+    for phrase in FORBIDDEN_POSITIVE_CERTIFICATION_PHRASES:
+        if phrase.lower() in lowered:
+            problems.append(
+                f"{path.relative_to(REPO_ROOT)}: "
+                f"forbidden over-certification wording: {phrase}"
+            )
+    return problems
+
+
 def main() -> int:
     """Validate the P1 operational documentation contract."""
     problems = []
@@ -82,6 +118,8 @@ def main() -> int:
     problems.extend(_validate_file(README_PATH, README_REQUIRED_TOKENS))
     problems.extend(_validate_file(RUNBOOK_PATH, RUNBOOK_REQUIRED_TOKENS))
     problems.extend(_validate_file(DOC_MAP_PATH, DOC_MAP_REQUIRED_TOKENS))
+    for path in OVER_CERTIFICATION_DOC_PATHS:
+        problems.extend(_find_forbidden_positive_certification_phrases(path))
 
     if not problems:
         print("Operational documentation consistency checks passed.")


### PR DESCRIPTION
### Motivation
- Prevent reintroduction of positive / over-claiming “certification” language in key operational docs that would imply unjustified production guarantees. 
- Add a machine-checkable guard to the existing operational docs quality checker so CI can catch regressions without changing runtime, build, or report generation behavior.

### Description
- Added a focused forbidden-phrase list `FORBIDDEN_POSITIVE_CERTIFICATION_PHRASES` containing the specified positive over-certification phrases such as `Release certification`, `Full Certification`, `production certified`, `certified for production`, `compliance guaranteed`, `guarantees compliance`, `proves production readiness`, `proves readiness`, `certifies readiness`, and `certifies production readiness` to `scripts/quality/check_operational_docs_consistency.py`.
- Declared `OVER_CERTIFICATION_DOC_PATHS` with the four targeted docs: `docs/en/operations/operational-readiness-runbook.md`, `docs/en/validation/production-validation.md`, `docs/ja/validation/production-validation.md`, and `docs/en/validation/current-implementation-matrix.md`.
- Implemented helper `_find_forbidden_positive_certification_phrases(path: pathlib.Path)` that performs case-insensitive detection and emits `forbidden over-certification wording: <phrase>` problems in the existing output format, and integrated this check into `main()` so it runs alongside the existing token checks.
- Kept boundary/disclaimer language allowed (no blanket ban on `certification`/`certified`), preserving phrases such as `not production certification`, `This is not full production certification.`, `This document is not third-party certification.`, and `Prepared / Not certified`.
- Changes are limited to the quality-check script only and do not modify runtime code, Makefiles, report generators, CI workflows, migrations, health endpoints, or storage semantics.

### Testing
- Ran `python3 scripts/quality/check_operational_docs_consistency.py` and it exited with success showing `Operational documentation consistency checks passed.`.
- Ran `python3 scripts/quality/check_bilingual_docs.py` and it exited with success showing all bilingual checks passed.
- Executed the grep verification `grep -R "Release certification\|Full Certification\|production certified\|certified for production\|compliance guaranteed\|guarantees compliance\|proves production readiness\|certifies readiness" docs/en docs/ja || true` with no matches found.
- No existing unit test harness for this specific checker was present, so no new unit tests were added and validation was performed via the script runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05a3d6907c8326bcf7e714ef9e857f)