### PR TITLE
demo: add Reviewer Evidence Packet schema v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ VERITAS includes a local/offline Reviewer Evidence Packet v1 export for the SaaS
 - Documentation: docs/en/demo/reviewer-evidence-packet.md
 - Script: scripts/demo/export_reviewer_evidence_packet.py
 - Golden fixture: docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+- Schema: docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 - Test: tests/demo/test_reviewer_evidence_packet.py
 
-A deterministic golden fixture is also checked in so reviewers can inspect the generated packet without running the exporter. CI tests verify that the generated packet matches the fixture.
+A deterministic golden fixture is also checked in so reviewers can inspect the generated packet without running the exporter. A JSON Schema is checked in for Reviewer Evidence Packet v1 so reviewers can inspect the packet contract and CI can detect unintended shape changes. CI tests verify that the generated packet matches the fixture.
 
 ## Bind Coverage Registry v1
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -111,9 +111,10 @@ VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加さ
 - ドキュメント: docs/en/demo/reviewer-evidence-packet.md
 - スクリプト: scripts/demo/export_reviewer_evidence_packet.py
 - Golden fixture: docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
+- Schema: docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 - テスト: tests/demo/test_reviewer_evidence_packet.py
 
-生成済みの deterministic golden fixture もリポジトリに保存されているため、レビュアーは exporter を実行しなくても packet の内容を確認できます。CI テストでは、現在生成される packet が fixture と一致することを検証します。
+生成済みの deterministic golden fixture もリポジトリに保存されているため、レビュアーは exporter を実行しなくても packet の内容を確認できます。Reviewer Evidence Packet v1 の JSON Schema もリポジトリに保存されています。これにより、レビュアーは packet の構造契約を確認でき、CI で意図しない shape change を検出できます。CI テストでは、現在生成される packet が fixture と一致することを検証します。
 
 ## Bind Coverage Registry v1
 

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -44,3 +44,12 @@ This fixture is generated from the local/offline Reviewer Evidence Packet export
 
 If the generated packet changes intentionally in the future, update the golden fixture in the same PR as the behavior change.
 
