### PR TITLE
Centralize legacy core shim deprecation warnings and annotate shims

### DIFF
--- a/veritas_os/core/_shim_deprecation.py
+++ b/veritas_os/core/_shim_deprecation.py
@@ -1,0 +1,33 @@
+"""Deprecation helpers for legacy core compatibility shims."""
+
+from __future__ import annotations
+
+import warnings
+
+SHIM_REMOVAL_VERSION = "v2.2.0"
+SHIM_REMOVAL_DATE = "2026-08-01"
+
+
+def warn_legacy_core_shim(
+    *,
+    legacy_module: str,
+    canonical_module: str,
+    stacklevel: int = 3,
+) -> None:
+    """Warn when a legacy core shim import path is used.
+
+    This intentionally uses DeprecationWarning rather than
+    FutureWarning/UserWarning so production runtime imports are not noisy by
+    default. CI, tests, and application boundaries can opt in with warning
+    filters when migration enforcement is desired.
+    """
+    warnings.warn(
+        (
+            f"{legacy_module} is a deprecated compatibility shim; "
+            f"import {canonical_module} instead. "
+            f"Removal planned for VERITAS OS {SHIM_REMOVAL_VERSION}, "
+            f"no earlier than {SHIM_REMOVAL_DATE}."
+        ),
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )

--- a/veritas_os/core/fuji_codes.py
+++ b/veritas_os/core/fuji_codes.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_codes")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_codes"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_helpers.py
+++ b/veritas_os/core/fuji_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_injection.py
+++ b/veritas_os/core/fuji_injection.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_injection")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_injection"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_policy.py
+++ b/veritas_os/core/fuji_policy.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_policy")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_policy"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_policy_rollout.py
+++ b/veritas_os/core/fuji_policy_rollout.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_policy_rollout")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_policy_rollout"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_safety_head.py
+++ b/veritas_os/core/fuji_safety_head.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_safety_head")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_safety_head"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory/__init__.py
+++ b/veritas_os/core/memory/__init__.py
@@ -40,6 +40,7 @@ import os
 import time
 import threading
 import logging
