### PR TITLE
Add Pipeline as core module, enforce pipeline/kernel boundary, and support kernel injection

### DIFF
--- a/docs/architecture/core_responsibility_boundaries.md
+++ b/docs/architecture/core_responsibility_boundaries.md
@@ -58,6 +58,30 @@ The goal is intentionally narrow:
 - new scoring or staging logic should move into stage/helper modules instead of
   deepening the main orchestrator.
 
+### Pipeline (`veritas_os.core.pipeline`)
+
+**Owns**:
+- pipeline-stage decomposition and compatibility-safe request/response shaping;
+- sequencing of pipeline helper stages without reintroducing kernel-level
+  orchestration cycles.
+
+**Public contract**:
+- stable pipeline entry points exposed through `pipeline.py` and
+  `veritas_os.core.pipeline`.
+
+**Preferred extension points**:
+- `veritas_os.core.pipeline_inputs`
+- `veritas_os.core.pipeline_execute`
+- `veritas_os.core.pipeline_policy`
+- `veritas_os.core.pipeline_response`
+- `veritas_os.core.pipeline_persist`
+- `veritas_os.core.pipeline_replay`
+
+**Compatibility layer notes**:
+- `pipeline.py` and `pipeline/__init__.py` keep compatibility-facing wrappers;
+- new pipeline behavior should be implemented in helper modules above and should
+  not depend on `veritas_os.core.kernel` orchestrator modules.
+
 ### FUJI (`veritas_os.core.fuji`)
 
 **Owns**:
@@ -121,6 +145,9 @@ When changing one of the four core modules above:
 4. The boundary checker intentionally skips helper files under common non-owned
    directories such as `tests/`, `fixtures/`, `vendor/`, and `third_party/`
    inside a logical module package.
+5. Boundary checks apply to helper/stage surfaces too (for example
+   `kernel_*.py`, `pipeline_*.py`, and `pipeline/*.py`) so responsibility
+   cycles cannot hide in orchestration-adjacent helper modules.
 
 ## Security note
 

--- a/scripts/architecture/check_responsibility_boundaries.py
+++ b/scripts/architecture/check_responsibility_boundaries.py
@@ -105,6 +105,10 @@ DEFAULT_RULES: tuple[BoundaryRule, ...] = (
         source_module="memory",
         forbidden_imports=frozenset({"kernel", "planner", "fuji"}),
     ),
+    BoundaryRule(
+        source_module="pipeline",
+        forbidden_imports=frozenset({"kernel"}),
+    ),
 )
 
 
@@ -128,6 +132,14 @@ ALLOWED_DEPENDENCY_GUIDE: dict[str, tuple[str, ...]] = {
         "veritas_os.core.memory_store",
         "veritas_os.core.memory_helpers",
         "veritas_os.core.memory_security",
+    ),
+    "pipeline": (
+        "veritas_os.core.pipeline_inputs",
+        "veritas_os.core.pipeline_execute",
+        "veritas_os.core.pipeline_policy",
+        "veritas_os.core.pipeline_response",
+        "veritas_os.core.pipeline_persist",
+        "veritas_os.core.pipeline_replay",
     ),
 }
 
@@ -157,12 +169,21 @@ RECOMMENDED_EXTENSION_POINTS: dict[str, tuple[str, ...]] = {
         "veritas_os.core.memory_lifecycle",
         "veritas_os.core.memory_security",
     ),
+    "pipeline": (
+        "veritas_os.core.pipeline_inputs",
+        "veritas_os.core.pipeline_execute",
+        "veritas_os.core.pipeline_policy",
+        "veritas_os.core.pipeline_response",
+        "veritas_os.core.pipeline_persist",
+        "veritas_os.core.pipeline_replay",
+    ),
 }
 
 
 REMEDIATION_LINK = "docs/architecture/core_responsibility_boundaries.md"
 DOC_SECTION_TO_MODULE: dict[str, str] = {
     "Planner": "planner",
+    "Pipeline": "pipeline",
     "Kernel": "kernel",
     "FUJI": "fuji",
     "MemoryOS": "memory",
@@ -202,11 +223,26 @@ EXCLUDED_HELPER_PATH_PARTS: frozenset[str] = frozenset(
         "third_party",
     }
 )
