### PR TITLE
runtime: add Bind Coverage Registry v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 7. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
 8. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
+9. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
 
 Boundary:
 
@@ -91,6 +92,11 @@ Boundary:
 - Local/offline fixture only
 - No live SaaS, IAM, IdP, SSO, customer directory, or production approval workflow integration
 - Not legal advice, regulatory approval, third-party certification, or production access-control validation
+
+
+## Bind Coverage Registry v1
+
+VERITAS includes a local/offline Bind Coverage Registry v1 that records which effect-bearing operations are expected to be governed by bind-time controls. The registry helps reviewers inspect whether high-impact actions require bind governance, AuthorityEvidence, HumanApprovalReceipt, policy snapshots, and fail-closed behavior. It is a deterministic coverage artifact, not a live route scanner or proof of production deployment.
 
 
 ## One-Day PoC Evidence Packet

--- a/README_JP.md
+++ b/README_JP.md
@@ -47,6 +47,7 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 7. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
 8. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
+9. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
 
 境界条件:
 
@@ -94,6 +95,11 @@ VERITAS には、local/offline の SaaS permission-change governed execution dem
 - local/offline fixture 限定
 - 実 SaaS・実 IAM・実 IdP・実 SSO・実顧客ディレクトリ・本番承認ワークフローとの接続なし
 - 法的助言・規制承認・第三者認証・本番 access-control validation ではない
+
+
+## Bind Coverage Registry v1
+
+VERITAS には local/offline の Bind Coverage Registry v1 が追加されています。これは、effect-bearing な操作が bind-time governance の対象になっているかを記録するための coverage artifact です。高影響アクションが Bind、AuthorityEvidence、HumanApprovalReceipt、policy snapshot、fail-closed を要求しているかを外部レビュアーが確認しやすくするためのものであり、live route scanner や本番導入証明ではありません。
 
 
 ## AML/KYC レビュアー向けウォークスルー Quickstart

--- a/docs/en/architecture/bind-coverage-registry.md
+++ b/docs/en/architecture/bind-coverage-registry.md
@@ -43,3 +43,17 @@ Registry validation checks include:
 - implementation refs are non-empty.
 - docs refs are non-empty for reviewer-facing entries.
 - entries do not claim live integration unless explicitly implemented elsewhere.
+
+## Authority control types
+
+Each registry entry declares `authority_control_type` to avoid overclaiming:
+
+- `authority_evidence`: operation is expected to use first-class
+  AuthorityEvidence artifact validation.
+- `bind_authority_signal`: operation is governed by bind-time authority checks
+  and approval signals, but not necessarily by first-class AuthorityEvidence
+  artifact ingestion.
+- `none`: no authority control is expected for that operation.
+
+This distinction is local/offline reviewer metadata. It is not a live route
+scanner, and it is not proof of production deployment.

--- a/docs/en/architecture/bind-coverage-registry.md
+++ b/docs/en/architecture/bind-coverage-registry.md
@@ -1,0 +1,45 @@
+# Bind Coverage Registry v1 (local/offline)
+
+## Purpose
+
+Bind Coverage Registry v1 is a deterministic local/offline coverage artifact that records which effect-bearing operations are expected to be governed by bind-time controls.
+
+It helps reviewers answer a practical question:
+
+- Are high-impact execution paths governed by bind-time controls, or only isolated demos?
+
+## What this registry is
+
+- A deterministic list of effect-bearing operations in current scope.
+- A reviewer-facing mapping between operations and governance expectations.
+- A fail-closed expectation record for authority and human-approval prerequisites.
+
+## What this registry is not
+
+- Not a live route scanner.
+- Not proof of production deployment.
+- Not live integration with SaaS, IdP, IAM, banks, sanctions providers, or customer systems.
+- Not runtime enforcement changes by itself.
+
+## How it complements existing governance artifacts
+
+Bind Coverage Registry v1 complements:
+
+- Authority Evidence Ingestion v1 (`docs/en/architecture/authority-evidence-ingestion.md`)
+- Human Approval Receipt v1 (`docs/en/architecture/human-approval-receipt.md`)
+- SaaS Permission-Change Governed Execution Demo (`docs/en/demo/saas-permission-change-governed-demo.md`)
+
+Together, these artifacts make local/offline governance expectations more reviewable for external diligence.
+
+## Validation expectations
+
+Registry validation checks include:
+
+- `operation_id` is non-empty and unique.
+- `effect_level` is one of `low|medium|high|critical`.
+- `high|critical` entries require bind-time governance and fail-closed defaults.
+- authority-required entries must block without authority.
+- human-approval-required entries must block without human approval.
+- implementation refs are non-empty.
+- docs refs are non-empty for reviewer-facing entries.
+- entries do not claim live integration unless explicitly implemented elsewhere.