+import warnings
 
 from ..config import capability_cfg, emit_capability_manifest, cfg
 from .memory_security import (
@@ -180,10 +181,12 @@ if capability_cfg.emit_manifest_on_import:
 
 memory_model_core = None
 try:
-    from veritas_os.core.models import memory_model as memory_model_core  # type: ignore
+    from . import models as memory_model_core  # type: ignore
 except (ImportError, ModuleNotFoundError):
     try:
-        from . import models as memory_model_core  # type: ignore
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from veritas_os.core.models import memory_model as memory_model_core  # type: ignore
     except (ImportError, ModuleNotFoundError):
         memory_model_core = None
 

--- a/veritas_os/core/memory_compliance.py
+++ b/veritas_os/core/memory_compliance.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_compliance")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_compliance"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_distillation.py
+++ b/veritas_os/core/memory_distillation.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_distillation")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_distillation"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_evidence.py
+++ b/veritas_os/core/memory_evidence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_evidence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_evidence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_helpers.py
+++ b/veritas_os/core/memory_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_lifecycle.py
+++ b/veritas_os/core/memory_lifecycle.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_lifecycle")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_lifecycle"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_search_helpers.py
+++ b/veritas_os/core/memory_search_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_search_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_search_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_security.py
+++ b/veritas_os/core/memory_security.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_security")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_security"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_storage.py
+++ b/veritas_os/core/memory_storage.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_storage")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_storage"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store.py
+++ b/veritas_os/core/memory_store.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store_compat.py
+++ b/veritas_os/core/memory_store_compat.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store_compat")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store_compat"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store_helpers.py
+++ b/veritas_os/core/memory_store_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_summary_helpers.py
+++ b/veritas_os/core/memory_summary_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_summary_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_summary_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_vector.py
+++ b/veritas_os/core/memory_vector.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_vector")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_vector"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/models/memory_model.py
+++ b/veritas_os/core/models/memory_model.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.models")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.models"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline/pipeline_gate.py
+++ b/veritas_os/core/pipeline/pipeline_gate.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -54,7 +55,12 @@ def _load_memory_model() -> Tuple[Any, Any, Any]:
     _pgl_fn = _default_predict_gate_label
 
     try:
-        from veritas_os.core.models import memory_model as memory_model_core
+        try:
+            from veritas_os.core.memory import models as memory_model_core
+        except (ImportError, ModuleNotFoundError):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                from veritas_os.core.models import memory_model as memory_model_core
 
         _mem_vec = getattr(memory_model_core, "MEM_VEC", None)
         _mem_clf = getattr(memory_model_core, "MEM_CLF", None)

--- a/veritas_os/core/pipeline_compat.py
+++ b/veritas_os/core/pipeline_compat.py
@@ -4,7 +4,13 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_compat")
+from veritas_os.core._shim_deprecation import (
+    warn_legacy_core_shim as _warn_legacy_core_shim,
+)
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_compat"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger("veritas_os.core.pipeline")
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_contracts.py
+++ b/veritas_os/core/pipeline_contracts.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_contracts")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_contracts"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_critique.py
+++ b/veritas_os/core/pipeline_critique.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_critique")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_critique"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_decide_stages.py
+++ b/veritas_os/core/pipeline_decide_stages.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_decide_stages")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_decide_stages"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_evidence.py
+++ b/veritas_os/core/pipeline_evidence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_evidence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_evidence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_execute.py
+++ b/veritas_os/core/pipeline_execute.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_execute")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_execute"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_gate.py
+++ b/veritas_os/core/pipeline_gate.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_gate")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_gate"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_helpers.py
+++ b/veritas_os/core/pipeline_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_inputs.py
+++ b/veritas_os/core/pipeline_inputs.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_inputs")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_inputs"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_memory_adapter.py
+++ b/veritas_os/core/pipeline_memory_adapter.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_memory_adapter")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_memory_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_persist.py
+++ b/veritas_os/core/pipeline_persist.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_persist")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_persist"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_persistence.py
+++ b/veritas_os/core/pipeline_persistence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_persistence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_persistence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_policy.py
+++ b/veritas_os/core/pipeline_policy.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_policy")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_policy"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_replay.py
+++ b/veritas_os/core/pipeline_replay.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_replay")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_replay"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_response.py
+++ b/veritas_os/core/pipeline_response.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_response")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_response"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_retrieval.py
+++ b/veritas_os/core/pipeline_retrieval.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_retrieval")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_retrieval"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_signature_adapter.py
+++ b/veritas_os/core/pipeline_signature_adapter.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_signature_adapter")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_signature_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_types.py
+++ b/veritas_os/core/pipeline_types.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_types")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_types"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_web_adapter.py
+++ b/veritas_os/core/pipeline_web_adapter.py
@@ -4,7 +4,13 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_web_adapter")
+from veritas_os.core._shim_deprecation import (
+    warn_legacy_core_shim as _warn_legacy_core_shim,
+)
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_web_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger("veritas_os.core.pipeline")
 _sys.modules[__name__] = _target

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -272,7 +272,7 @@ class TestFujiRejectionPath:
         monkeypatch.setattr(p, "fuji_core", fake_fuji)
 
         # Also patch lazy import path in pipeline_policy
-        import veritas_os.core.pipeline_policy as pp
+        import veritas_os.core.pipeline.pipeline_policy as pp
         original_lazy = pp._lazy_import
         def mock_lazy(name, attr):
             if "fuji" in str(name):
@@ -330,7 +330,7 @@ class TestFujiRejectionPath:
         )
         monkeypatch.setattr(p, "fuji_core", fake_fuji)
 
-        import veritas_os.core.pipeline_policy as pp
+        import veritas_os.core.pipeline.pipeline_policy as pp
         original_lazy = pp._lazy_import
         def mock_lazy(name, attr):
             if "fuji" in str(name):

