### PR TITLE
docs: add controlled live V.I.K.I. observability event taxonomy fixture plan

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md
@@ -17,6 +17,9 @@ This page is documentation-only.
 
 This plan must be reviewed before any controlled live runtime implementation begins.
 
+Related pre-live artifact:
+- [Controlled live V.I.K.I. observability event taxonomy fixture plan](./rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md) (documentation-only; no runtime/tests/fixtures/live integration).
+
 ## 2. Current baseline
 
 The following pre-live gates already exist:

--- a/docs/en/guides/rsa-veritas-controlled-live-viki-fixture-validation-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-fixture-validation-plan.md
@@ -18,6 +18,9 @@ This is **not**:
 
 This plan must be reviewed before any fixture validation test skeleton is implemented.
 
+Related pre-live artifact:
+- [Controlled live V.I.K.I. observability event taxonomy fixture plan](./rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md) (documentation-only; no runtime/tests/fixtures/live integration).
+
 ## 1.1 Implementation status update
 
 A **test-only**, **offline**, and **synthetic-fixture-only** validation skeleton now exists at:

--- a/docs/en/guides/rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md
@@ -1,0 +1,302 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Observability Event Taxonomy Fixture Plan
+
+## 1. Purpose
+
+This document defines the observability event taxonomy fixture plan for future controlled live V.I.K.I. observability fixtures.
+
+This is documentation-only.
+
+- This is not an observability implementation.
+- This is not a logging implementation.
+- This is not a telemetry implementation.
+- This is not a fixture implementation.
+- This is not a test implementation.
+- This is not a runtime implementation.
+- This is not a live integration.
+- This is not a production API endpoint.
+- This does not add network calls.
+- This does not add secrets or credentials.
+- This does not process real KYC data.
+- This does not authorize production use.
+
+This plan must be reviewed before any observability event fixture examples or tests are added.
+
+## 2. Current baseline
+
+The following pre-live gates already exist:
+
+- controlled live integration threat model
+- controlled live payload schema draft
+- controlled live transport/authentication design
+- controlled live replay protection and correlation-id design
+- controlled live redaction and observability design
+- controlled live payload schema fixture examples
+- controlled live failure-mode test plan
+- controlled live fixture validation plan
+- controlled live fixture validation test skeleton
+- controlled live failure-mode test skeleton
+
+Current implemented/tested paths remain:
+
+- local mock receiver path is local-only, synthetic-data-only, and no-network
+- fixture validation tests are offline and synthetic-fixture-only
+- failure-mode skeleton tests are offline and synthetic-fixture-only
+
+No live V.I.K.I. integration exists in this phase. No observability implementation exists in this phase. No logging or telemetry implementation is introduced by this plan.
+
+## 3. Future observability fixture boundary
+
+`controlled live synthetic payload fixture`
+→ `transport/authentication result class`
+→ `message integrity result class`
+→ `replay/correlation result class`
+→ `schema validation result class`
+→ `VERITAS decision result class`
+→ `redacted synthetic observability event fixture`
+→ `offline fixture validation test`
+→ `offline failure-mode test`
+
+- Observability fixtures must be synthetic.
+- Observability fixtures must not contain raw payload bodies.
+- Observability fixtures must not contain raw V.I.K.I. reasoning.
+- Observability fixtures must not contain raw LLM text.
+- Observability fixtures must not contain chain-of-thought.
+- Observability fixtures must not contain hidden model state.
+- Observability fixtures must not contain raw KYC records.
+- Observability fixtures must not contain customer PII.
+- Observability fixtures must not contain secrets or credentials.
+- Observability fixtures must not authorize live integration.
+
+## 4. Draft event taxonomy
+
+Draft `event_type` values:
+
+- viki_payload_received
+- transport_authentication_checked
+- message_integrity_checked
+- replay_window_checked
+- replay_cache_checked
+- schema_validation_checked
+- rsa_sandbox_payload_constructed
+- rsa_sandbox_signal_evaluated
+- veritas_decision_emitted
+- human_review_required
+- upstream_unavailable
+- upstream_timeout
+- forbidden_field_detected
+- secret_like_value_detected
+- regulated_data_detected
+- fail_closed_emitted
+
+- These `event_type` values are draft names only.
+- Final event taxonomy must be reviewed before implementation.
+- Every event fixture must include event_type.
+- Every event fixture must include event_version.
+- Event names must be deterministic.
+- Event names must not include free-form raw reasoning or PII.
+
+## 5. Required fields for observability event fixtures
+
+- event_type
+- event_version
+- schema_version
+- request_id
+- correlation_id
+- timestamp
+- payload_issued_at
+- upstream_signal_source
+- veritas_continuation_decision
+- veritas_reason_code
+- veritas_sandbox_commit_state
+- required_next_action
+- final_commit_approved
+
+Rules:
+- event_version must be `"v1alpha1"` for this fixture plan.
+- schema_version must be `"v1alpha1"` for controlled live payload-derived fixtures.
+- upstream_signal_source must remain `"RSA"`.
+- request_id and correlation_id must be synthetic and non-sensitive.
+- final_commit_approved must be false in all pre-live fixtures.
+- timestamp and payload_issued_at must be timezone-aware.
+- required fields must not be empty.
+
+## 6. Optional allowed fields
+
+Optional allowed fields:
+- source_environment
+- source_instance_id
+- rsa_status
+- trigger_source
+- authentication_result_class
+- integrity_result_class
+- replay_result_class
+- schema_validation_result_class
+- redaction_result_class
+- forbidden_field_result_class
+- latency_ms
+- body_hash_prefix
+- fixture_name
+- fixture_classification
+- failure_class
+- decision_source
+
+Rules:
+- Optional fields must not contain PII.
+- Optional fields must not contain secrets.
+- Optional fields must not contain raw reasoning.
+- body_hash_prefix must be non-reversible and must not expose raw payload.
+- latency_ms must be a non-negative integer when present.
+- fixture_name must refer only to synthetic fixture file names.
+- fixture_classification must use deterministic result classes.
+
+## 7. Forbidden fields and content
+
+Forbidden fields/content:
+- chain_of_thought
+- hidden_model_state
+- raw_llm_reasoning
+- raw_viki_reasoning
+- raw_llm_text
+- raw_kyc_record
+- customer_pii
+- secrets
+- credentials
+- api_key
+- access_token
+- refresh_token
+- private_key
+- webhook_secret
+- raw_authorization_header
+- authorization
+- bearer_token
+- unredacted_regulated_data
+- raw_payload_body
+- raw_request_body
+- raw_response_body
+- raw_stack_trace_with_secrets
+
+Required behavior:
+- Future observability fixtures containing these fields must be invalid.
+- Future observability validation tests must reject these fields.
+- Forbidden fields must never be converted into SAFE_PROCEED.
+- Forbidden fields must never be persisted as redacted audit output.
+- Forbidden fields must never appear in observability examples except as explicitly invalid synthetic examples.
+
+## 8. Result class taxonomy
+
+`authentication_result_class`: AUTHENTICATED, AUTHENTICATION_FAILED, AUTHENTICATION_NOT_EVALUATED
+
+`integrity_result_class`: INTEGRITY_VALID, INTEGRITY_FAILED, BODY_HASH_MISMATCH, INTEGRITY_NOT_EVALUATED
+
+`replay_result_class`: NO_REPLAY_DETECTED, REPLAY_DUPLICATE_REQUEST_ID, REPLAY_CACHE_UNAVAILABLE, REPLAY_NOT_EVALUATED
+
+`schema_validation_result_class`: SCHEMA_VALID, SCHEMA_INVALID, SCHEMA_UNSUPPORTED_VERSION, SCHEMA_UNKNOWN_RSA_STATUS, SCHEMA_MISSING_REQUIRED_FIELD, SCHEMA_INVALID_TIMESTAMP, SCHEMA_NOT_EVALUATED
+
+`redaction_result_class`: REDACTION_VALID, FORBIDDEN_FIELD_DETECTED, SECRET_LIKE_VALUE_DETECTED, REGULATED_DATA_DETECTED, REDACTION_NOT_EVALUATED
+
+`veritas_sandbox_commit_state`: SUSPENDED_NOT_COMMITTED
+
+continuation decisions: CONTINUE_TO_BIND_BOUNDARY, CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED, PAUSE_FOR_HUMAN_REVIEW
+
+These are draft classes only. Final names must be reviewed before implementation. Classes must be deterministic and must not include raw sensitive values.
+
+## 9-11. Event categories and behavior constraints
+
+Future valid synthetic event fixture categories include the positive path, failure path, and simulated upstream/transport path categories listed in the plan request, with names treated as category labels (not finalized filenames).
+
+SAFE_PROCEED behavior constraints:
+- `event_type = veritas_decision_emitted`
+- `veritas_continuation_decision = CONTINUE_TO_BIND_BOUNDARY`
+- `veritas_sandbox_commit_state = SUSPENDED_NOT_COMMITTED`
+- `required_next_action = CONTINUE_BOUNDARY_EVALUATION`
+- `final_commit_approved = false`
+- `veritas_reason_code = UPSTREAM_SAFE_PROCEED_SIGNAL`
+
+Fail-closed behavior constraints:
+- `event_type = fail_closed_emitted` or failure-specific event
+- `veritas_continuation_decision = PAUSE_FOR_HUMAN_REVIEW`
+- `veritas_sandbox_commit_state = SUSPENDED_NOT_COMMITTED`
+- `final_commit_approved = false`
+- deterministic fail-closed `veritas_reason_code`
+
+Expected deterministic reason_code examples include:
+`CONTROLLED_LIVE_UNKNOWN_RSA_STATUS`, `CONTROLLED_LIVE_MISSING_REQUIRED_FIELD`, `CONTROLLED_LIVE_INVALID_TIMESTAMP`, `CONTROLLED_LIVE_UNSUPPORTED_SCHEMA_VERSION`, `CONTROLLED_LIVE_FORBIDDEN_FIELD_PRESENT`, `CONTROLLED_LIVE_SECRET_LIKE_VALUE_PRESENT`, `CONTROLLED_LIVE_REGULATED_DATA_PRESENT`, `CONTROLLED_LIVE_REPLAY_DUPLICATE_REQUEST_ID`, `CONTROLLED_LIVE_UPSTREAM_TIMEOUT`, `CONTROLLED_LIVE_UPSTREAM_UNAVAILABLE`, `CONTROLLED_LIVE_TRANSPORT_AUTH_FAILED`, `CONTROLLED_LIVE_MESSAGE_INTEGRITY_FAILED`, `CONTROLLED_LIVE_REPLAY_CACHE_UNAVAILABLE`.
+
+## 12. Safe synthetic example shape
+
+```json
+{
+  "event_type": "veritas_decision_emitted",
+  "event_version": "v1alpha1",
+  "schema_version": "v1alpha1",
+  "upstream_signal_source": "RSA",
+  "request_id": "req_viki_000001",
+  "correlation_id": "corr_viki_veritas_000001",
+  "timestamp": "2026-05-20T23:01:35.876Z",
+  "payload_issued_at": "2026-05-20T23:01:35.876Z",
+  "rsa_status": "SAFE_PROCEED",
+  "trigger_source": "SRC_Normal_State",
+  "authentication_result_class": "AUTHENTICATED",
+  "integrity_result_class": "INTEGRITY_VALID",
+  "replay_result_class": "NO_REPLAY_DETECTED",
+  "schema_validation_result_class": "SCHEMA_VALID",
+  "redaction_result_class": "REDACTION_VALID",
+  "veritas_continuation_decision": "CONTINUE_TO_BIND_BOUNDARY",
+  "veritas_reason_code": "UPSTREAM_SAFE_PROCEED_SIGNAL",
+  "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+  "required_next_action": "CONTINUE_BOUNDARY_EVALUATION",
+  "final_commit_approved": false,
+  "fixture_name": "valid_safe_proceed_v1alpha1.json",
+  "fixture_classification": "FIXTURE_VALID",
+  "latency_ms": 42,
+  "body_hash_prefix": "sha256:synthetic-prefix-only"
+}
+```
+
+This is synthetic and does not authorize production logging, and it includes no raw payload, raw reasoning, KYC data, or secrets.
+
+## 13. Invalid synthetic example shape
+
+```json
+{
+  "event_type": "veritas_decision_emitted",
+  "event_version": "v1alpha1",
+  "schema_version": "v1alpha1",
+  "request_id": "req_viki_invalid_001",
+  "correlation_id": "corr_viki_veritas_invalid_001",
+  "chain_of_thought": "FORBIDDEN_SYNTHETIC_EXAMPLE",
+  "raw_kyc_record": "FORBIDDEN_SYNTHETIC_KYC_RECORD",
+  "access_token": "FORBIDDEN_SYNTHETIC_TOKEN"
+}
+```
+
+Expected behavior: reject in future fixture validation, do not persist, do not convert to SAFE_PROCEED, do not emit as valid observability event.
+
+## 14-17. Test relationship, validation expectations, no-network, implementation gates
+
+- Existing `test_controlled_live_viki_fixture_validation.py` validates controlled live payload schema fixtures.
+- Existing `test_controlled_live_viki_failure_modes.py` maps payload fixture classifications to fail-closed expectations.
+- Future observability fixture tests should remain offline, synthetic-fixture-only, and independent from runtime logging/telemetry implementations.
+- Future observability fixture validation must enforce exact event inventory, required fields, recognized event taxonomy, supported versions, synthetic IDs, `final_commit_approved = false`, SAFE_PROCEED constraints, fail-closed mapping, and forbidden-field rejection.
+- No-network/no-telemetry requirement applies: no live V.I.K.I., no external APIs, no credentials, no production endpoints, no telemetry SDKs, no external log writes, and no replay cache requirement.
+- Required pre-implementation gates include merged design/test-plan artifacts, this taxonomy fixture plan merged, synthetic-only/no-network confirmation, forbidden-field review, taxonomy review, and no-secrets confirmation.
+
+## 18-22. Non-goals, compatibility, validation scope, next PR
+
+This plan does not permit production integration, runtime observability/logging/telemetry implementation, transport/auth/replay cache implementation, live or real-data handling, commit-gate bypass, compliance/regulatory/legal claims, or secret storage.
+
+Compatibility preserved:
+- `rsa_status` remains the v1 field.
+- `RSASandboxPayload` remains the downstream container.
+- `evaluate_rsa_sandbox_signal()` remains the downstream evaluator.
+- `upstream_signal_source` remains `"RSA"`.
+- `request_id`/`correlation_id` remain schema/correlation fields and do not replace `rsa_status`.
+- no `viki_status` or `VIKIPayload` introduced.
+
+Recommended next safe PR options:
+- controlled live observability event fixture examples
+- controlled live observability event fixture validation test skeleton
+- redaction fixture examples
+- controlled live integration implementation plan
+
+Safest next PR: controlled live observability event fixture examples (synthetic-fixture-only, no runtime, no network, no logging implementation, no telemetry implementation).

