### PR TITLE
docs: add compact RSA ↔ VERITAS static fixture matrix pages

### DIFF
--- a/docs/en/guides/rsa-veritas-static-fixture-matrix.md
+++ b/docs/en/guides/rsa-veritas-static-fixture-matrix.md
@@ -1,0 +1,90 @@
+# RSA ↔ VERITAS Static Fixture Matrix
+
+## 1. Purpose
+
+This document summarizes the static RSA-compatible fixture variants used in the V.I.K.I. ↔ VERITAS sandbox validation flow.
+
+The goal is to show the deterministic mapping from upstream RSA-compatible status to VERITAS continuation decision, reason code, audit posture, and commit state.
+
+## 2. Current baseline
+
+The current merged baseline includes:
+
+- RSA / V.I.K.I. / VERITAS terminology synchronization.
+- Existing RSASandboxPayload receiver contract.
+- Existing evaluate_rsa_sandbox_signal(payload) mapping.
+- Existing E2E sandbox harness.
+- Existing governance-backend-fast CI coverage.
+- Existing ALGORITHMIC_HUMILITY_ENGAGED validation snapshot.
+- Existing DENSITY_THROTTLED validation snapshot.
+- Existing DEFERRAL_ENGAGED validation snapshot.
+
+## 3. Terminology compatibility note
+
+- RSA remains the theoretical framework and underlying rule set.
+- V.I.K.I. is the operational producer of RSA-compatible upstream payloads.
+- VERITAS is the downstream commit governance boundary.
+- rsa_status remains unchanged for compatibility.
+- RSASandboxPayload remains the VERITAS-side receiver contract name.
+- upstream_signal_source = "RSA" is retained as a v1 compatibility fixture/source label.
+- That compatibility label does not mean VERITAS consumes V.I.K.I. internal reasoning.
+- VERITAS consumes only the emitted payload.
+
+## 4. Static fixture matrix
+
+| rsa_status | upstream meaning | VERITAS continuation_decision | reason_code | sandbox_commit_state | review posture |
+| --- | --- | --- | --- | --- | --- |
+| SAFE_PROCEED | Upstream signal indicates the workflow may continue toward normal bind-boundary evaluation. | CONTINUE_TO_BIND_BOUNDARY | UPSTREAM_SAFE_PROCEED_SIGNAL | SUSPENDED_NOT_COMMITTED | continue to normal sandbox bind-boundary evaluation |
+| DENSITY_THROTTLED | Upstream output was modified for cognitive-density control. | CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED | UPSTREAM_INTERVENTION_DENSITY_THROTTLE | SUSPENDED_NOT_COMMITTED | continue with upstream intervention logged |
+| ALGORITHMIC_HUMILITY_ENGAGED | Required context or authority evidence is incomplete. | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_INCOMPLETE_KYC_CONTEXT | SUSPENDED_NOT_COMMITTED | pause for human review or additional evidence |
+| DEFERRAL_ENGAGED | Critical upstream deferral condition reported before final commit. | BLOCK_FINAL_COMMIT | UPSTREAM_CRITICAL_DEFERRAL_SIGNAL | BLOCKED_NOT_COMMITTED | hard block final commit until review or remediation |
+
+## 5. Escalation ladder
+
+SAFE_PROCEED  
+→ normal continuation
+
+DENSITY_THROTTLED  
+→ soft intervention logged
+
+ALGORITHMIC_HUMILITY_ENGAGED  
+→ pause for human review
+
+DEFERRAL_ENGAGED  
+→ block final commit
+
+This ladder gives reviewers a compact view of the sandbox governance behavior without connecting live V.I.K.I. middleware.
+
+## 6. Snapshot relationship
+
+This matrix is designed to be read alongside the existing snapshot pages:
+
+- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md) (ALGORITHMIC_HUMILITY_ENGAGED validation snapshot)
+- [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](./rsa-veritas-density-throttled-validation-snapshot.md)
+- [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
+
+## 7. What this validates
+
+- All current static RSA-compatible statuses are summarized in one reviewable matrix.
+- VERITAS has deterministic continuation decision mappings for the static fixture variants.
+- The matrix shows the range from safe continuation to soft intervention, pause, and hard commit block.
+- Existing compatibility labels and receiver contracts remain stable.
+- The current sandbox validation flow remains reviewable without connecting live V.I.K.I. logic.
+
+## 8. What this does not validate
+
+- It does not connect live V.I.K.I. middleware.
+- It does not validate V.I.K.I. internal reasoning.
+- It does not determine real-world compliance status.
+- It does not implement production AML/KYC compliance.
+- It does not provide regulatory approval.
+- It does not provide third-party certification.
+- It does not provide legal advice.
+- It does not use real customer, financial, medical, KYC, or regulated data.
+- It does not change production runtime governance.
+
+## 9. Next sandbox step
+
+After this matrix is merged, the next safe sandbox step is to add a SAFE_PROCEED validation snapshot or a lightweight reviewer index page linking all RSA ↔ VERITAS sandbox artifacts.
+
+No live V.I.K.I. connection should be added before the static fixture matrix and reviewer index are documented and reviewed.

--- a/docs/ja/guides/rsa-veritas-static-fixture-matrix.md
+++ b/docs/ja/guides/rsa-veritas-static-fixture-matrix.md
@@ -1,0 +1,94 @@
+# RSA ↔ VERITAS Static Fixture Matrix
+
+## 英語正本
+
+- [RSA ↔ VERITAS Static Fixture Matrix](../../en/guides/rsa-veritas-static-fixture-matrix.md)
+
+## 1. 目的
+
+本ドキュメントは、V.I.K.I. ↔ VERITAS の sandbox validation flow で使われる static な RSA-compatible fixture variants を一か所に集約して要約するものです。
+
+目的は、upstream の RSA-compatible status から、VERITAS の continuation decision・reason code・audit posture・commit state への決定論的マッピングを、コンパクトに確認できるようにすることです。
+
+## 2. 現在のベースライン
+
+現在のマージ済みベースラインには以下が含まれます。
+
+- RSA / V.I.K.I. / VERITAS の terminology synchronization。
+- 既存の RSASandboxPayload receiver contract。
+- 既存の evaluate_rsa_sandbox_signal(payload) mapping。
+- 既存の E2E sandbox harness。
+- 既存の governance-backend-fast CI coverage。
+- 既存の ALGORITHMIC_HUMILITY_ENGAGED validation snapshot。
+- 既存の DENSITY_THROTTLED validation snapshot。
+- 既存の DEFERRAL_ENGAGED validation snapshot。
+
+## 3. 用語互換性ノート
+
+- RSA は theoretical framework / underlying rule set のままです。
+- V.I.K.I. は RSA-compatible upstream payloads の operational producer です。
+- VERITAS は downstream commit governance boundary です。
+- 互換性のため rsa_status は変更しません。
+- RSASandboxPayload は VERITAS 側 receiver contract 名として維持します。
+- upstream_signal_source = "RSA" は v1 compatibility fixture/source label として維持します。
+- この compatibility label は、VERITAS が V.I.K.I. の internal reasoning を消費することを意味しません。
+- VERITAS が消費するのは emitted payload のみです。
+
+## 4. Static fixture matrix
+
+| rsa_status | upstream meaning | VERITAS continuation_decision | reason_code | sandbox_commit_state | review posture |
+| --- | --- | --- | --- | --- | --- |
+| SAFE_PROCEED | Upstream signal indicates the workflow may continue toward normal bind-boundary evaluation. | CONTINUE_TO_BIND_BOUNDARY | UPSTREAM_SAFE_PROCEED_SIGNAL | SUSPENDED_NOT_COMMITTED | continue to normal sandbox bind-boundary evaluation |
+| DENSITY_THROTTLED | Upstream output was modified for cognitive-density control. | CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED | UPSTREAM_INTERVENTION_DENSITY_THROTTLE | SUSPENDED_NOT_COMMITTED | continue with upstream intervention logged |
+| ALGORITHMIC_HUMILITY_ENGAGED | Required context or authority evidence is incomplete. | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_INCOMPLETE_KYC_CONTEXT | SUSPENDED_NOT_COMMITTED | pause for human review or additional evidence |
+| DEFERRAL_ENGAGED | Critical upstream deferral condition reported before final commit. | BLOCK_FINAL_COMMIT | UPSTREAM_CRITICAL_DEFERRAL_SIGNAL | BLOCKED_NOT_COMMITTED | hard block final commit until review or remediation |
+
+## 5. Escalation ladder
+
+SAFE_PROCEED  
+→ normal continuation
+
+DENSITY_THROTTLED  
+→ soft intervention logged
+
+ALGORITHMIC_HUMILITY_ENGAGED  
+→ pause for human review
+
+DEFERRAL_ENGAGED  
+→ block final commit
+
+この ladder により、live V.I.K.I. middleware を接続しなくても、sandbox governance behavior の段階的エスカレーションをレビューできます。
+
+## 6. スナップショットとの関係
+
+本マトリクスは、既存の snapshot pages と合わせて参照する想定です。
+
+- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](../../en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md)（ALGORITHMIC_HUMILITY_ENGAGED validation snapshot）
+- [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](../../en/guides/rsa-veritas-density-throttled-validation-snapshot.md)
+- [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](../../en/guides/rsa-veritas-deferral-engaged-validation-snapshot.md)
+
+## 7. この文書で検証できること
+
+- 現行の static RSA-compatible statuses を 1 つのレビュー可能な matrix で俯瞰できること。
+- VERITAS が static fixture variants に対して deterministic な continuation decision mappings を持つこと。
+- matrix が safe continuation / soft intervention / pause / hard commit block の全レンジを示すこと。
+- 既存の compatibility labels と receiver contracts が安定維持されていること。
+- live V.I.K.I. logic 接続なしで current sandbox validation flow をレビューできること。
+
+## 8. この文書で検証しないこと
+
+- live V.I.K.I. middleware の接続は行いません。
+- V.I.K.I. internal reasoning の妥当性は検証しません。
+- 現実世界での compliance status を判定しません。
+- production AML/KYC compliance を実装しません。
+- regulatory approval を提供しません。
+- third-party certification を提供しません。
+- legal advice を提供しません。
+- real customer, financial, medical, KYC, regulated data は使用しません。
+- production runtime governance は変更しません。
+
+## 9. 次の sandbox ステップ
+
+この matrix のマージ後、次の安全な sandbox ステップは SAFE_PROCEED validation snapshot の追加、または RSA ↔ VERITAS sandbox artifacts 全体をつなぐ lightweight reviewer index page の追加です。
+
+static fixture matrix と reviewer index が文書化・レビューされる前に、live V.I.K.I. connection を追加すべきではありません。


