### PR TITLE
runtime: add disabled-by-default controlled live V.I.K.I. receiver interface

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -378,3 +378,9 @@ A test-only default-disabled behavior skeleton now exists at
 [`tests/governance/test_controlled_live_viki_default_disabled.py`](../../../tests/governance/test_controlled_live_viki_default_disabled.py).
 
 This addition is offline and synthetic-input-only, and does not introduce runtime behavior, endpoint behavior, network calls, credentials, replay cache implementation, logging implementation, telemetry implementation, observability runtime implementation, or live V.I.K.I. integration.
+
+## Runtime status update (2026-05-24)
+
+A first minimal runtime module now exists at `veritas_os/governance/controlled_live_viki_interface.py`, with runtime validation in `tests/governance/test_controlled_live_viki_runtime_interface.py`.
+
+This runtime interface is disabled by default and local in-process only. It does not introduce endpoint behavior, network behavior, live V.I.K.I. integration, credentials, replay cache, logging implementation, telemetry implementation, observability runtime, or production behavior.

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -125,3 +125,6 @@ No live V.I.K.I. connection should be added in this PR.
 Live integration should be a later design phase, not part of the static sandbox documentation pass.
 
 The live V.I.K.I. integration page in this set is a future-design artifact only and does not introduce runtime integration.
+
+31. [Controlled live V.I.K.I. runtime interface (disabled-by-default local in-process runtime only; no endpoint behavior, network behavior, live integration, credentials, replay cache, logging implementation, telemetry implementation, or observability runtime)](../../../veritas_os/governance/controlled_live_viki_interface.py)
+32. [Controlled live V.I.K.I. runtime interface tests (offline and deterministic fail-closed runtime validation)](../../../tests/governance/test_controlled_live_viki_runtime_interface.py)

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -380,3 +380,9 @@ test-only の default-disabled behavior skeleton は
 [`tests/governance/test_controlled_live_viki_default_disabled.py`](../../../tests/governance/test_controlled_live_viki_default_disabled.py) に追加済みです。
 
 この追加は offline / synthetic-input-only であり、runtime behavior、endpoint behavior、network calls、credentials、replay cache implementation、logging implementation、telemetry implementation、observability runtime implementation、live V.I.K.I. integration は導入しません。
+
+## Runtime status update (2026-05-24)
+
+最初の最小 runtime module は `veritas_os/governance/controlled_live_viki_interface.py` に追加され、runtime validation は `tests/governance/test_controlled_live_viki_runtime_interface.py` に追加されました。
+
+この runtime interface は disabled-by-default かつ local in-process only です。endpoint behavior / network behavior / live V.I.K.I. integration / credentials / replay cache / logging implementation / telemetry implementation / observability runtime / production behavior は導入していません。

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -131,3 +131,6 @@
 live integration は後続の design phase とし、静的 sandbox documentation pass には含めません。
 
 本索引に追加された live V.I.K.I. integration ページは将来設計アーティファクトのみであり、runtime integration は導入しません。
+
+31. [Controlled live V.I.K.I. runtime interface（disabled-by-default の local in-process runtime のみ。endpoint behavior・network behavior・live integration・credentials・replay cache・logging implementation・telemetry implementation・observability runtime を導入しない）](../../../veritas_os/governance/controlled_live_viki_interface.py)
+32. [Controlled live V.I.K.I. runtime interface tests（offline かつ deterministic fail-closed runtime validation）](../../../tests/governance/test_controlled_live_viki_runtime_interface.py)

