### PR TITLE
docs: require schema-contract artifact sync for governance changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,6 +163,28 @@ ALL LLM calls MUST go through `veritas_os/core/llm_client.py`. Never call OpenAI
 - DCO sign-off required: `Signed-off-by: Name <email>`.
 - Any governance schema change must update the committed governance policy sample and schema drift tests in the same PR.
 
+### Schema-contract changes must update all artifacts
+
+Any change to a Pydantic schema, governance policy schema, API response schema, config schema, or policy model **must** update all related artifacts in the same PR.
+
+Required checklist for schema/config contract changes:
+- [ ] Update the Pydantic/schema model.
+- [ ] Update committed JSON/YAML sample or default files.
+- [ ] Update roundtrip serialization tests.
+- [ ] Update schema/config drift guard checks where applicable.
+- [ ] Update operational documentation.
+- [ ] Verify tests do not mutate committed production config artifacts.
+- [ ] Run the relevant sync/check script(s).
+
+Governance-specific requirement:
+- For `veritas_os/api/governance.py` and `veritas_os/api/governance.json`, every schema change must preserve committed JSON fields through `GovernancePolicy.model_validate(data).model_dump()`.
+- Every such change must pass `python scripts/quality/check_governance_policy_schema_sync.py`.
+
+AI-agent warning:
+- Rapid parallel agent development frequently introduces schema drift.
+- Do not merge schema changes that only update code or only update sample JSON.
+- Schema, sample policy, tests, docs, and CI guard must move together.
+
 ## 6. Testing Rules
 
 ### Python Tests
@@ -202,6 +224,7 @@ pnpm --filter frontend e2e   # Playwright E2E
 - [ ] New endpoints have `X-API-Key` authentication
 - [ ] Governance endpoints have RBAC guard
 - [ ] Web search results pass toxicity filter
+- [ ] Schema/config changes include sample artifact updates and roundtrip drift tests.
 
 ## 8. Key Environment Variables
 


### PR DESCRIPTION
### Motivation
- Prevent future schema drift between Pydantic models, committed governance artifacts, tests, docs, and CI guards by adding explicit contributor guidance. 
- Make governance schema changes (which are high risk) harder to land incorrectly by documenting required roundtrip checks and sync scripts. 
- Reduce failures caused by tests mutating committed JSON and by parallel agent development workflows that update only part of the contract surface.

### Description
- Added a new section `Schema-contract changes must update all artifacts` to `.github/copilot-instructions.md` that requires schema, sample, tests, docs, and CI-guard changes to land in the same PR. 
- Documented a required checklist covering updating the Pydantic/schema model, committed JSON/YAML samples, roundtrip serialization tests, schema drift guards, operational docs, and verification that tests do not mutate committed production config artifacts. 
- Added governance-specific language mandating that changes to `veritas_os/api/governance.py` and `veritas_os/api/governance.json` must preserve committed JSON fields via `GovernancePolicy.model_validate(data).model_dump()` and must pass `python scripts/quality/check_governance_policy_schema_sync.py`. 
- Added a required PR checklist item under the Security Checklist: `- [ ] Schema/config changes include sample artifact updates and roundtrip drift tests.`

### Testing
- Ran `python scripts/quality/check_operational_docs_consistency.py` which passed (invoked as `/usr/bin/python3` in this environment). 
- Ran `python scripts/architecture/check_responsibility_boundaries.py` which passed. 
- Ran `python scripts/quality/check_bilingual_docs.py` which passed. 
- No runtime code, governance.json, or test logic changes were made, and all documentation checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1174a2b8f08326aab5a2c0e56b5e24)