### PR TITLE
runtime: add Evidence Chain Manifest v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 3. Authority Evidence Ingestion (local/offline): docs/en/architecture/authority-evidence-ingestion.md
 4. Human Approval Receipt v1 (local/offline): docs/en/architecture/human-approval-receipt.md
 5. Outcome Receipt v1 (local/offline): docs/en/architecture/outcome-receipt.md
+6. Evidence Chain Manifest v1 (local/offline): docs/en/architecture/evidence-chain-manifest.md
 6. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
 7. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 8. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
@@ -102,6 +103,10 @@ Boundary:
 ## Bind Coverage Registry v1
 
 VERITAS includes a local/offline Bind Coverage Registry v1 that records which effect-bearing operations are expected to be governed by bind-time controls. The registry helps reviewers inspect whether high-impact actions require bind governance, AuthorityEvidence, HumanApprovalReceipt, policy snapshots, and fail-closed behavior. It is a deterministic coverage artifact, not a live route scanner or proof of production deployment.
+
+## Evidence Chain Manifest v1
+
+VERITAS includes a local/offline Evidence Chain Manifest v1 artifact that links AuthorityEvidence, HumanApprovalReceipt, bind-time decision evidence, OutcomeReceipt, and operation coverage metadata for a governed execution attempt. It helps reviewers inspect a complete evidence chain from pre-execution authority and approval through bind-time decisioning to post-execution outcome evidence. This is a local/offline manifest, not proof of live production execution.
 
 
 ## One-Day PoC Evidence Packet

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 4. Human Approval Receipt v1 (local/offline): docs/en/architecture/human-approval-receipt.md
 5. Outcome Receipt v1 (local/offline): docs/en/architecture/outcome-receipt.md
 6. Evidence Chain Manifest v1 (local/offline): docs/en/architecture/evidence-chain-manifest.md
-6. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-7. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
-8. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
-9. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
-10. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
+7. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+8. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+9. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
+10. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
+11. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
 
 Boundary:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -45,11 +45,11 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 4. Human Approval Receipt v1（local/offline）: docs/en/architecture/human-approval-receipt.md
 5. Outcome Receipt v1（local/offline）: docs/en/architecture/outcome-receipt.md
 6. Evidence Chain Manifest v1（local/offline）: docs/en/architecture/evidence-chain-manifest.md
-6. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-7. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
-8. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
-9. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
-10. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
+7. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+8. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+9. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
+10. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
+11. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
 
 境界条件:
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -44,6 +44,7 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 3. Authority Evidence Ingestion（local/offline）: docs/en/architecture/authority-evidence-ingestion.md
 4. Human Approval Receipt v1（local/offline）: docs/en/architecture/human-approval-receipt.md
 5. Outcome Receipt v1（local/offline）: docs/en/architecture/outcome-receipt.md
+6. Evidence Chain Manifest v1（local/offline）: docs/en/architecture/evidence-chain-manifest.md
 6. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
 7. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 8. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
@@ -105,6 +106,10 @@ VERITAS には、local/offline の SaaS permission-change governed execution dem
 ## Bind Coverage Registry v1
 
 VERITAS には local/offline の Bind Coverage Registry v1 が追加されています。これは、effect-bearing な操作が bind-time governance の対象になっているかを記録するための coverage artifact です。高影響アクションが Bind、AuthorityEvidence、HumanApprovalReceipt、policy snapshot、fail-closed を要求しているかを外部レビュアーが確認しやすくするためのものであり、live route scanner や本番導入証明ではありません。
+
+## Evidence Chain Manifest v1
+
+VERITAS には local/offline の Evidence Chain Manifest v1 artifact が追加されています。これは、governed execution attempt について、AuthorityEvidence、HumanApprovalReceipt、bind-time decision evidence、OutcomeReceipt、operation coverage metadata をひとつの証跡チェーンとして結び付けるためのものです。実行前の権限・承認から、bind-time の判定、実行後の outcome evidence までを外部レビュアーが追跡しやすくします。本番環境での実行証明ではなく、local/offline の manifest です。
 
 
 ## AML/KYC レビュアー向けウォークスルー Quickstart

