### PR TITLE
docs(architecture): add DecideResponse v2 architecture plan

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -1,0 +1,155 @@
+# DecideResponse v2 Architecture Plan (H-3)
+
+## Status
+
+- **Type**: Architecture proposal only.
+- **Implementation status**: Not implemented.
+- **Scope of this PR**: Documentation only; no runtime behavior change.
+
+## Problem Statement
+
+`DecideResponse` has grown into a broad mixed-surface payload. The current shape combines concerns with different stability and audience requirements:
+
+- user-facing decision output;
+- governance and audit metadata;
+- runtime diagnostics;
+- compatibility fields for legacy callers;
+- evidence and replay-oriented metadata.
+
+This coupling increases risk and cost for:
+
+- public API stability;
+- external documentation clarity;
+- strict schema validation;
+- future SDK generation and versioning.
+
+The architectural issue is not that these data classes exist, but that they are not cleanly separated into explicit contracts.
+
+## Design Goals
+
+DecideResponse v2 should provide:
+
+1. A stable public response contract with explicit schema versioning.
+2. Explicit governance metadata boundaries (separate from user-facing output).
+3. Replay and audit compatibility that preserves TrustLog/replay usefulness.
+4. Backward-compatible migration with v1 remaining functional.
+5. Strict separation between user-facing result data and internal diagnostics.
+6. No breaking change to v1 during initial rollout.
+7. No runtime behavior change in this planning PR.
+
+## Proposed v2 Shape (Draft)
+
+The following is a proposal, not a final schema:
+
+```json
+{
+  "schema_version": "decide_response.v2",
+  "decision": {
+    "answer": "...",
+    "alternatives": [],
+    "recommendation": {},
+    "confidence": null
+  },
+  "governance": {
+    "fuji_decision": {},
+    "policy_result": {},
+    "enforcement": {},
+    "risk": {}
+  },
+  "evidence": {
+    "items": [],
+    "retrieval": {},
+    "citations": []
+  },
+  "audit": {
+    "request_id": "...",
+    "trace_id": "...",
+    "trustlog_ref": null,
+    "replay_ref": null
+  },
+  "diagnostics": {
+    "warnings": [],
+    "degraded_modes": [],
+    "tool_status": {}
+  },
+  "compat": {
+    "v1_fields": {},
+    "migration_notes": []
+  }
+}
+```
+
+### Section intent (non-normative)
+
+- `decision`: user-facing decision/result semantics.
+- `governance`: FUJI/policy/enforcement/risk outputs needed for policy review and compliance.
+- `evidence`: evidence items, retrieval context, and citation metadata.
+- `audit`: stable identifiers for tracing and replay linkage.
+- `diagnostics`: operational signals for internal debugging/health visibility.
+- `compat`: transitional envelope for v1-compatible consumers.
+
+## Compatibility and Safety Rules
+
+1. **v1 remains default** until downstream migration is validated.
+2. **No field removal in this planning PR**.
+3. v2 introduction must be **additive first**, behind migration controls.
+4. Governance/audit fields must remain **replay-safe** and deterministic enough for investigation workflows.
+5. Diagnostics must not leak secrets or raw PII.
+6. `trustlog_ref` and `replay_ref` should be stable identifiers, not raw internal blobs.
+
+## Phased Migration Plan
+
+### Phase 0 — v1 Inventory and Classification
+
+- Freeze and document current v1 field inventory.
+- Classify each field into: `decision`, `governance`, `evidence`, `audit`, `diagnostics`, or `compat`.
+- Mark ambiguous fields with owner and migration note.
+
+### Phase 1 — Version Tag + Shadow v2 Payload
+
+- Add `schema_version` support.
+- Keep v1 as the default external contract.
+- Introduce optional v2 shadow payload behind feature flag for internal comparison.
+
+### Phase 2 — Parity and Regression Safety
+
+- Add snapshot/serialization tests that compare v1 and v2 semantic parity where expected.
+- Add negative tests for redaction and safe diagnostics behavior.
+
+### Phase 3 — Internal Exposure and SDK Preparation
+
+- Expose v2 in internal API surfaces and SDK preview pathways.
+- Publish migration notes and mapping guidance from v1 fields to v2 sections.
+
+### Phase 4 — Controlled Deprecation of Selected v1 Compat Fields
+
+- Deprecate selected compatibility fields only after downstream consumers have an explicit migration path.
+- Keep deprecation timelines and removals tied to usage telemetry and release governance.
+
+## Future Implementation Acceptance Checklist
+
+- [ ] Typed v2 schema exists.
+- [ ] Serialization tests exist.
+- [ ] Redaction/privacy tests exist.
+- [ ] v1 compatibility tests exist.
+- [ ] Documentation examples exist.
+- [ ] API contract test exists.
+- [ ] Migration feature flag exists.
+- [ ] Telemetry/TrustLog/replay references are stable identifiers.
+
+## Architectural Alignment
+
+This plan is intentionally aligned with current boundary and safety principles:
+
+- Responsibility boundaries remain unchanged across Planner / Kernel / FUJI / MemoryOS as defined in `docs/architecture/core_responsibility_boundaries.md`.
+- Continuation enforcement remains conceptually separate from FUJI safety semantics; see `docs/architecture/continuation_enforcement_design_note.md` where relevant.
+- TrustLog, FUJI, and pipeline concepts are preserved as existing systems of record and policy gating; this proposal only restructures response contract boundaries.
+
+## Non-Goals (for this PR)
+
+- No modification of runtime decision logic.
+- No FUJI policy behavior change.
+- No TrustLog storage/encryption behavior change.
+- No immediate SDK breaking changes.
+
+This document defines a migration strategy, not a shipping v2 implementation.


