### PR TITLE
Harden TrustLog encryption backend requirements for secure/prod posture

### DIFF
--- a/docs/en/operations/trustlog-production-readiness-checklist.md
+++ b/docs/en/operations/trustlog-production-readiness-checklist.md
@@ -36,6 +36,7 @@ Passing this checklist is not sufficient by itself and does not certify complian
 | TrustLog backend | `VERITAS_TRUSTLOG_BACKEND=postgresql` | Run `make check-trustlog-production-posture` | No failure for backend | `jsonl` is dev/demo only |
 | Database URL | `VERITAS_DATABASE_URL` or `DATABASE_URL` set | Run checker / inspect secret injection | No database URL failure | Do not print secrets in logs |
 | Encryption key | `VERITAS_ENCRYPTION_KEY` set | Run checker / inspect secret source | No encryption key failure | Use external secret manager in production |
+| Encryption backend | In `secure`/`prod`, cryptography-backed AES-256-GCM must be available | Verify deployment image/dependencies and `get_encryption_status()` | `backend_required=true`, `backend_available=true`, `backend_acceptable=true` | Install `veritas-os[signing]` or include `cryptography`; dev/staging may use HMAC-CTR fallback for compatibility |
 | Managed signer | `VERITAS_TRUSTLOG_SIGNER_BACKEND` resolves to `aws_kms` | Run checker | No signer backend failure | `aws_kms_ed25519` is accepted; `file`/`file_ed25519` fail |
 | KMS key id | `VERITAS_TRUSTLOG_KMS_KEY_ID` set when signer resolves to `aws_kms` | Run checker / inspect KMS env | No `KMS_KEY_ID` failure | Checker does not call KMS |
 | Break-glass override | `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` must not be relied on | Inspect env | Checker still fails file signer even if override is set | Production posture checker ignores the flag |

--- a/docs/ja/operations/trustlog-production-readiness-checklist.md
+++ b/docs/ja/operations/trustlog-production-readiness-checklist.md
@@ -35,6 +35,7 @@ PostgreSQL production guide、runtime startup validation、CI checks、live prov
 | TrustLog backend | `VERITAS_TRUSTLOG_BACKEND=postgresql` | `make check-trustlog-production-posture` を実行 | backend failure が出ない | `jsonl` は dev/demo 用です |
 | Database URL | `VERITAS_DATABASE_URL` または `DATABASE_URL` が設定されている | checker 実行 / secret injection を確認 | database URL failure が出ない | secret 値をログに出さないでください |
 | Encryption key | `VERITAS_ENCRYPTION_KEY` が設定されている | checker 実行 / secret source を確認 | encryption key failure が出ない | production では外部 secret manager を使います |
+| Encryption backend | `secure` / `prod` では cryptography-backed AES-256-GCM を必須にする | deployment image / dependencies と `get_encryption_status()` を確認 | `backend_required=true` かつ `backend_available=true` かつ `backend_acceptable=true` | `veritas-os[signing]` の導入、または deployment image に `cryptography` を含めてください。`dev` / `staging` は互換性のため HMAC-CTR fallback を許容します |
 | Managed signer | `VERITAS_TRUSTLOG_SIGNER_BACKEND` が `aws_kms` に解決される | checker を実行 | signer backend failure が出ない | `aws_kms_ed25519` は許可、`file` / `file_ed25519` は failure です |
 | KMS key id | signer が `aws_kms` に解決される場合 `VERITAS_TRUSTLOG_KMS_KEY_ID` が設定されている | checker 実行 / KMS 関連 env を確認 | `KMS_KEY_ID` failure が出ない | checker は KMS へ接続しません |
 | Break-glass override | `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` に依存しない | env を確認 | override があっても file signer は failure | production posture checker はこのフラグを無視します |

--- a/veritas_os/logging/encryption.py
+++ b/veritas_os/logging/encryption.py
@@ -38,6 +38,8 @@ import secrets
 import struct
 from typing import Optional, Protocol, Tuple
 
+from veritas_os.core.posture import PostureLevel, resolve_posture
+
 logger = logging.getLogger(__name__)
 
 _AES_BLOCK = 16