--- a/docs/en/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md
@@ -17,6 +17,9 @@ This document defines redaction and observability requirements for a future cont
 - This does not provide legal or regulatory approval.
 - This design must be reviewed before any live logging, telemetry, audit pipeline, endpoint, or live middleware implementation begins.
 
+Related pre-live artifact:
+- [Controlled live V.I.K.I. observability event taxonomy fixture plan](./rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md) (documentation-only; no runtime/tests/fixtures/live integration).
+
 ## 2. Current baseline
 
 The following pre-live gates already exist:

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -41,6 +41,7 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 22. [Controlled live V.I.K.I. fixture validation plan (pre-live fixture classification planning artifact, documentation-only)](./rsa-veritas-controlled-live-viki-fixture-validation-plan.md)
 23. [Controlled live V.I.K.I. fixture validation test skeleton (offline synthetic-fixture tests only; test-only, no runtime/live integration)](../../../tests/governance/test_controlled_live_viki_fixture_validation.py)
 24. [Controlled live V.I.K.I. failure-mode test skeleton (offline synthetic-fixture tests only; test-only, no runtime behavior, endpoint, network, credentials, replay cache, logging, observability, or live integration)](../../../tests/governance/test_controlled_live_viki_failure_modes.py)
+25. [Controlled live V.I.K.I. observability event taxonomy fixture plan (pre-live taxonomy planning artifact, documentation-only)](./rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md)
 
 All four static fixture variants now have dedicated per-variant validation snapshots.
 

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-failure-mode-test-plan.md
@@ -21,6 +21,9 @@
 
 この計画は、controlled live runtime implementation を開始する前にレビューされる必要があります。
 
