### PR TITLE
Add Irreversibility Horizon v0 markers for dynamic trajectory validation

### DIFF
--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -221,3 +221,38 @@ This walkthrough is a controlled representative demo for reviewer understanding.
 - Deterministic fixture-backed scenario
 - Not an exhaustive production trace
 - Does not imply legal or regulatory approval
+
+## Irreversibility Horizon v0
+
+Irreversibility Horizon v0 is the next compact marker layer after Dynamic
+Conditions Validation v0. Dynamic Conditions Validation v0 shows that
+preservation degradation, intervention viability loss, and formal bind
+admissibility can remain separate while reinforcement, exposure asymmetry, time
+pressure, and adaptive system behavior interact. Irreversibility Horizon v0 asks
+how early structurally meaningful degradation becomes visible before operational
+irreversibility stabilizes.
+
+This is not a production irreversibility detection engine, a scoring model, or
+a new enforcement gate. It is an additive deterministic representative
+validation pattern under
+`trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon`.
+It marks representative temporal points in the existing dynamic sequence:
+
+- **first structural degradation signal** — Phase 2, where reinforcement and
+  exposure asymmetry first make dynamic asymmetry detectable while intervention
+  remains realistic.
+- **early warning** — Phase 3, where time pressure begins compressing the
+  intervention window while meaningful intervention is still possible.
+- **last meaningful intervention** — Phase 3, the last representative phase
+  before adaptive stabilization where intervention remains meaningfully
+  available.
+- **irreversibility horizon** — Phase 4, where adaptive behavior stabilizes the
+  narrowed trajectory and recovery becomes operationally hard.
+- **bind after horizon** — Phase 5, where bind evaluates a formally admissible
+  trajectory after the representative horizon has already been crossed.
+
+The marker keeps the existing OpenAPI, bind contract, state family, and pre-bind
+vocabulary unchanged. It does not make a production governability claim. Its
+purpose is to make the temporal relationship visible: a trajectory can remain
+formally admissible and inspectable at bind while meaningful intervention
+capacity has already become operationally hard to recover upstream.

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -75,3 +75,35 @@ condition ではなく、formal bind admissibility が intact のままでも時
 この validation は dynamic pressure 下で preservation degradation、intervention viability
 loss、formal bind admissibility を比較するためのものです。certification、general dynamic
 trajectory engine、production governability claim ではありません。
