### PR TITLE
Add exportable hardcoded Debate inventory and Phase 2.5 parity tests

### DIFF
--- a/docs/architecture/debate-safety-policy-yaml-plan.md
+++ b/docs/architecture/debate-safety-policy-yaml-plan.md
@@ -86,6 +86,17 @@ These constants are the baseline behavior to preserve while migrating.
 - Compare shadow policy evaluation with hardcoded evaluation in tests.
 - Fail tests on unexpected drift.
 
+### Phase 2.5 — Export hardcoded inventory + conservative parity visibility
+
+- Export a review-facing hardcoded inventory metadata report from
+  `veritas_os/policy/debate_safety_policy_loader.py`.
+- Keep parity reporting conservative (`parity_unknown` is expected until full
+  inventory alignment is intentionally addressed).
+- Runtime Debate enforcement remains hardcoded and authoritative.
+- YAML remains non-authoritative in this phase.
+- Phase 3 is blocked until inventory parity gaps are intentionally resolved and
+  documented.
+
 ### Phase 3 — Feature-flag YAML enforcement
 
 - Gate YAML-based enforcement behind explicit capability/feature flag.
@@ -130,3 +141,21 @@ These constants are the baseline behavior to preserve while migrating.
 - Future production strict-mode requirement remains: malformed production policy
   must fail closed, but Phase 2 does not activate production enforcement from
   YAML.
+
+## Phase 2.5 status update (inventory export only)
+
+- Hardcoded Debate safety inventory metadata is now exportable for review/test
+  visibility (category names and pattern counts).
+- Parity report remains conservative by design and must not be interpreted as
+  semantic equivalence proof.
+- Runtime enforcement is still hardcoded in `veritas_os/core/debate.py`.
+- YAML policy remains non-authoritative and does not drive runtime decisions.
+
+## Phase 3 entry checklist (must pass before activation work)
+
+- No missing hardcoded categories in parity inventory, or an explicit and
+  reviewed migration decision documenting each remaining gap.
+- Parity-focused tests pass in CI.
+- Any feature flag for YAML enforcement defaults to off.
+- Malformed policy fail-closed behavior is designed and test-covered.
+- Policy diagnostics avoid raw PII/secrets output.

--- a/veritas_os/policy/debate_safety_policy_loader.py
+++ b/veritas_os/policy/debate_safety_policy_loader.py
@@ -45,6 +45,16 @@ class DebateSafetyPolicyParityReport:
     notes: list[str]
 
 
