### PR TITLE
Deprecate legacy core compatibility shims with centralized warning helper

### DIFF
--- a/veritas_os/core/_shim_deprecation.py
+++ b/veritas_os/core/_shim_deprecation.py
@@ -1,0 +1,36 @@
+"""Deprecation helpers for legacy core compatibility shims."""
+
+from __future__ import annotations
+
+import warnings
+
+SHIM_REMOVAL_VERSION = "v2.2.0"
+SHIM_REMOVAL_DATE = "2026-08-01"
+
+
+def warn_legacy_core_shim(
+    *,
+    legacy_module: str,
+    canonical_module: str,
+    stacklevel: int = 3,
+) -> None:
+    """Warn when a legacy core shim import path is used.
+
+    This intentionally uses DeprecationWarning rather than
+    FutureWarning/UserWarning so production runtime imports are not noisy by
+    default. CI, tests, and application boundaries can opt in with warning
+    filters when migration enforcement is desired.
+
+    The default stacklevel points warnings closer to the caller importing the
+    legacy shim instead of the shared helper itself.
+    """
+    warnings.warn(
+        (
+            f"{legacy_module} is a deprecated compatibility shim; "
+            f"import {canonical_module} instead. "
+            f"Removal planned for VERITAS OS {SHIM_REMOVAL_VERSION}, "
+            f"no earlier than {SHIM_REMOVAL_DATE}."
+        ),
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )

--- a/veritas_os/core/fuji_codes.py
+++ b/veritas_os/core/fuji_codes.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_codes")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_codes"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_helpers.py
+++ b/veritas_os/core/fuji_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_injection.py
+++ b/veritas_os/core/fuji_injection.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_injection")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_injection"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_policy.py
+++ b/veritas_os/core/fuji_policy.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_policy")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_policy"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_policy_rollout.py
+++ b/veritas_os/core/fuji_policy_rollout.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_policy_rollout")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_policy_rollout"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_safety_head.py
+++ b/veritas_os/core/fuji_safety_head.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_safety_head")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_safety_head"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_compliance.py
+++ b/veritas_os/core/memory_compliance.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_compliance")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_compliance"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_distillation.py
+++ b/veritas_os/core/memory_distillation.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_distillation")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_distillation"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_evidence.py
+++ b/veritas_os/core/memory_evidence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_evidence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_evidence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_helpers.py
+++ b/veritas_os/core/memory_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_lifecycle.py
+++ b/veritas_os/core/memory_lifecycle.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_lifecycle")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_lifecycle"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_search_helpers.py
+++ b/veritas_os/core/memory_search_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_search_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_search_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_security.py
+++ b/veritas_os/core/memory_security.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_security")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_security"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_storage.py
+++ b/veritas_os/core/memory_storage.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_storage")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_storage"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store.py
+++ b/veritas_os/core/memory_store.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store_compat.py
+++ b/veritas_os/core/memory_store_compat.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store_compat")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store_compat"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store_helpers.py
+++ b/veritas_os/core/memory_store_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_summary_helpers.py
+++ b/veritas_os/core/memory_summary_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_summary_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_summary_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_vector.py
+++ b/veritas_os/core/memory_vector.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_vector")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_vector"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/models/memory_model.py
+++ b/veritas_os/core/models/memory_model.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.models")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.models"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_compat.py
+++ b/veritas_os/core/pipeline_compat.py
@@ -4,7 +4,13 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_compat")
+from veritas_os.core._shim_deprecation import (
+    warn_legacy_core_shim as _warn_legacy_core_shim,
+)
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_compat"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger("veritas_os.core.pipeline")
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_contracts.py
+++ b/veritas_os/core/pipeline_contracts.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_contracts")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_contracts"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_critique.py
+++ b/veritas_os/core/pipeline_critique.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_critique")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_critique"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_decide_stages.py
+++ b/veritas_os/core/pipeline_decide_stages.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_decide_stages")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_decide_stages"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_evidence.py
+++ b/veritas_os/core/pipeline_evidence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_evidence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_evidence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_execute.py
+++ b/veritas_os/core/pipeline_execute.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_execute")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_execute"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_gate.py
+++ b/veritas_os/core/pipeline_gate.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_gate")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_gate"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_helpers.py
+++ b/veritas_os/core/pipeline_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_inputs.py
+++ b/veritas_os/core/pipeline_inputs.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_inputs")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_inputs"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_memory_adapter.py
+++ b/veritas_os/core/pipeline_memory_adapter.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_memory_adapter")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_memory_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_persist.py
+++ b/veritas_os/core/pipeline_persist.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_persist")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_persist"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_persistence.py
+++ b/veritas_os/core/pipeline_persistence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_persistence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_persistence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_policy.py
+++ b/veritas_os/core/pipeline_policy.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_policy")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_policy"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_replay.py
+++ b/veritas_os/core/pipeline_replay.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_replay")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_replay"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_response.py
+++ b/veritas_os/core/pipeline_response.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_response")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_response"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_retrieval.py
+++ b/veritas_os/core/pipeline_retrieval.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_retrieval")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_retrieval"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_signature_adapter.py
+++ b/veritas_os/core/pipeline_signature_adapter.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_signature_adapter")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_signature_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_types.py
+++ b/veritas_os/core/pipeline_types.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_types")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_types"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_web_adapter.py
+++ b/veritas_os/core/pipeline_web_adapter.py
@@ -4,7 +4,13 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_web_adapter")
+from veritas_os.core._shim_deprecation import (
+    warn_legacy_core_shim as _warn_legacy_core_shim,
+)
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_web_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger("veritas_os.core.pipeline")
 _sys.modules[__name__] = _target

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -272,7 +272,7 @@ class TestFujiRejectionPath:
         monkeypatch.setattr(p, "fuji_core", fake_fuji)
 
         # Also patch lazy import path in pipeline_policy
