### PR TITLE
Add Governance Safeguard Coverage Matrix v0 for governance attack surface visibility

### DIFF
--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -347,3 +347,41 @@ methodological restraint: the registry makes governance-process attack surfaces
 visible as representative classes and safeguard mappings; it does not turn those
 mappings into a scoring model, detection engine, blocking behavior, security
 guarantee, or certification claim.
+
+## Governance Safeguard Coverage Matrix v0
+
+Governance Safeguard Coverage Matrix v0 is the compact follow-on layer after
+Governance Attack Surface Registry v0. The registry identifies representative
+failure classes where the governance process itself can become an attack surface
+and lists structural safeguards that make those surfaces inspectable. The
+coverage matrix makes that relationship easier to review by mapping each
+failure class to a primary safeguard, supporting safeguards, and the visibility
+evidence required to inspect the coverage.
+
+The matrix asks: **Which structural safeguard covers which governance attack
+surface, and what evidence makes that coverage visible?** It is exposed
+additively under
+`governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix`
+so existing Trajectory Shaping Lineage v0, Dynamic Conditions Validation v0,
+Irreversibility Horizon v0, Actor Recognition Gap v0, and Governance Attack
+Surface Registry v0 consumers can continue to read their existing fields.
+
+The v0 matrix uses a deterministic representative visibility model. Each row
+keeps the relationship explicit:
+
+- `failure_class_id` — the representative governance attack surface from the
+  registry.
+- `primary_safeguard_id` — the main structural safeguard that makes the surface
+  visible.
+- `supporting_safeguard_ids` — additional safeguards that support review.
+- `evidence_requirement` — the evidence marker reviewers need in order to
+  inspect the coverage.
+- `visibility_question` — the review question the row is designed to answer.
+- `coverage_state` — `representative_visibility_only` for v0 rows.
+- `limitation` — an explicit non-claim attached to the row.
+
+This preserves methodological restraint. The matrix does **not** claim complete
+prevention, production security, scoring, automatic attack detection,
+automatic enforcement, formal verification, or certification. It makes the
+registry more inspectable without turning the registry into an enforcement
+engine.

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -184,3 +184,36 @@ snapshot hashing、approval receipt provenance、replayable escalation trace、a
 recognition gap visibility marker などの structural safeguards に対応づけられます。これは methodological
 restraint を維持するための registry です。representative class と safeguard mapping を可視化しますが、
 scoring model、detection engine、blocking behavior、security guarantee、certification claim にはしません。
+
+## Governance Safeguard Coverage Matrix v0
+
+Governance Safeguard Coverage Matrix v0 は、Governance Attack Surface Registry
+v0 の次に置く compact な follow-on layer です。Registry は、governance process
+自体が attack surface になり得る representative failure classes と、それを可視化する
+structural safeguards を識別します。Coverage Matrix は、その関係をさらに読みやすくし、
+各 failure class を primary safeguard、supporting safeguards、そして coverage を点検するための
+visibility evidence に対応付けます。
+
+この matrix が問うのは、**どの structural safeguard がどの governance attack surface を
+cover し、その coverage をどの evidence が visible にするのか**です。既存 contract を壊さない
+additive field として、
+`governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix`
+に配置されます。そのため、Trajectory Shaping Lineage v0、Dynamic Conditions Validation v0、
+Irreversibility Horizon v0、Actor Recognition Gap v0、Governance Attack Surface Registry v0
+の既存 consumer は、従来の field をそのまま参照できます。
+
+v0 matrix は deterministic representative visibility model として扱います。各 row は次の関係を
+明示します。
+
+- `failure_class_id` — registry にある representative governance attack surface。
+- `primary_safeguard_id` — その surface を可視化する主たる structural safeguard。
+- `supporting_safeguard_ids` — review を補助する safeguard。
+- `evidence_requirement` — coverage を点検するために reviewer が必要とする evidence marker。
+- `visibility_question` — その row が答える review question。
+- `coverage_state` — v0 では `representative_visibility_only`。
+- `limitation` — row ごとに明示される non-claim。
+
+これは methodological restraint を保つための visibility matrix です。complete prevention、
+production security、scoring、automatic attack detection、automatic enforcement、formal verification、
+certification は主張しません。Registry をより inspectable にする一方で、enforcement engine には
+変えません。

