### PR TITLE
docs: define governance.risk mapping in DecideResponse v2 plan

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -186,6 +186,15 @@ Example 2 — FUJI DEFER:
     not sourced from any single stage. This field is **advisory only** and MUST NOT gate
     FUJI enforcement decisions.
 - `governance`: FUJI/policy/enforcement/risk outputs needed for policy review and compliance.
+  - `fuji_decision`: output of the FUJI Gate evaluation for this decision request.
+  - `policy_result`: result of policy rule evaluation prior to FUJI Gate.
+  - `enforcement`: enforcement action taken (`ALLOW` / `BLOCK` / `DEFER`) with reason or
+    defer target. See "Enforcement Response Examples" above.
+  - `risk`: risk signal output. Maps from `risk_delta` computed in the Debate stage
+    (`debate.py`) combined with any FUJI policy risk classification result.
+    Schema TBD during Phase 0 inventory; minimum expected fields:
+    - `delta: float` — raw risk delta from Debate stage
+    - `level: str` — classified level: `"LOW"` | `"MEDIUM"` | `"HIGH"` | `"CRITICAL"`
 - `evidence`: evidence items, retrieval context, and citation metadata.
 - `audit`: stable identifiers for tracing and replay linkage.
   - `request_id`, `trace_id`: map from existing v1 fields; exact v1 key names


### PR DESCRIPTION
### Motivation
- Remove ambiguity in the `governance` section by specifying what implementers should expect for FUJI/policy/enforcement/risk outputs so Phase 0 field classification can be completed.

### Description
- Expanded the `Section intent (non-normative)` `governance` entry with per-field notes for `fuji_decision`, `policy_result`, `enforcement` (with a cross-reference to the Enforcement Response Examples), and `risk`.
- Documented that `governance.risk` maps from the Debate-stage `risk_delta` (`debate.py`) combined with any FUJI policy risk classification and added minimum Phase 0 fields `delta: float` and `level: str` with allowed values `"LOW" | "MEDIUM" | "HIGH" | "CRITICAL"`.
- This is a documentation-only change with no runtime behavior modifications. 

### Testing
- Ran `python3 scripts/architecture/check_responsibility_boundaries.py` which passed successfully.
- Ran `python3 scripts/quality/check_operational_docs_consistency.py` which passed successfully.
- Attempted `python3 -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q` but the `pytest` module was not available in the environment, so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d282de7748326a69afed0faf154dc)