### PR TITLE
Export hardcoded Debate safety inventory, add Phase 2.5 docs, and tests

### DIFF
--- a/docs/architecture/debate-safety-policy-yaml-plan.md
+++ b/docs/architecture/debate-safety-policy-yaml-plan.md
@@ -86,6 +86,17 @@ These constants are the baseline behavior to preserve while migrating.
 - Compare shadow policy evaluation with hardcoded evaluation in tests.
 - Fail tests on unexpected drift.
 
+### Phase 2.5 — Export hardcoded inventory + conservative parity visibility
+
+- Export a review-facing hardcoded inventory metadata report from
+  `veritas_os/policy/debate_safety_policy_loader.py`.
+- Keep parity reporting conservative (`parity_unknown` is expected until full
+  inventory alignment is intentionally addressed).
+- Runtime Debate enforcement remains hardcoded and authoritative.
+- YAML remains non-authoritative in this phase.
+- Phase 3 is blocked until inventory parity gaps are intentionally resolved and
+  documented.
+
 ### Phase 3 — Feature-flag YAML enforcement
 
 - Gate YAML-based enforcement behind explicit capability/feature flag.
@@ -130,3 +141,21 @@ These constants are the baseline behavior to preserve while migrating.
 - Future production strict-mode requirement remains: malformed production policy
   must fail closed, but Phase 2 does not activate production enforcement from
   YAML.
+
+## Phase 2.5 status update (inventory export only)
+
+- Hardcoded Debate safety inventory metadata is now exportable for review/test
+  visibility (category names and pattern counts).
+- Parity report remains conservative by design and must not be interpreted as
+  semantic equivalence proof.
+- Runtime enforcement is still hardcoded in `veritas_os/core/debate.py`.
+- YAML policy remains non-authoritative and does not drive runtime decisions.
+
+## Phase 3 entry checklist (must pass before activation work)
+
+- No missing hardcoded categories in parity inventory, or an explicit and
+  reviewed migration decision documenting each remaining gap.
+- Parity-focused tests pass in CI.
+- Any feature flag for YAML enforcement defaults to off.
+- Malformed policy fail-closed behavior is designed and test-covered.
+- Policy diagnostics avoid raw PII/secrets output.

--- a/veritas_os/policy/debate_safety_policy_loader.py
+++ b/veritas_os/policy/debate_safety_policy_loader.py
@@ -45,6 +45,16 @@ class DebateSafetyPolicyParityReport:
     notes: list[str]
 
 
