### PR TITLE
Add Phase 2.5 debate inventory export and conservative parity visibility

### DIFF
--- a/docs/architecture/debate-safety-policy-yaml-plan.md
+++ b/docs/architecture/debate-safety-policy-yaml-plan.md
@@ -130,3 +130,26 @@ These constants are the baseline behavior to preserve while migrating.
 - Future production strict-mode requirement remains: malformed production policy
   must fail closed, but Phase 2 does not activate production enforcement from
   YAML.
+
+## Phase 2.5 status update (inventory export + conservative parity)
+
+- Hardcoded Debate safety inventory is now exportable for review from
+  `export_hardcoded_debate_safety_inventory()` in
+  `veritas_os/policy/debate_safety_policy_loader.py`.
+- Exported inventory provides category names and pattern counts for review and
+  tests, while avoiding runtime behavior changes.
+- Parity reporting remains intentionally conservative (`parity_unknown` when
+  any hardcoded categories are missing in YAML).
+- Runtime enforcement is still hardcoded and authoritative in
+  `veritas_os/core/debate.py`; YAML remains non-authoritative.
+- Phase 3 (feature-flagged YAML enforcement) is blocked until intentional
+  inventory-parity decisions are documented and approved.
+
+### Phase 3 entry checklist
+
+- No missing hardcoded categories in YAML, or an explicit documented migration
+  decision for each gap.
+- Parity tests pass consistently in CI.
+- Feature-flag defaults remain off.
+- Malformed policy fail-closed behavior is designed before enforcement switch.
+- Policy diagnostics exclude raw PII/secrets.

--- a/veritas_os/policy/debate_safety_policy_loader.py
+++ b/veritas_os/policy/debate_safety_policy_loader.py
@@ -62,7 +62,7 @@ def export_hardcoded_debate_safety_inventory() -> dict[str, Any]:
     return {
         "categories": categories,
         "total_pattern_count": total_pattern_count,
-        "source": "veritas_os.core.debate",
+        "source": debate.__name__,
         "authoritative": True,
     }
 
@@ -175,15 +175,13 @@ def build_debate_safety_policy_shadow_report(
         "hardcoded_category_count": len(parity.hardcoded_categories),
         "missing_hardcoded_categories": parity.missing_hardcoded_categories,
         "extra_yaml_categories": parity.extra_yaml_categories,
+        "notes": parity.notes,
         "enforcement_authoritative": "hardcoded",
     }
 
 
 def _count_hardcoded_patterns() -> int:
-    total = 0
-    for value in _HARDCODED_CATEGORY_MAP.values():
-        total += _count_category_patterns(value)
-    return total
+    return sum(_count_category_patterns(v) for v in _HARDCODED_CATEGORY_MAP.values())
 
 
 def _count_category_patterns(value: Any) -> int:

--- a/veritas_os/policy/debate_safety_policy_loader.py
+++ b/veritas_os/policy/debate_safety_policy_loader.py
@@ -45,6 +45,28 @@ class DebateSafetyPolicyParityReport:
     notes: list[str]
 
 