--- a/docs/en/architecture/evidence-chain-manifest.md
+++ b/docs/en/architecture/evidence-chain-manifest.md
@@ -1,0 +1,35 @@
+# Evidence Chain Manifest v1 (local/offline)
+
+Evidence Chain Manifest v1 is a deterministic local/offline governance artifact for one governed execution attempt.
+
+It links the execution governance chain in one inspectable object:
+
+- AuthorityEvidence
+- HumanApprovalReceipt
+- BindReceipt / bind-time decision evidence
+- OutcomeReceipt
+- BindCoverageEntry-style operation coverage metadata
+
+The manifest helps reviewers inspect the full governance chain from pre-execution authority and human approval through bind-time decisioning to post-execution outcome evidence.
+
+## Chain states
+
+A manifest can represent these deterministic states:
+
+- `complete`
+- `blocked`
+- `incomplete`
+- `indeterminate`
+
+## Boundary in this PR
+
+In this PR, Evidence Chain Manifest v1 remains local/offline only.
+
+It is **not**:
+
+- proof of live production execution
+- connected to live SaaS, IdP, IAM, SSO, bank, sanctions, customer, or production approval systems
+- legal advice
+- regulatory approval
+- third-party certification
+- production access-control validation

--- a/scripts/demo/saas_permission_change_governed_demo.py
+++ b/scripts/demo/saas_permission_change_governed_demo.py
@@ -12,6 +12,7 @@ from veritas_os.governance import (
     CommitBoundaryEvaluator,
     HumanApprovalReceipt,
     RuntimeAuthorityValidator,
+    build_evidence_chain_manifest,
     build_outcome_receipt,
     build_human_approval_state,
 )
@@ -202,6 +203,37 @@ def _evaluate_case(
         evaluated_at=FIXED_NOW.isoformat(),
         metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},
     )
