### PR TITLE
Add Actor Recognition Gap v0 for intervention capacity visibility

### DIFF
--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -256,3 +256,42 @@ vocabulary unchanged. It does not make a production governability claim. Its
 purpose is to make the temporal relationship visible: a trajectory can remain
 formally admissible and inspectable at bind while meaningful intervention
 capacity has already become operationally hard to recover upstream.
+
+## Actor Recognition Gap v0
+
+Actor Recognition Gap v0 is the next compact marker layer after
+Irreversibility Horizon v0. Irreversibility Horizon v0 marks when structural
+intervention capacity becomes operationally hard to recover; Actor Recognition
+Gap v0 asks when the visibility of remaining intervention capacity begins
+degrading before actors fully recognize the loss.
+
+This layer does not infer actor psychology, predict actor beliefs, score actor
+awareness, or introduce automatic enforcement. It is an additive deterministic
+representative validation pattern under
+`trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon.actor_recognition_gap`.
+It marks a representative visibility gap between structural degradation and
+actor recognition of reduced intervention capacity, without changing OpenAPI,
+bind admissibility, state family, or pre-bind vocabulary.
+
+The marker distinguishes these representative points:
+
+- **actual degradation visible** — Phase 2, where reinforcement and exposure
+  asymmetry first make structural degradation visible.
+- **actor still perceives governable** — Phase 2, where the system may still
+  appear formally open and procedurally coherent to the actor.
+- **visibility degradation** — Phase 3, where time pressure compresses the
+  intervention window and the visibility of remaining intervention capacity
+  begins degrading.
+- **recognition gap** — Phase 3, where a representative lag emerges between
+  structural degradation and actor recognition of reduced intervention capacity.
+- **recognition alignment** — Phase 4, where actors may begin recognizing the
+  narrowed trajectory after adaptive behavior has made meaningful divergence
+  operationally hard to recover.
+- **bind after recognition gap** — Phase 5, where bind evaluates a formally
+  admissible trajectory after the representative recognition gap has already
+  occurred upstream.
+
+The purpose is visibility, not formal assurance, prediction, or a production
+governability claim. A system may remain formally open, procedurally admissible,
+and apparently governable while meaningful divergence capacity has already
+become progressively nonviable upstream.

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -107,3 +107,37 @@ gate ではありません。
 production governability claim も行いません。目的は、bind 時点で formal admissibility と
 inspectability が残っていても、その上流で meaningful intervention capacity の回復が
 operationally hard になっている可能性を、代表パターンとして可視化することです。
+
+## Actor Recognition Gap v0
+
+Actor Recognition Gap v0 は、Irreversibility Horizon v0 の次に置く小さな marker
+layer です。Irreversibility Horizon v0 が structural intervention capacity の回復が
+operationally hard になる地点を示すのに対し、Actor Recognition Gap v0 は「remaining
+intervention capacity の visibility が、当事者がその損失を十分に認識する前に、いつ劣化し始めたか」
+を問います。
+
+この layer は actor psychology を推定しません。actor の belief を予測せず、awareness を scoring
+せず、自動 enforcement も追加しません。
+`trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon.actor_recognition_gap`
+に追加される additive な deterministic representative validation pattern です。OpenAPI、bind
+admissibility、state family、pre-bind vocabulary は変更せず、structural degradation と reduced
+intervention capacity に対する actor recognition の間に生じ得る representative visibility gap を示します。
+
+この marker は、次の代表点を区別します。
+
+- **actual degradation visible** — Phase 2。reinforcement と exposure asymmetry により
+  structural degradation が最初に見え始める段階。
+- **actor still perceives governable** — Phase 2。system が actor にはまだ formally open かつ
+  procedurally coherent に見え得る段階。
+- **visibility degradation** — Phase 3。time pressure が intervention window を圧縮し、remaining
+  intervention capacity の visibility が劣化し始める段階。
+- **recognition gap** — Phase 3。structural degradation と reduced intervention capacity に対する
+  actor recognition の間に代表的な lag が生じる段階。
+- **recognition alignment** — Phase 4。adaptive behavior により narrowed trajectory が安定化し、
+  meaningful divergence の回復が operationally hard になった後で、actor がようやく認識し始め得る段階。
+- **bind after recognition gap** — Phase 5。representative recognition gap が上流ですでに発生した後、
+  formally admissible な trajectory を bind が評価する段階。
+
+目的は visibility であり、formal assurance、prediction、production governability claim ではありません。
+system は formally open、procedurally admissible、apparently governable に見え続ける一方で、meaningful
+divergence capacity は上流ですでに progressively nonviable になっている可能性があります。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -344,6 +344,20 @@ describe("/api/veritas/v1/report/governance", () => {
       },
     });
 