+## Schema
+
+Reviewer Evidence Packet v1 has a checked-in schema at:
+`docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`
+
+The schema documents the required packet fields, case summaries, nested evidence summaries, aggregate summary, reviewer notes, and packet hash format. The golden fixture and generated packet are tested against this schema. Future intentional packet-shape changes should update the schema, exporter, tests, and golden fixture in the same PR.
+
+This schema is for a local/offline reviewer packet. It is not a production audit certification, regulatory approval, or proof of live deployment.
+

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -1,0 +1,616 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/reviewer-evidence-packet-v1.schema.json",
+  "title": "Reviewer Evidence Packet v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "packet_id",
+    "packet_version",
+    "demo_id",
+    "generated_at",
+    "title",
+    "summary",
+    "boundary_note",
+    "local_offline_only",
+    "cases",
+    "aggregate_summary",
+    "reviewer_notes",
+    "packet_hash"
+  ],
+  "properties": {
+    "packet_id": {
+      "const": "reviewer-evidence-packet-saas-permission-change-v1"
+    },
+    "packet_version": {
+      "const": "v1"
+    },
+    "demo_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "boundary_note": {
+      "type": "string",
+      "minLength": 1
+    },
+    "local_offline_only": {
+      "const": true
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/case"
+      }
+    },
+    "aggregate_summary": {
+      "$ref": "#/$defs/aggregate_summary"
+    },
+    "reviewer_notes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "packet_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "nullable_sha256_hex": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "string_array": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "expected_outcome",
+        "actual_outcome",
+        "passed",
+        "requested_scope",
+        "target_system",
+        "target_resource",
+        "authority_validation_status",
+        "runtime_recommended_outcome",
+        "human_approval_summary",
+        "refusal_basis",
+        "failure_reasons",
+        "outcome_receipt_summary",
+        "evidence_chain_manifest_summary",
+        "evidence_chain_verification_summary",
+        "reviewer_interpretation",
+        "boundary_note"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_outcome": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actual_outcome": {
+          "enum": [
+            "block",
+            "commit",
+            "commit_eligible",
+            "refuse",
+            "refused"
+          ]
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "requested_scope": {
+          "$ref": "#/$defs/string_array"
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_validation_status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime_recommended_outcome": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_approval_summary": {
+          "$ref": "#/$defs/human_approval_summary"
+        },
+        "refusal_basis": {
+          "$ref": "#/$defs/string_array"
+        },
+        "failure_reasons": {
+          "$ref": "#/$defs/string_array"
+        },
+        "outcome_receipt_summary": {
+          "$ref": "#/$defs/outcome_receipt_summary"
+        },
+        "evidence_chain_manifest_summary": {
+          "$ref": "#/$defs/evidence_chain_manifest_summary"
+        },
+        "evidence_chain_verification_summary": {
+          "$ref": "#/$defs/evidence_chain_verification_summary"
+        },
+        "reviewer_interpretation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "boundary_note": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "human_approval_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "approved",
+        "approval_receipt_id",
+        "approver_identity",
+        "approver_role",
+        "approved_scope",
+        "receipt_hash_present",
+        "failure_reasons"
+      ],
+      "properties": {
+        "approved": {
+          "type": "boolean"
+        },
+        "approval_receipt_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "approver_identity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "approver_role": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "approved_scope": {
+          "$ref": "#/$defs/string_array"
+        },
+        "receipt_hash_present": {
+          "type": "boolean"
+        },
+        "failure_reasons": {
+          "$ref": "#/$defs/string_array"
+        }
+      }
+    },
+    "outcome_receipt_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome_receipt_id",
+        "decision_id",
+        "execution_intent_id",
+        "operation_id",
+        "action_class",
+        "target_system",
+        "target_resource",
+        "intended_action",
+        "requested_scope",
+        "final_outcome",
+        "committed",
+        "blocked",
+        "escalated",
+        "rolled_back",
+        "postcondition_status",
+        "observed_effects",
+        "failure_reasons",
+        "evaluated_at",
+        "outcome_hash",
+        "metadata"
+      ],
+      "properties": {
+        "outcome_receipt_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operation_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "intended_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requested_scope": {
+          "$ref": "#/$defs/string_array"
+        },
+        "final_outcome": {
+          "type": "string",
+          "minLength": 1
+        },
+        "committed": {
+          "type": "boolean"
+        },
+        "blocked": {
+          "type": "boolean"
+        },
+        "escalated": {
+          "type": "boolean"
+        },
+        "rolled_back": {
+          "type": "boolean"
+        },
+        "postcondition_status": {
+          "enum": [
+            "passed",
+            "failed",
+            "skipped",
+            "indeterminate"
+          ]
+        },
+        "observed_effects": {
+          "type": "array"
+        },
+        "failure_reasons": {
+          "$ref": "#/$defs/string_array"
+        },
+        "evaluated_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outcome_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "bind_receipt_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pre_state_fingerprint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "post_state_fingerprint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rollback_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "evidence_chain_manifest_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifest_id",
+        "decision_id",
+        "execution_intent_id",
+        "operation_id",
+        "action_class",
+        "target_system",
+        "target_resource",
+        "requested_scope",
+        "authority_evidence_id",
+        "authority_evidence_hash",
+        "human_approval_receipt_id",
+        "human_approval_receipt_hash",
+        "bind_receipt_id",
+        "bind_receipt_hash",
+        "outcome_receipt_id",
+        "outcome_receipt_hash",
+        "bind_coverage_operation_id",
+        "final_outcome",
+        "chain_status",
+        "missing_links",
+        "refusal_basis",
+        "observed_effects_summary",
+        "generated_at",
+        "manifest_hash",
+        "metadata"
+      ],
+      "properties": {
+        "manifest_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operation_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_resource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requested_scope": {
+          "$ref": "#/$defs/string_array"
+        },
+        "authority_evidence_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "authority_evidence_hash": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "human_approval_receipt_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "human_approval_receipt_hash": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "bind_receipt_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bind_receipt_hash": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "outcome_receipt_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outcome_receipt_hash": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "bind_coverage_operation_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "final_outcome": {
+          "type": "string",
+          "minLength": 1
+        },
+        "chain_status": {
+          "enum": [
+            "complete",
+            "incomplete",
+            "blocked",
+            "indeterminate"
+          ]
+        },
+        "missing_links": {
+          "$ref": "#/$defs/string_array"
+        },
+        "refusal_basis": {
+          "$ref": "#/$defs/string_array"
+        },
+        "observed_effects_summary": {
+          "type": "array"
+        },
+        "generated_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "manifest_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      }
+    },
+    "evidence_chain_verification_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "is_valid",
+        "verification_status",
+        "manifest_id",
+        "decision_id",
+        "execution_intent_id",
+        "operation_id",
+        "verified_links",
+        "missing_links",
+        "mismatched_links",
+        "failure_reasons",
+        "recomputed_manifest_hash",
+        "manifest_hash_matches",
+        "verified_at",
+        "metadata"
+      ],
+      "properties": {
+        "is_valid": {
+          "type": "boolean"
+        },
+        "verification_status": {
+          "enum": [
+            "verified",
+            "failed",
+            "incomplete",
+            "indeterminate"
+          ]
+        },
+        "manifest_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "execution_intent_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operation_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verified_links": {
+          "$ref": "#/$defs/string_array"
+        },
+        "missing_links": {
+          "$ref": "#/$defs/string_array"
+        },
+        "mismatched_links": {
+          "$ref": "#/$defs/string_array"
+        },
+        "failure_reasons": {
+          "$ref": "#/$defs/string_array"
+        },
+        "recomputed_manifest_hash": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "manifest_hash_matches": {
+          "type": "boolean"
+        },
+        "verified_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "metadata": {
+          "type": "object"
+        }
+      }
+    },
+    "aggregate_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total_cases",
+        "passed_cases",
+        "blocked_cases",
+        "committed_cases",
+        "verified_chains",
+        "failed_chains",
+        "incomplete_chains",
+        "indeterminate_chains",
+        "local_offline_only"
+      ],
+      "properties": {
+        "total_cases": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "passed_cases": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "blocked_cases": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "committed_cases": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "verified_chains": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed_chains": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "incomplete_chains": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indeterminate_chains": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "local_offline_only": {
+          "const": true
+        }
+      }
+    }
+  }
+}

