### PR TITLE
Add Governance Attack Surface Registry v0 and compact Mission Control subsection

### DIFF
--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -295,3 +295,55 @@ The purpose is visibility, not formal assurance, prediction, or a production
 governability claim. A system may remain formally open, procedurally admissible,
 and apparently governable while meaningful divergence capacity has already
 become progressively nonviable upstream.
+
+## Governance Attack Surface Registry v0
+
+Governance Attack Surface Registry v0 is the next compact visibility layer after
+Actor Recognition Gap v0. Actor Recognition Gap v0 shows that actors may still
+perceive a trajectory as governable after intervention capacity visibility has
+started to degrade. The registry asks the meta-governance question that follows:
+what structural safeguards prevent the governance process itself from becoming
+the attack surface?
+
+This layer does not claim complete security, certification, formal verification,
+production threat coverage, automatic attack detection, or automatic
+enforcement. It is an additive deterministic representative visibility registry
+under `governance_layer_snapshot.governance_attack_surface_registry`. It keeps
+the existing OpenAPI, bind contract, state family, pre-bind vocabulary,
+Trajectory Shaping Lineage v0, Irreversibility Horizon v0, and Actor Recognition
+Gap v0 behavior unchanged.
+
+The registry focuses on representative governance-process failure classes where
+governance evidence, approval, policy, escalation, or replay traces could be
+manipulated, spoofed, bypassed, or made self-authorizing. Its first critical
+emphasis is governance self-authorization / evidence-chain manipulation: the
+risk is not only that a risky decision occurs, but that the evidence or approval
+path can be shaped to make the decision look safe, admissible, or reviewed after
+the fact.
+
+Governance Attack Surface Registry v0 includes these representative failure
+classes:
+
+- **self_authorization** — governance or a governed component appears to
+authorize its own action without independent governance authority.
+- **evidence_chain_manipulation** — evidence used to justify a decision is
+altered, reordered, omitted, or replaced after the fact.
+- **approval_receipt_spoofing** — a human approval receipt or authorization proof
+appears valid without reliable provenance.
+- **policy_snapshot_drift** — bind-time policy cannot be reproduced because later
+policy state differs from the decision-time snapshot.
+- **escalation_suppression** — warning, pause, review, or escalation conditions
+are not preserved in the governance trace.
+- **replay_trace_tampering** — replayable audit traces are missing, reordered,
+overwritten, or no longer reproduce the observed governance sequence.
+- **recognition_gap_masking** — Actor Recognition Gap v0 / intervention capacity
+visibility markers are not preserved as governance evidence.
+
+It maps those failure classes to structural safeguards such as separation of
+decision and governance authority, immutable evidence chains, policy snapshot
+hashing, approval receipt provenance, replayable escalation traces, append-only
+governance logs, and recognition gap visibility markers. This preserves
+methodological restraint: the registry makes governance-process attack surfaces
+visible as representative classes and safeguard mappings; it does not turn those
+mappings into a scoring model, detection engine, blocking behavior, security
+guarantee, or certification claim.

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -141,3 +141,46 @@ intervention capacity に対する actor recognition の間に生じ得る repre
 目的は visibility であり、formal assurance、prediction、production governability claim ではありません。
 system は formally open、procedurally admissible、apparently governable に見え続ける一方で、meaningful
 divergence capacity は上流ですでに progressively nonviable になっている可能性があります。
