### PR TITLE
Introduce Pipeline core module to architecture docs and boundary checker

### DIFF
--- a/docs/architecture/core_responsibility_boundaries.md
+++ b/docs/architecture/core_responsibility_boundaries.md
@@ -58,6 +58,30 @@ The goal is intentionally narrow:
 - new scoring or staging logic should move into stage/helper modules instead of
   deepening the main orchestrator.
 
+### Pipeline (`veritas_os.core.pipeline`)
+
+**Owns**:
+- pipeline-stage decomposition and compatibility-safe request/response shaping;
+- sequencing of pipeline helper stages without reintroducing kernel-level
+  orchestration cycles.
+
+**Public contract**:
+- stable pipeline entry points exposed through `pipeline.py` and
+  `veritas_os.core.pipeline`.
+
+**Preferred extension points**:
+- `veritas_os.core.pipeline_inputs`
+- `veritas_os.core.pipeline_execute`
+- `veritas_os.core.pipeline_policy`
+- `veritas_os.core.pipeline_response`
+- `veritas_os.core.pipeline_persist`
+- `veritas_os.core.pipeline_replay`
+
+**Compatibility layer notes**:
+- `pipeline.py` and `pipeline/__init__.py` keep compatibility-facing wrappers;
+- new pipeline behavior should be implemented in helper modules above and should
+  not depend on `veritas_os.core.kernel` orchestrator modules.
+
 ### FUJI (`veritas_os.core.fuji`)
 
 **Owns**:
@@ -121,6 +145,9 @@ When changing one of the four core modules above:
 4. The boundary checker intentionally skips helper files under common non-owned
    directories such as `tests/`, `fixtures/`, `vendor/`, and `third_party/`
    inside a logical module package.
+5. Boundary checks apply to helper/stage surfaces too (for example
+   `kernel_*.py`, `pipeline_*.py`, and `pipeline/*.py`) so responsibility
+   cycles cannot hide in orchestration-adjacent helper modules.
 
 ## Security note
 

--- a/docs/architecture/core_responsibility_boundaries.md
+++ b/docs/architecture/core_responsibility_boundaries.md
@@ -4,11 +4,12 @@
 
 This document defines the current public contract, recommended extension points,
 and compatibility layers for the core VERITAS modules that most often attract
-structural complexity: Planner, Kernel, FUJI, and MemoryOS.
+structural complexity: Planner, Kernel, Pipeline, FUJI, and MemoryOS.
 
 The goal is intentionally narrow:
 
-- preserve the existing Planner / Kernel / FUJI / MemoryOS responsibility split;
+- preserve the existing Planner / Kernel / Pipeline / FUJI / MemoryOS
+  responsibility split;
 - show contributors the recommended extension point before they edit a large
   compatibility-heavy file;
 - make it easier for CI and code review to distinguish a valid extension from a
@@ -66,8 +67,8 @@ The goal is intentionally narrow:
   orchestration cycles.
 
 **Public contract**:
-- stable pipeline entry points exposed through `pipeline.py` and
-  `veritas_os.core.pipeline`.
+- stable pipeline entry points exposed through `veritas_os.core.pipeline`
+  (`veritas_os/core/pipeline/__init__.py`).
 
 **Preferred extension points**:
 - `veritas_os.core.pipeline_inputs`
@@ -78,7 +79,7 @@ The goal is intentionally narrow:
 - `veritas_os.core.pipeline_replay`
 
 **Compatibility layer notes**:
-- `pipeline.py` and `pipeline/__init__.py` keep compatibility-facing wrappers;
+- `pipeline/__init__.py` keeps compatibility-facing wrappers;
 - new pipeline behavior should be implemented in helper modules above and should
   not depend on `veritas_os.core.kernel` orchestrator modules.
 
@@ -134,14 +135,15 @@ The goal is intentionally narrow:
 
 ## Change policy
 
-When changing one of the four core modules above:
+When changing one of the five core modules above:
 
 1. Prefer an existing helper/stage module over adding another branch to the main
    module.
 2. If a change adds a new recommended extension point, update this document and
    the boundary checker guidance in `scripts/architecture/check_responsibility_boundaries.py`.
-3. Do not move responsibilities across Planner / Kernel / FUJI / MemoryOS unless
-   the architecture review explicitly approves the boundary change.
+3. Do not move responsibilities across Planner / Kernel / Pipeline / FUJI /
+   MemoryOS unless the architecture review explicitly approves the boundary
+   change.
 4. The boundary checker intentionally skips helper files under common non-owned
    directories such as `tests/`, `fixtures/`, `vendor/`, and `third_party/`
    inside a logical module package.

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -245,6 +245,53 @@ def _is_boundary_relevant_relative_alias(alias_name: str) -> bool:
     return any(normalized.startswith(f"{module}_") for module in LOGICAL_CORE_MODULES)
 
 
