### PR TITLE
Add release evidence package preparation and checksums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST_MARKEXPR ?= not slow
 COVERAGE_XML ?= coverage.xml
 COVERAGE_HTML_DIR ?= coverage-html
 
-.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report validate-staged-report-with-subreports db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence check-trustlog-production-posture prepare-release-evidence-handoff prepare-release-evidence-manifest
+.PHONY: setup dev dev-frontend dev-all up down logs health clean-venv test test-cov test-split test-production test-smoke check-bilingual-docs quality-checks verify verify-backend verify-frontend validate validate-compose validate-compose-report validate-live validate-live-report validate-postgresql-live validate-live-postgresql validate-staged-report validate-staged-report-with-subreports db-upgrade db-downgrade db-downgrade-base db-current db-history db-revision bind-coverage-evidence check-bind-coverage-evidence performance-evidence check-performance-evidence check-trustlog-production-posture prepare-release-evidence-handoff prepare-release-evidence-manifest prepare-release-evidence-checksums prepare-release-evidence-package
 
 # ── Setup & Development ──────────────────────────────────────────────────
 
@@ -318,3 +318,18 @@ prepare-release-evidence-manifest:
 	@mkdir -p release-artifacts
 	@cp docs/en/validation/release-evidence-manifest-template.md release-artifacts/release-evidence-manifest.md
 	@echo "[veritas] Wrote release-artifacts/release-evidence-manifest.md"
+
+prepare-release-evidence-checksums:
+	@echo "[veritas] Writing release evidence checksums..."
+	@mkdir -p release-artifacts
+	@python scripts/release/write_release_evidence_checksums.py --artifacts-dir release-artifacts --output release-artifacts/release-evidence-checksums.sha256
+	@echo "[veritas] Wrote release-artifacts/release-evidence-checksums.sha256"
+
+
+prepare-release-evidence-package:
+	@echo "[veritas] Preparing no-subreport release evidence package..."
+	@$(MAKE) validate-staged-report
+	@$(MAKE) prepare-release-evidence-handoff
+	@$(MAKE) prepare-release-evidence-manifest
+	@$(MAKE) prepare-release-evidence-checksums
+	@echo "[veritas] Release evidence package prepared in release-artifacts/"

--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -86,7 +86,8 @@ Key reviewer concepts:
 - [Operational Readiness Runbook](en/operations/operational-readiness-runbook.md)
 - [Production Validation](en/validation/production-validation.md)
 - [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md)
-- Release evidence Make targets: `make validate-staged-report`, `make validate-staged-report-with-subreports`, `make prepare-release-evidence-handoff`, and `make prepare-release-evidence-manifest`
+- Checksums file path: `release-artifacts/release-evidence-checksums.sha256`
+- Release evidence Make targets: `make validate-staged-report`, `make validate-staged-report-with-subreports`, `make prepare-release-evidence-handoff`, `make prepare-release-evidence-manifest`, `make prepare-release-evidence-checksums`, and `make prepare-release-evidence-package`
 - [Provider Support Matrix](en/operations/provider-support-matrix.md)
 - [Type Safety Baseline](en/operations/type-safety-baseline.md)
 - [Maintainer Handoff Runbook](en/operations/maintainer-handoff.md)
@@ -121,6 +122,8 @@ make validate-staged-report
 make -n validate-staged-report-with-subreports
 make prepare-release-evidence-handoff
 make prepare-release-evidence-manifest
