### PR TITLE
Constrain continuation enforcement severity values

### DIFF
--- a/tests/test_continuation_enforcement.py
+++ b/tests/test_continuation_enforcement.py
@@ -22,6 +22,7 @@ from veritas_os.core.continuation_runtime.enforcement import (
     EnforcementConditionType,
     EnforcementCondition,
     EnforcementEvent,
+    SeverityLevel,
     EnforcementConfig,
     ContinuationEnforcementEvaluator,
 )
@@ -114,6 +115,22 @@ class TestEnforcementAction:
 
 
 # =====================================================================
+# SeverityLevel enum
+# =====================================================================
+
+
+class TestSeverityLevel:
+    def test_severity_values(self):
+        assert SeverityLevel.INFO.value == "info"
+        assert SeverityLevel.MEDIUM.value == "medium"
+        assert SeverityLevel.HIGH.value == "high"
+        assert SeverityLevel.CRITICAL.value == "critical"
+
+    def test_severity_str(self):
+        assert str(SeverityLevel.CRITICAL) == "critical"
+
+
+# =====================================================================
 # EnforcementCondition serialization
 # =====================================================================
 
@@ -164,6 +181,7 @@ class TestEnforcementEvent:
             reasoning="test reasoning",
             severity="critical",
         )
+        assert event.severity == SeverityLevel.CRITICAL
         d = event.to_dict()
         assert d["mode"] == "enforce"
         assert d["action"] == "halt_chain"
@@ -175,6 +193,21 @@ class TestEnforcementEvent:
         assert restored.mode == EnforcementMode.ENFORCE
         assert restored.action == EnforcementAction.HALT_CHAIN
         assert restored.is_enforced is True
+        assert restored.severity == SeverityLevel.CRITICAL
+
+    def test_event_severity_accepts_enum_and_serializes_string(self):
+        event = EnforcementEvent(severity=SeverityLevel.HIGH)
+        assert event.severity == SeverityLevel.HIGH
+        assert event.to_dict()["severity"] == "high"
+
+    def test_event_from_dict_unknown_severity_falls_back_to_info(self):
+        event = EnforcementEvent.from_dict({"severity": "crit"})
+        assert event.severity == SeverityLevel.INFO
+        assert event.to_dict()["severity"] == "info"
+
+    def test_event_constructor_unknown_severity_falls_back_to_info(self):
+        event = EnforcementEvent(severity="CRITICAL")
+        assert event.severity == SeverityLevel.INFO
 
     def test_event_has_required_fields(self):
         event = EnforcementEvent()
@@ -581,7 +614,7 @@ class TestSeverityComputation:
         )
         halt_events = [e for e in events if e.action == EnforcementAction.HALT_CHAIN]
         assert len(halt_events) >= 1
-        assert halt_events[0].severity == "critical"
+        assert halt_events[0].severity == SeverityLevel.CRITICAL
 
     def test_require_human_review_is_high(self):
         evaluator = _make_evaluator(mode=EnforcementMode.ENFORCE)
@@ -597,7 +630,7 @@ class TestSeverityComputation:
             if e.action == EnforcementAction.REQUIRE_HUMAN_REVIEW
         ]
         assert len(review_events) >= 1
-        assert review_events[0].severity == "high"
+        assert review_events[0].severity == SeverityLevel.HIGH
 
     def test_escalate_alert_is_medium(self):
         evaluator = _make_evaluator(mode=EnforcementMode.ENFORCE)
@@ -611,7 +644,7 @@ class TestSeverityComputation:
             if e.action == EnforcementAction.ESCALATE_ALERT
         ]
         assert len(alert_events) >= 1
-        assert alert_events[0].severity == "medium"
+        assert alert_events[0].severity == SeverityLevel.MEDIUM
 
 
 # =====================================================================

--- a/tests/test_continuation_enforcement_audit.py
+++ b/tests/test_continuation_enforcement_audit.py
@@ -22,6 +22,7 @@ from veritas_os.core.continuation_runtime.enforcement import (
     EnforcementConditionType,
     EnforcementCondition,
     EnforcementEvent,
+    SeverityLevel,
     EnforcementConfig,
     ContinuationEnforcementEvaluator,
 )
@@ -325,9 +326,15 @@ class TestOperatorVisibility:
             policy_violation_detected=True,
             replay_divergence_ratio=0.8,
         )
-        valid_severities = {"info", "medium", "high", "critical"}
+        valid_severities = {
+            SeverityLevel.INFO,
+            SeverityLevel.MEDIUM,
+            SeverityLevel.HIGH,
+            SeverityLevel.CRITICAL,
+        }
         for event in events:
             assert event.severity in valid_severities
+            assert event.to_dict()["severity"] in {"info", "medium", "high", "critical"}
 
     def test_conditions_met_includes_explanation(self):
         config = EnforcementConfig(mode=EnforcementMode.ADVISORY)

--- a/veritas_os/core/continuation_runtime/enforcement.py
+++ b/veritas_os/core/continuation_runtime/enforcement.py
@@ -86,6 +86,30 @@ class EnforcementAction(str, Enum):
 # =====================================================================
 
 