+def _is_boundary_relevant_module_name(module_name: str) -> bool:
+    """Return whether a module leaf name is relevant for boundary checks."""
+    normalized = _normalize_module_name(module_name)
+    if normalized in LOGICAL_CORE_MODULES:
+        return True
+    return any(normalized.startswith(f"{module}_") for module in LOGICAL_CORE_MODULES)
+
+
+def _extract_lazy_import_module_names(node: ast.AST) -> set[str]:
+    """Extract boundary-relevant modules from narrow `_lazy_import(...)` calls."""
+    if not isinstance(node, ast.Call):
+        return set()
+
+    function_name = ""
+    if isinstance(node.func, ast.Name):
+        function_name = node.func.id
+    elif isinstance(node.func, ast.Attribute):
+        function_name = node.func.attr
+    if function_name != "_lazy_import":
+        return set()
+
+    if not node.args:
+        return set()
+
+    first_argument = node.args[0]
+    if not isinstance(first_argument, ast.Constant) or not isinstance(
+        first_argument.value, str
+    ):
+        return set()
+    first_name = _normalize_module_name(first_argument.value)
+
+    lazy_modules: set[str] = set()
+    if _is_boundary_relevant_module_name(first_name):
+        lazy_modules.add(first_name)
+
+    if first_argument.value == "veritas_os.core" and len(node.args) > 1:
+        second_argument = node.args[1]
+        if isinstance(second_argument, ast.Constant) and isinstance(
+            second_argument.value, str
+        ):
+            second_name = _normalize_module_name(second_argument.value)
+            if _is_boundary_relevant_module_name(second_name):
+                lazy_modules.add(second_name)
+
+    return lazy_modules
+
+
 def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
     """Collect module-leaf and symbol-leaf imports from a module AST."""
     module_names: set[str] = set()
@@ -270,6 +317,7 @@ def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
             else:
                 for alias in node.names:
                     symbol_names.add(_normalize_module_name(alias.name))
+        module_names.update(_extract_lazy_import_module_names(node))
     return ImportedNames(
         module_names=frozenset(module_names),
         symbol_names=frozenset(symbol_names),

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -105,6 +105,10 @@ DEFAULT_RULES: tuple[BoundaryRule, ...] = (
         source_module="memory",
         forbidden_imports=frozenset({"kernel", "planner", "fuji"}),
     ),
+    BoundaryRule(
+        source_module="pipeline",
+        forbidden_imports=frozenset({"kernel"}),
+    ),
 )
 
 
@@ -128,6 +132,14 @@ ALLOWED_DEPENDENCY_GUIDE: dict[str, tuple[str, ...]] = {
         "veritas_os.core.memory_store",
         "veritas_os.core.memory_helpers",
         "veritas_os.core.memory_security",
+    ),
+    "pipeline": (
+        "veritas_os.core.pipeline_inputs",
+        "veritas_os.core.pipeline_execute",
+        "veritas_os.core.pipeline_policy",
+        "veritas_os.core.pipeline_response",
+        "veritas_os.core.pipeline_persist",
+        "veritas_os.core.pipeline_replay",
     ),
 }
 
@@ -157,12 +169,21 @@ RECOMMENDED_EXTENSION_POINTS: dict[str, tuple[str, ...]] = {
         "veritas_os.core.memory_lifecycle",
         "veritas_os.core.memory_security",
     ),
+    "pipeline": (
+        "veritas_os.core.pipeline_inputs",
+        "veritas_os.core.pipeline_execute",
+        "veritas_os.core.pipeline_policy",
+        "veritas_os.core.pipeline_response",
+        "veritas_os.core.pipeline_persist",
+        "veritas_os.core.pipeline_replay",
+    ),
 }
 
 
 REMEDIATION_LINK = "docs/architecture/core_responsibility_boundaries.md"
 DOC_SECTION_TO_MODULE: dict[str, str] = {
     "Planner": "planner",
+    "Pipeline": "pipeline",
     "Kernel": "kernel",
     "FUJI": "fuji",
     "MemoryOS": "memory",
@@ -202,11 +223,26 @@ EXCLUDED_HELPER_PATH_PARTS: frozenset[str] = frozenset(
         "third_party",
     }
 )
