### PR TITLE
Add centralized shim deprecation helper and modernize legacy core shims & memory/pipeline compatibility

### DIFF
--- a/veritas_os/core/_shim_deprecation.py
+++ b/veritas_os/core/_shim_deprecation.py
@@ -1,0 +1,33 @@
+"""Deprecation helpers for legacy core compatibility shims."""
+
+from __future__ import annotations
+
+import warnings
+
+SHIM_REMOVAL_VERSION = "v2.2.0"
+SHIM_REMOVAL_DATE = "2026-08-01"
+
+
+def warn_legacy_core_shim(
+    *,
+    legacy_module: str,
+    canonical_module: str,
+    stacklevel: int = 3,
+) -> None:
+    """Warn when a legacy core shim import path is used.
+
+    This intentionally uses DeprecationWarning rather than
+    FutureWarning/UserWarning so production runtime imports are not noisy by
+    default. CI, tests, and application boundaries can opt in with warning
+    filters when migration enforcement is desired.
+    """
+    warnings.warn(
+        (
+            f"{legacy_module} is a deprecated compatibility shim; "
+            f"import {canonical_module} instead. "
+            f"Removal planned for VERITAS OS {SHIM_REMOVAL_VERSION}, "
+            f"no earlier than {SHIM_REMOVAL_DATE}."
+        ),
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )

--- a/veritas_os/core/fuji_codes.py
+++ b/veritas_os/core/fuji_codes.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_codes")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_codes"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_helpers.py
+++ b/veritas_os/core/fuji_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_injection.py
+++ b/veritas_os/core/fuji_injection.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_injection")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_injection"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_policy.py
+++ b/veritas_os/core/fuji_policy.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_policy")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_policy"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_policy_rollout.py
+++ b/veritas_os/core/fuji_policy_rollout.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_policy_rollout")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_policy_rollout"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/fuji_safety_head.py
+++ b/veritas_os/core/fuji_safety_head.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.fuji.fuji_safety_head")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.fuji.fuji_safety_head"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/kernel_stages.py
+++ b/veritas_os/core/kernel_stages.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import uuid
 import time
 import math
