### PR TITLE
ci: upload Reviewer Evidence Packet validation artifacts v1

### DIFF
--- a/.github/workflows/reviewer-evidence-packet-validation.yml
+++ b/.github/workflows/reviewer-evidence-packet-validation.yml
@@ -26,8 +26,36 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r veritas_os/requirements-core.txt
 
-      - name: Validate Reviewer Evidence Packet
-        run: python3 scripts/demo/validate_reviewer_evidence_packet.py
+      - name: Create Reviewer Evidence Packet artifact directory
+        run: mkdir -p artifacts/reviewer-evidence-packet
+
+      - name: Validate Reviewer Evidence Packet and write report
+        run: >
+          python3 scripts/demo/validate_reviewer_evidence_packet.py
+          > artifacts/reviewer-evidence-packet/reviewer-evidence-packet-validation-report.json
 
       - name: Check Reviewer Evidence Packet fixture
         run: python3 scripts/demo/check_reviewer_evidence_packet_fixture.py
+
+      - name: Export current Reviewer Evidence Packet
+        run: >
+          python3 scripts/demo/export_reviewer_evidence_packet.py
+          > artifacts/reviewer-evidence-packet/reviewer-evidence-packet-generated.json
+
+      - name: Copy reviewer evidence packet reference artifacts
+        run: |
+          cp docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json \
+            artifacts/reviewer-evidence-packet/reviewer-evidence-packet-golden-fixture.json
+          cp docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json \
+            artifacts/reviewer-evidence-packet/reviewer-evidence-packet-schema.json
+          cp docs/en/demo/external-reviewer-quickstart.md \
+            artifacts/reviewer-evidence-packet/external-reviewer-quickstart.md
+          cp docs/en/demo/external-reviewer-artifact-index.md \
+            artifacts/reviewer-evidence-packet/external-reviewer-artifact-index.md
+
+      - name: Upload Reviewer Evidence Packet validation artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: reviewer-evidence-packet-validation-artifacts
+          path: artifacts/reviewer-evidence-packet/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ VERITAS includes a local/offline Reviewer Evidence Packet v1 export for the SaaS
 - Script: scripts/demo/export_reviewer_evidence_packet.py
 - Validator script: scripts/demo/validate_reviewer_evidence_packet.py
 - CI gate: .github/workflows/reviewer-evidence-packet-validation.yml
+- CI artifacts: reviewer-evidence-packet-validation-artifacts
 - Golden fixture: docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
 - Schema: docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 - Test: tests/demo/test_reviewer_evidence_packet.py
@@ -125,6 +126,8 @@ A deterministic golden fixture is also checked in so reviewers can inspect the g
 A local/offline validation report is also available. It verifies that the generated packet matches the golden fixture, recomputes the packet hash, validates the packet shape against the JSON Schema when possible, checks deterministic case expectations, and emits a reviewer-facing pass/fail JSON report.
 
 A dedicated CI gate runs the Reviewer Evidence Packet validation report so the reviewer-facing packet, fixture, schema/fallback validation, case expectations, and evidence-chain verification summaries are continuously checked.
+
+The Reviewer Evidence Packet Validation workflow also uploads reviewer evidence artifacts, including the generated validation report, generated packet, golden fixture, and schema, so reviewers can inspect the exact CI-produced outputs.
 
 ## Bind Coverage Registry v1
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -119,6 +119,7 @@ VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加さ
 - スクリプト: scripts/demo/export_reviewer_evidence_packet.py
 - Validator script: scripts/demo/validate_reviewer_evidence_packet.py
 - CI gate: .github/workflows/reviewer-evidence-packet-validation.yml
+- CI artifacts: reviewer-evidence-packet-validation-artifacts
 - Golden fixture: docs/en/demo/fixtures/reviewer-evidence-packet-saas-permission-change-v1.json
 - Schema: docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
 - テスト: tests/demo/test_reviewer_evidence_packet.py
@@ -128,6 +129,8 @@ VERITAS には local/offline の Reviewer Evidence Packet v1 export が追加さ
 local/offline の validation report も用意されています。これは、生成された packet が golden fixture と一致すること、packet hash が再計算できること、可能な場合は JSON Schema に適合すること、deterministic case expectations を満たすことを検証し、レビュアー向けの pass/fail JSON report を出力します。
 
 Reviewer Evidence Packet validation report を実行する専用 CI gate も追加されています。これにより、reviewer-facing packet、golden fixture、schema / fallback validation、case expectations、evidence-chain verification summaries が継続的に検証されます。