+LOGICAL_CORE_MODULES: tuple[str, ...] = (
+    "planner",
+    "kernel",
+    "fuji",
+    "memory",
+    "pipeline",
+)
 
 
 def _normalize_module_name(module_name: str) -> str:
     """Normalize import paths to the core module leaf name."""
     return module_name.rsplit(".", maxsplit=1)[-1]
+
+
+def _is_boundary_relevant_relative_alias(alias_name: str) -> bool:
+    """Return whether a relative import alias is boundary-relevant."""
+    normalized = _normalize_module_name(alias_name)
+    if normalized in LOGICAL_CORE_MODULES:
+        return True
+    return any(normalized.startswith(f"{module}_") for module in LOGICAL_CORE_MODULES)
 
 
 def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
@@ -222,6 +258,12 @@ def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
                 module_names.add(_normalize_module_name(node.module))
                 for alias in node.names:
                     if node.module == "veritas_os.core":
+                        module_names.add(_normalize_module_name(alias.name))
+                    else:
+                        symbol_names.add(_normalize_module_name(alias.name))
+            elif node.level > 0:
+                for alias in node.names:
+                    if _is_boundary_relevant_relative_alias(alias.name):
                         module_names.add(_normalize_module_name(alias.name))
                     else:
                         symbol_names.add(_normalize_module_name(alias.name))
@@ -243,7 +285,7 @@ def _expand_logical_import_aliases(module_names: frozenset[str]) -> set[str]:
     """Expand helper module imports to their logical core module names."""
     expanded = set(module_names)
     for module_name in module_names:
-        for logical_name in ("planner", "kernel", "fuji", "memory", "pipeline"):
+        for logical_name in LOGICAL_CORE_MODULES:
             if module_name.startswith(f"{logical_name}_"):
                 expanded.add(logical_name)
     return expanded

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -319,6 +319,73 @@ def test_pipeline_relative_import_of_pipeline_helper_is_allowed(tmp_path: Path) 
     )
 
 
