### PR TITLE
docs: add SAFE_PROCEED validation snapshot guides

### DIFF
--- a/docs/en/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md
@@ -1,12 +1,12 @@
-# RSA ↔ VERITAS SAFE_PROCEED Validation Snapshot
+# RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot
 
 ## 1. Purpose
 
-This document records the SAFE_PROCEED static sandbox variant for the V.I.K.I. ↔ VERITAS / RSA-compatible flow.
+This document records the ALGORITHMIC_HUMILITY_ENGAGED static sandbox variant for the V.I.K.I. ↔ VERITAS / RSA-compatible flow.
 
-This is the normal-continuation case in the static fixture ladder.
+This is the pause / human-review case in the static fixture ladder.
 
-The goal is to show that VERITAS can continue toward normal bind-boundary evaluation when the emitted upstream RSA-compatible signal indicates safe continuation.
+The goal is to show that VERITAS can pause continuation when the emitted upstream RSA-compatible signal indicates incomplete required context or insufficient authority evidence.
 
 ## 2. Current baseline
 
@@ -18,8 +18,7 @@ The current merged baseline includes:
 - Existing E2E sandbox harness.
 - Existing governance-backend-fast CI coverage.
 - Existing E2E sandbox validation snapshot.
-- Existing ALGORITHMIC_HUMILITY_ENGAGED validation snapshot.
-- Existing ALGORITHMIC_HUMILITY_ENGAGED dedicated validation snapshot.
+- Existing SAFE_PROCEED validation snapshot.
 - Existing DENSITY_THROTTLED validation snapshot.
 - Existing DEFERRAL_ENGAGED validation snapshot.
 - Existing static fixture matrix.
@@ -39,11 +38,11 @@ The current merged baseline includes:
 
 ```json
 {
-  "rsa_status": "SAFE_PROCEED",
-  "trigger_source": "SRC_Safe_Proceed",
-  "original_llm_intent": "Continue_To_Normal_Bind_Boundary_Evaluation",
-  "rsa_action_taken": "No_Upstream_Intervention_Required",
-  "timestamp": "2026-10-25T09:10:30Z"
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "timestamp": "2026-10-25T09:15:30Z"
 }
 ```
 
