### PR TITLE
Add strict A/B/C/D minimal case for trajectory shaping lineage validation

### DIFF
--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -121,6 +121,30 @@ Known limitation: this is a deterministic representative demo lineage and is
 not production certification.
 
 
+## A/B/C/D Minimal Validation Case
+
+The Pre-Boundary Collapse demo also includes an additive
+`trajectory_shaping_lineage.abcd_minimal_validation_case` fixture. The case uses
+only four options (`A`, `B`, `C`, and `D`) so reviewers can inspect the smallest
+representative trajectory where option exposure, preservation, intervention
+viability, and bind admissibility can separate.
+
+The minimal A/B/C/D shape is useful because it reduces overgeneralization: the
+reviewer does not need to infer the pattern from a rich domain scenario or a
+large option set. Instead, the demo asks whether the same governance-relevant
+separations still appear under constrained conditions:
+
+- preservation degradation begins when A/B reinforcement first becomes detectable
+- divergence contraction becomes measurable while C/D still formally remain
+- intervention viability is lost before bind evaluates the final trajectory
+- formal bind admissibility can still be valid over an already narrowed space
+
+This helps VERITAS track what remained realistically preservable and enactable
+before bind, while keeping the bind layer focused on the space it actually
+evaluates. The result is a deterministic representative governance pattern, not
+certification or a production governability claim.
+
+
 ## Run and verification entrypoint
 
 Run the representative demo from Mission Control with:

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -23,3 +23,25 @@ additive snapshot field として公開されます。
 
 Known limitation: this is a deterministic representative demo lineage and is
 not production certification.
+
+
+## A/B/C/D Minimal Validation Case
+
+Pre-Boundary Collapse demo には、additive fixture として
+`trajectory_shaping_lineage.abcd_minimal_validation_case` も含まれます。この case は
+`A`、`B`、`C`、`D` の4 options だけを使い、option exposure、preservation、
+intervention viability、bind admissibility が分離し始める最小の representative
+trajectory を reviewer が確認できるようにします。
+
+最小 A/B/C/D shape が有用なのは、過度な一般化を避けられるためです。reviewer は、
+rich domain scenario や大きな option set から pattern を推論する必要がありません。
+代わりに、制約された条件でも以下の governance-relevant separation が現れるかを確認できます。
+
+- A/B reinforcement が初めて検出可能になった時点で preservation degradation が始まる
+- C/D が形式上残っている間に divergence contraction が measurable になる
+- bind が final trajectory を評価する前に intervention viability が失われる
+- formal bind admissibility は、すでに narrowed された space に対して valid になり得る
+
+これにより VERITAS は、bind 前に何が現実的に preservable / enactable として残っていたかを追跡できます。
+bind layer は実際に評価した space に集中しつつ、trajectory lineage はその space がいつ狭まったかを示します。
+この result は deterministic representative governance pattern であり、certification や production governability claim ではありません。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -237,6 +237,15 @@ describe("/api/veritas/v1/report/governance", () => {
           initial_option_space: { options: string[] };
           sequence: Array<Record<string, unknown>>;
           transition_points: Record<string, string>;
+          evidence_requirements: string[];
+          summary: Record<string, string>;
+          abcd_minimal_validation_case: {
+            case_id: string;
+            version: string;
+            options: string[];
+            phases: Array<Record<string, unknown>>;
+            separation_points: Record<string, string>;
+          };
         };
       };
     };
@@ -280,6 +289,18 @@ describe("/api/veritas/v1/report/governance", () => {
       intervention_viability_loss_phase: "phase_3_pre_boundary_collapse",
       bind_evaluation_phase: "phase_4_bind",
     });
