### PR TITLE
docs: add External Reviewer Quickstart v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ For external reviewers, start with `docs/REVIEWER_ENTRYPOINT.md`.
 
 For a 10-minute implementation snapshot, start here:
 
+External reviewers can start with the [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md), which explains how to inspect the golden fixture, run the validation report, review the JSON Schema, and understand the local/offline evidence chain in 10–15 minutes. See also the [External Reviewer Artifact Index](docs/en/demo/external-reviewer-artifact-index.md).
+
 For a concise business-facing overview, see [Enterprise Value Brief](docs/en/positioning/enterprise-value-brief.md).
 日本語補助版: [企業向け価値説明ブリーフ](docs/ja/positioning/enterprise-value-brief.md)
 
@@ -47,7 +49,9 @@ For a concise business-facing overview, see [Enterprise Value Brief](docs/en/pos
 10. [AML/KYC 1-day PoC Quickstart](docs/en/guides/poc-pack-financial-quickstart.md)
 11. [SaaS Permission-Change Governed Demo (local/offline)](docs/en/demo/saas-permission-change-governed-demo.md)
 12. [Reviewer Evidence Packet v1 (local/offline)](docs/en/demo/reviewer-evidence-packet.md)
-13. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
+13. [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md)
+14. [External Reviewer Artifact Index v1](docs/en/demo/external-reviewer-artifact-index.md)
+15. Bind Coverage Registry v1 (local/offline): docs/en/architecture/bind-coverage-registry.md
 
 Boundary:
 
@@ -106,6 +110,8 @@ Boundary:
 VERITAS includes a local/offline Reviewer Evidence Packet v1 export for the SaaS permission-change governed execution demo. It packages case outcomes, AuthorityEvidence/HumanApproval summaries, OutcomeReceipt summaries, EvidenceChainManifest summaries, EvidenceChainVerification summaries, aggregate counts, reviewer notes, and a deterministic packet hash into one JSON-friendly artifact. This is a local/offline review packet, not proof of live production deployment or audit certification.
 
 - Documentation: docs/en/demo/reviewer-evidence-packet.md
+- External Reviewer Quickstart: docs/en/demo/external-reviewer-quickstart.md
+- External Reviewer Artifact Index: docs/en/demo/external-reviewer-artifact-index.md
 - Validation report: docs/en/demo/reviewer-evidence-packet-validation-report.md
 - Script: scripts/demo/export_reviewer_evidence_packet.py
 - Validator script: scripts/demo/validate_reviewer_evidence_packet.py

--- a/README_JP.md
+++ b/README_JP.md
@@ -39,6 +39,8 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 
 10 分で実装スナップショットを確認する場合は、次の順で参照してください。
 
+外部レビュアーは [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md) から確認できます。このドキュメントでは、golden fixture の確認、validation report の実行、JSON Schema の確認、local/offline evidence chain の読み方を 10〜15 分で追えるように整理しています。あわせて [External Reviewer Artifact Index](docs/en/demo/external-reviewer-artifact-index.md) も参照してください。
+
 1. [External Validation Brief](docs/REVIEWER_ENTRYPOINT.md)
 2. [Current Implementation Matrix](docs/en/validation/current-implementation-matrix.md)
 3. Authority Evidence Ingestion（local/offline）: docs/en/architecture/authority-evidence-ingestion.md
@@ -51,7 +53,9 @@ VERITAS OS は **Decision Governance and Bind-Boundary Control Plane for AI Agen
 10. [AML/KYC 1-day PoC Quickstart](docs/ja/guides/poc-pack-financial-quickstart.md)
 11. [SaaS Permission-Change Governed Demo（local/offline）](docs/en/demo/saas-permission-change-governed-demo.md)
 12. [Reviewer Evidence Packet v1（local/offline）](docs/en/demo/reviewer-evidence-packet.md)
-13. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
+13. [External Reviewer Quickstart v1](docs/en/demo/external-reviewer-quickstart.md)
+14. [External Reviewer Artifact Index v1](docs/en/demo/external-reviewer-artifact-index.md)
+15. Bind Coverage Registry v1（local/offline）: docs/en/architecture/bind-coverage-registry.md
 
 境界条件:
 
@@ -109,6 +113,8 @@ VERITAS には、local/offline の SaaS permission-change governed execution dem
 VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加されています。これは、SaaS permission-change governed execution demo の結果を、case outcome、AuthorityEvidence / HumanApproval summary、OutcomeReceipt summary、EvidenceChainManifest summary、EvidenceChainVerification summary、aggregate counts、reviewer notes、決定論的 packet hash を含む JSON-friendly artifact としてまとめるものです。本番導入や監査認証の証明ではなく、local/offline の review packet です。
 
 - ドキュメント: docs/en/demo/reviewer-evidence-packet.md
+- External Reviewer Quickstart: docs/en/demo/external-reviewer-quickstart.md
+- External Reviewer Artifact Index: docs/en/demo/external-reviewer-artifact-index.md
 - Validation report: docs/en/demo/reviewer-evidence-packet-validation-report.md
 - スクリプト: scripts/demo/export_reviewer_evidence_packet.py
 - Validator script: scripts/demo/validate_reviewer_evidence_packet.py

--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -1,0 +1,28 @@
+# External Reviewer Artifact Index v1
+
+Key local/offline reviewer-facing artifacts:
+
+- `scripts/demo/saas_permission_change_governed_demo.py`
+  - deterministic local/offline SaaS permission-change governed execution demo
+- `scripts/demo/export_reviewer_evidence_packet.py`
+  - exports the Reviewer Evidence Packet JSON
+- `scripts/demo/validate_reviewer_evidence_packet.py`
+  - builds pass/fail validation report
+- `docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json`
+  - checked-in golden fixture
+- `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`
+  - JSON Schema contract
+- `docs/en/demo/reviewer-evidence-packet.md`
+  - Reviewer Evidence Packet documentation
+- `docs/en/demo/reviewer-evidence-packet-validation-report.md`
+  - validation report documentation
+- `docs/en/demo/saas-permission-change-governed-demo.md`
+  - SaaS permission-change demo documentation
+- `docs/en/architecture/outcome-receipt.md`
+  - OutcomeReceipt documentation
+- `docs/en/architecture/evidence-chain-manifest.md`
+  - EvidenceChainManifest documentation
+- `docs/en/architecture/evidence-chain-verifier.md`
+  - EvidenceChainVerifier documentation
+- `docs/en/architecture/bind-coverage-registry.md`
+  - Bind Coverage Registry documentation

--- a/docs/en/demo/external-reviewer-quickstart.md
+++ b/docs/en/demo/external-reviewer-quickstart.md
@@ -1,0 +1,135 @@
+# External Reviewer Quickstart v1
+
+## Purpose
+
+This quickstart helps reviewers inspect VERITAS local/offline reviewer artifacts without needing live SaaS, IAM, IdP, SSO, customer systems, banks, sanctions systems, credentials, or production approval workflows.
+
+It is intended for:
+
+- external reviewers
+- investors
+- enterprise stakeholders
+- governance, compliance, and platform engineering evaluators
+
+## What this quickstart verifies
+
+The current review path demonstrates:
+
+- an AI agent attempting a SaaS admin permission change
+- bind-time governance before commit
+- AuthorityEvidence and HumanApproval checks
+- block behavior for missing, expired, or scope-mismatched evidence
+- commit-eligible behavior for valid authority and approval
+- OutcomeReceipt post-execution evidence
+- EvidenceChainManifest linking artifacts
+- EvidenceChainVerifier checking manifest/artifact consistency
+- Reviewer Evidence Packet packaging the result
+- golden fixture, schema, and validation report checks
+
+## Fast path
+
+Use this 10–15 minute path for a reviewer-facing inspection:
+
+1. Read the golden fixture:
+   `docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json`
+2. Run the validation report:
+   `python3 scripts/demo/validate_reviewer_evidence_packet.py`
+3. Confirm expected report fields:
+   - `status == "pass"`
+   - `generated_packet_matches_golden_fixture == true`
+   - `packet_hash_recomputes == true`
+   - `schema_validation_status == "pass"` or `"skipped"` with fallback mode
+   - `case_expectations_passed == true`
+   - `blocked_cases_have_refusal_basis == true`
+   - `valid_case_chain_verified == true`
+   - `no_mismatched_links_in_demo == true`
+4. Inspect the schema:
+   `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`
+5. Inspect the exporter:
+   `scripts/demo/export_reviewer_evidence_packet.py`
+6. Inspect the original demo:
+   `scripts/demo/saas_permission_change_governed_demo.py`
+
+## One-command validation
+
+```text
+python3 scripts/demo/validate_reviewer_evidence_packet.py
+```
+
+This command:
+
+- prints deterministic JSON
+- exits `0` on pass
+- exits non-zero on fail
+- uses only local files
+- requires no credentials
+- makes no network calls
+
+## Expected current results
+
+The current deterministic summary is expected to show:
+
+- `total_cases: 5`
+- `blocked_cases: 4`
+- `committed_cases: 1`
+- `verified_chains: 5`
+- `failed_chains: 0`
+- `local_offline_only: true`
+
+Expected case outcomes:
+
+- `missing_authority` -> block
+- `missing_human_approval` -> block
+- `expired_human_approval` -> block
+- `scope_mismatch` -> block
+- `valid_authority_and_approval` -> commit or commit_eligible
+
+## How to interpret the artifacts
+
+### Reviewer Evidence Packet
+
+One JSON-friendly packet containing case outcomes, authority/human approval summaries, OutcomeReceipt summaries, EvidenceChainManifest summaries, EvidenceChainVerification summaries, aggregate counts, reviewer notes, and `packet_hash`.
+
+### Golden fixture
+
+A checked-in deterministic JSON output. Reviewers can inspect it without running code.
+
+### JSON Schema
+
+Defines the packet contract and helps detect unintended shape changes.
+
+### Validation Report
+
+A pass/fail report that verifies generated packet equality with the fixture, packet hash recomputation, schema/fallback validation, case expectations, and evidence-chain verification summaries.
+
+### Evidence Chain
+
+Authority, approval, bind-time decision, outcome, and verification are linked into a traceable local/offline evidence chain.
+
+## Boundary and non-claims
+
+This quickstart is:
+
+- local/offline only
+- no live SaaS
+- no live IAM, IdP, or SSO
+- no live customer directory
+- no bank or sanctions system
+- no production approval workflow
+- no credentials
+- no live audit store
+- not legal advice
+- not regulatory approval
+- not third-party certification
+- not production audit certification
+- not proof of live deployment
+
+## Suggested reviewer questions
+
+- Does the packet clearly show what the AI attempted?
+- Are blocked cases explained with `refusal_basis` and `failure_reasons`?
+- Does the valid case have a verified evidence chain?
+- Does the packet hash recompute?
+- Does the generated packet match the golden fixture?
+- Does the schema describe the packet shape?
+- Are local/offline boundaries clearly stated?

--- a/tests/docs/test_external_reviewer_quickstart_links.py
+++ b/tests/docs/test_external_reviewer_quickstart_links.py
@@ -1,0 +1,60 @@
+"""Tests for external reviewer quickstart documentation links."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+QUICKSTART_PATH = ROOT / "docs/en/demo/external-reviewer-quickstart.md"
+ARTIFACT_INDEX_PATH = ROOT / "docs/en/demo/external-reviewer-artifact-index.md"
+
+
+def _read_repo_file(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_external_reviewer_docs_exist() -> None:
+    assert QUICKSTART_PATH.exists()
+    assert ARTIFACT_INDEX_PATH.exists()
+
+
+def test_quickstart_references_core_artifacts() -> None:
+    quickstart = QUICKSTART_PATH.read_text(encoding="utf-8")
+
+    for expected_path in [
+        "scripts/demo/validate_reviewer_evidence_packet.py",
+        "scripts/demo/export_reviewer_evidence_packet.py",
+        (
+            "docs/en/demo/fixtures/"
+            "reviewer-evidence-packet-saas-permission-change-v1.json"
+        ),
+        "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json",
+    ]:
+        assert expected_path in quickstart
+
+
+def test_artifact_index_references_reviewer_artifacts() -> None:
+    artifact_index = ARTIFACT_INDEX_PATH.read_text(encoding="utf-8")
+
+    for expected_path in [
+        "scripts/demo/saas_permission_change_governed_demo.py",
+        "scripts/demo/export_reviewer_evidence_packet.py",
+        "scripts/demo/validate_reviewer_evidence_packet.py",
+        (
+            "docs/en/demo/fixtures/"
+            "reviewer-evidence-packet-saas-permission-change-v1.json"
+        ),
+        "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json",
+        "docs/en/architecture/outcome-receipt.md",
+        "docs/en/architecture/evidence-chain-manifest.md",
+        "docs/en/architecture/evidence-chain-verifier.md",
+        "docs/en/architecture/bind-coverage-registry.md",
+    ]:
+        assert expected_path in artifact_index
+
+
+def test_readmes_reference_external_reviewer_quickstart() -> None:
+    for readme_path in ["README.md", "README_JP.md"]:
+        readme = _read_repo_file(readme_path)
+        assert "external-reviewer-quickstart.md" in readme


### PR DESCRIPTION
### Motivation

- Provide a concise, reviewer-facing 10–15 minute quickstart so external reviewers, investors, and enterprise stakeholders can inspect the existing local/offline reviewer artifacts without live integrations.  
- Improve discoverability by adding a compact artifact index and linking the quickstart from English and Japanese READMEs.  
- Keep the change documentation-first and minimal with no runtime, credential, or network changes.  

### Description

- Added `docs/en/demo/external-reviewer-quickstart.md` with purpose, fast path, one-command validation, expected results, artifact interpretation, boundary/non-claims, and reviewer questions.  
- Added `docs/en/demo/external-reviewer-artifact-index.md` listing key reviewer-facing scripts, fixture, schema, docs, and architecture artifacts.  
- Updated `README.md` and `README_JP.md` to reference the new quickstart and artifact index.  
- Added lightweight docs tests in `tests/docs/test_external_reviewer_quickstart_links.py` that assert presence of the new docs and key referenced files.  

### Testing

- Ran the new docs tests with `PYENV_VERSION=3.11.15 pytest tests/docs/test_external_reviewer_quickstart_links.py` and they passed.  
- Ran the one-command validator with `python3 scripts/demo/validate_reviewer_evidence_packet.py` and it printed the deterministic pass JSON and exited successfully.  
- Verified the repo formatting/checks with `git diff --check` and `python -m py_compile` for the new test file with no issues.  
- Note: attempting to run a broader test collection in some local pyenv environments surfaced a pre-existing missing runtime dependency (`PyYAML`) during collection of existing demo tests; this is unrelated to the documentation changes and did not affect the new docs tests or the validator run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1953cfbc348326a9b20c47b03950a9)