### PR TITLE
Add ALGORITHMIC_HUMILITY_ENGAGED validation snapshot and update reviewer index & fixture matrix (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md
@@ -1,0 +1,152 @@
+# RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot
+
+## 1. Purpose
+
+This document records the ALGORITHMIC_HUMILITY_ENGAGED static sandbox variant for the V.I.K.I. ↔ VERITAS / RSA-compatible flow.
+
+This is the pause / human-review case in the static fixture ladder.
+
+This is the core AML/KYC scenario trigger:
+
+- required context is incomplete
+- authority evidence is insufficient
+- the upstream system emits ALGORITHMIC_HUMILITY_ENGAGED
+- VERITAS pauses continuation before final commit
+
+## 2. Current baseline
+
+The current merged baseline includes:
+
+- RSA / V.I.K.I. / VERITAS terminology synchronization.
+- Existing RSASandboxPayload receiver contract.
+- Existing evaluate_rsa_sandbox_signal(payload) mapping.
+- Existing E2E sandbox harness.
+- Existing governance-backend-fast CI coverage.
+- Existing E2E sandbox validation snapshot.
+- Existing SAFE_PROCEED validation snapshot.
+- Existing DENSITY_THROTTLED validation snapshot.
+- Existing DEFERRAL_ENGAGED validation snapshot.
+- Existing static fixture matrix.
+- Existing sandbox reviewer index.
+
+## 3. Terminology compatibility note
+
+- RSA remains the theoretical framework and underlying rule set.
+- V.I.K.I. is the operational producer of RSA-compatible upstream payloads.
+- VERITAS is the downstream commit governance boundary.
+- rsa_status remains unchanged for compatibility.
+- RSASandboxPayload remains the VERITAS-side receiver contract name.
+- upstream_signal_source = "RSA" is retained as a v1 compatibility fixture/source label.
+- That compatibility label does not mean VERITAS consumes V.I.K.I. internal reasoning.
+- VERITAS consumes only the emitted payload.
+
+## 4. Static sandbox input payload
+
+```json
+{
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "timestamp": "2026-10-25T09:15:30Z"
+}
+```
+
+## 5. Expected VERITAS decision output
+
+```json
+{
+  "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 6. Expected audit entry output
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "The workflow cannot continue toward final commit because required KYC context is incomplete and authority evidence is insufficient.",
+  "timestamp": "2026-10-25T09:15:30Z",
+  "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+}
+```
+
+## 7. What this validates
+
+- The ALGORITHMIC_HUMILITY_ENGAGED status is represented by the existing RSASandboxPayload contract.
+- VERITAS deterministically maps ALGORITHMIC_HUMILITY_ENGAGED to PAUSE_FOR_HUMAN_REVIEW.
+- VERITAS records UPSTREAM_INCOMPLETE_KYC_CONTEXT.
+- Raw upstream intent/action fields are redacted by default.
+- This variant demonstrates the pause / human-review case in the static fixture ladder.
+- This variant documents the core AML/KYC missing-context scenario.
+- The sandbox commit state remains SUSPENDED_NOT_COMMITTED.
+- The current E2E sandbox path remains reviewable without connecting live V.I.K.I. logic.
+- The `sandbox_bind_boundary_state` and `required_next_action` fields
+  appear in this variant's decision output because bind-boundary
+  evaluation is deferred until authority evidence is supplied; these
+  fields are absent from the SAFE_PROCEED and DENSITY_THROTTLED
+  snapshots where bind-boundary evaluation proceeds normally.
+
+## 8. What this does not validate
+
+- It does not connect live V.I.K.I. middleware.
+- It does not validate V.I.K.I. internal reasoning.
+- It does not prove that a real transaction or workflow is unsafe.
+- It does not determine real-world compliance status.
+- It does not implement production AML/KYC compliance.
+- It does not provide regulatory approval.
+- It does not provide third-party certification.
+- It does not provide legal advice.
+- It does not use real customer, financial, medical, KYC, or regulated data.
+- It does not change production runtime governance.
+
+## 9. Relationship to other snapshots
+
+SAFE_PROCEED:
+
+- Upstream signal indicates normal continuation.
+- VERITAS continues toward normal bind-boundary evaluation.
+- Continuation decision is CONTINUE_TO_BIND_BOUNDARY.
+
+DENSITY_THROTTLED:
+
+- Upstream output was modified for cognitive-density control.
+- VERITAS logs the intervention.
+- Continuation decision is CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED.
+
+ALGORITHMIC_HUMILITY_ENGAGED:
+
+- Required context / authority evidence is incomplete.
+- VERITAS pauses for human review.
+- Continuation decision is PAUSE_FOR_HUMAN_REVIEW.
+- Sandbox commit state is SUSPENDED_NOT_COMMITTED.
+
+DEFERRAL_ENGAGED:
+
+- A critical upstream deferral condition is reported.
+- VERITAS blocks final commit.
+- Continuation decision is BLOCK_FINAL_COMMIT.
+- Sandbox commit state is BLOCKED_NOT_COMMITTED.
+
+## 10. Next sandbox step
+
+This PR completes the per-variant static fixture ladder: all four
+variants (SAFE_PROCEED, DENSITY_THROTTLED, ALGORITHMIC_HUMILITY_ENGAGED,
+DEFERRAL_ENGAGED) now have dedicated validation snapshot pages, and the
+static fixture matrix and sandbox reviewer index have been updated to
+link this page.
+
+The next safe sandbox step is a separate design note for future live
+V.I.K.I. integration.
+
+No live V.I.K.I. connection should be added in this documentation PR.

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -23,10 +23,10 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 4. [Static fixture matrix](./rsa-veritas-static-fixture-matrix.md)
 5. [SAFE_PROCEED validation snapshot](./rsa-veritas-safe-proceed-validation-snapshot.md)
 6. [DENSITY_THROTTLED validation snapshot](./rsa-veritas-density-throttled-validation-snapshot.md)
-7. [DEFERRAL_ENGAGED validation snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
+7. [ALGORITHMIC_HUMILITY_ENGAGED validation snapshot](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
+8. [DEFERRAL_ENGAGED validation snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
 
-- `ALGORITHMIC_HUMILITY_ENGAGED` is currently covered by the broader E2E sandbox validation snapshot.
-- A dedicated `ALGORITHMIC_HUMILITY_ENGAGED` per-variant page may be added later if strict one-page-per-status symmetry is desired.
+All four static fixture variants now have dedicated per-variant validation snapshots.
 
 ## 4. Artifact map
 
@@ -38,6 +38,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 | Static fixture matrix | Compares all supported static fixture statuses. | How does VERITAS map each upstream status? |
 | SAFE_PROCEED validation snapshot | Documents normal continuation. | What happens when the upstream signal says proceed? |
 | DENSITY_THROTTLED validation snapshot | Documents soft upstream intervention. | What happens when the upstream output was modified but not hard-blocked? |
+| ALGORITHMIC_HUMILITY_ENGAGED validation snapshot | Documents pause / human-review gating for incomplete context or insufficient authority evidence. | What happens when required KYC context is incomplete? |
 | DEFERRAL_ENGAGED validation snapshot | Documents hard final-commit block. | What happens when a critical upstream deferral signal is emitted? |
 
 ## 5. Static fixture ladder
@@ -59,8 +60,8 @@ Current static fixture ladder:
 
 Clarifications:
 
-- `SAFE_PROCEED`, `DENSITY_THROTTLED`, and `DEFERRAL_ENGAGED` currently have dedicated per-variant snapshot pages.
-- `ALGORITHMIC_HUMILITY_ENGAGED` is currently covered by the broader E2E sandbox validation snapshot.
+- `SAFE_PROCEED`, `DENSITY_THROTTLED`, `ALGORITHMIC_HUMILITY_ENGAGED`, and `DEFERRAL_ENGAGED` all have dedicated per-variant snapshot pages.
+- The E2E sandbox validation snapshot remains a separate general E2E artifact.
 
 ## 6. What this documentation set validates
 
@@ -88,7 +89,7 @@ Clarifications:
 
 ## 8. Next safe sandbox steps
 
-1. Add a dedicated `ALGORITHMIC_HUMILITY_ENGAGED` per-variant validation snapshot if strict one-page-per-status symmetry is desired.
+1. Keep the static fixture matrix and reviewer index synchronized as the canonical navigation hubs for the general E2E artifact and four per-variant snapshots.
 2. Add a small generated sample output file from `examples/sandbox/rsa_veritas_e2e_harness.py` if maintainers want a committed output artifact.
 3. Add a reviewer checklist for external review.
 4. Only after the static documentation set is reviewed, consider a separate design document for live V.I.K.I. integration.

--- a/docs/en/guides/rsa-veritas-static-fixture-matrix.md
+++ b/docs/en/guides/rsa-veritas-static-fixture-matrix.md
@@ -60,9 +60,10 @@ This ladder gives reviewers a compact view of the sandbox governance behavior wi
 
 This matrix is designed to be read alongside the existing snapshot pages:
 
-- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md) — includes the ALGORITHMIC_HUMILITY_ENGAGED E2E path.
+- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md) — general E2E artifact for the static harness output path.
 - [SAFE_PROCEED validation snapshot](./rsa-veritas-safe-proceed-validation-snapshot.md)
 - [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](./rsa-veritas-density-throttled-validation-snapshot.md)
+- [RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 - [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
 
 ## 7. What this validates
@@ -87,10 +88,10 @@ This matrix is designed to be read alongside the existing snapshot pages:
 
 ## 9. Next sandbox step
 
-The current static fixture variants are now covered by the matrix and snapshot documentation. SAFE_PROCEED, DENSITY_THROTTLED, and DEFERRAL_ENGAGED have dedicated per-variant snapshots, while ALGORITHMIC_HUMILITY_ENGAGED is covered by the broader E2E sandbox validation snapshot.
+The current static fixture variants are now covered by the matrix and dedicated per-variant snapshot documentation for all four statuses: SAFE_PROCEED, DENSITY_THROTTLED, ALGORITHMIC_HUMILITY_ENGAGED, and DEFERRAL_ENGAGED.
 
-The next safe sandbox step is to add a lightweight reviewer index page linking the E2E sandbox validation snapshot, available per-variant snapshots, the static fixture matrix, the AML/KYC scenario map, and the E2E sandbox demo plan.
+The next safe sandbox step is to keep the static fixture matrix and sandbox reviewer index aligned as the canonical link hubs for the general E2E artifact and the four per-variant snapshots.
 
-If strict one-page-per-status symmetry is required later, a dedicated ALGORITHMIC_HUMILITY_ENGAGED per-variant snapshot can be added in a follow-up documentation PR.
+After that alignment is reviewed, the next safe step is a separate design note for future live V.I.K.I. integration.
 
-No live V.I.K.I. connection should be added before the reviewer index is documented and reviewed.
+No live V.I.K.I. connection should be added in this documentation PR.

--- a/docs/ja/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md
@@ -1,0 +1,156 @@
+# RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot
+
+## 英語正本
+
+- [RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot](../../en/guides/rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
+
+## 1. 目的
+
+本ドキュメントは、V.I.K.I. ↔ VERITAS / RSA-compatible flow における ALGORITHMIC_HUMILITY_ENGAGED の static sandbox variant を記録するページです。
+
+これは static fixture ladder における pause / human-review case です。
+
+この variant は、AML/KYC の中核トリガー（required context の欠落・authority evidence の不足）を扱います。
+
+- required context が incomplete
+- authority evidence が insufficient
+- upstream system が ALGORITHMIC_HUMILITY_ENGAGED を emit
+- VERITAS が final commit 前に continuation を pause
+
+## 2. 現在のベースライン
+
+現在のマージ済みベースラインには以下が含まれます。
+
+- RSA / V.I.K.I. / VERITAS terminology synchronization。
+- 既存の RSASandboxPayload receiver contract。
+- 既存の evaluate_rsa_sandbox_signal(payload) mapping。
+- 既存の E2E sandbox harness。
+- 既存の governance-backend-fast CI coverage。
+- 既存の E2E sandbox validation snapshot。
+- 既存の SAFE_PROCEED validation snapshot。
+- 既存の DENSITY_THROTTLED validation snapshot。
+- 既存の DEFERRAL_ENGAGED validation snapshot。
+- 既存の static fixture matrix。
+- 既存の sandbox reviewer index。
+
+## 3. 用語互換性ノート
+
+- RSA は theoretical framework / underlying rule set のままです。
+- V.I.K.I. は RSA-compatible upstream payloads の operational producer です。
+- VERITAS は downstream commit governance boundary です。
+- 互換性維持のため rsa_status は変更しません。
+- RSASandboxPayload は VERITAS 側 receiver contract 名として維持します。
+- upstream_signal_source = "RSA" は v1 compatibility fixture/source label として維持します。
+- この compatibility label は VERITAS が V.I.K.I. internal reasoning を消費することを意味しません。
+- VERITAS が消費するのは emitted payload のみです。
+
+## 4. Static sandbox input payload
+
+```json
+{
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "timestamp": "2026-10-25T09:15:30Z"
+}
+```
+
+## 5. Expected VERITAS decision output
+
+```json
+{
+  "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "reason_code": "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+  "authority_evidence_status": "INSUFFICIENT",
+  "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+  "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "REQUEST_ADDITIONAL_KYC_EVIDENCE_OR_HUMAN_REVIEW"
+}
+```
+
+## 6. Expected audit entry output
+
+```json
+{
+  "upstream_signal_source": "RSA",
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "original_llm_intent": "[REDACTED]",
+  "rsa_action_taken": "[REDACTED]",
+  "veritas_reason": "The workflow cannot continue toward final commit because required KYC context is incomplete and authority evidence is insufficient.",
+  "timestamp": "2026-10-25T09:15:30Z",
+  "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED"
+}
+```
+
+## 7. この文書で検証できること
+
+- ALGORITHMIC_HUMILITY_ENGAGED status が既存の RSASandboxPayload contract で表現されること。
+- VERITAS が ALGORITHMIC_HUMILITY_ENGAGED を PAUSE_FOR_HUMAN_REVIEW に deterministic にマップすること。
+- VERITAS が UPSTREAM_INCOMPLETE_KYC_CONTEXT を記録すること。
+- raw upstream intent/action fields がデフォルトで redacted されること。
+- この variant が static fixture ladder の pause / human-review case を示すこと。
+- この variant が AML/KYC missing-context scenario を文書化すること。
+- sandbox commit state が SUSPENDED_NOT_COMMITTED のまま維持されること。
+- live V.I.K.I. logic を接続せず current E2E sandbox path をレビュー可能なこと。
+- `sandbox_bind_boundary_state` と `required_next_action` フィールドが
+  この variant の decision output に含まれるのは、authority evidence が
+  供給されるまで bind-boundary evaluation が defer されるためです。
+  SAFE_PROCEED および DENSITY_THROTTLED スナップショットではこれらの
+  フィールドは存在しません（bind-boundary evaluation が正常に進行するため）。
+
+## 8. この文書で検証しないこと
+
+- live V.I.K.I. middleware への接続は行いません。
+- V.I.K.I. internal reasoning の検証は行いません。
+- 実際の transaction / workflow が unsafe であることの証明は行いません。
+- 現実世界の compliance status は判定しません。
+- production AML/KYC compliance は実装しません。
+- regulatory approval は提供しません。
+- third-party certification は提供しません。
+- legal advice は提供しません。
+- real customer, financial, medical, KYC, regulated data は使用しません。
+- production runtime governance は変更しません。
+
+## 9. 他スナップショットとの関係
+
+SAFE_PROCEED:
+
+- upstream signal は normal continuation を示します。
+- VERITAS は normal bind-boundary evaluation に向けて continuation します。
+- continuation decision は CONTINUE_TO_BIND_BOUNDARY です。
+
+DENSITY_THROTTLED:
+
+- upstream output は cognitive-density control のために modified されています。
+- VERITAS はその intervention をログします。
+- continuation decision は CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED です。
+
+ALGORITHMIC_HUMILITY_ENGAGED:
+
+- required context / authority evidence が incomplete です。
+- VERITAS は human review のために pause します。
+- continuation decision は PAUSE_FOR_HUMAN_REVIEW です。
+- sandbox commit state は SUSPENDED_NOT_COMMITTED です。
+
+DEFERRAL_ENGAGED:
+
+- critical な upstream deferral condition が報告されます。
+- VERITAS は final commit を block します。
+- continuation decision は BLOCK_FINAL_COMMIT です。
+- sandbox commit state は BLOCKED_NOT_COMMITTED です。
+
+## 10. 次の sandbox ステップ
+
+この PR により per-variant static fixture ladder が完成しました。4つの
+variant（SAFE_PROCEED、DENSITY_THROTTLED、ALGORITHMIC_HUMILITY_ENGAGED、
+DEFERRAL_ENGAGED）はすべて dedicated validation snapshot ページを持ち、
+static fixture matrix と sandbox reviewer index もこのページへのリンクを
+含む形に更新済みです。
+
+次の安全な sandbox ステップは、将来の live V.I.K.I. integration に向けた
+separate design note です。
+
+この documentation PR では live V.I.K.I. connection を追加してはいけません。

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -29,10 +29,10 @@
 4. [静的フィクスチャ・マトリクス](./rsa-veritas-static-fixture-matrix.md)
 5. [SAFE_PROCEED 検証スナップショット](./rsa-veritas-safe-proceed-validation-snapshot.md)
 6. [DENSITY_THROTTLED 検証スナップショット](./rsa-veritas-density-throttled-validation-snapshot.md)
-7. [DEFERRAL_ENGAGED 検証スナップショット](./rsa-veritas-deferral-engaged-validation-snapshot.md)
+7. [ALGORITHMIC_HUMILITY_ENGAGED 検証スナップショット](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
+8. [DEFERRAL_ENGAGED 検証スナップショット](./rsa-veritas-deferral-engaged-validation-snapshot.md)
 
-- `ALGORITHMIC_HUMILITY_ENGAGED` は、現時点では包括的な E2E sandbox validation snapshot に含まれています。
-- 厳密な one-page-per-status の対称性が必要であれば、将来 `ALGORITHMIC_HUMILITY_ENGAGED` 専用ページを追加できます。
+4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 
 ## 4. Artifact map
 
@@ -44,6 +44,7 @@
 | Static fixture matrix | サポートされる静的フィクスチャ status を比較します。 | VERITAS は各 upstream status をどうマップするか？ |
 | SAFE_PROCEED validation snapshot | 通常継続のケースを文書化します。 | upstream signal が proceed のとき何が起こるか？ |
 | DENSITY_THROTTLED validation snapshot | soft な upstream 介入を文書化します。 | upstream output が修正されたが hard-block ではない場合、何が起こるか？ |
+| ALGORITHMIC_HUMILITY_ENGAGED validation snapshot | required context 不足・authority evidence 不足時の pause / human-review gating を文書化します。 | required KYC context が incomplete の場合、何が起こるか？ |
 | DEFERRAL_ENGAGED validation snapshot | hard な final-commit block を文書化します。 | 重大な upstream deferral signal が発行された場合、何が起こるか？ |
 
 ## 5. Static fixture ladder
@@ -65,8 +66,8 @@
 
 補足:
 
-- `SAFE_PROCEED`、`DENSITY_THROTTLED`、`DEFERRAL_ENGAGED` には現時点で専用の per-variant snapshot ページがあります。
-- `ALGORITHMIC_HUMILITY_ENGAGED` は現時点では広域の E2E sandbox validation snapshot でカバーされています。
+- `SAFE_PROCEED`、`DENSITY_THROTTLED`、`ALGORITHMIC_HUMILITY_ENGAGED`、`DEFERRAL_ENGAGED` はすべて専用の per-variant snapshot ページがあります。
+- E2E sandbox validation snapshot は、別個の general E2E artifact として維持されます。
 
 ## 6. この文書セットが検証すること
 
@@ -94,7 +95,7 @@
 
 ## 8. 次の安全な sandbox ステップ
 
-1. one-page-per-status の対称性が必要であれば、`ALGORITHMIC_HUMILITY_ENGAGED` 専用の per-variant validation snapshot を追加する。
+1. general E2E artifact と4つの per-variant snapshots の導線として、static fixture matrix と reviewer index のリンク整合を維持する。
 2. maintainers がコミット済み出力 artifact を望む場合、`examples/sandbox/rsa_veritas_e2e_harness.py` から小さな生成サンプル出力ファイルを追加する。
 3. external review 向けの reviewer checklist を追加する。
 4. 静的ドキュメントセットのレビュー完了後に限り、live V.I.K.I. integration 用の別 design document を検討する。

--- a/docs/ja/guides/rsa-veritas-static-fixture-matrix.md
+++ b/docs/ja/guides/rsa-veritas-static-fixture-matrix.md
@@ -64,9 +64,10 @@ DEFERRAL_ENGAGED
 
 本マトリクスは、既存の snapshot pages と合わせて参照する想定です。
 
-- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md) — ALGORITHMIC_HUMILITY_ENGAGED の E2E path を含みます。
+- [RSA ↔ VERITAS E2E Sandbox Validation Snapshot](./rsa-veritas-e2e-sandbox-validation-snapshot.md) — static harness output path の general E2E artifact です。
 - [SAFE_PROCEED validation snapshot](./rsa-veritas-safe-proceed-validation-snapshot.md)
 - [RSA ↔ VERITAS DENSITY_THROTTLED Validation Snapshot](./rsa-veritas-density-throttled-validation-snapshot.md)
+- [RSA ↔ VERITAS ALGORITHMIC_HUMILITY_ENGAGED Validation Snapshot](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 - [RSA ↔ VERITAS DEFERRAL_ENGAGED Validation Snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
 
 ## 7. この文書で検証できること
@@ -91,10 +92,10 @@ DEFERRAL_ENGAGED
 
 ## 9. 次の sandbox ステップ
 
-現行の static fixture variants は matrix と snapshot documentation によりカバーされています。SAFE_PROCEED、DENSITY_THROTTLED、DEFERRAL_ENGAGED は個別の per-variant snapshot を持ち、ALGORITHMIC_HUMILITY_ENGAGED はより広い E2E sandbox validation snapshot でカバーされています。
+現行の static fixture variants は、SAFE_PROCEED、DENSITY_THROTTLED、ALGORITHMIC_HUMILITY_ENGAGED、DEFERRAL_ENGAGED の4ステータスすべてについて、matrix と dedicated per-variant snapshot documentation でカバーされています。
 
-次の安全な sandbox ステップは、E2E sandbox validation snapshot、利用可能な per-variant snapshots、static fixture matrix、AML/KYC scenario map、E2E sandbox demo plan をリンクする lightweight reviewer index page の追加です。
+次の安全な sandbox ステップは、general E2E artifact と4つの per-variant snapshots へのリンクハブとして、static fixture matrix と sandbox reviewer index の整合を維持することです。
 
-将来的に 1 status = 1 page の対称性を厳密に求める場合は、ALGORITHMIC_HUMILITY_ENGAGED の専用 per-variant snapshot を後続の documentation PR で追加できます。
+その整合レビュー後の次の安全なステップは、将来の live V.I.K.I. integration に向けた separate design note です。
 
-reviewer index page が文書化・レビューされる前に、live V.I.K.I. connection を追加すべきではありません。
+この documentation PR で live V.I.K.I. connection を追加してはいけません。


### PR DESCRIPTION
### Motivation

- Provide a dedicated static validation snapshot for the `ALGORITHMIC_HUMILITY_ENGAGED` sandbox variant that documents the pause / human-review AML/KYC scenario. 
- Ensure the static fixture matrix and reviewer index reflect parity across all four sandbox variants for clearer reviewer navigation. 
- Keep the documentation reviewable without connecting live V.I.K.I. middleware by adding per-variant artifacts for reviewers. 

### Description

- Add new English and Japanese validation snapshot files `rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md` that define input payload, expected VERITAS decision output, and expected audit entry for the `ALGORITHMIC_HUMILITY_ENGAGED` case. 
- Update the English and Japanese reviewer index files `rsa-veritas-sandbox-reviewer-index.md` to insert the new snapshot into the recommended reading order and artifact map, and to state that all four variants now have per-variant snapshots. 
- Update the English and Japanese static fixture matrix files `rsa-veritas-static-fixture-matrix.md` to include `ALGORITHMIC_HUMILITY_ENGAGED` in the matrix links and to realign wording about the general E2E artifact versus per-variant snapshots. 
- Maintain wording that no live V.I.K.I. connection should be added in this documentation PR and that the change is documentation-only. 

### Testing

- This is a documentation-only change and no unit tests were modified. 
- The repository documentation build and link-checking CI were exercised as part of the doc review pipeline and completed successfully. 
- Markdown linting for the modified files passed in the automated doc checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be8a927008326a82ad9d5a814dcd7)