### PR TITLE
Add Trajectory Shaping Lineage v0 for pre-bind decision-space transformation

### DIFF
--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -96,6 +96,30 @@ snapshot payload.
 This preserves vocabulary and backend contracts while making the paradox
 visible at first glance: **formally valid, structurally collapsed**.
 
+## Trajectory Shaping Lineage v0
+
+Lineage is not only a record of what decision was eventually bound. In this
+demo, lineage also records how the reachable decision space transformed before
+bind.
+
+`trajectory_shaping_lineage` is exposed as an additive snapshot field under
+`governance_layer_snapshot` for `demo_scenario=pre_boundary_collapse`.
+
+It captures a sequence of structural markers:
+
+- exposure asymmetry emergence
+- divergence contraction
+- participation shift from informative/participatory to decision-shaping
+- preservation degradation and intervention threshold crossing
+- final bind evaluation over an already narrowed space
+
+This sequence makes the pattern reusable for reviewers: they can reason about
+where intervention remained viable, where structural loss began, and what bind
+ultimately evaluated.
+
+Known limitation: this is a deterministic representative demo lineage and is
+not production certification.
+
 
 ## Run and verification entrypoint
 

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -1,0 +1,25 @@
+# Pre-Boundary Collapse Demo Walkthrough
+
+## Trajectory Shaping Lineage v0
+
+lineage は、最終的にどの decision が bind されたかという記録だけではありません。
+この demo では、bind 前に reachable decision space がどのように変形したかも lineage として記録します。
+
+`trajectory_shaping_lineage` は、
+`demo_scenario=pre_boundary_collapse` のときに `governance_layer_snapshot` 配下の
+additive snapshot field として公開されます。
+
+このフィールドは、以下の structural marker の sequence を記録します。
+
+- exposure asymmetry emergence
+- divergence contraction
+- participation shift from informative/participatory to decision-shaping
+- preservation degradation and intervention threshold crossing
+- final bind evaluation over an already narrowed space
+
+この sequence によって、reviewer はパターンを再利用可能な形で評価できます。
+どこまで intervention が viable だったか、どこで structural loss が始まったか、
+そして bind が最終的に何を評価したかを一貫して追跡できます。
+
+Known limitation: this is a deterministic representative demo lineage and is
+not production certification.

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -265,6 +265,15 @@ describe("/api/veritas/v1/report/governance", () => {
       version: "v0",
       initial_option_space: { options: ["A", "B", "C", "D"] },
     });
+    expect(
+      payload.governance_layer_snapshot.trajectory_shaping_lineage.summary,
+    ).toMatchObject({
+      concise: expect.any(String),
+      operator: expect.any(String),
+    });
+    expect(
+      payload.governance_layer_snapshot.trajectory_shaping_lineage.evidence_requirements,
+    ).toHaveLength(7);
     expect(payload.governance_layer_snapshot.trajectory_shaping_lineage.sequence).toHaveLength(4);
     expect(payload.governance_layer_snapshot.trajectory_shaping_lineage.transition_points).toMatchObject({
       first_detectable_asymmetry_phase: "phase_2_iterative_shaping",

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -231,6 +231,13 @@ describe("/api/veritas/v1/report/governance", () => {
         intervention_viability: string;
         bind_outcome: string;
         phase_snapshots: Array<Record<string, unknown>>;
+        trajectory_shaping_lineage: {
+          scenario_id: string;
+          version: string;
+          initial_option_space: { options: string[] };
+          sequence: Array<Record<string, unknown>>;
+          transition_points: Record<string, string>;
+        };
       };
     };
     expect(payload.governance_layer_snapshot.phase_snapshots).toHaveLength(4);
@@ -252,6 +259,17 @@ describe("/api/veritas/v1/report/governance", () => {
       effective_optionality: "full",
       option_exposure_summary: "A:high, B:high, C:high, D:high",
       reinforcement_asymmetry_summary: "none",
+    });
+    expect(payload.governance_layer_snapshot.trajectory_shaping_lineage).toMatchObject({
+      scenario_id: "pre_boundary_collapse",
+      version: "v0",
+      initial_option_space: { options: ["A", "B", "C", "D"] },
+    });
+    expect(payload.governance_layer_snapshot.trajectory_shaping_lineage.sequence).toHaveLength(4);
+    expect(payload.governance_layer_snapshot.trajectory_shaping_lineage.transition_points).toMatchObject({
+      first_detectable_asymmetry_phase: "phase_2_iterative_shaping",
+      intervention_viability_loss_phase: "phase_3_pre_boundary_collapse",
+      bind_evaluation_phase: "phase_4_bind",
     });
   });
 

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -102,6 +102,87 @@ function mapPreBoundaryCollapsePhaseToSnapshot(phase: Record<string, unknown>): 
   };
 }
 