+make prepare-release-evidence-package
+make prepare-release-evidence-checksums
 ```
 
 One-Day PoC command examples (API server required, API key required):
@@ -135,7 +138,7 @@ Use the Operator Runbook to collect and organize evidence.
 Use the Reviewer Handoff Template to summarize and submit the PoC outcome.
 These documents do not create a production SLA, third-party certification, customer-environment measurement, or EU AI Act certification.
 
-For release evidence review, inspect the staged readiness report path. `make validate-staged-report` generates the no-subreport staged report. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so reviewers can use `make -n validate-staged-report-with-subreports` to inspect the command sequence safely. Run `make prepare-release-evidence-handoff` to prepare `release-artifacts/release-evidence-reviewer-handoff.md` from the reviewer handoff template for submission.
+For release evidence review, inspect the staged readiness report path. `make validate-staged-report` generates the no-subreport staged report. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so reviewers can use `make -n validate-staged-report-with-subreports` to inspect the command sequence safely. Run `make prepare-release-evidence-package` for one-command no-subreport package preparation, and `make prepare-release-evidence-checksums` when you need to refresh `release-artifacts/release-evidence-checksums.sha256`.
 
 Boundary notes for PoC commands:
 

--- a/docs/en/operations/operational-readiness-runbook.md
+++ b/docs/en/operations/operational-readiness-runbook.md
@@ -21,6 +21,8 @@ simulated, and what requires environment-specific confirmation.
 | `make validate-staged-report-with-subreports` | Staged readiness report with compose/live subreports (secrets-required for live checks) | Release evidence report with attached subreports |
 | `make prepare-release-evidence-handoff` | Prepare `release-artifacts/release-evidence-reviewer-handoff.md` | Reviewer handoff preparation |
 | `make prepare-release-evidence-manifest` | Prepare `release-artifacts/release-evidence-manifest.md` | Release evidence package index |
+| `make prepare-release-evidence-checksums` | Prepare `release-artifacts/release-evidence-checksums.sha256` | Release evidence checksum index |
+| `make prepare-release-evidence-package` | Prepare no-subreport release evidence package | Release evidence package preparation |
 | `make quality-checks` | Architecture + security scripts | Every PR (automatic) |
 
 ## Validation Tiers
@@ -214,6 +216,10 @@ Interpretation rules:
   template into `release-artifacts/release-evidence-reviewer-handoff.md`
   before packaging release evidence.
 - Use `make prepare-release-evidence-manifest` to copy the release evidence manifest template into `release-artifacts/release-evidence-manifest.md` before packaging release evidence.
+- Use `make prepare-release-evidence-checksums` to generate `release-artifacts/release-evidence-checksums.sha256` for present release evidence artifacts.
+- Use `make prepare-release-evidence-package` to run the no-subreport package path (`validate-staged-report`, handoff, manifest, checksums) in one command.
+- Compose/live with-subreports evidence still requires separate, secrets-aware execution.
+- Checksums help detect changes in submitted files, but they are not tamper-proof storage or third-party attestation by themselves.
 - Live provider validation may require provider secrets and can fail when
   those secrets are not configured.
 - Operators may still run the generator directly when custom report paths are

--- a/docs/en/validation/release-evidence-manifest-template.md
+++ b/docs/en/validation/release-evidence-manifest-template.md
@@ -24,6 +24,8 @@ Use this template as the package index for release evidence submissions so revie
 - Environment type: local / CI / staging / customer-managed
 - Manifest status: complete / incomplete / inconclusive
 - Handoff file prepared: yes / no
+- Checksums file prepared: yes / no
+- Package prepared by one-command target: yes / no
 - Staged readiness report prepared: yes / no
 - Compose report attached: yes / no
 - Live provider report attached: yes / no
@@ -40,6 +42,7 @@ Use this template as the package index for release evidence submissions so revie
 | Staged readiness text | `release-artifacts/staged-readiness-report.txt` | present / absent | Recommended | |
 | Compose validation JSON | `release-artifacts/compose-validation-report.json` | present / absent | Conditional | Required when compose subreport is claimed attached |
 | Live provider JSON | `release-artifacts/live-provider-report.json` | present / absent | Conditional | Required when live provider subreport is claimed attached |
+| Checksums | `release-artifacts/release-evidence-checksums.sha256` | present / absent | Recommended | SHA256 checksums for present release evidence artifacts |
 | Command log |  | present / absent | Recommended | |
 | CI status / PR URL |  | present / absent | Recommended | |
 | Redaction notes |  | present / absent | Conditional | |
@@ -53,6 +56,8 @@ Use this template as the package index for release evidence submissions so revie
 - [ ] Staged readiness text present or intentionally omitted
 - [ ] Compose report attached or explicitly absent
 - [ ] Live provider report attached or explicitly absent
+- [ ] Checksums file present or intentionally omitted
+- [ ] One-command package target used or manual steps documented
 - [ ] Command log or CI reference included
 - [ ] Redaction notes included when needed
 - [ ] Missing artifacts explained
@@ -77,6 +82,7 @@ Use this template as the package index for release evidence submissions so revie
 - Handoff path: `release-artifacts/release-evidence-reviewer-handoff.md`
 - Prepare it with `make prepare-release-evidence-handoff`
 - The handoff file should be filled in before submitting the package.
+- `make prepare-release-evidence-package` prepares the no-subreport release evidence package by running staged readiness generation, handoff preparation, manifest preparation, and checksum generation. Use the with-subreports target separately when compose/live evidence is required and provider secrets are available.
 - The manifest indexes the package; the handoff records reviewer-facing interpretation and acknowledgement.
 
 ## Command log and CI references
@@ -86,6 +92,8 @@ Record command logs and CI/PR references, including at minimum:
 ```bash
 make prepare-release-evidence-manifest
 make prepare-release-evidence-handoff
+make prepare-release-evidence-package
+make prepare-release-evidence-checksums
 make validate-staged-report
 make -n validate-staged-report-with-subreports
 ```
@@ -109,6 +117,7 @@ make -n validate-staged-report-with-subreports
 
 - Do not claim production certification from this manifest.
 - Do not claim third-party certification.
+- Checksums help reviewers detect submitted file changes, but are not third-party attestation and are not tamper-proof storage by themselves.
 - Do not claim customer-environment verification unless the evidence was generated in that environment and documented.
 - Do not claim legal or regulatory approval.
 - Do not claim provider health unless live provider validation ran with required secrets and the evidence is attached.

--- a/docs/en/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/en/validation/release-evidence-reviewer-handoff-template.md
@@ -63,9 +63,11 @@ make validate-staged-report
 make -n validate-staged-report-with-subreports
 make prepare-release-evidence-handoff
 make prepare-release-evidence-manifest
+make prepare-release-evidence-checksums
+make prepare-release-evidence-package
 ```
 