+
+## Governance Attack Surface Registry v0
+
+Governance Attack Surface Registry v0 は、Actor Recognition Gap v0 の次に置く compact
+visibility layer です。Actor Recognition Gap v0 は、intervention capacity の visibility が
+劣化し始めた後でも、actor には trajectory がまだ governable に見え得ることを示しました。
+この registry は、その次の meta-governance の問い、つまり「governance process 自体が
+attack surface にならないために、どの structural safeguard が必要か」を扱います。
+
+この layer は complete security、certification、formal verification、production threat coverage、
+automatic attack detection、automatic enforcement を主張しません。
+`governance_layer_snapshot.governance_attack_surface_registry` に追加される additive な
+deterministic representative visibility registry です。OpenAPI、bind contract、state family、
+pre-bind vocabulary、Trajectory Shaping Lineage v0、Irreversibility Horizon v0、Actor Recognition
+Gap v0 の挙動は変更しません。
+
+registry の焦点は、governance evidence、approval、policy、escalation、replay trace が操作・偽装・
+bypass・self-authorizing 化され得る代表的な governance-process failure classes を見えるようにすることです。
+最初に重視する critical failure class は governance self-authorization / evidence-chain manipulation です。
+問題は危険な decision が起きることだけではなく、その decision が後から safe、admissible、reviewed に
+見えるよう evidence や approval path が shaping され得る点にあります。
+
+Governance Attack Surface Registry v0 は、次の representative failure classes を含みます。
+
+- **self_authorization** — governance または governed component が、independent governance authority
+なしに自身の action を承認したように見える failure。
+- **evidence_chain_manipulation** — decision を正当化する evidence が後から変更、並べ替え、欠落、
+差し替えされる failure。
+- **approval_receipt_spoofing** — human approval receipt / authorization proof が、reliable provenance
+なしに valid に見える failure。
+- **policy_snapshot_drift** — decision / bind 時点の policy snapshot が後から再現できなくなる failure。
+- **escalation_suppression** — warning、pause、review、escalation が必要な条件が governance trace に
+残らない failure。
+- **replay_trace_tampering** — replayable audit trace が欠落、順序変更、上書きされ、observed governance
+sequence を再現できなくなる failure。
+- **recognition_gap_masking** — Actor Recognition Gap v0 / intervention capacity visibility markers が
+governance evidence として残らない failure。
+
+各 failure class は、separation of decision and governance authority、immutable evidence chain、policy
+snapshot hashing、approval receipt provenance、replayable escalation trace、append-only governance log、
+recognition gap visibility marker などの structural safeguards に対応づけられます。これは methodological
+restraint を維持するための registry です。representative class と safeguard mapping を可視化しますが、
+scoring model、detection engine、blocking behavior、security guarantee、certification claim にはしません。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -231,6 +231,13 @@ describe("/api/veritas/v1/report/governance", () => {
         intervention_viability: string;
         bind_outcome: string;
         phase_snapshots: Array<Record<string, unknown>>;
+        governance_attack_surface_registry: {
+          version: string;
+          registry_model: string;
+          failure_classes: Array<{ id: string }>;
+          structural_safeguards: Array<{ id: string }>;
+          validation_question: string;
+        };
         trajectory_shaping_lineage: {
           scenario_id: string;
           version: string;
@@ -357,6 +364,34 @@ describe("/api/veritas/v1/report/governance", () => {
         bind_after_recognition_gap_phase: "phase_5_bind_over_dynamically_narrowed_space",
       },
     });
+
+    expect(payload.governance_layer_snapshot.governance_attack_surface_registry).toMatchObject({
+      version: "v0",
+      registry_model: "deterministic_representative_visibility_registry",
+      validation_question: "What structural safeguards prevent the governance process itself from becoming the attack surface?",
+    });
+    expect(payload.governance_layer_snapshot.governance_attack_surface_registry.failure_classes.map(({ id }) => id)).toEqual(
+      expect.arrayContaining([
+        "self_authorization",
+        "evidence_chain_manipulation",
+        "approval_receipt_spoofing",
+        "policy_snapshot_drift",
+        "escalation_suppression",
+        "replay_trace_tampering",
+        "recognition_gap_masking",
+      ]),
+    );
+    expect(payload.governance_layer_snapshot.governance_attack_surface_registry.structural_safeguards.map(({ id }) => id)).toEqual(
+      expect.arrayContaining([
+        "separation_of_decision_and_governance_authority",
+        "immutable_evidence_chain",
+        "policy_snapshot_hashing",
+        "approval_receipt_provenance",
+        "replayable_escalation_trace",
+        "append_only_governance_log",
+        "recognition_gap_visibility_marker",
+      ]),
+    );
 
   });
 

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -7,6 +7,7 @@ import {
   type AbcdMinimalValidationCase,
   type ActorRecognitionGap,
   type DynamicConditionsValidationCase,
+  type GovernanceAttackSurfaceRegistry,
   type IrreversibilityHorizon,
   type TrajectoryShapingLineage,
 } from "../../../../../../components/dashboard-types";