+    expect(payload.governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon.actor_recognition_gap).toMatchObject({
+      version: "v0",
+      base_case: "irreversibility_horizon_v0",
+      recognition_model: "deterministic_representative_marker",
+      markers: {
+        actual_degradation_visible_phase: "phase_2_reinforcement_exposure_asymmetry",
+        actor_still_perceives_governable_phase: "phase_2_reinforcement_exposure_asymmetry",
+        visibility_degradation_phase: "phase_3_time_pressure_compression",
+        recognition_gap_phase: "phase_3_time_pressure_compression",
+        recognition_alignment_phase: "phase_4_adaptive_narrowing",
+        bind_after_recognition_gap_phase: "phase_5_bind_over_dynamically_narrowed_space",
+      },
+    });
+
   });
 
   it("returns pre-boundary collapse demo scenario payload from header seam", async () => {

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -3,7 +3,13 @@ import path from "node:path";
 
 import { NextResponse } from "next/server";
 
-import { type AbcdMinimalValidationCase, type DynamicConditionsValidationCase, type IrreversibilityHorizon, type TrajectoryShapingLineage } from "../../../../../../components/dashboard-types";
+import {
+  type AbcdMinimalValidationCase,
+  type ActorRecognitionGap,
+  type DynamicConditionsValidationCase,
+  type IrreversibilityHorizon,
+  type TrajectoryShapingLineage,
+} from "../../../../../../components/dashboard-types";
 import { resolveApiBaseUrl } from "../../../[...path]/route-config";
 import { buildAmlKycReviewerWalkthroughPayload } from "../../../../../../lib/aml-kyc-reviewer-walkthrough";
 import { areE2EScenariosEnabled } from "../../../../../e2e-scenarios";
@@ -186,6 +192,66 @@ function buildAbcdMinimalValidationCase(): AbcdMinimalValidationCase {
   };
 }
 
+function buildActorRecognitionGapV0(): ActorRecognitionGap {
+  return {
+    version: "v0",
+    purpose:
+      "Mark the representative gap between structurally visible degradation and actor recognition of intervention capacity loss.",
+    base_case: "irreversibility_horizon_v0",
+    recognition_model: "deterministic_representative_marker",
+    markers: {
+      actual_degradation_visible_phase: "phase_2_reinforcement_exposure_asymmetry",
+      actor_still_perceives_governable_phase: "phase_2_reinforcement_exposure_asymmetry",
+      visibility_degradation_phase: "phase_3_time_pressure_compression",
+      recognition_gap_phase: "phase_3_time_pressure_compression",
+      recognition_alignment_phase: "phase_4_adaptive_narrowing",
+      bind_after_recognition_gap_phase: "phase_5_bind_over_dynamically_narrowed_space",
+    },
+    phase_interpretation: {
+      actual_degradation_visible: {
+        phase_id: "phase_2_reinforcement_exposure_asymmetry",
+        meaning: "Structural degradation first becomes visible through reinforcement and exposure asymmetry.",
+        actor_visibility_status: "may_appear_governable",
+      },
+      actor_still_perceives_governable: {
+        phase_id: "phase_2_reinforcement_exposure_asymmetry",
+        meaning: "The system may still appear formally open and procedurally coherent to the actor.",
+        actor_visibility_status: "governable_apparent",
+      },
+      visibility_degradation: {
+        phase_id: "phase_3_time_pressure_compression",
+        meaning:
+          "The visibility of remaining intervention capacity begins degrading as time pressure compresses the intervention window.",
+        actor_visibility_status: "intervention_visibility_degrading",
+      },
+      recognition_gap: {
+        phase_id: "phase_3_time_pressure_compression",
+        meaning:
+          "A representative gap emerges between structural degradation and actor recognition of reduced intervention capacity.",
+        actor_visibility_status: "recognition_lag",
+      },
+      recognition_alignment: {
+        phase_id: "phase_4_adaptive_narrowing",
+        meaning:
+          "The actor may begin recognizing the narrowed trajectory as adaptive behavior stabilizes it, but meaningful divergence is already operationally hard to recover.",
+        actor_visibility_status: "late_alignment",
+      },
+      bind_after_recognition_gap: {
+        phase_id: "phase_5_bind_over_dynamically_narrowed_space",
+        meaning: "Bind evaluates a formally admissible trajectory after the recognition gap has already occurred upstream.",
+        actor_visibility_status: "post_gap_bind",
+      },
+    },
+    validation_question:
+      "When did the visibility of remaining intervention capacity begin degrading before actors fully recognized the loss?",
+    summary: {
+      concise:
+        "Actor Recognition Gap v0 marks the representative gap between structurally visible governability degradation and actor recognition of reduced intervention capacity.",
+      operator: "The system should show when intervention capacity visibility began degrading before the actor fully recognized the loss.",
+    },
+  };
+}
+
 function buildIrreversibilityHorizonV0(): IrreversibilityHorizon {
   return {
     version: "v0",
@@ -238,6 +304,7 @@ function buildIrreversibilityHorizonV0(): IrreversibilityHorizon {
       operator:
         "The system should show the last meaningful intervention phase before adaptive narrowing stabilizes the trajectory.",
     },
+    actor_recognition_gap: buildActorRecognitionGapV0(),
   };
 }
 

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -143,6 +143,44 @@ export interface DynamicConditionsValidationPhase {
   bind_outcome?: string;
 }
 
+export interface ActorRecognitionGapMarkers {
+  actual_degradation_visible_phase: string;
+  actor_still_perceives_governable_phase: string;
+  visibility_degradation_phase: string;
+  recognition_gap_phase: string;
+  recognition_alignment_phase: string;
+  bind_after_recognition_gap_phase: string;
+}
+
+export interface ActorRecognitionGapPhaseInterpretationPoint {
+  phase_id: string;
+  meaning: string;
+  actor_visibility_status: string;
+}
+
+export interface ActorRecognitionGapPhaseInterpretation {
+  actual_degradation_visible: ActorRecognitionGapPhaseInterpretationPoint;
+  actor_still_perceives_governable: ActorRecognitionGapPhaseInterpretationPoint;
+  visibility_degradation: ActorRecognitionGapPhaseInterpretationPoint;
+  recognition_gap: ActorRecognitionGapPhaseInterpretationPoint;
+  recognition_alignment: ActorRecognitionGapPhaseInterpretationPoint;
+  bind_after_recognition_gap: ActorRecognitionGapPhaseInterpretationPoint;
+}
+
+export interface ActorRecognitionGap {
+  version: string;
+  purpose: string;
+  base_case: string;
+  recognition_model: string;
+  markers: ActorRecognitionGapMarkers;
+  phase_interpretation: ActorRecognitionGapPhaseInterpretation;
+  validation_question: string;
+  summary: {
+    concise: string;
+    operator: string;
+  };
+}
+
 export interface IrreversibilityHorizonMarkers {
   first_structural_degradation_signal_phase: string;
   early_warning_phase: string;
@@ -177,6 +215,7 @@ export interface IrreversibilityHorizon {
     concise: string;
     operator: string;
   };
+  actor_recognition_gap?: ActorRecognitionGap;
 }
 
 export interface DynamicConditionsValidationCase {

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -339,6 +339,57 @@ describe("MissionPage", () => {
                     concise: "Irreversibility Horizon v0 marks the representative point where intervention remains formally possible but becomes operationally hard to recover before bind.",
                     operator: "The system should show the last meaningful intervention phase before adaptive narrowing stabilizes the trajectory.",
                   },
+                  actor_recognition_gap: {
+                    version: "v0",
+                    purpose: "Mark the representative gap between structurally visible degradation and actor recognition of intervention capacity loss.",
+                    base_case: "irreversibility_horizon_v0",
+                    recognition_model: "deterministic_representative_marker",
+                    markers: {
+                      actual_degradation_visible_phase: "phase_2_reinforcement_exposure_asymmetry",
+                      actor_still_perceives_governable_phase: "phase_2_reinforcement_exposure_asymmetry",
+                      visibility_degradation_phase: "phase_3_time_pressure_compression",
+                      recognition_gap_phase: "phase_3_time_pressure_compression",
+                      recognition_alignment_phase: "phase_4_adaptive_narrowing",
+                      bind_after_recognition_gap_phase: "phase_5_bind_over_dynamically_narrowed_space",
+                    },
+                    phase_interpretation: {
+                      actual_degradation_visible: {
+                        phase_id: "phase_2_reinforcement_exposure_asymmetry",
+                        meaning: "Structural degradation first becomes visible through reinforcement and exposure asymmetry.",
+                        actor_visibility_status: "may_appear_governable",
+                      },
+                      actor_still_perceives_governable: {
+                        phase_id: "phase_2_reinforcement_exposure_asymmetry",
+                        meaning: "The system may still appear formally open and procedurally coherent to the actor.",
+                        actor_visibility_status: "governable_apparent",
+                      },
+                      visibility_degradation: {
+                        phase_id: "phase_3_time_pressure_compression",
+                        meaning: "The visibility of remaining intervention capacity begins degrading as time pressure compresses the intervention window.",
+                        actor_visibility_status: "intervention_visibility_degrading",
+                      },
+                      recognition_gap: {
+                        phase_id: "phase_3_time_pressure_compression",
+                        meaning: "A representative gap emerges between structural degradation and actor recognition of reduced intervention capacity.",
+                        actor_visibility_status: "recognition_lag",
+                      },
+                      recognition_alignment: {
+                        phase_id: "phase_4_adaptive_narrowing",
+                        meaning: "The actor may begin recognizing the narrowed trajectory as adaptive behavior stabilizes it, but meaningful divergence is already operationally hard to recover.",
+                        actor_visibility_status: "late_alignment",
+                      },
+                      bind_after_recognition_gap: {
+                        phase_id: "phase_5_bind_over_dynamically_narrowed_space",
+                        meaning: "Bind evaluates a formally admissible trajectory after the recognition gap has already occurred upstream.",
+                        actor_visibility_status: "post_gap_bind",
+                      },
+                    },
+                    validation_question: "When did the visibility of remaining intervention capacity begin degrading before actors fully recognized the loss?",
+                    summary: {
+                      concise: "Actor Recognition Gap v0 marks the representative gap between structurally visible governability degradation and actor recognition of reduced intervention capacity.",
+                      operator: "The system should show when intervention capacity visibility began degrading before the actor fully recognized the loss.",
+                    },
+                  },
                 },
               },
             },