--- a/tests/governance/test_controlled_live_viki_runtime_interface.py
+++ b/tests/governance/test_controlled_live_viki_runtime_interface.py
@@ -1,0 +1,137 @@
+"""Runtime tests for local disabled-by-default controlled live V.I.K.I. interface."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+_RUNTIME_MODULE_PATH = Path("veritas_os/governance/controlled_live_viki_interface.py")
+_RUNTIME_SPEC = importlib.util.spec_from_file_location(
+    "controlled_live_viki_interface",
+    _RUNTIME_MODULE_PATH,
+)
+assert _RUNTIME_SPEC is not None
+assert _RUNTIME_SPEC.loader is not None
+_RUNTIME_MODULE = importlib.util.module_from_spec(_RUNTIME_SPEC)
+_RUNTIME_SPEC.loader.exec_module(_RUNTIME_MODULE)
+
+is_controlled_live_viki_enabled = _RUNTIME_MODULE.is_controlled_live_viki_enabled
+receive_controlled_live_viki_payload = _RUNTIME_MODULE.receive_controlled_live_viki_payload
+
+
+EXPECTED_CONTINUATION = "PAUSE_FOR_HUMAN_REVIEW"
+EXPECTED_COMMIT_STATE = "SUSPENDED_NOT_COMMITTED"
+EXPECTED_NEXT_ACTION = "REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE"
+
+
+def test_runtime_interface_feature_flag_missing_is_disabled() -> None:
+    decision = receive_controlled_live_viki_payload(feature_flag_value=None)
+
+    assert decision["veritas_reason_code"] == "CONTROLLED_LIVE_DISABLED"
+    assert decision["veritas_continuation_decision"] == EXPECTED_CONTINUATION
+    assert decision["veritas_sandbox_commit_state"] == EXPECTED_COMMIT_STATE
+    assert decision["final_commit_approved"] is False
+
+
+def test_runtime_interface_feature_flag_empty_false_or_unknown_is_disabled() -> None:
+    disabled_values = ["", " ", "false", "0", "no", "off", "disabled", "TRUE", "True", "unexpected"]
+
+    for value in disabled_values:
+        assert is_controlled_live_viki_enabled(value) is False
+        decision = receive_controlled_live_viki_payload(feature_flag_value=value)
+        assert decision["veritas_reason_code"] == "CONTROLLED_LIVE_DISABLED"
+        assert decision["final_commit_approved"] is False
+        assert decision["veritas_continuation_decision"] != "SAFE_PROCEED"
+
+
+def test_runtime_interface_true_is_only_enabled_value_but_live_behavior_is_not_implemented() -> None:
+    assert is_controlled_live_viki_enabled("true") is True
+
+    decision = receive_controlled_live_viki_payload(feature_flag_value="true")
+    assert decision["veritas_reason_code"] == "CONTROLLED_LIVE_RUNTIME_NOT_IMPLEMENTED"
+    assert decision["veritas_continuation_decision"] == EXPECTED_CONTINUATION
+    assert decision["veritas_sandbox_commit_state"] == EXPECTED_COMMIT_STATE
+    assert decision["required_next_action"] == EXPECTED_NEXT_ACTION
+    assert decision["final_commit_approved"] is False
+
+
+def test_runtime_interface_disabled_decision_shape_is_deterministic() -> None:
+    decision = receive_controlled_live_viki_payload(feature_flag_value=None)
+
+    required_keys = {
+        "veritas_continuation_decision",
+        "veritas_reason_code",
+        "veritas_sandbox_commit_state",
+        "required_next_action",
+        "final_commit_approved",
+        "upstream_signal_source",
+        "request_id",
+        "correlation_id",
+        "schema_version",
+        "decision_source",
+    }
+    assert required_keys.issubset(decision.keys())
+
+
+def test_runtime_interface_preserves_synthetic_request_and_correlation_ids() -> None:
+    payload = {
+        "schema_version": "v1alpha1",
+        "rsa_status": "SAFE_PROCEED",
+        "request_id": "req_viki_runtime_001",
+        "correlation_id": "corr_viki_veritas_runtime_001",
+    }
+    decision = receive_controlled_live_viki_payload(payload=payload, feature_flag_value=None)
+
+    assert decision["request_id"] == "req_viki_runtime_001"
+    assert decision["correlation_id"] == "corr_viki_veritas_runtime_001"
+    assert decision["schema_version"] == "v1alpha1"
+    assert decision["final_commit_approved"] is False
+    assert decision["veritas_continuation_decision"] != "SAFE_PROCEED"
+
+
+def test_runtime_interface_does_not_emit_raw_payload_or_forbidden_fields() -> None:
+    payload = {
+        "request_id": "req_viki_runtime_002",
+        "correlation_id": "corr_viki_veritas_runtime_002",
+        "schema_version": "v1alpha1",
+        "chain_of_thought": "synthetic",
+        "raw_kyc_record": "synthetic",
+        "access_token": "synthetic",
+        "raw_payload_body": "synthetic",
+    }
+    decision = receive_controlled_live_viki_payload(payload=payload, feature_flag_value=None)
+
+    assert decision["veritas_reason_code"] == "CONTROLLED_LIVE_DISABLED"
+    assert decision["final_commit_approved"] is False
+    for forbidden_key in ("chain_of_thought", "raw_kyc_record", "access_token", "raw_payload_body"):
+        assert forbidden_key not in decision
+
+
+def test_runtime_interface_module_is_no_network_no_endpoint_no_telemetry() -> None:
+    source = _RUNTIME_MODULE_PATH.read_text(encoding="utf-8")
+    module = ast.parse(source)
+
+    disallowed_import_roots = {"requests", "httpx", "urllib", "socket", "opentelemetry", "sentry_sdk"}
+
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                assert root not in disallowed_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".")[0]
+            assert root not in disallowed_import_roots
+
+    lowered_source = source.lower()
+    forbidden_strings = [
+        "fastapi",
+        "flask",
+        "viki_live_client",
+        "api" + "_" + "key",
+        "bearer" + " ",
+        "http" + "://",
+        "https" + "://",
+    ]
+    for token in forbidden_strings:
+        assert token not in lowered_source

--- a/veritas_os/governance/controlled_live_viki_interface.py
+++ b/veritas_os/governance/controlled_live_viki_interface.py
@@ -1,0 +1,88 @@
+"""Local disabled-by-default runtime interface for controlled live V.I.K.I.
+
+This module intentionally provides only an in-process fail-closed interface.
+It does not implement endpoint, network, credential, replay cache, logging,
+telemetry, or live V.I.K.I. integration behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+CONTROLLED_LIVE_VIKI_FEATURE_FLAG = "VERITAS_CONTROLLED_LIVE_VIKI_ENABLE"
+
+_DISABLED_REASON_CODE = "CONTROLLED_LIVE_DISABLED"
+_NOT_IMPLEMENTED_REASON_CODE = "CONTROLLED_LIVE_RUNTIME_NOT_IMPLEMENTED"
+_REQUIRED_NEXT_ACTION = "REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE"
+_DEFAULT_REQUEST_ID = "req_viki_disabled_001"
+_DEFAULT_CORRELATION_ID = "corr_viki_veritas_disabled_001"
+_DEFAULT_SCHEMA_VERSION = "v1alpha1"
+
+
+def is_controlled_live_viki_enabled(value: str | None) -> bool:
+    """Return True only when the feature flag value is exactly ``"true"``."""
+    return value == "true"
+
+
+def _extract_string_field(
+    payload: Mapping[str, object] | None,
+    field_name: str,
+    default_value: str,
+) -> str:
+    if payload is None:
+        return default_value
+    raw_value = payload.get(field_name)
+    if isinstance(raw_value, str) and raw_value.strip():
+        return raw_value
+    return default_value
+
+
+def build_controlled_live_viki_disabled_decision(
+    request_id: str = _DEFAULT_REQUEST_ID,
+    correlation_id: str = _DEFAULT_CORRELATION_ID,
+    schema_version: str = _DEFAULT_SCHEMA_VERSION,
+) -> dict[str, object]:
+    """Build the deterministic fail-closed decision for disabled state."""
+    return {
+        "veritas_continuation_decision": "PAUSE_FOR_HUMAN_REVIEW",
+        "veritas_sandbox_commit_state": "SUSPENDED_NOT_COMMITTED",
+        "final_commit_approved": False,
+        "required_next_action": _REQUIRED_NEXT_ACTION,
+        "veritas_reason_code": _DISABLED_REASON_CODE,
+        "upstream_signal_source": "RSA",
+        "request_id": request_id,
+        "correlation_id": correlation_id,
+        "schema_version": schema_version,
+        "decision_source": "controlled_live_viki_disabled_runtime_interface",
+    }
+
+
+def receive_controlled_live_viki_payload(
+    payload: Mapping[str, object] | None = None,
+    *,
+    feature_flag_value: str | None = None,
+) -> dict[str, object]:
+    """Receive a local payload and return deterministic fail-closed decisions."""
+    request_id = _extract_string_field(payload, "request_id", _DEFAULT_REQUEST_ID)
+    correlation_id = _extract_string_field(
+        payload,
+        "correlation_id",
+        _DEFAULT_CORRELATION_ID,
+    )
+    schema_version = _extract_string_field(
+        payload,
+        "schema_version",
+        _DEFAULT_SCHEMA_VERSION,
+    )
+
+    decision = build_controlled_live_viki_disabled_decision(
+        request_id=request_id,
+        correlation_id=correlation_id,
+        schema_version=schema_version,
+    )
+    if not is_controlled_live_viki_enabled(feature_flag_value):
+        return decision
+
+    decision["veritas_reason_code"] = _NOT_IMPLEMENTED_REASON_CODE
+    decision["decision_source"] = "controlled_live_viki_runtime_interface_not_implemented"
+    return decision


