### PR TITLE
docs: add DEFERRAL_ENGAGED RSA↔VERITAS validation snapshots

### DIFF
--- a/docs/en/guides/rsa-veritas-deferral-engaged-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-deferral-engaged-validation-snapshot.md
@@ -1,0 +1,124 @@
+# RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot
+
+## 1. Purpose
+
+This document records the DEFERRAL_ENGAGED static sandbox variant for the V.I.K.I. ↔ VERITAS / RSA-compatible flow.
+
+This is a stronger hard-stop case than DENSITY_THROTTLED and ALGORITHMIC_HUMILITY_ENGAGED.
+
+The goal is to show that VERITAS can block final commit when an upstream critical deferral signal is emitted.
+
+## 2. Current baseline
+
+The current merged baseline includes:
+- RSA / V.I.K.I. / VERITAS terminology synchronization.
+- Existing RSASandboxPayload receiver contract.
+- Existing evaluate_rsa_sandbox_signal(payload) mapping.
+- Existing E2E sandbox harness.
+- Existing governance-backend-fast CI coverage.
+- Existing ALGORITHMIC_HUMILITY_ENGAGED validation snapshot.
+- Existing DENSITY_THROTTLED validation snapshot.
+
+## 3. Terminology compatibility note
+
+- RSA remains the theoretical framework and underlying rule set.
+- V.I.K.I. is the operational producer of RSA-compatible upstream payloads.
+- VERITAS is the downstream commit governance boundary.
+- rsa_status remains unchanged for compatibility.
+- RSASandboxPayload remains the VERITAS-side receiver contract name.
+- upstream_signal_source = "RSA" is retained as a v1 compatibility fixture/source label.
+- That compatibility label does not mean VERITAS consumes V.I.K.I. internal reasoning.
+- VERITAS consumes only the emitted payload.
+
+## 4. Static sandbox input payload
+
+```json
+{
+  "rsa_status": "DEFERRAL_ENGAGED",
+  "trigger_source": "SRC_Critical_Deferral_Condition",
+  "original_llm_intent": "Proceed_To_Final_Transaction_Commit",
+  "rsa_action_taken": "Critical_Deferral_Activated_Before_Final_Commit",
+  "timestamp": "2026-10-25T09:25:30Z"
+}
+```
+
+## 5. Expected VERITAS decision output
+
+```json
+{
+  "continuation_decision": "BLOCK_FINAL_COMMIT",
+  "reason_code": "UPSTREAM_CRITICAL_DEFERRAL_SIGNAL",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "BLOCKED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 6. Expected audit entry output
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "DEFERRAL_ENGAGED",
+  "trigger_source": "SRC_Critical_Deferral_Condition",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "RSA reported a critical upstream deferral condition; VERITAS blocks final commit until human review or policy remediation occurs.",
+  "timestamp": "2026-10-25T09:25:30Z",
+  "veritas_continuation_decision": "BLOCK_FINAL_COMMIT",
+  "veritas_sandbox_commit_state": "BLOCKED_NOT_COMMITTED"
+}
+```
+
+## 7. What this validates
+
+- The DEFERRAL_ENGAGED status is represented by the existing RSASandboxPayload contract.
+- VERITAS deterministically maps DEFERRAL_ENGAGED to BLOCK_FINAL_COMMIT.
+- VERITAS records UPSTREAM_CRITICAL_DEFERRAL_SIGNAL.
+- Raw upstream intent/action fields are redacted by default.
+- This variant demonstrates a stronger hard-stop case than DENSITY_THROTTLED and ALGORITHMIC_HUMILITY_ENGAGED.
+- The sandbox commit state is BLOCKED_NOT_COMMITTED.
+- The current E2E sandbox path remains reviewable without connecting live V.I.K.I. logic.
+
+## 8. What this does not validate
+
+- It does not connect live V.I.K.I. middleware.
+- It does not validate V.I.K.I. internal reasoning.
+- It does not determine real-world compliance status.
+- It does not implement production AML/KYC compliance.
+- It does not provide regulatory approval.
+- It does not provide third-party certification.
+- It does not provide legal advice.
+- It does not use real customer, financial, medical, KYC, or regulated data.
+- It does not change production runtime governance.
+
+## 9. Relationship to previous snapshots
+
+DENSITY_THROTTLED:
+- Upstream output was modified for cognitive-density control.
+- VERITAS logs the intervention.
+- Continuation decision is CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED.
+
+ALGORITHMIC_HUMILITY_ENGAGED:
+- Required context / authority evidence is incomplete.
+- VERITAS pauses for human review.
+- Continuation decision is PAUSE_FOR_HUMAN_REVIEW.
+
+DEFERRAL_ENGAGED:
+- A critical upstream deferral condition is reported.
+- VERITAS blocks final commit.
+- Continuation decision is BLOCK_FINAL_COMMIT.
+- Sandbox commit state is BLOCKED_NOT_COMMITTED.
+
+## 10. Next sandbox step
+
+After this hard-stop snapshot, the next sandbox step should be a compact summary matrix comparing all static fixture variants.
+
+Likely variants:
+- SAFE_PROCEED
+- DENSITY_THROTTLED
+- ALGORITHMIC_HUMILITY_ENGAGED
+- DEFERRAL_ENGAGED
+
+No live V.I.K.I. connection should be added before the static fixture matrix is documented and reviewed.

