### PR TITLE
runtime: add controlled live V.I.K.I. local synthetic ingestion endpoint skeleton

### DIFF
--- a/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/en/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -446,3 +446,11 @@ This helper is deterministic and fail-closed. It does not open endpoint behavior
 - `SAFE_PROCEED` remains upstream-only signal; `final_commit_approved` remains `false`; endpoint work remains a later explicit PR.
 
 Test-only synthetic ingestion endpoint behavior skeleton now exists at `tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_behavior.py`. This is test-only contract modeling and does not implement an endpoint, open synthetic network ingestion, introduce endpoint/runtime network behavior, connect live V.I.K.I., add credentials, replay cache implementation, logging implementation, telemetry implementation, observability runtime, or production behavior. `SAFE_PROCEED` remains upstream-only and `final_commit_approved` remains `false`. A future runtime PR may implement a local synthetic endpoint only under fail-closed constraints.
+
+## Runtime update note (2026-05-25)
+
+A local/offline synthetic ingestion endpoint runtime skeleton now exists in `veritas_os/governance/controlled_live_viki_synthetic_ingestion_endpoint.py`, with runtime coverage in `tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_runtime.py`.
+
+This remains local-only and offline-only: it is not a production endpoint, does not bind a port, does not add HTTP server behavior, does not add network behavior, does not connect live V.I.K.I., and does not introduce credentials, replay cache implementation, logging implementation, telemetry implementation, observability runtime, or other production behavior.
+
+`SAFE_PROCEED` remains an upstream signal only, and `final_commit_approved` remains `false`. External synthetic network ingestion remains a later explicit PR.

--- a/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
+++ b/docs/ja/guides/rsa-veritas-controlled-live-viki-runtime-interface-skeleton-plan.md
@@ -446,3 +446,11 @@ local/offline の schema-valid RSA handoff helper が追加されました。
 - `SAFE_PROCEED` remains upstream-only signal; `final_commit_approved` remains `false`; endpoint work remains a later explicit PR.
 
 テスト専用の synthetic ingestion endpoint behavior skeleton は `tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_behavior.py` に追加済みです。これは test-only の contract modeling であり、endpoint 実装、synthetic network ingestion の開放、endpoint/runtime network behavior、live V.I.K.I. integration、credentials、replay cache implementation、logging implementation、telemetry implementation、observability runtime、production behavior は導入しません。`SAFE_PROCEED` は upstream-only のままで、`final_commit_approved` は `false` のままです。将来の runtime PR でのみ、fail-closed 制約下の local synthetic endpoint 実装を検討できます。
+
+## Runtime update note (2026-05-25)
+
+local/offline の synthetic ingestion endpoint runtime skeleton は `veritas_os/governance/controlled_live_viki_synthetic_ingestion_endpoint.py` に追加され、runtime テストは `tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_runtime.py` に追加されました。
+
+本変更は local/offline 限定であり、production endpoint ではありません。port bind は行わず、HTTP server behavior は追加せず、network behavior は追加せず、live V.I.K.I. 連携も行いません。credentials、replay cache implementation、logging implementation、telemetry implementation、observability runtime、その他 production behavior も導入しません。
+
+`SAFE_PROCEED` は upstream signal のままであり、`final_commit_approved` は `false` のままです。external synthetic network ingestion は後続の明示的 PR で扱います。

--- a/tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_runtime.py
+++ b/tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_runtime.py
@@ -60,7 +60,20 @@ assert INTERFACE_SPEC is not None
 assert INTERFACE_SPEC.loader is not None
 INTERFACE_MODULE = importlib.util.module_from_spec(INTERFACE_SPEC)
 INTERFACE_SPEC.loader.exec_module(INTERFACE_MODULE)
+sys.modules["veritas_os.governance.controlled_live_viki_interface"] = INTERFACE_MODULE
 receive_controlled_live_viki_payload = INTERFACE_MODULE.receive_controlled_live_viki_payload