+関連する pre-live artifact:
+- [Controlled live V.I.K.I. observability event taxonomy fixture plan](./rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md)（documentation-only / runtime・tests・fixtures・live integration 追加なし）。
+
 ## 2. 現在の baseline
 
 以下の pre-live gates は既に存在します。

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-fixture-validation-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-fixture-validation-plan.md
@@ -20,6 +20,9 @@
 
 fixture validation test skeleton 実装前に、本計画のレビューを必須とする。
 
+関連する pre-live artifact:
+- [Controlled live V.I.K.I. observability event taxonomy fixture plan](./rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md)（documentation-only / runtime・tests・fixtures・live integration 追加なし）。
+
 ## 1.1 実装ステータス更新
 
 以下に **test-only** / **offline** / **synthetic-fixture-only** の validation skeleton が追加済み:

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md
@@ -1,0 +1,184 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Observability Event Taxonomy Fixture Plan
+
+## 英語正本
+
+- [RSA ↔ VERITAS Controlled Live V.I.K.I. Observability Event Taxonomy Fixture Plan](../../en/guides/rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md)
+
+## 1. 目的
+
+本書は、将来の controlled live V.I.K.I. observability fixtures に向けた observability event taxonomy fixture plan を定義する documentation-only 文書です。
+
+- observability implementation ではありません。
+- logging implementation ではありません。
+- telemetry implementation ではありません。
+- fixture implementation ではありません。
+- test implementation ではありません。
+- runtime implementation ではありません。
+- live integration ではありません。
+- production API endpoint ではありません。
+- network calls を追加しません。
+- secrets / credentials を追加しません。
+- real KYC data を処理しません。
+- production use を許可しません。
+
+observability event fixture examples や tests を追加する前に、必ず本計画をレビューします。
+
+## 2. Current baseline
+
+既存 pre-live gates:
+- controlled live integration threat model
+- controlled live payload schema draft
+- controlled live transport/authentication design
+- controlled live replay protection and correlation-id design
+- controlled live redaction and observability design
+- controlled live payload schema fixture examples
+- controlled live failure-mode test plan
+- controlled live fixture validation plan
+- controlled live fixture validation test skeleton
+- controlled live failure-mode test skeleton
+
+現行実装/検証パスは local-only・synthetic-data-only・no-network を維持します。現フェーズで live V.I.K.I. integration、observability implementation、logging/telemetry implementation は存在しません。
+
+## 3. Future observability fixture boundary
+
+`controlled live synthetic payload fixture`
+→ `transport/authentication result class`
+→ `message integrity result class`
+→ `replay/correlation result class`
+→ `schema validation result class`
+→ `VERITAS decision result class`
+→ `redacted synthetic observability event fixture`
+→ `offline fixture validation test`
+→ `offline failure-mode test`
+
+Observability fixtures は synthetic 限定とし、raw payload bodies、raw V.I.K.I. reasoning、raw LLM text、chain-of-thought、hidden model state、raw KYC records、customer PII、secrets / credentials を含めません。live integration の承認にもなりません。
+
+## 4-8. Draft taxonomy / fields / forbidden / result classes
+
+`event_type`（draft）:
+- viki_payload_received
+- transport_authentication_checked
+- message_integrity_checked
+- replay_window_checked
+- replay_cache_checked
+- schema_validation_checked
+- rsa_sandbox_payload_constructed
+- rsa_sandbox_signal_evaluated
+- veritas_decision_emitted
+- human_review_required
+- upstream_unavailable
+- upstream_timeout
+- forbidden_field_detected
+- secret_like_value_detected
+- regulated_data_detected
+- fail_closed_emitted
+
+必須 fields:
+- event_type
+- event_version (`v1alpha1`)
+- schema_version (`v1alpha1`)
+- request_id
+- correlation_id
+- timestamp
+- payload_issued_at
+- upstream_signal_source (`"RSA"`)
+- veritas_continuation_decision
+- veritas_reason_code
+- veritas_sandbox_commit_state
+- required_next_action
+- final_commit_approved (`false` in all pre-live fixtures)
+
+optional allowed fields:
+- source_environment
+- source_instance_id
+- rsa_status
+- trigger_source
+- authentication_result_class
+- integrity_result_class
+- replay_result_class
+- schema_validation_result_class
+- redaction_result_class
+- forbidden_field_result_class
+- latency_ms
+- body_hash_prefix
+- fixture_name
+- fixture_classification
+- failure_class
+- decision_source
+
+forbidden fields/content:
+- chain_of_thought
+- hidden_model_state
+- raw_llm_reasoning
+- raw_viki_reasoning
+- raw_llm_text
+- raw_kyc_record
+- customer_pii
+- secrets
+- credentials
+- api_key
+- access_token
+- refresh_token
+- private_key
+- webhook_secret
+- raw_authorization_header
+- authorization
+- bearer_token
+- unredacted_regulated_data
+- raw_payload_body
+- raw_request_body
+- raw_response_body
+- raw_stack_trace_with_secrets
+
+result class taxonomy（draft）:
+- authentication_result_class: AUTHENTICATED / AUTHENTICATION_FAILED / AUTHENTICATION_NOT_EVALUATED
+- integrity_result_class: INTEGRITY_VALID / INTEGRITY_FAILED / BODY_HASH_MISMATCH / INTEGRITY_NOT_EVALUATED
+- replay_result_class: NO_REPLAY_DETECTED / REPLAY_DUPLICATE_REQUEST_ID / REPLAY_CACHE_UNAVAILABLE / REPLAY_NOT_EVALUATED
+- schema_validation_result_class: SCHEMA_VALID / SCHEMA_INVALID / SCHEMA_UNSUPPORTED_VERSION / SCHEMA_UNKNOWN_RSA_STATUS / SCHEMA_MISSING_REQUIRED_FIELD / SCHEMA_INVALID_TIMESTAMP / SCHEMA_NOT_EVALUATED
+- redaction_result_class: REDACTION_VALID / FORBIDDEN_FIELD_DETECTED / SECRET_LIKE_VALUE_DETECTED / REGULATED_DATA_DETECTED / REDACTION_NOT_EVALUATED
+- veritas_sandbox_commit_state: SUSPENDED_NOT_COMMITTED
+- continuation decisions: CONTINUE_TO_BIND_BOUNDARY / CONTINUE_WITH_UPSTREAM_INTERVENTION_LOGGED / PAUSE_FOR_HUMAN_REVIEW
+
+## 9-13. Fixture categories and synthetic examples
+
+fixture category names（将来カテゴリ名、未確定 filename）:
+- positive path: valid_safe_proceed_decision_event, valid_density_throttled_decision_event, valid_algorithmic_humility_decision_event, valid_deferral_decision_event
+- failure path: invalid_unknown_rsa_status_fail_closed_event ほか
+- simulated upstream/transport path: upstream_timeout_fail_closed_event, upstream_unavailable_fail_closed_event, transport_auth_failed_event, message_integrity_failed_event, replay_cache_unavailable_event
+
+SAFE_PROCEED constraints:
+- `event_type = veritas_decision_emitted`
+- `rsa_status = SAFE_PROCEED`
+- `veritas_continuation_decision = CONTINUE_TO_BIND_BOUNDARY`
+- `veritas_sandbox_commit_state = SUSPENDED_NOT_COMMITTED`
+- `required_next_action = CONTINUE_BOUNDARY_EVALUATION`
+- `final_commit_approved = false`
+
+fail-closed constraints:
+- `PAUSE_FOR_HUMAN_REVIEW`
+- `SUSPENDED_NOT_COMMITTED`
+- deterministic `veritas_reason_code`
+
+本書は safe synthetic example shape / invalid synthetic example shape を EN 正本と同一キー・同一 enum で定義します。invalid 例の `chain_of_thought` / `raw_kyc_record` / `access_token` は将来 validation で reject されるべきです。
+
+## 14-22. テスト関係、非目標、互換性、次PR
+
+- 既存 `tests/governance/test_controlled_live_viki_fixture_validation.py` と `tests/governance/test_controlled_live_viki_failure_modes.py` は payload fixtures を対象とする offline synthetic-fixture-only tests です。
+- 将来 observability fixture validation も offline・no-network・no-credentials・no telemetry SDKs を維持します。
+- forbidden fields は reject し、SAFE_PROCEED へ変換せず、redacted audit output に永続化しません。
+
+互換性維持:
+- `rsa_status` 維持
+- `RSASandboxPayload` 維持
+- `evaluate_rsa_sandbox_signal()` 維持
+- `upstream_signal_source = "RSA"` 維持
+- `request_id` / `correlation_id` は schema/correlation field（`rsa_status` の置換ではない）
+- `viki_status` / `VIKIPayload` は導入しない（v2 の別変更対象）
+
+推奨次PR:
+- controlled live observability event fixture examples（最優先）
+- controlled live observability event fixture validation test skeleton
+- redaction fixture examples
+- controlled live integration implementation plan
+
+いずれも synthetic-fixture-only を維持し、runtime・network・logging implementation・telemetry implementation を導入しません。

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-redaction-observability-design.md
@@ -21,6 +21,9 @@
 - これは法的・規制上の承認を提供しません。
 - この設計は、live logging / telemetry / audit pipeline / endpoint / live middleware 実装開始前にレビューされる必要があります。
 
