### PR TITLE
Fail fast when policy signing crypto is unavailable in strict posture

### DIFF
--- a/veritas_os/core/posture.py
+++ b/veritas_os/core/posture.py
@@ -564,6 +564,8 @@ def validate_posture_startup(defaults: PostureDefaults) -> List[str]:
                     )
                 errors.append(msg)
 
+    errors.extend(_validate_policy_signing_crypto(defaults))
+
     # ── Layer 2: backend-specific config validation (vendor-aware) ───
     errors.extend(
         _validate_backend_config(
@@ -575,6 +577,27 @@ def validate_posture_startup(defaults: PostureDefaults) -> List[str]:
     )
 
     return errors
+
+
+def _validate_policy_signing_crypto(defaults: PostureDefaults) -> List[str]:
+    """Validate policy signing crypto availability for strict posture."""
+    if defaults.posture not in {PostureLevel.SECURE, PostureLevel.PROD}:
+        return []
+    try:
+        from veritas_os.policy.signing import (
+            has_crypto_backend,
+            signing_crypto_missing_message,
+        )
+    except ImportError as exc:
+        return [
+            "Policy signing crypto availability check failed: "
+            f"{exc}. Install with `pip install 'veritas-os[signing]'`."
+        ]
+
+    if has_crypto_backend():
+        return []
+
+    return [signing_crypto_missing_message()]
 
 
 # ── Startup banner ──────────────────────────────────────────────────────

--- a/veritas_os/policy/signing.py
+++ b/veritas_os/policy/signing.py
@@ -31,6 +31,20 @@ except ImportError:  # pragma: no cover – optional dependency
 SIGNING_ALGORITHM = "ed25519"
 
 
+def has_crypto_backend() -> bool:
+    """Return True when Ed25519 cryptography backend is available."""
+    return _HAS_CRYPTO
+
+
+def signing_crypto_missing_message() -> str:
+    """Return operator guidance when policy signing crypto is unavailable."""
+    return (
+        "Policy signing requires the 'cryptography' package for Ed25519 "
+        "verification in secure/prod posture. Install with "
+        "`pip install 'veritas-os[signing]'` or use the full install profile."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Key management helpers
 # ---------------------------------------------------------------------------

--- a/veritas_os/tests/test_policy_signing.py
+++ b/veritas_os/tests/test_policy_signing.py
@@ -13,6 +13,8 @@ from veritas_os.policy.runtime_adapter import (
     verify_manifest_signature,
 )
 from veritas_os.policy.signing import (
+    has_crypto_backend,
+    signing_crypto_missing_message,
     generate_keypair,
     sign_manifest,
     verify_manifest_ed25519,
@@ -27,6 +29,18 @@ def _load_json(path: Path) -> dict:
 
 
 # --- signing module unit tests ---
+
+
+def test_has_crypto_backend_reflects_import_state() -> None:
+    assert has_crypto_backend() is True
+
+
+def test_signing_crypto_missing_message_mentions_install_extra() -> None:
+    message = signing_crypto_missing_message()
+    assert "cryptography" in message
+    assert "Ed25519" in message
+    assert "secure/prod posture" in message
+    assert "veritas-os[signing]" in message
 
 
 def test_generate_keypair_produces_pem_bytes() -> None:

--- a/veritas_os/tests/test_posture.py
+++ b/veritas_os/tests/test_posture.py
@@ -413,6 +413,79 @@ class TestValidatePostureStartup:
         assert any("unconditionally refused" in e for e in errors)
 
 
+def _crypto_errors(errors: list[str]) -> list[str]:
+    return [
+        err
+        for err in errors
+        if "cryptography" in err or "veritas-os[signing]" in err
+    ]
+
+
+class TestPolicySigningCryptoPostureValidation:
+    """Policy signing cryptography checks are strict-posture fail-fast."""
+
+    def test_validate_policy_signing_crypto_skips_dev_and_staging(self, monkeypatch):
+        _clean_env(monkeypatch)
+        import veritas_os.policy.signing as signing
+
+        monkeypatch.setattr(signing, "has_crypto_backend", lambda: False)
+
+        for level in (PostureLevel.DEV, PostureLevel.STAGING):
+            defaults = derive_defaults(level)
+            errors = validate_posture_startup(defaults)
+            assert _crypto_errors(errors) == []
+
+    def test_validate_policy_signing_crypto_errors_in_secure_when_missing(
+        self,
+        monkeypatch,
+    ):
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:aws:kms:us-east-1:1:key/a")
+        import veritas_os.policy.signing as signing
+
+        monkeypatch.setattr(signing, "has_crypto_backend", lambda: False)
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.SECURE))
+        crypto_errors = _crypto_errors(errors)
+        assert crypto_errors
+        assert any("cryptography" in err and "veritas-os[signing]" in err for err in crypto_errors)
+
+    def test_validate_policy_signing_crypto_errors_in_prod_when_missing(
+        self,
+        monkeypatch,
+    ):
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:aws:kms:us-east-1:1:key/a")
+        import veritas_os.policy.signing as signing
+
+        monkeypatch.setattr(signing, "has_crypto_backend", lambda: False)
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.PROD))
+        crypto_errors = _crypto_errors(errors)
+        assert crypto_errors
+        assert any("cryptography" in err and "veritas-os[signing]" in err for err in crypto_errors)
+
+    def test_validate_policy_signing_crypto_allows_strict_when_available(
+        self,
+        monkeypatch,
+    ):
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:aws:kms:us-east-1:1:key/a")
+        import veritas_os.policy.signing as signing
+
+        monkeypatch.setattr(signing, "has_crypto_backend", lambda: True)
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.SECURE))
+        assert _crypto_errors(errors) == []
+
+
+
 # ============================================================
 # init_posture — full startup flow
 # ============================================================