--- a/frontend/app/api/veritas/v1/report/governance/route.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.test.ts
@@ -393,6 +393,36 @@ describe("/api/veritas/v1/report/governance", () => {
       ]),
     );
 
+    const coverageMatrix = payload.governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix;
+    expect(coverageMatrix).toMatchObject({
+      version: "v0",
+      coverage_model: "deterministic_representative_visibility_matrix",
+      validation_question:
+        "Which structural safeguard covers which governance attack surface, and what evidence makes that coverage visible?",
+    });
+    expect(coverageMatrix.rows.length).toBeGreaterThanOrEqual(7);
+    expect(coverageMatrix.rows.map(({ failure_class_id }) => failure_class_id)).toEqual(
+      expect.arrayContaining([
+        "self_authorization",
+        "evidence_chain_manipulation",
+        "approval_receipt_spoofing",
+        "policy_snapshot_drift",
+        "escalation_suppression",
+        "replay_trace_tampering",
+        "recognition_gap_masking",
+      ]),
+    );
+    expect(coverageMatrix.rows.find(({ failure_class_id }) => failure_class_id === "self_authorization")).toMatchObject({
+      primary_safeguard_id: "separation_of_decision_and_governance_authority",
+      evidence_requirement: "independent_governance_authority_marker",
+      coverage_state: "representative_visibility_only",
+    });
+    expect(coverageMatrix.rows.find(({ failure_class_id }) => failure_class_id === "recognition_gap_masking")).toMatchObject({
+      primary_safeguard_id: "recognition_gap_visibility_marker",
+      evidence_requirement: "actor_recognition_gap_marker_sequence",
+      limitation: "does_not_infer_actor_psychology_or_intent",
+    });
+
   });
 
   it("returns pre-boundary collapse demo scenario payload from header seam", async () => {

--- a/frontend/app/api/veritas/v1/report/governance/route.ts
+++ b/frontend/app/api/veritas/v1/report/governance/route.ts
@@ -8,6 +8,7 @@ import {
   type ActorRecognitionGap,
   type DynamicConditionsValidationCase,
   type GovernanceAttackSurfaceRegistry,
+  type GovernanceSafeguardCoverageMatrix,
   type IrreversibilityHorizon,
   type TrajectoryShapingLineage,
 } from "../../../../../../components/dashboard-types";
@@ -410,6 +411,109 @@ function buildDynamicConditionsValidationCase(): DynamicConditionsValidationCase
   };
 }
 
