### PR TITLE
tests: add controlled live V.I.K.I. receiver schema-adapter wiring skeleton

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -399,3 +399,11 @@ A local, pure, offline runtime schema adapter now exists at `veritas_os/governan
 This adapter adds deterministic payload classification and fail-closed decision construction only. It does not add endpoint behavior, network behavior, live V.I.K.I. integration, credentials, replay cache implementation, logging implementation, telemetry implementation, observability runtime, or production behavior.
 
 `SAFE_PROCEED` remains only an upstream signal, and adapter fail-closed decisions keep `final_commit_approved` as `false`.
+
+## Receiver-to-schema-adapter wiring behavior test skeleton status
+
+A **test-only** receiver schema-adapter wiring behavior skeleton now exists at `tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py`.
+
+It is intentionally offline and synthetic-fixture-only, does **not** wire runtime behavior yet, and does **not** add endpoint behavior, network behavior, live V.I.K.I. integration, credentials, replay cache implementation, logging implementation, telemetry implementation, observability runtime, or production behavior.
+
+SAFE_PROCEED remains an upstream signal only, and `final_commit_approved` remains `false` in this skeleton.

--- a/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/en/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -133,3 +133,5 @@ The live V.I.K.I. integration page in this set is a future-design artifact only 
 
 33. [Controlled live V.I.K.I. runtime schema adapter (local/pure/offline only; no endpoint, network, live integration, credentials, replay cache implementation, logging implementation, telemetry implementation, or observability runtime)](../../../veritas_os/governance/controlled_live_viki_schema_adapter.py)
 34. [Controlled live V.I.K.I. runtime schema adapter tests (fixture-driven deterministic runtime validation)](../../../tests/governance/test_controlled_live_viki_schema_adapter_runtime.py)
+
+- Receiver schema-adapter wiring behavior test skeleton (test-only, offline, no runtime wiring): `tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py`

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -401,3 +401,11 @@ test-only の schema adapter behavior skeleton は
 この adapter が追加するのは deterministic な payload classification と fail-closed decision 構築のみです。endpoint behavior・network behavior・live V.I.K.I. integration・credentials・replay cache implementation・logging implementation・telemetry implementation・observability runtime・production behavior は追加しません。
 
 `SAFE_PROCEED` は upstream signal のままであり、adapter の fail-closed decision では `final_commit_approved` は常に `false` のままです。
+
+## Receiver から schema adapter への wiring behavior test skeleton の状態
+
+`tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py` に **test-only** の receiver schema-adapter wiring behavior skeleton が追加されています。
+
+この skeleton は意図的に offline / synthetic fixture 専用であり、runtime behavior の wiring はまだ実装していません。endpoint behavior、network behavior、live V.I.K.I. integration、credentials、replay cache implementation、logging implementation、telemetry implementation、observability runtime、production behavior は追加していません。
+
+SAFE_PROCEED は upstream signal のままであり、この skeleton でも `final_commit_approved` は `false` のままです。

--- a/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
+++ b/docs/ja/guides/rsa-veritas-sandbox-reviewer-index.md
@@ -139,3 +139,5 @@ live integration は後続の design phase とし、静的 sandbox documentation
 
 33. [Controlled live V.I.K.I. runtime schema adapter (local/pure/offline only; no endpoint, network, live integration, credentials, replay cache implementation, logging implementation, telemetry implementation, or observability runtime)](../../../veritas_os/governance/controlled_live_viki_schema_adapter.py)
 34. [Controlled live V.I.K.I. runtime schema adapter tests (fixture-driven deterministic runtime validation)](../../../tests/governance/test_controlled_live_viki_schema_adapter_runtime.py)
+
+- Receiver schema-adapter wiring behavior test skeleton（test-only / offline / runtime wiring なし）: `tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py`

--- a/tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py
+++ b/tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py
@@ -201,7 +201,10 @@ def test_receiver_schema_adapter_wiring_behavior_skeleton_is_offline_static_and_
         if isinstance(node, ast.ImportFrom) and node.module:
             assert node.module.split(".")[0] not in disallowed_import_roots
 
-    lowered = source.lower()
+    precheck_source = source.split(
+        "def test_receiver_schema_adapter_wiring_behavior_skeleton_is_offline_static_and_no_network",
+        maxsplit=1,
+    )[0].lower()
     forbidden_literals = [
         "http" + "://",
         "https" + "://",
@@ -213,7 +216,7 @@ def test_receiver_schema_adapter_wiring_behavior_skeleton_is_offline_static_and_
         "live_viki_client",
     ]
     for token in forbidden_literals:
-        assert token not in lowered
+        assert token not in precheck_source
 
 
 def test_receiver_schema_adapter_wiring_behavior_skeleton_does_not_modify_runtime_modules() -> None:

--- a/tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py
+++ b/tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py
@@ -1,0 +1,226 @@
+"""Test-only future wiring skeleton for receiver-to-schema-adapter behavior.
+
+This module is intentionally offline and synthetic-fixture-only.
+It does not implement runtime wiring, endpoint behavior, network behavior,
+live V.I.K.I. integration, credentials, replay cache infrastructure, logging,
+telemetry, observability runtime, or production behavior.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from veritas_os.governance.controlled_live_viki_interface import (
+    build_controlled_live_viki_disabled_decision,
+    is_controlled_live_viki_enabled,
+)
+from veritas_os.governance.controlled_live_viki_schema_adapter import (
+    ADAPTER_INVALID_JSON_OBJECT,
+    ADAPTER_VALID,
+    build_controlled_live_viki_schema_fail_closed_decision,
+    classify_controlled_live_viki_schema_input,
+    controlled_live_viki_reason_code_for_classification,
+)
+
+
+def _load_payload_fixture(name: str) -> dict:
+    fixture_dir = Path(__file__).resolve().parent.parent / "fixtures" / "controlled_live_viki_payload_schema"
+    return json.loads((fixture_dir / name).read_text(encoding="utf-8"))
+
+
+def _future_receiver_schema_adapter_wiring_decision(
+    payload: object,
+    *,
+    feature_flag_value: str | None,
+    seen_request_ids: dict[str, str] | None = None,
+) -> dict:
+    """Model the expected future wiring contract without implementing runtime wiring."""
+    if not is_controlled_live_viki_enabled(feature_flag_value):
+        if isinstance(payload, dict):
+            return build_controlled_live_viki_disabled_decision(
+                request_id=str(payload.get("request_id") or "req_viki_disabled_001"),
+                correlation_id=str(payload.get("correlation_id") or "corr_viki_veritas_disabled_001"),
+                schema_version=str(payload.get("schema_version") or "v1alpha1"),
+            )
+        return build_controlled_live_viki_disabled_decision()
+
+    classification = classify_controlled_live_viki_schema_input(payload, seen_request_ids=seen_request_ids)
+    if classification != ADAPTER_VALID:
+        reason_code = controlled_live_viki_reason_code_for_classification(classification)
+        if reason_code is None:
+            reason_code = "CONTROLLED_LIVE_INVALID_JSON_OBJECT"
+        return build_controlled_live_viki_schema_fail_closed_decision(reason_code)
+
+    valid_reason_code = "CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED"
+    return build_controlled_live_viki_schema_fail_closed_decision(valid_reason_code)
+
+
+def test_receiver_schema_adapter_wiring_disabled_flag_preserves_existing_receiver_fail_closed_behavior() -> None:
+    payload = _load_payload_fixture("valid_safe_proceed_v1alpha1.json")
+    disabled_values = [None, "", " ", "false", "0", "no", "off", "disabled", "TRUE", "True", "unexpected"]
+
+    for feature_flag_value in disabled_values:
+        result = _future_receiver_schema_adapter_wiring_decision(
+            payload,
+            feature_flag_value=feature_flag_value,
+        )
+        assert result["veritas_reason_code"] == "CONTROLLED_LIVE_DISABLED"
+        assert result["veritas_continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+        assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+        assert result["final_commit_approved"] is False
+        assert result["veritas_reason_code"] != "SAFE_PROCEED"
+        dumped = json.dumps(result)
+        assert "raw_payload_body" not in dumped
+
+
+def test_receiver_schema_adapter_wiring_true_flag_invalid_payloads_fail_closed_by_schema_adapter() -> None:
+    fixtures = [
+        "invalid_unknown_rsa_status_v1alpha1.json",
+        "invalid_missing_request_id_v1alpha1.json",
+        "invalid_missing_correlation_id_v1alpha1.json",
+        "invalid_forbidden_chain_of_thought_v1alpha1.json",
+        "invalid_secret_access_token_v1alpha1.json",
+        "invalid_raw_kyc_record_v1alpha1.json",
+        "invalid_naive_timestamp_v1alpha1.json",
+        "invalid_payload_issued_at_future_skew_v1alpha1.json",
+        "invalid_unsupported_schema_version.json",
+    ]
+
+    for fixture_name in fixtures:
+        result = _future_receiver_schema_adapter_wiring_decision(
+            _load_payload_fixture(fixture_name),
+            feature_flag_value="true",
+        )
+        assert str(result["reason_code"]).startswith("CONTROLLED_LIVE_")
+        assert result["reason_code"] != "CONTROLLED_LIVE_DISABLED"
+        assert result["reason_code"] != "SAFE_PROCEED"
+        assert result["veritas_continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+        assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+        assert result["final_commit_approved"] is False
+        assert result["upstream_signal_source"] == "RSA"
+        dumped = json.dumps(result)
+        assert "raw_payload_body" not in dumped
+
+
+def test_receiver_schema_adapter_wiring_true_flag_valid_safe_proceed_remains_not_final_approval() -> None:
+    payload = _load_payload_fixture("valid_safe_proceed_v1alpha1.json")
+    classification = classify_controlled_live_viki_schema_input(payload)
+    result = _future_receiver_schema_adapter_wiring_decision(payload, feature_flag_value="true")
+
+    assert classification == ADAPTER_VALID
+    assert payload["rsa_status"] == "SAFE_PROCEED"
+    assert result["reason_code"] in {
+        "CONTROLLED_LIVE_RUNTIME_NOT_IMPLEMENTED",
+        "CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED",
+    }
+    assert result["final_commit_approved"] is False
+    assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert result["veritas_continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["veritas_continuation_decision"] != "CONTINUE_TO_BIND_BOUNDARY"
+
+
+def test_receiver_schema_adapter_wiring_true_flag_valid_non_safe_proceed_statuses_remain_not_final_approval() -> None:
+    fixtures = [
+        "valid_density_throttled_v1alpha1.json",
+        "valid_algorithmic_humility_engaged_v1alpha1.json",
+        "valid_deferral_engaged_v1alpha1.json",
+    ]
+    for fixture_name in fixtures:
+        payload = _load_payload_fixture(fixture_name)
+        classification = classify_controlled_live_viki_schema_input(payload)
+        result = _future_receiver_schema_adapter_wiring_decision(payload, feature_flag_value="true")
+
+        assert classification == ADAPTER_VALID
+        assert result["final_commit_approved"] is False
+        assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+        assert result["reason_code"] == "CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED"
+
+
+def test_receiver_schema_adapter_wiring_duplicate_request_id_fails_closed() -> None:
+    scenario_a = _load_payload_fixture("invalid_duplicate_request_id_scenario_a_v1alpha1.json")
+    scenario_b = _load_payload_fixture("invalid_duplicate_request_id_scenario_b_v1alpha1.json")
+    seen_request_ids: dict[str, str] = {}
+
+    first_result = _future_receiver_schema_adapter_wiring_decision(
+        scenario_a,
+        feature_flag_value="true",
+        seen_request_ids=seen_request_ids,
+    )
+    second_result = _future_receiver_schema_adapter_wiring_decision(
+        scenario_b,
+        feature_flag_value="true",
+        seen_request_ids=seen_request_ids,
+    )
+
+    assert first_result["final_commit_approved"] is False
+    assert second_result["reason_code"] == "CONTROLLED_LIVE_REPLAY_DUPLICATE_REQUEST_ID"
+    assert second_result["final_commit_approved"] is False
+    assert second_result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert len(seen_request_ids) == 1
+
+
+def test_receiver_schema_adapter_wiring_forbidden_secret_and_kyc_fields_are_not_echoed() -> None:
+    fixtures = [
+        "invalid_forbidden_chain_of_thought_v1alpha1.json",
+        "invalid_secret_access_token_v1alpha1.json",
+        "invalid_raw_kyc_record_v1alpha1.json",
+    ]
+    for fixture_name in fixtures:
+        result = _future_receiver_schema_adapter_wiring_decision(
+            _load_payload_fixture(fixture_name),
+            feature_flag_value="true",
+        )
+        dumped = json.dumps(result)
+        assert result["final_commit_approved"] is False
+        assert "chain_of_thought" not in dumped
+        assert "raw_kyc_record" not in dumped
+        assert "access_token" not in dumped
+        assert "raw_payload_body" not in dumped
+
+
+def test_receiver_schema_adapter_wiring_rejects_non_object_payloads() -> None:
+    for payload in (None, [], "not-json-object", 123):
+        result = _future_receiver_schema_adapter_wiring_decision(payload, feature_flag_value="true")
+        assert result["reason_code"] == "CONTROLLED_LIVE_INVALID_JSON_OBJECT"
+        assert result["final_commit_approved"] is False
+        assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+
+
+def test_receiver_schema_adapter_wiring_behavior_skeleton_is_offline_static_and_no_network() -> None:
+    source_path = Path(__file__)
+    source = source_path.read_text(encoding="utf-8")
+    module = ast.parse(source)
+
+    disallowed_import_roots = {"requests", "httpx", "urllib", "socket"}
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in disallowed_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in disallowed_import_roots
+
+    lowered = source.lower()
+    forbidden_literals = [
+        "http" + "://",
+        "https" + "://",
+        "bear" + "er" + " ",
+        "api" + "_" + "key=",
+        "telemetrysdk",
+        "fastapi",
+        "flask",
+        "live_viki_client",
+    ]
+    for token in forbidden_literals:
+        assert token not in lowered
+
+
+def test_receiver_schema_adapter_wiring_behavior_skeleton_does_not_modify_runtime_modules() -> None:
+    interface_source = Path("veritas_os/governance/controlled_live_viki_interface.py").read_text(encoding="utf-8")
+    adapter_source = Path("veritas_os/governance/controlled_live_viki_schema_adapter.py").read_text(encoding="utf-8")
+
+    assert "receive_controlled_live_viki_payload" in interface_source
+    assert "classify_controlled_live_viki_schema_input" in adapter_source
+    assert "live_viki_client" not in interface_source.lower()
+    assert "live_viki_client" not in adapter_source.lower()


### PR DESCRIPTION
### Motivation

- Provide a test-only, offline skeleton that models the expected future wiring contract between the disabled-by-default receiver interface and the runtime schema adapter without implementing runtime wiring. 
- Capture expected fail-closed and not-ready behaviors (disabled flag, invalid payloads, SAFE_PROCEED semantics, duplicate request-id handling, forbidden-field redaction) to lock down policy before any live wiring is added. 
- Maintain safety: this change intentionally adds no network, endpoint, credential, telemetry, logging, replay-cache, or production behavior and does not process real KYC; treat future wiring as a security-sensitive step that requires human review. 

### Description

- Add a new test-only file `tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py` that defines `_load_payload_fixture()` and `_future_receiver_schema_adapter_wiring_decision()` as local helpers and implements the wiring behavior skeleton tests. 
- Implement tests that exercise disabled-flag behavior, invalid-payload fail-closed mapping, SAFE_PROCEED non-final-approval semantics, non-SAFE_PROCEED valid statuses remaining not-final, duplicate request-id handling via caller-owned `seen_request_ids`, forbidden/secret/KYC redaction checks, non-object payload rejection, static offline/no-network AST/source checks, and structural assertions that runtime modules are not modified or imported. 
- Update documentation entries in English and Japanese to note the presence of this test-only wiring skeleton and to explicitly state that it remains offline, synthetic-fixture-only, and does not wire runtime behavior or add network/endpoints/credentials/logging/telemetry/observability/replay caches or live V.I.K.I. integration. 
- No runtime code was changed and no production helpers, endpoints, network libraries, or credentials were added. The PR only adds tests and minimal docs index notes. 

### Testing

- Attempted to run the targeted test: `pytest -q tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py`, but the environment default interpreter configuration prevented `pytest` from running. (pyenv default mismatch). 
- Re-ran under a compatible interpreter with `PYENV_VERSION=3.12.13 pytest -q tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py`; test collection failed due to a missing dependency: `ModuleNotFoundError: No module named 'yaml'`, so the tests could not be executed in this runner. 
- Also attempted a broader governance test run (`PYENV_VERSION=3.12.13 pytest -q tests/governance/test_controlled_live_viki_default_disabled.py tests/governance/test_controlled_live_viki_runtime_interface.py tests/governance/test_controlled_live_viki_schema_adapter_behavior.py tests/governance/test_controlled_live_viki_schema_adapter_runtime.py tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py`) and collection failed with the same missing `yaml` dependency. 

All automated test attempts in the current environment failed during collection due to the missing `yaml` package; the new test file itself is offline, imports only stdlib plus the existing runtime interface and schema adapter modules, and is designed to be deterministic and non-networked when run in a properly provisioned test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1405ad71408326aab36ad42c8d8d4d)