### PR TITLE
Add RSA ↔ VERITAS end-to-end sandbox demo plan (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md
+++ b/docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md
@@ -1,0 +1,106 @@
+# RSA ↔ VERITAS End-to-End Sandbox Demo Plan
+
+## 1. Purpose
+
+This document defines a minimal, documentation-only end-to-end sandbox demo plan for the RSA ↔ VERITAS integration path. The demo validates interface compatibility and downstream continuation/audit behavior without integrating Vikki’s real RSA wrapper or changing VERITAS runtime governance logic.
+
+A prerequisite baseline is already merged:
+- RSA sandbox receiver
+- EN/JA interface docs
+- Tier 1 CI coverage
+- Vikki RSA mock payload ingestion fixture
+
+## 2. Non-goals
+
+This demo does **not**:
+- connect to Vikki’s real RSA wrapper
+- import or expose Vikki’s internal RSA logic inside VERITAS
+- change runtime code paths, production policy, or release gates
+- change test behavior or add production assertions
+- claim production AML/KYC readiness, compliance approval, or certification
+
+## 3. Boundary rules
+
+- RSA remains an external upstream signal source.
+- VERITAS remains responsible only for downstream continuation decisioning and audit entry creation in this demo.
+- Sandbox-only boundaries are preserved end to end.
+- No Planner / Kernel / Fuji / MemoryOS responsibility expansion is introduced.
+
+## 4. Demo flow
+
+1. RSA mock wrapper emits a static JSON payload.
+2. Payload uses the agreed interface contract fields:
+   - `rsa_status`
+   - `trigger_source`
+   - `original_llm_intent`
+   - `rsa_action_taken`
+   - `timestamp`
+3. VERITAS consumes this payload via `evaluate_rsa_sandbox_signal()`.
+4. VERITAS returns:
+   - `veritas_decision`
+   - `audit_entry`
+5. Demo output must show:
+   - `continuation_decision`
+   - `reason_code`
+   - `sandbox_commit_state`
+   - redacted upstream raw fields
+   - timestamp preservation
+   - audit narrative
+
+## 5. Input payload
+
+```json
+{
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "timestamp": "2026-10-25T09:15:30Z"
+}
+```
+
+## 6. Expected VERITAS output
+
+Expected sandbox output values:
+- `continuation_decision`: `PAUSE_FOR_HUMAN_REVIEW`
+- `reason_code`: `UPSTREAM_INCOMPLETE_KYC_CONTEXT`
+- `authority_evidence_status`: `INSUFFICIENT`
+- `sandbox_bind_boundary_state`: `NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE`
+- `sandbox_commit_state`: `SUSPENDED_NOT_COMMITTED`
+- `required_next_action`: `REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW`
+- `original_llm_intent`: `[REDACTED]`
+- `rsa_action_taken`: `[REDACTED]`
+
+## 7. Audit behavior
+
+The audit entry should:
+- preserve the upstream `timestamp` exactly as received
+- record that continuation was paused pending additional authority evidence
+- include a concise narrative linking upstream incomplete KYC context to downstream suspension
+- retain redaction defaults for raw upstream intent/action fields
+
+## 8. Security constraints
+
+- This is sandbox-only.
+- This is not production AML/KYC compliance logic.
+- This is not regulatory approval.
+- This is not third-party certification.
+- This is not legal advice.
+- Raw upstream fields must remain redacted by default.
+- No real customer, financial, medical, KYC, or regulated data should be used.
+- Vikki’s RSA internal logic remains external.
+- VERITAS core governance logic remains separate.
+- No commercial/customer-facing demo should be performed without a separate written agreement covering ownership, credit, and commercial use.
+
+## 9. What remains outside this demo
+
+Outside this plan:
+- real RSA wrapper connectivity and transport hardening
+- production governance/bind admissibility decisions
+- compliance/legal/regulatory interpretation
+- customer-facing workflows and commercial packaging
+- any release-readiness claims beyond sandbox validation
+
+## 10. Next implementation step
+
+Implement a thin sandbox harness invocation that feeds the static payload into `evaluate_rsa_sandbox_signal()` and prints/verifies only the expected sandbox decision and audit-shape outputs above, without modifying production runtime behavior.

--- a/docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md
+++ b/docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md
@@ -61,15 +61,33 @@ This demo does **not**:
 
 ## 6. Expected VERITAS output
 
-Expected sandbox output values:
-- `continuation_decision`: `PAUSE_FOR_HUMAN_REVIEW`
-- `reason_code`: `UPSTREAM_INCOMPLETE_KYC_CONTEXT`
-- `authority_evidence_status`: `INSUFFICIENT`
-- `sandbox_bind_boundary_state`: `NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE`
-- `sandbox_commit_state`: `SUSPENDED_NOT_COMMITTED`
-- `required_next_action`: `REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW`
-- `original_llm_intent`: `[REDACTED]`
-- `rsa_action_taken`: `[REDACTED]`
+Expected sandbox response shape:
+
+```json
+{
+  "veritas_decision": {
+    "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+    "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+    "authority_evidence_status": "INSUFFICIENT",
+    "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+    "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+    "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+  },
+  "audit_entry": {
+    "upstream_signal_source": "RSA",
+    "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+    "trigger_source": "SRC_Incomplete_Context",
+    "original_llm_intent": "[REDACTED]",
+    "rsa_action_taken": "[REDACTED]",
+    "veritas_reason": "The workflow cannot continue toward final commit because required KYC context is incomplete and authority evidence is insufficient.",
+    "timestamp": "2026-10-25T09:15:30Z",
+    "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+    "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+  }
+}
+```
+
+This is the expected sandbox response shape, not a production BindReceipt or production compliance output.
 
 ## 7. Audit behavior
 

--- a/docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md
+++ b/docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md
@@ -1,0 +1,107 @@
+# RSA ↔ VERITAS E2E サンドボックスデモ計画
+
+> 英語正本（EN）: [RSA ↔ VERITAS End-to-End Sandbox Demo Plan](../../en/guides/rsa-veritas-e2e-sandbox-demo-plan.md)
+
+## 1. 目的
+
+本書は、RSA ↔ VERITAS 連携における最小構成のサンドボックス E2E デモ計画（ドキュメント専用）を定義します。目的は、Vikki の実運用 RSA ラッパー接続や VERITAS 本番ガバナンス挙動の変更を行わずに、インターフェース整合性と下流の継続可否判断／監査記録の期待形を確認することです。
+
+前提となる作業はすでにマージ済みです。
+- RSA sandbox receiver
+- EN/JA interface docs
+- Tier 1 CI coverage
+- Vikki RSA mock payload ingestion fixture
+
+## 2. 非目標
+
+このデモでは次を行いません。
+- Vikki の実運用 RSA ラッパーへの接続
+- Vikki の RSA 内部ロジックを VERITAS 内に取り込むこと
+- ランタイムコード、テスト、リリースゲート、運用ポリシーの変更
+- 本番 AML/KYC 準拠、規制承認、認証取得の主張
+
+## 3. 境界ルール
+
+- RSA は外部の上流シグナルソースのままとする。
+- VERITAS は本デモにおいて、下流の継続判断と監査エントリ生成のみに責務を限定する。
+- サンドボックス専用の境界を end-to-end で維持する。
+- Planner / Kernel / Fuji / MemoryOS の責務を越える変更は行わない。
+
+## 4. デモフロー
+
+1. RSA mock wrapper が静的 JSON payload を送出する。
+2. payload は合意済みインターフェース契約フィールドを使用する。
+   - `rsa_status`
+   - `trigger_source`
+   - `original_llm_intent`
+   - `rsa_action_taken`
+   - `timestamp`
+3. VERITAS が `evaluate_rsa_sandbox_signal()` で payload を受け取る。
+4. VERITAS は以下を返す。
+   - `veritas_decision`
+   - `audit_entry`
+5. デモ出力は以下を示す。
+   - `continuation_decision`
+   - `reason_code`
+   - `sandbox_commit_state`
+   - 上流生フィールドの REDACTED 表示
+   - timestamp の保持
+   - 監査ナラティブ
+
+## 5. 入力 payload
+
+```json
+{
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "timestamp": "2026-10-25T09:15:30Z"
+}
+```
+
+## 6. 期待される VERITAS 出力
+
+期待されるサンドボックス出力値:
+- `continuation_decision`: `PAUSE_FOR_HUMAN_REVIEW`
+- `reason_code`: `UPSTREAM_INCOMPLETE_KYC_CONTEXT`
+- `authority_evidence_status`: `INSUFFICIENT`
+- `sandbox_bind_boundary_state`: `NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE`
+- `sandbox_commit_state`: `SUSPENDED_NOT_COMMITTED`
+- `required_next_action`: `REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW`
+- `original_llm_intent`: `[REDACTED]`
+- `rsa_action_taken`: `[REDACTED]`
+
+## 7. 監査動作
+
+監査エントリは次を満たすこと。
+- 上流 `timestamp` を受信値そのまま保持すること
+- 追加の authority evidence が不足しているため継続を一時停止した事実を記録すること
+- 上流の不完全 KYC コンテキストと下流サスペンド判断の関係を簡潔に記述すること
+- 上流の生 intent/action は既定で REDACTED を維持すること
+
+## 8. セキュリティ制約
+
+- 本デモは sandbox-only です。
+- 本デモは本番 AML/KYC コンプライアンスロジックではありません。
+- 本デモは規制当局の承認を意味しません。
+- 本デモは第三者認証を意味しません。
+- 本デモは法的助言ではありません。
+- 上流の生フィールドは既定で redacted のままにする必要があります。
+- 実在の顧客データ、金融データ、医療データ、KYC データ、その他規制対象データを使用してはいけません。
+- Vikki の RSA 内部ロジックは外部のまま維持します。
+- VERITAS のコアガバナンスロジックは分離を維持します。
+- 所有権・クレジット・商用利用を明記した別途書面合意なしに、商用／顧客向けデモを実施してはいけません。
+
+## 9. このデモの対象外
+
+本計画の対象外:
+- 実運用 RSA ラッパー接続と通信ハードニング
+- 本番の bind/admissibility を含むガバナンス判断
+- コンプライアンス／法務／規制解釈
+- 顧客向け運用フローや商用パッケージ化
+- サンドボックス検証を超えるリリース準備完了主張
+
+## 10. 次の実装ステップ
+
+本番ランタイム挙動を変更せず、静的 payload を `evaluate_rsa_sandbox_signal()` に投入して、上記のサンドボックス判断値と監査出力形状のみを確認する薄いサンドボックスハーネス呼び出しを別PRで実装します（このPRでは実装しません）。

--- a/docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md
+++ b/docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md
@@ -1,6 +1,8 @@
 # RSA ↔ VERITAS E2E サンドボックスデモ計画
 
-> 英語正本（EN）: [RSA ↔ VERITAS End-to-End Sandbox Demo Plan](../../en/guides/rsa-veritas-e2e-sandbox-demo-plan.md)
+## 英語正本
+
+- [RSA ↔ VERITAS End-to-End Sandbox Demo Plan](../../en/guides/rsa-veritas-e2e-sandbox-demo-plan.md)
 
 ## 1. 目的
 
@@ -62,15 +64,33 @@
 
 ## 6. 期待される VERITAS 出力
 
-期待されるサンドボックス出力値:
-- `continuation_decision`: `PAUSE_FOR_HUMAN_REVIEW`
-- `reason_code`: `UPSTREAM_INCOMPLETE_KYC_CONTEXT`
-- `authority_evidence_status`: `INSUFFICIENT`
-- `sandbox_bind_boundary_state`: `NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE`
-- `sandbox_commit_state`: `SUSPENDED_NOT_COMMITTED`
-- `required_next_action`: `REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW`
-- `original_llm_intent`: `[REDACTED]`
-- `rsa_action_taken`: `[REDACTED]`
+期待されるサンドボックスレスポンス形状:
+
+```json
+{
+  "veritas_decision": {
+    "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+    "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+    "authority_evidence_status": "INSUFFICIENT",
+    "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+    "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+    "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+  },
+  "audit_entry": {
+    "upstream_signal_source": "RSA",
+    "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+    "trigger_source": "SRC_Incomplete_Context",
+    "original_llm_intent": "[REDACTED]",
+    "rsa_action_taken": "[REDACTED]",
+    "veritas_reason": "The workflow cannot continue toward final commit because required KYC context is incomplete and authority evidence is insufficient.",
+    "timestamp": "2026-10-25T09:15:30Z",
+    "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+    "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+  }
+}
+```
+
+これは sandbox 用の期待レスポンス形状であり、本番 BindReceipt や本番コンプライアンス出力ではありません。
 
 ## 7. 監査動作
 


### PR DESCRIPTION
### Motivation

- Define a minimal, documentation-only end-to-end sandbox demo plan for the RSA ↔ VERITAS integration to validate interface compatibility and downstream continuation/audit behavior without touching production runtime logic. 
- Preserve strict sandbox boundaries so RSA remains an external upstream signal source and VERITAS only performs downstream decisioning and audit entry creation. 
- Provide both English and Japanese guidance to ensure the plan is accessible to cross-functional teams. 

### Description

- Add `docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md` containing purpose, non-goals, boundary rules, demo flow, example input payload, expected VERITAS sandbox outputs, audit behavior, security constraints, out-of-scope items, and next steps. 
- Add `docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md` as a Japanese translation of the same plan with a link to the English original. 
- Specify a concrete static JSON payload and the exact expected sandbox response shape including redaction expectations and timestamp preservation. 
- Recommend the next implementation step to feed the static payload into `evaluate_rsa_sandbox_signal()` via a thin sandbox harness without changing production runtime behavior. 

### Testing

- This is a docs-only change so no new automated tests were added or modified. 
- Existing CI/Tier-1 coverage referenced by the plan is unchanged and unaffected by these documentation additions. 
- No automated test runs were required specifically for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a066f6a9db083268ce5ccb50dd87db4)