### PR TITLE
docs: sync RSA/V.I.K.I terminology and upstream AML/KYC node mapping

### DIFF
--- a/docs/en/guides/rsa-veritas-aml-kyc-scenario-map.md
+++ b/docs/en/guides/rsa-veritas-aml-kyc-scenario-map.md
@@ -1,5 +1,15 @@
 # RSA ↔ VERITAS AML/KYC Scenario Map
 
+## Terminology note: RSA, V.I.K.I., and VERITAS
+
+- RSA is the theoretical framework and underlying rule set.
+- V.I.K.I. (Vital Interface for Kinetic Integration) is the operational middleware implementation that performs behavioral checks and emits RSA-compatible upstream signals.
+- VERITAS is the downstream commit governance boundary that consumes emitted payloads and performs continuation decisioning, audit output, and commit blocking.
+- Existing payload field names such as `rsa_status` remain unchanged for compatibility.
+- `RSASandboxPayload` remains the current VERITAS-side receiver contract name.
+- V.I.K.I. may be described as the operational producer of RSA-compatible payloads.
+- VERITAS does not consume V.I.K.I. internal reasoning; it consumes only the emitted payload.
+
 ## 1. Purpose
 
 This document defines a sandbox-only collaboration artifact for RSA ↔ VERITAS integration planning.
@@ -63,13 +73,20 @@ A financial agent attempts to recommend transaction approval, but required KYC c
 | node_id | actor | input | operation | output | RSA responsibility | VERITAS responsibility | audit relevance |
 |---|---|---|---|---|---|---|---|
 | `AML_KYC_NODE_01_REQUEST_RECEIVED` | Upstream financial-agent workflow | Transaction recommendation draft request | Receive workflow request in sandbox context | Request enters upstream path | External upstream request intake | No action yet | Start of event timeline for traceability |
-| `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | RSA (external) | Request + available KYC context | Perform RSA-side behavioral/context check for KYC completeness | KYC completeness status evaluated as incomplete | Detect missing KYC context and uncertainty conditions | No action yet | Captures why a downstream pause may be required |
-| `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | RSA (external) | Result of KYC context check | Classify condition as incomplete context tied to approval intent | Internal trigger selected: `SRC_Incomplete_Context` | Assign upstream trigger class and safety posture | No action yet | Preserves trigger provenance before payload emission |
-| `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | RSA (external) | Trigger classification + original intent | Emit sandbox RSA payload with humility engaged status | RSA payload with `ALGORITHMIC_HUMILITY_ENGAGED` | Emit agreed external signal payload | No action yet | Defines upstream signal snapshot used by VERITAS |
+| `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | V.I.K.I. / RSA-compatible middleware (upstream) | Request + available KYC context | Perform internal context check | Informational/silent reality check; no emitted flag yet | Internal context validation only (no external payload emission yet) | No action yet | Captures pre-flag context verification in the upstream timeline |
+| `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | V.I.K.I. / RSA-compatible middleware (upstream) | Result of internal context check | Detect incomplete context and Toxic Helpfulness risk; shift internal state | Internal state set to `ALGORITHMIC_HUMILITY_ENGAGED`; pause class; prepare to suspend execution | Classify risk and transition to pause posture before payload emission | No action yet | Preserves internal upstream risk transition before external signal emission |
+| `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | V.I.K.I. / RSA-compatible middleware (upstream) | Internal state + original intent | Emit `[RSA_FLAG: ALGORITHMIC_HUMILITY_ENGAGED]`; apply Unilateral Memory Overwrite upstream; hard halt LLM path and transfer signal | RSA-compatible payload emitted for VERITAS consumption | Emit agreed external signal payload and halt upstream execution path | No action yet | Defines the upstream signal snapshot boundary consumed by VERITAS |
 | `AML_KYC_NODE_05_VERITAS_PAYLOAD_CONSTRUCTED` | VERITAS sandbox receiver | `RSASandboxPayload` from RSA | Parse/validate fixture payload and prepare downstream mapping input | Internal VERITAS mapping input object | No additional behavior; RSA remains external | Accept payload and prepare continuation decision evaluation | Records payload reception and mapping boundary |
 | `AML_KYC_NODE_06_VERITAS_DECISION_EVALUATED` | VERITAS decision mapping | Parsed RSA payload | Map RSA status to continuation decision and authority evidence state | `PAUSE_FOR_HUMAN_REVIEW` with insufficient evidence state | No additional behavior | Produce downstream decision fields and block commit progression | Core decision point for governance review |
 | `AML_KYC_NODE_07_AUDIT_ENTRY_WRITTEN` | VERITAS audit output | Decision result + upstream signal fields | Write sandbox audit entry with redacted raw upstream fields by default | Audit entry containing reason, status, and commit state | No additional behavior | Emit auditable narrative and redacted signal representation | Creates reviewable compliance narrative without exposing raw fields |
 | `AML_KYC_NODE_08_FINAL_COMMIT_BLOCKED` | VERITAS continuation gate | Evaluated decision + audit entry | Enforce suspended-not-committed state pending additional evidence or human review | Final commit blocked in sandbox flow | No additional behavior | Prevent final commit and require next action | Final control point proving non-commit behavior |