+関連する pre-live artifact:
+- [Controlled live V.I.K.I. observability event taxonomy fixture plan](./rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md)（documentation-only / runtime・tests・fixtures・live integration 追加なし）。
+
 ## 2. Current baseline
 
 以下の pre-live gate は既存として整備済みです。

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -47,6 +47,7 @@
 22. [Controlled live V.I.K.I. fixture validation plan（pre-live fixture 分類計画アーティファクト、documentation-only）](./rsa-veritas-controlled-live-viki-fixture-validation-plan.md)
 23. [Controlled live V.I.K.I. fixture validation test skeleton（offline synthetic-fixture tests のみ、test-only / runtime・live integration なし）](../../../tests/governance/test_controlled_live_viki_fixture_validation.py)
 24. [Controlled live V.I.K.I. failure-mode test skeleton（offline synthetic-fixture tests のみ、test-only / runtime behavior・endpoint・network・credentials・replay cache・logging・observability・live integration なし）](../../../tests/governance/test_controlled_live_viki_failure_modes.py)
+25. [Controlled live V.I.K.I. observability event taxonomy fixture plan（pre-live taxonomy planning artifact、documentation-only）](./rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md)
 
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 


### PR DESCRIPTION
### Motivation

- Define a pre-live, documentation-only observability event taxonomy and fixture plan to lock down the expected event shape, required/optional/forbidden fields, result-class taxonomy, and safe/forbidden example shapes before any observability fixtures, tests, or runtime instrumentation are added.
- Provide a clear, no-network, synthetic-only boundary and review gate so future fixture examples and validation tests can be implemented consistently and without leaking sensitive data.

