### PR TITLE
runtime: wire controlled live V.I.K.I. receiver to schema adapter

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -19,6 +19,24 @@ This plan does not add secrets or credentials, does not process real KYC data, a
 
 This plan must be reviewed before any runtime interface PR is created.
 
+## Runtime wiring status (current)
+
+The runtime receiver is now wired to the local schema adapter in runtime code, but it remains fail-closed and not-ready:
+
+- Runtime receiver: `veritas_os/governance/controlled_live_viki_interface.py`
+- Runtime schema adapter: `veritas_os/governance/controlled_live_viki_schema_adapter.py`
+- Runtime wiring tests: `tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_runtime.py`
+
+Behavior summary:
+
+- Feature flag disabled (anything except exact `"true"`) still returns `CONTROLLED_LIVE_DISABLED`.
+- Feature flag `"true"` runs schema adapter validation only.
+- Valid schema payloads return `CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED`.
+- Invalid schema payloads fail closed using schema-adapter reason-code mapping.
+- `SAFE_PROCEED` remains an upstream signal only and `final_commit_approved` remains `false`.
+
+This runtime wiring remains local/offline and does not add endpoint behavior, network behavior, live V.I.K.I. integration, credentials, replay cache implementation, logging implementation, telemetry implementation, observability runtime, or production behavior.
+
 ## 2. Current baseline
 
 The following controlled live pre-live gates already exist:

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -23,6 +23,24 @@
 
 runtime interface PR を作成する前に、本計画のレビューを必須とします。
 
+## Runtime wiring status（現状）
+
+runtime receiver は runtime code 上で local schema adapter に接続済みですが、fail-closed / not-ready を維持しています。
+
+- Runtime receiver: `veritas_os/governance/controlled_live_viki_interface.py`
+- Runtime schema adapter: `veritas_os/governance/controlled_live_viki_schema_adapter.py`
+- Runtime wiring tests: `tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_runtime.py`
+
+挙動サマリ:
+
+- feature flag が厳密一致 `"true"` 以外の場合、`CONTROLLED_LIVE_DISABLED` を維持。
+- feature flag が `"true"` の場合、schema adapter validation のみ実行。
+- 有効な schema payload は `CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED` を返す。
+- 無効な schema payload は schema adapter の reason code mapping で fail-closed。
+- `SAFE_PROCEED` は upstream signal のままで、`final_commit_approved` は `false` のまま。
+
+この runtime wiring は local/offline の範囲に限定され、endpoint behavior、network behavior、live V.I.K.I. integration、credentials、replay cache implementation、logging implementation、telemetry implementation、observability runtime、production behavior は追加しません。
+
 ## 2. 現在の baseline
 
 以下の controlled live pre-live gates は既に存在します。

--- a/tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_runtime.py
+++ b/tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_runtime.py
@@ -196,10 +196,16 @@ def test_receiver_schema_adapter_runtime_wiring_module_is_no_network_no_endpoint
 
 def test_receiver_schema_adapter_runtime_wiring_does_not_touch_downstream_contract() -> None:
     interface_source = Path("veritas_os/governance/controlled_live_viki_interface.py").read_text(encoding="utf-8")
+    adapter_source = Path("veritas_os/governance/controlled_live_viki_schema_adapter.py").read_text(
+        encoding="utf-8",
+    )
+    payload = _load_payload_fixture("valid_safe_proceed_v1alpha1.json")
 
     assert "viki_status" not in interface_source
     assert "VIKIPayload" not in interface_source
-    assert "rsa_status" in interface_source
+    assert "rsa_status" in adapter_source
+    assert payload["rsa_status"] == "SAFE_PROCEED"
+    assert classify_controlled_live_viki_schema_input(payload) == ADAPTER_VALID
 
     result = receive_controlled_live_viki_payload(feature_flag_value=None)
     assert result["upstream_signal_source"] == "RSA"

