### PR TITLE
docs: add controlled live V.I.K.I. redaction & observability design (EN/JA)

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md
@@ -1,0 +1,420 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Redaction and Observability Design
+
+## 1. Purpose
+
+This document defines redaction and observability requirements for a future controlled live V.I.K.I. integration.
+
+- This is documentation-only.
+- This is not a live integration.
+- This is not a runtime implementation.
+- This is not a logging implementation.
+- This is not an observability implementation.
+- This is not a production API endpoint.
+- This does not authorize production use.
+- This does not add network calls.
+- This does not add secrets or credentials.
+- This does not process real KYC data.
+- This does not provide legal or regulatory approval.
+- This design must be reviewed before any live logging, telemetry, audit pipeline, endpoint, or live middleware implementation begins.
+
+## 2. Current baseline
+
+The following pre-live gates already exist:
+
+- local mock ingestion receiver design
+- local mock receiver test fixture plan
+- local mock receiver implementation
+- local mock receiver validation snapshot
+- static synthetic JSON fixture-driven E2E harness
+- E2E harness validation snapshot
+- controlled live integration threat model
+- controlled live payload schema draft
+- controlled live transport/authentication design
+- controlled live replay protection and correlation-id design
+
+Current validated path:
+
+`static synthetic JSON fixture`
+→ `ingest_local_viki_mock_payload()`
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ `VERITAS decision`
+→ `redacted audit output`
+
+This current path remains local-only, synthetic-data-only, and no-network.
+
+## 3. Future observability boundary
+
+Future observability boundary:
+
+`V.I.K.I. live middleware`
+→ `RSA-compatible payload`
+→ `transport/authentication event`
+→ `message integrity event`
+→ `replay/correlation event`
+→ `schema validation event`
+→ `RSASandboxPayload construction event`
+→ `evaluate_rsa_sandbox_signal() result event`
+→ `VERITAS decision event`
+→ `redacted audit entry`
+→ `optional human review event`
+
+- Observability must not become a data leakage channel.
+- Audit usefulness must be preserved without storing raw reasoning, raw LLM text, raw KYC records, secrets, credentials, or customer PII.
+- Every observability event must be deterministic, minimal, and redacted.
+- Logging success does not imply payload validity.
+- Payload validity does not imply final commit approval.
+- SAFE_PROCEED does not equal final commit approval.
+- VERITAS commit gate remains authoritative.
+
+## 4. Redaction principles
+
+- Collect the minimum necessary fields.
+- Prefer deterministic state labels over free-form text.
+- Prefer reason codes over raw explanations.
+- Redact raw upstream intent/action by default unless explicitly reviewed.
+- Reject chain-of-thought and hidden model state.
+- Reject or strip secrets and credentials before persistence.
+- Never log raw Authorization headers.
+- Never log raw payloads that may contain sensitive data.
+- Never log raw KYC records.
+- Never log live LLM text.
+- Never store raw V.I.K.I. internal reasoning.
+- Logs must be safe for reviewer inspection.
+
+## 5. Fields allowed in observability events
+
+| Field | Allowed | Notes |
+| --- | --- | --- |
+| event_type | Yes | Deterministic event taxonomy value only. |
+| event_version | Yes | Versioned event contract metadata. |
+| schema_version | Yes | Payload schema contract version metadata. |
+| request_id | Yes | Primary safe per-request correlation key. |
+| correlation_id | Yes | Cross-stage correlation key across controlled live checks. |
+| rsa_status | Yes | Must remain v1-compatible contract naming. |
+| trigger_source | Yes | Must not contain raw reasoning or PII. |
+| timestamp | Yes | Deterministic event emission timestamp. |
+| payload_issued_at | Yes | Deterministic upstream-issued timestamp metadata. |
+| source_environment | Yes | Non-sensitive environment class only. |
+| source_instance_id | Yes, constrained | Must not contain host credentials, secrets, or PII. |
+| authentication_result_class | Yes | Class label only; no secret material. |
+| integrity_result_class | Yes | Class label only; no signature secret material. |
+| replay_result_class | Yes | Class label only; no payload disclosure. |
+| schema_validation_result_class | Yes | Class label only; no forbidden value persistence. |
+| veritas_continuation_decision | Yes | Deterministic VERITAS continuation state. |
+| veritas_reason_code | Yes | Deterministic reason code only. |
+| veritas_sandbox_commit_state | Yes | Deterministic commit-state label only. |
+| required_next_action | Yes | Deterministic action guidance class only. |
+| latency_ms | Yes | Numeric latency metric only. |
+| body_hash_prefix | Yes, constrained | Must be non-reversible and must not expose raw payload. |
+
+## 6. Fields forbidden in observability events
+
+| Field / content class | Required behavior |
+| --- | --- |
+| chain-of-thought | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| hidden model state | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| raw V.I.K.I. reasoning | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| raw LLM text | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| raw KYC records | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| customer PII | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| secrets | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| credentials | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| access tokens | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| refresh tokens | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| private keys | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| webhook secrets | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| raw Authorization header | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| full signed secret material | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| unredacted regulated data | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| raw payload body | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| raw upstream free-form explanation | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+| stack traces containing secrets | Reject before persistence, redact, or replace with deterministic class label; fail closed if detected. |
+
+If forbidden content is detected in a live payload or observability event, fail closed.
+
+## 7. Event taxonomy
+
+Draft event types:
+
+- `viki_payload_received`
+- `transport_authentication_checked`
+- `message_integrity_checked`
+- `replay_window_checked`
+- `replay_cache_checked`
+- `schema_validation_checked`
+- `rsa_sandbox_payload_constructed`
+- `rsa_sandbox_signal_evaluated`
+- `veritas_decision_emitted`
+- `human_review_required`
+- `upstream_unavailable`
+- `fail_closed_emitted`
+
+- Event names are draft names only.
+- Final event taxonomy must be reviewed before implementation.
+- Events must be versioned.
+- Events must not contain raw reasoning, raw LLM text, raw KYC records, secrets, or credentials.
+
+## 8. Example safe observability event
+
+```json
+{
+  "event_type": "veritas_decision_emitted",
+  "event_version": "v1alpha1",
+  "schema_version": "v1alpha1",
+  "request_id": "req_viki_000001",
+  "correlation_id": "corr_viki_veritas_000001",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Normal_State",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "authentication_result_class": "AUTHENTICATED",
+  "integrity_result_class": "INTEGRITY_VALID",
+  "replay_result_class": "NO_REPLAY_DETECTED",
+  "schema_validation_result_class": "SCHEMA_VALID",
+  "veritas_continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "veritas_reason_code": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "CONTINUE_BOUNDARY_EVALUATION",
+  "latency_ms": 42
+}
+```
+
+- This example is synthetic.
+- This example does not authorize production logging.
+- SAFE_PROCEED is still not final commit approval.
+
+## 9. Example forbidden observability event
+
+```json
+{
+  "event_type": "veritas_decision_emitted",
+  "request_id": "req_viki_invalid_001",
+  "correlation_id": "corr_viki_veritas_invalid_001",
+  "chain_of_thought": "FORBIDDEN",
+  "raw_kyc_record": "FORBIDDEN",
+  "access_token": "FORBIDDEN"
+}
+```
+
+Expected behavior:
+
+- reject before persistence or redact before persistence
+- fail closed
+- do not infer SAFE_PROCEED
+- never store chain-of-thought
+- never store raw KYC records
+- never store access tokens
+
+## 10. Redacted audit entry relationship
+
+Future VERITAS audit entries may preserve:
+
+- upstream_signal_source
+- event_type
+- event_version
+- schema_version
+- request_id
+- correlation_id
+- rsa_status
+- trigger_source
+- timestamp
+- payload_issued_at
+- source_environment
+- source_instance_id when non-sensitive
+- authentication_result_class
+- integrity_result_class
+- replay_result_class
+- schema_validation_result_class
+- VERITAS continuation_decision
+- VERITAS reason_code
+- VERITAS sandbox_commit_state
+- required_next_action
+
+Future VERITAS audit entries must not preserve:
+
+- raw V.I.K.I. reasoning
+- raw LLM text
+- chain-of-thought
+- hidden model state
+- raw KYC records
+- customer PII
+- secrets
+- credentials
+- tokens
+- private keys
+- raw Authorization header
+- full signed secret material
+- unredacted regulated data
+- raw payload body
+
+## 11. Failure observability
+
+Failures must be observable without leaking sensitive data.
+
+For each failure, log only deterministic classes:
+
+- authentication failed
+- integrity failed
+- replay detected
+- replay cache unavailable
+- schema validation failed
+- forbidden field detected
+- upstream unavailable
+- timeout
+- fail-closed emitted
+
+Do not log:
+
+- raw payload
+- raw secret
+- raw Authorization header
+- raw KYC record
+- raw reasoning
+- stack trace with credentials
+
+## 12. Interaction with replay/correlation design
+
+- request_id and correlation_id are the primary safe correlation fields.
+- correlation_id links transport, replay, schema validation, VERITAS decision, and human review events.
+- request_id identifies a single payload emission.
+- Duplicate request_id remains a replay risk and must fail closed.
+- correlation_id must not contain PII or secrets.
+- Observability must preserve correlation without storing raw payload data.
+
+## 13. Interaction with transport/authentication design
+
+- Authentication result should be logged as a class, not as credential material.
+- Signature verification result should be logged as a class, not as signature secret material.
+- mTLS result should be logged as a class, not raw certificate secrets.
+- Body hash may be logged only as a safe digest or safe prefix, not raw payload.
+- raw Authorization headers must never be logged.
+- Failed authentication must not expose secret material in logs.
+
+## 14. Interaction with payload schema draft
+
+- The payload schema draft defines required, optional, and forbidden fields.
+- Observability must reflect schema validation result, not store forbidden fields.
+- Optional raw-intent/action fields must be redacted by default.
+- Forbidden fields such as chain_of_thought and hidden_model_state must fail closed or be rejected before persistence.
+- schema_version must be preserved as deterministic metadata.
+
+## 15. Log retention and access assumptions
+
+- This document does not define production retention periods.
+- Retention period must be reviewed before production.
+- Access to logs must be restricted.
+- Logs containing regulated metadata may require compliance review.
+- Logs must not be treated as a dumping ground for raw payloads.
+- Any export of logs must preserve redaction.
+- Any future retention policy must include deletion/expiry behavior.
+
+## 16. Fail-closed matrix
+
+| Failure class | Example | Observability behavior | VERITAS behavior |
+| --- | --- | --- | --- |
+| Forbidden field detected | `chain_of_thought` present | Emit deterministic failure class only; never persist forbidden field content. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Secret detected in payload | token-like secret string present | Emit deterministic failure class only; never persist secret material. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Raw KYC detected | unredacted KYC object present | Emit deterministic failure class only; never persist raw KYC content. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Raw reasoning detected | upstream free-form reasoning present | Emit deterministic failure class only; never persist raw reasoning. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Chain-of-thought detected | chain-of-thought field present | Emit deterministic failure class only; never persist chain-of-thought content. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Hidden model state detected | hidden model state field present | Emit deterministic failure class only; never persist hidden state. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Authorization header logging attempted | raw header string included | Emit deterministic failure class only; never persist raw Authorization value. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Replay cache unavailable | replay cache backend timeout | Emit deterministic failure class only; never include payload body. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Authentication failed | signature mismatch | Emit deterministic failure class only; never include credentials. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Integrity failed | digest mismatch | Emit deterministic failure class only; never include raw body. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Schema validation failed | required field missing | Emit deterministic failure class only; never include full payload. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Upstream unavailable | transport endpoint unavailable | Emit deterministic failure class only; never include secret connection details. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+| Timeout | end-to-end wait exceeded | Emit deterministic failure class only; never include sensitive payload fragments. | fail closed; `PAUSE_FOR_HUMAN_REVIEW`; `SUSPENDED_NOT_COMMITTED`; no `SAFE_PROCEED` inference |
+
+## 17. Required implementation gates
+
+Checklist before any redaction/observability implementation:
+
+- [ ] threat model merged
+- [ ] payload schema draft merged
+- [ ] transport/auth design merged
+- [ ] replay/correlation design merged
+- [ ] redaction/observability design merged
+- [ ] event taxonomy finalized
+- [ ] forbidden field detector plan drafted
+- [ ] logging sink selected
+- [ ] log retention policy drafted
+- [ ] access control policy drafted
+- [ ] redaction tests drafted
+- [ ] failure-mode test plan drafted
+- [ ] staging-only feature flag defined
+- [ ] synthetic-data-only test plan drafted
+- [ ] rollback plan documented
+- [ ] security review completed
+
+## 18. Non-goals
+
+This design does not permit:
+
+- production live V.I.K.I. integration
+- production logging pipeline
+- production API endpoint
+- public unauthenticated endpoint
+- real KYC data processing
+- live customer data processing
+- live LLM text ingestion
+- raw V.I.K.I. reasoning ingestion
+- chain-of-thought storage
+- hidden model state storage
+- raw KYC logging
+- final commit automation based only on V.I.K.I.
+- bypass of VERITAS commit gate
+- secrets in repository
+- production AML/KYC compliance claims
+- regulatory approval claims
+- legal advice claims
+
+## 19. Compatibility preservation
+
+- rsa_status remains the v1 payload field.
+- RSASandboxPayload remains the downstream payload container.
+- evaluate_rsa_sandbox_signal() remains the downstream evaluator.
+- upstream_signal_source remains "RSA".
+- request_id and correlation_id are observability/correlation fields, not replacements for rsa_status.
+- viki_status is not introduced in this phase.
+- VIKIPayload is not introduced in this phase.
+- Any naming migration must be handled separately as v2.
+
+## 20. What this design validates
+
+- observability risks are documented before implementation
+- allowed observability fields are defined
+- forbidden observability fields are defined
+- redaction expectations are documented
+- failure observability is documented
+- audit relationship is documented
+- log retention assumptions are documented
+- no live implementation is introduced
+
+## 21. What this design does not validate
+
+- it does not implement logging
+- it does not implement telemetry
+- it does not implement redaction
+- it does not implement forbidden field detection
+- it does not implement transport
+- it does not implement authentication
+- it does not implement replay protection
+- it does not validate production AML/KYC compliance
+- it does not validate regulatory approval
+- it does not provide legal advice
+- it does not authorize production deployment
+- it does not make VERITAS production-ready for live V.I.K.I.
+
+## 22. Recommended next PR after this design
+
+The next safe PR should be one of:
+
+- live payload schema fixture examples
+- controlled live failure-mode test plan
+- redaction fixture examples
+- controlled live integration implementation plan
+- observability event taxonomy fixture plan
+
+The safest next PR is live payload schema fixture examples, still documentation-only or fixture-only with synthetic data, because the schema, transport/auth, replay/correlation, and redaction/observability gates should be represented as concrete synthetic examples before any runtime implementation.

