### PR TITLE
docs: add controlled live V.I.K.I. transport/authentication design (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-transport-authentication-design.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-transport-authentication-design.md
@@ -1,0 +1,399 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Transport Authentication Design
+
+## 1. Purpose
+
+This document defines the transport and authentication design for a future controlled live V.I.K.I. integration.
+
+- This is documentation-only.
+- This is not a live integration.
+- This is not a runtime implementation.
+- This is not a production API endpoint.
+- This does not authorize production use.
+- This does not add network calls.
+- This does not add secrets or credentials.
+- This does not process real KYC data.
+- This does not provide legal or regulatory approval.
+- This design must be reviewed before any transport, endpoint, credential, or live middleware implementation begins.
+
+## 2. Current baseline
+
+The following pre-live gates already exist:
+
+- local mock ingestion receiver design
+- local mock receiver test fixture plan
+- local mock receiver implementation
+- local mock receiver validation snapshot
+- static synthetic JSON fixture-driven E2E harness
+- E2E harness validation snapshot
+- controlled live integration threat model
+- controlled live payload schema draft
+
+Current validated path:
+
+static synthetic JSON fixture
+→ `ingest_local_viki_mock_payload()`
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ VERITAS decision
+→ redacted audit output
+
+This current path remains local-only, synthetic-data-only, and no-network.
+
+## 3. Future controlled transport boundary
+
+Future controlled transport boundary:
+
+V.I.K.I. live middleware
+→ RSA-compatible payload
+→ transport authentication layer
+→ message integrity verification
+→ replay protection check
+→ VERITAS live ingestion boundary
+→ schema validation
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ VERITAS decision
+→ redacted audit entry
+→ commit gate
+
+- VERITAS must treat every payload as untrusted until transport, integrity, replay, and schema validation pass.
+- Transport success does not imply payload validity.
+- Payload validity does not imply final commit approval.
+- `SAFE_PROCEED` does not equal final commit approval.
+- VERITAS commit gate remains authoritative.
+- Timeout, failed authentication, failed integrity verification, replay suspicion, malformed payload, or missing payload must fail closed.
+
+## 4. Proposed controlled transport assumptions
+
+Initial controlled live transport should be:
+
+- staging-only
+- synthetic-data-only
+- default-off
+- feature-flag gated
+- no production endpoint
+- no public unauthenticated endpoint
+- no real KYC data
+- no live customer data
+- no raw LLM text
+- no raw V.I.K.I. reasoning
+
+Transport assumptions:
+
+- HTTPS is required.
+- TLS 1.2 or TLS 1.3 should be required.
+- mTLS is preferred for controlled service-to-service authentication where feasible.
+- If mTLS is not available, signed requests using a secret stored outside the repository may be used for controlled testing.
+- Secrets must never be committed to the repository.
+- Endpoint URLs must not be added to public docs unless explicitly safe.
+- Any future endpoint must be staging-only until separate production readiness review.
+
+## 5. Authentication design
+
+Two acceptable future authentication options:
+
+### Option A: mTLS preferred
+
+- V.I.K.I. and VERITAS authenticate each other using certificates.
+- Certificates are provisioned outside the repository.
+- Certificate rotation is required before production consideration.
+- Certificate subject / SAN allowlisting should be defined before implementation.
+- Failed certificate validation must fail closed.
+
+### Option B: signed request fallback
+
+- Request is signed by V.I.K.I. using a secret or private key stored outside the repository.
+- VERITAS verifies the signature before schema validation.
+- Key id must be included in metadata or headers.
+- Secret rotation must be designed before implementation.
+- Failed signature verification must fail closed.
+
+- This design does not choose a production authentication mechanism.
+- The initial controlled implementation must document which option is used.
+- Authentication bypass is not permitted.
+- Missing authentication must fail closed.
+
+## 6. Draft transport metadata
+
+Draft metadata that future transport may use:
+
+- `X-VERITAS-Schema-Version`
+- `X-VERITAS-Request-Id`
+- `X-VERITAS-Correlation-Id`
+- `X-VERITAS-Payload-Issued-At`
+- `X-VERITAS-Signature`
+- `X-VERITAS-Key-Id`
+- `X-VERITAS-Body-SHA256`
+- `X-VERITAS-Source-Environment`
+- `X-VERITAS-Source-Instance-Id`
+
+- Header names are draft names only.
+- Final names must be reviewed before implementation.
+- Headers must not contain PII, raw reasoning, secrets, tokens, or regulated data.
+- `request_id` and `correlation_id` must match the payload where applicable.
+- Signature or integrity checks must cover the body and relevant metadata.
+
+## 7. Message integrity design
+
+Future controlled live transport must provide message integrity.
+
+Minimum integrity requirements:
+
+- Verify payload body hash.
+- Verify signature or mTLS identity.
+- Verify `request_id`.
+- Verify `correlation_id`.
+- Verify timestamp / `payload_issued_at`.
+- Verify `schema_version`.
+- Reject tampered payloads.
+- Reject modified `rsa_status`.
+- Reject modified `trigger_source`.
+- Reject body/header mismatch.
+
+For signed request designs, signature should cover:
+
+- HTTP method or transport operation name
+- request path or operation target
+- timestamp or `payload_issued_at`
+- `request_id`
+- `correlation_id`
+- body hash
+- `schema_version`
+
+- Exact canonicalization rules must be defined before implementation.
+- If canonicalization is ambiguous, implementation must not proceed.
+- Failed integrity verification must fail closed.
+
+## 8. Replay protection design
+
+Replay protection must be designed before live implementation.
+
+Minimum replay protection expectations:
+
+- `request_id` must be unique within a defined replay window.
+- `payload_issued_at` must be within accepted clock skew.
+- Duplicate `request_id` within replay window must fail closed.
+- Stale payloads must fail closed.
+- Future timestamps beyond allowed skew must fail closed.
+- Replay cache storage must be defined before implementation.
+- Replay cache TTL must be defined before implementation.
+- Replay cache failure should fail closed unless a separate reviewed degradation policy exists.
+
+Reference existing local mock rule:
+
+- local mock threshold: skew > 300 seconds fails closed
+- skew = 300 seconds is accepted
+
+- Controlled live integration may adopt the same skew threshold unless changed by separate reviewed design.
+- Replay protection is mandatory before any real live transport.
+
+## 9. Timeout and availability design
+
+- V.I.K.I. timeout must fail closed.
+- V.I.K.I. unreachable must fail closed.
+- Connection refused must fail closed.
+- Partial response must fail closed.
+- Delayed response beyond threshold must fail closed.
+- Missing payload must fail closed.
+- Transport error must fail closed.
+
+Expected generic behavior:
+
+- `continuation_decision`: `PAUSE_FOR_HUMAN_REVIEW`
+- `sandbox_commit_state`: `SUSPENDED_NOT_COMMITTED`
+- `required_next_action`: `REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE`
+
+- VERITAS must never infer `SAFE_PROCEED` from timeout or unavailability.
+- Availability failure must not become normal approval.
+- Retry behavior must be bounded and reviewed before implementation.
+
+## 10. Payload schema relationship
+
+This transport design depends on the controlled live payload schema draft.
+
+Required payload fields remain:
+
+- `schema_version`
+- `rsa_status`
+- `trigger_source`
+- `timestamp`
+- `request_id`
+- `correlation_id`
+- `payload_issued_at`
+
+- Transport metadata must align with payload fields.
+- Schema validation still runs after transport validation.
+- Transport authentication does not replace schema validation.
+- Schema validation does not replace transport authentication.
+- Both are required before payload is accepted.
+
+## 11. Redaction and logging policy
+
+Future transport logs may include:
+
+- `request_id`
+- `correlation_id`
+- `schema_version`
+- `source_environment`
+- `source_instance_id` when non-sensitive
+- authentication result class
+- integrity result class
+- replay result class
+- timeout result class
+- VERITAS `continuation_decision`
+- VERITAS `sandbox_commit_state`
+
+Future transport logs must not include:
+
+- secrets
+- credentials
+- access tokens
+- refresh tokens
+- private keys
+- webhook secrets
+- raw V.I.K.I. reasoning
+- raw LLM text
+- chain-of-thought
+- hidden model state
+- raw KYC records
+- customer PII
+- unredacted regulated data
+- full signed secret material
+- raw Authorization header
+
+- Logging must be deterministic and redacted.
+- Observability must not become a data leakage channel.
+- Failed authentication logs must not expose secret material.
+
+## 12. Credential and secret handling
+
+- Secrets must not be stored in the repository.
+- Secrets must not be stored in fixtures.
+- Secrets must not be printed in logs.
+- Secrets must not appear in docs.
+- Secrets must not be passed through raw payload fields.
+- Future implementation must use a secret manager or platform-provided secret storage.
+- Rotation plan must be documented before production consideration.
+- Revocation plan must be documented before production consideration.
+- Test credentials, if ever used, must be synthetic and scoped to staging only.
+
+## 13. Environment separation
+
+Controlled live integration must separate:
+
+- local
+- CI
+- staging
+- controlled-test
+- production
+
+Rules:
+
+- local mock receiver remains local-only and test-only.
+- controlled live transport must be staging-only at first.
+- production must not be enabled by this design.
+- `source_environment` must not be used as an authorization mechanism.
+- feature flags must be default-off.
+- production deployment requires separate production readiness review.
+
+## 14. Fail-closed matrix
+
+| Failure class | Example | Expected behavior |
+| --- | --- | --- |
+| Missing authentication | Missing certificate or missing signature metadata | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Failed authentication | mTLS certificate rejected | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Failed signature verification | Signature mismatch for payload body | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Body hash mismatch | `X-VERITAS-Body-SHA256` differs from payload body hash | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Replay detected | Previously seen signed payload replayed | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Duplicate request_id | Same `request_id` appears within replay window | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Stale timestamp | `payload_issued_at` older than accepted replay window | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Future timestamp beyond skew | `payload_issued_at` too far ahead of receiver clock | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Timeout | Upstream request exceeds configured timeout | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| V.I.K.I. unreachable | DNS/network/connectivity failure | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Malformed payload | Invalid JSON or missing required fields | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Unknown rsa_status | `rsa_status` value not in accepted contract | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Forbidden raw reasoning field | Payload includes raw reasoning field | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Secret detected in payload | Payload contains secret-like token or key material | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Raw KYC data detected | Payload includes unredacted regulated KYC record | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+
+## 15. Required implementation gates
+
+Checklist before any transport implementation:
+
+- threat model merged
+- payload schema draft merged
+- transport/auth design merged
+- authentication option selected
+- message integrity design finalized
+- replay protection design finalized
+- timeout policy finalized
+- redaction/logging policy finalized
+- secret storage approach approved
+- staging-only feature flag defined
+- synthetic-data-only test plan drafted
+- rollback plan documented
+- security review completed
+
+## 16. Non-goals
+
+This design does not permit:
+
+- production live V.I.K.I. integration
+- production API endpoint
+- public unauthenticated endpoint
+- real KYC data processing
+- live customer data processing
+- live LLM text ingestion
+- raw V.I.K.I. reasoning ingestion
+- final commit automation based only on V.I.K.I.
+- bypass of VERITAS commit gate
+- secrets in repository
+- production AML/KYC compliance claims
+- regulatory approval claims
+- legal advice claims
+
+## 17. Compatibility preservation
+
+- `rsa_status` remains the v1 payload field.
+- `RSASandboxPayload` remains the downstream payload container.
+- `evaluate_rsa_sandbox_signal()` remains the downstream evaluator.
+- `upstream_signal_source` remains `"RSA"`.
+- `viki_status` is not introduced in this phase.
+- `VIKIPayload` is not introduced in this phase.
+- Any naming migration must be handled separately as v2.
+
+## 18. What this design validates
+
+- transport risks are documented before implementation
+- authentication options are defined
+- message integrity is required
+- replay protection is required
+- timeout must fail closed
+- secrets must remain outside the repository
+- logs must be redacted
+- schema validation remains required
+- no live implementation is introduced
+
+## 19. What this design does not validate
+
+- it does not implement transport
+- it does not implement authentication
+- it does not implement authorization
+- it does not implement replay protection
+- it does not validate production AML/KYC compliance
+- it does not validate regulatory approval
+- it does not provide legal advice
+- it does not authorize production deployment
+- it does not make VERITAS production-ready for live V.I.K.I.
+
+## 20. Recommended next PR after this design
+
+The next safe PR should be one of:
+
+- replay protection and correlation-id design
+- redaction and observability design
+- live payload schema fixture examples
+- controlled live failure-mode test plan
+- controlled live integration implementation plan
+
+The safest next PR is replay protection and correlation-id design, still documentation-only, because transport authentication must be paired with replay protection before any runtime implementation.

--- a/docs/en/guides/rsa-veritas-live-viki-integration-design-note.md
+++ b/docs/en/guides/rsa-veritas-live-viki-integration-design-note.md
@@ -16,6 +16,7 @@ Related documentation artifacts:
 - [Live V.I.K.I. integration reviewer checklist](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 - [Controlled live V.I.K.I. integration threat model (documentation-only pre-live gate)](./rsa-veritas-controlled-live-viki-integration-threat-model.md)
 - [Controlled live V.I.K.I. payload schema draft (required pre-live schema gate, documentation-only)](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
+- [Controlled live V.I.K.I. transport authentication design (required pre-live transport/auth gate, documentation-only)](./rsa-veritas-controlled-live-viki-transport-authentication-design.md)
 
 ## 2. Current static baseline
 

--- a/docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
+++ b/docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
@@ -17,6 +17,7 @@ References:
 - [Sandbox reviewer index](./rsa-veritas-sandbox-reviewer-index.md)
 - [Controlled live V.I.K.I. integration threat model (documentation-only pre-live gate)](./rsa-veritas-controlled-live-viki-integration-threat-model.md)
 - [Controlled live V.I.K.I. payload schema draft (required pre-live schema gate, documentation-only)](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
+- [Controlled live V.I.K.I. transport authentication design (required pre-live transport/auth gate, documentation-only)](./rsa-veritas-controlled-live-viki-transport-authentication-design.md)
 
 ## 2. Review status legend
 

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -33,6 +33,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 14. [Local V.I.K.I. mock receiver validation snapshot (Phase 2 local mock implementation validation record, documentation-only)](./rsa-veritas-local-viki-mock-receiver-validation-snapshot.md)
 15. [Local V.I.K.I. mock receiver E2E harness validation snapshot (Phase 2 local mock fixture-driven harness validation record, documentation-only)](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
 16. [Controlled live V.I.K.I. payload schema draft (required pre-live schema gate, documentation-only)](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
+17. [Controlled live V.I.K.I. transport authentication design (required pre-live transport/auth gate, documentation-only)](./rsa-veritas-controlled-live-viki-transport-authentication-design.md)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-transport-authentication-design.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-transport-authentication-design.md
@@ -1,0 +1,403 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Transport Authentication Design
+
+## 英語正本
+
+- [RSA ↔ VERITAS Controlled Live V.I.K.I. Transport Authentication Design](../../en/guides/rsa-veritas-controlled-live-viki-transport-authentication-design.md)
+
+## 1. 目的
+
+この文書は、将来の controlled live V.I.K.I. integration に向けた transport と authentication の設計方針を定義します。
+
+- 本文書は documentation-only です。
+- 本文書は live integration ではありません。
+- 本文書は runtime implementation ではありません。
+- 本文書は production API endpoint ではありません。
+- 本文書は production use を承認しません。
+- 本文書は network calls を追加しません。
+- 本文書は secrets / credentials を追加しません。
+- 本文書は実データの KYC 処理を行いません。
+- 本文書は法規制承認や法的助言を提供しません。
+- transport / endpoint / credential / live middleware 実装に着手する前に、必ず本設計レビューを完了させる必要があります。
+
+## 2. 現在の baseline
+
+以下の pre-live gates は既に存在します。
+
+- local mock ingestion receiver design
+- local mock receiver test fixture plan
+- local mock receiver implementation
+- local mock receiver validation snapshot
+- static synthetic JSON fixture-driven E2E harness
+- E2E harness validation snapshot
+- controlled live integration threat model
+- controlled live payload schema draft
+
+現在の検証済み経路:
+
+static synthetic JSON fixture
+→ `ingest_local_viki_mock_payload()`
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ VERITAS decision
+→ redacted audit output
+
+この経路は引き続き local-only / synthetic-data-only / no-network です。
+
+## 3. 将来の controlled transport boundary
+
+将来の controlled transport boundary:
+
+V.I.K.I. live middleware
+→ RSA-compatible payload
+→ transport authentication layer
+→ message integrity verification
+→ replay protection check
+→ VERITAS live ingestion boundary
+→ schema validation
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ VERITAS decision
+→ redacted audit entry
+→ commit gate
+
+- VERITAS は、transport・integrity・replay・schema validation を通過するまで、すべての payload を untrusted として扱う必要があります。
+- Transport success は payload validity を意味しません。
+- Payload validity は final commit approval を意味しません。
+- `SAFE_PROCEED` は final commit approval と同義ではありません。
+- VERITAS commit gate は引き続き authoritative です。
+- timeout / failed authentication / failed integrity verification / replay suspicion / malformed payload / missing payload は fail closed にする必要があります。
+
+## 4. Proposed controlled transport assumptions
+
+初期の controlled live transport は次を前提とします。
+
+- staging-only
+- synthetic-data-only
+- default-off
+- feature-flag gated
+- no production endpoint
+- no public unauthenticated endpoint
+- no real KYC data
+- no live customer data
+- no raw LLM text
+- no raw V.I.K.I. reasoning
+
+Transport assumptions:
+
+- HTTPS は必須です。
+- TLS 1.2 または TLS 1.3 を必須化すべきです。
+- 可能であれば、service-to-service 認証には mTLS を優先します。
+- mTLS が使えない場合は、repository 外に保管した secret による署名付き request を controlled testing に限り利用できます。
+- secrets は repository にコミットしてはいけません。
+- endpoint URL は安全性が明示できる場合を除き public docs に掲載してはいけません。
+- 将来 endpoint を導入する場合も、別途 production readiness review 完了までは staging-only とします。
+
+## 5. Authentication design
+
+将来許容される authentication option は2つです。
+
+### Option A: mTLS preferred
+
+- V.I.K.I. と VERITAS は certificate で相互認証します。
+- certificate は repository 外で払い出します。
+- production consideration 前に certificate rotation が必要です。
+- 実装前に certificate subject / SAN allowlisting を定義すべきです。
+- certificate validation failure は fail closed 必須です。
+
+### Option B: signed request fallback
+
+- V.I.K.I. は repository 外に保管した secret または private key で request を署名します。
+- VERITAS は schema validation 前に署名検証を行います。
+- metadata または headers に key id を含める必要があります。
+- 実装前に secret rotation 設計が必要です。
+- signature verification failure は fail closed 必須です。
+
+- 本設計は production authentication mechanism を選定しません。
+- 初期 controlled implementation では採用 option を必ず明記する必要があります。
+- authentication bypass は禁止です。
+- missing authentication は fail closed 必須です。
+
+## 6. Draft transport metadata
+
+将来 transport で使用し得る draft metadata:
+
+- `X-VERITAS-Schema-Version`
+- `X-VERITAS-Request-Id`
+- `X-VERITAS-Correlation-Id`
+- `X-VERITAS-Payload-Issued-At`
+- `X-VERITAS-Signature`
+- `X-VERITAS-Key-Id`
+- `X-VERITAS-Body-SHA256`
+- `X-VERITAS-Source-Environment`
+- `X-VERITAS-Source-Instance-Id`
+
+- header 名は draft 名です。
+- final 名称は実装前にレビュー必須です。
+- headers に PII / raw reasoning / secrets / tokens / regulated data を含めてはいけません。
+- 該当する場合、`request_id` と `correlation_id` は payload と一致する必要があります。
+- signature または integrity checks は body と関連 metadata を対象化する必要があります。
+
+## 7. Message integrity design
+
+将来の controlled live transport は message integrity を必須とします。
+
+最小要件:
+
+- payload の body hash を検証する。
+- signature または mTLS identity を検証する。
+- `request_id` を検証する。
+- `correlation_id` を検証する。
+- timestamp / `payload_issued_at` を検証する。
+- `schema_version` を検証する。
+- tampered payload を拒否する。
+- 改ざんされた `rsa_status` を拒否する。
+- 改ざんされた `trigger_source` を拒否する。
+- body/header mismatch を拒否する。
+
+signed request 設計では、署名対象に以下を含めるべきです。
+
+- HTTP method または transport operation name
+- request path または operation target
+- timestamp または `payload_issued_at`
+- `request_id`
+- `correlation_id`
+- body hash
+- `schema_version`
+
+- canonicalization rules は実装前に厳密定義が必要です。
+- canonicalization が曖昧な場合、実装を進めてはいけません。
+- integrity verification failure は fail closed 必須です。
+
+## 8. Replay protection design
+
+live implementation 前に replay protection の設計が必須です。
+
+最小期待:
+
+- `request_id` は定義済み replay window 内で一意であること。
+- `payload_issued_at` は許容 clock skew 内であること。
+- replay window 内の duplicate `request_id` は fail closed。
+- stale payload は fail closed。
+- 許容 skew を超える未来 timestamp は fail closed。
+- replay cache storage の定義が実装前に必要。
+- replay cache TTL の定義が実装前に必要。
+- replay cache failure は、別途レビュー済み degradation policy がない限り fail closed。
+
+既存 local mock ルール参照:
+
+- local mock threshold: skew > 300 seconds は fail closed
+- skew = 300 seconds は許容
+
+- controlled live integration でも、別設計で変更されない限り同閾値採用を検討できます。
+- replay protection は実 live transport 前の必須条件です。
+
+## 9. Timeout and availability design
+
+- V.I.K.I. timeout は fail closed。
+- V.I.K.I. unreachable は fail closed。
+- connection refused は fail closed。
+- partial response は fail closed。
+- しきい値超過の遅延応答は fail closed。
+- missing payload は fail closed。
+- transport error は fail closed。
+
+期待される汎用挙動:
+
+- `continuation_decision`: `PAUSE_FOR_HUMAN_REVIEW`
+- `sandbox_commit_state`: `SUSPENDED_NOT_COMMITTED`
+- `required_next_action`: `REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE`
+
+- VERITAS は timeout / unavailability から `SAFE_PROCEED` を推論してはいけません。
+- availability failure を通常承認に変換してはいけません。
+- retry behavior は実装前に bounded かつレビュー済みである必要があります。
+
+## 10. Payload schema relationship
+
+この transport 設計は controlled live payload schema draft に依存します。
+
+required payload fields:
+
+- `schema_version`
+- `rsa_status`
+- `trigger_source`
+- `timestamp`
+- `request_id`
+- `correlation_id`
+- `payload_issued_at`
+
+- transport metadata は payload fields と整合している必要があります。
+- schema validation は transport validation の後にも必ず実行されます。
+- transport authentication は schema validation を置換しません。
+- schema validation は transport authentication を置換しません。
+- payload 受理には両方が必要です。
+
+## 11. Redaction and logging policy
+
+将来の transport logs に含めてもよい項目:
+
+- `request_id`
+- `correlation_id`
+- `schema_version`
+- `source_environment`
+- 非機微の場合の `source_instance_id`
+- authentication result class
+- integrity result class
+- replay result class
+- timeout result class
+- VERITAS `continuation_decision`
+- VERITAS `sandbox_commit_state`
+
+将来の transport logs に含めてはいけない項目:
+
+- secrets
+- credentials
+- access tokens
+- refresh tokens
+- private keys
+- webhook secrets
+- raw V.I.K.I. reasoning
+- raw LLM text
+- chain-of-thought
+- hidden model state
+- raw KYC records
+- customer PII
+- unredacted regulated data
+- full signed secret material
+- raw Authorization header
+
+- logging は deterministic かつ redacted である必要があります。
+- observability を data leakage channel にしてはいけません。
+- failed authentication logs は secret material を露出してはいけません。
+
+## 12. Credential and secret handling
+
+- secrets を repository に保存してはいけません。
+- secrets を fixtures に保存してはいけません。
+- secrets を logs に出力してはいけません。
+- secrets を docs に記載してはいけません。
+- secrets を raw payload fields で受け渡してはいけません。
+- 将来実装では secret manager または platform-provided secret storage を使用する必要があります。
+- production consideration 前に rotation plan を文書化する必要があります。
+- production consideration 前に revocation plan を文書化する必要があります。
+- test credentials を使う場合も synthetic かつ staging-only に限定する必要があります。
+
+## 13. Environment separation
+
+controlled live integration は以下の環境分離を必須とします。
+
+- local
+- CI
+- staging
+- controlled-test
+- production
+
+Rules:
+
+- local mock receiver は local-only / test-only のまま維持します。
+- controlled live transport は初期段階で staging-only とします。
+- 本設計で production を有効化してはいけません。
+- `source_environment` を authorization mechanism として使ってはいけません。
+- feature flags は default-off にします。
+- production deployment には別途 production readiness review が必要です。
+
+## 14. Fail-closed matrix
+
+| Failure class | Example | Expected behavior |
+| --- | --- | --- |
+| Missing authentication | certificate または signature metadata が欠落 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Failed authentication | mTLS certificate reject | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Failed signature verification | payload body の署名検証が不一致 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Body hash mismatch | `X-VERITAS-Body-SHA256` と body hash が不一致 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Replay detected | 既知 payload の再送検知 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Duplicate request_id | replay window 内で同一 `request_id` 再出現 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Stale timestamp | `payload_issued_at` が許容 replay window 外で過去 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Future timestamp beyond skew | `payload_issued_at` が許容 skew を超えて未来 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Timeout | upstream timeout 超過 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| V.I.K.I. unreachable | DNS/network/connectivity failure | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Malformed payload | JSON 破損または required fields 欠落 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Unknown rsa_status | 契約外 `rsa_status` 値 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Forbidden raw reasoning field | raw reasoning field を payload が含む | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Secret detected in payload | secret/token/key material 検出 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Raw KYC data detected | unredacted regulated KYC record 検出 | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+
+## 15. Required implementation gates
+
+transport implementation 前のチェックリスト:
+
+- threat model merged
+- payload schema draft merged
+- transport/auth design merged
+- authentication option selected
+- message integrity design finalized
+- replay protection design finalized
+- timeout policy finalized
+- redaction/logging policy finalized
+- secret storage approach approved
+- staging-only feature flag defined
+- synthetic-data-only test plan drafted
+- rollback plan documented
+- security review completed
+
+## 16. Non-goals
+
+本設計で許可しない項目:
+
+- production live V.I.K.I. integration
+- production API endpoint
+- public unauthenticated endpoint
+- real KYC data processing
+- live customer data processing
+- live LLM text ingestion
+- raw V.I.K.I. reasoning ingestion
+- final commit automation based only on V.I.K.I.
+- VERITAS commit gate の bypass
+- repository への secrets 保存
+- production AML/KYC compliance claims
+- regulatory approval claims
+- legal advice claims
+
+## 17. Compatibility preservation
+
+- `rsa_status` は v1 payload field のまま維持します。
+- `RSASandboxPayload` は downstream payload container のまま維持します。
+- `evaluate_rsa_sandbox_signal()` は downstream evaluator のまま維持します。
+- `upstream_signal_source` は `"RSA"` のまま維持します。
+- `viki_status` はこの phase では導入しません。
+- `VIKIPayload` はこの phase では導入しません。
+- naming migration が必要な場合は v2 として別管理します。
+
+## 18. この設計が検証すること
+
+- transport risks を実装前に文書化済み
+- authentication options を定義済み
+- message integrity を必須化
+- replay protection を必須化
+- timeout の fail closed を必須化
+- secrets の repository 外管理を必須化
+- logs の redaction を必須化
+- schema validation 必須を維持
+- live implementation を導入しない
+
+## 19. この設計が検証しないこと
+
+- transport を実装しない
+- authentication を実装しない
+- authorization を実装しない
+- replay protection を実装しない
+- production AML/KYC compliance を検証しない
+- regulatory approval を検証しない
+- legal advice を提供しない
+- production deployment を承認しない
+- live V.I.K.I. 向けに VERITAS を production-ready と見なさない
+
+## 20. この設計の次に推奨される PR
+
+次の安全な PR 候補:
+
+- replay protection and correlation-id design
+- redaction and observability design
+- live payload schema fixture examples
+- controlled live failure-mode test plan
+- controlled live integration implementation plan
+
+最も安全な次 PR は、documentation-only のまま進める replay protection and correlation-id design です。transport authentication は runtime implementation 前に replay protection と対でレビューされる必要があります。

--- a/docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md
+++ b/docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md
@@ -20,6 +20,7 @@
 - [Live V.I.K.I. integration reviewer checklist](./rsa-veritas-live-viki-integration-reviewer-checklist.md)
 - [Controlled live V.I.K.I. integration threat model (documentation-only pre-live gate)](./rsa-veritas-controlled-live-viki-integration-threat-model.md)
 - [Controlled live V.I.K.I. payload schema draft（pre-live 必須 schema gate、documentation-only）](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
+- [Controlled live V.I.K.I. transport authentication design（pre-live 必須 transport/auth gate、documentation-only）](./rsa-veritas-controlled-live-viki-transport-authentication-design.md)
 
 ## 2. 現在の静的ベースライン
 

--- a/docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
+++ b/docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
@@ -21,6 +21,7 @@
 - [Sandbox reviewer index](./rsa-veritas-sandbox-reviewer-index.md)
 - [Controlled live V.I.K.I. integration threat model (documentation-only pre-live gate)](./rsa-veritas-controlled-live-viki-integration-threat-model.md)
 - [Controlled live V.I.K.I. payload schema draft（pre-live 必須 schema gate、documentation-only）](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
+- [Controlled live V.I.K.I. transport authentication design（pre-live 必須 transport/auth gate、documentation-only）](./rsa-veritas-controlled-live-viki-transport-authentication-design.md)
 
 ## 2. Review status legend
 

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -39,6 +39,7 @@
 14. [Local V.I.K.I. mock receiver validation snapshot（Phase 2 ローカルモック実装検証記録、documentation-only）](./rsa-veritas-local-viki-mock-receiver-validation-snapshot.md)
 15. [Local V.I.K.I. mock receiver E2E harness validation snapshot（Phase 2 fixture-driven harness 検証記録、documentation-only）](./rsa-veritas-local-viki-mock-receiver-e2e-harness-validation-snapshot.md)
 16. [Controlled live V.I.K.I. payload schema draft（pre-live 必須 schema gate、documentation-only）](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
+17. [Controlled live V.I.K.I. transport authentication design（pre-live 必須 transport/auth gate、documentation-only）](./rsa-veritas-controlled-live-viki-transport-authentication-design.md)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 


### PR DESCRIPTION
### Motivation
- Provide a required pre-live transport and authentication design for a future controlled live V.I.K.I. → VERITAS integration so reviewers can approve a secure transport/auth boundary before any runtime work begins.
- Make explicit that this is documentation-only and must not introduce endpoints, network calls, credentials, secrets, runtime changes, or production authorization.
- Preserve the existing v1 compatibility contract (`rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`, `upstream_signal_source = "RSA"`) and integrate the new design as a required pre-live gate in reviewer navigation artifacts.

### Description
- Add English doc `docs/en/guides/rsa-veritas-controlled-live-viki-transport-authentication-design.md` describing purpose, baseline, controlled transport boundary, assumptions, authentication options (mTLS and signed-request fallback), draft headers, message integrity, replay protection, fail-closed matrix, redaction/logging, secret handling, environment separation, non-goals, compatibility, and recommended next PRs.
- Add aligned Japanese doc `docs/ja/guides/rsa-veritas-controlled-live-viki-transport-authentication-design.md` with Japanese-first explanations and preserved technical terms and enum values as specified.
- Update reviewer/navigation docs to reference the new transport/auth design as a required pre-live transport/auth gate in `docs/en/guides/rsa-veritas-sandbox-reviewer-index.md`, `docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md`, `docs/en/guides/rsa-veritas-live-viki-integration-design-note.md`, `docs/ja/guides/rsa-veritas-live-viki-integration-design-note.md`, `docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md`, and `docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md` to keep the artifact map synchronized.
- This PR is documentation-only and intentionally does not add runtime code, tests, CI changes, fixtures, endpoints, network calls, secrets, or live integrations.

### Testing
- Repository verification commands were executed to validate the change set, including `git status --short` and `git show --name-only --pretty='' HEAD`, and a local commit was created successfully (all commands succeeded).
- A PR metadata payload was produced via the `make_pr` helper to record the change intent, which completed successfully.
- No automated unit or integration tests were added or modified, and no CI jobs were run as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1132bc61a48326a0ab7dbd7a03ed84)