### PR TITLE
Install patched libgnutls30 in runtime image to satisfy Trivy CRITICAL gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ WORKDIR /app
 # セキュリティパッチ適用（ベースイメージの既知CVE修正）
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
+        libgnutls30=3.7.9-2+deb12u7 \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir --upgrade "pip>=24.3" "setuptools>=78.1.1" "wheel>=0.46.2"
 


### PR DESCRIPTION
### Motivation
- Fix GHCR publish failure caused by Trivy CRITICAL findings by ensuring the final runtime image does not contain `libgnutls30` version `3.7.9-2+deb12u6`, while noting that pinning an exact OS package version may require future updates if the package is moved or superseded.

### Description
- Update the runtime stage in `Dockerfile` to run `apt-get install -y --no-install-recommends libgnutls30=3.7.9-2+deb12u7` immediately after `apt-get update`/`apt-get upgrade`, preserving the existing multi-stage build and leaving the Trivy workflow and severity gates unchanged.

### Testing
- Verified the change by inspecting the modified lines with `nl -ba Dockerfile | sed -n '24,60p'` and committed the update with `git commit`, but `docker build -t veritas-os:test .` failed here because the Docker CLI is not available in this environment so the image build and GitHub Actions (`publish-ghcr`) run could not be executed; therefore CI/publish could not be confirmed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f256736448326ba7e6ec7eced9e19)