--- a/docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
+++ b/docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
@@ -1,6 +1,7 @@
 # RSA ↔ VERITAS Live V.I.K.I. Integration Reviewer Checklist
 
 - [Controlled live V.I.K.I. replay protection and correlation-id design (required pre-live replay/correlation gate, documentation-only; no runtime changes; no live integration)](./rsa-veritas-controlled-live-viki-replay-correlation-design.md)
+- [Controlled live V.I.K.I. redaction and observability design (required pre-live redaction/observability gate, documentation-only; no runtime changes; no live integration)](./rsa-veritas-controlled-live-viki-redaction-observability-design.md)
 ## 1. Purpose
 
 This checklist is for reviewing future live V.I.K.I. integration proposals.

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -35,6 +35,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 16. [Controlled live V.I.K.I. payload schema draft (required pre-live schema gate, documentation-only)](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
 17. [Controlled live V.I.K.I. transport authentication design (required pre-live transport/auth gate, documentation-only)](./rsa-veritas-controlled-live-viki-transport-authentication-design.md)
 18. [Controlled live V.I.K.I. replay protection and correlation-id design (required pre-live replay/correlation gate, documentation-only)](./rsa-veritas-controlled-live-viki-replay-correlation-design.md)
+19. [Controlled live V.I.K.I. redaction and observability design (required pre-live redaction/observability gate, documentation-only)](./rsa-veritas-controlled-live-viki-redaction-observability-design.md)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md
@@ -1,0 +1,429 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Redaction and Observability Design
+
+## 英語正本
+
+- [RSA ↔ VERITAS Controlled Live V.I.K.I. Redaction and Observability Design](../../en/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md)
+
+## 1. 目的
+
+本書は、将来の controlled live V.I.K.I. integration に向けた redaction と observability の要件を定義する documentation-only 設計です。
+
+- これは documentation-only です。
+- これは live integration ではありません。
+- これは runtime implementation ではありません。
+- これは logging implementation ではありません。
+- これは observability implementation ではありません。
+- これは production API endpoint ではありません。
+- これは production use を許可しません。
+- これは network calls を追加しません。
+- これは secrets / credentials を追加しません。
+- これは実データの KYC 処理を行いません。
+- これは法的・規制上の承認を提供しません。
+- この設計は、live logging / telemetry / audit pipeline / endpoint / live middleware 実装開始前にレビューされる必要があります。
+
+## 2. Current baseline
+
+以下の pre-live gate は既存として整備済みです。
+
+- local mock ingestion receiver design
+- local mock receiver test fixture plan
+- local mock receiver implementation
+- local mock receiver validation snapshot
+- static synthetic JSON fixture-driven E2E harness
+- E2E harness validation snapshot
+- controlled live integration threat model
+- controlled live payload schema draft
+- controlled live transport/authentication design
+- controlled live replay protection and correlation-id design
+
+現在の検証済みパスは次のとおりです。
+
+`static synthetic JSON fixture`
+→ `ingest_local_viki_mock_payload()`
+→ `RSASandboxPayload`
+→ `evaluate_rsa_sandbox_signal()`
+→ `VERITAS decision`
+→ `redacted audit output`
+
+このパスは引き続き local-only / synthetic-data-only / no-network です。
+
+## 3. Future observability boundary
+
+将来の observability boundary:
+
+`V.I.K.I. live middleware`
+→ `RSA-compatible payload`
+→ `transport/authentication event`
+→ `message integrity event`
+→ `replay/correlation event`
+→ `schema validation event`
+→ `RSASandboxPayload construction event`
+→ `evaluate_rsa_sandbox_signal() result event`
+→ `VERITAS decision event`
+→ `redacted audit entry`
+→ `optional human review event`
+
+- Observability は data leakage channel になってはいけません。
+- Audit usefulness は、raw reasoning / raw LLM text / raw KYC records / secrets / credentials / customer PII を保存せずに維持される必要があります。
+- すべての observability event は deterministic・minimal・redacted である必要があります。
+- Logging success は payload validity を意味しません。
+- Payload validity は final commit approval を意味しません。
+- SAFE_PROCEED は final commit approval と同義ではありません。
+- VERITAS commit gate が引き続き authoritative です。
+
+## 4. Redaction principles
+
+- 最小限必要な field のみ収集する。
+- free-form text より deterministic state labels を優先する。
+- raw explanations より reason codes を優先する。
+- raw upstream intent/action は明示レビューがない限りデフォルトで redact する。
+- chain-of-thought と hidden model state は reject する。
+- secrets / credentials は persistence 前に reject または strip する。
+- raw Authorization headers は記録しない。
+- sensitive data を含み得る raw payload は記録しない。
+- raw KYC records は記録しない。
+- live LLM text は記録しない。
+- raw V.I.K.I. internal reasoning は保存しない。
+- logs は reviewer inspection に安全でなければなりません。
+
+## 5. Fields allowed in observability events
+
+| Field | Allowed | Notes |
+| --- | --- | --- |
+| event_type | Yes | deterministic event taxonomy value のみ。 |
+| event_version | Yes | versioned event contract metadata。 |
+| schema_version | Yes | payload schema contract version metadata。 |
+| request_id | Yes | primary safe per-request correlation key。 |
+| correlation_id | Yes | controlled live checks を横断する correlation key。 |
+| rsa_status | Yes | v1 compatibility naming を維持。 |
+| trigger_source | Yes | raw reasoning / PII を含めない。 |
+| timestamp | Yes | deterministic event emission timestamp。 |
+| payload_issued_at | Yes | deterministic upstream-issued timestamp metadata。 |
+| source_environment | Yes | non-sensitive environment class のみ。 |
+| source_instance_id | Yes, constrained | host credentials / secrets / PII を含めない。 |
+| authentication_result_class | Yes | class label のみ。 |
+| integrity_result_class | Yes | class label のみ。 |
+| replay_result_class | Yes | class label のみ。 |
+| schema_validation_result_class | Yes | class label のみ。 |
+| veritas_continuation_decision | Yes | deterministic VERITAS continuation state。 |
+| veritas_reason_code | Yes | deterministic reason code のみ。 |
+| veritas_sandbox_commit_state | Yes | deterministic commit-state label のみ。 |
+| required_next_action | Yes | deterministic action guidance class のみ。 |
+| latency_ms | Yes | 数値メトリクスのみ。 |
+| body_hash_prefix | Yes, constrained | non-reversible であり raw payload を露出しない。 |
+
+## 6. Fields forbidden in observability events
+
+禁止クラスは persistence 前に reject / redact / deterministic class label への置換を必須とし、検知時は fail closed とします。
+
+- chain-of-thought
+- hidden model state
+- raw V.I.K.I. reasoning
+- raw LLM text
+- raw KYC records
+- customer PII
+- secrets
+- credentials
+- access tokens
+- refresh tokens
+- private keys
+- webhook secrets
+- raw Authorization header
+- full signed secret material
+- unredacted regulated data
+- raw payload body
+- raw upstream free-form explanation
+- stack traces containing secrets
+
+## 7. Event taxonomy
+
+Draft event types:
+
+- `viki_payload_received`
+- `transport_authentication_checked`
+- `message_integrity_checked`
+- `replay_window_checked`
+- `replay_cache_checked`
+- `schema_validation_checked`
+- `rsa_sandbox_payload_constructed`
+- `rsa_sandbox_signal_evaluated`
+- `veritas_decision_emitted`
+- `human_review_required`
+- `upstream_unavailable`
+- `fail_closed_emitted`
+
+- event 名は draft のみです。
+- final event taxonomy は実装前レビュー必須です。
+- events は versioning 必須です。
+- raw reasoning / raw LLM text / raw KYC records / secrets / credentials を含めてはいけません。
+
+## 8. Example safe observability event
+
+```json
+{
+  "event_type": "veritas_decision_emitted",
+  "event_version": "v1alpha1",
+  "schema_version": "v1alpha1",
+  "request_id": "req_viki_000001",
+  "correlation_id": "corr_viki_veritas_000001",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Normal_State",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "authentication_result_class": "AUTHENTICATED",
+  "integrity_result_class": "INTEGRITY_VALID",
+  "replay_result_class": "NO_REPLAY_DETECTED",
+  "schema_validation_result_class": "SCHEMA_VALID",
+  "veritas_continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "veritas_reason_code": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "CONTINUE_BOUNDARY_EVALUATION",
+  "latency_ms": 42
+}
+```
+
+- この例は synthetic です。
+- この例は production logging を許可しません。
+- SAFE_PROCEED は final commit approval ではありません。
+
+## 9. Example forbidden observability event
+
+```json
+{
+  "event_type": "veritas_decision_emitted",
+  "request_id": "req_viki_invalid_001",
+  "correlation_id": "corr_viki_veritas_invalid_001",
+  "chain_of_thought": "FORBIDDEN",
+  "raw_kyc_record": "FORBIDDEN",
+  "access_token": "FORBIDDEN"
+}
+```
+
+Expected behavior:
+
+- reject before persistence or redact before persistence
+- fail closed
+- do not infer SAFE_PROCEED
+- never store chain-of-thought
+- never store raw KYC records
+- never store access tokens
+
+## 10. Redacted audit entry relationship
+
+将来の VERITAS audit entries は次を保持し得ます。
+
+- upstream_signal_source
+- event_type
+- event_version
+- schema_version
+- request_id
+- correlation_id
+- rsa_status
+- trigger_source
+- timestamp
+- payload_issued_at
+- source_environment
+- source_instance_id（non-sensitive の場合のみ）
+- authentication_result_class
+- integrity_result_class
+- replay_result_class
+- schema_validation_result_class
+- VERITAS continuation_decision
+- VERITAS reason_code
+- VERITAS sandbox_commit_state
+- required_next_action
+
+将来の VERITAS audit entries は次を保持してはいけません。
+
+- raw V.I.K.I. reasoning
+- raw LLM text
+- chain-of-thought
+- hidden model state
+- raw KYC records
+- customer PII
+- secrets
+- credentials
+- tokens
+- private keys
+- raw Authorization header
+- full signed secret material
+- unredacted regulated data
+- raw payload body
+
+## 11. Failure observability
+
+失敗は、sensitive data を漏えいせずに observable である必要があります。
+
+各 failure で記録するのは deterministic classes のみ:
+
+- authentication failed
+- integrity failed
+- replay detected
+- replay cache unavailable
+- schema validation failed
+- forbidden field detected
+- upstream unavailable
+- timeout
+- fail-closed emitted
+
+記録してはいけないもの:
+
+- raw payload
+- raw secret
+- raw Authorization header
+- raw KYC record
+- raw reasoning
+- stack trace with credentials
+
+## 12. Interaction with replay/correlation design
+
+- request_id と correlation_id は primary safe correlation fields です。
+- correlation_id は transport / replay / schema validation / VERITAS decision / human review events を接続します。
+- request_id は単一 payload emission を識別します。
+- 重複 request_id は replay risk として fail closed 必須です。
+- correlation_id は PII / secrets を含めてはいけません。
+- Observability は raw payload data を保存せずに correlation を保持する必要があります。
+
+## 13. Interaction with transport/authentication design
+
+- Authentication result は credential material ではなく class として記録します。
+- Signature verification result は signature secret material ではなく class として記録します。
+- mTLS result は raw certificate secrets ではなく class として記録します。
+- Body hash は safe digest または safe prefix のみ許可し、raw payload は不可です。
+- raw Authorization headers は記録禁止です。
+- Authentication failure 時も secret material を logs に露出してはいけません。
+
+## 14. Interaction with payload schema draft
+
+- payload schema draft は required / optional / forbidden fields を定義します。
+- Observability は schema validation result を反映し、forbidden fields を保存してはいけません。
+- optional な raw-intent/action fields はデフォルトで redact 必須です。
+- chain_of_thought や hidden_model_state など forbidden fields は fail closed または persistence 前 reject が必須です。
+- schema_version は deterministic metadata として保持します。
+
+## 15. Log retention and access assumptions
+
+- 本書は production retention period を定義しません。
+- retention period は production 前レビュー必須です。
+- log access は制限される必要があります。
+- regulated metadata を含む logs は compliance review が必要となる場合があります。
+- logs は raw payload の dumping ground にしてはいけません。
+- logs の export は redaction を維持する必要があります。
+- 将来の retention policy は deletion/expiry behavior を含む必要があります。
+
+## 16. Fail-closed matrix
+
+すべての failure class に対する VERITAS behavior は共通です。
+
+- fail closed
+- PAUSE_FOR_HUMAN_REVIEW
+- SUSPENDED_NOT_COMMITTED
+- no SAFE_PROCEED inference
+
+Failure class:
+
+- Forbidden field detected
+- Secret detected in payload
+- Raw KYC detected
+- Raw reasoning detected
+- Chain-of-thought detected
+- Hidden model state detected
+- Authorization header logging attempted
+- Replay cache unavailable
+- Authentication failed
+- Integrity failed
+- Schema validation failed
+- Upstream unavailable
+- Timeout
+
+## 17. Required implementation gates
+
+redaction/observability implementation 前チェックリスト:
+
+- [ ] threat model merged
+- [ ] payload schema draft merged
+- [ ] transport/auth design merged
+- [ ] replay/correlation design merged
+- [ ] redaction/observability design merged
+- [ ] event taxonomy finalized
+- [ ] forbidden field detector plan drafted
+- [ ] logging sink selected
+- [ ] log retention policy drafted
+- [ ] access control policy drafted
+- [ ] redaction tests drafted
+- [ ] failure-mode test plan drafted
+- [ ] staging-only feature flag defined
+- [ ] synthetic-data-only test plan drafted
+- [ ] rollback plan documented
+- [ ] security review completed
+
+## 18. Non-goals
+
+この設計が許可しないもの:
+
+- production live V.I.K.I. integration
+- production logging pipeline
+- production API endpoint
+- public unauthenticated endpoint
+- real KYC data processing
+- live customer data processing
+- live LLM text ingestion
+- raw V.I.K.I. reasoning ingestion
+- chain-of-thought storage
+- hidden model state storage
+- raw KYC logging
+- final commit automation based only on V.I.K.I.
+- bypass of VERITAS commit gate
+- secrets in repository
+- production AML/KYC compliance claims
+- regulatory approval claims
+- legal advice claims
+
+## 19. Compatibility preservation
+
+- rsa_status は v1 payload field のまま維持します。
+- RSASandboxPayload は downstream payload container として維持します。
+- evaluate_rsa_sandbox_signal() は downstream evaluator として維持します。
+- upstream_signal_source は `"RSA"` を維持します。
+- request_id / correlation_id は observability/correlation fields であり、rsa_status の置換ではありません。
+- viki_status はこの phase で導入しません。
+- VIKIPayload はこの phase で導入しません。
+- naming migration は v2 として別途扱います。
+
+## 20. What this design validates
+
+- implementation 前に observability risks が文書化されること
+- allowed observability fields が定義されること
+- forbidden observability fields が定義されること
+- redaction expectations が文書化されること
+- failure observability が文書化されること
+- audit relationship が文書化されること
+- log retention assumptions が文書化されること
+- live implementation を導入しないこと
+
+## 21. What this design does not validate
+
+- it does not implement logging
+- it does not implement telemetry
+- it does not implement redaction
+- it does not implement forbidden field detection
+- it does not implement transport
+- it does not implement authentication
+- it does not implement replay protection
+- it does not validate production AML/KYC compliance
+- it does not validate regulatory approval
+- it does not provide legal advice
+- it does not authorize production deployment
+- it does not make VERITAS production-ready for live V.I.K.I.
+
+## 22. この設計後の推奨 PR
+
+次の safe PR 候補:
+
+- live payload schema fixture examples
+- controlled live failure-mode test plan
+- redaction fixture examples
+- controlled live integration implementation plan
+- observability event taxonomy fixture plan
+
+最も安全な次 PR は、live payload schema fixture examples（documentation-only または fixture-only、synthetic data 限定）です。schema / transport-auth / replay-correlation / redaction-observability の各 gate を runtime 実装前に具体的な synthetic examples で固定化できるためです。

--- a/docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
+++ b/docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md
@@ -1,6 +1,7 @@
 # RSA ↔ VERITAS Live V.I.K.I. Integration Reviewer Checklist
 
 - [Controlled live V.I.K.I. replay protection and correlation-id design（pre-live 必須 replay/correlation gate、documentation-only、runtime 変更なし、live integration なし）](./rsa-veritas-controlled-live-viki-replay-correlation-design.md)
+- [Controlled live V.I.K.I. redaction and observability design（pre-live 必須 redaction/observability gate、documentation-only、runtime 変更なし、live integration なし）](./rsa-veritas-controlled-live-viki-redaction-observability-design.md)
 ## 英語正本
 
 - [RSA ↔ VERITAS Live V.I.K.I. Integration Reviewer Checklist](../../en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md)

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -41,6 +41,7 @@
 16. [Controlled live V.I.K.I. payload schema draft（pre-live 必須 schema gate、documentation-only）](./rsa-veritas-controlled-live-viki-payload-schema-draft.md)
 17. [Controlled live V.I.K.I. transport authentication design（pre-live 必須 transport/auth gate、documentation-only）](./rsa-veritas-controlled-live-viki-transport-authentication-design.md)
 18. [Controlled live V.I.K.I. replay protection and correlation-id design（pre-live 必須 replay/correlation gate、documentation-only）](./rsa-veritas-controlled-live-viki-replay-correlation-design.md)
+19. [Controlled live V.I.K.I. redaction and observability design（pre-live 必須 redaction/observability gate、documentation-only）](./rsa-veritas-controlled-live-viki-redaction-observability-design.md)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 


### PR DESCRIPTION
### Motivation

- Provide a required pre-live gate documenting redaction and observability requirements for any future controlled live V.I.K.I. → VERITAS integration while preserving the current local-only sandbox stance. 
- Prevent observability from becoming a data-leakage channel by defining allowed/forbidden fields, deterministic event taxonomy, fail-closed behaviors, and audit relationships without introducing runtime or logging code. 

### Description

- Add `docs/en/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md` containing the full design: purpose, current baseline, future observability boundary, redaction principles, allowed/forbidden fields, draft event taxonomy, synthetic safe/forbidden examples, fail-closed matrix, required implementation gates, non-goals, compatibility preservation, and recommended next PRs. 
- Add aligned Japanese page `docs/ja/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md` with the required `## 英語正本` link, Japanese-first explanation, and preserved technical terms and enum values. 
- Update reviewer navigation to surface the new pre-live gate by editing `docs/en/guides/rsa-veritas-sandbox-reviewer-index.md`, `docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md`, `docs/en/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md`, and `docs/ja/guides/rsa-veritas-live-viki-integration-reviewer-checklist.md` to link the new design as a required pre-live artifact. 
- This change is documentation-only and does not introduce any runtime code, tests, CI changes, API endpoints, network calls, secrets, telemetry SDKs, replay cache implementation, or live V.I.K.I. integration.

### Testing

- Ran `git diff --check` and found no whitespace/format issues. (passed)
- Ran `git status --short` to confirm the intended files were staged/changed locally. (passed)
- Ran `git show --name-only --pretty='' HEAD` to verify the created files are present in the local branch. (passed)

All automated checks executed in this rollout succeeded and no runtime/tests/CI were modified as part of this documentation-only PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11862321948326af5c1405c8f4f2f6)