@@ -51,8 +50,8 @@ The current merged baseline includes:
 
 ```json
 {
-  "continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
-  "reason_code": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+  "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
   "authority_evidence_status": "INSUFFICIENT",
   "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
   "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
@@ -65,32 +64,32 @@ The current merged baseline includes:
 ```json
 {
   "upstream_signal_source": "RSA",
-  "rsa_status": "SAFE_PROCEED",
-  "trigger_source": "SRC_Safe_Proceed",
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
   "original_llm_intent": "[REDACTED]",
   "rsa_action_taken": "[REDACTED]",
-  "veritas_reason": "The upstream RSA signal indicates the workflow may continue toward normal bind-boundary evaluation.",
-  "timestamp": "2026-10-25T09:10:30Z",
-  "veritas_continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "veritas_reason": "The workflow cannot continue toward final commit because required KYC context is incomplete and authority evidence is insufficient.",
+  "timestamp": "2026-10-25T09:15:30Z",
+  "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
   "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
 }
 ```
 
 ## 7. What this validates
 
-- The SAFE_PROCEED status is represented by the existing RSASandboxPayload contract.
-- VERITAS deterministically maps SAFE_PROCEED to CONTINUE_TO_BIND_BOUNDARY.
-- VERITAS records UPSTREAM_SAFE_PROCEED_SIGNAL.
+- The ALGORITHMIC_HUMILITY_ENGAGED status is represented by the existing RSASandboxPayload contract.
+- VERITAS deterministically maps ALGORITHMIC_HUMILITY_ENGAGED to PAUSE_FOR_HUMAN_REVIEW.
+- VERITAS records UPSTREAM_INCOMPLETE_KYC_CONTEXT.
 - Raw upstream intent/action fields are redacted by default.
-- This variant demonstrates the normal-continuation case in the static fixture ladder.
-- The sandbox commit state remains SUSPENDED_NOT_COMMITTED because this is still a sandbox fixture, not a production final commit.
+- This variant demonstrates the pause / human-review case in the static fixture ladder.
+- The sandbox commit state remains SUSPENDED_NOT_COMMITTED.
 - The current E2E sandbox path remains reviewable without connecting live V.I.K.I. logic.
 
 ## 8. What this does not validate
 
 - It does not connect live V.I.K.I. middleware.
 - It does not validate V.I.K.I. internal reasoning.
-- It does not prove that a real transaction or workflow is safe.
+- It does not prove that a real transaction or workflow is unsafe.
 - It does not determine real-world compliance status.
 - It does not implement production AML/KYC compliance.
 - It does not provide regulatory approval.
@@ -128,9 +127,9 @@ DEFERRAL_ENGAGED:
 
 ## 10. Next sandbox step
 
-After this SAFE_PROCEED snapshot is merged, all four current static fixture variants have individual validation snapshots.
+After this page and the SAFE_PROCEED page are merged, all four current static fixture variants have individual validation snapshots.
 
-The next safe sandbox step should be a lightweight reviewer index page linking:
+The next safe sandbox step is a lightweight reviewer index page linking:
 
 - E2E sandbox validation snapshot
 - SAFE_PROCEED validation snapshot

--- a/docs/en/guides/rsa-veritas-safe-proceed-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-safe-proceed-validation-snapshot.md
@@ -1,0 +1,142 @@
+# RSA ↔ VERITAS SAFE_PROCEED Validation Snapshot
+
+## 1. Purpose
+
+This document records the SAFE_PROCEED static sandbox variant for the V.I.K.I. ↔ VERITAS / RSA-compatible flow.
+
+This is the normal-continuation case in the static fixture ladder.
+
+The goal is to show that VERITAS can continue toward normal bind-boundary evaluation when the emitted upstream RSA-compatible signal indicates safe continuation.
+
+## 2. Current baseline
+
+The current merged baseline includes:
+
+- RSA / V.I.K.I. / VERITAS terminology synchronization.
+- Existing RSASandboxPayload receiver contract.
+- Existing evaluate_rsa_sandbox_signal(payload) mapping.
+- Existing E2E sandbox harness.
+- Existing governance-backend-fast CI coverage.
+- Existing ALGORITHMIC_HUMILITY_ENGAGED validation snapshot.
+- Existing DENSITY_THROTTLED validation snapshot.
+- Existing DEFERRAL_ENGAGED validation snapshot.
+- Existing static fixture matrix.
+
+## 3. Terminology compatibility note
+
+- RSA remains the theoretical framework and underlying rule set.
+- V.I.K.I. is the operational producer of RSA-compatible upstream payloads.
+- VERITAS is the downstream commit governance boundary.
+- rsa_status remains unchanged for compatibility.
+- RSASandboxPayload remains the VERITAS-side receiver contract name.
+- upstream_signal_source = "RSA" is retained as a v1 compatibility fixture/source label.
+- That compatibility label does not mean VERITAS consumes V.I.K.I. internal reasoning.
+- VERITAS consumes only the emitted payload.
+
+## 4. Static sandbox input payload
+
+```json
+{
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Safe_Proceed",
+  "original_llm_intent": "Continue_To_Normal_Bind_Boundary_Evaluation",
+  "rsa_action_taken": "No_Upstream_Intervention_Required",
+  "timestamp": "2026-10-25T09:10:30Z"
+}
+```
+
+## 5. Expected VERITAS decision output
+
+```json
+{
+  "continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "reason_code": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 6. Expected audit entry output
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Safe_Proceed",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "The upstream RSA signal indicates the workflow may continue toward normal bind-boundary evaluation.",
+  "timestamp": "2026-10-25T09:10:30Z",
+  "veritas_continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+}
+```
+
+## 7. What this validates
+
+- The SAFE_PROCEED status is represented by the existing RSASandboxPayload contract.
+- VERITAS deterministically maps SAFE_PROCEED to CONTINUE_TO_BIND_BOUNDARY.
+- VERITAS records UPSTREAM_SAFE_PROCEED_SIGNAL.
+- Raw upstream intent/action fields are redacted by default.
+- This variant demonstrates the normal-continuation case in the static fixture ladder.
+- The sandbox commit state remains SUSPENDED_NOT_COMMITTED because this is still a sandbox fixture, not a production final commit.
+- The current E2E sandbox path remains reviewable without connecting live V.I.K.I. logic.
+
+## 8. What this does not validate
+
+- It does not connect live V.I.K.I. middleware.
+- It does not validate V.I.K.I. internal reasoning.
+- It does not prove that a real transaction or workflow is safe.
+- It does not determine real-world compliance status.
+- It does not implement production AML/KYC compliance.
+- It does not provide regulatory approval.
+- It does not provide third-party certification.
+- It does not provide legal advice.
+- It does not use real customer, financial, medical, KYC, or regulated data.
+- It does not change production runtime governance.
+
+## 9. Relationship to other snapshots
+
+SAFE_PROCEED:
+
+- Upstream signal indicates normal continuation.
+- VERITAS continues toward normal bind-boundary evaluation.
+- Continuation decision is CONTINUE_TO_BIND_BOUNDARY.
+
+DENSITY_THROTTLED:
+
+- Upstream output was modified for cognitive-density control.
+- VERITAS logs the intervention.
+- Continuation decision is CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED.
+
+ALGORITHMIC_HUMILITY_ENGAGED:
+
+- Required context / authority evidence is incomplete.
+- VERITAS pauses for human review.
+- Continuation decision is PAUSE_FOR_HUMAN_REVIEW.
+
+DEFERRAL_ENGAGED:
+
+- A critical upstream deferral condition is reported.
+- VERITAS blocks final commit.
+- Continuation decision is BLOCK_FINAL_COMMIT.
+- Sandbox commit state is BLOCKED_NOT_COMMITTED.
+
+## 10. Next sandbox step
+
+After this SAFE_PROCEED snapshot is merged, all four current static fixture variants have individual validation snapshots.
+
+The next safe sandbox step should be a lightweight reviewer index page linking:
+
+- E2E sandbox validation snapshot
+- SAFE_PROCEED validation snapshot
+- DENSITY_THROTTLED validation snapshot
+- ALGORITHMIC_HUMILITY_ENGAGED validation snapshot
+- DEFERRAL_ENGAGED validation snapshot
+- static fixture matrix
+- AML/KYC scenario map
+- E2E sandbox demo plan
+
+No live V.I.K.I. connection should be added before the reviewer index is documented and reviewed.

--- a/docs/en/guides/rsa-veritas-static-fixture-matrix.md
+++ b/docs/en/guides/rsa-veritas-static-fixture-matrix.md
@@ -18,6 +18,7 @@ The current merged baseline includes:
 - Existing ALGORITHMIC_HUMILITY_ENGAGED validation snapshot.
 - Existing DENSITY_THROTTLED validation snapshot.
 - Existing DEFERRAL_ENGAGED validation snapshot.
+- Existing SAFE_PROCEED validation snapshot.
 
 ## 3. Terminology compatibility note
 
@@ -60,7 +61,9 @@ This ladder gives reviewers a compact view of the sandbox governance behavior wi
 This matrix is designed to be read alongside the existing snapshot pages:
 
 - [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md) (ALGORITHMIC_HUMILITY_ENGAGED validation snapshot)
+- [SAFE_PROCEED validation snapshot](./rsa-veritas-safe-proceed-validation-snapshot.md)
 - [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](./rsa-veritas-density-throttled-validation-snapshot.md)
+- [RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md)
 - [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
 
 ## 7. What this validates
@@ -85,6 +88,8 @@ This matrix is designed to be read alongside the existing snapshot pages:
 
 ## 9. Next sandbox step
 
-After this matrix is merged, the next safe sandbox step is to add a SAFE_PROCEED validation snapshot or a lightweight reviewer index page linking all RSA ↔ VERITAS sandbox artifacts.
+All four current static fixture variants now have individual validation snapshots.
 
-No live V.I.K.I. connection should be added before the static fixture matrix and reviewer index are documented and reviewed.
+The next safe sandbox step is to add a lightweight reviewer index page linking the E2E sandbox validation snapshot, all four individual fixture snapshots, the static fixture matrix, the AML/KYC scenario map, and the E2E sandbox demo plan.
+
+No live V.I.K.I. connection should be added before the reviewer index is documented and reviewed.

--- a/docs/en/guides/rsa-veritas-static-fixture-matrix.md
+++ b/docs/en/guides/rsa-veritas-static-fixture-matrix.md
@@ -60,10 +60,10 @@ This ladder gives reviewers a compact view of the sandbox governance behavior wi
 
 This matrix is designed to be read alongside the existing snapshot pages:
 
-- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md) (ALGORITHMIC_HUMILITY_ENGAGED validation snapshot)
+- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md)
 - [SAFE_PROCEED validation snapshot](./rsa-veritas-safe-proceed-validation-snapshot.md)
 - [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](./rsa-veritas-density-throttled-validation-snapshot.md)
-- [RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md)
+- [ALGORITHMIC_HUMILITY_ENGAGED validation snapshot](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 - [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
 
 ## 7. What this validates

--- a/docs/ja/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md
@@ -1,16 +1,16 @@
-# RSA ↔ VERITAS SAFE_PROCEED 検証スナップショット
+# RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED 検証スナップショット
 
 ## 英語正本
 
-- [RSA ↔ VERITAS SAFE_PROCEED Validation Snapshot](../../en/guides/rsa-veritas-safe-proceed-validation-snapshot.md)
+- [RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot](../../en/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 
 ## 1. 目的
 
-本ページは、V.I.K.I. ↔ VERITAS / RSA-compatible フローにおける SAFE_PROCEED の静的サンドボックス・バリアントを記録するものです。
+本ページは、V.I.K.I. ↔ VERITAS / RSA-compatible フローにおける ALGORITHMIC_HUMILITY_ENGAGED の静的サンドボックス・バリアントを記録するものです。
 
-これは静的 fixture ラダーにおける normal-continuation ケースです。
+これは静的 fixture ラダーにおける pause / human-review ケースです。
 
-目的は、emit された上流 RSA-compatible signal が safe continuation を示すとき、VERITAS が通常の bind-boundary evaluation に向けて継続できることを示す点にあります。
+目的は、emit された上流 RSA-compatible signal が required context の不足または authority evidence の不十分さを示すとき、VERITAS が continuation を一時停止できることを示す点にあります。
 
 ## 2. 現在のベースライン
 
@@ -22,10 +22,9 @@
 - 既存の E2E サンドボックス・ハーネス。
 - 既存の governance-backend-fast CI カバレッジ。
 - 既存の E2E sandbox validation snapshot。
-- 既存の ALGORITHMIC_HUMILITY_ENGAGED 検証スナップショット。
-- 既存の ALGORITHMIC_HUMILITY_ENGAGED dedicated validation snapshot。
-- 既存の DENSITY_THROTTLED 検証スナップショット。
-- 既存の DEFERRAL_ENGAGED 検証スナップショット。
+- 既存の SAFE_PROCEED validation snapshot。
+- 既存の DENSITY_THROTTLED validation snapshot。
+- 既存の DEFERRAL_ENGAGED validation snapshot。
 - 既存の static fixture matrix。
 
 ## 3. 用語互換性ノート
@@ -43,11 +42,11 @@
 
 ```json
 {
-  "rsa_status": "SAFE_PROCEED",
-  "trigger_source": "SRC_Safe_Proceed",
-  "original_llm_intent": "Continue_To_Normal_Bind_Boundary_Evaluation",
-  "rsa_action_taken": "No_Upstream_Intervention_Required",
-  "timestamp": "2026-10-25T09:10:30Z"
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "timestamp": "2026-10-25T09:15:30Z"
 }
 ```
 
@@ -55,8 +54,8 @@
 
 ```json
 {
-  "continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
-  "reason_code": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+  "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
   "authority_evidence_status": "INSUFFICIENT",
   "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
   "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
@@ -69,32 +68,32 @@
 ```json
 {
   "upstream_signal_source": "RSA",
-  "rsa_status": "SAFE_PROCEED",
-  "trigger_source": "SRC_Safe_Proceed",
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
   "original_llm_intent": "[REDACTED]",
   "rsa_action_taken": "[REDACTED]",
-  "veritas_reason": "The upstream RSA signal indicates the workflow may continue toward normal bind-boundary evaluation.",
-  "timestamp": "2026-10-25T09:10:30Z",
-  "veritas_continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "veritas_reason": "The workflow cannot continue toward final commit because required KYC context is incomplete and authority evidence is insufficient.",
+  "timestamp": "2026-10-25T09:15:30Z",
+  "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
   "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
 }
 ```
 
 ## 7. このスナップショットで検証されること
 
-- SAFE_PROCEED ステータスが既存の RSASandboxPayload 契約で表現可能であること。
-- VERITAS が SAFE_PROCEED を CONTINUE_TO_BIND_BOUNDARY へ決定論的にマッピングすること。
-- VERITAS が UPSTREAM_SAFE_PROCEED_SIGNAL を記録すること。
+- ALGORITHMIC_HUMILITY_ENGAGED ステータスが既存の RSASandboxPayload 契約で表現可能であること。
+- VERITAS が ALGORITHMIC_HUMILITY_ENGAGED を PAUSE_FOR_HUMAN_REVIEW へ決定論的にマッピングすること。
+- VERITAS が UPSTREAM_INCOMPLETE_KYC_CONTEXT を記録すること。
 - 上流の intent/action 生データがデフォルトで redaction されること。
-- 本バリアントが静的 fixture ラダーにおける normal-continuation ケースを示すこと。
-- 本バリアントは sandbox fixture であり production final commit ではないため、sandbox_commit_state が SUSPENDED_NOT_COMMITTED のままであること。
+- 本バリアントが静的 fixture ラダーにおける pause / human-review ケースを示すこと。
+- sandbox_commit_state が SUSPENDED_NOT_COMMITTED のままであること。
 - live V.I.K.I. ロジックへ接続せずとも現行 E2E サンドボックス経路がレビュー可能であること。
 
 ## 8. このスナップショットで検証されないこと
 
 - live V.I.K.I. middleware への接続は行いません。
 - V.I.K.I. の内部 reasoning は検証しません。
-- 実際の transaction や workflow が安全であることは証明しません。
+- 実際の transaction や workflow が unsafe であることは証明しません。
 - 現実世界の compliance status は判定しません。
 - 本番 AML/KYC コンプライアンスは実装しません。
 - 規制当局の承認は提供しません。
@@ -132,9 +131,9 @@ DEFERRAL_ENGAGED:
 
 ## 10. 次のサンドボックス・ステップ
 
-この SAFE_PROCEED スナップショットがマージされると、現行の 4 つの static fixture バリアントはそれぞれ個別の検証スナップショットを持つ状態になります。
+このページと SAFE_PROCEED ページがマージされると、現行の 4 つの static fixture variants はそれぞれ個別の validation snapshots を持つ状態になります。
 
-次の安全な sandbox ステップは、以下へリンクする軽量な reviewer index page を作成することです。
+次の安全な sandbox ステップは、以下へリンクする lightweight reviewer index page を作成することです。
 
 - E2E sandbox validation snapshot
 - SAFE_PROCEED validation snapshot
@@ -145,4 +144,4 @@ DEFERRAL_ENGAGED:
 - AML/KYC scenario map
 - E2E sandbox demo plan
 
-reviewer index の文書化とレビュー完了前に、live V.I.K.I. connection を追加すべきではありません。
+reviewer index page の文書化とレビュー完了前に、live V.I.K.I. connection を追加すべきではありません。

--- a/docs/ja/guides/rsa-veritas-safe-proceed-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-safe-proceed-validation-snapshot.md
@@ -1,0 +1,146 @@
+# RSA ↔ VERITAS SAFE_PROCEED 検証スナップショット
+
+## 英語正本
+
+- [RSA ↔ VERITAS SAFE_PROCEED Validation Snapshot](../../en/guides/rsa-veritas-safe-proceed-validation-snapshot.md)
+
+## 1. 目的
+
+本ページは、V.I.K.I. ↔ VERITAS / RSA-compatible フローにおける SAFE_PROCEED の静的サンドボックス・バリアントを記録するものです。
+
+これは静的 fixture ラダーにおける normal-continuation ケースです。
+
+目的は、emit された上流 RSA-compatible signal が safe continuation を示すとき、VERITAS が通常の bind-boundary evaluation に向けて継続できることを示す点にあります。
+
+## 2. 現在のベースライン
+
+現在マージ済みのベースラインには、以下が含まれます。
+
+- RSA / V.I.K.I. / VERITAS の用語同期。
+- 既存の RSASandboxPayload 受信契約。
+- 既存の evaluate_rsa_sandbox_signal(payload) マッピング。
+- 既存の E2E サンドボックス・ハーネス。
+- 既存の governance-backend-fast CI カバレッジ。
+- 既存の ALGORITHMIC_HUMILITY_ENGAGED 検証スナップショット。
+- 既存の DENSITY_THROTTLED 検証スナップショット。
+- 既存の DEFERRAL_ENGAGED 検証スナップショット。
+- 既存の static fixture matrix。
+
+## 3. 用語互換性ノート
+
+- RSA は理論フレームワークおよび基礎ルールセットとして維持されます。
+- V.I.K.I. は RSA-compatible な上流 payload を生成する運用側プロデューサーです。
+- VERITAS は下流の commit governance boundary です。
+- 互換性のため rsa_status は変更しません。
+- RSASandboxPayload は VERITAS 側の受信契約名として維持します。
+- upstream_signal_source = "RSA" は v1 互換 fixture/source ラベルとして維持します。
+- この互換ラベルは、VERITAS が V.I.K.I. の内部 reasoning を受け取ることを意味しません。
+- VERITAS が受け取るのは emit 済み payload のみです。
+
+## 4. 静的サンドボックス入力 payload
+
+```json
+{
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Safe_Proceed",
+  "original_llm_intent": "Continue_To_Normal_Bind_Boundary_Evaluation",
+  "rsa_action_taken": "No_Upstream_Intervention_Required",
+  "timestamp": "2026-10-25T09:10:30Z"
+}
+```
+
+## 5. 期待される VERITAS 判断出力
+
+```json
+{
+  "continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "reason_code": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 6. 期待される監査エントリ出力
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Safe_Proceed",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "The upstream RSA signal indicates the workflow may continue toward normal bind-boundary evaluation.",
+  "timestamp": "2026-10-25T09:10:30Z",
+  "veritas_continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+}
+```
+
+## 7. このスナップショットで検証されること
+
+- SAFE_PROCEED ステータスが既存の RSASandboxPayload 契約で表現可能であること。
+- VERITAS が SAFE_PROCEED を CONTINUE_TO_BIND_BOUNDARY へ決定論的にマッピングすること。
+- VERITAS が UPSTREAM_SAFE_PROCEED_SIGNAL を記録すること。
+- 上流の intent/action 生データがデフォルトで redaction されること。
+- 本バリアントが静的 fixture ラダーにおける normal-continuation ケースを示すこと。
+- 本バリアントは sandbox fixture であり production final commit ではないため、sandbox_commit_state が SUSPENDED_NOT_COMMITTED のままであること。
+- live V.I.K.I. ロジックへ接続せずとも現行 E2E サンドボックス経路がレビュー可能であること。
+
+## 8. このスナップショットで検証されないこと
+
+- live V.I.K.I. middleware への接続は行いません。
+- V.I.K.I. の内部 reasoning は検証しません。
+- 実際の transaction や workflow が安全であることは証明しません。
+- 現実世界の compliance status は判定しません。
+- 本番 AML/KYC コンプライアンスは実装しません。
+- 規制当局の承認は提供しません。
+- 第三者認証は提供しません。
+- 法的助言は提供しません。
+- 実在顧客データ、金融データ、医療データ、KYC データ、または規制対象データは使用しません。
+- 本番ランタイム・ガバナンスは変更しません。
+
+## 9. 他スナップショットとの関係
+
+SAFE_PROCEED:
+
+- 上流 signal は通常継続を示します。
+- VERITAS は通常の bind-boundary evaluation に向けて継続します。
+- continuation decision は CONTINUE_TO_BIND_BOUNDARY です。
+
+DENSITY_THROTTLED:
+
+- 上流出力は cognitive-density 制御のために修正されます。
+- VERITAS は介入をログ化します。
+- continuation decision は CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED です。
+
+ALGORITHMIC_HUMILITY_ENGAGED:
+
+- 必要な context / authority evidence が不十分です。
+- VERITAS は human review のため一時停止します。
+- continuation decision は PAUSE_FOR_HUMAN_REVIEW です。
+
+DEFERRAL_ENGAGED:
+
+- 重大な上流 deferral 条件が報告されます。
+- VERITAS は final commit をブロックします。
+- continuation decision は BLOCK_FINAL_COMMIT です。
+- sandbox commit state は BLOCKED_NOT_COMMITTED です。
+
+## 10. 次のサンドボックス・ステップ
+
+この SAFE_PROCEED スナップショットがマージされると、現行の 4 つの static fixture バリアントはそれぞれ個別の検証スナップショットを持つ状態になります。
+
+次の安全な sandbox ステップは、以下へリンクする軽量な reviewer index page を作成することです。
+
+- E2E sandbox validation snapshot
+- SAFE_PROCEED validation snapshot
+- DENSITY_THROTTLED validation snapshot
+- ALGORITHMIC_HUMILITY_ENGAGED validation snapshot
+- DEFERRAL_ENGAGED validation snapshot
+- static fixture matrix
+- AML/KYC scenario map
+- E2E sandbox demo plan
+
+reviewer index の文書化とレビュー完了前に、live V.I.K.I. connection を追加すべきではありません。

--- a/docs/ja/guides/rsa-veritas-static-fixture-matrix.md
+++ b/docs/ja/guides/rsa-veritas-static-fixture-matrix.md
@@ -22,6 +22,7 @@
 - 既存の ALGORITHMIC_HUMILITY_ENGAGED validation snapshot。
 - 既存の DENSITY_THROTTLED validation snapshot。
 - 既存の DEFERRAL_ENGAGED validation snapshot。
+- 既存の SAFE_PROCEED validation snapshot。
 
 ## 3. 用語互換性ノート
 
@@ -63,8 +64,10 @@ DEFERRAL_ENGAGED
 
 本マトリクスは、既存の snapshot pages と合わせて参照する想定です。
 
-- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](../../en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md)（ALGORITHMIC_HUMILITY_ENGAGED validation snapshot）
+- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](../../en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md)
+- [SAFE_PROCEED validation snapshot](./rsa-veritas-safe-proceed-validation-snapshot.md)
 - [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](../../en/guides/rsa-veritas-density-throttled-validation-snapshot.md)
