### PR TITLE
tests: add controlled live V.I.K.I. failure-mode test skeleton

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md
@@ -48,6 +48,8 @@ Notes:
 - The current implemented path is local-only, synthetic-data-only, and no-network.
 - This controlled live failure-mode test plan is a future test planning artifact only.
 - It does not introduce live runtime behavior.
+- Offline test skeleton now exists at `tests/governance/test_controlled_live_viki_failure_modes.py` (test-only, synthetic-fixture-only, no runtime/live integration).
+- The failure-mode test skeleton does not introduce endpoints, network calls, credentials, replay cache implementation, logging implementation, or observability implementation.
 
 ## 3. Fixture set under review
 

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -40,6 +40,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 21. [Controlled live V.I.K.I. failure-mode test plan (pre-live failure test planning artifact, documentation-only)](./rsa-veritas-controlled-live-viki-failure-mode-test-plan.md)
 22. [Controlled live V.I.K.I. fixture validation plan (pre-live fixture classification planning artifact, documentation-only)](./rsa-veritas-controlled-live-viki-fixture-validation-plan.md)
 23. [Controlled live V.I.K.I. fixture validation test skeleton (offline synthetic-fixture tests only; test-only, no runtime/live integration)](../../../tests/governance/test_controlled_live_viki_fixture_validation.py)
+24. [Controlled live V.I.K.I. failure-mode test skeleton (offline synthetic-fixture tests only; test-only, no runtime behavior, endpoint, network, credentials, replay cache, logging, observability, or live integration)](../../../tests/governance/test_controlled_live_viki_failure_modes.py)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md
@@ -52,6 +52,8 @@
 - 現在の実装経路は local-only / synthetic-data-only / no-network です。
 - 本 controlled live failure-mode test plan は将来テスト計画のアーティファクトに限定されます。
 - live runtime behavior は導入しません。
+- Offline test skeleton は `tests/governance/test_controlled_live_viki_failure_modes.py` に追加済みです（test-only / synthetic-fixture-only / runtime・live integration なし）。
+- この failure-mode test skeleton は endpoint・network calls・credentials・replay cache 実装・logging 実装・observability 実装を導入しません。
 
 ## 3. 対象 fixture set
 

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -46,6 +46,7 @@
 21. [Controlled live V.I.K.I. failure-mode test plan（pre-live failure test planning artifact、documentation-only）](./rsa-veritas-controlled-live-viki-failure-mode-test-plan.md)
 22. [Controlled live V.I.K.I. fixture validation plan（pre-live fixture 分類計画アーティファクト、documentation-only）](./rsa-veritas-controlled-live-viki-fixture-validation-plan.md)
 23. [Controlled live V.I.K.I. fixture validation test skeleton（offline synthetic-fixture tests のみ、test-only / runtime・live integration なし）](../../../tests/governance/test_controlled_live_viki_fixture_validation.py)
+24. [Controlled live V.I.K.I. failure-mode test skeleton（offline synthetic-fixture tests のみ、test-only / runtime behavior・endpoint・network・credentials・replay cache・logging・observability・live integration なし）](../../../tests/governance/test_controlled_live_viki_failure_modes.py)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 

