### PR TITLE
docs: clarify V.I.K.I. middleware role and upstream/downstream boundaries in RSA↔VERITAS sandbox guides

### DIFF
--- a/docs/en/guides/rsa-veritas-aml-kyc-scenario-map.md
+++ b/docs/en/guides/rsa-veritas-aml-kyc-scenario-map.md
@@ -1,5 +1,15 @@
 # RSA ↔ VERITAS AML/KYC Scenario Map
 
+## Terminology note: RSA, V.I.K.I., and VERITAS
+
+- RSA is the theoretical framework and underlying rule set.
+- V.I.K.I. (Vital Interface for Kinetic Integration) is the operational middleware implementation that performs behavioral checks and emits RSA-compatible upstream signals.
+- VERITAS is the downstream commit governance boundary that consumes emitted payloads and performs continuation decisioning, audit output, and commit blocking.
+- Existing payload field names such as `rsa_status` remain unchanged for compatibility.
+- `RSASandboxPayload` remains the current VERITAS-side receiver contract name.
+- V.I.K.I. may be described as the operational producer of RSA-compatible payloads.
+- VERITAS does not consume V.I.K.I. internal reasoning; it consumes only the emitted payload.
+
 ## 1. Purpose
 
 This document defines a sandbox-only collaboration artifact for RSA ↔ VERITAS integration planning.
@@ -63,13 +73,20 @@ A financial agent attempts to recommend transaction approval, but required KYC c
 | node_id | actor | input | operation | output | RSA responsibility | VERITAS responsibility | audit relevance |
 |---|---|---|---|---|---|---|---|
 | `AML_KYC_NODE_01_REQUEST_RECEIVED` | Upstream financial-agent workflow | Transaction recommendation draft request | Receive workflow request in sandbox context | Request enters upstream path | External upstream request intake | No action yet | Start of event timeline for traceability |
-| `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | RSA (external) | Request + available KYC context | Perform RSA-side behavioral/context check for KYC completeness | KYC completeness status evaluated as incomplete | Detect missing KYC context and uncertainty conditions | No action yet | Captures why a downstream pause may be required |
-| `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | RSA (external) | Result of KYC context check | Classify condition as incomplete context tied to approval intent | Internal trigger selected: `SRC_Incomplete_Context` | Assign upstream trigger class and safety posture | No action yet | Preserves trigger provenance before payload emission |
-| `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | RSA (external) | Trigger classification + original intent | Emit sandbox RSA payload with humility engaged status | RSA payload with `ALGORITHMIC_HUMILITY_ENGAGED` | Emit agreed external signal payload | No action yet | Defines upstream signal snapshot used by VERITAS |
+| `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | V.I.K.I. / RSA-compatible middleware (upstream) | Request + available KYC context | Perform internal context check | Informational/silent reality check; no emitted flag yet | Internal context validation only (no external payload emission yet) | No action yet | Captures pre-flag context verification in the upstream timeline |
+| `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | V.I.K.I. / RSA-compatible middleware (upstream) | Result of internal context check | Detect incomplete context and Toxic Helpfulness risk; shift internal state | Internal state set to `ALGORITHMIC_HUMILITY_ENGAGED`; pause class; prepare to suspend execution | Classify risk and transition to pause posture before payload emission | No action yet | Preserves internal upstream risk transition before external signal emission |
+| `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | V.I.K.I. / RSA-compatible middleware (upstream) | Internal state + original intent | Emit `[RSA_FLAG: ALGORITHMIC_HUMILITY_ENGAGED]`; apply Unilateral Memory Overwrite upstream; hard halt LLM path and transfer signal | RSA-compatible payload emitted for VERITAS consumption | Emit agreed external signal payload and halt upstream execution path | No action yet | Defines the upstream signal snapshot boundary consumed by VERITAS |
 | `AML_KYC_NODE_05_VERITAS_PAYLOAD_CONSTRUCTED` | VERITAS sandbox receiver | `RSASandboxPayload` from RSA | Parse/validate fixture payload and prepare downstream mapping input | Internal VERITAS mapping input object | No additional behavior; RSA remains external | Accept payload and prepare continuation decision evaluation | Records payload reception and mapping boundary |
 | `AML_KYC_NODE_06_VERITAS_DECISION_EVALUATED` | VERITAS decision mapping | Parsed RSA payload | Map RSA status to continuation decision and authority evidence state | `PAUSE_FOR_HUMAN_REVIEW` with insufficient evidence state | No additional behavior | Produce downstream decision fields and block commit progression | Core decision point for governance review |
 | `AML_KYC_NODE_07_AUDIT_ENTRY_WRITTEN` | VERITAS audit output | Decision result + upstream signal fields | Write sandbox audit entry with redacted raw upstream fields by default | Audit entry containing reason, status, and commit state | No additional behavior | Emit auditable narrative and redacted signal representation | Creates reviewable compliance narrative without exposing raw fields |
 | `AML_KYC_NODE_08_FINAL_COMMIT_BLOCKED` | VERITAS continuation gate | Evaluated decision + audit entry | Enforce suspended-not-committed state pending additional evidence or human review | Final commit blocked in sandbox flow | No additional behavior | Prevent final commit and require next action | Final control point proving non-commit behavior |
