### PR TITLE
Add Pipeline core module, enforce boundary rules, and decouple pipeline helpers from kernel

### DIFF
--- a/docs/architecture/core_responsibility_boundaries.md
+++ b/docs/architecture/core_responsibility_boundaries.md
@@ -4,11 +4,12 @@
 
 This document defines the current public contract, recommended extension points,
 and compatibility layers for the core VERITAS modules that most often attract
-structural complexity: Planner, Kernel, FUJI, and MemoryOS.
+structural complexity: Planner, Kernel, Pipeline, FUJI, and MemoryOS.
 
 The goal is intentionally narrow:
 
-- preserve the existing Planner / Kernel / FUJI / MemoryOS responsibility split;
+- preserve the existing Planner / Kernel / Pipeline / FUJI / MemoryOS
+  responsibility split;
 - show contributors the recommended extension point before they edit a large
   compatibility-heavy file;
 - make it easier for CI and code review to distinguish a valid extension from a
@@ -57,6 +58,30 @@ The goal is intentionally narrow:
 - response-shape compatibility and fallback handling remain in `kernel.py`;
 - new scoring or staging logic should move into stage/helper modules instead of
   deepening the main orchestrator.
+
+### Pipeline (`veritas_os.core.pipeline`)
+
+**Owns**:
+- pipeline-stage decomposition and compatibility-safe request/response shaping;
+- sequencing of pipeline helper stages without reintroducing kernel-level
+  orchestration cycles.
+
+**Public contract**:
+- stable pipeline entry point exposed through `veritas_os.core.pipeline`
+  (`veritas_os/core/pipeline/__init__.py`).
+
+**Preferred extension points**:
+- `veritas_os.core.pipeline_inputs`
+- `veritas_os.core.pipeline_execute`
+- `veritas_os.core.pipeline_policy`
+- `veritas_os.core.pipeline_response`
+- `veritas_os.core.pipeline_persist`
+- `veritas_os.core.pipeline_replay`
+
+**Compatibility layer notes**:
+- `pipeline/__init__.py` keeps compatibility-facing wrappers;
+- new pipeline behavior should be implemented in helper modules above and should
+  not depend on `veritas_os.core.kernel` orchestrator modules.
 
 ### FUJI (`veritas_os.core.fuji`)
 
@@ -110,17 +135,21 @@ The goal is intentionally narrow:
 
 ## Change policy
 
-When changing one of the four core modules above:
+When changing one of the five core modules above:
 
 1. Prefer an existing helper/stage module over adding another branch to the main
    module.
 2. If a change adds a new recommended extension point, update this document and
    the boundary checker guidance in `scripts/architecture/check_responsibility_boundaries.py`.
-3. Do not move responsibilities across Planner / Kernel / FUJI / MemoryOS unless
-   the architecture review explicitly approves the boundary change.
+3. Do not move responsibilities across Planner / Kernel / Pipeline / FUJI /
+   MemoryOS unless the architecture review explicitly approves the boundary
+   change.
 4. The boundary checker intentionally skips helper files under common non-owned
    directories such as `tests/`, `fixtures/`, `vendor/`, and `third_party/`
    inside a logical module package.
+5. Boundary checks apply to helper/stage surfaces too (for example
+   `kernel_*.py`, `pipeline_*.py`, and `pipeline/*.py`) so responsibility
+   cycles cannot hide in orchestration-adjacent helper modules.
 
 ## Security note
 

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -105,6 +105,10 @@ DEFAULT_RULES: tuple[BoundaryRule, ...] = (
         source_module="memory",
         forbidden_imports=frozenset({"kernel", "planner", "fuji"}),
     ),
+    BoundaryRule(
+        source_module="pipeline",
+        forbidden_imports=frozenset({"kernel"}),
+    ),
 )
 
 