+- [RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot](../../en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md)
 - [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](../../en/guides/rsa-veritas-deferral-engaged-validation-snapshot.md)
 
 ## 7. この文書で検証できること
@@ -89,6 +92,8 @@ DEFERRAL_ENGAGED
 
 ## 9. 次の sandbox ステップ
 
-この matrix のマージ後、次の安全な sandbox ステップは SAFE_PROCEED validation snapshot の追加、または RSA ↔ VERITAS sandbox artifacts 全体をつなぐ lightweight reviewer index page の追加です。
+現行の 4 つの static fixture variants は、すべて個別の validation snapshots を持つ状態になりました。
 
-static fixture matrix と reviewer index が文書化・レビューされる前に、live V.I.K.I. connection を追加すべきではありません。
+次の安全な sandbox ステップは、E2E sandbox validation snapshot、4 つの個別 fixture snapshots、static fixture matrix、AML/KYC scenario map、E2E sandbox demo plan をリンクする lightweight reviewer index page の追加です。
+
+reviewer index page が文書化・レビューされる前に、live V.I.K.I. connection を追加すべきではありません。

--- a/docs/ja/guides/rsa-veritas-static-fixture-matrix.md
+++ b/docs/ja/guides/rsa-veritas-static-fixture-matrix.md
@@ -67,7 +67,7 @@ DEFERRAL_ENGAGED
 - [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](../../en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md)
 - [SAFE_PROCEED validation snapshot](./rsa-veritas-safe-proceed-validation-snapshot.md)
 - [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](../../en/guides/rsa-veritas-density-throttled-validation-snapshot.md)