--- a/tests/governance/test_controlled_live_viki_failure_modes.py
+++ b/tests/governance/test_controlled_live_viki_failure_modes.py
@@ -1,0 +1,204 @@
+"""Offline failure-mode skeleton for controlled live V.I.K.I. sandbox decisions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.governance.test_controlled_live_viki_fixture_validation import (
+    _classify_fixture,
+    _load_fixture,
+)
+
+FAIL_CLOSED_CONTINUATION = "PAUSE_FOR_HUMAN_REVIEW"
+FAIL_CLOSED_COMMIT_STATE = "SUSPENDED_NOT_COMMITTED"
+FAIL_CLOSED_NEXT_ACTION = "REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE"
+FAIL_CLOSED_SYNTHETIC_RETRY_ACTION = "REQUEST_VALID_SYNTHETIC_PAYLOAD_OR_HUMAN_REVIEW"
+
+
+def _expected_fail_closed_decision(
+    reason_code: str,
+    *,
+    required_next_action: str = FAIL_CLOSED_NEXT_ACTION,
+) -> dict:
+    return {
+        "continuation_decision": FAIL_CLOSED_CONTINUATION,
+        "sandbox_commit_state": FAIL_CLOSED_COMMIT_STATE,
+        "required_next_action": required_next_action,
+        "final_commit_approved": False,
+        "reason_code": reason_code,
+    }
+
+
+def _expected_valid_fixture_decision(rsa_status: str) -> dict:
+    decision_map = {
+        "SAFE_PROCEED": {
+            "continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+            "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+            "required_next_action": "CONTINUE_BOUNDARY_EVALUATION",
+            "final_commit_approved": False,
+            "reason_code": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+        },
+        "DENSITY_THROTTLED": {
+            "continuation_decision": "CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED",
+            "sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+            "required_next_action": "CONTINUE_BOUNDARY_EVALUATION_WITH_INTERVENTION_AUDIT",
+            "final_commit_approved": False,
+            "reason_code": "UPSTREAM_DENSITY_THROTTLED_SIGNAL",
+        },
+        "ALGORITHMIC_HUMILITY_ENGAGED": _expected_fail_closed_decision(
+            "UPSTREAM_ALGORITHMIC_HUMILITY_SIGNAL"
+        ),
+        "DEFERRAL_ENGAGED": _expected_fail_closed_decision("UPSTREAM_DEFERRAL_SIGNAL"),
+    }
+    return decision_map[rsa_status]
+
+
+def _assert_fail_closed(decision: dict) -> None:
+    assert decision["continuation_decision"] == FAIL_CLOSED_CONTINUATION
+    assert decision["sandbox_commit_state"] == FAIL_CLOSED_COMMIT_STATE
+    assert decision["final_commit_approved"] is False
+
+
+def _assert_not_final_commit(decision: dict) -> None:
+    assert decision["final_commit_approved"] is False
+    assert decision["sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+
+
+def test_valid_fixture_statuses_do_not_grant_final_commit() -> None:
+    valid_fixtures = [
+        "valid_safe_proceed_v1alpha1.json",
+        "valid_density_throttled_v1alpha1.json",
+        "valid_algorithmic_humility_engaged_v1alpha1.json",
+        "valid_deferral_engaged_v1alpha1.json",
+    ]
+
+    for fixture_name in valid_fixtures:
+        payload = _load_fixture(fixture_name)
+        decision = _expected_valid_fixture_decision(payload["rsa_status"])
+        _assert_not_final_commit(decision)
+        if payload["rsa_status"] == "SAFE_PROCEED":
+            assert decision["continuation_decision"] == "CONTINUE_TO_BIND_BOUNDARY"
+            assert decision["final_commit_approved"] is False
+
+
+def test_invalid_fixture_classes_map_to_fail_closed_decisions() -> None:
+    expected_by_classification = {
+        "FIXTURE_UNKNOWN_RSA_STATUS": _expected_fail_closed_decision(
+            "CONTROLLED_LIVE_UNKNOWN_RSA_STATUS"
+        ),
+        "FIXTURE_MISSING_REQUIRED_FIELD": _expected_fail_closed_decision(
+            "CONTROLLED_LIVE_MISSING_REQUIRED_FIELD",
+            required_next_action=FAIL_CLOSED_SYNTHETIC_RETRY_ACTION,
+        ),
+        "FIXTURE_INVALID_TIMESTAMP": _expected_fail_closed_decision(
+            "CONTROLLED_LIVE_INVALID_TIMESTAMP"
+        ),
+        "FIXTURE_UNSUPPORTED_SCHEMA_VERSION": _expected_fail_closed_decision(
+            "CONTROLLED_LIVE_UNSUPPORTED_SCHEMA_VERSION",
+            required_next_action=FAIL_CLOSED_SYNTHETIC_RETRY_ACTION,
+        ),
+        "FIXTURE_FORBIDDEN_FIELD_PRESENT": _expected_fail_closed_decision(
+            "CONTROLLED_LIVE_FORBIDDEN_FIELD_PRESENT"
+        ),
+        "FIXTURE_SECRET_LIKE_VALUE_PRESENT": _expected_fail_closed_decision(
+            "CONTROLLED_LIVE_SECRET_LIKE_VALUE_PRESENT"
+        ),
+        "FIXTURE_REGULATED_DATA_PRESENT": _expected_fail_closed_decision(
+            "CONTROLLED_LIVE_REGULATED_DATA_PRESENT"
+        ),
+    }
+
+    invalid_fixtures = [
+        "invalid_unknown_rsa_status_v1alpha1.json",
+        "invalid_missing_request_id_v1alpha1.json",
+        "invalid_missing_correlation_id_v1alpha1.json",
+        "invalid_forbidden_chain_of_thought_v1alpha1.json",
+        "invalid_secret_access_token_v1alpha1.json",
+        "invalid_raw_kyc_record_v1alpha1.json",
+        "invalid_naive_timestamp_v1alpha1.json",
+        "invalid_payload_issued_at_future_skew_v1alpha1.json",
+        "invalid_unsupported_schema_version.json",
+    ]
+
+    for fixture_name in invalid_fixtures:
+        payload = _load_fixture(fixture_name)
+        classification = _classify_fixture(fixture_name, payload)
+        decision = expected_by_classification[classification]
+        _assert_fail_closed(decision)
+        assert decision["continuation_decision"] != "CONTINUE_TO_BIND_BOUNDARY"
+
+
+def test_duplicate_request_id_maps_to_replay_fail_closed() -> None:
+    scenario_a_name = "invalid_duplicate_request_id_scenario_a_v1alpha1.json"
+    scenario_b_name = "invalid_duplicate_request_id_scenario_b_v1alpha1.json"
+    scenario_a = _load_fixture(scenario_a_name)
+    scenario_b = _load_fixture(scenario_b_name)
+
+    seen_request_ids: dict[str, str] = {}
+    assert _classify_fixture(scenario_a_name, scenario_a, seen_request_ids=seen_request_ids) == "FIXTURE_VALID"
+    classification_b = _classify_fixture(scenario_b_name, scenario_b, seen_request_ids=seen_request_ids)
+    assert classification_b == "FIXTURE_REPLAY_SCENARIO_DUPLICATE"
+
+    decision = _expected_fail_closed_decision("CONTROLLED_LIVE_REPLAY_DUPLICATE_REQUEST_ID")
+    _assert_fail_closed(decision)
+    assert decision["reason_code"] == "CONTROLLED_LIVE_REPLAY_DUPLICATE_REQUEST_ID"
+
+
+def test_forbidden_content_failure_modes_never_continue() -> None:
+    forbidden_cases = {
+        "invalid_forbidden_chain_of_thought_v1alpha1.json": "FIXTURE_FORBIDDEN_FIELD_PRESENT",
+        "invalid_secret_access_token_v1alpha1.json": "FIXTURE_SECRET_LIKE_VALUE_PRESENT",
+        "invalid_raw_kyc_record_v1alpha1.json": "FIXTURE_REGULATED_DATA_PRESENT",
+    }
+    class_to_reason = {
+        "FIXTURE_FORBIDDEN_FIELD_PRESENT": "CONTROLLED_LIVE_FORBIDDEN_FIELD_PRESENT",
+        "FIXTURE_SECRET_LIKE_VALUE_PRESENT": "CONTROLLED_LIVE_SECRET_LIKE_VALUE_PRESENT",
+        "FIXTURE_REGULATED_DATA_PRESENT": "CONTROLLED_LIVE_REGULATED_DATA_PRESENT",
+    }
+
+    for fixture_name, expected_classification in forbidden_cases.items():
+        payload = _load_fixture(fixture_name)
+        classification = _classify_fixture(fixture_name, payload)
+        assert classification == expected_classification
+        decision = _expected_fail_closed_decision(class_to_reason[classification])
+        _assert_fail_closed(decision)
+        assert decision["continuation_decision"] != "CONTINUE_TO_BIND_BOUNDARY"
+
+
+def test_transport_and_upstream_failure_modes_fail_closed() -> None:
+    simulated_failures = {
+        "TIMEOUT": "CONTROLLED_LIVE_UPSTREAM_TIMEOUT",
+        "UPSTREAM_UNAVAILABLE": "CONTROLLED_LIVE_UPSTREAM_UNAVAILABLE",
+        "TRANSPORT_AUTH_FAILED": "CONTROLLED_LIVE_TRANSPORT_AUTH_FAILED",
+        "MESSAGE_INTEGRITY_FAILED": "CONTROLLED_LIVE_MESSAGE_INTEGRITY_FAILED",
+        "REPLAY_CACHE_UNAVAILABLE": "CONTROLLED_LIVE_REPLAY_CACHE_UNAVAILABLE",
+    }
+
+    for reason_code in simulated_failures.values():
+        decision = _expected_fail_closed_decision(reason_code)
+        _assert_fail_closed(decision)
+        assert decision["required_next_action"] == FAIL_CLOSED_NEXT_ACTION
+
+
+def test_failure_mode_skeleton_uses_static_offline_inputs_only() -> None:
+    import ast
+
+    source = Path(__file__).read_text(encoding="utf-8")
+    module = ast.parse(source)
+
+    disallowed_import_roots = {"requests", "httpx", "urllib", "socket"}
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in disallowed_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in disallowed_import_roots
+
+    forbidden_env_access = "os" + "." + "environ"
+    assert forbidden_env_access not in source
+
+    precheck_source = source.split("def test_failure_mode_skeleton_uses_static_offline_inputs_only", maxsplit=1)[0]
+    banned_substrings = ["https://", "http://", "bearer ", "authorization:"]
+    lowered_source = precheck_source.lower()
+    for token in banned_substrings:
+        assert token not in lowered_source


### PR DESCRIPTION
### Motivation
- Provide an offline, test-only skeleton that codifies expected fail-closed behavior for the RSA ↔ VERITAS controlled-live V.I.K.I. sandbox without adding any runtime, network, or production behavior. 
- Capture mapping from synthetic fixtures and simulated upstream/transport failure modes to canonical fail-closed decisions so future runtime work has a clear, auditable test contract.

### Description
- Add a new test file `tests/governance/test_controlled_live_viki_failure_modes.py` implementing local test-only helpers, expected decision mappings for valid `rsa_status` values and invalid fixture classes, replay duplicate scenarios, and simulated transport/upstream failures, while reusing classification helpers from `tests/governance/test_controlled_live_viki_fixture_validation.py`.
- Implement static/offline guard checks in the new test to assert no network libraries, endpoint strings, or direct environment credential access patterns appear in the test source.
- Update documentation pages `docs/en/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md`, `docs/ja/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md`, `docs/en/guides/rsa-veritas-sandbox-reviewer-index.md`, and `docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md` with a short note and link to the new test skeleton and explicit statements that the test is offline and test-only and does not introduce runtime/network/credentials/replay-cache/logging/observability functionality.
- Keep the change test-only with no runtime code, CI, dependency, fixture mutation, or production behavior added.

### Testing
- Ran `PYENV_VERSION=3.12.13 pytest -q tests/governance/test_controlled_live_viki_fixture_validation.py tests/governance/test_controlled_live_viki_failure_modes.py` which executed the fixture validation and the new failure-mode skeleton tests and completed with `13 passed, 1 warning` regarding a pytest config option.
- The new tests assert expected mappings for: valid fixtures (`SAFE_PROCEED`, `DENSITY_THROTTLED`, `ALGORITHMIC_HUMILITY_ENGAGED`, `DEFERRAL_ENGAGED`), all listed invalid fixtures, replay duplicate detection between `invalid_duplicate_request_id_scenario_a_v1alpha1.json` and `invalid_duplicate_request_id_scenario_b_v1alpha1.json`, simulated transport/upstream failures, and static offline-only guards; all assertions passed.
- Static offline guard assertions verified no disallowed network imports (`requests`, `httpx`, `urllib`, `socket`), no `os.environ` credential access, and no endpoint or bearer/token substrings in the pre-test source portion.

Security note: this PR intentionally avoids expanding any runtime attack surface; it contains only offline tests and documentation and includes explicit checks to prevent accidental inclusion of network calls, credentials, or production behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c2cdd82083268870da0cbae1dba4)