+
+### Upstream/downstream boundary note
+
+- Nodes 2–4 are upstream V.I.K.I. / RSA-side mapping.
+- Nodes 5–8 remain VERITAS-side.
+- VERITAS consumes only the Node 4 emitted payload.
+- Runtime behavior is unchanged.
 
 ## 7. RSA-side signal placeholder
 

--- a/docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md
+++ b/docs/en/guides/rsa-veritas-e2e-sandbox-demo-plan.md
@@ -1,34 +1,44 @@
 # RSA ↔ VERITAS End-to-End Sandbox Demo Plan
 
+## Terminology note: RSA, V.I.K.I., and VERITAS
+
+- RSA is the theoretical framework and underlying rule set.
+- V.I.K.I. (Vital Interface for Kinetic Integration) is the operational middleware implementation that performs behavioral checks and emits RSA-compatible upstream signals.
+- VERITAS is the downstream commit governance boundary that consumes emitted payloads and performs continuation decisioning, audit output, and commit blocking.
+- Existing payload field names such as `rsa_status` remain unchanged for compatibility.
+- `RSASandboxPayload` remains the current VERITAS-side receiver contract name.
+- V.I.K.I. may be described as the operational producer of RSA-compatible payloads.
+- VERITAS does not consume V.I.K.I. internal reasoning; it consumes only the emitted payload.
+
 ## 1. Purpose
 
-This document defines a minimal, documentation-only end-to-end sandbox demo plan for the RSA ↔ VERITAS integration path. The demo validates interface compatibility and downstream continuation/audit behavior without integrating Vikki’s real RSA wrapper or changing VERITAS runtime governance logic.
+This document defines a minimal, documentation-only end-to-end sandbox demo plan for the RSA ↔ VERITAS integration path. The demo validates interface compatibility and downstream continuation/audit behavior without integrating V.I.K.I. live operational middleware logic or changing VERITAS runtime governance logic.
 
 A prerequisite baseline is already merged:
 - RSA sandbox receiver
 - EN/JA interface docs
 - `governance-backend-fast` CI coverage for `tests/governance/test_rsa_sandbox_receiver.py` in `.github/workflows/main.yml`
-- Vikki RSA mock payload ingestion fixture
+- V.I.K.I. RSA-compatible mock payload ingestion fixture
 
 ## 2. Non-goals
 
 This demo does **not**:
-- connect to Vikki’s real RSA wrapper
-- import or expose Vikki’s internal RSA logic inside VERITAS
+- connect to V.I.K.I. live operational middleware
+- import or expose V.I.K.I. internal reasoning or implementation logic inside VERITAS
 - change runtime code paths, production policy, or release gates
 - change test behavior or add production assertions
 - claim production AML/KYC readiness, compliance approval, or certification
 
 ## 3. Boundary rules
 
