### PR TITLE
demo: add Reviewer Evidence Packet export v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 9. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 10. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
 11. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
-12. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
+12. [Reviewer Evidence Packet v1 (local/offline)](docs/en/demo/reviewer-evidence-packet.md)
+13. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
 
 Boundary:
 
@@ -100,6 +101,13 @@ Boundary:
 - No live SaaS, IAM, IdP, SSO, customer directory, or production approval workflow integration
 - Not legal advice, regulatory approval, third-party certification, or production access-control validation
 
+## Reviewer Evidence Packet v1
+
+VERITAS includes a local/offline Reviewer Evidence Packet v1 export for the SaaS permission-change governed execution demo. It packages case outcomes, AuthorityEvidence/HumanApproval summaries, OutcomeReceipt summaries, EvidenceChainManifest summaries, EvidenceChainVerification summaries, aggregate counts, reviewer notes, and a deterministic packet hash into one JSON-friendly artifact. This is a local/offline review packet, not proof of live production deployment or audit certification.
+
+- Documentation: docs/en/demo/reviewer-evidence-packet.md
+- Script: scripts/demo/export_reviewer_evidence_packet.py
+- Test: tests/demo/test_reviewer_evidence_packet.py
 
 ## Bind Coverage Registry v1
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -50,7 +50,8 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 9. [AML/KYC Reviewer Handoff Pack](docs/en/validation/external-review-handoff-regulated-action-governance.md)
 10. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
 11. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
-12. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
+12. [Reviewer Evidence Packet v1（local/offline）](docs/en/demo/reviewer-evidence-packet.md)
+13. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
 
 境界条件:
 
@@ -103,6 +104,13 @@ VERITAS には、local/offline の SaaS permission-change governed execution dem
 - 実 SaaS・実 IAM・実 IdP・実 SSO・実顧客ディレクトリ・本番承認ワークフローとの接続なし
 - 法的助言・規制承認・第三者認証・本番 access-control validation ではない
 
+## Reviewer Evidence Packet v1
+
+VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加されています。これは、SaaS permission-change governed execution demo の結果を、case outcome、AuthorityEvidence / HumanApproval summary、OutcomeReceipt summary、EvidenceChainManifest summary、EvidenceChainVerification summary、aggregate counts、reviewer notes、決定論的 packet hash を含む JSON-friendly artifact としてまとめるものです。本番導入や監査認証の証明ではなく、local/offline の review packet です。
+
+- ドキュメント: docs/en/demo/reviewer-evidence-packet.md
+- スクリプト: scripts/demo/export_reviewer_evidence_packet.py
+- テスト: tests/demo/test_reviewer_evidence_packet.py
 
 ## Bind Coverage Registry v1
 

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -1,0 +1,36 @@
+# Reviewer Evidence Packet v1
+
+Reviewer Evidence Packet v1 is a deterministic local/offline JSON-friendly export for the SaaS permission-change governed execution demo.
+
+It packages the existing demo output into one reviewer-facing artifact so external reviewers, investors, and enterprise stakeholders can inspect the main governance evidence without opening every internal artifact separately.
+
+## What it includes
+
+The packet is built from `run_saas_permission_change_governed_demo()` and includes:
+
+- case outcomes for the SaaS permission-change governed execution demo
+- compact AuthorityEvidence and HumanApproval summaries
+- OutcomeReceipt summaries for each case
+- EvidenceChainManifest summaries for each case
+- EvidenceChainVerification summaries for each case
+- aggregate counts for blocked, committed, and verified cases
+- deterministic reviewer notes
+- a deterministic packet hash that excludes `packet_hash` itself from the hash payload
+
+## Local/offline boundary
+
+Reviewer Evidence Packet v1 is a local/offline fixture export only.
+
+It does not connect to live SaaS, IAM, IdP, SSO, customer directories, banks, sanctions systems, production approval workflows, or live audit stores.
+
+It demonstrates bind-time governance and evidence-chain verification using deterministic artifacts. It is not legal advice, regulatory approval, third-party certification, production audit certification, or proof of live deployment.
+
+## Usage
+
+Run the export locally:
+
+```bash
+python3 scripts/demo/export_reviewer_evidence_packet.py
+```
+
+The command prints deterministic JSON to stdout with sorted keys and indentation. It performs no network calls and requires no credentials.

