### PR TITLE
docs: add Debate safety YAML migration mapping (H-7 Phase 2.6)

### DIFF
--- a/docs/architecture/debate-safety-policy-migration-map.md
+++ b/docs/architecture/debate-safety-policy-migration-map.md
@@ -41,6 +41,17 @@ The current hardcoded inventory exported by
 > - `derived`: YAML value derived from structured/weighted source, not copied verbatim
 > - `TBD`: unresolved mapping design
 
+
+> Note: three proposed YAML category names differ from their hardcoded
+> counterparts. In all other cases the proposed YAML category name is
+> identical to the hardcoded name.
+>
+> | Hardcoded name                  | Proposed YAML name               |
+> |---|---|
+> | ascii_risk_negation_by_keyword  | risk_negation_by_keyword_ascii   |
+> | ja_risk_negation_by_keyword     | risk_negation_by_keyword_ja      |
+> | risk_keywords_weighted          | risk_keyword_weights             |
+
 | Hardcoded category | Proposed YAML category | Migration status | Notes / risks |
 |---|---|---|---|
 | `danger_terms_ja` | `danger_terms_ja` | `direct` | Low structural risk; semantic parity still requires regex/term review. |
@@ -87,6 +98,11 @@ Phase 3 remains blocked until all criteria below are satisfied:
 5. Fail-closed behavior is designed for malformed production policy.
 6. No remote policy fetch.
 7. No runtime enforcement switch yet.
+8. Migration mapping document is promoted to a machine-readable artifact
+   (e.g. a structured YAML or JSON file under docs/architecture/) and a
+   validation script confirms that every key in _HARDCODED_CATEGORY_MAP
+   has an explicit entry in the mapping file before Phase 3 enforcement
+   is enabled.
 
 ## Security and operations note
 

--- a/docs/architecture/debate-safety-policy-migration-map.md
+++ b/docs/architecture/debate-safety-policy-migration-map.md
@@ -1,0 +1,95 @@
+# Debate Safety Policy Migration Mapping (Phase 2.6)
+
+## Purpose
+
+This document defines the **Phase 2.6 planning/mapping baseline** for migrating
+hardcoded Debate safety categories into a future YAML policy model.
+
+It exists to prevent accidental behavior drift during Phase 3 planning:
+
+- YAML remains **non-authoritative** in Phase 2.x.
+- Hardcoded Debate behavior in `veritas_os/core/debate.py` remains the source of
+  truth for runtime enforcement.
+- No runtime enforcement switch is introduced by this mapping document.
+
+## Current hardcoded inventory categories
+
+The current hardcoded inventory exported by
+`export_hardcoded_debate_safety_inventory()` includes the following categories:
+
+1. `danger_terms_ja`
+2. `danger_patterns_en`
+3. `benign_context_strong_terms`
+4. `benign_context_weak_terms`
+5. `dangerous_intent_patterns`
+6. `actionable_intent_patterns`
+7. `instructional_cue_patterns`
+8. `risk_negation_terms`
+9. `ascii_risk_negation_by_keyword`
+10. `ja_risk_negation_by_keyword`
+11. `refusal_context_patterns`
+12. `risk_keywords_weighted`
+13. `regulatory_ambiguity_patterns`
+14. `regulatory_ambiguity_negation_terms`
+
+## Proposed YAML mapping table (planning only)
+
+> Status vocabulary:
+> - `direct`: expected one-to-one mapping
+> - `split`: one hardcoded category likely split across multiple YAML categories
+> - `merge`: multiple hardcoded categories likely merged into one YAML category
+> - `derived`: YAML value derived from structured/weighted source, not copied verbatim
+> - `TBD`: unresolved mapping design
+
+| Hardcoded category | Proposed YAML category | Migration status | Notes / risks |
+|---|---|---|---|
+| `danger_terms_ja` | `danger_terms_ja` | `direct` | Low structural risk; semantic parity still requires regex/term review. |
+| `danger_patterns_en` | `danger_patterns_en` | `direct` | Low structural risk; language-boundary edge cases still need validation. |
+| `benign_context_strong_terms` | `benign_context_strong_terms` | `direct` | Context interaction risk if used without companion weak/context signals. |
+| `benign_context_weak_terms` | `benign_context_weak_terms` | `direct` | Weak signals are calibration-sensitive; avoid accidental weighting drift. |
+| `dangerous_intent_patterns` | `dangerous_intent_patterns` | `direct` | High safety sensitivity; must preserve strict intent matching behavior. |
+| `actionable_intent_patterns` | `actionable_intent_patterns` | `direct` | Actionability semantics may be coupled to runtime scoring/decision flow. |
+| `instructional_cue_patterns` | `instructional_cue_patterns` | `direct` | Cue patterns can be over-broad; parity review must include false-positive risk. |
+| `risk_negation_terms` | `risk_negation_terms` | `direct` | Negation handling is brittle; do not migrate without targeted tests. |
+| `ascii_risk_negation_by_keyword` | `risk_negation_by_keyword_ascii` | `derived` | Keyword-indexed structure may need canonical ordering/normalization rules. |
+| `ja_risk_negation_by_keyword` | `risk_negation_by_keyword_ja` | `derived` | Locale-specific tokenization/normalization rules must be explicitly defined. |
+| `refusal_context_patterns` | `refusal_context_patterns` | `direct` | Refusal heuristics can suppress risk; migration must verify no safety weakening. |
+| `risk_keywords_weighted` | `risk_keyword_weights` | `derived` | Weighted map cannot be blindly converted to flat patterns without scoring design. |
+| `regulatory_ambiguity_patterns` | `regulatory_ambiguity_patterns` | `direct` | Ambiguity logic interacts with policy interpretation; preserve conservative behavior. |
+| `regulatory_ambiguity_negation_terms` | `regulatory_ambiguity_negation_terms` | `direct` | Negation + ambiguity coupling requires explicit precedence/ordering in Phase 3 design. |
+
+## Categories that must not be blindly migrated
+
+The following categories are structurally and semantically sensitive. They
+require explicit design notes and dedicated tests before any enforcement-path
+switch:
+
+- Negation terms:
+  - `risk_negation_terms`
+  - `regulatory_ambiguity_negation_terms`
+- Context terms:
+  - `benign_context_strong_terms`
+  - `benign_context_weak_terms`
+  - `refusal_context_patterns`
+- Weighted risk maps:
+  - `risk_keywords_weighted`
+- Ambiguity patterns:
+  - `regulatory_ambiguity_patterns`
+
+## Phase 3 entry criteria (gating)
+
+Phase 3 remains blocked until all criteria below are satisfied:
+
+1. No unexplained missing hardcoded categories.
+2. Explicit mapping decision for every hardcoded category.
+3. Tests that detect category inventory drift.
+4. Feature flag default remains off.
+5. Fail-closed behavior is designed for malformed production policy.
+6. No remote policy fetch.
+7. No runtime enforcement switch yet.
+
+## Security and operations note
+
+This migration area is safety-sensitive. Any mapping change that can alter
+runtime behavior must be reviewed as a security-relevant change before
+feature-flagged enforcement is considered.

