### PR TITLE
docs: add RSA↔VERITAS live V.I.K.I. integration reviewer checklist (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-live-viki-integration-design-note.md
+++ b/docs/en/guides/rsa-veritas-live-viki-integration-design-note.md
@@ -8,6 +8,11 @@ This document is a design note for a possible future live V.I.K.I. integration.
 - This is not a live middleware connection.
 - This is not production AML/KYC compliance.
 - This is a boundary and validation design note for future review.
+- This design note should be reviewed together with the reviewer checklist.
+
+Related review-gate artifact:
+
+- [Live V.I.K.I. integration reviewer checklist](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 
 ## 2. Current static baseline
 
@@ -22,6 +27,7 @@ The static sandbox documentation set already includes:
 - DENSITY_THROTTLED validation snapshot.
 - ALGORITHMIC_HUMILITY_ENGAGED validation snapshot.
 - DEFERRAL_ENGAGED validation snapshot.
+- Live V.I.K.I. integration reviewer checklist (documentation-only review-gate artifact).
 
 The static fixture ladder is now symmetrical:
 

--- a/docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
+++ b/docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
@@ -1,0 +1,137 @@
+# RSA ↔ VERITAS Live V.I.K.I. Integration Reviewer Checklist
+
+## 1. Purpose
+
+This checklist is for reviewing future live V.I.K.I. integration proposals.
+
+- This checklist is not a runtime implementation.
+- This checklist does not connect live V.I.K.I. middleware.
+- This checklist is a review gate before any live adapter work.
+- This checklist should be used with the Live V.I.K.I. Integration Design Note.
+
+References:
+
+- [Live V.I.K.I. integration design note](./rsa-veritas-live-viki-integration-design-note.md)
+- [Sandbox reviewer index](./rsa-veritas-sandbox-reviewer-index.md)
+
+## 2. Review status legend
+
+- PASS: requirement is satisfied.
+- FAIL: requirement is violated.
+- NEEDS DESIGN: requirement is not yet specified.
+- BLOCKER: issue must be resolved before implementation.
+- NOT APPLICABLE: requirement does not apply to the reviewed proposal.
+
+## 3. Boundary checklist
+
+- [ ] RSA is treated only as the theoretical framework / underlying rule set.
+- [ ] V.I.K.I. remains external to VERITAS.
+- [ ] VERITAS consumes only emitted RSA-compatible payloads.
+- [ ] VERITAS does not consume V.I.K.I. internal reasoning.
+- [ ] VERITAS does not ingest hidden reasoning, chain-of-thought, or raw internal model state.
+- [ ] VERITAS remains responsible only for downstream continuation decision, audit entry, and commit-state control.
+- [ ] The live adapter does not bypass VERITAS boundary validation.
+
+## 4. Compatibility contract checklist
+
+- [ ] rsa_status remains unchanged for v1 compatibility.
+- [ ] RSASandboxPayload remains the VERITAS-side receiver contract name.
+- [ ] evaluate_rsa_sandbox_signal() remains the boundary evaluation entrypoint.
+- [ ] upstream_signal_source = "RSA" remains a v1 compatibility fixture/source label unless a separate v2 migration is explicitly approved.
+- [ ] No viki_status or VIKIPayload rename is introduced in the v1 live integration path.
+- [ ] Any v2 naming migration is documented separately and not mixed into this v1 design.
+
+## 5. Payload schema checklist
+
+- [ ] Allowed rsa_status values are explicitly defined.
+- [ ] Required fields are explicitly defined.
+- [ ] Optional fields are explicitly defined.
+- [ ] Unknown fields behavior is explicitly defined.
+- [ ] Missing required fields fail closed.
+- [ ] Malformed payloads fail closed.
+- [ ] Unknown rsa_status values fail closed or map to a safe failure state.
+- [ ] Timestamp validation behavior is defined.
+- [ ] Schema versioning behavior is defined.
+- [ ] Replay protection expectations are defined before live transport is added.
+
+## 6. Audit and redaction checklist
+
+- [ ] Audit entries preserve VERITAS continuation_decision.
+- [ ] Audit entries preserve VERITAS reason_code.
+- [ ] Raw upstream original_llm_intent remains redacted by default.
+- [ ] Raw upstream rsa_action_taken remains redacted by default.
+- [ ] Audit output does not expose V.I.K.I. internal reasoning.
+- [ ] Audit output contains enough information for external review.
+- [ ] Redaction behavior is tested or explicitly planned before live integration.
+
+## 7. Failure-mode checklist
+
+- [ ] Unknown rsa_status cannot proceed silently.
+- [ ] Missing required fields cannot proceed silently.
+- [ ] Invalid payload shape cannot proceed silently.
+- [ ] Untrusted raw upstream content cannot enter audit output without redaction.
+- [ ] Final commit cannot occur from an unvalidated live signal.
+- [ ] Live integration fails closed when payload validity cannot be established.
+- [ ] Operator-facing remediation or next-action guidance is defined for each failure class.
+
+## 8. Security and privacy checklist
+
+- [ ] No secrets are committed.
+- [ ] No API keys are committed.
+- [ ] No webhook URLs are committed.
+- [ ] No production endpoints are committed.
+- [ ] No credentials are committed.
+- [ ] No real customer data is used.
+- [ ] No financial account data is used.
+- [ ] No medical data is used.
+- [ ] No KYC documents are used.
+- [ ] No regulated data is used.
+- [ ] Synthetic data is used for all test examples.
+- [ ] No live production workflow authority is introduced.
+
+## 9. Environment gate checklist
+
+- [ ] Phase 0 remains static sandbox only.
+- [ ] Phase 1 is contract-only design.
+- [ ] Phase 2 is local mock adapter only.
+- [ ] Phase 3 controlled integration test requires explicit approval.
+- [ ] Phase 4 production-readiness review is separate and out of scope.
+- [ ] No phase is skipped.
+- [ ] Moving between phases requires reviewer approval.
+- [ ] Test-only environment is required before any controlled integration.
+- [ ] Synthetic data is mandatory before any controlled integration.
+
+## 10. Non-goals checklist
+
+- [ ] The proposal does not claim production AML/KYC compliance.
+- [ ] The proposal does not claim regulatory approval.
+- [ ] The proposal does not claim third-party certification.
+- [ ] The proposal does not provide legal advice.
+- [ ] The proposal does not claim real-world transaction safety.
+- [ ] The proposal does not introduce live V.I.K.I. connection in documentation-only PRs.
+- [ ] The proposal does not change production runtime governance without a separate implementation PR.
+
+## 11. Reviewer decision template
+
+Reviewer decision:
+- Status: PASS / FAIL / NEEDS DESIGN / BLOCKER / NOT APPLICABLE
+- Reviewed artifact:
+- Boundary concerns:
+- Schema concerns:
+- Audit/redaction concerns:
+- Security/privacy concerns:
+- Required follow-up:
+- Approved next phase:
+- Reviewer:
+- Date:
+
+## 12. Recommended next PR after this checklist
+
+After this checklist is merged, the next safe PR should be one of:
+
+- local mock adapter design note
+- local mock adapter test fixture plan
+- live payload schema draft
+- controlled integration threat model
+
+Do not implement live V.I.K.I. integration until the design note and reviewer checklist are reviewed.

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -26,6 +26,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 7. [ALGORITHMIC_HUMILITY_ENGAGED validation snapshot](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 8. [DEFERRAL_ENGAGED validation snapshot](./rsa-veritas-deferral-engaged-validation-snapshot.md)
 9. [Live V.I.K.I. integration design note (future design artifact)](./rsa-veritas-live-viki-integration-design-note.md)
+10. [Live V.I.K.I. integration reviewer checklist (review-gate artifact, documentation-only)](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 
@@ -92,8 +93,8 @@ Clarifications:
 
 1. Keep the static fixture matrix and reviewer index synchronized as the canonical navigation hubs for the general E2E artifact and four per-variant snapshots.
 2. Add a small generated sample output file from `examples/sandbox/rsa_veritas_e2e_harness.py` if maintainers want a committed output artifact.
-3. Add a reviewer checklist for external review.
-4. Only after the static documentation set is reviewed, consider a separate design document for live V.I.K.I. integration.
+3. Use the live integration reviewer checklist as a required review-gate artifact for future live adapter proposals.
+4. Only after the static documentation set is reviewed, consider a separate design or contract artifact for live V.I.K.I. integration.
 
 No live V.I.K.I. connection should be added in this PR.
 

--- a/docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md
+++ b/docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md
@@ -12,6 +12,11 @@
 - これは live middleware connection ではありません。
 - これは production AML/KYC compliance ではありません。
 - これは将来レビューのための boundary と validation の設計メモです。
+- この design note は reviewer checklist と併読してレビューします。
+
+関連する review-gate artifact:
+
+- [Live V.I.K.I. integration reviewer checklist](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 
 ## 2. 現在の静的ベースライン
 
@@ -26,6 +31,7 @@
 - DENSITY_THROTTLED validation snapshot
 - ALGORITHMIC_HUMILITY_ENGAGED validation snapshot
 - DEFERRAL_ENGAGED validation snapshot
+- Live V.I.K.I. integration reviewer checklist（documentation-only の review-gate artifact）
 
 static fixture ladder は現在、対称的にそろっています。
 

--- a/docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
+++ b/docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
@@ -1,0 +1,141 @@
+# RSA ↔ VERITAS Live V.I.K.I. Integration Reviewer Checklist
+
+## 英語正本
+
+- [RSA ↔ VERITAS Live V.I.K.I. Integration Reviewer Checklist](../../en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md)
+
+## 1. 目的
+
+このチェックリストは、将来の live V.I.K.I. integration 提案をレビューするための文書です。
+
+- このチェックリストは runtime implementation ではありません。
+- このチェックリストは live V.I.K.I. middleware を接続しません。
+- このチェックリストは、live adapter 作業の前段で適用する review gate です。
+- このチェックリストは、Live V.I.K.I. Integration Design Note と併用してください。
+
+参照先:
+
+- [Live V.I.K.I. integration design note](./rsa-veritas-live-viki-integration-design-note.md)
+- [Sandbox reviewer index](./rsa-veritas-sandbox-reviewer-index.md)
+
+## 2. Review status legend
+
+- PASS: requirement is satisfied.
+- FAIL: requirement is violated.
+- NEEDS DESIGN: requirement is not yet specified.
+- BLOCKER: issue must be resolved before implementation.
+- NOT APPLICABLE: requirement does not apply to the reviewed proposal.
+
+## 3. Boundary checklist
+
+- [ ] RSA is treated only as the theoretical framework / underlying rule set.
+- [ ] V.I.K.I. remains external to VERITAS.
+- [ ] VERITAS consumes only emitted RSA-compatible payloads.
+- [ ] VERITAS does not consume V.I.K.I. internal reasoning.
+- [ ] VERITAS does not ingest hidden reasoning, chain-of-thought, or raw internal model state.
+- [ ] VERITAS remains responsible only for downstream continuation decision, audit entry, and commit-state control.
+- [ ] The live adapter does not bypass VERITAS boundary validation.
+
+## 4. Compatibility contract checklist
+
+- [ ] rsa_status remains unchanged for v1 compatibility.
+- [ ] RSASandboxPayload remains the VERITAS-side receiver contract name.
+- [ ] evaluate_rsa_sandbox_signal() remains the boundary evaluation entrypoint.
+- [ ] upstream_signal_source = "RSA" remains a v1 compatibility fixture/source label unless a separate v2 migration is explicitly approved.
+- [ ] No viki_status or VIKIPayload rename is introduced in the v1 live integration path.
+- [ ] Any v2 naming migration is documented separately and not mixed into this v1 design.
+
+## 5. Payload schema checklist
+
+- [ ] Allowed rsa_status values are explicitly defined.
+- [ ] Required fields are explicitly defined.
+- [ ] Optional fields are explicitly defined.
+- [ ] Unknown fields behavior is explicitly defined.
+- [ ] Missing required fields fail closed.
+- [ ] Malformed payloads fail closed.
+- [ ] Unknown rsa_status values fail closed or map to a safe failure state.
+- [ ] Timestamp validation behavior is defined.
+- [ ] Schema versioning behavior is defined.
+- [ ] Replay protection expectations are defined before live transport is added.
+
+## 6. Audit and redaction checklist
+
+- [ ] Audit entries preserve VERITAS continuation_decision.
+- [ ] Audit entries preserve VERITAS reason_code.
+- [ ] Raw upstream original_llm_intent remains redacted by default.
+- [ ] Raw upstream rsa_action_taken remains redacted by default.
+- [ ] Audit output does not expose V.I.K.I. internal reasoning.
+- [ ] Audit output contains enough information for external review.
+- [ ] Redaction behavior is tested or explicitly planned before live integration.
+
+## 7. Failure-mode checklist
+
+- [ ] Unknown rsa_status cannot proceed silently.
+- [ ] Missing required fields cannot proceed silently.
+- [ ] Invalid payload shape cannot proceed silently.
+- [ ] Untrusted raw upstream content cannot enter audit output without redaction.
+- [ ] Final commit cannot occur from an unvalidated live signal.
+- [ ] Live integration fails closed when payload validity cannot be established.
+- [ ] Operator-facing remediation or next-action guidance is defined for each failure class.
+
+## 8. Security and privacy checklist
+
+- [ ] No secrets are committed.
+- [ ] No API keys are committed.
+- [ ] No webhook URLs are committed.
+- [ ] No production endpoints are committed.
+- [ ] No credentials are committed.
+- [ ] No real customer data is used.
+- [ ] No financial account data is used.
+- [ ] No medical data is used.
+- [ ] No KYC documents are used.
+- [ ] No regulated data is used.
+- [ ] Synthetic data is used for all test examples.
+- [ ] No live production workflow authority is introduced.
+
+## 9. Environment gate checklist
+
+- [ ] Phase 0 remains static sandbox only.
+- [ ] Phase 1 is contract-only design.
+- [ ] Phase 2 is local mock adapter only.
+- [ ] Phase 3 controlled integration test requires explicit approval.
+- [ ] Phase 4 production-readiness review is separate and out of scope.
+- [ ] No phase is skipped.
+- [ ] Moving between phases requires reviewer approval.
+- [ ] Test-only environment is required before any controlled integration.
+- [ ] Synthetic data is mandatory before any controlled integration.
+
+## 10. Non-goals checklist
+
+- [ ] The proposal does not claim production AML/KYC compliance.
+- [ ] The proposal does not claim regulatory approval.
+- [ ] The proposal does not claim third-party certification.
+- [ ] The proposal does not provide legal advice.
+- [ ] The proposal does not claim real-world transaction safety.
+- [ ] The proposal does not introduce live V.I.K.I. connection in documentation-only PRs.
+- [ ] The proposal does not change production runtime governance without a separate implementation PR.
+
+## 11. Reviewer decision template
+
+Reviewer decision:
+- Status: PASS / FAIL / NEEDS DESIGN / BLOCKER / NOT APPLICABLE
+- Reviewed artifact:
+- Boundary concerns:
+- Schema concerns:
+- Audit/redaction concerns:
+- Security/privacy concerns:
+- Required follow-up:
+- Approved next phase:
+- Reviewer:
+- Date:
+
+## 12. このチェックリスト後の推奨 PR
+
+このチェックリストのマージ後、次の安全な PR は次のいずれかです。
+
+- local mock adapter design note
+- local mock adapter test fixture plan
+- live payload schema draft
+- controlled integration threat model
+
+design note と reviewer checklist のレビュー完了前に、live V.I.K.I. integration を実装してはいけません。

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -32,6 +32,7 @@
 7. [ALGORITHMIC_HUMILITY_ENGAGED 検証スナップショット](./rsa-veritas-algorithmic-humility-engaged-validation-snapshot.md)
 8. [DEFERRAL_ENGAGED 検証スナップショット](./rsa-veritas-deferral-engaged-validation-snapshot.md)
 9. [Live V.I.K.I. integration design note（将来設計アーティファクト）](./rsa-veritas-live-viki-integration-design-note.md)
+10. [Live V.I.K.I. integration reviewer checklist（review-gate artifact / documentation-only）](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 
@@ -98,8 +99,8 @@
 
 1. general E2E artifact と4つの per-variant snapshots の導線として、static fixture matrix と reviewer index のリンク整合を維持する。
 2. maintainers がコミット済み出力 artifact を望む場合、`examples/sandbox/rsa_veritas_e2e_harness.py` から小さな生成サンプル出力ファイルを追加する。
-3. external review 向けの reviewer checklist を追加する。
-4. 静的ドキュメントセットのレビュー完了後に限り、live V.I.K.I. integration 用の別 design document を検討する。
+3. live adapter 提案時の review gate として reviewer checklist を利用する。
+4. 静的ドキュメントセットのレビュー完了後に限り、live V.I.K.I. integration 用の別 design / contract artifact を検討する。
 
 この PR で live V.I.K.I. connection を追加してはいけません。
 


### PR DESCRIPTION
### Motivation

- Provide a clear, review-gate checklist for any future live V.I.K.I. integration proposals so reviewers can verify boundary separation, compatibility, schema validation, fail-closed behavior, audit redaction, and security/privacy constraints.
- Ensure the reviewer artifact is documentation-only and explicitly forbids runtime connection, production claims, secrets, or live data until separate, approved implementation phases.

### Description

- Add `docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md` containing the requested sections, status legend, boundary/compatibility/schema/audit/failure/security/environment/non-goals checklists, reviewer decision template, and recommended next PRs. 
- Add `docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md` as a Japanese-first aligned translation that preserves the exact technical terms and enum/JSON keys and links to the English source via the required `英語正本` block. 
- Update `docs/en/guides/rsa-veritas-sandbox-reviewer-index.md` and `docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md` to link the new checklist as a review-gate artifact and to clarify the recommended next steps. 
- Update `docs/en/guides/rsa-veritas-live-viki-integration-design-note.md` and `docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md` to reference the reviewer checklist and clarify that the design note must be reviewed together with the checklist; no runtime, schema, tests, CI, or network behaviors were changed. 

### Testing

- Created the EN/JA checklist files and verified their contents with file-inspection commands (content printed and reviewed via `nl -ba`/`sed`) and those checks completed successfully. 
- Updated index and design-note pages and validated the updated link text and inserted checklist references via the same content-inspection commands, which completed successfully. 
- No code, tests, CI workflows, network calls, secrets, or runtime behavior were modified, and there are no unit or integration test changes required by this documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2b3425ac8326a66a7bd0a40a4d34)