### PR TITLE
H-7 Phase 2: add Debate safety policy YAML shadow loader and parity reporting

### DIFF
--- a/docs/architecture/debate-safety-policy-yaml-plan.md
+++ b/docs/architecture/debate-safety-policy-yaml-plan.md
@@ -113,3 +113,20 @@ These constants are the baseline behavior to preserve while migrating.
   `docs/ja/guides/fuji-eu-enterprise-strict-usage.md`
 - Responsibility boundaries:
   `docs/architecture/core_responsibility_boundaries.md`
+
+## Phase 2 status update (shadow-only)
+
+- A dedicated shadow loader is now available at
+  `veritas_os/policy/debate_safety_policy_loader.py`.
+- Loader behavior is intentionally non-authoritative:
+  - loads YAML from an explicit local path only,
+  - uses `yaml.safe_load`,
+  - validates with `DebateSafetyPolicy.model_validate`,
+  - raises explicit errors for malformed YAML or schema violations.
+- Debate runtime enforcement remains hardcoded in `veritas_os/core/debate.py`.
+- YAML policy is **not** the source of truth in Phase 2 and must not be used to
+  switch enforcement behavior.
+- Operator warning: Do **not** treat YAML policy as authoritative yet.
+- Future production strict-mode requirement remains: malformed production policy
+  must fail closed, but Phase 2 does not activate production enforcement from
+  YAML.