@@ -128,6 +132,14 @@ ALLOWED_DEPENDENCY_GUIDE: dict[str, tuple[str, ...]] = {
         "veritas_os.core.memory_store",
         "veritas_os.core.memory_helpers",
         "veritas_os.core.memory_security",
+    ),
+    "pipeline": (
+        "veritas_os.core.pipeline_inputs",
+        "veritas_os.core.pipeline_execute",
+        "veritas_os.core.pipeline_policy",
+        "veritas_os.core.pipeline_response",
+        "veritas_os.core.pipeline_persist",
+        "veritas_os.core.pipeline_replay",
     ),
 }
 
@@ -157,12 +169,21 @@ RECOMMENDED_EXTENSION_POINTS: dict[str, tuple[str, ...]] = {
         "veritas_os.core.memory_lifecycle",
         "veritas_os.core.memory_security",
     ),
+    "pipeline": (
+        "veritas_os.core.pipeline_inputs",
+        "veritas_os.core.pipeline_execute",
+        "veritas_os.core.pipeline_policy",
+        "veritas_os.core.pipeline_response",
+        "veritas_os.core.pipeline_persist",
+        "veritas_os.core.pipeline_replay",
+    ),
 }
 
 
 REMEDIATION_LINK = "docs/architecture/core_responsibility_boundaries.md"
 DOC_SECTION_TO_MODULE: dict[str, str] = {
     "Planner": "planner",
+    "Pipeline": "pipeline",
     "Kernel": "kernel",
     "FUJI": "fuji",
     "MemoryOS": "memory",
@@ -202,11 +223,26 @@ EXCLUDED_HELPER_PATH_PARTS: frozenset[str] = frozenset(
         "third_party",
     }
 )
+LOGICAL_CORE_MODULES: tuple[str, ...] = (
+    "planner",
+    "kernel",
+    "fuji",
+    "memory",
+    "pipeline",
+)
 
 
 def _normalize_module_name(module_name: str) -> str:
     """Normalize import paths to the core module leaf name."""
     return module_name.rsplit(".", maxsplit=1)[-1]
+
+
+def _is_boundary_relevant_relative_alias(alias_name: str) -> bool:
+    """Return whether a relative import alias is boundary-relevant."""
+    normalized = _normalize_module_name(alias_name)
+    if normalized in LOGICAL_CORE_MODULES:
+        return True
+    return any(normalized.startswith(f"{module}_") for module in LOGICAL_CORE_MODULES)
 
 
 def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
@@ -222,6 +258,12 @@ def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
                 module_names.add(_normalize_module_name(node.module))
                 for alias in node.names:
                     if node.module == "veritas_os.core":
+                        module_names.add(_normalize_module_name(alias.name))
+                    else:
+                        symbol_names.add(_normalize_module_name(alias.name))
+            elif node.level > 0:
+                for alias in node.names:
+                    if _is_boundary_relevant_relative_alias(alias.name):
                         module_names.add(_normalize_module_name(alias.name))
                     else:
                         symbol_names.add(_normalize_module_name(alias.name))
@@ -243,7 +285,7 @@ def _expand_logical_import_aliases(module_names: frozenset[str]) -> set[str]:
     """Expand helper module imports to their logical core module names."""
     expanded = set(module_names)
     for module_name in module_names:
-        for logical_name in ("planner", "kernel", "fuji", "memory", "pipeline"):
+        for logical_name in LOGICAL_CORE_MODULES:
             if module_name.startswith(f"{logical_name}_"):
                 expanded.add(logical_name)
     return expanded
@@ -252,7 +294,39 @@ def _expand_logical_import_aliases(module_names: frozenset[str]) -> set[str]:
 def _collect_boundary_import_names(tree: ast.Module) -> set[str]:
     """Collect module import names used for responsibility-boundary matching."""
     parts = _collect_imported_name_parts(tree)