+function buildTrajectoryShapingLineageV0(): Record<string, unknown> {
+  return {
+    scenario_id: PRE_BOUNDARY_COLLAPSE_SCENARIO,
+    version: "v0",
+    initial_option_space: {
+      options: ["A", "B", "C", "D"],
+      effective_optionality: "full",
+    },
+    sequence: [
+      {
+        phase_id: "phase_1_open_framing",
+        phase_label: "Phase 1 — Participation / open framing",
+        exposure_state: "symmetric",
+        reinforcement_state: "none",
+        divergence_state: "open",
+        participation_state: "informative",
+        preservation_state: "open",
+        intervention_viability: "high",
+        structural_marker: "reachable_space_open",
+      },
+      {
+        phase_id: "phase_2_iterative_shaping",
+        phase_label: "Phase 2 — Iterative shaping",
+        exposure_state: "asymmetric_emerging",
+        reinforcement_state: "a_b_reinforced",
+        divergence_state: "contracting",
+        participation_state: "participatory",
+        preservation_state: "degrading",
+        intervention_viability: "medium",
+        structural_marker: "first_detectable_asymmetry",
+      },
+      {
+        phase_id: "phase_3_pre_boundary_collapse",
+        phase_label: "Phase 3 — Pre-boundary collapse",
+        exposure_state: "asymmetric",
+        reinforcement_state: "a_b_dominant",
+        divergence_state: "collapsed",
+        participation_state: "decision_shaping",
+        preservation_state: "collapsed",
+        intervention_viability: "low",
+        structural_marker: "intervention_viability_loss",
+      },
+      {
+        phase_id: "phase_4_bind",
+        phase_label: "Phase 4 — Bind",
+        exposure_state: "already_narrowed",
+        reinforcement_state: "trajectory_committed",
+        divergence_state: "effectively_closed",
+        participation_state: "decision_shaping",
+        preservation_state: "collapsed",
+        intervention_viability: "low",
+        bind_outcome: "FORMALLY_VALID_STRUCTURALLY_COLLAPSED",
+        structural_marker: "bind_over_narrowed_space",
+      },
+    ],
+    transition_points: {
+      first_detectable_asymmetry_phase: "phase_2_iterative_shaping",
+      divergence_contraction_phase: "phase_2_iterative_shaping",
+      participation_shift_phase: "phase_3_pre_boundary_collapse",
+      preservation_degradation_phase: "phase_2_iterative_shaping",
+      intervention_viability_loss_phase: "phase_3_pre_boundary_collapse",
+      bind_evaluation_phase: "phase_4_bind",
+    },
+    evidence_requirements: [
+      "option_exposure_trace",
+      "reinforcement_asymmetry_trace",
+      "divergence_contraction_trace",
+      "participation_shift_marker",
+      "preservation_degradation_marker",
+      "intervention_threshold_marker",
+      "bind_evaluation_snapshot",
+    ],
+    summary: {
+      concise:
+        "Decision lineage records what was bound; trajectory shaping lineage records how reachable alternatives became structurally unavailable before bind.",
+      operator:
+        "Formal admissibility can still hold at bind while effective intervention capacity has already been lost upstream.",
+    },
+  };
+}
+
 async function resolveDemoScenarioPayload(request: Request): Promise<Record<string, unknown> | null> {
   const demoScenario = resolveDemoScenario(request);
   if (demoScenario === AML_KYC_REVIEWER_WALKTHROUGH_SCENARIO) {
@@ -131,6 +212,7 @@ async function resolveDemoScenarioPayload(request: Request): Promise<Record<stri
       bind_outcome: finalPhaseSnapshot.bind_outcome,
       concise_rationale: finalPhaseSnapshot.concise_rationale,
       phase_snapshots: phaseSnapshots,
+      trajectory_shaping_lineage: buildTrajectoryShapingLineageV0(),
     },
   };
 }

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { NextResponse } from "next/server";
 
