### PR TITLE
demo: add Reviewer Evidence Packet validation report v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,16 @@ Boundary:
 VERITAS includes a local/offline Reviewer Evidence Packet v1 export for the SaaS permission-change governed execution demo. It packages case outcomes, AuthorityEvidence/HumanApproval summaries, OutcomeReceipt summaries, EvidenceChainManifest summaries, EvidenceChainVerification summaries, aggregate counts, reviewer notes, and a deterministic packet hash into one JSON-friendly artifact. This is a local/offline review packet, not proof of live production deployment or audit certification.
 
 - Documentation: docs/en/demo/reviewer-evidence-packet.md
+- Validation report: docs/en/demo/reviewer-evidence-packet-validation-report.md
 - Script: scripts/demo/export_reviewer_evidence_packet.py
+- Validator script: scripts/demo/validate_reviewer_evidence_packet.py
 - Golden fixture: docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
 - Schema: docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 - Test: tests/demo/test_reviewer_evidence_packet.py
 
 A deterministic golden fixture is also checked in so reviewers can inspect the generated packet without running the exporter. A JSON Schema is checked in for Reviewer Evidence Packet v1 so reviewers can inspect the packet contract and CI can detect unintended shape changes. CI tests verify that the generated packet matches the fixture.
+
+A local/offline validation report is also available. It verifies that the generated packet matches the golden fixture, recomputes the packet hash, validates the packet shape against the JSON Schema when possible, checks deterministic case expectations, and emits a reviewer-facing pass/fail JSON report.
 
 ## Bind Coverage Registry v1
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -109,12 +109,16 @@ VERITAS には、local/offline の SaaS permission-change governed execution dem
 VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加されています。これは、SaaS permission-change governed execution demo の結果を、case outcome、AuthorityEvidence / HumanApproval summary、OutcomeReceipt summary、EvidenceChainManifest summary、EvidenceChainVerification summary、aggregate counts、reviewer notes、決定論的 packet hash を含む JSON-friendly artifact としてまとめるものです。本番導入や監査認証の証明ではなく、local/offline の review packet です。
 
 - ドキュメント: docs/en/demo/reviewer-evidence-packet.md
+- Validation report: docs/en/demo/reviewer-evidence-packet-validation-report.md
 - スクリプト: scripts/demo/export_reviewer_evidence_packet.py
+- Validator script: scripts/demo/validate_reviewer_evidence_packet.py
 - Golden fixture: docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
 - Schema: docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 - テスト: tests/demo/test_reviewer_evidence_packet.py
 
 生成済みの deterministic golden fixture もリポジトリに保存されているため、レビュアーは exporter を実行しなくても packet の内容を確認できます。Reviewer Evidence Packet v1 の JSON Schema もリポジトリに保存されています。これにより、レビュアーは packet の構造契約を確認でき、CI で意図しない shape change を検出できます。CI テストでは、現在生成される packet が fixture と一致することを検証します。
+
+local/offline の validation report も用意されています。これは、生成された packet が golden fixture と一致すること、packet hash が再計算できること、可能な場合は JSON Schema に適合すること、deterministic case expectations を満たすことを検証し、レビュアー向けの pass/fail JSON report を出力します。
 
 ## Bind Coverage Registry v1
 