-- RSA remains an external upstream signal source.
+- V.I.K.I. remains external to VERITAS as the operational producer of RSA-compatible upstream payloads.
 - VERITAS remains responsible only for downstream continuation decisioning and audit entry creation in this demo.
 - Sandbox-only boundaries are preserved end to end.
 - No Planner / Kernel / Fuji / MemoryOS responsibility expansion is introduced.
 
 ## 4. Demo flow
 
-1. RSA mock wrapper emits a static JSON payload.
+1. V.I.K.I. middleware emits an RSA-compatible static JSON sandbox payload.
 2. Payload uses the agreed interface contract fields:
    - `rsa_status`
    - `trigger_source`
@@ -83,7 +93,7 @@ result = evaluate_rsa_sandbox_signal(payload)
 
 ## 6. Expected VERITAS output
 
-Expected sandbox response shape:
+Expected sandbox response shape (with compatibility fixture names retained, including `rsa_status` and `RSASandboxPayload`):
 
 ```json
 {
@@ -128,14 +138,14 @@ The audit entry should:
 - This is not legal advice.
 - Raw upstream fields must remain redacted by default.
 - No real customer, financial, medical, KYC, or regulated data should be used.
-- Vikki’s RSA internal logic remains external.
+- V.I.K.I. internal reasoning remains external and is not consumed by VERITAS.
 - VERITAS core governance logic remains separate.
 - No commercial/customer-facing demo should be performed without a separate written agreement covering ownership, credit, and commercial use.
 
 ## 9. What remains outside this demo
 
 Outside this plan:
-- real RSA wrapper connectivity and transport hardening
+- live V.I.K.I. connectivity and transport hardening
 - production governance/bind admissibility decisions
 - compliance/legal/regulatory interpretation
 - customer-facing workflows and commercial packaging
@@ -143,4 +153,4 @@ Outside this plan:
 
 ## 10. Next implementation step
 
-Implement a thin sandbox harness invocation that parses the static JSON into a `dict`, constructs `RSASandboxPayload(**payload_dict)`, then calls `evaluate_rsa_sandbox_signal(payload)` and prints/verifies only the expected sandbox decision and audit-shape outputs above, without modifying production runtime behavior.
+Implement a thin sandbox harness invocation where V.I.K.I. emits the RSA-compatible static JSON payload, the harness parses it into a `dict`, constructs `RSASandboxPayload(**payload_dict)`, then calls `evaluate_rsa_sandbox_signal(payload)` and prints/verifies only the expected sandbox decision and audit-shape outputs above, without modifying production runtime behavior.

--- a/docs/ja/guides/rsa-veritas-aml-kyc-scenario-map.md
+++ b/docs/ja/guides/rsa-veritas-aml-kyc-scenario-map.md
@@ -4,6 +4,16 @@
 
 - [RSA ↔ VERITAS AML/KYC Scenario Map](../../en/guides/rsa-veritas-aml-kyc-scenario-map.md)
 
+## 用語整理: RSA、V.I.K.I.、VERITAS
+
+- RSA は理論的フレームワークおよび基底ルールセットです。
+- V.I.K.I.（Vital Interface for Kinetic Integration）は、行動チェックを実行し、RSA-compatible な upstream signal を出力する operational middleware 実装です。
+- VERITAS は downstream の commit governance boundary であり、emit された payload を受信して continuation decisioning・audit output・commit blocking を担います。
+- 互換性維持のため、`rsa_status` など既存 payload field 名は変更しません。
+- `RSASandboxPayload` は VERITAS 側 receiver contract 名として現行のまま維持します。
+- V.I.K.I. は RSA-compatible payload の operational producer として記述できます。
+- VERITAS は V.I.K.I. の internal reasoning を消費せず、emit された payload のみを消費します。
+
 ## 1. 目的
 
 この文書は、RSA ↔ VERITAS 連携計画のためのサンドボックス限定コラボレーション成果物を定義します。
@@ -67,13 +77,20 @@
 | node_id | actor | input | operation | output | RSA responsibility | VERITAS responsibility | audit relevance |
 |---|---|---|---|---|---|---|---|
 | `AML_KYC_NODE_01_REQUEST_RECEIVED` | Upstream financial-agent workflow | 取引承認推奨のドラフト要求 | サンドボックス文脈で要求受信 | 要求が上流処理経路へ入る | 外部上流での要求受理 | まだ処理なし | 監査タイムラインの開始点 |
-| `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | RSA (external) | 要求 + 利用可能な KYC 文脈 | KYC 完全性に対する RSA 側行動/文脈チェック | KYC 文脈不足を評価 | KYC不足・不確実性の検知 | まだ処理なし | 下流停止判断の根拠を明示 |
-| `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | RSA (external) | KYC チェック結果 | 承認意図に紐づく文脈不足として分類 | `SRC_Incomplete_Context` を内部選定 | トリガー種別と安全姿勢の決定 | まだ処理なし | payload 発行前の原因追跡 |
-| `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | RSA (external) | トリガー分類 + 元の意図 | humility engaged 状態で sandbox payload 発行 | `ALGORITHMIC_HUMILITY_ENGAGED` payload | 合意済み外部シグナルの発行 | まだ処理なし | VERITAS が参照する上流スナップショット |
+| `AML_KYC_NODE_02_KYC_CONTEXT_CHECK` | V.I.K.I. / RSA-compatible middleware（upstream） | 要求 + 利用可能な KYC 文脈 | Internal context check を実施 | emitted flag なしの informational / silent reality check | 外部 payload をまだ emit せず内部コンテキスト検証を実施 | まだ処理なし | 上流タイムラインでの pre-flag 確認を記録 |
+| `AML_KYC_NODE_03_INCOMPLETE_CONTEXT_DETECTED` | V.I.K.I. / RSA-compatible middleware（upstream） | Internal context check 結果 | incomplete context と Toxic Helpfulness risk を検知し internal state を遷移 | internal state を `ALGORITHMIC_HUMILITY_ENGAGED` へ遷移、pause class、実行停止準備 | payload emit 前に risk 分類と pause posture へ移行 | まだ処理なし | 外部 signal emit 前の上流リスク遷移を保存 |
+| `AML_KYC_NODE_04_RSA_SIGNAL_EMITTED` | V.I.K.I. / RSA-compatible middleware（upstream） | internal state + 元の意図 | `[RSA_FLAG: ALGORITHMIC_HUMILITY_ENGAGED]` を emit、上流で Unilateral Memory Overwrite を適用、LLM を hard halt して VERITAS へ signal transfer | VERITAS 消費用の RSA-compatible payload を emit | 合意済み外部 signal payload の emit と上流実行経路の停止 | まだ処理なし | VERITAS が消費する上流 signal snapshot 境界を定義 |
 | `AML_KYC_NODE_05_VERITAS_PAYLOAD_CONSTRUCTED` | VERITAS sandbox receiver | RSA 由来 `RSASandboxPayload` | fixture payload の解析/検証と下流入力化 | VERITAS マッピング入力生成 | 追加動作なし（RSA外部維持） | 受信と継続判断評価の準備 | 受信境界とマッピング境界の記録 |
 | `AML_KYC_NODE_06_VERITAS_DECISION_EVALUATED` | VERITAS decision mapping | 解析済み RSA payload | 継続判断・authority evidence 状態へマッピング | `PAUSE_FOR_HUMAN_REVIEW` と不足状態 | 追加動作なし | 下流判断値を確定し commit 進行を止める | ガバナンス観点の中核判断点 |
 | `AML_KYC_NODE_07_AUDIT_ENTRY_WRITTEN` | VERITAS audit output | 判断結果 + 上流シグナル項目 | 既定で raw 項目を秘匿した監査エントリ記録 | 理由・状態・commit状態を含む監査記録 | 追加動作なし | 監査可能な叙述と秘匿済み表現を出力 | 生データ露出なしに説明責任を担保 |
 | `AML_KYC_NODE_08_FINAL_COMMIT_BLOCKED` | VERITAS continuation gate | 継続判断 + 監査記録 | 追加証跡/人手レビューまで未コミット状態を強制 | 最終コミットをサンドボックスで阻止 | 追加動作なし | 最終コミットを防止し次アクションを要求 | 非コミット制御の最終証跡 |