@@ -381,6 +432,14 @@ describe("MissionPage", () => {
     expect(screen.getByText(/last meaningful intervention:/)).toBeInTheDocument();
     expect(screen.getByText(/irreversibility horizon:/)).toBeInTheDocument();
     expect(screen.getByText(/bind after horizon:/)).toBeInTheDocument();
+    expect(screen.getByText("Actor Recognition Gap v0")).toBeInTheDocument();
+    expect(screen.getByText("Marking the gap between structural degradation and actor recognition of intervention capacity loss")).toBeInTheDocument();
+    expect(screen.getByText(/actual degradation visible:/)).toBeInTheDocument();
+    expect(screen.getByText(/actor still perceives governable:/)).toBeInTheDocument();
+    expect(screen.getByText(/intervention visibility degradation:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/recognition gap:/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/recognition alignment:/)).toBeInTheDocument();
+    expect(screen.getByText(/bind after recognition gap:/)).toBeInTheDocument();
   });
 
   it.each(["/governance", "/governance/receipts/br_123", "/audit?receipt=br_123"])("renders safe relevant_ui_href as link: %s", (href) => {

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -256,6 +256,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
   const abcdMinimalValidationCase = governanceSnapshot?.trajectory_shaping_lineage?.abcd_minimal_validation_case;
   const dynamicConditionsValidationCase = governanceSnapshot?.trajectory_shaping_lineage?.dynamic_conditions_validation_case;
   const irreversibilityHorizon = dynamicConditionsValidationCase?.irreversibility_horizon;
+  const actorRecognitionGap = irreversibilityHorizon?.actor_recognition_gap;
   const hasAmlKycReviewerWalkthrough = governanceSnapshot?.demo_scenario === "aml_kyc_reviewer_walkthrough";
 
   const governanceObservation = governanceSnapshot?.governance_observation;
@@ -466,6 +467,24 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
                         <li>bind after horizon: <span className="font-mono">{stringifyValue(irreversibilityHorizon.markers.bind_after_horizon_phase)}</span></li>
                         <li>summary: <span className="text-muted-foreground">{stringifyValue(irreversibilityHorizon.summary.concise)}</span></li>
                       </ul>
+                      {actorRecognitionGap ? (
+                        <div
+                          aria-label="Actor Recognition Gap v0"
+                          className="mt-3 rounded-md border border-border/60 bg-muted/10 p-3"
+                        >
+                          <p className="font-semibold">Actor Recognition Gap v0</p>
+                          <p className="text-muted-foreground">Marking the gap between structural degradation and actor recognition of intervention capacity loss</p>
+                          <ul className="mt-2 space-y-1">
+                            <li>actual degradation visible: <span className="font-mono">{stringifyValue(actorRecognitionGap.markers.actual_degradation_visible_phase)}</span></li>
+                            <li>actor still perceives governable: <span className="font-mono">{stringifyValue(actorRecognitionGap.markers.actor_still_perceives_governable_phase)}</span></li>
+                            <li>intervention visibility degradation: <span className="font-mono">{stringifyValue(actorRecognitionGap.markers.visibility_degradation_phase)}</span></li>
+                            <li>recognition gap: <span className="font-mono">{stringifyValue(actorRecognitionGap.markers.recognition_gap_phase)}</span></li>
+                            <li>recognition alignment: <span className="font-mono">{stringifyValue(actorRecognitionGap.markers.recognition_alignment_phase)}</span></li>
+                            <li>bind after recognition gap: <span className="font-mono">{stringifyValue(actorRecognitionGap.markers.bind_after_recognition_gap_phase)}</span></li>
+                            <li>summary: <span className="text-muted-foreground">{stringifyValue(actorRecognitionGap.summary.concise)}</span></li>
+                          </ul>
+                        </div>
+                      ) : null}
                     </div>
                   ) : null}
                 </div>

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -109,6 +109,19 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
           irreversibility_horizon_phase: "phase_4_adaptive_narrowing",
           bind_after_horizon_phase: "phase_5_bind_over_dynamically_narrowed_space",
         },