--- a/docs/en/demo/reviewer-evidence-packet-validation-report.md
+++ b/docs/en/demo/reviewer-evidence-packet-validation-report.md
@@ -1,0 +1,54 @@
+# Reviewer Evidence Packet Validation Report v1
+
+Reviewer Evidence Packet Validation Report v1 is a deterministic local/offline pass/fail report for the existing Reviewer Evidence Packet v1 fixture.
+
+It is intended to help external reviewers, investors, and enterprise stakeholders verify the checked-in demo packet with one local command.
+
+## What it verifies
+
+The validation report checks that:
+
+- the generated Reviewer Evidence Packet matches the checked-in golden fixture
+- the `packet_hash` field is present and recomputes correctly from the generated packet
+- the packet validates against the Reviewer Evidence Packet JSON Schema v1 when `jsonschema` is available locally
+- deterministic fallback structural validation runs when `jsonschema` is unavailable
+- the expected demo case outcomes still hold
+- blocked demo cases include refusal bases and outcome failure reasons
+- evidence-chain verification summaries are present for every case
+- the valid authority-and-approval case has a verified evidence chain
+- no demo case reports mismatched evidence-chain links
+- the local/offline boundary remains explicit
+
+## Usage
+
+Run the validator locally:
+
+```bash
+python3 scripts/demo/validate_reviewer_evidence_packet.py
+```
+
+The command prints deterministic JSON to stdout with sorted keys and indentation. It exits with status code `0` when the report status is `pass` and a non-zero status when the report status is `fail`.
+
+## Inputs
+
+The report uses only local deterministic artifacts:
+
+- generated packet from `build_reviewer_evidence_packet()`
+- golden fixture at `docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json`
+- schema at `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`
+
+It does not require credentials and performs no live network calls.
+
+## Schema and fallback validation
+
+When `jsonschema` is available in the local environment, the validator checks both the generated packet and the golden fixture against Reviewer Evidence Packet JSON Schema v1.
+
+When `jsonschema` is unavailable, the validator does not add or require a dependency. Instead, it runs deterministic fallback structural checks for required top-level fields, `packet_id`, `packet_version`, `local_offline_only`, packet hash format, non-empty cases, aggregate summary, and nested case evidence summaries.
+
+## Boundary
+
+This report validates a local/offline Reviewer Evidence Packet fixture only.
+
+It does not connect to live SaaS, IAM, IdP, SSO, customer directories, banks, sanctions systems, production approval workflows, or live audit stores.
+
+It is not legal advice, regulatory approval, third-party certification, production audit certification, or proof of live deployment.