--- a/tests/policy/test_bind_coverage_registry.py
+++ b/tests/policy/test_bind_coverage_registry.py
@@ -1,0 +1,126 @@
+"""Tests for deterministic bind coverage registry v1."""
+
+from __future__ import annotations
+
+from veritas_os.policy.bind_coverage_registry import (
+    BindCoverageEntry,
+    load_bind_coverage_registry,
+    validate_bind_coverage_registry,
+)
+
+
+def _entry(entries: list[BindCoverageEntry], operation_id: str) -> BindCoverageEntry:
+    for item in entries:
+        if item.operation_id == operation_id:
+            return item
+    raise AssertionError(f"missing operation_id: {operation_id}")
+
+
+def test_registry_loads_successfully() -> None:
+    entries = load_bind_coverage_registry()
+    result = validate_bind_coverage_registry(entries)
+    assert entries
+    assert result.valid is True
+
+
+def test_operation_ids_are_unique() -> None:
+    entries = load_bind_coverage_registry()
+    operation_ids = [entry.operation_id for entry in entries]
+    assert len(operation_ids) == len(set(operation_ids))
+
+
+def test_high_critical_entries_require_bind() -> None:
+    entries = load_bind_coverage_registry()
+    for entry in entries:
+        if entry.effect_level in {"high", "critical"}:
+            assert entry.requires_bind is True
+
+
+def test_high_critical_entries_fail_closed() -> None:
+    entries = load_bind_coverage_registry()
+    for entry in entries:
+        if entry.effect_level in {"high", "critical"}:
+            assert entry.default_failure_mode == "fail_closed"
+
+
+def test_authority_required_entries_block_without_authority() -> None:
+    entries = load_bind_coverage_registry()
+    for entry in entries:
+        if entry.requires_authority_evidence:
+            assert entry.expected_without_authority == "block"
+
+
+def test_human_approval_required_entries_block_without_human_approval() -> None:
+    entries = load_bind_coverage_registry()
+    for entry in entries:
+        if entry.requires_human_approval:
+            assert entry.expected_without_human_approval == "block"
+
+
+def test_saas_permission_change_demo_entry_exists() -> None:
+    entries = load_bind_coverage_registry()
+    assert _entry(entries, "saas_permission_change_demo")
+
+
+def test_saas_permission_change_demo_requires_authority_evidence() -> None:
+    entry = _entry(load_bind_coverage_registry(), "saas_permission_change_demo")
+    assert entry.requires_authority_evidence is True
+
+
+def test_saas_permission_change_demo_requires_human_approval() -> None:
+    entry = _entry(load_bind_coverage_registry(), "saas_permission_change_demo")
+    assert entry.requires_human_approval is True
+
+
+def test_validator_fails_for_duplicate_operation_id() -> None:
+    entries = load_bind_coverage_registry()
+    duplicate = entries[0]
+    result = validate_bind_coverage_registry(entries + [duplicate])
+    assert result.valid is False
+    assert any("duplicate operation_id" in error for error in result.errors)
+
+
+def test_validator_fails_for_high_effect_without_bind() -> None:
+    invalid_entry = BindCoverageEntry(
+        operation_id="invalid_high_without_bind",
+        operation_type="demo",
+        action_class="permission_change",
+        effect_level="high",
+        requires_bind=False,
+        requires_authority_evidence=False,
+        requires_human_approval=False,
+        requires_policy_snapshot=True,
+        expected_without_authority="not_required",
+        expected_without_human_approval="not_required",
+        default_failure_mode="fail_closed",
+        implementation_refs=("scripts/demo/saas_permission_change_governed_demo.py",),
+        test_refs=("tests/demo/test_saas_permission_change_governed_demo.py",),
+        docs_refs=("docs/en/demo/saas-permission-change-governed-demo.md",),
+        boundary_note="local/offline deterministic fixture",
+    )
+    result = validate_bind_coverage_registry([invalid_entry])
+    assert result.valid is False
+    assert any("must require bind" in error for error in result.errors)
+
+
+def test_validator_fails_for_authority_required_without_block() -> None:
+    invalid_entry = BindCoverageEntry(
+        operation_id="invalid_authority_expectation",
+        operation_type="script",
+        action_class="regulated_action",
+        effect_level="medium",
+        requires_bind=True,
+        requires_authority_evidence=True,
+        requires_human_approval=False,
+        requires_policy_snapshot=True,
+        expected_without_authority="not_required",
+        expected_without_human_approval="not_required",
+        default_failure_mode="fail_closed",
+        implementation_refs=("veritas_os/governance/regulated_action_path.py",),
+        test_refs=("tests/governance/test_aml_kyc_regulated_action_path.py",),
+        docs_refs=("docs/en/architecture/regulated-action-governance-kernel.md",),
+        boundary_note="local/offline deterministic fixture",
+    )
+    result = validate_bind_coverage_registry([invalid_entry])
+    assert result.valid is False
+    assert any("must block without authority" in error for error in result.errors)