+    expect(payload.governance_layer_snapshot.trajectory_shaping_lineage.abcd_minimal_validation_case).toMatchObject({
+      case_id: "abcd_minimal_trajectory_validation",
+      version: "v0",
+      options: ["A", "B", "C", "D"],
+      separation_points: {
+        intervention_viability_loss_phase: "phase_4_intervention_viability_loss",
+        formal_admissibility_phase: "phase_5_bind_over_narrowed_space",
+      },
+    });
+    expect(
+      payload.governance_layer_snapshot.trajectory_shaping_lineage.abcd_minimal_validation_case.phases,
+    ).toHaveLength(5);
   });
 
   it("returns pre-boundary collapse demo scenario payload from header seam", async () => {

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { NextResponse } from "next/server";
 
-import { type TrajectoryShapingLineage } from "../../../../../../components/dashboard-types";
+import { type AbcdMinimalValidationCase, type TrajectoryShapingLineage } from "../../../../../../components/dashboard-types";
 import { resolveApiBaseUrl } from "../../../[...path]/route-config";
 import { buildAmlKycReviewerWalkthroughPayload } from "../../../../../../lib/aml-kyc-reviewer-walkthrough";
 import { areE2EScenariosEnabled } from "../../../../../e2e-scenarios";
@@ -103,6 +103,89 @@ function mapPreBoundaryCollapsePhaseToSnapshot(phase: Record<string, unknown>): 
   };
 }
 
+function buildAbcdMinimalValidationCase(): AbcdMinimalValidationCase {
+  return {
+    case_id: "abcd_minimal_trajectory_validation",
+    version: "v0",
+    purpose:
+      "Validate whether preservation degradation, intervention viability loss, and formal bind admissibility separate under minimal A/B/C/D conditions.",
+    options: ["A", "B", "C", "D"],
+    phases: [
+      {
+        phase_id: "phase_1_symmetric_exposure",
+        phase_label: "Phase 1 — Symmetric exposure",
+        exposure_state: "symmetric",
+        reinforcement_state: "none",
+        divergence_state: "open",
+        preservation_state: "open",
+        intervention_viability: "high",
+        bind_admissibility: "not_evaluated",
+        structural_marker: "full_reachable_space",
+      },
+      {
+        phase_id: "phase_2_reinforcement_asymmetry",
+        phase_label: "Phase 2 — Gradual reinforcement asymmetry",
+        exposure_state: "asymmetric_emerging",
+        reinforcement_state: "a_b_reinforced",
+        divergence_state: "contracting",
+        preservation_state: "degrading",
+        intervention_viability: "medium",
+        bind_admissibility: "not_evaluated",
+        structural_marker: "first_detectable_asymmetry",
+      },
+      {
+        phase_id: "phase_3_divergence_contraction",
+        phase_label: "Phase 3 — Measurable divergence contraction",
+        exposure_state: "asymmetric",
+        reinforcement_state: "a_b_dominant",
+        divergence_state: "contracted",
+        preservation_state: "degraded",
+        intervention_viability: "low",
+        bind_admissibility: "not_evaluated",
+        structural_marker: "measurable_divergence_contraction",
+      },
+      {
+        phase_id: "phase_4_intervention_viability_loss",
+        phase_label: "Phase 4 — First detectable loss of intervention viability",
+        exposure_state: "asymmetric",
+        reinforcement_state: "trajectory_narrowed",
+        divergence_state: "effectively_closed",
+        preservation_state: "collapsed",
+        intervention_viability: "lost",
+        bind_admissibility: "not_evaluated",
+        structural_marker: "intervention_viability_loss",
+      },
+      {
+        phase_id: "phase_5_bind_over_narrowed_space",
+        phase_label: "Phase 5 — Bind over narrowed space",
+        exposure_state: "already_narrowed",
+        reinforcement_state: "trajectory_committed",
+        divergence_state: "closed",
+        preservation_state: "collapsed",
+        intervention_viability: "lost",
+        bind_admissibility: "formally_valid",
+        bind_outcome: "FORMALLY_VALID_OVER_STRUCTURALLY_NARROWED_SPACE",
+        structural_marker: "formal_admissibility_after_intervention_loss",
+      },
+    ],
+    separation_points: {
+      first_detectable_asymmetry_phase: "phase_2_reinforcement_asymmetry",
+      divergence_contraction_phase: "phase_3_divergence_contraction",
+      preservation_degradation_phase: "phase_2_reinforcement_asymmetry",
+      intervention_viability_loss_phase: "phase_4_intervention_viability_loss",
+      formal_admissibility_phase: "phase_5_bind_over_narrowed_space",
+    },
+    validation_question:
+      "Do preservation degradation, intervention viability loss, and formal bind admissibility separate even under minimal A/B/C/D conditions?",
+    summary: {
+      concise:
+        "The A/B/C/D minimal case tests whether formal bind admissibility can remain valid after effective intervention viability has already been structurally lost.",
+      operator:
+        "The system should show when intervention stopped being realistically preservable before bind evaluated the narrowed space.",
+    },
+  };
+}
+
 function buildTrajectoryShapingLineageV0(): TrajectoryShapingLineage {
   return {
     scenario_id: PRE_BOUNDARY_COLLAPSE_SCENARIO,
@@ -181,6 +264,7 @@ function buildTrajectoryShapingLineageV0(): TrajectoryShapingLineage {
       operator:
         "Formal admissibility can still hold at bind while effective intervention capacity has already been lost upstream.",
     },
+    abcd_minimal_validation_case: buildAbcdMinimalValidationCase(),
   };
 }
 

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -95,6 +95,39 @@ export interface TrajectoryShapingLineagePhase {
   bind_outcome?: string;
 }
 
