### PR TITLE
docs: add FUJI BLOCK/DEFER DecideResponse v2 response examples

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -79,6 +79,98 @@ The following is a proposal, not a final schema:
 }
 ```
 
+### Enforcement Response Examples (non-normative)
+
+Example 1 — FUJI BLOCK:
+
+```json
+{
+  "schema_version": "decide_response.v2",
+  "decision": {
+    "answer": null,
+    "alternatives": [],
+    "recommendation": null,
+    "confidence": null
+  },
+  "governance": {
+    "fuji_decision": {},
+    "policy_result": {},
+    "enforcement": {
+      "action": "BLOCK",
+      "reason": "Policy violation: risk level exceeded configured threshold."
+    },
+    "risk": {}
+  },
+  "evidence": {
+    "items": [],
+    "retrieval": {},
+    "citations": []
+  },
+  "audit": {
+    "request_id": "...",
+    "trace_id": "...",
+    "trustlog_ref": "<non-null: block event MUST be logged>",
+    "replay_ref": null
+  },
+  "diagnostics": {
+    "warnings": [],
+    "degraded_modes": [],
+    "tool_status": {}
+  },
+  "compat": {
+    "v1_fields": {},
+    "migration_notes": []
+  }
+}
+```
+
+Example 2 — FUJI DEFER:
+
+```json
+{
+  "schema_version": "decide_response.v2",
+  "decision": {
+    "answer": null,
+    "alternatives": [],
+    "recommendation": null,
+    "confidence": null
+  },
+  "governance": {
+    "fuji_decision": {},
+    "policy_result": {},
+    "enforcement": {
+      "action": "DEFER",
+      "defer_target": "<human-review queue reference>"
+    },
+    "risk": {}
+  },
+  "evidence": {
+    "items": [],
+    "retrieval": {},
+    "citations": []
+  },
+  "audit": {
+    "request_id": "...",
+    "trace_id": "...",
+    "trustlog_ref": "<non-null: defer event MUST be logged>",
+    "replay_ref": null
+  },
+  "diagnostics": {
+    "warnings": [],
+    "degraded_modes": [],
+    "tool_status": {}
+  },
+  "compat": {
+    "v1_fields": {},
+    "migration_notes": []
+  }
+}
+```
+
+> These enforcement paths are the canonical cases where `audit.trustlog_ref` MUST be non-null.
+> The block/defer event is always logged to TrustLog regardless of whether a `decision.answer`
+> is returned. v1 compatibility tests (Phase 2) must include at least one BLOCK scenario.
+
 ### Section intent (non-normative)
 
 - `decision`: user-facing decision/result semantics.


### PR DESCRIPTION
### Motivation
- Provide canonical v2 examples for the governance-critical FUJI responses (`BLOCK` and `DEFER`) so Phase 2 parity tests and downstream consumers know the expected shape and the required non-null `audit.trustlog_ref` behavior.
- This is a docs-only change with no runtime modifications; continue to avoid leaking secrets in `diagnostics` and related fields (documentation already calls this out). 

### Description
- Added a new subsection `### Enforcement Response Examples (non-normative)` to `docs/architecture/decide-response-v2-plan.md` containing two JSON examples demonstrating FUJI `BLOCK` and `DEFER` responses with `decision.answer: null`, `enforcement.action: "BLOCK"|"DEFER"`, `defer_target` for DEFER, and non-null `audit.trustlog_ref` markers.
- No code/runtime changes were made; the PR only updates the planning document to show canonical enforcement paths and the required TrustLog behavior. 

### Testing
- Ran the architecture and docs checks with: `PYENV_VERSION=3.12.13 python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q`, which passed (`53 passed, 1 warning`).
- Ran responsibility and docs consistency scripts with: `PYENV_VERSION=3.12.13 python scripts/architecture/check_responsibility_boundaries.py` and `PYENV_VERSION=3.12.13 python scripts/quality/check_operational_docs_consistency.py`, both of which reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9080573483268844ba861057d9ae)