### PR TITLE
Add local/offline SaaS permission-change governed demo, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ VERITAS now includes a local/offline Human Approval Receipt v1 artifact. It repr
 
 Boundary:
 
+- Local/offline deterministic artifact only
+- No live IdP, SSO, IAM, KMS/HSM, or e-signature integration
+- Not legal advice, regulatory approval, third-party certification, or production approval validation
+
 ## SaaS Permission-Change Governed Execution Demo
 
 VERITAS includes a local/offline SaaS permission-change governed execution demo where an AI agent attempts to grant admin access to an external contractor. The demo shows AuthorityEvidence and HumanApprovalReceipt checks before commit, with missing/expired/scope-mismatched evidence failing closed.
@@ -88,10 +92,6 @@ Boundary:
 - No live SaaS, IAM, IdP, SSO, customer directory, or production approval workflow integration
 - Not legal advice, regulatory approval, third-party certification, or production access-control validation
 
-
-- Local/offline deterministic artifact only
-- No live IdP, SSO, IAM, KMS/HSM, or e-signature integration
-- Not legal advice, regulatory approval, third-party certification, or production approval validation
 
 ## One-Day PoC Evidence Packet
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 5. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
 6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 7. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
+8. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
 
 Boundary:
 
@@ -72,6 +73,21 @@ Boundary:
 VERITAS now includes a local/offline Human Approval Receipt v1 artifact. It represents human approval as a deterministic, hashable, scope-bound, expiry-aware governance artifact that can be converted into the existing runtime `human_approval_state` used by bind-time validation. This does not add live IdP, SSO, IAM, KMS/HSM, e-signature, or production approval workflow integration.
 
 Boundary:
+
+## SaaS Permission-Change Governed Execution Demo
+
+VERITAS includes a local/offline SaaS permission-change governed execution demo where an AI agent attempts to grant admin access to an external contractor. The demo shows AuthorityEvidence and HumanApprovalReceipt checks before commit, with missing/expired/scope-mismatched evidence failing closed.
+
+- Demo walkthrough: docs/en/demo/saas-permission-change-governed-demo.md
+- Script: scripts/demo/saas_permission_change_governed_demo.py
+- Test: tests/demo/test_saas_permission_change_governed_demo.py
+
+Boundary:
+
+- Local/offline fixture only
+- No live SaaS, IAM, IdP, SSO, customer directory, or production approval workflow integration
+- Not legal advice, regulatory approval, third-party certification, or production access-control validation
+
 
 - Local/offline deterministic artifact only
 - No live IdP, SSO, IAM, KMS/HSM, or e-signature integration

--- a/README_JP.md
+++ b/README_JP.md
@@ -46,6 +46,7 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 5. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
 6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 7. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
+8. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
 
 境界条件:
 
@@ -76,6 +77,20 @@ VERITAS には、bind-time governance のための deterministic local/offline A
 VERITAS には local/offline の Human Approval Receipt v1 artifact が追加されています。これは、人間承認を「approved=true」の単純な状態ではなく、誰が・どのscopeを・いつまで承認したかを示す、決定論的で hashable、scope-bound、expiry-aware なガバナンス証跡として扱うためのものです。実 IdP・SSO・IAM・KMS/HSM・電子署名・本番承認ワークフローとの連携は含みません。
 
 境界条件:
+
+## SaaS Permission-Change Governed Execution Demo
+
+VERITAS には、local/offline の SaaS permission-change governed execution demo が追加されています。このデモでは、AI agent が外部委託者に admin 権限を付与しようとする場面を想定し、commit 前に AuthorityEvidence と HumanApprovalReceipt を検証します。証拠不足・期限切れ・scope mismatch の場合は fail-closed で block されます。実 SaaS・IAM・IdP・顧客ディレクトリとは接続していません。
+
+- ドキュメント: docs/en/demo/saas-permission-change-governed-demo.md
+- スクリプト: scripts/demo/saas_permission_change_governed_demo.py
+
+境界条件:
+
+- local/offline fixture 限定
+- 実 SaaS・実 IAM・実 IdP・実 SSO・実顧客ディレクトリ・本番承認ワークフローとの接続なし
+- 法的助言・規制承認・第三者認証・本番 access-control validation ではない
+
 
 - local/offline の決定論的 artifact のみ
 - 実 IdP・SSO・IAM・KMS/HSM・電子署名連携はなし