+LOGICAL_CORE_MODULES: tuple[str, ...] = (
+    "planner",
+    "kernel",
+    "fuji",
+    "memory",
+    "pipeline",
+)
 
 
 def _normalize_module_name(module_name: str) -> str:
     """Normalize import paths to the core module leaf name."""
     return module_name.rsplit(".", maxsplit=1)[-1]
+
+
+def _is_boundary_relevant_relative_alias(alias_name: str) -> bool:
+    """Return whether a relative import alias is boundary-relevant."""
+    normalized = _normalize_module_name(alias_name)
+    if normalized in LOGICAL_CORE_MODULES:
+        return True
+    return any(normalized.startswith(f"{module}_") for module in LOGICAL_CORE_MODULES)
 
 
 def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
@@ -225,9 +261,30 @@ def _collect_imported_name_parts(tree: ast.Module) -> ImportedNames:
                         module_names.add(_normalize_module_name(alias.name))
                     else:
                         symbol_names.add(_normalize_module_name(alias.name))
+            elif node.level > 0:
+                for alias in node.names:
+                    if _is_boundary_relevant_relative_alias(alias.name):
+                        module_names.add(_normalize_module_name(alias.name))
+                    else:
+                        symbol_names.add(_normalize_module_name(alias.name))
             else:
                 for alias in node.names:
                     symbol_names.add(_normalize_module_name(alias.name))
