### PR TITLE
Expand responsibility boundary checks to helper modules

### DIFF
--- a/docs/architecture/core_responsibility_boundaries.md
+++ b/docs/architecture/core_responsibility_boundaries.md
@@ -119,6 +119,15 @@ When changing one of the four core modules above:
 3. Do not move responsibilities across Planner / Kernel / FUJI / MemoryOS unless
    the architecture review explicitly approves the boundary change.
 
+### Helper module ownership convention
+
+The CI responsibility-boundary checker treats top-level
+`veritas_os/core/{module}_*.py` files as helper shims owned by the corresponding
+logical `{module}`. Python files under `veritas_os/core/{module}/` are also treated
+as implementation helpers for that logical module, including nested subpackages.
+Contributors should avoid using a `{module}_*.py` prefix for files owned by a
+different logical module.
+
 ## Security note
 
 Boundary violations are not only a maintainability issue. They can also weaken

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -209,23 +209,26 @@ def _collect_imported_names(tree: ast.Module) -> set[str]:
 
 def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
     """Check one rule and return violation messages, one per forbidden import found."""
-    path = core_dir / f"{rule.source_module}.py"
-    if not path.exists():
-        pkg_init = core_dir / rule.source_module / "__init__.py"
-        if pkg_init.exists():
-            path = pkg_init
-    try:
-        source = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return [f"Boundary check error: '{rule.source_module}' not found at {path}"]
-    tree = ast.parse(source, filename=str(path))
-    imported = _collect_imported_names(tree)
-    violations = sorted(imported & rule.forbidden_imports)
-
-    return [
-        f"Boundary violation: '{rule.source_module}' imports forbidden module '{v}' ({path})"
-        for v in violations
-    ]
+    messages: list[str] = []
+    for path in _resolve_module_source_paths(core_dir, rule.source_module):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            messages.append(
+                f"Boundary check error: '{rule.source_module}' not found at {path}"
+            )
+            continue
+        tree = ast.parse(source, filename=str(path))
+        imported = _collect_imported_names(tree)
+        violations = sorted(imported & rule.forbidden_imports)
+        messages.extend(
+            [
+                "Boundary violation: "
+                f"'{rule.source_module}' imports forbidden module '{v}' ({path})"
+                for v in violations
+            ]
+        )
+    return messages
 
 
 def _resolve_module_source_path(core_dir: Path, module_name: str) -> Path:
@@ -237,6 +240,32 @@ def _resolve_module_source_path(core_dir: Path, module_name: str) -> Path:
     if pkg_init.exists():
         return pkg_init
     return path
+
+
+def _resolve_module_source_paths(core_dir: Path, module_name: str) -> tuple[Path, ...]:
+    """Resolve source paths for a module and its helper modules."""
+    candidates: list[Path] = []
+    flat_path = core_dir / f"{module_name}.py"
+    if flat_path.exists():
+        candidates.append(flat_path)
+
+    pkg_init = core_dir / module_name / "__init__.py"
+    if pkg_init.exists():
+        candidates.append(pkg_init)
+
+    candidates.extend(sorted(core_dir.glob(f"{module_name}_*.py")))
+
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        unique.append(path)
+
+    if not unique:
+        return (flat_path,)
+    return tuple(unique)
 
 
 def _parse_imported_names(path: Path) -> set[str]:
@@ -334,58 +363,61 @@ def collect_boundary_issues(
             )
         )
     for rule in rules:
-        path = _resolve_module_source_path(core_dir, rule.source_module)
-        try:
-            imported = _parse_imported_names(path)
-        except FileNotFoundError:
-            issues.append(
-                BoundaryIssue(
-                    code="input_invalid",
-                    message=f"Boundary check error: '{rule.source_module}' not found at {path}",
-                    path=path,
-                    source_module=rule.source_module,
+        for path in _resolve_module_source_paths(core_dir, rule.source_module):
+            try:
+                imported = _parse_imported_names(path)
+            except FileNotFoundError:
+                issues.append(
+                    BoundaryIssue(
+                        code="input_invalid",
+                        message=(
+                            f"Boundary check error: '{rule.source_module}' "
+                            f"not found at {path}"
+                        ),
+                        path=path,
+                        source_module=rule.source_module,
+                    )
                 )
-            )
-            continue
-        except PermissionError:
-            issues.append(
-                BoundaryIssue(
-                    code="permission_denied",
-                    message=f"Boundary check error: permission denied for {path}",
-                    path=path,
-                    source_module=rule.source_module,
+                continue
+            except PermissionError:
+                issues.append(
+                    BoundaryIssue(
+                        code="permission_denied",
+                        message=f"Boundary check error: permission denied for {path}",
+                        path=path,
+                        source_module=rule.source_module,
+                    )
                 )
-            )
-            continue
-        except SyntaxError as exc:
-            issues.append(
-                BoundaryIssue(
-                    code="input_invalid",
-                    message=(
-                        "Boundary check error: invalid Python syntax in "
-                        f"{path} at line {exc.lineno}"
-                    ),
-                    path=path,
-                    source_module=rule.source_module,
+                continue
+            except SyntaxError as exc:
+                issues.append(
+                    BoundaryIssue(
+                        code="input_invalid",
+                        message=(
+                            "Boundary check error: invalid Python syntax in "
+                            f"{path} at line {exc.lineno}"
+                        ),
+                        path=path,
+                        source_module=rule.source_module,
+                    )
                 )
-            )
-            continue
+                continue
 
-        violations = sorted(imported & rule.forbidden_imports)
-        for forbidden_module in violations:
-            issues.append(
-                BoundaryIssue(
-                    code="boundary_violation",
-                    message=(
-                        "Boundary violation: "
-                        f"'{rule.source_module}' imports forbidden module "
-                        f"'{forbidden_module}' ({path})"
-                    ),
-                    path=path,
-                    source_module=rule.source_module,
-                    forbidden_module=forbidden_module,
+            violations = sorted(imported & rule.forbidden_imports)
+            for forbidden_module in violations:
+                issues.append(
+                    BoundaryIssue(
+                        code="boundary_violation",
+                        message=(
+                            "Boundary violation: "
+                            f"'{rule.source_module}' imports forbidden module "
+                            f"'{forbidden_module}' ({path})"
+                        ),
+                        path=path,
+                        source_module=rule.source_module,
+                        forbidden_module=forbidden_module,
+                    )
                 )
-            )
     return issues
 
 
@@ -396,22 +428,22 @@ def _collect_violations(
     """Collect structured violation details for remediation guidance output."""
     violation_details: list[ViolationDetail] = []
     for rule in rules:
-        path = core_dir / f"{rule.source_module}.py"
-        try:
-            source = path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            continue
-        tree = ast.parse(source, filename=str(path))
-        imported = _collect_imported_names(tree)
-        violations = sorted(imported & rule.forbidden_imports)
-        for forbidden_module in violations:
-            violation_details.append(
-                ViolationDetail(
-                    source_module=rule.source_module,
-                    forbidden_module=forbidden_module,
-                    path=path,
+        for path in _resolve_module_source_paths(core_dir, rule.source_module):
+            try:
+                source = path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                continue
+            tree = ast.parse(source, filename=str(path))
+            imported = _collect_imported_names(tree)
+            violations = sorted(imported & rule.forbidden_imports)
+            for forbidden_module in violations:
+                violation_details.append(
+                    ViolationDetail(
+                        source_module=rule.source_module,
+                        forbidden_module=forbidden_module,
+                        path=path,
+                    )
                 )
-            )
     return violation_details
 
 

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -185,6 +185,31 @@ def _normalize_module_name(module_name: str) -> str:
     return module_name.rsplit(".", maxsplit=1)[-1]
 
 
+LOGICAL_MODULE_PREFIXES: tuple[str, ...] = (
+    "planner",
+    "kernel",
+    "fuji",
+    "memory",
+    "pipeline",
+)
+
+
+def _expand_logical_import_aliases(imported: Iterable[str]) -> set[str]:
+    """Expand helper-module import leaves to their logical module owners."""
+    expanded = set(imported)
+    for name in imported:
+        for prefix in LOGICAL_MODULE_PREFIXES:
+            if name.startswith(f"{prefix}_"):
+                expanded.add(prefix)
+    return expanded
+
+
+def _format_syntax_error_message(path: Path, exc: SyntaxError) -> str:
+    """Format a boundary-check syntax error message with a stable line fallback."""
+    line: int | str = exc.lineno if exc.lineno is not None else "unknown line"
+    return f"Boundary check error: invalid Python syntax in {path} at line {line}"
+
+
 def _collect_imported_names(tree: ast.Module) -> set[str]:
     """Collect imported module names from a module AST."""
     imported: set[str] = set()
@@ -224,12 +249,9 @@ def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
         try:
             tree = ast.parse(source, filename=str(path))
         except SyntaxError as exc:
-            messages.append(
-                "Boundary check error: invalid Python syntax in "
-                f"{path} at line {exc.lineno}"
-            )
+            messages.append(_format_syntax_error_message(path, exc))
             continue
-        imported = _collect_imported_names(tree)
+        imported = _expand_logical_import_aliases(_collect_imported_names(tree))
         violations = sorted(imported & rule.forbidden_imports)
         messages.extend(
             [
@@ -239,11 +261,6 @@ def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
             ]
         )
     return messages
-
-
-def _resolve_module_source_path(core_dir: Path, module_name: str) -> Path:
-    """Resolve the primary source path for backward-compatible callers."""
-    return _resolve_module_source_paths(core_dir, module_name)[0]
 
 
 def _resolve_module_source_paths(core_dir: Path, module_name: str) -> tuple[Path, ...]:
@@ -268,11 +285,7 @@ def _resolve_module_source_paths(core_dir: Path, module_name: str) -> tuple[Path
 
     candidates.extend(sorted(core_dir.glob(f"{module_name}_*.py")))
     if package_dir.exists() and package_dir.is_dir():
-        candidates.extend(
-            path
-            for path in sorted(package_dir.rglob("*.py"))
-            if path.name != "__init__.py"
-        )
+        candidates.extend(sorted(package_dir.rglob("*.py")))
 
     unique: list[Path] = []
     seen: set[Path] = set()
@@ -412,17 +425,15 @@ def collect_boundary_issues(
                 issues.append(
                     BoundaryIssue(
                         code="input_invalid",
-                        message=(
-                            "Boundary check error: invalid Python syntax in "
-                            f"{path} at line {exc.lineno}"
-                        ),
+                        message=_format_syntax_error_message(path, exc),
                         path=path,
                         source_module=rule.source_module,
                     )
                 )
                 continue
 
-            violations = sorted(imported & rule.forbidden_imports)
+            expanded_imported = _expand_logical_import_aliases(imported)
+            violations = sorted(expanded_imported & rule.forbidden_imports)
             for forbidden_module in violations:
                 issues.append(
                     BoundaryIssue(
@@ -458,7 +469,7 @@ def _collect_violations(
                 tree = ast.parse(source, filename=str(path))
             except (FileNotFoundError, PermissionError, SyntaxError):
                 continue
-            imported = _collect_imported_names(tree)
+            imported = _expand_logical_import_aliases(_collect_imported_names(tree))
             violations = sorted(imported & rule.forbidden_imports)
             for forbidden_module in violations:
                 violation_details.append(

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -247,7 +247,15 @@ def _resolve_module_source_path(core_dir: Path, module_name: str) -> Path:
 
 
 def _resolve_module_source_paths(core_dir: Path, module_name: str) -> tuple[Path, ...]:
-    """Resolve source paths for a logical module and its helper modules."""
+    """Resolve source paths for a logical module and its helper modules.
+
+    Ownership contract:
+    - ``core/{module}.py`` and ``core/{module}/__init__.py`` belong to ``{module}``.
+    - Top-level ``core/{module}_*.py`` files are treated as helper shims owned by
+      ``{module}``.
+    - Python files under ``core/{module}/`` (recursively) are treated as
+      implementation helpers owned by ``{module}``.
+    """
     candidates: list[Path] = []
     flat_path = core_dir / f"{module_name}.py"
     if flat_path.exists():
@@ -261,7 +269,9 @@ def _resolve_module_source_paths(core_dir: Path, module_name: str) -> tuple[Path
     candidates.extend(sorted(core_dir.glob(f"{module_name}_*.py")))
     if package_dir.exists() and package_dir.is_dir():
         candidates.extend(
-            path for path in sorted(package_dir.glob("*.py")) if path.name != "__init__.py"
+            path
+            for path in sorted(package_dir.rglob("*.py"))
+            if path.name != "__init__.py"
         )
 
     unique: list[Path] = []
@@ -437,16 +447,17 @@ def _collect_violations(
     """Collect structured violation details for remediation guidance output.
 
     Input errors are reported by collect_boundary_issues/check_boundaries;
-    this helper only returns actual boundary violations.
+    this helper skips unreadable or unparsable files and only returns actual
+    boundary violations.
     """
     violation_details: list[ViolationDetail] = []
     for rule in rules:
         for path in _resolve_module_source_paths(core_dir, rule.source_module):
             try:
                 source = path.read_text(encoding="utf-8")
-            except FileNotFoundError:
+                tree = ast.parse(source, filename=str(path))
+            except (FileNotFoundError, PermissionError, SyntaxError):
                 continue
-            tree = ast.parse(source, filename=str(path))
             imported = _collect_imported_names(tree)
             violations = sorted(imported & rule.forbidden_imports)
             for forbidden_module in violations:

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -218,7 +218,17 @@ def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
                 f"Boundary check error: '{rule.source_module}' not found at {path}"
             )
             continue
-        tree = ast.parse(source, filename=str(path))
+        except PermissionError:
+            messages.append(f"Boundary check error: permission denied for {path}")
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            messages.append(
+                "Boundary check error: invalid Python syntax in "
+                f"{path} at line {exc.lineno}"
+            )
+            continue
         imported = _collect_imported_names(tree)
         violations = sorted(imported & rule.forbidden_imports)
         messages.extend(
@@ -232,28 +242,27 @@ def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
 
 
 def _resolve_module_source_path(core_dir: Path, module_name: str) -> Path:
-    """Resolve module source path for flat module or package module."""
-    path = core_dir / f"{module_name}.py"
-    if path.exists():
-        return path
-    pkg_init = core_dir / module_name / "__init__.py"
-    if pkg_init.exists():
-        return pkg_init
-    return path
+    """Resolve the primary source path for backward-compatible callers."""
+    return _resolve_module_source_paths(core_dir, module_name)[0]
 
 
 def _resolve_module_source_paths(core_dir: Path, module_name: str) -> tuple[Path, ...]:
-    """Resolve source paths for a module and its helper modules."""
+    """Resolve source paths for a logical module and its helper modules."""
     candidates: list[Path] = []
     flat_path = core_dir / f"{module_name}.py"
     if flat_path.exists():
         candidates.append(flat_path)
 
-    pkg_init = core_dir / module_name / "__init__.py"
+    package_dir = core_dir / module_name
+    pkg_init = package_dir / "__init__.py"
     if pkg_init.exists():
         candidates.append(pkg_init)
 
     candidates.extend(sorted(core_dir.glob(f"{module_name}_*.py")))
+    if package_dir.exists() and package_dir.is_dir():
+        candidates.extend(
+            path for path in sorted(package_dir.glob("*.py")) if path.name != "__init__.py"
+        )
 
     unique: list[Path] = []
     seen: set[Path] = set()
@@ -425,7 +434,11 @@ def _collect_violations(
     core_dir: Path,
     rules: Iterable[BoundaryRule] = DEFAULT_RULES,
 ) -> list[ViolationDetail]:
-    """Collect structured violation details for remediation guidance output."""
+    """Collect structured violation details for remediation guidance output.
+
+    Input errors are reported by collect_boundary_issues/check_boundaries;
+    this helper only returns actual boundary violations.
+    """
     violation_details: list[ViolationDetail] = []
     for rule in rules:
         for path in _resolve_module_source_paths(core_dir, rule.source_module):

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -973,3 +973,76 @@ def test_classify_issue_theme_promotes_fuji_and_memory_violations_to_security() 
 
     assert classify_issue_theme(fuji_issue) == "security"
     assert classify_issue_theme(memory_issue) == "security"
+
+def test_collect_boundary_issues_detects_forbidden_import_in_helper_module(
+    tmp_path: Path,
+) -> None:
+    """Forbidden imports in helper modules should be reported as violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji_helpers.py", "import veritas_os.core.kernel\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "fuji"
+    assert violations[0].forbidden_module == "kernel"
+    assert violations[0].path.name == "fuji_helpers.py"
+
+
+def test_check_boundaries_detects_forbidden_import_in_memory_helper_module(
+    tmp_path: Path,
+) -> None:
+    """check_boundaries should report violations coming from memory helpers."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(
+        tmp_path / "memory_security.py",
+        "from veritas_os.core import planner\n",
+    )
+
+    issues = check_boundaries(core_dir=tmp_path)
+
+    assert len(issues) == 1
+    assert "memory" in issues[0]
+    assert "planner" in issues[0]
+    assert "memory_security.py" in issues[0]
+
+
+def test_custom_kernel_rule_applies_to_kernel_helper_modules(tmp_path: Path) -> None:
+    """Custom kernel rules should apply to kernel helper modules as well."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(
+        tmp_path / "kernel_stages.py",
+        "from veritas_os.core.memory import add\n",
+    )
+
+    custom_rule = BoundaryRule(
+        source_module="kernel",
+        forbidden_imports=frozenset({"memory"}),
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path, rules=(custom_rule,))
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].path.name == "kernel_stages.py"
+    assert violations[0].source_module == "kernel"
+    assert violations[0].forbidden_module == "memory"
+
+
+def test_collect_boundary_issues_reports_helper_syntax_error_with_path(
+    tmp_path: Path,
+) -> None:
+    """Syntax errors in helper modules should report the helper file path."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji_helpers.py", "def broken(:\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    input_invalid_issues = [issue for issue in issues if issue.code == "input_invalid"]
+    assert len(input_invalid_issues) == 1
+    assert input_invalid_issues[0].path.name == "fuji_helpers.py"

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -1046,3 +1046,69 @@ def test_collect_boundary_issues_reports_helper_syntax_error_with_path(
     input_invalid_issues = [issue for issue in issues if issue.code == "input_invalid"]
     assert len(input_invalid_issues) == 1
     assert input_invalid_issues[0].path.name == "fuji_helpers.py"
+
+
+def test_collect_boundary_issues_detects_forbidden_import_in_package_helper_module(
+    tmp_path: Path,
+) -> None:
+    """Forbidden imports inside package helpers should be reported."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "fuji"
+    package_dir.mkdir()
+    _write_module(package_dir / "__init__.py", "# fuji package\n")
+    _write_module(
+        package_dir / "fuji_helpers.py",
+        "import veritas_os.core.kernel\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "fuji"
+    assert violations[0].forbidden_module == "kernel"
+    assert violations[0].path.name == "fuji_helpers.py"
+    assert violations[0].path.parent.name == "fuji"
+
+
+def test_collect_boundary_issues_detects_forbidden_import_in_package_helper_with_nonprefixed_name(
+    tmp_path: Path,
+) -> None:
+    """Package helper scans should include non-prefixed Python module names."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "memory"
+    package_dir.mkdir()
+    _write_module(package_dir / "__init__.py", "# memory package\n")
+    _write_module(
+        package_dir / "security.py",
+        "from veritas_os.core import planner\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "memory"
+    assert violations[0].forbidden_module == "planner"
+    assert violations[0].path.parent.name == "memory"
+    assert violations[0].path.name == "security.py"
+
+
+def test_check_boundaries_reports_syntax_error_in_package_helper_module(
+    tmp_path: Path,
+) -> None:
+    """Text-mode checker should return clean syntax errors for package helpers."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "fuji"
+    package_dir.mkdir()
+    _write_module(package_dir / "__init__.py", "# fuji package\n")
+    _write_module(package_dir / "fuji_helpers.py", "def broken(:\n")
+
+    issues = check_boundaries(core_dir=tmp_path)
+
+    assert len(issues) == 1
+    assert "invalid Python syntax" in issues[0]
+    assert "fuji_helpers.py" in issues[0]

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from scripts.architecture.check_responsibility_boundaries import (
     REMEDIATION_LINK,
+    _collect_violations,
     BoundaryIssue,
     BoundaryRule,
     DocAlignmentIssue,
@@ -1112,3 +1113,46 @@ def test_check_boundaries_reports_syntax_error_in_package_helper_module(
     assert len(issues) == 1
     assert "invalid Python syntax" in issues[0]
     assert "fuji_helpers.py" in issues[0]
+
+
+def test_collect_violations_skips_bad_helper_but_keeps_other_violations(
+    tmp_path: Path,
+) -> None:
+    """Violation collection should skip bad helpers and keep valid violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji_helpers.py", "def broken(:\n")
+    _write_module(tmp_path / "fuji_policy.py", "import veritas_os.core.kernel\n")
+
+    violations = _collect_violations(core_dir=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].source_module == "fuji"
+    assert violations[0].forbidden_module == "kernel"
+    assert violations[0].path.name == "fuji_policy.py"
+
+
+def test_collect_boundary_issues_detects_forbidden_import_in_nested_package_helper(
+    tmp_path: Path,
+) -> None:
+    """Nested package helper modules should be scanned for violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "memory"
+    nested_dir = package_dir / "search"
+    nested_dir.mkdir(parents=True)
+    _write_module(package_dir / "__init__.py", "# memory package\n")
+    _write_module(nested_dir / "__init__.py", "# memory search package\n")
+    _write_module(
+        nested_dir / "adapter.py",
+        "from veritas_os.core import planner\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "memory"
+    assert violations[0].forbidden_module == "planner"
+    assert violations[0].path.name == "adapter.py"
+    assert violations[0].path.parent.name == "search"

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from scripts.architecture.check_responsibility_boundaries import (
     REMEDIATION_LINK,
     _collect_violations,
+    _format_syntax_error_message,
     BoundaryIssue,
     BoundaryRule,
     DocAlignmentIssue,
@@ -171,6 +172,46 @@ def test_check_boundaries_detects_from_core_import_pattern(tmp_path: Path) -> No
     assert len(issues) == 1
     assert "planner" in issues[0]
     assert "kernel" in issues[0]
+
+
+def test_check_boundaries_detects_forbidden_import_of_kernel_helper_module(
+    tmp_path: Path,
+) -> None:
+    """Helper import leaves should map to logical forbidden modules."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(
+        tmp_path / "planner.py",
+        "from veritas_os.core import kernel_stages\n",
+    )
+
+    issues = check_boundaries(core_dir=tmp_path)
+
+    assert len(issues) == 1
+    assert "planner" in issues[0]
+    assert "kernel" in issues[0]
+    assert "planner.py" in issues[0]
+
+
+def test_collect_boundary_issues_detects_forbidden_import_of_memory_helper_module(
+    tmp_path: Path,
+) -> None:
+    """Logical-module aliases should detect helper imports as owner modules."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(
+        tmp_path / "planner.py",
+        "import veritas_os.core.memory_security\n",
+    )
+    custom_rule = BoundaryRule(
+        source_module="planner",
+        forbidden_imports=frozenset({"memory"}),
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path, rules=(custom_rule,))
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "planner"
+    assert violations[0].forbidden_module == "memory"
 
 
 def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
@@ -1156,3 +1197,39 @@ def test_collect_boundary_issues_detects_forbidden_import_in_nested_package_help
     assert violations[0].forbidden_module == "planner"
     assert violations[0].path.name == "adapter.py"
     assert violations[0].path.parent.name == "search"
+
+
+def test_collect_boundary_issues_detects_forbidden_import_in_nested_package_init(
+    tmp_path: Path,
+) -> None:
+    """Nested package __init__.py files should be scanned for violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "memory"
+    nested_dir = package_dir / "search"
+    nested_dir.mkdir(parents=True)
+    _write_module(package_dir / "__init__.py", "# memory package\n")
+    _write_module(
+        nested_dir / "__init__.py",
+        "from veritas_os.core import planner\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "memory"
+    assert violations[0].forbidden_module == "planner"
+    assert violations[0].path.name == "__init__.py"
+    assert violations[0].path.parent.name == "search"
+
+
+def test_format_syntax_error_message_handles_missing_lineno(tmp_path: Path) -> None:
+    """Syntax-error formatter should use unknown line when lineno is missing."""
+    exc = SyntaxError("bad")
+    exc.lineno = None
+
+    message = _format_syntax_error_message(tmp_path / "bad.py", exc)
+
+    assert "unknown line" in message
+    assert "line None" not in message


### PR DESCRIPTION
### Motivation
- The existing boundary checker only resolved a single source path per logical module and thus missed forbidden imports placed in helper files like `fuji_helpers.py` or `kernel_stages.py`. 
- CI/architecture guidance requires helper modules to be considered so forbidden imports are reliably detected for logical modules such as `fuji`, `memory`, and `kernel`.

### Description
- Add `_resolve_module_source_paths(core_dir, module_name)` that returns primary flat module, package `__init__.py`, and deterministic sorted `module_*.py` helper files with de-duplication and legacy fallback. 
- Update `collect_boundary_issues()` to iterate all resolved paths per `BoundaryRule`, emit `BoundaryIssue` entries per-path while preserving the logical `source_module` and existing message shape. 
- Update `_collect_violations()` and `_check_rule()` to use the new multi-path resolver so remediation guidance and the old text-mode rules both include helper-file violations. 
- Add focused unit tests in `veritas_os/tests/test_responsibility_boundary_checker.py` validating helper-file forbidden-import detection for `fuji`, `memory`, and `kernel` helpers and that helper-file syntax errors are reported with the helper path; docstring guard scope is unchanged.

### Testing
- Executed the CLI checker with `python3 scripts/architecture/check_responsibility_boundaries.py`, which returned a passing result. 
- Added focused unit tests and committed them, but running `pytest` in this environment failed because the interpreter lacks the `pytest` runner/module so the test suite could not be executed here. 
- Performed local static checks (`git diff --check`) and ensured the public output shape (issue keys and `source_module` semantics) was preserved.

Note: This change broadens detection surface and may surface new security-sensitive findings for `fuji`/`memory` modules; such findings should be reviewed by maintainers (human review is required for security-sensitive remediation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085c335de083269dc1c40a27a95517)