### PR TITLE
runtime: add Evidence Chain Verifier v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 4. Human Approval Receipt v1 (local/offline): docs/en/architecture/human-approval-receipt.md
 5. Outcome Receipt v1 (local/offline): docs/en/architecture/outcome-receipt.md
 6. Evidence Chain Manifest v1 (local/offline): docs/en/architecture/evidence-chain-manifest.md
-7. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-8. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
-9. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
-10. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
-11. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
+7. Evidence Chain Verifier v1 (local/offline): docs/en/architecture/evidence-chain-verifier.md
+8. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+9. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+10. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
+11. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
+12. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
 
 Boundary:
 
@@ -107,6 +108,8 @@ VERITAS includes a local/offline Bind Coverage Registry v1 that records which ef
 ## Evidence Chain Manifest v1
 
 VERITAS includes a local/offline Evidence Chain Manifest v1 artifact that links AuthorityEvidence, HumanApprovalReceipt, bind-time decision evidence, OutcomeReceipt, and operation coverage metadata for a governed execution attempt. It helps reviewers inspect a complete evidence chain from pre-execution authority and approval through bind-time decisioning to post-execution outcome evidence. This is a local/offline manifest, not proof of live production execution.
+
+VERITAS includes a local/offline Evidence Chain Verifier v1 that checks whether an EvidenceChainManifest matches the supplied governance artifacts. It recomputes or reads deterministic artifact hashes and reports verified, missing, mismatched, or indeterminate links. This is a local/offline verifier, not proof of live production audit certification.
 
 
 ## One-Day PoC Evidence Packet

--- a/README_JP.md
+++ b/README_JP.md
@@ -45,11 +45,12 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 4. Human Approval Receipt v1（local/offline）: docs/en/architecture/human-approval-receipt.md
 5. Outcome Receipt v1（local/offline）: docs/en/architecture/outcome-receipt.md
 6. Evidence Chain Manifest v1（local/offline）: docs/en/architecture/evidence-chain-manifest.md
-7. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
-8. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
-9. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
-10. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
-11. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
+7. Evidence Chain Verifier v1（local/offline）: docs/en/architecture/evidence-chain-verifier.md
+8. [Regulated Action Governance Proof Pack](docs/en/validation/regulated-action-governance-proof-pack.md)
+9. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
+10. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
+11. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
+12. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
 
 境界条件:
 
@@ -110,6 +111,8 @@ VERITAS には local/offline の Bind Coverage Registry v1 が追加されてい
 ## Evidence Chain Manifest v1
 
 VERITAS には local/offline の Evidence Chain Manifest v1 artifact が追加されています。これは、governed execution attempt について、AuthorityEvidence、HumanApprovalReceipt、bind-time decision evidence、OutcomeReceipt、operation coverage metadata をひとつの証跡チェーンとして結び付けるためのものです。実行前の権限・承認から、bind-time の判定、実行後の outcome evidence までを外部レビュアーが追跡しやすくします。本番環境での実行証明ではなく、local/offline の manifest です。
+
+VERITAS には local/offline の Evidence Chain Verifier v1 が追加されています。これは、EvidenceChainManifest が実際に渡された governance artifacts と整合しているかを検証するためのものです。各 artifact の hash を再計算または読み取り、verified / missing / mismatched / indeterminate な link を報告します。本番監査認証ではなく、local/offline の verifier です。
 
 
 ## AML/KYC レビュアー向けウォークスルー Quickstart