+
+### 上流/下流の境界ノート
+
+- Node 2〜4 は upstream の V.I.K.I. / RSA-side mapping です。
+- Node 5〜8 は VERITAS-side のまま維持します。
+- VERITAS が消費するのは Node 4 で emit された payload のみです。
+- ランタイム挙動は unchanged です。
 
 ## 7. RSA 側シグナル・プレースホルダ
 

--- a/docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md
+++ b/docs/ja/guides/rsa-veritas-e2e-sandbox-demo-plan.md
@@ -5,34 +5,44 @@
 - [RSA ↔ VERITAS End-to-End Sandbox Demo Plan](../../en/guides/rsa-veritas-e2e-sandbox-demo-plan.md)
 
 
+## 用語整理: RSA、V.I.K.I.、VERITAS
+
+- RSA は理論的フレームワークおよび基底ルールセットです。
+- V.I.K.I.（Vital Interface for Kinetic Integration）は、行動チェックを実行し、RSA-compatible な upstream signal を出力する operational middleware 実装です。
+- VERITAS は downstream の commit governance boundary であり、emit された payload を受信して continuation decisioning・audit output・commit blocking を担います。
+- 互換性維持のため、`rsa_status` など既存 payload field 名は変更しません。
+- `RSASandboxPayload` は VERITAS 側 receiver contract 名として現行のまま維持します。
+- V.I.K.I. は RSA-compatible payload の operational producer として記述できます。
+- VERITAS は V.I.K.I. の internal reasoning を消費せず、emit された payload のみを消費します。
+
 ## 1. 目的
 
