### PR TITLE
docs: clarify decision.answer vs decision.recommendation in DecideResponse v2 plan

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -174,9 +174,13 @@ Example 2 — FUJI DEFER:
 ### Section intent (non-normative)
 
 - `decision`: user-facing decision/result semantics.
-  - `answer`: primary string output surfaced to the API caller.
+  - `answer`: primary string output surfaced to the API caller. Maps directly from the
+    v1 top-level `answer` (or equivalent) field. Always a string or `null` (on BLOCK/DEFER).
   - `alternatives`: ordered list of alternative decision strings; empty list when not applicable.
-  - `recommendation`: structured output object for ranked/typed planner results (see Task 6).
+  - `recommendation`: structured output object for cases where the pipeline produces a
+    ranked or typed recommendation (e.g. multi-option Planner output). `null` when the
+    pipeline produces a plain answer. **New field with no v1 equivalent**; introduction
+    scoped to Phase 3. Do not populate in Phase 1 shadow payload.
   - `confidence`: `float | null`, range 0.0–1.0. `null` when the pipeline did not produce
     a calibrated confidence signal. Derived by Kernel aggregation across pipeline stages;
     not sourced from any single stage. This field is **advisory only** and MUST NOT gate


### PR DESCRIPTION
### Motivation
- The `decision` subsection in the v2 plan was ambiguous about how `answer` and `recommendation` relate to existing v1 fields, blocking Phase 0 classification and safe migration guidance for implementers.

### Description
- Add explicit per-field notes to `docs/architecture/decide-response-v2-plan.md` making `decision.answer` map from the v1 top-level `answer` (always `string | null` on BLOCK/DEFER), defining `decision.recommendation` as a structured/ranked output distinct from `answer`, marking `recommendation` as a new field with no v1 equivalent scoped to Phase 3, and instructing it must not be populated in the Phase 1 shadow payload.

### Testing
- Ran responsibility and docs checks with `PYENV_VERSION=3.12.13 python scripts/architecture/check_responsibility_boundaries.py`, `PYENV_VERSION=3.12.13 python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q`, and `PYENV_VERSION=3.12.13 python scripts/quality/check_operational_docs_consistency.py`, and all automated checks passed (responsibility boundary check passed, `pytest` reported 53 passed, and operational docs consistency passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d21faae60832687f5217fb0efc669)