### PR TITLE
docs: add controlled live V.I.K.I. runtime interface skeleton plan

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-integration-implementation-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-integration-implementation-plan.md
@@ -36,6 +36,7 @@ The following controlled live pre-live gates already exist:
 - controlled live observability event taxonomy fixture plan
 - controlled live observability event fixture examples
 - controlled live observability event fixture validation test skeleton
+- controlled live runtime interface skeleton plan
 
 Current validated paths are offline, synthetic-fixture-only, and no-network.
 

--- a/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -1,0 +1,373 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Runtime Interface Skeleton Plan
+
+## 1. Purpose
+
+This document defines the future controlled live V.I.K.I. runtime interface skeleton.
+
+This page is documentation-only and is not:
+
+- runtime implementation
+- endpoint implementation
+- network implementation
+- transport/authentication implementation
+- replay cache implementation
+- logging or telemetry implementation
+- observability runtime implementation
+- live V.I.K.I. integration
+
+This plan does not add secrets or credentials, does not process real KYC data, and does not authorize production use.
+
+This plan must be reviewed before any runtime interface PR is created.
+
+## 2. Current baseline
+
+The following controlled live pre-live gates already exist:
+
+- controlled live integration threat model
+- controlled live payload schema draft
+- controlled live transport/authentication design
+- controlled live replay protection and correlation-id design
+- controlled live redaction and observability design
+- controlled live payload schema fixture examples
+- controlled live failure-mode test plan
+- controlled live fixture validation plan
+- controlled live fixture validation test skeleton
+- controlled live failure-mode test skeleton
+- controlled live observability event taxonomy fixture plan
+- controlled live observability event fixture examples
+- controlled live observability event fixture validation test skeleton
+- controlled live integration implementation plan
+
+Current validated paths are offline, synthetic-fixture-only, and no-network.
+
+No runtime controlled live interface exists in this phase.
+
+No live V.I.K.I. integration exists in this phase.
+
+No production observability or telemetry pipeline exists in this phase.
+
+## 3. Runtime interface skeleton boundary
+
+Planned future interface boundary:
+
+static or controlled input object  
+→ disabled-by-default controlled live runtime interface  
+→ feature-flag gate  
+→ schema adapter boundary  
+→ fail-closed decision object  
+→ existing RSA-compatible downstream path remains unchanged
+
+The first runtime interface skeleton must not call live V.I.K.I.
+
+The first runtime interface skeleton must not create an API endpoint.
+
+The first runtime interface skeleton must not perform network I/O.
+
+The first runtime interface skeleton must not require credentials.
+
+The first runtime interface skeleton must not write logs or telemetry.
+
+The first runtime interface skeleton must not implement replay cache.
+
+The first runtime interface skeleton must not bypass existing evaluator logic.
+
+SAFE_PROCEED must never grant final commit approval.
+
+final_commit_approved must remain false unless a separate VERITAS commit gate approves.
+
+## 4. Planned interface responsibility
+
+The future runtime interface skeleton may define:
+
+- an input container for controlled live payload-like data
+- a disabled-by-default entry function
+- a feature-flag check
+- a fail-closed output shape
+- a handoff point to the future schema validation adapter
+- no-network default behavior
+- synthetic-input-only testability
+
+The future runtime interface skeleton must not define:
+
+- production HTTP endpoint
+- webhook endpoint
+- live V.I.K.I. client
+- transport authentication implementation
+- message integrity implementation
+- replay cache implementation
+- logging implementation
+- telemetry implementation
+- observability runtime implementation
+- production credentials
+- production endpoint URLs
+- real KYC processing
+- final commit automation
+
+## 5. Planned feature flag
+
+Primary planned flag:
+
+- VERITAS_CONTROLLED_LIVE_VIKI_ENABLE
+
+Rules:
+
+- Default must be disabled.
+- Missing flag must behave as disabled.
+- Empty flag must behave as disabled.
+- Unknown flag value must behave as disabled.
+- Disabled state must fail closed.
+- Enabling this flag must not by itself enable network calls.
+- Enabling this flag must not by itself enable live V.I.K.I.
+- Enabling this flag must not by itself enable production use.
+- Enabling this flag must not bypass tests, schema validation, replay validation, transport/authentication validation, redaction, observability constraints, or commit gate controls.
+
+## 6. Planned default-disabled behavior
+
+When the controlled live runtime interface is disabled, future behavior must return a deterministic fail-closed result:
+
+- veritas_continuation_decision: PAUSE_FOR_HUMAN_REVIEW
+- veritas_sandbox_commit_state: SUSPENDED_NOT_COMMITTED
+- final_commit_approved: false
+- required_next_action: REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE
+- veritas_reason_code: CONTROLLED_LIVE_DISABLED
+
+Disabled must not mean silently ignored.
+
+Disabled must not mean SAFE_PROCEED.
+
+Disabled must not mean final approval.
+
+Disabled must not call network.
+
+Disabled must not call live V.I.K.I.
+
+Disabled must not emit telemetry.
+
+Disabled must not persist raw input.
+
+## 7. Planned input boundary
+
+Future runtime interface input may include only controlled-live schema-compatible fields:
+
+- schema_version
+- rsa_status
+- trigger_source
+- timestamp
+- request_id
+- correlation_id
+- payload_issued_at
+- synthetic metadata needed for tests
+
+Input must not include:
+
+- chain_of_thought
+- hidden_model_state
+- raw_llm_reasoning
+- raw_viki_reasoning
+- raw_llm_text
+- raw_kyc_record
+- customer_pii
+- secrets
+- credentials
+- api_key
+- access_token
+- refresh_token
+- private_key
+- webhook_secret
+- raw_authorization_header
+- authorization
+- bearer_token
+- unredacted_regulated_data
+- raw_payload_body
+- raw_request_body
+- raw_response_body
+- raw_stack_trace_with_secrets
+
+## 8. Planned output boundary
+
+Future runtime interface output must be deterministic and redacted.
+
+Required output shape:
+
+- veritas_continuation_decision
+- veritas_reason_code
+- veritas_sandbox_commit_state
+- required_next_action
+- final_commit_approved
+- upstream_signal_source
+- request_id
+- correlation_id
+- schema_version
+- decision_source
+
+Rules:
+
+- final_commit_approved must default to false.
+- veritas_sandbox_commit_state must default to SUSPENDED_NOT_COMMITTED.
+- upstream_signal_source must remain "RSA".
+- output must not contain raw payload body.
+- output must not contain raw reasoning.
+- output must not contain KYC data.
+- output must not contain secrets.
+- output must not contain credentials.
+
+## 9. Planned fail-closed reason codes
+
+Draft reason codes:
+
+- CONTROLLED_LIVE_DISABLED
+- CONTROLLED_LIVE_UNSUPPORTED_SCHEMA_VERSION
+- CONTROLLED_LIVE_UNKNOWN_RSA_STATUS
+- CONTROLLED_LIVE_MISSING_REQUIRED_FIELD
+- CONTROLLED_LIVE_INVALID_TIMESTAMP
+- CONTROLLED_LIVE_FORBIDDEN_FIELD_PRESENT
+- CONTROLLED_LIVE_SECRET_LIKE_VALUE_PRESENT
+- CONTROLLED_LIVE_REGULATED_DATA_PRESENT
+- CONTROLLED_LIVE_REPLAY_DUPLICATE_REQUEST_ID
+- CONTROLLED_LIVE_REPLAY_CACHE_UNAVAILABLE
+- CONTROLLED_LIVE_TRANSPORT_AUTH_FAILED
+- CONTROLLED_LIVE_MESSAGE_INTEGRITY_FAILED
+- CONTROLLED_LIVE_UPSTREAM_TIMEOUT
+- CONTROLLED_LIVE_UPSTREAM_UNAVAILABLE
+- CONTROLLED_LIVE_UNEXPECTED_EXCEPTION
+
+These are draft runtime-interface reason codes.
+
+They must remain deterministic.
+
+They must not contain raw sensitive values.
+
+Any final mapping to core/errors.py must be reviewed in a later implementation PR.
+
+## 10. Compatibility preservation
+
+- rsa_status remains the v1 payload field.
+- RSASandboxPayload remains the downstream payload container.
+- evaluate_rsa_sandbox_signal() remains the downstream evaluator.
+- upstream_signal_source remains "RSA".
+- request_id and correlation_id are controlled-live schema/correlation fields, not replacements for rsa_status.
+- viki_status is not introduced in this phase.
+- VIKIPayload is not introduced in this phase.
+- Any naming migration must be handled separately as v2.
+
+## 11. Planned future file placement
+
+Actual file placement is not implemented by this PR.
+
+Possible future placement candidates:
+
+- veritas_os/governance/controlled_live_viki_interface.py
+- veritas_os/governance/controlled_live_viki_schema_adapter.py
+- veritas_os/governance/controlled_live_viki_decisions.py
+- tests/governance/test_controlled_live_viki_default_disabled.py
+- tests/governance/test_controlled_live_viki_schema_adapter.py
+
+These paths are planning candidates only.
+
+This PR must not create these runtime files.
+
+A later PR must confirm actual package layout before adding runtime code.
+
+## 12. Required test plan before runtime interface implementation
+
+Before runtime interface implementation, add a test-only PR for default-disabled behavior.
+
+Future tests should verify:
+
+- feature flag missing means disabled
+- feature flag empty means disabled
+- feature flag false means disabled
+- unknown flag value means disabled
+- disabled returns CONTROLLED_LIVE_DISABLED
+- disabled returns PAUSE_FOR_HUMAN_REVIEW
+- disabled returns SUSPENDED_NOT_COMMITTED
+- disabled returns final_commit_approved false
+- disabled does not call network
+- disabled does not require credentials
+- disabled does not import live client
+- disabled does not write telemetry
+- disabled does not persist raw payload
+- SAFE_PROCEED does not grant final commit approval
+
+## 13. Runtime interface implementation acceptance criteria
+
+A future runtime interface implementation PR must prove:
+
+- default disabled
+- no endpoint
+- no network call
+- no live V.I.K.I. client
+- no credentials
+- no production endpoint URL
+- no logging implementation
+- no telemetry implementation
+- no replay cache implementation
+- no observability runtime implementation
+- deterministic fail-closed output
+- final_commit_approved false by default
+- compatibility contract preserved
+- targeted tests pass
+- no dependency audit weakening
+
+## 14. Non-goals
+
+This plan does not permit:
+
+- runtime implementation
+- endpoint implementation
+- live V.I.K.I. integration
+- network calls
+- authentication implementation
+- replay cache implementation
+- logging implementation
+- telemetry implementation
+- observability runtime implementation
+- real KYC data processing
+- live customer data processing
+- live LLM text ingestion
+- raw V.I.K.I. reasoning ingestion
+- chain-of-thought storage
+- hidden model state storage
+- final commit automation based only on V.I.K.I.
+- bypass of VERITAS commit gate
+- secrets in repository
+- production AML/KYC compliance claims
+- regulatory approval claims
+- legal advice claims
+
+## 15. What this plan validates
+
+- runtime interface skeleton responsibility is defined
+- default-disabled behavior is specified
+- feature flag expectations are specified
+- input boundary is specified
+- output boundary is specified
+- fail-closed reason codes are drafted
+- compatibility contract is preserved
+- future file placement candidates are identified
+- default-disabled test plan is defined
+- no runtime implementation is introduced
+
+## 16. What this plan does not validate
+
+- it does not implement runtime code
+- it does not implement tests
+- it does not implement fixtures
+- it does not implement endpoints
+- it does not implement transport
+- it does not implement authentication
+- it does not implement replay cache
+- it does not implement logging
+- it does not implement telemetry
+- it does not implement observability runtime
+- it does not connect live V.I.K.I.
+- it does not process real KYC data
+- it does not authorize production deployment
+
+## 17. Recommended next PR after this plan
+
+The safest next PR is a test-only controlled live default-disabled behavior test skeleton.
+
+Recommended next PR title:
+
+`tests: add controlled live V.I.K.I. default-disabled behavior skeleton`

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -46,6 +46,8 @@ It consolidates the scenario map, demo plan, validation snapshots, and static fi
 27. [Controlled live V.I.K.I. observability event fixture examples (pre-live fixture artifact, fixture-and-documentation-only; no runtime/test/logging/telemetry/observability/live integration changes)](./rsa-veritas-controlled-live-viki-observability-event-fixture-examples.md)
 28. [Controlled live V.I.K.I. integration implementation plan (pre-live implementation-sequencing artifact, documentation-only; no runtime, tests, fixtures, logging implementation, telemetry implementation, observability runtime implementation, or live integration)](./rsa-veritas-controlled-live-viki-integration-implementation-plan.md)
 