+import importlib
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 import logging
@@ -107,8 +108,8 @@ def collect_memory_evidence(
         return result
 
     try:
-        from . import memory as mem_core
-        memory_summary = mem_core.summarize_for_planner(
+        memory_module = importlib.import_module("veritas_os.core.memory")
+        memory_summary = memory_module.summarize_for_planner(
             user_id=user_id,
             query=query,
             limit=pipeline_cfg.memory_search_limit,
@@ -653,7 +654,10 @@ def save_episode_to_memory(
         return True
 
     try:
-        from . import memory as mem_core
+        memory_module = importlib.import_module("veritas_os.core.memory")
+        mem_store = getattr(memory_module, "MEM", None)
+        if mem_store is None:
+            return False
 
         user_id = context.get("user_id", "cli")
         req_id = context.get("request_id", uuid.uuid4().hex)
@@ -678,9 +682,9 @@ def save_episode_to_memory(
         }
 
         try:
-            mem_core.MEM.put("episodic", episode_record)
+            mem_store.put("episodic", episode_record)
         except TypeError:
-            mem_core.MEM.put(
+            mem_store.put(
                 user_id,
                 f"decision:{req_id}",
                 episode_record,

--- a/veritas_os/core/memory/__init__.py
+++ b/veritas_os/core/memory/__init__.py
@@ -40,6 +40,7 @@ import os
 import time
 import threading
 import logging
+import warnings
 
 from ..config import capability_cfg, emit_capability_manifest, cfg
 from .memory_security import (
@@ -180,10 +181,12 @@ if capability_cfg.emit_manifest_on_import:
 
 memory_model_core = None
 try:
-    from veritas_os.core.models import memory_model as memory_model_core  # type: ignore
+    from . import models as memory_model_core  # type: ignore
 except (ImportError, ModuleNotFoundError):
     try:
-        from . import models as memory_model_core  # type: ignore
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from veritas_os.core.models import memory_model as memory_model_core  # type: ignore
     except (ImportError, ModuleNotFoundError):
         memory_model_core = None
 
@@ -430,13 +433,30 @@ def locked_memory(path: Path, timeout: float = 5.0):
 
 def _compat_locked_memory(path: Path, timeout: float = 5.0) -> Any:
     """Route shared MemoryStore locking through memory.py for test compatibility."""
-    return locked_memory(path, timeout=timeout)
+    memory_module = sys.modules[__name__]
+    return memory_module.locked_memory(path, timeout=timeout)
+
+
+def _compat_filter_recent_records(
+    records: List[Dict[str, Any]],
+    *,
+    contains: Optional[str] = None,
+    limit: int = 20,
+) -> List[Dict[str, Any]]:
+    """Route recent-record filtering through memory.py for test compatibility."""
+    memory_module = sys.modules[__name__]
+    return memory_module.filter_recent_records(
+        records,
+        contains=contains,
+        limit=limit,
+    )
 
 
 install_memory_store_compat_hooks(
     locked_memory_fn=_compat_locked_memory,
     get_mem_vec_fn=_get_mem_vec,
     memory_module=sys.modules[__name__],
+    filter_recent_records_fn=_compat_filter_recent_records,
 )
 
 

--- a/veritas_os/core/memory/memory_store.py
+++ b/veritas_os/core/memory/memory_store.py
@@ -22,6 +22,7 @@ import logging
 
 from .memory_storage import locked_memory
 from .memory_summary_helpers import build_planner_summary
+from .memory_store_helpers import filter_recent_records
 from .memory_compliance import (
     erase_user_data,
     is_record_legal_hold,
@@ -380,46 +381,7 @@ class MemoryStore:
     ) -> List[Dict[str, Any]]:
         """最近のレコードを取得"""
         items = self.list_all(user_id)
-        items.sort(key=lambda r: r.get("ts", 0), reverse=True)
-
-        if contains:
-            s = contains.strip()
-            filtered: List[Dict[str, Any]] = []
-            for r in items:
-                v = r.get("value")
-                if isinstance(v, dict):
-                    q = str(v.get("query") or v.get("text") or "")
-                else:
-                    q = str(v)
-                if s in q:
-                    filtered.append(r)
-            items = filtered
-
-        return items[:limit]
-
-    def _simple_score(self, query: str, text: str) -> float:
-        """シンプルな類似度スコア計算"""
-        q = (query or "").strip().lower()
-        t = (text or "").strip().lower()
-        if not q or not t:
-            return 0.0
-
-        # 部分一致
-        if q in t or t in q:
-            base = 0.5
-        else:
-            base = 0.0
-
-        # トークン一致
-        q_tokens = set(q.split())
-        t_tokens = set(t.split())
-        if q_tokens and t_tokens:
-            inter = q_tokens & t_tokens
-            token_score = len(inter) / max(len(q_tokens), 1)
-        else:
-            token_score = 0.0
-
-        return min(1.0, base + 0.5 * token_score)
+        return filter_recent_records(items, limit=limit, contains=contains)
 
     def search(
         self,

--- a/veritas_os/core/memory/memory_store_compat.py
+++ b/veritas_os/core/memory/memory_store_compat.py
@@ -65,6 +65,7 @@ def install_memory_store_compat_hooks(
     locked_memory_fn: Callable[..., Any],
     get_mem_vec_fn: Callable[[], Any],
     memory_module: Any,
+    filter_recent_records_fn: Optional[Callable[..., Any]] = None,
 ) -> None:
     """Patch ``MemoryStore`` methods to route through importable symbols.
 
@@ -138,17 +139,9 @@ def install_memory_store_compat_hooks(
         limit: int = 20,
         contains: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        return recent_records_compat(
-            store=self,
-            helper_module=_memory_store_module,
-            original_helper=_ORIGINAL_FILTER_RECENT_RECORDS,
-            fallback_helper=getattr(
-                memory_module, "filter_recent_records", filter_recent_records,
-            ),
-            user_id=user_id,
-            contains=contains,
-            limit=limit,
-        )
+        records = self.list_all(user_id)
+        helper = getattr(memory_module, "filter_recent_records", filter_recent_records)
+        return helper(records, limit=limit, contains=contains)
 
     def _simple_score_compat(self: MemoryStore, query: str, text: str) -> float:
         return _simple_score_impl(query, text)
@@ -217,7 +210,9 @@ def install_memory_store_compat_hooks(
     # ---- Apply patches ----
     _memory_store_module.locked_memory = locked_memory_fn
     _memory_store_module.erase_user_data = erase_user_data
-    _memory_store_module.filter_recent_records = filter_recent_records
+    _memory_store_module.filter_recent_records = (
+        filter_recent_records_fn or filter_recent_records
+    )
     _memory_store_module.build_kvs_search_hits = build_kvs_search_hits
     MemoryStore._parse_expires_at = staticmethod(_parse_expires_at_compat)
     MemoryStore._normalize_lifecycle = staticmethod(_normalize_lifecycle_compat)

--- a/veritas_os/core/memory_compliance.py
+++ b/veritas_os/core/memory_compliance.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_compliance")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_compliance"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_distillation.py
+++ b/veritas_os/core/memory_distillation.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_distillation")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_distillation"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_evidence.py
+++ b/veritas_os/core/memory_evidence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_evidence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_evidence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_helpers.py
+++ b/veritas_os/core/memory_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_lifecycle.py
+++ b/veritas_os/core/memory_lifecycle.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_lifecycle")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_lifecycle"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_search_helpers.py
+++ b/veritas_os/core/memory_search_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_search_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_search_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_security.py
+++ b/veritas_os/core/memory_security.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_security")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_security"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_storage.py
+++ b/veritas_os/core/memory_storage.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_storage")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_storage"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store.py
+++ b/veritas_os/core/memory_store.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store_compat.py
+++ b/veritas_os/core/memory_store_compat.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store_compat")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store_compat"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_store_helpers.py
+++ b/veritas_os/core/memory_store_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_store_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_store_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_summary_helpers.py
+++ b/veritas_os/core/memory_summary_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_summary_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_summary_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/memory_vector.py
+++ b/veritas_os/core/memory_vector.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.memory_vector")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.memory_vector"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/models/memory_model.py
+++ b/veritas_os/core/models/memory_model.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.memory.models")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.memory.models"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline/pipeline_gate.py
+++ b/veritas_os/core/pipeline/pipeline_gate.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -35,7 +36,9 @@ predict_gate_label = _default_predict_gate_label
 
 def _mem_model_path() -> str:
     try:
-        from veritas_os.core.models import memory_model as mm
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from veritas_os.core.models import memory_model as mm
         for k in ("MODEL_FILE", "MODEL_PATH"):
             if hasattr(mm, k):
                 return str(getattr(mm, k))
@@ -54,15 +57,15 @@ def _load_memory_model() -> Tuple[Any, Any, Any]:
     _pgl_fn = _default_predict_gate_label
 
     try:
-        from veritas_os.core.models import memory_model as memory_model_core
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from veritas_os.core.models import memory_model as memory_model_core
 
         _mem_vec = getattr(memory_model_core, "MEM_VEC", None)
         _mem_clf = getattr(memory_model_core, "MEM_CLF", None)
 
-        if hasattr(memory_model_core, "predict_gate_label"):
-            from veritas_os.core.models.memory_model import (
-                predict_gate_label as _pgl_raw,
-            )
+        _pgl_raw = getattr(memory_model_core, "predict_gate_label", None)
+        if callable(_pgl_raw):
 
             def _safe_pgl(text: str) -> Dict[str, float]:
                 try:

--- a/veritas_os/core/pipeline_compat.py
+++ b/veritas_os/core/pipeline_compat.py
@@ -4,7 +4,13 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_compat")
+from veritas_os.core._shim_deprecation import (
+    warn_legacy_core_shim as _warn_legacy_core_shim,
+)
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_compat"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger("veritas_os.core.pipeline")
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_contracts.py
+++ b/veritas_os/core/pipeline_contracts.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_contracts")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_contracts"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_critique.py
+++ b/veritas_os/core/pipeline_critique.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_critique")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_critique"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_decide_stages.py
+++ b/veritas_os/core/pipeline_decide_stages.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_decide_stages")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_decide_stages"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_evidence.py
+++ b/veritas_os/core/pipeline_evidence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_evidence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_evidence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_execute.py
+++ b/veritas_os/core/pipeline_execute.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_execute")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_execute"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_gate.py
+++ b/veritas_os/core/pipeline_gate.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_gate")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_gate"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_helpers.py
+++ b/veritas_os/core/pipeline_helpers.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_helpers")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_helpers"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_inputs.py
+++ b/veritas_os/core/pipeline_inputs.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_inputs")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_inputs"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_memory_adapter.py
+++ b/veritas_os/core/pipeline_memory_adapter.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_memory_adapter")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_memory_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_persist.py
+++ b/veritas_os/core/pipeline_persist.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_persist")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_persist"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_persistence.py
+++ b/veritas_os/core/pipeline_persistence.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_persistence")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_persistence"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_policy.py
+++ b/veritas_os/core/pipeline_policy.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_policy")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_policy"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_replay.py
+++ b/veritas_os/core/pipeline_replay.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_replay")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_replay"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_response.py
+++ b/veritas_os/core/pipeline_response.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_response")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_response"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_retrieval.py
+++ b/veritas_os/core/pipeline_retrieval.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_retrieval")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_retrieval"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_signature_adapter.py
+++ b/veritas_os/core/pipeline_signature_adapter.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_signature_adapter")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_signature_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_types.py
+++ b/veritas_os/core/pipeline_types.py
@@ -4,7 +4,11 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_types")
+from veritas_os.core._shim_deprecation import warn_legacy_core_shim as _warn_legacy_core_shim
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_types"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger(__name__)
 _sys.modules[__name__] = _target

--- a/veritas_os/core/pipeline_web_adapter.py
+++ b/veritas_os/core/pipeline_web_adapter.py
@@ -4,7 +4,13 @@ from importlib import import_module as _import_module
 import logging as _logging
 import sys as _sys
 
-_target = _import_module("veritas_os.core.pipeline.pipeline_web_adapter")
+from veritas_os.core._shim_deprecation import (
+    warn_legacy_core_shim as _warn_legacy_core_shim,
+)
+
+_TARGET_MODULE = "veritas_os.core.pipeline.pipeline_web_adapter"
+_warn_legacy_core_shim(legacy_module=__name__, canonical_module=_TARGET_MODULE)
+_target = _import_module(_TARGET_MODULE)
 if hasattr(_target, "logger"):
     _target.logger = _logging.getLogger("veritas_os.core.pipeline")
 _sys.modules[__name__] = _target

--- a/veritas_os/tests/test_decide_e2e_reliability.py
+++ b/veritas_os/tests/test_decide_e2e_reliability.py
@@ -272,7 +272,7 @@ class TestFujiRejectionPath:
         monkeypatch.setattr(p, "fuji_core", fake_fuji)
 
         # Also patch lazy import path in pipeline_policy
-        import veritas_os.core.pipeline_policy as pp
+        import veritas_os.core.pipeline.pipeline_policy as pp
         original_lazy = pp._lazy_import
         def mock_lazy(name, attr):
             if "fuji" in str(name):
@@ -330,7 +330,7 @@ class TestFujiRejectionPath:
         )
         monkeypatch.setattr(p, "fuji_core", fake_fuji)
 
-        import veritas_os.core.pipeline_policy as pp
+        import veritas_os.core.pipeline.pipeline_policy as pp
         original_lazy = pp._lazy_import
         def mock_lazy(name, attr):
             if "fuji" in str(name):

--- a/veritas_os/tests/test_legacy_core_shim_deprecations.py
+++ b/veritas_os/tests/test_legacy_core_shim_deprecations.py
@@ -1,0 +1,314 @@
+import importlib
+import importlib.util
+import sys
+import types
+import warnings
+from pathlib import Path
+
+import pytest
+
+from veritas_os.core._shim_deprecation import (
+    SHIM_REMOVAL_DATE,
+    SHIM_REMOVAL_VERSION,
+    warn_legacy_core_shim,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+CORE_DIR = ROOT / "veritas_os" / "core"
+
+
+def _load_shim_module(module_name: str):
+    module_relpath = module_name.replace(".", "/") + ".py"
+    module_path = ROOT / module_relpath
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return sys.modules[module_name]
+
+
+def _assert_shim_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    legacy_module: str,
+    canonical_module: str,
+) -> None:
+    fake_target = types.ModuleType(canonical_module)
+
+    def _fake_import_module(module_name: str):
+        assert module_name == canonical_module
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    previous_legacy = sys.modules.get(legacy_module)
+    had_previous_legacy = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning) as warning:
+            module = _load_shim_module(legacy_module)
+
+        message = str(warning[0].message)
+        assert legacy_module in message
+        assert canonical_module in message
+        assert SHIM_REMOVAL_VERSION in message
+        assert SHIM_REMOVAL_DATE in message
+        assert module is fake_target
+    finally:
+        if had_previous_legacy:
+            sys.modules[legacy_module] = previous_legacy
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_fuji_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.fuji_helpers",
+        "veritas_os.core.fuji.fuji_helpers",
+    )
+
+
+def test_memory_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.memory_helpers",
+        "veritas_os.core.memory.memory_helpers",
+    )
+
+
+def test_pipeline_helpers_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.pipeline_helpers",
+        "veritas_os.core.pipeline.pipeline_helpers",
+    )
+
+
+def test_shim_deprecation_helper_message_contract() -> None:
+    with pytest.warns(DeprecationWarning) as warning:
+        warn_legacy_core_shim(
+            legacy_module="veritas_os.core.old",
+            canonical_module="veritas_os.core.new.old",
+        )
+
+    message = str(warning[0].message)
+    assert "veritas_os.core.old" in message
+    assert "veritas_os.core.new.old" in message
+    assert SHIM_REMOVAL_VERSION in message
+    assert SHIM_REMOVAL_DATE in message
+
+
+
+def _capture_stacklevel_warning(stacklevel: int) -> warnings.WarningMessage:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        warn_legacy_core_shim(
+            legacy_module="veritas_os.core.old",
+            canonical_module="veritas_os.core.new.old",
+            stacklevel=stacklevel,
+        )
+
+    assert caught
+    return caught[0]
+
+
+def test_warn_legacy_core_shim_stacklevel_changes_warning_location() -> None:
+    level_1 = _capture_stacklevel_warning(1)
+    level_2 = _capture_stacklevel_warning(2)
+
+    assert str(level_1.message) == str(level_2.message)
+    assert (level_1.filename, level_1.lineno) != (level_2.filename, level_2.lineno)
+
+
+def test_memory_package_import_does_not_emit_legacy_memory_model_warning() -> None:
+    previous_memory = sys.modules.get("veritas_os.core.memory")
+    previous_legacy = sys.modules.get("veritas_os.core.models.memory_model")
+    previous_llm_client = sys.modules.get("veritas_os.core.llm_client")
+    had_memory = "veritas_os.core.memory" in sys.modules
+    had_legacy = "veritas_os.core.models.memory_model" in sys.modules
+    had_llm_client = "veritas_os.core.llm_client" in sys.modules
+
+    try:
+        sys.modules.pop("veritas_os.core.memory", None)
+        sys.modules.pop("veritas_os.core.models.memory_model", None)
+        sys.modules["veritas_os.core.llm_client"] = types.ModuleType(
+            "veritas_os.core.llm_client"
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            importlib.import_module("veritas_os.core.memory")
+
+        messages = [str(item.message) for item in caught]
+        assert not any(
+            "veritas_os.core.models.memory_model is a deprecated compatibility shim"
+            in message
+            for message in messages
+        )
+    finally:
+        if had_memory:
+            sys.modules["veritas_os.core.memory"] = previous_memory
+        else:
+            sys.modules.pop("veritas_os.core.memory", None)
+
+        if had_legacy:
+            sys.modules["veritas_os.core.models.memory_model"] = previous_legacy
+        else:
+            sys.modules.pop("veritas_os.core.models.memory_model", None)
+
+        if had_llm_client:
+            sys.modules["veritas_os.core.llm_client"] = previous_llm_client
+        else:
+            sys.modules.pop("veritas_os.core.llm_client", None)
+
+
+def test_nested_memory_model_shim_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_shim_warning(
+        monkeypatch,
+        "veritas_os.core.models.memory_model",
+        "veritas_os.core.memory.models",
+    )
+
+
+def test_pipeline_compat_shim_preserves_pipeline_logger_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_target = types.ModuleType("veritas_os.core.pipeline.pipeline_compat")
+    fake_target.logger = None
+
+    def _fake_import_module(module_name: str):
+        assert module_name == "veritas_os.core.pipeline.pipeline_compat"
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    legacy_module = "veritas_os.core.pipeline_compat"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning):
+            module = _load_shim_module(legacy_module)
+
+        assert module is fake_target
+        assert fake_target.logger.name == "veritas_os.core.pipeline"
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_pipeline_web_adapter_shim_preserves_pipeline_logger_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_target = types.ModuleType("veritas_os.core.pipeline.pipeline_web_adapter")
+    fake_target.logger = None
+
+    def _fake_import_module(module_name: str):
+        assert module_name == "veritas_os.core.pipeline.pipeline_web_adapter"
+        return fake_target
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    legacy_module = "veritas_os.core.pipeline_web_adapter"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        with pytest.warns(DeprecationWarning):
+            module = _load_shim_module(legacy_module)
+
+        assert module is fake_target
+        assert fake_target.logger.name == "veritas_os.core.pipeline"
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_assert_shim_warning_restores_legacy_sys_modules_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_module = "veritas_os.core.fuji_helpers"
+    sentinel = types.ModuleType(legacy_module)
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules[legacy_module] = sentinel
+        _assert_shim_warning(
+            monkeypatch,
+            legacy_module,
+            "veritas_os.core.fuji.fuji_helpers",
+        )
+        assert sys.modules[legacy_module] is sentinel
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def test_assert_shim_warning_removes_legacy_sys_modules_entry_when_absent_before(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_module = "veritas_os.core.fuji_helpers"
+    previous = sys.modules.get(legacy_module)
+    had_previous = legacy_module in sys.modules
+    try:
+        sys.modules.pop(legacy_module, None)
+        _assert_shim_warning(
+            monkeypatch,
+            legacy_module,
+            "veritas_os.core.fuji.fuji_helpers",
+        )
+        assert legacy_module not in sys.modules
+    finally:
+        if had_previous:
+            sys.modules[legacy_module] = previous
+        else:
+            sys.modules.pop(legacy_module, None)
+
+
+def _is_legacy_shim_source(text: str) -> bool:
+    return (
+        text.startswith('"""Backward-compatible module alias')
+        and "import_module(" in text
+        and "veritas_os.core." in text
+        and (
+            "sys.modules[__name__] = _target" in text
+            or "_sys.modules[__name__] = _target" in text
+        )
+    )
+
+
+def test_all_legacy_core_shims_call_deprecation_helper() -> None:
+    missing: list[str] = []
+    for path in sorted(CORE_DIR.rglob("*.py")):
+        if path.name == "_shim_deprecation.py":
+            continue
+        if "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        is_legacy_shim = _is_legacy_shim_source(text)
+        calls_helper = (
+            "_warn_legacy_core_shim(" in text
+            or "warn_legacy_core_shim(" in text
+        )
+        if not is_legacy_shim or calls_helper:
+            continue
+        missing.append(path.relative_to(ROOT).as_posix())
+
+    assert not missing, (
+        "Legacy core shims missing deprecation warning: " + ", ".join(missing)
+    )


### PR DESCRIPTION
### Motivation

- Centralize deprecation messaging for legacy core compatibility shim modules and provide a clear migration notice and removal window. 
- Modernize memory and pipeline compatibility plumbing so runtime imports resolve correctly, preserve logger names, and make store hooks test-friendly.

### Description

- Add `veritas_os.core._shim_deprecation.warn_legacy_core_shim` with removal version/date constants and use of `DeprecationWarning` for legacy shim imports. 
- Update many legacy shim alias modules (memory, pipeline, fuji, models, etc.) to call the deprecation helper and forward-import their canonical modules. 
- Refactor `veritas_os.core.memory` to suppress nested legacy shim warnings during model import, add compatibility routing helpers (`_compat_locked_memory`, `_compat_filter_recent_records`), and wire an optional `filter_recent_records_fn` into `install_memory_store_compat_hooks`. 
- Move the `MemoryStore.recent()` implementation to use the common `filter_recent_records` helper (removing the previous inline filtering and scoring logic). 
- Update `kernel_stages` and `pipeline_gate` to use `importlib.import_module` and to suppress undesired deprecation noise when loading nested `memory_model` code; preserve pipeline logger naming in pipeline shims. 
- Adjust a couple of tests to import the canonical pipeline policy path and add a comprehensive new test module `veritas_os/tests/test_legacy_core_shim_deprecations.py` that validates the deprecation helper message contract, stacklevel behavior, and that all legacy shims call the helper.

### Testing

- Ran the new shim deprecation unit tests with `pytest veritas_os/tests/test_legacy_core_shim_deprecations.py`, which passed. 
- Ran the modified decide reliability tests (including the FUJI rejection path) with `pytest veritas_os/tests/test_decide_e2e_reliability.py`, which passed locally in the CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091fcfb2bc8326a515556a720f4c0b)