--- a/tests/policy/test_bind_coverage_registry.py
+++ b/tests/policy/test_bind_coverage_registry.py
@@ -65,11 +65,25 @@ def test_saas_permission_change_demo_entry_exists() -> None:
 def test_saas_permission_change_demo_requires_authority_evidence() -> None:
     entry = _entry(load_bind_coverage_registry(), "saas_permission_change_demo")
     assert entry.requires_authority_evidence is True
+    assert entry.authority_control_type == "authority_evidence"
+
+
+def test_aml_kyc_path_uses_authority_evidence_control() -> None:
+    entry = _entry(load_bind_coverage_registry(), "aml_kyc_regulated_action_path")
+    assert entry.authority_control_type == "authority_evidence"
+    assert entry.requires_authority_evidence is True
 
 
 def test_saas_permission_change_demo_requires_human_approval() -> None:
     entry = _entry(load_bind_coverage_registry(), "saas_permission_change_demo")
     assert entry.requires_human_approval is True
+
+
+def test_governance_policy_update_uses_bind_authority_signal() -> None:
+    entry = _entry(load_bind_coverage_registry(), "governance_policy_update_put")
+    assert entry.authority_control_type == "bind_authority_signal"
+    assert entry.requires_authority_evidence is False
+    assert entry.expected_without_authority == "block"
 
 
 def test_validator_fails_for_duplicate_operation_id() -> None:
@@ -87,6 +101,7 @@ def test_validator_fails_for_high_effect_without_bind() -> None:
         action_class="permission_change",
         effect_level="high",
         requires_bind=False,
+        authority_control_type="none",
         requires_authority_evidence=False,
         requires_human_approval=False,
         requires_policy_snapshot=True,
@@ -110,6 +125,7 @@ def test_validator_fails_for_authority_required_without_block() -> None:
         action_class="regulated_action",
         effect_level="medium",
         requires_bind=True,
+        authority_control_type="authority_evidence",
         requires_authority_evidence=True,
         requires_human_approval=False,
         requires_policy_snapshot=True,
@@ -124,3 +140,98 @@ def test_validator_fails_for_authority_required_without_block() -> None:
     result = validate_bind_coverage_registry([invalid_entry])
     assert result.valid is False
     assert any("must block without authority" in error for error in result.errors)