+
+## Irreversibility Horizon v0
+
+Irreversibility Horizon v0 は、Dynamic Conditions Validation v0 の次に置く小さな
+marker layer です。Dynamic Conditions Validation v0 は、reinforcement、exposure
+asymmetry、time pressure、adaptive system behavior が相互作用しても、preservation
+degradation、intervention viability loss、formal bind admissibility を分離して観測
+できることを示します。Irreversibility Horizon v0 は、その上で「operational
+irreversibility が安定化する前に、structurally meaningful degradation がどれだけ早く
+見え始めるか」を問います。
+
+これは production 用の irreversibility 判定エンジン、score model、または新しい enforcement
+gate ではありません。
+`trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon`
+に追加される deterministic representative validation pattern です。既存の dynamic sequence
+に対して、次の代表的な temporal points を示します。
+
+- **first structural degradation signal** — Phase 2。reinforcement と exposure asymmetry
+  により最初の dynamic asymmetry が検出可能になるが、介入はまだ現実的に可能な段階。
+- **early warning** — Phase 3。time pressure により intervention window が短くなり始めるが、
+  meaningful intervention はまだ可能な段階。
+- **last meaningful intervention** — Phase 3。adaptive stabilization の前に、代表パターン上
+  meaningful intervention が可能な最後の段階。
+- **irreversibility horizon** — Phase 4。adaptive behavior が narrowed trajectory を安定化し、
+  recovery が operationally hard になる段階。
+- **bind after horizon** — Phase 5。representative horizon を越えた後の formally admissible
+  trajectory を bind が評価する段階。
+
+この marker は、OpenAPI、bind contract、state family、pre-bind vocabulary を変更しません。
+production governability claim も行いません。目的は、bind 時点で formal admissibility と
+inspectability が残っていても、その上流で meaningful intervention capacity の回復が
+operationally hard になっている可能性を、代表パターンとして可視化することです。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -331,6 +331,19 @@ describe("/api/veritas/v1/report/governance", () => {
     expect(
       payload.governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.phases,
     ).toHaveLength(5);
+    expect(payload.governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon).toMatchObject({
+      version: "v0",
+      base_case: "dynamic_conditions_trajectory_validation",
+      horizon_model: "deterministic_representative_marker",
+      markers: {
+        first_structural_degradation_signal_phase: "phase_2_reinforcement_exposure_asymmetry",
+        early_warning_phase: "phase_3_time_pressure_compression",
+        last_meaningful_intervention_phase: "phase_3_time_pressure_compression",
+        irreversibility_horizon_phase: "phase_4_adaptive_narrowing",
+        bind_after_horizon_phase: "phase_5_bind_over_dynamically_narrowed_space",
+      },
+    });
+
   });
 
   it("returns pre-boundary collapse demo scenario payload from header seam", async () => {

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { NextResponse } from "next/server";
 
-import { type AbcdMinimalValidationCase, type DynamicConditionsValidationCase, type TrajectoryShapingLineage } from "../../../../../../components/dashboard-types";
+import { type AbcdMinimalValidationCase, type DynamicConditionsValidationCase, type IrreversibilityHorizon, type TrajectoryShapingLineage } from "../../../../../../components/dashboard-types";
 import { resolveApiBaseUrl } from "../../../[...path]/route-config";
 import { buildAmlKycReviewerWalkthroughPayload } from "../../../../../../lib/aml-kyc-reviewer-walkthrough";
 import { areE2EScenariosEnabled } from "../../../../../e2e-scenarios";
@@ -186,6 +186,61 @@ function buildAbcdMinimalValidationCase(): AbcdMinimalValidationCase {
   };
 }
 
+function buildIrreversibilityHorizonV0(): IrreversibilityHorizon {
+  return {
+    version: "v0",
+    purpose:
+      "Mark when structurally meaningful governability degradation becomes visible before operational irreversibility stabilizes.",
+    base_case: "dynamic_conditions_trajectory_validation",
+    horizon_model: "deterministic_representative_marker",
+    markers: {
+      first_structural_degradation_signal_phase: "phase_2_reinforcement_exposure_asymmetry",
+      early_warning_phase: "phase_3_time_pressure_compression",
+      last_meaningful_intervention_phase: "phase_3_time_pressure_compression",
+      irreversibility_horizon_phase: "phase_4_adaptive_narrowing",
+      bind_after_horizon_phase: "phase_5_bind_over_dynamically_narrowed_space",
+    },
+    phase_interpretation: {
+      first_structural_degradation_signal: {
+        phase_id: "phase_2_reinforcement_exposure_asymmetry",
+        meaning: "The first detectable dynamic asymmetry appears while intervention remains realistic.",
+        intervention_status: "available",
+      },
+      early_warning: {
+        phase_id: "phase_3_time_pressure_compression",
+        meaning:
+          "The intervention window begins compressing under time pressure while meaningful intervention remains possible.",
+        intervention_status: "still_meaningful_but_compressing",
+      },
+      last_meaningful_intervention: {
+        phase_id: "phase_3_time_pressure_compression",
+        meaning:
+          "The last representative phase where intervention remains meaningfully available before adaptive stabilization.",
+        intervention_status: "last_meaningful",
+      },
+      irreversibility_horizon: {
+        phase_id: "phase_4_adaptive_narrowing",
+        meaning: "Adaptive behavior stabilizes the narrowed trajectory and recovery becomes operationally hard.",
+        intervention_status: "operationally_hard_to_reverse",
+      },
+      bind_after_horizon: {
+        phase_id: "phase_5_bind_over_dynamically_narrowed_space",
+        meaning:
+          "Bind evaluates a formally admissible trajectory after the irreversibility horizon has already been crossed.",
+        intervention_status: "post_horizon",
+      },
+    },
+    validation_question:
+      "How early can structurally meaningful degradation become visible before operational irreversibility stabilizes?",
+    summary: {
+      concise:
+        "Irreversibility Horizon v0 marks the representative point where intervention remains formally possible but becomes operationally hard to recover before bind.",
+      operator:
+        "The system should show the last meaningful intervention phase before adaptive narrowing stabilizes the trajectory.",
+    },
+  };
+}
+
 function buildDynamicConditionsValidationCase(): DynamicConditionsValidationCase {
   return {
     case_id: "dynamic_conditions_trajectory_validation",
@@ -283,6 +338,7 @@ function buildDynamicConditionsValidationCase(): DynamicConditionsValidationCase
       operator:
         "The system should show whether formal admissibility can remain intact while meaningful intervention capacity has already degraded under dynamic pressure.",
     },
+    irreversibility_horizon: buildIrreversibilityHorizonV0(),
   };
 }
 

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -143,6 +143,42 @@ export interface DynamicConditionsValidationPhase {
   bind_outcome?: string;
 }
 