-`make validate-staged-report` generates the no-subreport staged report. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so `make -n validate-staged-report-with-subreports` can be used to inspect the command sequence safely before running the secrets-required path. `make prepare-release-evidence-handoff` copies this template to `release-artifacts/release-evidence-reviewer-handoff.md` so operators can fill in the handoff file alongside generated staged readiness artifacts. `make prepare-release-evidence-manifest` copies the manifest template to `release-artifacts/release-evidence-manifest.md` so reviewers can navigate the submitted release evidence package.
+`make validate-staged-report` generates the no-subreport staged report. `make prepare-release-evidence-package` runs the no-subreport package path end-to-end, including checksum generation. `make prepare-release-evidence-checksums` can be run separately when regenerating checksums only. `make validate-staged-report-with-subreports` attaches compose/live reports but may require provider secrets, so `make -n validate-staged-report-with-subreports` can be used to inspect the command sequence safely before running the secrets-required path. `make prepare-release-evidence-handoff` copies this template to `release-artifacts/release-evidence-reviewer-handoff.md` so operators can fill in the handoff file alongside generated staged readiness artifacts. `make prepare-release-evidence-manifest` copies the manifest template to `release-artifacts/release-evidence-manifest.md` so reviewers can navigate the submitted release evidence package.
 
 ## Evidence artifacts provided
 
@@ -75,6 +77,7 @@ make prepare-release-evidence-manifest
 | Staged readiness text | `release-artifacts/staged-readiness-report.txt` | Recommended | |
 | Compose validation JSON | `release-artifacts/compose-validation-report.json` | Conditional | Required when compose subreport is claimed attached |
 | Live provider JSON | `release-artifacts/live-provider-report.json` | Conditional | Required when live provider subreport is claimed attached |
+| Checksums | `release-artifacts/release-evidence-checksums.sha256` | Recommended | SHA256 checksums for present release evidence artifacts |
 | Command log |  | Recommended | |
 | CI status / PR URL |  | Recommended | |
 | Redaction notes |  | Conditional | |

--- a/docs/ja/validation/release-evidence-manifest-template.md
+++ b/docs/ja/validation/release-evidence-manifest-template.md
@@ -16,7 +16,9 @@
 
 1. `make prepare-release-evidence-manifest` を実行し、`release-artifacts/release-evidence-manifest.md` を準備します。
 2. `make prepare-release-evidence-handoff` を実行し、`release-artifacts/release-evidence-reviewer-handoff.md` を準備します。
-3. manifest で提出物の索引を埋め、handoff file で reviewer-facing interpretation / acknowledgement を記録します。
+3. `make prepare-release-evidence-checksums` で `release-artifacts/release-evidence-checksums.sha256` を生成します。
+4. `make prepare-release-evidence-package` を使うと、no-subreport release evidence package を 1 コマンドで準備できます。
+5. manifest で提出物の索引を埋め、handoff file で reviewer-facing interpretation / acknowledgement を記録します。
 
 ## 主な提出物
 
@@ -26,6 +28,7 @@
 - `release-artifacts/staged-readiness-report.txt`
 - `release-artifacts/compose-validation-report.json`
 - `release-artifacts/live-provider-report.json`
+- `release-artifacts/release-evidence-checksums.sha256`
 
 ## compose/live artifact の確認
 
@@ -41,6 +44,8 @@
 
 - 本番認証ではない。
 - 第三者認証ではない。
+- checksum は提出ファイルの変更確認を助けるが、それ自体は第三者証明ではない。
+- checksum は提出ファイルの変更確認を助けるが、それ自体は改ざん不能保管ではない。
 - 顧客環境で実行・記録されていない限り、顧客環境検証ではない。
 
 ## 関連文書

--- a/docs/ja/validation/release-evidence-manifest-template.md
+++ b/docs/ja/validation/release-evidence-manifest-template.md
@@ -8,7 +8,7 @@
 
 ## 目的
 
-- manifest は release evidence package の索引です。
+- manifest はリリース証跡パッケージの索引です。
 - 提出物の存在/未存在、必須/条件付き項目、確認境界を 1 枚で共有します。
 - 本番認証ではない境界を明示します。
 
@@ -17,7 +17,7 @@
 1. `make prepare-release-evidence-manifest` を実行し、`release-artifacts/release-evidence-manifest.md` を準備します。
 2. `make prepare-release-evidence-handoff` を実行し、`release-artifacts/release-evidence-reviewer-handoff.md` を準備します。
 3. `make prepare-release-evidence-checksums` で `release-artifacts/release-evidence-checksums.sha256` を生成します。