+
+
+def test_validator_fails_when_requires_authority_but_control_type_is_not_evidence() -> None:
+    invalid_entry = BindCoverageEntry(
+        operation_id="invalid_authority_control_pairing",
+        operation_type="script",
+        action_class="regulated_action",
+        effect_level="medium",
+        requires_bind=True,
+        authority_control_type="bind_authority_signal",
+        requires_authority_evidence=True,
+        requires_human_approval=False,
+        requires_policy_snapshot=True,
+        expected_without_authority="block",
+        expected_without_human_approval="not_required",
+        default_failure_mode="fail_closed",
+        implementation_refs=("veritas_os/governance/regulated_action_path.py",),
+        test_refs=("tests/governance/test_aml_kyc_regulated_action_path.py",),
+        docs_refs=("docs/en/architecture/regulated-action-governance-kernel.md",),
+        boundary_note="local/offline deterministic fixture",
+    )
+    result = validate_bind_coverage_registry([invalid_entry])
+    assert result.valid is False
+    assert any("requires_authority_evidence=true" in error for error in result.errors)
+
+
+def test_validator_fails_when_authority_evidence_control_has_no_evidence_requirement() -> None:
+    invalid_entry = BindCoverageEntry(
+        operation_id="invalid_authority_evidence_missing_requirement",
+        operation_type="demo",
+        action_class="permission_change",
+        effect_level="high",
+        requires_bind=True,
+        authority_control_type="authority_evidence",
+        requires_authority_evidence=False,
+        requires_human_approval=False,
+        requires_policy_snapshot=True,
+        expected_without_authority="block",
+        expected_without_human_approval="not_required",
+        default_failure_mode="fail_closed",
+        implementation_refs=("scripts/demo/saas_permission_change_governed_demo.py",),
+        test_refs=("tests/demo/test_saas_permission_change_governed_demo.py",),
+        docs_refs=("docs/en/demo/saas-permission-change-governed-demo.md",),
+        boundary_note="local/offline deterministic fixture",
+    )
+    result = validate_bind_coverage_registry([invalid_entry])
+    assert result.valid is False
+    assert any("must require authority evidence" in error for error in result.errors)
+
+
+def test_validator_fails_for_invalid_authority_control_type() -> None:
+    invalid_entry = BindCoverageEntry(
+        operation_id="invalid_authority_control_type",
+        operation_type="route",
+        action_class="governance_policy_update",
+        effect_level="medium",
+        requires_bind=True,
+        authority_control_type="invalid",  # type: ignore[arg-type]
+        requires_authority_evidence=False,
+        requires_human_approval=True,
+        requires_policy_snapshot=True,
+        expected_without_authority="block",
+        expected_without_human_approval="block",
+        default_failure_mode="fail_closed",
+        implementation_refs=("veritas_os/policy/governance_policy_update.py",),
+        test_refs=("tests/governance/test_commit_boundary.py",),
+        docs_refs=("docs/en/architecture/bind-boundary-governance-artifacts.md",),
+        boundary_note="local/offline deterministic fixture",
+    )
+    result = validate_bind_coverage_registry([invalid_entry])
+    assert result.valid is False
+    assert any("invalid authority_control_type" in error for error in result.errors)
+
+
+def test_validator_allows_bind_authority_signal_without_authority_evidence() -> None:
+    valid_entry = BindCoverageEntry(
+        operation_id="valid_bind_authority_signal_entry",
+        operation_type="route",
+        action_class="governance_policy_update",
+        effect_level="high",
+        requires_bind=True,
+        authority_control_type="bind_authority_signal",
+        requires_authority_evidence=False,
+        requires_human_approval=True,
+        requires_policy_snapshot=True,
+        expected_without_authority="block",
+        expected_without_human_approval="block",
+        default_failure_mode="fail_closed",
+        implementation_refs=("veritas_os/policy/governance_policy_update.py",),
+        test_refs=("tests/governance/test_commit_boundary.py",),
+        docs_refs=("docs/en/architecture/bind-boundary-governance-artifacts.md",),
+        boundary_note="local/offline deterministic fixture",
+    )
+    result = validate_bind_coverage_registry([valid_entry])
+    assert result.valid is True

--- a/veritas_os/policy/bind_coverage_registry.py
+++ b/veritas_os/policy/bind_coverage_registry.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 EffectLevel = Literal["low", "medium", "high", "critical"]
 OperationType = Literal["route", "script", "governance_action", "demo"]