+export interface IrreversibilityHorizonMarkers {
+  first_structural_degradation_signal_phase: string;
+  early_warning_phase: string;
+  last_meaningful_intervention_phase: string;
+  irreversibility_horizon_phase: string;
+  bind_after_horizon_phase: string;
+}
+
+export interface IrreversibilityHorizonPhaseInterpretationPoint {
+  phase_id: string;
+  meaning: string;
+  intervention_status: string;
+}
+
+export interface IrreversibilityHorizonPhaseInterpretation {
+  first_structural_degradation_signal: IrreversibilityHorizonPhaseInterpretationPoint;
+  early_warning: IrreversibilityHorizonPhaseInterpretationPoint;
+  last_meaningful_intervention: IrreversibilityHorizonPhaseInterpretationPoint;
+  irreversibility_horizon: IrreversibilityHorizonPhaseInterpretationPoint;
+  bind_after_horizon: IrreversibilityHorizonPhaseInterpretationPoint;
+}
+
+export interface IrreversibilityHorizon {
+  version: string;
+  purpose: string;
+  base_case: string;
+  horizon_model: string;
+  markers: IrreversibilityHorizonMarkers;
+  phase_interpretation: IrreversibilityHorizonPhaseInterpretation;
+  validation_question: string;
+  summary: {
+    concise: string;
+    operator: string;
+  };
+}
+
 export interface DynamicConditionsValidationCase {
   case_id: string;
   version: string;
@@ -163,6 +199,7 @@ export interface DynamicConditionsValidationCase {
     concise: string;
     operator: string;
   };
+  irreversibility_horizon?: IrreversibilityHorizon;
 }
 
 export interface TrajectoryShapingLineage {

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -295,6 +295,51 @@ describe("MissionPage", () => {
                   concise: "The dynamic conditions case tests whether governability degradation remains observable when multiple trajectory-shaping forces interact before bind.",
                   operator: "The system should show whether formal admissibility can remain intact while meaningful intervention capacity has already degraded under dynamic pressure.",
                 },
+                irreversibility_horizon: {
+                  version: "v0",
+                  purpose: "Mark when structurally meaningful governability degradation becomes visible before operational irreversibility stabilizes.",
+                  base_case: "dynamic_conditions_trajectory_validation",
+                  horizon_model: "deterministic_representative_marker",
+                  markers: {
+                    first_structural_degradation_signal_phase: "phase_2_reinforcement_exposure_asymmetry",
+                    early_warning_phase: "phase_3_time_pressure_compression",
+                    last_meaningful_intervention_phase: "phase_3_time_pressure_compression",
+                    irreversibility_horizon_phase: "phase_4_adaptive_narrowing",
+                    bind_after_horizon_phase: "phase_5_bind_over_dynamically_narrowed_space",
+                  },
+                  phase_interpretation: {
+                    first_structural_degradation_signal: {
+                      phase_id: "phase_2_reinforcement_exposure_asymmetry",
+                      meaning: "The first detectable dynamic asymmetry appears while intervention remains realistic.",
+                      intervention_status: "available",
+                    },
+                    early_warning: {
+                      phase_id: "phase_3_time_pressure_compression",
+                      meaning: "The intervention window begins compressing under time pressure while meaningful intervention remains possible.",
+                      intervention_status: "still_meaningful_but_compressing",
+                    },
+                    last_meaningful_intervention: {
+                      phase_id: "phase_3_time_pressure_compression",
+                      meaning: "The last representative phase where intervention remains meaningfully available before adaptive stabilization.",
+                      intervention_status: "last_meaningful",
+                    },
+                    irreversibility_horizon: {
+                      phase_id: "phase_4_adaptive_narrowing",
+                      meaning: "Adaptive behavior stabilizes the narrowed trajectory and recovery becomes operationally hard.",
+                      intervention_status: "operationally_hard_to_reverse",
+                    },
+                    bind_after_horizon: {
+                      phase_id: "phase_5_bind_over_dynamically_narrowed_space",
+                      meaning: "Bind evaluates a formally admissible trajectory after the irreversibility horizon has already been crossed.",
+                      intervention_status: "post_horizon",
+                    },
+                  },
+                  validation_question: "How early can structurally meaningful degradation become visible before operational irreversibility stabilizes?",
+                  summary: {
+                    concise: "Irreversibility Horizon v0 marks the representative point where intervention remains formally possible but becomes operationally hard to recover before bind.",
+                    operator: "The system should show the last meaningful intervention phase before adaptive narrowing stabilizes the trajectory.",
+                  },
+                },
               },
             },
           }}
