### PR TITLE
docs: clarify audit.replay_ref as new DecideResponse v2 field

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -177,6 +177,12 @@ Example 2 — FUJI DEFER:
 - `governance`: FUJI/policy/enforcement/risk outputs needed for policy review and compliance.
 - `evidence`: evidence items, retrieval context, and citation metadata.
 - `audit`: stable identifiers for tracing and replay linkage.
+  - `request_id`, `trace_id`: map from existing v1 fields.
+  - `trustlog_ref`: stable identifier referencing the TrustLog entry for this decision;
+    MUST be non-null for all FUJI enforcement events (BLOCK, DEFER).
+  - `replay_ref`: **new field with no v1 equivalent**. Introduction scoped to Phase 3.
+    Format TBD during Phase 0 inventory (candidate: opaque string token referencing the
+    Continuation Runtime replay index). MUST NOT be populated in the Phase 1 shadow payload.
 - `diagnostics`: operational signals for internal debugging/health visibility.
 - `compat`: transitional envelope for v1-compatible consumers. `v1_fields` is a
   **field-mapping index** (not a data copy) of the form
@@ -219,6 +225,8 @@ Example 2 — FUJI DEFER:
 
 - Expose v2 in internal API surfaces and SDK preview pathways.
 - Publish migration notes and mapping guidance from v1 fields to v2 sections.
+- Define `replay_ref` format (opaque token vs. structured ref) and populate it in the
+  SDK preview pathway alongside `trustlog_ref`.
 
 ### Phase 4 — Controlled Deprecation of Selected v1 Compat Fields
 


### PR DESCRIPTION
### Motivation

- Prevent implementers from assuming `audit.replay_ref` is a renamed v1 field by explicitly marking it as a new Phase 3-only field and documenting usage constraints so Phase 3 implementation work does not stall.

### Description

- Update `docs/architecture/decide-response-v2-plan.md` to expand the `audit` section with `request_id`/`trace_id` mapping, require `trustlog_ref` be non-null for FUJI enforcement (BLOCK/DEFER), mark `replay_ref` as **new field with no v1 equivalent** with format TBD and `MUST NOT` be populated in the Phase 1 shadow payload, and add a Phase 3 bullet to define and populate `replay_ref` in SDK preview pathways.

### Testing

- `python scripts/architecture/check_responsibility_boundaries.py` — passed.
- `python scripts/quality/check_operational_docs_consistency.py` — passed.
- `python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q` — could not be run in the current environment due to missing `pytest` (automated test runner not available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cff3258f48326952a335320f41429)