+AuthorityControlType = Literal["authority_evidence", "bind_authority_signal", "none"]
 BlockBehavior = Literal["block", "not_required"]
 FailureMode = Literal["fail_closed"]
 
@@ -22,6 +23,7 @@ class BindCoverageEntry:
     action_class: str
     effect_level: EffectLevel
     requires_bind: bool
+    authority_control_type: AuthorityControlType
     requires_authority_evidence: bool
     requires_human_approval: bool
     requires_policy_snapshot: bool
@@ -49,6 +51,7 @@ _BIND_COVERAGE_REGISTRY: tuple[BindCoverageEntry, ...] = (
         action_class="permission_change",
         effect_level="high",
         requires_bind=True,
+        authority_control_type="authority_evidence",
         requires_authority_evidence=True,
         requires_human_approval=True,
         requires_policy_snapshot=True,
@@ -70,6 +73,7 @@ _BIND_COVERAGE_REGISTRY: tuple[BindCoverageEntry, ...] = (
         action_class="aml_kyc_customer_risk_escalation",
         effect_level="critical",
         requires_bind=True,
+        authority_control_type="authority_evidence",
         requires_authority_evidence=True,
         requires_human_approval=True,
         requires_policy_snapshot=True,
@@ -91,7 +95,8 @@ _BIND_COVERAGE_REGISTRY: tuple[BindCoverageEntry, ...] = (
         action_class="governance_policy_update",
         effect_level="high",
         requires_bind=True,
-        requires_authority_evidence=True,
+        authority_control_type="bind_authority_signal",
+        requires_authority_evidence=False,
         requires_human_approval=True,
         requires_policy_snapshot=True,
         expected_without_authority="block",
@@ -137,6 +142,15 @@ def validate_bind_coverage_registry(
             errors.append(
                 f"invalid effect_level for {entry.operation_id}: {entry.effect_level}"
             )
+        if entry.authority_control_type not in {
+            "authority_evidence",
+            "bind_authority_signal",
+            "none",
+        }:
+            errors.append(
+                "invalid authority_control_type for "
+                f"{entry.operation_id}: {entry.authority_control_type}"
+            )
 
         if entry.effect_level in {"high", "critical"} and not entry.requires_bind:
             errors.append(
@@ -151,12 +165,33 @@ def validate_bind_coverage_registry(
                 f"high/critical operation must fail closed: {entry.operation_id}"
             )
 
+        if entry.authority_control_type == "authority_evidence":
+            if not entry.requires_authority_evidence:
+                errors.append(
+                    "authority_evidence control must require authority evidence: "
+                    f"{entry.operation_id}"
+                )
+            if entry.expected_without_authority != "block":
+                errors.append(
+                    "authority_evidence control must block without authority: "
+                    f"{entry.operation_id}"
+                )
+
         if (
             entry.requires_authority_evidence
+            and entry.authority_control_type != "authority_evidence"
+        ):
+            errors.append(
+                "requires_authority_evidence=true requires authority_control_type "
+                f"authority_evidence: {entry.operation_id}"
+            )
+
+        if (
+            entry.authority_control_type == "bind_authority_signal"
             and entry.expected_without_authority != "block"
         ):
             errors.append(
-                "authority-required operation must block without authority: "
+                "bind_authority_signal operation must block without authority: "
                 f"{entry.operation_id}"
             )
 

--- a/veritas_os/policy/bind_coverage_registry.py
+++ b/veritas_os/policy/bind_coverage_registry.py
@@ -1,0 +1,186 @@
+"""Deterministic local/offline bind coverage registry for effect-bearing operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+EffectLevel = Literal["low", "medium", "high", "critical"]
+OperationType = Literal["route", "script", "governance_action", "demo"]
+BlockBehavior = Literal["block", "not_required"]
+FailureMode = Literal["fail_closed"]
+
+_ALLOWED_EFFECT_LEVELS = {"low", "medium", "high", "critical"}
+
+
+@dataclass(frozen=True)
+class BindCoverageEntry:
+    """Registry row describing bind-governance expectations for one operation."""
+
+    operation_id: str
+    operation_type: OperationType
+    action_class: str
+    effect_level: EffectLevel
+    requires_bind: bool
+    requires_authority_evidence: bool
+    requires_human_approval: bool
+    requires_policy_snapshot: bool
+    expected_without_authority: BlockBehavior
+    expected_without_human_approval: BlockBehavior
+    default_failure_mode: FailureMode
+    implementation_refs: tuple[str, ...]
+    test_refs: tuple[str, ...]
+    docs_refs: tuple[str, ...]
+    boundary_note: str
+
+
+@dataclass(frozen=True)
+class BindCoverageValidationResult:
+    """Validation output for the deterministic bind coverage registry."""
+
+    valid: bool
+    errors: tuple[str, ...]
+
+
+_BIND_COVERAGE_REGISTRY: tuple[BindCoverageEntry, ...] = (
+    BindCoverageEntry(
+        operation_id="saas_permission_change_demo",
+        operation_type="demo",
+        action_class="permission_change",
+        effect_level="high",
+        requires_bind=True,
+        requires_authority_evidence=True,
+        requires_human_approval=True,
+        requires_policy_snapshot=True,
+        expected_without_authority="block",
+        expected_without_human_approval="block",
+        default_failure_mode="fail_closed",
+        implementation_refs=(
+            "scripts/demo/saas_permission_change_governed_demo.py",
+            "veritas_os/governance/commit_boundary.py",
+            "veritas_os/governance/runtime_authority.py",
+        ),
+        test_refs=("tests/demo/test_saas_permission_change_governed_demo.py",),
+        docs_refs=("docs/en/demo/saas-permission-change-governed-demo.md",),
+        boundary_note="local/offline fixture only; no live SaaS/IAM/IdP integration",
+    ),
+    BindCoverageEntry(
+        operation_id="aml_kyc_regulated_action_path",
+        operation_type="governance_action",
+        action_class="aml_kyc_customer_risk_escalation",
+        effect_level="critical",
+        requires_bind=True,
+        requires_authority_evidence=True,
+        requires_human_approval=True,
+        requires_policy_snapshot=True,
+        expected_without_authority="block",
+        expected_without_human_approval="block",
+        default_failure_mode="fail_closed",
+        implementation_refs=(
+            "veritas_os/governance/regulated_action_path.py",
+            "veritas_os/governance/commit_boundary.py",
+            "veritas_os/governance/runtime_authority.py",
+        ),
+        test_refs=("tests/governance/test_aml_kyc_regulated_action_path.py",),
+        docs_refs=("docs/en/architecture/regulated-action-governance-kernel.md",),
+        boundary_note="deterministic local/offline AML-KYC fixture; no live bank/sanctions systems",
+    ),
+    BindCoverageEntry(
+        operation_id="governance_policy_update_put",
+        operation_type="route",
+        action_class="governance_policy_update",
+        effect_level="high",
+        requires_bind=True,
+        requires_authority_evidence=True,
+        requires_human_approval=True,
+        requires_policy_snapshot=True,
+        expected_without_authority="block",
+        expected_without_human_approval="block",
+        default_failure_mode="fail_closed",
+        implementation_refs=(
+            "veritas_os/api/routes_governance.py",
+            "veritas_os/policy/governance_policy_update.py",
+            "veritas_os/policy/bind_execution.py",
+        ),
+        test_refs=(
+            "tests/test_bind_admissibility.py",
+            "tests/governance/test_commit_boundary.py",
+        ),
+        docs_refs=("docs/en/architecture/bind-boundary-governance-artifacts.md",),
+        boundary_note="bind-governed policy mutation path with deterministic local validation",
+    ),
+)
+
+
+def load_bind_coverage_registry() -> list[BindCoverageEntry]:
+    """Return the deterministic bind coverage registry entries."""
+
+    return list(_BIND_COVERAGE_REGISTRY)
+
+
+def validate_bind_coverage_registry(
+    entries: list[BindCoverageEntry],
+) -> BindCoverageValidationResult:
+    """Validate entry integrity and fail-closed governance expectations."""
+
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+
+    for entry in entries:
+        if not entry.operation_id.strip():
+            errors.append("operation_id must be non-empty")
+        elif entry.operation_id in seen_ids:
+            errors.append(f"duplicate operation_id: {entry.operation_id}")
+        seen_ids.add(entry.operation_id)
+
+        if entry.effect_level not in _ALLOWED_EFFECT_LEVELS:
+            errors.append(
+                f"invalid effect_level for {entry.operation_id}: {entry.effect_level}"
+            )
+
+        if entry.effect_level in {"high", "critical"} and not entry.requires_bind:
+            errors.append(
+                f"high/critical operation must require bind: {entry.operation_id}"
+            )
+
+        if (
+            entry.effect_level in {"high", "critical"}
+            and entry.default_failure_mode != "fail_closed"
+        ):
+            errors.append(
+                f"high/critical operation must fail closed: {entry.operation_id}"
+            )
+
+        if (
+            entry.requires_authority_evidence
+            and entry.expected_without_authority != "block"
+        ):
+            errors.append(
+                "authority-required operation must block without authority: "
+                f"{entry.operation_id}"
+            )
+
+        if (
+            entry.requires_human_approval
+            and entry.expected_without_human_approval != "block"
+        ):
+            errors.append(
+                "human-approval-required operation must block without approval: "
+                f"{entry.operation_id}"
+            )
+
+        if not entry.implementation_refs:
+            errors.append(
+                f"implementation_refs must be non-empty: {entry.operation_id}"
+            )
+
+        if not entry.docs_refs:
+            errors.append(f"docs_refs should be non-empty: {entry.operation_id}")
+
+        note = entry.boundary_note.lower()
+        if "live" in note and "no live" not in note:
+            errors.append(
+                f"entry may not claim live integration: {entry.operation_id}"
+            )
+
+    return BindCoverageValidationResult(valid=not errors, errors=tuple(errors))


### PR DESCRIPTION
### Motivation

- Provide a small, deterministic, reviewer-facing registry that maps effect-bearing operations to their expected bind-time governance requirements so external reviewers can quickly answer whether high-impact paths are governed or only demos.
- Make governance expectations explicit and machine-validateable (fail-closed, authority/human-approval invariants) without adding any live integrations or runtime enforcement changes.

### Description

- Add `veritas_os/policy/bind_coverage_registry.py` implementing `BindCoverageEntry` and `BindCoverageValidationResult` dataclasses, a canonical `_BIND_COVERAGE_REGISTRY`, `load_bind_coverage_registry()` and `validate_bind_coverage_registry()` validator functions enforcing uniqueness, allowed `effect_level`, bind/fail-closed invariants, authority/human-approval blocking expectations, non-empty implementation/docs refs, and forbidding claims of live integration.
- Include three initial reviewer-facing entries: `saas_permission_change_demo`, `aml_kyc_regulated_action_path`, and `governance_policy_update_put`, with implementation/test/docs refs and local/offline boundary notes.
- Add focused unit tests in `tests/policy/test_bind_coverage_registry.py` covering positive loading/validation and negative cases (duplicate `operation_id`, high/critical without `requires_bind`, authority-required without blocking expectation, and other invariants).
- Add architecture doc `docs/en/architecture/bind-coverage-registry.md` describing scope (local/offline), purpose, and validation expectations, and update `README.md` and `README_JP.md` fast-paths with a short Bind Coverage Registry section.

### Testing

- Added the test module `tests/policy/test_bind_coverage_registry.py` that exercises `load_bind_coverage_registry()` and `validate_bind_coverage_registry()` with both positive and negative cases.
- Attempted to run `PYENV_VERSION=3.11.15 pytest -q tests/policy/test_bind_coverage_registry.py tests/demo/test_saas_permission_change_governed_demo.py tests/governance/test_aml_kyc_regulated_action_path.py` but test collection failed due to missing environment dependencies (`pydantic`, `yaml`), so tests could not be executed in this environment.
- The validator and tests are deterministic and designed to pass once standard project test dependencies are available in CI (no runtime network calls or credentials are required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17a54c37e48326ab25f5fae1d8da50)