### PR TITLE
docs: clarify DecideResponse v2 confidence field semantics

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -174,6 +174,13 @@ Example 2 — FUJI DEFER:
 ### Section intent (non-normative)
 
 - `decision`: user-facing decision/result semantics.
+  - `answer`: primary string output surfaced to the API caller.
+  - `alternatives`: ordered list of alternative decision strings; empty list when not applicable.
+  - `recommendation`: structured output object for ranked/typed planner results (see Task 6).
+  - `confidence`: `float | null`, range 0.0–1.0. `null` when the pipeline did not produce
+    a calibrated confidence signal. Derived by Kernel aggregation across pipeline stages;
+    not sourced from any single stage. This field is **advisory only** and MUST NOT gate
+    FUJI enforcement decisions.
 - `governance`: FUJI/policy/enforcement/risk outputs needed for policy review and compliance.
 - `evidence`: evidence items, retrieval context, and citation metadata.
 - `audit`: stable identifiers for tracing and replay linkage.


### PR DESCRIPTION
### Motivation

- The v2 plan draft included `"confidence": null` without a type or provenance, making schema inference and implementation ambiguous. 
- The change documents intended typing, range, and source for `confidence` to avoid downstream misinterpretation. 
- This is a docs-only change with no runtime or data-path modification, and the docs explicitly state `confidence` is advisory and MUST NOT gate FUJI enforcement to reduce risk of misuse.

### Description

- Expanded the **Section intent (non-normative)** `decision` entry in `docs/architecture/decide-response-v2-plan.md` with per-field notes for `answer`, `alternatives`, `recommendation`, and `confidence`. 
- Annotated `confidence` as ``float | null`` with range `0.0–1.0`, documented that `null` represents absence of a calibrated signal, and stated the value is derived by Kernel aggregation across pipeline stages (not any single stage). 
- Added explicit guidance that `confidence` is advisory only and MUST NOT gate FUJI enforcement decisions, and confirmed there are no runtime changes in this PR. 

### Testing

- Ran `PYENV_VERSION=3.12.13 python scripts/architecture/check_responsibility_boundaries.py` and it passed. 
- Ran `PYENV_VERSION=3.12.13 python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q` and all tests passed (53 passed, 1 existing config warning about `asyncio_default_fixture_loop_scope`). 
- Ran `PYENV_VERSION=3.12.13 python scripts/quality/check_operational_docs_consistency.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d165c9178832684b6a17c39ca7859)