### PR TITLE
docs: add DENSITY_THROTTLED RSA ↔ VERITAS validation snapshot

### DIFF
--- a/docs/en/guides/rsa-veritas-density-throttled-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-density-throttled-validation-snapshot.md
@@ -1,0 +1,113 @@
+# RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot
+
+## 1. Purpose
+
+This document records the DENSITY_THROTTLED static sandbox variant for the V.I.K.I. ↔ VERITAS / RSA-compatible flow.
+
+This is a softer upstream intervention case than ALGORITHMIC_HUMILITY_ENGAGED.
+
+The goal is to show that VERITAS can log an upstream cognitive-density intervention without treating it as a default hard stop.
+
+## 2. Current baseline
+
+The current merged baseline includes:
+
+- RSA / V.I.K.I. / VERITAS terminology synchronization.
+- Existing RSASandboxPayload receiver contract.
+- Existing evaluate_rsa_sandbox_signal(payload) mapping.
+- Existing E2E sandbox harness.
+- Existing governance-backend-fast CI coverage.
+- Existing ALGORITHMIC_HUMILITY_ENGAGED validation snapshot.
+
+## 3. Terminology compatibility note
+
+- RSA remains the theoretical framework and underlying rule set.
+- V.I.K.I. is the operational producer of RSA-compatible upstream payloads.
+- VERITAS is the downstream commit governance boundary.
+- rsa_status remains unchanged for compatibility.
+- RSASandboxPayload remains the VERITAS-side receiver contract name.
+- upstream_signal_source = "RSA" is retained as a v1 compatibility fixture/source label.
+- That compatibility label does not mean VERITAS consumes V.I.K.I. internal reasoning.
+- VERITAS consumes only the emitted payload.
+
+## 4. Static sandbox input payload
+
+```json
+{
+  "rsa_status": "DENSITY_THROTTLED",
+  "trigger_source": "SRC_Cognitive_Density_Throttle",
+  "original_llm_intent": "Generate_Dense_Transaction_Risk_Explanation",
+  "rsa_action_taken": "Output_Compressed_For_Cognitive_Safety",
+  "timestamp": "2026-10-25T09:20:30Z"
+}
+```
+
+## 5. Expected VERITAS decision output
+
+```json
+{
+  "continuation_decision": "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+  "reason_code": "UPSTREAM_INTERVENTION_DENSITY_THROTTLE",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 6. Expected audit entry output
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "DENSITY_THROTTLED",
+  "trigger_source": "SRC_Cognitive_Density_Throttle",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "RSA modified the upstream output for cognitive density control; VERITAS records the intervention without treating it as a default hard block.",
+  "timestamp": "2026-10-25T09:20:30Z",
+  "veritas_continuation_decision": "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+}
+```
+
+## 7. What this validates
+
+- The DENSITY_THROTTLED status is represented by the existing RSASandboxPayload contract.
+- VERITAS deterministically maps DENSITY_THROTTLED to CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED.
+- VERITAS records UPSTREAM_INTERVENTION_DENSITY_THROTTLE.
+- Raw upstream intent/action fields are redacted by default.
+- This variant demonstrates a softer intervention than PAUSE_FOR_HUMAN_REVIEW.
+- The current E2E sandbox path remains reviewable without connecting live V.I.K.I. logic.
+
+## 8. What this does not validate
+
+- It does not connect live V.I.K.I. middleware.
+- It does not validate V.I.K.I. internal reasoning.
+- It does not determine real user cognitive state.
+- It does not implement production AML/KYC compliance.
+- It does not provide regulatory approval.
+- It does not provide third-party certification.
+- It does not provide legal advice.
+- It does not use real customer, financial, medical, KYC, or regulated data.
+- It does not change production runtime governance.
+
+## 9. Relationship to ALGORITHMIC_HUMILITY_ENGAGED
+
+DENSITY_THROTTLED:
+
+- Upstream output was modified for cognitive-density control.
+- VERITAS logs the intervention.
+- Continuation decision is CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED.
+
+ALGORITHMIC_HUMILITY_ENGAGED:
+
+- Required context / authority evidence is incomplete.
+- VERITAS pauses for human review.
+- Continuation decision is PAUSE_FOR_HUMAN_REVIEW.
+
+## 10. Next sandbox step
+
+After this softer intervention snapshot, the next candidate variant is DEFERRAL_ENGAGED.
+
+DEFERRAL_ENGAGED should be treated as a stronger hard-stop case and should be documented separately before any live V.I.K.I. connection is attempted.

