### PR TITLE
Enhance responsibility boundary checker to scan helper modules and ignore non-owned subtrees

### DIFF
--- a/docs/architecture/core_responsibility_boundaries.md
+++ b/docs/architecture/core_responsibility_boundaries.md
@@ -118,6 +118,9 @@ When changing one of the four core modules above:
    the boundary checker guidance in `scripts/architecture/check_responsibility_boundaries.py`.
 3. Do not move responsibilities across Planner / Kernel / FUJI / MemoryOS unless
    the architecture review explicitly approves the boundary change.
+4. The boundary checker intentionally skips helper files under common non-owned
+   directories such as `tests/`, `fixtures/`, `vendor/`, and `third_party/`
+   inside a logical module package.
 
 ## Security note
 

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -43,6 +43,19 @@ class BoundaryIssue:
     forbidden_module: str | None = None
 
 
+@dataclass(frozen=True)
+class ImportedNames:
+    """Imported names split by module-path leaves and imported symbol leaves."""
+
+    module_names: frozenset[str]
+    symbol_names: frozenset[str]
+
+    @property
+    def all_names(self) -> set[str]:
+        """Return both module and symbol leaves as a single set."""
+        return set(self.module_names) | set(self.symbol_names)
+
+
 THEME_BY_ISSUE_CODE: dict[str, str] = {
     "boundary_violation": "architecture",
     "doc_alignment_error": "operations",
@@ -178,6 +191,17 @@ MODULE_DOCSTRING_EXTENSION_POINTS: dict[str, tuple[str, ...]] = {
     "fuji": RECOMMENDED_EXTENSION_POINTS["fuji"],
     "memory": RECOMMENDED_EXTENSION_POINTS["memory"],
 }
+EXCLUDED_HELPER_PATH_PARTS: frozenset[str] = frozenset(
+    {
+        "__pycache__",
+        ".pytest_cache",
+        "tests",
+        "test",
+        "fixtures",
+        "vendor",
+        "third_party",
+    }
+)
 
 
 def _normalize_module_name(module_name: str) -> str:
@@ -185,65 +209,147 @@ def _normalize_module_name(module_name: str) -> str:
     return module_name.rsplit(".", maxsplit=1)[-1]
 
 
-def _collect_imported_names(tree: ast.Module) -> set[str]:
-    """Collect imported module names from a module AST."""
-    imported: set[str] = set()
+def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
+    """Collect module-leaf and symbol-leaf imports from a module AST."""
+    module_names: set[str] = set()
+    symbol_names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                imported.add(_normalize_module_name(alias.name))
+                module_names.add(_normalize_module_name(alias.name))
         elif isinstance(node, ast.ImportFrom):
-            # Include imported symbols to detect patterns like:
-            #   from veritas_os.core import kernel
-            # This is a forbidden dependency equivalent to
-            #   import veritas_os.core.kernel
-            for alias in node.names:
-                imported.add(_normalize_module_name(alias.name))
             if node.module:
-                imported.add(_normalize_module_name(node.module))
+                module_names.add(_normalize_module_name(node.module))
+                for alias in node.names:
+                    if node.module == "veritas_os.core":
+                        module_names.add(_normalize_module_name(alias.name))
+                    else:
+                        symbol_names.add(_normalize_module_name(alias.name))
             else:
                 for alias in node.names:
-                    imported.add(_normalize_module_name(alias.name))
-    return imported
+                    symbol_names.add(_normalize_module_name(alias.name))
+    return ImportedNames(
+        module_names=frozenset(module_names),
+        symbol_names=frozenset(symbol_names),
+    )
+
+
+def _collect_imported_names(tree: ast.Module) -> set[str]:
+    """Collect imported module and symbol leaf names from a module AST."""
+    return _collect_imported_name_parts(tree).all_names
+
+
+def _expand_logical_import_aliases(module_names: frozenset[str]) -> set[str]:
+    """Expand helper module imports to their logical core module names."""
+    expanded = set(module_names)
+    for module_name in module_names:
+        for logical_name in ("planner", "kernel", "fuji", "memory", "pipeline"):
+            if module_name.startswith(f"{logical_name}_"):
+                expanded.add(logical_name)
+    return expanded
+
+
+def _collect_boundary_import_names(tree: ast.Module) -> set[str]:
+    """Collect module import names used for responsibility-boundary matching."""
+    parts = _collect_imported_name_parts(tree)
+    return _expand_logical_import_aliases(parts.module_names)
 
 
 def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:
     """Check one rule and return violation messages, one per forbidden import found."""
-    path = core_dir / f"{rule.source_module}.py"
-    if not path.exists():
-        pkg_init = core_dir / rule.source_module / "__init__.py"
-        if pkg_init.exists():
-            path = pkg_init
-    try:
-        source = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return [f"Boundary check error: '{rule.source_module}' not found at {path}"]
-    tree = ast.parse(source, filename=str(path))
-    imported = _collect_imported_names(tree)
-    violations = sorted(imported & rule.forbidden_imports)
-
-    return [
-        f"Boundary violation: '{rule.source_module}' imports forbidden module '{v}' ({path})"
-        for v in violations
-    ]
+    messages: list[str] = []
+    for path in _resolve_module_source_paths(core_dir, rule.source_module):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            messages.append(
+                f"Boundary check error: '{rule.source_module}' not found at {path}"
+            )
+            continue
+        except PermissionError:
+            messages.append(f"Boundary check error: permission denied for {path}")
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            messages.append(
+                "Boundary check error: invalid Python syntax in "
+                f"{path} at line {exc.lineno}"
+            )
+            continue
+        imported = _collect_boundary_import_names(tree)
+        violations = sorted(imported & rule.forbidden_imports)
+        messages.extend(
+            [
+                "Boundary violation: "
+                f"'{rule.source_module}' imports forbidden module '{v}' ({path})"
+                for v in violations
+            ]
+        )
+    return messages
 
 
 def _resolve_module_source_path(core_dir: Path, module_name: str) -> Path:
-    """Resolve module source path for flat module or package module."""
-    path = core_dir / f"{module_name}.py"
-    if path.exists():
-        return path
-    pkg_init = core_dir / module_name / "__init__.py"
+    """Resolve the primary source path for backward-compatible callers."""
+    return _resolve_module_source_paths(core_dir, module_name)[0]
+
+
+def _resolve_module_source_paths(core_dir: Path, module_name: str) -> tuple[Path, ...]:
+    """Resolve source paths for a logical module and its helper modules.
+
+    Ownership contract:
+    - ``core/{module}.py`` and ``core/{module}/__init__.py`` belong to ``{module}``.
+    - Top-level ``core/{module}_*.py`` files are treated as helper shims owned by
+      ``{module}``.
+    - Python files under ``core/{module}/`` (recursively) are treated as
+      implementation helpers owned by ``{module}``.
+    - Helper scans skip common non-owned subtrees such as ``tests``,
+      ``fixtures``, ``vendor``, and ``third_party``.
+    """
+    candidates: list[Path] = []
+    flat_path = core_dir / f"{module_name}.py"
+    if flat_path.exists():
+        candidates.append(flat_path)
+
+    package_dir = core_dir / module_name
+    pkg_init = package_dir / "__init__.py"
     if pkg_init.exists():
-        return pkg_init
-    return path
+        candidates.append(pkg_init)
+
+    candidates.extend(sorted(core_dir.glob(f"{module_name}_*.py")))
+    if package_dir.exists() and package_dir.is_dir():
+        candidates.extend(
+            path
+            for path in sorted(package_dir.rglob("*.py"))
+            if _is_boundary_helper_path(path, package_dir)
+        )
+
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        unique.append(path)
+
+    if not unique:
+        return (flat_path,)
+    return tuple(unique)
 
 
 def _parse_imported_names(path: Path) -> set[str]:
-    """Parse a module and return imported names from its AST."""
+    """Parse a module and return boundary-relevant imported names from its AST."""
     source = path.read_text(encoding="utf-8")
     tree = ast.parse(source, filename=str(path))
-    return _collect_imported_names(tree)
+    return _collect_boundary_import_names(tree)
+
+
+def _is_boundary_helper_path(path: Path, package_dir: Path) -> bool:
+    """Return whether a package path should be scanned as a helper module."""
+    relative_parts = set(path.relative_to(package_dir).parts[:-1])
+    if relative_parts & EXCLUDED_HELPER_PATH_PARTS:
+        return False
+    return path.suffix == ".py"
 
 
 def _load_module_docstring(path: Path) -> str:
@@ -334,58 +440,61 @@ def collect_boundary_issues(
             )
         )
     for rule in rules:
-        path = _resolve_module_source_path(core_dir, rule.source_module)
-        try:
-            imported = _parse_imported_names(path)
-        except FileNotFoundError:
-            issues.append(
-                BoundaryIssue(
-                    code="input_invalid",
-                    message=f"Boundary check error: '{rule.source_module}' not found at {path}",
-                    path=path,
-                    source_module=rule.source_module,
+        for path in _resolve_module_source_paths(core_dir, rule.source_module):
+            try:
+                imported = _parse_imported_names(path)
+            except FileNotFoundError:
+                issues.append(
+                    BoundaryIssue(
+                        code="input_invalid",
+                        message=(
+                            f"Boundary check error: '{rule.source_module}' "
+                            f"not found at {path}"
+                        ),
+                        path=path,
+                        source_module=rule.source_module,
+                    )
                 )
-            )
-            continue
-        except PermissionError:
-            issues.append(
-                BoundaryIssue(
-                    code="permission_denied",
-                    message=f"Boundary check error: permission denied for {path}",
-                    path=path,
-                    source_module=rule.source_module,
+                continue
+            except PermissionError:
+                issues.append(
+                    BoundaryIssue(
+                        code="permission_denied",
+                        message=f"Boundary check error: permission denied for {path}",
+                        path=path,
+                        source_module=rule.source_module,
+                    )
                 )
-            )
-            continue
-        except SyntaxError as exc:
-            issues.append(
-                BoundaryIssue(
-                    code="input_invalid",
-                    message=(
-                        "Boundary check error: invalid Python syntax in "
-                        f"{path} at line {exc.lineno}"
-                    ),
-                    path=path,
-                    source_module=rule.source_module,
+                continue
+            except SyntaxError as exc:
+                issues.append(
+                    BoundaryIssue(
+                        code="input_invalid",
+                        message=(
+                            "Boundary check error: invalid Python syntax in "
+                            f"{path} at line {exc.lineno}"
+                        ),
+                        path=path,
+                        source_module=rule.source_module,
+                    )
                 )
-            )
-            continue
+                continue
 
-        violations = sorted(imported & rule.forbidden_imports)
-        for forbidden_module in violations:
-            issues.append(
-                BoundaryIssue(
-                    code="boundary_violation",
-                    message=(
-                        "Boundary violation: "
-                        f"'{rule.source_module}' imports forbidden module "
-                        f"'{forbidden_module}' ({path})"
-                    ),
-                    path=path,
-                    source_module=rule.source_module,
-                    forbidden_module=forbidden_module,
+            violations = sorted(imported & rule.forbidden_imports)
+            for forbidden_module in violations:
+                issues.append(
+                    BoundaryIssue(
+                        code="boundary_violation",
+                        message=(
+                            "Boundary violation: "
+                            f"'{rule.source_module}' imports forbidden module "
+                            f"'{forbidden_module}' ({path})"
+                        ),
+                        path=path,
+                        source_module=rule.source_module,
+                        forbidden_module=forbidden_module,
+                    )
                 )
-            )
     return issues
 
 
@@ -393,25 +502,30 @@ def _collect_violations(
     core_dir: Path,
     rules: Iterable[BoundaryRule] = DEFAULT_RULES,
 ) -> list[ViolationDetail]:
-    """Collect structured violation details for remediation guidance output."""
+    """Collect structured violation details for remediation guidance output.
+
+    Input errors are reported by collect_boundary_issues/check_boundaries;
+    this helper skips unreadable or unparsable files and only returns actual
+    boundary violations.
+    """
     violation_details: list[ViolationDetail] = []
     for rule in rules:
-        path = core_dir / f"{rule.source_module}.py"
-        try:
-            source = path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            continue
-        tree = ast.parse(source, filename=str(path))
-        imported = _collect_imported_names(tree)
-        violations = sorted(imported & rule.forbidden_imports)
-        for forbidden_module in violations:
-            violation_details.append(
-                ViolationDetail(
-                    source_module=rule.source_module,
-                    forbidden_module=forbidden_module,
-                    path=path,
+        for path in _resolve_module_source_paths(core_dir, rule.source_module):
+            try:
+                source = path.read_text(encoding="utf-8")
+                tree = ast.parse(source, filename=str(path))
+            except (FileNotFoundError, PermissionError, SyntaxError):
+                continue
+            imported = _collect_boundary_import_names(tree)
+            violations = sorted(imported & rule.forbidden_imports)
+            for forbidden_module in violations:
+                violation_details.append(
+                    ViolationDetail(
+                        source_module=rule.source_module,
+                        forbidden_module=forbidden_module,
+                        path=path,
+                    )
                 )
-            )
     return violation_details
 
 
@@ -421,7 +535,12 @@ def build_remediation_guide(
 ) -> str:
     """Build a CI-friendly remediation guide for boundary violations."""
     rows: list[str] = []
+    seen_pairs: set[tuple[str, str]] = set()
     for violation in violations:
+        pair = (violation.source_module, violation.forbidden_module)
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
         alternatives = ", ".join(
             ALLOWED_DEPENDENCY_GUIDE.get(violation.source_module, ("N/A",))
         )

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from scripts.architecture.check_responsibility_boundaries import (
     REMEDIATION_LINK,
+    _collect_violations,
     BoundaryIssue,
     BoundaryRule,
     DocAlignmentIssue,
@@ -973,3 +974,236 @@ def test_classify_issue_theme_promotes_fuji_and_memory_violations_to_security() 
 
     assert classify_issue_theme(fuji_issue) == "security"
     assert classify_issue_theme(memory_issue) == "security"
+
+def test_collect_boundary_issues_detects_forbidden_import_in_helper_module(
+    tmp_path: Path,
+) -> None:
+    """Forbidden imports in helper modules should be reported as violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji_helpers.py", "import veritas_os.core.kernel\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "fuji"
+    assert violations[0].forbidden_module == "kernel"
+    assert violations[0].path.name == "fuji_helpers.py"
+
+
+def test_check_boundaries_detects_forbidden_import_in_memory_helper_module(
+    tmp_path: Path,
+) -> None:
+    """check_boundaries should report violations coming from memory helpers."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(
+        tmp_path / "memory_security.py",
+        "from veritas_os.core import planner\n",
+    )
+
+    issues = check_boundaries(core_dir=tmp_path)
+
+    assert len(issues) == 1
+    assert "memory" in issues[0]
+    assert "planner" in issues[0]
+    assert "memory_security.py" in issues[0]
+
+
+def test_custom_kernel_rule_applies_to_kernel_helper_modules(tmp_path: Path) -> None:
+    """Custom kernel rules should apply to kernel helper modules as well."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(
+        tmp_path / "kernel_stages.py",
+        "from veritas_os.core.memory import add\n",
+    )
+
+    custom_rule = BoundaryRule(
+        source_module="kernel",
+        forbidden_imports=frozenset({"memory"}),
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path, rules=(custom_rule,))
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].path.name == "kernel_stages.py"
+    assert violations[0].source_module == "kernel"
+    assert violations[0].forbidden_module == "memory"
+
+
+def test_collect_boundary_issues_reports_helper_syntax_error_with_path(
+    tmp_path: Path,
+) -> None:
+    """Syntax errors in helper modules should report the helper file path."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji_helpers.py", "def broken(:\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    input_invalid_issues = [issue for issue in issues if issue.code == "input_invalid"]
+    assert len(input_invalid_issues) == 1
+    assert input_invalid_issues[0].path.name == "fuji_helpers.py"
+
+
+def test_collect_boundary_issues_detects_forbidden_import_in_package_helper_module(
+    tmp_path: Path,
+) -> None:
+    """Forbidden imports inside package helpers should be reported."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "fuji"
+    package_dir.mkdir()
+    _write_module(package_dir / "__init__.py", "# fuji package\n")
+    _write_module(
+        package_dir / "fuji_helpers.py",
+        "import veritas_os.core.kernel\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "fuji"
+    assert violations[0].forbidden_module == "kernel"
+    assert violations[0].path.name == "fuji_helpers.py"
+    assert violations[0].path.parent.name == "fuji"
+
+
+def test_collect_boundary_issues_detects_forbidden_import_in_package_helper_with_nonprefixed_name(
+    tmp_path: Path,
+) -> None:
+    """Package helper scans should include non-prefixed Python module names."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "memory"
+    package_dir.mkdir()
+    _write_module(package_dir / "__init__.py", "# memory package\n")
+    _write_module(
+        package_dir / "security.py",
+        "from veritas_os.core import planner\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "memory"
+    assert violations[0].forbidden_module == "planner"
+    assert violations[0].path.parent.name == "memory"
+    assert violations[0].path.name == "security.py"
+
+
+def test_check_boundaries_reports_syntax_error_in_package_helper_module(
+    tmp_path: Path,
+) -> None:
+    """Text-mode checker should return clean syntax errors for package helpers."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "fuji"
+    package_dir.mkdir()
+    _write_module(package_dir / "__init__.py", "# fuji package\n")
+    _write_module(package_dir / "fuji_helpers.py", "def broken(:\n")
+
+    issues = check_boundaries(core_dir=tmp_path)
+
+    assert len(issues) == 1
+    assert "invalid Python syntax" in issues[0]
+    assert "fuji_helpers.py" in issues[0]
+
+
+def test_collect_violations_skips_bad_helper_but_keeps_other_violations(
+    tmp_path: Path,
+) -> None:
+    """Violation collection should skip bad helpers and keep valid violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji_helpers.py", "def broken(:\n")
+    _write_module(tmp_path / "fuji_policy.py", "import veritas_os.core.kernel\n")
+
+    violations = _collect_violations(core_dir=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].source_module == "fuji"
+    assert violations[0].forbidden_module == "kernel"
+    assert violations[0].path.name == "fuji_policy.py"
+
+
+def test_collect_boundary_issues_detects_forbidden_import_in_nested_package_helper(
+    tmp_path: Path,
+) -> None:
+    """Nested package helper modules should be scanned for violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    package_dir = tmp_path / "memory"
+    nested_dir = package_dir / "search"
+    nested_dir.mkdir(parents=True)
+    _write_module(package_dir / "__init__.py", "# memory package\n")
+    _write_module(nested_dir / "__init__.py", "# memory search package\n")
+    _write_module(
+        nested_dir / "adapter.py",
+        "from veritas_os.core import planner\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    violations = [issue for issue in issues if issue.code == "boundary_violation"]
+    assert len(violations) == 1
+    assert violations[0].source_module == "memory"
+    assert violations[0].forbidden_module == "planner"
+    assert violations[0].path.name == "adapter.py"
+    assert violations[0].path.parent.name == "search"
+
+
+def test_boundary_matching_does_not_promote_imported_symbol_prefixes(
+    tmp_path: Path,
+) -> None:
+    """Symbol imports that start with module prefixes should not be promoted."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(
+        tmp_path / "planner.py",
+        "from veritas_os.core.utils import fuji_codes_const\n",
+    )
+
+    assert check_boundaries(core_dir=tmp_path) == []
+
+
+def test_build_remediation_guide_deduplicates_same_source_forbidden_pair(
+    tmp_path: Path,
+) -> None:
+    """Remediation guide should not duplicate the same forbidden pair rows."""
+    violations = [
+        ViolationDetail(
+            source_module="fuji",
+            forbidden_module="kernel",
+            path=tmp_path / "fuji_helpers.py",
+        ),
+        ViolationDetail(
+            source_module="fuji",
+            forbidden_module="kernel",
+            path=tmp_path / "fuji_policy.py",
+        ),
+    ]
+
+    guide = build_remediation_guide(violations)
+
+    assert guide.count("fuji -> kernel") == 1
+
+
+def test_collect_boundary_issues_ignores_vendor_subpackage_helpers(
+    tmp_path: Path,
+) -> None:
+    """Helpers under vendor directories should be excluded from scans."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    vendor_dir = tmp_path / "memory" / "vendor"
+    vendor_dir.mkdir(parents=True)
+    _write_module(tmp_path / "memory" / "__init__.py", "# memory package\n")
+    _write_module(vendor_dir / "adapter.py", "from veritas_os.core import planner\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert [issue for issue in issues if issue.code == "boundary_violation"] == []


### PR DESCRIPTION
### Motivation

- Make the static responsibility boundary checker detect violations in helper modules (e.g. `core/foo_helpers.py` or files under `core/foo/`) while avoiding noise from non-owned helper dirs like `tests/`, `vendor/`, and `third_party`.
- Improve robustness of the checker by handling multiple source paths per logical module and surfacing clear errors for unreadable or unparsable helper files.

### Description

- Update docs in `docs/architecture/core_responsibility_boundaries.md` to document that helper files under common non-owned directories (`tests/`, `fixtures/`, `vendor/`, `third_party`) are intentionally skipped by the boundary checker.
- Rework `scripts/architecture/check_responsibility_boundaries.py` to split imported names into module and symbol leaves via a new `ImportedNames` dataclass and to avoid promoting symbol imports to logical-module matches.
- Add helper discovery to resolve multiple source paths per logical module with `_resolve_module_source_paths` and `_is_boundary_helper_path`, expand logical aliases from helper filenames (e.g. `fuji_helpers` -> `fuji`), and skip excluded helper subtrees using `EXCLUDED_HELPER_PATH_PARTS`.
- Improve error handling and reporting by parsing all candidate files, catching `FileNotFoundError`, `PermissionError`, and `SyntaxError` with clear messages, and deduplicate remediation rows in `build_remediation_guide`.
- Update `_collect_violations` and import-collection helpers to operate across helper files and package modules rather than only the flat `core/{module}.py` path.
- Add and update unit tests in `veritas_os/tests/test_responsibility_boundary_checker.py` to cover helper-module scanning, package helpers, nested helpers, syntax error reporting, symbol-import matching behavior, remediation deduplication, and exclusion of vendor/test helpers.

### Testing

- Ran the responsibility boundary checker unit test file with `pytest veritas_os/tests/test_responsibility_boundary_checker.py`; all tests passed.
- Exercised code paths for helper-file discovery, syntax-error handling, and remediation guide generation via the newly added tests, which succeeded.
- Verified `check_boundaries` and `collect_boundary_issues` behavior against helper files, package helpers, and excluded vendor/test subtrees through the automated test suite, with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085c335de083269dc1c40a27a95517)