### PR DESCRIPTION
### Motivation

- Provide the first minimal in-process runtime interface for the controlled live V.I.K.I. path while keeping the runtime disabled-by-default and fail-closed to avoid any accidental live integration or network behavior.  
- Preserve existing RSA-compatible downstream contract and avoid touching `RSASandboxPayload`, `rsa_status`, or `evaluate_rsa_sandbox_signal()` so v1 compatibility remains unchanged.  
- Keep the change extremely small and reviewable as the initial runtime step before any live or networked implementation.

### Description

- Added a new runtime module `veritas_os/governance/controlled_live_viki_interface.py` exposing `CONTROLLED_LIVE_VIKI_FEATURE_FLAG`, `is_controlled_live_viki_enabled`, `build_controlled_live_viki_disabled_decision`, and `receive_controlled_live_viki_payload`, with deterministic fail-closed behavior when disabled.  
- Implemented strict feature-flag semantics where only the exact string `"true"` is treated as enabled; all other values (missing, empty, `"false"`, `"0"`, `"no"`, `"off"`, `"disabled"`, `"TRUE"`, `"True"`, unknown values) are treated as disabled.  
- When disabled the module returns a deterministic fail-closed decision containing the required fields (`veritas_continuation_decision`, `veritas_reason_code`, `veritas_sandbox_commit_state`, `required_next_action`, `final_commit_approved`, `upstream_signal_source`, `request_id`, `correlation_id`, `schema_version`, `decision_source`), and when feature flag is exactly `"true"` the module still returns a deterministic not-implemented fail-closed result (`CONTROLLED_LIVE_RUNTIME_NOT_IMPLEMENTED`) rather than performing any live behavior.  
- Added runtime tests at `tests/governance/test_controlled_live_viki_runtime_interface.py` that validate flag handling, decision shape, request/correlation/schema propagation, forbidden-field non-emission, and static source checks to ensure no network/endpoint/telemetry imports or strings.  
- Updated English/Japanese guide docs to note that the disabled-by-default local runtime interface now exists and remains local/in-process only and non-network/non-endpoint.

### Testing

- Ran `pytest -q tests/governance/test_controlled_live_viki_default_disabled.py tests/governance/test_controlled_live_viki_runtime_interface.py` and observed the test run complete successfully (`16 passed, 1 warning`).  
- Ran the wider target set `pytest -q tests/governance/test_controlled_live_viki_fixture_validation.py tests/governance/test_controlled_live_viki_failure_modes.py tests/governance/test_controlled_live_viki_observability_event_fixtures.py tests/governance/test_controlled_live_viki_default_disabled.py tests/governance/test_controlled_live_viki_runtime_interface.py` and observed successful completion (`38 passed, 1 warning`).  
- All added tests pass and the runtime module has no network/imports/endpoint code per the static inspection tests included in the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1312d5424883269aa3845caa31bb3c)