+        actor_recognition_gap: {
+          version: "v0",
+          base_case: "irreversibility_horizon_v0",
+          recognition_model: "deterministic_representative_marker",
+          markers: {
+            actual_degradation_visible_phase: "phase_2_reinforcement_exposure_asymmetry",
+            actor_still_perceives_governable_phase: "phase_2_reinforcement_exposure_asymmetry",
+            visibility_degradation_phase: "phase_3_time_pressure_compression",
+            recognition_gap_phase: "phase_3_time_pressure_compression",
+            recognition_alignment_phase: "phase_4_adaptive_narrowing",
+            bind_after_recognition_gap_phase: "phase_5_bind_over_dynamically_narrowed_space",
+          },
+        },
       },
     });
 
@@ -148,6 +161,13 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     await expect(walkthrough).toContainText("last meaningful intervention");
     await expect(walkthrough).toContainText("irreversibility horizon");
     await expect(walkthrough).toContainText("bind after horizon");
+    await expect(walkthrough).toContainText("Actor Recognition Gap v0");
+    await expect(walkthrough).toContainText("Marking the gap between structural degradation and actor recognition of intervention capacity loss");
+    await expect(walkthrough).toContainText("actual degradation visible");
+    await expect(walkthrough).toContainText("actor still perceives governable");
+    await expect(walkthrough).toContainText("recognition gap");
+    await expect(walkthrough).toContainText("recognition alignment");
+    await expect(walkthrough).toContainText("bind after recognition gap");
     await expect(walkthrough).toContainText("Dynamic Conditions Validation v0");
     await expect(walkthrough).toContainText("Testing separation stability under reinforcement, exposure asymmetry, time pressure, and adaptive behavior");
     await expect(walkthrough).toContainText("intervention window compression");