--- a/docs/en/architecture/evidence-chain-verifier.md
+++ b/docs/en/architecture/evidence-chain-verifier.md
@@ -1,0 +1,57 @@
+# Evidence Chain Verifier v1
+
+Evidence Chain Verifier v1 is a deterministic local/offline verifier for
+`EvidenceChainManifest` artifacts.
+
+It answers a narrow question:
+
+> Does this `EvidenceChainManifest` match the supplied governance artifacts it
+> claims to reference?
+
+## What it verifies
+
+The verifier compares a manifest with supplied local/offline artifacts by:
+
+- recomputing `manifest.deterministic_digest()` and comparing it with
+  `manifest.manifest_hash`;
+- recomputing artifact hashes through `deterministic_digest()` when available;
+- reading deterministic hash fields such as `evidence_hash`, `receipt_hash`,
+  `outcome_hash`, `manifest_hash`, or `bind_receipt_hash` when a digest method
+  is not available;
+- checking claimed bind coverage operation metadata against the supplied
+  operation id; and
+- reporting verified, missing, mismatched, or indeterminate links.
+
+For v1, the verifier is intentionally small and additive. It complements
+Evidence Chain Manifest v1 by checking whether the manifest's claimed links match
+available local artifacts, rather than only validating the manifest shape.
+
+## Result statuses
+
+`EvidenceChainVerificationResult` uses deterministic statuses:
+
+- `verified` — the manifest exists, the manifest hash matches, every claimed
+  supplied link verifies, and no failure reason is present.
+- `failed` — a manifest hash or artifact hash mismatch is detected, or verifier
+  timestamp validation fails.
+- `incomplete` — a manifest claims a link but the required artifact or coverage
+  operation id was not supplied.
+- `indeterminate` — an artifact was supplied, but the verifier cannot determine
+  a deterministic hash for it and no direct mismatch is proven.
+
+The verifier preserves the manifest's own `missing_links` information for
+blocked or incomplete chains. Missing links recorded by the manifest itself are
+not treated as tampering unless the manifest claims a hash and the corresponding
+artifact is absent, mismatched, or indeterminate.
+
+## Local/offline boundary
+
+Evidence Chain Verifier v1 does **not** connect to live SaaS, IdP, IAM, SSO,
+bank, sanctions, customer systems, production approval systems, or live audit
+stores. It performs no live network calls, requires no credentials, and does not
+introduce production execution behavior.
+
+This verifier is not legal advice, regulatory approval, third-party
+certification, production audit certification, or proof of live production audit
+coverage. It is a deterministic local/offline consistency checker for governance
+artifacts supplied to it.

--- a/scripts/demo/saas_permission_change_governed_demo.py
+++ b/scripts/demo/saas_permission_change_governed_demo.py
@@ -15,6 +15,8 @@ from veritas_os.governance import (
     build_evidence_chain_manifest,
     build_outcome_receipt,
     build_human_approval_state,
+    verify_evidence_chain_manifest,
+    with_receipt_hash,
 )
 from veritas_os.governance.authority_evidence_ingestion import (
     ingest_authority_evidence_payload,
@@ -234,6 +236,20 @@ def _evaluate_case(
         generated_at=FIXED_NOW.isoformat(),
         metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},
     )
