### PR TITLE
Add release evidence reviewer handoff template

### DIFF
--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -30,6 +30,7 @@
 | Validation: Third-party review readiness | `docs/en/validation/third-party-review-readiness.md` | `docs/ja/validation/third-party-review-readiness.md` | JA explanation / EN canonical | 省略版レビュー入口 |
 | Validation: Backend parity coverage | `docs/en/validation/backend-parity-coverage.md` | `docs/ja/validation/backend-parity-coverage.md` | JA explanation / EN canonical | バックエンド差分確認 |
 | Validation: Production validation | `docs/en/validation/production-validation.md` | `docs/ja/validation/production-validation.md` | JA explanation / EN canonical | 本番検証導線 |
+| Validation: Release evidence reviewer handoff template | `docs/en/validation/release-evidence-reviewer-handoff-template.md` | `docs/ja/validation/release-evidence-reviewer-handoff-template.md` | JA explanation / EN canonical | Reviewer-facing release evidence handoff template for staged readiness artifacts, compose/live subreport presence, advisory findings, and non-claim boundaries. |
 | Validation: PostgreSQL proof map | `docs/en/validation/postgresql-production-proof-map.md` | `docs/ja/validation/postgresql-production-proof-map.md` | JA explanation / EN canonical | 本番証跡索引 |
 | Validation: Bilingual docs quality gate | — | `docs/ja/validation/bilingual-docs-quality-gate.md` | JA primary | 日本語ファースト導線と英日整合性チェックの実行確認 |
 | Operations: PostgreSQL production | `docs/en/operations/postgresql-production-guide.md` | `docs/ja/operations/postgresql-production-guide.md` | JA explanation / EN canonical | PostgreSQL本番運用 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,6 +25,7 @@
 | Current Implementation Matrix | [Current implementation matrix (EN)](en/validation/current-implementation-matrix.md) | — |
 | Backend Parity Coverage | [Backend parity coverage (EN)](en/validation/backend-parity-coverage.md) | [バックエンドパリティカバレッジ (JA)](ja/validation/backend-parity-coverage.md) |
 | Production Validation | [Production validation (EN)](en/validation/production-validation.md) | [本番検証 (JA)](ja/validation/production-validation.md) |
+| Release Evidence Reviewer Handoff Template | [Release evidence reviewer handoff template (EN)](en/validation/release-evidence-reviewer-handoff-template.md) | [リリース証跡レビュー引き渡しテンプレート (JA)](ja/validation/release-evidence-reviewer-handoff-template.md) |
 | PostgreSQL Production Proof Map | [PostgreSQL production proof map (EN)](en/validation/postgresql-production-proof-map.md) | [PostgreSQL本番証跡マップ (JA)](ja/validation/postgresql-production-proof-map.md) |
 | Bilingual Docs Quality Gate | — | [Bilingual docs quality gate (JA)](ja/validation/bilingual-docs-quality-gate.md) |
 | Operations | [Operations (EN)](en/operations/) | [Operations (JA)](ja/operations/) |
@@ -99,6 +100,7 @@
 | 第三者レビュー準備性 | [Third-party review readiness（英語正本）](en/validation/third-party-review-readiness.md) | [第三者レビュー準備性（日本語解説）](ja/validation/third-party-review-readiness.md) |
 | バックエンドパリティカバレッジ | [Backend parity coverage（英語正本）](en/validation/backend-parity-coverage.md) | [バックエンドパリティカバレッジ（日本語解説）](ja/validation/backend-parity-coverage.md) |
 | 本番検証 | [Production validation（英語正本）](en/validation/production-validation.md) | [本番検証（日本語解説）](ja/validation/production-validation.md) |