--- a/tests/demo/test_reviewer_evidence_packet_schema.py
+++ b/tests/demo/test_reviewer_evidence_packet_schema.py
@@ -1,0 +1,419 @@
+"""Tests for the Reviewer Evidence Packet v1 JSON Schema contract."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+SCHEMA_PATH = Path("docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json")
+FIXTURE_PATH = Path(
+    "docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json"
+)
+SHA256_HEX_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+REQUIRED_TOP_LEVEL_FIELDS = [
+    "packet_id",
+    "packet_version",
+    "demo_id",
+    "generated_at",
+    "title",
+    "summary",
+    "boundary_note",
+    "local_offline_only",
+    "cases",
+    "aggregate_summary",
+    "reviewer_notes",
+    "packet_hash",
+]
+REQUIRED_CASE_FIELDS = [
+    "case_id",
+    "expected_outcome",
+    "actual_outcome",
+    "passed",
+    "requested_scope",
+    "target_system",
+    "target_resource",
+    "authority_validation_status",
+    "runtime_recommended_outcome",
+    "human_approval_summary",
+    "refusal_basis",
+    "failure_reasons",
+    "outcome_receipt_summary",
+    "evidence_chain_manifest_summary",
+    "evidence_chain_verification_summary",
+    "reviewer_interpretation",
+    "boundary_note",
+]
+REQUIRED_HUMAN_APPROVAL_FIELDS = [
+    "approved",
+    "approval_receipt_id",
+    "approver_identity",
+    "approver_role",
+    "approved_scope",
+    "receipt_hash_present",
+    "failure_reasons",
+]
+REQUIRED_OUTCOME_RECEIPT_FIELDS = [
+    "outcome_receipt_id",
+    "decision_id",
+    "execution_intent_id",
+    "operation_id",
+    "action_class",
+    "target_system",
+    "target_resource",
+    "intended_action",
+    "requested_scope",
+    "final_outcome",
+    "committed",
+    "blocked",
+    "escalated",
+    "rolled_back",
+    "postcondition_status",
+    "observed_effects",
+    "failure_reasons",
+    "evaluated_at",
+    "outcome_hash",
+    "metadata",
+]
+REQUIRED_MANIFEST_FIELDS = [
+    "manifest_id",
+    "decision_id",
+    "execution_intent_id",
+    "operation_id",
+    "action_class",
+    "target_system",
+    "target_resource",
+    "requested_scope",
+    "authority_evidence_id",
+    "authority_evidence_hash",
+    "human_approval_receipt_id",
+    "human_approval_receipt_hash",
+    "bind_receipt_id",
+    "bind_receipt_hash",
+    "outcome_receipt_id",
+    "outcome_receipt_hash",
+    "bind_coverage_operation_id",
+    "final_outcome",
+    "chain_status",
+    "missing_links",
+    "refusal_basis",
+    "observed_effects_summary",
+    "generated_at",
+    "manifest_hash",
+    "metadata",
+]
+REQUIRED_VERIFICATION_FIELDS = [
+    "is_valid",
+    "verification_status",
+    "manifest_id",
+    "decision_id",
+    "execution_intent_id",
+    "operation_id",
+    "verified_links",
+    "missing_links",
+    "mismatched_links",
+    "failure_reasons",
+    "recomputed_manifest_hash",
+    "manifest_hash_matches",
+    "verified_at",
+    "metadata",
+]
+REQUIRED_AGGREGATE_FIELDS = [
+    "total_cases",
+    "passed_cases",
+    "blocked_cases",
+    "committed_cases",
+    "verified_chains",
+    "failed_chains",
+    "incomplete_chains",
+    "indeterminate_chains",
+    "local_offline_only",
+]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _build_reviewer_evidence_packet() -> dict[str, Any]:
+    from scripts.demo.export_reviewer_evidence_packet import (
+        build_reviewer_evidence_packet,
+    )
+
+    return build_reviewer_evidence_packet()
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _assert_required_fields(payload: dict[str, Any], fields: list[str]) -> None:
+    missing = [field for field in fields if field not in payload]
+    assert not missing, f"missing required fields: {missing}"
+
+
+def _assert_string_array(value: Any) -> None:
+    assert isinstance(value, list)
+    assert all(isinstance(item, str) for item in value)
+
+
+def _assert_nullable_hash(value: Any) -> None:
+    assert value is None or SHA256_HEX_PATTERN.fullmatch(value)
+
+
+def _assert_fallback_packet_shape(packet: dict[str, Any]) -> None:
+    _assert_required_fields(packet, REQUIRED_TOP_LEVEL_FIELDS)
+    assert packet["packet_id"] == "reviewer-evidence-packet-saas-permission-change-v1"
+    assert packet["packet_version"] == "v1"
+    assert packet["local_offline_only"] is True
+    assert SHA256_HEX_PATTERN.fullmatch(packet["packet_hash"])
+    assert isinstance(packet["reviewer_notes"], list)
+    assert packet["reviewer_notes"]
+    assert all(isinstance(note, str) and note for note in packet["reviewer_notes"])
+    assert isinstance(packet["cases"], list)
+    assert packet["cases"]
+    for case in packet["cases"]:
+        _assert_case_shape(case)
+    _assert_aggregate_summary_shape(packet["aggregate_summary"])
+
+
+def _assert_case_shape(case: dict[str, Any]) -> None:
+    _assert_required_fields(case, REQUIRED_CASE_FIELDS)
+    assert isinstance(case["case_id"], str)
+    assert isinstance(case["expected_outcome"], str)
+    assert case["actual_outcome"] in {
+        "block",
+        "commit",
+        "commit_eligible",
+        "refuse",
+        "refused",
+    }
+    assert isinstance(case["passed"], bool)
+    _assert_string_array(case["requested_scope"])
+    _assert_string_array(case["refusal_basis"])
+    _assert_string_array(case["failure_reasons"])
+    assert isinstance(case["boundary_note"], str)
+    _assert_human_approval_shape(case["human_approval_summary"])
+    _assert_outcome_receipt_shape(case["outcome_receipt_summary"])
+    _assert_manifest_shape(case["evidence_chain_manifest_summary"])
+    _assert_verification_shape(case["evidence_chain_verification_summary"])
+
+
+def _assert_human_approval_shape(summary: dict[str, Any]) -> None:
+    _assert_required_fields(summary, REQUIRED_HUMAN_APPROVAL_FIELDS)
+    assert isinstance(summary["approved"], bool)
+    assert summary["approval_receipt_id"] is None or isinstance(
+        summary["approval_receipt_id"], str
+    )
+    assert summary["approver_identity"] is None or isinstance(
+        summary["approver_identity"], str
+    )
+    assert summary["approver_role"] is None or isinstance(summary["approver_role"], str)
+    _assert_string_array(summary["approved_scope"])
+    assert isinstance(summary["receipt_hash_present"], bool)
+    _assert_string_array(summary["failure_reasons"])
+
+
+def _assert_outcome_receipt_shape(summary: dict[str, Any]) -> None:
+    _assert_required_fields(summary, REQUIRED_OUTCOME_RECEIPT_FIELDS)
+    assert isinstance(summary["final_outcome"], str)
+    assert isinstance(summary["committed"], bool)
+    assert isinstance(summary["blocked"], bool)
+    assert isinstance(summary["escalated"], bool)
+    assert isinstance(summary["rolled_back"], bool)
+    assert summary["postcondition_status"] in {
+        "passed",
+        "failed",
+        "skipped",
+        "indeterminate",
+    }
+    assert isinstance(summary["observed_effects"], list)
+    _assert_string_array(summary["failure_reasons"])
+    assert SHA256_HEX_PATTERN.fullmatch(summary["outcome_hash"])
+
+
+def _assert_manifest_shape(summary: dict[str, Any]) -> None:
+    _assert_required_fields(summary, REQUIRED_MANIFEST_FIELDS)
+    assert summary["chain_status"] in {
+        "complete",
+        "incomplete",
+        "blocked",
+        "indeterminate",
+    }
+    _assert_nullable_hash(summary["authority_evidence_hash"])
+    _assert_nullable_hash(summary["human_approval_receipt_hash"])
+    _assert_nullable_hash(summary["bind_receipt_hash"])
+    assert SHA256_HEX_PATTERN.fullmatch(summary["outcome_receipt_hash"])
+    _assert_string_array(summary["missing_links"])
+    _assert_string_array(summary["refusal_basis"])
+    assert isinstance(summary["observed_effects_summary"], list)
+    assert SHA256_HEX_PATTERN.fullmatch(summary["manifest_hash"])
+
+
+def _assert_verification_shape(summary: dict[str, Any]) -> None:
+    _assert_required_fields(summary, REQUIRED_VERIFICATION_FIELDS)
+    assert isinstance(summary["is_valid"], bool)
+    assert summary["verification_status"] in {
+        "verified",
+        "failed",
+        "incomplete",
+        "indeterminate",
+    }
+    assert isinstance(summary["manifest_hash_matches"], bool)
+    _assert_string_array(summary["verified_links"])
+    _assert_string_array(summary["missing_links"])
+    _assert_string_array(summary["mismatched_links"])
+    _assert_string_array(summary["failure_reasons"])
+    _assert_nullable_hash(summary["recomputed_manifest_hash"])
+
+
+def _assert_aggregate_summary_shape(summary: dict[str, Any]) -> None:
+    _assert_required_fields(summary, REQUIRED_AGGREGATE_FIELDS)
+    for field in REQUIRED_AGGREGATE_FIELDS[:-1]:
+        assert isinstance(summary[field], int)
+        assert summary[field] >= 0
+    assert summary["local_offline_only"] is True
+
+
+def _validate_or_fallback(packet: dict[str, Any], schema: dict[str, Any]) -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        _assert_fallback_packet_shape(packet)
+        return
+    validator = jsonschema.Draft202012Validator(schema)
+    validator.validate(packet)
+
+
+def _is_rejected_or_fallback_detected(
+    packet: dict[str, Any], schema: dict[str, Any]
+) -> bool:
+    try:
+        _validate_or_fallback(packet, schema)
+    except (AssertionError, Exception):
+        return True
+    return False
+
+
+def test_schema_file_exists() -> None:
+    assert SCHEMA_PATH.is_file()
+
+
+def test_schema_file_parses_as_json() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    assert isinstance(schema, dict)
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_schema_declares_core_packet_properties() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    for field in [
+        "packet_id",
+        "packet_version",
+        "cases",
+        "aggregate_summary",
+        "packet_hash",
+    ]:
+        assert field in schema["required"]
+        assert field in schema["properties"]
+
+
+def test_golden_fixture_validates_against_schema_or_fallback() -> None:
+    _validate_or_fallback(_load_json(FIXTURE_PATH), _load_json(SCHEMA_PATH))
+
+
+def test_generated_packet_validates_against_schema_or_fallback() -> None:
+    _validate_or_fallback(_build_reviewer_evidence_packet(), _load_json(SCHEMA_PATH))
+
+
+def test_schema_requires_packet_hash() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    assert "packet_hash" in schema["required"]
+
+
+def test_schema_constrains_packet_hash_to_sha256_hex() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    assert schema["$defs"]["sha256_hex"]["pattern"] == "^[0-9a-f]{64}$"
+
+
+@pytest.mark.parametrize("packet_hash", ["", "A" * 64, "0" * 63, "g" * 64])
+def test_schema_rejects_invalid_packet_hash(packet_hash: str) -> None:
+    packet = _load_json(FIXTURE_PATH)
+    packet["packet_hash"] = packet_hash
+    assert _is_rejected_or_fallback_detected(packet, _load_json(SCHEMA_PATH))
+
+
+def test_schema_constrains_packet_version_to_v1() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    assert schema["properties"]["packet_version"] == {"const": "v1"}
+
+
+def test_schema_constrains_local_offline_only_to_true() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    assert schema["properties"]["local_offline_only"] == {"const": True}
+    assert schema["$defs"]["aggregate_summary"]["properties"][
+        "local_offline_only"
+    ] == {"const": True}
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "outcome_receipt_summary",
+        "evidence_chain_manifest_summary",
+        "evidence_chain_verification_summary",
+    ],
+)
+def test_schema_requires_nested_case_summaries(field: str) -> None:
+    schema = _load_json(SCHEMA_PATH)
+    assert field in schema["$defs"]["case"]["required"]
+
+
+def test_schema_requires_aggregate_summary() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    assert "aggregate_summary" in schema["required"]
+
+
+def test_schema_rejects_or_fallback_detects_missing_packet_hash() -> None:
+    packet = _load_json(FIXTURE_PATH)
+    packet.pop("packet_hash")
+    assert _is_rejected_or_fallback_detected(packet, _load_json(SCHEMA_PATH))
+
+
+def test_schema_rejects_or_fallback_detects_invalid_packet_version() -> None:
+    packet = _load_json(FIXTURE_PATH)
+    packet["packet_version"] = "v2"
+    assert _is_rejected_or_fallback_detected(packet, _load_json(SCHEMA_PATH))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "outcome_receipt_summary",
+        "evidence_chain_manifest_summary",
+        "evidence_chain_verification_summary",
+    ],
+)
+def test_schema_rejects_or_fallback_detects_missing_case_summary(field: str) -> None:
+    packet = copy.deepcopy(_load_json(FIXTURE_PATH))
+    packet["cases"][0].pop(field)
+    assert _is_rejected_or_fallback_detected(packet, _load_json(SCHEMA_PATH))
+
+
+def test_schema_validation_requires_no_network_or_environment_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _validate_or_fallback(_build_reviewer_evidence_packet(), _load_json(SCHEMA_PATH))


### PR DESCRIPTION
### Motivation

- Make the Reviewer Evidence Packet v1 shape explicit and reviewable so CI and reviewers can detect unintended packet-shape changes. 
- Complement the existing exporter, golden fixture, and packet-hash tests with a deterministic local/offline JSON Schema contract. 
- Preserve the local/offline boundary and avoid adding runtime, network, credential, or production behavior changes.

### Description

- Add a Draft 2020-12 JSON Schema at `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json` that declares required top-level fields, enforces `packet_id`/`packet_version` constants, requires `local_offline_only: true`, requires a 64-character lowercase SHA-256 `packet_hash`, and prohibits extra top-level properties where practical. 
- Define a required `case` schema and nested summaries for `human_approval_summary`, `outcome_receipt_summary`, `evidence_chain_manifest_summary`, and `evidence_chain_verification_summary` with the requested enums, nullable hash rules, and aggregate counts constraints in `$defs`. 
- Add schema-aware tests in `tests/demo/test_reviewer_evidence_packet_schema.py` that parse the schema JSON, check core properties, validate the checked-in golden fixture and (when possible) the runtime `build_reviewer_evidence_packet()` output with `jsonschema`, and otherwise run deterministic fallback structural assertions; the tests cover missing/invalid `packet_hash`, `packet_version`, and required nested summaries. 
- Document the schema in `docs/en/demo/reviewer-evidence-packet.md` and link the schema from `README.md` and `README_JP.md` while preserving the local/offline boundary text. 
- No new runtime dependencies were added to the repo; the tests will use `jsonschema` if available, otherwise they perform a deterministic fallback validation.

### Testing

- Verified the schema file is valid JSON with `python3 -m json.tool docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`. 
- Ran the schema test suite with pytest in this environment exercising the schema tests (filtered/targeted runs) and observed successful automated results (schema tests passed; e.g. a representative run: `PYENV_VERSION=3.12.13 python -m pytest -q tests/demo/test_reviewer_evidence_packet_schema.py -k "not generated and not no_network"` produced passing tests). 
- Verified the golden fixture and many schema assertions using the fallback structural checks when `jsonschema` is not available. 
- Noted an environment limitation: a full in-container `pytest` run that imports the exporter can fail here because `PyYAML` (a transitive dependency used by other modules) is not installed in the container and installing it was blocked by the environment's package-index tunnel; this is an environment/setup issue and not a regression in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19144f434c8326ab2d4adc6d91c1b9)