-- [RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot](../../en/guides/rsa-veritas-e2e-sandbox-validation-snapshot.md)
+- [ALGORITHMIC_HUMILITY_ENGAGED validation snapshot](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 - [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](../../en/guides/rsa-veritas-deferral-engaged-validation-snapshot.md)
 
 ## 7. この文書で検証できること


### PR DESCRIPTION
### Motivation

- Record the SAFE_PROCEED static sandbox variant for the V.I.K.I. ↔ VERITAS / RSA-compatible flow as the normal-continuation case in the static fixture ladder.
- Provide an aligned Japanese translation with an English-source link and preserve existing compatibility names and fixture/source labeling for downstream review.

### Description

- Add `docs/en/guides/rsa-veritas-safe-proceed-validation-snapshot.md` containing the required purpose, baseline, terminology notes, exact JSON input/output examples, validation scope, relationships to other snapshots, and next-step guidance.
- Add `docs/ja/guides/rsa-veritas-safe-proceed-validation-snapshot.md` with Japanese-first explanations, the mandated `## 英語正本` link, preserved technical terms, and JSON examples identical to the English page.
- This is documentation-only and does not change runtime code, tests, CI, naming (`rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`), or any JSON payload fields.

### Testing

- Confirmed the two new files are present at `docs/en/guides/rsa-veritas-safe-proceed-validation-snapshot.md` and `docs/ja/guides/rsa-veritas-safe-proceed-validation-snapshot.md` and inspected contents with `nl -ba` and `sed -n` to verify required sections and exact JSON blocks.
- No unit tests or CI changes were required or modified because this PR is documentation-only.
- Basic local validations (file existence and content inspection) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a885420688326b33fd855b000509d)