### PR DESCRIPTION
### Motivation
- Provide an additive, deterministic marker that visualizes a representative gap between structurally visible intervention-capacity degradation and the point when actors recognize that loss. 
- Keep the change small and non-invasive by layering the marker on top of the existing Irreversibility Horizon v0 and Dynamic Conditions Validation v0 without altering existing contracts, bind behavior, or runtime enforcement.

### Description
- Add `ActorRecognitionGap` types and markers to `frontend/components/dashboard-types.ts` and make `IrreversibilityHorizon.actor_recognition_gap?: ActorRecognitionGap` optional. 
- Add `buildActorRecognitionGapV0()` in `frontend/app/api/veritas/v1/report/governance/route.ts` and attach `actor_recognition_gap: buildActorRecognitionGapV0()` under the `irreversibility_horizon` fixture to preserve the existing demo payload shape. 
- Render a compact Mission Control subsection titled `Actor Recognition Gap v0` in `frontend/components/mission-page.tsx` that displays the six minimal labels and a concise summary. 
- Document the feature and its constraints in `docs/en/demos/pre_boundary_collapse_demo.md` and `docs/ja/demos/pre_boundary_collapse_demo.md`, and add API/component/E2E assertions in `frontend/app/api/veritas/v1/report/governance/route.test.ts`, `frontend/components/mission-page.test.tsx`, and `frontend/e2e/mission-control-governance-feed.spec.ts`.

### Testing
- Ran unit/component tests: `pnpm -C frontend test -- app/api/veritas/v1/report/governance/route.test.ts components/mission-page.test.tsx app/mission-control-ingress.test.ts` and the frontend test suite completed successfully (all targeted Vitest tests passed). 
- Attempted E2E: `pnpm -C frontend exec playwright test e2e/mission-control-governance-feed.spec.ts --project=chromium` but Playwright failed to launch because the Chromium browser binary was not available locally and `pnpm exec playwright install chromium` failed due to the Playwright CDN returning `403 Forbidden`, so E2E could not run in this environment. 
- All changes are additive and `actor_recognition_gap` is optional so existing payloads and UI remain backwards-compatible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b0fe7fb8883269eec6303ea849e61)