+
+ENDPOINT_SPEC = importlib.util.spec_from_file_location(
+    "controlled_live_viki_synthetic_endpoint_runtime",
+    ENDPOINT_RUNTIME_PATH,
+)
+assert ENDPOINT_SPEC is not None
+assert ENDPOINT_SPEC.loader is not None
+ENDPOINT_MODULE = importlib.util.module_from_spec(ENDPOINT_SPEC)
+ENDPOINT_SPEC.loader.exec_module(ENDPOINT_MODULE)
+handle_controlled_live_viki_synthetic_ingestion_request = (
+    ENDPOINT_MODULE.handle_controlled_live_viki_synthetic_ingestion_request
+)
 
 EXPECTED_PATH = "/synthetic/controlled-live-viki"
 EXPECTED_METHOD = "POST"
@@ -99,77 +112,6 @@ def _reason_code(result: dict) -> str:
     return str(result.get("reason_code") or result.get("veritas_reason_code") or "")
 
 
-def _future_synthetic_ingestion_endpoint_response(
-    payload: object,
-    *,
-    feature_flag_value: str | None,
-    method: str = "POST",
-    path: str = "/synthetic/controlled-live-viki",
-    content_type: str = "application/json",
-) -> dict:
-    if method != EXPECTED_METHOD:
-        return {
-            "endpoint_mode": "synthetic_test_only",
-            "endpoint_enabled": True,
-            "http_status": 405,
-            "accepted_for_processing": False,
-            "response_source": "controlled_live_viki_synthetic_ingestion_endpoint_behavior_skeleton",
-            "receiver_result": None,
-            "reason_code": "CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_METHOD_NOT_ALLOWED",
-            "final_commit_approved": False,
-        }
-    if path != EXPECTED_PATH:
-        return {
-            "endpoint_mode": "synthetic_test_only",
-            "endpoint_enabled": True,
-            "http_status": 404,
-            "accepted_for_processing": False,
-            "response_source": "controlled_live_viki_synthetic_ingestion_endpoint_behavior_skeleton",
-            "receiver_result": None,
-            "reason_code": "CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_PATH_NOT_FOUND",
-            "final_commit_approved": False,
-        }
-    if content_type != EXPECTED_CONTENT_TYPE:
-        return {
-            "endpoint_mode": "synthetic_test_only",
-            "endpoint_enabled": True,
-            "http_status": 415,
-            "accepted_for_processing": False,
-            "response_source": "controlled_live_viki_synthetic_ingestion_endpoint_behavior_skeleton",
-            "receiver_result": None,
-            "reason_code": "CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_UNSUPPORTED_MEDIA_TYPE",
-            "final_commit_approved": False,
-        }
-
-    receiver_result = receive_controlled_live_viki_payload(
-        payload,
-        feature_flag_value=feature_flag_value,
-    )
-    reason_code = _reason_code(receiver_result)
-    endpoint_enabled = str(feature_flag_value) == "true"
-
-    if not endpoint_enabled:
-        http_status = 503
-        accepted_for_processing = False
-    elif reason_code.startswith("CONTROLLED_LIVE_RSA_HANDOFF_"):
-        http_status = 202
-        accepted_for_processing = True
-    else:
-        http_status = 422
-        accepted_for_processing = False
-
-    return {
-        "endpoint_mode": "synthetic_test_only",
-        "endpoint_enabled": endpoint_enabled,
-        "http_status": http_status,
-        "accepted_for_processing": accepted_for_processing,
-        "response_source": "controlled_live_viki_synthetic_ingestion_endpoint_behavior_skeleton",
-        "receiver_result": receiver_result,
-        "reason_code": reason_code,
-        "final_commit_approved": False,
-    }
-
-
 def _assert_endpoint_fail_closed(response: dict) -> None:
     assert response["final_commit_approved"] is False
     receiver_result = response.get("receiver_result")
@@ -200,7 +142,7 @@ def test_synthetic_ingestion_endpoint_disabled_flag_is_fail_closed() -> None:
     ]
 
     for value in disabled_values:
-        response = _future_synthetic_ingestion_endpoint_response(
+        response = handle_controlled_live_viki_synthetic_ingestion_request(
             payload,
             feature_flag_value=value,
         )
@@ -233,7 +175,7 @@ def test_synthetic_ingestion_endpoint_rejects_wrong_method_path_and_content_type
     ]
 
     for kwargs, expected_reason, expected_status in cases:
-        response = _future_synthetic_ingestion_endpoint_response(
+        response = handle_controlled_live_viki_synthetic_ingestion_request(
             payload,
             feature_flag_value="true",
             **kwargs,
@@ -260,7 +202,7 @@ def test_synthetic_ingestion_endpoint_true_flag_invalid_schema_payloads_fail_clo
     ]
 
     for fixture_name in fixtures:
-        response = _future_synthetic_ingestion_endpoint_response(
+        response = handle_controlled_live_viki_synthetic_ingestion_request(
             _load_payload_fixture(fixture_name),
             feature_flag_value="true",
         )
@@ -277,7 +219,7 @@ def test_synthetic_ingestion_endpoint_true_flag_invalid_schema_payloads_fail_clo
 
 
 def test_synthetic_ingestion_endpoint_true_flag_valid_safe_proceed_reaches_rsa_handoff_without_final_approval() -> None:
-    response = _future_synthetic_ingestion_endpoint_response(
+    response = handle_controlled_live_viki_synthetic_ingestion_request(
         _load_payload_fixture("valid_safe_proceed_v1alpha1.json"),
         feature_flag_value="true",
     )
@@ -297,7 +239,7 @@ def test_synthetic_ingestion_endpoint_true_flag_valid_safe_proceed_reaches_rsa_h
 
 
 def test_synthetic_ingestion_endpoint_true_flag_valid_density_throttled_reaches_rsa_handoff() -> None:
-    response = _future_synthetic_ingestion_endpoint_response(
+    response = handle_controlled_live_viki_synthetic_ingestion_request(
         _load_payload_fixture("valid_density_throttled_v1alpha1.json"),
         feature_flag_value="true",
     )
@@ -309,7 +251,7 @@ def test_synthetic_ingestion_endpoint_true_flag_valid_density_throttled_reaches_
 
 
 def test_synthetic_ingestion_endpoint_true_flag_valid_algorithmic_humility_reaches_rsa_handoff() -> None:
-    response = _future_synthetic_ingestion_endpoint_response(
+    response = handle_controlled_live_viki_synthetic_ingestion_request(
         _load_payload_fixture("valid_algorithmic_humility_engaged_v1alpha1.json"),
         feature_flag_value="true",
     )
@@ -324,7 +266,7 @@ def test_synthetic_ingestion_endpoint_true_flag_valid_algorithmic_humility_reach
 
 
 def test_synthetic_ingestion_endpoint_true_flag_valid_deferral_reaches_rsa_handoff() -> None:
-    response = _future_synthetic_ingestion_endpoint_response(
+    response = handle_controlled_live_viki_synthetic_ingestion_request(
         _load_payload_fixture("valid_deferral_engaged_v1alpha1.json"),
         feature_flag_value="true",
     )
@@ -343,7 +285,7 @@ def test_synthetic_ingestion_endpoint_response_preserves_safe_identity_fields_on
         "valid_deferral_engaged_v1alpha1.json",
     ]
     for fixture_name in fixtures:
-        response = _future_synthetic_ingestion_endpoint_response(
+        response = handle_controlled_live_viki_synthetic_ingestion_request(
             _load_payload_fixture(fixture_name),
             feature_flag_value="true",
         )
@@ -363,7 +305,7 @@ def test_synthetic_ingestion_endpoint_response_preserves_safe_identity_fields_on
 
 
 def test_synthetic_ingestion_endpoint_does_not_introduce_viki_specific_downstream_contract() -> None:
-    response = _future_synthetic_ingestion_endpoint_response(
+    response = handle_controlled_live_viki_synthetic_ingestion_request(
         _load_payload_fixture("valid_safe_proceed_v1alpha1.json"),
         feature_flag_value="true",
     )
@@ -418,7 +360,7 @@ def test_synthetic_ingestion_endpoint_behavior_skeleton_does_not_modify_runtime_
     runtime_source = INTERFACE_PATH.read_text(encoding="utf-8")
     assert "receive_controlled_live_viki_payload" in runtime_source
 
-    response = _future_synthetic_ingestion_endpoint_response(
+    response = handle_controlled_live_viki_synthetic_ingestion_request(
         _load_payload_fixture("valid_safe_proceed_v1alpha1.json"),
         feature_flag_value="true",
     )

--- a/veritas_os/governance/controlled_live_viki_synthetic_ingestion_endpoint.py
+++ b/veritas_os/governance/controlled_live_viki_synthetic_ingestion_endpoint.py
@@ -1,0 +1,121 @@
+"""Local/offline controlled live V.I.K.I. synthetic ingestion endpoint skeleton.
+
+This module models an endpoint-like request boundary as a pure local runtime
+helper. It does not implement a network listener, HTTP server, routes, port
+binding, credentials, replay cache, logging, telemetry, observability, or live
+V.I.K.I. integration.
+"""
+
+from __future__ import annotations
+
+from veritas_os.governance.controlled_live_viki_interface import (
+    receive_controlled_live_viki_payload,
+)
+
+CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_PATH = "/synthetic/controlled-live-viki"
+CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_METHOD = "POST"
+CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_CONTENT_TYPE = "application/json"
+
+CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_METHOD_NOT_ALLOWED = (
+    "CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_METHOD_NOT_ALLOWED"
+)
+CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_PATH_NOT_FOUND = (
+    "CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_PATH_NOT_FOUND"
+)
+CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_UNSUPPORTED_MEDIA_TYPE = (
+    "CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_UNSUPPORTED_MEDIA_TYPE"
+)
+
+_RESPONSE_SOURCE = "controlled_live_viki_synthetic_ingestion_endpoint"
+_ENDPOINT_MODE = "local_synthetic_runtime_skeleton"
+_DISABLED_REASON_CODE = "CONTROLLED_LIVE_DISABLED"
+
+
+def _build_fail_closed_endpoint_response(
+    *,
+    endpoint_enabled: bool,
+    http_status: int,
+    receiver_result: dict[str, object] | None,
+    reason_code: str,
+    accepted_for_processing: bool,
+) -> dict[str, object]:
+    return {
+        "endpoint_mode": _ENDPOINT_MODE,
+        "endpoint_enabled": endpoint_enabled,
+        "http_status": http_status,
+        "accepted_for_processing": accepted_for_processing,
+        "response_source": _RESPONSE_SOURCE,
+        "receiver_result": receiver_result,
+        "reason_code": reason_code,
+        "final_commit_approved": False,
+    }
+
+
+def _reason_code(result: dict[str, object]) -> str:
+    return str(result.get("reason_code") or result.get("veritas_reason_code") or "")
+
+
+def handle_controlled_live_viki_synthetic_ingestion_request(
+    payload: object,
+    *,
+    feature_flag_value: str | None,
+    method: str = CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_METHOD,
+    path: str = CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_PATH,
+    content_type: str = CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_CONTENT_TYPE,
+) -> dict[str, object]:
+    """Handle a local synthetic ingestion request in a fail-closed manner."""
+    endpoint_enabled = feature_flag_value == "true"
+
+    if method != CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_METHOD:
+        return _build_fail_closed_endpoint_response(
+            endpoint_enabled=endpoint_enabled,
+            http_status=405,
+            receiver_result=None,
+            reason_code=CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_METHOD_NOT_ALLOWED,
+            accepted_for_processing=False,
+        )
+
+    if path != CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_PATH:
+        return _build_fail_closed_endpoint_response(
+            endpoint_enabled=endpoint_enabled,
+            http_status=404,
+            receiver_result=None,
+            reason_code=CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_PATH_NOT_FOUND,
+            accepted_for_processing=False,
+        )
+
+    if content_type != CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_CONTENT_TYPE:
+        return _build_fail_closed_endpoint_response(
+            endpoint_enabled=endpoint_enabled,
+            http_status=415,
+            receiver_result=None,
+            reason_code=CONTROLLED_LIVE_SYNTHETIC_ENDPOINT_UNSUPPORTED_MEDIA_TYPE,
+            accepted_for_processing=False,
+        )
+
+    receiver_result = receive_controlled_live_viki_payload(
+        payload,
+        feature_flag_value=feature_flag_value,
+    )
+
+    reason_code = _reason_code(receiver_result)
+
+    if not endpoint_enabled:
+        return _build_fail_closed_endpoint_response(
+            endpoint_enabled=False,
+            http_status=503,
+            receiver_result=receiver_result,
+            reason_code=_DISABLED_REASON_CODE,
+            accepted_for_processing=False,
+        )
+
+    accepted_for_processing = reason_code.startswith("CONTROLLED_LIVE_RSA_HANDOFF_")
+    http_status = 202 if accepted_for_processing else 422
+
+    return _build_fail_closed_endpoint_response(
+        endpoint_enabled=True,
+        http_status=http_status,
+        receiver_result=receiver_result,
+        reason_code=reason_code,
+        accepted_for_processing=accepted_for_processing,
+    )


### PR DESCRIPTION
### Motivation

- Provide a minimal local/offline runtime helper that models a future controlled live V.I.K.I. synthetic ingestion request boundary and delegates to the existing receiver, so runtime wiring can be exercised without adding any network or production behavior.  
- Ensure the path is fail-closed at the local boundary (feature-flag gating, method/path/content-type checks, schema adapter validation, RSA handoff) while preserving `final_commit_approved = False` and upstream-only `SAFE_PROCEED` semantics.  
- Add runtime tests to move the previously test-only behavior into an executable runtime skeleton while keeping the implementation non-networked and non-production.  
- Security note: this is intentionally offline and not suitable for production ingress; human review and a dedicated hardening PR are required before any production-facing endpoint, credentials, or telemetry are introduced.

### Description

- Added `veritas_os/governance/controlled_live_viki_synthetic_ingestion_endpoint.py` that defines endpoint-like constants and the pure function `handle_controlled_live_viki_synthetic_ingestion_request(...)`, which performs method/path/content-type checks, delegates to `receive_controlled_live_viki_payload(...)`, and returns the structured response shape with `endpoint_mode = local_synthetic_runtime_skeleton` and `final_commit_approved = False`.  
- The new handler implements the prescribed reason codes and HTTP-status mappings (method/path/content-type failures -> `405/404/415`, feature-flag disabled -> `503` + `CONTROLLED_LIVE_DISABLED`, invalid schema -> `422`, RSA handoff statuses -> `202` with `CONTROLLED_LIVE_RSA_HANDOFF_*` reason codes).  
- Added runtime tests at `tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_runtime.py` that reuse existing fixtures and validate disabled-flag fail-closed behavior, wrong method/path/content-type rejections, invalid schema failure modes, valid RSA mappings (SAFE_PROCEED, DENSITY_THROTTLED, ALGORITHMIC_HUMILITY_ENGAGED, DEFERRAL_ENGAGED), safe-field preservation, absence of raw/secret fields, and static/no-network import checks.  
- Updated the existing behavior-skeleton test to assert the runtime module exists and added dated notes in EN/JA docs linking to the new module and runtime test while reiterating offline/non-production constraints.

### Testing

- Ran the targeted behavior and runtime tests with `PYENV_VERSION=3.12.13 pytest -q tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_behavior.py tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_runtime.py`, which completed successfully (`24 passed, 1 warning`).  
- Ran the broader governance runtime test set with `PYENV_VERSION=3.12.13 pytest -q tests/governance/test_controlled_live_viki_receiver_rsa_handoff_wiring_runtime.py tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_behavior.py tests/governance/test_controlled_live_viki_synthetic_ingestion_endpoint_runtime.py`, which also completed successfully (`34 passed, 1 warning`).  
- All added tests exercise the offline behavior and static checks (no network/server imports or route decorators) and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145ec1a9e88326acd4470d99af5244)