--- a/docs/architecture/debate-safety-policy-yaml-plan.md
+++ b/docs/architecture/debate-safety-policy-yaml-plan.md
@@ -144,6 +144,10 @@ These constants are the baseline behavior to preserve while migrating.
   `veritas_os/core/debate.py`; YAML remains non-authoritative.
 - Phase 3 (feature-flagged YAML enforcement) is blocked until intentional
   inventory-parity decisions are documented and approved.
+- Required review artifact before Phase 3: `docs/architecture/debate-safety-policy-migration-map.md`
+  (Phase 2.6 mapping baseline).
+- Phase 3 remains blocked until the migration mapping document is reviewed and
+  approved by maintainers.
 
 ### Phase 3 entry checklist
 


### PR DESCRIPTION
### Motivation

- Provide a Phase 2.6 planning/mapping baseline that documents how current hardcoded Debate safety categories map to a future YAML policy model before any Phase 3 feature-flag work. 
- Prevent accidental behavior drift by making explicit mapping decisions and gating Phase 3 until the mapping is reviewed and approved. 
- Preserve the current operational stance that YAML is non-authoritative and hardcoded behavior in `veritas_os/core/debate.py` remains the source of truth. 
- Security warning: this area is safety-sensitive and any mapping that could alter runtime behavior must receive human security review before enabling policy-based enforcement.

### Description

- Added `docs/architecture/debate-safety-policy-migration-map.md` containing purpose, the full list of exported hardcoded categories (14 categories), a proposed per-category YAML mapping with migration status (`direct`/`derived`/etc.) and notes/risks, and a list of categories that must not be blindly migrated. 
- Updated `docs/architecture/debate-safety-policy-yaml-plan.md` to link to the new mapping doc and explicitly state that Phase 3 is blocked until the mapping document is reviewed and approved. 
- The change is documentation-only and introduces no runtime behavior change, no YAML enforcement flag, and no remote fetch; runtime enforcement remains hardcoded. 
- Files changed: `docs/architecture/debate-safety-policy-migration-map.md` (new) and `docs/architecture/debate-safety-policy-yaml-plan.md` (link/update).

### Testing

- Ran `python3 scripts/architecture/check_responsibility_boundaries.py`, which passed. 
- Ran `python3 scripts/quality/check_operational_docs_consistency.py`, which passed. 
- Attempted `pytest -q veritas_os/tests/test_debate_safety_policy_loader.py --tb=short` and `pytest -q veritas_os/tests -k "debate_safety_policy" --tb=short` but `pytest` was unavailable in the execution environment (pyenv points to a missing Python version), so unit tests could not be executed here. 
- No runtime tests were changed or added as this is a docs-only PR; Phase 3 enforcement is explicitly gated pending mapping review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e780f13a08326afee2d9725662650)