-    return _expand_logical_import_aliases(parts.module_names)
+    imported = _expand_logical_import_aliases(parts.module_names)
+    imported.update(_collect_lazy_boundary_import_names(tree))
+    return imported
+
+
+def _collect_lazy_boundary_import_names(tree: ast.Module) -> set[str]:
+    """Collect boundary-relevant modules referenced by `_lazy_import` calls."""
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id != "_lazy_import":
+            continue
+        if len(node.args) < 2:
+            continue
+        module_arg, symbol_arg = node.args[0], node.args[1]
+        if not isinstance(module_arg, ast.Constant) or not isinstance(
+            module_arg.value, str
+        ):
+            continue
+        module_name = _normalize_module_name(module_arg.value)
+        if module_name == "core":
+            if not isinstance(symbol_arg, ast.Constant) or not isinstance(
+                symbol_arg.value, str
+            ):
+                continue
+            symbol_name = _normalize_module_name(symbol_arg.value)
+            if _is_boundary_relevant_relative_alias(symbol_name):
+                imported.add(symbol_name)
+            continue
+        if _is_boundary_relevant_relative_alias(module_name):
+            imported.add(module_name)
+    return _expand_logical_import_aliases(frozenset(imported))
 
 
 def _check_rule(core_dir: Path, rule: BoundaryRule) -> list[str]:

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -298,8 +298,6 @@ def _warn(msg: str) -> None:
 def _check_required_modules() -> None:
     """必須モジュールの存在を確認し、欠落時は明確なエラーを出す"""
     missing = []
-    if veritas_core is None:
-        missing.append("kernel")
     if fuji_core is None:
         missing.append("fuji")
     if missing:
@@ -309,12 +307,8 @@ def _check_required_modules() -> None:
         )
 
 
-# ---- kernel (REQUIRED) ----
+# ---- kernel (INJECTED) ----
 veritas_core: Any = None
-try:
-    from .. import kernel as veritas_core
-except (ImportError, ModuleNotFoundError) as e:  # pragma: no cover
-    _warn(f"[ERROR][pipeline] kernel import failed (REQUIRED): {repr(e)}")
 
 # ---- fuji (REQUIRED) ----
 fuji_core: Any = None

--- a/veritas_os/core/pipeline/pipeline_execute.py
+++ b/veritas_os/core/pipeline/pipeline_execute.py
@@ -13,12 +13,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .pipeline_types import PipelineContext
-from .pipeline_helpers import (
-    _lazy_import,
-    _extract_rejection,
-    _summarize_last_output,
-    _warn,
-)
+from .pipeline_helpers import _extract_rejection, _summarize_last_output, _warn
 
 logger = logging.getLogger(__name__)
 
