### PR TITLE
fix(governance): prevent retention schema drift and governance.json data loss

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -161,6 +161,7 @@ ALL LLM calls MUST go through `veritas_os/core/llm_client.py`. Never call OpenAI
 - File names: snake_case (Python), kebab-case (TypeScript).
 - Commit messages: conventional commits format.
 - DCO sign-off required: `Signed-off-by: Name <email>`.
+- Any governance schema change must update the committed governance policy sample and schema drift tests in the same PR.
 
 ## 6. Testing Rules
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,9 @@ jobs:
       - name: requirements.txt sync check
         run: python scripts/quality/check_requirements_sync.py
 
+      - name: Governance policy/schema sync check
+        run: python scripts/quality/check_governance_policy_schema_sync.py
+
       - name: Memory directory allowlist check
         env:
           VERITAS_ENV: "production"
@@ -244,6 +247,9 @@ jobs:
             --tb=short \
             --durations=10 \
             --junitxml=test-reports/smoke.xml
+
+      - name: "[Tier 1] Guard governance policy against test mutation"
+        run: git diff --exit-code -- veritas_os/api/governance.json
 
       - name: Upload smoke test report
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,9 @@ jobs:
       - name: requirements.txt sync check
         run: python scripts/quality/check_requirements_sync.py
 
+      - name: Install governance schema check runtime deps
+        run: python -m pip install -r veritas_os/requirements-core.txt
+
       - name: Governance policy/schema sync check
         run: python scripts/quality/check_governance_policy_schema_sync.py
 

--- a/docs/en/development/ai-assisted-development.md
+++ b/docs/en/development/ai-assisted-development.md
@@ -94,6 +94,16 @@ External AI feedback must not become a merge blocker by itself.
 5. Missing tests for code changes
 6. Refactor or style suggestions
 
+## Governance Schema Drift Guardrail
+
+- Baseline governance log retention must remain **180 days**.
+- High-risk governance log retention must remain **365 days**.
+- Any governance schema change must update, in the same PR:
+  - `veritas_os/api/governance.py` Pydantic schema,
+  - `veritas_os/api/governance.json` committed policy sample,
+  - governance roundtrip/drift regression tests,
+  - `scripts/quality/check_governance_policy_schema_sync.py` validation guard.
+
 ## Non-Goals
 
 This guide does not introduce:

--- a/scripts/quality/check_governance_policy_schema_sync.py
+++ b/scripts/quality/check_governance_policy_schema_sync.py
@@ -7,11 +7,14 @@ import json
 import sys
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from pydantic import ValidationError
 
 from veritas_os.api.governance import GovernancePolicy
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
 GOVERNANCE_PATH = REPO_ROOT / "veritas_os" / "api" / "governance.json"
 
 

