### PR TITLE
Expand responsibility boundary guard coverage for pipeline/kernel helpers

### DIFF
--- a/docs/architecture/core_responsibility_boundaries.md
+++ b/docs/architecture/core_responsibility_boundaries.md
@@ -121,6 +121,9 @@ When changing one of the four core modules above:
 4. The boundary checker intentionally skips helper files under common non-owned
    directories such as `tests/`, `fixtures/`, `vendor/`, and `third_party/`
    inside a logical module package.
+5. Boundary checks apply to helper/stage surfaces too (for example
+   `kernel_*.py`, `pipeline_*.py`, and `pipeline/*.py`) so responsibility
+   cycles cannot hide in orchestration-adjacent helper modules.
 
 ## Security note
 

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -206,11 +206,29 @@ EXCLUDED_HELPER_PATH_PARTS: frozenset[str] = frozenset(
         "third_party",
     }
 )
+LOGICAL_CORE_MODULES: tuple[str, ...] = (
+    "planner",
+    "kernel",
+    "fuji",
+    "memory",
+    "pipeline",
+)
 
 
 def _normalize_module_name(module_name: str) -> str:
     """Normalize import paths to the core module leaf name."""
     return module_name.rsplit(".", maxsplit=1)[-1]
+
+
+def _is_boundary_relevant_relative_alias(alias_name: str) -> bool:
+    """Return whether a relative alias should be treated as a core dependency."""
+    normalized_alias = _normalize_module_name(alias_name)
+    if normalized_alias in LOGICAL_CORE_MODULES:
+        return True
+    return any(
+        normalized_alias.startswith(f"{logical_name}_")
+        for logical_name in LOGICAL_CORE_MODULES
+    )
 
 
 def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
@@ -226,6 +244,12 @@ def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
                 module_names.add(_normalize_module_name(node.module))
                 for alias in node.names:
                     if node.module == "veritas_os.core":
+                        module_names.add(_normalize_module_name(alias.name))
+                    else:
+                        symbol_names.add(_normalize_module_name(alias.name))
+            elif node.level > 0:
+                for alias in node.names:
+                    if _is_boundary_relevant_relative_alias(alias.name):
                         module_names.add(_normalize_module_name(alias.name))
                     else:
                         symbol_names.add(_normalize_module_name(alias.name))
@@ -247,7 +271,7 @@ def _expand_logical_import_aliases(module_names: frozenset[str]) -> set[str]:
     """Expand helper module imports to their logical core module names."""
     expanded = set(module_names)
     for module_name in module_names:
-        for logical_name in ("planner", "kernel", "fuji", "memory", "pipeline"):
+        for logical_name in LOGICAL_CORE_MODULES:
             if module_name.startswith(f"{logical_name}_"):
                 expanded.add(logical_name)
     return expanded

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -105,6 +105,10 @@ DEFAULT_RULES: tuple[BoundaryRule, ...] = (
         source_module="memory",
         forbidden_imports=frozenset({"kernel", "planner", "fuji"}),
     ),
+    BoundaryRule(
+        source_module="pipeline",
+        forbidden_imports=frozenset({"kernel"}),
+    ),
 )
 
 

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -258,6 +258,78 @@ def test_pipeline_rule_alias_expansion_maps_kernel_helper_names(
     )
 
 