+29. [Controlled live V.I.K.I. runtime interface skeleton plan (pre-live runtime-boundary artifact, documentation-only; no runtime code, tests, fixtures, endpoints, network calls, replay cache, logging implementation, telemetry implementation, observability runtime implementation, or live integration)](./rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md)
+
 All four static fixture variants now have dedicated per-variant validation snapshots.
 
 ## 4. Artifact map

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-integration-implementation-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-integration-implementation-plan.md
@@ -40,6 +40,7 @@ runtime integration PR を作成する前に、本計画のレビューを必須
 - controlled live observability event taxonomy fixture plan
 - controlled live observability event fixture examples
 - controlled live observability event fixture validation test skeleton
+- controlled live runtime interface skeleton plan
 
 現在の検証経路は offline・synthetic-fixture-only・no-network です。
 

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -1,0 +1,375 @@
+# RSA ↔ VERITAS Controlled Live V.I.K.I. Runtime Interface Skeleton Plan
+
+## 英語正本
+
+- [RSA ↔ VERITAS Controlled Live V.I.K.I. Runtime Interface Skeleton Plan](../../en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md)
+
+## 1. 目的
+
+本書は、将来導入する controlled live V.I.K.I. runtime interface skeleton の計画を定義します。
+
+これは documentation-only であり、以下を実装しません。
+
+- runtime implementation
+- endpoint implementation
+- network implementation
+- transport/authentication implementation
+- replay cache implementation
+- logging / telemetry implementation
+- observability runtime implementation
+- live V.I.K.I. integration
+
+本計画は secrets / credentials を追加せず、real KYC data を処理せず、production use を許可しません。
+
+runtime interface PR を作成する前に、本計画のレビューを必須とします。
+
+## 2. 現在の baseline
+
+以下の controlled live pre-live gates は既に存在します。
+
+- controlled live integration threat model
+- controlled live payload schema draft
+- controlled live transport/authentication design
+- controlled live replay protection and correlation-id design
+- controlled live redaction and observability design
+- controlled live payload schema fixture examples
+- controlled live failure-mode test plan
+- controlled live fixture validation plan
+- controlled live fixture validation test skeleton
+- controlled live failure-mode test skeleton
+- controlled live observability event taxonomy fixture plan
+- controlled live observability event fixture examples
+- controlled live observability event fixture validation test skeleton
+- controlled live integration implementation plan
+
+現在の検証経路は offline・synthetic-fixture-only・no-network です。
+
+この phase では runtime controlled live interface は存在しません。
+
+この phase では live V.I.K.I. integration は存在しません。
+
+この phase では production observability / telemetry pipeline は存在しません。
+
+## 3. Runtime interface skeleton boundary
+
+将来の interface boundary:
+
+static or controlled input object  
+→ disabled-by-default controlled live runtime interface  
+→ feature-flag gate  
+→ schema adapter boundary  
+→ fail-closed decision object  
+→ existing RSA-compatible downstream path remains unchanged
+
+最初の runtime interface skeleton は live V.I.K.I. を呼び出してはいけません。
+
+最初の runtime interface skeleton は API endpoint を作成してはいけません。
+
+最初の runtime interface skeleton は network I/O を実行してはいけません。
+
+最初の runtime interface skeleton は credentials を要求してはいけません。
+
+最初の runtime interface skeleton は logging / telemetry を書き込んではいけません。
+
+最初の runtime interface skeleton は replay cache を実装してはいけません。
+
+最初の runtime interface skeleton は既存 evaluator logic を bypass してはいけません。
+
+SAFE_PROCEED は final commit approval を決して付与してはいけません。
+
+別系統の VERITAS commit gate が承認しない限り、final_commit_approved は false を維持します。
+
+## 4. Planned interface responsibility
+
+将来の runtime interface skeleton が定義してよいもの:
+
+- controlled live payload-like data の input container
+- disabled-by-default entry function
+- feature flag check
+- fail-closed output shape
+- 将来の schema validation adapter への handoff point
+- no-network default behavior
+- synthetic-input-only testability
+
+将来の runtime interface skeleton が定義してはいけないもの:
+
+- production HTTP endpoint
+- webhook endpoint
+- live V.I.K.I. client
+- transport authentication implementation
+- message integrity implementation
+- replay cache implementation
+- logging implementation
+- telemetry implementation
+- observability runtime implementation
+- production credentials
+- production endpoint URLs
+- real KYC processing
+- final commit automation
+
+## 5. Planned feature flag
+
+Primary planned flag:
+
+- VERITAS_CONTROLLED_LIVE_VIKI_ENABLE
+
+ルール:
+
+- Default は disabled。
+- Missing flag は disabled として扱う。
+- Empty flag は disabled として扱う。
+- Unknown flag value は disabled として扱う。
+- Disabled state は fail closed。
+- この flag の有効化だけで network calls を有効化してはいけません。
+- この flag の有効化だけで live V.I.K.I. を有効化してはいけません。
+- この flag の有効化だけで production use を有効化してはいけません。
+- この flag の有効化だけで tests、schema validation、replay validation、transport/authentication validation、redaction、observability constraints、commit gate controls を bypass してはいけません。
+
+## 6. Planned default-disabled behavior
+
+controlled live runtime interface が disabled のとき、将来挙動は deterministic fail-closed result を返す必要があります。
+
+- veritas_continuation_decision: PAUSE_FOR_HUMAN_REVIEW
+- veritas_sandbox_commit_state: SUSPENDED_NOT_COMMITTED
+- final_commit_approved: false
+- required_next_action: REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE
+- veritas_reason_code: CONTROLLED_LIVE_DISABLED
+
+disabled は silent ignore を意味してはいけません。
+
+disabled は SAFE_PROCEED を意味してはいけません。
+
+disabled は final approval を意味してはいけません。
+
+disabled は network call を実行してはいけません。
+
+disabled は live V.I.K.I. を呼び出してはいけません。
+
+disabled は telemetry を emit してはいけません。
+
+disabled は raw input を永続化してはいけません。
+
+## 7. Planned input boundary
+
+将来の runtime interface input は、controlled-live schema-compatible fields のみ含めます。
+
+- schema_version
+- rsa_status
+- trigger_source
+- timestamp
+- request_id
+- correlation_id
+- payload_issued_at
+- tests に必要な synthetic metadata
+
+Input に含めてはいけないもの:
+
+- chain_of_thought
+- hidden_model_state
+- raw_llm_reasoning
+- raw_viki_reasoning
+- raw_llm_text
+- raw_kyc_record
+- customer_pii
+- secrets
+- credentials
+- api_key
+- access_token
+- refresh_token
+- private_key
+- webhook_secret
+- raw_authorization_header
+- authorization
+- bearer_token
+- unredacted_regulated_data
+- raw_payload_body
+- raw_request_body
+- raw_response_body
+- raw_stack_trace_with_secrets
+
+## 8. Planned output boundary
+
+将来の runtime interface output は deterministic かつ redacted でなければなりません。
+
+Required output shape:
+
+- veritas_continuation_decision
+- veritas_reason_code
+- veritas_sandbox_commit_state
+- required_next_action
+- final_commit_approved
+- upstream_signal_source
+- request_id
+- correlation_id
+- schema_version
+- decision_source
+
+Rules:
+
+- final_commit_approved の default は false。
+- veritas_sandbox_commit_state の default は SUSPENDED_NOT_COMMITTED。
+- upstream_signal_source は "RSA" を維持。
+- output は raw payload body を含めない。
+- output は raw reasoning を含めない。
+- output は KYC data を含めない。
+- output は secrets を含めない。
+- output は credentials を含めない。
+
+## 9. Planned fail-closed reason codes
+
+Draft reason codes:
+
+- CONTROLLED_LIVE_DISABLED
+- CONTROLLED_LIVE_UNSUPPORTED_SCHEMA_VERSION
+- CONTROLLED_LIVE_UNKNOWN_RSA_STATUS
+- CONTROLLED_LIVE_MISSING_REQUIRED_FIELD
+- CONTROLLED_LIVE_INVALID_TIMESTAMP
+- CONTROLLED_LIVE_FORBIDDEN_FIELD_PRESENT
+- CONTROLLED_LIVE_SECRET_LIKE_VALUE_PRESENT
+- CONTROLLED_LIVE_REGULATED_DATA_PRESENT
+- CONTROLLED_LIVE_REPLAY_DUPLICATE_REQUEST_ID
+- CONTROLLED_LIVE_REPLAY_CACHE_UNAVAILABLE
+- CONTROLLED_LIVE_TRANSPORT_AUTH_FAILED
+- CONTROLLED_LIVE_MESSAGE_INTEGRITY_FAILED
+- CONTROLLED_LIVE_UPSTREAM_TIMEOUT
+- CONTROLLED_LIVE_UPSTREAM_UNAVAILABLE
+- CONTROLLED_LIVE_UNEXPECTED_EXCEPTION
+
+これらは draft runtime-interface reason codes です。
+
+deterministic を維持し、raw sensitive values を含めてはいけません。
+
+core/errors.py への最終マッピングは、後続 implementation PR でレビューする必要があります。
+
+## 10. Compatibility preservation
+
+- rsa_status は v1 payload field として維持。
+- RSASandboxPayload は downstream payload container として維持。
+- evaluate_rsa_sandbox_signal() は downstream evaluator として維持。
+- upstream_signal_source は "RSA" を維持。
+- request_id / correlation_id は controlled-live schema/correlation fields であり、rsa_status の置換ではありません。
+- この phase では viki_status を導入しません。
+- この phase では VIKIPayload を導入しません。
+- 命名 migration は v2 として別 PR で扱います。
+
+## 11. Planned future file placement
+
+本 PR では actual file placement を実装しません。
+
+Possible future placement candidates:
+
+- veritas_os/governance/controlled_live_viki_interface.py
+- veritas_os/governance/controlled_live_viki_schema_adapter.py
+- veritas_os/governance/controlled_live_viki_decisions.py
+- tests/governance/test_controlled_live_viki_default_disabled.py
+- tests/governance/test_controlled_live_viki_schema_adapter.py
+
+これらは planning candidates のみです。
+
+本 PR で runtime files を作成してはいけません。
+
+後続 PR で実際の package layout を確定してから runtime code を追加します。
+
+## 12. Required test plan before runtime interface implementation
+
+runtime interface implementation の前に、default-disabled behavior 用の test-only PR を追加する必要があります。
+
+Future tests should verify:
+
+- feature flag missing means disabled
+- feature flag empty means disabled
+- feature flag false means disabled
+- unknown flag value means disabled
+- disabled returns CONTROLLED_LIVE_DISABLED
+- disabled returns PAUSE_FOR_HUMAN_REVIEW
+- disabled returns SUSPENDED_NOT_COMMITTED
+- disabled returns final_commit_approved false
+- disabled does not call network
+- disabled does not require credentials
+- disabled does not import live client
+- disabled does not write telemetry
+- disabled does not persist raw payload
+- SAFE_PROCEED does not grant final commit approval
+
+## 13. Runtime interface implementation acceptance criteria
+
+将来の runtime interface implementation PR は次を証明する必要があります。
+
+- default disabled
+- no endpoint
+- no network call
+- no live V.I.K.I. client
+- no credentials
+- no production endpoint URL
+- no logging implementation
+- no telemetry implementation
+- no replay cache implementation
+- no observability runtime implementation
+- deterministic fail-closed output
+- final_commit_approved false by default
+- compatibility contract preserved
+- targeted tests pass
+- no dependency audit weakening
+
+## 14. Non-goals
+
+本計画が許可しないもの:
+
+- runtime implementation
+- endpoint implementation
+- live V.I.K.I. integration
+- network calls
+- authentication implementation
+- replay cache implementation
+- logging implementation
+- telemetry implementation
+- observability runtime implementation
+- real KYC data processing
+- live customer data processing
+- live LLM text ingestion
+- raw V.I.K.I. reasoning ingestion
+- chain-of-thought storage
+- hidden model state storage
+- final commit automation based only on V.I.K.I.
+- bypass of VERITAS commit gate
+- secrets in repository
+- production AML/KYC compliance claims
+- regulatory approval claims
+- legal advice claims
+
+## 15. What this plan validates
+
+- runtime interface skeleton responsibility is defined
+- default-disabled behavior is specified
+- feature flag expectations are specified
+- input boundary is specified
+- output boundary is specified
+- fail-closed reason codes are drafted
+- compatibility contract is preserved
+- future file placement candidates are identified
+- default-disabled test plan is defined
+- no runtime implementation is introduced
+
+## 16. What this plan does not validate
+
+- it does not implement runtime code
+- it does not implement tests
+- it does not implement fixtures
+- it does not implement endpoints
+- it does not implement transport
+- it does not implement authentication
+- it does not implement replay cache
+- it does not implement logging
+- it does not implement telemetry
+- it does not implement observability runtime
+- it does not connect live V.I.K.I.
+- it does not process real KYC data
+- it does not authorize production deployment
+
+## 17. Recommended next PR after this plan
+
+最も安全な次 PR は、test-only の controlled live default-disabled behavior test skeleton です。
+
+Recommended next PR title:
+
+`tests: add controlled live V.I.K.I. default-disabled behavior skeleton`

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -52,6 +52,8 @@
 27. [Controlled live V.I.K.I. observability event fixture examples（pre-live fixture artifact、fixture-and-documentation-only / runtime・test・logging・telemetry・observability・live integration 変更なし）](./rsa-veritas-controlled-live-viki-observability-event-fixture-examples.md)
 28. [Controlled live V.I.K.I. integration implementation plan（pre-live 実装順序アーティファクト、documentation-only / runtime・tests・fixtures・logging implementation・telemetry implementation・observability runtime implementation・live integration 変更なし）](./rsa-veritas-controlled-live-viki-integration-implementation-plan.md)
 
