### PR TITLE
ci: add Reviewer Evidence Packet validation gate v1

### DIFF
--- a/.github/workflows/reviewer-evidence-packet-validation.yml
+++ b/.github/workflows/reviewer-evidence-packet-validation.yml
@@ -1,0 +1,33 @@
+name: Reviewer Evidence Packet Validation
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  reviewer-evidence-packet-validation:
+    name: reviewer-evidence-packet-validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install local validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r veritas_os/requirements-core.txt
+
+      - name: Validate Reviewer Evidence Packet
+        run: python3 scripts/demo/validate_reviewer_evidence_packet.py
+
+      - name: Check Reviewer Evidence Packet fixture
+        run: python3 scripts/demo/check_reviewer_evidence_packet_fixture.py

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ VERITAS includes a local/offline Reviewer Evidence Packet v1 export for the SaaS
 - Validation report: docs/en/demo/reviewer-evidence-packet-validation-report.md
 - Script: scripts/demo/export_reviewer_evidence_packet.py
 - Validator script: scripts/demo/validate_reviewer_evidence_packet.py
+- CI gate: .github/workflows/reviewer-evidence-packet-validation.yml
 - Golden fixture: docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
 - Schema: docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 - Test: tests/demo/test_reviewer_evidence_packet.py
@@ -122,6 +123,8 @@ VERITAS includes a local/offline Reviewer Evidence Packet v1 export for the SaaS
 A deterministic golden fixture is also checked in so reviewers can inspect the generated packet without running the exporter. A JSON Schema is checked in for Reviewer Evidence Packet v1 so reviewers can inspect the packet contract and CI can detect unintended shape changes. CI tests verify that the generated packet matches the fixture.
 
 A local/offline validation report is also available. It verifies that the generated packet matches the golden fixture, recomputes the packet hash, validates the packet shape against the JSON Schema when possible, checks deterministic case expectations, and emits a reviewer-facing pass/fail JSON report.
+
+A dedicated CI gate runs the Reviewer Evidence Packet validation report so the reviewer-facing packet, fixture, schema/fallback validation, case expectations, and evidence-chain verification summaries are continuously checked.
 
 ## Bind Coverage Registry v1
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -118,6 +118,7 @@ VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加さ
 - Validation report: docs/en/demo/reviewer-evidence-packet-validation-report.md
 - スクリプト: scripts/demo/export_reviewer_evidence_packet.py
 - Validator script: scripts/demo/validate_reviewer_evidence_packet.py
+- CI gate: .github/workflows/reviewer-evidence-packet-validation.yml
 - Golden fixture: docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
 - Schema: docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 - テスト: tests/demo/test_reviewer_evidence_packet.py
@@ -125,6 +126,8 @@ VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加さ
 生成済みの deterministic golden fixture もリポジトリに保存されているため、レビュアーは exporter を実行しなくても packet の内容を確認できます。Reviewer Evidence Packet v1 の JSON Schema もリポジトリに保存されています。これにより、レビュアーは packet の構造契約を確認でき、CI で意図しない shape change を検出できます。CI テストでは、現在生成される packet が fixture と一致することを検証します。
 
 local/offline の validation report も用意されています。これは、生成された packet が golden fixture と一致すること、packet hash が再計算できること、可能な場合は JSON Schema に適合すること、deterministic case expectations を満たすことを検証し、レビュアー向けの pass/fail JSON report を出力します。
+
+Reviewer Evidence Packet validation report を実行する専用 CI gate も追加されています。これにより、reviewer-facing packet、golden fixture、schema / fallback validation、case expectations、evidence-chain verification summaries が継続的に検証されます。
 
 ## Bind Coverage Registry v1
 

--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -16,6 +16,8 @@ Key local/offline reviewer-facing artifacts:
   - Reviewer Evidence Packet documentation
 - `docs/en/demo/reviewer-evidence-packet-validation-report.md`
   - validation report documentation
+- `.github/workflows/reviewer-evidence-packet-validation.yml`
+  - CI gate for Reviewer Evidence Packet validation report
 - `docs/en/demo/saas-permission-change-governed-demo.md`
   - SaaS permission-change demo documentation
 - `docs/en/architecture/outcome-receipt.md`

--- a/docs/en/demo/external-reviewer-quickstart.md
+++ b/docs/en/demo/external-reviewer-quickstart.md
@@ -65,6 +65,8 @@ This command:
 - requires no credentials
 - makes no network calls
 
+The same validation path is enforced in CI by the Reviewer Evidence Packet Validation workflow, so reviewers can see that the packet, fixture, schema/fallback validation, case expectations, and evidence-chain verification summaries are continuously checked.
+
 ## Expected current results
 
 The current deterministic summary is expected to show:

--- a/docs/en/demo/reviewer-evidence-packet-validation-report.md
+++ b/docs/en/demo/reviewer-evidence-packet-validation-report.md
@@ -45,6 +45,21 @@ When `jsonschema` is available in the local environment, the validator checks bo
 
 When `jsonschema` is unavailable, the validator does not add or require a dependency. Instead, it runs deterministic fallback structural checks for required top-level fields, `packet_id`, `packet_version`, `local_offline_only`, packet hash format, non-empty cases, aggregate summary, and nested case evidence summaries.
 