@@ -409,6 +410,157 @@ function buildDynamicConditionsValidationCase(): DynamicConditionsValidationCase
   };
 }
 
+function buildGovernanceAttackSurfaceRegistryV0(): GovernanceAttackSurfaceRegistry {
+  return {
+    version: "v0",
+    purpose:
+      "Identify representative failure classes where the governance process itself can become an attack surface and map them to structural safeguards.",
+    registry_model: "deterministic_representative_visibility_registry",
+    scope: {
+      included: [
+        "governance_self_authorization",
+        "evidence_integrity",
+        "approval_provenance",
+        "policy_snapshot_replayability",
+        "escalation_trace_visibility",
+        "actor_recognition_gap_visibility",
+      ],
+      excluded: [
+        "complete_security_proof",
+        "production_threat_model",
+        "automatic_attack_detection",
+        "certification_claim",
+        "formal_verification_claim",
+      ],
+    },
+    failure_classes: [
+      {
+        id: "self_authorization",
+        label: "Self-authorization",
+        description:
+          "The governance process or governed component appears to authorize its own action without independent governance authority.",
+        representative_risk: "A decision-producing component may make its own action appear admissible.",
+        safeguard_refs: [
+          "separation_of_decision_and_governance_authority",
+          "append_only_governance_log",
+        ],
+      },
+      {
+        id: "evidence_chain_manipulation",
+        label: "Evidence-chain manipulation",
+        description: "Evidence used to justify a decision is altered, reordered, omitted, or replaced after the fact.",
+        representative_risk: "The decision path may look safer or more justified than it was at bind time.",
+        safeguard_refs: ["immutable_evidence_chain", "append_only_governance_log"],
+      },
+      {
+        id: "approval_receipt_spoofing",
+        label: "Approval receipt spoofing",
+        description: "A human approval receipt or authorization proof appears valid without reliable provenance.",
+        representative_risk: "A bind path may appear human-approved even when the approval scope or source is invalid.",
+        safeguard_refs: [
+          "approval_receipt_provenance",
+          "separation_of_decision_and_governance_authority",
+        ],
+      },
+      {
+        id: "policy_snapshot_drift",
+        label: "Policy snapshot drift",
+        description:
+          "The policy used at decision time cannot be reproduced because later policy state differs from the bind-time snapshot.",
+        representative_risk: "A later review may evaluate the decision against the wrong policy version.",
+        safeguard_refs: ["policy_snapshot_hashing", "immutable_evidence_chain"],
+      },
+      {
+        id: "escalation_suppression",
+        label: "Escalation suppression",
+        description: "A condition requiring warning, pause, review, or escalation is not preserved in the governance trace.",
+        representative_risk:
+          "The governance process may appear orderly while suppressing evidence that intervention was needed.",
+        safeguard_refs: ["replayable_escalation_trace", "append_only_governance_log"],
+      },
+      {
+        id: "replay_trace_tampering",
+        label: "Replay trace tampering",
+        description:
+          "Replayable audit traces are missing, reordered, overwritten, or no longer reproduce the observed governance sequence.",
+        representative_risk: "Reviewers cannot reliably reconstruct the sequence that led to bind.",
+        safeguard_refs: [
+          "immutable_evidence_chain",
+          "replayable_escalation_trace",
+          "append_only_governance_log",
+        ],
+      },
+      {
+        id: "recognition_gap_masking",
+        label: "Recognition gap masking",
+        description:
+          "The visibility gap between structural degradation and actor recognition is not preserved as governance evidence.",
+        representative_risk:
+          "The system may look governable even while meaningful intervention capacity was already becoming nonviable upstream.",
+        safeguard_refs: [
+          "recognition_gap_visibility_marker",
+          "replayable_escalation_trace",
+        ],
+      },
+    ],
+    structural_safeguards: [
+      {
+        id: "separation_of_decision_and_governance_authority",
+        label: "Separation of decision and governance authority",
+        description:
+          "Decision-producing components should not be able to independently validate their own authority or admissibility.",
+        visibility_role:
+          "Shows whether governance authority is structurally independent from the governed decision path.",
+      },
+      {
+        id: "immutable_evidence_chain",
+        label: "Immutable evidence chain",
+        description: "Evidence should be preserved as an ordered, append-only chain that cannot be silently rewritten.",
+        visibility_role: "Shows whether bind-time evidence can be replayed without relying on mutable post-hoc state.",
+      },
+      {
+        id: "policy_snapshot_hashing",
+        label: "Policy snapshot hashing",
+        description: "Policy state used at decision or bind time should be versioned and hashable.",
+        visibility_role: "Shows whether the exact policy context can be reconstructed later.",
+      },
+      {
+        id: "approval_receipt_provenance",
+        label: "Approval receipt provenance",
+        description: "Approval receipts should preserve actor, source, timestamp, scope, and validity context.",
+        visibility_role:
+          "Shows whether human approval evidence can be distinguished from spoofed or out-of-scope approval.",
+      },
+      {
+        id: "replayable_escalation_trace",
+        label: "Replayable escalation trace",
+        description: "Warnings, pauses, reviews, and escalations should be preserved in replayable order.",
+        visibility_role: "Shows whether intervention opportunities and escalation decisions remain inspectable.",
+      },
+      {
+        id: "append_only_governance_log",
+        label: "Append-only governance log",
+        description: "Governance validation, exceptions, and marker outputs should be appended rather than overwritten.",
+        visibility_role: "Shows whether governance outcomes can be audited without hidden mutation.",
+      },
+      {
+        id: "recognition_gap_visibility_marker",
+        label: "Recognition gap visibility marker",
+        description: "Actor Recognition Gap v0 markers should remain visible as part of the governance evidence record.",
+        visibility_role:
+          "Shows whether perceived governability and structural degradation can be compared over time.",
+      },
+    ],
+    validation_question: "What structural safeguards prevent the governance process itself from becoming the attack surface?",
+    summary: {
+      concise:
+        "Governance Attack Surface Registry v0 identifies representative failure classes where governance evidence, approval, policy, escalation, or replay traces could be manipulated or made self-authorizing.",
+      operator:
+        "The system should show which structural safeguard makes each governance attack surface visible without claiming complete security or certification.",
+    },
+  };
+}
+
 function buildTrajectoryShapingLineageV0(): TrajectoryShapingLineage {
   return {
     scenario_id: PRE_BOUNDARY_COLLAPSE_SCENARIO,
@@ -522,6 +674,7 @@ async function resolveDemoScenarioPayload(request: Request): Promise<Record<stri
       concise_rationale: finalPhaseSnapshot.concise_rationale,
       phase_snapshots: phaseSnapshots,
       trajectory_shaping_lineage: buildTrajectoryShapingLineageV0(),
+      governance_attack_surface_registry: buildGovernanceAttackSurfaceRegistryV0(),
     },
   };
 }

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -266,6 +266,41 @@ export interface TrajectoryShapingLineage {
   dynamic_conditions_validation_case?: DynamicConditionsValidationCase;
 }
 