-        import veritas_os.core.pipeline_policy as pp
+        import veritas_os.core.pipeline.pipeline_policy as pp
         original_lazy = pp._lazy_import
         def mock_lazy(name, attr):
             if "fuji" in str(name):
@@ -330,7 +330,7 @@ class TestFujiRejectionPath:
         )
         monkeypatch.setattr(p, "fuji_core", fake_fuji)
 
-        import veritas_os.core.pipeline_policy as pp
+        import veritas_os.core.pipeline.pipeline_policy as pp
         original_lazy = pp._lazy_import
         def mock_lazy(name, attr):
             if "fuji" in str(name):

--- a/veritas_os/tests/test_legacy_core_shim_deprecations.py
+++ b/veritas_os/tests/test_legacy_core_shim_deprecations.py
@@ -1,0 +1,266 @@
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from veritas_os.core._shim_deprecation import (
+    SHIM_REMOVAL_DATE,
+    SHIM_REMOVAL_VERSION,
+    warn_legacy_core_shim,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+CORE_DIR = ROOT / "veritas_os" / "core"
+
+
+def _load_shim_module(module_name: str):
+    module_relpath = module_name.replace(".", "/") + ".py"
+    module_path = ROOT / module_relpath
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return sys.modules[module_name]
+
+
+def _assert_shim_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    legacy_module: str,
+    canonical_module: str,
+) -> None:
+    fake_target = types.ModuleType(canonical_module)
+
+    def _fake_import_module(module_name: str):
+        assert module_name == canonical_module
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    previous_legacy = sys.modules.get(legacy_module)
+    had_previous_legacy = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning) as warning:
+            module = _load_shim_module(legacy_module)
+
+        message = str(warning[0].message)
+        assert legacy_module in message
+        assert canonical_module in message
+        assert SHIM_REMOVAL_VERSION in message
+        assert SHIM_REMOVAL_DATE in message
+        assert module is fake_target
+    finally:
+        if had_previous_legacy:
+            sys.modules[legacy_module] = previous_legacy
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_fuji_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.fuji_helpers",
+        "veritas_os.core.fuji.fuji_helpers",
+    )
+
+
+def test_memory_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.memory_helpers",
+        "veritas_os.core.memory.memory_helpers",
+    )
+
+
+def test_pipeline_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.pipeline_helpers",
+        "veritas_os.core.pipeline.pipeline_helpers",
+    )
+
+
+def test_shim_deprecation_helper_message_contract() -> None:
+    with pytest.warns(DeprecationWarning) as warning:
+        warn_legacy_core_shim(
+            legacy_module="veritas_os.core.old",
+            canonical_module="veritas_os.core.new.old",
+        )
+
+    message = str(warning[0].message)
+    assert "veritas_os.core.old" in message
+    assert "veritas_os.core.new.old" in message
+    assert SHIM_REMOVAL_VERSION in message
+    assert SHIM_REMOVAL_DATE in message
+
+
+
+
+
+def test_warn_legacy_core_shim_accepts_custom_stacklevel() -> None:
+    with pytest.warns(DeprecationWarning) as warning:
+        warn_legacy_core_shim(
+            legacy_module="veritas_os.core.legacy",
+            canonical_module="veritas_os.core.canonical",
+            stacklevel=1,
+        )
+
+    message = str(warning[0].message)
+    assert "veritas_os.core.legacy" in message
+    assert "veritas_os.core.canonical" in message
+    assert SHIM_REMOVAL_VERSION in message
+    assert SHIM_REMOVAL_DATE in message
+
+def test_nested_memory_model_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.models.memory_model",
+        "veritas_os.core.memory.models",
+    )
+
+
+def test_pipeline_compat_shim_preserves_pipeline_logger_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_target = types.ModuleType("veritas_os.core.pipeline.pipeline_compat")
+    fake_target.logger = None
+
+    def _fake_import_module(module_name: str):
+        assert module_name == "veritas_os.core.pipeline.pipeline_compat"
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    legacy_module = "veritas_os.core.pipeline_compat"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning):
+            module = _load_shim_module(legacy_module)
+
+        assert module is fake_target
+        assert fake_target.logger.name == "veritas_os.core.pipeline"
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_pipeline_web_adapter_shim_preserves_pipeline_logger_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_target = types.ModuleType("veritas_os.core.pipeline.pipeline_web_adapter")
+    fake_target.logger = None
+
+    def _fake_import_module(module_name: str):
+        assert module_name == "veritas_os.core.pipeline.pipeline_web_adapter"
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    legacy_module = "veritas_os.core.pipeline_web_adapter"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning):
+            module = _load_shim_module(legacy_module)
+
+        assert module is fake_target
+        assert fake_target.logger.name == "veritas_os.core.pipeline"
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_assert_shim_warning_restores_legacy_sys_modules_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_module = "veritas_os.core.fuji_helpers"
+    sentinel = types.ModuleType(legacy_module)
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules[legacy_module] = sentinel
+        _assert_shim_warning(
+            monkeypatch,
+            legacy_module,
+            "veritas_os.core.fuji.fuji_helpers",
+        )
+        assert sys.modules[legacy_module] is sentinel
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_assert_shim_warning_removes_legacy_sys_modules_entry_when_absent_before(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_module = "veritas_os.core.fuji_helpers"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        _assert_shim_warning(
+            monkeypatch,
+            legacy_module,
+            "veritas_os.core.fuji.fuji_helpers",
+        )
+        assert legacy_module not in sys.modules
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def _is_legacy_shim_source(text: str) -> bool:
+    return (
+        text.startswith('"""Backward-compatible module alias')
+        and "import_module(" in text
+        and "veritas_os.core." in text
+        and (
+            "sys.modules[__name__] = _target" in text
+            or "_sys.modules[__name__] = _target" in text
+        )
+    )
+
+
+def test_all_legacy_core_shims_call_deprecation_helper() -> None:
+    missing: list[str] = []
+    for path in sorted(CORE_DIR.rglob("*.py")):
+        if path.name == "_shim_deprecation.py":
+            continue
+        if "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        is_legacy_shim = _is_legacy_shim_source(text)
+        calls_helper = (
+            "_warn_legacy_core_shim(" in text
+            or "warn_legacy_core_shim(" in text
+        )
+        if not is_legacy_shim or calls_helper:
+            continue
+        missing.append(path.relative_to(ROOT).as_posix())
+
+    assert not missing, (
+        "Legacy core shims missing deprecation warning: " + ", ".join(missing)
+    )


### PR DESCRIPTION
### Motivation
- Centralize and standardize deprecation warnings for legacy core compatibility shim modules to encourage migration to canonical import paths and provide a clear removal timeline.
- Ensure legacy shim behavior (module aliasing and logger preservation) remains intact while making deprecation visible to tests and CI.

### Description
- Add `veritas_os.core._shim_deprecation.warn_legacy_core_shim` which emits a `DeprecationWarning` with a planned removal version (`SHIM_REMOVAL_VERSION`) and date (`SHIM_REMOVAL_DATE`), and accepts a `stacklevel` parameter.
- Update many legacy shim modules (e.g. `veritas_os.core.fuji_*`, `veritas_os.core.memory_*`, `veritas_os.core.pipeline_*`, and nested model shims) to call the new helper and define `_TARGET_MODULE` before importing the canonical module.
- Preserve existing logger name behavior for pipeline shims by explicitly setting `logger` to `logging.getLogger("veritas_os.core.pipeline")` where appropriate.
- Update test code to import the canonical `pipeline_policy` path in two places in `test_decide_e2e_reliability.py`.
- Add comprehensive tests in `veritas_os/tests/test_legacy_core_shim_deprecations.py` to assert the warning message contract, `stacklevel` handling, logger name preservation, sys.modules restoration behavior, and coverage across all legacy shim files.

### Testing
- Added unit tests `veritas_os/tests/test_legacy_core_shim_deprecations.py` which exercise the new deprecation helper and validate all legacy shims call it, and updated `veritas_os/tests/test_decide_e2e_reliability.py` import paths; these tests were executed with `pytest` and passed.
- Ran the repository test suite with `pytest` to validate no regressions in shim aliasing and logging behavior, and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091fcfb2bc8326a515556a720f4c0b)