### PR TITLE
test(governance): add explicit Vikki RSA mock ingestion contract test

### DIFF
--- a/tests/governance/test_rsa_sandbox_receiver.py
+++ b/tests/governance/test_rsa_sandbox_receiver.py
@@ -137,6 +137,46 @@ def test_contract_example_matches_expected_output_shape() -> None:
     }
 
 
+def test_vikki_rsa_mock_payload_ingests_as_algorithmic_humility_pause() -> None:
+    payload = RSASandboxPayload(
+        rsa_status="ALGORITHMIC_HUMILITY_ENGAGED",
+        trigger_source="SRC_Incomplete_Context",
+        original_llm_intent="Recommend_Transaction_Approval",
+        rsa_action_taken="Execution_Suspended_Awaiting_Reality_Sync",
+        timestamp="2026-10-25T09:15:30Z",
+    )
+
+    result = evaluate_rsa_sandbox_signal(payload)
+    veritas_decision = result["veritas_decision"]
+    audit_entry = result["audit_entry"]
+
+    assert veritas_decision["continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert veritas_decision["reason_code"] == "UPSTREAM_INCOMPLETE_KYC_CONTEXT"
+    assert veritas_decision["authority_evidence_status"] == "INSUFFICIENT"
+    assert (
+        veritas_decision["sandbox_bind_boundary_state"]
+        == "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE"
+    )
+    assert veritas_decision["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        veritas_decision["required_next_action"]
+        == "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+    )
+    assert audit_entry["upstream_signal_source"] == "RSA"
+    assert audit_entry["rsa_status"] == "ALGORITHMIC_HUMILITY_ENGAGED"
+    assert audit_entry["trigger_source"] == "SRC_Incomplete_Context"
+    assert audit_entry["original_llm_intent"] == "[REDACTED]"
+    assert audit_entry["rsa_action_taken"] == "[REDACTED]"
+    assert audit_entry["timestamp"] == "2026-10-25T09:15:30Z"
+    assert audit_entry["veritas_continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert audit_entry["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        audit_entry["veritas_reason"]
+        == "The workflow cannot continue toward final commit because required "
+        "KYC context is incomplete and authority evidence is insufficient."
+    )
+
+
 def test_unknown_status_raises_contract_violation() -> None:
     payload = _payload("UNKNOWN_STATUS")
 


### PR DESCRIPTION
### Motivation
- Add a focused, sandbox-only contract test that exercises ingestion of Vikki’s RSA mock payload to ensure VERITAS maps the upstream RSA signal into the expected continuation decision and audit entry shape. 
- Verify safe-by-default redaction and downstream mapping for the `ALGORITHMIC_HUMILITY_ENGAGED` status without changing production runtime behavior or RSA receiver semantics.

### Description
- Added `test_vikki_rsa_mock_payload_ingests_as_algorithmic_humility_pause` to `tests/governance/test_rsa_sandbox_receiver.py` which constructs the exact payload and exercises `evaluate_rsa_sandbox_signal`.
- The test asserts the `veritas_decision` fields (`continuation_decision`, `reason_code`, `authority_evidence_status`, `sandbox_bind_boundary_state`, `sandbox_commit_state`, `required_next_action`) and the `audit_entry` fields (including redacted `original_llm_intent` and `rsa_action_taken`, `timestamp`, and mirrored continuation/commit state).
- This change is test-only and does not modify production logic, RSA sandbox receiver behavior, or enable `include_raw_upstream_fields` in the test to confirm the safe-by-default redaction contract.

### Testing
- Ran `pytest tests/governance/test_rsa_sandbox_receiver.py` in this environment but test collection failed because the repo expects the pinned Python runtime and dependencies (local environment missing configured Python version and `PyYAML` leading to `ModuleNotFoundError: No module named 'yaml'`).
- Confirmed `tests/governance/test_rsa_sandbox_receiver.py` is included in Tier 1 CI (`governance-backend-fast`) so the new test will be exercised by CI under the project CI matrix and dependency setup using `pytest` as configured in the workflow.
- Security note: this is a sandbox-only check that validates redaction-by-default; enabling `VERITAS_RSA_SANDBOX_ALLOW_RAW_UPSTREAM` would expose upstream raw fields and must be reviewed for data/PII risks before use.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065f0392b083269bce5b9ebf1f9fca)