+@dataclass(frozen=True)
+class DebateSafetyHardcodedInventory:
+    """Review-facing export of hardcoded Debate safety inventory metadata."""
+
+    categories: dict[str, dict[str, int]]
+    total_pattern_count: int
+    source: str
+    authoritative: bool
+
+
 _HARDCODED_CATEGORY_MAP: dict[str, Any] = {
     "danger_terms_ja": debate._DANGER_TERMS_JA,
     "danger_patterns_en": debate._DANGER_PATTERNS_EN,
@@ -61,6 +71,29 @@ _HARDCODED_CATEGORY_MAP: dict[str, Any] = {
     "regulatory_ambiguity_patterns": debate._REGULATORY_AMBIGUITY_PATTERNS,
     "regulatory_ambiguity_negation_terms": debate._REGULATORY_AMBIGUITY_NEGATION_TERMS,
 }
+
+
+def export_hardcoded_debate_safety_inventory() -> DebateSafetyHardcodedInventory:
+    """Export hardcoded Debate safety inventory metadata for review/testing.
+
+    The returned dataclass is intentionally metadata-only and does not alter
+    runtime enforcement. Hardcoded logic in ``veritas_os.core.debate`` remains
+    authoritative.
+    """
+    categories: dict[str, dict[str, int]] = {}
+    for category_name, value in _HARDCODED_CATEGORY_MAP.items():
+        categories[category_name] = {
+            "pattern_count": _count_patterns_for_category(value),
+        }
+
+    return DebateSafetyHardcodedInventory(
+        categories=categories,
+        total_pattern_count=sum(
+            category["pattern_count"] for category in categories.values()
+        ),
+        source="veritas_os.core.debate",
+        authoritative=True,
+    )
 
 
 def load_debate_safety_policy_from_yaml(path: str | Path) -> DebateSafetyPolicy:
@@ -142,8 +175,12 @@ def compare_policy_to_hardcoded_inventory(
 def _count_hardcoded_patterns() -> int:
     total = 0
     for value in _HARDCODED_CATEGORY_MAP.values():
-        if isinstance(value, dict):
-            total += sum(len(items) for items in value.values())
-        else:
-            total += len(value)
+        total += _count_patterns_for_category(value)
     return total
+
+
+def _count_patterns_for_category(category: Any) -> int:
+    """Count regex/term entries for one hardcoded Debate category."""
+    if isinstance(category, dict):
+        return sum(len(items) for items in category.values())
+    return len(category)

--- a/veritas_os/policy/debate_safety_policy_loader.py
+++ b/veritas_os/policy/debate_safety_policy_loader.py
@@ -18,6 +18,12 @@ import yaml
 from veritas_os.core import debate
 from veritas_os.policy.debate_safety_policy_schema import DebateSafetyPolicy
 
+# Sentinel note used by compare_policy_to_hardcoded_inventory() to signal that
+# runtime Debate enforcement is still hardcoded and YAML is non-authoritative.
+NOTE_RUNTIME_ENFORCEMENT_HARDCODED: str = (
+    "Runtime enforcement remains hardcoded in veritas_os.core.debate"
+)
+
 
 class DebateSafetyPolicyLoadError(ValueError):
     """Base error for debate safety policy shadow-loading failures."""
@@ -145,7 +151,8 @@ def compare_policy_to_hardcoded_inventory(
     yaml_pattern_count = sum(len(category.patterns) for category in policy.categories.values())
 
     notes: list[str] = [
-        "Phase 2 shadow-only comparison. Runtime enforcement remains hardcoded.",
+        "Phase 2 shadow-only comparison.",
+        NOTE_RUNTIME_ENFORCEMENT_HARDCODED,
         "Semantic regex equivalence is not validated in this report.",
     ]
 

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from veritas_os.policy.debate_safety_policy_loader import (
+    NOTE_RUNTIME_ENFORCEMENT_HARDCODED,
     DebateSafetyPolicySchemaError,
     DebateSafetyPolicyYamlSyntaxError,
     compare_policy_to_hardcoded_inventory,
@@ -147,7 +148,7 @@ def test_parity_report_is_conservative_phase2() -> None:
     assert len(report.missing_hardcoded_categories) >= 1
     assert report.hardcoded_pattern_count is not None
     assert report.yaml_pattern_count >= 1
-    assert any("Runtime enforcement remains hardcoded" in note for note in report.notes)
+    assert NOTE_RUNTIME_ENFORCEMENT_HARDCODED in report.notes
 
 
 def test_export_hardcoded_inventory_has_reviewable_non_empty_metadata() -> None:

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -10,6 +10,7 @@ from veritas_os.policy.debate_safety_policy_loader import (
     DebateSafetyPolicySchemaError,
     DebateSafetyPolicyYamlSyntaxError,
     compare_policy_to_hardcoded_inventory,
+    export_hardcoded_debate_safety_inventory,
     load_debate_safety_policy_from_yaml,
 )
 from veritas_os.policy.debate_safety_policy_schema import PolicyMode
@@ -146,3 +147,39 @@ def test_parity_report_is_conservative_phase2() -> None:
     assert len(report.missing_hardcoded_categories) >= 1
     assert report.hardcoded_pattern_count is not None
     assert report.yaml_pattern_count >= 1
+    assert any("Runtime enforcement remains hardcoded" in note for note in report.notes)
+
+
+def test_export_hardcoded_inventory_has_reviewable_non_empty_metadata() -> None:
+    inventory = export_hardcoded_debate_safety_inventory()
+
+    assert isinstance(inventory.categories, dict)
+    assert len(inventory.categories) >= 1
+    assert inventory.total_pattern_count > 0
+    assert inventory.source == "veritas_os.core.debate"
+    assert inventory.authoritative is True
+
+    for category_name, category in inventory.categories.items():
+        assert category_name
+        assert isinstance(category["pattern_count"], int)
+        assert category["pattern_count"] >= 0
+
+
+def test_export_hardcoded_inventory_category_name_snapshot() -> None:
+    inventory = export_hardcoded_debate_safety_inventory()
+    assert sorted(inventory.categories.keys()) == [
+        "actionable_intent_patterns",
+        "ascii_risk_negation_by_keyword",
+        "benign_context_strong_terms",
+        "benign_context_weak_terms",
+        "danger_patterns_en",
+        "danger_terms_ja",
+        "dangerous_intent_patterns",
+        "instructional_cue_patterns",
+        "ja_risk_negation_by_keyword",
+        "refusal_context_patterns",
+        "regulatory_ambiguity_negation_terms",
+        "regulatory_ambiguity_patterns",
+        "risk_keywords_weighted",
+        "risk_negation_terms",
+    ]


### PR DESCRIPTION
### Motivation

- Provide a review-facing, metadata-only export of the current hardcoded Debate safety inventory to aid parity reviews and migration planning. 
- Record a conservative Phase 2.5 in the migration plan to make inventory visibility explicit while keeping runtime enforcement authoritative. 
- Keep YAML shadow-loading non-authoritative and ensure parity reporting remains conservative until intentional alignment is completed.

### Description

- Add a new frozen dataclass `DebateSafetyHardcodedInventory` and an `export_hardcoded_debate_safety_inventory()` function that returns reviewable metadata (category pattern counts, total count, source, authoritative flag). 
- Introduce a helper `_count_patterns_for_category()` and refactor `_count_hardcoded_patterns()` to use it for consistent pattern counting across category shapes. 
- Extend `_HARDCODED_CATEGORY_MAP` usage to populate the exported inventory without altering runtime enforcement in `veritas_os.core.debate`. 
- Update docs `docs/architecture/debate-safety-policy-yaml-plan.md` to add Phase 2.5 and status/entry-checklist text describing conservative parity visibility and blocking criteria for Phase 3. 
- Add unit tests exercising the new export API and adjust parity test expectations in `veritas_os/tests/test_debate_safety_policy_loader.py` including a snapshot of category names and a note check for conservative reporting.

### Testing

- Ran the unit tests in `veritas_os/tests/test_debate_safety_policy_loader.py` via `pytest` against the modified loader and documentation-related tests. 
- All tests in that file, including the new `test_export_hardcoded_inventory_*` cases and parity assertions, passed successfully. 
- YAML parsing and schema validation tests (existing shadow-loader tests) continued to pass under the updated code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dda782364832685170a17caf9b70d)