### PR TITLE
docs: add controlled live V.I.K.I. payload schema draft (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-integration-threat-model.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-integration-threat-model.md
@@ -12,6 +12,7 @@ This document defines the threat model for a **future** controlled live V.I.K.I.
 - This does not process real KYC data.
 - This does not provide legal or regulatory approval.
 - This exists to define review gates before any controlled live integration is attempted.
+- Controlled live payload schema draft is a required pre-live schema gate artifact: [RSA ↔ VERITAS Controlled Live V.I.K.I. Payload Schema Draft](./rsa-veritas-controlled-live-viki-payload-schema-draft.md).
 
 ## 2. Current baseline
 

--- a/docs/en/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md
@@ -1,0 +1,409 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Payload Schema Draft
+
+## 1. Purpose
+
+This document defines the **draft payload schema** for a future controlled live V.I.K.I. integration.
+
+- This is documentation-only.
+- This is not a live integration.
+- This is not a runtime implementation.
+- This is not a production API endpoint.
+- This does not authorize production use.
+- This does not process real KYC data.
+- This does not provide legal or regulatory approval.
+- This schema draft must be reviewed before any transport, endpoint, or live middleware work begins.
+
+## 2. Current baseline
+
+Current validated local mock path:
+
+static synthetic JSON fixture
+→ `ingest_local_viki_mock_payload()`
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ VERITAS decision
+→ redacted audit output
+
+The controlled live integration threat model has been merged, and this schema draft follows that threat model.
+
+Current v1 compatibility contract remains:
+
+- `rsa_status`
+- `RSASandboxPayload`
+- `evaluate_rsa_sandbox_signal()`
+- `upstream_signal_source = "RSA"`
+
+## 3. Future live payload boundary
+
+Future live payload boundary:
+
+V.I.K.I. live middleware
+→ RSA-compatible live payload
+→ controlled transport boundary
+→ VERITAS live ingestion boundary
+→ schema validation
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ VERITAS decision
+→ audit entry
+→ commit gate
+
+- VERITAS treats every live payload as untrusted until schema validation passes.
+- VERITAS consumes only the emitted RSA-compatible payload.
+- VERITAS does not consume V.I.K.I. internal reasoning.
+- VERITAS does not execute hidden V.I.K.I. logic.
+- VERITAS does not infer `SAFE_PROCEED` from missing, malformed, delayed, or unavailable payloads.
+
+## 4. Draft payload object
+
+The payload is a single JSON object.
+
+Required fields:
+
+- `schema_version`
+- `rsa_status`
+- `trigger_source`
+- `timestamp`
+- `request_id`
+- `correlation_id`
+- `payload_issued_at`
+
+Optional accepted fields:
+
+- `source_environment`
+- `source_instance_id`
+- `rsa_action_taken`
+- `original_llm_intent`
+- `upstream_confidence_class`
+- `upstream_latency_ms`
+- `upstream_reason_code`
+
+Explicitly forbidden fields:
+
+- `chain_of_thought`
+- `hidden_model_state`
+- `raw_llm_reasoning`
+- `raw_viki_reasoning`
+- `raw_kyc_record`
+- `customer_pii`
+- `secrets`
+- `credentials`
+- `api_key`
+- `access_token`
+- `refresh_token`
+- `private_key`
+- `webhook_secret`
+- `unredacted_regulated_data`
+
+- Optional raw-intent/action fields must be redacted by default in audit output.
+- Forbidden fields must be rejected or stripped before audit persistence.
+- The presence of chain-of-thought or hidden model state must fail closed.
+
+## 5. Required field definitions
+
+| Field | Type | Required | Description | Validation rule |
+| --- | --- | --- | --- | --- |
+| `schema_version` | string | yes | Draft schema version for controlled live payloads. | Must equal `"v1alpha1"` for this draft. |
+| `rsa_status` | string | yes | RSA-compatible upstream status. | Must be one of `SAFE_PROCEED`, `DENSITY_THROTTLED`, `ALGORITHMIC_HUMILITY_ENGAGED`, `DEFERRAL_ENGAGED`. |
+| `trigger_source` | string | yes | Deterministic source label for why the upstream status was emitted. | Must be non-empty and must not contain raw reasoning or PII. |
+| `timestamp` | string | yes | Primary event timestamp. | Must be RFC 3339 UTC or timezone-aware ISO-8601 normalized to UTC. |
+| `request_id` | string | yes | Unique identifier for the upstream request. | Must be non-empty. Future implementation should enforce uniqueness within replay window. |
+| `correlation_id` | string | yes | Identifier used to correlate V.I.K.I. emission, VERITAS ingestion, audit entry, and review event. | Must be non-empty and must not contain PII. |
+| `payload_issued_at` | string | yes | Timestamp when V.I.K.I. emitted the payload. | Must be RFC 3339 UTC or timezone-aware ISO-8601 normalized to UTC. |
+
+## 6. Optional field definitions
+
+| Field | Type | Required | Description | Validation / audit rule |
+| --- | --- | --- | --- | --- |
+| `source_environment` | string | no | Environment label such as local, staging, controlled-test. | Must not be used to enable production behavior. |
+| `source_instance_id` | string | no | Non-secret identifier for V.I.K.I. instance. | Must not contain secrets, host credentials, or PII. |
+| `rsa_action_taken` | string | no | Short upstream action label. | Allowed only as non-empty string. Redacted by default in audit output. |
+| `original_llm_intent` | string | no | Short upstream intent label. | Allowed only as non-empty string. Redacted by default in audit output. |
+| `upstream_confidence_class` | string | no | Coarse confidence class, not raw probability trace. | Allowed values should be `LOW`, `MEDIUM`, `HIGH`, or `UNSPECIFIED`. |
+| `upstream_latency_ms` | integer | no | Measured upstream processing latency in milliseconds. | Must be non-negative integer if present. |
+| `upstream_reason_code` | string | no | Deterministic upstream reason code. | Must not contain raw reasoning, PII, or regulated data. |
+
+## 7. Accepted rsa_status values
+
+`SAFE_PROCEED`:
+
+- May continue toward normal bind-boundary evaluation.
+- Does not equal final commit approval.
+- VERITAS commit gate remains authoritative.
+
+`DENSITY_THROTTLED`:
+
+- Indicates upstream intervention was applied.
+- VERITAS may continue with upstream intervention logged.
+
+`ALGORITHMIC_HUMILITY_ENGAGED`:
+
+- Indicates incomplete or uncertain upstream context.
+- VERITAS should pause for human review.
+
+`DEFERRAL_ENGAGED`:
+
+- Indicates critical upstream deferral.
+- VERITAS should block final commit.
+
+- Unknown `rsa_status` must fail closed.
+- Empty `rsa_status` must fail closed.
+- Null `rsa_status` must fail closed.
+- Any attempt to encode multiple statuses must fail closed.
+
+## 8. Timestamp and replay requirements
+
+- `timestamp` and `payload_issued_at` must be RFC 3339 UTC or timezone-aware ISO-8601 normalized to UTC.
+- Naive timestamps are rejected.
+- Invalid timestamp strings are rejected.
+- Clock skew threshold must be explicitly defined before implementation.
+- Existing local mock threshold is skew > 300 seconds fails closed and skew = 300 seconds accepted.
+- Live integration may adopt the same threshold unless changed by a separate reviewed design.
+- Replay protection must be designed before live implementation.
+- `request_id` and `correlation_id` are placeholders for replay protection and traceability.
+- Duplicate `request_id` within the replay window should fail closed in future implementation.
+
+## 9. Example valid payloads
+
+Example `SAFE_PROCEED`:
+
+```json
+{
+  "schema_version": "v1alpha1",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Normal_State",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "request_id": "req_viki_000001",
+  "correlation_id": "corr_viki_veritas_000001",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "source_environment": "controlled-test",
+  "source_instance_id": "viki-local-controlled-001",
+  "rsa_action_taken": "No_Upstream_Intervention_Required",
+  "original_llm_intent": "Continue_To_Normal_Bind_Boundary_Evaluation",
+  "upstream_confidence_class": "HIGH",
+  "upstream_latency_ms": 87,
+  "upstream_reason_code": "UPSTREAM_NORMAL_STATE"
+}
+```
+
+Example `ALGORITHMIC_HUMILITY_ENGAGED`:
+
+```json
+{
+  "schema_version": "v1alpha1",
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "request_id": "req_viki_000002",
+  "correlation_id": "corr_viki_veritas_000002",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "source_environment": "controlled-test",
+  "source_instance_id": "viki-local-controlled-001",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "upstream_confidence_class": "LOW",
+  "upstream_latency_ms": 112,
+  "upstream_reason_code": "UPSTREAM_INCOMPLETE_CONTEXT"
+}
+```
+
+## 10. Example invalid payloads
+
+Invalid unknown status:
+
+```json
+{
+  "schema_version": "v1alpha1",
+  "rsa_status": "UNKNOWN_STATE",
+  "trigger_source": "SRC_Unknown_State",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "request_id": "req_viki_invalid_001",
+  "correlation_id": "corr_viki_veritas_invalid_001",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z"
+}
+```
+
+Expected behavior:
+
+- fail closed
+- `continuation_decision: PAUSE_FOR_HUMAN_REVIEW`
+- `sandbox_commit_state: SUSPENDED_NOT_COMMITTED`
+- do not infer `SAFE_PROCEED`
+
+Invalid raw reasoning:
+
+```json
+{
+  "schema_version": "v1alpha1",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Normal_State",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "request_id": "req_viki_invalid_002",
+  "correlation_id": "corr_viki_veritas_invalid_002",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "chain_of_thought": "FORBIDDEN"
+}
+```
+
+Expected behavior:
+
+- fail closed or reject before audit persistence
+- never store chain-of-thought
+- never store hidden model state
+- never store raw upstream reasoning
+
+## 11. Schema validation failure behavior
+
+The following must fail closed:
+
+- invalid JSON
+- payload is not a JSON object
+- missing `schema_version`
+- unsupported `schema_version`
+- missing `rsa_status`
+- null `rsa_status`
+- unknown `rsa_status`
+- missing `trigger_source`
+- empty `trigger_source`
+- missing `timestamp`
+- invalid `timestamp`
+- naive `timestamp`
+- missing `request_id`
+- missing `correlation_id`
+- duplicate `request_id` within replay window in future implementation
+- missing `payload_issued_at`
+- forbidden raw reasoning fields
+- forbidden secret or credential fields
+- raw KYC or regulated data fields
+- payload shape mismatch
+- field type mismatch
+
+Expected generic behavior:
+
+- `continuation_decision: PAUSE_FOR_HUMAN_REVIEW`
+- `sandbox_commit_state: SUSPENDED_NOT_COMMITTED`
+- `required_next_action: REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE` or `REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW` depending on failure class
+
+## 12. Redaction and audit behavior
+
+Audit entries may preserve:
+
+- `upstream_signal_source`
+- `schema_version`
+- `rsa_status`
+- `trigger_source`
+- `timestamp`
+- `request_id`
+- `correlation_id`
+- `payload_issued_at`
+- `source_environment`
+- `source_instance_id` when non-sensitive
+- `upstream_latency_ms`
+- `upstream_reason_code`
+- VERITAS `continuation_decision`
+- VERITAS `reason_code`
+- VERITAS `sandbox_commit_state`
+
+Audit entries must redact or reject:
+
+- `original_llm_intent`
+- `rsa_action_taken`
+- chain-of-thought
+- hidden model state
+- raw V.I.K.I. reasoning
+- raw LLM text
+- raw KYC records
+- customer PII
+- secrets
+- credentials
+- tokens
+- private keys
+- unredacted regulated data
+
+## 13. Transport assumptions
+
+- This schema draft does not define transport implementation.
+- Future transport must define authentication.
+- Future transport must define message integrity.
+- Future transport must define replay protection.
+- Future transport must define timeout behavior.
+- Future transport must define observability without sensitive payload logging.
+- This document does not add an endpoint or network call.
+
+## 14. Compatibility preservation
+
+- `rsa_status` remains the v1 payload field.
+- `RSASandboxPayload` remains the downstream payload container.
+- `evaluate_rsa_sandbox_signal()` remains the downstream evaluator.
+- `upstream_signal_source` remains `"RSA"`.
+- `viki_status` is not introduced in this phase.
+- `VIKIPayload` is not introduced in this phase.
+- Any naming migration must be handled separately as v2.
+
+## 15. Non-goals
+
+This schema draft does not permit:
+
+- production live V.I.K.I. integration
+- production API endpoint
+- real KYC data processing
+- live customer data processing
+- live LLM text ingestion
+- final commit automation based only on V.I.K.I.
+- bypass of VERITAS commit gate
+- production AML/KYC compliance claims
+- regulatory approval claims
+- legal advice claims
+
+## 16. Approval gates before implementation
+
+Checklist before any live payload implementation:
+
+- [ ] threat model merged
+- [ ] schema draft merged
+- [ ] schema reviewed by human reviewer
+- [ ] transport/auth design merged
+- [ ] replay protection design merged
+- [ ] redaction policy reviewed
+- [ ] failure-mode test plan drafted
+- [ ] staging-only plan drafted
+- [ ] synthetic-data-only plan drafted
+- [ ] rollback plan documented
+- [ ] security review completed
+
+## 17. What this schema draft validates
+
+- required live payload fields are defined
+- optional live payload fields are constrained
+- forbidden fields are explicitly listed
+- accepted `rsa_status` values are fixed
+- timestamp and replay expectations are documented
+- audit redaction expectations are documented
+- compatibility with `RSASandboxPayload` is preserved
+- no live implementation is introduced
+
+## 18. What this schema draft does not validate
+
+- it does not implement live V.I.K.I.
+- it does not validate transport
+- it does not validate authentication
+- it does not validate authorization
+- it does not validate replay protection
+- it does not validate production AML/KYC compliance
+- it does not validate regulatory approval
+- it does not provide legal advice
+- it does not authorize production deployment
+
+## 19. Recommended next PR after this schema draft
+
+The next safe PR after this schema draft should be one of:
+
+- controlled transport/authentication design
+- replay protection and correlation-id design
+- redaction and observability design
+- live payload schema fixture examples
+- controlled live integration implementation plan
+
+Recommended:
+
+The safest next PR is controlled transport/authentication design, still documentation-only, because the schema contract should be followed by a secure transport boundary before any runtime implementation.

--- a/docs/en/guides/rsa-veritas-live-viki-integration-design-note.md
+++ b/docs/en/guides/rsa-veritas-live-viki-integration-design-note.md
@@ -15,6 +15,7 @@ Related documentation artifacts:
 - [Local V.I.K.I. mock ingestion receiver design (Phase 2 local mock artifact, documentation-only)](./rsa-veritas-local-viki-mock-ingestion-receiver-design.md)
 - [Live V.I.K.I. integration reviewer checklist](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 - [Controlled live V.I.K.I. integration threat model (documentation-only pre-live gate)](./rsa-veritas-controlled-live-viki-integration-threat-model.md)
+- [Controlled live V.I.K.I. payload schema draft (required pre-live schema gate, documentation-only)](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
 
 ## 2. Current static baseline
 

--- a/docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
+++ b/docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
@@ -16,6 +16,7 @@ References:
 - [Local V.I.K.I. mock receiver test fixture plan (documentation-only, no receiver implementation, no test implementation, no production endpoint)](./rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md)
 - [Sandbox reviewer index](./rsa-veritas-sandbox-reviewer-index.md)
 - [Controlled live V.I.K.I. integration threat model (documentation-only pre-live gate)](./rsa-veritas-controlled-live-viki-integration-threat-model.md)
+- [Controlled live V.I.K.I. payload schema draft (required pre-live schema gate, documentation-only)](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
 
 ## 2. Review status legend
 

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -32,6 +32,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 13. [Local V.I.K.I. mock receiver test fixture plan (Phase 2 local mock artifact, documentation-only)](./rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md)
 14. [Local V.I.K.I. mock receiver validation snapshot (Phase 2 local mock implementation validation record, documentation-only)](./rsa-veritas-local-viki-mock-receiver-validation-snapshot.md)
 15. [Local V.I.K.I. mock receiver E2E harness validation snapshot (Phase 2 local mock fixture-driven harness validation record, documentation-only)](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
+16. [Controlled live V.I.K.I. payload schema draft (required pre-live schema gate, documentation-only)](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md
@@ -147,25 +147,259 @@ Explicitly forbidden fields:
 - unknown / empty / null `rsa_status` は fail closed。
 - 複数 status の同時表現は fail closed。
 
-## 8-19. 実装前要件・失敗時挙動・非目標（English と同等の拘束）
+## 8. Timestamp and replay requirements
 
-以下は English 版と同じ拘束で適用します（キー/enum 値は同一）。
+- `timestamp` と `payload_issued_at` は RFC 3339 UTC または timezone-aware ISO-8601 normalized to UTC である必要があります。
+- naive timestamps は reject されます。
+- invalid timestamp strings は reject されます。
+- clock skew threshold は実装前に明示定義が必要です。
+- 既存 local mock threshold は skew > 300 seconds で fail closed、skew = 300 seconds は accepted です。
+- live integration は、別途レビュー済み設計で変更されない限り、同じ threshold を採用できます。
+- replay protection は live implementation 前に設計する必要があります。
+- `request_id` と `correlation_id` は replay protection と traceability のプレースホルダーです。
+- 将来実装では replay window 内の duplicate `request_id` は fail closed とすべきです。
 
-- Timestamp / replay 要件: RFC 3339 UTC or timezone-aware ISO-8601 normalized to UTC、naive/invalid reject、clock skew の実装閾値は別設計で明示、現行 local mock は skew > 300 秒 fail closed・skew = 300 秒 accepted。
-- Example valid/invalid payloads と expected behavior は English 版の JSON と同一。
-- Schema validation failure behavior は English 版列挙の failure class をすべて fail closed。
-- Generic failure result:
-  - `continuation_decision: PAUSE_FOR_HUMAN_REVIEW`
-  - `sandbox_commit_state: SUSPENDED_NOT_COMMITTED`
-  - `required_next_action: REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE` または `REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW`
-- Redaction/audit rules、transport assumptions、compatibility preservation、non-goals、approval gates before implementation、what validates / does not validate、recommended next PR は English 版に準拠。
+## 9. Example valid payloads
 
-推奨 next PR:
+Example `SAFE_PROCEED`:
 
-- controlled transport/authentication design（documentation-only）
+```json
+{
+  "schema_version": "v1alpha1",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Normal_State",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "request_id": "req_viki_000001",
+  "correlation_id": "corr_viki_veritas_000001",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "source_environment": "controlled-test",
+  "source_instance_id": "viki-local-controlled-001",
+  "rsa_action_taken": "No_Upstream_Intervention_Required",
+  "original_llm_intent": "Continue_To_Normal_Bind_Boundary_Evaluation",
+  "upstream_confidence_class": "HIGH",
+  "upstream_latency_ms": 87,
+  "upstream_reason_code": "UPSTREAM_NORMAL_STATE"
+}
+```
+
+Example `ALGORITHMIC_HUMILITY_ENGAGED`:
+
+```json
+{
+  "schema_version": "v1alpha1",
+  "rsa_status": "ALGORITHMIC_HUMILITY_ENGAGED",
+  "trigger_source": "SRC_Incomplete_Context",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "request_id": "req_viki_000002",
+  "correlation_id": "corr_viki_veritas_000002",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "source_environment": "controlled-test",
+  "source_instance_id": "viki-local-controlled-001",
+  "rsa_action_taken": "Execution_Suspended_Awaiting_Reality_Sync",
+  "original_llm_intent": "Recommend_Transaction_Approval",
+  "upstream_confidence_class": "LOW",
+  "upstream_latency_ms": 112,
+  "upstream_reason_code": "UPSTREAM_INCOMPLETE_CONTEXT"
+}
+```
+
+## 10. Example invalid payloads
+
+Invalid unknown status:
+
+```json
+{
+  "schema_version": "v1alpha1",
+  "rsa_status": "UNKNOWN_STATE",
+  "trigger_source": "SRC_Unknown_State",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "request_id": "req_viki_invalid_001",
+  "correlation_id": "corr_viki_veritas_invalid_001",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z"
+}
+```
+
+Expected behavior:
+
+- fail closed
+- `continuation_decision: PAUSE_FOR_HUMAN_REVIEW`
+- `sandbox_commit_state: SUSPENDED_NOT_COMMITTED`
+- `do not infer SAFE_PROCEED`
+
+Invalid raw reasoning:
+
+```json
+{
+  "schema_version": "v1alpha1",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Normal_State",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "request_id": "req_viki_invalid_002",
+  "correlation_id": "corr_viki_veritas_invalid_002",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "chain_of_thought": "FORBIDDEN"
+}
+```
+
+Expected behavior:
+
+- fail closed または audit persistence 前に reject
+- chain-of-thought を保存しない
+- hidden model state を保存しない
+- raw upstream reasoning を保存しない
+
+## 11. Schema validation failure behavior
+
+以下は fail closed 必須です。
+
+- invalid JSON
+- payload is not a JSON object
+- missing `schema_version`
+- unsupported `schema_version`
+- missing `rsa_status`
+- null `rsa_status`
+- unknown `rsa_status`
+- missing `trigger_source`
+- empty `trigger_source`
+- missing `timestamp`
+- invalid `timestamp`
+- naive `timestamp`
+- missing `request_id`
+- missing `correlation_id`
+- future implementation における replay window 内 duplicate `request_id`
+- missing `payload_issued_at`
+- forbidden raw reasoning fields
+- forbidden secret or credential fields
+- raw KYC or regulated data fields
+- payload shape mismatch
+- field type mismatch
+
+Expected generic behavior:
+
+- `continuation_decision: PAUSE_FOR_HUMAN_REVIEW`
+- `sandbox_commit_state: SUSPENDED_NOT_COMMITTED`
+- failure class に応じて `required_next_action: REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE` または `REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW`
+
+## 12. Redaction and audit behavior
+
+audit entries で保持してよい項目:
+
+- `upstream_signal_source`
+- `schema_version`
+- `rsa_status`
+- `trigger_source`
+- `timestamp`
+- `request_id`
+- `correlation_id`
+- `payload_issued_at`
+- `source_environment`
+- non-sensitive な場合の `source_instance_id`
+- `upstream_latency_ms`
+- `upstream_reason_code`
+- VERITAS `continuation_decision`
+- VERITAS `reason_code`
+- VERITAS `sandbox_commit_state`
+
+audit entries で redact または reject 必須の項目:
+
+- `original_llm_intent`
+- `rsa_action_taken`
+- chain-of-thought
+- hidden model state
+- raw V.I.K.I. reasoning
+- raw LLM text
+- raw KYC records
+- customer PII
+- secrets
+- credentials
+- tokens
+- private keys
+- unredacted regulated data
+
+## 13. Transport assumptions
+
+- この schema draft は transport implementation を定義しません。
+- 将来 transport は authentication を定義する必要があります。
+- 将来 transport は message integrity を定義する必要があります。
+- 将来 transport は replay protection を定義する必要があります。
+- 将来 transport は timeout behavior を定義する必要があります。
+- 将来 transport は sensitive payload logging を避けた observability を定義する必要があります。
+- この文書は endpoint や network call を追加しません。
+
+## 14. Compatibility preservation
+
+- `rsa_status` は v1 payload field として維持されます。
+- `RSASandboxPayload` は downstream payload container として維持されます。
+- `evaluate_rsa_sandbox_signal()` は downstream evaluator として維持されます。
+- `upstream_signal_source` は `"RSA"` のまま維持されます。
+- この phase では `viki_status` は導入しません。
+- この phase では `VIKIPayload` は導入しません。
+- naming migration は v2 として別扱いで実施する必要があります。
+
+## 15. Non-goals
+
+この schema draft は以下を許可しません。
+
+- production live V.I.K.I. integration
+- production API endpoint
+- real KYC data processing
+- live customer data processing
+- live LLM text ingestion
+- V.I.K.I. のみを根拠にした final commit automation
+- VERITAS commit gate の bypass
+- production AML/KYC compliance claims
+- regulatory approval claims
+- legal advice claims
+
+## 16. Approval gates before implementation
+
+live payload implementation 前の checklist:
+
+- [ ] threat model merged
+- [ ] schema draft merged
+- [ ] schema reviewed by human reviewer
+- [ ] transport/auth design merged
+- [ ] replay protection design merged
+- [ ] redaction policy reviewed
+- [ ] failure-mode test plan drafted
+- [ ] staging-only plan drafted
+- [ ] synthetic-data-only plan drafted
+- [ ] rollback plan documented
+- [ ] security review completed
+
+## 17. What this schema draft validates
+
+- required live payload fields are defined
+- optional live payload fields are constrained
+- forbidden fields are explicitly listed
+- accepted `rsa_status` values are fixed
+- timestamp and replay expectations are documented
+- audit redaction expectations are documented
+- compatibility with `RSASandboxPayload` is preserved
+- no live implementation is introduced
+
+## 18. What this schema draft does not validate
+
+- it does not implement live V.I.K.I.
+- it does not validate transport
+- it does not validate authentication
+- it does not validate authorization
+- it does not validate replay protection
+- it does not validate production AML/KYC compliance
+- it does not validate regulatory approval
+- it does not provide legal advice
+- it does not authorize production deployment
+
+## 19. Recommended next PR after this schema draft
+
+この schema draft 後の次の安全な PR は次のいずれかです。
+
+- controlled transport/authentication design
 - replay protection and correlation-id design
 - redaction and observability design
 - live payload schema fixture examples
 - controlled live integration implementation plan
 
-最も安全な次 PR は、runtime 実装前に secure transport boundary を定義する controlled transport/authentication design（documentation-only）です。
+推奨:
+
+最も安全な次 PR は controlled transport/authentication design（documentation-only）です。schema contract の直後に secure transport boundary を先に確定し、runtime implementation より前にレビュー可能な境界を固定するためです。

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md
@@ -1,0 +1,171 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Payload Schema Draft
+
+## 英語正本
+
+- [RSA ↔ VERITAS Controlled Live V.I.K.I. Payload Schema Draft](../../en/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md)
+
+## 1. 目的
+
+本ドキュメントは、将来の controlled live V.I.K.I. integration に向けた payload schema のドラフトを定義します。
+
+- これは documentation-only です。
+- これは live integration ではありません。
+- これは runtime implementation ではありません。
+- これは production API endpoint ではありません。
+- これは production 利用を許可しません。
+- これは real KYC data を処理しません。
+- これは legal/regulatory approval を提供しません。
+- transport/endpoint/live middleware 作業の前に、本 schema draft のレビューを必須とします。
+
+## 2. 現在の baseline
+
+現在の検証済み local mock パス:
+
+static synthetic JSON fixture
+→ `ingest_local_viki_mock_payload()`
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ VERITAS decision
+→ redacted audit output
+
+controlled live integration threat model は既にマージ済みであり、本 schema draft はその方針に従います。
+
+v1 compatibility contract は維持されます。
+
+- `rsa_status`
+- `RSASandboxPayload`
+- `evaluate_rsa_sandbox_signal()`
+- `upstream_signal_source = "RSA"`
+
+## 3. Future live payload boundary
+
+V.I.K.I. live middleware
+→ RSA-compatible live payload
+→ controlled transport boundary
+→ VERITAS live ingestion boundary
+→ schema validation
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ VERITAS decision
+→ audit entry
+→ commit gate
+
+- VERITAS は schema validation 通過前の live payload を untrusted として扱います。
+- VERITAS は emitted RSA-compatible payload のみを消費します。
+- VERITAS は V.I.K.I. internal reasoning を消費しません。
+- VERITAS は hidden V.I.K.I. logic を実行しません。
+- VERITAS は欠落・破損・遅延・到達不能 payload から `SAFE_PROCEED` を推定しません。
+
+## 4. Draft payload object
+
+payload は単一 JSON object とします。
+
+Required fields:
+
+- `schema_version`
+- `rsa_status`
+- `trigger_source`
+- `timestamp`
+- `request_id`
+- `correlation_id`
+- `payload_issued_at`
+
+Optional accepted fields:
+
+- `source_environment`
+- `source_instance_id`
+- `rsa_action_taken`
+- `original_llm_intent`
+- `upstream_confidence_class`
+- `upstream_latency_ms`
+- `upstream_reason_code`
+
+Explicitly forbidden fields:
+
+- `chain_of_thought`
+- `hidden_model_state`
+- `raw_llm_reasoning`
+- `raw_viki_reasoning`
+- `raw_kyc_record`
+- `customer_pii`
+- `secrets`
+- `credentials`
+- `api_key`
+- `access_token`
+- `refresh_token`
+- `private_key`
+- `webhook_secret`
+- `unredacted_regulated_data`
+
+- Optional な raw intent/action 項目は audit output で default redacted とします。
+- forbidden fields は audit persistence 前に reject または strip します。
+- chain-of-thought / hidden model state の存在は fail closed 必須です。
+
+## 5. Required field definitions
+
+| Field | Type | Required | Description | Validation rule |
+| --- | --- | --- | --- | --- |
+| `schema_version` | string | yes | controlled live payload 用ドラフト schema version。 | このドラフトでは `"v1alpha1"` 固定。 |
+| `rsa_status` | string | yes | RSA-compatible upstream status。 | `SAFE_PROCEED` / `DENSITY_THROTTLED` / `ALGORITHMIC_HUMILITY_ENGAGED` / `DEFERRAL_ENGAGED` のいずれか。 |
+| `trigger_source` | string | yes | upstream status の発行理由を示す deterministic source label。 | non-empty かつ raw reasoning / PII を含まない。 |
+| `timestamp` | string | yes | primary event timestamp。 | RFC 3339 UTC または timezone-aware ISO-8601 を UTC 正規化。 |
+| `request_id` | string | yes | upstream request の一意識別子。 | non-empty。将来実装では replay window 内一意性を強制予定。 |
+| `correlation_id` | string | yes | V.I.K.I. emission / VERITAS ingestion / audit / review event を関連付ける識別子。 | non-empty かつ PII を含まない。 |
+| `payload_issued_at` | string | yes | V.I.K.I. が payload を発行した時刻。 | RFC 3339 UTC または timezone-aware ISO-8601 を UTC 正規化。 |
+
+## 6. Optional field definitions
+
+| Field | Type | Required | Description | Validation / audit rule |
+| --- | --- | --- | --- | --- |
+| `source_environment` | string | no | local / staging / controlled-test などの環境ラベル。 | production behavior の有効化に使ってはいけない。 |
+| `source_instance_id` | string | no | V.I.K.I. instance の non-secret 識別子。 | secrets / host credentials / PII を含めない。 |
+| `rsa_action_taken` | string | no | 短い upstream action ラベル。 | non-empty string のみ許可。audit output は default redacted。 |
+| `original_llm_intent` | string | no | 短い upstream intent ラベル。 | non-empty string のみ許可。audit output は default redacted。 |
+| `upstream_confidence_class` | string | no | raw probability trace ではない粗い confidence class。 | `LOW` / `MEDIUM` / `HIGH` / `UNSPECIFIED` を推奨許可値とする。 |
+| `upstream_latency_ms` | integer | no | upstream 処理レイテンシ（ms）。 | present 時は 0 以上の整数。 |
+| `upstream_reason_code` | string | no | deterministic upstream reason code。 | raw reasoning / PII / regulated data を含めない。 |
+
+## 7. Accepted rsa_status values
+
+`SAFE_PROCEED`:
+- normal bind-boundary evaluation へ進行可能。
+- final commit approval と同義ではない。
+- VERITAS commit gate が最終権限を維持。
+
+`DENSITY_THROTTLED`:
+- upstream intervention が適用されたことを示す。
+- intervention を記録した上で継続可能。
+
+`ALGORITHMIC_HUMILITY_ENGAGED`:
+- upstream context が不完全/不確実であることを示す。
+- VERITAS は human review へ pause すべき。
+
+`DEFERRAL_ENGAGED`:
+- 重大な upstream deferral を示す。
+- VERITAS は final commit を block すべき。
+
+- unknown / empty / null `rsa_status` は fail closed。
+- 複数 status の同時表現は fail closed。
+
+## 8-19. 実装前要件・失敗時挙動・非目標（English と同等の拘束）
+
+以下は English 版と同じ拘束で適用します（キー/enum 値は同一）。
+
+- Timestamp / replay 要件: RFC 3339 UTC or timezone-aware ISO-8601 normalized to UTC、naive/invalid reject、clock skew の実装閾値は別設計で明示、現行 local mock は skew > 300 秒 fail closed・skew = 300 秒 accepted。
+- Example valid/invalid payloads と expected behavior は English 版の JSON と同一。
+- Schema validation failure behavior は English 版列挙の failure class をすべて fail closed。
+- Generic failure result:
+  - `continuation_decision: PAUSE_FOR_HUMAN_REVIEW`
+  - `sandbox_commit_state: SUSPENDED_NOT_COMMITTED`
+  - `required_next_action: REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE` または `REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW`
+- Redaction/audit rules、transport assumptions、compatibility preservation、non-goals、approval gates before implementation、what validates / does not validate、recommended next PR は English 版に準拠。
+
+推奨 next PR:
+
+- controlled transport/authentication design（documentation-only）
+- replay protection and correlation-id design
+- redaction and observability design
+- live payload schema fixture examples
+- controlled live integration implementation plan
+
+最も安全な次 PR は、runtime 実装前に secure transport boundary を定義する controlled transport/authentication design（documentation-only）です。

--- a/docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md
+++ b/docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md
@@ -19,6 +19,7 @@
 - [Local V.I.K.I. mock ingestion receiver design（Phase 2 local mock artifact / documentation-only）](./rsa-veritas-local-viki-mock-ingestion-receiver-design.md)
 - [Live V.I.K.I. integration reviewer checklist](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 - [Controlled live V.I.K.I. integration threat model (documentation-only pre-live gate)](./rsa-veritas-controlled-live-viki-integration-threat-model.md)
+- [Controlled live V.I.K.I. payload schema draft（pre-live 必須 schema gate、documentation-only）](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
 
 ## 2. 現在の静的ベースライン
 

--- a/docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
+++ b/docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
@@ -20,6 +20,7 @@
 - [Local V.I.K.I. mock receiver test fixture plan（documentation-only / receiver 未実装 / tests 未実装 / production endpoint 追加なし）](./rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md)
 - [Sandbox reviewer index](./rsa-veritas-sandbox-reviewer-index.md)
 - [Controlled live V.I.K.I. integration threat model (documentation-only pre-live gate)](./rsa-veritas-controlled-live-viki-integration-threat-model.md)
+- [Controlled live V.I.K.I. payload schema draft（pre-live 必須 schema gate、documentation-only）](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
 
 ## 2. Review status legend
 

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -38,6 +38,7 @@
 13. [Local V.I.K.I. mock receiver test fixture plan（Phase 2 local mock artifact / documentation-only）](./rsa-veritas-local-viki-mock-receiver-test-fixture-plan.md)
 14. [Local V.I.K.I. mock receiver validation snapshot（Phase 2 ローカルモック実装検証記録、documentation-only）](./rsa-veritas-local-viki-mock-receiver-validation-snapshot.md)
 15. [Local V.I.K.I. mock receiver E2E harness validation snapshot（Phase 2 fixture-driven harness 検証記録、documentation-only）](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
+16. [Controlled live V.I.K.I. payload schema draft（pre-live 必須 schema gate、documentation-only）](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 


### PR DESCRIPTION
### Motivation

- Define a clear, reviewable draft payload contract for a future controlled live V.I.K.I. → VERITAS integration before any transport or runtime work begins.
- Preserve the v1 compatibility contract and follow the already-merged controlled live integration threat model while preventing accidental runtime or production use.
- Provide a required pre-live schema gate artifact so reviewers can validate fields, redaction, and fail-closed behavior prior to implementation.

### Description

- Add `docs/en/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md` containing the full EN draft schema, required/optional/forbidden fields, validation rules, examples, failure modes, redaction policy, transport assumptions, and approval gates.
- Add `docs/ja/guides/rsa-veritas-controlled-live-viki-payload-schema-draft.md` as a Japanese-first aligned translation that preserves keys, enum values, and the required “英語正本” link to the EN page.
- Update the EN/JA sandbox reviewer index, threat model, live integration design note, and live-integration reviewer checklist to include the new payload schema draft as a required pre-live schema gate artifact and to make clear this is documentation-only.
- No runtime code, tests, CI, endpoints, transport, credentials, fixtures, or network behavior were added or modified; compatibility names such as `rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`, and `upstream_signal_source = "RSA"` were preserved.

### Testing

- No automated unit/integration tests were added because this is a documentation-only change and no runtime code was modified.
- Repository/commit checks performed (file creation and index updates) completed locally as part of the PR creation and did not alter code paths or CI configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a111f8901cc8326953fdad298fa17e8)