+@dataclass(frozen=True)
+class DebateSafetyHardcodedInventory:
+    """Review-facing export of hardcoded Debate safety inventory metadata."""
+
+    categories: dict[str, dict[str, int]]
+    total_pattern_count: int
+    source: str
+    authoritative: bool
+
+
 _HARDCODED_CATEGORY_MAP: dict[str, Any] = {
     "danger_terms_ja": debate._DANGER_TERMS_JA,
     "danger_patterns_en": debate._DANGER_PATTERNS_EN,
@@ -61,6 +71,35 @@ _HARDCODED_CATEGORY_MAP: dict[str, Any] = {
     "regulatory_ambiguity_patterns": debate._REGULATORY_AMBIGUITY_PATTERNS,
     "regulatory_ambiguity_negation_terms": debate._REGULATORY_AMBIGUITY_NEGATION_TERMS,
 }
+
+
+def export_hardcoded_debate_safety_inventory() -> dict[str, Any]:
+    """Export hardcoded Debate safety inventory metadata for review/testing.
+
+    The returned structure is intentionally metadata-only and does not alter
+    runtime enforcement. Hardcoded logic in ``veritas_os.core.debate`` remains
+    authoritative.
+    """
+    categories: dict[str, dict[str, int]] = {}
+    for category_name, value in _HARDCODED_CATEGORY_MAP.items():
+        categories[category_name] = {
+            "pattern_count": _count_patterns_for_category(value),
+        }
+
+    inventory = DebateSafetyHardcodedInventory(
+        categories=categories,
+        total_pattern_count=sum(
+            category["pattern_count"] for category in categories.values()
+        ),
+        source="veritas_os.core.debate",
+        authoritative=True,
+    )
+    return {
+        "categories": inventory.categories,
+        "total_pattern_count": inventory.total_pattern_count,
+        "source": inventory.source,
+        "authoritative": inventory.authoritative,
+    }
 
 
 def load_debate_safety_policy_from_yaml(path: str | Path) -> DebateSafetyPolicy:
@@ -142,8 +181,12 @@ def compare_policy_to_hardcoded_inventory(
 def _count_hardcoded_patterns() -> int:
     total = 0
     for value in _HARDCODED_CATEGORY_MAP.values():
-        if isinstance(value, dict):
-            total += sum(len(items) for items in value.values())
-        else:
-            total += len(value)
+        total += _count_patterns_for_category(value)
     return total
+
+
+def _count_patterns_for_category(category: Any) -> int:
+    """Count regex/term entries for one hardcoded Debate category."""
+    if isinstance(category, dict):
+        return sum(len(items) for items in category.values())
+    return len(category)

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -168,6 +168,18 @@ def test_export_hardcoded_inventory_has_reviewable_non_empty_metadata() -> None:
 
 def test_export_hardcoded_inventory_category_name_snapshot() -> None:
     inventory = export_hardcoded_debate_safety_inventory()
+
+    # INTENTIONAL SNAPSHOT — do not relax or delete without review.
+    #
+    # This assertion fails whenever a category is added to or removed from
+    # _HARDCODED_CATEGORY_MAP in debate_safety_policy_loader.py.
+    # That failure is deliberate: it forces the developer to:
+    #   1. Update this list to include the new category name.
+    #   2. Document the corresponding parity gap (or resolution) in:
+    #      docs/architecture/debate-safety-policy-yaml-plan.md
+    #
+    # Phase 3 is blocked until all parity gaps are intentionally resolved.
+    # See: Phase 3 entry checklist in debate-safety-policy-yaml-plan.md
     assert sorted(inventory["categories"].keys()) == [
         "actionable_intent_patterns",
         "ascii_risk_negation_by_keyword",

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -10,6 +10,7 @@ from veritas_os.policy.debate_safety_policy_loader import (
     DebateSafetyPolicySchemaError,
     DebateSafetyPolicyYamlSyntaxError,
     compare_policy_to_hardcoded_inventory,
+    export_hardcoded_debate_safety_inventory,
     load_debate_safety_policy_from_yaml,
 )
 from veritas_os.policy.debate_safety_policy_schema import PolicyMode
@@ -146,3 +147,40 @@ def test_parity_report_is_conservative_phase2() -> None:
     assert len(report.missing_hardcoded_categories) >= 1
     assert report.hardcoded_pattern_count is not None
     assert report.yaml_pattern_count >= 1
+    assert any("Runtime enforcement remains hardcoded" in note for note in report.notes)
+
+
+def test_export_hardcoded_inventory_has_reviewable_non_empty_metadata() -> None:
+    inventory = export_hardcoded_debate_safety_inventory()
+    categories = inventory["categories"]
+
+    assert isinstance(categories, dict)
+    assert len(categories) >= 1
+    assert inventory["total_pattern_count"] > 0
+    assert inventory["source"] == "veritas_os.core.debate"
+    assert inventory["authoritative"] is True
+
+    for category_name, category in categories.items():
+        assert category_name
+        assert isinstance(category["pattern_count"], int)
+        assert category["pattern_count"] >= 0
+
+
+def test_export_hardcoded_inventory_category_name_snapshot() -> None:
+    inventory = export_hardcoded_debate_safety_inventory()
+    assert sorted(inventory["categories"].keys()) == [
+        "actionable_intent_patterns",
+        "ascii_risk_negation_by_keyword",
+        "benign_context_strong_terms",
+        "benign_context_weak_terms",
+        "danger_patterns_en",
+        "danger_terms_ja",
+        "dangerous_intent_patterns",
+        "instructional_cue_patterns",
+        "ja_risk_negation_by_keyword",
+        "refusal_context_patterns",
+        "regulatory_ambiguity_negation_terms",
+        "regulatory_ambiguity_patterns",
+        "risk_keywords_weighted",
+        "risk_negation_terms",
+    ]


### PR DESCRIPTION
### Motivation

- Make the current hardcoded Debate safety inventory explicit and reviewable without changing runtime enforcement, so inventory parity can be audited before any YAML-based enforcement work. 
- Provide a small operator/testable export and stronger parity assertions to surface gaps conservatively in Phase 2.

### Description

- Added a review-facing dataclass `DebateSafetyHardcodedInventory` and the function `export_hardcoded_debate_safety_inventory()` which returns category-level `pattern_count`, `total_pattern_count`, `source`, and `authoritative` metadata and does not mutate runtime state. 
- Introduced `_count_patterns_for_category()` and refactored `_count_hardcoded_patterns()` so per-category and total counting use shared logic. 
- Extended tests in `veritas_os/tests/test_debate_safety_policy_loader.py` to assert that `export_hardcoded_debate_safety_inventory()` returns non-empty metadata, that each category has a non-negative integer `pattern_count`, and that `compare_policy_to_hardcoded_inventory(...)` remains conservative (expects `parity_unknown`, non-empty `missing_hardcoded_categories`, and notes the runtime enforcement is hardcoded). 
- Updated `docs/architecture/debate-safety-policy-yaml-plan.md` with a Phase 2.5 description and a Phase 3 entry checklist that emphasize the exportable inventory, conservative parity stance, and that YAML remains non-authoritative.

### Testing

- Ran responsibility/docs checks with `python scripts/architecture/check_responsibility_boundaries.py` and `python scripts/quality/check_operational_docs_consistency.py`, both of which passed in the test environment. 
- Attempted to run the new pytest subset via `pytest -q veritas_os/tests/test_debate_safety_policy_loader.py`, but collection failed due to an unavailable test-time dependency (`ModuleNotFoundError: No module named 'pydantic'`) in the interpreter used here, so the new tests could not be executed end-to-end in this environment. 
- Notes: the added tests are present and designed to be deterministic (category-name snapshot only, not volatile internals); please run the test suite in CI (with `pydantic` available) to validate passing results.

Security note: this PR intentionally does not change any runtime enforcement, does not add any environment flags, remote fetches, or `eval`/`exec`, and preserves all hardcoded patterns; because this touches a security-sensitive policy surface, please ensure CI runs and human review sign-off before any Phase 3 work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dda782364832685170a17caf9b70d)