### PR TITLE
docs: add non-normative TypedDict appendix for DecideResponse v2 plan

### DIFF
--- a/docs/architecture/decide-response-v2-plan.md
+++ b/docs/architecture/decide-response-v2-plan.md
@@ -285,3 +285,62 @@ This plan is intentionally aligned with current boundary and safety principles:
 - No immediate SDK breaking changes.
 
 This document defines a migration strategy, not a shipping v2 implementation.
+
+## Appendix: Non-normative TypedDict Sketch
+
+> **NON-NORMATIVE** — subject to change during Phase 0 field inventory.
+> This sketch exists to make section boundaries machine-checkable, not to finalize
+> nested field schemas. Nested types use `dict` as a placeholder until Phase 0 completes.
+
+```python
+from __future__ import annotations
+from typing import TypedDict, Optional
+
+
+class DecisionSection(TypedDict):
+    answer: Optional[str]
+    alternatives: list[str]
+    recommendation: Optional[dict]   # new in Phase 3; null until then
+    confidence: Optional[float]      # 0.0–1.0; null when unavailable
+
+
+class GovernanceSection(TypedDict):
+    fuji_decision: dict
+    policy_result: dict
+    enforcement: dict                # action: ALLOW | BLOCK | DEFER
+    risk: dict                       # delta: float, level: LOW|MEDIUM|HIGH|CRITICAL
+
+
+class EvidenceSection(TypedDict):
+    items: list[dict]
+    retrieval: dict
+    citations: list[dict]
+
+
+class AuditSection(TypedDict):
+    request_id: str
+    trace_id: str
+    trustlog_ref: Optional[str]      # MUST be non-null for BLOCK/DEFER events
+    replay_ref: Optional[str]        # new in Phase 3; null until then
+
+
+class DiagnosticsSection(TypedDict):
+    warnings: list[str]
+    degraded_modes: list[str]
+    tool_status: dict
+
+
+class CompatSection(TypedDict):
+    v1_fields: dict[str, str]        # mapping index: v1_field_name -> v2.section.field_path
+    migration_notes: list[str]
+
+
+class DecideResponseV2(TypedDict):
+    schema_version: str              # "decide_response.v2"
+    decision: DecisionSection
+    governance: GovernanceSection
+    evidence: EvidenceSection
+    audit: AuditSection
+    diagnostics: DiagnosticsSection
+    compat: CompatSection
+```


### PR DESCRIPTION
### Motivation
- Provide a machine-checkable, non-normative sketch of the DecideResponse v2 schema to reduce the gap between the migration plan and a future implementation.
- Surface section boundaries and phase-scoped notes so implementers can create tests and serializers that align with the plan without finalizing nested field shapes.
- Keep the work documentation-only to avoid accidental runtime changes or premature API exposure.

### Description
- Appended a new `## Appendix: Non-normative TypedDict Sketch` section at the end of `docs/architecture/decide-response-v2-plan.md` immediately after the Non-Goals section.
- Added the explicit **NON-NORMATIVE** disclaimer and Phase 0 guidance that nested types use `dict` placeholders until inventory is complete.
- Defined `DecisionSection`, `GovernanceSection`, `EvidenceSection`, `AuditSection`, `DiagnosticsSection`, `CompatSection`, and the top-level `DecideResponseV2` `TypedDict`s, and included the required inline comments for `confidence`, `trustlog_ref`, `replay_ref`, and `v1_fields` mapping semantics.
- This change is documentation-only and does not modify or import any runtime `.py` modules; the typed sketch must not be imported into runtime to avoid leaking or mis-using stable/internal identifiers.

### Testing
- Running `python scripts/architecture/check_responsibility_boundaries.py`, `python -m pytest veritas_os/tests/test_responsibility_boundary_checker.py -q`, and `python scripts/quality/check_operational_docs_consistency.py` initially failed in this environment due to the repo pin to `3.12.12` not being installed.
- Re-ran the checks with `PYENV_VERSION=3.12.13` and the responsibility boundary check passed, `pytest` completed with `53 passed, 1 warning`, and the operational docs consistency check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d37a8d5d083269f2ecbf6e549964c)