### PR TITLE
docs: align local V.I.K.I. validation snapshot and reviewer index

### DIFF
--- a/docs/en/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md
@@ -94,9 +94,10 @@ Implemented clock skew rule:
 
 | Clock skew | Expected result |
 | --- | --- |
-| 299 seconds | accepted |
-| 300 seconds | accepted |
-| 301 seconds | fail closed |
+| 299 seconds (past) | accepted |
+| 300 seconds (past, boundary) | accepted |
+| -299 seconds / future skew 299 seconds | accepted |
+| 301 seconds (past) | fail closed |
 | -301 seconds / future skew 301 seconds | fail closed |
 
 Failed clock skew validation maps to:

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -29,6 +29,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 10. [Live V.I.K.I. integration design note (future design artifact, documentation-only)](./rsa-veritas-live-viki-integration-design-note.md)
 11. [Live V.I.K.I. integration reviewer checklist (review-gate artifact, documentation-only)](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 12. [Local V.I.K.I. mock receiver test fixture plan (Phase 2 local mock artifact, documentation-only)](./rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md)
+13. [Local V.I.K.I. mock receiver validation snapshot (Phase 2 local mock implementation validation record, documentation-only)](./rsa-veritas-local-viki-mock-receiver-validation-snapshot.md)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 

--- a/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md
@@ -94,9 +94,10 @@ Truthy values:
 
 | Clock skew | Expected result |
 | --- | --- |
-| 299 seconds | accepted |
-| 300 seconds | accepted |
-| 301 seconds | fail closed |
+| 299 seconds (past) | accepted |
+| 300 seconds (past, boundary) | accepted |
+| -299 seconds / future skew 299 seconds | accepted |
+| 301 seconds (past) | fail closed |
 | -301 seconds / future skew 301 seconds | fail closed |
 
 clock skew 検証失敗時のマッピング:

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -35,6 +35,7 @@
 10. [Live V.I.K.I. integration design note（将来設計アーティファクト / documentation-only）](./rsa-veritas-live-viki-integration-design-note.md)
 11. [Live V.I.K.I. integration reviewer checklist（review-gate artifact / documentation-only）](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 12. [Local V.I.K.I. mock receiver test fixture plan（Phase 2 local mock artifact / documentation-only）](./rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md)
+13. [Local V.I.K.I. mock receiver validation snapshot（Phase 2 ローカルモック実装検証記録、documentation-only）](./rsa-veritas-local-viki-mock-receiver-validation-snapshot.md)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 


### PR DESCRIPTION
### Motivation
- Bring the Local V.I.K.I. mock receiver validation snapshot documentation into alignment with the implemented parameterized tests by adding the missing future-within-threshold case and register the snapshot in the sandbox reviewer index so reviewers can find the artifact.

### Description
- Update `docs/en/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md` to add the missing `-299 seconds / future skew 299 seconds | accepted` row and clarify the 299/300/301 rows as `(past)`/`(past, boundary)`/`(past)` respectively in Section 6 (clock skew table). 
- Apply the identical table update to `docs/ja/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md` while keeping the table values in English. 
- Add item 13 to `docs/en/guides/rsa-veritas-sandbox-reviewer-index.md` linking to the EN snapshot file. 
- Add item 13 to `docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md` linking to the JA snapshot file.

### Testing
- Automated validation of requested checks: 1) EN table contains `-299 seconds / future skew 299 seconds | accepted`: PASS; 2) JA table has the same 5 rows with English table values: PASS; 3) EN reviewer index contains item 13 pointing to the EN snapshot file: PASS; 4) JA reviewer index contains item 13 pointing to the JA snapshot file: PASS; 5) Index numbering up to 13 has no duplicates or gaps in EN/JA: PASS; 6) No runtime files were modified (docs-only changes): PASS; 7) No other sections changed beyond the requested table/index edits: PASS. 
- Commands executed (all succeeded): `rg` searches for affected strings, `sed` to inspect the modified ranges, `git status` / `git add` / `git commit` to record the change, and `make_pr` to produce the PR metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e9b7540883269e5276440cd1cb54)