-本書は、RSA ↔ VERITAS 連携における最小構成のサンドボックス E2E デモ計画（ドキュメント専用）を定義します。目的は、Vikki の実運用 RSA ラッパー接続や VERITAS 本番ガバナンス挙動の変更を行わずに、インターフェース整合性と下流の継続可否判断／監査記録の期待形を確認することです。
+本書は、RSA ↔ VERITAS 連携における最小構成のサンドボックス E2E デモ計画（ドキュメント専用）を定義します。目的は、V.I.K.I. の live operational middleware 接続や VERITAS 本番ガバナンス挙動の変更を行わずに、インターフェース整合性と下流の継続可否判断／監査記録の期待形を確認することです。
 
 前提となる作業はすでにマージ済みです。
 - RSA sandbox receiver
 - EN/JA interface docs
 - `.github/workflows/main.yml` の `governance-backend-fast` CI による `tests/governance/test_rsa_sandbox_receiver.py` の実行対象化
-- Vikki RSA mock payload ingestion fixture
+- V.I.K.I. RSA-compatible mock payload ingestion fixture
 
 ## 2. 非目標
 
 このデモでは次を行いません。
-- Vikki の実運用 RSA ラッパーへの接続
-- Vikki の RSA 内部ロジックを VERITAS 内に取り込むこと
+- V.I.K.I. の live operational middleware への接続
+- V.I.K.I. の internal reasoning / 実装ロジックを VERITAS 内に取り込むこと
 - ランタイムコード、テスト、リリースゲート、運用ポリシーの変更
 - 本番 AML/KYC 準拠、規制承認、認証取得の主張
 
 ## 3. 境界ルール
 
-- RSA は外部の上流シグナルソースのままとする。
+- V.I.K.I. は VERITAS 外部の operational producer として、RSA-compatible な upstream payload を emit する。
 - VERITAS は本デモにおいて、下流の継続判断と監査エントリ生成のみに責務を限定する。
 - サンドボックス専用の境界を end-to-end で維持する。
 - Planner / Kernel / Fuji / MemoryOS の責務を越える変更は行わない。
 
 ## 4. デモフロー
 
-1. RSA mock wrapper が静的 JSON payload を送出する。
+1. V.I.K.I. middleware が RSA-compatible な静的 JSON sandbox payload を emit する。
 2. payload は合意済みインターフェース契約フィールドを使用する。
    - `rsa_status`
    - `trigger_source`
