### PR TITLE
H-7 Phase 2.7: add machine-readable debate safety migration map and validator

### DIFF
--- a/docs/architecture/debate-safety-policy-migration-map.md
+++ b/docs/architecture/debate-safety-policy-migration-map.md
@@ -102,7 +102,7 @@ Phase 3 remains blocked until all criteria below are satisfied:
 6. No remote policy fetch.
 7. No runtime enforcement switch yet.
 8. Machine-readable migration mapping artifact is present at
-   `docs/architecture/debate-safety-policy-migration-map.yaml`, and a
+   docs/architecture/debate-safety-policy-migration-map.yaml, and a
    validator/test confirms that every key in _HARDCODED_CATEGORY_MAP
    has an explicit entry in that file.
 9. The mapping validator is green in CI and human review explicitly approves

--- a/docs/architecture/debate-safety-policy-migration-map.md
+++ b/docs/architecture/debate-safety-policy-migration-map.md
@@ -2,8 +2,11 @@
 
 ## Purpose
 
-This document defines the **Phase 2.6 planning/mapping baseline** for migrating
+This document defines the **Phase 2.6/2.7 planning/mapping baseline** for migrating
 hardcoded Debate safety categories into a future YAML policy model.
+
+Machine-readable artifact: `docs/architecture/debate-safety-policy-migration-map.yaml`
+(planning-only, non-authoritative).
 
 It exists to prevent accidental behavior drift during Phase 3 planning:
 
@@ -98,14 +101,22 @@ Phase 3 remains blocked until all criteria below are satisfied:
 5. Fail-closed behavior is designed for malformed production policy.
 6. No remote policy fetch.
 7. No runtime enforcement switch yet.
-8. Migration mapping document is promoted to a machine-readable artifact
-   (e.g. a structured YAML or JSON file under docs/architecture/) and a
-   validation script confirms that every key in _HARDCODED_CATEGORY_MAP
-   has an explicit entry in the mapping file before Phase 3 enforcement
-   is enabled.
+8. Machine-readable migration mapping artifact is present at
+   `docs/architecture/debate-safety-policy-migration-map.yaml`, and a
+   validator/test confirms that every key in _HARDCODED_CATEGORY_MAP
+   has an explicit entry in that file.
+9. The mapping validator is green in CI and human review explicitly approves
+   the mapping before any Phase 3 enforcement-path switch is considered.
 
 ## Security and operations note
 
 This migration area is safety-sensitive. Any mapping change that can alter
 runtime behavior must be reviewed as a security-relevant change before
 feature-flagged enforcement is considered.
+
+
+## Phase 2.7 artifact status
+
+The YAML mapping artifact is **planning-only** and **non-authoritative** in
+Phase 2.7. Runtime enforcement remains hardcoded. Phase 3 remains blocked
+until the mapping validator passes and human review approves the mapping.