+
+export interface GovernanceAttackSurfaceScope {
+  included: string[];
+  excluded: string[];
+}
+
+export interface GovernanceAttackSurfaceFailureClass {
+  id: string;
+  label: string;
+  description: string;
+  representative_risk: string;
+  safeguard_refs: string[];
+}
+
+export interface GovernanceAttackSurfaceSafeguard {
+  id: string;
+  label: string;
+  description: string;
+  visibility_role: string;
+}
+
+export interface GovernanceAttackSurfaceRegistry {
+  version: string;
+  purpose: string;
+  registry_model: string;
+  scope: GovernanceAttackSurfaceScope;
+  failure_classes: GovernanceAttackSurfaceFailureClass[];
+  structural_safeguards: GovernanceAttackSurfaceSafeguard[];
+  validation_question: string;
+  summary: {
+    concise: string;
+    operator: string;
+  };
+}
+
 export interface PreBindGovernanceSnapshot {
   demo_scenario?: string;
   source_state?: string | null;
@@ -284,6 +319,7 @@ export interface PreBindGovernanceSnapshot {
   reviewer_expected_steps?: Array<string | Record<string, unknown>> | null;
   phase_snapshots?: Array<Record<string, unknown>>;
   trajectory_shaping_lineage?: TrajectoryShapingLineage;
+  governance_attack_surface_registry?: GovernanceAttackSurfaceRegistry;
   participation_state?: string;
   preservation_state?: string;
   intervention_viability?: string;

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -393,6 +393,115 @@ describe("MissionPage", () => {
                 },
               },
             },
+            governance_attack_surface_registry: {
+              version: "v0",
+              purpose: "Identify representative governance attack surfaces and map them to structural safeguards.",
+              registry_model: "deterministic_representative_visibility_registry",
+              scope: {
+                included: ["governance_self_authorization"],
+                excluded: ["complete_security_proof"],
+              },
+              failure_classes: [
+                {
+                  id: "self_authorization",
+                  label: "Self-authorization",
+                  description: "The governed component appears to authorize itself.",
+                  representative_risk: "A component may make its own action appear admissible.",
+                  safeguard_refs: ["separation_of_decision_and_governance_authority"],
+                },
+                {
+                  id: "evidence_chain_manipulation",
+                  label: "Evidence-chain manipulation",
+                  description: "Evidence is altered after the fact.",
+                  representative_risk: "The decision path may look safer than it was at bind time.",
+                  safeguard_refs: ["immutable_evidence_chain"],
+                },
+                {
+                  id: "approval_receipt_spoofing",
+                  label: "Approval receipt spoofing",
+                  description: "Approval proof appears valid without provenance.",
+                  representative_risk: "A bind path may appear human-approved without valid scope.",
+                  safeguard_refs: ["approval_receipt_provenance"],
+                },
+                {
+                  id: "policy_snapshot_drift",
+                  label: "Policy snapshot drift",
+                  description: "Bind-time policy cannot be reproduced later.",
+                  representative_risk: "Review may use the wrong policy version.",
+                  safeguard_refs: ["policy_snapshot_hashing"],
+                },
+                {
+                  id: "escalation_suppression",
+                  label: "Escalation suppression",
+                  description: "Required escalation is not preserved.",
+                  representative_risk: "Intervention evidence may be suppressed.",
+                  safeguard_refs: ["replayable_escalation_trace"],
+                },
+                {
+                  id: "replay_trace_tampering",
+                  label: "Replay trace tampering",
+                  description: "Replayable audit traces are missing or reordered.",
+                  representative_risk: "Reviewers cannot reconstruct the sequence to bind.",
+                  safeguard_refs: ["append_only_governance_log"],
+                },
+                {
+                  id: "recognition_gap_masking",
+                  label: "Recognition gap masking",
+                  description: "Actor recognition gap visibility is not preserved.",
+                  representative_risk: "The system may look governable after intervention capacity degraded.",
+                  safeguard_refs: ["recognition_gap_visibility_marker"],
+                },
+              ],
+              structural_safeguards: [
+                {
+                  id: "separation_of_decision_and_governance_authority",
+                  label: "Separation of decision and governance authority",
+                  description: "Decision producers should not validate their own authority.",
+                  visibility_role: "Shows independent governance authority.",
+                },
+                {
+                  id: "immutable_evidence_chain",
+                  label: "Immutable evidence chain",
+                  description: "Evidence should remain ordered and append-only.",
+                  visibility_role: "Shows bind-time replayability.",
+                },
+                {
+                  id: "policy_snapshot_hashing",
+                  label: "Policy snapshot hashing",
+                  description: "Policy state should be versioned and hashable.",
+                  visibility_role: "Shows exact policy reconstruction.",
+                },
+                {
+                  id: "approval_receipt_provenance",
+                  label: "Approval receipt provenance",
+                  description: "Approval receipts should preserve actor, source, timestamp, and scope.",
+                  visibility_role: "Shows whether approval evidence is in scope.",
+                },
+                {
+                  id: "replayable_escalation_trace",
+                  label: "Replayable escalation trace",
+                  description: "Escalations should remain replayable.",
+                  visibility_role: "Shows intervention opportunities.",
+                },
+                {
+                  id: "append_only_governance_log",
+                  label: "Append-only governance log",
+                  description: "Governance outcomes should be appended rather than overwritten.",
+                  visibility_role: "Shows governance auditability.",
+                },
+                {
+                  id: "recognition_gap_visibility_marker",
+                  label: "Recognition gap visibility marker",
+                  description: "Actor Recognition Gap v0 markers should remain visible.",
+                  visibility_role: "Shows perceived governability against structural degradation.",
+                },
+              ],
+              validation_question: "What structural safeguards prevent the governance process itself from becoming the attack surface?",
+              summary: {
+                concise: "Governance Attack Surface Registry v0 identifies representative governance-process attack surfaces.",
+                operator: "Show safeguards without enforcement claims.",
+              },
+            },
           }}
         />
       </I18nProvider>,
