### PR TITLE
runtime: add Human Approval Receipt v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 1. [Reviewer Entrypoint](docs/REVIEWER_ENTRYPOINT.md)
 2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
 3. Authority Evidence Ingestion (local/offline): docs/en/architecture/authority-evidence-ingestion.md
-4. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-5. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
-6. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
+4. Human Approval Receipt v1 (local/offline): docs/en/architecture/human-approval-receipt.md
+5. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+7. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
 
 Boundary:
 
@@ -64,6 +65,17 @@ Boundary:
 - Local/offline normalization only
 - No live SaaS, bank, sanctions, identity-provider, or customer-system integration
 - Not legal advice, regulatory approval, third-party certification, or production authority-source validation
+
+
+## Human Approval Receipt v1
+
+VERITAS now includes a local/offline Human Approval Receipt v1 artifact. It represents human approval as a deterministic, hashable, scope-bound, expiry-aware governance artifact that can be converted into the existing runtime `human_approval_state` used by bind-time validation. This does not add live IdP, SSO, IAM, KMS/HSM, e-signature, or production approval workflow integration.
+
+Boundary:
+
+- Local/offline deterministic artifact only
+- No live IdP, SSO, IAM, KMS/HSM, or e-signature integration
+- Not legal advice, regulatory approval, third-party certification, or production approval validation
 
 ## One-Day PoC Evidence Packet
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -42,9 +42,10 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 1. [Reviewer Entrypoint](docs/REVIEWER_ENTRYPOINT.md)
 2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
 3. Authority Evidence Ingestion（local/offline）: docs/en/architecture/authority-evidence-ingestion.md
-4. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-5. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
-6. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
+4. Human Approval Receipt v1（local/offline）: docs/en/architecture/human-approval-receipt.md
+5. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+7. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
 
 境界条件:
 
@@ -68,6 +69,17 @@ VERITAS には、bind-time governance のための deterministic local/offline A
 - local/offline normalization のみ
 - 実 SaaS・実銀行・実制裁 API・実 IdP・実顧客システムとは接続していない
 - 法的助言・規制承認・第三者認証・本番 authority source validation ではない
+
+
+## Human Approval Receipt v1（人間承認レシート）
+
+VERITAS には local/offline の Human Approval Receipt v1 artifact が追加されています。これは、人間承認を「approved=true」の単純な状態ではなく、誰が・どのscopeを・いつまで承認したかを示す、決定論的で hashable、scope-bound、expiry-aware なガバナンス証跡として扱うためのものです。実 IdP・SSO・IAM・KMS/HSM・電子署名・本番承認ワークフローとの連携は含みません。
+
+境界条件:
+
+- local/offline の決定論的 artifact のみ
+- 実 IdP・SSO・IAM・KMS/HSM・電子署名連携はなし
+- 法的助言・規制承認・第三者認証・本番承認妥当性の主張ではない
 
 ## AML/KYC レビュアー向けウォークスルー Quickstart
 

--- a/docs/en/architecture/human-approval-receipt.md
+++ b/docs/en/architecture/human-approval-receipt.md
@@ -1,0 +1,53 @@
+# Human Approval Receipt v1 (local/offline)
+
+## Purpose
+
+Human Approval Receipt v1 is a local/offline deterministic artifact that represents human approval as a reviewable governance record before execution.
+
+It is designed to make approval:
+
+- reviewable,
+- hashable,
+- scope-bound,
+- expiry-aware, and
+- fail-closed during runtime validation.
+
+## What this v1 includes
+
+- A deterministic `HumanApprovalReceipt` dataclass artifact.
+- Deterministic canonical hashing (`receipt_hash`) with self-hash recursion excluded.
+- Fail-closed validation helper for:
+  - missing approval,
+  - non-approved outcomes,
+  - unverified signature flag,
+  - missing approver identity/role,
+  - expiry invalid/expired,
+  - scope mismatch,
+  - policy snapshot mismatch,
+  - action-class mismatch.
+- A compatibility helper that converts the receipt into the existing runtime `human_approval_state` shape.
+
+## Explicit boundary (non-goals)
+
+This is local/offline v1 only.
+
+This does **not** include:
+
+- live IdP integration,
+- SSO/IAM integration,
+- KMS/HSM integration,
+- real e-signature verification,
+- production approval workflow integration,
+- network calls,
+- credentials or SaaS bank integrations.
+
+## Compliance and claims boundary
+
+This artifact is an engineering governance control, not a legal or certification claim.
+
+It is:
+
+- not legal advice,
+- not regulatory approval,
+- not third-party certification,
+- not production approval validation.

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -10,6 +10,7 @@ from veritas_os.governance.human_approval_receipt import (
     HumanApprovalReceipt,
     build_human_approval_state,
     validate_human_approval_receipt,
+    with_receipt_hash,
 )
 from veritas_os.governance.runtime_authority import RuntimeAuthorityValidator
 