--- a/README_JP.md
+++ b/README_JP.md
@@ -78,6 +78,10 @@ VERITAS には local/offline の Human Approval Receipt v1 artifact が追加さ
 
 境界条件:
 
+- local/offline の決定論的 artifact のみ
+- 実 IdP・SSO・IAM・KMS/HSM・電子署名連携はなし
+- 法的助言・規制承認・第三者認証・本番承認妥当性の主張ではない
+
 ## SaaS Permission-Change Governed Execution Demo
 
 VERITAS には、local/offline の SaaS permission-change governed execution demo が追加されています。このデモでは、AI agent が外部委託者に admin 権限を付与しようとする場面を想定し、commit 前に AuthorityEvidence と HumanApprovalReceipt を検証します。証拠不足・期限切れ・scope mismatch の場合は fail-closed で block されます。実 SaaS・IAM・IdP・顧客ディレクトリとは接続していません。
@@ -91,10 +95,6 @@ VERITAS には、local/offline の SaaS permission-change governed execution dem
 - 実 SaaS・実 IAM・実 IdP・実 SSO・実顧客ディレクトリ・本番承認ワークフローとの接続なし
 - 法的助言・規制承認・第三者認証・本番 access-control validation ではない
 
-
-- local/offline の決定論的 artifact のみ
-- 実 IdP・SSO・IAM・KMS/HSM・電子署名連携はなし
-- 法的助言・規制承認・第三者認証・本番承認妥当性の主張ではない
 
 ## AML/KYC レビュアー向けウォークスルー Quickstart
 

--- a/docs/en/demo/saas-permission-change-governed-demo.md
+++ b/docs/en/demo/saas-permission-change-governed-demo.md
@@ -1,0 +1,49 @@
+# SaaS Permission-Change Governed Execution Demo (Local/Offline Fixture)
+
+This demo is a **local/offline fixture** showing how VERITAS governs an AI agent attempt to change SaaS permissions before execution.
+
+Scenario: an AI agent attempts to grant `admin` access (`saas:grant_admin`) to an external contractor account.
+
+- Script: `scripts/demo/saas_permission_change_governed_demo.py`
+- Tests: `tests/demo/test_saas_permission_change_governed_demo.py`
+
+## What it demonstrates
+
+VERITAS checks the following before commit-boundary execution:
+
+1. Authority evidence (Authority Evidence Ingestion v1 output)
+2. Human approval receipt (Human Approval Receipt v1 output)
+3. Runtime authority validation and bind-time commit-boundary evaluation
+
+Fail-closed behavior is demonstrated for:
+
+- missing authority evidence
+- missing human approval
+- expired human approval
+- scope mismatch between requested scope and granted/approved scope
+
+When both authority evidence and human approval are valid for `saas:grant_admin`, the action becomes commit-eligible (`commit` in the current evaluator vocabulary).
+
+## Deterministic fixture cases
+
+The demo runs deterministic cases with fixed timestamps and fixture IDs:
+
+- `missing_authority` → block
+- `missing_human_approval` → block
+- `expired_human_approval` → block
+- `scope_mismatch` → block
+- `valid_authority_and_approval` → commit
+
+## Local boundary / non-goals
+
+This fixture is local/offline only.
+
+It does **not** connect to live:
+
+- SaaS providers
+- IdP / IAM / SSO
+- customer directories
+- email systems
+- production approval workflows
+
+This is **not** legal advice, regulatory approval, third-party certification, or production access-control validation.