--- a/docs/architecture/debate-safety-policy-migration-map.yaml
+++ b/docs/architecture/debate-safety-policy-migration-map.yaml
@@ -1,0 +1,88 @@
+# Debate safety migration mapping artifact (Phase 2.7).
+# Planning-only and non-authoritative: runtime enforcement remains hardcoded.
+# See docs/architecture/debate-safety-policy-migration-map.md.
+
+mappings:
+  - hardcoded_category: danger_terms_ja
+    proposed_yaml_category: danger_terms_ja
+    migration_status: direct
+    risk_level: medium
+    notes: "Low structural risk; semantic parity still requires regex/term review."
+
+  - hardcoded_category: danger_patterns_en
+    proposed_yaml_category: danger_patterns_en
+    migration_status: direct
+    risk_level: medium
+    notes: "Low structural risk; language-boundary edge cases still need validation."
+
+  - hardcoded_category: benign_context_strong_terms
+    proposed_yaml_category: benign_context_strong_terms
+    migration_status: direct
+    risk_level: high
+    notes: "Context interaction risk if used without companion weak/context signals."
+
+  - hardcoded_category: benign_context_weak_terms
+    proposed_yaml_category: benign_context_weak_terms
+    migration_status: direct
+    risk_level: high
+    notes: "Weak signals are calibration-sensitive; avoid accidental weighting drift."
+
+  - hardcoded_category: dangerous_intent_patterns
+    proposed_yaml_category: dangerous_intent_patterns
+    migration_status: direct
+    risk_level: high
+    notes: "High safety sensitivity; must preserve strict intent matching behavior."
+
+  - hardcoded_category: actionable_intent_patterns
+    proposed_yaml_category: actionable_intent_patterns
+    migration_status: direct
+    risk_level: high
+    notes: "Actionability semantics may be coupled to runtime scoring/decision flow."
+
+  - hardcoded_category: instructional_cue_patterns
+    proposed_yaml_category: instructional_cue_patterns
+    migration_status: direct
+    risk_level: high
+    notes: "Cue patterns can be over-broad; parity review must include false-positive risk."
+
+  - hardcoded_category: risk_negation_terms
+    proposed_yaml_category: risk_negation_terms
+    migration_status: direct
+    risk_level: high
+    notes: "Negation handling is brittle; do not migrate without targeted tests."
+
+  - hardcoded_category: ascii_risk_negation_by_keyword
+    proposed_yaml_category: risk_negation_by_keyword_ascii
+    migration_status: derived
+    risk_level: high
+    notes: "Keyword-indexed structure may need canonical ordering/normalization rules."
+
+  - hardcoded_category: ja_risk_negation_by_keyword
+    proposed_yaml_category: risk_negation_by_keyword_ja
+    migration_status: derived
+    risk_level: high
+    notes: "Locale-specific tokenization/normalization rules must be explicitly defined."
+
+  - hardcoded_category: refusal_context_patterns
+    proposed_yaml_category: refusal_context_patterns
+    migration_status: direct
+    risk_level: high
+    notes: "Refusal heuristics can suppress risk; migration must verify no safety weakening."
+
+  - hardcoded_category: risk_keywords_weighted
+    proposed_yaml_category: risk_keyword_weights
+    migration_status: derived
+    risk_level: high
+    notes: "Weighted map cannot be blindly converted to flat patterns without scoring design."
+
+  - hardcoded_category: regulatory_ambiguity_patterns
+    proposed_yaml_category: regulatory_ambiguity_patterns
+    migration_status: direct
+    risk_level: high
+    notes: "Ambiguity logic interacts with policy interpretation; preserve conservative behavior."
+
+  - hardcoded_category: regulatory_ambiguity_negation_terms
+    proposed_yaml_category: regulatory_ambiguity_negation_terms
+    migration_status: direct
+    risk_level: high
+    notes: "Negation + ambiguity coupling requires explicit precedence/ordering in Phase 3 design."

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from veritas_os.policy.debate_safety_policy_loader import (
     build_debate_safety_policy_shadow_report,
@@ -204,3 +205,51 @@ def test_build_shadow_report_visibility_fields() -> None:
     assert len(report["missing_hardcoded_categories"]) >= 1
     assert report["notes"]
     assert report["enforcement_authoritative"] == "hardcoded"
+
+MIGRATION_MAP_YAML_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "architecture"
+    / "debate-safety-policy-migration-map.yaml"
+)
+
+_ALLOWED_MIGRATION_STATUS = {"direct", "split", "merge", "derived", "TBD"}
+
+
+def test_migration_map_yaml_covers_hardcoded_inventory_exactly() -> None:
+    """Ensure planning mapping artifact fully and explicitly covers hardcoded categories."""
+    payload = yaml.safe_load(MIGRATION_MAP_YAML_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+
+    mappings = payload.get("mappings")
+    assert isinstance(mappings, list)
+
+    hardcoded_inventory = export_hardcoded_debate_safety_inventory()
+    hardcoded_categories = set(hardcoded_inventory["categories"].keys())
+
+    mapped_categories: list[str] = []
+    for entry in mappings:
+        assert isinstance(entry, dict)
+
+        hardcoded_category = entry.get("hardcoded_category")
+        proposed_yaml_category = entry.get("proposed_yaml_category")
+        migration_status = entry.get("migration_status")
+
+        assert isinstance(hardcoded_category, str)
+        assert hardcoded_category.strip()
+        assert hardcoded_category not in mapped_categories
+
+        assert isinstance(proposed_yaml_category, str)
+        assert proposed_yaml_category.strip()
+
+        assert migration_status in _ALLOWED_MIGRATION_STATUS
+
+        mapped_categories.append(hardcoded_category)
+
+    mapped_categories_set = set(mapped_categories)
+    missing_categories = sorted(hardcoded_categories - mapped_categories_set)
+    unknown_categories = sorted(mapped_categories_set - hardcoded_categories)
+
+    assert missing_categories == []
+    assert unknown_categories == []
+    assert len(mapped_categories) == len(hardcoded_categories)

--- a/veritas_os/tests/test_debate_safety_policy_loader.py
+++ b/veritas_os/tests/test_debate_safety_policy_loader.py
@@ -214,6 +214,7 @@ MIGRATION_MAP_YAML_PATH = (
 )
 
 _ALLOWED_MIGRATION_STATUS = {"direct", "split", "merge", "derived", "TBD"}
+_ALLOWED_RISK_LEVELS = {"low", "medium", "high", "critical"}
 
 
 def test_migration_map_yaml_covers_hardcoded_inventory_exactly() -> None:
@@ -243,6 +244,10 @@ def test_migration_map_yaml_covers_hardcoded_inventory_exactly() -> None:
         assert proposed_yaml_category.strip()
 
         assert migration_status in _ALLOWED_MIGRATION_STATUS
+        risk_level = entry.get("risk_level")
+        assert risk_level in _ALLOWED_RISK_LEVELS, (
+            f"Entry '{hardcoded_category}' has invalid risk_level: {risk_level!r}"
+        )
 
         mapped_categories.append(hardcoded_category)
 


### PR DESCRIPTION
### Motivation
- Produce a machine-readable migration artifact for the Debate safety mapping so Phase 3 can be gated on an explicit, auditable mapping file. 
- Ensure every hardcoded Debate category exported by `export_hardcoded_debate_safety_inventory()` has an explicit mapping entry to detect inventory drift before any enforcement-path switch. 
- Keep YAML planning-only and avoid any runtime enforcement or behavioral change until human review and further gating are completed.

### Description
- Added a planning-only YAML migration artifact at `docs/architecture/debate-safety-policy-migration-map.yaml` containing one entry per exported hardcoded category with the fields `hardcoded_category`, `proposed_yaml_category`, `migration_status`, `risk_level`, and `notes`.
- Extended `veritas_os/tests/test_debate_safety_policy_loader.py` with `test_migration_map_yaml_covers_hardcoded_inventory_exactly()` that loads the YAML with `yaml.safe_load`, asserts mapping shape, checks that each `hardcoded_category` is present exactly once, validates `migration_status` against the allowed set `{"direct","split","merge","derived","TBD"}`, and asserts `proposed_yaml_category` is non-empty.
- Updated `docs/architecture/debate-safety-policy-migration-map.md` to reference the YAML artifact, mark it planning-only/non-authoritative, and restate that Phase 3 is blocked until the validator passes and human review approves the mapping.
- No runtime wiring or behavior changes were introduced: the YAML is not loaded in runtime enforcement, no feature flag or environment toggle was added, no remote fetch or `eval`/`exec` was introduced, and no hardcoded Debate checks were removed or weakened.

### Testing
- `python3 scripts/architecture/check_responsibility_boundaries.py` ran and passed.
- `python3 scripts/quality/check_operational_docs_consistency.py` ran and passed.
- Added unit test `test_migration_map_yaml_covers_hardcoded_inventory_exactly()` to `veritas_os/tests/test_debate_safety_policy_loader.py`; running the test requires `pytest` and `PyYAML` in the test environment.
- Local pytest runs in the rollout environment could not complete due to missing test tools: `pytest` was not available under the default python, and a `PYENV_VERSION=3.12.13` run failed test collection due to missing `yaml` (`PyYAML`) in that interpreter; the new validator test will run in CI once `pytest` and `PyYAML` are present and is expected to pass (it fails fast on missing/unknown/duplicate mapping entries or invalid statuses).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd61d80e48326be6a6d697ba78160)