--- a/scripts/quality/check_governance_policy_schema_sync.py
+++ b/scripts/quality/check_governance_policy_schema_sync.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Guard against governance policy/schema drift and retention data loss."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from veritas_os.api.governance import GovernancePolicy
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOVERNANCE_PATH = REPO_ROOT / "veritas_os" / "api" / "governance.json"
+
+
+def main() -> int:
+    """Validate committed governance policy safely roundtrips through schema."""
+    errors: list[str] = []
+
+    try:
+        committed = json.loads(GOVERNANCE_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"[GOV-SCHEMA] Missing committed policy file: {GOVERNANCE_PATH}")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"[GOV-SCHEMA] Invalid JSON in {GOVERNANCE_PATH}: {exc}")
+        return 1
+
+    try:
+        roundtripped = GovernancePolicy.model_validate(committed).model_dump()
+    except ValidationError as exc:
+        print("[GOV-SCHEMA] Committed governance policy failed schema validation.")
+        print(exc)
+        return 1
+
+    committed_retention = committed.get("log_retention", {})
+    roundtrip_retention = roundtripped.get("log_retention", {})
+
+    if "retention_days_high_risk" not in roundtrip_retention:
+        errors.append("log_retention.retention_days_high_risk disappeared after roundtrip.")
+    if roundtrip_retention.get("retention_days") != 180:
+        errors.append(
+            "log_retention.retention_days drifted from expected safe baseline 180 "
+            f"(found {roundtrip_retention.get('retention_days')})."
+        )
+    if roundtrip_retention.get("retention_days_high_risk") != 365:
+        errors.append(
+            "log_retention.retention_days_high_risk drifted from expected baseline 365 "
+            f"(found {roundtrip_retention.get('retention_days_high_risk')})."
+        )
+
+    for key, value in committed_retention.items():
+        if roundtrip_retention.get(key) != value:
+            errors.append(
+                f"Committed log_retention.{key}={value} changed to "
+                f"{roundtrip_retention.get(key)} after schema roundtrip."
+            )
+
+    committed_sections = set(committed.keys())
+    schema_sections = set(roundtripped.keys())
+    schema_only = sorted(schema_sections - committed_sections)
+
+    if errors:
+        print("[GOV-SCHEMA] Governance policy/schema sync check FAILED:")
+        for error in errors:
+            print(f"- {error}")
+        if schema_only:
+            print(
+                "- Schema-only sections (present via defaults, missing in committed JSON): "
+                + ", ".join(schema_only)
+            )
+        return 1
+
+    print("Governance policy schema roundtrip checks passed.")
+    if schema_only:
+        print(
+            "Schema-only default sections detected (informational): "
+            + ", ".join(schema_only)
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/veritas_os/api/governance.py
+++ b/veritas_os/api/governance.py
@@ -78,7 +78,8 @@ class AutoStop(BaseModel):
 
 
 class LogRetention(BaseModel):
-    retention_days: int = Field(default=90, ge=1, le=3650)
+    retention_days: int = Field(default=180, ge=180, le=3650)
+    retention_days_high_risk: int = Field(default=365, ge=180, le=3650)
     audit_level: Literal["none", "minimal", "summary", "standard", "full", "strict"] = "full"
     include_fields: list[str] = Field(
         default_factory=lambda: ["status", "risk", "reasons", "violations", "categories"]

--- a/veritas_os/tests/conftest.py
+++ b/veritas_os/tests/conftest.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
+from pathlib import Path
 from typing import Any
 
 import pytest
+
+from veritas_os.api.governance import set_governance_repository_factory
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -100,3 +103,21 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "contention: advisory-lock contention and concurrency integration tests",
     )
+
+
+@pytest.fixture(autouse=True)
+def _reset_governance_repository_factory():
+    """Prevent governance repository factory state leakage across tests."""
+    yield
+    set_governance_repository_factory(None)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _restore_committed_governance_json():
+    """Protect committed governance policy from accidental test mutations."""
+    governance_path = Path(__file__).resolve().parents[1] / "api" / "governance.json"
+    original = governance_path.read_text(encoding="utf-8")
+    yield
+    current = governance_path.read_text(encoding="utf-8")
+    if current != original:
+        governance_path.write_text(original, encoding="utf-8")

--- a/veritas_os/tests/integration/test_governance_api.py
+++ b/veritas_os/tests/integration/test_governance_api.py
@@ -359,7 +359,7 @@ class TestGovernanceModule:
         assert policy.fuji_rules.pii_check is True
         assert policy.risk_thresholds.allow_upper == 0.40
         assert policy.auto_stop.enabled is True
-        assert policy.log_retention.retention_days == 90
+        assert policy.log_retention.retention_days == 180
         assert policy.wat.enabled is False
         assert policy.wat.issuance_mode == "shadow_only"
         assert policy.psid.enforcement_mode == "full_digest_only"

--- a/veritas_os/tests/test_governance_schema_sync.py
+++ b/veritas_os/tests/test_governance_schema_sync.py
@@ -1,0 +1,62 @@
+"""Regression tests for governance schema/policy roundtrip safety."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from veritas_os.api import governance as gov
+from veritas_os.governance.file_repository import FileGovernanceRepository
+
+
+def _committed_governance_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "api" / "governance.json"
+
+
+def _temp_repo(tmp_path: Path) -> FileGovernanceRepository:
+    return FileGovernanceRepository(
+        policy_path=tmp_path / "governance.json",
+        history_path=tmp_path / "governance_history.jsonl",
+        default_factory=lambda: gov.GovernancePolicy().model_dump(),
+    )
+
+
+def test_committed_governance_roundtrip_preserves_retention_fields() -> None:
+    committed = json.loads(_committed_governance_path().read_text(encoding="utf-8"))
+    dumped = gov.GovernancePolicy.model_validate(committed).model_dump()
+    retention = dumped["log_retention"]
+    assert retention["retention_days"] == 180
+    assert retention["retention_days_high_risk"] == 365
+
+
+def test_governance_policy_defaults_include_safe_retention_baselines() -> None:
+    retention = gov.GovernancePolicy().model_dump()["log_retention"]
+    assert retention["retention_days"] == 180
+    assert retention["retention_days_high_risk"] == 365
+
+
+def test_update_policy_empty_patch_preserves_retention_fields(tmp_path: Path) -> None:
+    gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
+    updated = gov.update_policy({})
+    retention = updated["log_retention"]
+    assert retention["retention_days"] == 180
+    assert retention["retention_days_high_risk"] == 365
+
+
+def test_update_policy_unrelated_field_does_not_drop_high_risk_retention(tmp_path: Path) -> None:
+    gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
+    updated = gov.update_policy({"version": "governance_v2", "updated_by": "auditor"})
+    retention = updated["log_retention"]
+    assert retention["retention_days"] == 180
+    assert retention["retention_days_high_risk"] == 365
+
+
+def test_rejects_unsafe_log_retention_values(tmp_path: Path) -> None:
+    gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
+    with pytest.raises(ValueError):
+        gov.update_policy({"log_retention": {"retention_days": 179}})
+
+    with pytest.raises(ValueError):
+        gov.update_policy({"log_retention": {"retention_days_high_risk": 179}})

--- a/veritas_os/tests/test_governance_schema_sync.py
+++ b/veritas_os/tests/test_governance_schema_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -16,10 +17,27 @@ def _committed_governance_path() -> Path:
 
 
 def _temp_repo(tmp_path: Path) -> FileGovernanceRepository:
+    """Build an isolated governance repository rooted in ``tmp_path``."""
+    policy_path = tmp_path / "governance.json"
+    history_path = tmp_path / "governance_policy_history.jsonl"
+
+    if not policy_path.exists():
+        policy_path.write_text(
+            json.dumps(
+                gov.GovernancePolicy().model_dump(),
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
     return FileGovernanceRepository(
-        policy_path=tmp_path / "governance.json",
-        history_path=tmp_path / "governance_history.jsonl",
-        default_factory=lambda: gov.GovernancePolicy().model_dump(),
+        policy_path=policy_path,
+        history_path=history_path,
+        lock=threading.Lock(),
+        policy_history_max=100,
+        has_atomic_io=False,
     )
 
 
@@ -38,25 +56,34 @@ def test_governance_policy_defaults_include_safe_retention_baselines() -> None:
 
 
 def test_update_policy_empty_patch_preserves_retention_fields(tmp_path: Path) -> None:
-    gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
-    updated = gov.update_policy({})
-    retention = updated["log_retention"]
-    assert retention["retention_days"] == 180
-    assert retention["retention_days_high_risk"] == 365
+    try:
+        gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
+        updated = gov.update_policy({})
+        retention = updated["log_retention"]
+        assert retention["retention_days"] == 180
+        assert retention["retention_days_high_risk"] == 365
+    finally:
+        gov.set_governance_repository_factory(None)
 
 
 def test_update_policy_unrelated_field_does_not_drop_high_risk_retention(tmp_path: Path) -> None:
-    gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
-    updated = gov.update_policy({"version": "governance_v2", "updated_by": "auditor"})
-    retention = updated["log_retention"]
-    assert retention["retention_days"] == 180
-    assert retention["retention_days_high_risk"] == 365
+    try:
+        gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
+        updated = gov.update_policy({"version": "governance_v2", "updated_by": "auditor"})
+        retention = updated["log_retention"]
+        assert retention["retention_days"] == 180
+        assert retention["retention_days_high_risk"] == 365
+    finally:
+        gov.set_governance_repository_factory(None)
 
 
 def test_rejects_unsafe_log_retention_values(tmp_path: Path) -> None:
-    gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
-    with pytest.raises(ValueError):
-        gov.update_policy({"log_retention": {"retention_days": 179}})
+    try:
+        gov.set_governance_repository_factory(lambda: _temp_repo(tmp_path))
+        with pytest.raises(ValueError):
+            gov.update_policy({"log_retention": {"retention_days": 179}})
 
-    with pytest.raises(ValueError):
-        gov.update_policy({"log_retention": {"retention_days_high_risk": 179}})
+        with pytest.raises(ValueError):
+            gov.update_policy({"log_retention": {"retention_days_high_risk": 179}})
+    finally:
+        gov.set_governance_repository_factory(None)


### PR DESCRIPTION
### Motivation

- Close a critical schema/config drift that allowed committed `veritas_os/api/governance.json` retention fields to be lost during Pydantic validation/serialization roundtrips. 
- Enforce safe baseline retention values so automated regeneration cannot silently reduce audit retention (baseline 180 days, high-risk 365 days). 
- Reduce risk of accidental test-induced mutation of the committed policy by adding test isolation and a CI guard.

### Description

- Update `LogRetention` in `veritas_os/api/governance.py` to set `retention_days: int = Field(default=180, ge=180, le=3650)` and add `retention_days_high_risk: int = Field(default=365, ge=180, le=3650)` so defaults and bounds match the committed sample policy. 
- Add regression tests in `veritas_os/tests/test_governance_schema_sync.py` that assert schema roundtrip preservation, default generation, `update_policy({})` retention preservation, unrelated field updates preserving retention, and rejection of unsafe low values. 
- Harden test isolation in `veritas_os/tests/conftest.py` with an autouse fixture that resets the governance repository factory after tests and a session fixture that snapshots and restores the committed `veritas_os/api/governance.json` if mutated. 
- Add `scripts/quality/check_governance_policy_schema_sync.py` which validates the committed `governance.json` via `GovernancePolicy`, ensures roundtrip preservation of committed fields and safe retention baselines, and emits actionable failures; wire this check into the CI quality workflow (`.github/workflows/main.yml`) and add a post-smoke-test guard that fails the job if tests mutate `veritas_os/api/governance.json`. 
- Update a governance integration assertion to reflect the new default (`90 -> 180`), and add contributor/docs guidance that any governance schema changes must update the Pydantic schema, committed sample, tests, and the schema-sync guard in the same PR.

### Testing

- Added automated tests: `veritas_os/tests/test_governance_schema_sync.py` (new) which should be picked up by pytest in CI; these tests were added but not executed successfully in the local edit environment due to missing project runtime/dependencies. 
- Executed the new schema-sync script locally but it failed in this environment with `ModuleNotFoundError: No module named 'pydantic'` because project dependencies were not installed; CI (with full deps) will run `python scripts/quality/check_governance_policy_schema_sync.py`. 
- Attempted `pytest` runs were not completed here because the local environment did not have the configured Python toolchain/dependencies; CI will run the relevant `pytest` targets (the PR wires the schema check into `main.yml`). 
- Verified no test-induced mutation of the committed policy file in the working tree after the changes (`veritas_os/api/governance.json` remained unchanged locally); CI includes a `git diff --exit-code -- veritas_os/api/governance.json` guard to catch regressions during test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1143c2ef208326886160d036e4b341)