+def test_pipeline_lazy_import_of_kernel_module_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Lazy import should classify veritas_os.core.kernel as kernel dependency."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        '_lazy_import("veritas_os.core.kernel", None)\n',
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline_execute.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_lazy_import_of_kernel_symbol_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Lazy import should classify core+kernel symbol pattern as kernel dependency."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        '_lazy_import("veritas_os.core", "kernel")\n',
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline_execute.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_lazy_import_of_pipeline_helper_is_allowed(tmp_path: Path) -> None:
+    """Lazy imports of pipeline-owned helpers should not trigger kernel violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        '_lazy_import("veritas_os.core", "pipeline_execute")\n',
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
 def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
     """Remediation guide should include forbidden dependency, alternatives, and link."""
     violations = [

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -173,6 +173,152 @@ def test_check_boundaries_detects_from_core_import_pattern(tmp_path: Path) -> No
     assert "kernel" in issues[0]
 
 
+def test_pipeline_helper_importing_kernel_is_boundary_violation(tmp_path: Path) -> None:
+    """Pipeline helper modules should not import the kernel orchestrator surface."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(tmp_path / "pipeline_execute.py", "from veritas_os.core import kernel\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline_execute.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_helpers_allow_pipeline_owned_imports(tmp_path: Path) -> None:
+    """Pipeline helper modules may import other pipeline-owned modules."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(tmp_path / "pipeline_execute.py", "from veritas_os.core import pipeline_inputs\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_still_excludes_vendor_and_third_party_helpers(
+    tmp_path: Path,
+) -> None:
+    """Excluded helper paths should remain out-of-scope for boundary matching."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline" / "vendor").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "pipeline" / "third_party").mkdir(parents=True, exist_ok=True)
+    _write_module(
+        tmp_path / "pipeline" / "vendor" / "shim.py",
+        "import veritas_os.core.kernel\n",
+    )
+    _write_module(
+        tmp_path / "pipeline" / "third_party" / "shim.py",
+        "import veritas_os.core.kernel\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_alias_expansion_maps_kernel_helper_names(
+    tmp_path: Path,
+) -> None:
+    """Logical alias expansion should map kernel_* helper imports to kernel ownership."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        "from veritas_os.core import kernel_stages\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_kernel_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Relative imports from pipeline helpers should detect kernel dependencies."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "__init__.py", "from .. import kernel as veritas_core\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline" / "__init__.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_kernel_helper_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Relative helper imports should map kernel_* aliases to kernel ownership."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "some_helper.py", "from .. import kernel_stages\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline" / "some_helper.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_pipeline_helper_is_allowed(tmp_path: Path) -> None:
+    """Pipeline-owned relative imports should remain allowed."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "__init__.py", "from . import pipeline_execute\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
 def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
     """Remediation guide should include forbidden dependency, alternatives, and link."""
     violations = [
@@ -199,6 +345,26 @@ def test_build_remediation_guide_returns_empty_for_no_violations() -> None:
     guide = build_remediation_guide([])
 
     assert guide == ""
+
+
+def test_pipeline_remediation_guide_includes_allowed_and_extension_points(
+    tmp_path: Path,
+) -> None:
+    """Pipeline remediation output should include concrete guidance rows."""
+    violations = [
+        ViolationDetail(
+            source_module="pipeline",
+            forbidden_module="kernel",
+            path=tmp_path / "pipeline_execute.py",
+        ),
+    ]
+
+    guide = build_remediation_guide(violations)
+
+    assert "pipeline -> kernel" in guide
+    assert "N/A" not in guide
+    assert "veritas_os.core.pipeline_inputs" in guide
+    assert "veritas_os.core.pipeline_execute" in guide
 
 
 def test_collect_boundary_issues_classifies_missing_module(tmp_path: Path) -> None:
@@ -595,6 +761,29 @@ def test_build_machine_report_includes_doc_aligned_extension_points(tmp_path: Pa
     ]
 
 
+def test_build_machine_report_includes_pipeline_guidance(tmp_path: Path) -> None:
+    """Pipeline violations should include concrete dependency/remediation guidance."""
+    issues = [
+        BoundaryIssue(
+            code="boundary_violation",
+            message="violation",
+            path=tmp_path / "pipeline_execute.py",
+            source_module="pipeline",
+            forbidden_module="kernel",
+        ),
+    ]
+
+    report = json.loads(build_machine_report(issues))
+    report_issue = report["issues"][0]
+
+    assert report_issue["allowed_dependencies"]
+    assert report_issue["recommended_extension_points"]
+    assert "veritas_os.core.pipeline_inputs" in report_issue["allowed_dependencies"]
+    assert "veritas_os.core.pipeline_replay" in report_issue[
+        "recommended_extension_points"
+    ]
+
+
 def test_extract_doc_extension_points_reads_architecture_doc() -> None:
     """Architecture doc parser should extract module-specific extension points."""
     points = extract_doc_extension_points(
@@ -907,6 +1096,15 @@ def test_find_doc_alignment_issues_ignores_bullet_order_only(tmp_path: Path) -> 
 - `veritas_os.core.pipeline_contracts`
 - `veritas_os.core.kernel_qa`
 - `veritas_os.core.kernel_stages`
+
+### Pipeline (`veritas_os.core.pipeline`)
+**Preferred extension points**:
+- `veritas_os.core.pipeline_replay`
+- `veritas_os.core.pipeline_persist`
+- `veritas_os.core.pipeline_response`
+- `veritas_os.core.pipeline_policy`
+- `veritas_os.core.pipeline_execute`
+- `veritas_os.core.pipeline_inputs`
 
 ### FUJI (`veritas_os.core.fuji`)
 **Preferred extension points**:


### PR DESCRIPTION
### Motivation
- Make `pipeline` a first-class core module with explicit ownership and prevent pipeline helpers from depending on the kernel orchestrator to keep responsibility boundaries clear.
- Ensure the boundary checker understands pipeline helper/alias patterns and relative imports so violations cannot hide in orchestration-adjacent modules.

### Description
- Add a `Pipeline` section to `docs/architecture/core_responsibility_boundaries.md` documenting ownership, public contract, preferred extension points, and compatibility notes.
- Extend `scripts/architecture/check_responsibility_boundaries.py` to recognize `pipeline` as a logical core module, add a `pipeline` boundary rule forbidding imports of `kernel`, and register pipeline-specific allowed dependencies and recommended extension points.
- Enhance import collection logic to expand helper-module aliases and detect boundary-relevant relative imports via `_is_boundary_relevant_relative_alias` and to use `LOGICAL_CORE_MODULES` for alias expansion.
- Add tests in `veritas_os/tests/test_responsibility_boundary_checker.py` that validate pipeline helper import rules, alias expansion, relative import detection, exclusion of vendor/third_party helpers, and remediation/machine report output.

### Testing
- Ran the responsibility boundary checker unit tests in `veritas_os/tests/test_responsibility_boundary_checker.py` which include the new pipeline-focused cases, and they passed locally.
- Existing doc-extraction and remediation guide tests were run and continue to pass with the new pipeline entries.
- No automated tests failed as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbe959fc48326b0cf4800e54094f9)