--- a/veritas_os/tests/test_legacy_core_shim_deprecations.py
+++ b/veritas_os/tests/test_legacy_core_shim_deprecations.py
@@ -1,0 +1,314 @@
+import importlib
+import importlib.util
+import sys
+import types
+import warnings
+from pathlib import Path
+
+import pytest
+
+from veritas_os.core._shim_deprecation import (
+    SHIM_REMOVAL_DATE,
+    SHIM_REMOVAL_VERSION,
+    warn_legacy_core_shim,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+CORE_DIR = ROOT / "veritas_os" / "core"
+
+
+def _load_shim_module(module_name: str):
+    module_relpath = module_name.replace(".", "/") + ".py"
+    module_path = ROOT / module_relpath
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return sys.modules[module_name]
+
+
+def _assert_shim_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    legacy_module: str,
+    canonical_module: str,
+) -> None:
+    fake_target = types.ModuleType(canonical_module)
+
+    def _fake_import_module(module_name: str):
+        assert module_name == canonical_module
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    previous_legacy = sys.modules.get(legacy_module)
+    had_previous_legacy = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning) as warning:
+            module = _load_shim_module(legacy_module)
+
+        message = str(warning[0].message)
+        assert legacy_module in message
+        assert canonical_module in message
+        assert SHIM_REMOVAL_VERSION in message
+        assert SHIM_REMOVAL_DATE in message
+        assert module is fake_target
+    finally:
+        if had_previous_legacy:
+            sys.modules[legacy_module] = previous_legacy
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_fuji_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.fuji_helpers",
+        "veritas_os.core.fuji.fuji_helpers",
+    )
+
+
+def test_memory_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.memory_helpers",
+        "veritas_os.core.memory.memory_helpers",
+    )
+
+
+def test_pipeline_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.pipeline_helpers",
+        "veritas_os.core.pipeline.pipeline_helpers",
+    )
+
+
+def test_shim_deprecation_helper_message_contract() -> None:
+    with pytest.warns(DeprecationWarning) as warning:
+        warn_legacy_core_shim(
+            legacy_module="veritas_os.core.old",
+            canonical_module="veritas_os.core.new.old",
+        )
+
+    message = str(warning[0].message)
+    assert "veritas_os.core.old" in message
+    assert "veritas_os.core.new.old" in message
+    assert SHIM_REMOVAL_VERSION in message
+    assert SHIM_REMOVAL_DATE in message
+
+
+
+def _capture_stacklevel_warning(stacklevel: int) -> warnings.WarningMessage:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        warn_legacy_core_shim(
+            legacy_module="veritas_os.core.old",
+            canonical_module="veritas_os.core.new.old",
+            stacklevel=stacklevel,
+        )
+
+    assert caught
+    return caught[0]
+
+
+def test_warn_legacy_core_shim_stacklevel_changes_warning_location() -> None:
+    level_1 = _capture_stacklevel_warning(1)
+    level_2 = _capture_stacklevel_warning(2)
+
+    assert str(level_1.message) == str(level_2.message)
+    assert (level_1.filename, level_1.lineno) != (level_2.filename, level_2.lineno)
+
+
+def test_memory_package_import_does_not_emit_legacy_memory_model_warning() -> None:
+    previous_memory = sys.modules.get("veritas_os.core.memory")
+    previous_legacy = sys.modules.get("veritas_os.core.models.memory_model")
+    previous_llm_client = sys.modules.get("veritas_os.core.llm_client")
+    had_memory = "veritas_os.core.memory" in sys.modules
+    had_legacy = "veritas_os.core.models.memory_model" in sys.modules
+    had_llm_client = "veritas_os.core.llm_client" in sys.modules
+
+    try:
+        sys.modules.pop("veritas_os.core.memory", None)
+        sys.modules.pop("veritas_os.core.models.memory_model", None)
+        sys.modules["veritas_os.core.llm_client"] = types.ModuleType(
+            "veritas_os.core.llm_client"
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            importlib.import_module("veritas_os.core.memory")
+
+        messages = [str(item.message) for item in caught]
+        assert not any(
+            "veritas_os.core.models.memory_model is a deprecated compatibility shim"
+            in message
+            for message in messages
+        )
+    finally:
+        if had_memory:
+            sys.modules["veritas_os.core.memory"] = previous_memory
+        else:
+            sys.modules.pop("veritas_os.core.memory", None)
+
+        if had_legacy:
+            sys.modules["veritas_os.core.models.memory_model"] = previous_legacy
+        else:
+            sys.modules.pop("veritas_os.core.models.memory_model", None)
+
+        if had_llm_client:
+            sys.modules["veritas_os.core.llm_client"] = previous_llm_client
+        else:
+            sys.modules.pop("veritas_os.core.llm_client", None)
+
+
+def test_nested_memory_model_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.models.memory_model",
+        "veritas_os.core.memory.models",
+    )
+
+
+def test_pipeline_compat_shim_preserves_pipeline_logger_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_target = types.ModuleType("veritas_os.core.pipeline.pipeline_compat")
+    fake_target.logger = None
+
+    def _fake_import_module(module_name: str):
+        assert module_name == "veritas_os.core.pipeline.pipeline_compat"
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    legacy_module = "veritas_os.core.pipeline_compat"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning):
+            module = _load_shim_module(legacy_module)
+
+        assert module is fake_target
+        assert fake_target.logger.name == "veritas_os.core.pipeline"
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_pipeline_web_adapter_shim_preserves_pipeline_logger_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_target = types.ModuleType("veritas_os.core.pipeline.pipeline_web_adapter")
+    fake_target.logger = None
+
+    def _fake_import_module(module_name: str):
+        assert module_name == "veritas_os.core.pipeline.pipeline_web_adapter"
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    legacy_module = "veritas_os.core.pipeline_web_adapter"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning):
+            module = _load_shim_module(legacy_module)
+
+        assert module is fake_target
+        assert fake_target.logger.name == "veritas_os.core.pipeline"
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_assert_shim_warning_restores_legacy_sys_modules_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_module = "veritas_os.core.fuji_helpers"
+    sentinel = types.ModuleType(legacy_module)
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules[legacy_module] = sentinel
+        _assert_shim_warning(
+            monkeypatch,
+            legacy_module,
+            "veritas_os.core.fuji.fuji_helpers",
+        )
+        assert sys.modules[legacy_module] is sentinel
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_assert_shim_warning_removes_legacy_sys_modules_entry_when_absent_before(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_module = "veritas_os.core.fuji_helpers"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        _assert_shim_warning(
+            monkeypatch,
+            legacy_module,
+            "veritas_os.core.fuji.fuji_helpers",
+        )
+        assert legacy_module not in sys.modules
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def _is_legacy_shim_source(text: str) -> bool:
+    return (
+        text.startswith('"""Backward-compatible module alias')
+        and "import_module(" in text
+        and "veritas_os.core." in text
+        and (
+            "sys.modules[__name__] = _target" in text
+            or "_sys.modules[__name__] = _target" in text
+        )
+    )
+
+
+def test_all_legacy_core_shims_call_deprecation_helper() -> None:
+    missing: list[str] = []
+    for path in sorted(CORE_DIR.rglob("*.py")):
+        if path.name == "_shim_deprecation.py":
+            continue
+        if "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        is_legacy_shim = _is_legacy_shim_source(text)
+        calls_helper = (
+            "_warn_legacy_core_shim(" in text
+            or "warn_legacy_core_shim(" in text
+        )
+        if not is_legacy_shim or calls_helper:
+            continue
+        missing.append(path.relative_to(ROOT).as_posix())
+
+    assert not missing, (
+        "Legacy core shims missing deprecation warning: " + ", ".join(missing)
+    )


### PR DESCRIPTION
### Motivation

- Provide a single helper to emit consistent deprecation warnings for legacy `veritas_os.core.*` compatibility shims with an explicit removal version and date.  
- Ensure legacy shim imports are discoverable in tests/CI while remaining quiet by default at production runtime.  
- Make the memory model import fallbacks less noisy by preferring the new relative package and suppressing the shim warning when falling back.  

### Description

- Add `veritas_os/core/_shim_deprecation.py` exposing `warn_legacy_core_shim` and constants `SHIM_REMOVAL_VERSION` and `SHIM_REMOVAL_DATE`.  
- Update many legacy shim modules (pipeline, memory, fuji, models, etc.) to call the new deprecation helper and to use a `_TARGET_MODULE` constant before delegating to the real module.  
- Adjust `veritas_os/core/memory/__init__.py` to prefer the relative `from . import models` import and to import `veritas_os.core.models.memory_model` inside a `warnings.catch_warnings()` block to suppress a DeprecationWarning during the fallback.  
- Add comprehensive unit tests in `veritas_os/tests/test_legacy_core_shim_deprecations.py` that validate the deprecation message contract, stacklevel behavior, that shims restore `sys.modules` correctly, and that the memory package import path does not emit an unwanted legacy shim warning.  
- Update a couple of tests in `veritas_os/tests/test_decide_e2e_reliability.py` to reference the canonical pipeline import path (`veritas_os.core.pipeline.pipeline_policy`).  

### Testing

- Ran the new shim deprecation tests with `pytest veritas_os/tests/test_legacy_core_shim_deprecations.py` and all assertions passed.  
- Exercised the modified Fuji/decision tests with `pytest veritas_os/tests/test_decide_e2e_reliability.py::TestFujiRejectionPath` and they passed after updating import paths.  
- The change is covered by the added unit tests which validate warning text, stacklevel behavior, `sys.modules` restoration, and the memory import fallback behavior, and these tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091fcfb2bc8326a515556a720f4c0b)