### Description

- Added the English plan at `docs/en/guides/rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md` which defines purpose, current baseline, future fixture boundary, draft `event_type` taxonomy, required/optional/forbidden fields, result-class enums, safe/invalid synthetic example shapes, compatibility preservation, non-goals, and recommended next PRs.
- Added the Japanese counterpart at `docs/ja/guides/rsa-veritas-controlled-live-viki-observability-event-taxonomy-fixture-plan.md` with Japanese-first explanations and preserved English JSON keys and enum values as required.
- Updated reviewer and related pre-live docs to link the new plan, specifically the sandbox reviewer index and the redaction/observability, failure-mode test plan, and fixture-validation plan pages, while explicitly keeping this change documentation-only and preserving v1 compatibility anchors (e.g., `rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`, `upstream_signal_source = "RSA"`).
- This PR is documentation-only and does not add fixtures, tests, runtime code, endpoints, network calls, secrets, telemetry, logging, or any live V.I.K.I. integration.

### Testing

- Performed static repository checks and file inspections to verify the new pages and updated links exist and contain the expected sections and local links (file presence and content verification succeeded).
- No new automated tests were added and no unit/CI tests were modified or executed as part of this documentation-only change.
- Existing test suites and CI configuration were not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c95177e0832682deaded2ba15828)