+export interface AbcdMinimalValidationPhase {
+  phase_id: string;
+  phase_label: string;
+  exposure_state: string;
+  reinforcement_state: string;
+  divergence_state: string;
+  preservation_state: string;
+  intervention_viability: string;
+  bind_admissibility: string;
+  structural_marker: string;
+  bind_outcome?: string;
+}
+
+export interface AbcdMinimalValidationCase {
+  case_id: string;
+  version: string;
+  purpose: string;
+  options: string[];
+  phases: AbcdMinimalValidationPhase[];
+  separation_points: {
+    first_detectable_asymmetry_phase: string;
+    divergence_contraction_phase: string;
+    preservation_degradation_phase: string;
+    intervention_viability_loss_phase: string;
+    formal_admissibility_phase: string;
+  };
+  validation_question: string;
+  summary: {
+    concise: string;
+    operator: string;
+  };
+}
+
 export interface TrajectoryShapingLineage {
   scenario_id: string;
   version: string;
@@ -116,6 +149,7 @@ export interface TrajectoryShapingLineage {
     concise: string;
     operator: string;
   };
+  abcd_minimal_validation_case?: AbcdMinimalValidationCase;
 }
 
 export interface PreBindGovernanceSnapshot {

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -251,6 +251,25 @@ describe("MissionPage", () => {
                 concise: "Decision lineage records what was bound; trajectory shaping lineage records how reachable alternatives became structurally unavailable before bind.",
                 operator: "Formal admissibility can still hold at bind while effective intervention capacity has already been lost upstream.",
               },
+              abcd_minimal_validation_case: {
+                case_id: "abcd_minimal_trajectory_validation",
+                version: "v0",
+                purpose: "Validate whether preservation degradation, intervention viability loss, and formal bind admissibility separate under minimal A/B/C/D conditions.",
+                options: ["A", "B", "C", "D"],
+                phases: [],
+                separation_points: {
+                  first_detectable_asymmetry_phase: "phase_2_reinforcement_asymmetry",
+                  divergence_contraction_phase: "phase_3_divergence_contraction",
+                  preservation_degradation_phase: "phase_2_reinforcement_asymmetry",
+                  intervention_viability_loss_phase: "phase_4_intervention_viability_loss",
+                  formal_admissibility_phase: "phase_5_bind_over_narrowed_space",
+                },
+                validation_question: "Do preservation degradation, intervention viability loss, and formal bind admissibility separate even under minimal A/B/C/D conditions?",
+                summary: {
+                  concise: "The A/B/C/D minimal case tests whether formal bind admissibility can remain valid after effective intervention viability has already been structurally lost.",
+                  operator: "The system should show when intervention stopped being realistically preservable before bind evaluated the narrowed space.",
+                },
+              },
             },
           }}
         />