+
+function buildGovernanceSafeguardCoverageMatrixV0(): GovernanceSafeguardCoverageMatrix {
+  return {
+    version: "v0",
+    purpose:
+      "Map representative governance attack surfaces to structural safeguards and the evidence required to make coverage visible.",
+    coverage_model: "deterministic_representative_visibility_matrix",
+    scope: {
+      included: [
+        "failure_class_to_safeguard_mapping",
+        "visibility_evidence_requirements",
+        "representative_coverage_state",
+        "coverage_limitations",
+      ],
+      excluded: [
+        "complete_prevention_claim",
+        "production_security_guarantee",
+        "automatic_attack_detection",
+        "scoring_model",
+        "certification_claim",
+        "formal_verification_claim",
+      ],
+    },
+    rows: [
+      {
+        failure_class_id: "self_authorization",
+        primary_safeguard_id: "separation_of_decision_and_governance_authority",
+        supporting_safeguard_ids: ["append_only_governance_log"],
+        evidence_requirement: "independent_governance_authority_marker",
+        visibility_question:
+          "Can reviewers see whether the decision-producing component was structurally separate from the governance-validating component?",
+        coverage_state: "representative_visibility_only",
+        limitation: "does_not_claim_complete_prevention_or_runtime_enforcement",
+      },
+      {
+        failure_class_id: "evidence_chain_manipulation",
+        primary_safeguard_id: "immutable_evidence_chain",
+        supporting_safeguard_ids: ["append_only_governance_log"],
+        evidence_requirement: "ordered_append_only_evidence_chain",
+        visibility_question: "Can reviewers replay the evidence sequence without relying on mutable post-hoc state?",
+        coverage_state: "representative_visibility_only",
+        limitation: "does_not_claim_tamper_proof_storage_or_formal_verification",
+      },
+      {
+        failure_class_id: "approval_receipt_spoofing",
+        primary_safeguard_id: "approval_receipt_provenance",
+        supporting_safeguard_ids: ["separation_of_decision_and_governance_authority"],
+        evidence_requirement: "actor_source_timestamp_scope_validity_context",
+        visibility_question: "Can reviewers distinguish valid approval provenance from spoofed or out-of-scope approval?",
+        coverage_state: "representative_visibility_only",
+        limitation: "does_not_claim_identity_proof_or_production_authentication",
+      },
+      {
+        failure_class_id: "policy_snapshot_drift",
+        primary_safeguard_id: "policy_snapshot_hashing",
+        supporting_safeguard_ids: ["immutable_evidence_chain"],
+        evidence_requirement: "bind_time_policy_hash_and_version",
+        visibility_question:
+          "Can reviewers reconstruct the policy state used at bind time rather than a later policy version?",
+        coverage_state: "representative_visibility_only",
+        limitation: "does_not_claim_policy_correctness_or_regulatory_certification",
+      },
+      {
+        failure_class_id: "escalation_suppression",
+        primary_safeguard_id: "replayable_escalation_trace",
+        supporting_safeguard_ids: ["append_only_governance_log"],
+        evidence_requirement: "warning_pause_review_escalation_sequence",
+        visibility_question: "Can reviewers see whether warning, pause, review, or escalation opportunities were preserved?",
+        coverage_state: "representative_visibility_only",
+        limitation: "does_not_claim_automatic_escalation_or_blocking",
+      },
+      {
+        failure_class_id: "replay_trace_tampering",
+        primary_safeguard_id: "append_only_governance_log",
+        supporting_safeguard_ids: ["immutable_evidence_chain", "replayable_escalation_trace"],
+        evidence_requirement: "append_only_replayable_governance_sequence",
+        visibility_question:
+          "Can reviewers reconstruct the governance sequence without hidden mutation or ordering ambiguity?",
+        coverage_state: "representative_visibility_only",
+        limitation: "does_not_claim_tamper_proof_infrastructure",
+      },
+      {
+        failure_class_id: "recognition_gap_masking",
+        primary_safeguard_id: "recognition_gap_visibility_marker",
+        supporting_safeguard_ids: ["replayable_escalation_trace"],
+        evidence_requirement: "actor_recognition_gap_marker_sequence",
+        visibility_question:
+          "Can reviewers compare perceived governability with structurally visible degradation over time?",
+        coverage_state: "representative_visibility_only",
+        limitation: "does_not_infer_actor_psychology_or_intent",
+      },
+    ],
+    validation_question:
+      "Which structural safeguard covers which governance attack surface, and what evidence makes that coverage visible?",
+    summary: {
+      concise:
+        "Governance Safeguard Coverage Matrix v0 maps each representative governance attack surface to structural safeguards and the evidence required to inspect coverage.",
+      operator:
+        "The system should show which safeguard makes each failure class visible without claiming complete prevention, certification, or production security.",
+    },
+  };
+}
+
 function buildGovernanceAttackSurfaceRegistryV0(): GovernanceAttackSurfaceRegistry {
   return {
     version: "v0",
@@ -551,6 +655,7 @@ function buildGovernanceAttackSurfaceRegistryV0(): GovernanceAttackSurfaceRegist
           "Shows whether perceived governability and structural degradation can be compared over time.",
       },
     ],