--- a/scripts/demo/validate_reviewer_evidence_packet.py
+++ b/scripts/demo/validate_reviewer_evidence_packet.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Build a deterministic local/offline validation report for reviewer packets."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.export_reviewer_evidence_packet import (  # noqa: E402
+    BOUNDARY_NOTE,
+    PACKET_ID,
+    PACKET_VERSION,
+    build_reviewer_evidence_packet,
+    compute_reviewer_packet_hash,
+)
+
+REPORT_ID = "reviewer-evidence-packet-validation-report-v1"
+REPORT_VERSION = "v1"
+FIXTURE_PATH = (
+    REPO_ROOT
+    / "docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json"
+)
+SCHEMA_PATH = REPO_ROOT / "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json"
+SHA256_HEX_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+REQUIRED_TOP_LEVEL_FIELDS = [
+    "packet_id",
+    "packet_version",
+    "demo_id",
+    "generated_at",
+    "title",
+    "summary",
+    "boundary_note",
+    "local_offline_only",
+    "cases",
+    "aggregate_summary",
+    "reviewer_notes",
+    "packet_hash",
+]
+REQUIRED_CASE_FIELDS = [
+    "case_id",
+    "expected_outcome",
+    "actual_outcome",
+    "passed",
+    "requested_scope",
+    "target_system",
+    "target_resource",
+    "authority_validation_status",
+    "runtime_recommended_outcome",
+    "human_approval_summary",
+    "refusal_basis",
+    "failure_reasons",
+    "outcome_receipt_summary",
+    "evidence_chain_manifest_summary",
+    "evidence_chain_verification_summary",
+    "reviewer_interpretation",
+    "boundary_note",
+]
+REQUIRED_FALLBACK_CASE_SUMMARIES = [
+    "outcome_receipt_summary",
+    "evidence_chain_manifest_summary",
+    "evidence_chain_verification_summary",
+]
+CASE_EXPECTED_OUTCOMES = {
+    "missing_authority": "block",
+    "missing_human_approval": "block",
+    "expired_human_approval": "block",
+    "scope_mismatch": "block",
+}
+VALID_COMMIT_OUTCOMES = {"commit", "commit_eligible"}
+VALID_CASE_ID = "valid_authority_and_approval"
+REVIEWER_NOTES = [
+    "This report validates a local/offline Reviewer Evidence Packet fixture.",
+    (
+        "It checks generated packet equality, packet hash recomputation, "
+        "schema or fallback structural validation, case expectations, and "
+        "evidence-chain verification summaries."
+    ),
+    (
+        "It does not connect to live SaaS, IAM, IdP, SSO, customer "
+        "directories, banks, sanctions systems, production approval workflows, "
+        "or live audit stores."
+    ),
+    (
+        "It is not legal advice, regulatory approval, third-party "
+        "certification, production audit certification, or proof of live "
+        "deployment."
+    ),
+]
+FAILURE_REASON_BY_CHECK = {
+    "golden_fixture_exists": "golden_fixture_missing",
+    "golden_fixture_json_parseable": "golden_fixture_json_unparseable",
+    "generated_packet_matches_golden_fixture": "generated_packet_mismatch",
+    "packet_hash_present": "packet_hash_missing",
+    "packet_hash_length_valid": "packet_hash_length_invalid",
+    "packet_hash_recomputes": "packet_hash_recompute_mismatch",
+    "schema_file_exists": "schema_file_missing",
+    "schema_json_parseable": "schema_json_unparseable",
+    "schema_validation_status": "schema_validation_failed",
+    "required_top_level_fields_present": "required_top_level_fields_missing",
+    "required_case_fields_present": "required_case_fields_missing",
+    "case_expectations_passed": "case_expectations_failed",
+    "blocked_cases_have_refusal_basis": "blocked_case_refusal_basis_missing",
+    "blocked_cases_have_outcome_failure_reasons": (
+        "blocked_case_outcome_failure_reasons_missing"
+    ),
+    "evidence_chain_verification_present": "evidence_chain_verification_missing",
+    "valid_case_chain_verified": "valid_case_chain_not_verified",
+    "no_mismatched_links_in_demo": "demo_mismatched_links_present",
+    "local_offline_boundary_present": "local_offline_boundary_missing",
+}
+
+
+def _load_json_file(path: Path) -> tuple[dict[str, Any] | None, bool, bool]:
+    """Load a local JSON object and return object, exists, and parse status."""
+    exists = path.is_file()
+    if not exists:
+        return None, False, False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None, True, False
+    if not isinstance(payload, dict):
+        return None, True, False
+    return payload, True, True
+
+
+def _jsonschema_module() -> Any | None:
+    """Return the optional jsonschema module when it is locally available."""
+    try:
+        import jsonschema
+    except ImportError:
+        return None
+    return jsonschema
+
+
+def _has_required_fields(payload: dict[str, Any], required: list[str]) -> bool:
+    """Return whether all required keys are present in a mapping."""
+    return all(field in payload for field in required)
+
+
+def _required_case_fields_present(packet: dict[str, Any]) -> bool:
+    """Return whether every packet case has required reviewer-facing fields."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    return all(
+        isinstance(case, dict) and _has_required_fields(case, REQUIRED_CASE_FIELDS)
+        for case in cases
+    )
+
+
+def _fallback_structural_validation(packet: dict[str, Any]) -> bool:
+    """Run deterministic local structural checks when jsonschema is unavailable."""
+    if not _has_required_fields(packet, REQUIRED_TOP_LEVEL_FIELDS):
+        return False
+    if packet.get("packet_id") != PACKET_ID:
+        return False
+    if packet.get("packet_version") != PACKET_VERSION:
+        return False
+    if packet.get("local_offline_only") is not True:
+        return False
+    if not SHA256_HEX_PATTERN.fullmatch(str(packet.get("packet_hash", ""))):
+        return False
+    cases = packet.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    if not isinstance(packet.get("aggregate_summary"), dict):
+        return False
+    for case in cases:
+        if not isinstance(case, dict):
+            return False
+        if not all(field in case for field in REQUIRED_FALLBACK_CASE_SUMMARIES):
+            return False
+    return True
+
+
+def _schema_validation_status(
+    generated_packet: dict[str, Any],
+    golden_packet: dict[str, Any] | None,
+    schema: dict[str, Any] | None,
+) -> tuple[str, str]:
+    """Validate packets with jsonschema or deterministic fallback checks."""
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        generated_valid = _fallback_structural_validation(generated_packet)
+        golden_valid = golden_packet is not None and _fallback_structural_validation(
+            golden_packet
+        )
+        if generated_valid and golden_valid:
+            return "skipped", "fallback"
+        return "fail", "fallback"
+    if schema is None or golden_packet is None:
+        return "fail", "jsonschema"
+    try:
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(generated_packet)
+        validator.validate(golden_packet)
+    except jsonschema.ValidationError:
+        return "fail", "jsonschema"
+    except jsonschema.SchemaError:
+        return "fail", "jsonschema"
+    return "pass", "jsonschema"
+
+
+def _case_expectations_passed(packet: dict[str, Any]) -> bool:
+    """Return whether deterministic demo case outcomes still hold."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return False
+    if len(cases) != 5:
+        return False
+    cases_by_id = {
+        case.get("case_id"): case for case in cases if isinstance(case, dict)
+    }
+    for case_id, expected_outcome in CASE_EXPECTED_OUTCOMES.items():
+        if cases_by_id.get(case_id, {}).get("actual_outcome") != expected_outcome:
+            return False
+    valid_case = cases_by_id.get(VALID_CASE_ID, {})
+    if valid_case.get("actual_outcome") not in VALID_COMMIT_OUTCOMES:
+        return False
+    return all(case.get("passed") is True for case in cases)
+
+
+def _blocked_cases_have_refusal_basis(packet: dict[str, Any]) -> bool:
+    """Return whether blocked demo cases include top-level refusal bases."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return False
+    blocked_cases = [case for case in cases if case.get("actual_outcome") == "block"]
+    if not blocked_cases:
+        return False
+    return all(bool(case.get("refusal_basis")) for case in blocked_cases)
+
+
+def _blocked_cases_have_outcome_failure_reasons(packet: dict[str, Any]) -> bool:
+    """Return whether blocked cases include outcome receipt failure reasons."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return False
+    blocked_cases = [case for case in cases if case.get("actual_outcome") == "block"]
+    if not blocked_cases:
+        return False
+    return all(
+        bool(case.get("outcome_receipt_summary", {}).get("failure_reasons"))
+        for case in blocked_cases
+    )
+
+
+def _evidence_chain_verification_present(packet: dict[str, Any]) -> bool:
+    """Return whether every case includes evidence-chain verification summary."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    return all(
+        isinstance(case, dict)
+        and isinstance(case.get("evidence_chain_verification_summary"), dict)
+        for case in cases
+    )
+
+
+def _valid_case_chain_verified(packet: dict[str, Any]) -> bool:
+    """Return whether the valid authority case has a verified evidence chain."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list):
+        return False
+    for case in cases:
+        if case.get("case_id") != VALID_CASE_ID:
+            continue
+        summary = case.get("evidence_chain_verification_summary", {})
+        return (
+            summary.get("verification_status") == "verified"
+            and summary.get("is_valid") is True
+        )
+    return False
+
+
+def _no_mismatched_links_in_demo(packet: dict[str, Any]) -> bool:
+    """Return whether no demo case has mismatched evidence-chain links."""
+    cases = packet.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    return all(
+        not case.get("evidence_chain_verification_summary", {}).get(
+            "mismatched_links"
+        )
+        for case in cases
+    )
+
+
+def _local_offline_boundary_present(packet: dict[str, Any]) -> bool:
+    """Return whether packet-level local/offline boundary markers are present."""
+    boundary_note = packet.get("boundary_note")
+    return (
+        packet.get("local_offline_only") is True
+        and isinstance(boundary_note, str)
+        and bool(boundary_note)
+    )
+
+
+def _build_checks(
+    generated_packet: dict[str, Any],
+    golden_packet: dict[str, Any] | None,
+    schema: dict[str, Any] | None,
+    fixture_exists: bool,
+    fixture_parseable: bool,
+    schema_exists: bool,
+    schema_parseable: bool,
+) -> dict[str, Any]:
+    """Build deterministic validation check statuses for the report."""
+    schema_status, schema_mode = _schema_validation_status(
+        generated_packet, golden_packet, schema
+    )
+    packet_hash = generated_packet.get("packet_hash")
+    return {
+        "golden_fixture_exists": fixture_exists,
+        "golden_fixture_json_parseable": fixture_parseable,
+        "generated_packet_matches_golden_fixture": generated_packet == golden_packet,
+        "packet_hash_present": bool(packet_hash),
+        "packet_hash_length_valid": isinstance(packet_hash, str)
+        and bool(SHA256_HEX_PATTERN.fullmatch(packet_hash)),
+        "packet_hash_recomputes": packet_hash
+        == compute_reviewer_packet_hash(generated_packet),
+        "schema_file_exists": schema_exists,
+        "schema_json_parseable": schema_parseable,
+        "schema_validation_status": schema_status,
+        "schema_validation_mode": schema_mode,
+        "required_top_level_fields_present": _has_required_fields(
+            generated_packet, REQUIRED_TOP_LEVEL_FIELDS
+        ),
+        "required_case_fields_present": _required_case_fields_present(generated_packet),
+        "case_expectations_passed": _case_expectations_passed(generated_packet),
+        "blocked_cases_have_refusal_basis": _blocked_cases_have_refusal_basis(
+            generated_packet
+        ),
+        "blocked_cases_have_outcome_failure_reasons": (
+            _blocked_cases_have_outcome_failure_reasons(generated_packet)
+        ),
+        "evidence_chain_verification_present": _evidence_chain_verification_present(
+            generated_packet
+        ),
+        "valid_case_chain_verified": _valid_case_chain_verified(generated_packet),
+        "no_mismatched_links_in_demo": _no_mismatched_links_in_demo(generated_packet),
+        "local_offline_boundary_present": _local_offline_boundary_present(
+            generated_packet
+        ),
+    }
+
+
+def _failure_reasons(checks: dict[str, Any]) -> list[str]:
+    """Return stable failure reason codes for failed required checks."""
+    reasons: list[str] = []
+    for check_name, reason in FAILURE_REASON_BY_CHECK.items():
+        value = checks[check_name]
+        failed = value is False or (
+            check_name == "schema_validation_status" and value == "fail"
+        )
+        if failed:
+            reasons.append(reason)
+    return reasons
+
+
+def _aggregate_summary(packet: dict[str, Any]) -> dict[str, Any]:
+    """Return aggregate summary values copied from the generated packet."""
+    source = packet.get("aggregate_summary", {})
+    return {
+        "total_cases": source.get("total_cases", 0),
+        "passed_cases": source.get("passed_cases", 0),
+        "blocked_cases": source.get("blocked_cases", 0),
+        "committed_cases": source.get("committed_cases", 0),
+        "verified_chains": source.get("verified_chains", 0),
+        "failed_chains": source.get("failed_chains", 0),
+        "incomplete_chains": source.get("incomplete_chains", 0),
+        "indeterminate_chains": source.get("indeterminate_chains", 0),
+        "local_offline_only": bool(source.get("local_offline_only", False)),
+    }
+
+
+def _build_report_for_packet(
+    generated_packet: dict[str, Any],
+    golden_packet: dict[str, Any] | None,
+    schema: dict[str, Any] | None,
+    fixture_exists: bool,
+    fixture_parseable: bool,
+    schema_exists: bool,
+    schema_parseable: bool,
+) -> dict[str, Any]:
+    """Build a validation report from already loaded local artifacts."""
+    packet = copy.deepcopy(generated_packet)
+    checks = _build_checks(
+        packet,
+        copy.deepcopy(golden_packet),
+        copy.deepcopy(schema),
+        fixture_exists,
+        fixture_parseable,
+        schema_exists,
+        schema_parseable,
+    )
+    failure_reasons = _failure_reasons(checks)
+    return {
+        "report_id": REPORT_ID,
+        "report_version": REPORT_VERSION,
+        "generated_at": packet.get("generated_at"),
+        "packet_id": packet.get("packet_id"),
+        "packet_version": packet.get("packet_version"),
+        "status": "pass" if not failure_reasons else "fail",
+        "local_offline_only": True,
+        "checks": checks,
+        "aggregate_summary": _aggregate_summary(packet),
+        "failure_reasons": failure_reasons,
+        "reviewer_notes": list(REVIEWER_NOTES),
+        "boundary_note": packet.get("boundary_note", BOUNDARY_NOTE),
+    }
+
+
+def build_reviewer_evidence_packet_validation_report() -> dict[str, Any]:
+    """Build the deterministic local/offline reviewer validation report.
+
+    The report uses only checked-in local files and deterministic packet builders.
+    It performs no network calls and does not require credentials.
+    """
+    generated_packet = build_reviewer_evidence_packet()
+    golden_packet, fixture_exists, fixture_parseable = _load_json_file(FIXTURE_PATH)
+    schema, schema_exists, schema_parseable = _load_json_file(SCHEMA_PATH)
+    return _build_report_for_packet(
+        generated_packet,
+        golden_packet,
+        schema,
+        fixture_exists,
+        fixture_parseable,
+        schema_exists,
+        schema_parseable,
+    )
+
+
+def main() -> int:
+    """Print deterministic validation report JSON and return status code."""
+    report = build_reviewer_evidence_packet_validation_report()
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_reviewer_evidence_packet_validation_report.py
+++ b/tests/demo/test_reviewer_evidence_packet_validation_report.py
@@ -1,0 +1,144 @@
+"""Tests for the Reviewer Evidence Packet validation report."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+
+from scripts.demo.export_reviewer_evidence_packet import build_reviewer_evidence_packet
+from scripts.demo.validate_reviewer_evidence_packet import (
+    REPORT_ID,
+    REPORT_VERSION,
+    _build_report_for_packet,
+    build_reviewer_evidence_packet_validation_report,
+)
+
+
+def test_build_reviewer_evidence_packet_validation_report_returns_dict() -> None:
+    report = build_reviewer_evidence_packet_validation_report()
+
+    assert isinstance(report, dict)
+
+
+def test_validation_report_core_fields_pass() -> None:
+    report = build_reviewer_evidence_packet_validation_report()
+
+    assert report["report_id"] == REPORT_ID
+    assert report["report_version"] == REPORT_VERSION
+    assert report["local_offline_only"] is True
+    assert report["status"] == "pass"
+
+
+def test_validation_report_checks_pass() -> None:
+    report = build_reviewer_evidence_packet_validation_report()
+    checks = report["checks"]
+
+    assert checks["generated_packet_matches_golden_fixture"] is True
+    assert checks["packet_hash_recomputes"] is True
+    assert checks["schema_file_exists"] is True
+    assert checks["schema_json_parseable"] is True
+    assert checks["required_top_level_fields_present"] is True
+    assert checks["required_case_fields_present"] is True
+    assert checks["case_expectations_passed"] is True
+    assert checks["blocked_cases_have_refusal_basis"] is True
+    assert checks["blocked_cases_have_outcome_failure_reasons"] is True
+    assert checks["evidence_chain_verification_present"] is True
+    assert checks["valid_case_chain_verified"] is True
+    assert checks["no_mismatched_links_in_demo"] is True
+
+
+def test_validation_report_aggregate_summary() -> None:
+    report = build_reviewer_evidence_packet_validation_report()
+    summary = report["aggregate_summary"]
+
+    assert summary["total_cases"] == 5
+    assert summary["blocked_cases"] == 4
+    assert summary["committed_cases"] == 1
+    assert summary["verified_chains"] == 5
+
+
+def test_validation_report_failure_reasons_and_notes() -> None:
+    report = build_reviewer_evidence_packet_validation_report()
+
+    assert report["failure_reasons"] == []
+    assert report["reviewer_notes"]
+
+
+def test_validation_report_output_is_deterministic_across_calls() -> None:
+    first = build_reviewer_evidence_packet_validation_report()
+    second = build_reviewer_evidence_packet_validation_report()
+
+    assert first == second
+
+
+def test_validation_report_cli_exits_zero_and_prints_json() -> None:
+    completed = subprocess.run(
+        [sys.executable, "scripts/demo/validate_reviewer_evidence_packet.py"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["report_id"] == REPORT_ID
+    assert payload["status"] == "pass"
+
+
+def test_validation_report_requires_no_network_or_environment_dependency(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    report = build_reviewer_evidence_packet_validation_report()
+
+    assert report["status"] == "pass"
+    assert report["local_offline_only"] is True
+
+
+def _report_for_mutated_packet(packet: dict[str, object]) -> dict[str, object]:
+    return _build_report_for_packet(
+        packet,
+        build_reviewer_evidence_packet(),
+        None,
+        fixture_exists=True,
+        fixture_parseable=True,
+        schema_exists=True,
+        schema_parseable=True,
+    )
+
+
+def test_validation_report_detects_missing_packet_hash() -> None:
+    packet = copy.deepcopy(build_reviewer_evidence_packet())
+    packet.pop("packet_hash")
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert "packet_hash_missing" in report["failure_reasons"]
+
+
+def test_validation_report_detects_invalid_packet_version() -> None:
+    packet = copy.deepcopy(build_reviewer_evidence_packet())
+    packet["packet_version"] = "v2"
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert "generated_packet_mismatch" in report["failure_reasons"]
+    assert "schema_validation_failed" in report["failure_reasons"]
+
+
+def test_validation_report_detects_missing_evidence_chain_verification() -> None:
+    packet = copy.deepcopy(build_reviewer_evidence_packet())
+    packet["cases"][0].pop("evidence_chain_verification_summary")
+
+    report = _report_for_mutated_packet(packet)
+
+    assert report["status"] == "fail"
+    assert "required_case_fields_missing" in report["failure_reasons"]
+    assert "evidence_chain_verification_missing" in report["failure_reasons"]


### PR DESCRIPTION
### Motivation
- Provide a single deterministic, local/offline reviewer-facing validation report that summarizes golden-fixture equality, packet_hash recomputation, schema (or fallback) validation, deterministic case expectations, and evidence-chain verification summaries for Reviewer Evidence Packet v1.  
- Make it easy for external reviewers, investors, and enterprise stakeholders to verify the checked-in demo packet with one command without network calls or credentials.  
- Preserve the local/offline boundary and avoid adding new runtime dependencies; use `jsonschema` only when already available and otherwise run deterministic fallback structural checks.  
- Maintain repository QA & safety rules (no live integrations, no credential changes, tests and docs added).  

### Description
- Add `scripts/demo/validate_reviewer_evidence_packet.py` which exposes `build_reviewer_evidence_packet_validation_report() -> dict[str, Any]` and is executable as a CLI; it prints deterministic JSON (`indent=2`, `sort_keys=True`) and exits `0` on pass, non-zero on fail.  
- The report top-level includes `report_id`, `report_version`, `generated_at`, `packet_id`, `packet_version`, `status`, `local_offline_only`, `checks`, `aggregate_summary`, `failure_reasons`, `reviewer_notes`, and `boundary_note`; `checks` contains the boolean/status checks requested (golden fixture, packet_hash, schema mode/status, structural fallbacks, case expectations, evidence-chain checks, etc.).  
- Schema validation uses the checked-in schema `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json` when `jsonschema` is available; otherwise deterministic fallback structural validation runs.  
- Add tests `tests/demo/test_reviewer_evidence_packet_validation_report.py` covering report shape, deterministic output, CLI JSON/exit, environment independence, and small negative helper cases (missing `packet_hash`, invalid `packet_version`, missing evidence-chain verification).  
- Add docs `docs/en/demo/reviewer-evidence-packet-validation-report.md` and lightweight README / README_JP updates linking to the report and validator script; no changes to packet exporter, schema, or golden fixture were made.  

### Testing
- Ran the validator CLI and inspected JSON: `python3 scripts/demo/validate_reviewer_evidence_packet.py` (passed; report `status == "pass"`, deterministic JSON printed).  
- Verified fixture equality check: `python3 scripts/demo/check_reviewer_evidence_packet_fixture.py` (passed).  
- Static checks and compilation: `PYENV_VERSION=3.12.13 ruff check ...` and `.venv/bin/python -m compileall ...` (passed).  
- Ran the new unit test file via lint/compile and exercised the internal helpers with assertions; full `pytest` run was not available in the base environment (attempts to run `pytest` failed due to missing interpreter/network in the environment), so the tests were added and validated where possible (CLI, deterministic assertions, and helper-driven negative-case checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1949d1cbcc83268bbf44a63199632e)