+| リリース証跡レビュー引き渡しテンプレート | [Release evidence reviewer handoff template（英語正本）](en/validation/release-evidence-reviewer-handoff-template.md) | [リリース証跡レビュー引き渡しテンプレート（日本語解説）](ja/validation/release-evidence-reviewer-handoff-template.md) |
 | PostgreSQL本番証跡マップ | [PostgreSQL production proof map（英語正本）](en/validation/postgresql-production-proof-map.md) | [PostgreSQL本番証跡マップ（日本語解説）](ja/validation/postgresql-production-proof-map.md) |
 | Bilingual Docs Quality Gate | — | [Bilingual docs quality gate (JA)](ja/validation/bilingual-docs-quality-gate.md) |
 | 運用 | [Operations（英語正本）](en/operations/) | [Operations（日本語）](ja/operations/) |

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -19,7 +19,7 @@ This entry point is organized around the current enterprise review path: busines
 7. [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md) — submit-ready handoff format for PoC results.
 8. [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md) — submit-ready format for release evidence, staged readiness interpretation, subreport presence/absence, and reviewer acknowledgement.
 9. [Provider Support Matrix](en/operations/provider-support-matrix.md) — provider tiers, support boundaries, and non-claims.
-9. [Public Positioning](en/positioning/public-positioning.md) — conservative positioning and legal/compliance boundary statements.
+10. [Public Positioning](en/positioning/public-positioning.md) — conservative positioning and legal/compliance boundary statements.
 
 ## 30-minute technical review path
 

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -17,7 +17,8 @@ This entry point is organized around the current enterprise review path: busines
 5. [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md) — what reviewers should inspect, collect, and treat as success/failure evidence in a One-Day PoC.
 6. [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md) — how operators prepare, collect, package, and hand off PoC evidence.
 7. [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md) — submit-ready handoff format for PoC results.
-8. [Provider Support Matrix](en/operations/provider-support-matrix.md) — provider tiers, support boundaries, and non-claims.
+8. [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md) — submit-ready format for release evidence, staged readiness interpretation, subreport presence/absence, and reviewer acknowledgement.
+9. [Provider Support Matrix](en/operations/provider-support-matrix.md) — provider tiers, support boundaries, and non-claims.
 9. [Public Positioning](en/positioning/public-positioning.md) — conservative positioning and legal/compliance boundary statements.
 
 ## 30-minute technical review path