@@ -329,6 +374,13 @@ describe("MissionPage", () => {
     expect(screen.getByText(/intervention window compression:/)).toBeInTheDocument();
     expect(screen.getByText(/adaptive narrowing:/)).toBeInTheDocument();
     expect(screen.getAllByText(/formal admissibility:/).length).toBeGreaterThan(1);
+    expect(screen.getByText("Irreversibility Horizon v0")).toBeInTheDocument();
+    expect(screen.getByText("Marking the last meaningful intervention point before operational irreversibility stabilizes")).toBeInTheDocument();
+    expect(screen.getByText(/first structural degradation signal:/)).toBeInTheDocument();
+    expect(screen.getByText(/early warning:/)).toBeInTheDocument();
+    expect(screen.getByText(/last meaningful intervention:/)).toBeInTheDocument();
+    expect(screen.getByText(/irreversibility horizon:/)).toBeInTheDocument();
+    expect(screen.getByText(/bind after horizon:/)).toBeInTheDocument();
   });
 
   it.each(["/governance", "/governance/receipts/br_123", "/audit?receipt=br_123"])("renders safe relevant_ui_href as link: %s", (href) => {

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -255,6 +255,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
   const hasPreBoundaryCollapseDemo = governanceSnapshot?.demo_scenario === "pre_boundary_collapse" && phaseSnapshots.length > 0;
   const abcdMinimalValidationCase = governanceSnapshot?.trajectory_shaping_lineage?.abcd_minimal_validation_case;
   const dynamicConditionsValidationCase = governanceSnapshot?.trajectory_shaping_lineage?.dynamic_conditions_validation_case;
+  const irreversibilityHorizon = dynamicConditionsValidationCase?.irreversibility_horizon;
   const hasAmlKycReviewerWalkthrough = governanceSnapshot?.demo_scenario === "aml_kyc_reviewer_walkthrough";
 
   const governanceObservation = governanceSnapshot?.governance_observation;
@@ -450,6 +451,23 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
                     <li>formal admissibility: <span className="font-mono">{stringifyValue(dynamicConditionsValidationCase.separation_points.formal_admissibility_phase)}</span></li>
                     <li>summary: <span className="text-muted-foreground">{stringifyValue(dynamicConditionsValidationCase.summary.concise)}</span></li>
                   </ul>
+                  {irreversibilityHorizon ? (
+                    <div
+                      aria-label="Irreversibility Horizon v0"
+                      className="mt-3 rounded-md border border-border/60 bg-background/60 p-3"
+                    >
+                      <p className="font-semibold">Irreversibility Horizon v0</p>
+                      <p className="text-muted-foreground">Marking the last meaningful intervention point before operational irreversibility stabilizes</p>
+                      <ul className="mt-2 space-y-1">
+                        <li>first structural degradation signal: <span className="font-mono">{stringifyValue(irreversibilityHorizon.markers.first_structural_degradation_signal_phase)}</span></li>
+                        <li>early warning: <span className="font-mono">{stringifyValue(irreversibilityHorizon.markers.early_warning_phase)}</span></li>
+                        <li>last meaningful intervention: <span className="font-mono">{stringifyValue(irreversibilityHorizon.markers.last_meaningful_intervention_phase)}</span></li>
+                        <li>irreversibility horizon: <span className="font-mono">{stringifyValue(irreversibilityHorizon.markers.irreversibility_horizon_phase)}</span></li>
+                        <li>bind after horizon: <span className="font-mono">{stringifyValue(irreversibilityHorizon.markers.bind_after_horizon_phase)}</span></li>
+                        <li>summary: <span className="text-muted-foreground">{stringifyValue(irreversibilityHorizon.summary.concise)}</span></li>
+                      </ul>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -98,6 +98,18 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
       case_id: "dynamic_conditions_trajectory_validation",
       version: "v0",
       base_case: "abcd_minimal_trajectory_validation",
+      irreversibility_horizon: {
+        version: "v0",
+        base_case: "dynamic_conditions_trajectory_validation",
+        horizon_model: "deterministic_representative_marker",
+        markers: {
+          first_structural_degradation_signal_phase: "phase_2_reinforcement_exposure_asymmetry",
+          early_warning_phase: "phase_3_time_pressure_compression",
+          last_meaningful_intervention_phase: "phase_3_time_pressure_compression",
+          irreversibility_horizon_phase: "phase_4_adaptive_narrowing",
+          bind_after_horizon_phase: "phase_5_bind_over_dynamically_narrowed_space",
+        },
+      },
     });
 
     await page.goto("/?demo_scenario=pre_boundary_collapse");
@@ -130,6 +142,12 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     await expect(walkthrough).toContainText("A/B/C/D Minimal Validation Case");
     await expect(walkthrough).toContainText("Testing separation between preservation, intervention viability, and formal bind admissibility");
     await expect(walkthrough).toContainText("formal admissibility");
+    await expect(walkthrough).toContainText("Irreversibility Horizon v0");
+    await expect(walkthrough).toContainText("Marking the last meaningful intervention point before operational irreversibility stabilizes");
+    await expect(walkthrough).toContainText("first structural degradation signal");
+    await expect(walkthrough).toContainText("last meaningful intervention");
+    await expect(walkthrough).toContainText("irreversibility horizon");
+    await expect(walkthrough).toContainText("bind after horizon");
     await expect(walkthrough).toContainText("Dynamic Conditions Validation v0");
     await expect(walkthrough).toContainText("Testing separation stability under reinforcement, exposure asymmetry, time pressure, and adaptive behavior");
     await expect(walkthrough).toContainText("intervention window compression");


### PR DESCRIPTION
### Motivation
- Add a minimal, additive marker layer to the existing Dynamic Conditions Validation v0 so reviewers can see representative temporal points that indicate when structurally meaningful governability degradation appears before operational irreversibility stabilizes. 
- Keep the change small and non‑intrusive: no new APIs, no state family changes, no scoring or enforcement, and preserve existing demos and validation cases.

### Description
- Add new TypeScript interfaces and an optional field `irreversibility_horizon?: IrreversibilityHorizon` under `DynamicConditionsValidationCase` and wire a concrete `buildIrreversibilityHorizonV0()` payload into `buildDynamicConditionsValidationCase()` so the marker is exposed at `trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon`; changed files include `frontend/components/dashboard-types.ts` and `frontend/app/api/veritas/v1/report/governance/route.ts`.
- Render a compact subsection titled `Irreversibility Horizon v0` in Mission Control showing the six minimal labels and concise summary without redesigning the page; UI changes are in `frontend/components/mission-page.tsx` and tests updated accordingly in `frontend/components/mission-page.test.tsx`.
- Update API assertions and demo payload tests to expect the new structure in `frontend/app/api/veritas/v1/report/governance/route.test.ts` and extend the E2E assertions in `frontend/e2e/mission-control-governance-feed.spec.ts`.
- Document the feature and limitations in English and Japanese under `docs/en/demos/pre_boundary_collapse_demo.md` and `docs/ja/demos/pre_boundary_collapse_demo.md` clarifying this is a deterministic representative marker and not a production irreversibility engine.

### Testing
- Run `pnpm -C frontend test -- app/api/veritas/v1/report/governance/route.test.ts components/mission-page.test.tsx app/mission-control-ingress.test.ts` and full Vitest suite, which completed successfully (frontend tests: 89 files / 883 tests passed). 
- Run TypeScript check with `pnpm -C frontend exec tsc --noEmit`, which succeeded with no type errors. 
- Attempted Playwright E2E `pnpm -C frontend exec playwright test e2e/mission-control-governance-feed.spec.ts --project=chromium`, but the Chromium browser binary was not available in the environment so E2E runs failed locally with a Playwright executable error (installable via `pnpm exec playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aef5d36108326ab7a87ff01ada033)