+def export_hardcoded_debate_safety_inventory() -> dict[str, Any]:
+    """Export current hardcoded Debate safety inventory metadata.
+
+    Returns a review-friendly summary for tests and operator visibility.
+    Runtime enforcement remains hardcoded and authoritative.
+    """
+    categories: dict[str, dict[str, int]] = {}
+    total_pattern_count = 0
+
+    for category_name, value in _HARDCODED_CATEGORY_MAP.items():
+        pattern_count = _count_category_patterns(value)
+        categories[category_name] = {"pattern_count": pattern_count}
+        total_pattern_count += pattern_count
+
+    return {
+        "categories": categories,
+        "total_pattern_count": total_pattern_count,
+        "source": "veritas_os.core.debate",
+        "authoritative": True,
+    }
+
+
 _HARDCODED_CATEGORY_MAP: dict[str, Any] = {
     "danger_terms_ja": debate._DANGER_TERMS_JA,
     "danger_patterns_en": debate._DANGER_PATTERNS_EN,
@@ -139,11 +161,32 @@ def compare_policy_to_hardcoded_inventory(
     )
 
 
+def build_debate_safety_policy_shadow_report(
+    policy: DebateSafetyPolicy,
+) -> dict[str, Any]:
+    """Build a CLI-free review report for shadow-loaded policy visibility."""
+    parity = compare_policy_to_hardcoded_inventory(policy)
+    return {
+        "policy_id": policy.policy_id,
+        "mode": policy.mode.value,
+        "schema_version": policy.schema_version,
+        "parity_status": parity.status,
+        "yaml_category_count": len(parity.yaml_categories),
+        "hardcoded_category_count": len(parity.hardcoded_categories),
+        "missing_hardcoded_categories": parity.missing_hardcoded_categories,
+        "extra_yaml_categories": parity.extra_yaml_categories,
+        "enforcement_authoritative": "hardcoded",
+    }
+
+
 def _count_hardcoded_patterns() -> int:
     total = 0
     for value in _HARDCODED_CATEGORY_MAP.values():
-        if isinstance(value, dict):
-            total += sum(len(items) for items in value.values())
-        else:
-            total += len(value)
+        total += _count_category_patterns(value)
     return total
+
+
+def _count_category_patterns(value: Any) -> int:
+    if isinstance(value, dict):
+        return sum(len(items) for items in value.values())
+    return len(value)

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -7,9 +7,11 @@ from pathlib import Path
 import pytest
 
 from veritas_os.policy.debate_safety_policy_loader import (
+    build_debate_safety_policy_shadow_report,
     DebateSafetyPolicySchemaError,
     DebateSafetyPolicyYamlSyntaxError,
     compare_policy_to_hardcoded_inventory,
+    export_hardcoded_debate_safety_inventory,
     load_debate_safety_policy_from_yaml,
 )
 from veritas_os.policy.debate_safety_policy_schema import PolicyMode
@@ -146,3 +148,54 @@ def test_parity_report_is_conservative_phase2() -> None:
     assert len(report.missing_hardcoded_categories) >= 1
     assert report.hardcoded_pattern_count is not None
     assert report.yaml_pattern_count >= 1
+    assert any("Runtime enforcement remains hardcoded" in note for note in report.notes)
+
+
+def test_export_hardcoded_inventory_has_non_empty_categories_and_counts() -> None:
+    inventory = export_hardcoded_debate_safety_inventory()
+
+    assert inventory["source"] == "veritas_os.core.debate"
+    assert inventory["authoritative"] is True
+    assert isinstance(inventory["categories"], dict)
+    assert len(inventory["categories"]) >= 1
+    assert inventory["total_pattern_count"] > 0
+
+    for category_name, metadata in inventory["categories"].items():
+        assert category_name
+        assert isinstance(metadata["pattern_count"], int)
+        assert metadata["pattern_count"] >= 0
+
+
+def test_export_hardcoded_inventory_category_snapshot_names_only() -> None:
+    inventory = export_hardcoded_debate_safety_inventory()
+    expected_categories = {
+        "actionable_intent_patterns",
+        "ascii_risk_negation_by_keyword",
+        "benign_context_strong_terms",
+        "benign_context_weak_terms",
+        "danger_patterns_en",
+        "danger_terms_ja",
+        "dangerous_intent_patterns",
+        "instructional_cue_patterns",
+        "ja_risk_negation_by_keyword",
+        "refusal_context_patterns",
+        "regulatory_ambiguity_negation_terms",
+        "regulatory_ambiguity_patterns",
+        "risk_keywords_weighted",
+        "risk_negation_terms",
+    }
+    assert set(inventory["categories"].keys()) == expected_categories
+
+
+def test_build_shadow_report_visibility_fields() -> None:
+    policy = load_debate_safety_policy_from_yaml(EXAMPLE_YAML_PATH)
+    report = build_debate_safety_policy_shadow_report(policy)
+
+    assert report["policy_id"] == policy.policy_id
+    assert report["mode"] == policy.mode.value
+    assert report["schema_version"] == policy.schema_version
+    assert report["parity_status"] == "parity_unknown"
+    assert report["yaml_category_count"] >= 1
+    assert report["hardcoded_category_count"] >= 1
+    assert len(report["missing_hardcoded_categories"]) >= 1
+    assert report["enforcement_authoritative"] == "hardcoded"

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -14,6 +14,7 @@ from veritas_os.policy.debate_safety_policy_loader import (
     export_hardcoded_debate_safety_inventory,
     load_debate_safety_policy_from_yaml,
 )
+from veritas_os.core import debate
 from veritas_os.policy.debate_safety_policy_schema import PolicyMode
 
 
@@ -154,7 +155,7 @@ def test_parity_report_is_conservative_phase2() -> None:
 def test_export_hardcoded_inventory_has_non_empty_categories_and_counts() -> None:
     inventory = export_hardcoded_debate_safety_inventory()
 
-    assert inventory["source"] == "veritas_os.core.debate"
+    assert inventory["source"] == debate.__name__
     assert inventory["authoritative"] is True
     assert isinstance(inventory["categories"], dict)
     assert len(inventory["categories"]) >= 1
@@ -164,6 +165,9 @@ def test_export_hardcoded_inventory_has_non_empty_categories_and_counts() -> Non
         assert category_name
         assert isinstance(metadata["pattern_count"], int)
         assert metadata["pattern_count"] >= 0
+    assert sum(
+        meta["pattern_count"] for meta in inventory["categories"].values()
+    ) == inventory["total_pattern_count"]
 
 
 def test_export_hardcoded_inventory_category_snapshot_names_only() -> None:
@@ -198,4 +202,5 @@ def test_build_shadow_report_visibility_fields() -> None:
     assert report["yaml_category_count"] >= 1
     assert report["hardcoded_category_count"] >= 1
     assert len(report["missing_hardcoded_categories"]) >= 1
+    assert report["notes"]
     assert report["enforcement_authoritative"] == "hardcoded"


### PR DESCRIPTION
### Motivation
- Make the current hardcoded Debate safety inventory explicit, reviewable, and testable without touching runtime enforcement or changing behavior.
- Provide operator/reviewer-facing visibility and snapshot-style tests to detect inventory drift before any Phase 3 enforcement work.
- Preserve security posture by ensuring YAML remains non-authoritative and all enforcement stays tied to existing hardcoded logic.

### Description
- Add `export_hardcoded_debate_safety_inventory()` which returns a review-friendly summary with per-category `pattern_count`, `total_pattern_count`, `source`, and `authoritative` flag while reading existing `_HARDCODED_CATEGORY_MAP` only.
- Add `build_debate_safety_policy_shadow_report(policy: DebateSafetyPolicy)` to produce a CLI-free shadow report containing `policy_id`, `mode`, `schema_version`, parity status, YAML/hardcoded counts, missing/extra categories, and `enforcement_authoritative: "hardcoded"` for reviewer visibility.
- Refactor pattern counting with `_count_category_patterns()` and reuse it in `_count_hardcoded_patterns()` and the export helper; include docstrings for the new helpers.
- Add tests in `veritas_os/tests/test_debate_safety_policy_loader.py` that assert the export shape and non-empty counts, per-category non-negative integer `pattern_count`, a snapshot-style check of category names only, that parity remains conservative (`parity_unknown` + informative notes), and that the shadow report contains expected visibility fields.
- Update `docs/architecture/debate-safety-policy-yaml-plan.md` with a Phase 2.5 section describing exportability, conservative parity posture, YAML non-authoritative status, and a Phase 3 entry checklist.
- No runtime enforcement changes, no feature-flag to enable YAML enforcement, no remote fetches, no `eval`/`exec`, and no removal or weakening of existing hardcoded patterns.

### Testing
- Ran `python scripts/architecture/check_responsibility_boundaries.py` and it passed.
- Ran `python scripts/quality/check_operational_docs_consistency.py` and it passed.
- Ran pytest for the modified loader tests but collection failed due to an environment dependency: `ModuleNotFoundError: No module named 'pydantic'`, so the new tests were not executed in this environment; CI should run them once `pydantic` is available.
- Recommendation: ensure CI/test environment includes `pydantic` so the added tests and parity assertions run in CI (local checks showed docs/responsibility scripts passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e532deea88326af441330400a909e)