### PR TITLE
Require cryptography-backed AES-GCM in strict TrustLog posture and fail-fast when unavailable

### DIFF
--- a/docs/en/operations/trustlog-production-readiness-checklist.md
+++ b/docs/en/operations/trustlog-production-readiness-checklist.md
@@ -36,6 +36,7 @@ Passing this checklist is not sufficient by itself and does not certify complian
 | TrustLog backend | `VERITAS_TRUSTLOG_BACKEND=postgresql` | Run `make check-trustlog-production-posture` | No failure for backend | `jsonl` is dev/demo only |
 | Database URL | `VERITAS_DATABASE_URL` or `DATABASE_URL` set | Run checker / inspect secret injection | No database URL failure | Do not print secrets in logs |
 | Encryption key | `VERITAS_ENCRYPTION_KEY` set | Run checker / inspect secret source | No encryption key failure | Use external secret manager in production |
+| Encryption backend hardening | In `secure`/`prod`, `cryptography` backend for AES-256-GCM is available | Validate deployment image / run startup checks | No runtime `EncryptionBackendUnavailable` during TrustLog encrypt/decrypt | Install `veritas-os[signing]` or include `cryptography`; `dev`/`staging` may use HMAC-CTR fallback for compatibility |
 | Managed signer | `VERITAS_TRUSTLOG_SIGNER_BACKEND` resolves to `aws_kms` | Run checker | No signer backend failure | `aws_kms_ed25519` is accepted; `file`/`file_ed25519` fail |
 | KMS key id | `VERITAS_TRUSTLOG_KMS_KEY_ID` set when signer resolves to `aws_kms` | Run checker / inspect KMS env | No `KMS_KEY_ID` failure | Checker does not call KMS |
 | Break-glass override | `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` must not be relied on | Inspect env | Checker still fails file signer even if override is set | Production posture checker ignores the flag |

--- a/docs/ja/operations/trustlog-production-readiness-checklist.md
+++ b/docs/ja/operations/trustlog-production-readiness-checklist.md
@@ -35,6 +35,7 @@ PostgreSQL production guide、runtime startup validation、CI checks、live prov
 | TrustLog backend | `VERITAS_TRUSTLOG_BACKEND=postgresql` | `make check-trustlog-production-posture` を実行 | backend failure が出ない | `jsonl` は dev/demo 用です |
 | Database URL | `VERITAS_DATABASE_URL` または `DATABASE_URL` が設定されている | checker 実行 / secret injection を確認 | database URL failure が出ない | secret 値をログに出さないでください |
 | Encryption key | `VERITAS_ENCRYPTION_KEY` が設定されている | checker 実行 / secret source を確認 | encryption key failure が出ない | production では外部 secret manager を使います |
+| Encryption backend hardening | `secure`/`prod` では AES-256-GCM 用 `cryptography` backend が利用可能である | deployment image を確認 / startup checks を実行 | TrustLog encrypt/decrypt 時に `EncryptionBackendUnavailable` が発生しない | `veritas-os[signing]` を導入、または deployment image に `cryptography` を含めます。互換目的で `dev`/`staging` は HMAC-CTR fallback を利用可能です |
 | Managed signer | `VERITAS_TRUSTLOG_SIGNER_BACKEND` が `aws_kms` に解決される | checker を実行 | signer backend failure が出ない | `aws_kms_ed25519` は許可、`file` / `file_ed25519` は failure です |
 | KMS key id | signer が `aws_kms` に解決される場合 `VERITAS_TRUSTLOG_KMS_KEY_ID` が設定されている | checker 実行 / KMS 関連 env を確認 | `KMS_KEY_ID` failure が出ない | checker は KMS へ接続しません |
 | Break-glass override | `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` に依存しない | env を確認 | override があっても file signer は failure | production posture checker はこのフラグを無視します |

--- a/tests/test_trustlog_posture.py
+++ b/tests/test_trustlog_posture.py
@@ -50,21 +50,60 @@ def test_prod_posture_postgresql_with_db_and_key_is_ok(monkeypatch: pytest.Monke
     monkeypatch.setenv("VERITAS_POSTURE", "prod")
     monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "postgresql")
     monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://user:pass@localhost:5432/veritas")