@@ -228,3 +229,52 @@ def test_high_irreversibility_blocks_with_invalid_human_approval_state() -> None
 
     assert result.status == "fail"
     assert result.recommended_outcome == "block"
+
+
+def test_with_receipt_hash_populates_non_empty_hash() -> None:
+    finalized = with_receipt_hash(_receipt())
+
+    assert finalized.receipt_hash
+
+
+def test_with_receipt_hash_populates_sha256_length() -> None:
+    finalized = with_receipt_hash(_receipt())
+
+    assert len(finalized.receipt_hash) == 64
+
+
+def test_with_receipt_hash_is_deterministic_for_same_content() -> None:
+    one = with_receipt_hash(_receipt(metadata={"x": "1"}))
+    two = with_receipt_hash(_receipt(metadata={"x": "1"}))
+
+    assert one.receipt_hash == two.receipt_hash
+
+
+def test_with_receipt_hash_changes_when_meaningful_field_changes() -> None:
+    one = with_receipt_hash(_receipt(approved_scope=["ledger:debit"]))
+    two = with_receipt_hash(_receipt(approved_scope=["ledger:credit"]))
+
+    assert one.receipt_hash != two.receipt_hash
+
+
+def test_receipt_hash_does_not_recursively_affect_own_hash() -> None:
+    first = with_receipt_hash(_receipt(receipt_hash=""))
+    second = with_receipt_hash(_receipt(receipt_hash="tampered"))
+
+    assert first.receipt_hash == second.receipt_hash
+
+
+def test_human_approval_state_uses_finalized_receipt_hash() -> None:
+    receipt = _receipt()
+    finalized = with_receipt_hash(receipt)
+
+    state = build_human_approval_state(
+        receipt,
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert state["approved"] is True
+    assert state["receipt_hash"] == finalized.receipt_hash

--- a/tests/governance/test_human_approval_receipt.py
+++ b/tests/governance/test_human_approval_receipt.py
@@ -1,0 +1,230 @@
+"""Tests for local/offline Human Approval Receipt v1 helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from veritas_os.governance.action_contracts import ActionClassContract
+from veritas_os.governance.authority_evidence import AuthorityEvidence, VerificationResult
+from veritas_os.governance.human_approval_receipt import (
+    HumanApprovalReceipt,
+    build_human_approval_state,
+    validate_human_approval_receipt,
+)
+from veritas_os.governance.runtime_authority import RuntimeAuthorityValidator
+
+
+def _receipt(**overrides: object) -> HumanApprovalReceipt:
+    payload = {
+        "approval_receipt_id": "har-001",
+        "decision_id": "decision-001",
+        "execution_intent_id": "intent-001",
+        "approver_identity": "operator:approver-1",
+        "approver_role": "risk_manager",
+        "approved_action_class": "wire_transfer",
+        "approved_scope": ["ledger:debit", "ledger:credit"],
+        "approval_basis_refs": ["policy:wire:v1"],
+        "approved_at": "2026-05-01T00:00:00+00:00",
+        "expires_at": "2026-06-01T00:00:00+00:00",
+        "policy_snapshot_id": "policy-001",
+        "authority_evidence_id": "aev-001",
+        "approval_result": "approved",
+        "signature_verified": True,
+        "receipt_hash": "",
+        "metadata": {"note": "offline"},
+    }
+    payload.update(overrides)
+    return HumanApprovalReceipt(**payload)
+
+
+def _contract(**overrides: object) -> ActionClassContract:
+    payload = {
+        "id": "wire_transfer",
+        "version": "1.0.0",
+        "domain": "payments",
+        "action_class": "wire_transfer",
+        "description": "Wire transfer action.",
+        "declared_intent": "Perform regulated wire transfer.",
+        "allowed_scope": ["ledger:debit", "ledger:credit"],
+        "prohibited_scope": ["ledger:mint"],
+        "authority_sources": ["policy.payments"],
+        "required_evidence": ["kyc_status"],
+        "evidence_freshness": {"kyc_status": "P1D"},
+        "irreversibility": {"boundary": "funds_settled", "level": "high"},
+        "human_approval_rules": {"minimum_approvals": 1},
+        "refusal_conditions": [],
+        "escalation_conditions": [],
+        "default_failure_mode": "fail_closed",
+        "metadata": {},
+    }
+    payload.update(overrides)
+    return ActionClassContract(**payload)
+
+
+def _authority() -> AuthorityEvidence:
+    return AuthorityEvidence(
+        authority_evidence_id="aev-001",
+        action_contract_id="wire_transfer",
+        action_contract_version="1.0.0",
+        actor_identity="operator:alice",
+        actor_role="payments_operator",
+        authority_source_refs=["policy.payments"],
+        role_or_policy_basis=["role:payments_operator"],
+        scope_grants=["ledger:debit", "ledger:credit"],
+        scope_limitations=["ledger:mint"],
+        validity_window={
+            "issued_at": "2026-05-01T00:00:00+00:00",
+            "valid_from": "2026-05-01T00:00:00+00:00",
+            "valid_until": "2026-06-15T00:00:00+00:00",
+        },
+        issued_at="2026-05-01T00:00:00+00:00",
+        valid_from="2026-05-01T00:00:00+00:00",
+        valid_until="2026-06-15T00:00:00+00:00",
+        revalidated_at=None,
+        policy_snapshot_id="policy-001",
+        evidence_hash="",
+        verification_result=VerificationResult.VALID,
+        failure_reasons=[],
+        metadata={},
+    )
+
+
+def test_valid_receipt_produces_deterministic_receipt_hash() -> None:
+    one = _receipt(metadata={"k": "v"})
+    two = _receipt(metadata={"k": "v"})
+
+    assert one.deterministic_digest() == two.deterministic_digest()
+
+
+def test_valid_receipt_builds_approved_human_approval_state() -> None:
+    state = build_human_approval_state(
+        _receipt(),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert state["approved"] is True
+    assert state["approval_receipt_id"] == "har-001"
+
+
+def test_missing_receipt_builds_not_approved_state() -> None:
+    state = build_human_approval_state(None, requested_scope=["ledger:debit"])
+
+    assert state == {"approved": False, "failure_reasons": ["human_approval_missing"]}
+
+
+def test_denied_receipt_fails_validation() -> None:
+    result = validate_human_approval_receipt(
+        _receipt(approval_result="denied"),
+        requested_scope=["ledger:debit"],
+    )
+
+    assert result.is_valid is False
+    assert "human_approval_not_approved" in result.failure_reasons
+
+
+def test_expired_receipt_fails_validation() -> None:
+    result = validate_human_approval_receipt(
+        _receipt(expires_at="2026-04-01T00:00:00+00:00"),
+        requested_scope=["ledger:debit"],
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.is_valid is False
+    assert "human_approval_expired" in result.failure_reasons
+
+
+def test_signature_unverified_fails_validation() -> None:
+    result = validate_human_approval_receipt(
+        _receipt(signature_verified=False),
+        requested_scope=["ledger:debit"],
+    )
+
+    assert result.is_valid is False
+    assert "human_approval_signature_unverified" in result.failure_reasons
+
+
+def test_requested_scope_not_covered_fails_validation() -> None:
+    result = validate_human_approval_receipt(
+        _receipt(approved_scope=["ledger:credit"]),
+        requested_scope=["ledger:debit"],
+    )
+
+    assert result.is_valid is False
+    assert "human_approval_scope_not_granted" in result.failure_reasons
+
+
+def test_policy_snapshot_mismatch_fails_validation() -> None:
+    result = validate_human_approval_receipt(
+        _receipt(policy_snapshot_id="policy-other"),
+        requested_scope=["ledger:debit"],
+        policy_snapshot_id="policy-001",
+    )
+
+    assert result.is_valid is False
+    assert "human_approval_policy_snapshot_mismatch" in result.failure_reasons
+
+
+def test_action_class_mismatch_fails_validation() -> None:
+    result = validate_human_approval_receipt(
+        _receipt(approved_action_class="other_action"),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+    )
+
+    assert result.is_valid is False
+    assert "human_approval_action_class_mismatch" in result.failure_reasons
+
+
+def test_high_irreversibility_passes_with_valid_human_approval_state() -> None:
+    validator = RuntimeAuthorityValidator()
+    approval_state = build_human_approval_state(
+        _receipt(),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = validator.validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state=approval_state,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "pass"
+    assert result.recommended_outcome == "commit"
+
+
+def test_high_irreversibility_blocks_with_invalid_human_approval_state() -> None:
+    validator = RuntimeAuthorityValidator()
+    approval_state = build_human_approval_state(
+        _receipt(expires_at="2026-04-01T00:00:00+00:00"),
+        requested_scope=["ledger:debit"],
+        action_class="wire_transfer",
+        policy_snapshot_id="policy-001",
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    result = validator.validate(
+        action_contract=_contract(),
+        authority_evidence=_authority(),
+        requested_scope=["ledger:debit"],
+        required_evidence_metadata={"kyc_status": {"present": True, "fresh": True}},
+        policy_snapshot_id="policy-001",
+        actor_identity="operator:alice",
+        human_approval_state=approval_state,
+        bind_context_metadata={"session_id": "bind-001"},
+        now=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert result.status == "fail"
+    assert result.recommended_outcome == "block"

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -26,6 +26,7 @@ from veritas_os.governance.human_approval_receipt import (
     HumanApprovalValidationResult,
     build_human_approval_state,
     validate_human_approval_receipt,
+    with_receipt_hash,
 )
 
 from veritas_os.governance.commit_boundary import (
@@ -62,6 +63,7 @@ __all__ = [
     "build_human_approval_state",
     "HumanApprovalValidationResult",
     "HumanApprovalReceipt",
+    "with_receipt_hash",
     "create_governance_repository",
     "CommitBoundaryResult",
     "CommitBoundaryEvaluator",

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -21,6 +21,13 @@ from veritas_os.governance.action_contracts import (
     load_action_class_contract,
     validate_action_class_contract,
 )
+from veritas_os.governance.human_approval_receipt import (
+    HumanApprovalReceipt,
+    HumanApprovalValidationResult,
+    build_human_approval_state,
+    validate_human_approval_receipt,
+)
+
 from veritas_os.governance.commit_boundary import (
     CommitBoundaryResult,
     CommitBoundaryEvaluator,
@@ -51,6 +58,10 @@ __all__ = [
     "VerificationResult",
     "ActionClassContract",
     "ActionClassContractValidationError",
+    "validate_human_approval_receipt",
+    "build_human_approval_state",
+    "HumanApprovalValidationResult",
+    "HumanApprovalReceipt",
     "create_governance_repository",
     "CommitBoundaryResult",
     "CommitBoundaryEvaluator",

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -1,0 +1,164 @@
+"""Local/offline deterministic Human Approval Receipt artifact helpers.
+
+This module intentionally stays local/offline and deterministic for v1.
+No live identity-provider, signature service, or network integrations are included.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from veritas_os.security.hash import sha256_of_canonical_json
+
+ApprovalResult = Literal["approved", "denied", "expired", "indeterminate"]
+
+
+@dataclass(frozen=True)
+class HumanApprovalReceipt:
+    """Deterministic local/offline human approval receipt artifact."""
+
+    approval_receipt_id: str
+    decision_id: str
+    execution_intent_id: str
+    approver_identity: str
+    approver_role: str
+    approved_action_class: str
+    approved_scope: list[str]
+    approval_basis_refs: list[str]
+    approved_at: str
+    expires_at: str
+    policy_snapshot_id: str | None
+    authority_evidence_id: str | None
+    approval_result: ApprovalResult
+    signature_verified: bool
+    receipt_hash: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain deterministic dictionary representation."""
+        return {
+            "approval_receipt_id": self.approval_receipt_id,
+            "decision_id": self.decision_id,
+            "execution_intent_id": self.execution_intent_id,
+            "approver_identity": self.approver_identity,
+            "approver_role": self.approver_role,
+            "approved_action_class": self.approved_action_class,
+            "approved_scope": sorted(str(scope) for scope in self.approved_scope),
+            "approval_basis_refs": sorted(str(ref) for ref in self.approval_basis_refs),
+            "approved_at": self.approved_at,
+            "expires_at": self.expires_at,
+            "policy_snapshot_id": self.policy_snapshot_id,
+            "authority_evidence_id": self.authority_evidence_id,
+            "approval_result": self.approval_result,
+            "signature_verified": self.signature_verified,
+            "receipt_hash": self.receipt_hash,
+            "metadata": self.metadata,
+        }
+
+    def to_dict_for_hash(self) -> dict[str, Any]:
+        """Return canonical hash payload excluding ``receipt_hash`` recursion."""
+        payload = self.to_dict()
+        payload.pop("receipt_hash", None)
+        return payload
+
+    def deterministic_digest(self) -> str:
+        """Compute canonical SHA-256 digest of the receipt hash payload."""
+        return sha256_of_canonical_json(self.to_dict_for_hash())
+
+
+@dataclass(frozen=True)
+class HumanApprovalValidationResult:
+    """Deterministic fail-closed validation result for human approval receipts."""
+
+    is_valid: bool
+    failure_reasons: list[str]
+
+
+def validate_human_approval_receipt(
+    receipt: HumanApprovalReceipt | None,
+    *,
+    requested_scope: list[str],
+    action_class: str | None = None,
+    policy_snapshot_id: str | None = None,
+    now: datetime | None = None,
+) -> HumanApprovalValidationResult:
+    """Validate a human approval receipt with deterministic fail-closed behavior."""
+    if receipt is None:
+        return HumanApprovalValidationResult(False, ["human_approval_missing"])
+
+    failure_reasons: list[str] = []
+    evaluated_at = now or datetime.now(UTC)
+
+    if receipt.approval_result != "approved":
+        failure_reasons.append("human_approval_not_approved")
+    if receipt.signature_verified is not True:
+        failure_reasons.append("human_approval_signature_unverified")
+    if not str(receipt.approver_identity).strip():
+        failure_reasons.append("human_approval_approver_identity_missing")
+    if not str(receipt.approver_role).strip():
+        failure_reasons.append("human_approval_approver_role_missing")
+
+    expiration_dt = _parse_iso_datetime(receipt.expires_at)
+    if expiration_dt is None:
+        failure_reasons.append("human_approval_expiry_unparseable")
+    elif expiration_dt <= evaluated_at:
+        failure_reasons.append("human_approval_expired")
+
+    approved_scope = {str(item).strip() for item in receipt.approved_scope if str(item).strip()}
+    requested_scope_set = {str(item).strip() for item in requested_scope if str(item).strip()}
+    if not requested_scope_set.issubset(approved_scope):
+        failure_reasons.append("human_approval_scope_not_granted")
+
+    if policy_snapshot_id is not None and policy_snapshot_id != receipt.policy_snapshot_id:
+        failure_reasons.append("human_approval_policy_snapshot_mismatch")
+
+    if action_class is not None and action_class != receipt.approved_action_class:
+        failure_reasons.append("human_approval_action_class_mismatch")
+
+    return HumanApprovalValidationResult(not failure_reasons, sorted(set(failure_reasons)))
+
+
+def build_human_approval_state(
+    receipt: HumanApprovalReceipt | None,
+    *,
+    requested_scope: list[str],
+    action_class: str | None = None,
+    policy_snapshot_id: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build runtime-compatible ``human_approval_state`` from a receipt."""
+    evaluated_at = now or datetime.now(UTC)
+    validation_result = validate_human_approval_receipt(
+        receipt,
+        requested_scope=requested_scope,
+        action_class=action_class,
+        policy_snapshot_id=policy_snapshot_id,
+        now=evaluated_at,
+    )
+    if not validation_result.is_valid or receipt is None:
+        return {
+            "approved": False,
+            "failure_reasons": validation_result.failure_reasons,
+        }
+
+    return {
+        "approved": True,
+        "approval_receipt_id": receipt.approval_receipt_id,
+        "approver_identity": receipt.approver_identity,
+        "approver_role": receipt.approver_role,
+        "approved_scope": sorted(str(scope) for scope in receipt.approved_scope),
+        "receipt_hash": receipt.deterministic_digest(),
+        "validated_at": evaluated_at.isoformat(),
+    }
+
+
+def _parse_iso_datetime(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/veritas_os/governance/human_approval_receipt.py
+++ b/veritas_os/governance/human_approval_receipt.py
@@ -68,6 +68,14 @@ class HumanApprovalReceipt:
         return sha256_of_canonical_json(self.to_dict_for_hash())
 
 
+def with_receipt_hash(receipt: HumanApprovalReceipt) -> HumanApprovalReceipt:
+    """Return a new receipt finalized with a deterministic ``receipt_hash``."""
+    digest = receipt.deterministic_digest()
+    data = receipt.to_dict()
+    data["receipt_hash"] = digest
+    return HumanApprovalReceipt(**data)
+
+
 @dataclass(frozen=True)
 class HumanApprovalValidationResult:
     """Deterministic fail-closed validation result for human approval receipts."""
@@ -143,13 +151,15 @@ def build_human_approval_state(
             "failure_reasons": validation_result.failure_reasons,
         }
 
+    finalized_receipt = with_receipt_hash(receipt)
+
     return {
         "approved": True,
-        "approval_receipt_id": receipt.approval_receipt_id,
-        "approver_identity": receipt.approver_identity,
-        "approver_role": receipt.approver_role,
-        "approved_scope": sorted(str(scope) for scope in receipt.approved_scope),
-        "receipt_hash": receipt.deterministic_digest(),
+        "approval_receipt_id": finalized_receipt.approval_receipt_id,
+        "approver_identity": finalized_receipt.approver_identity,
+        "approver_role": finalized_receipt.approver_role,
+        "approved_scope": sorted(str(scope) for scope in finalized_receipt.approved_scope),
+        "receipt_hash": finalized_receipt.receipt_hash,
         "validated_at": evaluated_at.isoformat(),
     }
 


### PR DESCRIPTION
### Motivation

- Introduce a minimal deterministic local/offline Human Approval Receipt v1 to make human approvals reviewable, hashable, scope-bound, expiry-aware, and fail-closed before execution.
- Keep compatibility with existing `human_approval_state` flow so existing runtime validators continue to operate without refactor.

### Description

- Add `veritas_os/governance/human_approval_receipt.py` defining `HumanApprovalReceipt` with `to_dict()`, `to_dict_for_hash()`, and `deterministic_digest()` using `sha256_of_canonical_json` and excluding `receipt_hash` from its own hash computation.
- Add `HumanApprovalValidationResult` dataclass plus `validate_human_approval_receipt(...)` that fails closed with deterministic failure reason tokens (e.g. `human_approval_missing`, `human_approval_not_approved`, `human_approval_signature_unverified`, `human_approval_expired`, `human_approval_scope_not_granted`, `human_approval_policy_snapshot_mismatch`, `human_approval_action_class_mismatch`, `human_approval_expiry_unparseable`).
- Add `build_human_approval_state(...)` helper that returns a runtime-compatible `human_approval_state` dict (`approved: True` with receipt fields or `approved: False` with `failure_reasons`).
- Export new artifacts from `veritas_os.governance` package surface for additive consumption.
- Add focused tests in `tests/governance/test_human_approval_receipt.py` covering deterministic hashing, approved/denied/expired/signature/scope/policy/action-class cases, and integration scenarios exercising high-irreversibility behavior via the existing `RuntimeAuthorityValidator`.
- Add `docs/en/architecture/human-approval-receipt.md` and light README updates in `README.md` and `README_JP.md` documenting local/offline boundaries and non-goals (no IdP/SSO/IAM/KMS/HSM/e-signature/production workflow).

### Testing

- Added unit tests in `tests/governance/test_human_approval_receipt.py` that exercise deterministic digest, `build_human_approval_state`, and all specified fail-closed validation cases plus high-irreversibility pass/block scenarios.
- Ran local test invocation attempts (`pytest -q tests/governance/test_human_approval_receipt.py tests/governance/test_runtime_authority_validation.py`) but execution was blocked by the local environment missing a runnable `pytest` under the repository pyenv constraints, so tests were not executed in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a83bdc188326896fc67f33c1f18b)