+def test_pipeline_package_relative_import_of_kernel_is_violation(
+    tmp_path: Path,
+) -> None:
+    """Pipeline package relative imports should detect kernel orchestrator usage."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(
+        tmp_path / "pipeline" / "__init__.py",
+        "from .. import kernel as veritas_core\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline" / "__init__.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_package_relative_import_of_kernel_helper_is_violation(
+    tmp_path: Path,
+) -> None:
+    """Relative imports of kernel_* helpers should map to logical kernel ownership."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(
+        tmp_path / "pipeline" / "__init__.py",
+        "from .. import kernel_stages\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline" / "__init__.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_package_relative_import_of_pipeline_helper_is_allowed(
+    tmp_path: Path,
+) -> None:
+    """Pipeline-owned relative helper imports should remain allowed."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(
+        tmp_path / "pipeline" / "__init__.py",
+        "from . import pipeline_execute\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
 def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
     """Remediation guide should include forbidden dependency, alternatives, and link."""
     violations = [

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -173,6 +173,91 @@ def test_check_boundaries_detects_from_core_import_pattern(tmp_path: Path) -> No
     assert "kernel" in issues[0]
 
 
+def test_pipeline_helper_importing_kernel_is_boundary_violation(tmp_path: Path) -> None:
+    """Pipeline helper modules should not import the kernel orchestrator surface."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(tmp_path / "pipeline_execute.py", "from veritas_os.core import kernel\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline_execute.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_helpers_allow_pipeline_owned_imports(tmp_path: Path) -> None:
+    """Pipeline helper modules may import other pipeline-owned modules."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(tmp_path / "pipeline_execute.py", "from veritas_os.core import pipeline_inputs\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_still_excludes_vendor_and_third_party_helpers(
+    tmp_path: Path,
+) -> None:
+    """Excluded helper paths should remain out-of-scope for boundary matching."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline" / "vendor").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "pipeline" / "third_party").mkdir(parents=True, exist_ok=True)
+    _write_module(
+        tmp_path / "pipeline" / "vendor" / "shim.py",
+        "import veritas_os.core.kernel\n",
+    )
+    _write_module(
+        tmp_path / "pipeline" / "third_party" / "shim.py",
+        "import veritas_os.core.kernel\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_alias_expansion_maps_kernel_helper_names(
+    tmp_path: Path,
+) -> None:
+    """Logical alias expansion should map kernel_* helper imports to kernel ownership."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        "from veritas_os.core import kernel_stages\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        for issue in issues
+    )
+
+
 def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
     """Remediation guide should include forbidden dependency, alternatives, and link."""
     violations = [


### PR DESCRIPTION
### Motivation
- Prevent responsibility drift hidden in orchestration-adjacent helpers by treating pipeline-owned helper surfaces as first-class boundary sources so they cannot silently import back into the kernel orchestrator. 
- Keep the rule narrow to avoid blocking legitimate kernel orchestration and to reduce noisy false positives while improving CI detectability of responsibility cycles. 
- Boundary violations can hide security-sensitive behavior, so the checker should continue being run in CI to preserve auditability. 

### Description
- Add a focused boundary rule `pipeline -> kernel` to `DEFAULT_RULES` so `pipeline` top-level and helper surfaces (resolved by existing helper path expansion) are checked for imports into `kernel`. 
- Reuse existing helper-path ownership and alias-expansion logic (no parallel scanning added) so imports like `kernel_stages` or `kernel_*` expand to `kernel` for matching. 
- Update documentation `docs/architecture/core_responsibility_boundaries.md` to state that helper/stage surfaces such as `kernel_*.py`, `pipeline_*.py`, and `pipeline/*.py` are covered by boundary checks. 
- Add targeted tests in `veritas_os/tests/test_responsibility_boundary_checker.py` covering pipeline->kernel violations, allowed pipeline-owned imports, excluded helper paths (`vendor`/`third_party`), and alias expansion mapping. 

### Testing
- Ran the boundary checker with `python scripts/architecture/check_responsibility_boundaries.py` and the CI-formatted report with `python scripts/architecture/check_responsibility_boundaries.py --report-format json`, both of which passed. 
- Ran the unit tests with `pytest -q veritas_os/tests/test_responsibility_boundary_checker.py --tb=short`, which completed successfully with all tests passing (`46 passed`, `1 warning`). 
- The change is limited to `scripts/architecture/check_responsibility_boundaries.py`, `docs/architecture/core_responsibility_boundaries.md`, and `veritas_os/tests/test_responsibility_boundary_checker.py` and preserves existing AST-based, deterministic scanning and alias expansion behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbe959fc48326b0cf4800e54094f9)