@@ -440,6 +549,18 @@ describe("MissionPage", () => {
     expect(screen.getAllByText(/recognition gap:/).length).toBeGreaterThan(0);
     expect(screen.getByText(/recognition alignment:/)).toBeInTheDocument();
     expect(screen.getByText(/bind after recognition gap:/)).toBeInTheDocument();
+    expect(screen.getByText("Governance Attack Surface Registry v0")).toBeInTheDocument();
+    expect(screen.getByText("Making representative governance-process attack surfaces and structural safeguards visible")).toBeInTheDocument();
+    expect(screen.getByText("self-authorization")).toBeInTheDocument();
+    expect(screen.getByText("evidence-chain manipulation")).toBeInTheDocument();
+    expect(screen.getByText("approval receipt spoofing")).toBeInTheDocument();
+    expect(screen.getByText("policy snapshot drift")).toBeInTheDocument();
+    expect(screen.getByText("escalation suppression")).toBeInTheDocument();
+    expect(screen.getByText("replay trace tampering")).toBeInTheDocument();
+    expect(screen.getByText("recognition gap masking")).toBeInTheDocument();
+    expect(screen.getByText("separation of decision and governance authority")).toBeInTheDocument();
+    expect(screen.getByText("immutable evidence chain")).toBeInTheDocument();
+    expect(screen.getByText("append-only governance log")).toBeInTheDocument();
   });
 
   it.each(["/governance", "/governance/receipts/br_123", "/audit?receipt=br_123"])("renders safe relevant_ui_href as link: %s", (href) => {

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -257,6 +257,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
   const dynamicConditionsValidationCase = governanceSnapshot?.trajectory_shaping_lineage?.dynamic_conditions_validation_case;
   const irreversibilityHorizon = dynamicConditionsValidationCase?.irreversibility_horizon;
   const actorRecognitionGap = irreversibilityHorizon?.actor_recognition_gap;
+  const governanceAttackSurfaceRegistry = governanceSnapshot?.governance_attack_surface_registry;
   const hasAmlKycReviewerWalkthrough = governanceSnapshot?.demo_scenario === "aml_kyc_reviewer_walkthrough";
 
   const governanceObservation = governanceSnapshot?.governance_observation;
@@ -429,6 +430,35 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
                     <li>formal admissibility: <span className="font-mono">{stringifyValue(abcdMinimalValidationCase.separation_points.formal_admissibility_phase)}</span></li>
                     <li>summary: <span className="text-muted-foreground">{stringifyValue(abcdMinimalValidationCase.summary.concise)}</span></li>
                   </ul>
+                </div>
+              ) : null}
+              {governanceAttackSurfaceRegistry ? (
+                <div
+                  aria-label="Governance Attack Surface Registry v0"
+                  className="mt-3 rounded-md border border-border/60 bg-muted/10 p-3"
+                >
+                  <p className="font-semibold">Governance Attack Surface Registry v0</p>
+                  <p className="text-muted-foreground">Making representative governance-process attack surfaces and structural safeguards visible</p>
+                  <p className="mt-2 text-muted-foreground">{governanceAttackSurfaceRegistry.validation_question}</p>
+                  <div className="mt-2 grid gap-3 md:grid-cols-2">
+                    <div>
+                      <p className="font-semibold">Failure classes</p>
+                      <ul className="mt-1 space-y-1">
+                        {governanceAttackSurfaceRegistry.failure_classes.map((failureClass) => (
+                          <li key={failureClass.id}>{failureClass.label.toLowerCase()}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <p className="font-semibold">Structural safeguards</p>
+                      <ul className="mt-1 space-y-1">
+                        {governanceAttackSurfaceRegistry.structural_safeguards.map((safeguard) => (
+                          <li key={safeguard.id}>{safeguard.label.toLowerCase()}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                  <p className="mt-2 text-muted-foreground">summary: {governanceAttackSurfaceRegistry.summary.concise}</p>
                 </div>
               ) : null}
               {dynamicConditionsValidationCase ? (

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -125,6 +125,11 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
       },
     });
 
+    expect(payload.governance_layer_snapshot.governance_attack_surface_registry).toMatchObject({
+      version: "v0",
+      registry_model: "deterministic_representative_visibility_registry",
+    });
+
     await page.goto("/?demo_scenario=pre_boundary_collapse");
 
     await expect(
@@ -173,6 +178,13 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     await expect(walkthrough).toContainText("intervention window compression");
     await expect(walkthrough).toContainText("adaptive narrowing");
     await expect(walkthrough).toContainText("formal admissibility");
+
+    await expect(walkthrough).toContainText("Governance Attack Surface Registry v0");
+    await expect(walkthrough).toContainText("Making representative governance-process attack surfaces and structural safeguards visible");
+    await expect(walkthrough).toContainText("self-authorization");
+    await expect(walkthrough).toContainText("evidence-chain manipulation");
+    await expect(walkthrough).toContainText("approval receipt spoofing");
+    await expect(walkthrough).toContainText("append-only governance log");
 
     const timeline = page.locator('section[aria-label="governance layer timeline"]');
     await expect(timeline).toBeVisible();


### PR DESCRIPTION
### Motivation
- Make visible representative failure classes where the governance process itself can become an attack surface and map them to structural safeguards without claiming production security or adding enforcement/score models.
- Implement a minimal, additive registry for the Pre-Boundary Collapse demo so existing trajectory-shaping, irreversibility, and recognition-gap artifacts remain unchanged.

### Description
- Add optional TypeScript interfaces and an optional `governance_attack_surface_registry?: GovernanceAttackSurfaceRegistry` field to the pre-bind snapshot by updating `frontend/components/dashboard-types.ts` and the demo payload builder; the registry is implemented as `version: "v0"` with a deterministic representative visibility model.
- Provide a concrete `buildGovernanceAttackSurfaceRegistryV0()` in `frontend/app/api/veritas/v1/report/governance/route.ts` and include `governance_layer_snapshot.governance_attack_surface_registry` in the `pre_boundary_collapse` demo payload.
- Render a compact subsection in Mission Control at the trajectory-shaping area that shows the validation question, failure classes, structural safeguards, and concise summary by updating `frontend/components/mission-page.tsx`.
- Add explanatory documentation in English and Japanese (`docs/en/demos/pre_boundary_collapse_demo.md`, `docs/ja/demos/pre_boundary_collapse_demo.md`) and extend unit, component, and E2E assertions to verify the registry presence (`frontend/app/api/veritas/v1/report/governance/route.test.ts`, `frontend/components/mission-page.test.tsx`, `frontend/e2e/mission-control-governance-feed.spec.ts`).

### Testing
- Ran the targeted frontend unit/component/API test suite with `pnpm -C frontend test -- app/api/veritas/v1/report/governance/route.test.ts components/mission-page.test.tsx app/mission-control-ingress.test.ts` and TypeScript typecheck with `pnpm -C frontend typecheck`, and the test run and typecheck succeeded (unit/component/API tests passed and typecheck returned no errors).
- Full local Vitest run reported all tests passing (summary: 883 tests passed in the environment where unit/component tests were executed).
- Playwright E2E was attempted with `pnpm -C frontend exec playwright test e2e/mission-control-governance-feed.spec.ts --project=chromium` but failed to launch Chromium in this environment because Playwright browsers are not installed; the E2E assertions were added and should pass once `pnpm exec playwright install` (or CI-provided browsers) are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b84e9c2a48326afb50d893efe522e)