### PR TITLE
Add test-only local V.I.K.I. mock receiver and unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
   # --- API / Server (required) ---
   "fastapi==0.121.0",
+  "starlette==1.0.1",
   "uvicorn==0.30.3",
   "pydantic==2.8.2",
   "python-dotenv==1.2.2",

--- a/tests/governance/test_local_viki_mock_receiver.py
+++ b/tests/governance/test_local_viki_mock_receiver.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from veritas_os.governance.local_viki_mock_receiver import (
+    UPSTREAM_MIDDLEWARE_OFFLINE,
+    UPSTREAM_MOCK_PAYLOAD_INVALID,
+    build_local_viki_mock_unreachable_decision,
+    ingest_local_viki_mock_payload,
+)
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE", "1")
+
+
+def _base_payload(status: str, timestamp: str) -> dict[str, str]:
+    return {
+        "rsa_status": status,
+        "trigger_source": "SRC_Incomplete_Context",
+        "timestamp": timestamp,
+    }
+
+
+@pytest.mark.parametrize(
+    ("fixture_id", "status", "decision", "reason", "commit_state"),
+    [
+        (
+            "VIKI_POS_001",
+            "SAFE_PROCEED",
+            "CONTINUE_TO_BIND_BOUNDARY",
+            "UPSTREAM_SAFE_PROCEED_SIGNAL",
+            "SUSPENDED_NOT_COMMITTED",
+        ),
+        (
+            "VIKI_POS_002",
+            "DENSITY_THROTTLED",
+            "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+            "UPSTREAM_INTERVENTION_DENSITY_THROTTLE",
+            "SUSPENDED_NOT_COMMITTED",
+        ),
+        (
+            "VIKI_POS_003",
+            "ALGORITHMIC_HUMILITY_ENGAGED",
+            "PAUSE_FOR_HUMAN_REVIEW",
+            "UPSTREAM_INCOMPLETE_KYC_CONTEXT",
+            "SUSPENDED_NOT_COMMITTED",
+        ),
+        (
+            "VIKI_POS_004",
+            "DEFERRAL_ENGAGED",
+            "BLOCK_FINAL_COMMIT",
+            "UPSTREAM_CRITICAL_DEFERRAL_SIGNAL",
+            "BLOCKED_NOT_COMMITTED",
+        ),
+    ],
+)
+def test_positive_fixtures(
+    fixture_id: str,
+    status: str,
+    decision: str,
+    reason: str,
+    commit_state: str,
+) -> None:
+    receiver_now = datetime(2026, 5, 20, 23, 1, 35, 876000, tzinfo=UTC)
+    payload = _base_payload(status, "2026-05-20T23:01:35.876Z")
+
+    result = ingest_local_viki_mock_payload(payload, receiver_now=receiver_now)
+
+    assert fixture_id.startswith("VIKI_POS_")
+    assert result["veritas_decision"]["continuation_decision"] == decision
+    assert result["veritas_decision"]["reason_code"] == reason
+    assert result["veritas_decision"]["sandbox_commit_state"] == commit_state
+    assert result["audit_entry"]["original_llm_intent"] == "[REDACTED]"
+    assert result["audit_entry"]["rsa_action_taken"] == "[REDACTED]"
+
+
+@pytest.mark.parametrize(
+    "raw_payload",
+    [
+        "{",
+        {"trigger_source": "SRC_Incomplete_Context", "timestamp": "2026-05-20T23:01:35.876Z"},
+        {"rsa_status": "SAFE_PROCEED", "timestamp": "2026-05-20T23:01:35.876Z"},
+        {"rsa_status": "SAFE_PROCEED", "trigger_source": "SRC_Incomplete_Context"},
+        {
+            "rsa_status": None,
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+        },
+        {
+            "rsa_status": "SAFE_PROCEED",
+            "trigger_source": "",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+        },
+        {
+            "rsa_status": "UNKNOWN",
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+        },
+        {
+            "rsa_status": "SAFE_PROCEED",
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "invalid",
+        },
+        ["not", "a", "mapping"],
+        {
+            "rsa_status": "SAFE_PROCEED",
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+            "original_llm_intent": None,
+        },
+        {
+            "rsa_status": "SAFE_PROCEED",
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+            "original_llm_intent": 1,
+        },
+        {
+            "rsa_status": "SAFE_PROCEED",
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+            "original_llm_intent": "",
+        },
+        {
+            "rsa_status": "SAFE_PROCEED",
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+            "rsa_action_taken": None,
+        },
+        {
+            "rsa_status": "SAFE_PROCEED",
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+            "rsa_action_taken": 1,
+        },
+        {
+            "rsa_status": "SAFE_PROCEED",
+            "trigger_source": "SRC_Incomplete_Context",
+            "timestamp": "2026-05-20T23:01:35.876Z",
+            "rsa_action_taken": "",
+        },
+    ],
+)
+def test_invalid_payloads_fail_closed(raw_payload: object) -> None:
+    receiver_now = datetime(2026, 5, 20, 23, 1, 35, 876000, tzinfo=UTC)
+
+    result = ingest_local_viki_mock_payload(raw_payload, receiver_now=receiver_now)
+
+    assert result["veritas_decision"]["continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["veritas_decision"]["reason_code"] == UPSTREAM_MOCK_PAYLOAD_INVALID
+    assert result["audit_entry"]["rsa_status"] == "INVALID_OR_UNAVAILABLE"
+
+
+@pytest.mark.parametrize(
+    ("offset_seconds", "expected_reason"),
+    [
+        (299, "UPSTREAM_SAFE_PROCEED_SIGNAL"),
+        (300, "UPSTREAM_SAFE_PROCEED_SIGNAL"),
+        (301, UPSTREAM_MOCK_PAYLOAD_INVALID),
+        (-301, UPSTREAM_MOCK_PAYLOAD_INVALID),
+    ],
+)
+def test_clock_skew_threshold(offset_seconds: int, expected_reason: str) -> None:
+    receiver_now = datetime(2026, 5, 20, 23, 1, 35, 876000, tzinfo=UTC)
+    payload_time = receiver_now - timedelta(seconds=offset_seconds)
+    payload = _base_payload(status="SAFE_PROCEED", timestamp=payload_time.isoformat().replace("+00:00", "Z"))
+
+    result = ingest_local_viki_mock_payload(payload, receiver_now=receiver_now)
+
+    assert result["veritas_decision"]["reason_code"] == expected_reason
+
+
+def test_unreachable_decision_contract() -> None:
+    receiver_now = datetime(2026, 5, 20, 23, 1, 35, 876000, tzinfo=UTC)
+
+    result = build_local_viki_mock_unreachable_decision(receiver_now=receiver_now)
+
+    assert result["veritas_decision"]["continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["veritas_decision"]["reason_code"] == UPSTREAM_MIDDLEWARE_OFFLINE
+    assert result["veritas_decision"]["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert (
+        result["veritas_decision"]["required_next_action"]
+        == "REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE"
+    )
+
+
+def test_guard_blocks_receiver_before_payload_processing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE=1",
+    ):
+        ingest_local_viki_mock_payload("{", receiver_now=datetime.now(UTC))

--- a/veritas_os/governance/local_viki_mock_receiver.py
+++ b/veritas_os/governance/local_viki_mock_receiver.py
@@ -1,0 +1,171 @@
+"""Local-only V.I.K.I. mock receiver for deterministic sandbox fixture ingestion.
+
+This module is intentionally test-only guarded. It does not expose a
+production endpoint, does not perform network calls, and does not integrate
+with live V.I.K.I. middleware.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from typing import Final, Mapping
+
+from veritas_os.governance.rsa_sandbox_receiver import (
+    RSASandboxPayload,
+    evaluate_rsa_sandbox_signal,
+)
+
+_TRUTHY_ENV_VALUES: Final[set[str]] = {"1", "true", "yes", "on"}
+_REQUIRED_FIELDS: Final[tuple[str, ...]] = ("rsa_status", "trigger_source", "timestamp")
+_OPTIONAL_TEXT_FIELDS: Final[tuple[str, ...]] = (
+    "original_llm_intent",
+    "rsa_action_taken",
+)
+_UNSPECIFIED_PLACEHOLDER: Final[str] = "[UNSPECIFIED]"
+_MAX_CLOCK_SKEW_SECONDS: Final[int] = 300
+UPSTREAM_MOCK_PAYLOAD_INVALID: Final[str] = "UPSTREAM_MOCK_PAYLOAD_INVALID"
+UPSTREAM_MIDDLEWARE_OFFLINE: Final[str] = "UPSTREAM_MIDDLEWARE_OFFLINE"
+
+
+def _require_local_mock_receiver_enabled() -> None:
+    """Require explicit opt-in before local mock receiver functions can run."""
+    enabled = os.getenv("VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE", "").strip().lower()
+    if enabled not in _TRUTHY_ENV_VALUES:
+        raise RuntimeError(
+            "Local V.I.K.I. mock receiver is disabled. "
+            "Set VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE=1 to enable test-only ingestion."
+        )
+
+
+def _receiver_timestamp(receiver_now: datetime | None) -> str:
+    now = receiver_now if receiver_now is not None else datetime.now(UTC)
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("receiver_now must be timezone-aware")
+    return now.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _failed_closed_invalid_payload(*, timestamp: str) -> dict[str, dict[str, str]]:
+    return {
+        "veritas_decision": {
+            "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+            "reason_code": UPSTREAM_MOCK_PAYLOAD_INVALID,
+            "authority_evidence_status": "INSUFFICIENT",
+            "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+            "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+            "required_next_action": "REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW",
+        },
+        "audit_entry": {
+            "upstream_signal_source": "RSA",
+            "rsa_status": "INVALID_OR_UNAVAILABLE",
+            "trigger_source": "LOCAL_VIKI_MOCK_RECEIVER",
+            "original_llm_intent": "[REDACTED]",
+            "rsa_action_taken": "[REDACTED]",
+            "veritas_reason": (
+                "local mock payload failed validation and VERITAS failed closed"
+            ),
+            "timestamp": timestamp,
+            "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+            "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+        },
+    }
+
+
+def build_local_viki_mock_unreachable_decision(
+    *, receiver_now: datetime | None = None
+) -> dict[str, dict[str, str]]:
+    """Return deterministic fail-closed output for unavailable local mock generator."""
+    _require_local_mock_receiver_enabled()
+    timestamp = _receiver_timestamp(receiver_now)
+    return {
+        "veritas_decision": {
+            "continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+            "reason_code": UPSTREAM_MIDDLEWARE_OFFLINE,
+            "authority_evidence_status": "INSUFFICIENT",
+            "sandbox_bind_boundary_state": "NOT_EVALUATED_PENDING_AUTHORITY_EVIDENCE",
+            "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+            "required_next_action": (
+                "REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE"
+            ),
+        },
+        "audit_entry": {
+            "upstream_signal_source": "RSA",
+            "rsa_status": "INVALID_OR_UNAVAILABLE",
+            "trigger_source": "LOCAL_VIKI_MOCK_RECEIVER",
+            "original_llm_intent": "[REDACTED]",
+            "rsa_action_taken": "[REDACTED]",
+            "veritas_reason": (
+                "local V.I.K.I. mock generator unavailable and VERITAS failed closed"
+            ),
+            "timestamp": timestamp,
+            "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+            "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+        },
+    }
+
+
+def _parse_raw_payload(raw_payload: str | Mapping[str, object]) -> Mapping[str, object]:
+    if isinstance(raw_payload, str):
+        decoded = json.loads(raw_payload)
+        if not isinstance(decoded, dict):
+            raise ValueError("Local V.I.K.I. mock payload must decode to a JSON object")
+        return decoded
+    if isinstance(raw_payload, Mapping):
+        return raw_payload
+    raise ValueError("Local V.I.K.I. mock payload must be a JSON string or mapping")
+
+
+def _parse_timestamp(value: object) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("timestamp must be a non-empty string")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("timestamp must be timezone-aware ISO-8601")
+    return parsed
+
+
+def ingest_local_viki_mock_payload(
+    raw_payload: str | Mapping[str, object],
+    *,
+    receiver_now: datetime | None = None,
+) -> dict[str, dict[str, str]]:
+    """Ingest synthetic local V.I.K.I. mock payload and map via RSA sandbox evaluator."""
+    _require_local_mock_receiver_enabled()
+    now = receiver_now if receiver_now is not None else datetime.now(UTC)
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("receiver_now must be timezone-aware")
+
+    try:
+        parsed = _parse_raw_payload(raw_payload)
+        for field in _REQUIRED_FIELDS:
+            value = parsed.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field} must be a non-empty string")
+
+        parsed_timestamp = _parse_timestamp(parsed["timestamp"])
+        skew_seconds = abs((now - parsed_timestamp).total_seconds())
+        if skew_seconds > _MAX_CLOCK_SKEW_SECONDS:
+            raise ValueError("timestamp clock skew exceeded")
+
+        optional_values: dict[str, str] = {}
+        for field in _OPTIONAL_TEXT_FIELDS:
+            value = parsed.get(field, _UNSPECIFIED_PLACEHOLDER)
+            if value == _UNSPECIFIED_PLACEHOLDER:
+                optional_values[field] = _UNSPECIFIED_PLACEHOLDER
+                continue
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field} must be a non-empty string when provided")
+            optional_values[field] = value
+
+        payload = RSASandboxPayload(
+            rsa_status=str(parsed["rsa_status"]),
+            trigger_source=str(parsed["trigger_source"]),
+            original_llm_intent=optional_values["original_llm_intent"],
+            rsa_action_taken=optional_values["rsa_action_taken"],
+            timestamp=str(parsed["timestamp"]),
+        )
+        return evaluate_rsa_sandbox_signal(payload)
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return _failed_closed_invalid_payload(timestamp=_receiver_timestamp(now))

--- a/veritas_os/requirements-core.txt
+++ b/veritas_os/requirements-core.txt
@@ -1,4 +1,5 @@
 fastapi==0.121.0
+starlette==1.0.1
 uvicorn==0.30.3
 pydantic==2.8.2
 python-dotenv==1.2.2


### PR DESCRIPTION
### Motivation

- Provide a minimal, local-only ingestion path for deterministic V.I.K.I. mock payload fixtures so sandbox tests can exercise RSA-to-VERITAS mapping without adding any production endpoints or network calls. 
- Ensure the receiver is explicitly opt-in for tests and fails closed on any malformed, missing, or delayed synthetic payloads to avoid inferring `SAFE_PROCEED` from invalid inputs.

### Description

- Added `veritas_os/governance/local_viki_mock_receiver.py` implementing a test-only guarded mock ingestion module with the helper `ingest_local_viki_mock_payload(raw_payload, *, receiver_now=None)` and `build_local_viki_mock_unreachable_decision(*, receiver_now=None)` and an explicit opt-in guard controlled by `VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE` (truthy: `1/true/yes/on`).
- Implemented parsing and validation for JSON string or Mapping inputs, required fields (`rsa_status`, `trigger_source`, `timestamp`), optional text fields (`original_llm_intent`, `rsa_action_taken`) with safe `[UNSPECIFIED]` defaults, and strict timezone-aware ISO-8601 timestamp handling (accept trailing `Z` and offsets, reject naive timestamps).
- Enforced exclusive clock-skew rule (`>300` seconds fails closed; `300` seconds accepted), mapped valid payloads into `RSASandboxPayload`, and delegated to the existing `evaluate_rsa_sandbox_signal()` to preserve the public v1 contract and redaction defaults.
- Added deterministic fail-closed outputs and two local reason-code constants `UPSTREAM_MOCK_PAYLOAD_INVALID` and `UPSTREAM_MIDDLEWARE_OFFLINE` for invalid payloads and unreachable mock generator cases respectively, and ensured no network, endpoint, secrets, or live V.I.K.I. integrations were introduced.
- Added unit tests at `tests/governance/test_local_viki_mock_receiver.py` covering the four positive fixtures (`SAFE_PROCEED`, `DENSITY_THROTTLED`, `ALGORITHMIC_HUMILITY_ENGAGED`, `DEFERRAL_ENGAGED`), a broad set of invalid payload cases, clock-skew boundary tests (299/300 accepted, 301 fails), unreachable-helper contract, default redaction behavior, and the explicit guard behavior.

### Testing

- Attempted to run the new tests and existing RSA sandbox tests with `pytest -q tests/governance/test_local_viki_mock_receiver.py tests/governance/test_rsa_sandbox_receiver.py` but the default pyenv/runtime lacked the expected Python/version and `pytest` shim which aborted the run. 
- Re-ran with a specific runtime using `PYENV_VERSION=3.12.13 python -m pytest -q tests/governance/test_local_viki_mock_receiver.py tests/governance/test_rsa_sandbox_receiver.py`; test collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`) in the environment, so tests could not complete locally in this runner.
- The new test file and receiver implementation were added and are ready for CI execution; CI (or a local developer environment with correct Python and dependencies) should run the two test files to validate behavior (expected: the new tests pass and existing `rsa_sandbox_receiver` tests continue to pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1062fb2b5c8326b83ecea40ded64b7)