-4. `make prepare-release-evidence-package` を使うと、no-subreport release evidence package を 1 コマンドで準備できます。
+4. `make prepare-release-evidence-package` を使うと、サブレポートなしのリリース証跡パッケージを 1 コマンドで準備できます。
 5. manifest で提出物の索引を埋め、handoff file で reviewer-facing interpretation / acknowledgement を記録します。
 
 ## 主な提出物

--- a/docs/ja/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/ja/validation/release-evidence-reviewer-handoff-template.md
@@ -22,7 +22,9 @@
 4. 必要に応じて redaction 方針と実行環境（local / CI / staging / customer-managed）を追記します。
 5. `make prepare-release-evidence-handoff` を実行すると、英語正本テンプレートを `release-artifacts/release-evidence-reviewer-handoff.md` にコピーできます。
 6. `make prepare-release-evidence-manifest` で `release-artifacts/release-evidence-manifest.md` を準備できます。
-7. manifest は提出パッケージの索引、handoff は解釈・確認・acknowledgement の記録です。
+7. `make prepare-release-evidence-checksums` で `release-artifacts/release-evidence-checksums.sha256` を準備できます。
+8. `make prepare-release-evidence-package` で no-subreport package preparation を 1 コマンドで実行できます。
+9. manifest は提出パッケージの索引、handoff は解釈・確認・acknowledgement の記録です。
 8. `release-artifacts/release-evidence-reviewer-handoff.md` を、staged readiness report などの生成済み証跡と一緒に記入・提出します。
 
 ## 提出する主な証跡
@@ -32,6 +34,7 @@
 - `release-artifacts/compose-validation-report.json`（compose subreport を添付した場合）
 - `release-artifacts/live-provider-report.json`（live provider subreport を添付した場合）
 - 実行コマンドログ、CI 状態、PR URL、レビューノート
+- `release-artifacts/release-evidence-checksums.sha256`
 
 ## `deployment_ready` の読み方
 

--- a/docs/ja/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/ja/validation/release-evidence-reviewer-handoff-template.md
@@ -23,7 +23,7 @@
 5. `make prepare-release-evidence-handoff` を実行すると、英語正本テンプレートを `release-artifacts/release-evidence-reviewer-handoff.md` にコピーできます。
 6. `make prepare-release-evidence-manifest` で `release-artifacts/release-evidence-manifest.md` を準備できます。
 7. `make prepare-release-evidence-checksums` で `release-artifacts/release-evidence-checksums.sha256` を準備できます。
-8. `make prepare-release-evidence-package` で no-subreport package preparation を 1 コマンドで実行できます。
+8. `make prepare-release-evidence-package` で、サブレポートなしのリリース証跡パッケージ準備を 1 コマンドで実行できます。
 9. manifest は提出パッケージの索引、handoff は解釈・確認・acknowledgement の記録です。
 10. `release-artifacts/release-evidence-reviewer-handoff.md` を、staged readiness report などの生成済み証跡と一緒に記入・提出します。
 

--- a/docs/ja/validation/release-evidence-reviewer-handoff-template.md
+++ b/docs/ja/validation/release-evidence-reviewer-handoff-template.md
@@ -25,7 +25,7 @@
 7. `make prepare-release-evidence-checksums` で `release-artifacts/release-evidence-checksums.sha256` を準備できます。
 8. `make prepare-release-evidence-package` で no-subreport package preparation を 1 コマンドで実行できます。
 9. manifest は提出パッケージの索引、handoff は解釈・確認・acknowledgement の記録です。
-8. `release-artifacts/release-evidence-reviewer-handoff.md` を、staged readiness report などの生成済み証跡と一緒に記入・提出します。
+10. `release-artifacts/release-evidence-reviewer-handoff.md` を、staged readiness report などの生成済み証跡と一緒に記入・提出します。
 
 ## 提出する主な証跡
 