--- a/tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_runtime.py
+++ b/tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_runtime.py
@@ -1,0 +1,205 @@
+"""Runtime wiring tests for controlled live V.I.K.I. receiver + schema adapter.
+
+This suite verifies local/offline fail-closed wiring only.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from veritas_os.governance.controlled_live_viki_interface import (
+    receive_controlled_live_viki_payload,
+)
+from veritas_os.governance.controlled_live_viki_schema_adapter import (
+    ADAPTER_VALID,
+    classify_controlled_live_viki_schema_input,
+)
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "controlled_live_viki_payload_schema"
+
+
+def _load_payload_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _reason_code(result: dict[str, object]) -> str:
+    return str(result.get("reason_code") or result.get("veritas_reason_code") or "")
+
+
+def test_receiver_schema_adapter_runtime_wiring_disabled_flag_preserves_existing_fail_closed_behavior() -> None:
+    payload = _load_payload_fixture("valid_safe_proceed_v1alpha1.json")
+    disabled_values = [None, "", " ", "false", "0", "no", "off", "disabled", "TRUE", "True", "unexpected"]
+
+    for value in disabled_values:
+        result = receive_controlled_live_viki_payload(payload, feature_flag_value=value)
+        assert _reason_code(result) == "CONTROLLED_LIVE_DISABLED"
+        assert result["veritas_continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+        assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+        assert result["final_commit_approved"] is False
+        assert result["veritas_continuation_decision"] != "SAFE_PROCEED"
+        dumped = json.dumps(result)
+        assert "raw_payload_body" not in dumped
+
+
+def test_receiver_schema_adapter_runtime_wiring_true_flag_invalid_payloads_fail_closed_by_schema_adapter() -> None:
+    fixtures = [
+        "invalid_unknown_rsa_status_v1alpha1.json",
+        "invalid_missing_request_id_v1alpha1.json",
+        "invalid_missing_correlation_id_v1alpha1.json",
+        "invalid_forbidden_chain_of_thought_v1alpha1.json",
+        "invalid_secret_access_token_v1alpha1.json",
+        "invalid_raw_kyc_record_v1alpha1.json",
+        "invalid_naive_timestamp_v1alpha1.json",
+        "invalid_payload_issued_at_future_skew_v1alpha1.json",
+        "invalid_unsupported_schema_version.json",
+    ]
+
+    for fixture_name in fixtures:
+        result = receive_controlled_live_viki_payload(
+            _load_payload_fixture(fixture_name),
+            feature_flag_value="true",
+        )
+        reason_code = _reason_code(result)
+        assert reason_code.startswith("CONTROLLED_LIVE_")
+        assert reason_code != "CONTROLLED_LIVE_DISABLED"
+        assert reason_code != "SAFE_PROCEED"
+        assert result["veritas_continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+        assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+        assert result["final_commit_approved"] is False
+        assert result["upstream_signal_source"] == "RSA"
+        dumped = json.dumps(result)
+        assert "raw_payload_body" not in dumped
+
+
+def test_receiver_schema_adapter_runtime_wiring_true_flag_valid_safe_proceed_remains_not_final_approval() -> None:
+    payload = _load_payload_fixture("valid_safe_proceed_v1alpha1.json")
+
+    assert classify_controlled_live_viki_schema_input(payload) == ADAPTER_VALID
+    assert payload["rsa_status"] == "SAFE_PROCEED"
+
+    result = receive_controlled_live_viki_payload(payload, feature_flag_value="true")
+    assert _reason_code(result) == "CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED"
+    assert result["final_commit_approved"] is False
+    assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert result["veritas_continuation_decision"] == "PAUSE_FOR_HUMAN_REVIEW"
+    assert result["veritas_continuation_decision"] != "CONTINUE_TO_BIND_BOUNDARY"
+
+
+def test_receiver_schema_adapter_runtime_wiring_true_flag_valid_non_safe_proceed_statuses_remain_not_final_approval() -> None:
+    fixtures = [
+        "valid_density_throttled_v1alpha1.json",
+        "valid_algorithmic_humility_engaged_v1alpha1.json",
+        "valid_deferral_engaged_v1alpha1.json",
+    ]
+
+    for fixture_name in fixtures:
+        payload = _load_payload_fixture(fixture_name)
+        assert classify_controlled_live_viki_schema_input(payload) == ADAPTER_VALID
+
+        result = receive_controlled_live_viki_payload(payload, feature_flag_value="true")
+        assert _reason_code(result) == "CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED"
+        assert result["final_commit_approved"] is False
+        assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+
+
+def test_receiver_schema_adapter_runtime_wiring_duplicate_request_id_fails_closed() -> None:
+    scenario_a = _load_payload_fixture("invalid_duplicate_request_id_scenario_a_v1alpha1.json")
+    scenario_b = _load_payload_fixture("invalid_duplicate_request_id_scenario_b_v1alpha1.json")
+    seen_request_ids: dict[str, str] = {}
+
+    result_a = receive_controlled_live_viki_payload(
+        scenario_a,
+        feature_flag_value="true",
+        seen_request_ids=seen_request_ids,
+    )
+    result_b = receive_controlled_live_viki_payload(
+        scenario_b,
+        feature_flag_value="true",
+        seen_request_ids=seen_request_ids,
+    )
+
+    assert _reason_code(result_a) == "CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED"
+    assert _reason_code(result_b) == "CONTROLLED_LIVE_REPLAY_DUPLICATE_REQUEST_ID"
+    assert result_b["final_commit_approved"] is False
+    assert result_b["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+    assert len(seen_request_ids) == 1
+
+
+def test_receiver_schema_adapter_runtime_wiring_forbidden_secret_and_kyc_fields_are_not_echoed() -> None:
+    fixtures = [
+        "invalid_forbidden_chain_of_thought_v1alpha1.json",
+        "invalid_secret_access_token_v1alpha1.json",
+        "invalid_raw_kyc_record_v1alpha1.json",
+    ]
+
+    for fixture_name in fixtures:
+        result = receive_controlled_live_viki_payload(
+            _load_payload_fixture(fixture_name),
+            feature_flag_value="true",
+        )
+        dumped = json.dumps(result)
+        assert result["final_commit_approved"] is False
+        assert "chain_of_thought" not in dumped
+        assert "raw_kyc_record" not in dumped
+        assert "access_token" not in dumped
+        assert "raw_payload_body" not in dumped
+
+
+def test_receiver_schema_adapter_runtime_wiring_rejects_non_object_payloads() -> None:
+    for payload in (None, [], "not-json-object", 123):
+        result = receive_controlled_live_viki_payload(payload, feature_flag_value="true")
+        assert _reason_code(result) == "CONTROLLED_LIVE_INVALID_JSON_OBJECT"
+        assert result["final_commit_approved"] is False
+        assert result["veritas_sandbox_commit_state"] == "SUSPENDED_NOT_COMMITTED"
+
+
+def test_receiver_schema_adapter_runtime_wiring_module_is_no_network_no_endpoint_no_telemetry() -> None:
+    source_paths = [
+        Path("veritas_os/governance/controlled_live_viki_interface.py"),
+        Path("veritas_os/governance/controlled_live_viki_schema_adapter.py"),
+        Path(__file__),
+    ]
+
+    disallowed_import_roots = {"requests", "httpx", "urllib", "socket", "opentelemetry", "sentry_sdk"}
+    for source_path in source_paths:
+        source = source_path.read_text(encoding="utf-8")
+        module = ast.parse(source)
+        for node in ast.walk(module):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name.split(".")[0] not in disallowed_import_roots
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert node.module.split(".")[0] not in disallowed_import_roots
+
+    test_source = Path(__file__).read_text(encoding="utf-8")
+    precheck_source = test_source.split(
+        "def test_receiver_schema_adapter_runtime_wiring_module_is_no_network_no_endpoint_no_telemetry",
+        maxsplit=1,
+    )[0].lower()
+    forbidden_literals = [
+        "http" + "://",
+        "https" + "://",
+        "bear" + "er" + " ",
+        "api" + "_" + "key=",
+        "fastapi",
+        "flask",
+        "viki_live_client",
+        "live_viki_client",
+        "telemetrysdk",
+    ]
+    for token in forbidden_literals:
+        assert token not in precheck_source
+
+
+def test_receiver_schema_adapter_runtime_wiring_does_not_touch_downstream_contract() -> None:
+    interface_source = Path("veritas_os/governance/controlled_live_viki_interface.py").read_text(encoding="utf-8")
+
+    assert "viki_status" not in interface_source
+    assert "VIKIPayload" not in interface_source
+    assert "rsa_status" in interface_source
+
+    result = receive_controlled_live_viki_payload(feature_flag_value=None)
+    assert result["upstream_signal_source"] == "RSA"

--- a/tests/governance/test_controlled_live_viki_runtime_interface.py
+++ b/tests/governance/test_controlled_live_viki_runtime_interface.py
@@ -45,11 +45,11 @@ def test_runtime_interface_feature_flag_empty_false_or_unknown_is_disabled() -> 
         assert decision["veritas_continuation_decision"] != "SAFE_PROCEED"
 
 
-def test_runtime_interface_true_is_only_enabled_value_but_live_behavior_is_not_implemented() -> None:
+def test_runtime_interface_true_is_only_enabled_value_but_remains_fail_closed_not_ready() -> None:
     assert is_controlled_live_viki_enabled("true") is True
 
     decision = receive_controlled_live_viki_payload(feature_flag_value="true")
-    assert decision["veritas_reason_code"] == "CONTROLLED_LIVE_RUNTIME_NOT_IMPLEMENTED"
+    assert decision["reason_code"] == "CONTROLLED_LIVE_INVALID_JSON_OBJECT"
     assert decision["veritas_continuation_decision"] == EXPECTED_CONTINUATION
     assert decision["veritas_sandbox_commit_state"] == EXPECTED_COMMIT_STATE
     assert decision["required_next_action"] == EXPECTED_NEXT_ACTION

--- a/veritas_os/governance/controlled_live_viki_interface.py
+++ b/veritas_os/governance/controlled_live_viki_interface.py
@@ -7,12 +7,19 @@ telemetry, or live V.I.K.I. integration behavior.
 
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping, MutableMapping
+
+from veritas_os.governance.controlled_live_viki_schema_adapter import (
+    ADAPTER_VALID,
+    build_controlled_live_viki_schema_fail_closed_decision,
+    classify_controlled_live_viki_schema_input,
+    controlled_live_viki_reason_code_for_classification,
+)
 
 CONTROLLED_LIVE_VIKI_FEATURE_FLAG = "VERITAS_CONTROLLED_LIVE_VIKI_ENABLE"
 
 _DISABLED_REASON_CODE = "CONTROLLED_LIVE_DISABLED"
-_NOT_IMPLEMENTED_REASON_CODE = "CONTROLLED_LIVE_RUNTIME_NOT_IMPLEMENTED"
+_SCHEMA_VALID_NOT_YET_WIRED_REASON_CODE = "CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED"
 _REQUIRED_NEXT_ACTION = "REQUEST_HUMAN_REVIEW_OR_RETRY_WITH_VALID_UPSTREAM_STATE"
 _DEFAULT_REQUEST_ID = "req_viki_disabled_001"
 _DEFAULT_CORRELATION_ID = "corr_viki_veritas_disabled_001"
@@ -61,6 +68,7 @@ def receive_controlled_live_viki_payload(
     payload: Mapping[str, object] | None = None,
     *,
     feature_flag_value: str | None = None,
+    seen_request_ids: MutableMapping[str, str] | None = None,
 ) -> dict[str, object]:
     """Receive a local payload and return deterministic fail-closed decisions."""
     request_id = _extract_string_field(payload, "request_id", _DEFAULT_REQUEST_ID)
@@ -83,6 +91,24 @@ def receive_controlled_live_viki_payload(
     if not is_controlled_live_viki_enabled(feature_flag_value):
         return decision
 
-    decision["veritas_reason_code"] = _NOT_IMPLEMENTED_REASON_CODE
-    decision["decision_source"] = "controlled_live_viki_runtime_interface_not_implemented"
-    return decision
+    classification = classify_controlled_live_viki_schema_input(
+        payload,
+        seen_request_ids=seen_request_ids,
+    )
+    if classification != ADAPTER_VALID:
+        reason_code = controlled_live_viki_reason_code_for_classification(classification)
+        if reason_code is None:
+            reason_code = "CONTROLLED_LIVE_INVALID_JSON_OBJECT"
+        return build_controlled_live_viki_schema_fail_closed_decision(
+            reason_code,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            schema_version=schema_version,
+        )
+
+    return build_controlled_live_viki_schema_fail_closed_decision(
+        _SCHEMA_VALID_NOT_YET_WIRED_REASON_CODE,
+        request_id=request_id,
+        correlation_id=correlation_id,
+        schema_version=schema_version,
+    )

--- a/veritas_os/governance/controlled_live_viki_interface.py
+++ b/veritas_os/governance/controlled_live_viki_interface.py
@@ -32,11 +32,11 @@ def is_controlled_live_viki_enabled(value: str | None) -> bool:
 
 
 def _extract_string_field(
-    payload: Mapping[str, object] | None,
+    payload: object,
     field_name: str,
     default_value: str,
 ) -> str:
-    if payload is None:
+    if not isinstance(payload, Mapping):
         return default_value
     raw_value = payload.get(field_name)
     if isinstance(raw_value, str) and raw_value.strip():
@@ -65,7 +65,7 @@ def build_controlled_live_viki_disabled_decision(
 
 
 def receive_controlled_live_viki_payload(
-    payload: Mapping[str, object] | None = None,
+    payload: object = None,
     *,
     feature_flag_value: str | None = None,
     seen_request_ids: MutableMapping[str, str] | None = None,


### PR DESCRIPTION
### Motivation
- Add a minimal runtime wiring so the disabled-by-default receiver can invoke the existing local schema adapter when explicitly enabled, while keeping the end-to-end path fail-closed and not-ready. 
- Preserve all safety boundaries (no network/endpoint/credentials/telemetry/observability/live V.I.K.I. integration or persistence) and keep `SAFE_PROCEED` as an upstream-only signal. 

### Description
- Wire `receive_controlled_live_viki_payload` to call `classify_controlled_live_viki_schema_input()` only when `feature_flag_value == "true"`, and return deterministic fail-closed decisions otherwise. 
- Add an optional caller-owned `seen_request_ids: MutableMapping[str, str] | None` parameter to the receiver for duplicate `request_id` checks, with no module-level cache or persistence. 
- Map non-`ADAPTER_VALID` classifications via `controlled_live_viki_reason_code_for_classification()` and return `build_controlled_live_viki_schema_fail_closed_decision(...)`, and return `CONTROLLED_LIVE_SCHEMA_VALID_NOT_YET_WIRED` for adapter-valid payloads (still not-ready / fail-closed). 
- Files changed: `veritas_os/governance/controlled_live_viki_interface.py`, added `tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_runtime.py`, adjusted `tests/governance/test_controlled_live_viki_runtime_interface.py`, and updated docs `docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md` and `docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md` with a short runtime-wiring note. 
- No network, endpoint, credential, live-client, replay cache, logging, telemetry, or observability code was added. 

### Testing
- Ran targeted pytest invocation for the requested governance tests with: `PYENV_VERSION=3.12.13 python -m pytest -q tests/governance/test_controlled_live_viki_runtime_interface.py tests/governance/test_controlled_live_viki_schema_adapter_runtime.py tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_behavior.py tests/governance/test_controlled_live_viki_receiver_schema_adapter_wiring_runtime.py`, but collection failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`) in the environment. 
- An earlier pytest attempt failed because the repo-selected `pyenv` version (`3.12.12`) was not installed in the environment, causing `pytest` to be unavailable under that version. 
- No tests were marked failing due to code logic; failures were environment/toolchain related and should be re-run in CI or an environment with the repo Python version and dependencies (notably `PyYAML`) installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141f56847c8326976d2fd6cccb81bc)