### PR TITLE
Add missing V.I.K.I. negative fixtures and register them in E2E harness

### DIFF
--- a/tests/fixtures/local_viki_mock_receiver/viki_neg_006_missing_trigger_source.json
+++ b/tests/fixtures/local_viki_mock_receiver/viki_neg_006_missing_trigger_source.json
@@ -1,0 +1,4 @@
+{
+  "rsa_status": "SAFE_PROCEED",
+  "timestamp": "2026-05-20T23:01:35.876Z"
+}

--- a/tests/fixtures/local_viki_mock_receiver/viki_neg_007_null_required_field.json
+++ b/tests/fixtures/local_viki_mock_receiver/viki_neg_007_null_required_field.json
@@ -1,0 +1,5 @@
+{
+  "rsa_status": null,
+  "trigger_source": "SRC_Normal_State",
+  "timestamp": "2026-05-20T23:01:35.876Z"
+}

--- a/tests/governance/test_local_viki_mock_receiver_e2e_harness.py
+++ b/tests/governance/test_local_viki_mock_receiver_e2e_harness.py
@@ -86,6 +86,8 @@ def test_local_fixture_e2e_positive(
         "viki_neg_003_unknown_rsa_status.json",
         "viki_neg_004_invalid_timestamp.json",
         "viki_neg_005_payload_shape_array.json",
+        "viki_neg_006_missing_trigger_source.json",
+        "viki_neg_007_null_required_field.json",
     ],
 )
 def test_local_fixture_e2e_negative(monkeypatch: pytest.MonkeyPatch, fixture_name: str) -> None:


### PR DESCRIPTION
### Motivation
- Complete the local V.I.K.I. E2E harness by adding two negative fixtures that were referenced by the fixture plan and unit tests but missing from the static E2E fixtures directory. 
- This is a low-risk test-only change that does not modify runtime production code, but avoid placing any sensitive data in fixtures as a general security precaution.

### Description
- Added `tests/fixtures/local_viki_mock_receiver/viki_neg_006_missing_trigger_source.json` containing valid JSON with `rsa_status` and `timestamp` and intentionally no `trigger_source` key. 
- Added `tests/fixtures/local_viki_mock_receiver/viki_neg_007_null_required_field.json` containing valid JSON where `rsa_status` is present but set to `null`. 
- Updated the negative E2E harness `pytest.mark.parametrize` list in `tests/governance/test_local_viki_mock_receiver_e2e_harness.py` to append the two new fixtures, producing seven negative cases (`viki_neg_001` through `viki_neg_007`).

### Testing
- Attempted to run the harness with `pytest tests/governance/test_local_viki_mock_receiver_e2e_harness.py`, but test collection failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`).
- Verified automatically that the two fixture files exist at `tests/fixtures/local_viki_mock_receiver/` and contain the exact JSON requested. 
- Confirmed the negative parametrize list in `tests/governance/test_local_viki_mock_receiver_e2e_harness.py` now contains 7 entries including `"viki_neg_006_missing_trigger_source.json"` and `"viki_neg_007_null_required_field.json"`. 
- No other files were modified beyond the two new fixtures and the single test-file list update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10fc4edefc83269d574af21707dcd1)