-    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+    result = get_trustlog_security_posture(
+        encryption_status={
+            "encryption_enabled": True,
+            "key_configured": True,
+            "secure_by_default": True,
+            "backend_available": True,
+            "backend_required": True,
+            "backend_acceptable": True,
+        }
+    )
 
-    result = get_trustlog_security_posture()
+    assert result["status"] == "ok"
+    assert result["posture"] == "prod"
+    assert result["trustlog_backend"] == "postgresql"
+    assert result["encryption_enabled"] is True
+    assert result["key_configured"] is True
+    assert result["backend_available"] is True
+    assert result["backend_required"] is True
+    assert result["backend_acceptable"] is True
+    assert result["secure_by_default"] is True
+    assert result["reasons"] == []
+    assert result["remediation"] == []
 
-    assert result == {
-        "status": "ok",
-        "posture": "prod",
-        "trustlog_backend": "postgresql",
-        "encryption_enabled": True,
-        "key_configured": True,
-        "secure_by_default": True,
-        "reasons": [],
-        "remediation": [],
-    }
-    validate_trustlog_secure_defaults()
+
+def test_secure_posture_blocks_when_encryption_backend_unacceptable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict posture must block when backend_acceptable is false."""
+    monkeypatch.setenv("VERITAS_POSTURE", "secure")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://user:pass@localhost:5432/veritas")
+
+    import veritas_os.security.trustlog_posture as posture_module
+
+    monkeypatch.setattr(
+        posture_module,
+        "get_encryption_status",
+        lambda: {
+            "encryption_enabled": True,
+            "key_configured": True,
+            "secure_by_default": True,
+            "backend_available": False,
+            "backend_required": True,
+            "backend_acceptable": False,
+        },
+    )
+
+    result = posture_module.get_trustlog_security_posture()
+    assert result["status"] == "blocked"
+    assert result["backend_acceptable"] is False
+    assert any("backend" in reason.lower() for reason in result["reasons"])
+
+    with pytest.raises(RuntimeError, match="TrustLog secure posture violation"):
+        posture_module.validate_trustlog_secure_defaults()
 
 
 def test_secure_posture_missing_database_url_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -324,6 +363,49 @@ def test_security_posture_snapshot_fallback_key_provider_from_env(
     assert "secret path" not in rendered_snapshot
     assert "/prod/foo" not in rendered_snapshot
     assert "token abc" not in rendered_snapshot
+
+
+def test_validate_trustlog_secure_defaults_raises_for_blocked_dev_posture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blocked status must fail closed even when reported posture is dev."""
+    import veritas_os.security.trustlog_posture as posture_module
+
+    monkeypatch.setattr(
+        posture_module,
+        "get_trustlog_security_posture",
+        lambda: {
+            "status": "blocked",
+            "posture": "dev",
+            "backend_required": True,
+            "backend_acceptable": False,
+            "reasons": ["backend unavailable under enforced strict posture"],
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="backend_required=True"):
+        posture_module.validate_trustlog_secure_defaults()
+
+
+def test_validate_trustlog_secure_defaults_does_not_raise_for_degraded_dev(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Degraded dev diagnostics remain non-fatal for startup validation."""
+    import veritas_os.security.trustlog_posture as posture_module
+
+    monkeypatch.setattr(
+        posture_module,
+        "get_trustlog_security_posture",
+        lambda: {
+            "status": "degraded",
+            "posture": "dev",
+            "backend_required": False,
+            "backend_acceptable": True,
+            "reasons": ["development mode without configured key"],
+        },
+    )
+
+    posture_module.validate_trustlog_secure_defaults()
 
 
 def test_security_posture_snapshot_fallback_key_provider_default_env(

--- a/veritas_os/logging/encryption.py
+++ b/veritas_os/logging/encryption.py
@@ -38,6 +38,8 @@ import secrets
 import struct
 from typing import Optional, Protocol, Tuple
 
+from veritas_os.core.posture import PostureLevel, resolve_posture
+
 logger = logging.getLogger(__name__)
 
 _AES_BLOCK = 16
@@ -48,6 +50,7 @@ _AESGCM_NONCE_SIZE = 12
 # via HMAC-SHA256 so that both encryption and authentication use 256-bit keys.
 _HMAC_CTR_ENC_INFO = b"veritas-hmac-ctr-enc"
 _HMAC_CTR_MAC_INFO = b"veritas-hmac-ctr-mac"
+_STRICT_RUNTIME_ENV_ALIASES = frozenset({"prod", "production", "secure", "hardened"})
 
 
 def _derive_hmac_ctr_keys(master: bytes) -> tuple[bytes, bytes]:
@@ -213,6 +216,42 @@ class EncryptionKeyMissing(RuntimeError):
 
 class DecryptionError(RuntimeError):
     """Raised when decryption fails (fail-closed principle)."""
+
+
+class EncryptionBackendUnavailable(RuntimeError):
+    """Raised when strict posture requires AES-GCM but cryptography is unavailable."""
+
+
+def _strict_encryption_backend_required() -> bool:
+    """Return whether current runtime must require cryptography-backed AES-GCM."""
+    env_posture = (os.getenv("VERITAS_ENV") or "").strip().lower()
+    enforce_production = _is_truthy(
+        os.getenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", "")
+    )
+    if enforce_production or env_posture in _STRICT_RUNTIME_ENV_ALIASES:
+        return True
+    posture = resolve_posture()
+    return posture in {PostureLevel.SECURE, PostureLevel.PROD}
+
+
+def _require_strong_encryption_backend() -> None:
+    """Fail fast when strict posture requires AES-GCM but backend is unavailable."""
+    if _strict_encryption_backend_required() and not _USE_REAL_AES:
+        posture = resolve_posture()
+        env_posture = (os.getenv("VERITAS_POSTURE") or "").strip() or "<unset>"
+        env_runtime = (os.getenv("VERITAS_ENV") or "").strip() or "<unset>"
+        enforced = (os.getenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE") or "").strip()
+        enforcement_flag = enforced or "<unset>"
+        raise EncryptionBackendUnavailable(
+            "Strong encryption backend is required because strict TrustLog posture is active. "
+            f"Resolved posture={posture.value!r}, VERITAS_POSTURE={env_posture!r}, "
+            f"VERITAS_ENV={env_runtime!r}, "
+            "VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE="
+            f"{enforcement_flag!r}. Strict mode can be triggered by resolved secure/prod posture, "
+            "VERITAS_ENV=production/prod/secure/hardened, "
+            "or VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE truthy. "
+            "Install veritas-os[signing] or include cryptography in the deployment image."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +426,8 @@ def encrypt(plaintext: str) -> str:
             "call generate_key() to create one."
         )
 
+    _require_strong_encryption_backend()
+
     if _USE_REAL_AES:
         return "ENC:aesgcm:" + _encrypt_aesgcm_raw(plaintext, key)
     return "ENC:hmac-ctr:" + _encrypt_hmac_ctr_raw(plaintext, key)
@@ -415,8 +456,21 @@ def decrypt(ciphertext: str) -> str:
     try:
         algorithm, payload = _split_encrypted_token(ciphertext)
         if algorithm == "aesgcm":
+            _require_strong_encryption_backend()
             return _decrypt_aesgcm_raw(payload, key)
         if algorithm == "hmac-ctr":
+            # Security model:
+            # - strict posture blocks *new writes* via encrypt() fail-fast when
+            #   cryptography-backed AES-GCM is unavailable.
+            # - read-only decrypt of legacy HMAC-CTR records remains available
+            #   only through the explicit VERITAS_ENCRYPTION_LEGACY_DECRYPT
+            #   migration escape hatch so historical audit data is recoverable.
+            if _strict_encryption_backend_required() and not _legacy_decrypt_enabled():
+                raise EncryptionBackendUnavailable(
+                    "Strict TrustLog posture blocks HMAC-CTR decrypt unless "
+                    "VERITAS_ENCRYPTION_LEGACY_DECRYPT is explicitly enabled for "
+                    "migration of historical records."
+                )
             return _decrypt_hmac_ctr_raw(payload, key)
         raise ValueError("unsupported encryption algorithm marker")
     except (ValueError, TypeError, KeyError) as exc:
@@ -507,19 +561,49 @@ def get_encryption_status() -> dict:
     enabled = is_encryption_enabled()
     backend = "AES-256-GCM" if _USE_REAL_AES else "HMAC-SHA256 CTR-mode"
     provider = os.getenv(_ENCRYPTION_PROVIDER_ENV, "env").strip().lower() or "env"
-    return {
+    posture_error_type = None
+    try:
+        posture_value = resolve_posture().value
+        backend_required = _strict_encryption_backend_required()
+    except Exception as exc:  # noqa: BLE001
+        posture_error_type = exc.__class__.__name__
+        posture_value = "<unresolved>"
+        backend_required = False
+    backend_acceptable = (not backend_required) or _USE_REAL_AES
+
+    if not enabled:
+        note = (
+            "VERITAS_ENCRYPTION_KEY is NOT configured. "
+            "TrustLog writes will fail until a key is set."
+        )
+    elif backend_required and not _USE_REAL_AES:
+        note = (
+            "Strict posture requires cryptography-backed AES-256-GCM, but it is "
+            "currently unavailable. Install veritas-os[signing] or include "
+            "cryptography in the deployment image."
+        )
+    else:
+        note = f"At-rest encryption is active ({backend})."
+    if posture_error_type is not None:
+        note = (
+            "Encryption status degraded: posture resolution failed "
+            f"({posture_error_type}); backend_required is reported conservatively."
+        )
+
+    status = {
         "encryption_enabled": enabled,
         "algorithm": backend if enabled else "none",
         "key_provider": provider,
         "key_configured": enabled,
         "secure_by_default": True,
         "eu_ai_act_article": "Art. 12",
-        "note": (
-            f"At-rest encryption is active ({backend})."
-            if enabled
-            else (
-                "VERITAS_ENCRYPTION_KEY is NOT configured. "
-                "TrustLog writes will fail until a key is set."
-            )
-        ),
+        "posture": posture_value,
+        "backend_available": _USE_REAL_AES,
+        "backend_required": backend_required,
+        "backend_acceptable": backend_acceptable,
+        "note": note,
     }
+    if posture_error_type is not None:
+        status["posture_error_type"] = posture_error_type
+        status["error_type"] = posture_error_type
+    return status

--- a/veritas_os/security/trustlog_posture.py
+++ b/veritas_os/security/trustlog_posture.py
@@ -47,6 +47,9 @@ def get_trustlog_security_posture(
             encryption_error_type = raw_error_type.strip()
     encryption_enabled = bool(encryption.get("encryption_enabled", False))
     key_configured = bool(encryption.get("key_configured", False))
+    backend_available = bool(encryption.get("backend_available", False))
+    backend_required = bool(encryption.get("backend_required", False))
+    backend_acceptable = bool(encryption.get("backend_acceptable", True))
     db_url_configured = bool((os.getenv("VERITAS_DATABASE_URL") or "").strip())
 
     reasons: list[str] = []
@@ -78,6 +81,14 @@ def get_trustlog_security_posture(
             reasons.append("TrustLog encryption key is not configured.")
             remediation.append(
                 "Set VERITAS_ENCRYPTION_KEY or configure a supported KMS/Vault key provider."
+            )
+        if not backend_acceptable:
+            reasons.append(
+                "TrustLog encryption backend is not acceptable for strict posture; "
+                "cryptography-backed AES-256-GCM is required."
+            )
+            remediation.append(
+                "Install veritas-os[signing] or include cryptography in the deployment image."
             )
     elif posture_level == "staging":
         if backend != "postgresql":
@@ -111,6 +122,9 @@ def get_trustlog_security_posture(
         "trustlog_backend": backend,
         "encryption_enabled": encryption_enabled,
         "key_configured": key_configured,
+        "backend_available": backend_available,
+        "backend_required": backend_required,
+        "backend_acceptable": backend_acceptable,
         "secure_by_default": bool(encryption.get("secure_by_default", True)),
         "reasons": reasons,
         "remediation": remediation,
@@ -118,14 +132,22 @@ def get_trustlog_security_posture(
 
 
 def validate_trustlog_secure_defaults() -> None:
-    """Fail closed when secure/prod posture violates TrustLog hardening baseline."""
+    """Fail closed whenever TrustLog posture diagnostics report blocked status."""
     posture_info = get_trustlog_security_posture()
-    if posture_info["posture"] in {"secure", "prod"} and posture_info["status"] == "blocked":
+    if posture_info["status"] == "blocked":
+        posture = posture_info.get("posture", "<unknown>")
+        backend_required = posture_info.get("backend_required", "<unknown>")
+        backend_acceptable = posture_info.get("backend_acceptable", "<unknown>")
+        reasons = posture_info.get("reasons", [])
+        reasons_text = "; ".join(str(item) for item in reasons)
         raise RuntimeError(
             "TrustLog secure posture violation: "
-            f"VERITAS_POSTURE={posture_info['posture']} requires "
-            "VERITAS_TRUSTLOG_BACKEND=postgresql, VERITAS_DATABASE_URL, "
-            "and configured encryption key. Set VERITAS_DATABASE_URL and "
-            "VERITAS_ENCRYPTION_KEY or a supported KMS/Vault provider. "
-            f"Reasons: {'; '.join(posture_info['reasons'])}"
+            "blocking controls can be triggered by secure/prod posture, "
+            "VERITAS_ENV strict aliases (production/prod/secure/hardened), or "
+            "VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE truthy. "
+            f"posture={posture!r}, backend_required={backend_required!r}, "
+            f"backend_acceptable={backend_acceptable!r}. "
+            "Ensure VERITAS_TRUSTLOG_BACKEND=postgresql, VERITAS_DATABASE_URL, "
+            "configured encryption key, and cryptography-backed AES-256-GCM backend. "
+            f"Reasons: {reasons_text}"
         )

--- a/veritas_os/security/trustlog_production_posture.py
+++ b/veritas_os/security/trustlog_production_posture.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from os import environ
 from typing import Mapping
 
+import veritas_os.logging.encryption as encryption_module
 from veritas_os.security.trustlog_backend_normalization import (
     normalize_trustlog_anchor_backend,
     normalize_trustlog_mirror_backend,
@@ -88,6 +89,15 @@ def check_trustlog_production_posture(
 
     if not (current_env.get("VERITAS_ENCRYPTION_KEY", "") or "").strip():
         failures.append("production TrustLog encryption requires VERITAS_ENCRYPTION_KEY")
+    else:
+        backend_required = _is_production_mode(current_env)
+        backend_available = bool(getattr(encryption_module, "_USE_REAL_AES", False))
+        backend_acceptable = (not backend_required) or backend_available
+        if not backend_acceptable:
+            failures.append(
+                "TrustLog encryption backend is not acceptable for production posture; "
+                "cryptography-backed AES-256-GCM is required."
+            )
 
     signer_backend = normalize_trustlog_signer_backend(
         current_env.get("VERITAS_TRUSTLOG_SIGNER_BACKEND")

--- a/veritas_os/tests/test_production_encryption.py
+++ b/veritas_os/tests/test_production_encryption.py
@@ -204,3 +204,184 @@ class TestEncryptionEnabled:
         from veritas_os.logging.encryption import is_encryption_enabled
 
         assert is_encryption_enabled() is False
+
+
+@pytest.mark.production
+class TestStrictPostureEncryptionBackend:
+    """Verify strict posture backend requirements for TrustLog encryption."""
+
+    def test_encrypt_allows_hmac_ctr_fallback_in_dev_when_cryptography_unavailable(
+        self,
+        monkeypatch,
+    ):
+        """DEV posture keeps compatibility fallback when cryptography is unavailable."""
+        from veritas_os.logging.encryption import encrypt, generate_key
+        import veritas_os.logging.encryption as enc
+
+        monkeypatch.setenv("VERITAS_POSTURE", "dev")
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+        monkeypatch.setattr(enc, "_USE_REAL_AES", False)
+
+        ciphertext = encrypt("dev compatible fallback")
+        assert ciphertext.startswith("ENC:hmac-ctr:")
+
+    @pytest.mark.parametrize("posture", ["secure", "prod"])
+    def test_encrypt_fails_in_strict_posture_when_cryptography_unavailable(
+        self,
+        monkeypatch,
+        posture,
+    ):
+        """SECURE/PROD must fail fast when AES-GCM backend is unavailable."""
+        import veritas_os.logging.encryption as enc
+        from veritas_os.logging.encryption import (
+            EncryptionBackendUnavailable,
+            encrypt,
+            generate_key,
+        )
+
+        monkeypatch.setenv("VERITAS_POSTURE", posture)
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+        monkeypatch.setattr(enc, "_USE_REAL_AES", False)
+
+        with pytest.raises(EncryptionBackendUnavailable):
+            encrypt("strict posture should fail fast")
+
+    @pytest.mark.parametrize("posture", ["secure", "prod"])
+    def test_decrypt_fails_in_strict_posture_when_cryptography_unavailable(
+        self,
+        monkeypatch,
+        posture,
+    ):
+        """SECURE/PROD decrypt path also fail-fast when backend is unavailable."""
+        import veritas_os.logging.encryption as enc
+        from veritas_os.logging.encryption import (
+            EncryptionBackendUnavailable,
+            decrypt,
+            generate_key,
+        )
+
+        monkeypatch.setenv("VERITAS_POSTURE", posture)
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+        monkeypatch.setattr(enc, "_USE_REAL_AES", False)
+
+        with pytest.raises(EncryptionBackendUnavailable):
+            decrypt("ENC:hmac-ctr:Zm9v")
+
+    def test_get_encryption_status_reports_backend_requirement(self, monkeypatch):
+        """Status must expose backend availability/requirement in strict posture."""
+        import veritas_os.logging.encryption as enc
+        from veritas_os.logging.encryption import (
+            generate_key,
+            get_encryption_status,
+        )
+
+        monkeypatch.setenv("VERITAS_POSTURE", "prod")
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+        monkeypatch.setattr(enc, "_USE_REAL_AES", False)
+
+        status = get_encryption_status()
+        assert status["posture"] == "prod"
+        assert status["backend_available"] is False
+        assert status["backend_required"] is True
+        assert status["backend_acceptable"] is False
+
+    def test_strict_backend_error_mentions_resolved_posture_sources(self, monkeypatch):
+        """Strict backend error should mention resolved posture and env sources."""
+        import veritas_os.logging.encryption as enc
+        from veritas_os.logging.encryption import (
+            EncryptionBackendUnavailable,
+            encrypt,
+            generate_key,
+        )
+
+        monkeypatch.delenv("VERITAS_POSTURE", raising=False)
+        monkeypatch.setenv("VERITAS_ENV", "production")
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+        monkeypatch.setattr(enc, "_USE_REAL_AES", False)
+
+        with pytest.raises(EncryptionBackendUnavailable) as excinfo:
+            encrypt("strict")
+
+        message = str(excinfo.value)
+        assert "production" in message or "prod" in message
+        assert "VERITAS_POSTURE" in message
+        assert "VERITAS_ENV" in message
+
+    def test_require_production_flag_enforces_strict_backend_in_dev_posture(
+        self,
+        monkeypatch,
+    ):
+        """Production posture enforcement flag must force strict backend in DEV posture."""
+        import veritas_os.logging.encryption as enc
+        from veritas_os.logging.encryption import (
+            EncryptionBackendUnavailable,
+            decrypt,
+            encrypt,
+            generate_key,
+        )
+
+        monkeypatch.setenv("VERITAS_POSTURE", "dev")
+        monkeypatch.setenv("VERITAS_ENV", "dev")
+        monkeypatch.setenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", "1")
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+        monkeypatch.setattr(enc, "_USE_REAL_AES", False)
+
+        with pytest.raises(EncryptionBackendUnavailable):
+            encrypt("strict due to enforcement flag")
+        with pytest.raises(EncryptionBackendUnavailable) as excinfo:
+            decrypt("ENC:hmac-ctr:Zm9v")
+        message = str(excinfo.value)
+        assert "VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE" in message
+
+    @pytest.mark.parametrize("env_alias", ["secure", "hardened"])
+    def test_legacy_strict_veritas_env_aliases_enforce_backend_in_dev_posture(
+        self,
+        monkeypatch,
+        env_alias,
+    ):
+        """VERITAS_ENV strict aliases must enforce AES-GCM even with dev posture."""
+        import veritas_os.logging.encryption as enc
+        from veritas_os.logging.encryption import (
+            EncryptionBackendUnavailable,
+            decrypt,
+            encrypt,
+            generate_key,
+        )
+
+        monkeypatch.setenv("VERITAS_POSTURE", "dev")
+        monkeypatch.setenv("VERITAS_ENV", env_alias)
+        monkeypatch.delenv("VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE", raising=False)
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+        monkeypatch.setattr(enc, "_USE_REAL_AES", False)
+
+        with pytest.raises(EncryptionBackendUnavailable):
+            encrypt("strict due to VERITAS_ENV alias")
+        with pytest.raises(EncryptionBackendUnavailable):
+            decrypt("ENC:hmac-ctr:Zm9v")
+
+    def test_strict_posture_allows_legacy_hmac_ctr_decrypt_when_escape_hatch_enabled(
+        self,
+        monkeypatch,
+    ):
+        """Strict posture permits legacy HMAC-CTR decrypt only with migration flag."""
+        import veritas_os.logging.encryption as enc
+        from veritas_os.logging.encryption import decrypt, _encrypt_hmac_ctr_raw, generate_key
+
+        key_b64 = generate_key()
+        monkeypatch.setenv("VERITAS_POSTURE", "prod")
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", key_b64)
+        monkeypatch.setenv("VERITAS_ENCRYPTION_LEGACY_DECRYPT", "1")
+        monkeypatch.setattr(enc, "_USE_REAL_AES", False)
+
+        key = enc._get_key_bytes()
+        assert key is not None
+        token = "ENC:hmac-ctr:" + _encrypt_hmac_ctr_raw("historical-audit-record", key)
+        assert decrypt(token) == "historical-audit-record"
+
+    def test_decrypt_fails_closed_for_unknown_encrypted_scheme(self, monkeypatch):
+        """Unknown ENC scheme must fail closed with DecryptionError."""
+        from veritas_os.logging.encryption import DecryptionError, decrypt, generate_key
+
+        monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", generate_key())
+        with pytest.raises(DecryptionError):
+            decrypt("ENC:unknown:Zm9v")

--- a/veritas_os/tests/test_trustlog_production_posture.py
+++ b/veritas_os/tests/test_trustlog_production_posture.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from scripts.security.check_trustlog_production_posture import main
 from veritas_os.security.trustlog_production_posture import check_trustlog_production_posture
 
@@ -420,3 +422,74 @@ def test_cli_main_returns_zero_in_production_fully_configured(monkeypatch) -> No
     monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED", "1")
     monkeypatch.setenv("VERITAS_TRUSTLOG_TRANSPARENCY_LOG_PATH", "/tmp/transparency.jsonl")
     assert main() == 0
+
+
+def test_production_posture_fails_when_encryption_backend_unacceptable(monkeypatch) -> None:
+    """Production posture checker must fail when AES-GCM backend is unavailable."""
+    import veritas_os.security.trustlog_production_posture as posture_module
+
+    monkeypatch.setattr(posture_module.encryption_module, "_USE_REAL_AES", False)
+
+    result = posture_module.check_trustlog_production_posture(_production_base_env())
+    assert result.passed is False
+    assert any("AES-256-GCM" in item for item in result.failures)
+
+
+def test_startup_validation_fails_when_encryption_backend_unacceptable(monkeypatch) -> None:
+    """Startup validation must fail-fast when production backend is unacceptable."""
+    import logging
+
+    import veritas_os.api.startup_health as startup_health
+    import veritas_os.security.trustlog_production_posture as posture_module
+
+    monkeypatch.setenv("VERITAS_ENV", "production")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_BACKEND", "postgresql")
+    monkeypatch.setenv("VERITAS_DATABASE_URL", "postgresql://example")
+    monkeypatch.setenv("VERITAS_ENCRYPTION_KEY", "dummy")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+    monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "dummy-kms-key")
+
+    monkeypatch.setattr(posture_module.encryption_module, "_USE_REAL_AES", False)
+
+    with pytest.raises(RuntimeError, match="AES-256-GCM|backend|cryptography"):
+        startup_health.validate_trustlog_production_posture_on_startup(
+            logger=logging.getLogger(__name__)
+        )
+
+
+def test_production_env_dict_enforces_backend_when_process_env_is_dev(monkeypatch) -> None:
+    """Explicit env mapping must drive backend requirement independent of process env."""
+    import veritas_os.security.trustlog_production_posture as posture_module
+
+    monkeypatch.setenv("VERITAS_ENV", "dev")
+    monkeypatch.setattr(posture_module.encryption_module, "_USE_REAL_AES", False)
+
+    result = posture_module.check_trustlog_production_posture(_production_base_env())
+    assert result.passed is False
+    assert any("AES-256-GCM" in item for item in result.failures)
+
+
+def test_production_env_dict_no_backend_failure_when_backend_available(
+    monkeypatch,
+) -> None:
+    """Backend availability check should pass when AES-GCM backend is available."""
+    import veritas_os.security.trustlog_production_posture as posture_module
+
+    monkeypatch.setattr(posture_module.encryption_module, "_USE_REAL_AES", True)
+
+    result = posture_module.check_trustlog_production_posture(_production_base_env())
+    assert not any("AES-256-GCM" in item for item in result.failures)
+
+
+def test_missing_encryption_key_uses_current_env_failure() -> None:
+    """Missing key must fail via explicit current_env validation path."""
+    env = {
+        "VERITAS_ENV": "production",
+        "VERITAS_TRUSTLOG_BACKEND": "postgresql",
+        "VERITAS_DATABASE_URL": "postgresql://example",
+        "VERITAS_TRUSTLOG_SIGNER_BACKEND": "aws_kms",
+        "VERITAS_TRUSTLOG_KMS_KEY_ID": "dummy-kms-key",
+    }
+    result = check_trustlog_production_posture(env)
+    assert result.passed is False
+    assert any("VERITAS_ENCRYPTION_KEY" in item for item in result.failures)


### PR DESCRIPTION
### Motivation

- Enforce stronger at-rest encryption guarantees for TrustLog in strict/production posture by preferring cryptography-backed AES-256-GCM and failing startup when unavailable. 
- Surface backend availability and posture resolution in encryption diagnostics so posture checks can block deployments missing the required crypto backend. 

### Description

- Added runtime checks that determine when strict posture is active by consulting resolved posture, `VERITAS_ENV` legacy aliases, and `VERITAS_REQUIRE_PRODUCTION_TRUSTLOG_POSTURE`, and introduced `EncryptionBackendUnavailable` to fail fast when AES-GCM is required but `cryptography` is unavailable. 
- Updated `veritas_os/logging/encryption.py` to: expose backend availability/requirement in `get_encryption_status`, require a strong backend in `encrypt`/`decrypt` when strict posture is active, and provide clearer notes and error context including posture resolution sources. 
- Updated posture logic in `veritas_os/security/trustlog_posture.py` to consume the extended encryption status (`backend_available`, `backend_required`, `backend_acceptable`) and mark strict posture as blocked when the encryption backend is unacceptable; `validate_trustlog_secure_defaults` now fails on any blocked status and includes backend details in the error. 
- Updated `veritas_os/security/trustlog_production_posture.py` to enforce cryptography-backed AES-GCM for production env mappings and report a failure when the backend is unacceptable. 
- Expanded tests and test expectations: added comprehensive tests for strict-posture backend enforcement, escape hatches (legacy decrypt flag), posture-source messaging, and adjusted existing TrustLog posture tests to validate the new diagnostics. 
- Documentation update in English and Japanese readiness checklists to document the new encryption backend hardening requirement and verification guidance. 

### Testing

- Ran unit tests for encryption and posture: `pytest -q veritas_os/tests/test_production_encryption.py`, `pytest -q tests/test_trustlog_posture.py`, and `pytest -q veritas_os/tests/test_trustlog_production_posture.py`, all of which passed. 
- Exercised the CLI/checker path with `make check-trustlog-production-posture` and the updated posture-checking logic under simulated env mappings; the checker returned expected non-zero failures when AES-GCM backend was unavailable. 
- Verified `validate_trustlog_secure_defaults()` and startup validation behavior by running the relevant tests that assert raising `RuntimeError`/`EncryptionBackendUnavailable` in blocked strict/posture scenarios, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac03d3f088326b434c60990ada773)