### PR TITLE
docs: add RSA ↔ VERITAS Live V.I.K.I. integration design note (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-live-viki-integration-design-note.md
+++ b/docs/en/guides/rsa-veritas-live-viki-integration-design-note.md
@@ -1,0 +1,197 @@
+# RSA ↔ VERITAS Live V.I.K.I. Integration Design Note
+
+## 1. Purpose
+
+This document is a design note for a possible future live V.I.K.I. integration.
+
+- This is not a runtime implementation.
+- This is not a live middleware connection.
+- This is not production AML/KYC compliance.
+- This is a boundary and validation design note for future review.
+
+## 2. Current static baseline
+
+The static sandbox documentation set already includes:
+
+- AML/KYC scenario map.
+- E2E sandbox demo plan.
+- E2E sandbox validation snapshot.
+- Static fixture matrix.
+- Sandbox reviewer index.
+- SAFE_PROCEED validation snapshot.
+- DENSITY_THROTTLED validation snapshot.
+- ALGORITHMIC_HUMILITY_ENGAGED validation snapshot.
+- DEFERRAL_ENGAGED validation snapshot.
+
+The static fixture ladder is now symmetrical:
+
+- SAFE_PROCEED
+- DENSITY_THROTTLED
+- ALGORITHMIC_HUMILITY_ENGAGED
+- DEFERRAL_ENGAGED
+
+## 3. Boundary model
+
+RSA:
+
+- theoretical framework and underlying rule set.
+
+V.I.K.I.:
+
+- operational middleware.
+- performs upstream behavioral/context checks.
+- emits RSA-compatible upstream payloads.
+- remains external to VERITAS.
+
+VERITAS:
+
+- consumes only the emitted payload.
+- does not consume V.I.K.I. internal reasoning.
+- maps the emitted payload to continuation decisions.
+- emits audit entries.
+- prevents unsafe final commit where applicable.
+
+## 4. Compatibility contract
+
+The following names remain stable in the v1 sandbox contract:
+
+- rsa_status
+- RSASandboxPayload
+- evaluate_rsa_sandbox_signal()
+- upstream_signal_source = "RSA"
+
+Notes:
+
+- upstream_signal_source = "RSA" remains a v1 compatibility fixture/source label.
+- This label does not mean VERITAS consumes V.I.K.I. internal reasoning.
+- A future live V.I.K.I. integration may emit RSA-compatible payloads into the same receiver contract.
+- Any renaming such as viki_status or VIKIPayload should be considered a separate v2 migration and must not be mixed into the v1 live integration design.
+
+## 5. Proposed live integration flow
+
+V.I.K.I. runtime check
+→ RSA-compatible upstream payload emitted
+→ RSASandboxPayload validation at VERITAS boundary
+→ evaluate_rsa_sandbox_signal(payload)
+→ VERITAS continuation decision
+→ audit entry
+→ commit state decision
+
+Additional constraints:
+
+- VERITAS must only trust the emitted payload after schema validation.
+- VERITAS must not ingest V.I.K.I. hidden reasoning, chain-of-thought, or raw internal model state.
+- Any raw upstream fields that may contain sensitive intent/action data should remain redacted by default in audit output.
+
+## 6. Phase gates before live connection
+
+Phase 0: Current static sandbox
+
+- Static fixtures only.
+- No network connection.
+- No live middleware.
+- No real regulated data.
+
+Phase 1: Contract-only live adapter design
+
+- Define payload schema boundaries.
+- Define allowed enum values.
+- Define redaction expectations.
+- Define error handling and reject behavior.
+- No runtime connection yet.
+
+Phase 2: Local mock adapter
+
+- Local mock V.I.K.I. emitter.
+- Deterministic test payloads.
+- No external network.
+- No secrets.
+- No real data.
+
+Phase 3: Controlled integration test
+
+- Explicitly gated.
+- Test-only environment.
+- Synthetic data only.
+- No production commit authority.
+- Full audit output review.
+
+Phase 4: Future production-readiness review
+
+- Separate review.
+- Separate security model.
+- Separate compliance review.
+- Separate operational approval.
+- Not covered by this design note.
+
+## 7. Failure and reject behavior
+
+- Unknown rsa_status must be rejected or mapped to safe failure behavior.
+- Malformed payloads must not proceed.
+- Missing required fields must not proceed.
+- Invalid timestamps should be recorded or rejected according to future schema rules.
+- Untrusted raw upstream content must not be included in audit output without redaction.
+- Live integration must fail closed when payload validity cannot be established.
+- Final commit must not occur from an unvalidated live signal.
+
+## 8. Audit and redaction expectations
+
+- Audit entries should preserve the VERITAS decision and reason code.
+- Raw upstream intent/action fields should remain redacted by default.
+- The audit entry should show enough information for review without exposing V.I.K.I. internal reasoning.
+- The boundary should remain reviewable by external auditors.
+
+## 9. Security and privacy constraints
+
+- No secrets in docs.
+- No API keys.
+- No webhook URLs.
+- No production endpoints.
+- No real customer data.
+- No financial account data.
+- No medical data.
+- No KYC documents.
+- No regulated data.
+- No live production workflow authority.
+
+## 10. What this design note validates
+
+- The intended live integration boundary is documented.
+- The static sandbox artifacts now have a path toward a future live adapter.
+- The v1 compatibility contract remains stable.
+- VERITAS remains downstream-only.
+- V.I.K.I. remains external.
+- Live integration is explicitly gated and not silently introduced.
+
+## 11. What this design note does not validate
+
+- It does not connect live V.I.K.I. middleware.
+- It does not validate V.I.K.I. internal reasoning.
+- It does not validate network transport.
+- It does not validate authentication or authorization.
+- It does not validate production compliance.
+- It does not validate real AML/KYC use.
+- It does not provide regulatory approval.
+- It does not provide legal advice.
+- It does not change production runtime behavior.
+
+## 12. Open questions before implementation
+
+- What exact live payload transport would be used?
+- How would payload authenticity be verified?
+- How would replay protection work?
+- How would schema versioning be handled?
+- Should v1 keep rsa_status permanently or introduce v2 viki_status later?
+- What audit fields are mandatory for live review?
+- What failure mode is required for each malformed payload class?
+- What environment gating is required before controlled integration tests?
+- Who approves moving from local mock adapter to controlled integration test?
+
+## 13. Recommended next PR after this note
+
+After this design note is merged, the next safe PR should be either:
+
+- a reviewer checklist for the live integration design, or
+- a local mock adapter design note.
+
+Do not implement live V.I.K.I. integration until the design note and checklist are reviewed.

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -25,6 +25,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 6. [DENSITY_THROTTLED validation snapshot](./rsa-veritas-density-throttled-validation-snapshot.md)
 7. [ALGORITHMIC_HUMILITY_ENGAGED validation snapshot](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 8. [DEFERRAL_ENGAGED validation snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
+9. [Live V.I.K.I. integration design note (future design artifact)](./rsa-veritas-live-viki-integration-design-note.md)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 
@@ -97,3 +98,5 @@ Clarifications:
 No live V.I.K.I. connection should be added in this PR.
 
 Live integration should be a later design phase, not part of the static sandbox documentation pass.
+
+The live V.I.K.I. integration page in this set is a future-design artifact only and does not introduce runtime integration.

--- a/docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md
+++ b/docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md
@@ -1,0 +1,201 @@
+# RSA ↔ VERITAS Live V.I.K.I. Integration Design Note
+
+## 英語正本
+
+- [RSA ↔ VERITAS Live V.I.K.I. Integration Design Note](../../en/guides/rsa-veritas-live-viki-integration-design-note.md)
+
+## 1. 目的
+
+この文書は、将来の live V.I.K.I. integration に向けた設計メモ（design note）です。
+
+- これは runtime implementation ではありません。
+- これは live middleware connection ではありません。
+- これは production AML/KYC compliance ではありません。
+- これは将来レビューのための boundary と validation の設計メモです。
+
+## 2. 現在の静的ベースライン
+
+静的 sandbox 文書セットには、すでに以下が含まれています。
+
+- AML/KYC scenario map
+- E2E sandbox demo plan
+- E2E sandbox validation snapshot
+- Static fixture matrix
+- Sandbox reviewer index
+- SAFE_PROCEED validation snapshot
+- DENSITY_THROTTLED validation snapshot
+- ALGORITHMIC_HUMILITY_ENGAGED validation snapshot
+- DEFERRAL_ENGAGED validation snapshot
+
+static fixture ladder は現在、対称的にそろっています。
+
+- SAFE_PROCEED
+- DENSITY_THROTTLED
+- ALGORITHMIC_HUMILITY_ENGAGED
+- DEFERRAL_ENGAGED
+
+## 3. Boundary model
+
+RSA:
+
+- theoretical framework と underlying rule set。
+
+V.I.K.I.:
+
+- operational middleware。
+- upstream behavioral/context checks を実行。
+- RSA-compatible な upstream payloads を emit。
+- VERITAS の外部コンポーネントとして存在。
+
+VERITAS:
+
+- emit された payload のみを consume。
+- V.I.K.I. internal reasoning は consume しない。
+- emit された payload を continuation decision に map。
+- audit entries を emit。
+- 必要に応じ unsafe final commit を防止。
+
+## 4. Compatibility contract
+
+v1 sandbox contract では、次の名称を安定維持します。
+
+- rsa_status
+- RSASandboxPayload
+- evaluate_rsa_sandbox_signal()
+- upstream_signal_source = "RSA"
+
+補足:
+
+- upstream_signal_source = "RSA" は、v1 compatibility fixture/source label として維持します。
+- この label は、VERITAS が V.I.K.I. internal reasoning を consume することを意味しません。
+- 将来の live V.I.K.I. integration では、同じ receiver contract に RSA-compatible payloads を emit できます。
+- viki_status や VIKIPayload などの rename は、別の v2 migration として扱い、v1 live integration design に混在させません。
+
+## 5. 提案される live integration flow
+
+V.I.K.I. runtime check
+→ RSA-compatible upstream payload emitted
+→ VERITAS boundary で RSASandboxPayload validation
+→ evaluate_rsa_sandbox_signal(payload)
+→ VERITAS continuation decision
+→ audit entry
+→ commit state decision
+
+追加制約:
+
+- VERITAS は schema validation 後の emitted payload のみを trust する必要があります。
+- VERITAS は V.I.K.I. の hidden reasoning、chain-of-thought、raw internal model state を ingest してはいけません。
+- sensitive intent/action data を含みうる raw upstream fields は、audit output でデフォルト redacted を維持する必要があります。
+
+## 6. live connection 前の phase gate
+
+Phase 0: Current static sandbox
+
+- Static fixtures only
+- No network connection
+- No live middleware
+- No real regulated data
+
+Phase 1: Contract-only live adapter design
+
+- payload schema boundaries を定義
+- allowed enum values を定義
+- redaction expectations を定義
+- error handling と reject behavior を定義
+- まだ runtime connection は行わない
+
+Phase 2: Local mock adapter
+
+- local mock V.I.K.I. emitter
+- deterministic test payloads
+- no external network
+- no secrets
+- no real data
+
+Phase 3: Controlled integration test
+
+- 明示的 gate を必須化
+- test-only environment
+- synthetic data only
+- no production commit authority
+- full audit output review
+
+Phase 4: Future production-readiness review
+
+- separate review
+- separate security model
+- separate compliance review
+- separate operational approval
+- この design note の対象外
+
+## 7. Failure と reject behavior
+
+- 未知の rsa_status は reject するか safe failure behavior に map する必要があります。
+- malformed payloads は proceed してはいけません。
+- required fields 欠落時は proceed してはいけません。
+- invalid timestamps は将来 schema rules に従って記録または reject します。
+- untrusted raw upstream content は、redaction なしで audit output に含めてはいけません。
+- payload validity を確立できない場合、live integration は fail closed で動作する必要があります。
+- unvalidated live signal から final commit を行ってはいけません。
+
+## 8. Audit と redaction の期待値
+
+- audit entries は VERITAS decision と reason code を保持する必要があります。
+- raw upstream intent/action fields はデフォルトで redacted を維持する必要があります。
+- audit entry は、V.I.K.I. internal reasoning を露出せずに review 可能な情報量を示す必要があります。
+- boundary は external auditors から reviewable な状態を維持する必要があります。
+
+## 9. Security と privacy の制約
+
+- No secrets in docs
+- No API keys
+- No webhook URLs
+- No production endpoints
+- No real customer data
+- No financial account data
+- No medical data
+- No KYC documents
+- No regulated data
+- No live production workflow authority
+
+## 10. この design note が検証すること
+
+- 意図した live integration boundary が文書化されていること。
+- static sandbox artifacts から将来 live adapter へ進む経路が示されていること。
+- v1 compatibility contract が安定維持されること。
+- VERITAS が downstream-only であること。
+- V.I.K.I. が external component であること。
+- live integration が明示的に gate され、暗黙導入されないこと。
+
+## 11. この design note が検証しないこと
+
+- live V.I.K.I. middleware を接続しません。
+- V.I.K.I. internal reasoning を検証しません。
+- network transport を検証しません。
+- authentication / authorization を検証しません。
+- production compliance を検証しません。
+- real AML/KYC use を検証しません。
+- regulatory approval を提供しません。
+- legal advice を提供しません。
+- production runtime behavior を変更しません。
+
+## 12. 実装前の open questions
+
+- 実際の live payload transport は何を使うべきか？
+- payload authenticity をどのように検証するか？
+- replay protection をどう設計するか？
+- schema versioning をどう扱うか？
+- v1 で rsa_status を恒久維持するか、将来 v2 で viki_status を導入するか？
+- live review のために必須となる audit fields は何か？
+- malformed payload のクラスごとに必要な failure mode は何か？
+- controlled integration tests 前に必要な environment gating は何か？
+- local mock adapter から controlled integration test への移行は誰が承認するか？
+
+## 13. このノート後の推奨 PR
+
+この design note のマージ後、次の安全な PR は次のいずれかに限定します。
+
+- live integration design 向け reviewer checklist
+- local mock adapter design note
+
+design note と checklist のレビュー完了までは、live V.I.K.I. integration を実装してはいけません。

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -31,6 +31,7 @@
 6. [DENSITY_THROTTLED 検証スナップショット](./rsa-veritas-density-throttled-validation-snapshot.md)
 7. [ALGORITHMIC_HUMILITY_ENGAGED 検証スナップショット](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 8. [DEFERRAL_ENGAGED 検証スナップショット](./rsa-veritas-deferral-engaged-validation-snapshot.md)
+9. [Live V.I.K.I. integration design note（将来設計アーティファクト）](./rsa-veritas-live-viki-integration-design-note.md)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 
@@ -103,3 +104,5 @@
 この PR で live V.I.K.I. connection を追加してはいけません。
 
 live integration は後続の design phase とし、静的 sandbox documentation pass には含めません。
+
+本索引に追加された live V.I.K.I. integration ページは将来設計アーティファクトのみであり、runtime integration は導入しません。


### PR DESCRIPTION
### Motivation

- Document a guarded, non-runtime design note describing a future live V.I.K.I. integration boundary for the RSA ↔ VERITAS sandbox without introducing any live middleware or runtime wiring. 
- Preserve the existing static sandbox as the validated baseline while providing a clear path, constraints, and phase gates toward any future live adapter. 
- Explicitly keep v1 compatibility names and receiver contract assumptions stable (for example `rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`, and `upstream_signal_source = "RSA"`).

### Description

- Add English design note at `docs/en/guides/rsa-veritas-live-viki-integration-design-note.md` that covers purpose, current static baseline, boundary model, compatibility contract, proposed flow, phase gates, failure behavior, audit/redaction expectations, security/privacy constraints, validated/non-validated scope, open questions, and recommended next PRs. 
- Add aligned Japanese design note at `docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md` that includes the required `## 英語正本` link and preserves the specified technical terms and enum/key names untranslated. 
- Update the EN/JA reviewer index pages (`docs/en/guides/rsa-veritas-sandbox-reviewer-index.md` and `docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md`) to include the new design note as a "future-design artifact" and to clarify that this is documentation-only and does not introduce runtime integration. 
- No runtime, test, CI, schema, field, name, network, credential, or production claims were added or modified.

### Testing

- Verified file creation and contents by listing and printing the new files with `nl -ba` and confirmed their inclusion in the repository. (succeeded) 
- Updated reviewer index files and inspected diffs with `git diff` to confirm the new links and clarifying language were added. (succeeded) 
- Committed the changes and recorded PR metadata via the local `make_pr` helper which produced the PR title/body. (succeeded) 
- A scripted Python edit attempt emitted a local `pyenv` version warning but did not affect the committed documentation edits, and all repository changes were committed despite that environment warning. (warning observed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1f5e848c8326a7a28593398994fc)