### PR TITLE
docs: define H-3 horizon in DecideResponse v2 status

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -5,6 +5,8 @@
 - **Type**: Architecture proposal only.
 - **Implementation status**: Not implemented.
 - **Scope of this PR**: Documentation only; no runtime behavior change.
+- **Horizon**: H-3 — planned but not committed to any current sprint; requires Phase 0
+  completion before scheduling. (H-1 = in-sprint, H-2 = next sprint, H-3 = backlog/planned.)
 
 ## Problem Statement
 


### PR DESCRIPTION
### Motivation
- Clarify the meaning of the `H-3` horizon label in `docs/architecture/decide-response-v2-plan.md` so readers know it denotes backlog/planned work and requires Phase 0 completion before scheduling.

### Description
- Added a `- **Horizon**: H-3 — planned but not committed to any current sprint; requires Phase 0 completion before scheduling. (H-1 = in-sprint, H-2 = next sprint, H-3 = backlog/planned.)` bullet to the `## Status` section of `docs/architecture/decide-response-v2-plan.md` with no runtime changes.

### Testing
- Executed `python scripts/architecture/check_responsibility_boundaries.py`, `python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q`, and `python scripts/quality/check_operational_docs_consistency.py`, which initially failed with the default `python` due to a `pyenv` version mismatch but all checks passed when run with `PYENV_VERSION=3.12.13` (responsibility check passed, `pytest` passed, and operational docs consistency passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d337629608326923aa879b565fd59)