### PR TITLE
Add release evidence handoff preparation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST_MARKEXPR ?= not slow
 COVERAGE_XML ?= coverage.xml
 COVERAGE_HTML_DIR ?= coverage-html
 
-.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report validate-staged-report-with-subreports db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence check-trustlog-production-posture
+.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report validate-staged-report-with-subreports db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence check-trustlog-production-posture prepare-release-evidence-handoff
 
 # ── Setup & Development ──────────────────────────────────────────────────
 
@@ -251,6 +251,13 @@ validate-staged-report:
 		--sha $$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
 		--output release-artifacts/staged-readiness-report.json \
 		--text-output release-artifacts/staged-readiness-report.txt
+
+
+prepare-release-evidence-handoff:
+	@echo "[veritas] Preparing release evidence reviewer handoff template..."
+	@mkdir -p release-artifacts
+	@cp docs/en/validation/release-evidence-reviewer-handoff-template.md release-artifacts/release-evidence-reviewer-handoff.md
+	@echo "[veritas] Wrote release-artifacts/release-evidence-reviewer-handoff.md"
 
 validate-staged-report-with-subreports:
 	@echo "[veritas] Generating compose/live validation reports and staged readiness report..."

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -86,7 +86,7 @@ Key reviewer concepts:
 - [Operational Readiness Runbook](en/operations/operational-readiness-runbook.md)
 - [Production Validation](en/validation/production-validation.md)
 - [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md)
-- Release evidence Make targets: `make validate-staged-report` and `make validate-staged-report-with-subreports`
+- Release evidence Make targets: `make validate-staged-report`, `make validate-staged-report-with-subreports`, and `make prepare-release-evidence-handoff`
 - [Provider Support Matrix](en/operations/provider-support-matrix.md)
 - [Type Safety Baseline](en/operations/type-safety-baseline.md)
 - [Maintainer Handoff Runbook](en/operations/maintainer-handoff.md)
@@ -119,6 +119,7 @@ pytest -q veritas_os/tests/test_staged_readiness_report.py
 pytest -q veritas_os/tests/test_staged_readiness_make_targets.py
 make validate-staged-report
 make -n validate-staged-report-with-subreports
+make prepare-release-evidence-handoff
 ```
 
 One-Day PoC command examples (API server required, API key required):
@@ -133,7 +134,7 @@ Use the Operator Runbook to collect and organize evidence.
 Use the Reviewer Handoff Template to summarize and submit the PoC outcome.
 These documents do not create a production SLA, third-party certification, customer-environment measurement, or EU AI Act certification.
 
-For release evidence review, inspect the staged readiness report path. `make validate-staged-report` generates the no-subreport staged report. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so reviewers can use `make -n validate-staged-report-with-subreports` to inspect the command sequence safely.
+For release evidence review, inspect the staged readiness report path. `make validate-staged-report` generates the no-subreport staged report. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so reviewers can use `make -n validate-staged-report-with-subreports` to inspect the command sequence safely. Run `make prepare-release-evidence-handoff` to prepare `release-artifacts/release-evidence-reviewer-handoff.md` from the reviewer handoff template for submission.
 
 Boundary notes for PoC commands:
 

--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -208,6 +208,9 @@ Interpretation rules:
 - The with-subreports target runs compose validation and live provider
   validation first, then passes their JSON reports to
   `scripts/generate_staged_readiness_report.py`.
+- Use `make prepare-release-evidence-handoff` to copy the reviewer handoff
+  template into `release-artifacts/release-evidence-reviewer-handoff.md`
+  before packaging release evidence.
 - Live provider validation may require provider secrets and can fail when
   those secrets are not configured.
 - Operators may still run the generator directly when custom report paths are

--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -19,6 +19,7 @@ simulated, and what requires environment-specific confirmation.
 | `make validate-live-report` | Live provider + JSON report | Release evidence report |
 | `make validate-staged-report` | Staged readiness report | Release evidence report without attached compose/live subreports |
 | `make validate-staged-report-with-subreports` | Staged readiness report with compose/live subreports (secrets-required for live checks) | Release evidence report with attached subreports |
+| `make prepare-release-evidence-handoff` | Prepare `release-artifacts/release-evidence-reviewer-handoff.md` | Reviewer handoff preparation |
 | `make quality-checks` | Architecture + security scripts | Every PR (automatic) |
 
 ## Validation Tiers

--- a/docs/en/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/en/validation/release-evidence-reviewer-handoff-template.md
@@ -61,9 +61,10 @@ pytest -q veritas_os/tests/test_staged_readiness_report.py
 pytest -q veritas_os/tests/test_staged_readiness_make_targets.py
 make validate-staged-report
 make -n validate-staged-report-with-subreports
+make prepare-release-evidence-handoff
 ```
 