@@ -34,9 +35,10 @@ This entry point is organized around the current enterprise review path: busines
 10. [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
 11. [Type Safety Baseline](en/operations/type-safety-baseline.md)
 12. [Maintainer Handoff](en/operations/maintainer-handoff.md)
-13. [Provider Support Matrix](en/operations/provider-support-matrix.md)
-14. [Regulated Action Governance Kernel](en/architecture/regulated-action-governance-kernel.md)
-15. [Bind Boundary Governance Artifacts](en/architecture/bind-boundary-governance-artifacts.md)
+13. [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md)
+14. [Provider Support Matrix](en/operations/provider-support-matrix.md)
+15. [Regulated Action Governance Kernel](en/architecture/regulated-action-governance-kernel.md)
+16. [Bind Boundary Governance Artifacts](en/architecture/bind-boundary-governance-artifacts.md)
 
 ## What VERITAS OS is
 
@@ -57,7 +59,7 @@ Key reviewer concepts:
 |---|---|---|
 | What problem does VERITAS solve? | [Enterprise Value Brief](en/positioning/enterprise-value-brief.md) | Enterprise value, target users, and priority use cases. |
 | What is implemented today? | [Current Implementation Matrix](en/validation/current-implementation-matrix.md) | Clear separation between current facts and roadmap/foundation-only items. |
-| What release evidence exists? | [Operational Readiness Runbook](en/operations/operational-readiness-runbook.md), [Production Validation](en/validation/production-validation.md) | Review validation tiers, staged readiness v2.1 interpretation, `deployment_ready` boundaries, and compose/live subreport handling. |
+| What release evidence exists? | [Operational Readiness Runbook](en/operations/operational-readiness-runbook.md), [Production Validation](en/validation/production-validation.md), [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md) | Review validation tiers, staged readiness v2.1 interpretation, `deployment_ready` boundaries, compose/live subreport handling, and handoff expectations. |
 | What should reviewers inspect in the One-Day PoC? | [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md) | Evidence checklist, walkthrough scenarios, success/failure criteria, and non-claim boundaries. |
 | How should operators prepare and package the PoC evidence? | [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md) | Pre-flight checklist, evidence folder layout, run sequence, redaction notes, and review handoff package. |
 | What should be handed to the reviewer after the PoC? | [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md) | Submit-ready summary of scope, environment, scenarios, evidence, results, limitations, and open questions. |
@@ -83,6 +85,7 @@ Key reviewer concepts:
 - [Regulated Action Governance Proof Pack](en/validation/regulated-action-governance-proof-pack.md)
 - [Operational Readiness Runbook](en/operations/operational-readiness-runbook.md)
 - [Production Validation](en/validation/production-validation.md)
+- [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md)
 - Release evidence Make targets: `make validate-staged-report` and `make validate-staged-report-with-subreports`
 - [Provider Support Matrix](en/operations/provider-support-matrix.md)
 - [Type Safety Baseline](en/operations/type-safety-baseline.md)
@@ -107,6 +110,7 @@ pytest -q veritas_os/tests/test_type_safety_baseline.py
 pytest -q veritas_os/tests/test_maintainer_handoff_docs.py
 pytest -q veritas_os/tests/test_llm_client_anthropic_contract.py
 pytest -q veritas_os/tests/test_reviewer_entrypoint_current_path.py
+pytest -q veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
 
 # Release evidence / staged readiness path
 python scripts/quality/check_operational_docs_consistency.py
@@ -194,6 +198,7 @@ Observe Mode boundary reminders:
 - [ ] Review release evidence commands and staged readiness interpretation.
 - [ ] Confirm `deployment_ready` is not being treated as production certification.
 - [ ] Confirm compose/live subreports are attached or explicitly absent when reviewing release evidence.
+- [ ] Complete or review the Release Evidence Reviewer Handoff Template when submitting release evidence.
 - [ ] Generate or inspect evidence packet.
 - [ ] Confirm Evidence Packet / Evidence Pack / Handoff Template are not being presented as production audit evidence or certification.
 - [ ] Review performance report boundaries.

--- a/docs/en/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/en/validation/release-evidence-reviewer-handoff-template.md
@@ -1,0 +1,160 @@
+# Release Evidence Reviewer Handoff Template
+
+- This is a reviewer-facing handoff template for release evidence and staged readiness review.
+- It summarizes what was run, what evidence was collected, what passed, what failed, and what remains open.
+- It complements the Operational Readiness Runbook and Production Validation documentation.
+- It is not production certification.
+- It is not third-party certification.
+- It is not customer-environment verification unless explicitly run and documented in that environment.
+- It does not certify legal, regulatory, or compliance status.
+- Live provider evidence depends on configured provider secrets and separately recorded execution.
+
+## Purpose
+
+Use this template to submit release evidence for external review with clear scope, artifacts, command history, boundaries, and unresolved items.
+
+## Handoff summary
+
+- Review date:
+- Operator:
+- Reviewer / organization:
+- Repository:
+- Commit SHA:
+- Branch or tag:
+- Environment type: local / CI / staging / customer-managed
+- Evidence folder:
+- Overall release evidence status: pass / fail / inconclusive
+- Compose subreport attached: yes / no
+- Live provider subreport attached: yes / no
+- Provider secrets configured: yes / no / partial / unknown
+- Redaction status:
+
+## Release evidence scope
+
+- [ ] Operational Readiness Runbook reviewed
+- [ ] Production Validation documentation reviewed
+- [ ] Staged readiness report generated or inspected
+- [ ] `deployment_ready` interpretation reviewed
+- [ ] Compose validation report attached or explicitly absent
+- [ ] Live provider report attached or explicitly absent
+- [ ] Advisory findings reviewed
+- [ ] Non-claim boundaries explained
+- [ ] Open questions documented
+
+## Environment and commit
+
+- Repository URL:
+- Commit SHA:
+- Branch/tag:
+- Runtime profile (local/CI/staging/customer-managed):
+- Date/time window:
+- Operator notes:
+
+## Commands run
+
+Run and record the commands below as part of release evidence packaging and review handoff:
+
+```bash
+python scripts/quality/check_operational_docs_consistency.py
+pytest -q veritas_os/tests/test_operational_docs_certification_guard.py
+pytest -q veritas_os/tests/test_staged_readiness_report.py
+pytest -q veritas_os/tests/test_staged_readiness_make_targets.py
+make validate-staged-report
+make -n validate-staged-report-with-subreports
+```
+
+`make validate-staged-report` generates the no-subreport staged report. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so `make -n validate-staged-report-with-subreports` can be used to inspect the command sequence safely before running the secrets-required path.
+
+## Evidence artifacts provided
+
+| Evidence item | File/path | Required? | Notes |
+|---|---|---|---|
+| Staged readiness JSON | `release-artifacts/staged-readiness-report.json` | Yes | |
+| Staged readiness text | `release-artifacts/staged-readiness-report.txt` | Recommended | |
+| Compose validation JSON | `release-artifacts/compose-validation-report.json` | Conditional | Required when compose subreport is claimed attached |
+| Live provider JSON | `release-artifacts/live-provider-report.json` | Conditional | Required when live provider subreport is claimed attached |
+| Command log |  | Recommended | |
+| CI status / PR URL |  | Recommended | |
+| Redaction notes |  | Conditional | |
+| Reviewer notes |  | Yes | |
+
+## Staged readiness interpretation
+
+- `deployment_ready=true` means blocking governance checks passed and no attached compose report failed.
+- `deployment_ready=true` does not mean compose validation was attached; check `compose_validation`.
+- `deployment_ready=true` does not mean live providers were checked; check `live_provider_validation`.
+- Advisory failures are non-blocking but require reviewer/operator review.
+- The report is evidence for release review, not production certification.
+
+## Compose and live provider subreports
+
+- `compose_validation` present / absent:
+- `live_provider_validation` present / absent:
+- Compose result:
+- Live provider result:
+- Missing artifact explanation:
+- Secrets configured:
+- Reviewer note:
+
+Absent compose/live subreports are treated as not failed by the staged report generator, but absence is not evidence that those validations ran.
+Live provider validation may require provider secrets and may skip checks when secrets are absent.
+
+## Advisory findings review
+
+- `overall_readiness.advisory_issue_count`:
+- `overall_readiness.advisory_issues`:
+- `governance.advisory_failure_labels`:
+- Reviewer decision:
+- Follow-up required:
+
+## Results summary
+
+- Overall status: pass / fail / inconclusive
+- Governance blocking checks:
+- Compose validation:
+- Live provider validation:
+- Advisory findings:
+- Evidence completeness:
+- Reviewer confidence:
+- Follow-up required:
+
+## Known limitations
+
+- Evidence reflects the documented environment and execution window only.
+- Missing provider secrets can limit live validation scope.
+- Advisory findings may remain open while blocking checks pass.
+
+## Non-claim boundaries
+
+- Do not claim production certification from this handoff.
+- Do not claim third-party certification.
+- Do not claim customer-environment verification unless the evidence was actually generated in that environment and documented.
+- Do not claim legal or regulatory approval.
+- Do not claim provider health unless live provider validation was run with required secrets and evidence is attached.
+- Do not treat `deployment_ready=true` as proof that all advisory issues are cleared.
+- Do not treat absent compose/live subreports as proof that those validations ran.
+
+## Open questions and follow-up
+
+- Open question:
+- Owner:
+- Target date:
+- Required artifact update:
+
+## Reviewer acknowledgement
+
+- Reviewer name:
+- Organization:
+- Date:
+- Acknowledgement:
+  - [ ] I reviewed the provided release evidence.
+  - [ ] I understand the stated non-claim boundaries.
+  - [ ] I understand `deployment_ready` is not production certification.
+  - [ ] I understand absent compose/live subreports are not evidence that those validations ran.
+
+## Related documents
+
+- [`docs/REVIEWER_ENTRYPOINT.md`](../../REVIEWER_ENTRYPOINT.md)
+- [`docs/en/operations/operational-readiness-runbook.md`](../operations/operational-readiness-runbook.md)
+- [`docs/en/validation/production-validation.md`](production-validation.md)
+- [`docs/en/validation/current-implementation-matrix.md`](current-implementation-matrix.md)

--- a/docs/ja/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/ja/validation/release-evidence-reviewer-handoff-template.md
@@ -1,0 +1,53 @@
+# リリース証跡レビュー引き渡しテンプレート
+
+この文書は、[`docs/en/validation/release-evidence-reviewer-handoff-template.md`](../../en/validation/release-evidence-reviewer-handoff-template.md) の日本語説明ページです。外部レビュアー、企業評価者、技術 DD チーム向けに、release evidence / staged readiness review の提出フォーマットの目的と読み方を整理します。
+
+## 目的
+
+- release evidence と staged readiness review を、レビュアーへ引き渡す際の提出フォーマットを明確化する。
+- 何を実行したか、どの証跡を提出したか、何が未解決かを整理する。
+- 過大な主張を避け、非主張境界を明示する。
+
+## 使い方
+
+1. 英語正本テンプレートに沿って、実行コマンド・証跡・結果を記入します。
+2. `deployment_ready` の値だけで判断せず、compose/live subreport の添付有無を確認します。
+3. advisory findings と未解決事項を記録し、レビュアー判断に必要な補足を残します。
+4. 必要に応じて redaction 方針と実行環境（local / CI / staging / customer-managed）を追記します。
+
+## 提出する主な証跡
+
+- `release-artifacts/staged-readiness-report.json`
+- `release-artifacts/staged-readiness-report.txt`
+- `release-artifacts/compose-validation-report.json`（compose subreport を添付した場合）
+- `release-artifacts/live-provider-report.json`（live provider subreport を添付した場合）
+- 実行コマンドログ、CI 状態、PR URL、レビューノート
+
+## `deployment_ready` の読み方
+
+- `deployment_ready=true` は、blocking governance checks が通り、添付済み compose report に失敗がないことを示します。
+- これは本番認証ではない、または認証ではないという境界を前提に解釈します。
+- `deployment_ready=true` でも、compose validation が未添付なら compose 実行の証跡にはなりません。
+- `deployment_ready=true` でも、live provider validation が未添付なら live provider 実行の証跡にはなりません。
+
+## compose/live subreport の確認
+
+- compose/live subreport が添付済みか未添付かを明示して確認してください。
+- 未添付は、compose/live validation が走った証拠ではありません。
+- live provider validation は provider secrets が必要になる場合があります。
+- provider secrets が未設定の場合、live provider checks が skip される場合があります。
+
+## 非主張境界
+
+- この引き渡しは法的・規制上・コンプライアンス上の認証を意味しません。
+- 顧客環境で実行・記録されていない限り、顧客環境検証ではないと扱います。
+- 第三者認証を主張しません。
+- 本番運用可否の最終判断を代替する資料として扱いません。
+
+## 関連文書
+
+- [`docs/en/validation/release-evidence-reviewer-handoff-template.md`](../../en/validation/release-evidence-reviewer-handoff-template.md)
+- [`docs/REVIEWER_ENTRYPOINT.md`](../../REVIEWER_ENTRYPOINT.md)
+- [`docs/en/operations/operational-readiness-runbook.md`](../../en/operations/operational-readiness-runbook.md)
+- [`docs/en/validation/production-validation.md`](../../en/validation/production-validation.md)
+- [`docs/ja/validation/production-validation.md`](production-validation.md)

--- a/docs/ja/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/ja/validation/release-evidence-reviewer-handoff-template.md
@@ -2,6 +2,10 @@
 
 この文書は、[`docs/en/validation/release-evidence-reviewer-handoff-template.md`](../../en/validation/release-evidence-reviewer-handoff-template.md) の日本語説明ページです。外部レビュアー、企業評価者、技術 DD チーム向けに、release evidence / staged readiness review の提出フォーマットの目的と読み方を整理します。
 
+## 英語正本
+
+- [`docs/en/validation/release-evidence-reviewer-handoff-template.md`](../../en/validation/release-evidence-reviewer-handoff-template.md)
+
 ## 目的
 
 - release evidence と staged readiness review を、レビュアーへ引き渡す際の提出フォーマットを明確化する。

--- a/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
+++ b/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
@@ -1,0 +1,116 @@
+"""Docs checks for the release evidence reviewer handoff template."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "docs/en/validation/release-evidence-reviewer-handoff-template.md"
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def _template_text() -> str:
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def _markdown_link_targets() -> list[str]:
+    return MARKDOWN_LINK_RE.findall(_template_text())
+
+
+def _link_file_part(target: str) -> str:
+    return target.split("#", 1)[0].split("?", 1)[0]
+
+
+def test_release_evidence_handoff_template_exists() -> None:
+    assert TEMPLATE.exists()
+
+
+def test_release_evidence_handoff_template_has_required_sections() -> None:
+    text = _template_text()
+    for section in [
+        "## Purpose",
+        "## Handoff summary",
+        "## Release evidence scope",
+        "## Environment and commit",
+        "## Commands run",
+        "## Evidence artifacts provided",
+        "## Staged readiness interpretation",
+        "## Compose and live provider subreports",
+        "## Advisory findings review",
+        "## Results summary",
+        "## Known limitations",
+        "## Non-claim boundaries",
+        "## Open questions and follow-up",
+        "## Reviewer acknowledgement",
+        "## Related documents",
+    ]:
+        assert section in text
+
+
+def test_release_evidence_handoff_template_has_required_commands() -> None:
+    text = _template_text()
+    for command in [
+        "python scripts/quality/check_operational_docs_consistency.py",
+        "pytest -q veritas_os/tests/test_operational_docs_certification_guard.py",
+        "pytest -q veritas_os/tests/test_staged_readiness_report.py",
+        "pytest -q veritas_os/tests/test_staged_readiness_make_targets.py",
+        "make validate-staged-report",
+        "make -n validate-staged-report-with-subreports",
+    ]:
+        assert command in text
+
+
+def test_release_evidence_handoff_template_has_required_artifact_paths() -> None:
+    text = _template_text()
+    for artifact in [
+        "release-artifacts/staged-readiness-report.json",
+        "release-artifacts/staged-readiness-report.txt",
+        "release-artifacts/compose-validation-report.json",
+        "release-artifacts/live-provider-report.json",
+    ]:
+        assert artifact in text
+
+
+def test_release_evidence_handoff_template_has_required_boundaries() -> None:
+    text = _template_text().lower()
+    for phrase in [
+        "not production certification",
+        "not third-party certification",
+        "not customer-environment verification",
+        "deployment_ready=true",
+        "absent compose/live subreports are not evidence",
+    ]:
+        assert phrase in text
+
+
+def test_release_evidence_handoff_template_related_links_exist() -> None:
+    targets = _markdown_link_targets()
+    assert targets
+
+    for target in targets:
+        if target.startswith(("http://", "https://", "#", "/")):
+            continue
+
+        file_part = _link_file_part(target)
+        if not file_part:
+            continue
+
+        assert (TEMPLATE.parent / file_part).exists(), target
+
+
+def test_release_evidence_handoff_template_avoids_positive_overclaim_phrases() -> None:
+    text = _template_text().lower()
+    for phrase in [
+        "release certification",
+        "full certification",
+        "production certified",
+        "certified for production",
+        "compliance guaranteed",
+        "guarantees compliance",
+        "proves production readiness",
+        "proves readiness",
+        "certifies readiness",
+        "certifies production readiness",
+    ]:
+        assert phrase not in text

--- a/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
+++ b/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
@@ -164,9 +164,15 @@ def test_release_evidence_handoff_ja_related_links_exist() -> None:
 
 
 def test_release_evidence_handoff_templates_are_linked_from_public_indexes() -> None:
-    combined = "\n".join(path.read_text(encoding="utf-8") for path in INDEX_PATHS)
-    assert "docs/en/validation/release-evidence-reviewer-handoff-template.md" in combined
-    assert "docs/ja/validation/release-evidence-reviewer-handoff-template.md" in combined
+    docs_index = (REPO_ROOT / "docs/INDEX.md").read_text(encoding="utf-8")
+    docs_map = (REPO_ROOT / "docs/DOCUMENTATION_MAP.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "en/validation/release-evidence-reviewer-handoff-template.md" in docs_index
+    assert "ja/validation/release-evidence-reviewer-handoff-template.md" in docs_index
+    assert "docs/en/validation/release-evidence-reviewer-handoff-template.md" in docs_map
+    assert "docs/ja/validation/release-evidence-reviewer-handoff-template.md" in docs_map
 
 
 def test_release_evidence_handoff_ja_avoids_positive_overclaim_phrases() -> None:
@@ -182,3 +188,11 @@ def test_release_evidence_handoff_ja_avoids_positive_overclaim_phrases() -> None
         "規制承認済み",
     ]:
         assert phrase not in text
+
+
+def test_release_evidence_handoff_ja_explanation_exposes_english_canonical() -> None:
+    text = _ja_template_text()
+    assert "## 英語正本" in text
+    assert (
+        "../../en/validation/release-evidence-reviewer-handoff-template.md" in text
+    )

--- a/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
+++ b/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TEMPLATE = REPO_ROOT / "docs/en/validation/release-evidence-reviewer-handoff-template.md"
+JA_TEMPLATE = REPO_ROOT / "docs/ja/validation/release-evidence-reviewer-handoff-template.md"
+INDEX_PATHS = [
+    REPO_ROOT / "docs/INDEX.md",
+    REPO_ROOT / "docs/DOCUMENTATION_MAP.md",
+]
 MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
 
@@ -112,5 +117,68 @@ def test_release_evidence_handoff_template_avoids_positive_overclaim_phrases() -
         "proves readiness",
         "certifies readiness",
         "certifies production readiness",
+    ]:
+        assert phrase not in text
+
+
+def _ja_template_text() -> str:
+    return JA_TEMPLATE.read_text(encoding="utf-8")
+
+
+def _markdown_link_targets_from_text(text: str) -> list[str]:
+    return MARKDOWN_LINK_RE.findall(text)
+
+
+def test_release_evidence_handoff_ja_explanation_exists() -> None:
+    assert JA_TEMPLATE.exists()
+
+
+def test_release_evidence_handoff_ja_explanation_has_required_content() -> None:
+    text = _ja_template_text()
+    for phrase in [
+        "# リリース証跡レビュー引き渡しテンプレート",
+        "docs/en/validation/release-evidence-reviewer-handoff-template.md",
+        "docs/REVIEWER_ENTRYPOINT.md",
+        "`deployment_ready`",
+        "compose/live subreport",
+        "未添付",
+        "認証ではない",
+        "顧客環境検証ではない",
+    ]:
+        assert phrase in text
+
+
+def test_release_evidence_handoff_ja_related_links_exist() -> None:
+    targets = _markdown_link_targets_from_text(_ja_template_text())
+    assert targets
+
+    for target in targets:
+        if target.startswith(("http://", "https://", "#", "/")):
+            continue
+
+        file_part = _link_file_part(target)
+        if not file_part:
+            continue
+
+        assert (JA_TEMPLATE.parent / file_part).exists(), target
+
+
+def test_release_evidence_handoff_templates_are_linked_from_public_indexes() -> None:
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in INDEX_PATHS)
+    assert "docs/en/validation/release-evidence-reviewer-handoff-template.md" in combined
+    assert "docs/ja/validation/release-evidence-reviewer-handoff-template.md" in combined
+
+
+def test_release_evidence_handoff_ja_avoids_positive_overclaim_phrases() -> None:
+    text = _ja_template_text()
+    for phrase in [
+        "完全準拠",
+        "認証済み製品",
+        "本番SLA保証",
+        "24時間365日サポート保証",
+        "本番準備完了を証明",
+        "コンプライアンス保証",
+        "法的保証",
+        "規制承認済み",
     ]:
         assert phrase not in text

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -59,6 +59,7 @@ def test_reviewer_entrypoint_links_required_current_docs() -> None:
         "en/operations/maintainer-handoff.md",
         "en/operations/operational-readiness-runbook.md",
         "en/validation/production-validation.md",
+        "en/validation/release-evidence-reviewer-handoff-template.md",
     ]
     for link in required_links:
         assert link in targets
@@ -165,6 +166,7 @@ def test_reviewer_entrypoint_validation_commands_include_poc_doc_guardrails() ->
         "pytest -q veritas_os/tests/test_one_day_poc_evidence_pack_docs.py",
         "pytest -q veritas_os/tests/test_one_day_poc_operator_runbook_docs.py",
         "pytest -q veritas_os/tests/test_one_day_poc_reviewer_handoff_template_docs.py",
+        "pytest -q veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py",
     ]:
         assert command in text
 
@@ -179,6 +181,8 @@ def test_reviewer_entrypoint_includes_release_evidence_path() -> None:
         "test_staged_readiness_report.py",
         "test_staged_readiness_make_targets.py",
         "test_operational_docs_certification_guard.py",
+        "test_release_evidence_reviewer_handoff_template_docs.py",
+        "Release Evidence Reviewer Handoff Template",
         "`deployment_ready`",
         "compose/live subreports",
     ]:
@@ -188,5 +192,6 @@ def test_reviewer_entrypoint_includes_release_evidence_path() -> None:
     for link in [
         "en/operations/operational-readiness-runbook.md",
         "en/validation/production-validation.md",
+        "en/validation/release-evidence-reviewer-handoff-template.md",
     ]:
         assert link in targets

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -195,3 +195,8 @@ def test_reviewer_entrypoint_includes_release_evidence_path() -> None:
         "en/validation/release-evidence-reviewer-handoff-template.md",
     ]:
         assert link in targets
+
+
+def test_reviewer_entrypoint_numbers_public_positioning_in_10_minute_path() -> None:
+    text = _entrypoint_text()
+    assert "10. [Public Positioning]" in text


### PR DESCRIPTION
### Motivation
- Provide a standard, reviewer-facing handoff template to submit release evidence and staged readiness artifacts that complements the Operational Readiness Runbook and Production Validation documentation.
- Make clear which artifacts to provide, which commands were run, how `deployment_ready` should be interpreted, and how compose/live subreport presence/absence and advisory findings are handled.
- Maintain conservative non-claim language and document that live-provider validation may require configured provider secrets and therefore may be conditional or require dry-run inspection.

### Description
- Add `docs/en/validation/release-evidence-reviewer-handoff-template.md` containing all required sections, the command block, the artifact table, staged readiness interpretation, compose/live subreport boundaries, non-claim bullets, reviewer acknowledgement fields, and relative related-doc links.
- Update `docs/REVIEWER_ENTRYPOINT.md` to link to the new template in the 10-/30-minute review paths, the "What to verify first" table, current proof assets, recommended validation commands, and the reviewer checklist with a short 1–2 line description.
- Add focused docs test `veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py` to assert template presence, sections, commands, artifact paths, non-claim phrases, related relative links, and banned overclaim phrases, and update `veritas_os/tests/test_reviewer_entrypoint_current_path.py` to require the new link and validation command.
- No runtime, Makefile, report generator, CI workflow, migration, health, storage, or staged-readiness/deployment_ready semantic changes are included in this PR.

### Testing
- Ran `python3 scripts/quality/check_operational_docs_consistency.py` which completed successfully.
- New focused docs tests were added: `veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py` and the updated `veritas_os/tests/test_reviewer_entrypoint_current_path.py` which validate the template content and entrypoint links and commands.
- Attempted to run `pytest` locally for the new docs test but `pytest` was not available in this environment; CI should run `pytest -q veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py` and the updated entrypoint tests as part of normal validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c6b71bfc8326a196acecef8bf938)