### PR TITLE
docs: add RSA ↔ VERITAS sandbox reviewer index (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -1,0 +1,98 @@
+# RSA ↔ VERITAS Sandbox Reviewer Index
+
+## 1. Purpose
+
+This page is the reviewer entrypoint for the RSA-compatible V.I.K.I. ↔ VERITAS sandbox documentation set.
+
+It consolidates the scenario map, demo plan, validation snapshots, and static fixture matrix into one navigable index so reviewers can inspect the sandbox flow without connecting live V.I.K.I. middleware.
+
+## 2. Current taxonomy
+
+- RSA remains the theoretical framework and underlying rule set.
+- V.I.K.I. is the operational middleware that emits RSA-compatible upstream payloads.
+- VERITAS is the downstream commit governance boundary.
+- VERITAS consumes only the emitted payload.
+- VERITAS does not consume V.I.K.I. internal reasoning.
+- Existing compatibility names such as `rsa_status`, `RSASandboxPayload`, and `upstream_signal_source = "RSA"` remain unchanged for v1 sandbox compatibility.
+
+## 3. Recommended reading order
+
+1. [AML/KYC scenario map](./rsa-veritas-aml-kyc-scenario-map.md)
+2. [E2E sandbox demo plan](./rsa-veritas-e2e-sandbox-demo-plan.md)
+3. [E2E sandbox validation snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md)
+4. [Static fixture matrix](./rsa-veritas-static-fixture-matrix.md)
+5. [SAFE_PROCEED validation snapshot](./rsa-veritas-safe-proceed-validation-snapshot.md)
+6. [DENSITY_THROTTLED validation snapshot](./rsa-veritas-density-throttled-validation-snapshot.md)
+7. [DEFERRAL_ENGAGED validation snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
+
+- `ALGORITHMIC_HUMILITY_ENGAGED` is currently covered by the broader E2E sandbox validation snapshot.
+- A dedicated `ALGORITHMIC_HUMILITY_ENGAGED` per-variant page may be added later if strict one-page-per-status symmetry is desired.
+
+## 4. Artifact map
+
+| Artifact | Purpose | Primary reviewer question answered |
+| --- | --- | --- |
+| AML/KYC scenario map | Shows the node-by-node upstream/downstream boundary. | Where does V.I.K.I. stop and where does VERITAS begin? |
+| E2E sandbox demo plan | Describes the static sandbox demonstration flow. | What is the intended demo path? |
+| E2E sandbox validation snapshot | Records the current static E2E output shape. | What does the current harness output look like? |
+| Static fixture matrix | Compares all supported static fixture statuses. | How does VERITAS map each upstream status? |
+| SAFE_PROCEED validation snapshot | Documents normal continuation. | What happens when the upstream signal says proceed? |
+| DENSITY_THROTTLED validation snapshot | Documents soft upstream intervention. | What happens when the upstream output was modified but not hard-blocked? |
+| DEFERRAL_ENGAGED validation snapshot | Documents hard final-commit block. | What happens when a critical upstream deferral signal is emitted? |
+
+## 5. Static fixture ladder
+
+Current static fixture ladder:
+
+- `SAFE_PROCEED`
+  - → `CONTINUE_TO_BIND_BOUNDARY`
+  - → normal continuation
+- `DENSITY_THROTTLED`
+  - → `CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED`
+  - → soft intervention logged
+- `ALGORITHMIC_HUMILITY_ENGAGED`
+  - → `PAUSE_FOR_HUMAN_REVIEW`
+  - → pause / human review
+- `DEFERRAL_ENGAGED`
+  - → `BLOCK_FINAL_COMMIT`
+  - → hard final-commit block
+
+Clarifications:
+
+- `SAFE_PROCEED`, `DENSITY_THROTTLED`, and `DEFERRAL_ENGAGED` currently have dedicated per-variant snapshot pages.
+- `ALGORITHMIC_HUMILITY_ENGAGED` is currently covered by the broader E2E sandbox validation snapshot.
+
+## 6. What this documentation set validates
+
+- The sandbox has a documented RSA / V.I.K.I. / VERITAS terminology boundary.
+- The sandbox has a documented AML/KYC scenario map.
+- The sandbox has a documented E2E demo plan.
+- The sandbox has a documented validation snapshot for the current static E2E path.
+- The sandbox has a static fixture matrix covering `SAFE_PROCEED`, `DENSITY_THROTTLED`, `ALGORITHMIC_HUMILITY_ENGAGED`, and `DEFERRAL_ENGAGED`.
+- The sandbox demonstrates deterministic mapping from RSA-compatible upstream statuses to VERITAS continuation decisions.
+- The sandbox shows how audit entries redact raw upstream intent/action fields by default.
+- The sandbox remains reviewable without connecting live V.I.K.I. logic.
+
+## 7. What this documentation set does not validate
+
+- It does not connect live V.I.K.I. middleware.
+- It does not validate V.I.K.I. internal reasoning.
+- It does not prove that a real transaction or workflow is safe.
+- It does not determine real-world compliance status.
+- It does not implement production AML/KYC compliance.
+- It does not provide regulatory approval.
+- It does not provide third-party certification.
+- It does not provide legal advice.
+- It does not use real customer, financial, medical, KYC, or regulated data.
+- It does not change production runtime governance.
+
+## 8. Next safe sandbox steps
+
+1. Add a dedicated `ALGORITHMIC_HUMILITY_ENGAGED` per-variant validation snapshot if strict one-page-per-status symmetry is desired.
+2. Add a small generated sample output file from `examples/sandbox/rsa_veritas_e2e_harness.py` if maintainers want a committed output artifact.
+3. Add a reviewer checklist for external review.
+4. Only after the static documentation set is reviewed, consider a separate design document for live V.I.K.I. integration.
+
+No live V.I.K.I. connection should be added in this PR.
+
+Live integration should be a later design phase, not part of the static sandbox documentation pass.

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -1,0 +1,104 @@
+# RSA ↔ VERITAS Sandbox Reviewer Index
+
+このページは、RSA-compatible な V.I.K.I. ↔ VERITAS サンドボックス文書群をレビューするための索引（review entrypoint）です。レビュー担当者が、各資料の役割と読み順を短時間で把握できるように整理しています。
+
+## 英語正本
+
+- [RSA ↔ VERITAS Sandbox Reviewer Index](../../en/guides/rsa-veritas-sandbox-reviewer-index.md)
+
+## 1. 目的
+
+この索引は、V.I.K.I. ↔ VERITAS / RSA-compatible サンドボックス文書セットのレビュー入口です。
+
+シナリオマップ、デモ計画、検証スナップショット、静的フィクスチャ・マトリクスを1ページに集約し、live V.I.K.I. middleware へ接続せずにサンドボックスの流れを確認できるようにします。
+
+## 2. 現在の taxonomy
+
+- RSA は理論フレームワークおよび基礎ルールセットとして位置づけられます。
+- V.I.K.I. は RSA-compatible な upstream payload を発行する運用 middleware です。
+- VERITAS は downstream の commit governance boundary です。
+- VERITAS は発行された payload のみを消費します。
+- VERITAS は V.I.K.I. の internal reasoning を消費しません。
+- `rsa_status`、`RSASandboxPayload`、`upstream_signal_source = "RSA"` といった既存の互換名は、v1 sandbox compatibility のため変更しません。
+
+## 3. 推奨読了順
+
+1. [AML/KYC シナリオマップ](./rsa-veritas-aml-kyc-scenario-map.md)
+2. [E2E サンドボックス・デモ計画](./rsa-veritas-e2e-sandbox-demo-plan.md)
+3. [E2E サンドボックス検証スナップショット](./rsa-veritas-e2e-sandbox-validation-snapshot.md)
+4. [静的フィクスチャ・マトリクス](./rsa-veritas-static-fixture-matrix.md)
+5. [SAFE_PROCEED 検証スナップショット](./rsa-veritas-safe-proceed-validation-snapshot.md)
+6. [DENSITY_THROTTLED 検証スナップショット](./rsa-veritas-density-throttled-validation-snapshot.md)
+7. [DEFERRAL_ENGAGED 検証スナップショット](./rsa-veritas-deferral-engaged-validation-snapshot.md)
+
+- `ALGORITHMIC_HUMILITY_ENGAGED` は、現時点では包括的な E2E sandbox validation snapshot に含まれています。
+- 厳密な one-page-per-status の対称性が必要であれば、将来 `ALGORITHMIC_HUMILITY_ENGAGED` 専用ページを追加できます。
+
+## 4. Artifact map
+
+| Artifact | Purpose | Primary reviewer question answered |
+| --- | --- | --- |
+| AML/KYC scenario map | node-by-node の upstream/downstream boundary を示します。 | V.I.K.I. はどこまでで、VERITAS はどこから始まるか？ |
+| E2E sandbox demo plan | 静的サンドボックスのデモフローを説明します。 | 想定されたデモ経路は何か？ |
+| E2E sandbox validation snapshot | 現在の静的 E2E 出力形状を記録します。 | 現行ハーネスの出力はどのような形か？ |
+| Static fixture matrix | サポートされる静的フィクスチャ status を比較します。 | VERITAS は各 upstream status をどうマップするか？ |
+| SAFE_PROCEED validation snapshot | 通常継続のケースを文書化します。 | upstream signal が proceed のとき何が起こるか？ |
+| DENSITY_THROTTLED validation snapshot | soft な upstream 介入を文書化します。 | upstream output が修正されたが hard-block ではない場合、何が起こるか？ |
+| DEFERRAL_ENGAGED validation snapshot | hard な final-commit block を文書化します。 | 重大な upstream deferral signal が発行された場合、何が起こるか？ |
+
+## 5. Static fixture ladder
+
+現在の static fixture ladder は次の通りです。
+
+- `SAFE_PROCEED`
+  - → `CONTINUE_TO_BIND_BOUNDARY`
+  - → normal continuation
+- `DENSITY_THROTTLED`
+  - → `CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED`
+  - → soft intervention logged
+- `ALGORITHMIC_HUMILITY_ENGAGED`
+  - → `PAUSE_FOR_HUMAN_REVIEW`
+  - → pause / human review
+- `DEFERRAL_ENGAGED`
+  - → `BLOCK_FINAL_COMMIT`
+  - → hard final-commit block
+
+補足:
+
+- `SAFE_PROCEED`、`DENSITY_THROTTLED`、`DEFERRAL_ENGAGED` には現時点で専用の per-variant snapshot ページがあります。
+- `ALGORITHMIC_HUMILITY_ENGAGED` は現時点では広域の E2E sandbox validation snapshot でカバーされています。
+
+## 6. この文書セットが検証すること
+
+- サンドボックスには RSA / V.I.K.I. / VERITAS の terminology boundary が文書化されています。
+- サンドボックスには AML/KYC scenario map が文書化されています。
+- サンドボックスには E2E demo plan が文書化されています。
+- サンドボックスには current static E2E path の validation snapshot が文書化されています。
+- サンドボックスには `SAFE_PROCEED`、`DENSITY_THROTTLED`、`ALGORITHMIC_HUMILITY_ENGAGED`、`DEFERRAL_ENGAGED` を含む static fixture matrix があります。
+- サンドボックスは RSA-compatible upstream status から VERITAS continuation decision への deterministic mapping を示します。
+- サンドボックスは監査エントリが raw upstream intent/action fields をデフォルトで redact する挙動を示します。
+- サンドボックスは live V.I.K.I. logic へ接続せずにレビュー可能です。
+
+## 7. この文書セットが検証しないこと
+
+- live V.I.K.I. middleware への接続は行いません。
+- V.I.K.I. の internal reasoning は検証しません。
+- 実際の取引やワークフローが安全であることを証明しません。
+- 現実世界の compliance status を判定しません。
+- 本番の AML/KYC compliance を実装しません。
+- 規制当局の承認を提供しません。
+- 第三者認証を提供しません。
+- 法的助言を提供しません。
+- 実在の顧客・金融・医療・KYC・規制対象データは使用しません。
+- 本番 runtime governance は変更しません。
+
+## 8. 次の安全な sandbox ステップ
+
+1. one-page-per-status の対称性が必要であれば、`ALGORITHMIC_HUMILITY_ENGAGED` 専用の per-variant validation snapshot を追加する。
+2. maintainers がコミット済み出力 artifact を望む場合、`examples/sandbox/rsa_veritas_e2e_harness.py` から小さな生成サンプル出力ファイルを追加する。
+3. external review 向けの reviewer checklist を追加する。
+4. 静的ドキュメントセットのレビュー完了後に限り、live V.I.K.I. integration 用の別 design document を検討する。
+
+この PR で live V.I.K.I. connection を追加してはいけません。
+
+live integration は後続の design phase とし、静的 sandbox documentation pass には含めません。


### PR DESCRIPTION
### Motivation

- Provide a single reviewer-facing entrypoint that consolidates the RSA-compatible V.I.K.I. ↔ VERITAS sandbox artifacts so reviewers can inspect the static sandbox flow without a live V.I.K.I. connection. 
- Make the scope and boundaries explicit (what is validated vs not validated) and preserve v1 compatibility names such as `rsa_status`, `RSASandboxPayload`, and `upstream_signal_source = "RSA"`. 
- Keep the change documentation-only and small to remain reviewable and safe (no runtime, test, or CI changes, and no live V.I.K.I. integration). 

### Description

- Add `docs/en/guides/rsa-veritas-sandbox-reviewer-index.md` containing purpose, taxonomy, recommended reading order, an artifact map table, the static fixture ladder, validation boundaries, and next safe sandbox steps. 
- Add `docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md` as a Japanese-first aligned page that includes the required `## 英語正本` link and preserves the specified technical terms and enum values verbatim. 
- Wire the index to the existing per-variant docs via local relative links to the existing files and clearly state that no live V.I.K.I. connection or production AML/KYC/regulatory claims are being made. 
- Ensure the change is strictly documentation-only and does not rename `rsa_status` or `RSASandboxPayload`, alter JSON payload fields, change `evaluate_rsa_sandbox_signal()`, or modify runtime/test/CI behavior. 

### Testing

- Verified the new files appear alongside other RSA/VERITAS docs using `rg --files docs/en/guides docs/ja/guides | rg 'rsa-veritas|rsa_veritas|sandbox'`, and the command completed successfully. 
- Inspected the created pages with `nl -ba docs/en/guides/rsa-veritas-sandbox-reviewer-index.md` and `nl -ba docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md` to confirm content and structure, and the inspections completed successfully. 
- Ran `rg --files -g 'AGENTS.md'` and `git status --short` to confirm repository context and working-tree status, and those checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aad671588832693a8d950471c9d9b)