+## CI gate
+
+Reviewer Evidence Packet Validation is also enforced by a dedicated GitHub Actions workflow at:
+`.github/workflows/reviewer-evidence-packet-validation.yml`
+
+The workflow runs:
+
+```bash
+python3 scripts/demo/validate_reviewer_evidence_packet.py
+```
+
+This verifies that the generated packet matches the golden fixture, `packet_hash` recomputes correctly, schema or fallback validation passes, deterministic case expectations hold, and evidence-chain verification summaries remain valid.
+
+This CI gate is local/offline only and does not connect to live SaaS, IAM, IdP, SSO, customer systems, banks, sanctions systems, production approval workflows, or live audit stores.
+
 ## Boundary
 
 This report validates a local/offline Reviewer Evidence Packet fixture only.

--- a/tests/docs/test_reviewer_evidence_packet_ci_gate.py
+++ b/tests/docs/test_reviewer_evidence_packet_ci_gate.py
@@ -1,0 +1,57 @@
+"""Tests for Reviewer Evidence Packet CI gate references."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = ROOT / ".github/workflows/reviewer-evidence-packet-validation.yml"
+WORKFLOW_REFERENCE = ".github/workflows/reviewer-evidence-packet-validation.yml"
+VALIDATOR_REFERENCE = "scripts/demo/validate_reviewer_evidence_packet.py"
+
+
+def _read_repo_file(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_reviewer_evidence_packet_validation_workflow_exists() -> None:
+    assert WORKFLOW_PATH.exists()
+
+
+def test_reviewer_evidence_packet_validation_workflow_runs_validator() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert VALIDATOR_REFERENCE in workflow
+    assert "continue-on-error" not in workflow
+
+
+def test_validation_report_docs_reference_workflow_path() -> None:
+    docs = _read_repo_file(
+        "docs/en/demo/reviewer-evidence-packet-validation-report.md"
+    )
+
+    assert WORKFLOW_REFERENCE in docs
+
+
+def test_quickstart_mentions_ci_validation() -> None:
+    quickstart = _read_repo_file(
+        "docs/en/demo/external-reviewer-quickstart.md"
+    )
+
+    assert "Reviewer Evidence Packet Validation workflow" in quickstart
+    assert "continuously checked" in quickstart
+
+
+def test_artifact_index_references_workflow_path() -> None:
+    artifact_index = _read_repo_file(
+        "docs/en/demo/external-reviewer-artifact-index.md"
+    )
+
+    assert WORKFLOW_REFERENCE in artifact_index
+
+
+def test_readmes_reference_workflow_path() -> None:
+    for readme_path in ["README.md", "README_JP.md"]:
+        readme = _read_repo_file(readme_path)
+        assert WORKFLOW_REFERENCE in readme


### PR DESCRIPTION
### Motivation

- Make the reviewer-facing evidence path a first-class, continuously verified CI artifact by running the local/offline Reviewer Evidence Packet validation report on every PR and push.
- Detect unintended changes to the reviewed packet path early by verifying generated packet equality to the golden fixture, packet_hash recomputation, schema/fallback validation, deterministic case expectations, and evidence-chain verification summaries.
- Keep the change small and additive, preserving the local/offline boundary and avoiding live integrations or secrets.

### Description

- Add a new GitHub Actions workflow at `.github/workflows/reviewer-evidence-packet-validation.yml` that triggers on `pull_request` and `push`, sets up Python (3.12), installs local validation dependencies from `veritas_os/requirements-core.txt`, runs `python3 scripts/demo/validate_reviewer_evidence_packet.py`, and then runs `python3 scripts/demo/check_reviewer_evidence_packet_fixture.py` as a focused fixture check.
- Update docs to reference the CI gate: add a `## CI gate` section to `docs/en/demo/reviewer-evidence-packet-validation-report.md`, add a CI-note to `docs/en/demo/external-reviewer-quickstart.md`, and add the workflow path to `docs/en/demo/external-reviewer-artifact-index.md`.
- Surface the gate in top-level docs by adding the workflow reference to `README.md` and `README_JP.md` and add lightweight presence tests in `tests/docs/test_reviewer_evidence_packet_ci_gate.py` that assert the workflow file exists and the docs/readmes reference it.
- Changes are additive and do not modify packet generation, the packet schema, the validator logic, demo outcomes, live integrations, credentials, or governance/runtime behavior.

### Testing

- Ran the validator CLI: `python3 scripts/demo/validate_reviewer_evidence_packet.py` and it exited `0` and produced the deterministic JSON report (pass).
- Ran the fixture equality check: `python3 scripts/demo/check_reviewer_evidence_packet_fixture.py` and it reported the fixture matches the generated packet (pass).
- Executed the new docs tests: `PYENV_VERSION=3.11.15 python -m pytest tests/docs/test_reviewer_evidence_packet_ci_gate.py` and the combined docs tests (`tests/docs/test_external_reviewer_quickstart_links.py` + the new test) and they passed (10 passed with 1 warning); `git diff --check` also passed.
- Note: an attempt to run the full demo-related pytest collection initially failed in a constrained local environment due to missing `PyYAML` installation (network/proxy restrictions), but the CI workflow installs `veritas_os/requirements-core.txt` so required runtime deps (including `PyYAML`) will be available in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1973555fa48326b09ebc2f7a3efff9)