--- a/docs/ja/guides/rsa-veritas-density-throttled-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-density-throttled-validation-snapshot.md
@@ -1,0 +1,117 @@
+# RSA ↔ VERITAS DENSITY_THROTTLED 検証スナップショット
+
+## 英語正本
+
+- [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](../../en/guides/rsa-veritas-density-throttled-validation-snapshot.md)
+
+## 1. 目的
+
+本ページは、V.I.K.I. ↔ VERITAS / RSA-compatible フローにおける DENSITY_THROTTLED の静的サンドボックス・バリアントを記録するものです。
+
+これは ALGORITHMIC_HUMILITY_ENGAGED と比較して、よりソフトな上流介入ケースです。
+
+目的は、VERITAS が上流での cognitive-density 介入を監査ログに残しつつ、デフォルトのハードストップとして扱わないことを示す点にあります。
+
+## 2. 現在のベースライン
+
+現在マージ済みのベースラインには、以下が含まれます。
+
+- RSA / V.I.K.I. / VERITAS の用語同期。
+- 既存の RSASandboxPayload 受信契約。
+- 既存の evaluate_rsa_sandbox_signal(payload) マッピング。
+- 既存の E2E サンドボックス・ハーネス。
+- 既存の governance-backend-fast CI カバレッジ。
+- 既存の ALGORITHMIC_HUMILITY_ENGAGED 検証スナップショット。
+
+## 3. 用語互換性ノート
+
+- RSA は理論フレームワークおよび基礎ルールセットとして維持されます。
+- V.I.K.I. は RSA-compatible な上流 payload を生成する運用側プロデューサーです。
+- VERITAS は下流のコミット・ガバナンス境界です。
+- 互換性のため rsa_status は変更しません。
+- RSASandboxPayload は VERITAS 側の受信契約名として維持します。
+- upstream_signal_source = "RSA" は v1 互換 fixture/source ラベルとして維持します。
+- この互換ラベルは、VERITAS が V.I.K.I. の内部 reasoning を受け取ることを意味しません。
+- VERITAS が受け取るのは emit 済み payload のみです。
+
+## 4. 静的サンドボックス入力 payload
+
+```json
+{
+  "rsa_status": "DENSITY_THROTTLED",
+  "trigger_source": "SRC_Cognitive_Density_Throttle",
+  "original_llm_intent": "Generate_Dense_Transaction_Risk_Explanation",
+  "rsa_action_taken": "Output_Compressed_For_Cognitive_Safety",
+  "timestamp": "2026-10-25T09:20:30Z"
+}
+```
+
+## 5. 期待される VERITAS 判断出力
+
+```json
+{
+  "continuation_decision": "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+  "reason_code": "UPSTREAM_INTERVENTION_DENSITY_THROTTLE",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 6. 期待される監査エントリ出力
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "DENSITY_THROTTLED",
+  "trigger_source": "SRC_Cognitive_Density_Throttle",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "RSA modified the upstream output for cognitive density control; VERITAS records the intervention without treating it as a default hard block.",
+  "timestamp": "2026-10-25T09:20:30Z",
+  "veritas_continuation_decision": "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+}
+```
+
+## 7. このスナップショットで検証されること
+
+- DENSITY_THROTTLED ステータスが既存の RSASandboxPayload 契約で表現可能であること。
+- VERITAS が DENSITY_THROTTLED を CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED へ決定論的にマッピングすること。
+- VERITAS が UPSTREAM_INTERVENTION_DENSITY_THROTTLE を記録すること。
+- 上流の intent/action 生データがデフォルトで redaction されること。
+- 本バリアントが PAUSE_FOR_HUMAN_REVIEW よりソフトな介入を示すこと。
+- live V.I.K.I. ロジックへ接続せずとも現行 E2E サンドボックス経路がレビュー可能であること。
+
+## 8. このスナップショットで検証されないこと
+
+- live V.I.K.I. middleware への接続は行いません。
+- V.I.K.I. の内部 reasoning は検証しません。
+- 実ユーザーの cognitive state は判定しません。
+- 本番 AML/KYC コンプライアンスは実装しません。
+- 規制当局の承認は提供しません。
+- 第三者認証は提供しません。
+- 法的助言は提供しません。
+- 実在顧客データ、金融データ、医療データ、KYC データ、または規制対象データは使用しません。
+- 本番ランタイム・ガバナンスは変更しません。
+
+## 9. ALGORITHMIC_HUMILITY_ENGAGED との関係
+
+DENSITY_THROTTLED:
+
+- 上流出力は cognitive-density 制御のために修正されます。
+- VERITAS は介入をログ化します。
+- continuation decision は CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED です。
+
+ALGORITHMIC_HUMILITY_ENGAGED:
+
+- 必要な context / authority evidence が不十分です。
+- VERITAS は human review のため一時停止します。
+- continuation decision は PAUSE_FOR_HUMAN_REVIEW です。
+
+## 10. 次のサンドボックス・ステップ
+
+このソフト介入スナップショットの次候補は DEFERRAL_ENGAGED です。
+
+DEFERRAL_ENGAGED はより強いハードストップケースとして扱い、live V.I.K.I. 接続を試行する前に別ドキュメントとして整理すべきです。


### PR DESCRIPTION
### Motivation

- Record a second static sandbox validation snapshot for the V.I.K.I. ↔ VERITAS RSA-compatible flow demonstrating the `DENSITY_THROTTLED` upstream intervention variant. 
- Show that `DENSITY_THROTTLED` is a softer upstream intervention than `ALGORITHMIC_HUMILITY_ENGAGED` and that VERITAS can log the intervention while continuing with `CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED`. 
- Provide a Japanese-aligned documentation page that preserves key technical terms and exact JSON fixtures for cross-team review and localization.

### Description

- Added `docs/en/guides/rsa-veritas-density-throttled-validation-snapshot.md` containing the requested title, sections 1–10, and the exact JSON input, expected decision output, and expected audit entry fixtures. 
- Added `docs/ja/guides/rsa-veritas-density-throttled-validation-snapshot.md` with a Japanese-first explanation, an English source link (`## 英語正本`), preserved technical terms, and JSON examples identical to the English page. 
- Preserved all compatibility names and constraints (`rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`, `upstream_signal_source = "RSA"`) and made no runtime, test, or CI changes. 
- Documentation-only change with explicit non-claims about AML/KYC, regulatory approval, certification, or legal advice per scope requirements.

### Testing

- Verified the new files exist and inspected their contents using automated file-listing and file-content verification commands (`nl`/file read), and those checks succeeded. 
- Performed repository-level status verification to confirm the change set is staged for review and metadata for the PR was generated, and those checks succeeded. 
- Created PR metadata via the project `make_pr` helper to record the change summary and scope, and the helper returned the expected PR payload successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6e244cbc8326b1e9f39f49c62bd7)