### PR TITLE
docs: align `compat` section intent to sub-bullet style

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -184,12 +184,13 @@ Example 2 — FUJI DEFER:
     Format TBD during Phase 0 inventory (candidate: opaque string token referencing the
     Continuation Runtime replay index). MUST NOT be populated in the Phase 1 shadow payload.
 - `diagnostics`: operational signals for internal debugging/health visibility.
-- `compat`: transitional envelope for v1-compatible consumers. `v1_fields` is a
-  **field-mapping index** (not a data copy) of the form
-  `{ "v1_field_name": "v2.section.field_path" }`, populated only when the response
-  is served to a caller that has not opted into v2.
-  Callers MUST NOT receive both the structured v2 sections and a full v1 copy simultaneously.
-  `migration_notes` carries human-readable deprecation notices keyed by v1 field name.
+- `compat`: transitional envelope for v1-compatible consumers.
+  - `v1_fields`: **field-mapping index** (not a data copy) of the form
+    `{ "v1_field_name": "v2.section.field_path" }`, populated only when the response
+    is served to a caller that has not opted into v2.
+    Callers MUST NOT receive both the structured v2 sections and a full v1 copy simultaneously.
+    The mapping index MUST NOT include fields excluded by Rule 5 (secrets, raw PII).
+  - `migration_notes`: human-readable deprecation notices keyed by v1 field name.
 
 ## Compatibility and Safety Rules
 


### PR DESCRIPTION
### Motivation

- Standardize the `compat` entry in `docs/architecture/decide-response-v2-plan.md` to match the readable sub-bullet style used by `audit` and improve consistency and scanability. 
- Add the missing security constraint that the `v1_fields` mapping must not include fields excluded by Rule 5 (secrets, raw PII).

### Description

- Rewrote the `compat` top-level entry to a short label and introduced sub-bullets for `v1_fields` and `migration_notes` in `docs/architecture/decide-response-v2-plan.md`. 
- Moved the mapping-index definition `{ "v1_field_name": "v2.section.field_path" }` and the constraint that callers must not receive both structured v2 sections and a full v1 copy under `v1_fields`. 
- Added the sentence `The mapping index MUST NOT include fields excluded by Rule 5 (secrets, raw PII).` under `v1_fields`. 
- This is a documentation-only change and introduces no runtime behavior modifications.

### Testing

- Ran `python scripts/architecture/check_responsibility_boundaries.py` and it passed. 
- Ran `python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q` which returned `53 passed, 1 warning`. 
- Ran `python scripts/quality/check_operational_docs_consistency.py` and it passed. 
- The checks were executed with `PYENV_VERSION=3.12.13` in the environment and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0e0cf2b8832698fdb7e403375375)