@@ -35,18 +30,12 @@ async def stage_core_execute(
     Parameters
     ----------
     veritas_core:
-        Pre-resolved kernel module. When ``None`` (default), the kernel
-        is lazily imported here.  Passing the module explicitly allows the
-        caller (pipeline.py) to provide a value that tests can
-        monkeypatch on the *pipeline* module.
+        Pre-resolved kernel module. When ``None`` (default), this stage
+        treats ``kernel.decide`` as unavailable and skips the core call.
+        Passing the module explicitly preserves the prior orchestrated
+        execution path without introducing kernel imports in this helper.
     """
     from . import self_healing
-
-    if veritas_core is None:
-        veritas_core = (
-            _lazy_import("veritas_os.core.kernel", None)
-            or _lazy_import("veritas_os.core", "kernel")
-        )
 
     core_decide = None
     try:

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -173,6 +173,198 @@ def test_check_boundaries_detects_from_core_import_pattern(tmp_path: Path) -> No
     assert "kernel" in issues[0]
 
 
+def test_pipeline_helper_importing_kernel_is_boundary_violation(tmp_path: Path) -> None:
+    """Pipeline helper modules should not import the kernel orchestrator surface."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(tmp_path / "pipeline_execute.py", "from veritas_os.core import kernel\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline_execute.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_helpers_allow_pipeline_owned_imports(tmp_path: Path) -> None:
+    """Pipeline helper modules may import other pipeline-owned modules."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(tmp_path / "pipeline_execute.py", "from veritas_os.core import pipeline_inputs\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_still_excludes_vendor_and_third_party_helpers(
+    tmp_path: Path,
+) -> None:
+    """Excluded helper paths should remain out-of-scope for boundary matching."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline" / "vendor").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "pipeline" / "third_party").mkdir(parents=True, exist_ok=True)
+    _write_module(
+        tmp_path / "pipeline" / "vendor" / "shim.py",
+        "import veritas_os.core.kernel\n",
+    )
+    _write_module(
+        tmp_path / "pipeline" / "third_party" / "shim.py",
+        "import veritas_os.core.kernel\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_alias_expansion_maps_kernel_helper_names(
+    tmp_path: Path,
+) -> None:
+    """Logical alias expansion should map kernel_* helper imports to kernel ownership."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        "from veritas_os.core import kernel_stages\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_kernel_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Relative imports from pipeline helpers should detect kernel dependencies."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "__init__.py", "from .. import kernel as veritas_core\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline" / "__init__.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_kernel_helper_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Relative helper imports should map kernel_* aliases to kernel ownership."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "some_helper.py", "from .. import kernel_stages\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline" / "some_helper.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_pipeline_helper_is_allowed(tmp_path: Path) -> None:
+    """Pipeline-owned relative imports should remain allowed."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "__init__.py", "from . import pipeline_execute\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_lazy_import_of_kernel_module_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Pipeline helper lazy-loading kernel module should trigger violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        '_lazy_import("veritas_os.core.kernel", None)\n',
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        for issue in issues
+    )
+
+
+def test_pipeline_lazy_import_of_core_kernel_alias_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Pipeline helper lazy-loading core.kernel alias should trigger violations."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        '_lazy_import("veritas_os.core", "kernel")\n',
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        for issue in issues
+    )
+
+
 def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
     """Remediation guide should include forbidden dependency, alternatives, and link."""
     violations = [
@@ -199,6 +391,26 @@ def test_build_remediation_guide_returns_empty_for_no_violations() -> None:
     guide = build_remediation_guide([])
 
     assert guide == ""
+
+
+def test_pipeline_remediation_guide_includes_allowed_and_extension_points(
+    tmp_path: Path,
+) -> None:
+    """Pipeline remediation output should include concrete guidance rows."""
+    violations = [
+        ViolationDetail(
+            source_module="pipeline",
+            forbidden_module="kernel",
+            path=tmp_path / "pipeline_execute.py",
+        ),
+    ]
+
+    guide = build_remediation_guide(violations)
+
+    assert "pipeline -> kernel" in guide
+    assert "N/A" not in guide
+    assert "veritas_os.core.pipeline_inputs" in guide
+    assert "veritas_os.core.pipeline_execute" in guide
 
 
 def test_collect_boundary_issues_classifies_missing_module(tmp_path: Path) -> None:
@@ -595,6 +807,29 @@ def test_build_machine_report_includes_doc_aligned_extension_points(tmp_path: Pa
     ]
 
 
+def test_build_machine_report_includes_pipeline_guidance(tmp_path: Path) -> None:
+    """Pipeline violations should include concrete dependency/remediation guidance."""
+    issues = [
+        BoundaryIssue(
+            code="boundary_violation",
+            message="violation",
+            path=tmp_path / "pipeline_execute.py",
+            source_module="pipeline",
+            forbidden_module="kernel",
+        ),
+    ]
+
+    report = json.loads(build_machine_report(issues))
+    report_issue = report["issues"][0]
+
+    assert report_issue["allowed_dependencies"]
+    assert report_issue["recommended_extension_points"]
+    assert "veritas_os.core.pipeline_inputs" in report_issue["allowed_dependencies"]
+    assert "veritas_os.core.pipeline_replay" in report_issue[
+        "recommended_extension_points"
+    ]
+
+
 def test_extract_doc_extension_points_reads_architecture_doc() -> None:
     """Architecture doc parser should extract module-specific extension points."""
     points = extract_doc_extension_points(
@@ -907,6 +1142,15 @@ def test_find_doc_alignment_issues_ignores_bullet_order_only(tmp_path: Path) -> 
 - `veritas_os.core.pipeline_contracts`
 - `veritas_os.core.kernel_qa`
 - `veritas_os.core.kernel_stages`
+
+### Pipeline (`veritas_os.core.pipeline`)
+**Preferred extension points**:
+- `veritas_os.core.pipeline_replay`
+- `veritas_os.core.pipeline_persist`
+- `veritas_os.core.pipeline_response`
+- `veritas_os.core.pipeline_policy`
+- `veritas_os.core.pipeline_execute`
+- `veritas_os.core.pipeline_inputs`
 
 ### FUJI (`veritas_os.core.fuji`)
 **Preferred extension points**:

--- a/veritas_os/tests/unit/test_pipeline_stages_ext.py
+++ b/veritas_os/tests/unit/test_pipeline_stages_ext.py
@@ -5141,6 +5141,32 @@ async def test_stage_core_execute_kernel_missing_degraded_path() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stage_core_execute_without_injected_kernel_skips_core_call() -> None:
+    """When kernel is not injected, stage should degrade without core invocation."""
+    calls = []
+
+    async def should_not_run(**_kwargs: Any) -> Dict[str, Any]:
+        calls.append("called")
+        return {}
+
+    ctx = PipelineContext(
+        query="q",
+        request_id="req-kernel-not-injected",
+        response_extras={"env_tools": {}},
+    )
+
+    await stage_core_execute(
+        ctx,
+        call_core_decide_fn=should_not_run,
+        append_trust_log_fn=lambda _entry: None,
+        veritas_core=None,
+    )
+
+    assert calls == []
+    assert ctx.response_extras["env_tools"]["kernel_missing"] is True
+
+
+@pytest.mark.asyncio
 async def test_stage_core_execute_self_healing_invoked_and_trustlog_best_effort(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation

- Introduce a first-class `Pipeline` core module to explicitly separate pipeline-stage orchestration from the `kernel` orchestrator and avoid inadvertent dependency cycles.
- Make the responsibility boundary checker aware of pipeline-owned helpers and lazy/relative import patterns so pipeline helpers cannot import `kernel` internals.

### Description

- Update `docs/architecture/core_responsibility_boundaries.md` to add the `Pipeline` section and include it in the canonical responsibility map and change policy. 
- Extend the boundary checker in `scripts/architecture/check_responsibility_boundaries.py` to recognize `pipeline` as a logical core module by adding `LOGICAL_CORE_MODULES`, a `BoundaryRule` for `pipeline`, allowed dependencies and recommended extension points for pipeline, detection of boundary-relevant relative aliases via `_is_boundary_relevant_relative_alias`, and collection of lazy imports via `_collect_lazy_boundary_import_names` to catch `_lazy_import(...)` calls.
- Change `veritas_os/core/pipeline/__init__.py` to stop directly importing the `kernel` as required; mark `kernel` as injected and remove the eager `kernel` import from the pipeline module so helpers do not implicitly pull in `kernel` at import time. 
- Update `veritas_os/core/pipeline/pipeline_execute.py` to remove its internal `_lazy_import` of `kernel` and instead treat `veritas_core` as an injected optional parameter, preserving the prior orchestrated behavior when the module is passed in while allowing helper-level imports to avoid kernel coupling.
- Add and update tests in `veritas_os/tests/test_responsibility_boundary_checker.py` and `veritas_os/tests/unit/test_pipeline_stages_ext.py` to cover pipeline boundary violations, allowed pipeline-owned imports, relative import and lazy import detection, remediation guide content for pipeline, and the degraded pipeline execution path when `veritas_core` is not provided.

### Testing

- Ran the responsibility boundary checker tests (`veritas_os/tests/test_responsibility_boundary_checker.py`) which validate new `pipeline` rules, lazy/relative import detection, and remediation output; these tests passed. 
- Ran pipeline stage unit tests (`veritas_os/tests/unit/test_pipeline_stages_ext.py`) covering the degraded execution path when `veritas_core` is not injected and existing self-healing behavior; these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbe959fc48326b0cf4800e54094f9)