### PR TITLE
Improve local VIKI mock receiver comments and env-guard test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,8 +155,10 @@ jobs:
           # Temporary narrow exception:
           # - PYSEC-2026-161 is fixed in starlette>=1.0.1.
           # - fastapi==0.121.0 currently does not resolve with starlette==1.0.1.
-          # - Do not broaden this ignore; remove once a compatible non-vulnerable
-          #   FastAPI/Starlette resolution is available.
+          # - Do not broaden this ignore.
+          # - To remove: confirm `pip install "fastapi>=X" "starlette>=1.0.1"`
+          #   resolves without conflict, then delete --ignore-vuln PYSEC-2026-161
+          #   from this file and from security-gates.yml (or main.yml).
           pip-audit -r veritas_os/requirements-core.txt --desc --ignore-vuln PYSEC-2026-161
 
       - name: Python full/optional dependency audit (informational)

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -55,8 +55,10 @@ jobs:
           # Temporary narrow exception:
           # - PYSEC-2026-161 is fixed in starlette>=1.0.1.
           # - fastapi==0.121.0 currently does not resolve with starlette==1.0.1.
-          # - Do not broaden this ignore; remove once a compatible non-vulnerable
-          #   FastAPI/Starlette resolution is available.
+          # - Do not broaden this ignore.
+          # - To remove: confirm `pip install "fastapi>=X" "starlette>=1.0.1"`
+          #   resolves without conflict, then delete --ignore-vuln PYSEC-2026-161
+          #   from this file and from security-gates.yml (or main.yml).
           pip-audit -r veritas_os/requirements-core.txt --desc --ignore-vuln PYSEC-2026-161
 
       - name: Python full/optional dependency audit (pip-audit, informational)

--- a/tests/governance/test_local_viki_mock_receiver.py
+++ b/tests/governance/test_local_viki_mock_receiver.py
@@ -198,3 +198,15 @@ def test_guard_blocks_receiver_before_payload_processing(
         match="VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE=1",
     ):
         ingest_local_viki_mock_payload("{", receiver_now=datetime.now(UTC))
+
+
+def test_guard_blocks_unreachable_decision_before_processing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE=1",
+    ):
+        build_local_viki_mock_unreachable_decision(receiver_now=datetime.now(UTC))

--- a/veritas_os/governance/local_viki_mock_receiver.py
+++ b/veritas_os/governance/local_viki_mock_receiver.py
@@ -150,6 +150,11 @@ def ingest_local_viki_mock_payload(
             raise ValueError("timestamp clock skew exceeded")
 
         optional_values: dict[str, str] = {}
+        # Optional fields: if present, must be a non-empty string.
+        # A present-but-invalid value (None, non-string, empty) is rejected
+        # as UPSTREAM_MOCK_PAYLOAD_INVALID rather than silently redacted,
+        # because an invalid value indicates a malformed payload, not a
+        # legitimate field that should be suppressed.
         for field in _OPTIONAL_TEXT_FIELDS:
             value = parsed.get(field, _UNSPECIFIED_PLACEHOLDER)
             if value == _UNSPECIFIED_PLACEHOLDER:


### PR DESCRIPTION
### Motivation
- Clarify the intended validation behavior for optional text fields in the local V.I.K.I. mock receiver so reviewers and future maintainers understand why present-but-invalid optional values are rejected rather than silently redacted.
- Ensure the unreachable-decision helper is covered by the same opt-in guard tests that protect payload ingestion from accidental use in non-test environments.
- Make the temporary `--ignore-vuln PYSEC-2026-161` workflow comment actionable by adding an explicit verification step to avoid forgetting the removal condition.

### Description
- Added an inline design-intent comment above the optional-field validation block in `veritas_os/governance/local_viki_mock_receiver.py` explaining that present-but-invalid optional values are rejected as `UPSTREAM_MOCK_PAYLOAD_INVALID` (comment-only, no logic change). 
- Added a new test `test_guard_blocks_unreachable_decision_before_processing` to `tests/governance/test_local_viki_mock_receiver.py` immediately after the existing env-guard test to assert `build_local_viki_mock_unreachable_decision` enforces the `VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE` guard. 
- Updated the temporary `PYSEC-2026-161` removal-condition comment in both `.github/workflows/main.yml` and `.github/workflows/security-gates.yml` to include the concrete verification command to confirm safe removal (comment-only, no change to the `pip-audit` command). 
- No runtime logic changes were made; the unreachable-decision function already called `_require_local_mock_receiver_enabled()`, so no implementation change was required for the env-guard.

### Testing
- Confirmed by inspecting files that `veritas_os/governance/local_viki_mock_receiver.py` contains the optional-field validation comment, `tests/governance/test_local_viki_mock_receiver.py` contains `test_guard_blocks_unreachable_decision_before_processing`, `build_local_viki_mock_unreachable_decision` already enforces the env guard, both workflow files contain the updated removal-condition comment, and only the four requested files were modified. 
- Attempted to run the test module with `python3.12 -m pytest tests/governance/test_local_viki_mock_receiver.py` and `pytest tests/governance/test_local_viki_mock_receiver.py`, but both attempts failed in this environment because `pytest` is not installed / available under the active pyenv shim (error: `No module named pytest` or `pytest: command not found`), so automated tests could not be executed here. 
- Changes were committed locally (4 files changed) and are ready for CI which should run the new test; given the guard already exists the added test is expected to pass in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1083a16f1c8326b5082a197c50f2ee)