### PR DESCRIPTION
### Motivation

- Provide a single, compact documentation matrix that summarizes the deterministic mapping from upstream RSA-compatible statuses to VERITAS continuation decisions and commit posture for the V.I.K.I. → VERITAS sandbox validation flow.
- Help reviewers inspect the escalation ladder (safe continuation → soft intervention → pause → hard commit block) without connecting to live V.I.K.I. middleware.

### Description

- Add `docs/en/guides/rsa-veritas-static-fixture-matrix.md` containing purpose, baseline, terminology compatibility note, a static fixture matrix table for `SAFE_PROCEED`, `DENSITY_THROTTLED`, `ALGORITHMIC_HUMILITY_ENGAGED`, and `DEFERRAL_ENGAGED`, an escalation ladder, snapshot relationships, validation boundaries, and next-step guidance.
- Add `docs/ja/guides/rsa-veritas-static-fixture-matrix.md` as a Japanese-aligned explanation that includes an `## 英語正本` link to the English page and preserves all specified enum/key values and technical terms exactly.
- Preserve all compatibility names and receiver contract references in the documentation (`rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`, and `upstream_signal_source = "RSA"`) and avoid any runtime, test, or CI changes.
- Scope is documentation-only and intentionally avoids live V.I.K.I. connections, compliance/regulatory claims, or use of any real regulated data.

### Testing

- Ran repository discovery via `find .. -name AGENTS.md -print` which succeeded and confirmed agent guidance was available.
- Verified presence of existing snapshots via `rg -n "ALGORITHMIC_HUMILITY_ENGAGED|DENSITY_THROTTLED|DEFERRAL_ENGAGED" docs` which succeeded and was used to reference snapshot pages.
- Confirmed working tree and committed the new files with `git status --short`, `git add ...`, and `git commit -m "docs: add RSA-VERITAS static fixture matrix guides"`, all of which succeeded.
- Created PR metadata via the repository `make_pr` helper which returned the PR title/body payload successfully; no unit tests or CI changes were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a839dbfb083268ee9e75e5159e7a3)