### PR TITLE
docs: add local V.I.K.I. mock receiver E2E harness validation snapshot (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md
@@ -75,6 +75,8 @@ Negative fixtures validate that malformed, missing, unknown, invalid, or wrongly
 | `tests/fixtures/local_viki_mock_receiver/viki_neg_003_unknown_rsa_status.json` | Unknown rsa_status | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
 | `tests/fixtures/local_viki_mock_receiver/viki_neg_004_invalid_timestamp.json` | Invalid timestamp | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
 | `tests/fixtures/local_viki_mock_receiver/viki_neg_005_payload_shape_array.json` | Payload shape is array instead of object | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_006_missing_trigger_source.json` | Missing trigger_source | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_007_null_required_field.json` | rsa_status present but null | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
 
 ## 6. Guard validation
 
@@ -167,6 +169,8 @@ Compatibility clarifications:
 - Unknown `rsa_status` does not proceed.
 - Invalid timestamp does not proceed.
 - Array payload shape does not proceed.
+- Missing trigger_source does not proceed.
+- A present-but-null required field does not proceed.
 - Default audit redaction remains active.
 - The explicit guard is validated.
 - No live V.I.K.I. connection exists.

--- a/docs/en/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md
@@ -1,0 +1,198 @@
+# RSA ↔ VERITAS Local V.I.K.I. Mock Receiver E2E Harness Validation Snapshot
+
+## 1. Purpose
+
+This snapshot documents the current validation state of the fixture-driven local V.I.K.I. mock receiver E2E harness.
+
+- This is documentation-only.
+- This is not a new runtime implementation.
+- This is not a live V.I.K.I. integration.
+- This is not a production API endpoint.
+- This records the implemented local fixture-driven E2E harness behavior after it was merged.
+
+## 2. Implemented harness surface
+
+Harness test file:
+
+- `tests/governance/test_local_viki_mock_receiver_e2e_harness.py`
+
+Fixture directory:
+
+- `tests/fixtures/local_viki_mock_receiver/`
+
+The harness:
+
+- reads static synthetic JSON fixture files as raw text
+- passes raw fixture text into `ingest_local_viki_mock_payload()`
+- uses a fixed receiver clock
+- enables the explicit test-only guard with `VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE=1`
+- asserts expected VERITAS decisions
+- asserts default audit redaction
+- asserts fail-closed behavior for invalid fixtures
+- asserts the guard raises `RuntimeError` when disabled
+
+The harness does not:
+
+- open a socket
+- run an HTTP server
+- call a network service
+- connect to live V.I.K.I.
+- consume live LLM text
+- process real KYC data
+- add production commit authority
+
+## 3. E2E validation flow
+
+```text
+static synthetic JSON fixture
+→ raw fixture text
+→ ingest_local_viki_mock_payload()
+→ RSASandboxPayload
+→ evaluate_rsa_sandbox_signal()
+→ VERITAS decision
+→ redacted audit output
+```
+
+This validates the local mock path without introducing network transport or live middleware.
+
+## 4. Positive fixture inventory
+
+| Fixture file | rsa_status | Expected continuation_decision | Expected reason_code | Expected sandbox_commit_state | Validation result |
+| --- | --- | --- | --- | --- | --- |
+| `tests/fixtures/local_viki_mock_receiver/viki_pos_001_safe_proceed.json` | SAFE_PROCEED | CONTINUE_TO_BIND_BOUNDARY | UPSTREAM_SAFE_PROCEED_SIGNAL | SUSPENDED_NOT_COMMITTED | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_pos_002_density_throttled.json` | DENSITY_THROTTLED | CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED | UPSTREAM_INTERVENTION_DENSITY_THROTTLE | SUSPENDED_NOT_COMMITTED | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_pos_003_algorithmic_humility_engaged.json` | ALGORITHMIC_HUMILITY_ENGAGED | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_INCOMPLETE_KYC_CONTEXT | SUSPENDED_NOT_COMMITTED | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_pos_004_deferral_engaged.json` | DEFERRAL_ENGAGED | BLOCK_FINAL_COMMIT | UPSTREAM_CRITICAL_DEFERRAL_SIGNAL | BLOCKED_NOT_COMMITTED | Implemented |
+
+## 5. Negative fixture inventory
+
+Negative fixtures validate that malformed, missing, unknown, invalid, or wrongly shaped payloads are never converted into `SAFE_PROCEED`.
+
+| Fixture file | Invalid condition | Expected continuation_decision | Expected reason_code | Expected sandbox_commit_state | Expected next action | Validation result |
+| --- | --- | --- | --- | --- | --- | --- |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_001_invalid_json.json` | Malformed JSON | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_002_missing_rsa_status.json` | Missing rsa_status | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_003_unknown_rsa_status.json` | Unknown rsa_status | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_004_invalid_timestamp.json` | Invalid timestamp | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_005_payload_shape_array.json` | Payload shape is array instead of object | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+
+## 6. Guard validation
+
+The E2E harness includes a guard-path test.
+
+Expected behavior:
+
+- when `VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE` is unset, `ingest_local_viki_mock_payload()` raises `RuntimeError`
+- the guard blocks before payload processing
+- this prevents accidental use outside explicit local mock test contexts
+
+Clarifications:
+
+- the guard is a test-only opt-in control
+- the guard is not production authentication
+- the guard does not make this receiver production-ready
+
+## 7. Audit redaction validation
+
+Every positive E2E fixture asserts:
+
+- `audit_entry.upstream_signal_source == "RSA"`
+- `audit_entry.original_llm_intent == "[REDACTED]"`
+- `audit_entry.rsa_action_taken == "[REDACTED]"`
+- `audit_entry.veritas_continuation_decision` matches the expected `continuation_decision`
+- `audit_entry.veritas_sandbox_commit_state` matches the expected `sandbox_commit_state`
+
+For negative fixtures, the harness asserts:
+
+- `audit_entry.rsa_status == "INVALID_OR_UNAVAILABLE"`
+- `audit_entry.trigger_source == "LOCAL_VIKI_MOCK_RECEIVER"`
+- `audit_entry.original_llm_intent == "[REDACTED]"`
+- `audit_entry.rsa_action_taken == "[REDACTED]"`
+
+This means:
+
+- raw upstream reasoning is not stored
+- V.I.K.I. internal reasoning is not stored
+- chain-of-thought is not stored
+- hidden model state is not stored
+
+## 8. No-network validation boundary
+
+- The harness reads only local fixture files.
+- The harness does not mock `requests` or `httpx`.
+- The harness does not require sockets.
+- The harness does not perform network I/O.
+- The harness does not use live middleware.
+- The harness does not use secrets or credentials.
+
+## 9. Test command
+
+Intended focused test command:
+
+```bash
+python -m pytest -q tests/governance/test_local_viki_mock_receiver.py tests/governance/test_local_viki_mock_receiver_e2e_harness.py
+```
+
+If applicable:
+
+```bash
+python -m pytest -q tests/governance/test_rsa_sandbox_receiver.py
+```
+
+This snapshot does not modify tests or CI; it only records the intended validation surface.
+
+## 10. Compatibility validation
+
+The E2E harness preserves:
+
+- `rsa_status`
+- `RSASandboxPayload`
+- `evaluate_rsa_sandbox_signal()`
+- `upstream_signal_source = "RSA"`
+
+Compatibility clarifications:
+
+- `rsa_status` was not renamed to `viki_status`
+- `RSASandboxPayload` was not renamed to `VIKIPayload`
+- `evaluate_rsa_sandbox_signal()` remains the downstream evaluator
+- naming migration remains out of scope and must be handled as a separate v2 migration
+
+## 11. What this snapshot validates
+
+- Static synthetic JSON fixtures exist.
+- The harness drives the receiver from raw fixture text.
+- The four positive `rsa_status` variants map to expected VERITAS decisions.
+- Negative fixtures fail closed.
+- Malformed JSON does not proceed.
+- Unknown `rsa_status` does not proceed.
+- Invalid timestamp does not proceed.
+- Array payload shape does not proceed.
+- Default audit redaction remains active.
+- The explicit guard is validated.
+- No live V.I.K.I. connection exists.
+
+## 12. What this snapshot does not validate
+
+- It does not validate live V.I.K.I. middleware.
+- It does not validate network transport.
+- It does not validate authentication or authorization.
+- It does not validate production AML/KYC compliance.
+- It does not validate regulatory approval.
+- It does not provide legal advice.
+- It does not validate real KYC data.
+- It does not validate live LLM text.
+- It does not make the local mock receiver production-ready.
+- It does not replace the need for controlled integration threat modeling.
+
+## 13. Recommended next PR after this snapshot
+
+The next safe PR should be one of:
+
+- controlled live V.I.K.I. integration threat model
+- live payload schema draft
+- local mock receiver CI validation command documentation
+- fixture manifest / coverage index
+
+Recommended:
+
+The safest next PR is the controlled live V.I.K.I. integration threat model, because the local mock phase now has design notes, fixture plan, implementation, validation snapshot, and fixture-driven E2E harness.

--- a/docs/en/guides/rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md
+++ b/docs/en/guides/rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md
@@ -25,6 +25,10 @@ The current merged baseline includes:
 
 This fixture plan follows the local mock ingestion receiver design and remains local-only and synthetic-data-only.
 
+Implemented follow-up artifact:
+
+- [Local V.I.K.I. mock receiver E2E harness validation snapshot](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
+
 ## 3. Test boundary model
 
 - V.I.K.I. mock generator emits synthetic RSA-compatible payloads.

--- a/docs/en/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md
+++ b/docs/en/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md
@@ -4,6 +4,10 @@
 
 This snapshot documents the current implemented validation state of the VERITAS-side local V.I.K.I. mock receiver.
 
+Related artifact:
+
+- [Local V.I.K.I. mock receiver E2E harness validation snapshot](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
+
 - This is documentation-only.
 - This is not a new implementation.
 - This is not a live V.I.K.I. integration.

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -30,6 +30,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 11. [Live V.I.K.I. integration reviewer checklist (review-gate artifact, documentation-only)](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 12. [Local V.I.K.I. mock receiver test fixture plan (Phase 2 local mock artifact, documentation-only)](./rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md)
 13. [Local V.I.K.I. mock receiver validation snapshot (Phase 2 local mock implementation validation record, documentation-only)](./rsa-veritas-local-viki-mock-receiver-validation-snapshot.md)
+14. [Local V.I.K.I. mock receiver E2E harness validation snapshot (Phase 2 local mock fixture-driven harness validation record, documentation-only)](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 

--- a/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md
@@ -1,0 +1,202 @@
+# RSA ↔ VERITAS ローカル V.I.K.I. Mock Receiver E2E Harness 検証スナップショット
+
+## 英語正本
+
+- [RSA ↔ VERITAS Local V.I.K.I. Mock Receiver E2E Harness Validation Snapshot](../../en/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
+
+## 1. 目的
+
+本スナップショットは、fixture-driven なローカル V.I.K.I. mock receiver E2E harness の現時点の検証状態を記録する文書です。
+
+- これは documentation-only です。
+- これは新しい runtime implementation ではありません。
+- これは live V.I.K.I. integration ではありません。
+- これは production API endpoint ではありません。
+- これは、マージ済みの local fixture-driven E2E harness の実装挙動を記録します。
+
+## 2. 実装済みハーネスの対象範囲
+
+Harness test file:
+
+- `tests/governance/test_local_viki_mock_receiver_e2e_harness.py`
+
+Fixture directory:
+
+- `tests/fixtures/local_viki_mock_receiver/`
+
+この harness は次を実施します。
+
+- static synthetic JSON fixture files を raw text として読み込む
+- raw fixture text を `ingest_local_viki_mock_payload()` に渡す
+- fixed receiver clock を使用する
+- 明示的な test-only guard として `VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE=1` を有効化する
+- 期待される VERITAS decision を検証する
+- default audit redaction を検証する
+- invalid fixtures の fail-closed behavior を検証する
+- guard 無効時に `RuntimeError` が発生することを検証する
+
+この harness は次を行いません。
+
+- socket を開く
+- HTTP server を起動する
+- network service を呼び出す
+- live V.I.K.I. に接続する
+- live LLM text を取り込む
+- 実データの KYC を処理する
+- production commit authority を追加する
+
+## 3. E2E 検証フロー
+
+```text
+static synthetic JSON fixture
+→ raw fixture text
+→ ingest_local_viki_mock_payload()
+→ RSASandboxPayload
+→ evaluate_rsa_sandbox_signal()
+→ VERITAS decision
+→ redacted audit output
+```
+
+これにより、network transport や live middleware を導入せずに local mock path を検証します。
+
+## 4. Positive fixture inventory
+
+| Fixture file | rsa_status | Expected continuation_decision | Expected reason_code | Expected sandbox_commit_state | Validation result |
+| --- | --- | --- | --- | --- | --- |
+| `tests/fixtures/local_viki_mock_receiver/viki_pos_001_safe_proceed.json` | SAFE_PROCEED | CONTINUE_TO_BIND_BOUNDARY | UPSTREAM_SAFE_PROCEED_SIGNAL | SUSPENDED_NOT_COMMITTED | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_pos_002_density_throttled.json` | DENSITY_THROTTLED | CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED | UPSTREAM_INTERVENTION_DENSITY_THROTTLE | SUSPENDED_NOT_COMMITTED | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_pos_003_algorithmic_humility_engaged.json` | ALGORITHMIC_HUMILITY_ENGAGED | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_INCOMPLETE_KYC_CONTEXT | SUSPENDED_NOT_COMMITTED | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_pos_004_deferral_engaged.json` | DEFERRAL_ENGAGED | BLOCK_FINAL_COMMIT | UPSTREAM_CRITICAL_DEFERRAL_SIGNAL | BLOCKED_NOT_COMMITTED | Implemented |
+
+## 5. Negative fixture inventory
+
+Negative fixtures は、malformed / missing / unknown / invalid / shape mismatch の payload が `SAFE_PROCEED` に変換されないことを検証します。
+
+| Fixture file | Invalid condition | Expected continuation_decision | Expected reason_code | Expected sandbox_commit_state | Expected next action | Validation result |
+| --- | --- | --- | --- | --- | --- | --- |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_001_invalid_json.json` | Malformed JSON | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_002_missing_rsa_status.json` | Missing rsa_status | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_003_unknown_rsa_status.json` | Unknown rsa_status | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_004_invalid_timestamp.json` | Invalid timestamp | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_005_payload_shape_array.json` | Payload shape is array instead of object | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+
+## 6. Guard validation
+
+E2E harness には guard-path test が含まれます。
+
+期待挙動:
+
+- `VERITAS_LOCAL_VIKI_MOCK_RECEIVER_ENABLE` が未設定の場合、`ingest_local_viki_mock_payload()` は `RuntimeError` を送出する
+- guard は payload processing より前にブロックする
+- これにより、明示的な local mock test context 以外での accidental use を防ぐ
+
+明確化:
+
+- guard は test-only の opt-in control である
+- guard は production authentication ではない
+- guard はこの receiver を production-ready にしない
+
+## 7. Audit redaction validation
+
+すべての positive E2E fixture で次を検証します。
+
+- `audit_entry.upstream_signal_source == "RSA"`
+- `audit_entry.original_llm_intent == "[REDACTED]"`
+- `audit_entry.rsa_action_taken == "[REDACTED]"`
+- `audit_entry.veritas_continuation_decision` が期待 `continuation_decision` と一致
+- `audit_entry.veritas_sandbox_commit_state` が期待 `sandbox_commit_state` と一致
+
+negative fixtures では次を検証します。
+
+- `audit_entry.rsa_status == "INVALID_OR_UNAVAILABLE"`
+- `audit_entry.trigger_source == "LOCAL_VIKI_MOCK_RECEIVER"`
+- `audit_entry.original_llm_intent == "[REDACTED]"`
+- `audit_entry.rsa_action_taken == "[REDACTED]"`
+
+したがって次は保存されません。
+
+- raw upstream reasoning
+- V.I.K.I. internal reasoning
+- chain-of-thought
+- hidden model state
+
+## 8. No-network validation boundary
+
+- harness は local fixture files のみを読み込みます。
+- harness は `requests` / `httpx` を mock しません。
+- harness は sockets を必要としません。
+- harness は network I/O を実行しません。
+- harness は live middleware を使用しません。
+- harness は secrets / credentials を使用しません。
+
+## 9. Test command
+
+意図された focused test command:
+
+```bash
+python -m pytest -q tests/governance/test_local_viki_mock_receiver.py tests/governance/test_local_viki_mock_receiver_e2e_harness.py
+```
+
+必要に応じて:
+
+```bash
+python -m pytest -q tests/governance/test_rsa_sandbox_receiver.py
+```
+
+この snapshot は tests や CI を変更せず、意図された validation surface の記録のみを行います。
+
+## 10. Compatibility validation
+
+E2E harness は次を保持します。
+
+- `rsa_status`
+- `RSASandboxPayload`
+- `evaluate_rsa_sandbox_signal()`
+- `upstream_signal_source = "RSA"`
+
+互換性に関する明確化:
+
+- `rsa_status` は `viki_status` に rename していない
+- `RSASandboxPayload` は `VIKIPayload` に rename していない
+- `evaluate_rsa_sandbox_signal()` は downstream evaluator のままである
+- naming migration は out of scope であり、別の v2 migration として扱う
+
+## 11. この snapshot が検証すること
+
+- Static synthetic JSON fixtures が存在する。
+- harness が raw fixture text から receiver を駆動する。
+- 4 つの positive `rsa_status` variants が期待 VERITAS decisions にマップされる。
+- negative fixtures は fail closed になる。
+- malformed JSON は proceed しない。
+- unknown `rsa_status` は proceed しない。
+- invalid timestamp は proceed しない。
+- array payload shape は proceed しない。
+- default audit redaction が維持される。
+- 明示 guard が検証される。
+- live V.I.K.I. connection は存在しない。
+
+## 12. この snapshot が検証しないこと
+
+- live V.I.K.I. middleware は検証しない。
+- network transport は検証しない。
+- authentication / authorization は検証しない。
+- production AML/KYC compliance は検証しない。
+- regulatory approval は検証しない。
+- legal advice は提供しない。
+- real KYC data は検証しない。
+- live LLM text は検証しない。
+- local mock receiver を production-ready にはしない。
+- controlled integration threat modeling の必要性を置き換えない。
+
+## 13. この snapshot の次に推奨する PR
+
+次の safe PR は次のいずれかです。
+
+- controlled live V.I.K.I. integration threat model
+- live payload schema draft
+- local mock receiver CI validation command documentation
+- fixture manifest / coverage index
+
+推奨:
+
+最も安全な次 PR は controlled live V.I.K.I. integration threat model です。理由は、local mock phase に design notes / fixture plan / implementation / validation snapshot / fixture-driven E2E harness がそろっているためです。

--- a/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md
@@ -79,6 +79,8 @@ Negative fixtures は、malformed / missing / unknown / invalid / shape mismatch
 | `tests/fixtures/local_viki_mock_receiver/viki_neg_003_unknown_rsa_status.json` | Unknown rsa_status | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
 | `tests/fixtures/local_viki_mock_receiver/viki_neg_004_invalid_timestamp.json` | Invalid timestamp | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
 | `tests/fixtures/local_viki_mock_receiver/viki_neg_005_payload_shape_array.json` | Payload shape is array instead of object | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_006_missing_trigger_source.json` | Missing trigger_source | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
+| `tests/fixtures/local_viki_mock_receiver/viki_neg_007_null_required_field.json` | rsa_status present but null | PAUSE_FOR_HUMAN_REVIEW | UPSTREAM_MOCK_PAYLOAD_INVALID | SUSPENDED_NOT_COMMITTED | REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW | Implemented |
 
 ## 6. Guard validation
 
@@ -171,6 +173,8 @@ E2E harness は次を保持します。
 - unknown `rsa_status` は proceed しない。
 - invalid timestamp は proceed しない。
 - array payload shape は proceed しない。
+- missing trigger_source は proceed しない。
+- 必須フィールドが存在していても null の場合は proceed しない。
 - default audit redaction が維持される。
 - 明示 guard が検証される。
 - live V.I.K.I. connection は存在しない。

--- a/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md
+++ b/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md
@@ -29,6 +29,10 @@
 
 本計画は local mock ingestion receiver design に従い、local-only / synthetic-data-only を維持します。
 
+実装後の関連アーティファクト:
+
+- [Local V.I.K.I. mock receiver E2E harness validation snapshot](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
+
 ## 3. テスト境界モデル
 
 - V.I.K.I. mock generator は synthetic RSA-compatible payloads を出力します。

--- a/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md
+++ b/docs/ja/guides/rsa-veritas-local-viki-mock-receiver-validation-snapshot.md
@@ -2,6 +2,10 @@
 
 ## 1. Purpose
 
+関連アーティファクト:
+
+- [Local V.I.K.I. mock receiver E2E harness validation snapshot](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
+
 このスナップショットは、VERITAS 側ローカル V.I.K.I. モックレシーバーの**現在実装済み**の検証状態を記録するものです。
 
 - これは documentation-only の更新です。

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -36,6 +36,7 @@
 11. [Live V.I.K.I. integration reviewer checklist（review-gate artifact / documentation-only）](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 12. [Local V.I.K.I. mock receiver test fixture plan（Phase 2 local mock artifact / documentation-only）](./rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md)
 13. [Local V.I.K.I. mock receiver validation snapshot（Phase 2 ローカルモック実装検証記録、documentation-only）](./rsa-veritas-local-viki-mock-receiver-validation-snapshot.md)
+14. [Local V.I.K.I. mock receiver E2E harness validation snapshot（Phase 2 fixture-driven harness 検証記録、documentation-only）](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 


### PR DESCRIPTION
### Motivation

- Record the implemented validation surface for the fixture-driven local V.I.K.I. mock receiver E2E harness so reviewers can inspect what the merged harness validates without introducing runtime changes. 
- Make explicit which static synthetic fixtures, positive and negative paths, audit redaction checks, and guard behavior the harness covers. 
- Keep the change documentation-only and explicitly avoid changing runtime, tests, CI, fixtures, or adding any network/live integration. 

### Description

- Add two new pages: `docs/en/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md` and `docs/ja/guides/rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md` that document purpose, harness surface, E2E flow, positive/negative fixture inventories, guard validation, audit redaction, no-network boundary, compatibility, and next recommended PRs. 
- Update EN/JA reviewer index pages to link the new E2E harness validation snapshot as a Phase 2 local mock artifact. 
- Add cross-links from the existing EN/JA `rsa-veritas-local-viki-mock-receiver-validation-snapshot.md` and `rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md` pages to the new E2E harness snapshot. 
- Preserve all naming, runtime code, tests, fixtures, CI, and security/audit exceptions; no runtime or test code was modified. 

### Testing

- Performed repository checks including `git status --short` to confirm commits and `rg` searches to verify the new files and links, and these checks succeeded. 
- File edits and additions were committed (`git commit`) and the commit containing the documentation changes was created successfully. 
- No unit or integration test suites were modified or executed as part of this documentation-only PR, and no CI changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a110237c5d88326ac3d52f650b8ee6b)