@@ -448,6 +521,20 @@ class TestInitPosture:
         d = init_posture(explicit="prod")
         assert d.posture == PostureLevel.PROD
         assert d.is_strict is True
+
+    def test_init_posture_secure_fails_when_policy_crypto_missing(self, monkeypatch):
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:aws:kms:us-east-1:1:key/a")
+        import veritas_os.policy.signing as signing
+
+        monkeypatch.setattr(signing, "has_crypto_backend", lambda: False)
+
+        with pytest.raises(PostureStartupError) as exc_info:
+            init_posture(explicit="secure", fail_on_error=True)
+
+        assert "cryptography" in str(exc_info.value) or "veritas-os[signing]" in str(exc_info.value)
 
     def test_secure_fails_without_integrations(self, monkeypatch):
         _clean_env(monkeypatch)


### PR DESCRIPTION
### Motivation
- Ensure secure/prod postures fail-fast at startup when Ed25519 signing support (`cryptography`) is missing so silent downgrade to weaker integrity checks is avoided.
- Do this without changing dependency profiles: keep `cryptography` as the `[signing]` extra and avoid promoting it to core dependencies.
- Preserve existing dev/staging behavior (optional crypto, warnings, and legacy SHA-256 fallback) while making strict postures explicit and operator-actionable.

### Description
- Add `has_crypto_backend()` and `signing_crypto_missing_message()` to `veritas_os.policy.signing` to expose crypto availability and provide operator guidance (message mentions `cryptography`, `Ed25519`, and `veritas-os[signing]`).
- Add `_validate_policy_signing_crypto(defaults: PostureDefaults) -> List[str]` to `veritas_os.core.posture` and call it from `validate_posture_startup()` so strict postures (`secure`/`prod`) return a startup error when crypto is missing.
- Make `ImportError` during the check surface as a startup error with actionable guidance to install `veritas-os[signing]` in strict postures; keep dev/staging non-fatal.
- Add focused tests: unit checks for the helpers in `veritas_os/tests/test_policy_signing.py` and posture validation tests in `veritas_os/tests/test_posture.py` that assert dev/staging skip the check and secure/prod fail when `has_crypto_backend()` is false.

### Testing
- Ran `python -m pytest -q veritas_os/tests/test_dependency_profiles.py` which passed locally (`7 passed`).
- Attempted `pytest -q veritas_os/tests/test_policy_signing.py` but collection failed due to missing test-environment packages (`ModuleNotFoundError: pydantic`) so the module-level tests could not be completely executed in this environment.
- Ran targeted posture tests with `python -m pytest -q veritas_os/tests/test_posture.py -k "policy_signing_crypto or init_posture_secure_fails_when_policy_crypto_missing"` and observed the added posture tests exercising the new checks; some runs failed due to the same environment/import issues during test collection in the current sandbox (missing test deps / pytest resolution). 
- `git diff --check` showed no whitespace errors and the code changes were committed for review; CI should run the full test matrix where required packages (`pydantic`, test runner) are available and is expected to verify the new posture tests pass once the environment has standard test deps installed.

Note: This is a targeted runtime posture/security change; it does not alter dependency profiles, signing semantics, SHA-256 fallback, governance, or release infra. Security improvement: strict postures now explicitly refuse to start without Ed25519 crypto, reducing silent downgrade risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b47c978c8326b8e244ac6e6cd95b)