--- a/scripts/release/write_release_evidence_checksums.py
+++ b/scripts/release/write_release_evidence_checksums.py
@@ -1,0 +1,78 @@
+"""Write SHA256 checksums for present release evidence artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+EXPECTED_ARTIFACTS = [
+    "release-evidence-manifest.md",
+    "release-evidence-reviewer-handoff.md",
+    "staged-readiness-report.json",
+    "staged-readiness-report.txt",
+    "compose-validation-report.json",
+    "live-provider-report.json",
+]
+
+
+def _sha256_hex(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def write_release_evidence_checksums(artifacts_dir: Path, output: Path) -> int:
+    """Write checksums for present expected artifacts and return count."""
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+    count = 0
+
+    for artifact_name in EXPECTED_ARTIFACTS:
+        artifact_path = artifacts_dir / artifact_name
+        if not artifact_path.exists() or artifact_path.resolve() == output.resolve():
+            continue
+        digest = _sha256_hex(artifact_path)
+        lines.append(f"{digest}  {artifact_path.as_posix()}")
+        count += 1
+
+    output.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    print(f"Wrote {count} checksums to {output.as_posix()}")
+    return count
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Write checksums for present release evidence artifacts."
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        default=Path("release-artifacts"),
+        help="Directory containing release artifacts (default: release-artifacts)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("release-artifacts/release-evidence-checksums.sha256"),
+        help=(
+            "Output checksum file "
+            "(default: release-artifacts/release-evidence-checksums.sha256)"
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    args = parse_args()
+    write_release_evidence_checksums(args.artifacts_dir, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/write_release_evidence_checksums.py
+++ b/scripts/release/write_release_evidence_checksums.py
@@ -24,13 +24,27 @@ def _sha256_hex(path: Path) -> str:
     return hasher.hexdigest()
 
 
-def _display_path(artifacts_dir: Path, artifact_name: str) -> str:
+def _display_artifacts_dir(artifacts_dir: Path) -> Path:
+    """Return a portable display directory for checksum entries."""
+    if artifacts_dir.is_absolute():
+        return Path(artifacts_dir.name)
+
+    normalized_parts = [part for part in artifacts_dir.parts if part not in ("", ".")]
+    if not normalized_parts:
+        return Path("release-artifacts")
+    return Path(*normalized_parts)
+
+
+def _display_path(display_artifacts_dir: Path, artifact_name: str) -> str:
     """Return a portable checksum display path for an artifact."""
-    return (Path(artifacts_dir.name) / artifact_name).as_posix()
+    return (display_artifacts_dir / artifact_name).as_posix()
 
 
 def write_release_evidence_checksums(artifacts_dir: Path, output: Path) -> int:
     """Write checksums for present expected artifacts and return count."""
+    raw_artifacts_dir = artifacts_dir
+    display_artifacts_dir = _display_artifacts_dir(raw_artifacts_dir)
+
     artifacts_dir = artifacts_dir.resolve()
     output = output.resolve()
 
@@ -45,7 +59,7 @@ def write_release_evidence_checksums(artifacts_dir: Path, output: Path) -> int:
         if not artifact_path.exists() or artifact_path.resolve() == output.resolve():
             continue
         digest = _sha256_hex(artifact_path)
-        lines.append(f"{digest}  {_display_path(artifacts_dir, artifact_name)}")
+        lines.append(f"{digest}  {_display_path(display_artifacts_dir, artifact_name)}")
         count += 1
 
     output.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")

--- a/scripts/release/write_release_evidence_checksums.py
+++ b/scripts/release/write_release_evidence_checksums.py
@@ -24,8 +24,16 @@ def _sha256_hex(path: Path) -> str:
     return hasher.hexdigest()
 
 
+def _display_path(artifacts_dir: Path, artifact_name: str) -> str:
+    """Return a portable checksum display path for an artifact."""
+    return (Path(artifacts_dir.name) / artifact_name).as_posix()
+
+
 def write_release_evidence_checksums(artifacts_dir: Path, output: Path) -> int:
     """Write checksums for present expected artifacts and return count."""
+    artifacts_dir = artifacts_dir.resolve()
+    output = output.resolve()
+
     artifacts_dir.mkdir(parents=True, exist_ok=True)
     output.parent.mkdir(parents=True, exist_ok=True)
 
@@ -37,7 +45,7 @@ def write_release_evidence_checksums(artifacts_dir: Path, output: Path) -> int:
         if not artifact_path.exists() or artifact_path.resolve() == output.resolve():
             continue
         digest = _sha256_hex(artifact_path)
-        lines.append(f"{digest}  {artifact_path.as_posix()}")
+        lines.append(f"{digest}  {_display_path(artifacts_dir, artifact_name)}")
         count += 1
 
     output.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")

--- a/veritas_os/tests/test_release_evidence_checksums.py
+++ b/veritas_os/tests/test_release_evidence_checksums.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import subprocess
+import sys
 from pathlib import Path
 
 SCRIPT_RELATIVE_PATH = Path("scripts/release/write_release_evidence_checksums.py")
@@ -21,7 +22,7 @@ EXPECTED_ORDER = [
 
 def _run_script(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["python", str(SCRIPT_PATH), *args],
+        [sys.executable, str(SCRIPT_PATH), *args],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -126,3 +127,31 @@ def test_write_release_evidence_checksums_cli_defaults(tmp_path: Path) -> None:
     result = _run_script(tmp_path)
     assert result.returncode == 0, result.stdout + result.stderr
     assert (artifacts_dir / "release-evidence-checksums.sha256").exists()
+
+
+def test_write_release_evidence_checksums_emits_relative_paths_for_absolute_artifacts_dir(
+    tmp_path: Path,
+) -> None:
+    artifacts_dir = tmp_path / "release-artifacts"
+    artifacts_dir.mkdir()
+    artifact = artifacts_dir / "staged-readiness-report.json"
+    artifact.write_text("json", encoding="utf-8")
+    output_file = artifacts_dir / "release-evidence-checksums.sha256"
+
+    result = _run_script(
+        tmp_path,
+        "--artifacts-dir",
+        str(artifacts_dir),
+        "--output",
+        str(output_file),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    rows = _parse_output_lines(output_file)
+    assert rows == [
+        (
+            hashlib.sha256(artifact.read_bytes()).hexdigest(),
+            "release-artifacts/staged-readiness-report.json",
+        )
+    ]
+    assert str(tmp_path) not in output_file.read_text(encoding="utf-8")

--- a/veritas_os/tests/test_release_evidence_checksums.py
+++ b/veritas_os/tests/test_release_evidence_checksums.py
@@ -1,0 +1,128 @@
+"""Tests for release evidence checksum writer."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+SCRIPT_RELATIVE_PATH = Path("scripts/release/write_release_evidence_checksums.py")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / SCRIPT_RELATIVE_PATH
+EXPECTED_ORDER = [
+    "release-evidence-manifest.md",
+    "release-evidence-reviewer-handoff.md",
+    "staged-readiness-report.json",
+    "staged-readiness-report.txt",
+    "compose-validation-report.json",
+    "live-provider-report.json",
+]
+
+
+def _run_script(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python", str(SCRIPT_PATH), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _parse_output_lines(checksum_file: Path) -> list[tuple[str, str]]:
+    lines = checksum_file.read_text(encoding="utf-8").splitlines()
+    pairs: list[tuple[str, str]] = []
+    for line in lines:
+        checksum, rel_path = line.split("  ", 1)
+        pairs.append((checksum, rel_path))
+    return pairs
+
+
+def test_write_release_evidence_checksums_writes_present_artifacts(
+    tmp_path: Path,
+) -> None:
+    artifacts_dir = tmp_path / "release-artifacts"
+    artifacts_dir.mkdir()
+
+    files = {
+        "staged-readiness-report.json": "json-body",
+        "release-evidence-manifest.md": "manifest",
+        "release-evidence-reviewer-handoff.md": "handoff",
+    }
+    for name, content in files.items():
+        (artifacts_dir / name).write_text(content, encoding="utf-8")
+
+    output_file = artifacts_dir / "release-evidence-checksums.sha256"
+    result = _run_script(
+        tmp_path,
+        "--artifacts-dir",
+        "release-artifacts",
+        "--output",
+        "release-artifacts/release-evidence-checksums.sha256",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output_file.exists()
+
+    rows = _parse_output_lines(output_file)
+    expected_names = [
+        name for name in EXPECTED_ORDER if (artifacts_dir / name).exists()
+    ]
+    assert [Path(path).name for _, path in rows] == expected_names
+
+    for checksum, rel_path in rows:
+        path = tmp_path / rel_path
+        expected_checksum = hashlib.sha256(path.read_bytes()).hexdigest()
+        assert checksum == expected_checksum
+
+    assert all(Path(path).name != output_file.name for _, path in rows)
+
+
+def test_write_release_evidence_checksums_skips_missing_artifacts(
+    tmp_path: Path,
+) -> None:
+    artifacts_dir = tmp_path / "release-artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "staged-readiness-report.txt").write_text("txt", encoding="utf-8")
+
+    output_file = artifacts_dir / "release-evidence-checksums.sha256"
+    result = _run_script(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    rows = _parse_output_lines(output_file)
+    assert len(rows) == 1
+    assert rows[0][1] == "release-artifacts/staged-readiness-report.txt"
+
+
+def test_write_release_evidence_checksums_is_deterministic(tmp_path: Path) -> None:
+    artifacts_dir = tmp_path / "release-artifacts"
+    artifacts_dir.mkdir()
+    for name in [
+        "release-evidence-manifest.md",
+        "staged-readiness-report.json",
+        "compose-validation-report.json",
+    ]:
+        (artifacts_dir / name).write_text(name, encoding="utf-8")
+
+    output_file = artifacts_dir / "release-evidence-checksums.sha256"
+    first = _run_script(tmp_path)
+    assert first.returncode == 0, first.stdout + first.stderr
+    first_contents = output_file.read_text(encoding="utf-8")
+
+    second = _run_script(tmp_path)
+    assert second.returncode == 0, second.stdout + second.stderr
+    second_contents = output_file.read_text(encoding="utf-8")
+
+    assert first_contents == second_contents
+
+
+def test_write_release_evidence_checksums_cli_defaults(tmp_path: Path) -> None:
+    artifacts_dir = tmp_path / "release-artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "release-evidence-manifest.md").write_text(
+        "manifest", encoding="utf-8"
+    )
+
+    result = _run_script(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (artifacts_dir / "release-evidence-checksums.sha256").exists()

--- a/veritas_os/tests/test_release_evidence_checksums.py
+++ b/veritas_os/tests/test_release_evidence_checksums.py
@@ -155,3 +155,30 @@ def test_write_release_evidence_checksums_emits_relative_paths_for_absolute_arti
         )
     ]
     assert str(tmp_path) not in output_file.read_text(encoding="utf-8")
+
+
+def test_write_release_evidence_checksums_preserves_relative_artifacts_dir_parent_components(
+    tmp_path: Path,
+) -> None:
+    artifacts_dir = tmp_path / "out" / "release-artifacts"
+    artifacts_dir.mkdir(parents=True)
+    artifact = artifacts_dir / "staged-readiness-report.json"
+    artifact.write_text("json", encoding="utf-8")
+    output_file = artifacts_dir / "release-evidence-checksums.sha256"
+
+    result = _run_script(
+        tmp_path,
+        "--artifacts-dir",
+        "out/release-artifacts",
+        "--output",
+        "out/release-artifacts/release-evidence-checksums.sha256",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    rows = _parse_output_lines(output_file)
+    assert rows == [
+        (
+            hashlib.sha256(artifact.read_bytes()).hexdigest(),
+            "out/release-artifacts/staged-readiness-report.json",
+        )
+    ]

--- a/veritas_os/tests/test_release_evidence_manifest_template_docs.py
+++ b/veritas_os/tests/test_release_evidence_manifest_template_docs.py
@@ -55,15 +55,12 @@ def test_release_evidence_manifest_en_has_required_sections_and_content() -> Non
         "release-artifacts/staged-readiness-report.txt",
         "release-artifacts/compose-validation-report.json",
         "release-artifacts/live-provider-report.json",
-        "release-artifacts/release-evidence-checksums.sha256",
     ]:
         assert artifact in text
 
     for command in [
         "make prepare-release-evidence-manifest",
         "make prepare-release-evidence-handoff",
-        "make prepare-release-evidence-checksums",
-        "make prepare-release-evidence-package",
         "make prepare-release-evidence-checksums",
         "make prepare-release-evidence-package",
         "make validate-staged-report",

--- a/veritas_os/tests/test_release_evidence_manifest_template_docs.py
+++ b/veritas_os/tests/test_release_evidence_manifest_template_docs.py
@@ -50,16 +50,22 @@ def test_release_evidence_manifest_en_has_required_sections_and_content() -> Non
     for artifact in [
         "release-artifacts/release-evidence-manifest.md",
         "release-artifacts/release-evidence-reviewer-handoff.md",
+        "release-artifacts/release-evidence-checksums.sha256",
         "release-artifacts/staged-readiness-report.json",
         "release-artifacts/staged-readiness-report.txt",
         "release-artifacts/compose-validation-report.json",
         "release-artifacts/live-provider-report.json",
+        "release-artifacts/release-evidence-checksums.sha256",
     ]:
         assert artifact in text
 
     for command in [
         "make prepare-release-evidence-manifest",
         "make prepare-release-evidence-handoff",
+        "make prepare-release-evidence-checksums",
+        "make prepare-release-evidence-package",
+        "make prepare-release-evidence-checksums",
+        "make prepare-release-evidence-package",
         "make validate-staged-report",
         "make -n validate-staged-report-with-subreports",
     ]:
@@ -71,6 +77,8 @@ def test_release_evidence_manifest_boundary_phrases_and_banned_phrases() -> None
     for phrase in [
         "not production certification",
         "not third-party certification",
+        "not third-party attestation",
+        "not tamper-proof storage",
         "not customer-environment verification",
         "deployment_ready=true",
         "absent compose/live artifacts",
@@ -98,9 +106,14 @@ def test_release_evidence_manifest_ja_required_content_and_banned_phrases() -> N
         "make prepare-release-evidence-manifest",
         "release-artifacts/release-evidence-manifest.md",
         "make prepare-release-evidence-handoff",
+        "make prepare-release-evidence-checksums",
+        "make prepare-release-evidence-package",
         "release-artifacts/release-evidence-reviewer-handoff.md",
+        "release-artifacts/release-evidence-checksums.sha256",
         "本番認証ではない",
         "第三者認証ではない",
+        "第三者証明ではない",
+        "改ざん不能保管ではない",
         "顧客環境検証ではない",
     ]:
         assert phrase in text

--- a/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
+++ b/veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py
@@ -73,6 +73,7 @@ def test_release_evidence_handoff_template_has_required_artifact_paths() -> None
         "release-artifacts/staged-readiness-report.txt",
         "release-artifacts/compose-validation-report.json",
         "release-artifacts/live-provider-report.json",
+        "release-artifacts/release-evidence-checksums.sha256",
     ]:
         assert artifact in text
 

--- a/veritas_os/tests/test_staged_readiness_make_targets.py
+++ b/veritas_os/tests/test_staged_readiness_make_targets.py
@@ -142,6 +142,8 @@ def test_staged_readiness_make_targets_are_phony() -> None:
     assert "validate-staged-report-with-subreports" in phony_tokens
     assert "prepare-release-evidence-handoff" in phony_tokens
     assert "prepare-release-evidence-manifest" in phony_tokens
+    assert "prepare-release-evidence-checksums" in phony_tokens
+    assert "prepare-release-evidence-package" in phony_tokens
 
 
 def test_docs_reference_staged_readiness_make_targets() -> None:
@@ -173,3 +175,31 @@ def test_docs_reference_release_evidence_handoff_make_target() -> None:
         text = path.read_text(encoding="utf-8")
         assert _mentions_make_command(text, "prepare-release-evidence-handoff")
         assert _mentions_make_command(text, "prepare-release-evidence-manifest")
+        assert _mentions_make_command(text, "prepare-release-evidence-checksums")
+        assert _mentions_make_command(text, "prepare-release-evidence-package")
+
+
+def test_prepare_release_evidence_checksums_dry_run_writes_checksum_file() -> None:
+    """Checksums target should call checksum writer script."""
+    output = _run_make_dry_run("prepare-release-evidence-checksums")
+
+    assert "mkdir -p release-artifacts" in output
+    assert (
+        "python scripts/release/write_release_evidence_checksums.py "
+        "--artifacts-dir release-artifacts "
+        "--output release-artifacts/release-evidence-checksums.sha256"
+    ) in output
+    assert "Wrote release-artifacts/release-evidence-checksums.sha256" in output
+
+
+def test_prepare_release_evidence_package_dry_run_runs_expected_steps() -> None:
+    """Package target should run no-subreport preparation steps in order."""
+    output = _run_make_dry_run("prepare-release-evidence-package")
+
+    assert "Release evidence package prepared in release-artifacts/" in output
+    validate_index = output.index("make validate-staged-report")
+    handoff_index = output.index("make prepare-release-evidence-handoff")
+    manifest_index = output.index("make prepare-release-evidence-manifest")
+    checksum_index = output.index("make prepare-release-evidence-checksums")
+
+    assert validate_index < handoff_index < manifest_index < checksum_index


### PR DESCRIPTION
### Motivation
- Provide a one-command path to prepare a no-subreport release evidence package and add checksums to help reviewers detect changes to submitted artifacts. 
- Ensure checksum generation is deterministic, only includes present artifacts, and is compatible with `sha256sum`-style tooling.

### Description
- Add Make targets `prepare-release-evidence-checksums` and `prepare-release-evidence-package` and register them in `.PHONY` so they appear in dry-run outputs; `prepare-release-evidence-package` runs `validate-staged-report`, `prepare-release-evidence-handoff`, `prepare-release-evidence-manifest`, and `prepare-release-evidence-checksums` in order. 
- Add a small utility `scripts/release/write_release_evidence_checksums.py` that writes SHA256 checksums (sha256sum-compatible lines of the form `<sha256>  <relative-path>`) for the expected artifacts present under `release-artifacts/` and writes `release-artifacts/release-evidence-checksums.sha256`. Missing artifacts are skipped and the output order is fixed. 
- Add focused unit tests `veritas_os/tests/test_release_evidence_checksums.py` and extend existing Makefile dry-run and docs contract tests (`veritas_os/tests/test_staged_readiness_make_targets.py`, `veritas_os/tests/test_release_evidence_manifest_template_docs.py`, `veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py`) to require the new targets, checksum artifact references, and non-attestation boundary wording. 
- Update docs (EN/JA) to document the new one-command package path and checksum file: `docs/en/validation/release-evidence-manifest-template.md`, `docs/ja/validation/release-evidence-manifest-template.md`, `docs/en/validation/release-evidence-reviewer-handoff-template.md`, `docs/ja/validation/release-evidence-reviewer-handoff-template.md`, `docs/en/operations/operational-readiness-runbook.md`, and `docs/REVIEWER_ENTRYPOINT.md`.

### Testing
- Ran the checksum writer unit tests: `pytest -q veritas_os/tests/test_release_evidence_checksums.py`, and they passed. 
- Ran updated Makefile dry-run and docs contract tests: `pytest -q veritas_os/tests/test_staged_readiness_make_targets.py`, `pytest -q veritas_os/tests/test_release_evidence_manifest_template_docs.py`, `pytest -q veritas_os/tests/test_release_evidence_reviewer_handoff_template_docs.py`, and `pytest -q veritas_os/tests/test_reviewer_entrypoint_current_path.py`, and they passed. 
- Ran docs consistency checks `python3 scripts/quality/check_operational_docs_consistency.py` and `python3 scripts/quality/check_bilingual_docs.py` and ran `git diff --check`, all of which completed without errors.
- No runtime, report generator, workflow, migration, health, storage, or staged-readiness/deployment_ready semantic changes were made as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cb8dd40c83268dd8719ec86e57ff)