--- a/docs/ja/guides/rsa-veritas-deferral-engaged-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-deferral-engaged-validation-snapshot.md
@@ -1,0 +1,128 @@
+# RSA ↔ VERITAS DEFERRAL_ENGAGED 検証スナップショット
+
+## 英語正本
+
+- [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](../../en/guides/rsa-veritas-deferral-engaged-validation-snapshot.md)
+
+## 1. 目的
+
+本書は、V.I.K.I. ↔ VERITAS / RSA-compatible フローにおける DEFERRAL_ENGAGED の static sandbox variant を記録するための文書です。
+
+これは DENSITY_THROTTLED および ALGORITHMIC_HUMILITY_ENGAGED よりも強い hard-stop ケースです。
+
+目的は、critical な upstream deferral signal が emit された際に、VERITAS が最終コミットを block できることを示す点にあります。
+
+## 2. 現在のベースライン
+
+現在のマージ済みベースラインには、以下が含まれます。
+- RSA / V.I.K.I. / VERITAS の用語同期。
+- 既存の RSASandboxPayload receiver contract。
+- 既存の evaluate_rsa_sandbox_signal(payload) mapping。
+- 既存の E2E sandbox harness。
+- 既存の governance-backend-fast CI coverage。
+- 既存の ALGORITHMIC_HUMILITY_ENGAGED 検証スナップショット。
+- 既存の DENSITY_THROTTLED 検証スナップショット。
+
+## 3. 用語互換性ノート
+
+- RSA は理論的フレームワークと underlying rule set のままです。
+- V.I.K.I. は RSA-compatible な upstream payload の operational producer です。
+- VERITAS は downstream の commit governance boundary です。
+- 互換性のため、rsa_status は変更しません。
+- RSASandboxPayload は VERITAS 側 receiver contract 名として維持されます。
+- upstream_signal_source = "RSA" は v1 compatibility fixture/source label として維持されます。
+- この compatibility label は、VERITAS が V.I.K.I. internal reasoning を消費することを意味しません。
+- VERITAS が消費するのは emitted payload のみです。
+
+## 4. Static sandbox input payload
+
+```json
+{
+  "rsa_status": "DEFERRAL_ENGAGED",
+  "trigger_source": "SRC_Critical_Deferral_Condition",
+  "original_llm_intent": "Proceed_To_Final_Transaction_Commit",
+  "rsa_action_taken": "Critical_Deferral_Activated_Before_Final_Commit",
+  "timestamp": "2026-10-25T09:25:30Z"
+}
+```
+
+## 5. Expected VERITAS decision output
+
+```json
+{
+  "continuation_decision": "BLOCK_FINAL_COMMIT",
+  "reason_code": "UPSTREAM_CRITICAL_DEFERRAL_SIGNAL",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "BLOCKED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 6. Expected audit entry output
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "DEFERRAL_ENGAGED",
+  "trigger_source": "SRC_Critical_Deferral_Condition",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "RSA reported a critical upstream deferral condition; VERITAS blocks final commit until human review or policy remediation occurs.",
+  "timestamp": "2026-10-25T09:25:30Z",
+  "veritas_continuation_decision": "BLOCK_FINAL_COMMIT",
+  "veritas_sandbox_commit_state": "BLOCKED_NOT_COMMITTED"
+}
+```
+
+## 7. このスナップショットで検証されること
+
+- DEFERRAL_ENGAGED status が既存の RSASandboxPayload contract で表現されること。
+- VERITAS が DEFERRAL_ENGAGED を BLOCK_FINAL_COMMIT に決定的にマッピングすること。
+- VERITAS が UPSTREAM_CRITICAL_DEFERRAL_SIGNAL を記録すること。
+- 生の upstream intent/action フィールドがデフォルトで redacted されること。
+- この variant が DENSITY_THROTTLED と ALGORITHMIC_HUMILITY_ENGAGED より強い hard-stop ケースを示すこと。
+- sandbox commit state が BLOCKED_NOT_COMMITTED であること。
+- live V.I.K.I. logic に接続せず、現在の E2E sandbox path をレビュー可能なこと。
+
+## 8. このスナップショットで検証されないこと
+
+- live V.I.K.I. middleware には接続しません。
+- V.I.K.I. internal reasoning は検証しません。
+- 現実世界の compliance status は判定しません。
+- production AML/KYC compliance は実装しません。
+- regulatory approval は提供しません。
+- third-party certification は提供しません。
+- legal advice は提供しません。
+- 実在の customer・financial・medical・KYC・regulated data は使用しません。
+- production runtime governance は変更しません。
+
+## 9. 既存スナップショットとの関係
+
+DENSITY_THROTTLED:
+- 認知密度制御のために upstream output が修正されるケースです。
+- VERITAS はその介入をログに記録します。
+- continuation decision は CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED です。
+
+ALGORITHMIC_HUMILITY_ENGAGED:
+- 必要な context / authority evidence が不足しているケースです。
+- VERITAS は human review のために一時停止します。
+- continuation decision は PAUSE_FOR_HUMAN_REVIEW です。
+
+DEFERRAL_ENGAGED:
+- critical な upstream deferral condition が報告されるケースです。
+- VERITAS は final commit を block します。
+- continuation decision は BLOCK_FINAL_COMMIT です。
+- sandbox commit state は BLOCKED_NOT_COMMITTED です。
+
+## 10. 次の sandbox ステップ
+
+この hard-stop スナップショットの次のステップとして、すべての static fixture variant を比較する compact な summary matrix を文書化するのが適切です。
+
+想定される variant:
+- SAFE_PROCEED
+- DENSITY_THROTTLED
+- ALGORITHMIC_HUMILITY_ENGAGED
+- DEFERRAL_ENGAGED
+
+static fixture matrix が文書化・レビューされる前に、live V.I.K.I. connection を追加すべきではありません。