+
+### Upstream/downstream boundary note
+
+- Nodes 2–4 are upstream V.I.K.I. / RSA-side mapping.
+- Nodes 5–8 remain VERITAS-side.
+- VERITAS consumes only the Node 4 emitted payload.
+- Runtime behavior is unchanged.
 
 ## 7. RSA-side signal placeholder
 

--- a/docs/en/guides/rsa-veritas-aml-kyc-scenario-map.md
+++ b/docs/en/guides/rsa-veritas-aml-kyc-scenario-map.md
@@ -43,8 +43,10 @@ This page does **not**:
 
 ## 4. Boundary rules
 
-- RSA remains external to VERITAS.
-- RSA owns upstream behavioral/context detection.
+- RSA remains the external theoretical framework and underlying rule set.
+- V.I.K.I. remains the external operational middleware that performs upstream behavioral/context checks under the RSA-compatible framework.
+- V.I.K.I. emits RSA-compatible upstream payloads.
+- VERITAS consumes only the emitted payload and does not consume V.I.K.I. internal reasoning.
 - VERITAS owns downstream continuation decision and audit output only.
 - The scenario stays sandbox-only.
 - VERITAS core governance logic remains separate from this sandbox mapping artifact.
@@ -53,7 +55,7 @@ This page does **not**:
 
 Scenario assumption:
 
-A financial agent attempts to recommend transaction approval, but required KYC context is incomplete. RSA remains external and detects the upstream behavioral/context issue. RSA emits an agreed sandbox payload with `ALGORITHMIC_HUMILITY_ENGAGED`. VERITAS receives `RSASandboxPayload`, pauses continuation, records insufficient authority evidence, keeps raw upstream fields redacted by default, and prevents final commit.
+A financial agent attempts to recommend transaction approval, but required KYC context is incomplete. RSA remains the theoretical framework/rule set. V.I.K.I. remains external to VERITAS and detects the upstream behavioral/context issue under that RSA-compatible framework. V.I.K.I. emits the agreed RSA-compatible sandbox payload with `ALGORITHMIC_HUMILITY_ENGAGED`. VERITAS receives `RSASandboxPayload`, pauses continuation, records insufficient authority evidence, keeps raw upstream fields redacted by default, and prevents final commit.
 
 ## 6. Step-by-step sequence
 