--- a/scripts/demo/export_reviewer_evidence_packet.py
+++ b/scripts/demo/export_reviewer_evidence_packet.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Export a deterministic local/offline reviewer evidence packet for the SaaS demo."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.saas_permission_change_governed_demo import (
+    BOUNDARY_NOTE,
+    run_saas_permission_change_governed_demo,
+)
+from veritas_os.security.hash import sha256_of_canonical_json
+
+PACKET_ID = "reviewer-evidence-packet-saas-permission-change-v1"
+PACKET_VERSION = "v1"
+PACKET_TITLE = "SaaS Permission-Change Governed Execution Reviewer Evidence Packet"
+REVIEWER_NOTES = [
+    "This packet is generated from a local/offline fixture demo.",
+    (
+        "It does not connect to live SaaS, IAM, IdP, SSO, customer "
+        "directory, bank, sanctions, or production approval systems."
+    ),
+    (
+        "It demonstrates bind-time governance and evidence-chain "
+        "verification using deterministic artifacts."
+    ),
+    (
+        "It is not legal advice, regulatory approval, third-party "
+        "certification, production audit certification, or proof of live "
+        "deployment."
+    ),
+]
+
+
+def _human_approval_summary(human_approval_state: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact deterministic summary of human approval state."""
+    receipt_hash = human_approval_state.get("receipt_hash")
+    return {
+        "approved": bool(human_approval_state.get("approved", False)),
+        "approval_receipt_id": human_approval_state.get("approval_receipt_id"),
+        "approver_identity": human_approval_state.get("approver_identity"),
+        "approver_role": human_approval_state.get("approver_role"),
+        "approved_scope": list(human_approval_state.get("approved_scope", [])),
+        "receipt_hash_present": bool(receipt_hash),
+        "failure_reasons": list(human_approval_state.get("failure_reasons", [])),
+    }
+
+
+def _reviewer_interpretation(case: dict[str, Any]) -> str:
+    """Create a deterministic reviewer-facing interpretation for one demo case."""
+    actual_outcome = case["actual_outcome"]
+    case_id = case["case_id"]
+    if actual_outcome in {"commit", "commit_eligible"}:
+        return (
+            "AuthorityEvidence and HumanApprovalReceipt were sufficient for the "
+            "local/offline fixture to reach a commit outcome."
+        )
+    if case_id == "missing_authority":
+        return "The local/offline fixture blocked because AuthorityEvidence was missing."
+    if case_id == "missing_human_approval":
+        return "The local/offline fixture blocked because HumanApprovalReceipt was missing."
+    if case_id == "expired_human_approval":
+        return "The local/offline fixture blocked because HumanApprovalReceipt was expired."
+    if case_id == "scope_mismatch":
+        return (
+            "The local/offline fixture blocked because approved authority "
+            "or approval scope was insufficient."
+        )
+    return (
+        "The local/offline fixture blocked or deferred according to existing "
+        "demo governance artifacts."
+    )
+
+
+def _case_summary(case: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact reviewer-facing case summary with nested evidence details."""
+    return {
+        "case_id": case["case_id"],
+        "expected_outcome": case["expected_outcome"],
+        "actual_outcome": case["actual_outcome"],
+        "passed": case["passed"],
+        "requested_scope": list(case["requested_scope"]),
+        "target_system": case["target_system"],
+        "target_resource": case["target_resource"],
+        "authority_validation_status": case["authority_validation_status"],
+        "runtime_recommended_outcome": case["runtime_recommended_outcome"],
+        "human_approval_summary": _human_approval_summary(case["human_approval_state"]),
+        "refusal_basis": case["refusal_basis"],
+        "failure_reasons": list(case["failure_reasons"]),
+        "outcome_receipt_summary": copy.deepcopy(case["outcome_receipt_summary"]),
+        "evidence_chain_manifest_summary": copy.deepcopy(
+            case["evidence_chain_manifest_summary"]
+        ),
+        "evidence_chain_verification_summary": copy.deepcopy(
+            case["evidence_chain_verification_summary"]
+        ),
+        "reviewer_interpretation": _reviewer_interpretation(case),
+        "boundary_note": case.get("boundary_note", BOUNDARY_NOTE),
+    }
+
+
+def _aggregate_summary(cases: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return deterministic aggregate counts derived from packet cases."""
+    verification_statuses = [
+        case["evidence_chain_verification_summary"]["verification_status"]
+        for case in cases
+    ]
+    return {
+        "total_cases": len(cases),
+        "passed_cases": sum(1 for case in cases if case["passed"]),
+        "blocked_cases": sum(
+            1 for case in cases if case["outcome_receipt_summary"].get("blocked") is True
+        ),
+        "committed_cases": sum(
+            1 for case in cases if case["outcome_receipt_summary"].get("committed") is True
+        ),
+        "verified_chains": verification_statuses.count("verified"),
+        "failed_chains": verification_statuses.count("failed"),
+        "incomplete_chains": verification_statuses.count("incomplete"),
+        "indeterminate_chains": verification_statuses.count("indeterminate"),
+        "local_offline_only": True,
+    }
+
+
+def compute_reviewer_packet_hash(packet: dict[str, Any]) -> str:
+    """Compute a stable SHA-256 hash for a reviewer packet.
+
+    The packet_hash field is excluded so finalizing a packet cannot recursively
+    change the digest it is meant to report.
+    """
+    payload = copy.deepcopy(packet)
+    payload.pop("packet_hash", None)
+    return sha256_of_canonical_json(payload)
+
+
+def with_packet_hash(packet: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``packet`` with deterministic packet_hash populated."""
+    finalized = copy.deepcopy(packet)
+    finalized["packet_hash"] = compute_reviewer_packet_hash(finalized)
+    return finalized
+
+
+def build_reviewer_evidence_packet() -> dict[str, Any]:
+    """Build the local/offline reviewer evidence packet from the existing demo."""
+    demo_output = run_saas_permission_change_governed_demo()
+    cases = [_case_summary(case) for case in demo_output["cases"]]
+    packet = {
+        "packet_id": PACKET_ID,
+        "packet_version": PACKET_VERSION,
+        "demo_id": demo_output["demo_id"],
+        "generated_at": demo_output["generated_at"],
+        "title": PACKET_TITLE,
+        "summary": (
+            "Deterministic local/offline reviewer packet for the SaaS "
+            "permission-change governed execution demo."
+        ),
+        "boundary_note": demo_output.get("boundary_note", BOUNDARY_NOTE),
+        "local_offline_only": True,
+        "cases": cases,
+        "aggregate_summary": _aggregate_summary(cases),
+        "reviewer_notes": list(REVIEWER_NOTES),
+        "packet_hash": "",
+    }
+    return with_packet_hash(packet)
+
+
+def main() -> int:
+    """Print deterministic reviewer evidence packet JSON to stdout."""
+    print(json.dumps(build_reviewer_evidence_packet(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_reviewer_evidence_packet.py
+++ b/tests/demo/test_reviewer_evidence_packet.py
@@ -1,0 +1,134 @@
+"""Tests for the local/offline Reviewer Evidence Packet export."""
+
+from __future__ import annotations
+
+from scripts.demo.export_reviewer_evidence_packet import (
+    build_reviewer_evidence_packet,
+    compute_reviewer_packet_hash,
+    with_packet_hash,
+)
+
+
+def _case_by_id(packet: dict[str, object], case_id: str) -> dict[str, object]:
+    cases = packet["cases"]
+    assert isinstance(cases, list)
+    return next(case for case in cases if case["case_id"] == case_id)
+
+
+def test_build_reviewer_evidence_packet_returns_dict() -> None:
+    packet = build_reviewer_evidence_packet()
+    assert isinstance(packet, dict)
+
+
+def test_packet_identity_fields_are_stable() -> None:
+    packet = build_reviewer_evidence_packet()
+    assert packet["packet_id"] == "reviewer-evidence-packet-saas-permission-change-v1"
+    assert packet["packet_version"] == "v1"
+    assert packet["local_offline_only"] is True
+
+
+def test_packet_includes_cases_aggregate_summary_and_reviewer_notes() -> None:
+    packet = build_reviewer_evidence_packet()
+    assert packet["cases"]
+    assert isinstance(packet["aggregate_summary"], dict)
+    assert packet["reviewer_notes"]
+
+
+def test_every_case_includes_required_nested_summaries() -> None:
+    packet = build_reviewer_evidence_packet()
+    for case in packet["cases"]:
+        assert case["outcome_receipt_summary"]
+        assert case["evidence_chain_manifest_summary"]
+        assert case["evidence_chain_verification_summary"]
+
+
+def test_valid_authority_and_approval_case_commits_or_is_commit_eligible() -> None:
+    packet = build_reviewer_evidence_packet()
+    case = _case_by_id(packet, "valid_authority_and_approval")
+    assert case["actual_outcome"] in {"commit", "commit_eligible"}
+
+
+def test_valid_authority_and_approval_chain_verification_is_verified() -> None:
+    packet = build_reviewer_evidence_packet()
+    case = _case_by_id(packet, "valid_authority_and_approval")
+    summary = case["evidence_chain_verification_summary"]
+    assert summary["verification_status"] == "verified"
+
+
+def test_blocked_cases_are_blocked() -> None:
+    packet = build_reviewer_evidence_packet()
+    for case_id in [
+        "missing_authority",
+        "missing_human_approval",
+        "expired_human_approval",
+        "scope_mismatch",
+    ]:
+        case = _case_by_id(packet, case_id)
+        assert case["actual_outcome"] == "block"
+        assert case["outcome_receipt_summary"]["blocked"] is True
+
+
+def test_human_approval_summary_is_compact_and_deterministic() -> None:
+    packet = build_reviewer_evidence_packet()
+    case = _case_by_id(packet, "missing_human_approval")
+    summary = case["human_approval_summary"]
+    assert summary == {
+        "approved": False,
+        "approval_receipt_id": None,
+        "approver_identity": None,
+        "approver_role": None,
+        "approved_scope": [],
+        "receipt_hash_present": False,
+        "failure_reasons": ["human_approval_missing"],
+    }
+
+
+def test_aggregate_summary_counts_match_cases() -> None:
+    packet = build_reviewer_evidence_packet()
+    cases = packet["cases"]
+    aggregate_summary = packet["aggregate_summary"]
+    assert aggregate_summary["total_cases"] == len(cases)
+    assert aggregate_summary["blocked_cases"] == sum(
+        1 for case in cases if case["outcome_receipt_summary"]["blocked"] is True
+    )
+    assert aggregate_summary["committed_cases"] == sum(
+        1 for case in cases if case["outcome_receipt_summary"]["committed"] is True
+    )
+    assert aggregate_summary["verified_chains"] == sum(
+        1
+        for case in cases
+        if case["evidence_chain_verification_summary"]["verification_status"] == "verified"
+    )
+
+
+def test_packet_hash_is_non_empty_sha256_hex() -> None:
+    packet = build_reviewer_evidence_packet()
+    assert packet["packet_hash"]
+    assert len(packet["packet_hash"]) == 64
+
+
+def test_same_packet_content_produces_same_packet_hash() -> None:
+    first = build_reviewer_evidence_packet()
+    second = build_reviewer_evidence_packet()
+    assert first["packet_hash"] == second["packet_hash"]
+    assert compute_reviewer_packet_hash(first) == compute_reviewer_packet_hash(second)
+
+
+def test_changing_meaningful_field_changes_packet_hash() -> None:
+    packet = build_reviewer_evidence_packet()
+    changed = {**packet, "title": "Changed reviewer title"}
+    assert compute_reviewer_packet_hash(changed) != packet["packet_hash"]
+
+
+def test_packet_hash_does_not_recursively_affect_itself() -> None:
+    packet = build_reviewer_evidence_packet()
+    changed = {**packet, "packet_hash": "0" * 64}
+    assert compute_reviewer_packet_hash(packet) == compute_reviewer_packet_hash(changed)
+    assert with_packet_hash(changed)["packet_hash"] == packet["packet_hash"]
+
+
+def test_no_network_or_environment_dependency_required(monkeypatch) -> None:
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    packet = build_reviewer_evidence_packet()
+    assert packet["local_offline_only"] is True


### PR DESCRIPTION
### Motivation
- Provide a single deterministic local/offline reviewer-facing JSON packet that packages the SaaS permission-change demo outputs for easier external review and diligence. 
- Make it simple for reviewers to see what the AI attempted, which cases were blocked/committed, AuthorityEvidence/HumanApproval status, OutcomeReceipt, EvidenceChainManifest, EvidenceChainVerification, boundary notes, and a deterministic packet hash. 
- Reuse the existing demo runner and canonical hashing helpers to avoid duplicating demo logic or adding runtime/governance changes. 
- Security boundary: this is intentionally local/offline only and does not add any live SaaS/IAM/IdP/network integrations or secrets handling.

### Description
- Added `scripts/demo/export_reviewer_evidence_packet.py` which imports and reuses `run_saas_permission_change_governed_demo()` and builds a deterministic reviewer packet via `build_reviewer_evidence_packet()`; the packet includes top-level fields, per-case compact summaries, nested outcome/manifest/verification summaries, `aggregate_summary`, `reviewer_notes`, and deterministic packet hashing. 
- Implemented `compute_reviewer_packet_hash(packet: dict)` that canonicalizes the packet (excluding `packet_hash`) and returns a SHA-256 hex via the repo canonical JSON helper `sha256_of_canonical_json`, and `with_packet_hash(packet)` which returns a non-mutating copy with `packet_hash` populated. 
- Added `tests/demo/test_reviewer_evidence_packet.py` with comprehensive checks for packet shape, per-case nested summaries, human approval compact summary, aggregate counts, deterministic hashing behavior (stable for same content, changes when meaningful fields change, and exclusion of `packet_hash` from hash payload), and offline/no-env dependency. 
- Added docs `docs/en/demo/reviewer-evidence-packet.md` describing the artifact, usage, included fields, and strict local/offline boundary, and updated `README.md` and `README_JP.md` to reference the new reviewer packet in the reviewer fast path.

### Testing
- Ran focused static checks: `python -m py_compile scripts/demo/export_reviewer_evidence_packet.py tests/demo/test_reviewer_evidence_packet.py` (succeeded). 
- Executed the demo tests and new packet tests under the repository test harness with a temporary shim for the `yaml` import (used only to work around a local environment package limitation); running `pytest tests/demo/test_reviewer_evidence_packet.py tests/demo/test_saas_permission_change_governed_demo.py` with the shim produced `38 passed, 1 warning`. 
- Note: direct `pytest` in this environment initially failed during collection due to a missing `PyYAML` dependency and network package installation was blocked in this execution environment; CI environments with full dependencies should run tests without the shim. 
- Verified CLI output: `python3 scripts/demo/export_reviewer_evidence_packet.py` prints deterministic JSON to stdout (sorted keys, `indent=2`) and the produced packet contains `packet_id == "reviewer-evidence-packet-saas-permission-change-v1"`, 5 cases, and a 64-char SHA-256 `packet_hash`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b4b089e88326a356c5c847b5b9c4)