### PR TITLE
feat(debate-safety): add Pydantic schema for debate safety policy YAML

### DIFF
--- a/veritas_os/policy/__init__.py
+++ b/veritas_os/policy/__init__.py
@@ -1,5 +1,8 @@
 """Policy-as-Code public interfaces for schema validation and canonicalization."""
 
+# debate_safety_policy_schema: Phase 1 schema definition only.
+# Not wired into runtime enforcement. See debate-safety-policy-yaml-plan.md.
+
 from .compiler import COMPILER_VERSION, CompileResult, compile_policy_to_bundle
 from .bind_artifacts import (
     BindReceipt,

--- a/veritas_os/policy/debate_safety_policy_schema.py
+++ b/veritas_os/policy/debate_safety_policy_schema.py
@@ -1,0 +1,50 @@
+"""
+Pydantic schema for the Debate safety policy YAML format.
+
+This module is the single source of truth for the debate_safety_policy YAML
+structure. It is Phase 1 schema-definition only and is NOT wired into any
+runtime enforcement path. Production loading (Phase 3+) must use
+DebateSafetyPolicy.model_validate() before any enforcement switch.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated
+
+import pydantic
+
+
+class PolicyMode(str, Enum):
+    example_only = "example_only"
+    shadow = "shadow"
+    enforced = "enforced"
+
+
+class Severity(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+    critical = "critical"
+
+
+class PolicyAction(str, Enum):
+    review = "review"
+    escalate_or_block = "escalate_or_block"
+    block = "block"
+
+
+class PatternCategory(pydantic.BaseModel):
+    severity: Severity
+    action: PolicyAction
+    patterns: list[Annotated[str, pydantic.StringConstraints(min_length=1)]]
+
+
+class DebateSafetyPolicy(pydantic.BaseModel):
+    schema_version: int
+    policy_id: str
+    mode: PolicyMode
+    notes: list[str] = []
+    categories: dict[str, PatternCategory]
+
+    model_config = pydantic.ConfigDict(extra="forbid")

--- a/veritas_os/tests/test_debate_safety_policy_example_yaml.py
+++ b/veritas_os/tests/test_debate_safety_policy_example_yaml.py
@@ -1,34 +1,33 @@
-"""Validation tests for the Debate safety policy example YAML skeleton."""
-
-from __future__ import annotations
-
-from pathlib import Path
+import pathlib
 
 import yaml
 
+from veritas_os.policy.debate_safety_policy_schema import (
+    DebateSafetyPolicy,
+    PolicyMode,
+)
 
-def test_debate_safety_policy_example_yaml_parses_and_has_expected_shape() -> None:
-    """Example policy file should parse and preserve required scaffold keys."""
-    policy_path = Path("configs/debate_safety_policy.example.yaml")
+EXAMPLE_YAML_PATH = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "configs"
+    / "debate_safety_policy.example.yaml"
+)
 
-    assert policy_path.exists()
-    loaded = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
 
-    assert isinstance(loaded, dict)
-    assert loaded.get("schema_version") == 1
-    assert isinstance(loaded.get("policy_id"), str)
-    assert loaded.get("mode") == "example_only"
+def test_example_yaml_parses_against_schema():
+    raw = yaml.safe_load(EXAMPLE_YAML_PATH.read_text(encoding="utf-8"))
+    policy = DebateSafetyPolicy.model_validate(raw)
+    assert policy.mode == PolicyMode.example_only
 
-    categories = loaded.get("categories")
-    assert isinstance(categories, dict)
-    assert categories
 
-    for category_name, category in categories.items():
-        assert isinstance(category_name, str)
-        assert isinstance(category, dict)
-        assert isinstance(category.get("severity"), str)
-        assert isinstance(category.get("action"), str)
-        patterns = category.get("patterns")
-        assert isinstance(patterns, list)
-        assert patterns
-        assert all(isinstance(pattern, str) for pattern in patterns)
+def test_example_yaml_has_at_least_one_category():
+    raw = yaml.safe_load(EXAMPLE_YAML_PATH.read_text(encoding="utf-8"))
+    policy = DebateSafetyPolicy.model_validate(raw)
+    assert len(policy.categories) >= 1
+
+
+def test_each_category_has_non_empty_patterns():
+    raw = yaml.safe_load(EXAMPLE_YAML_PATH.read_text(encoding="utf-8"))
+    policy = DebateSafetyPolicy.model_validate(raw)
+    for name, cat in policy.categories.items():
+        assert len(cat.patterns) >= 1, f"Category '{name}' has no patterns"


### PR DESCRIPTION
### Motivation
- Provide a Phase 1 single-source Pydantic schema for the Debate safety policy YAML so schema drift is detected earlier and Phase 2/3 implementations have a stable contract to code against.
- Upgrade the example YAML test to validate against that contract instead of only checking key existence.
- Keep runtime behavior unchanged by making this a schema-and-test-only change and explicitly avoiding wiring into enforcement paths; any future runtime wiring must receive human review and approval.

### Description
- Add `veritas_os/policy/debate_safety_policy_schema.py` containing the module docstring and Pydantic models and enums: `PolicyMode`, `Severity`, `PolicyAction`, `PatternCategory`, and `DebateSafetyPolicy` with `model_config = pydantic.ConfigDict(extra="forbid")`.
- Replace `veritas_os/tests/test_debate_safety_policy_example_yaml.py` with schema-based tests that `model_validate()` the example YAML and assert the `mode` is `example_only`, ensure at least one category, and ensure each category has non-empty `patterns`.
- Annotate `veritas_os/policy/__init__.py` with a Phase 1 comment: the schema is not wired into runtime enforcement and is Phase 1 only.
- No runtime code paths (including `veritas_os/core/debate.py`) were modified and no requirements files were changed.

### Testing
- Ran `python3 scripts/quality/check_operational_docs_consistency.py`, which passed successfully.
- Attempted to run `pytest -q veritas_os/tests/test_debate_safety_policy_example_yaml.py --tb=short` but `pytest` is not available in the current runtime environment, so local collection/execution could not be performed; CI/maintainer environments with `pytest` should collect and run the three tests and they are expected to pass when `DebateSafetyPolicy.model_validate()` accepts the example YAML.
- The change includes automated tests (three schema-validation tests) and those should be verified in CI where `pytest` is available.

Security note: This change only adds a schema and tests and does not alter enforcement behavior or secret handling, but wiring this schema into runtime enforcement would be a high-risk change requiring human review per project policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da2c6b02c8326bfed2fd389251c53)