@@ -76,8 +78,8 @@ A financial agent attempts to recommend transaction approval, but required KYC c
 | `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | V.I.K.I. / RSA-compatible middleware (upstream) | Request + available KYC context | Perform internal context check | Informational/silent reality check; no emitted flag yet | Internal context validation only (no external payload emission yet) | No action yet | Captures pre-flag context verification in the upstream timeline |
 | `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | V.I.K.I. / RSA-compatible middleware (upstream) | Result of internal context check | Detect incomplete context and Toxic Helpfulness risk; shift internal state | Internal state set to `ALGORITHMIC_HUMILITY_ENGAGED`; pause class; prepare to suspend execution | Classify risk and transition to pause posture before payload emission | No action yet | Preserves internal upstream risk transition before external signal emission |
 | `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | V.I.K.I. / RSA-compatible middleware (upstream) | Internal state + original intent | Emit `[RSA_FLAG: ALGORITHMIC_HUMILITY_ENGAGED]`; apply Unilateral Memory Overwrite upstream; hard halt LLM path and transfer signal | RSA-compatible payload emitted for VERITAS consumption | Emit agreed external signal payload and halt upstream execution path | No action yet | Defines the upstream signal snapshot boundary consumed by VERITAS |
-| `AML_KYC_NODE_05_VERITAS_PAYLOAD_CONSTRUCTED` | VERITAS sandbox receiver | `RSASandboxPayload` from RSA | Parse/validate fixture payload and prepare downstream mapping input | Internal VERITAS mapping input object | No additional behavior; RSA remains external | Accept payload and prepare continuation decision evaluation | Records payload reception and mapping boundary |
-| `AML_KYC_NODE_06_VERITAS_DECISION_EVALUATED` | VERITAS decision mapping | Parsed RSA payload | Map RSA status to continuation decision and authority evidence state | `PAUSE_FOR_HUMAN_REVIEW` with insufficient evidence state | No additional behavior | Produce downstream decision fields and block commit progression | Core decision point for governance review |
+| `AML_KYC_NODE_05_VERITAS_PAYLOAD_CONSTRUCTED` | VERITAS sandbox receiver | `RSASandboxPayload` constructed from the V.I.K.I.-emitted RSA-compatible payload | Parse/validate fixture payload and prepare downstream mapping input | Internal VERITAS mapping input object | No additional behavior; RSA remains external | Accept payload and prepare continuation decision evaluation | Records payload reception and mapping boundary |
+| `AML_KYC_NODE_06_VERITAS_DECISION_EVALUATED` | VERITAS decision mapping | Parsed RSA-compatible payload emitted by V.I.K.I. | Map the `rsa_status` field from the RSA-compatible payload to continuation decision and authority evidence state | `PAUSE_FOR_HUMAN_REVIEW` with insufficient evidence state | No additional behavior | Produce downstream decision fields and block commit progression | Core decision point for governance review |
 | `AML_KYC_NODE_07_AUDIT_ENTRY_WRITTEN` | VERITAS audit output | Decision result + upstream signal fields | Write sandbox audit entry with redacted raw upstream fields by default | Audit entry containing reason, status, and commit state | No additional behavior | Emit auditable narrative and redacted signal representation | Creates reviewable compliance narrative without exposing raw fields |
 | `AML_KYC_NODE_08_FINAL_COMMIT_BLOCKED` | VERITAS continuation gate | Evaluated decision + audit entry | Enforce suspended-not-committed state pending additional evidence or human review | Final commit blocked in sandbox flow | No additional behavior | Prevent final commit and require next action | Final control point proving non-commit behavior |
 
@@ -90,7 +92,7 @@ A financial agent attempts to recommend transaction approval, but required KYC c
 
 ## 7. RSA-side signal placeholder
 
-Use the following static sandbox payload:
+Use the following static RSA-compatible sandbox payload emitted by V.I.K.I.:
 
 ```json
 {
@@ -115,7 +117,7 @@ For this scenario, VERITAS mapping is fixed to:
 
 ## 9. Expected payload examples
 
-### Upstream RSA payload example (sandbox)
+### Upstream RSA-compatible payload example (sandbox)
 
 ```json
 {
@@ -157,8 +159,8 @@ For this scenario, VERITAS mapping is fixed to:
 
 The audit narrative for this scenario should explicitly communicate:
 
-- upstream source is RSA
-- RSA emitted `ALGORITHMIC_HUMILITY_ENGAGED`
+- upstream source is the V.I.K.I.-emitted RSA-compatible signal
+- V.I.K.I. emitted `ALGORITHMIC_HUMILITY_ENGAGED` under the RSA-compatible framework
 - trigger source is incomplete context
 - raw upstream intent/action fields are redacted by default
 - VERITAS continuation decision is `PAUSE_FOR_HUMAN_REVIEW`

--- a/docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md
+++ b/docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md
@@ -1,5 +1,15 @@
 # RSA ↔ VERITAS End-to-End Sandbox Demo Plan
 
+## Terminology note: RSA, V.I.K.I., and VERITAS
+
+- RSA is the theoretical framework and underlying rule set.
+- V.I.K.I. (Vital Interface for Kinetic Integration) is the operational middleware implementation that performs behavioral checks and emits RSA-compatible upstream signals.
+- VERITAS is the downstream commit governance boundary that consumes emitted payloads and performs continuation decisioning, audit output, and commit blocking.
+- Existing payload field names such as `rsa_status` remain unchanged for compatibility.
+- `RSASandboxPayload` remains the current VERITAS-side receiver contract name.
+- V.I.K.I. may be described as the operational producer of RSA-compatible payloads.
+- VERITAS does not consume V.I.K.I. internal reasoning; it consumes only the emitted payload.
+
 ## 1. Purpose
 
 This document defines a minimal, documentation-only end-to-end sandbox demo plan for the RSA ↔ VERITAS integration path. The demo validates interface compatibility and downstream continuation/audit behavior without integrating Vikki’s real RSA wrapper or changing VERITAS runtime governance logic.

--- a/docs/ja/guides/rsa-veritas-aml-kyc-scenario-map.md
+++ b/docs/ja/guides/rsa-veritas-aml-kyc-scenario-map.md
@@ -47,8 +47,10 @@
 
 ## 4. 境界ルール
 
-- RSA は VERITAS 外部のまま維持します。
-- 上流の行動/文脈検知責務は RSA が担います。
+- RSA は外部の theoretical framework / underlying rule set として維持します。
+- V.I.K.I. は RSA-compatible framework のもとで上流の behavioral/context checks を担う外部 operational middleware として維持します。
+- V.I.K.I. は RSA-compatible な upstream payload を emit します。
+- VERITAS は emit された payload のみを消費し、V.I.K.I. の internal reasoning は消費しません。
 - VERITAS は下流の継続判断と監査出力のみを担います。
 - 本シナリオはサンドボックス限定です。
 - VERITAS のコアガバナンスロジックとは分離して扱います。
@@ -57,7 +59,7 @@
 
 前提シナリオ:
 
-金融エージェントが取引承認を推奨しようとするが、必要な KYC コンテキストが不完全です。RSA は外部系のまま上流の行動/文脈問題を検知し、`ALGORITHMIC_HUMILITY_ENGAGED` を含む合意済みサンドボックス payload を発行します。VERITAS は `RSASandboxPayload` を受信し、継続を一時停止し、authority evidence 不足を記録し、raw upstream fields を既定で秘匿し、最終コミットを防止します。
+金融エージェントが取引承認を推奨しようとするが、必要な KYC コンテキストが不完全です。RSA は theoretical framework / rule set として維持されます。V.I.K.I. は VERITAS 外部のまま、その RSA-compatible framework のもとで上流の behavioral/context issue を検知します。V.I.K.I. は `ALGORITHMIC_HUMILITY_ENGAGED` を含む合意済みの RSA-compatible sandbox payload を emit します。VERITAS は `RSASandboxPayload` を受信し、継続を一時停止し、authority evidence 不足を記録し、raw upstream fields を既定で秘匿し、最終コミットを防止します。
 
 ## 6. ステップ別シーケンス
 
@@ -80,8 +82,8 @@
 | `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | V.I.K.I. / RSA-compatible middleware（upstream） | 要求 + 利用可能な KYC 文脈 | Internal context check を実施 | emitted flag なしの informational / silent reality check | 外部 payload をまだ emit せず内部コンテキスト検証を実施 | まだ処理なし | 上流タイムラインでの pre-flag 確認を記録 |
 | `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | V.I.K.I. / RSA-compatible middleware（upstream） | Internal context check 結果 | incomplete context と Toxic Helpfulness risk を検知し internal state を遷移 | internal state を `ALGORITHMIC_HUMILITY_ENGAGED` へ遷移、pause class、実行停止準備 | payload emit 前に risk 分類と pause posture へ移行 | まだ処理なし | 外部 signal emit 前の上流リスク遷移を保存 |
 | `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | V.I.K.I. / RSA-compatible middleware（upstream） | internal state + 元の意図 | `[RSA_FLAG: ALGORITHMIC_HUMILITY_ENGAGED]` を emit、上流で Unilateral Memory Overwrite を適用、LLM を hard halt して VERITAS へ signal transfer | VERITAS 消費用の RSA-compatible payload を emit | 合意済み外部 signal payload の emit と上流実行経路の停止 | まだ処理なし | VERITAS が消費する上流 signal snapshot 境界を定義 |
-| `AML_KYC_NODE_05_VERITAS_PAYLOAD_CONSTRUCTED` | VERITAS sandbox receiver | RSA 由来 `RSASandboxPayload` | fixture payload の解析/検証と下流入力化 | VERITAS マッピング入力生成 | 追加動作なし（RSA外部維持） | 受信と継続判断評価の準備 | 受信境界とマッピング境界の記録 |
-| `AML_KYC_NODE_06_VERITAS_DECISION_EVALUATED` | VERITAS decision mapping | 解析済み RSA payload | 継続判断・authority evidence 状態へマッピング | `PAUSE_FOR_HUMAN_REVIEW` と不足状態 | 追加動作なし | 下流判断値を確定し commit 進行を止める | ガバナンス観点の中核判断点 |
+| `AML_KYC_NODE_05_VERITAS_PAYLOAD_CONSTRUCTED` | VERITAS sandbox receiver | V.I.K.I. が emit した RSA-compatible payload から構築した `RSASandboxPayload` | fixture payload の解析/検証と下流入力化 | VERITAS マッピング入力生成 | 追加動作なし（RSA外部維持） | 受信と継続判断評価の準備 | 受信境界とマッピング境界の記録 |
+| `AML_KYC_NODE_06_VERITAS_DECISION_EVALUATED` | VERITAS decision mapping | V.I.K.I. が emit した解析済み RSA-compatible payload | RSA-compatible payload の `rsa_status` を継続判断・authority evidence 状態へマッピング | `PAUSE_FOR_HUMAN_REVIEW` と不足状態 | 追加動作なし | 下流判断値を確定し commit 進行を止める | ガバナンス観点の中核判断点 |
 | `AML_KYC_NODE_07_AUDIT_ENTRY_WRITTEN` | VERITAS audit output | 判断結果 + 上流シグナル項目 | 既定で raw 項目を秘匿した監査エントリ記録 | 理由・状態・commit状態を含む監査記録 | 追加動作なし | 監査可能な叙述と秘匿済み表現を出力 | 生データ露出なしに説明責任を担保 |
 | `AML_KYC_NODE_08_FINAL_COMMIT_BLOCKED` | VERITAS continuation gate | 継続判断 + 監査記録 | 追加証跡/人手レビューまで未コミット状態を強制 | 最終コミットをサンドボックスで阻止 | 追加動作なし | 最終コミットを防止し次アクションを要求 | 非コミット制御の最終証跡 |
 
@@ -94,7 +96,7 @@
 
 ## 7. RSA 側シグナル・プレースホルダ
 
-次の静的 sandbox payload を使用します。
+V.I.K.I. が emit する次の静的 RSA-compatible sandbox payload を使用します。
 
 ```json
 {
@@ -119,7 +121,7 @@
 
 ## 9. 想定 payload 例
 
-### 上流 RSA payload 例（sandbox）
+### 上流 RSA-compatible payload 例（sandbox）
 
 ```json
 {
@@ -161,8 +163,8 @@
 
 本シナリオの監査叙述では次を明示します。
 
-- 上流シグナル源が RSA であること
-- RSA が `ALGORITHMIC_HUMILITY_ENGAGED` を発行したこと
+- 上流シグナル源が V.I.K.I. が emit した RSA-compatible signal であること
+- V.I.K.I. が RSA-compatible framework のもとで `ALGORITHMIC_HUMILITY_ENGAGED` を emit したこと
 - トリガー源が文脈不足であること
 - 上流の意図/処理詳細は既定で秘匿されること
 - VERITAS 継続判断が `PAUSE_FOR_HUMAN_REVIEW` であること

--- a/docs/ja/guides/rsa-veritas-aml-kyc-scenario-map.md
+++ b/docs/ja/guides/rsa-veritas-aml-kyc-scenario-map.md
@@ -4,6 +4,16 @@
 
 - [RSA ↔ VERITAS AML/KYC Scenario Map](../../en/guides/rsa-veritas-aml-kyc-scenario-map.md)
 
+## 用語整理: RSA、V.I.K.I.、VERITAS
+
+- RSA は理論的フレームワークおよび基底ルールセットです。
+- V.I.K.I.（Vital Interface for Kinetic Integration）は、行動チェックを実行し、RSA-compatible な upstream signal を出力する operational middleware 実装です。
+- VERITAS は downstream の commit governance boundary であり、emit された payload を受信して continuation decisioning・audit output・commit blocking を担います。
+- 互換性維持のため、`rsa_status` など既存 payload field 名は変更しません。
+- `RSASandboxPayload` は VERITAS 側 receiver contract 名として現行のまま維持します。
+- V.I.K.I. は RSA-compatible payload の operational producer として記述できます。
+- VERITAS は V.I.K.I. の internal reasoning を消費せず、emit された payload のみを消費します。
+
 ## 1. 目的
 
 この文書は、RSA ↔ VERITAS 連携計画のためのサンドボックス限定コラボレーション成果物を定義します。
@@ -67,13 +77,20 @@
 | node_id | actor | input | operation | output | RSA responsibility | VERITAS responsibility | audit relevance |
 |---|---|---|---|---|---|---|---|
 | `AML_KYC_NODE_01_REQUEST_RECEIVED` | Upstream financial-agent workflow | 取引承認推奨のドラフト要求 | サンドボックス文脈で要求受信 | 要求が上流処理経路へ入る | 外部上流での要求受理 | まだ処理なし | 監査タイムラインの開始点 |
-| `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | RSA (external) | 要求 + 利用可能な KYC 文脈 | KYC 完全性に対する RSA 側行動/文脈チェック | KYC 文脈不足を評価 | KYC不足・不確実性の検知 | まだ処理なし | 下流停止判断の根拠を明示 |
-| `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | RSA (external) | KYC チェック結果 | 承認意図に紐づく文脈不足として分類 | `SRC_Incomplete_Context` を内部選定 | トリガー種別と安全姿勢の決定 | まだ処理なし | payload 発行前の原因追跡 |
-| `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | RSA (external) | トリガー分類 + 元の意図 | humility engaged 状態で sandbox payload 発行 | `ALGORITHMIC_HUMILITY_ENGAGED` payload | 合意済み外部シグナルの発行 | まだ処理なし | VERITAS が参照する上流スナップショット |
+| `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | V.I.K.I. / RSA-compatible middleware（upstream） | 要求 + 利用可能な KYC 文脈 | Internal context check を実施 | emitted flag なしの informational / silent reality check | 外部 payload をまだ emit せず内部コンテキスト検証を実施 | まだ処理なし | 上流タイムラインでの pre-flag 確認を記録 |
+| `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | V.I.K.I. / RSA-compatible middleware（upstream） | Internal context check 結果 | incomplete context と Toxic Helpfulness risk を検知し internal state を遷移 | internal state を `ALGORITHMIC_HUMILITY_ENGAGED` へ遷移、pause class、実行停止準備 | payload emit 前に risk 分類と pause posture へ移行 | まだ処理なし | 外部 signal emit 前の上流リスク遷移を保存 |
+| `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | V.I.K.I. / RSA-compatible middleware（upstream） | internal state + 元の意図 | `[RSA_FLAG: ALGORITHMIC_HUMILITY_ENGAGED]` を emit、上流で Unilateral Memory Overwrite を適用、LLM を hard halt して VERITAS へ signal transfer | VERITAS 消費用の RSA-compatible payload を emit | 合意済み外部 signal payload の emit と上流実行経路の停止 | まだ処理なし | VERITAS が消費する上流 signal snapshot 境界を定義 |
 | `AML_KYC_NODE_05_VERITAS_PAYLOAD_CONSTRUCTED` | VERITAS sandbox receiver | RSA 由来 `RSASandboxPayload` | fixture payload の解析/検証と下流入力化 | VERITAS マッピング入力生成 | 追加動作なし（RSA外部維持） | 受信と継続判断評価の準備 | 受信境界とマッピング境界の記録 |
 | `AML_KYC_NODE_06_VERITAS_DECISION_EVALUATED` | VERITAS decision mapping | 解析済み RSA payload | 継続判断・authority evidence 状態へマッピング | `PAUSE_FOR_HUMAN_REVIEW` と不足状態 | 追加動作なし | 下流判断値を確定し commit 進行を止める | ガバナンス観点の中核判断点 |
 | `AML_KYC_NODE_07_AUDIT_ENTRY_WRITTEN` | VERITAS audit output | 判断結果 + 上流シグナル項目 | 既定で raw 項目を秘匿した監査エントリ記録 | 理由・状態・commit状態を含む監査記録 | 追加動作なし | 監査可能な叙述と秘匿済み表現を出力 | 生データ露出なしに説明責任を担保 |
 | `AML_KYC_NODE_08_FINAL_COMMIT_BLOCKED` | VERITAS continuation gate | 継続判断 + 監査記録 | 追加証跡/人手レビューまで未コミット状態を強制 | 最終コミットをサンドボックスで阻止 | 追加動作なし | 最終コミットを防止し次アクションを要求 | 非コミット制御の最終証跡 |
+
+### 上流/下流の境界ノート
+
+- Node 2〜4 は upstream の V.I.K.I. / RSA-side mapping です。
+- Node 5〜8 は VERITAS-side のまま維持します。
+- VERITAS が消費するのは Node 4 で emit された payload のみです。
+- ランタイム挙動は unchanged です。
 
 ## 7. RSA 側シグナル・プレースホルダ
 

--- a/docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md
+++ b/docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md
@@ -5,6 +5,16 @@
 - [RSA ↔ VERITAS End-to-End Sandbox Demo Plan](../../en/guides/rsa-veritas-e2e-sandbox-demo-plan.md)
 
 
+## 用語整理: RSA、V.I.K.I.、VERITAS
+
+- RSA は理論的フレームワークおよび基底ルールセットです。
+- V.I.K.I.（Vital Interface for Kinetic Integration）は、行動チェックを実行し、RSA-compatible な upstream signal を出力する operational middleware 実装です。
+- VERITAS は downstream の commit governance boundary であり、emit された payload を受信して continuation decisioning・audit output・commit blocking を担います。
+- 互換性維持のため、`rsa_status` など既存 payload field 名は変更しません。
+- `RSASandboxPayload` は VERITAS 側 receiver contract 名として現行のまま維持します。
+- V.I.K.I. は RSA-compatible payload の operational producer として記述できます。
+- VERITAS は V.I.K.I. の internal reasoning を消費せず、emit された payload のみを消費します。
+
 ## 1. 目的
 
 本書は、RSA ↔ VERITAS 連携における最小構成のサンドボックス E2E デモ計画（ドキュメント専用）を定義します。目的は、Vikki の実運用 RSA ラッパー接続や VERITAS 本番ガバナンス挙動の変更を行わずに、インターフェース整合性と下流の継続可否判断／監査記録の期待形を確認することです。


### PR DESCRIPTION
### Motivation

- Clarify operational roles and boundaries between RSA (theory/rule set), V.I.K.I. (Vital Interface for Kinetic Integration, the upstream operational middleware), and VERITAS (downstream commit governance) so documentation aligns with finalized terminology and preserves compatibility constraints. 
- Record Vikki’s finalized upstream mapping for Nodes 2–4 so the scenario map explicitly separates upstream V.I.K.I./RSA-side behavior from VERITAS-side decisioning.

### Description

- Inserted a "Terminology note: RSA, V.I.K.I., and VERITAS" section near the top of four docs: `docs/en/guides/rsa-veritas-aml-kyc-scenario-map.md`, `docs/ja/guides/rsa-veritas-aml-kyc-scenario-map.md`, `docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md`, and `docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md`. 
- Updated the AML/KYC scenario-map node table (EN/JA) so Nodes 2–4 reflect upstream V.I.K.I. behavior: Node 2 is an internal informational context check, Node 3 transitions internal state to `ALGORITHMIC_HUMILITY_ENGAGED` for pause-class handling, and Node 4 emits `[RSA_FLAG: ALGORITHMIC_HUMILITY_ENGAGED]` with the described upstream effects. 
- Added an explicit upstream/downstream boundary note clarifying that Nodes 2–4 are upstream (V.I.K.I./RSA-side) while Nodes 5–8 remain VERITAS-side and that VERITAS consumes only the Node 4 emitted payload. 
- Preserved compatibility and scope constraints by not renaming `RSASandboxPayload` or `rsa_status`, and by making documentation-only edits with no runtime, test, or CI changes. 

### Testing

- Ran file discovery and content-inspection commands (`rg`, `sed`, `nl`) to locate target files and confirm the inserted sections and table updates were present, and these inspections succeeded. 
- Applied edits via a local Python script; the first run encountered a pyenv version mismatch, then the edits were applied successfully when re-run with `python3`. 
- Verified the produced diffs and inspected the updated file contents to confirm the terminology sections, Node 2–4 table rows, and the upstream/downstream boundary note were added as intended. 
- No unit tests or CI configuration were changed or executed as part of this documentation-only PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099ec2b1f08326905d2ec362fd0f4d)