+    safeguard_coverage_matrix: buildGovernanceSafeguardCoverageMatrixV0(),
     validation_question: "What structural safeguards prevent the governance process itself from becoming the attack surface?",
     summary: {
       concise:

--- a/frontend/components/dashboard-types.ts
+++ b/frontend/components/dashboard-types.ts
@@ -287,6 +287,34 @@ export interface GovernanceAttackSurfaceSafeguard {
   visibility_role: string;
 }
 
+export interface GovernanceSafeguardCoverageScope {
+  included: string[];
+  excluded: string[];
+}
+
+export interface GovernanceSafeguardCoverageRow {
+  failure_class_id: string;
+  primary_safeguard_id: string;
+  supporting_safeguard_ids: string[];
+  evidence_requirement: string;
+  visibility_question: string;
+  coverage_state: string;
+  limitation: string;
+}
+
+export interface GovernanceSafeguardCoverageMatrix {
+  version: string;
+  purpose: string;
+  coverage_model: string;
+  scope: GovernanceSafeguardCoverageScope;
+  rows: GovernanceSafeguardCoverageRow[];
+  validation_question: string;
+  summary: {
+    concise: string;
+    operator: string;
+  };
+}
+
 export interface GovernanceAttackSurfaceRegistry {
   version: string;
   purpose: string;
@@ -294,6 +322,7 @@ export interface GovernanceAttackSurfaceRegistry {
   scope: GovernanceAttackSurfaceScope;
   failure_classes: GovernanceAttackSurfaceFailureClass[];
   structural_safeguards: GovernanceAttackSurfaceSafeguard[];
+  safeguard_coverage_matrix?: GovernanceSafeguardCoverageMatrix;
   validation_question: string;
   summary: {
     concise: string;

--- a/frontend/components/mission-page.test.tsx
+++ b/frontend/components/mission-page.test.tsx
@@ -496,6 +496,67 @@ describe("MissionPage", () => {
                   visibility_role: "Shows perceived governability against structural degradation.",
                 },
               ],
+              safeguard_coverage_matrix: {
+                version: "v0",
+                purpose: "Map representative governance attack surfaces to structural safeguards and the evidence required to make coverage visible.",
+                coverage_model: "deterministic_representative_visibility_matrix",
+                scope: {
+                  included: ["failure_class_to_safeguard_mapping"],
+                  excluded: ["complete_prevention_claim"],
+                },
+                rows: [
+                  {
+                    failure_class_id: "self_authorization",
+                    primary_safeguard_id: "separation_of_decision_and_governance_authority",
+                    supporting_safeguard_ids: ["append_only_governance_log"],
+                    evidence_requirement: "independent_governance_authority_marker",
+                    visibility_question: "Can reviewers see whether authority is separate?",
+                    coverage_state: "representative_visibility_only",
+                    limitation: "does_not_claim_complete_prevention_or_runtime_enforcement",
+                  },
+                  {
+                    failure_class_id: "evidence_chain_manipulation",
+                    primary_safeguard_id: "immutable_evidence_chain",
+                    supporting_safeguard_ids: ["append_only_governance_log"],
+                    evidence_requirement: "ordered_append_only_evidence_chain",
+                    visibility_question: "Can reviewers replay evidence?",
+                    coverage_state: "representative_visibility_only",
+                    limitation: "does_not_claim_tamper_proof_storage_or_formal_verification",
+                  },
+                  {
+                    failure_class_id: "approval_receipt_spoofing",
+                    primary_safeguard_id: "approval_receipt_provenance",
+                    supporting_safeguard_ids: ["separation_of_decision_and_governance_authority"],
+                    evidence_requirement: "actor_source_timestamp_scope_validity_context",
+                    visibility_question: "Can reviewers distinguish approval provenance?",
+                    coverage_state: "representative_visibility_only",
+                    limitation: "does_not_claim_identity_proof_or_production_authentication",
+                  },
+                  {
+                    failure_class_id: "policy_snapshot_drift",
+                    primary_safeguard_id: "policy_snapshot_hashing",
+                    supporting_safeguard_ids: ["immutable_evidence_chain"],
+                    evidence_requirement: "bind_time_policy_hash_and_version",
+                    visibility_question: "Can reviewers reconstruct bind-time policy?",
+                    coverage_state: "representative_visibility_only",
+                    limitation: "does_not_claim_policy_correctness_or_regulatory_certification",
+                  },
+                  {
+                    failure_class_id: "recognition_gap_masking",
+                    primary_safeguard_id: "recognition_gap_visibility_marker",
+                    supporting_safeguard_ids: ["replayable_escalation_trace"],
+                    evidence_requirement: "actor_recognition_gap_marker_sequence",
+                    visibility_question: "Can reviewers compare perceived governability with degradation?",
+                    coverage_state: "representative_visibility_only",
+                    limitation: "does_not_infer_actor_psychology_or_intent",
+                  },
+                ],
+                validation_question: "Which structural safeguard covers which governance attack surface, and what evidence makes that coverage visible?",
+                summary: {
+                  concise: "Governance Safeguard Coverage Matrix v0 maps each representative governance attack surface to structural safeguards and the evidence required to inspect coverage.",
+                  operator: "Show coverage visibility without prevention claims.",
+                },
+              },
               validation_question: "What structural safeguards prevent the governance process itself from becoming the attack surface?",
               summary: {
                 concise: "Governance Attack Surface Registry v0 identifies representative governance-process attack surfaces.",
@@ -551,16 +612,29 @@ describe("MissionPage", () => {
     expect(screen.getByText(/bind after recognition gap:/)).toBeInTheDocument();
     expect(screen.getByText("Governance Attack Surface Registry v0")).toBeInTheDocument();
     expect(screen.getByText("Making representative governance-process attack surfaces and structural safeguards visible")).toBeInTheDocument();
-    expect(screen.getByText("self-authorization")).toBeInTheDocument();
-    expect(screen.getByText("evidence-chain manipulation")).toBeInTheDocument();
-    expect(screen.getByText("approval receipt spoofing")).toBeInTheDocument();
-    expect(screen.getByText("policy snapshot drift")).toBeInTheDocument();
+    expect(screen.getAllByText("self-authorization").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("evidence-chain manipulation").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("approval receipt spoofing").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("policy snapshot drift").length).toBeGreaterThan(0);
     expect(screen.getByText("escalation suppression")).toBeInTheDocument();
     expect(screen.getByText("replay trace tampering")).toBeInTheDocument();
-    expect(screen.getByText("recognition gap masking")).toBeInTheDocument();
-    expect(screen.getByText("separation of decision and governance authority")).toBeInTheDocument();
-    expect(screen.getByText("immutable evidence chain")).toBeInTheDocument();
+    expect(screen.getAllByText("recognition gap masking").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("separation of decision and governance authority").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("immutable evidence chain").length).toBeGreaterThan(0);
     expect(screen.getByText("append-only governance log")).toBeInTheDocument();
+    expect(screen.getByText("Governance Safeguard Coverage Matrix v0")).toBeInTheDocument();
+    expect(screen.getByText("Mapping governance attack surfaces to structural safeguards and visibility evidence")).toBeInTheDocument();
+    expect(screen.getAllByText("self-authorization").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("separation of decision and governance authority").length).toBeGreaterThan(0);
+    expect(screen.getByText("independent governance authority marker")).toBeInTheDocument();
+    expect(screen.getAllByText("evidence-chain manipulation").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("immutable evidence chain").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("approval receipt spoofing").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("approval receipt provenance").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("policy snapshot drift").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("policy snapshot hashing").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("recognition gap masking").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("recognition gap visibility marker").length).toBeGreaterThan(0);
   });
 
   it.each(["/governance", "/governance/receipts/br_123", "/audit?receipt=br_123"])("renders safe relevant_ui_href as link: %s", (href) => {

--- a/frontend/components/mission-page.tsx
+++ b/frontend/components/mission-page.tsx
@@ -194,6 +194,30 @@ const HEALTH_SECURITY_POSTURE = {
   directFujiApi: "disabled",
 };
 
+const GOVERNANCE_COVERAGE_DISPLAY_LABELS: Readonly<Record<string, string>> = {
+  self_authorization: "self-authorization",
+  evidence_chain_manipulation: "evidence-chain manipulation",
+  approval_receipt_spoofing: "approval receipt spoofing",
+  policy_snapshot_drift: "policy snapshot drift",
+  escalation_suppression: "escalation suppression",
+  replay_trace_tampering: "replay trace tampering",
+  recognition_gap_masking: "recognition gap masking",
+  separation_of_decision_and_governance_authority: "separation of decision and governance authority",
+  immutable_evidence_chain: "immutable evidence chain",
+  approval_receipt_provenance: "approval receipt provenance",
+  policy_snapshot_hashing: "policy snapshot hashing",
+  replayable_escalation_trace: "replayable escalation trace",
+  append_only_governance_log: "append-only governance log",
+  recognition_gap_visibility_marker: "recognition gap visibility marker",
+  independent_governance_authority_marker: "independent governance authority marker",
+  ordered_append_only_evidence_chain: "ordered append-only evidence chain",
+  actor_source_timestamp_scope_validity_context: "actor / source / timestamp / scope / validity context",
+  bind_time_policy_hash_and_version: "bind-time policy hash and version",
+  warning_pause_review_escalation_sequence: "warning / pause / review / escalation sequence",
+  append_only_replayable_governance_sequence: "append-only replayable governance sequence",
+  actor_recognition_gap_marker_sequence: "actor recognition gap marker sequence",
+};
+
 /**
  * MissionPage renders the operational command-center view.
  *
@@ -217,6 +241,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
       return String(value);
     }
   };
+  const formatCoverageToken = (value: string): string => GOVERNANCE_COVERAGE_DISPLAY_LABELS[value] ?? value.replaceAll("_", " ");
   const resolvePreBindSourceTone = (source?: string): string => {
     if (source === "trustlog_matching_decision" || source === "trustlog_matching_request" || source === "trustlog_matching_execution_intent") {
       return "matched";
@@ -258,6 +283,7 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
   const irreversibilityHorizon = dynamicConditionsValidationCase?.irreversibility_horizon;
   const actorRecognitionGap = irreversibilityHorizon?.actor_recognition_gap;
   const governanceAttackSurfaceRegistry = governanceSnapshot?.governance_attack_surface_registry;
+  const safeguardCoverageMatrix = governanceAttackSurfaceRegistry?.safeguard_coverage_matrix;
   const hasAmlKycReviewerWalkthrough = governanceSnapshot?.demo_scenario === "aml_kyc_reviewer_walkthrough";
 
   const governanceObservation = governanceSnapshot?.governance_observation;
@@ -459,6 +485,28 @@ export function MissionPage({ title, subtitle, chips, governanceLayerSnapshot }:
                     </div>
                   </div>
                   <p className="mt-2 text-muted-foreground">summary: {governanceAttackSurfaceRegistry.summary.concise}</p>
+                  {safeguardCoverageMatrix ? (
+                    <div
+                      aria-label="Governance Safeguard Coverage Matrix v0"
+                      className="mt-3 rounded-md border border-border/60 bg-background/60 p-3"
+                    >
+                      <p className="font-semibold">Governance Safeguard Coverage Matrix v0</p>
+                      <p className="text-muted-foreground">Mapping governance attack surfaces to structural safeguards and visibility evidence</p>
+                      <p className="mt-2 text-muted-foreground">{safeguardCoverageMatrix.validation_question}</p>
+                      <ul className="mt-2 space-y-1">
+                        {safeguardCoverageMatrix.rows.map((row) => (
+                          <li key={row.failure_class_id}>
+                            <span>{formatCoverageToken(row.failure_class_id)}</span>
+                            <span className="text-muted-foreground"> → </span>
+                            <span>{formatCoverageToken(row.primary_safeguard_id)}</span>
+                            <span className="text-muted-foreground"> → </span>
+                            <span>{formatCoverageToken(row.evidence_requirement)}</span>
+                          </li>
+                        ))}
+                      </ul>
+                      <p className="mt-2 text-muted-foreground">summary: {safeguardCoverageMatrix.summary.concise}</p>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
               {dynamicConditionsValidationCase ? (

--- a/frontend/e2e/mission-control-governance-feed.spec.ts
+++ b/frontend/e2e/mission-control-governance-feed.spec.ts
@@ -130,6 +130,18 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
       registry_model: "deterministic_representative_visibility_registry",
     });
 
+    expect(payload.governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix).toMatchObject({
+      version: "v0",
+      coverage_model: "deterministic_representative_visibility_matrix",
+      validation_question:
+        "Which structural safeguard covers which governance attack surface, and what evidence makes that coverage visible?",
+    });
+    expect(
+      payload.governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix.rows.map(
+        ({ failure_class_id }: { failure_class_id: string }) => failure_class_id,
+      ),
+    ).toEqual(expect.arrayContaining(["self_authorization", "recognition_gap_masking"]));
+
     await page.goto("/?demo_scenario=pre_boundary_collapse");
 
     await expect(
@@ -185,6 +197,14 @@ test.describe("Mission Control: governance feed frontend E2E", () => {
     await expect(walkthrough).toContainText("evidence-chain manipulation");
     await expect(walkthrough).toContainText("approval receipt spoofing");
     await expect(walkthrough).toContainText("append-only governance log");
+    await expect(walkthrough).toContainText("Governance Safeguard Coverage Matrix v0");
+    await expect(walkthrough).toContainText("Mapping governance attack surfaces to structural safeguards and visibility evidence");
+    await expect(walkthrough).toContainText("self-authorization");
+    await expect(walkthrough).toContainText("independent governance authority marker");
+    await expect(walkthrough).toContainText("evidence-chain manipulation");
+    await expect(walkthrough).toContainText("immutable evidence chain");
+    await expect(walkthrough).toContainText("recognition gap masking");
+    await expect(walkthrough).toContainText("recognition gap visibility marker");
 
     const timeline = page.locator('section[aria-label="governance layer timeline"]');
     await expect(timeline).toBeVisible();


### PR DESCRIPTION
### Motivation
- Provide an additive, inspectable mapping from representative governance failure classes to the structural safeguards that make those failures visible and the evidence required to inspect that coverage.
- Keep the change small, additive, and non-invasive so existing registry, trajectory-shaping, irreversibility, and recognition-gap consumers keep working without contract changes.

### Description
- Add new TypeScript interfaces `GovernanceSafeguardCoverageMatrix`, `GovernanceSafeguardCoverageScope`, and `GovernanceSafeguardCoverageRow` and an optional `safeguard_coverage_matrix?: GovernanceSafeguardCoverageMatrix` field on `GovernanceAttackSurfaceRegistry` in `frontend/components/dashboard-types.ts`.
- Add `buildGovernanceSafeguardCoverageMatrixV0()` and attach its output to the existing governance fixture under `governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix` in `frontend/app/api/veritas/v1/report/governance/route.ts` implementing the required rows (seven failure classes) and explicit non-claims.
- Render a compact Mission Control subsection `Governance Safeguard Coverage Matrix v0` in `frontend/components/mission-page.tsx` that displays the validation question and compact rows as `failure class → primary safeguard → evidence requirement` without redesigning the page.
- Update tests and fixtures: extend API route test, MissionPage component test, and E2E expectations to assert presence and shape of the matrix, and add English/Japanese docs under `docs/en/demos/pre_boundary_collapse_demo.md` and `docs/ja/demos/pre_boundary_collapse_demo.md` describing purpose and limitations.

### Testing
- Ran unit/component API tests: `pnpm -C frontend test -- app/api/veritas/v1/report/governance/route.test.ts components/mission-page.test.tsx app/mission-control-ingress.test.ts` and related frontend test suites; all updated assertions passed (Vitest run completed, component/API tests green).
- Updated `frontend/app/api/veritas/v1/report/governance/route.test.ts` to assert `safeguard_coverage_matrix` presence and row contents and those assertions passed.
- Updated `frontend/components/mission-page.test.tsx` to assert the compact UI subsection and sample rows and those assertions passed.
- Attempted Playwright E2E: `pnpm -C frontend exec playwright test e2e/mission-control-governance-feed.spec.ts --project=chromium` but Playwright could not launch Chromium in this environment because the browser executable was not installed, so E2E runs were blocked locally (Playwright browser install required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba95e74688326821ccf1d001ab8a8)