@@ -215,6 +217,10 @@ class DecryptionError(RuntimeError):
     """Raised when decryption fails (fail-closed principle)."""
 
 
+class EncryptionBackendUnavailable(RuntimeError):
+    """Raised when strict posture requires AES-GCM but cryptography is unavailable."""
+
+
 # ---------------------------------------------------------------------------
 # Optional real AES backend
 # ---------------------------------------------------------------------------
@@ -310,6 +316,21 @@ def _legacy_decrypt_enabled() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
+def _strict_encryption_backend_required() -> bool:
+    """Return True when posture requires cryptography-backed AES-GCM."""
+    posture = resolve_posture()
+    return posture in {PostureLevel.SECURE, PostureLevel.PROD}
+
+
+def _require_strong_encryption_backend() -> None:
+    """Fail fast in strict posture when cryptography backend is unavailable."""
+    if _strict_encryption_backend_required() and not _USE_REAL_AES:
+        raise EncryptionBackendUnavailable(
+            "VERITAS_POSTURE=secure/prod requires cryptography-backed AES-256-GCM. "
+            "Install veritas-os[signing] or include cryptography in the deployment image."
+        )
+
+
 def _split_encrypted_token(token: str) -> Tuple[str, str]:
     """Parse ``ENC:<algorithm>:<base64>`` with explicit fail-closed checks.
 
@@ -387,6 +408,8 @@ def encrypt(plaintext: str) -> str:
             "call generate_key() to create one."
         )
 
+    _require_strong_encryption_backend()
+
     if _USE_REAL_AES:
         return "ENC:aesgcm:" + _encrypt_aesgcm_raw(plaintext, key)
     return "ENC:hmac-ctr:" + _encrypt_hmac_ctr_raw(plaintext, key)
@@ -411,6 +434,8 @@ def decrypt(ciphertext: str) -> str:
         raise EncryptionKeyMissing(
             "Cannot decrypt: VERITAS_ENCRYPTION_KEY not set"
         )
+
+    _require_strong_encryption_backend()
 
     try:
         algorithm, payload = _split_encrypted_token(ciphertext)
@@ -507,19 +532,31 @@ def get_encryption_status() -> dict:
     enabled = is_encryption_enabled()
     backend = "AES-256-GCM" if _USE_REAL_AES else "HMAC-SHA256 CTR-mode"
     provider = os.getenv(_ENCRYPTION_PROVIDER_ENV, "env").strip().lower() or "env"
+    posture = resolve_posture()
+    backend_required = _strict_encryption_backend_required()
+    backend_acceptable = (not backend_required) or _USE_REAL_AES
     return {
         "encryption_enabled": enabled,
         "algorithm": backend if enabled else "none",
         "key_provider": provider,
         "key_configured": enabled,
+        "posture": posture.value,
+        "backend_available": _USE_REAL_AES,
+        "backend_required": backend_required,
+        "backend_acceptable": backend_acceptable,
         "secure_by_default": True,
         "eu_ai_act_article": "Art. 12",
         "note": (
             f"At-rest encryption is active ({backend})."
-            if enabled
+            if enabled and backend_acceptable
             else (
-                "VERITAS_ENCRYPTION_KEY is NOT configured. "
-                "TrustLog writes will fail until a key is set."
+                "At-rest encryption key is configured but backend is not acceptable for "
+                f"VERITAS_POSTURE={posture.value}. Install cryptography for AES-256-GCM."
+                if enabled
+                else (
+                    "VERITAS_ENCRYPTION_KEY is NOT configured. "
+                    "TrustLog writes will fail until a key is set."
+                )
             )
         ),
     }

--- a/veritas_os/tests/test_logging_encryption_hardening.py
+++ b/veritas_os/tests/test_logging_encryption_hardening.py
@@ -110,6 +110,53 @@ class TestEncryptDecryptFlow:
         with pytest.raises(encryption.DecryptionError):
             encryption.decrypt(ciphertext)
 
+    def test_encrypt_allows_hmac_ctr_fallback_in_dev_when_cryptography_unavailable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _set_valid_key(monkeypatch)
+        monkeypatch.setenv("VERITAS_POSTURE", "dev")
+        monkeypatch.setattr(encryption, "_USE_REAL_AES", False)
+
+        ciphertext = encryption.encrypt("compat")
+
+        assert ciphertext.startswith("ENC:hmac-ctr:")
+
+    def test_encrypt_fails_in_secure_when_cryptography_unavailable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _set_valid_key(monkeypatch)
+        monkeypatch.setenv("VERITAS_POSTURE", "secure")
+        monkeypatch.setattr(encryption, "_USE_REAL_AES", False)
+
+        with pytest.raises(encryption.EncryptionBackendUnavailable):
+            encryption.encrypt("strict")
+
+    def test_encrypt_fails_in_prod_when_cryptography_unavailable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _set_valid_key(monkeypatch)
+        monkeypatch.setenv("VERITAS_POSTURE", "prod")
+        monkeypatch.setattr(encryption, "_USE_REAL_AES", False)
+
+        with pytest.raises(encryption.EncryptionBackendUnavailable):
+            encryption.encrypt("strict")
+
+    def test_encrypt_uses_aesgcm_in_prod_when_available(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _set_valid_key(monkeypatch)
+        monkeypatch.setenv("VERITAS_POSTURE", "prod")
+        monkeypatch.setattr(encryption, "_USE_REAL_AES", True)
+        monkeypatch.setattr(encryption, "_encrypt_aesgcm_raw", lambda plaintext, key: "stub")
+
+        ciphertext = encryption.encrypt("strict")
+
+        assert ciphertext == "ENC:aesgcm:stub"
+
 
 class TestFallbackAndExceptionPath:
     def test_legacy_like_marker_without_separator_fails_closed(
@@ -158,3 +205,20 @@ class TestFallbackAndExceptionPath:
 
         with pytest.raises(encryption.DecryptionError, match="invalid base64 payload"):
             encryption.decrypt("ENC:hmac-ctr:not_base64!!!")
+
+
+class TestEncryptionStatus:
+    def test_get_encryption_status_reports_backend_required_and_unavailable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _set_valid_key(monkeypatch)
+        monkeypatch.setenv("VERITAS_POSTURE", "secure")
+        monkeypatch.setattr(encryption, "_USE_REAL_AES", False)
+
+        status = encryption.get_encryption_status()
+
+        assert status["posture"] == "secure"
+        assert status["backend_required"] is True
+        assert status["backend_available"] is False
+        assert status["backend_acceptable"] is False


### PR DESCRIPTION
### Motivation

- Prevent silent fallback from cryptography/AES-GCM to the pure-Python HMAC-CTR backend in `secure`/`prod` posture by failing fast at encrypt/decrypt time. 
- Preserve compatibility in `dev`/`staging` by continuing to allow the HMAC-CTR fallback there, while making production posture requirements explicit and operator-actionable.

### Description

- Import posture helpers and add posture-aware enforcement by importing `PostureLevel` and `resolve_posture` and implementing `_strict_encryption_backend_required()` and `_require_strong_encryption_backend()`.
- Add a new exception `EncryptionBackendUnavailable` which is raised when `secure`/`prod` require AES-GCM but `_USE_REAL_AES` is False.
- Call `_require_strong_encryption_backend()` in `encrypt()` and `decrypt()` after key presence checks so key-missing still fails closed and backend absence in strict posture fails fast.
- Extend `get_encryption_status()` with `posture`, `backend_available`, `backend_required`, and `backend_acceptable`, and update the status `note` to surface backend acceptability.
- Add focused unit tests covering `dev` fallback allowance, `secure`/`prod` fail-fast behavior, `prod` AES-GCM path when available, and status reporting; and add short EN/JA checklist entries noting cryptography requirement in strict posture.

### Testing

- Ran `python -m pytest -q veritas_os/tests/test_logging_encryption_hardening.py --tb=short` and the file's suite passed (19 tests passed).
- Ran `python -m pytest -q veritas_os/tests/test_posture.py --tb=short` which failed due to missing local dependency (`pydantic`) causing unrelated posture/policy-signing tests to error in this environment; this is an environment dependency issue, not caused by the encryption changes.
- `git diff --check` returned clean (no whitespace/error issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab8efec8c832682974b440916c78e)