### PR TITLE
runtime: add Outcome Receipt v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
 3. Authority Evidence Ingestion (local/offline): docs/en/architecture/authority-evidence-ingestion.md
 4. Human Approval Receipt v1 (local/offline): docs/en/architecture/human-approval-receipt.md
-5. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+5. Outcome Receipt v1 (local/offline): docs/en/architecture/outcome-receipt.md
+6. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
 6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 7. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
 8. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
-9. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
+10. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
 
 Boundary:
 
@@ -78,6 +79,10 @@ Boundary:
 - Local/offline deterministic artifact only
 - No live IdP, SSO, IAM, KMS/HSM, or e-signature integration
 - Not legal advice, regulatory approval, third-party certification, or production approval validation
+
+## Outcome Receipt v1
+
+VERITAS includes a local/offline Outcome Receipt v1 artifact that records post-execution outcome evidence for governed execution attempts. It captures final outcome, commit/block/rollback status, postcondition status, state fingerprints, observed effects, and deterministic outcome hashing. This is a local/offline evidence artifact, not proof of live production execution.
 
 ## SaaS Permission-Change Governed Execution Demo
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ For a 10-minute implementation snapshot, start here:
 For a concise business-facing overview, see [Enterprise Value Brief](docs/en/positioning/enterprise-value-brief.md).
 日本語補助版: [企業向け価値説明ブリーフ](docs/ja/positioning/enterprise-value-brief.md)
 
-1. [Reviewer Entrypoint](docs/REVIEWER_ENTRYPOINT.md)
+1. [External Validation Brief](docs/REVIEWER_ENTRYPOINT.md)
 2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
 3. Authority Evidence Ingestion (local/offline): docs/en/architecture/authority-evidence-ingestion.md
 4. Human Approval Receipt v1 (local/offline): docs/en/architecture/human-approval-receipt.md
 5. Outcome Receipt v1 (local/offline): docs/en/architecture/outcome-receipt.md
 6. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
-7. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
-8. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
+7. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+8. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
+9. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
 10. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
 
 Boundary:

--- a/README_JP.md
+++ b/README_JP.md
@@ -39,15 +39,15 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 
 10 分で実装スナップショットを確認する場合は、次の順で参照してください。
 
-1. [Reviewer Entrypoint](docs/REVIEWER_ENTRYPOINT.md)
+1. [External Validation Brief](docs/REVIEWER_ENTRYPOINT.md)
 2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
 3. Authority Evidence Ingestion（local/offline）: docs/en/architecture/authority-evidence-ingestion.md
 4. Human Approval Receipt v1（local/offline）: docs/en/architecture/human-approval-receipt.md
 5. Outcome Receipt v1（local/offline）: docs/en/architecture/outcome-receipt.md
 6. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
-7. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
-8. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
+7. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+8. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
+9. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
 10. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
 
 境界条件:

--- a/README_JP.md
+++ b/README_JP.md
@@ -43,11 +43,12 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
 3. Authority Evidence Ingestion（local/offline）: docs/en/architecture/authority-evidence-ingestion.md
 4. Human Approval Receipt v1（local/offline）: docs/en/architecture/human-approval-receipt.md
-5. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+5. Outcome Receipt v1（local/offline）: docs/en/architecture/outcome-receipt.md
+6. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
 6. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 7. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
 8. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
-9. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
+10. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
 
 境界条件:
 
@@ -82,6 +83,10 @@ VERITAS には local/offline の Human Approval Receipt v1 artifact が追加さ
 - local/offline の決定論的 artifact のみ
 - 実 IdP・SSO・IAM・KMS/HSM・電子署名連携はなし
 - 法的助言・規制承認・第三者認証・本番承認妥当性の主張ではない
+
+## Outcome Receipt v1
+
+VERITAS には local/offline の Outcome Receipt v1 artifact が追加されています。これは、governed execution attempt の実行後結果を記録するための証跡であり、final outcome、commit/block/rollback 状態、postcondition status、state fingerprint、observed effects、決定論的 outcome hash を扱います。本番環境での実行証明ではなく、local/offline の evidence artifact です。
 
 ## SaaS Permission-Change Governed Execution Demo
 