+class SeverityLevel(str, Enum):
+    """Operator-facing severity levels for enforcement events."""
+
+    INFO = "info"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def _coerce_severity(value: Any) -> SeverityLevel:
+    """Coerce severity values to a constrained level with safe fallback."""
+    if isinstance(value, SeverityLevel):
+        return value
+    if isinstance(value, str):
+        try:
+            return SeverityLevel(value)
+        except ValueError:
+            return SeverityLevel.INFO
+    return SeverityLevel.INFO
+
+
 class EnforcementConditionType(str, Enum):
     """Types of high-confidence conditions that trigger enforcement."""
 
@@ -176,7 +200,11 @@ class EnforcementEvent:
     # context for operator
     claim_status: str = ""
     boundary_outcome: str = ""
-    severity: str = "info"
+    severity: SeverityLevel = SeverityLevel.INFO
+
+    def __post_init__(self) -> None:
+        """Normalize severity to constrained enum values."""
+        self.severity = _coerce_severity(self.severity)
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a JSON-serializable dict representation."""
@@ -198,7 +226,7 @@ class EnforcementEvent:
             "reason_codes": list(self.reason_codes),
             "claim_status": self.claim_status,
             "boundary_outcome": self.boundary_outcome,
-            "severity": self.severity,
+            "severity": self.severity.value,
         }
 
     @classmethod
@@ -209,6 +237,8 @@ class EnforcementEvent:
             data["mode"] = EnforcementMode(data["mode"])
         if "action" in data and isinstance(data["action"], str):
             data["action"] = EnforcementAction(data["action"])
+        if "severity" in data:
+            data["severity"] = _coerce_severity(data["severity"])
         if "conditions_evaluated" in data:
             data["conditions_evaluated"] = [
                 EnforcementCondition.from_dict(c) if isinstance(c, dict) else c
@@ -677,21 +707,21 @@ class ContinuationEnforcementEvaluator:
         self,
         condition: EnforcementCondition,
         action: EnforcementAction,
-    ) -> str:
+    ) -> SeverityLevel:
         """Compute severity level for operator visibility."""
         if action == EnforcementAction.HALT_CHAIN:
-            return "critical"
+            return SeverityLevel.CRITICAL
         if action == EnforcementAction.REQUIRE_HUMAN_REVIEW:
-            return "high"
+            return SeverityLevel.HIGH
         if condition.confidence >= 0.95:
-            return "high"
-        return "medium"
+            return SeverityLevel.HIGH
+        return SeverityLevel.MEDIUM
 
     def _build_reasoning(
         self,
         condition: EnforcementCondition,
         action: EnforcementAction,
-    ) -> str:
+    ) -> SeverityLevel:
         """Build explicit, inspectable reasoning string."""
         return (
             f"Enforcement action '{action.value}' triggered by "

--- a/veritas_os/core/continuation_runtime/enforcement.py
+++ b/veritas_os/core/continuation_runtime/enforcement.py
@@ -721,7 +721,7 @@ class ContinuationEnforcementEvaluator:
         self,
         condition: EnforcementCondition,
         action: EnforcementAction,
-    ) -> SeverityLevel:
+    ) -> str:
         """Build explicit, inspectable reasoning string."""
         return (
             f"Enforcement action '{action.value}' triggered by "


### PR DESCRIPTION
### Motivation

- Prevent free-form/typo severity strings from entering enforcement audit artifacts which can break downstream routing and observability.  
- Constrain severity to a small, operator-facing set (`info`, `medium`, `high`, `critical`) while preserving existing serialized shape for compatibility.

### Description

- Adds `SeverityLevel(str, Enum)` and a `_coerce_severity(value: Any) -> SeverityLevel` helper to coerce string/enum inputs and safely fallback unknown values to `SeverityLevel.INFO`.  
- Changes `EnforcementEvent.severity` to type `SeverityLevel` with default `SeverityLevel.INFO` and adds `__post_init__()` to normalize constructor inputs.  
- Updates `EnforcementEvent.to_dict()` to emit `severity` as a string (`self.severity.value`) and updates `EnforcementEvent.from_dict()` to coerce incoming `severity` values via `_coerce_severity()` without raising on unknown values.  
- Updates `ContinuationEnforcementEvaluator._compute_severity()` to return `SeverityLevel` values and updates tests to assert enum-level semantics while still validating that `to_dict()` returns string values.

### Testing

- Ran the focused test suite with `PYENV_VERSION=3.12.13 python -m pytest -q tests/test_continuation_enforcement.py tests/test_continuation_enforcement_audit.py` which passed with `76 passed, 1 warning`.  
- Iterated on failing assertions discovered during testing and added focused tests: `TestSeverityLevel`, `test_event_severity_accepts_enum_and_serializes_string`, `test_event_from_dict_unknown_severity_falls_back_to_info`, and `test_event_constructor_unknown_severity_falls_back_to_info`.  
- Verified serialized compatibility by asserting `event.to_dict()["severity"]` remains a string for enum-constructed and string-constructed events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0846cc6cd0832696845594938539ad)