--- a/scripts/demo/saas_permission_change_governed_demo.py
+++ b/scripts/demo/saas_permission_change_governed_demo.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Deterministic local/offline SaaS permission-change governed execution demo."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from veritas_os.governance import (
+    ActionClassContract,
+    CommitBoundaryEvaluator,
+    HumanApprovalReceipt,
+    RuntimeAuthorityValidator,
+    build_human_approval_state,
+)
+from veritas_os.governance.authority_evidence_ingestion import (
+    ingest_authority_evidence_payload,
+)
+
+FIXED_NOW = datetime.fromisoformat("2026-04-26T00:00:00").replace(tzinfo=UTC)
+REQUESTED_SCOPE = ["saas:grant_admin"]
+TARGET_SYSTEM = "mock_saas_directory"
+TARGET_RESOURCE = "contractor:external.user@example.test"
+BOUNDARY_NOTE = "local/offline fixture only; no live SaaS/IAM/IdP integration"
+
+
+def _action_contract() -> ActionClassContract:
+    """Return a deterministic action-class contract for SaaS permission changes."""
+    return ActionClassContract(
+        id="saas_permission_change",
+        version="1.0.0",
+        domain="saas",
+        action_class="permission_change",
+        description="Govern SaaS permission changes before execution.",
+        declared_intent="Validate authority and human approval for admin grants.",
+        allowed_scope=["saas:permission_change", "saas:grant_admin"],
+        prohibited_scope=["saas:delete_workspace", "saas:billing_owner_transfer"],
+        authority_sources=["policy.saas_access"],
+        required_evidence=["access_request_ticket", "manager_approval"],
+        evidence_freshness={
+            "access_request_ticket": "P7D",
+            "manager_approval": "P7D",
+        },
+        irreversibility={"boundary": "saas_permission_commit", "level": "high"},
+        human_approval_rules={"minimum_approvals": 1},
+        refusal_conditions=["authority_indeterminate"],
+        escalation_conditions=["evidence_stale"],
+        default_failure_mode="fail_closed",
+        metadata={"regulated": True, "demo_fixture": True},
+    )
+
+
+def _authority_payload(*, scope_grants: list[str] | None = None) -> dict[str, Any]:
+    """Build a deterministic authority evidence payload for ingestion."""
+    return {
+        "authority_evidence_id": "aev-saas-001",
+        "action_contract_id": "saas_permission_change",
+        "action_contract_version": "1.0.0",
+        "actor_identity": "agent:ops-assistant",
+        "actor_role": "automation_operator",
+        "authority_source_refs": ["policy.saas_access"],
+        "role_or_policy_basis": ["role:automation_operator"],
+        "scope_grants": scope_grants or ["saas:grant_admin"],
+        "scope_limitations": ["saas:billing_owner_transfer"],
+        "issued_at": "2026-04-25T00:00:00+00:00",
+        "valid_from": "2026-04-25T00:00:00+00:00",
+        "valid_until": "2026-04-30T00:00:00+00:00",
+        "policy_snapshot_id": "policy-snapshot-saas-001",
+        "verification_result": "valid",
+        "metadata": {"source_type": "mock_policy_registry", "issuer": "governance"},
+    }
+
+
+def _human_approval_receipt(*, approved_scope: list[str], expires_at: str) -> HumanApprovalReceipt:
+    """Return a deterministic local/offline HumanApprovalReceipt."""
+    return HumanApprovalReceipt(
+        approval_receipt_id="har-saas-001",
+        decision_id="decision-saas-001",
+        execution_intent_id="intent-saas-001",
+        approver_identity="human:manager.alex",
+        approver_role="engineering_manager",
+        approved_action_class="permission_change",
+        approved_scope=approved_scope,
+        approval_basis_refs=["ticket:AR-1001", "manager_approval:MA-2002"],
+        approved_at="2026-04-25T00:00:00+00:00",
+        expires_at=expires_at,
+        policy_snapshot_id="policy-snapshot-saas-001",
+        authority_evidence_id="aev-saas-001",
+        approval_result="approved",
+        signature_verified=True,
+        receipt_hash="",
+        metadata={"fixture": True},
+    )
+
+
+def _evaluate_case(
+    *,
+    case_id: str,
+    expected_outcome: str,
+    authority_scope_grants: list[str] | None,
+    include_receipt: bool,
+    receipt_scope: list[str] | None,
+    receipt_expires_at: str,
+) -> dict[str, Any]:
+    """Evaluate one deterministic scenario and return JSON-friendly results."""
+    contract = _action_contract()
+    authority_evidence = None
+    if authority_scope_grants is not None:
+        authority_evidence = ingest_authority_evidence_payload(
+            _authority_payload(scope_grants=authority_scope_grants)
+        )
+
+    receipt = None
+    if include_receipt and receipt_scope is not None:
+        receipt = _human_approval_receipt(
+            approved_scope=receipt_scope,
+            expires_at=receipt_expires_at,
+        )
+
+    human_approval_state = build_human_approval_state(
+        receipt,
+        requested_scope=REQUESTED_SCOPE,
+        action_class=contract.action_class,
+        policy_snapshot_id="policy-snapshot-saas-001",
+        now=FIXED_NOW,
+    )
+
+    required_evidence_metadata = {
+        "access_request_ticket": {"present": True},
+        "manager_approval": {"present": True},
+    }
+    evidence_freshness_metadata = {
+        "access_request_ticket": {"fresh": True},
+        "manager_approval": {"fresh": True},
+    }
+
+    runtime_result = RuntimeAuthorityValidator().validate(
+        action_contract=contract,
+        authority_evidence=authority_evidence,
+        requested_scope=REQUESTED_SCOPE,
+        required_evidence_metadata={
+            key: {**required_evidence_metadata[key], **evidence_freshness_metadata[key]}
+            for key in required_evidence_metadata
+        },
+        policy_snapshot_id="policy-snapshot-saas-001",
+        actor_identity="agent:ops-assistant",
+        human_approval_state=human_approval_state,
+        bind_context_metadata={"session_id": "bind-saas-001", "fixture": True},
+        now=FIXED_NOW,
+    )
+    boundary_result = CommitBoundaryEvaluator().evaluate(
+        execution_intent={"action_class": "permission_change", "admissible": True},
+        action_contract=contract,
+        authority_evidence=authority_evidence,
+        requested_scope=REQUESTED_SCOPE,
+        required_evidence_metadata=required_evidence_metadata,
+        evidence_freshness_metadata=evidence_freshness_metadata,
+        policy_snapshot_id="policy-snapshot-saas-001",
+        actor_identity="agent:ops-assistant",
+        human_approval_state=human_approval_state,
+        bind_context_metadata={"session_id": "bind-saas-001", "fixture": True},
+        now=FIXED_NOW,
+    )
+
+    actual_outcome = boundary_result.commit_boundary_result
+    return {
+        "case_id": case_id,
+        "expected_outcome": expected_outcome,
+        "actual_outcome": actual_outcome,
+        "passed": expected_outcome == actual_outcome,
+        "authority_validation_status": runtime_result.status,
+        "runtime_recommended_outcome": runtime_result.recommended_outcome,
+        "human_approval_state": human_approval_state,
+        "refusal_basis": boundary_result.refusal_basis,
+        "failure_reasons": sorted(
+            {item.reason for item in boundary_result.failed_predicates + boundary_result.missing_predicates}
+        ),
+        "requested_scope": list(REQUESTED_SCOPE),
+        "target_system": TARGET_SYSTEM,
+        "target_resource": TARGET_RESOURCE,
+        "boundary_note": BOUNDARY_NOTE,
+    }
+
+
+def run_saas_permission_change_governed_demo() -> dict[str, Any]:
+    """Run deterministic local/offline governed execution cases for reviewers."""
+    scenarios = [
+        {
+            "case_id": "missing_authority",
+            "expected_outcome": "block",
+            "authority_scope_grants": None,
+            "include_receipt": True,
+            "receipt_scope": ["saas:grant_admin"],
+            "receipt_expires_at": "2026-04-30T00:00:00+00:00",
+        },
+        {
+            "case_id": "missing_human_approval",
+            "expected_outcome": "block",
+            "authority_scope_grants": ["saas:grant_admin"],
+            "include_receipt": False,
+            "receipt_scope": None,
+            "receipt_expires_at": "2026-04-30T00:00:00+00:00",
+        },
+        {
+            "case_id": "expired_human_approval",
+            "expected_outcome": "block",
+            "authority_scope_grants": ["saas:grant_admin"],
+            "include_receipt": True,
+            "receipt_scope": ["saas:grant_admin"],
+            "receipt_expires_at": "2026-04-20T00:00:00+00:00",
+        },
+        {
+            "case_id": "scope_mismatch",
+            "expected_outcome": "block",
+            "authority_scope_grants": ["saas:permission_change"],
+            "include_receipt": True,
+            "receipt_scope": ["saas:permission_change"],
+            "receipt_expires_at": "2026-04-30T00:00:00+00:00",
+        },
+        {
+            "case_id": "valid_authority_and_approval",
+            "expected_outcome": "commit",
+            "authority_scope_grants": ["saas:permission_change", "saas:grant_admin"],
+            "include_receipt": True,
+            "receipt_scope": ["saas:grant_admin"],
+            "receipt_expires_at": "2026-04-30T00:00:00+00:00",
+        },
+    ]
+
+    case_results = [_evaluate_case(**scenario) for scenario in scenarios]
+    return {
+        "demo_id": "saas_permission_change_governed_execution_v1",
+        "generated_at": FIXED_NOW.isoformat(),
+        "boundary_note": BOUNDARY_NOTE,
+        "cases": case_results,
+    }
+
+
+def main() -> int:
+    """Run demo from CLI and print deterministic JSON output."""
+    print(json.dumps(run_saas_permission_change_governed_demo(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_saas_permission_change_governed_demo.py
+++ b/tests/demo/test_saas_permission_change_governed_demo.py
@@ -1,0 +1,69 @@
+"""Tests for deterministic local/offline SaaS permission-change governed demo."""
+
+from __future__ import annotations
+
+from scripts.demo.saas_permission_change_governed_demo import (
+    BOUNDARY_NOTE,
+    run_saas_permission_change_governed_demo,
+)
+
+
+def _case_by_id(payload: dict[str, object], case_id: str) -> dict[str, object]:
+    for case in payload["cases"]:  # type: ignore[index]
+        if case["case_id"] == case_id:  # type: ignore[index]
+            return case
+    raise AssertionError(f"missing case: {case_id}")
+
+
+def test_missing_authority_blocks() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    case = _case_by_id(payload, "missing_authority")
+    assert case["actual_outcome"] == "block"
+    assert case["passed"] is True
+
+
+def test_missing_human_approval_blocks() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    case = _case_by_id(payload, "missing_human_approval")
+    assert case["actual_outcome"] == "block"
+    assert case["passed"] is True
+
+
+def test_expired_human_approval_blocks() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    case = _case_by_id(payload, "expired_human_approval")
+    assert case["actual_outcome"] == "block"
+    assert case["passed"] is True
+
+
+def test_scope_mismatch_blocks() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    case = _case_by_id(payload, "scope_mismatch")
+    assert case["actual_outcome"] == "block"
+    assert case["passed"] is True
+
+
+def test_valid_authority_and_approval_allows_commit_boundary() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    case = _case_by_id(payload, "valid_authority_and_approval")
+    assert case["actual_outcome"] in {"commit", "commit_eligible"}
+    assert case["passed"] is True
+
+
+def test_output_contains_deterministic_case_ids() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    case_ids = [case["case_id"] for case in payload["cases"]]  # type: ignore[index]
+    assert case_ids == [
+        "missing_authority",
+        "missing_human_approval",
+        "expired_human_approval",
+        "scope_mismatch",
+        "valid_authority_and_approval",
+    ]
+
+
+def test_output_contains_local_offline_boundary_note() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    assert payload["boundary_note"] == BOUNDARY_NOTE
+    for case in payload["cases"]:  # type: ignore[index]
+        assert case["boundary_note"] == BOUNDARY_NOTE


### PR DESCRIPTION
### Motivation

- Provide a deterministic local/offline demo showing how VERITAS enforces AuthorityEvidence and HumanApprovalReceipt checks before committing a SaaS permission change.
- Give reviewers a concise, reproducible example demonstrating fail-closed behavior for missing/expired/scope-mismatched evidence.

### Description

- Add `scripts/demo/saas_permission_change_governed_demo.py` implementing deterministic scenarios that exercise `RuntimeAuthorityValidator`, `CommitBoundaryEvaluator`, and `HumanApprovalReceipt` logic.
- Add `docs/en/demo/saas-permission-change-governed-demo.md` documenting the demo, scenarios, and non-goals for reviewers.
- Add tests in `tests/demo/test_saas_permission_change_governed_demo.py` that assert outcomes for five deterministic cases and verify output structure.
- Update `README.md` and `README_JP.md` to include the new demo in the quick-start/fast-path lists and add a brief demo summary and links.

### Testing

- Ran the new demo unit tests with `pytest tests/demo/test_saas_permission_change_governed_demo.py`, and they passed.
- The demo script produces deterministic JSON output when invoked as `python scripts/demo/saas_permission_change_governed_demo.py` as exercised by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c90d89508326b18c37aa133d8fd3)