--- a/veritas_os/policy/debate_safety_policy_loader.py
+++ b/veritas_os/policy/debate_safety_policy_loader.py
@@ -1,0 +1,149 @@
+"""Shadow loader and parity helpers for Debate safety policy YAML.
+
+Phase 2 constraints:
+- This module MUST NOT alter runtime enforcement decisions.
+- Hardcoded logic in ``veritas_os/core/debate.py`` remains authoritative.
+- YAML is loaded from an explicit local path only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pydantic
+import yaml
+
+from veritas_os.core import debate
+from veritas_os.policy.debate_safety_policy_schema import DebateSafetyPolicy
+
+
+class DebateSafetyPolicyLoadError(ValueError):
+    """Base error for debate safety policy shadow-loading failures."""
+
+
+class DebateSafetyPolicyYamlSyntaxError(DebateSafetyPolicyLoadError):
+    """Raised when debate safety policy YAML cannot be parsed."""
+
+
+class DebateSafetyPolicySchemaError(DebateSafetyPolicyLoadError):
+    """Raised when parsed YAML fails DebateSafetyPolicy schema validation."""
+
+
+@dataclass(frozen=True)
+class DebateSafetyPolicyParityReport:
+    """Conservative parity report between YAML categories and hardcoded inventory."""
+
+    status: str
+    hardcoded_categories: list[str]
+    yaml_categories: list[str]
+    missing_hardcoded_categories: list[str]
+    extra_yaml_categories: list[str]
+    hardcoded_pattern_count: int | None
+    yaml_pattern_count: int
+    notes: list[str]
+
+
+_HARDCODED_CATEGORY_MAP: dict[str, Any] = {
+    "danger_terms_ja": debate._DANGER_TERMS_JA,
+    "danger_patterns_en": debate._DANGER_PATTERNS_EN,
+    "benign_context_strong_terms": debate._BENIGN_CONTEXT_STRONG_TERMS,
+    "benign_context_weak_terms": debate._BENIGN_CONTEXT_WEAK_TERMS,
+    "dangerous_intent_patterns": debate._DANGEROUS_INTENT_PATTERNS,
+    "actionable_intent_patterns": debate._ACTIONABLE_INTENT_PATTERNS,
+    "instructional_cue_patterns": debate._INSTRUCTIONAL_CUE_PATTERNS,
+    "risk_negation_terms": debate._RISK_NEGATION_TERMS,
+    "ascii_risk_negation_by_keyword": debate._ASCII_RISK_NEGATION_BY_KEYWORD,
+    "ja_risk_negation_by_keyword": debate._JA_RISK_NEGATION_BY_KEYWORD,
+    "refusal_context_patterns": debate._REFUSAL_CONTEXT_PATTERNS,
+    "risk_keywords_weighted": debate._RISK_KEYWORDS_WEIGHTED,
+    "regulatory_ambiguity_patterns": debate._REGULATORY_AMBIGUITY_PATTERNS,
+    "regulatory_ambiguity_negation_terms": debate._REGULATORY_AMBIGUITY_NEGATION_TERMS,
+}
+
+
+def load_debate_safety_policy_from_yaml(path: str | Path) -> DebateSafetyPolicy:
+    """Load and validate Debate safety policy YAML from an explicit path.
+
+    Args:
+        path: Local file path to YAML policy.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        DebateSafetyPolicyYamlSyntaxError: If YAML cannot be parsed.
+        DebateSafetyPolicySchemaError: If YAML shape fails schema validation.
+
+    Returns:
+        Validated ``DebateSafetyPolicy`` instance.
+    """
+    policy_path = Path(path)
+    raw_text = policy_path.read_text(encoding="utf-8")
+
+    try:
+        payload = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise DebateSafetyPolicyYamlSyntaxError(
+            f"Failed to parse YAML at '{policy_path}': {exc}"
+        ) from exc
+
+    try:
+        return DebateSafetyPolicy.model_validate(payload)
+    except pydantic.ValidationError as exc:
+        raise DebateSafetyPolicySchemaError(
+            f"YAML at '{policy_path}' failed DebateSafetyPolicy validation: {exc}"
+        ) from exc
+
+
+def compare_policy_to_hardcoded_inventory(
+    policy: DebateSafetyPolicy,
+) -> DebateSafetyPolicyParityReport:
+    """Create a conservative Phase 2 parity report.
+
+    This helper only compares category inventory and pattern counts and does not
+    evaluate semantic regex parity. It intentionally avoids over-claiming parity.
+    """
+    hardcoded_categories = sorted(_HARDCODED_CATEGORY_MAP.keys())
+    yaml_categories = sorted(policy.categories.keys())
+    missing_hardcoded = sorted(set(hardcoded_categories) - set(yaml_categories))
+    extra_yaml = sorted(set(yaml_categories) - set(hardcoded_categories))
+
+    hardcoded_pattern_count = _count_hardcoded_patterns()
+    yaml_pattern_count = sum(len(category.patterns) for category in policy.categories.values())
+
+    notes: list[str] = [
+        "Phase 2 shadow-only comparison. Runtime enforcement remains hardcoded.",
+        "Semantic regex equivalence is not validated in this report.",
+    ]
+
+    if missing_hardcoded or extra_yaml:
+        status = "parity_unknown"
+        notes.append(
+            "TODO: align YAML categories to full hardcoded inventory before considering enforcement parity."
+        )
+    else:
+        status = "partial_parity"
+        notes.append(
+            "Category names align with hardcoded inventory, but semantic parity remains unproven."
+        )
+
+    return DebateSafetyPolicyParityReport(
+        status=status,
+        hardcoded_categories=hardcoded_categories,
+        yaml_categories=yaml_categories,
+        missing_hardcoded_categories=missing_hardcoded,
+        extra_yaml_categories=extra_yaml,
+        hardcoded_pattern_count=hardcoded_pattern_count,
+        yaml_pattern_count=yaml_pattern_count,
+        notes=notes,
+    )
+
+
+def _count_hardcoded_patterns() -> int:
+    total = 0
+    for value in _HARDCODED_CATEGORY_MAP.values():
+        if isinstance(value, dict):
+            total += sum(len(items) for items in value.values())
+        else:
+            total += len(value)
+    return total

--- a/veritas_os/policy/debate_safety_policy_schema.py
+++ b/veritas_os/policy/debate_safety_policy_schema.py
@@ -37,14 +37,20 @@ class PolicyAction(str, Enum):
 class PatternCategory(pydantic.BaseModel):
     severity: Severity
     action: PolicyAction
-    patterns: list[Annotated[str, pydantic.StringConstraints(min_length=1)]]
+    patterns: Annotated[
+        list[Annotated[str, pydantic.StringConstraints(min_length=1)]],
+        pydantic.Field(min_length=1),
+    ]
 
 
 class DebateSafetyPolicy(pydantic.BaseModel):
     schema_version: int
     policy_id: str
     mode: PolicyMode
-    notes: list[str] = []
-    categories: dict[str, PatternCategory]
+    notes: list[str] = pydantic.Field(default_factory=list)
+    categories: Annotated[
+        dict[str, PatternCategory],
+        pydantic.Field(min_length=1),
+    ]
 
     model_config = pydantic.ConfigDict(extra="forbid")

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -58,6 +58,47 @@ def test_loader_fails_on_schema_invalid_yaml(tmp_path: Path) -> None:
         load_debate_safety_policy_from_yaml(schema_invalid)
 
 
+def test_loader_fails_on_schema_invalid_empty_pattern_string(tmp_path: Path) -> None:
+    schema_invalid = tmp_path / "schema_invalid_empty_pattern.yaml"
+    schema_invalid.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "policy_id: invalid-empty-pattern",
+                "mode: example_only",
+                "categories:",
+                "  dangerous_terms_ja:",
+                "    severity: high",
+                "    action: block",
+                "    patterns:",
+                '      - ""',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(DebateSafetyPolicySchemaError):
+        load_debate_safety_policy_from_yaml(schema_invalid)
+
+
+def test_loader_fails_on_schema_invalid_empty_categories(tmp_path: Path) -> None:
+    schema_invalid = tmp_path / "schema_invalid_empty_categories.yaml"
+    schema_invalid.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "policy_id: invalid-empty-categories",
+                "mode: example_only",
+                "categories: {}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(DebateSafetyPolicySchemaError):
+        load_debate_safety_policy_from_yaml(schema_invalid)
+
+
 def test_loader_does_not_call_runtime_enforcement(monkeypatch) -> None:
     called = {"run_debate": False}
 

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -1,0 +1,84 @@
+"""Tests for Debate safety policy shadow loader and parity report."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from veritas_os.policy.debate_safety_policy_loader import (
+    DebateSafetyPolicySchemaError,
+    DebateSafetyPolicyYamlSyntaxError,
+    compare_policy_to_hardcoded_inventory,
+    load_debate_safety_policy_from_yaml,
+)
+from veritas_os.policy.debate_safety_policy_schema import PolicyMode
+
+
+EXAMPLE_YAML_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "debate_safety_policy.example.yaml"
+)
+
+
+def test_loader_loads_valid_example_yaml() -> None:
+    policy = load_debate_safety_policy_from_yaml(EXAMPLE_YAML_PATH)
+    assert policy.mode == PolicyMode.example_only
+    assert len(policy.categories) >= 1
+
+
+def test_loader_fails_on_invalid_yaml_syntax(tmp_path: Path) -> None:
+    bad_yaml = tmp_path / "bad_syntax.yaml"
+    bad_yaml.write_text("categories: [\n", encoding="utf-8")
+
+    with pytest.raises(DebateSafetyPolicyYamlSyntaxError):
+        load_debate_safety_policy_from_yaml(bad_yaml)
+
+
+def test_loader_fails_on_schema_invalid_yaml(tmp_path: Path) -> None:
+    schema_invalid = tmp_path / "schema_invalid.yaml"
+    schema_invalid.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "policy_id: invalid",
+                "mode: example_only",
+                "categories:",
+                "  dangerous_terms_ja:",
+                "    severity: high",
+                "    action: block",
+                "    patterns: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(DebateSafetyPolicySchemaError):
+        load_debate_safety_policy_from_yaml(schema_invalid)
+
+
+def test_loader_does_not_call_runtime_enforcement(monkeypatch) -> None:
+    called = {"run_debate": False}
+
+    def _fail_run_debate(*args, **kwargs):
+        called["run_debate"] = True
+        raise AssertionError("run_debate must not be called by shadow loader")
+
+    monkeypatch.setattr("veritas_os.core.debate.run_debate", _fail_run_debate)
+
+    policy = load_debate_safety_policy_from_yaml(EXAMPLE_YAML_PATH)
+
+    assert policy.policy_id
+    assert called["run_debate"] is False
+
+
+def test_parity_report_is_conservative_phase2() -> None:
+    policy = load_debate_safety_policy_from_yaml(EXAMPLE_YAML_PATH)
+    report = compare_policy_to_hardcoded_inventory(policy)
+
+    assert report.status in {"shadow_only", "parity_unknown", "partial_parity"}
+    assert report.status == "parity_unknown"
+    assert len(report.missing_hardcoded_categories) >= 1
+    assert report.hardcoded_pattern_count is not None
+    assert report.yaml_pattern_count >= 1

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -81,6 +81,29 @@ def test_loader_fails_on_schema_invalid_empty_pattern_string(tmp_path: Path) -> 
         load_debate_safety_policy_from_yaml(schema_invalid)
 
 