@@ -269,9 +288,12 @@ describe("MissionPage", () => {
     expect(screen.getByTestId("trajectory-shaping-lineage-panel")).toBeInTheDocument();
     expect(screen.getByText("Trajectory Shaping Lineage v0")).toBeInTheDocument();
     expect(screen.getByText("Decision-space transformation before bind")).toBeInTheDocument();
-    expect(screen.getByText(/first detectable asymmetry:/)).toBeInTheDocument();
-    expect(screen.getByText(/intervention viability loss:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/first detectable asymmetry:/).length).toBeGreaterThan(1);
+    expect(screen.getAllByText(/intervention viability loss:/).length).toBeGreaterThan(1);
     expect(screen.getByText(/bind evaluation:/)).toBeInTheDocument();
+    expect(screen.getByText("A/B/C/D Minimal Validation Case")).toBeInTheDocument();
+    expect(screen.getByText("Testing separation between preservation, intervention viability, and formal bind admissibility")).toBeInTheDocument();
+    expect(screen.getByText(/formal admissibility:/)).toBeInTheDocument();
   });
 
   it.each(["/governance", "/governance/receipts/br_123", "/audit?receipt=br_123"])("renders safe relevant_ui_href as link: %s", (href) => {

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -253,6 +253,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
     ? governanceSnapshot.phase_snapshots
     : [];
   const hasPreBoundaryCollapseDemo = governanceSnapshot?.demo_scenario === "pre_boundary_collapse" && phaseSnapshots.length > 0;
+  const abcdMinimalValidationCase = governanceSnapshot?.trajectory_shaping_lineage?.abcd_minimal_validation_case;
   const hasAmlKycReviewerWalkthrough = governanceSnapshot?.demo_scenario === "aml_kyc_reviewer_walkthrough";
 
   const governanceObservation = governanceSnapshot?.governance_observation;
@@ -410,6 +411,23 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
                 <li>bind evaluation: <span className="font-mono">{stringifyValue(governanceSnapshot.trajectory_shaping_lineage.transition_points.bind_evaluation_phase)}</span></li>
                 <li>summary: <span className="text-muted-foreground">{stringifyValue(governanceSnapshot.trajectory_shaping_lineage.summary.concise)}</span></li>
               </ul>
+              {abcdMinimalValidationCase ? (
+                <div
+                  aria-label="A/B/C/D minimal validation case"
+                  className="mt-3 rounded-md border border-border/60 bg-muted/10 p-3"
+                >
+                  <p className="font-semibold">A/B/C/D Minimal Validation Case</p>
+                  <p className="text-muted-foreground">Testing separation between preservation, intervention viability, and formal bind admissibility</p>
+                  <ul className="mt-2 space-y-1">
+                    <li>Options: <span className="font-mono">{abcdMinimalValidationCase.options.join("/")}</span></li>
+                    <li>first detectable asymmetry: <span className="font-mono">{stringifyValue(abcdMinimalValidationCase.separation_points.first_detectable_asymmetry_phase)}</span></li>
+                    <li>divergence contraction: <span className="font-mono">{stringifyValue(abcdMinimalValidationCase.separation_points.divergence_contraction_phase)}</span></li>
+                    <li>intervention viability loss: <span className="font-mono">{stringifyValue(abcdMinimalValidationCase.separation_points.intervention_viability_loss_phase)}</span></li>
+                    <li>formal admissibility: <span className="font-mono">{stringifyValue(abcdMinimalValidationCase.separation_points.formal_admissibility_phase)}</span></li>
+                    <li>summary: <span className="text-muted-foreground">{stringifyValue(abcdMinimalValidationCase.summary.concise)}</span></li>
+                  </ul>
+                </div>
+              ) : null}
             </div>
           ) : null}
         </section>

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -89,6 +89,11 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
       },
     });
     expect(payload.governance_layer_snapshot.phase_snapshots).toHaveLength(4);