-`make validate-staged-report` generates the no-subreport staged report. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so `make -n validate-staged-report-with-subreports` can be used to inspect the command sequence safely before running the secrets-required path.
+`make validate-staged-report` generates the no-subreport staged report. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so `make -n validate-staged-report-with-subreports` can be used to inspect the command sequence safely before running the secrets-required path. `make prepare-release-evidence-handoff` copies this template to `release-artifacts/release-evidence-reviewer-handoff.md` so operators can fill in the handoff file alongside generated staged readiness artifacts.
 
 ## Evidence artifacts provided
 

--- a/docs/ja/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/ja/validation/release-evidence-reviewer-handoff-template.md
@@ -18,6 +18,8 @@
 2. `deployment_ready` の値だけで判断せず、compose/live subreport の添付有無を確認します。
 3. advisory findings と未解決事項を記録し、レビュアー判断に必要な補足を残します。
 4. 必要に応じて redaction 方針と実行環境（local / CI / staging / customer-managed）を追記します。
+5. `make prepare-release-evidence-handoff` を実行すると、英語正本テンプレートを `release-artifacts/release-evidence-reviewer-handoff.md` にコピーできます。
+6. `release-artifacts/release-evidence-reviewer-handoff.md` を、staged readiness report などの生成済み証跡と一緒に記入・提出します。
 
 ## 提出する主な証跡
 

--- a/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
+++ b/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
@@ -144,6 +144,8 @@ def test_release_evidence_handoff_ja_explanation_has_required_content() -> None:
         "未添付",
         "認証ではない",
         "顧客環境検証ではない",
+        "make prepare-release-evidence-handoff",
+        "release-artifacts/release-evidence-reviewer-handoff.md",
     ]:
         assert phrase in text
 

--- a/veritas_os/tests/test_staged_readiness_make_targets.py
+++ b/veritas_os/tests/test_staged_readiness_make_targets.py
@@ -110,7 +110,6 @@ def test_validate_staged_report_with_subreports_dry_run_attaches_subreports() ->
 
 
 
-
 def test_prepare_release_evidence_handoff_dry_run_copies_template() -> None:
     """Handoff target should copy the release evidence reviewer template."""
     output = _run_make_dry_run("prepare-release-evidence-handoff")
@@ -121,6 +120,7 @@ def test_prepare_release_evidence_handoff_dry_run_copies_template() -> None:
         "release-artifacts/release-evidence-reviewer-handoff.md"
     ) in output
     assert "Wrote release-artifacts/release-evidence-reviewer-handoff.md" in output
+
 
 def test_staged_readiness_make_targets_are_phony() -> None:
     """Makefile should mark both staged readiness targets as phony."""
@@ -153,6 +153,7 @@ def test_docs_reference_release_evidence_handoff_make_target() -> None:
         REPO_ROOT / "docs/en/validation/release-evidence-reviewer-handoff-template.md",
         REPO_ROOT / "docs/en/operations/operational-readiness-runbook.md",
         REPO_ROOT / "docs/REVIEWER_ENTRYPOINT.md",
+        REPO_ROOT / "docs/ja/validation/release-evidence-reviewer-handoff-template.md",
     ]
 
     for path in docs:

--- a/veritas_os/tests/test_staged_readiness_make_targets.py
+++ b/veritas_os/tests/test_staged_readiness_make_targets.py
@@ -109,6 +109,19 @@ def test_validate_staged_report_with_subreports_dry_run_attaches_subreports() ->
     assert "--text-output release-artifacts/staged-readiness-report.txt" in output
 
 
+
+
+def test_prepare_release_evidence_handoff_dry_run_copies_template() -> None:
+    """Handoff target should copy the release evidence reviewer template."""
+    output = _run_make_dry_run("prepare-release-evidence-handoff")
+
+    assert "mkdir -p release-artifacts" in output
+    assert (
+        "cp docs/en/validation/release-evidence-reviewer-handoff-template.md "
+        "release-artifacts/release-evidence-reviewer-handoff.md"
+    ) in output
+    assert "Wrote release-artifacts/release-evidence-reviewer-handoff.md" in output
+
 def test_staged_readiness_make_targets_are_phony() -> None:
     """Makefile should mark both staged readiness targets as phony."""
     makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
@@ -117,6 +130,7 @@ def test_staged_readiness_make_targets_are_phony() -> None:
     assert phony_tokens, "No .PHONY declarations found in Makefile"
     assert "validate-staged-report" in phony_tokens
     assert "validate-staged-report-with-subreports" in phony_tokens
+    assert "prepare-release-evidence-handoff" in phony_tokens
 
 
 def test_docs_reference_staged_readiness_make_targets() -> None:
@@ -131,3 +145,16 @@ def test_docs_reference_staged_readiness_make_targets() -> None:
         text = path.read_text(encoding="utf-8")
         assert _mentions_make_command(text, "validate-staged-report")
         assert _mentions_make_command(text, "validate-staged-report-with-subreports")
+
+
+def test_docs_reference_release_evidence_handoff_make_target() -> None:
+    """Release evidence docs should reference the handoff preparation target."""
+    docs = [
+        REPO_ROOT / "docs/en/validation/release-evidence-reviewer-handoff-template.md",
+        REPO_ROOT / "docs/en/operations/operational-readiness-runbook.md",
+        REPO_ROOT / "docs/REVIEWER_ENTRYPOINT.md",
+    ]
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert _mentions_make_command(text, "prepare-release-evidence-handoff")


### PR DESCRIPTION
### Motivation
- Ensure the Release Evidence Reviewer Handoff Template is reproducibly prepared into the artifact folder for reviewers as a simple copy operation.  
- Provide a Make target that operators can run (`make prepare-release-evidence-handoff`) so the handoff file appears at a well-known artifact path.  
- Fix the documentation and add dry-run/docs-reference checks so the command path remains discoverable and regression-protected.

### Description
- Adds a new phony Make target `prepare-release-evidence-handoff` that creates `release-artifacts/` and copies `docs/en/validation/release-evidence-reviewer-handoff-template.md` to `release-artifacts/release-evidence-reviewer-handoff.md`.  
- Adds `prepare-release-evidence-handoff` to the Makefile `.PHONY` list to match existing style.  
- Documents the new command in `docs/en/validation/release-evidence-reviewer-handoff-template.md`, `docs/en/operations/operational-readiness-runbook.md`, and `docs/REVIEWER_ENTRYPOINT.md` and updates the recommended commands.  
- Extends `veritas_os/tests/test_staged_readiness_make_targets.py` with a dry-run contract test for `make -n prepare-release-evidence-handoff`, a `.PHONY` membership assertion, and a docs reference test that checks the three docs mention the exact `make prepare-release-evidence-handoff` command.

### Testing
- Ran `PYENV_VERSION=3.12.13 pytest -q veritas_os/tests/test_staged_readiness_make_targets.py` and the new/updated tests passed (6 passed, 1 warning).  
- Ran `PYENV_VERSION=3.12.13 pytest -q veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py veritas_os/tests/test_reviewer_entrypoint_current_path.py` and they passed (25 passed, 1 warning).  
- Ran docs quality checks `python3 scripts/quality/check_operational_docs_consistency.py` and `python3 scripts/quality/check_bilingual_docs.py`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065a64cf308326a0cbf1d599b46d7b)