### PR TITLE
Add tests for positive certification wording guard

### DIFF
--- a/veritas_os/tests/test_operational_docs_certification_guard.py
+++ b/veritas_os/tests/test_operational_docs_certification_guard.py
@@ -1,0 +1,82 @@
+"""Focused tests for positive certification wording guard behavior."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.quality.check_operational_docs_consistency import (
+    FORBIDDEN_POSITIVE_CERTIFICATION_PHRASES,
+    _find_forbidden_positive_certification_phrases,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_positive_certification_phrases_are_reported(tmp_path: Path) -> None:
+    """Every forbidden positive phrase should be reported exactly once."""
+    for phrase in FORBIDDEN_POSITIVE_CERTIFICATION_PHRASES:
+        filename = phrase.replace(" ", "_").lower().replace("/", "_")
+        path = tmp_path / f"{filename}.md"
+        path.write_text(f"This doc says: {phrase}.", encoding="utf-8")
+
+        problems = _find_forbidden_positive_certification_phrases(path)
+
+        assert len(problems) == 1
+        assert "forbidden over-certification wording" in problems[0]
+        assert phrase in problems[0]
+
+
+def test_positive_certification_phrases_are_case_insensitive(
+    tmp_path: Path,
+) -> None:
+    """Forbidden phrases should be detected regardless of case."""
+    path = tmp_path / "case.md"
+    path.write_text("this says RELEASE CERTIFICATION for production", encoding="utf-8")
+
+    problems = _find_forbidden_positive_certification_phrases(path)
+
+    assert any("Release certification" in problem for problem in problems)
+
+
+def test_non_certification_boundary_language_is_allowed(tmp_path: Path) -> None:
+    """Boundary/disclaimer wording must stay allowed by the guard."""
+    path = tmp_path / "allowed-boundary.md"
+    allowed_text = """
+This document is not third-party certification.
+This is not full production certification.
+The report is evidence for release review, not production certification.
+The matrix documents non-certification boundaries.
+Status: Prepared / Not certified.
+"""
+    path.write_text(allowed_text, encoding="utf-8")
+
+    problems = _find_forbidden_positive_certification_phrases(path)
+
+    assert problems == []
+
+
+def test_missing_file_reports_missing_file(tmp_path: Path) -> None:
+    """Missing files should return the expected diagnostic."""
+    missing_path = tmp_path / "missing.md"
+
+    problems = _find_forbidden_positive_certification_phrases(missing_path)
+
+    assert problems == [f"Missing file: {missing_path}"]
+
+
+def test_operational_docs_consistency_script_runs_successfully() -> None:
+    """Checker script should execute successfully against current docs."""
+    result = subprocess.run(
+        [sys.executable, "scripts/quality/check_operational_docs_consistency.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "Operational documentation consistency checks passed." in output

--- a/veritas_os/tests/test_operational_docs_certification_guard.py
+++ b/veritas_os/tests/test_operational_docs_certification_guard.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+from scripts.quality import check_operational_docs_consistency as docs_checker
 from scripts.quality.check_operational_docs_consistency import (
     FORBIDDEN_POSITIVE_CERTIFICATION_PHRASES,
     _find_forbidden_positive_certification_phrases,
@@ -14,8 +16,13 @@ from scripts.quality.check_operational_docs_consistency import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_positive_certification_phrases_are_reported(tmp_path: Path) -> None:
+def test_positive_certification_phrases_are_reported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Every forbidden positive phrase should be reported exactly once."""
+    monkeypatch.setattr(docs_checker, "REPO_ROOT", tmp_path)
+
     for phrase in FORBIDDEN_POSITIVE_CERTIFICATION_PHRASES:
         filename = phrase.replace(" ", "_").lower().replace("/", "_")
         path = tmp_path / f"{filename}.md"
@@ -30,8 +37,11 @@ def test_positive_certification_phrases_are_reported(tmp_path: Path) -> None:
 
 def test_positive_certification_phrases_are_case_insensitive(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Forbidden phrases should be detected regardless of case."""
+    monkeypatch.setattr(docs_checker, "REPO_ROOT", tmp_path)
+
     path = tmp_path / "case.md"
     path.write_text("this says RELEASE CERTIFICATION for production", encoding="utf-8")
 
@@ -40,8 +50,13 @@ def test_positive_certification_phrases_are_case_insensitive(
     assert any("Release certification" in problem for problem in problems)
 
 
-def test_non_certification_boundary_language_is_allowed(tmp_path: Path) -> None:
+def test_non_certification_boundary_language_is_allowed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Boundary/disclaimer wording must stay allowed by the guard."""
+    monkeypatch.setattr(docs_checker, "REPO_ROOT", tmp_path)
+
     path = tmp_path / "allowed-boundary.md"
     allowed_text = """
 This document is not third-party certification.


### PR DESCRIPTION
### Motivation
- Lock the behavior of the positive over-certification wording guard so future regressions in the forbidden phrase list or helper logic are caught by focused unit tests.
- Ensure the checker detects all configured forbidden phrases, is case-insensitive, and does not block allowed boundary/disclaimer language.
- Provide an automated smoke check that the existing operational-docs checker script still runs successfully against the repository docs.

### Description
- Add `veritas_os/tests/test_operational_docs_certification_guard.py` which imports `FORBIDDEN_POSITIVE_CERTIFICATION_PHRASES` and `_find_forbidden_positive_certification_phrases` from `scripts.quality.check_operational_docs_consistency` and implements five focused tests (forbidden-phrase detection, case-insensitive detection, allowed boundary wording, missing-file behavior, and direct script execution).
- The tests validate each configured forbidden phrase is reported once, that detection is case-insensitive, that boundary/disclaimer language is allowed, and that missing files return the expected diagnostic.
- Add a direct execution test that runs `scripts/quality/check_operational_docs_consistency.py` from the repository root and asserts it exits with `0` and prints `Operational documentation consistency checks passed.`.
- This is a tests-only change and does not modify runtime code, docs, Makefile, report generators, CI workflows, migrations, or storage behavior, and the checker script body was left unchanged.

### Testing
- Attempted to run `python -m pytest -q veritas_os/tests/test_operational_docs_certification_guard.py`, but the environment failed due to the configured `pyenv` Python version and missing `pytest` (automated test run errored because `python` pointed to an unavailable `3.12.12` and `python3` had no `pytest` module).
- Executed `python3 scripts/quality/check_operational_docs_consistency.py` and it completed successfully with `Operational documentation consistency checks passed.`.
- Executed `python3 scripts/quality/check_bilingual_docs.py` and it completed successfully with its checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b02ce7388326a51d405b85d68a89)