### PR TITLE
Clarify `compat.v1_fields` mapping semantics in DecideResponse v2 plan

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -178,7 +178,12 @@ Example 2 — FUJI DEFER:
 - `evidence`: evidence items, retrieval context, and citation metadata.
 - `audit`: stable identifiers for tracing and replay linkage.
 - `diagnostics`: operational signals for internal debugging/health visibility.
-- `compat`: transitional envelope for v1-compatible consumers.
+- `compat`: transitional envelope for v1-compatible consumers. `v1_fields` is a
+  **field-mapping index** (not a data copy) of the form
+  `{ "v1_field_name": "v2.section.field_path" }`, populated only when the response
+  is served to a caller that has not opted into v2.
+  Callers MUST NOT receive both the structured v2 sections and a full v1 copy simultaneously.
+  `migration_notes` carries human-readable deprecation notices keyed by v1 field name.
 
 ## Compatibility and Safety Rules
 
@@ -188,6 +193,8 @@ Example 2 — FUJI DEFER:
 4. Governance/audit fields must remain **replay-safe** and deterministic enough for investigation workflows.
 5. Diagnostics must not leak secrets or raw PII.
 6. `trustlog_ref` and `replay_ref` should be stable identifiers, not raw internal blobs.
+7. `compat.v1_fields` MUST be a mapping index, not a data copy. Full v1 payload
+   mirroring is explicitly prohibited to prevent payload doubling.
 
 ## Phased Migration Plan
 


### PR DESCRIPTION
### Motivation
- Clarify ambiguous `compat.v1_fields` semantics to prevent payload-doubling during migration and to give implementers explicit guidance for Phase 3; this change is documentation-only and does not alter runtime behavior, but implementers must still ensure mapping logic does not accidentally expose sensitive fields.

### Description
- Updated `docs/architecture/decide-response-v2-plan.md` to define `compat.v1_fields` as a field-mapping index of the form `{ "v1_field_name": "v2.section.field_path" }`, added explicit `MUST NOT` language preventing callers from receiving both structured v2 sections and a full v1 copy, documented `migration_notes` as human-readable deprecation notices keyed by v1 field name, and appended Compatibility and Safety Rule 7 prohibiting full v1 payload mirroring.

### Testing
- Ran `PYENV_VERSION=3.12.13 python scripts/architecture/check_responsibility_boundaries.py`, `PYENV_VERSION=3.12.13 python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q`, and `PYENV_VERSION=3.12.13 python scripts/quality/check_operational_docs_consistency.py`; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf43fc23c83269ccdc44201d4c4df)