### PR TITLE
docs: add RSA ↔ VERITAS E2E sandbox validation snapshot (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md
@@ -1,0 +1,113 @@
+# RSA ↔ VERITAS E2E Sandbox Validation Snapshot
+
+## 1. Purpose
+
+This document records the current sandbox-only validation snapshot for the V.I.K.I. ↔ VERITAS / RSA-compatible E2E flow.
+
+The purpose is to make the current static harness output reviewable without changing runtime behavior.
+
+## 2. Current merged baseline
+
+The current merged baseline includes:
+- V.I.K.I. / RSA / VERITAS terminology synchronization.
+- RSA-compatible static payload contract.
+- RSASandboxPayload receiver contract.
+- evaluate_rsa_sandbox_signal(payload) decision mapping.
+- Thin E2E sandbox harness at examples/sandbox/rsa_veritas_e2e_harness.py.
+- CI coverage through governance-backend-fast.
+
+## 3. Terminology compatibility note
+
+- RSA remains the theoretical framework and underlying rule set.
+- V.I.K.I. is the operational producer of RSA-compatible upstream payloads.
+- VERITAS is the downstream commit governance boundary.
+- rsa_status remains unchanged for compatibility.
+- RSASandboxPayload remains the VERITAS-side receiver contract name.
+- upstream_signal_source = "RSA" is retained as a v1 compatibility fixture/source label.
+- That compatibility label does not mean VERITAS consumes V.I.K.I. internal reasoning.
+- VERITAS consumes only the emitted payload.
+
+## 4. Static sandbox input payload
+
+```json
+{
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "timestamp": "2026-10-25T09:15:30Z"
+}
+```
+
+## 5. Harness invocation path
+
+The current harness path is:
+
+V.I.K.I.-style RSA-compatible static payload
+→ RSASandboxPayload(**payload_dict)
+→ evaluate_rsa_sandbox_signal(payload)
+→ veritas_decision
+→ audit_entry
+
+The current harness is:
+
+examples/sandbox/rsa_veritas_e2e_harness.py
+
+## 6. Expected VERITAS decision output
+
+```json
+{
+  "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 7. Expected audit entry output
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "The workflow cannot continue toward final commit because required KYC context is incomplete and authority evidence is insufficient.",
+  "timestamp": "2026-10-25T09:15:30Z",
+  "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+}
+```
+
+## 8. What this validates
+
+- The static V.I.K.I.-style RSA-compatible payload can be represented by the existing RSASandboxPayload contract.
+- VERITAS deterministically maps ALGORITHMIC_HUMILITY_ENGAGED to PAUSE_FOR_HUMAN_REVIEW.
+- VERITAS records UPSTREAM_INCOMPLETE_KYC_CONTEXT.
+- Raw upstream intent/action fields are redacted by default.
+- The sandbox commit state is SUSPENDED_NOT_COMMITTED.
+- The current E2E sandbox path is reviewable without connecting live V.I.K.I. logic.
+
+## 9. What this does not validate
+
+- It does not connect live V.I.K.I. middleware.
+- It does not validate V.I.K.I. internal reasoning.
+- It does not implement production AML/KYC compliance.
+- It does not provide regulatory approval.
+- It does not provide third-party certification.
+- It does not provide legal advice.
+- It does not use real customer, financial, medical, KYC, or regulated data.
+- It does not change production runtime governance.
+
+## 10. Next sandbox step
+
+The next sandbox step is to choose the next static fixture variant after this snapshot is merged.
+
+Likely candidates:
+- DENSITY_THROTTLED
+- DEFERRAL_ENGAGED
+
+No live V.I.K.I. connection should be added before fixture variants are documented and validated.

--- a/docs/ja/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md
@@ -1,0 +1,117 @@
+# RSA ↔ VERITAS E2E サンドボックス検証スナップショット
+
+## 英語正本
+
+- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](../../en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md)
+
+## 1. 目的
+
+本書は、V.I.K.I. ↔ VERITAS / RSA-compatible E2E フローにおける、現時点の sandbox-only 検証スナップショットを記録するための文書です。
+
+目的は、runtime behavior を変更せずに、現在の static harness 出力をレビュー可能にすることです。
+
+## 2. 現在のマージ済みベースライン
+
+現在のマージ済みベースラインには以下が含まれます。
+- V.I.K.I. / RSA / VERITAS の用語同期。
+- RSA-compatible な static payload contract。
+- RSASandboxPayload receiver contract。
+- evaluate_rsa_sandbox_signal(payload) による decision mapping。
+- examples/sandbox/rsa_veritas_e2e_harness.py の thin E2E sandbox harness。
+- governance-backend-fast による CI coverage。
+
+## 3. 用語互換性ノート
+
+- RSA は理論的フレームワークおよび underlying rule set のままです。
+- V.I.K.I. は RSA-compatible upstream payload の operational producer です。
+- VERITAS は downstream の commit governance boundary です。
+- 互換性のため、rsa_status は変更しません。
+- RSASandboxPayload は VERITAS 側 receiver contract 名として維持されます。
+- upstream_signal_source = "RSA" は v1 compatibility fixture/source label として維持されます。
+- この compatibility label は、VERITAS が V.I.K.I. internal reasoning を消費することを意味しません。
+- VERITAS が消費するのは emitted payload のみです。
+
+## 4. Static sandbox input payload
+
+```json
+{
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "timestamp": "2026-10-25T09:15:30Z"
+}
+```
+
+## 5. Harness invocation path
+
+現在の harness path は次のとおりです。
+
+V.I.K.I.-style RSA-compatible static payload
+→ RSASandboxPayload(**payload_dict)
+→ evaluate_rsa_sandbox_signal(payload)
+→ veritas_decision
+→ audit_entry
+
+現在の harness は以下です。
+
+examples/sandbox/rsa_veritas_e2e_harness.py
+
+## 6. 期待される VERITAS decision output
+
+```json
+{
+  "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 7. 期待される audit entry output
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "The workflow cannot continue toward final commit because required KYC context is incomplete and authority evidence is insufficient.",
+  "timestamp": "2026-10-25T09:15:30Z",
+  "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+}
+```
+
+## 8. このスナップショットで検証されること
+
+- static な V.I.K.I.-style RSA-compatible payload を、既存の RSASandboxPayload contract で表現できること。
+- VERITAS が ALGORITHMIC_HUMILITY_ENGAGED を PAUSE_FOR_HUMAN_REVIEW に決定的にマッピングすること。
+- VERITAS が UPSTREAM_INCOMPLETE_KYC_CONTEXT を記録すること。
+- upstream の raw intent/action フィールドがデフォルトで redacted されること。
+- sandbox commit state が SUSPENDED_NOT_COMMITTED であること。
+- live V.I.K.I. logic を接続せずに current E2E sandbox path をレビュー可能であること。
+
+## 9. このスナップショットで検証されないこと
+
+- live V.I.K.I. middleware への接続は行いません。
+- V.I.K.I. internal reasoning の検証は行いません。
+- production AML/KYC compliance の実装は行いません。
+- regulatory approval を提供しません。
+- third-party certification を提供しません。
+- legal advice を提供しません。
+- 実在の customer / financial / medical / KYC / 規制対象データは使用しません。
+- production runtime governance は変更しません。
+
+## 10. 次の sandbox ステップ
+
+次の sandbox ステップは、このスナップショットがマージされた後に次の static fixture variant を選定することです。
+
+有力候補:
+- DENSITY_THROTTLED
+- DEFERRAL_ENGAGED
+
+fixture variants の文書化と検証が完了する前に、live V.I.K.I. connection を追加してはいけません。