### PR DESCRIPTION
### Motivation

- The existing `DecideResponse` payload has accumulated mixed concerns (user-facing output, governance/audit metadata, runtime diagnostics, compatibility fields, evidence/replay metadata) which complicates API stability, schema validation, SDK generation, and external documentation.
- This change introduces a focused, reviewer-facing architecture plan that defines goals and a phased, backward-compatible migration strategy for a cleaner `decide_response.v2` contract, and it intentionally does not implement or change runtime behavior.

### Description

- Added a new architecture proposal at `docs/architecture/decide-response-v2-plan.md` that documents the problem statement, design goals, a draft top-level v2 shape, compatibility/safety rules, and a four-phase migration plan (Phase 0–4).
- The draft v2 shape proposes a `schema_version` and clear top-level sections: `decision`, `governance`, `evidence`, `audit`, `diagnostics`, and `compat` (example JSON included), plus non-normative intent notes for each section.
- The doc includes explicit compatibility rules (v1 remains default, additive rollout, diagnostics redaction requirements, replay-safe governance/audit refs), an acceptance checklist for future implementation, and cross-references to existing architecture docs such as `core_responsibility_boundaries.md` and continuation/FUJI/TrustLog notes.
- No runtime modules, API surfaces, or behavior were changed in this PR; this is documentation-only and intended to be an implementation-independent plan.

### Testing

- Attempted `python -m pip install -q -e .` to prepare environment, but dependency resolution failed due to remote/package fetch restrictions; this install failure was non-blocking for the documentation checks and is noted here.
- Ran the responsibility/boundary checker script which passed (`scripts/architecture/check_responsibility_boundaries.py`).
- Ran the targeted pytest check `veritas_os/tests/test_responsibility_boundary_checker.py` which passed (`53 passed, 1 warning`).
- Ran documentation consistency checks (`scripts/quality/check_operational_docs_consistency.py`, `scripts/quality/check_frontend_docs_consistency.py`, and bilingual docs checks) which passed.
- Overall: automated architecture and docs checks passed; the only tooling failure observed was the optional environment `pip install` step due to network/build dependency constraints and did not affect the doc-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c80baf1dc8326ae512bf08c68589a)