### PR TITLE
Add sandbox-only RSA↔VERITAS thin E2E harness and test

### DIFF
--- a/examples/sandbox/rsa_veritas_e2e_harness.py
+++ b/examples/sandbox/rsa_veritas_e2e_harness.py
@@ -1,0 +1,49 @@
+"""Thin sandbox-only RSA ↔ VERITAS end-to-end harness.
+
+This harness is for deterministic sandbox demonstration only.
+It is not a production AML/KYC compliance implementation, not regulatory
+approval evidence, not third-party certification, and not legal advice.
+No real regulated data is used.
+
+RSA remains external upstream context; VERITAS core governance remains
+separate and only consumes the static payload to produce downstream
+continuation and audit output.
+"""
+
+from __future__ import annotations
+
+import json
+
+from veritas_os.governance.rsa_sandbox_receiver import (
+    RSASandboxPayload,
+    evaluate_rsa_sandbox_signal,
+)
+
+
+def run_rsa_veritas_e2e_harness() -> dict[str, dict[str, str]]:
+    """Run the documented static-payload sandbox flow and return deterministic output."""
+    payload_dict = {
+        "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+        "trigger_source": "SRC_Incomplete_Context",
+        "original_llm_intent": "Recommend_Transaction_Approval",
+        "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+        "timestamp": "2026-10-25T09:15:30Z",
+    }
+
+    payload = RSASandboxPayload(**payload_dict)
+    result = evaluate_rsa_sandbox_signal(payload)
+
+    return {
+        "veritas_decision": result["veritas_decision"],
+        "audit_entry": result["audit_entry"],
+    }
+
+
+if __name__ == "__main__":
+    print(
+        json.dumps(
+            run_rsa_veritas_e2e_harness(),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )

--- a/tests/governance/test_rsa_veritas_e2e_harness.py
+++ b/tests/governance/test_rsa_veritas_e2e_harness.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from examples.sandbox.rsa_veritas_e2e_harness import run_rsa_veritas_e2e_harness
+
+
+def test_rsa_veritas_e2e_harness_returns_expected_sandbox_contract() -> None:
+    result = run_rsa_veritas_e2e_harness()
+
+    assert result["veritas_decision"]["continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["veritas_decision"]["reason_code"] == "UPSTREAM_INCOMPLETE_KYC_CONTEXT"
+    assert result["veritas_decision"]["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert result["audit_entry"]["original_llm_intent"] == "[REDACTED]"
+    assert result["audit_entry"]["rsa_action_taken"] == "[REDACTED]"
+    assert result["audit_entry"]["timestamp"] == "2026-10-25T09:15:30Z"
+    assert result["audit_entry"]["veritas_continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["audit_entry"]["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"


### PR DESCRIPTION
### Motivation
- Provide a minimal, sandbox-only example demonstrating the documented RSA → VERITAS E2E flow that constructs an `RSASandboxPayload` from static JSON, calls `evaluate_rsa_sandbox_signal(payload)`, and surfaces the deterministic downstream decision/audit shape for reviewers.
- This is intentionally sandbox-scoped and includes a security reminder that raw upstream fields are redacted by default and that this change makes no production governance, compliance, or external RSA integration changes.

### Description
- Add `examples/sandbox/rsa_veritas_e2e_harness.py` which defines the requested static payload, constructs `RSASandboxPayload(**payload_dict)`, calls `evaluate_rsa_sandbox_signal(payload)`, and returns/prints a deterministic JSON containing only `veritas_decision` and `audit_entry`; code is PEP8-conformant and includes the required docstring warnings about non-production use.  
- Add `tests/governance/test_rsa_veritas_e2e_harness.py` which imports the harness and asserts the exact sandbox contract values including default redaction of upstream raw fields (`original_llm_intent` and `rsa_action_taken`).

### Testing
- Ran `pytest tests/governance/test_rsa_sandbox_receiver.py tests/governance/test_rsa_veritas_e2e_harness.py` and `PYENV_VERSION=3.12.13 python -m pytest tests/governance/test_rsa_sandbox_receiver.py tests/governance/test_rsa_veritas_e2e_harness.py` in the container, but test collection failed due to a missing dependency (`yaml` / PyYAML) causing import errors.  
- No tests in this environment succeeded because of the dependency/pyenv issues; the new harness unit test is deterministic and should pass once the test environment has PyYAML available and standard interpreter selection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069f13f2648326b2f60b4a22bd3317)