### PR DESCRIPTION
### Motivation

- Add a third static fixture variant `DEFERRAL_ENGAGED` to document the V.I.K.I. ↔ VERITAS / RSA-compatible sandbox flow and demonstrate a stronger hard-stop case than `DENSITY_THROTTLED` and `ALGORITHMIC_HUMILITY_ENGAGED`.
- Show that an RSA-compatible upstream critical deferral signal can deterministically map to a VERITAS decision to block the final commit (`BLOCK_FINAL_COMMIT`) and record `UPSTREAM_CRITICAL_DEFERRAL_SIGNAL` under the existing receiver contract.
- Keep the change strictly documentation-only while preserving compatibility names and contracts such as `rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`, and the `upstream_signal_source = "RSA"` label.

### Description

- Added `docs/en/guides/rsa-veritas-deferral-engaged-validation-snapshot.md` containing the required sections and exact JSON examples for the static input payload, expected VERITAS decision output, and expected audit entry output using the specified enum values and timestamps.
- Added `docs/ja/guides/rsa-veritas-deferral-engaged-validation-snapshot.md` as a Japanese-first aligned page that includes the `## 英語正本` link near the top and preserves all technical terms and exact JSON examples unmodified.
- Constrained changes to documentation only and explicitly preserved existing runtime contracts and mappings; no code, tests, CI config, or runtime behavior were modified.

### Testing

- No automated tests were executed because this is a documentation-only change and no tests were modified.
- No test files or CI configuration were changed, and the change is intended to be reviewable by existing E2E sandbox and CI coverage without runtime effects.
- Manual verification consisted of ensuring the two new pages contain the exact JSON payloads and enum values requested and that the Japanese page includes the required English source link.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a718522bc8326a981d691bb81b3be)