### PR TITLE
docs: clarify v1 request_id/trace_id field-name mapping in audit section

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -177,7 +177,9 @@ Example 2 — FUJI DEFER:
 - `governance`: FUJI/policy/enforcement/risk outputs needed for policy review and compliance.
 - `evidence`: evidence items, retrieval context, and citation metadata.
 - `audit`: stable identifiers for tracing and replay linkage.
-  - `request_id`, `trace_id`: map from existing v1 fields.
+  - `request_id`, `trace_id`: map from existing v1 fields; exact v1 key names
+    to be confirmed during Phase 0 field inventory (v2 names are canonical and
+    may differ from v1 key names).
   - `trustlog_ref`: stable identifier referencing the TrustLog entry for this decision;
     MUST be non-null for all FUJI enforcement events (BLOCK, DEFER).
   - `replay_ref`: **new field with no v1 equivalent**. Introduction scoped to Phase 3.


### PR DESCRIPTION
### Motivation
- The original `audit` bullet "map from existing v1 fields" was ambiguous about exact v1 key names and could lead implementers to assume identical keys; the intent is to defer confirmation to the Phase 0 field inventory.

### Description
- Replace the single `audit` sub-bullet for `request_id`, `trace_id` with explicit TBD wording that the exact v1 key names will be confirmed during Phase 0 and that v2 names are canonical and may differ from v1.

### Testing
- Ran the architecture and docs checks: `PYENV_VERSION=3.12.13 python scripts/architecture/check_responsibility_boundaries.py`, `PYENV_VERSION=3.12.13 python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q`, and `PYENV_VERSION=3.12.13 python scripts/quality/check_operational_docs_consistency.py`, and all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d11d096e48326b91e002c0e15c972)