### PR TITLE
Lazy-load PostgreSQL governance repository dependency

### DIFF
--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -1,5 +1,9 @@
 """Governance domain persistence abstractions."""
 
+from __future__ import annotations
+
+from typing import Any
+
 from veritas_os.governance.authority_evidence import (
     AuthorityEvidence,
     AuthorityEvidenceValidationResult,
@@ -39,7 +43,6 @@ from veritas_os.governance.models import (
     GovernancePolicyEventRecord,
     GovernancePolicyRecord,
 )
-from veritas_os.governance.postgresql_repository import PostgresGovernanceRepository
 from veritas_os.governance.repository import GovernanceRepository
 
 __all__ = [
@@ -72,3 +75,14 @@ __all__ = [
     "validate_governance_backend",
     "validate_runtime_authority",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve optional PostgreSQL governance repository exports."""
+    if name == "PostgresGovernanceRepository":
+        from veritas_os.governance.postgresql_repository import (
+            PostgresGovernanceRepository,
+        )
+
+        return PostgresGovernanceRepository
+    raise AttributeError(name)

--- a/veritas_os/governance/factory.py
+++ b/veritas_os/governance/factory.py
@@ -8,11 +8,24 @@ from pathlib import Path
 
 from veritas_os.governance.config import validate_governance_backend
 from veritas_os.governance.file_repository import FileGovernanceRepository
-from veritas_os.governance.postgresql_repository import PostgresGovernanceRepository
 from veritas_os.governance.repository import GovernanceRepository
 from veritas_os.observability.metrics import set_db_backend_selected
 
 logger = logging.getLogger(__name__)
+
+def _resolve_postgres_repository_class() -> type[GovernanceRepository]:
+    """Resolve PostgreSQL repository class only when backend selection requires it."""
+    try:
+        from veritas_os.governance.postgresql_repository import (
+            PostgresGovernanceRepository,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL governance backend requires the optional "
+            "postgresql dependencies. Install with `pip install 'veritas-os[postgresql]'`."
+        ) from exc
+    return PostgresGovernanceRepository
+
 
 
 def create_governance_repository(
@@ -28,7 +41,8 @@ def create_governance_repository(
     if backend == "postgresql":
         logger.info("Governance backend: postgresql")
         set_db_backend_selected("governance", "postgresql")
-        repository = PostgresGovernanceRepository()
+        repository_cls = _resolve_postgres_repository_class()
+        repository = repository_cls()
         repository.health_check()
         return repository
 

--- a/veritas_os/governance/factory.py
+++ b/veritas_os/governance/factory.py
@@ -13,6 +13,7 @@ from veritas_os.observability.metrics import set_db_backend_selected
 
 logger = logging.getLogger(__name__)
 
+
 def _resolve_postgres_repository_class() -> type[GovernanceRepository]:
     """Resolve PostgreSQL repository class only when backend selection requires it."""
     try:
@@ -41,8 +42,7 @@ def create_governance_repository(
     if backend == "postgresql":
         logger.info("Governance backend: postgresql")
         set_db_backend_selected("governance", "postgresql")
-        repository_cls = _resolve_postgres_repository_class()
-        repository = repository_cls()
+        repository = _resolve_postgres_repository_class()()
         repository.health_check()
         return repository
 

--- a/veritas_os/governance/factory.py
+++ b/veritas_os/governance/factory.py
@@ -28,7 +28,6 @@ def _resolve_postgres_repository_class() -> type[GovernanceRepository]:
     return PostgresGovernanceRepository
 
 
-
 def create_governance_repository(
     *,
     policy_path: Path,

--- a/veritas_os/governance/postgresql_repository.py
+++ b/veritas_os/governance/postgresql_repository.py
@@ -12,8 +12,6 @@ from datetime import datetime, timezone
 from time import monotonic
 from typing import Any, Callable, Iterator
 
-from psycopg.types.json import Jsonb
-
 from veritas_os.governance.repository import (
     GovernanceRepository,
     GovernanceWriteConflictError,
@@ -25,6 +23,31 @@ from veritas_os.observability.metrics import (
     record_governance_repository_operation,
     set_db_health_status,
 )
+
+
+
+
+def _jsonb(value: Any) -> Any:
+    """Wrap payload as Jsonb only when psycopg json helpers are available."""
+    try:
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL governance backend requires psycopg. "
+            "Install with `pip install 'veritas-os[postgresql]'`."
+        ) from exc
+    return Jsonb(value)
+
+
+def _unwrap_jsonb(value: Any) -> Any:
+    """Return raw JSON payload from Jsonb values when psycopg is installed."""
+    try:
+        from psycopg.types.json import Jsonb
+    except ImportError:
+        return value
+    if isinstance(value, Jsonb):
+        return value.obj
+    return value
 
 
 class PostgresGovernanceRepository(GovernanceRepository):
@@ -43,7 +66,8 @@ class PostgresGovernanceRepository(GovernanceRepository):
             import psycopg
         except ImportError as exc:  # pragma: no cover
             raise RuntimeError(
-                "psycopg is required for PostgresGovernanceRepository"
+                "PostgreSQL governance backend requires psycopg. "
+                "Install with `pip install 'veritas-os[postgresql]'`."
             ) from exc
 
         dsn = self._database_url or build_conninfo()
@@ -76,9 +100,7 @@ class PostgresGovernanceRepository(GovernanceRepository):
                     if row is None:
                         conn.rollback()
                         return default_factory()
-                    payload = row[0]
-                    if isinstance(payload, Jsonb):
-                        payload = payload.obj
+                    payload = _unwrap_jsonb(row[0])
                     conn.rollback()
                     return payload if isinstance(payload, dict) else default_factory()
         except Exception:
@@ -133,7 +155,7 @@ class PostgresGovernanceRepository(GovernanceRepository):
                             event.changed_by,
                             self._parse_timestamp(event.changed_at),
                             "",
-                            Jsonb({
+                            _jsonb({
                                 "previous_version": event.previous_version,
                                 "new_version": event.new_version,
                             }),
@@ -353,12 +375,12 @@ class PostgresGovernanceRepository(GovernanceRepository):
                         """,
                         (
                             str(updated.get("version", "")),
-                            Jsonb(updated),
+                            _jsonb(updated),
                             new_digest,
                             changed_at,
                             changed_by,
                             next_revision,
-                            Jsonb({"expected_previous_digest": expected_digest}),
+                            _jsonb({"expected_previous_digest": expected_digest}),
                         ),
                     )
                     new_policy_id = cur.fetchone()[0]
@@ -389,7 +411,7 @@ class PostgresGovernanceRepository(GovernanceRepository):
                             changed_by,
                             changed_at,
                             reason,
-                            Jsonb({
+                            _jsonb({
                                 "previous_version": previous.get("version"),
                                 "new_version": updated.get("version"),
                                 "previous_revision": current_revision,
@@ -413,7 +435,7 @@ class PostgresGovernanceRepository(GovernanceRepository):
                                 event_id,
                                 approval["reviewer"],
                                 approval["signature"],
-                                Jsonb({}),
+                                _jsonb({}),
                             ),
                         )
                 conn.commit()

--- a/veritas_os/governance/postgresql_repository.py
+++ b/veritas_os/governance/postgresql_repository.py
@@ -24,6 +24,7 @@ from veritas_os.observability.metrics import (
     set_db_health_status,
 )
 
+
 def _jsonb(value: Any) -> Any:
     """Wrap payload as Jsonb only when psycopg json helpers are available."""
     try:

--- a/veritas_os/governance/postgresql_repository.py
+++ b/veritas_os/governance/postgresql_repository.py
@@ -24,9 +24,6 @@ from veritas_os.observability.metrics import (
     set_db_health_status,
 )
 
-
-
-
 def _jsonb(value: Any) -> Any:
     """Wrap payload as Jsonb only when psycopg json helpers are available."""
     try:

--- a/veritas_os/tests/test_governance_backend_selection.py
+++ b/veritas_os/tests/test_governance_backend_selection.py
@@ -114,7 +114,11 @@ def test_governance_backend_postgresql_path_works(monkeypatch: pytest.MonkeyPatc
         def health_check(self) -> None:
             return
 
-    monkeypatch.setattr(governance_factory, "PostgresGovernanceRepository", _StubPostgresRepo)
+    monkeypatch.setattr(
+        governance_factory,
+        "_resolve_postgres_repository_class",
+        lambda: _StubPostgresRepo,
+    )
 
     repo = governance_factory.create_governance_repository(
         policy_path=Path("unused-policy.json"),

--- a/veritas_os/tests/test_governance_repository_optional_dependencies.py
+++ b/veritas_os/tests/test_governance_repository_optional_dependencies.py
@@ -11,21 +11,25 @@ from pathlib import Path
 import pytest
 
 
-def _block_psycopg_import(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Block psycopg imports to emulate a core-only installation."""
+def _block_psycopg_import(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Block psycopg imports and record attempted import names."""
     original_import = builtins.__import__
+    attempted: list[str] = []
 
     def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "psycopg" or name.startswith("psycopg."):
+            attempted.append(name)
             raise ModuleNotFoundError("No module named 'psycopg'")
         return original_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", guarded_import)
+    return attempted
 
 
 def _drop_governance_modules() -> None:
     """Drop governance modules so each test can re-import with fresh state."""
     for name in [
+        "veritas_os.governance",
         "veritas_os.governance.factory",
         "veritas_os.governance.postgresql_repository",
     ]:
@@ -35,28 +39,30 @@ def _drop_governance_modules() -> None:
 def test_governance_factory_import_does_not_require_psycopg(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _block_psycopg_import(monkeypatch)
+    attempted = _block_psycopg_import(monkeypatch)
     _drop_governance_modules()
 
     importlib.import_module("veritas_os.governance.factory")
 
-    assert "veritas_os.governance.postgresql_repository" not in sys.modules
+    assert attempted == []
 
 
 def test_postgresql_repository_module_import_does_not_require_psycopg(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _block_psycopg_import(monkeypatch)
+    attempted = _block_psycopg_import(monkeypatch)
     _drop_governance_modules()
 
     importlib.import_module("veritas_os.governance.postgresql_repository")
+
+    assert attempted == []
 
 
 def test_file_governance_repository_creation_does_not_require_psycopg(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    _block_psycopg_import(monkeypatch)
+    attempted = _block_psycopg_import(monkeypatch)
     _drop_governance_modules()
     monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "file")
 
@@ -71,21 +77,21 @@ def test_file_governance_repository_creation_does_not_require_psycopg(
     )
 
     assert repository.__class__.__name__ == "FileGovernanceRepository"
-    assert "veritas_os.governance.postgresql_repository" not in sys.modules
+    assert attempted == []
 
 
 def test_postgresql_governance_backend_requires_postgresql_extra_when_psycopg_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    _block_psycopg_import(monkeypatch)
+    attempted = _block_psycopg_import(monkeypatch)
     _drop_governance_modules()
     monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "postgresql")
     monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://example/example")
 
     factory = importlib.import_module("veritas_os.governance.factory")
 
-    with pytest.raises(RuntimeError, match="postgresql"):
+    with pytest.raises(RuntimeError) as exc_info:
         factory.create_governance_repository(
             policy_path=tmp_path / "governance.json",
             history_path=tmp_path / "history.jsonl",
@@ -93,3 +99,5 @@ def test_postgresql_governance_backend_requires_postgresql_extra_when_psycopg_mi
             policy_history_max=10,
             has_atomic_io=True,
         )
+    assert "veritas-os[postgresql]" in str(exc_info.value)
+    assert any(name == "psycopg" or name.startswith("psycopg.") for name in attempted)

--- a/veritas_os/tests/test_governance_repository_optional_dependencies.py
+++ b/veritas_os/tests/test_governance_repository_optional_dependencies.py
@@ -43,6 +43,15 @@ def test_governance_factory_import_does_not_require_psycopg(
     assert "veritas_os.governance.postgresql_repository" not in sys.modules
 
 
+def test_postgresql_repository_module_import_does_not_require_psycopg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _block_psycopg_import(monkeypatch)
+    _drop_governance_modules()
+
+    importlib.import_module("veritas_os.governance.postgresql_repository")
+
+
 def test_file_governance_repository_creation_does_not_require_psycopg(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/veritas_os/tests/test_governance_repository_optional_dependencies.py
+++ b/veritas_os/tests/test_governance_repository_optional_dependencies.py
@@ -1,0 +1,86 @@
+"""Tests for optional governance PostgreSQL dependencies."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+def _block_psycopg_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Block psycopg imports to emulate a core-only installation."""
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "psycopg" or name.startswith("psycopg."):
+            raise ModuleNotFoundError("No module named 'psycopg'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+
+def _drop_governance_modules() -> None:
+    """Drop governance modules so each test can re-import with fresh state."""
+    for name in [
+        "veritas_os.governance.factory",
+        "veritas_os.governance.postgresql_repository",
+    ]:
+        sys.modules.pop(name, None)
+
+
+def test_governance_factory_import_does_not_require_psycopg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _block_psycopg_import(monkeypatch)
+    _drop_governance_modules()
+
+    importlib.import_module("veritas_os.governance.factory")
+
+    assert "veritas_os.governance.postgresql_repository" not in sys.modules
+
+
+def test_file_governance_repository_creation_does_not_require_psycopg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _block_psycopg_import(monkeypatch)
+    _drop_governance_modules()
+    monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "file")
+
+    factory = importlib.import_module("veritas_os.governance.factory")
+
+    repository = factory.create_governance_repository(
+        policy_path=tmp_path / "governance.json",
+        history_path=tmp_path / "history.jsonl",
+        lock=threading.Lock(),
+        policy_history_max=10,
+        has_atomic_io=True,
+    )
+
+    assert repository.__class__.__name__ == "FileGovernanceRepository"
+    assert "veritas_os.governance.postgresql_repository" not in sys.modules
+
+
+def test_postgresql_governance_backend_requires_postgresql_extra_when_psycopg_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _block_psycopg_import(monkeypatch)
+    _drop_governance_modules()
+    monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://example/example")
+
+    factory = importlib.import_module("veritas_os.governance.factory")
+
+    with pytest.raises(RuntimeError, match="postgresql"):
+        factory.create_governance_repository(
+            policy_path=tmp_path / "governance.json",
+            history_path=tmp_path / "history.jsonl",
+            lock=threading.Lock(),
+            policy_history_max=10,
+            has_atomic_io=True,
+        )

--- a/veritas_os/tests/test_governance_repository_optional_dependencies.py
+++ b/veritas_os/tests/test_governance_repository_optional_dependencies.py
@@ -26,21 +26,21 @@ def _block_psycopg_import(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     return attempted
 
 
-def _drop_governance_modules() -> None:
-    """Drop governance modules so each test can re-import with fresh state."""
+def _drop_governance_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Temporarily drop governance modules so tests can re-import fresh state."""
     for name in [
         "veritas_os.governance",
         "veritas_os.governance.factory",
         "veritas_os.governance.postgresql_repository",
     ]:
-        sys.modules.pop(name, None)
+        monkeypatch.delitem(sys.modules, name, raising=False)
 
 
 def test_governance_factory_import_does_not_require_psycopg(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     attempted = _block_psycopg_import(monkeypatch)
-    _drop_governance_modules()
+    _drop_governance_modules(monkeypatch)
 
     importlib.import_module("veritas_os.governance.factory")
 
@@ -51,7 +51,7 @@ def test_postgresql_repository_module_import_does_not_require_psycopg(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     attempted = _block_psycopg_import(monkeypatch)
-    _drop_governance_modules()
+    _drop_governance_modules(monkeypatch)
 
     importlib.import_module("veritas_os.governance.postgresql_repository")
 
@@ -63,7 +63,7 @@ def test_file_governance_repository_creation_does_not_require_psycopg(
     tmp_path: Path,
 ) -> None:
     attempted = _block_psycopg_import(monkeypatch)
-    _drop_governance_modules()
+    _drop_governance_modules(monkeypatch)
     monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "file")
 
     factory = importlib.import_module("veritas_os.governance.factory")
@@ -85,7 +85,7 @@ def test_postgresql_governance_backend_requires_postgresql_extra_when_psycopg_mi
     tmp_path: Path,
 ) -> None:
     attempted = _block_psycopg_import(monkeypatch)
-    _drop_governance_modules()
+    _drop_governance_modules(monkeypatch)
     monkeypatch.setenv("VERITAS_GOVERNANCE_BACKEND", "postgresql")
     monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://example/example")
 


### PR DESCRIPTION
### Motivation
- Top-level imports of `PostgresGovernanceRepository` and `psycopg.types.json.Jsonb` forced `psycopg` to be present even for core/file-backend installs, contradicting the `[postgresql]` optional-extra design. 
- The goal is to allow importing the governance package in core-only installs (file backend) without requiring `psycopg`, while still requiring the optional extra when the PostgreSQL backend is explicitly selected.

### Description
- Remove top-level `PostgresGovernanceRepository` import from `veritas_os/governance/factory.py` and add a `_resolve_postgres_repository_class()` helper that lazy-imports the PostgreSQL repository only when `backend == "postgresql"` and raises a clear `RuntimeError` instructing to `pip install 'veritas-os[postgresql]'` if imports fail. 
- Remove top-level `Jsonb` import from `veritas_os/governance/postgresql_repository.py` and add `_jsonb()` and `_unwrap_jsonb()` helpers so `Jsonb` is only imported/used at runtime when `psycopg` is available, and `isinstance(..., Jsonb)` checks are handled safely. 
- Update `_connect()` error message to clearly recommend `pip install 'veritas-os[postgresql]'` when `psycopg` is missing. 
- Replace all `Jsonb(...)` usages with `_jsonb(...)` and replace direct `isinstance(..., Jsonb)` usage with `_unwrap_jsonb(...)` calls so the module can import without `psycopg`. 
- Add focused tests in `veritas_os/tests/test_governance_repository_optional_dependencies.py` that emulate `psycopg` absence by monkeypatching `builtins.__import__` and assert that factory import and file-backend repository creation do not require `psycopg`, and that selecting the PostgreSQL backend without the extra raises a clear `RuntimeError` mentioning `postgresql`/the extra.

### Testing
- Added `veritas_os/tests/test_governance_repository_optional_dependencies.py` with `test_governance_factory_import_does_not_require_psycopg`, `test_file_governance_repository_creation_does_not_require_psycopg`, and `test_postgresql_governance_backend_requires_postgresql_extra_when_psycopg_missing` which simulate missing `psycopg` via import monkeypatching. 
- Attempted to run `pytest -q veritas_os/tests/test_governance_repository_optional_dependencies.py` and `python3 -m pytest -q veritas_os/tests/test_governance_repository_optional_dependencies.py`, but both failed to execute in this environment because `pytest` is not installed / the configured `pyenv` interpreter is not available; tests are expected to run and pass in CI where the test runner and interpreters are correctly provisioned. 
- The change is small and localized and is expected to be validated by the new tests in CI where `psycopg` may be present or monkeypatched as in the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e9d7519c83269930c041ced0d87d)