+
+Reviewer Evidence Packet Validation workflow では、生成された validation report、generated packet、golden fixture、schema を GitHub Actions artifact としてアップロードします。これにより、レビュアーは CI 上で生成・検証された成果物を直接確認できます。
 
 ## Bind Coverage Registry v1
 

--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -18,6 +18,8 @@ Key local/offline reviewer-facing artifacts:
   - validation report documentation
 - `.github/workflows/reviewer-evidence-packet-validation.yml`
   - CI gate for Reviewer Evidence Packet validation report
+- `reviewer-evidence-packet-validation-artifacts`
+  - GitHub Actions artifact containing validation report, generated packet, golden fixture, and schema
 - `docs/en/demo/saas-permission-change-governed-demo.md`
   - SaaS permission-change demo documentation
 - `docs/en/architecture/outcome-receipt.md`

--- a/docs/en/demo/external-reviewer-quickstart.md
+++ b/docs/en/demo/external-reviewer-quickstart.md
@@ -67,6 +67,8 @@ This command:
 
 The same validation path is enforced in CI by the Reviewer Evidence Packet Validation workflow, so reviewers can see that the packet, fixture, schema/fallback validation, case expectations, and evidence-chain verification summaries are continuously checked.
 
+On GitHub Actions, the Reviewer Evidence Packet Validation workflow also uploads `reviewer-evidence-packet-validation-artifacts`, which contains the generated validation report, generated packet, checked-in golden fixture, and schema for inspection.
+
 ## Expected current results
 
 The current deterministic summary is expected to show:

--- a/docs/en/demo/reviewer-evidence-packet-validation-report.md
+++ b/docs/en/demo/reviewer-evidence-packet-validation-report.md
@@ -60,6 +60,22 @@ This verifies that the generated packet matches the golden fixture, `packet_hash
 
 This CI gate is local/offline only and does not connect to live SaaS, IAM, IdP, SSO, customer systems, banks, sanctions systems, production approval workflows, or live audit stores.
 
+## CI artifacts
+
+The Reviewer Evidence Packet Validation workflow uploads CI artifacts under the artifact name:
+`reviewer-evidence-packet-validation-artifacts`
+
+The uploaded artifact includes:
+
+- `reviewer-evidence-packet-validation-report.json`
+- `reviewer-evidence-packet-generated.json`
+- `reviewer-evidence-packet-golden-fixture.json`
+- `reviewer-evidence-packet-schema.json`
+
+These files allow reviewers to inspect the exact validation report, generated packet, checked-in fixture, and schema used by CI.
+
+This artifact is local/offline only and does not represent live SaaS execution, production deployment, audit certification, regulatory approval, or third-party certification.
+
 ## Boundary
 
 This report validates a local/offline Reviewer Evidence Packet fixture only.

--- a/tests/docs/test_reviewer_evidence_packet_ci_gate.py
+++ b/tests/docs/test_reviewer_evidence_packet_ci_gate.py
@@ -9,6 +9,11 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = ROOT / ".github/workflows/reviewer-evidence-packet-validation.yml"
 WORKFLOW_REFERENCE = ".github/workflows/reviewer-evidence-packet-validation.yml"
 VALIDATOR_REFERENCE = "scripts/demo/validate_reviewer_evidence_packet.py"
+ARTIFACT_NAME = "reviewer-evidence-packet-validation-artifacts"
+VALIDATION_REPORT_ARTIFACT = "reviewer-evidence-packet-validation-report.json"
+GENERATED_PACKET_ARTIFACT = "reviewer-evidence-packet-generated.json"
+GOLDEN_FIXTURE_ARTIFACT = "reviewer-evidence-packet-golden-fixture.json"
+SCHEMA_ARTIFACT = "reviewer-evidence-packet-schema.json"
 
 
 def _read_repo_file(relative_path: str) -> str:
@@ -26,12 +31,36 @@ def test_reviewer_evidence_packet_validation_workflow_runs_validator() -> None:
     assert "continue-on-error" not in workflow
 
 
+def test_reviewer_evidence_packet_workflow_uploads_artifacts() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "actions/upload-artifact" in workflow
+    assert ARTIFACT_NAME in workflow
+
+
+def test_reviewer_evidence_packet_workflow_writes_artifact_files() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert VALIDATION_REPORT_ARTIFACT in workflow
+    assert GENERATED_PACKET_ARTIFACT in workflow
+    assert GOLDEN_FIXTURE_ARTIFACT in workflow
+    assert SCHEMA_ARTIFACT in workflow
+
+
 def test_validation_report_docs_reference_workflow_path() -> None:
     docs = _read_repo_file(
         "docs/en/demo/reviewer-evidence-packet-validation-report.md"
     )
 
     assert WORKFLOW_REFERENCE in docs
+
+
+def test_validation_report_docs_reference_ci_artifacts() -> None:
+    docs = _read_repo_file(
+        "docs/en/demo/reviewer-evidence-packet-validation-report.md"
+    )
+
+    assert ARTIFACT_NAME in docs
 
 
 def test_quickstart_mentions_ci_validation() -> None:
@@ -43,6 +72,14 @@ def test_quickstart_mentions_ci_validation() -> None:
     assert "continuously checked" in quickstart
 
 
+def test_quickstart_mentions_ci_artifacts() -> None:
+    quickstart = _read_repo_file(
+        "docs/en/demo/external-reviewer-quickstart.md"
+    )
+
+    assert ARTIFACT_NAME in quickstart
+
+
 def test_artifact_index_references_workflow_path() -> None:
     artifact_index = _read_repo_file(
         "docs/en/demo/external-reviewer-artifact-index.md"
@@ -51,7 +88,21 @@ def test_artifact_index_references_workflow_path() -> None:
     assert WORKFLOW_REFERENCE in artifact_index
 
 
+def test_artifact_index_references_ci_artifacts() -> None:
+    artifact_index = _read_repo_file(
+        "docs/en/demo/external-reviewer-artifact-index.md"
+    )
+
+    assert ARTIFACT_NAME in artifact_index
+
+
 def test_readmes_reference_workflow_path() -> None:
     for readme_path in ["README.md", "README_JP.md"]:
         readme = _read_repo_file(readme_path)
         assert WORKFLOW_REFERENCE in readme
+
+
+def test_readmes_reference_ci_artifacts() -> None:
+    for readme_path in ["README.md", "README_JP.md"]:
+        readme = _read_repo_file(readme_path)
+        assert ARTIFACT_NAME in readme


### PR DESCRIPTION
### Motivation
- Make the Reviewer Evidence Packet CI more useful to external reviewers by uploading the CI-produced validation report and reviewer artifacts so the exact outputs can be downloaded from GitHub Actions.
- Preserve the existing local/offline validation gate while exposing the deterministic outputs for inspection without changing generation or validation logic.

### Description
- Update `.github/workflows/reviewer-evidence-packet-validation.yml` to create `artifacts/reviewer-evidence-packet/`, run the validator and redirect deterministic JSON to `artifacts/reviewer-evidence-packet/reviewer-evidence-packet-validation-report.json` (the validator remains the failure gate), run the fixture check, run the exporter to `artifacts/reviewer-evidence-packet/reviewer-evidence-packet-generated.json`, copy the checked-in golden fixture and schema and reviewer docs into the artifact dir, and upload them with `actions/upload-artifact@v4` as `reviewer-evidence-packet-validation-artifacts` with a 14-day retention.
- Add documentation text to `docs/en/demo/reviewer-evidence-packet-validation-report.md`, `docs/en/demo/external-reviewer-quickstart.md`, `docs/en/demo/external-reviewer-artifact-index.md`, `README.md`, and `README_JP.md` describing the CI artifact name and the files included while preserving the explicit local/offline boundary.
- Add lightweight docs/workflow string-presence tests at `tests/docs/test_reviewer_evidence_packet_ci_gate.py` to assert the workflow includes `actions/upload-artifact`, the artifact name, the artifact filenames, and the updated docs reference the artifact name.

### Testing
- Ran `PYENV_VERSION=3.12.13 python -m pytest tests/docs/test_reviewer_evidence_packet_ci_gate.py` and the new tests passed (12 passed, 1 warning).
- Ran `git diff --check` and static diff checks reported no issues.
- Attempted to run the full validator/exporter end-to-end in this environment but dependency installation was blocked by the environment's package index (proxy 403) and the local interpreter initially lacked `PyYAML`, so writing/validating the actual generated artifacts could not be completed here (these runtime checks are preserved in CI where dependencies are installed by the workflow).

Security note: no secrets, credentials, live network integrations, or production behavior were added, but uploaded GitHub Actions artifacts are accessible to users with artifact access for the repo so reviewers should avoid including any secrets in generated artifacts; the docs explicitly state the artifacts are local/offline reviewer artifacts and not evidence of live production execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197b2cc6c4832696424c5c649ca996)