### PR TITLE
Lazy-load FastAPI dependencies in observability exporters

### DIFF
--- a/veritas_os/observability/exporters.py
+++ b/veritas_os/observability/exporters.py
@@ -5,9 +5,6 @@ import logging
 import os
 from typing import Any, Optional
 
-from fastapi import Depends
-from fastapi.responses import JSONResponse, Response
-
 logger = logging.getLogger(__name__)
 
 
@@ -23,13 +20,34 @@ def _metrics_auth_required() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
-def _build_prometheus_endpoint():
+def _resolve_fastapi_responses() -> tuple[type[Any], type[Any]]:
+    try:
+        from fastapi.responses import JSONResponse, Response
+    except ImportError as exc:
+        raise RuntimeError(
+            "Prometheus metrics endpoint requires FastAPI response dependencies. "
+            "Install API dependencies before enabling VERITAS_METRICS_EXPORTER=prometheus."
+        ) from exc
+    return JSONResponse, Response
+
+
+def _resolve_fastapi_depends() -> Any:
+    try:
+        from fastapi import Depends
+    except ImportError as exc:
+        raise RuntimeError(
+            "Authenticated Prometheus metrics endpoint requires FastAPI. "
+            "Install API dependencies before enabling VERITAS_METRICS_AUTH=1."
+        ) from exc
+    return Depends
+
+
+def _build_prometheus_endpoint() -> Any:
+    JSONResponse, Response = _resolve_fastapi_responses()
     try:
         from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
     except Exception:
-        CONTENT_TYPE_LATEST = "application/json"
-
-        def endpoint() -> Response:
+        def endpoint() -> Any:
             return JSONResponse(
                 status_code=503,
                 content={"ok": False, "error": "prometheus_client is not installed"},
@@ -37,7 +55,7 @@ def _build_prometheus_endpoint():
 
         return endpoint
 
-    def endpoint() -> Response:
+    def endpoint() -> Any:
         return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
     return endpoint
@@ -51,6 +69,7 @@ def _install_prometheus_endpoint(app: Any, auth_dependency: Optional[Any]) -> No
     endpoint = _build_prometheus_endpoint()
     dependencies = []
     if _metrics_auth_required() and auth_dependency is not None:
+        Depends = _resolve_fastapi_depends()
         dependencies = [Depends(auth_dependency)]
     app.add_api_route("/metrics", endpoint, methods=["GET"], include_in_schema=False, dependencies=dependencies)
     _METRICS_ROUTE_INSTALLED = True

--- a/veritas_os/tests/test_observability_exporters_optional_dependencies.py
+++ b/veritas_os/tests/test_observability_exporters_optional_dependencies.py
@@ -1,0 +1,95 @@
+"""Optional dependency behavior tests for observability exporters."""
+
+import builtins
+import importlib
+import sys
+from typing import Any
+
+import pytest
+
+
+def _block_fastapi_import(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    original_import = builtins.__import__
+    attempted: list[str] = []
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "fastapi" or name.startswith("fastapi."):
+            attempted.append(name)
+            raise ModuleNotFoundError("No module named 'fastapi'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    return attempted
+
+
+def _drop_observability_exporters(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "veritas_os.observability.exporters", raising=False)
+
+
+class _DummyApp:
+    def add_api_route(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("add_api_route should not be called")
+
+
+def test_observability_exporters_import_does_not_require_fastapi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempted = _block_fastapi_import(monkeypatch)
+    _drop_observability_exporters(monkeypatch)
+
+    importlib.import_module("veritas_os.observability.exporters")
+
+    assert attempted == []
+
+
+def test_configure_metrics_exporter_none_does_not_require_fastapi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempted = _block_fastapi_import(monkeypatch)
+    _drop_observability_exporters(monkeypatch)
+    monkeypatch.setenv("VERITAS_METRICS_EXPORTER", "none")
+
+    exporters = importlib.import_module("veritas_os.observability.exporters")
+    assert exporters.configure_metrics_exporter(_DummyApp()) == "none"
+    assert attempted == []
+
+
+def test_configure_metrics_exporter_unknown_mode_does_not_require_fastapi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempted = _block_fastapi_import(monkeypatch)
+    _drop_observability_exporters(monkeypatch)
+    monkeypatch.setenv("VERITAS_METRICS_EXPORTER", "unknown")
+
+    exporters = importlib.import_module("veritas_os.observability.exporters")
+    assert exporters.configure_metrics_exporter(_DummyApp()) == "none"
+    assert attempted == []
+
+
+def test_configure_metrics_exporter_otlp_does_not_require_fastapi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempted = _block_fastapi_import(monkeypatch)
+    _drop_observability_exporters(monkeypatch)
+    monkeypatch.setenv("VERITAS_METRICS_EXPORTER", "otlp")
+
+    exporters = importlib.import_module("veritas_os.observability.exporters")
+    monkeypatch.setattr(exporters, "_configure_otlp_exporter", lambda: True)
+
+    assert exporters.configure_metrics_exporter(_DummyApp()) == "otlp"
+    assert attempted == []
+
+
+def test_configure_metrics_exporter_prometheus_requires_fastapi_responses_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempted = _block_fastapi_import(monkeypatch)
+    _drop_observability_exporters(monkeypatch)
+    monkeypatch.setenv("VERITAS_METRICS_EXPORTER", "prometheus")
+
+    exporters = importlib.import_module("veritas_os.observability.exporters")
+
+    with pytest.raises(RuntimeError, match="FastAPI|API dependencies"):
+        exporters.configure_metrics_exporter(_DummyApp())
+
+    assert any(name == "fastapi.responses" or name == "fastapi" for name in attempted)

--- a/veritas_os/tests/test_observability_exporters_optional_dependencies.py
+++ b/veritas_os/tests/test_observability_exporters_optional_dependencies.py
@@ -31,6 +31,14 @@ class _DummyApp:
         raise AssertionError("add_api_route should not be called")
 
 
+class _RecordingApp:
+    def __init__(self) -> None:
+        self.routes: list[dict[str, Any]] = []
+
+    def add_api_route(self, *args: Any, **kwargs: Any) -> None:
+        self.routes.append({"args": args, "kwargs": kwargs})
+
+
 def test_observability_exporters_import_does_not_require_fastapi(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -93,3 +101,86 @@ def test_configure_metrics_exporter_prometheus_requires_fastapi_responses_when_m
         exporters.configure_metrics_exporter(_DummyApp())
 
     assert any(name == "fastapi.responses" or name == "fastapi" for name in attempted)
+
+
+def test_configure_metrics_exporter_prometheus_auth_requires_fastapi_depends_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _drop_observability_exporters(monkeypatch)
+    monkeypatch.setenv("VERITAS_METRICS_EXPORTER", "prometheus")
+    monkeypatch.setenv("VERITAS_METRICS_AUTH", "1")
+
+    exporters = importlib.import_module("veritas_os.observability.exporters")
+    monkeypatch.setattr(exporters, "_build_prometheus_endpoint", lambda: lambda: None)
+
+    def missing_depends() -> Any:
+        raise RuntimeError(
+            "Authenticated Prometheus metrics endpoint requires FastAPI. "
+            "Install API dependencies before enabling VERITAS_METRICS_AUTH=1."
+        )
+
+    monkeypatch.setattr(exporters, "_resolve_fastapi_depends", missing_depends)
+
+    def auth_dependency() -> bool:
+        return True
+
+    with pytest.raises(RuntimeError) as exc_info:
+        exporters.configure_metrics_exporter(
+            _RecordingApp(),
+            auth_dependency=auth_dependency,
+        )
+
+    assert "VERITAS_METRICS_AUTH=1" in str(exc_info.value)
+
+
+def test_configure_metrics_exporter_prometheus_auth_adds_dependency_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+    _drop_observability_exporters(monkeypatch)
+    monkeypatch.setenv("VERITAS_METRICS_EXPORTER", "prometheus")
+    monkeypatch.setenv("VERITAS_METRICS_AUTH", "1")
+
+    exporters = importlib.import_module("veritas_os.observability.exporters")
+    monkeypatch.setattr(exporters, "_build_prometheus_endpoint", lambda: lambda: None)
+
+    app = _RecordingApp()
+
+    def auth_dependency() -> bool:
+        return True
+
+    assert exporters.configure_metrics_exporter(
+        app,
+        auth_dependency=auth_dependency,
+    ) == "prometheus"
+    assert len(app.routes) == 1
+    dependencies = app.routes[0]["kwargs"]["dependencies"]
+    assert dependencies
+
+
+def test_configure_metrics_exporter_prometheus_auth_disabled_does_not_resolve_depends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _drop_observability_exporters(monkeypatch)
+    monkeypatch.setenv("VERITAS_METRICS_EXPORTER", "prometheus")
+    monkeypatch.setenv("VERITAS_METRICS_AUTH", "0")
+
+    exporters = importlib.import_module("veritas_os.observability.exporters")
+    monkeypatch.setattr(exporters, "_build_prometheus_endpoint", lambda: lambda: None)
+
+    def fail_depends() -> Any:
+        raise AssertionError("_resolve_fastapi_depends should not be called")
+
+    monkeypatch.setattr(exporters, "_resolve_fastapi_depends", fail_depends)
+
+    app = _RecordingApp()
+
+    def auth_dependency() -> bool:
+        return True
+
+    assert exporters.configure_metrics_exporter(
+        app,
+        auth_dependency=auth_dependency,
+    ) == "prometheus"
+    assert len(app.routes) == 1
+    assert app.routes[0]["kwargs"]["dependencies"] == []


### PR DESCRIPTION
### Motivation
- The observability exporters module had top-level imports from FastAPI which makes importing `veritas_os.observability.exporters` fail in core-only environments without FastAPI installed. 
- The goal is to ensure the module can be imported and non-Prometheus modes can run without FastAPI, while only requiring FastAPI when installing a Prometheus endpoint.

### Description
- Removed top-level `fastapi` imports from `veritas_os/observability/exporters.py` and added lazy resolvers `_resolve_fastapi_responses()` and `_resolve_fastapi_depends()` to import `JSONResponse`/`Response` and `Depends` only when required. 
- Updated `_build_prometheus_endpoint()` to call `_resolve_fastapi_responses()` inside the function and return endpoints typed as `Any`, preserving the existing fallback when `prometheus_client` is missing but raising a clear `RuntimeError` when FastAPI response deps are absent. 
- Updated `_install_prometheus_endpoint()` to call `_resolve_fastapi_depends()` only when authentication is required (i.e., `VERITAS_METRICS_EXPORTER=prometheus` and auth enabled and `auth_dependency` provided), so `Depends` is imported only when needed. 
- Kept `configure_metrics_exporter()` semantics unchanged for `none`, `otlp`, `prometheus`, and unknown modes. 
- Added focused tests in `veritas_os/tests/test_observability_exporters_optional_dependencies.py` that verify module import and non-prometheus modes do not require FastAPI, and that Prometheus mode raises a clear error when FastAPI is missing.

### Testing
- Ran the focused optional-dependency test file with `PYENV_VERSION=3.12.13 pytest -q veritas_os/tests/test_observability_exporters_optional_dependencies.py` and all tests passed (`5 passed`).
- An initial `pytest -q veritas_os/tests/test_observability_exporters_optional_dependencies.py` attempt failed due to the local pyenv Python version mismatch, which was resolved by setting `PYENV_VERSION` and re-running the test. 
- Ran `git diff --check` and there were no check errors for the introduced changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0826e4f9708326bc62a12070175c8b)