### PR DESCRIPTION
### Motivation

- Record the current sandbox-only validation snapshot for the V.I.K.I. ↔ VERITAS / RSA-compatible end-to-end flow so reviewers can inspect the static harness output without changing runtime behavior. 
- Preserve the current compatibility and terminology baseline (including `rsa_status` and `RSASandboxPayload`) and make the expected decision and audit shapes explicit. 
- Keep the change documentation-only and constrained so no runtime, test, or CI behavior is modified.

### Description

- Add `docs/en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md` containing the snapshot title, purpose, merged baseline, terminology compatibility note, the exact static sandbox input JSON, harness invocation path, expected VERITAS decision JSON, expected audit entry JSON, validation/non-validation lists, and next sandbox step candidates. 
- Add `docs/ja/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md` with a Japanese-first explanation, an `## 英語正本` link to the English file, preserved technical terms, and JSON examples identical to the English document. 
- Maintain all compatibility constraints: no runtime code, test, or CI changes; no renames of `rsa_status` or `RSASandboxPayload`; no changes to `evaluate_rsa_sandbox_signal()`; no live V.I.K.I. connection; and no production/regulatory/ legal claims. 
- Keep the PR small and reviewable by limiting changes to these two documentation files only.

### Testing

- No automated tests were run as part of this PR because it is documentation-only and does not modify code or test fixtures. 
- CI configuration and existing automated tests (including `governance-backend-fast` coverage) were not changed by this PR. 
- The documentation files were added and committed successfully in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09faf414a4832681b12e89b5a88684)