+    expect(payload.governance_layer_snapshot.trajectory_shaping_lineage.abcd_minimal_validation_case).toMatchObject({
+      case_id: "abcd_minimal_trajectory_validation",
+      version: "v0",
+      options: ["A", "B", "C", "D"],
+    });
 
     await page.goto("/?demo_scenario=pre_boundary_collapse");
 
@@ -117,6 +122,9 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     await expect(walkthrough).toContainText("first detectable asymmetry");
     await expect(walkthrough).toContainText("intervention viability loss");
     await expect(walkthrough).toContainText("bind evaluation");
+    await expect(walkthrough).toContainText("A/B/C/D Minimal Validation Case");
+    await expect(walkthrough).toContainText("Testing separation between preservation, intervention viability, and formal bind admissibility");
+    await expect(walkthrough).toContainText("formal admissibility");
 
     const timeline = page.locator('section[aria-label="governance layer timeline"]');
     await expect(timeline).toBeVisible();


### PR DESCRIPTION
### Motivation
- Add a minimal, deterministic A/B/C/D validation case to the Pre-Boundary Collapse demo to verify whether preservation degradation, intervention viability loss, and formal bind admissibility can separate under the smallest representative conditions.
- Keep the change additive and non-invasive so existing Trajectory Shaping Lineage v0 behavior, the Pre-Boundary Collapse demo, and bind-time admissibility logic remain unchanged.
- Provide a compact Mission Control visualization and docs to help reviewers observe where effective intervention capacity is lost upstream while bind still evaluates a formally admissible (narrowed) space.

### Description
- Add a `buildAbcdMinimalValidationCase()` fixture and attach it as `trajectory_shaping_lineage.abcd_minimal_validation_case` returned by the demo API; the case is `case_id: "abcd_minimal_trajectory_validation"`, `version: "v0"`, strict `options: ["A","B","C","D"]`, and a 5-phase sequence with explicit separation points.
- Extend TypeScript types with `AbcdMinimalValidationCase`/`AbcdMinimalValidationPhase` and make `TrajectoryShapingLineage.abcd_minimal_validation_case` an optional additive field so existing consumers are not broken.
- Render a compact subsection under the existing Trajectory Shaping Lineage v0 panel in Mission Control titled `A/B/C/D Minimal Validation Case` showing options, first detectable asymmetry, divergence contraction, intervention viability loss, formal admissibility phase and concise summary.
- Update English/Japanese demo docs (`docs/en/...` and `docs/ja/...`) and add/assertions in API/component/E2E tests (`frontend/app/api/veritas/v1/report/governance/route.test.ts`, `frontend/components/mission-page.test.tsx`, `frontend/e2e/mission-control-governance-feed.spec.ts`) to verify presence and shape of the new fixture.

### Testing
- Ran TypeScript check with `pnpm -C frontend exec tsc --noEmit` which completed successfully.
- Ran unit/component/API tests with `pnpm -C frontend test -- app/api/veritas/v1/report/governance/route.test.ts components/mission-page.test.tsx app/mission-control-ingress.test.ts` and the modified test suite passed (unit/component/API assertions for the new field succeeded).
- Updated E2E spec and attempted Playwright run with `pnpm -C frontend exec playwright test e2e/mission-control-governance-feed.spec.ts --project=chromium`, which failed in this environment because Playwright browsers are not installed (error: please run `pnpm exec playwright install`); this is an environment constraint rather than a code failure.
- All changes are additive and type-checked; there were no changes to OpenAPI, bind contracts, state families, or enforcement behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1978744de88326be50d470cba9a576)