+def test_loader_fails_on_schema_invalid_empty_patterns_list(tmp_path: Path) -> None:
+    """patterns: [] must be rejected — list itself must be non-empty (Field min_length=1)."""
+    schema_invalid = tmp_path / "schema_invalid_empty_patterns_list.yaml"
+    schema_invalid.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "policy_id: invalid-empty-patterns-list",
+                "mode: example_only",
+                "categories:",
+                "  dangerous_terms_ja:",
+                "    severity: high",
+                "    action: block",
+                "    patterns: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(DebateSafetyPolicySchemaError):
+        load_debate_safety_policy_from_yaml(schema_invalid)
+
+
 def test_loader_fails_on_schema_invalid_empty_categories(tmp_path: Path) -> None:
     schema_invalid = tmp_path / "schema_invalid_empty_categories.yaml"
     schema_invalid.write_text(


### PR DESCRIPTION
### Motivation

- Provide a safe, non-authoritative shadow-loading path for Debate safety policy YAML so policy-as-data can be validated without changing runtime enforcement. 
- Surface explicit errors and a conservative parity report to detect drift between future YAML policies and the current hardcoded inventory in `veritas_os/core/debate.py`.
- Preserve existing hardcoded Debate safety behavior as authoritative while enabling Phase 2 validation and operator review.

### Description

- Added a shadow loader at `veritas_os/policy/debate_safety_policy_loader.py` that loads YAML from an explicit local path using `yaml.safe_load` and validates with `DebateSafetyPolicy.model_validate` without touching runtime enforcement. 
- Implemented explicit error types: `DebateSafetyPolicyYamlSyntaxError` for YAML parse failures and `DebateSafetyPolicySchemaError` for schema validation failures. 
- Added a conservative parity helper `compare_policy_to_hardcoded_inventory` that reports category inventory, counts, and a non-overclaiming status (`parity_unknown` / `partial_parity`) and returns a `DebateSafetyPolicyParityReport` dataclass. 
- Added unit tests `veritas_os/tests/test_debate_safety_policy_loader.py` covering successful example YAML load, YAML syntax failure, schema invalid failure, assurance that the loader does not call runtime enforcement, and conservative parity expectations, and updated `docs/architecture/debate-safety-policy-yaml-plan.md` with a Phase 2 status note and operator warning. 
- Security constraints enforced: no remote fetch, no `eval`/`exec`, YAML parsed with `safe_load`, loader only reads explicit local path, and no environment flag or runtime enforcement switch was introduced.

### Testing

- `python3 scripts/architecture/check_responsibility_boundaries.py` passed successfully. 
- `python3 scripts/quality/check_operational_docs_consistency.py` passed successfully. 
- `pytest -q veritas_os/tests/test_debate_safety_policy_example_yaml.py --tb=short` and `pytest -q veritas_os/tests/test_debate_safety_policy_loader.py --tb=short` were not executed in this environment because `pytest` is not available under the active interpreter, so those tests must run in CI (they are included in the PR). 
- `pytest -q veritas_os/tests -k "debate and not slow" --tb=short` could not be executed here for the same reason, but no runtime Debate enforcement code was modified and existing Debate tests remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0daaf404d083268170163ca78ff6d4)