+
+    finalized_human_approval_receipt = None
+    if receipt is not None and human_approval_state.get("approved"):
+        finalized_human_approval_receipt = with_receipt_hash(receipt)
+
+    evidence_chain_verification = verify_evidence_chain_manifest(
+        manifest=evidence_chain_manifest,
+        authority_evidence=authority_evidence,
+        human_approval_receipt=finalized_human_approval_receipt,
+        outcome_receipt=outcome_receipt,
+        bind_coverage_operation_id="saas_permission_change_demo",
+        verified_at=FIXED_NOW.isoformat(),
+        metadata={"fixture_only": True, "boundary_note": BOUNDARY_NOTE},
+    )
     return {
         "case_id": case_id,
         "expected_outcome": expected_outcome,
@@ -252,6 +268,7 @@ def _evaluate_case(
         "boundary_note": BOUNDARY_NOTE,
         "outcome_receipt_summary": outcome_receipt.to_dict(),
         "evidence_chain_manifest_summary": evidence_chain_manifest.to_dict(),
+        "evidence_chain_verification_summary": evidence_chain_verification.to_dict(),
     }
 
 

--- a/tests/demo/test_saas_permission_change_governed_demo.py
+++ b/tests/demo/test_saas_permission_change_governed_demo.py
@@ -178,3 +178,58 @@ def test_missing_human_approval_manifest_has_missing_human_approval_link() -> No
     payload = run_saas_permission_change_governed_demo()
     summary = _case_by_id(payload, "missing_human_approval")["evidence_chain_manifest_summary"]
     assert "human_approval_receipt_hash" in summary["missing_links"]  # type: ignore[index]
+
+
+def test_every_demo_case_includes_evidence_chain_verification_summary() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case in payload["cases"]:  # type: ignore[index]
+        summary = case["evidence_chain_verification_summary"]  # type: ignore[index]
+        assert isinstance(summary, dict)
+        assert summary["verification_status"] in {  # type: ignore[index]
+            "verified",
+            "failed",
+            "incomplete",
+            "indeterminate",
+        }
+        assert summary["verified_at"] == payload["generated_at"]  # type: ignore[index]
+
+
+def test_valid_authority_and_approval_verification_is_verified() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    summary = _case_by_id(payload, "valid_authority_and_approval")[
+        "evidence_chain_verification_summary"
+    ]
+    assert summary["verification_status"] == "verified"  # type: ignore[index]
+    assert summary["is_valid"] is True  # type: ignore[index]
+    assert summary["manifest_hash_matches"] is True  # type: ignore[index]
+
+
+def test_demo_does_not_simulate_tampering_in_verification_summary() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case in payload["cases"]:  # type: ignore[index]
+        summary = case["evidence_chain_verification_summary"]  # type: ignore[index]
+        assert summary["manifest_hash_matches"] is True  # type: ignore[index]
+        assert summary["mismatched_links"] == []  # type: ignore[index]
+
+
+def test_blocked_cases_include_deterministic_verification_status() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case_id in [
+        "missing_authority",
+        "missing_human_approval",
+        "expired_human_approval",
+        "scope_mismatch",
+    ]:
+        summary = _case_by_id(payload, case_id)["evidence_chain_verification_summary"]
+        assert summary["verification_status"] == "verified"  # type: ignore[index]
+        assert summary["is_valid"] is True  # type: ignore[index]
+        assert summary["failure_reasons"] == []  # type: ignore[index]
+
+
+def test_verification_summary_preserves_no_network_environment_dependency() -> None:
+    payload = run_saas_permission_change_governed_demo()
+    for case in payload["cases"]:  # type: ignore[index]
+        summary = case["evidence_chain_verification_summary"]  # type: ignore[index]
+        metadata = summary["metadata"]  # type: ignore[index]
+        assert metadata["fixture_only"] is True  # type: ignore[index]
+        assert metadata["boundary_note"] == BOUNDARY_NOTE  # type: ignore[index]

--- a/tests/governance/test_evidence_chain_verifier.py
+++ b/tests/governance/test_evidence_chain_verifier.py
@@ -1,0 +1,173 @@
+"""Tests for deterministic local/offline Evidence Chain Verifier v1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from veritas_os.governance.evidence_chain_manifest import (
+    EvidenceChainManifest,
+    build_evidence_chain_manifest,
+)
+from veritas_os.governance.evidence_chain_verifier import (
+    EvidenceChainVerificationResult,
+    _extract_artifact_hash,
+    verify_evidence_chain_manifest,
+)
+
+VERIFIED_AT = "2026-04-26T00:00:00+00:00"
+AUTHORITY_HASH = "a" * 64
+APPROVAL_HASH = "b" * 64
+OUTCOME_HASH = "c" * 64
+
+
+@dataclass(frozen=True)
+class DigestArtifact:
+    """Test artifact exposing a deterministic_digest method."""
+
+    digest: str
+
+    def deterministic_digest(self) -> str:
+        """Return the configured deterministic digest."""
+        return self.digest
+
+
+class UnsupportedArtifact:
+    """Test artifact with no deterministic hash surface."""
+
+
+def _complete_manifest() -> EvidenceChainManifest:
+    return build_evidence_chain_manifest(
+        decision_id="decision-1",
+        execution_intent_id="intent-1",
+        operation_id="operation-1",
+        action_class="permission_change",
+        target_system="mock_saas",
+        target_resource="user:alice",
+        requested_scope=["saas:grant_admin"],
+        final_outcome="commit",
+        authority_evidence_id="aev-1",
+        authority_evidence_hash=AUTHORITY_HASH,
+        human_approval_receipt_id="har-1",
+        human_approval_receipt_hash=APPROVAL_HASH,
+        outcome_receipt_id="outcome-1",
+        outcome_receipt_hash=OUTCOME_HASH,
+        bind_coverage_operation_id="saas_permission_change_demo",
+        generated_at=VERIFIED_AT,
+        metadata={"fixture_only": True},
+    )
+
+
+def _verify_complete(**overrides: object) -> EvidenceChainVerificationResult:
+    kwargs = {
+        "manifest": _complete_manifest(),
+        "authority_evidence": {"evidence_hash": AUTHORITY_HASH},
+        "human_approval_receipt": {"receipt_hash": APPROVAL_HASH},
+        "outcome_receipt": {"outcome_hash": OUTCOME_HASH},
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "verified_at": VERIFIED_AT,
+    }
+    kwargs.update(overrides)
+    return verify_evidence_chain_manifest(**kwargs)
+
+
+def test_missing_manifest_fails_verification() -> None:
+    result = verify_evidence_chain_manifest(manifest=None, verified_at=VERIFIED_AT)
+    assert result.is_valid is False
+    assert result.verification_status == "failed"
+    assert "evidence_chain_manifest_missing" in result.failure_reasons
+
+
+def test_valid_complete_chain_verifies_successfully() -> None:
+    result = _verify_complete()
+    assert result.is_valid is True
+    assert result.verification_status == "verified"
+    assert result.manifest_hash_matches is True
+    assert result.verified_links == [
+        "authority_evidence_hash",
+        "bind_coverage_operation_id",
+        "human_approval_receipt_hash",
+        "manifest_hash",
+        "outcome_receipt_hash",
+    ]
+    assert result.failure_reasons == []
+
+
+def test_manifest_hash_mismatch_fails_verification() -> None:
+    manifest = _complete_manifest()
+    tampered_manifest = type(manifest)(**{**manifest.to_dict(), "manifest_hash": "x" * 64})
+    result = _verify_complete(manifest=tampered_manifest)
+    assert result.is_valid is False
+    assert result.verification_status == "failed"
+    assert "manifest_hash" in result.mismatched_links
+    assert "evidence_chain_manifest_hash_mismatch" in result.failure_reasons
+
+
+def test_authority_evidence_hash_mismatch_fails_verification() -> None:
+    result = _verify_complete(authority_evidence={"evidence_hash": "x" * 64})
+    assert result.verification_status == "failed"
+    assert "authority_evidence_hash" in result.mismatched_links
+    assert "evidence_chain_authority_evidence_hash_mismatch" in result.failure_reasons
+
+
+def test_human_approval_receipt_hash_mismatch_fails_verification() -> None:
+    result = _verify_complete(human_approval_receipt={"receipt_hash": "x" * 64})
+    assert result.verification_status == "failed"
+    assert "human_approval_receipt_hash" in result.mismatched_links
+    assert "evidence_chain_human_approval_receipt_hash_mismatch" in result.failure_reasons
+
+
+def test_outcome_receipt_hash_mismatch_fails_verification() -> None:
+    result = _verify_complete(outcome_receipt={"outcome_hash": "x" * 64})
+    assert result.verification_status == "failed"
+    assert "outcome_receipt_hash" in result.mismatched_links
+    assert "evidence_chain_outcome_receipt_hash_mismatch" in result.failure_reasons
+
+
+def test_missing_authority_evidence_for_claimed_hash_is_not_verified() -> None:
+    result = _verify_complete(authority_evidence=None)
+    assert result.is_valid is False
+    assert result.verification_status == "incomplete"
+    assert "authority_evidence_hash" in result.missing_links
+    assert "evidence_chain_authority_evidence_missing" in result.failure_reasons
+
+
+def test_bind_coverage_operation_mismatch_fails_verification() -> None:
+    result = _verify_complete(bind_coverage_operation_id="different_operation")
+    assert result.verification_status == "failed"
+    assert "bind_coverage_operation_id" in result.mismatched_links
+    assert "evidence_chain_bind_coverage_operation_mismatch" in result.failure_reasons
+
+
+def test_bind_coverage_operation_missing_is_not_verified() -> None:
+    result = _verify_complete(bind_coverage_operation_id=None)
+    assert result.is_valid is False
+    assert result.verification_status == "incomplete"
+    assert "bind_coverage_operation_id" in result.missing_links
+    assert "evidence_chain_bind_coverage_operation_missing" in result.failure_reasons
+
+
+def test_verified_at_missing_fails_verification() -> None:
+    result = _verify_complete(verified_at="")
+    assert result.is_valid is False
+    assert result.verification_status == "failed"
+    assert "evidence_chain_verified_at_missing" in result.failure_reasons
+
+
+def test_verified_at_unparseable_fails_verification() -> None:
+    result = _verify_complete(verified_at="not-a-date")
+    assert result.is_valid is False
+    assert result.verification_status == "failed"
+    assert "evidence_chain_verified_at_unparseable" in result.failure_reasons
+
+
+def test_extract_artifact_hash_supports_deterministic_digest() -> None:
+    assert _extract_artifact_hash(DigestArtifact("d" * 64)) == "d" * 64
+
+
+def test_extract_artifact_hash_supports_dict_hash_fields() -> None:
+    assert _extract_artifact_hash({"receipt_hash": "r" * 64}) == "r" * 64
+    assert _extract_artifact_hash({"outcome_hash": "o" * 64}) == "o" * 64
+
+
+def test_extract_artifact_hash_returns_none_for_unsupported_artifacts() -> None:
+    assert _extract_artifact_hash(UnsupportedArtifact()) is None

--- a/veritas_os/governance/__init__.py
+++ b/veritas_os/governance/__init__.py
@@ -44,6 +44,10 @@ from veritas_os.governance.evidence_chain_manifest import (
     validate_evidence_chain_manifest,
     with_manifest_hash,
 )
+from veritas_os.governance.evidence_chain_verifier import (
+    EvidenceChainVerificationResult,
+    verify_evidence_chain_manifest,
+)
 
 from veritas_os.governance.commit_boundary import (
     CommitBoundaryResult,
@@ -83,9 +87,11 @@ __all__ = [
     "OutcomeReceipt",
     "EvidenceChainManifest",
     "EvidenceChainManifestValidationResult",
+    "EvidenceChainVerificationResult",
     "build_evidence_chain_manifest",
     "validate_evidence_chain_manifest",
     "with_manifest_hash",
+    "verify_evidence_chain_manifest",
     "OutcomeReceiptValidationResult",
     "build_outcome_receipt",
     "validate_outcome_receipt",

--- a/veritas_os/governance/evidence_chain_verifier.py
+++ b/veritas_os/governance/evidence_chain_verifier.py
@@ -1,0 +1,305 @@
+"""Deterministic local/offline Evidence Chain Verifier v1.
+
+The verifier compares an EvidenceChainManifest with supplied governance
+artifacts without network access, credential use, live SaaS calls, or production
+audit-store integration. It is intentionally minimal and additive for v1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from veritas_os.governance.evidence_chain_manifest import EvidenceChainManifest
+
+_VERIFICATION_STATUSES = {"verified", "failed", "incomplete", "indeterminate"}
+_HASH_FIELD_NAMES = (
+    "evidence_hash",
+    "receipt_hash",
+    "outcome_hash",
+    "manifest_hash",
+    "bind_receipt_hash",
+)
+
+
+@dataclass(frozen=True)
+class EvidenceChainVerificationResult:
+    """Result of local/offline EvidenceChainManifest link verification."""
+
+    is_valid: bool
+    verification_status: str
+    manifest_id: str | None
+    decision_id: str | None
+    execution_intent_id: str | None
+    operation_id: str | None
+    verified_links: list[str] = field(default_factory=list)
+    missing_links: list[str] = field(default_factory=list)
+    mismatched_links: list[str] = field(default_factory=list)
+    failure_reasons: list[str] = field(default_factory=list)
+    recomputed_manifest_hash: str | None = None
+    manifest_hash_matches: bool = False
+    verified_at: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic JSON-friendly verification summary."""
+        return {
+            "is_valid": self.is_valid,
+            "verification_status": self.verification_status,
+            "manifest_id": self.manifest_id,
+            "decision_id": self.decision_id,
+            "execution_intent_id": self.execution_intent_id,
+            "operation_id": self.operation_id,
+            "verified_links": sorted(self.verified_links),
+            "missing_links": sorted(self.missing_links),
+            "mismatched_links": sorted(self.mismatched_links),
+            "failure_reasons": sorted(self.failure_reasons),
+            "recomputed_manifest_hash": self.recomputed_manifest_hash,
+            "manifest_hash_matches": self.manifest_hash_matches,
+            "verified_at": self.verified_at,
+            "metadata": dict(self.metadata),
+        }
+
+
+def verify_evidence_chain_manifest(
+    *,
+    manifest: EvidenceChainManifest | None,
+    authority_evidence: Any | None = None,
+    human_approval_receipt: Any | None = None,
+    outcome_receipt: Any | None = None,
+    bind_coverage_operation_id: str | None = None,
+    bind_receipt: Any | None = None,
+    verified_at: str,
+    metadata: dict[str, Any] | None = None,
+) -> EvidenceChainVerificationResult:
+    """Verify an EvidenceChainManifest against supplied local/offline artifacts.
+
+    The function never performs network calls and never mutates supplied
+    artifacts. It verifies only links claimed by the manifest, preserving the
+    manifest's own ``missing_links`` for incomplete or blocked chains.
+    """
+    verified_links: list[str] = []
+    missing_links: list[str] = []
+    mismatched_links: list[str] = []
+    failure_reasons: list[str] = []
+    indeterminate_links: list[str] = []
+
+    _validate_verified_at(verified_at, failure_reasons)
+
+    if manifest is None:
+        failure_reasons.append("evidence_chain_manifest_missing")
+        status = "failed"
+        return EvidenceChainVerificationResult(
+            is_valid=False,
+            verification_status=status,
+            manifest_id=None,
+            decision_id=None,
+            execution_intent_id=None,
+            operation_id=None,
+            verified_links=[],
+            missing_links=[],
+            mismatched_links=[],
+            failure_reasons=sorted(set(failure_reasons)),
+            recomputed_manifest_hash=None,
+            manifest_hash_matches=False,
+            verified_at=verified_at,
+            metadata=dict(metadata or {}),
+        )
+
+    missing_links.extend(str(link) for link in manifest.missing_links if str(link).strip())
+
+    recomputed_manifest_hash = manifest.deterministic_digest()
+    manifest_hash_matches = recomputed_manifest_hash == manifest.manifest_hash
+    if manifest_hash_matches:
+        verified_links.append("manifest_hash")
+    else:
+        mismatched_links.append("manifest_hash")
+        failure_reasons.append("evidence_chain_manifest_hash_mismatch")
+
+    _verify_hash_link(
+        manifest_hash=manifest.authority_evidence_hash,
+        artifact=authority_evidence,
+        link_name="authority_evidence_hash",
+        missing_reason="evidence_chain_authority_evidence_missing",
+        mismatch_reason="evidence_chain_authority_evidence_hash_mismatch",
+        indeterminate_reason="evidence_chain_authority_evidence_hash_indeterminate",
+        verified_links=verified_links,
+        missing_links=missing_links,
+        mismatched_links=mismatched_links,
+        indeterminate_links=indeterminate_links,
+        failure_reasons=failure_reasons,
+    )
+    _verify_hash_link(
+        manifest_hash=manifest.human_approval_receipt_hash,
+        artifact=human_approval_receipt,
+        link_name="human_approval_receipt_hash",
+        missing_reason="evidence_chain_human_approval_receipt_missing",
+        mismatch_reason="evidence_chain_human_approval_receipt_hash_mismatch",
+        indeterminate_reason="evidence_chain_human_approval_receipt_hash_indeterminate",
+        verified_links=verified_links,
+        missing_links=missing_links,
+        mismatched_links=mismatched_links,
+        indeterminate_links=indeterminate_links,
+        failure_reasons=failure_reasons,
+    )
+    _verify_hash_link(
+        manifest_hash=manifest.outcome_receipt_hash,
+        artifact=outcome_receipt,
+        link_name="outcome_receipt_hash",
+        missing_reason="evidence_chain_outcome_receipt_missing",
+        mismatch_reason="evidence_chain_outcome_receipt_hash_mismatch",
+        indeterminate_reason="evidence_chain_outcome_receipt_hash_indeterminate",
+        verified_links=verified_links,
+        missing_links=missing_links,
+        mismatched_links=mismatched_links,
+        indeterminate_links=indeterminate_links,
+        failure_reasons=failure_reasons,
+    )
+
+    if str(manifest.bind_coverage_operation_id or "").strip():
+        if not str(bind_coverage_operation_id or "").strip():
+            missing_links.append("bind_coverage_operation_id")
+            failure_reasons.append("evidence_chain_bind_coverage_operation_missing")
+        elif bind_coverage_operation_id == manifest.bind_coverage_operation_id:
+            verified_links.append("bind_coverage_operation_id")
+        else:
+            mismatched_links.append("bind_coverage_operation_id")
+            failure_reasons.append("evidence_chain_bind_coverage_operation_mismatch")
+
+    _verify_hash_link(
+        manifest_hash=manifest.bind_receipt_hash,
+        artifact=bind_receipt,
+        link_name="bind_receipt_hash",
+        missing_reason="evidence_chain_bind_receipt_missing",
+        mismatch_reason="evidence_chain_bind_receipt_hash_mismatch",
+        indeterminate_reason="evidence_chain_bind_receipt_hash_indeterminate",
+        verified_links=verified_links,
+        missing_links=missing_links,
+        mismatched_links=mismatched_links,
+        indeterminate_links=indeterminate_links,
+        failure_reasons=failure_reasons,
+    )
+
+    unique_verified = sorted(set(verified_links))
+    unique_missing = sorted(set(missing_links))
+    unique_mismatched = sorted(set(mismatched_links))
+    unique_failures = sorted(set(failure_reasons))
+    status = _derive_status(
+        manifest_exists=True,
+        manifest_hash_matches=manifest_hash_matches,
+        mismatched_links=unique_mismatched,
+        failure_reasons=unique_failures,
+        indeterminate_links=indeterminate_links,
+    )
+
+    return EvidenceChainVerificationResult(
+        is_valid=status == "verified",
+        verification_status=status,
+        manifest_id=manifest.manifest_id,
+        decision_id=manifest.decision_id,
+        execution_intent_id=manifest.execution_intent_id,
+        operation_id=manifest.operation_id,
+        verified_links=unique_verified,
+        missing_links=unique_missing,
+        mismatched_links=unique_mismatched,
+        failure_reasons=unique_failures,
+        recomputed_manifest_hash=recomputed_manifest_hash,
+        manifest_hash_matches=manifest_hash_matches,
+        verified_at=verified_at,
+        metadata=dict(metadata or {}),
+    )
+
+
+def _extract_artifact_hash(artifact: Any) -> str | None:
+    """Return a deterministic artifact hash without mutating the artifact."""
+    if artifact is None:
+        return None
+
+    deterministic_digest = getattr(artifact, "deterministic_digest", None)
+    if callable(deterministic_digest):
+        digest = deterministic_digest()
+        return str(digest) if digest is not None else None
+
+    for field_name in _HASH_FIELD_NAMES:
+        if isinstance(artifact, dict):
+            value = artifact.get(field_name)
+        else:
+            value = getattr(artifact, field_name, None)
+        if value is not None:
+            return str(value)
+
+    return None
+
+
+def _verify_hash_link(
+    *,
+    manifest_hash: str | None,
+    artifact: Any | None,
+    link_name: str,
+    missing_reason: str,
+    mismatch_reason: str,
+    indeterminate_reason: str,
+    verified_links: list[str],
+    missing_links: list[str],
+    mismatched_links: list[str],
+    indeterminate_links: list[str],
+    failure_reasons: list[str],
+) -> None:
+    if not str(manifest_hash or "").strip():
+        return
+
+    if artifact is None:
+        missing_links.append(link_name)
+        failure_reasons.append(missing_reason)
+        return
+
+    artifact_hash = _extract_artifact_hash(artifact)
+    if not str(artifact_hash or "").strip():
+        indeterminate_links.append(link_name)
+        failure_reasons.append(indeterminate_reason)
+        return
+
+    if artifact_hash == manifest_hash:
+        verified_links.append(link_name)
+    else:
+        mismatched_links.append(link_name)
+        failure_reasons.append(mismatch_reason)
+
+
+def _validate_verified_at(verified_at: str, failure_reasons: list[str]) -> None:
+    if not str(verified_at or "").strip():
+        failure_reasons.append("evidence_chain_verified_at_missing")
+        return
+    try:
+        datetime.fromisoformat(str(verified_at))
+    except ValueError:
+        failure_reasons.append("evidence_chain_verified_at_unparseable")
+
+
+def _derive_status(
+    *,
+    manifest_exists: bool,
+    manifest_hash_matches: bool,
+    mismatched_links: list[str],
+    failure_reasons: list[str],
+    indeterminate_links: list[str],
+) -> str:
+    if not manifest_exists:
+        return "failed"
+    if mismatched_links or not manifest_hash_matches:
+        return "failed"
+    verified_at_failures = {
+        "evidence_chain_verified_at_missing",
+        "evidence_chain_verified_at_unparseable",
+    }
+    if verified_at_failures.intersection(failure_reasons):
+        return "failed"
+    if indeterminate_links:
+        return "indeterminate"
+    if failure_reasons:
+        return "incomplete"
+    return "verified"
+
+
+assert _VERIFICATION_STATUSES == {"verified", "failed", "incomplete", "indeterminate"}


### PR DESCRIPTION
### Motivation
- Provide a small, deterministic local/offline Evidence Chain Verifier v1 that answers whether an `EvidenceChainManifest` actually matches the AuthorityEvidence, HumanApprovalReceipt, OutcomeReceipt, bind coverage metadata, and bind receipt it claims to reference. 
- Complement existing artifacts (Authority Evidence Ingestion, Human Approval Receipt, Outcome Receipt, Evidence Chain Manifest, Bind Coverage Registry) without adding any live network, credential, or production execution behavior.

### Description
- Add `veritas_os/governance/evidence_chain_verifier.py` implementing `EvidenceChainVerificationResult` and `verify_evidence_chain_manifest(...)` with deterministic manifest hash recomputation, per-link verification, missing/mismatched/indeterminate classification, `verified_at` validation, and deterministic status derivation (`verified`, `failed`, `incomplete`, `indeterminate`).
- Add `_extract_artifact_hash(...)` helper to read `deterministic_digest()` or common hash fields (`evidence_hash`, `receipt_hash`, `outcome_hash`, `manifest_hash`, `bind_receipt_hash`) without mutating artifacts.
- Integrate verifier lightly into `scripts/demo/saas_permission_change_governed_demo.py` to emit `evidence_chain_verification_summary` using only local artifacts and a finalized receipt when available.
- Export verifier API from `veritas_os.governance.__init__`, add `docs/en/architecture/evidence-chain-verifier.md`, and update `README.md` / `README_JP.md` to reference the new verifier.
- Add focused unit tests `tests/governance/test_evidence_chain_verifier.py` and extend demo tests `tests/demo/test_saas_permission_change_governed_demo.py` to assert the presence and expected shape/statuses of verification summaries.

### Testing
- Performed static/compile checks: `python -m py_compile` for the new modules and updated scripts succeeded. 
- Lint/static checks: `ruff check` passed for the modified/added files.
- Attempted to run targeted `pytest` for the new verifier and demo tests, but test collection could not complete in this environment due to missing environment dependencies (missing `yaml` / PyYAML) and an inability to fetch a PyPI package during virtualenv setup; as a result full pytest execution was not completed here. 
- All added tests and runtime behavior are unit-focused and deterministic; CI (with network-enabled dependency installation) is expected to run the new tests fully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186b2cbe8483269da97e495cf79bfb)