### PR TITLE
fix(test-env): resolve fastapi missing-module error in tests/test_wat_api.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dev = [
   "pytest==9.0.3",
   "pytest-asyncio==1.3.0",
   "pytest-cov==6.0.0",
+  "fastapi==0.121.0",
   "httpx==0.27.2",
   "mypy==1.13.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# Development/test dependencies for local and CI usage.
+# Includes runtime dependencies plus dev tooling.
+-r veritas_os/requirements.txt
+
+# Explicit test-time web stack pins used by tests/test_wat_api.py.
+fastapi==0.121.0
+httpx==0.27.2


### PR DESCRIPTION
### Motivation
- `tests/test_wat_api.py` imports `fastapi.testclient.TestClient` and the test suite failed to collect with `ModuleNotFoundError: No module named 'fastapi'` in typical dev installs.
- The project had runtime pins for `fastapi`/`httpx` but the `dev` install/profile and a root dev requirements file did not guarantee those packages when developers install dev dependencies via common paths. 
- This change ensures dev/test installation paths include the FastAPI web stack so the WAT API tests are collectable.

### Description
- Added `fastapi==0.121.0` to the `dev` extra in `pyproject.toml` so `pip install -e ".[dev]"` explicitly includes FastAPI. 
- Added a new `requirements-dev.txt` that references `veritas_os/requirements.txt` and explicitly pins `fastapi==0.121.0` and `httpx==0.27.2` for environments that install dev deps via requirements files. 
- No changes were made to production code or test logic; this PR only updates dev dependency declarations.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pip install -e '.[dev]'` which failed in this environment due to external package index/network restrictions while resolving build dependencies, so installation could not complete. 
- Ran `PYENV_VERSION=3.11.15 python -m pytest -q tests/test_wat_api.py --tb=short` which still errored with `ModuleNotFoundError: No module named 'fastapi'` because the install step above failed to provision dependencies. 
- Verified GitHub Actions workflows already install `veritas_os/requirements.txt` (which contains `fastapi` and `httpx`), so CI job behavior is unchanged; no workflow exclusions of `tests/test_wat_api.py` were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5141ffcc8326b8b354500d96696b)