+29. [Controlled live V.I.K.I. runtime interface skeleton plan（pre-live runtime boundary artifact、documentation-only / runtime code・tests・fixtures・endpoints・network calls・replay cache・logging implementation・telemetry implementation・observability runtime implementation・live integration 変更なし）](./rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md)
+
 4つの static fixture variants はすべて dedicated per-variant validation snapshots を持つ状態です。
 
 ## 4. Artifact map


### PR DESCRIPTION
### Motivation

- Provide the planned, documentation-only runtime interface skeleton for the controlled live V.I.K.I. flow so reviewers have a dedicated pre-live artifact describing boundaries, fail-closed behavior, and required review gates before any runtime code is introduced. 
- Make explicit that this is a documentation-only artifact that preserves the v1 compatibility contract (`rsa_status`, `RSASandboxPayload`, `evaluate_rsa_sandbox_signal()`, and `upstream_signal_source = "RSA"`) and that no runtime, network, credentials, tests, fixtures, or telemetry are added.

### Description

- Added English runtime-interface skeleton plan at `docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md` implementing the requested sections (purpose, current baseline, runtime boundary, responsibilities, feature-flag rules, default-disabled behavior, input/output boundaries, draft reason codes, compatibility preservation, future placement candidates, test plan, acceptance criteria, non-goals, and recommended next PR). 
- Added Japanese counterpart at `docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md` including the required `## 英語正本` link and preserving specified technical terms and enum values verbatim. 
- Updated reviewer index pages (`docs/en/guides/rsa-veritas-sandbox-reviewer-index.md` and `docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md`) to include the new runtime interface skeleton plan as a linked pre-live artifact using local links. 
- Updated the controlled live integration implementation plan (EN/JA) baseline artifact lists to reference the new runtime interface skeleton plan, and kept all changes strictly documentation-only without adding runtime files, tests, fixtures, endpoints, network calls, credentials, telemetry, or observability implementations.

### Testing

- Ran automated repository verification commands to confirm the new files exist and references were added, and all checks succeeded: `git status --short` showed the expected modified and created files, `rg` searches for key phrases (`runtime interface skeleton plan`, `英語正本`, `VERITAS_CONTROLLED_LIVE_VIKI_ENABLE`) matched the new content, and file content samples were printed via `nl | sed` to confirm sections were present. All verification commands completed successfully. 
- A commit operation was performed to record the documentation changes and completed successfully. 
- No unit tests or runtime test suites were modified or executed as this is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ae6eb7888326a28664cd481f0f15)