### PR TITLE
ci: lock RSA↔VERITAS thin E2E harness into governance-backend-fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,6 +310,7 @@ jobs:
             veritas_os/tests/test_governance_artifact_signing.py::TestGovernedRollback \
             veritas_os/tests/test_governance_artifact_signing.py::TestGovernanceHistoryDigests \
             tests/governance/test_rsa_sandbox_receiver.py \
+            tests/governance/test_rsa_veritas_e2e_harness.py \
             --tb=short \
             --durations=20 \
             --junitxml=test-reports/governance-backend-fast.xml


### PR DESCRIPTION
### Motivation
- Ensure the newly merged RSA ↔ VERITAS thin E2E harness test is enforced by Tier 1 CI by explicitly adding it to the `governance-backend-fast` job so coverage cannot regress.

### Description
- Add `tests/governance/test_rsa_veritas_e2e_harness.py` to the pytest invocation in `.github/workflows/main.yml` immediately next to `tests/governance/test_rsa_sandbox_receiver.py`, with no changes to dependency install paths, runtime code, harness logic, or RSA sandbox behavior.

### Testing
- No local automated tests were executed for this YAML-only change; the updated `governance-backend-fast` GitHub Actions job will run and report the result for the newly included test when the PR is validated in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a4296fd08326a61cf4efe98bddb7)