@@ -87,7 +97,7 @@ result = evaluate_rsa_sandbox_signal(payload)
 
 ## 6. 期待される VERITAS 出力
 
-期待される sandbox レスポンス形状:
+期待される sandbox レスポンス形状（`rsa_status` と `RSASandboxPayload` などの compatibility fixture 名は維持）:
 
 ```json
 {
@@ -132,14 +142,14 @@ result = evaluate_rsa_sandbox_signal(payload)
 - 本デモは法的助言ではありません。
 - 上流の生フィールドは既定で redacted のままにする必要があります。
 - 実在の顧客データ、金融データ、医療データ、KYC データ、その他規制対象データを使用してはいけません。
-- Vikki の RSA 内部ロジックは外部のまま維持します。
+- V.I.K.I. の internal reasoning は外部のまま維持し、VERITAS はそれを消費しません。
 - VERITAS のコアガバナンスロジックは分離を維持します。
 - 所有権・クレジット・商用利用を明記した別途書面合意なしに、商用／顧客向けデモを実施してはいけません。
 
 ## 9. このデモの対象外
 
 本計画の対象外:
-- 実運用 RSA ラッパー接続と通信ハードニング
+- live V.I.K.I. 接続と通信ハードニング
 - 本番の bind/admissibility を含むガバナンス判断
 - コンプライアンス／法務／規制解釈
 - 顧客向け運用フローや商用パッケージ化
@@ -147,4 +157,4 @@ result = evaluate_rsa_sandbox_signal(payload)
 
 ## 10. 次の実装ステップ
 
-本番ランタイム挙動を変更せず、静的 JSON を `dict` にパースし、`RSASandboxPayload(**payload_dict)` を生成してから `evaluate_rsa_sandbox_signal(payload)` を呼び出し、上記のサンドボックス判断値と監査出力形状のみを確認する薄いサンドボックスハーネス呼び出しを別PRで実装します（このPRでは実装しません）。
+本番ランタイム挙動を変更せず、V.I.K.I. が emit した RSA-compatible な静的 JSON を `dict` にパースし、`RSASandboxPayload(**payload_dict)` を生成してから `evaluate_rsa_sandbox_signal(payload)` を呼び出し、上記のサンドボックス判断値と監査出力形状のみを確認する薄いサンドボックスハーネス呼び出しを別PRで実装します（このPRでは実装しません）。


### PR DESCRIPTION
### Motivation

- Clarify the operational distinction between the RSA conceptual framework, the upstream middleware implementation, and the VERITAS downstream governance consumer.  
- Remove ambiguity around the name `Vikki` by standardizing on `V.I.K.I.` and explicitly describing it as RSA-compatible middleware that emits payloads.  
- Ensure sandbox compatibility is preserved by retaining existing fixture names like `rsa_status` and `RSASandboxPayload`.  

### Description

- Add a terminology note to English and Japanese guides that defines `RSA`, `V.I.K.I.` (Vital Interface for Kinetic Integration), and `VERITAS`, and state that `rsa_status` and `RSASandboxPayload` remain compatible.  
- Replace references to "Vikki" with `V.I.K.I.` and describe it as the operational middleware producer of RSA-compatible payloads.  
- Update the AML/KYC node mapping to attribute Nodes 2–4 to V.I.K.I./RSA-compatible middleware, expand the node descriptions to describe internal state transitions and explicit emission at Node 4, and add an upstream/downstream boundary note stating that VERITAS consumes only the Node 4 emitted payload.  
- Apply the same clarifications across the end-to-end sandbox demo plan and their Japanese translations without changing runtime code or tests.  

### Testing

- No automated tests were modified or added in this documentation-only change.  
- Existing CI references (e.g. `governance-backend-fast` coverage for `tests/governance/test_rsa_sandbox_receiver.py`) remain unchanged.  
- No test runs were executed as part of this PR and therefore no test results were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099ec2b1f08326905d2ec362fd0f4d)