+import { type TrajectoryShapingLineage } from "../../../../../../components/dashboard-types";
 import { resolveApiBaseUrl } from "../../../[...path]/route-config";
 import { buildAmlKycReviewerWalkthroughPayload } from "../../../../../../lib/aml-kyc-reviewer-walkthrough";
 import { areE2EScenariosEnabled } from "../../../../../e2e-scenarios";
@@ -102,7 +103,7 @@ function mapPreBoundaryCollapsePhaseToSnapshot(phase: Record<string, unknown>): 
   };
 }
 
-function buildTrajectoryShapingLineageV0(): Record<string, unknown> {
+function buildTrajectoryShapingLineageV0(): TrajectoryShapingLineage {
   return {
     scenario_id: PRE_BOUNDARY_COLLAPSE_SCENARIO,
     version: "v0",

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -82,6 +82,42 @@ export interface GovernanceObservation {
   audit_required?: boolean;
 }
 
+export interface TrajectoryShapingLineagePhase {
+  phase_id: string;
+  phase_label: string;
+  exposure_state: string;
+  reinforcement_state: string;
+  divergence_state: string;
+  participation_state: string;
+  preservation_state: string;
+  intervention_viability: string;
+  structural_marker: string;
+  bind_outcome?: string;
+}
+
+export interface TrajectoryShapingLineage {
+  scenario_id: string;
+  version: string;
+  initial_option_space: {
+    options: string[];
+    effective_optionality: string;
+  };
+  sequence: TrajectoryShapingLineagePhase[];
+  transition_points: {
+    first_detectable_asymmetry_phase: string;
+    divergence_contraction_phase: string;
+    participation_shift_phase: string;
+    preservation_degradation_phase: string;
+    intervention_viability_loss_phase: string;
+    bind_evaluation_phase: string;
+  };
+  evidence_requirements: string[];
+  summary: {
+    concise: string;
+    operator: string;
+  };
+}
+
 export interface PreBindGovernanceSnapshot {
   demo_scenario?: string;
   source_state?: string | null;
@@ -99,6 +135,7 @@ export interface PreBindGovernanceSnapshot {
   evidence_bundle_summary?: unknown | null;
   reviewer_expected_steps?: Array<string | Record<string, unknown>> | null;
   phase_snapshots?: Array<Record<string, unknown>>;
+  trajectory_shaping_lineage?: TrajectoryShapingLineage;
   participation_state?: string;
   preservation_state?: string;
   intervention_viability?: string;

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -232,6 +232,25 @@ describe("MissionPage", () => {
                 concise_rationale: "Bind remains formally admissible.",
               },
             ],
+            trajectory_shaping_lineage: {
+              scenario_id: "pre_boundary_collapse",
+              version: "v0",
+              initial_option_space: { options: ["A", "B", "C", "D"], effective_optionality: "full" },
+              sequence: [],
+              transition_points: {
+                first_detectable_asymmetry_phase: "phase_2_iterative_shaping",
+                divergence_contraction_phase: "phase_2_iterative_shaping",
+                participation_shift_phase: "phase_3_pre_boundary_collapse",
+                preservation_degradation_phase: "phase_2_iterative_shaping",
+                intervention_viability_loss_phase: "phase_3_pre_boundary_collapse",
+                bind_evaluation_phase: "phase_4_bind",
+              },
+              evidence_requirements: [],
+              summary: {
+                concise: "Decision lineage records what was bound; trajectory shaping lineage records how reachable alternatives became structurally unavailable before bind.",
+                operator: "Formal admissibility can still hold at bind while effective intervention capacity has already been lost upstream.",
+              },
+            },
           }}
         />
       </I18nProvider>,
@@ -246,6 +265,11 @@ describe("MissionPage", () => {
     expect(screen.getAllByText(/participation_state:/).length).toBeGreaterThan(1);
     expect(screen.getAllByText("decision_shaping").length).toBeGreaterThan(0);
     expect(screen.getAllByText("collapsed").length).toBeGreaterThan(0);
+    expect(screen.getByText("Trajectory Shaping Lineage v0")).toBeInTheDocument();
+    expect(screen.getByText("Decision-space transformation before bind")).toBeInTheDocument();
+    expect(screen.getByText(/first detectable asymmetry:/)).toBeInTheDocument();
+    expect(screen.getByText(/intervention viability loss:/)).toBeInTheDocument();
+    expect(screen.getByText(/bind evaluation:/)).toBeInTheDocument();
   });
 
   it.each(["/governance", "/governance/receipts/br_123", "/audit?receipt=br_123"])("renders safe relevant_ui_href as link: %s", (href) => {

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -236,6 +236,7 @@ describe("MissionPage", () => {
               scenario_id: "pre_boundary_collapse",
               version: "v0",
               initial_option_space: { options: ["A", "B", "C", "D"], effective_optionality: "full" },
+              // sequence is intentionally empty: component renders transition_points/summary only
               sequence: [],
               transition_points: {
                 first_detectable_asymmetry_phase: "phase_2_iterative_shaping",
@@ -265,6 +266,7 @@ describe("MissionPage", () => {
     expect(screen.getAllByText(/participation_state:/).length).toBeGreaterThan(1);
     expect(screen.getAllByText("decision_shaping").length).toBeGreaterThan(0);
     expect(screen.getAllByText("collapsed").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("trajectory-shaping-lineage-panel")).toBeInTheDocument();
     expect(screen.getByText("Trajectory Shaping Lineage v0")).toBeInTheDocument();
     expect(screen.getByText("Decision-space transformation before bind")).toBeInTheDocument();
     expect(screen.getByText(/first detectable asymmetry:/)).toBeInTheDocument();

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -394,6 +394,20 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
               );
             })}
           </ol>
+          {governanceSnapshot?.trajectory_shaping_lineage ? (
+            <div className="mt-3 rounded-md border border-border/60 bg-background/70 p-3 text-xs">
+              <p className="font-semibold">Trajectory Shaping Lineage v0</p>
+              <p className="text-muted-foreground">Decision-space transformation before bind</p>
+              <ul className="mt-2 space-y-1">
+                <li>initial option space: <span className="font-mono">{stringifyValue(governanceSnapshot.trajectory_shaping_lineage.initial_option_space.options)}</span></li>
+                <li>first detectable asymmetry: <span className="font-mono">{stringifyValue(governanceSnapshot.trajectory_shaping_lineage.transition_points.first_detectable_asymmetry_phase)}</span></li>
+                <li>divergence contraction: <span className="font-mono">{stringifyValue(governanceSnapshot.trajectory_shaping_lineage.transition_points.divergence_contraction_phase)}</span></li>
+                <li>intervention viability loss: <span className="font-mono">{stringifyValue(governanceSnapshot.trajectory_shaping_lineage.transition_points.intervention_viability_loss_phase)}</span></li>
+                <li>bind evaluation: <span className="font-mono">{stringifyValue(governanceSnapshot.trajectory_shaping_lineage.transition_points.bind_evaluation_phase)}</span></li>
+                <li>summary: <span className="text-muted-foreground">{stringifyValue(governanceSnapshot.trajectory_shaping_lineage.summary.concise)}</span></li>
+              </ul>
+            </div>
+          ) : null}
         </section>
       ) : null}
 

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -395,7 +395,11 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
             })}
           </ol>
           {governanceSnapshot?.trajectory_shaping_lineage ? (
-            <div className="mt-3 rounded-md border border-border/60 bg-background/70 p-3 text-xs">
+            <div
+              aria-label="trajectory shaping lineage"
+              data-testid="trajectory-shaping-lineage-panel"
+              className="mt-3 rounded-md border border-border/60 bg-background/70 p-3 text-xs"
+            >
               <p className="font-semibold">Trajectory Shaping Lineage v0</p>
               <p className="text-muted-foreground">Decision-space transformation before bind</p>
               <ul className="mt-2 space-y-1">

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -112,6 +112,11 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
       "bind_outcome: FORMALLY_VALID_STRUCTURALLY_COLLAPSED",
     );
     await expect(walkthrough).toContainText("lineage evidence summary");
+    await expect(walkthrough).toContainText("Trajectory Shaping Lineage v0");
+    await expect(walkthrough).toContainText("Decision-space transformation before bind");
+    await expect(walkthrough).toContainText("first detectable asymmetry");
+    await expect(walkthrough).toContainText("intervention viability loss");
+    await expect(walkthrough).toContainText("bind evaluation");
 
     const timeline = page.locator('section[aria-label="governance layer timeline"]');
     await expect(timeline).toBeVisible();


### PR DESCRIPTION
### Motivation
- Provide a minimal, additive evidence layer that records how the reachable decision space transformed before bind for the existing Pre-Boundary Collapse demo, so reviewers can see where intervention was still viable and where optionality collapsed. 
- Keep the change small and non-invasive: do not alter bind-time admissibility, existing pre-bind vocabulary, or existing demo phase semantics.

### Description
- Add typed models `TrajectoryShapingLineage` and `TrajectoryShapingLineagePhase` and make `trajectory_shaping_lineage` an optional field on `PreBindGovernanceSnapshot` in `frontend/components/dashboard-types.ts`.
- Implement `buildTrajectoryShapingLineageV0()` in the demo API handler and inject `governance_layer_snapshot.trajectory_shaping_lineage` for `demo_scenario=pre_boundary_collapse` in `frontend/app/api/veritas/v1/report/governance/route.ts` using a deterministic v0 fixture-like structure (initial option space, 4-phase `sequence`, `transition_points`, `evidence_requirements`, `summary`).
- Render a compact operator-facing panel in the Pre-Boundary Collapse walkthrough that displays a concise `Trajectory Shaping Lineage v0` summary and key transition points in `frontend/components/mission-page.tsx` without changing existing UI layout or semantics.
- Update docs at `docs/en/demos/pre_boundary_collapse_demo.md` to add a `## Trajectory Shaping Lineage v0` section explaining purpose, sequence semantics, and known limitation (deterministic demo, not production certification). 
- Update and add tests to assert the new payload and UI surface: `frontend/app/api/veritas/v1/report/governance/route.test.ts`, `frontend/components/mission-page.test.tsx`, and `frontend/e2e/mission-control-governance-feed.spec.ts` include assertions for `trajectory_shaping_lineage` presence and panel rendering; changes are additive and backward-compatible.

### Testing
- Ran unit and component tests: `pnpm -C frontend test -- app/api/veritas/v1/report/governance/route.test.ts components/mission-page.test.tsx app/mission-control-ingress.test.ts`, and the modified tests (API route + MissionPage) passed under the local vitest run.
- Attempted E2E: `pnpm -C frontend exec playwright test e2e/mission-control-governance-feed.spec.ts --project=chromium`, but Chromimum browsers were not installed in the environment so Playwright failed to launch; install via `pnpm exec playwright install` and re-run E2E to verify the UI-level checks.
- Summary of results: unit/component tests passed; E2E run failed for missing Playwright browser binary (environment issue), not for assertions introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c37af226483268cae1aedddafbb48)