### PR TITLE
Normalize enforcement event severity with SeverityLevel enum and coercion

### DIFF
--- a/tests/test_continuation_enforcement.py
+++ b/tests/test_continuation_enforcement.py
@@ -22,6 +22,7 @@ from veritas_os.core.continuation_runtime.enforcement import (
     EnforcementConditionType,
     EnforcementCondition,
     EnforcementEvent,
+    SeverityLevel,
     EnforcementConfig,
     ContinuationEnforcementEvaluator,
 )
@@ -114,6 +115,22 @@ class TestEnforcementAction:
 
 
 # =====================================================================
+# SeverityLevel enum
+# =====================================================================
+
+
+class TestSeverityLevel:
+    def test_severity_values(self):
+        assert SeverityLevel.INFO.value == "info"
+        assert SeverityLevel.MEDIUM.value == "medium"
+        assert SeverityLevel.HIGH.value == "high"
+        assert SeverityLevel.CRITICAL.value == "critical"
+
+    def test_severity_str(self):
+        assert str(SeverityLevel.CRITICAL) == "critical"
+
+
+# =====================================================================
 # EnforcementCondition serialization
 # =====================================================================
 
@@ -164,6 +181,7 @@ class TestEnforcementEvent:
             reasoning="test reasoning",
             severity="critical",
         )
+        assert event.severity == SeverityLevel.CRITICAL
         d = event.to_dict()
         assert d["mode"] == "enforce"
         assert d["action"] == "halt_chain"
@@ -175,6 +193,41 @@ class TestEnforcementEvent:
         assert restored.mode == EnforcementMode.ENFORCE
         assert restored.action == EnforcementAction.HALT_CHAIN
         assert restored.is_enforced is True
+        assert restored.severity == SeverityLevel.CRITICAL
+
+    def test_event_severity_accepts_enum_and_serializes_string(self):
+        event = EnforcementEvent(severity=SeverityLevel.HIGH)
+        assert event.severity == SeverityLevel.HIGH
+        assert event.to_dict()["severity"] == "high"
+
+    def test_event_from_dict_unknown_severity_falls_back_to_info(self):
+        event = EnforcementEvent.from_dict({"severity": "crit"})
+        assert event.severity == SeverityLevel.INFO
+        assert event.to_dict()["severity"] == "info"
+
+    def test_event_constructor_case_variant_severity_falls_back_to_info(self):
+        event = EnforcementEvent(severity="CRITICAL")
+        assert event.severity == SeverityLevel.INFO
+
+
+    def test_event_constructor_whitespace_padded_severity_falls_back_to_info(self):
+        event = EnforcementEvent(severity=" critical ")
+        assert event.severity == SeverityLevel.INFO
+
+    def test_event_to_dict_handles_reassigned_string_severity(self):
+        event = EnforcementEvent(severity=SeverityLevel.HIGH)
+        event.severity = "critical"
+        assert event.to_dict()["severity"] == "critical"
+
+    def test_event_to_dict_falls_back_for_reassigned_unknown_severity(self):
+        event = EnforcementEvent(severity=SeverityLevel.HIGH)
+        event.severity = "crit"
+        assert event.to_dict()["severity"] == "info"
+
+    def test_event_to_dict_falls_back_for_reassigned_case_variant_severity(self):
+        event = EnforcementEvent(severity=SeverityLevel.HIGH)
+        event.severity = "CRITICAL"
+        assert event.to_dict()["severity"] == "info"
 
     def test_event_has_required_fields(self):
         event = EnforcementEvent()
@@ -581,7 +634,7 @@ class TestSeverityComputation:
         )
         halt_events = [e for e in events if e.action == EnforcementAction.HALT_CHAIN]
         assert len(halt_events) >= 1
-        assert halt_events[0].severity == "critical"
+        assert halt_events[0].severity == SeverityLevel.CRITICAL
 
     def test_require_human_review_is_high(self):
         evaluator = _make_evaluator(mode=EnforcementMode.ENFORCE)
@@ -597,7 +650,7 @@ class TestSeverityComputation:
             if e.action == EnforcementAction.REQUIRE_HUMAN_REVIEW
         ]
         assert len(review_events) >= 1
-        assert review_events[0].severity == "high"
+        assert review_events[0].severity == SeverityLevel.HIGH
 
     def test_escalate_alert_is_medium(self):
         evaluator = _make_evaluator(mode=EnforcementMode.ENFORCE)
@@ -611,7 +664,7 @@ class TestSeverityComputation:
             if e.action == EnforcementAction.ESCALATE_ALERT
         ]
         assert len(alert_events) >= 1
-        assert alert_events[0].severity == "medium"
+        assert alert_events[0].severity == SeverityLevel.MEDIUM
 
 
 # =====================================================================

--- a/tests/test_continuation_enforcement_audit.py
+++ b/tests/test_continuation_enforcement_audit.py
@@ -22,6 +22,7 @@ from veritas_os.core.continuation_runtime.enforcement import (
     EnforcementConditionType,
     EnforcementCondition,
     EnforcementEvent,
+    SeverityLevel,
     EnforcementConfig,
     ContinuationEnforcementEvaluator,
 )