+        elif isinstance(node, ast.Call):
+            if not (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "_lazy_import"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                continue
+            module_arg = node.args[0].value
+            module_names.add(_normalize_module_name(module_arg))
+            if len(node.args) >= 2:
+                attr_arg = node.args[1]
+                if isinstance(attr_arg, ast.Constant) and isinstance(attr_arg.value, str):
+                    module_names.add(_normalize_module_name(attr_arg.value))
     return ImportedNames(
         module_names=frozenset(module_names),
         symbol_names=frozenset(symbol_names),
@@ -243,7 +300,7 @@ def _expand_logical_import_aliases(module_names: frozenset[str]) -> set[str]:
     """Expand helper module imports to their logical core module names."""
     expanded = set(module_names)
     for module_name in module_names:
-        for logical_name in ("planner", "kernel", "fuji", "memory", "pipeline"):
+        for logical_name in LOGICAL_CORE_MODULES:
             if module_name.startswith(f"{logical_name}_"):
                 expanded.add(logical_name)
     return expanded

--- a/veritas_os/api/dependency_resolver.py
+++ b/veritas_os/api/dependency_resolver.py
@@ -74,6 +74,12 @@ def resolve_decision_pipeline(
         state.attempted = True
         try:
             pipeline = importlib.import_module("veritas_os.core.pipeline")
+            try:
+                kernel = importlib.import_module("veritas_os.core.kernel")
+                if hasattr(pipeline, "set_veritas_core"):
+                    pipeline.set_veritas_core(kernel)
+            except Exception as exc:  # pragma: no cover - optional runtime injection
+                logger.warning("kernel injection into pipeline failed: %s", errstr(exc))
             state.obj = pipeline
             state.err = None
             return pipeline

--- a/veritas_os/api/dependency_resolver.py
+++ b/veritas_os/api/dependency_resolver.py
@@ -76,10 +76,18 @@ def resolve_decision_pipeline(
             pipeline = importlib.import_module("veritas_os.core.pipeline")
             try:
                 kernel = importlib.import_module("veritas_os.core.kernel")
-                if hasattr(pipeline, "set_veritas_core"):
-                    pipeline.set_veritas_core(kernel)
-            except Exception as exc:  # pragma: no cover - optional runtime injection
-                logger.warning("kernel injection into pipeline failed: %s", errstr(exc))
+            except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover - optional runtime
+                logger.warning(
+                    "kernel import failed for pipeline injection: %s",
+                    errstr(exc),
+                    exc_info=True,
+                )
+            else:
+                if not hasattr(pipeline, "set_veritas_core"):
+                    raise RuntimeError(
+                        "pipeline.set_veritas_core is required for kernel injection"
+                    )
+                pipeline.set_veritas_core(kernel)
             state.obj = pipeline
             state.err = None
             return pipeline

--- a/veritas_os/core/pipeline/__init__.py
+++ b/veritas_os/core/pipeline/__init__.py
@@ -65,6 +65,7 @@ import inspect  # noqa: F401 – re-exported; tests access pipeline.inspect
 import logging
 import os
 import time
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -298,8 +299,6 @@ def _warn(msg: str) -> None:
 def _check_required_modules() -> None:
     """必須モジュールの存在を確認し、欠落時は明確なエラーを出す"""
     missing = []
-    if veritas_core is None:
-        missing.append("kernel")
     if fuji_core is None:
         missing.append("fuji")
     if missing:
@@ -309,12 +308,14 @@ def _check_required_modules() -> None:
         )
 
 
-# ---- kernel (REQUIRED) ----
-veritas_core: Any = None
-try:
-    from .. import kernel as veritas_core
-except (ImportError, ModuleNotFoundError) as e:  # pragma: no cover
-    _warn(f"[ERROR][pipeline] kernel import failed (REQUIRED): {repr(e)}")
+# ---- kernel (INJECTED via allowed callers) ----
+veritas_core: Any = SimpleNamespace()
+
+
+def set_veritas_core(module: Any) -> None:
+    """Inject kernel module/adapter from an allowed higher-level boundary."""
+    global veritas_core
+    veritas_core = module if module is not None else SimpleNamespace()
 
 # ---- fuji (REQUIRED) ----
 fuji_core: Any = None

--- a/veritas_os/core/pipeline/pipeline_execute.py
+++ b/veritas_os/core/pipeline/pipeline_execute.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 
 from .pipeline_types import PipelineContext
 from .pipeline_helpers import (
-    _lazy_import,
     _extract_rejection,
     _summarize_last_output,
     _warn,
@@ -35,18 +34,10 @@ async def stage_core_execute(
     Parameters
     ----------
     veritas_core:
-        Pre-resolved kernel module. When ``None`` (default), the kernel
-        is lazily imported here.  Passing the module explicitly allows the
-        caller (pipeline.py) to provide a value that tests can
-        monkeypatch on the *pipeline* module.
+        Pre-resolved kernel module or kernel adapter. This stage relies on
+        injected dependencies only and does not import kernel directly.
     """
     from . import self_healing
-
-    if veritas_core is None:
-        veritas_core = (
-            _lazy_import("veritas_os.core.kernel", None)
-            or _lazy_import("veritas_os.core", "kernel")
-        )
 
     core_decide = None
     try:

--- a/veritas_os/tests/test_api_dependency_resolver.py
+++ b/veritas_os/tests/test_api_dependency_resolver.py
@@ -108,3 +108,50 @@ def test_lazy_state_defaults_are_thread_safe():
     assert first.err is None
     assert first.attempted is False
     assert first.lock is not second.lock
+
+
+def test_resolve_decision_pipeline_injects_kernel_when_available(monkeypatch):
+    state = _make_state()
+    injected: list[object] = []
+    pipeline = SimpleNamespace(set_veritas_core=lambda module: injected.append(module))
+    kernel = SimpleNamespace(decide=lambda **_kwargs: {})
+
+    def _import(name: str):
+        if name == "veritas_os.core.pipeline":
+            return pipeline
+        if name == "veritas_os.core.kernel":
+            return kernel
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(dependency_resolver.importlib, "import_module", _import)
+    resolved = dependency_resolver.resolve_decision_pipeline(
+        state,
+        errstr=_errstr,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert resolved is pipeline
+    assert injected == [kernel]
+
+
+def test_resolve_decision_pipeline_logs_kernel_import_failure(caplog, monkeypatch):
+    state = _make_state()
+    pipeline = SimpleNamespace(set_veritas_core=lambda _module: None)
+
+    def _import(name: str):
+        if name == "veritas_os.core.pipeline":
+            return pipeline
+        if name == "veritas_os.core.kernel":
+            raise ImportError("kernel missing")
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(dependency_resolver.importlib, "import_module", _import)
+    with caplog.at_level(logging.WARNING):
+        resolved = dependency_resolver.resolve_decision_pipeline(
+            state,
+            errstr=_errstr,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert resolved is pipeline
+    assert "kernel import failed for pipeline injection" in caplog.text

--- a/veritas_os/tests/test_responsibility_boundary_checker.py
+++ b/veritas_os/tests/test_responsibility_boundary_checker.py
@@ -173,6 +173,198 @@ def test_check_boundaries_detects_from_core_import_pattern(tmp_path: Path) -> No
     assert "kernel" in issues[0]
 
 
+def test_pipeline_helper_importing_kernel_is_boundary_violation(tmp_path: Path) -> None:
+    """Pipeline helper modules should not import the kernel orchestrator surface."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(tmp_path / "pipeline_execute.py", "from veritas_os.core import kernel\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline_execute.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_helpers_allow_pipeline_owned_imports(tmp_path: Path) -> None:
+    """Pipeline helper modules may import other pipeline-owned modules."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(tmp_path / "pipeline_execute.py", "from veritas_os.core import pipeline_inputs\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_still_excludes_vendor_and_third_party_helpers(
+    tmp_path: Path,
+) -> None:
+    """Excluded helper paths should remain out-of-scope for boundary matching."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline" / "vendor").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "pipeline" / "third_party").mkdir(parents=True, exist_ok=True)
+    _write_module(
+        tmp_path / "pipeline" / "vendor" / "shim.py",
+        "import veritas_os.core.kernel\n",
+    )
+    _write_module(
+        tmp_path / "pipeline" / "third_party" / "shim.py",
+        "import veritas_os.core.kernel\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_alias_expansion_maps_kernel_helper_names(
+    tmp_path: Path,
+) -> None:
+    """Logical alias expansion should map kernel_* helper imports to kernel ownership."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        "from veritas_os.core import kernel_stages\n",
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_detects_lazy_import_kernel_module_pattern(
+    tmp_path: Path,
+) -> None:
+    """Pipeline rule should catch `_lazy_import("veritas_os.core.kernel", None)`."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        '_lazy_import("veritas_os.core.kernel", None)\n',
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        for issue in issues
+    )
+
+
+def test_pipeline_rule_detects_lazy_import_kernel_attr_pattern(
+    tmp_path: Path,
+) -> None:
+    """Pipeline rule should catch `_lazy_import("veritas_os.core", "kernel")`."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    _write_module(
+        tmp_path / "pipeline_execute.py",
+        '_lazy_import("veritas_os.core", "kernel")\n',
+    )
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_kernel_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Relative imports from pipeline helpers should detect kernel dependencies."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "__init__.py", "from .. import kernel as veritas_core\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline" / "__init__.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_kernel_helper_is_boundary_violation(
+    tmp_path: Path,
+) -> None:
+    """Relative helper imports should map kernel_* aliases to kernel ownership."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "some_helper.py", "from .. import kernel_stages\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert any(
+        issue.code == "boundary_violation"
+        and issue.source_module == "pipeline"
+        and issue.forbidden_module == "kernel"
+        and issue.path == tmp_path / "pipeline" / "some_helper.py"
+        for issue in issues
+    )
+
+
+def test_pipeline_relative_import_of_pipeline_helper_is_allowed(tmp_path: Path) -> None:
+    """Pipeline-owned relative imports should remain allowed."""
+    _write_guarded_core_docstrings(tmp_path)
+    _write_module(tmp_path / "planner.py", "# planner module\n")
+    _write_module(tmp_path / "fuji.py", "# fuji module\n")
+    _write_module(tmp_path / "memory.py", "# memory module\n")
+    (tmp_path / "pipeline").mkdir(parents=True, exist_ok=True)
+    _write_module(tmp_path / "pipeline" / "__init__.py", "from . import pipeline_execute\n")
+
+    issues = collect_boundary_issues(core_dir=tmp_path)
+
+    assert not any(
+        issue.code == "boundary_violation" and issue.source_module == "pipeline"
+        for issue in issues
+    )
+
+
 def test_build_remediation_guide_contains_required_columns(tmp_path: Path) -> None:
     """Remediation guide should include forbidden dependency, alternatives, and link."""
     violations = [
@@ -199,6 +391,26 @@ def test_build_remediation_guide_returns_empty_for_no_violations() -> None:
     guide = build_remediation_guide([])
 
     assert guide == ""
+
+
+def test_pipeline_remediation_guide_includes_allowed_and_extension_points(
+    tmp_path: Path,
+) -> None:
+    """Pipeline remediation output should include concrete guidance rows."""
+    violations = [
+        ViolationDetail(
+            source_module="pipeline",
+            forbidden_module="kernel",
+            path=tmp_path / "pipeline_execute.py",
+        ),
+    ]
+
+    guide = build_remediation_guide(violations)
+
+    assert "pipeline -> kernel" in guide
+    assert "N/A" not in guide
+    assert "veritas_os.core.pipeline_inputs" in guide
+    assert "veritas_os.core.pipeline_execute" in guide
 
 
 def test_collect_boundary_issues_classifies_missing_module(tmp_path: Path) -> None:
@@ -595,6 +807,29 @@ def test_build_machine_report_includes_doc_aligned_extension_points(tmp_path: Pa
     ]
 
 
+def test_build_machine_report_includes_pipeline_guidance(tmp_path: Path) -> None:
+    """Pipeline violations should include concrete dependency/remediation guidance."""
+    issues = [
+        BoundaryIssue(
+            code="boundary_violation",
+            message="violation",
+            path=tmp_path / "pipeline_execute.py",
+            source_module="pipeline",
+            forbidden_module="kernel",
+        ),
+    ]
+
+    report = json.loads(build_machine_report(issues))
+    report_issue = report["issues"][0]
+
+    assert report_issue["allowed_dependencies"]
+    assert report_issue["recommended_extension_points"]
+    assert "veritas_os.core.pipeline_inputs" in report_issue["allowed_dependencies"]
+    assert "veritas_os.core.pipeline_replay" in report_issue[
+        "recommended_extension_points"
+    ]
+
+
 def test_extract_doc_extension_points_reads_architecture_doc() -> None:
     """Architecture doc parser should extract module-specific extension points."""
     points = extract_doc_extension_points(
@@ -907,6 +1142,15 @@ def test_find_doc_alignment_issues_ignores_bullet_order_only(tmp_path: Path) -> 
 - `veritas_os.core.pipeline_contracts`
 - `veritas_os.core.kernel_qa`
 - `veritas_os.core.kernel_stages`
+
+### Pipeline (`veritas_os.core.pipeline`)
+**Preferred extension points**:
+- `veritas_os.core.pipeline_replay`
+- `veritas_os.core.pipeline_persist`
+- `veritas_os.core.pipeline_response`
+- `veritas_os.core.pipeline_policy`
+- `veritas_os.core.pipeline_execute`
+- `veritas_os.core.pipeline_inputs`
 
 ### FUJI (`veritas_os.core.fuji`)
 **Preferred extension points**:

--- a/veritas_os/tests/unit/test_pipeline_kernel_injection.py
+++ b/veritas_os/tests/unit/test_pipeline_kernel_injection.py
@@ -14,9 +14,13 @@ from veritas_os.core.pipeline.pipeline_types import PipelineContext
 
 def test_set_veritas_core_supports_monkeypatch_compatible_placeholder() -> None:
     """`set_veritas_core(None)` should preserve attribute-monkeypatch compatibility."""
-    pipeline.set_veritas_core(None)
-    setattr(pipeline.veritas_core, "decide", lambda **_kwargs: {})
-    assert callable(pipeline.veritas_core.decide)
+    original = pipeline.veritas_core
+    try:
+        pipeline.set_veritas_core(None)
+        setattr(pipeline.veritas_core, "decide", lambda **_kwargs: {})
+        assert callable(pipeline.veritas_core.decide)
+    finally:
+        pipeline.set_veritas_core(original)
 
 
 @pytest.mark.asyncio

--- a/veritas_os/tests/unit/test_pipeline_kernel_injection.py
+++ b/veritas_os/tests/unit/test_pipeline_kernel_injection.py
@@ -1,0 +1,74 @@
+"""Regression tests for pipeline/kernel dependency injection compatibility."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from veritas_os.core import pipeline
+from veritas_os.core.pipeline.pipeline_execute import stage_core_execute
+from veritas_os.core.pipeline.pipeline_types import PipelineContext
+
+
+def test_set_veritas_core_supports_monkeypatch_compatible_placeholder() -> None:
+    """`set_veritas_core(None)` should preserve attribute-monkeypatch compatibility."""
+    pipeline.set_veritas_core(None)
+    setattr(pipeline.veritas_core, "decide", lambda **_kwargs: {})
+    assert callable(pipeline.veritas_core.decide)
+
+
+@pytest.mark.asyncio
+async def test_stage_core_execute_uses_injected_decide() -> None:
+    """Injected kernel adapter should execute the core-decision path."""
+    calls: list[dict[str, Any]] = []
+
+    async def _call_core_decide_fn(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"alternatives": [{"title": "A"}], "evidence": []}
+
+    ctx = PipelineContext(
+        request_id="rid",
+        query="q",
+        input_alts=[],
+        plan=[],
+        context={},
+        min_ev=0,
+    )
+    kernel = SimpleNamespace(decide=lambda **_kwargs: {})
+
+    await stage_core_execute(
+        ctx,
+        call_core_decide_fn=_call_core_decide_fn,
+        append_trust_log_fn=lambda _entry: None,
+        veritas_core=kernel,
+    )
+
+    assert calls
+    assert "kernel_missing" not in (ctx.response_extras.get("env_tools") or {})
+
+
+@pytest.mark.asyncio
+async def test_stage_core_execute_marks_kernel_missing_when_not_injected() -> None:
+    """Missing injection should take the degraded kernel-missing fallback path."""
+    ctx = PipelineContext(
+        request_id="rid",
+        query="q",
+        input_alts=[],
+        plan=[],
+        context={},
+        min_ev=0,
+    )
+
+    async def _should_not_run(**_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("core decide should not run without injected decide")
+
+    await stage_core_execute(
+        ctx,
+        call_core_decide_fn=_should_not_run,
+        append_trust_log_fn=lambda _entry: None,
+        veritas_core=SimpleNamespace(),
+    )
+
+    assert ctx.response_extras["env_tools"]["kernel_missing"] is True

--- a/veritas_os/tests/unit/test_pipeline_stages_ext.py
+++ b/veritas_os/tests/unit/test_pipeline_stages_ext.py
@@ -1286,8 +1286,7 @@ class TestCheckRequiredModules:
     def test_missing_kernel(self, monkeypatch):
         monkeypatch.setattr(pipeline, "veritas_core", None)
         monkeypatch.setattr(pipeline, "fuji_core", MagicMock())
-        with pytest.raises(ImportError, match="kernel"):
-            pipeline._check_required_modules()
+        pipeline._check_required_modules()
 
     def test_missing_fuji(self, monkeypatch):
         monkeypatch.setattr(pipeline, "veritas_core", MagicMock())
@@ -1298,7 +1297,7 @@ class TestCheckRequiredModules:
     def test_missing_both(self, monkeypatch):
         monkeypatch.setattr(pipeline, "veritas_core", None)
         monkeypatch.setattr(pipeline, "fuji_core", None)
-        with pytest.raises(ImportError, match="kernel.*fuji"):
+        with pytest.raises(ImportError, match="fuji"):
             pipeline._check_required_modules()
 
 
@@ -1808,8 +1807,7 @@ from veritas_os.core import pipeline as pl
 
 
 class TestCheckRequiredModules_v2:
-    """_check_required_modules must raise ImportError when core modules are
-    absent and succeed silently when they are present."""
+    """_check_required_modules treats fuji as required and kernel as injected."""
 
     def test_both_present_no_error(self, monkeypatch):
         monkeypatch.setattr(pl, "veritas_core", types.SimpleNamespace())
@@ -1819,8 +1817,7 @@ class TestCheckRequiredModules_v2:
     def test_kernel_missing(self, monkeypatch):
         monkeypatch.setattr(pl, "veritas_core", None)
         monkeypatch.setattr(pl, "fuji_core", types.SimpleNamespace())
-        with pytest.raises(ImportError, match="kernel"):
-            pl._check_required_modules()
+        pl._check_required_modules()
 
     def test_fuji_missing(self, monkeypatch):
         monkeypatch.setattr(pl, "veritas_core", types.SimpleNamespace())
@@ -1831,7 +1828,7 @@ class TestCheckRequiredModules_v2:
     def test_both_missing(self, monkeypatch):
         monkeypatch.setattr(pl, "veritas_core", None)
         monkeypatch.setattr(pl, "fuji_core", None)
-        with pytest.raises(ImportError, match="kernel.*fuji"):
+        with pytest.raises(ImportError, match="fuji"):
             pl._check_required_modules()
 
 
@@ -2343,11 +2340,18 @@ class TestRunDecidePipelineOrchestration:
 
     @pytest.mark.anyio
     async def test_kernel_missing_raises(self, pipeline_env, monkeypatch):
-        """When veritas_core is None, pipeline must raise ImportError."""
+        """Kernel missing should degrade and keep a structured response contract."""
         monkeypatch.setattr(pipeline_env, "veritas_core", None)
         body = {"query": "should fail", "context": {"user_id": "u1"}}
-        with pytest.raises(ImportError, match="kernel"):
-            await pipeline_env.run_decide_pipeline(DummyReqModel(body), DummyRequest())
+        payload = await pipeline_env.run_decide_pipeline(
+            DummyReqModel(body),
+            DummyRequest(),
+        )
+        assert isinstance(payload, dict)
+        assert isinstance(payload.get("alternatives"), list)
+        extras = payload.get("extras") or {}
+        env_tools = extras.get("env_tools") or {}
+        assert env_tools.get("kernel_missing") is True
 
 
 # =========================================================
@@ -3858,9 +3862,7 @@ class TestCheckRequiredModulesMessages:
     def test_kernel_only_missing_mentions_kernel_not_fuji(self, monkeypatch):
         monkeypatch.setattr(pl, "veritas_core", None)
         monkeypatch.setattr(pl, "fuji_core", types.SimpleNamespace())
-        with pytest.raises(ImportError, match="kernel") as exc_info:
-            pl._check_required_modules()
-        assert "fuji" not in str(exc_info.value)
+        assert pl._check_required_modules() is None
 
     def test_fuji_only_missing_mentions_fuji_not_kernel(self, monkeypatch):
         monkeypatch.setattr(pl, "veritas_core", types.SimpleNamespace())
@@ -3875,7 +3877,6 @@ class TestCheckRequiredModulesMessages:
         with pytest.raises(ImportError) as exc_info:
             pl._check_required_modules()
         msg = str(exc_info.value)
-        assert "kernel" in msg
         assert "fuji" in msg
         assert "FATAL" in msg
 

--- a/veritas_os/tests/unit/test_pipeline_stages_ext.py
+++ b/veritas_os/tests/unit/test_pipeline_stages_ext.py
@@ -3859,7 +3859,7 @@ from veritas_os.core import pipeline as pl
 class TestCheckRequiredModulesMessages:
     """Verify the ImportError message contains the correct module names."""
 
-    def test_kernel_only_missing_mentions_kernel_not_fuji(self, monkeypatch):
+    def test_kernel_only_missing_is_non_fatal(self, monkeypatch):
         monkeypatch.setattr(pl, "veritas_core", None)
         monkeypatch.setattr(pl, "fuji_core", types.SimpleNamespace())
         assert pl._check_required_modules() is None
@@ -3871,7 +3871,7 @@ class TestCheckRequiredModulesMessages:
             pl._check_required_modules()
         assert "kernel" not in str(exc_info.value)
 
-    def test_both_missing_message_contains_both(self, monkeypatch):
+    def test_both_missing_message_mentions_fuji_and_fatal(self, monkeypatch):
         monkeypatch.setattr(pl, "veritas_core", None)
         monkeypatch.setattr(pl, "fuji_core", None)
         with pytest.raises(ImportError) as exc_info:


### PR DESCRIPTION
### Motivation
- Treat the pipeline as a first-class core module with its own responsibility boundary and prevent pipeline helper modules from depending on the kernel orchestrator to avoid cyclic/orchestration-level leakage.
- Make pipeline import resilient and avoid hard kernel imports by enabling an explicit runtime injection point for the kernel adapter.
- Extend the boundary checker to recognize pipeline helpers, relative imports, and lazy-import patterns so violations cannot be hidden in helper modules.

### Description
- Updated `docs/architecture/core_responsibility_boundaries.md` to add the `Pipeline` section and document public contract, extension points, and compatibility guidance for `veritas_os.core.pipeline`.
- Extended the boundary checker (`scripts/architecture/check_responsibility_boundaries.py`) to: add `pipeline` to `DEFAULT_RULES`, `ALLOWED_DEPENDENCY_GUIDE`, and `RECOMMENDED_EXTENSION_POINTS`; introduce `LOGICAL_CORE_MODULES`; detect boundary-relevant relative imports; detect `_lazy_import(...)` call patterns; and expand alias handling for logical helper prefixes.
- Made the decision pipeline resolvers inject the kernel adapter by updating `veritas_os/api/dependency_resolver.py` to call `pipeline.set_veritas_core(kernel)` when resolving the pipeline.
- Reworked pipeline import surface in `veritas_os/core/pipeline/__init__.py` to avoid a required direct `kernel` import, provide a `set_veritas_core()` injection function, and use a `SimpleNamespace` placeholder for backward-compatible monkeypatching.
- Updated `veritas_os/core/pipeline/pipeline_execute.py` to rely on injected `veritas_core` (no lazy-import of kernel) and accept the kernel adapter via a `veritas_core` parameter to `stage_core_execute`.
- Added and updated tests in `veritas_os/tests/test_responsibility_boundary_checker.py` to cover the new pipeline boundary rules and lazy/relative import detection, and added `veritas_os/tests/unit/test_pipeline_kernel_injection.py` to validate the injection and fallback behavior.

### Testing
- Ran the boundary-checker unit tests in `veritas_os/tests/test_responsibility_boundary_checker.py`, including the new pipeline-specific cases, and they passed.
- Ran the new pipeline injection unit tests in `veritas_os/tests/unit/test_pipeline_kernel_injection.py` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbe959fc48326b0cf4800e54094f9)