--- a/docs/en/architecture/outcome-receipt.md
+++ b/docs/en/architecture/outcome-receipt.md
@@ -1,0 +1,27 @@
+# Outcome Receipt v1 (local/offline)
+
+Outcome Receipt v1 is a deterministic local/offline artifact that records post-execution outcome evidence for governed execution attempts.
+
+It complements:
+
+- Authority Evidence Ingestion v1
+- Human Approval Receipt v1
+- SaaS Permission-Change Governed Demo
+- Bind Coverage Registry v1
+
+It can represent:
+
+- what execution was attempted
+- final outcome (`commit`, `block`, `escalate`, etc.)
+- commit/block/escalation/rollback status
+- postcondition status (`passed`, `failed`, `skipped`, `indeterminate`)
+- optional pre/post state fingerprints
+- observed effects captured as local/offline fixtures
+- deterministic `outcome_hash` for review and replay stability
+
+Boundary in this PR:
+
+- Local/offline deterministic artifact only
+- No live SaaS/IdP/IAM/SSO/bank/sanctions/customer-system integrations
+- Not proof of live production execution
+- Not legal advice, regulatory approval, third-party certification, or production access-control validation

--- a/scripts/demo/saas_permission_change_governed_demo.py
+++ b/scripts/demo/saas_permission_change_governed_demo.py
@@ -12,6 +12,7 @@ from veritas_os.governance import (
     CommitBoundaryEvaluator,
     HumanApprovalReceipt,
     RuntimeAuthorityValidator,
+    build_outcome_receipt,
     build_human_approval_state,
 )
 from veritas_os.governance.authority_evidence_ingestion import (
@@ -164,6 +165,37 @@ def _evaluate_case(
     )
 
     actual_outcome = boundary_result.commit_boundary_result
+    observed_effects: list[dict[str, Any]] = []
+    postcondition_status = "skipped"
+    if case_id == "valid_authority_and_approval":
+        observed_effects = [
+            {
+                "effect_type": "permission_grant",
+                "permission": "saas:grant_admin",
+                "target_resource": TARGET_RESOURCE,
+                "fixture_only": True,
+            }
+        ]
+        postcondition_status = "passed"
+
+    outcome_receipt = build_outcome_receipt(
+        decision_id="decision-saas-001",
+        execution_intent_id="intent-saas-001",
+        bind_receipt_id=None,
+        operation_id=f"saas-permission-change-{case_id}",
+        action_class=contract.action_class,
+        target_system=TARGET_SYSTEM,
+        target_resource=TARGET_RESOURCE,
+        intended_action="grant_admin_permission",
+        requested_scope=list(REQUESTED_SCOPE),
+        final_outcome=actual_outcome,
+        postcondition_status=postcondition_status,
+        observed_effects=observed_effects,
+        failure_reasons=[boundary_result.refusal_basis] if boundary_result.refusal_basis else [],
+        rollback_status=None,
+        evaluated_at=FIXED_NOW.isoformat(),
+        metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},
+    )
     return {
         "case_id": case_id,
         "expected_outcome": expected_outcome,
@@ -180,6 +212,7 @@ def _evaluate_case(
         "target_system": TARGET_SYSTEM,
         "target_resource": TARGET_RESOURCE,
         "boundary_note": BOUNDARY_NOTE,
+        "outcome_receipt_summary": outcome_receipt.to_dict(),
     }
 
 

--- a/scripts/demo/saas_permission_change_governed_demo.py
+++ b/scripts/demo/saas_permission_change_governed_demo.py
@@ -191,7 +191,13 @@ def _evaluate_case(
         final_outcome=actual_outcome,
         postcondition_status=postcondition_status,
         observed_effects=observed_effects,
-        failure_reasons=[boundary_result.refusal_basis] if boundary_result.refusal_basis else [],
+        failure_reasons=sorted(
+            {
+                item.reason
+                for item in boundary_result.failed_predicates
+                + boundary_result.missing_predicates
+            }
+        ),
         rollback_status=None,
         evaluated_at=FIXED_NOW.isoformat(),
         metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},

--- a/tests/demo/test_saas_permission_change_governed_demo.py
+++ b/tests/demo/test_saas_permission_change_governed_demo.py
@@ -67,3 +67,48 @@ def test_output_contains_local_offline_boundary_note() -> None:
     assert payload["boundary_note"] == BOUNDARY_NOTE
     for case in payload["cases"]:  # type: ignore[index]
         assert case["boundary_note"] == BOUNDARY_NOTE
+
+
+def test_every_case_includes_outcome_receipt_summary() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case in payload["cases"]:  # type: ignore[index]
+        summary = case["outcome_receipt_summary"]  # type: ignore[index]
+        assert isinstance(summary, dict)
+        assert summary["outcome_hash"]  # type: ignore[index]
+
+
+def test_blocked_cases_mark_committed_false_and_blocked_true() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case_id in [
+        "missing_authority",
+        "missing_human_approval",
+        "expired_human_approval",
+        "scope_mismatch",
+    ]:
+        summary = _case_by_id(payload, case_id)["outcome_receipt_summary"]
+        assert summary["committed"] is False  # type: ignore[index]
+        assert summary["blocked"] is True  # type: ignore[index]
+
+
+def test_valid_case_has_committed_true_and_postcondition_passed() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    summary = _case_by_id(payload, "valid_authority_and_approval")["outcome_receipt_summary"]
+    assert summary["committed"] is True  # type: ignore[index]
+    assert summary["postcondition_status"] == "passed"  # type: ignore[index]
+
+
+def test_valid_case_observed_effects_include_local_offline_permission_grant_fixture() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    summary = _case_by_id(payload, "valid_authority_and_approval")["outcome_receipt_summary"]
+    effects = summary["observed_effects"]  # type: ignore[index]
+    assert {
+        "effect_type": "permission_grant",
+        "permission": "saas:grant_admin",
+        "target_resource": "contractor:external.user@example.test",
+        "fixture_only": True,
+    } in effects
+
+
+def test_demo_has_no_network_or_environment_dependency() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    assert payload["demo_id"] == "saas_permission_change_governed_execution_v1"

--- a/tests/demo/test_saas_permission_change_governed_demo.py
+++ b/tests/demo/test_saas_permission_change_governed_demo.py
@@ -90,6 +90,21 @@ def test_blocked_cases_mark_committed_false_and_blocked_true() -> None:
         assert summary["blocked"] is True  # type: ignore[index]
 
 
+def test_blocked_cases_failure_reasons_are_flat_string_list() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case_id in [
+        "missing_authority",
+        "missing_human_approval",
+        "expired_human_approval",
+        "scope_mismatch",
+    ]:
+        summary = _case_by_id(payload, case_id)["outcome_receipt_summary"]
+        failure_reasons = summary["failure_reasons"]  # type: ignore[index]
+        assert isinstance(failure_reasons, list)
+        assert all(isinstance(reason, str) for reason in failure_reasons)
+        assert all(not isinstance(reason, list) for reason in failure_reasons)
+
+
 def test_valid_case_has_committed_true_and_postcondition_passed() -> None:
     payload = run_saas_permission_change_governed_demo()
     summary = _case_by_id(payload, "valid_authority_and_approval")["outcome_receipt_summary"]

--- a/tests/governance/test_outcome_receipt.py
+++ b/tests/governance/test_outcome_receipt.py
@@ -1,0 +1,117 @@
+"""Tests for deterministic local/offline Outcome Receipt v1 helpers."""
+
+from __future__ import annotations
+
+from veritas_os.governance.outcome_receipt import (
+    OutcomeReceipt,
+    build_outcome_receipt,
+    validate_outcome_receipt,
+    with_outcome_hash,
+)
+
+
+def _base_receipt() -> OutcomeReceipt:
+    return OutcomeReceipt(
+        outcome_receipt_id="outcome-op-001",
+        decision_id="decision-001",
+        execution_intent_id="intent-001",
+        bind_receipt_id="bind-001",
+        operation_id="op-001",
+        action_class="permission_change",
+        target_system="mock_saas_directory",
+        target_resource="contractor:external.user@example.test",
+        intended_action="grant_admin_permission",
+        requested_scope=["saas:grant_admin"],
+        final_outcome="commit",
+        committed=True,
+        blocked=False,
+        escalated=False,
+        rolled_back=False,
+        pre_state_fingerprint="pre-hash",
+        post_state_fingerprint="post-hash",
+        postcondition_status="passed",
+        observed_effects=[{"effect_type": "permission_grant", "fixture_only": True}],
+        failure_reasons=[],
+        rollback_status=None,
+        evaluated_at="2026-04-26T00:00:00+00:00",
+        outcome_hash="",
+        metadata={"fixture_only": True},
+    )
+
+
+def test_valid_committed_outcome_receipt_has_deterministic_non_empty_outcome_hash() -> None:
+    receipt = with_outcome_hash(_base_receipt())
+    assert receipt.outcome_hash
+
+
+def test_same_content_produces_same_hash() -> None:
+    first = with_outcome_hash(_base_receipt())
+    second = with_outcome_hash(_base_receipt())
+    assert first.outcome_hash == second.outcome_hash
+
+
+def test_changing_meaningful_field_changes_hash() -> None:
+    first = with_outcome_hash(_base_receipt())
+    changed = _base_receipt()
+    changed = OutcomeReceipt(**{**changed.to_dict(), "final_outcome": "block", "committed": False, "blocked": True})
+    second = with_outcome_hash(changed)
+    assert first.outcome_hash != second.outcome_hash
+
+
+def test_outcome_hash_does_not_recursively_affect_its_own_hash() -> None:
+    first = with_outcome_hash(_base_receipt())
+    second = with_outcome_hash(OutcomeReceipt(**{**first.to_dict(), "outcome_hash": "different"}))
+    assert first.outcome_hash == second.outcome_hash
+
+
+def test_missing_receipt_fails_validation() -> None:
+    result = validate_outcome_receipt(None)
+    assert result.is_valid is False
+    assert "outcome_receipt_missing" in result.failure_reasons
+
+
+def test_committed_and_blocked_conflict_fails_validation() -> None:
+    receipt = with_outcome_hash(OutcomeReceipt(**{**_base_receipt().to_dict(), "blocked": True}))
+    result = validate_outcome_receipt(receipt)
+    assert "outcome_receipt_committed_and_blocked_conflict" in result.failure_reasons
+
+
+def test_invalid_postcondition_status_fails_validation() -> None:
+    receipt = with_outcome_hash(OutcomeReceipt(**{**_base_receipt().to_dict(), "postcondition_status": "unknown"}))
+    result = validate_outcome_receipt(receipt)
+    assert "outcome_receipt_invalid_postcondition_status" in result.failure_reasons
+
+
+def test_committed_true_with_blocked_final_outcome_fails_validation() -> None:
+    receipt = with_outcome_hash(OutcomeReceipt(**{**_base_receipt().to_dict(), "final_outcome": "block", "committed": True}))
+    result = validate_outcome_receipt(receipt)
+    assert "outcome_receipt_committed_outcome_mismatch" in result.failure_reasons
+
+
+def test_rollback_without_failure_reason_fails_validation() -> None:
+    receipt = with_outcome_hash(OutcomeReceipt(**{**_base_receipt().to_dict(), "committed": False, "rolled_back": True}))
+    result = validate_outcome_receipt(receipt)
+    assert "outcome_receipt_rollback_without_failure_reason" in result.failure_reasons
+
+
+def test_unparseable_evaluated_at_fails_validation() -> None:
+    receipt = with_outcome_hash(OutcomeReceipt(**{**_base_receipt().to_dict(), "evaluated_at": "not-a-date"}))
+    result = validate_outcome_receipt(receipt)
+    assert "outcome_receipt_evaluated_at_unparseable" in result.failure_reasons
+
+
+def test_build_outcome_receipt_returns_hash_populated_receipt() -> None:
+    receipt = build_outcome_receipt(
+        decision_id="decision-001",
+        execution_intent_id="intent-001",
+        bind_receipt_id="bind-001",
+        operation_id="op-001",
+        action_class="permission_change",
+        target_system="mock_saas_directory",
+        target_resource="contractor:external.user@example.test",
+        intended_action="grant_admin_permission",
+        requested_scope=["saas:grant_admin"],
+        final_outcome="commit",
+        evaluated_at="2026-04-26T00:00:00+00:00",
+    )
+    assert receipt.outcome_hash

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -29,6 +29,14 @@ from veritas_os.governance.human_approval_receipt import (
     with_receipt_hash,
 )
 
+from veritas_os.governance.outcome_receipt import (
+    OutcomeReceipt,
+    OutcomeReceiptValidationResult,
+    build_outcome_receipt,
+    validate_outcome_receipt,
+    with_outcome_hash,
+)
+
 from veritas_os.governance.commit_boundary import (
     CommitBoundaryResult,
     CommitBoundaryEvaluator,
@@ -64,6 +72,11 @@ __all__ = [
     "HumanApprovalValidationResult",
     "HumanApprovalReceipt",
     "with_receipt_hash",
+    "OutcomeReceipt",
+    "OutcomeReceiptValidationResult",
+    "build_outcome_receipt",
+    "validate_outcome_receipt",
+    "with_outcome_hash",
     "create_governance_repository",
     "CommitBoundaryResult",
     "CommitBoundaryEvaluator",

--- a/veritas_os/governance/outcome_receipt.py
+++ b/veritas_os/governance/outcome_receipt.py
@@ -1,0 +1,214 @@
+"""Local/offline deterministic Outcome Receipt artifact helpers.
+
+Outcome Receipt v1 records post-execution outcome evidence for governed
+execution attempts without introducing live integrations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from veritas_os.security.hash import sha256_of_canonical_json
+
+PostconditionStatus = Literal["passed", "failed", "skipped", "indeterminate"]
+_ALLOWED_POSTCONDITION_STATUS = {"passed", "failed", "skipped", "indeterminate"}
+_COMMITTED_OUTCOMES = {"commit", "committed"}
+
+
+@dataclass(frozen=True)
+class OutcomeReceipt:
+    """Deterministic local/offline post-execution outcome evidence artifact."""
+
+    outcome_receipt_id: str
+    decision_id: str
+    execution_intent_id: str
+    bind_receipt_id: str | None
+    operation_id: str
+    action_class: str
+    target_system: str
+    target_resource: str
+    intended_action: str
+    requested_scope: list[str]
+    final_outcome: str
+    committed: bool
+    blocked: bool
+    escalated: bool
+    rolled_back: bool
+    pre_state_fingerprint: str | None
+    post_state_fingerprint: str | None
+    postcondition_status: PostconditionStatus
+    observed_effects: list[dict[str, Any]]
+    failure_reasons: list[str]
+    rollback_status: str | None
+    evaluated_at: str
+    outcome_hash: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return deterministic dictionary representation."""
+        return {
+            "outcome_receipt_id": self.outcome_receipt_id,
+            "decision_id": self.decision_id,
+            "execution_intent_id": self.execution_intent_id,
+            "bind_receipt_id": self.bind_receipt_id,
+            "operation_id": self.operation_id,
+            "action_class": self.action_class,
+            "target_system": self.target_system,
+            "target_resource": self.target_resource,
+            "intended_action": self.intended_action,
+            "requested_scope": sorted(str(scope) for scope in self.requested_scope),
+            "final_outcome": self.final_outcome,
+            "committed": self.committed,
+            "blocked": self.blocked,
+            "escalated": self.escalated,
+            "rolled_back": self.rolled_back,
+            "pre_state_fingerprint": self.pre_state_fingerprint,
+            "post_state_fingerprint": self.post_state_fingerprint,
+            "postcondition_status": self.postcondition_status,
+            "observed_effects": self.observed_effects,
+            "failure_reasons": sorted(str(reason) for reason in self.failure_reasons),
+            "rollback_status": self.rollback_status,
+            "evaluated_at": self.evaluated_at,
+            "outcome_hash": self.outcome_hash,
+            "metadata": self.metadata,
+        }
+
+    def to_dict_for_hash(self) -> dict[str, Any]:
+        """Return canonical hash payload excluding self-referential outcome hash."""
+        payload = self.to_dict()
+        payload.pop("outcome_hash", None)
+        return payload
+
+    def deterministic_digest(self) -> str:
+        """Compute deterministic SHA-256 digest from canonical hash payload."""
+        return sha256_of_canonical_json(self.to_dict_for_hash())
+
+
+@dataclass(frozen=True)
+class OutcomeReceiptValidationResult:
+    """Fail-closed validation output for an outcome receipt."""
+
+    is_valid: bool
+    failure_reasons: list[str]
+
+
+def with_outcome_hash(receipt: OutcomeReceipt) -> OutcomeReceipt:
+    """Return a finalized copy with deterministic ``outcome_hash`` populated."""
+    data = receipt.to_dict()
+    data["outcome_hash"] = receipt.deterministic_digest()
+    return OutcomeReceipt(**data)
+
+
+def validate_outcome_receipt(receipt: OutcomeReceipt | None) -> OutcomeReceiptValidationResult:
+    """Validate outcome receipt with deterministic fail-closed checks."""
+    if receipt is None:
+        return OutcomeReceiptValidationResult(False, ["outcome_receipt_missing"])
+
+    failure_reasons: list[str] = []
+
+    if not str(receipt.decision_id).strip():
+        failure_reasons.append("outcome_receipt_decision_id_missing")
+    if not str(receipt.execution_intent_id).strip():
+        failure_reasons.append("outcome_receipt_execution_intent_id_missing")
+    if not str(receipt.operation_id).strip():
+        failure_reasons.append("outcome_receipt_operation_id_missing")
+    if not str(receipt.target_system).strip():
+        failure_reasons.append("outcome_receipt_target_system_missing")
+    if not str(receipt.target_resource).strip():
+        failure_reasons.append("outcome_receipt_target_resource_missing")
+    if not str(receipt.intended_action).strip():
+        failure_reasons.append("outcome_receipt_intended_action_missing")
+    if not str(receipt.final_outcome).strip():
+        failure_reasons.append("outcome_receipt_final_outcome_missing")
+
+    if receipt.postcondition_status not in _ALLOWED_POSTCONDITION_STATUS:
+        failure_reasons.append("outcome_receipt_invalid_postcondition_status")
+
+    normalized_outcome = str(receipt.final_outcome).strip().lower()
+    if receipt.committed and normalized_outcome not in _COMMITTED_OUTCOMES:
+        failure_reasons.append("outcome_receipt_committed_outcome_mismatch")
+    if receipt.blocked and receipt.committed:
+        failure_reasons.append("outcome_receipt_committed_and_blocked_conflict")
+    if receipt.rolled_back and not receipt.committed and not receipt.failure_reasons:
+        failure_reasons.append("outcome_receipt_rollback_without_failure_reason")
+
+    evaluated_at_raw = str(receipt.evaluated_at).strip()
+    if not evaluated_at_raw:
+        failure_reasons.append("outcome_receipt_evaluated_at_missing")
+    elif _parse_iso_datetime(evaluated_at_raw) is None:
+        failure_reasons.append("outcome_receipt_evaluated_at_unparseable")
+
+    if not str(receipt.outcome_hash).strip():
+        failure_reasons.append("outcome_receipt_hash_missing")
+
+    return OutcomeReceiptValidationResult(not failure_reasons, sorted(set(failure_reasons)))
+
+
+def build_outcome_receipt(
+    *,
+    decision_id: str,
+    execution_intent_id: str,
+    bind_receipt_id: str | None,
+    operation_id: str,
+    action_class: str,
+    target_system: str,
+    target_resource: str,
+    intended_action: str,
+    requested_scope: list[str],
+    final_outcome: str,
+    pre_state_fingerprint: str | None = None,
+    post_state_fingerprint: str | None = None,
+    postcondition_status: str = "skipped",
+    observed_effects: list[dict[str, Any]] | None = None,
+    failure_reasons: list[str] | None = None,
+    rollback_status: str | None = None,
+    evaluated_at: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> OutcomeReceipt:
+    """Build a deterministic local/offline finalized outcome receipt."""
+    normalized_outcome = str(final_outcome).strip().lower()
+    normalized_rollback = str(rollback_status or "").strip().lower()
+    committed = normalized_outcome in _COMMITTED_OUTCOMES
+    blocked = normalized_outcome in {"block", "blocked", "refuse", "refused"}
+    escalated = normalized_outcome in {"escalate", "escalated"}
+    rolled_back = normalized_rollback in {"performed", "rolled_back", "success", "completed"}
+
+    receipt = OutcomeReceipt(
+        outcome_receipt_id=f"outcome-{operation_id}",
+        decision_id=decision_id,
+        execution_intent_id=execution_intent_id,
+        bind_receipt_id=bind_receipt_id,
+        operation_id=operation_id,
+        action_class=action_class,
+        target_system=target_system,
+        target_resource=target_resource,
+        intended_action=intended_action,
+        requested_scope=list(requested_scope),
+        final_outcome=final_outcome,
+        committed=committed,
+        blocked=blocked,
+        escalated=escalated,
+        rolled_back=rolled_back,
+        pre_state_fingerprint=pre_state_fingerprint,
+        post_state_fingerprint=post_state_fingerprint,
+        postcondition_status=postcondition_status,  # type: ignore[arg-type]
+        observed_effects=list(observed_effects or []),
+        failure_reasons=list(failure_reasons or []),
+        rollback_status=rollback_status,
+        evaluated_at=evaluated_at,
+        outcome_hash="",
+        metadata=dict(metadata or {}),
+    )
+    return with_outcome_hash(receipt)
+
+
+def _parse_iso_datetime(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)


### PR DESCRIPTION
### Motivation
- Add a minimal deterministic local/offline Outcome Receipt v1 artifact to record post-execution outcome evidence (what was attempted, whether it committed, final outcome, postcondition status, rollback, state fingerprints, and observed effects) without introducing live integrations. 
- Provide deterministic hashing and fail-closed validation so outcome receipts can be referenced in reviewable audit/evidence paths and complement existing artifacts (Authority Evidence Ingestion v1, Human Approval Receipt v1, Bind Coverage Registry v1). 
- Keep the change small and additive with explicit local/offline boundaries and no network/credentials/DB/UI/live-SaaS behavior. 

### Description
- Added `veritas_os/governance/outcome_receipt.py` implementing `OutcomeReceipt` dataclass, `OutcomeReceiptValidationResult`, `to_dict()`, `to_dict_for_hash()`, `deterministic_digest()`, `with_outcome_hash()`, `validate_outcome_receipt()`, and `build_outcome_receipt()` using the repo's canonical JSON + SHA-256 helpers. 
- Integrated outcome receipt summaries into the SaaS permission-change demo by adding `outcome_receipt_summary` to each demo case and a local/offline permission grant fixture effect for the valid commit case in `scripts/demo/saas_permission_change_governed_demo.py`. 
- Exported the new helpers from the governance package surface (`veritas_os/govenance/__init__.py`), added focused unit tests (`tests/governance/test_outcome_receipt.py`) and demo tests updates (`tests/demo/test_saas_permission_change_governed_demo.py`), and added architecture docs plus README/README_JP references (`docs/en/architecture/outcome-receipt.md`, README.md, README_JP.md). 

### Testing
- Added targeted tests: `tests/governance/test_outcome_receipt.py` exercising deterministic hashing, non-recursive hash behavior, validation fail-closed cases, and builder finalization, and updates to `tests/demo/test_saas_permission_change_governed_demo.py` to assert presence and shape of `outcome_receipt_summary`. 
- Attempted to run the two targeted test modules with `pytest -q tests/governance/test_outcome_receipt.py tests/demo/test_saas_permission_change_governed_demo.py`, but test collection failed due to the environment lacking the `yaml` dependency required by existing governance modules (ModuleNotFoundError: No module named 'yaml'), so tests could not complete in this execution environment. 
- The changes are additive and small; maintainers should run the full test suite (e.g., `make test` / `pytest`) in a properly provisioned environment (install dependencies from project config) to verify CI gates and coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d4f42c988326a13743906a4c85c1)