@@ -325,9 +326,15 @@ class TestOperatorVisibility:
             policy_violation_detected=True,
             replay_divergence_ratio=0.8,
         )
-        valid_severities = {"info", "medium", "high", "critical"}
+        valid_severities = {
+            SeverityLevel.INFO,
+            SeverityLevel.MEDIUM,
+            SeverityLevel.HIGH,
+            SeverityLevel.CRITICAL,
+        }
         for event in events:
             assert event.severity in valid_severities
+            assert event.to_dict()["severity"] in {"info", "medium", "high", "critical"}
 
     def test_conditions_met_includes_explanation(self):
         config = EnforcementConfig(mode=EnforcementMode.ADVISORY)

--- a/veritas_os/core/continuation_runtime/enforcement.py
+++ b/veritas_os/core/continuation_runtime/enforcement.py
@@ -86,6 +86,35 @@ class EnforcementAction(str, Enum):
 # =====================================================================
 
 
+class SeverityLevel(str, Enum):
+    """Operator-facing severity levels for enforcement events."""
+
+    INFO = "info"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def _coerce_severity(value: Any) -> SeverityLevel:
+    """Return canonical severity for exact values, else safe INFO fallback.
+
+    Only canonical lowercase severity values are accepted. Case variants,
+    whitespace-padded values, non-string values, and unknown strings fall
+    back to INFO so audit artifacts never carry non-canonical severities.
+    """
+    if isinstance(value, SeverityLevel):
+        return value
+    if isinstance(value, str):
+        try:
+            return SeverityLevel(value)
+        except ValueError:
+            return SeverityLevel.INFO
+    return SeverityLevel.INFO
+
+
 class EnforcementConditionType(str, Enum):
     """Types of high-confidence conditions that trigger enforcement."""
 
@@ -176,7 +205,11 @@ class EnforcementEvent:
     # context for operator
     claim_status: str = ""
     boundary_outcome: str = ""
-    severity: str = "info"
+    severity: SeverityLevel = SeverityLevel.INFO
+
+    def __post_init__(self) -> None:
+        """Normalize severity to constrained enum values."""
+        self.severity = _coerce_severity(self.severity)
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a JSON-serializable dict representation."""
@@ -198,7 +231,7 @@ class EnforcementEvent:
             "reason_codes": list(self.reason_codes),
             "claim_status": self.claim_status,
             "boundary_outcome": self.boundary_outcome,
-            "severity": self.severity,
+            "severity": _coerce_severity(self.severity).value,
         }
 
     @classmethod
@@ -209,6 +242,8 @@ class EnforcementEvent:
             data["mode"] = EnforcementMode(data["mode"])
         if "action" in data and isinstance(data["action"], str):
             data["action"] = EnforcementAction(data["action"])
+        if "severity" in data:
+            data["severity"] = _coerce_severity(data["severity"])
         if "conditions_evaluated" in data:
             data["conditions_evaluated"] = [
                 EnforcementCondition.from_dict(c) if isinstance(c, dict) else c
@@ -677,15 +712,15 @@ class ContinuationEnforcementEvaluator:
         self,
         condition: EnforcementCondition,
         action: EnforcementAction,
-    ) -> str:
+    ) -> SeverityLevel:
         """Compute severity level for operator visibility."""
         if action == EnforcementAction.HALT_CHAIN:
-            return "critical"
+            return SeverityLevel.CRITICAL
         if action == EnforcementAction.REQUIRE_HUMAN_REVIEW:
-            return "high"
+            return SeverityLevel.HIGH
         if condition.confidence >= 0.95:
-            return "high"
-        return "medium"
+            return SeverityLevel.HIGH
+        return SeverityLevel.MEDIUM
 
     def _build_reasoning(
         self,


### PR DESCRIPTION
### Motivation

- Enforce canonical, operator-facing severity values for enforcement events so audit artifacts never carry non-canonical or malformed severities.
- Improve serialization/deserialization robustness and ensure severity handling integrates with existing enforcement severity computation and tests.

### Description

- Introduce a `SeverityLevel` enum with values `info`, `medium`, `high`, and `critical` and add a `_coerce_severity` helper to normalize inputs to canonical enum values or fall back to `INFO` for unknown/case/whitespace variants.
- Change `EnforcementEvent.severity` to use `SeverityLevel` and normalize it in `__post_init__`; update `to_dict` to emit canonical severity strings and `from_dict` to coerce incoming values.
- Update `_compute_severity` to return `SeverityLevel` values for each action/confidence branch.
- Update tests to assert enum-typed severities, add unit tests covering enum serialization, deserialization, fallback behavior, reassignment handling, and verify `to_dict()` continues to emit string values.

### Testing

- Ran unit tests for the modified modules with `pytest tests/test_continuation_enforcement.py tests/test_continuation_enforcement_audit.py` and the updated assertions; all tests passed.
- Ran the repository unit test suite with `pytest` to validate serialization and evaluator behavior; the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0846cc6cd0832696845594938539ad)