+    authority_evidence_id = (
+        authority_evidence.authority_evidence_id if authority_evidence is not None else None
+    )
+    authority_evidence_hash = authority_evidence.evidence_hash if authority_evidence is not None else None
+    approval_receipt_id = (
+        human_approval_state.get("approval_receipt_id") if human_approval_state.get("approved") else None
+    )
+    approval_receipt_hash = (
+        human_approval_state.get("receipt_hash") if human_approval_state.get("approved") else None
+    )
+    evidence_chain_manifest = build_evidence_chain_manifest(
+        decision_id="decision-saas-001",
+        execution_intent_id="intent-saas-001",
+        operation_id=f"saas-permission-change-{case_id}",
+        action_class=contract.action_class,
+        target_system=TARGET_SYSTEM,
+        target_resource=TARGET_RESOURCE,
+        requested_scope=list(REQUESTED_SCOPE),
+        final_outcome=actual_outcome,
+        authority_evidence_id=authority_evidence_id,
+        authority_evidence_hash=authority_evidence_hash,
+        human_approval_receipt_id=str(approval_receipt_id) if approval_receipt_id else None,
+        human_approval_receipt_hash=str(approval_receipt_hash) if approval_receipt_hash else None,
+        outcome_receipt_id=outcome_receipt.outcome_receipt_id,
+        outcome_receipt_hash=outcome_receipt.outcome_hash,
+        bind_coverage_operation_id="saas_permission_change_demo",
+        refusal_basis=boundary_result.refusal_basis,
+        observed_effects_summary=observed_effects,
+        generated_at=FIXED_NOW.isoformat(),
+        metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},
+    )
     return {
         "case_id": case_id,
         "expected_outcome": expected_outcome,
@@ -219,6 +251,7 @@ def _evaluate_case(
         "target_resource": TARGET_RESOURCE,
         "boundary_note": BOUNDARY_NOTE,
         "outcome_receipt_summary": outcome_receipt.to_dict(),
+        "evidence_chain_manifest_summary": evidence_chain_manifest.to_dict(),
     }
 
 

--- a/tests/demo/test_saas_permission_change_governed_demo.py
+++ b/tests/demo/test_saas_permission_change_governed_demo.py
@@ -127,3 +127,54 @@ def test_valid_case_observed_effects_include_local_offline_permission_grant_fixt
 def test_demo_has_no_network_or_environment_dependency() -> None:
     payload = run_saas_permission_change_governed_demo()
     assert payload["demo_id"] == "saas_permission_change_governed_execution_v1"
+
+
+def test_every_demo_case_includes_evidence_chain_manifest_summary() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case in payload["cases"]:  # type: ignore[index]
+        summary = case["evidence_chain_manifest_summary"]  # type: ignore[index]
+        assert isinstance(summary, dict)
+        assert summary["manifest_hash"]  # type: ignore[index]
+
+
+def test_blocked_cases_manifest_chain_status_is_blocked() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case_id in [
+        "missing_authority",
+        "missing_human_approval",
+        "expired_human_approval",
+        "scope_mismatch",
+    ]:
+        summary = _case_by_id(payload, case_id)["evidence_chain_manifest_summary"]
+        assert summary["chain_status"] == "blocked"  # type: ignore[index]
+
+
+def test_valid_case_manifest_chain_status_complete_and_no_missing_links() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    summary = _case_by_id(payload, "valid_authority_and_approval")["evidence_chain_manifest_summary"]
+    assert summary["chain_status"] == "complete"  # type: ignore[index]
+    assert summary["missing_links"] == []  # type: ignore[index]
+
+
+def test_valid_case_manifest_observed_effects_include_permission_grant_fixture() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    summary = _case_by_id(payload, "valid_authority_and_approval")["evidence_chain_manifest_summary"]
+    effects = summary["observed_effects_summary"]  # type: ignore[index]
+    assert {
+        "effect_type": "permission_grant",
+        "permission": "saas:grant_admin",
+        "target_resource": "contractor:external.user@example.test",
+        "fixture_only": True,
+    } in effects
+
+
+def test_missing_authority_manifest_has_missing_authority_link() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    summary = _case_by_id(payload, "missing_authority")["evidence_chain_manifest_summary"]
+    assert "authority_evidence_hash" in summary["missing_links"]  # type: ignore[index]
+
+
+def test_missing_human_approval_manifest_has_missing_human_approval_link() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    summary = _case_by_id(payload, "missing_human_approval")["evidence_chain_manifest_summary"]
+    assert "human_approval_receipt_hash" in summary["missing_links"]  # type: ignore[index]

--- a/tests/governance/test_evidence_chain_manifest.py
+++ b/tests/governance/test_evidence_chain_manifest.py
@@ -1,0 +1,187 @@
+"""Tests for deterministic local/offline Evidence Chain Manifest v1."""
+
+from __future__ import annotations
+
+from veritas_os.governance.evidence_chain_manifest import (
+    EvidenceChainManifest,
+    build_evidence_chain_manifest,
+    validate_evidence_chain_manifest,
+    with_manifest_hash,
+)
+
+
+def _base_manifest() -> EvidenceChainManifest:
+    return EvidenceChainManifest(
+        manifest_id="ecm-op-1",
+        decision_id="decision-1",
+        execution_intent_id="intent-1",
+        operation_id="operation-1",
+        action_class="permission_change",
+        target_system="mock_saas",
+        target_resource="user:alice",
+        requested_scope=["saas:grant_admin"],
+        authority_evidence_id="aev-1",
+        authority_evidence_hash="a" * 64,
+        human_approval_receipt_id="har-1",
+        human_approval_receipt_hash="b" * 64,
+        bind_receipt_id=None,
+        bind_receipt_hash=None,
+        outcome_receipt_id="outcome-1",
+        outcome_receipt_hash="c" * 64,
+        bind_coverage_operation_id="saas_permission_change_demo",
+        final_outcome="commit",
+        chain_status="complete",
+        missing_links=[],
+        refusal_basis=[],
+        observed_effects_summary=[{"effect_type": "permission_grant"}],
+        generated_at="2026-04-26T00:00:00+00:00",
+        manifest_hash="",
+        metadata={"fixture_only": True},
+    )
+
+
+def test_valid_complete_manifest_has_deterministic_non_empty_manifest_hash() -> None:
+    manifest = with_manifest_hash(_base_manifest())
+    assert manifest.manifest_hash
+    assert validate_evidence_chain_manifest(manifest).is_valid is True
+
+
+def test_same_content_produces_same_manifest_hash() -> None:
+    assert with_manifest_hash(_base_manifest()).manifest_hash == with_manifest_hash(_base_manifest()).manifest_hash
+
+
+def test_changing_meaningful_field_changes_manifest_hash() -> None:
+    one = with_manifest_hash(_base_manifest())
+    changed = _base_manifest()
+    changed_data = changed.to_dict()
+    changed_data["target_resource"] = "user:bob"
+    two = with_manifest_hash(EvidenceChainManifest(**changed_data))
+    assert one.manifest_hash != two.manifest_hash
+
+
+def test_manifest_hash_does_not_recursively_affect_its_own_hash() -> None:
+    manifest = with_manifest_hash(_base_manifest())
+    mutated = EvidenceChainManifest(**{**manifest.to_dict(), "manifest_hash": "x" * 64})
+    assert manifest.deterministic_digest() == mutated.deterministic_digest()
+
+
+def test_missing_manifest_fails_validation() -> None:
+    result = validate_evidence_chain_manifest(None)
+    assert result.is_valid is False
+    assert "evidence_chain_manifest_missing" in result.failure_reasons
+
+
+def test_invalid_chain_status_fails_validation() -> None:
+    manifest = with_manifest_hash(EvidenceChainManifest(**{**_base_manifest().to_dict(), "chain_status": "bad"}))
+    result = validate_evidence_chain_manifest(manifest)
+    assert result.is_valid is False
+    assert "evidence_chain_invalid_chain_status" in result.failure_reasons
+
+
+def test_complete_manifest_missing_required_hashes_fails_validation() -> None:
+    manifest = with_manifest_hash(
+        EvidenceChainManifest(**{**_base_manifest().to_dict(), "authority_evidence_hash": None})
+    )
+    result = validate_evidence_chain_manifest(manifest)
+    assert "evidence_chain_complete_missing_required_hash" in result.failure_reasons
+
+
+def test_complete_manifest_with_missing_links_fails_validation() -> None:
+    manifest = with_manifest_hash(
+        EvidenceChainManifest(**{**_base_manifest().to_dict(), "missing_links": ["authority_evidence_hash"]})
+    )
+    result = validate_evidence_chain_manifest(manifest)
+    assert "evidence_chain_complete_has_missing_links" in result.failure_reasons
+
+
+def test_blocked_manifest_with_commit_outcome_fails_validation() -> None:
+    manifest = with_manifest_hash(
+        EvidenceChainManifest(
+            **{**_base_manifest().to_dict(), "chain_status": "blocked", "final_outcome": "commit", "refusal_basis": ["x"]}
+        )
+    )
+    result = validate_evidence_chain_manifest(manifest)
+    assert "evidence_chain_blocked_outcome_mismatch" in result.failure_reasons
+
+
+def test_blocked_manifest_without_refusal_basis_fails_validation() -> None:
+    manifest = with_manifest_hash(
+        EvidenceChainManifest(**{**_base_manifest().to_dict(), "chain_status": "blocked", "final_outcome": "block", "refusal_basis": []})
+    )
+    result = validate_evidence_chain_manifest(manifest)
+    assert "evidence_chain_blocked_without_refusal_basis" in result.failure_reasons
+
+
+def test_generated_at_unparseable_fails_validation() -> None:
+    manifest = with_manifest_hash(EvidenceChainManifest(**{**_base_manifest().to_dict(), "generated_at": "bad"}))
+    result = validate_evidence_chain_manifest(manifest)
+    assert "evidence_chain_generated_at_unparseable" in result.failure_reasons
+
+
+def test_build_evidence_chain_manifest_returns_hash_populated_manifest() -> None:
+    manifest = build_evidence_chain_manifest(
+        decision_id="decision-1",
+        execution_intent_id="intent-1",
+        operation_id="op-1",
+        action_class="permission_change",
+        target_system="mock_saas",
+        target_resource="user:alice",
+        requested_scope=["saas:grant_admin"],
+        final_outcome="commit",
+        authority_evidence_hash="a" * 64,
+        human_approval_receipt_hash="b" * 64,
+        outcome_receipt_hash="c" * 64,
+        bind_coverage_operation_id="saas_permission_change_demo",
+        generated_at="2026-04-26T00:00:00+00:00",
+    )
+    assert manifest.manifest_hash
+
+
+def test_build_evidence_chain_manifest_derives_complete_when_required_links_exist() -> None:
+    manifest = build_evidence_chain_manifest(
+        decision_id="d",
+        execution_intent_id="i",
+        operation_id="op",
+        action_class="ac",
+        target_system="ts",
+        target_resource="tr",
+        requested_scope=["x"],
+        final_outcome="commit",
+        authority_evidence_hash="a" * 64,
+        human_approval_receipt_hash="b" * 64,
+        outcome_receipt_hash="c" * 64,
+        bind_coverage_operation_id="cov",
+        generated_at="2026-04-26T00:00:00+00:00",
+    )
+    assert manifest.chain_status == "complete"
+
+
+def test_build_evidence_chain_manifest_derives_blocked_when_final_outcome_blocked() -> None:
+    manifest = build_evidence_chain_manifest(
+        decision_id="d",
+        execution_intent_id="i",
+        operation_id="op",
+        action_class="ac",
+        target_system="ts",
+        target_resource="tr",
+        requested_scope=["x"],
+        final_outcome="blocked",
+        refusal_basis=["authority_missing"],
+        generated_at="2026-04-26T00:00:00+00:00",
+    )
+    assert manifest.chain_status == "blocked"
+
+
+def test_build_evidence_chain_manifest_derives_incomplete_when_non_blocked_lacks_links() -> None:
+    manifest = build_evidence_chain_manifest(
+        decision_id="d",
+        execution_intent_id="i",
+        operation_id="op",
+        action_class="ac",
+        target_system="ts",
+        target_resource="tr",
+        requested_scope=["x"],
+        final_outcome="commit",
+        generated_at="2026-04-26T00:00:00+00:00",
+    )
+    assert manifest.chain_status == "incomplete"

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -37,6 +37,14 @@ from veritas_os.governance.outcome_receipt import (
     with_outcome_hash,
 )
 
+from veritas_os.governance.evidence_chain_manifest import (
+    EvidenceChainManifest,
+    EvidenceChainManifestValidationResult,
+    build_evidence_chain_manifest,
+    validate_evidence_chain_manifest,
+    with_manifest_hash,
+)
+
 from veritas_os.governance.commit_boundary import (
     CommitBoundaryResult,
     CommitBoundaryEvaluator,
@@ -73,6 +81,11 @@ __all__ = [
     "HumanApprovalReceipt",
     "with_receipt_hash",
     "OutcomeReceipt",
+    "EvidenceChainManifest",
+    "EvidenceChainManifestValidationResult",
+    "build_evidence_chain_manifest",
+    "validate_evidence_chain_manifest",
+    "with_manifest_hash",
     "OutcomeReceiptValidationResult",
     "build_outcome_receipt",
     "validate_outcome_receipt",

--- a/veritas_os/governance/evidence_chain_manifest.py
+++ b/veritas_os/governance/evidence_chain_manifest.py
@@ -1,0 +1,247 @@
+"""Deterministic local/offline Evidence Chain Manifest v1 helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from veritas_os.security.hash import sha256_of_canonical_json
+
+_ALLOWED_CHAIN_STATUS = {"complete", "incomplete", "blocked", "indeterminate"}
+_BLOCKED_OUTCOMES = {"block", "blocked", "refuse", "refused"}
+_COMMITTED_OUTCOMES = {"commit", "committed", "commit_eligible"}
+_REQUIRED_COMPLETE_HASH_FIELDS = (
+    "authority_evidence_hash",
+    "human_approval_receipt_hash",
+    "outcome_receipt_hash",
+)
+
+
+@dataclass(frozen=True)
+class EvidenceChainManifest:
+    """Deterministic local/offline evidence-chain manifest for one execution."""
+
+    manifest_id: str
+    decision_id: str
+    execution_intent_id: str
+    operation_id: str
+    action_class: str
+    target_system: str
+    target_resource: str
+    requested_scope: list[str]
+    authority_evidence_id: str | None
+    authority_evidence_hash: str | None
+    human_approval_receipt_id: str | None
+    human_approval_receipt_hash: str | None
+    bind_receipt_id: str | None
+    bind_receipt_hash: str | None
+    outcome_receipt_id: str | None
+    outcome_receipt_hash: str | None
+    bind_coverage_operation_id: str | None
+    final_outcome: str
+    chain_status: str
+    missing_links: list[str]
+    refusal_basis: list[str]
+    observed_effects_summary: list[dict[str, Any]]
+    generated_at: str
+    manifest_hash: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return deterministic dictionary representation."""
+        return {
+            "manifest_id": self.manifest_id,
+            "decision_id": self.decision_id,
+            "execution_intent_id": self.execution_intent_id,
+            "operation_id": self.operation_id,
+            "action_class": self.action_class,
+            "target_system": self.target_system,
+            "target_resource": self.target_resource,
+            "requested_scope": sorted(str(scope) for scope in self.requested_scope),
+            "authority_evidence_id": self.authority_evidence_id,
+            "authority_evidence_hash": self.authority_evidence_hash,
+            "human_approval_receipt_id": self.human_approval_receipt_id,
+            "human_approval_receipt_hash": self.human_approval_receipt_hash,
+            "bind_receipt_id": self.bind_receipt_id,
+            "bind_receipt_hash": self.bind_receipt_hash,
+            "outcome_receipt_id": self.outcome_receipt_id,
+            "outcome_receipt_hash": self.outcome_receipt_hash,
+            "bind_coverage_operation_id": self.bind_coverage_operation_id,
+            "final_outcome": self.final_outcome,
+            "chain_status": self.chain_status,
+            "missing_links": sorted(str(link) for link in self.missing_links),
+            "refusal_basis": sorted(str(reason) for reason in self.refusal_basis),
+            "observed_effects_summary": self.observed_effects_summary,
+            "generated_at": self.generated_at,
+            "manifest_hash": self.manifest_hash,
+            "metadata": self.metadata,
+        }
+
+    def to_dict_for_hash(self) -> dict[str, Any]:
+        """Return canonical hash payload excluding ``manifest_hash`` recursion."""
+        payload = self.to_dict()
+        payload.pop("manifest_hash", None)
+        return payload
+
+    def deterministic_digest(self) -> str:
+        """Compute deterministic SHA-256 digest from canonical hash payload."""
+        return sha256_of_canonical_json(self.to_dict_for_hash())
+
+
+@dataclass(frozen=True)
+class EvidenceChainManifestValidationResult:
+    """Fail-closed validation output for an evidence-chain manifest."""
+
+    is_valid: bool
+    failure_reasons: list[str]
+
+
+def with_manifest_hash(manifest: EvidenceChainManifest) -> EvidenceChainManifest:
+    """Return a new manifest finalized with deterministic ``manifest_hash``."""
+    data = manifest.to_dict()
+    data["manifest_hash"] = manifest.deterministic_digest()
+    return EvidenceChainManifest(**data)
+
+
+def validate_evidence_chain_manifest(
+    manifest: EvidenceChainManifest | None,
+) -> EvidenceChainManifestValidationResult:
+    """Validate manifest with deterministic fail-closed checks."""
+    if manifest is None:
+        return EvidenceChainManifestValidationResult(False, ["evidence_chain_manifest_missing"])
+
+    failure_reasons: list[str] = []
+
+    if not str(manifest.manifest_id).strip():
+        failure_reasons.append("evidence_chain_manifest_id_missing")
+    if not str(manifest.decision_id).strip():
+        failure_reasons.append("evidence_chain_decision_id_missing")
+    if not str(manifest.execution_intent_id).strip():
+        failure_reasons.append("evidence_chain_execution_intent_id_missing")
+    if not str(manifest.operation_id).strip():
+        failure_reasons.append("evidence_chain_operation_id_missing")
+    if not str(manifest.action_class).strip():
+        failure_reasons.append("evidence_chain_action_class_missing")
+    if not str(manifest.target_system).strip():
+        failure_reasons.append("evidence_chain_target_system_missing")
+    if not str(manifest.target_resource).strip():
+        failure_reasons.append("evidence_chain_target_resource_missing")
+    if not str(manifest.final_outcome).strip():
+        failure_reasons.append("evidence_chain_final_outcome_missing")
+
+    if manifest.chain_status not in _ALLOWED_CHAIN_STATUS:
+        failure_reasons.append("evidence_chain_invalid_chain_status")
+
+    if manifest.chain_status == "complete":
+        for field_name in _REQUIRED_COMPLETE_HASH_FIELDS:
+            if not str(getattr(manifest, field_name) or "").strip():
+                failure_reasons.append("evidence_chain_complete_missing_required_hash")
+                break
+        if not str(manifest.bind_coverage_operation_id or "").strip():
+            failure_reasons.append("evidence_chain_complete_missing_required_hash")
+        if manifest.missing_links:
+            failure_reasons.append("evidence_chain_complete_has_missing_links")
+
+    normalized_outcome = str(manifest.final_outcome).strip().lower()
+    if manifest.chain_status == "blocked":
+        if normalized_outcome not in _BLOCKED_OUTCOMES:
+            failure_reasons.append("evidence_chain_blocked_outcome_mismatch")
+        if not [item for item in manifest.refusal_basis if str(item).strip()]:
+            failure_reasons.append("evidence_chain_blocked_without_refusal_basis")
+
+    generated_at_raw = str(manifest.generated_at).strip()
+    if not generated_at_raw:
+        failure_reasons.append("evidence_chain_generated_at_missing")
+    elif _parse_iso_datetime(generated_at_raw) is None:
+        failure_reasons.append("evidence_chain_generated_at_unparseable")
+
+    if not str(manifest.manifest_hash).strip():
+        failure_reasons.append("evidence_chain_manifest_hash_missing")
+
+    return EvidenceChainManifestValidationResult(not failure_reasons, sorted(set(failure_reasons)))
+
+
+def build_evidence_chain_manifest(
+    *,
+    decision_id: str,
+    execution_intent_id: str,
+    operation_id: str,
+    action_class: str,
+    target_system: str,
+    target_resource: str,
+    requested_scope: list[str],
+    final_outcome: str,
+    authority_evidence_id: str | None = None,
+    authority_evidence_hash: str | None = None,
+    human_approval_receipt_id: str | None = None,
+    human_approval_receipt_hash: str | None = None,
+    bind_receipt_id: str | None = None,
+    bind_receipt_hash: str | None = None,
+    outcome_receipt_id: str | None = None,
+    outcome_receipt_hash: str | None = None,
+    bind_coverage_operation_id: str | None = None,
+    refusal_basis: list[str] | None = None,
+    observed_effects_summary: list[dict[str, Any]] | None = None,
+    generated_at: str,
+    metadata: dict[str, Any] | None = None,
+) -> EvidenceChainManifest:
+    """Build a deterministic local/offline finalized EvidenceChainManifest."""
+    missing_links: list[str] = []
+    for label, value in (
+        ("authority_evidence_hash", authority_evidence_hash),
+        ("human_approval_receipt_hash", human_approval_receipt_hash),
+        ("outcome_receipt_hash", outcome_receipt_hash),
+        ("bind_coverage_operation_id", bind_coverage_operation_id),
+    ):
+        if not str(value or "").strip():
+            missing_links.append(label)
+
+    normalized_outcome = str(final_outcome).strip().lower()
+    if normalized_outcome in _BLOCKED_OUTCOMES:
+        chain_status = "blocked"
+    elif normalized_outcome in _COMMITTED_OUTCOMES:
+        chain_status = "complete" if not missing_links else "incomplete"
+    elif normalized_outcome:
+        chain_status = "incomplete" if missing_links else "indeterminate"
+    else:
+        chain_status = "indeterminate"
+
+    manifest = EvidenceChainManifest(
+        manifest_id=f"ecm-{operation_id}",
+        decision_id=decision_id,
+        execution_intent_id=execution_intent_id,
+        operation_id=operation_id,
+        action_class=action_class,
+        target_system=target_system,
+        target_resource=target_resource,
+        requested_scope=list(requested_scope),
+        authority_evidence_id=authority_evidence_id,
+        authority_evidence_hash=authority_evidence_hash,
+        human_approval_receipt_id=human_approval_receipt_id,
+        human_approval_receipt_hash=human_approval_receipt_hash,
+        bind_receipt_id=bind_receipt_id,
+        bind_receipt_hash=bind_receipt_hash,
+        outcome_receipt_id=outcome_receipt_id,
+        outcome_receipt_hash=outcome_receipt_hash,
+        bind_coverage_operation_id=bind_coverage_operation_id,
+        final_outcome=final_outcome,
+        chain_status=chain_status,
+        missing_links=missing_links,
+        refusal_basis=list(refusal_basis or []),
+        observed_effects_summary=list(observed_effects_summary or []),
+        generated_at=generated_at,
+        manifest_hash="",
+        metadata=dict(metadata or {}),
+    )
+    return with_manifest_hash(manifest)
+
+
+def _parse_iso_datetime(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)


### PR DESCRIPTION
### Motivation
- Provide a minimal deterministic local/offline Evidence Chain Manifest v1 artifact to link together governance artifacts for a single governed execution attempt so external reviewers can follow the full evidence chain.
- Make the chain explicit: AuthorityEvidence → HumanApprovalReceipt → BindReceipt decision → OutcomeReceipt → BindCoverageEntry metadata, without adding live integrations or production execution behavior.
- Keep the change small and additive, preserving existing fail-closed behavior and deterministic hashing patterns used elsewhere in governance artifacts.

### Description
- Added new module `veritas_os/governance/evidence_chain_manifest.py` with `EvidenceChainManifest` dataclass, deterministic `to_dict`, `to_dict_for_hash`, and `deterministic_digest` using the repo's canonical JSON SHA-256 helper, plus `with_manifest_hash` non-mutating finalizer.
- Implemented `EvidenceChainManifestValidationResult` and `validate_evidence_chain_manifest(...)` with deterministic fail-closed checks and the specified failure reason codes and parsing checks.
- Implemented `build_evidence_chain_manifest(...)` to derive `chain_status` deterministically, populate `missing_links`, and return a finalized manifest with a manifest hash.
- Exported new APIs from `veritas_os.governance` package, lightly integrated manifest summaries into `scripts/demo/saas_permission_change_governed_demo.py` (adds `evidence_chain_manifest_summary` per case), added architecture doc `docs/en/architecture/evidence-chain-manifest.md`, and updated `README.md` and `README_JP.md` to mention Evidence Chain Manifest v1 and the local/offline boundary.
- Added unit tests: `tests/governance/test_evidence_chain_manifest.py` for hashing/validation/builder behavior and extended `tests/demo/test_saas_permission_change_governed_demo.py` to assert manifest summary presence and expected states in demo cases.

### Testing
- New tests added: `tests/governance/test_evidence_chain_manifest.py` and added assertions to `tests/demo/test_saas_permission_change_governed_demo.py`; these cover determinism, hash recursion exclusion, validation fail-closed rules, and builder-derived chain states.
- Attempted to run the focused test set with `PYENV_VERSION=3.11.15 python -m pytest tests/governance/test_evidence_chain_manifest.py tests/demo/test_saas_permission_change_governed_demo.py`, but test collection failed with `ModuleNotFoundError: No module named 'yaml'` due to an environment dependency missing; tests were not executed to completion in this environment.
- Tests are present and deterministic; CI in the repository environment (with dependencies installed) should run these new tests and existing test suites as part of normal validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181998796883268d7e03fd6d0f2712)