### PR TITLE
governance: add Governance Evidence Packet contract v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,11 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
   - Intervention Actionability Map v0 now has a schema and golden fixture contract. The contract keeps marker-to-intervention guidance deterministic, inspectable, and explicitly non-enforcement.
   - Intervention Actionability Map schema: `docs/en/demo/schemas/intervention-actionability-map-v0.schema.json`
   - Intervention Actionability Map fixture: `docs/en/demo/fixtures/intervention-actionability-map-v0.json`
+  - Governance Evidence Packet v0 now has a reviewer-ready contract that keeps the deterministic representative reviewer packet structurally stable and explicitly limited to non-certifying review guidance.
+  - Governance Evidence Packet schema: `docs/en/demo/schemas/governance-evidence-packet-v0.schema.json`
+  - Governance Evidence Packet fixture: `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
+  - Governance Evidence Packet contract test: `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
+  - Non-claims: not certification; not production security guarantee; not automatic enforcement; not scoring model; not legal conclusion.
 - **Mini proof: covered `/v1/decide` pre-bind formation refusal**: [`docs/en/validation/pre-bind-formation-refusal-mini-proof.md`](docs/en/validation/pre-bind-formation-refusal-mini-proof.md)
 - **Regulated Action Governance Kernel**: [`docs/en/architecture/regulated-action-governance-kernel.md`](docs/en/architecture/regulated-action-governance-kernel.md)
 - **Authority Evidence vs Audit Log**: [`docs/en/architecture/authority-evidence-vs-audit-log.md`](docs/en/architecture/authority-evidence-vs-audit-log.md)

--- a/README_JP.md
+++ b/README_JP.md
@@ -250,6 +250,11 @@ VERITAS は、本番の enforce と開発時の observe を区別します。本
 - Intervention Actionability Map v0 には schema と golden fixture contract が追加されています。これにより、marker から intervention guidance への対応が deterministic / inspectable に保たれ、automatic enforcement ではないことも明確化されます。
   - Intervention Actionability Map schema: `docs/en/demo/schemas/intervention-actionability-map-v0.schema.json`
   - Intervention Actionability Map fixture: `docs/en/demo/fixtures/intervention-actionability-map-v0.json`
+- Governance Evidence Packet v0 には reviewer-ready contract が追加されています。deterministic representative reviewer packet の構造を安定させ、review guidance が certification ではないことを明示します。
+  - Governance Evidence Packet schema: `docs/en/demo/schemas/governance-evidence-packet-v0.schema.json`
+  - Governance Evidence Packet fixture: `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
+  - Governance Evidence Packet contract test: `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
+  - Non-claims: not certification; not production security guarantee; not automatic enforcement; not scoring model; not legal conclusion.
 
 ## 何を解決するか
 

--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -20,6 +20,12 @@ Key local/offline reviewer-facing artifacts:
   - JSON Schema contract for Intervention Actionability Map v0
 - `docs/en/demo/fixtures/intervention-actionability-map-v0.json`
   - golden fixture for Intervention Actionability Map v0
+- `docs/en/demo/schemas/governance-evidence-packet-v0.schema.json`
+  - JSON Schema contract for Governance Evidence Packet v0
+- `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
+  - golden fixture for Governance Evidence Packet v0
+- `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
+  - contract test that validates the API packet against the schema, fixture, required sections, reviewer questions, preserved evidence refs, and non-claims
 - `docs/en/demo/reviewer-evidence-packet.md`
   - Reviewer Evidence Packet documentation
 - `docs/en/demo/reviewer-evidence-packet-validation-report.md`

--- a/docs/en/demo/fixtures/governance-evidence-packet-v0.json
+++ b/docs/en/demo/fixtures/governance-evidence-packet-v0.json
@@ -1,0 +1,146 @@
+{
+  "version": "v0",
+  "packet_id": "pre_boundary_collapse_governance_evidence_packet_v0",
+  "packet_model": "deterministic_representative_reviewer_packet",
+  "purpose": "Summarize the governance trace, evidence refs, safeguards, and representative intervention categories for reviewer inspection.",
+  "generated_from": {
+    "scenario_id": "pre_boundary_collapse",
+    "source_payload": "governance_layer_snapshot"
+  },
+  "decision_context_summary": {
+    "bind_outcome": "FORMALLY_VALID_STRUCTURALLY_COLLAPSED",
+    "participation_signal": "decision_shaping",
+    "preservation_state": "collapsed",
+    "intervention_viability": "lost",
+    "decision_space_state": "structurally_narrowed_before_bind",
+    "summary": "The bind outcome remains formally valid while governance evidence indicates decision-space narrowing and intervention viability loss occurred upstream."
+  },
+  "packet_sections": [
+    {
+      "id": "trajectory_summary",
+      "source_layer": "trajectory_shaping_lineage_v0",
+      "title": "Trajectory shaping summary",
+      "key_points": [
+        "Decision-space transformation occurred before bind.",
+        "Preservation degradation and intervention viability loss are visible in the trajectory.",
+        "Formal bind admissibility is evaluated after structural narrowing."
+      ],
+      "evidence_refs": [
+        "governance_layer_snapshot.trajectory_shaping_lineage",
+        "governance_layer_snapshot.phase_snapshots",
+        "governance_layer_snapshot.bind_outcome"
+      ]
+    },
+    {
+      "id": "dynamic_degradation_summary",
+      "source_layer": "dynamic_conditions_validation_v0",
+      "title": "Dynamic degradation summary",
+      "key_points": [
+        "Reinforcement, exposure asymmetry, time pressure, and adaptive behavior interact before bind.",
+        "The intervention window compresses before bind.",
+        "The decision is evaluated over a dynamically narrowed space."
+      ],
+      "evidence_refs": [
+        "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case"
+      ]
+    },
+    {
+      "id": "irreversibility_summary",
+      "source_layer": "irreversibility_horizon_v0",
+      "title": "Irreversibility horizon summary",
+      "key_points": [
+        "The first structural degradation signal is marked.",
+        "The last meaningful intervention phase is marked.",
+        "Bind occurs after the representative horizon."
+      ],
+      "evidence_refs": [
+        "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon"
+      ]
+    },
+    {
+      "id": "recognition_gap_summary",
+      "source_layer": "actor_recognition_gap_v0",
+      "title": "Actor recognition gap summary",
+      "key_points": [
+        "Structural degradation may become visible before actors fully recognize intervention capacity loss.",
+        "The recognition gap is represented without inferring actor psychology.",
+        "Bind occurs after the recognition gap."
+      ],
+      "evidence_refs": [
+        "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon.actor_recognition_gap"
+      ]
+    },
+    {
+      "id": "governance_attack_surface_summary",
+      "source_layer": "governance_attack_surface_registry_v0",
+      "title": "Governance attack surface summary",
+      "key_points": [
+        "The governance process itself can become an attack surface.",
+        "Representative failure classes include self-authorization, evidence-chain manipulation, spoofed approval, policy drift, escalation suppression, replay tampering, and recognition-gap masking.",
+        "The registry does not claim complete security or certification."
+      ],
+      "evidence_refs": [
+        "governance_layer_snapshot.governance_attack_surface_registry"
+      ]
+    },
+    {
+      "id": "safeguard_coverage_summary",
+      "source_layer": "governance_safeguard_coverage_matrix_v0",
+      "title": "Safeguard coverage summary",
+      "key_points": [
+        "Each representative failure class is mapped to a primary safeguard.",
+        "Each row includes evidence requirements for visibility.",
+        "Coverage remains representative visibility only."
+      ],
+      "evidence_refs": [
+        "governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix"
+      ]
+    },
+    {
+      "id": "intervention_actionability_summary",
+      "source_layer": "intervention_actionability_map_v0",
+      "title": "Intervention actionability summary",
+      "key_points": [
+        "Visible governance markers are mapped to representative intervention categories.",
+        "The map provides guidance without automatic enforcement.",
+        "Evidence preservation remains explicit."
+      ],
+      "evidence_refs": [
+        "governance_layer_snapshot.intervention_actionability_map"
+      ]
+    }
+  ],
+  "reviewer_questions": [
+    "What was the bind outcome?",
+    "What decision-space narrowing occurred before bind?",
+    "When did intervention viability begin degrading?",
+    "Where was the last meaningful intervention point?",
+    "Did actor recognition lag behind structural degradation?",
+    "Which governance attack surfaces were relevant?",
+    "Which safeguards made those surfaces visible?",
+    "Which intervention categories were representative?",
+    "What does this packet not claim?"
+  ],
+  "preserved_evidence_refs": [
+    "governance_layer_snapshot.trajectory_shaping_lineage",
+    "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case",
+    "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon",
+    "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon.actor_recognition_gap",
+    "governance_layer_snapshot.governance_attack_surface_registry",
+    "governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix",
+    "governance_layer_snapshot.intervention_actionability_map"
+  ],
+  "limitations": [
+    "not_certification",
+    "not_production_security_guarantee",
+    "not_automatic_enforcement",
+    "not_automatic_attack_detection",
+    "not_scoring_model",
+    "not_legal_conclusion",
+    "representative_demo_packet_only"
+  ],
+  "summary": {
+    "concise": "Governance Evidence Packet v0 gives reviewers a compact, deterministic summary of the governance trace, evidence refs, safeguards, and representative intervention categories.",
+    "operator": "The system should show what evidence a reviewer should inspect without claiming certification, automatic enforcement, or production security."
+  }
+}

--- a/docs/en/demo/schemas/governance-evidence-packet-v0.schema.json
+++ b/docs/en/demo/schemas/governance-evidence-packet-v0.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/governance-evidence-packet-v0.schema.json",
+  "title": "Governance Evidence Packet v0",
+  "description": "Deterministic, reviewer-ready, non-certifying contract for Governance Evidence Packet v0.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "packet_id",
+    "packet_model",
+    "purpose",
+    "generated_from",
+    "decision_context_summary",
+    "packet_sections",
+    "reviewer_questions",
+    "preserved_evidence_refs",
+    "limitations",
+    "summary"
+  ],
+  "properties": {
+    "version": { "const": "v0" },
+    "packet_id": { "const": "pre_boundary_collapse_governance_evidence_packet_v0" },
+    "packet_model": { "const": "deterministic_representative_reviewer_packet" },
+    "purpose": { "type": "string", "minLength": 1 },
+    "generated_from": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenario_id", "source_payload"],
+      "properties": {
+        "scenario_id": { "const": "pre_boundary_collapse" },
+        "source_payload": { "const": "governance_layer_snapshot" }
+      }
+    },
+    "decision_context_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bind_outcome",
+        "participation_signal",
+        "preservation_state",
+        "intervention_viability",
+        "decision_space_state",
+        "summary"
+      ],
+      "properties": {
+        "bind_outcome": { "const": "FORMALLY_VALID_STRUCTURALLY_COLLAPSED" },
+        "participation_signal": { "const": "decision_shaping" },
+        "preservation_state": { "const": "collapsed" },
+        "intervention_viability": { "const": "lost" },
+        "decision_space_state": { "const": "structurally_narrowed_before_bind" },
+        "summary": { "type": "string", "minLength": 1 }
+      }
+    },
+    "packet_sections": {
+      "type": "array",
+      "minItems": 7,
+      "items": { "$ref": "#/$defs/packetSection" },
+      "allOf": [
+        { "contains": { "type": "object", "required": ["id"], "properties": { "id": { "const": "trajectory_summary" } } } },
+        { "contains": { "type": "object", "required": ["id"], "properties": { "id": { "const": "dynamic_degradation_summary" } } } },
+        { "contains": { "type": "object", "required": ["id"], "properties": { "id": { "const": "irreversibility_summary" } } } },
+        { "contains": { "type": "object", "required": ["id"], "properties": { "id": { "const": "recognition_gap_summary" } } } },
+        { "contains": { "type": "object", "required": ["id"], "properties": { "id": { "const": "governance_attack_surface_summary" } } } },
+        { "contains": { "type": "object", "required": ["id"], "properties": { "id": { "const": "safeguard_coverage_summary" } } } },
+        { "contains": { "type": "object", "required": ["id"], "properties": { "id": { "const": "intervention_actionability_summary" } } } }
+      ]
+    },
+    "reviewer_questions": {
+      "type": "array",
+      "minItems": 9,
+      "items": { "type": "string", "minLength": 1 },
+      "allOf": [
+        { "contains": { "const": "What was the bind outcome?" } },
+        { "contains": { "const": "What decision-space narrowing occurred before bind?" } },
+        { "contains": { "const": "When did intervention viability begin degrading?" } },
+        { "contains": { "const": "Where was the last meaningful intervention point?" } },
+        { "contains": { "const": "Did actor recognition lag behind structural degradation?" } },
+        { "contains": { "const": "Which governance attack surfaces were relevant?" } },
+        { "contains": { "const": "Which safeguards made those surfaces visible?" } },
+        { "contains": { "const": "Which intervention categories were representative?" } },
+        { "contains": { "const": "What does this packet not claim?" } }
+      ]
+    },
+    "preserved_evidence_refs": {
+      "type": "array",
+      "minItems": 7,
+      "items": { "type": "string", "minLength": 1 },
+      "allOf": [
+        { "contains": { "const": "governance_layer_snapshot.trajectory_shaping_lineage" } },
+        { "contains": { "const": "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case" } },
+        { "contains": { "const": "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon" } },
+        { "contains": { "const": "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon.actor_recognition_gap" } },
+        { "contains": { "const": "governance_layer_snapshot.governance_attack_surface_registry" } },
+        { "contains": { "const": "governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix" } },
+        { "contains": { "const": "governance_layer_snapshot.intervention_actionability_map" } }
+      ]
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 7,
+      "items": { "type": "string", "minLength": 1 },
+      "allOf": [
+        { "contains": { "const": "not_certification" } },
+        { "contains": { "const": "not_production_security_guarantee" } },
+        { "contains": { "const": "not_automatic_enforcement" } },
+        { "contains": { "const": "not_automatic_attack_detection" } },
+        { "contains": { "const": "not_scoring_model" } },
+        { "contains": { "const": "not_legal_conclusion" } },
+        { "contains": { "const": "representative_demo_packet_only" } }
+      ]
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["concise", "operator"],
+      "properties": {
+        "concise": { "type": "string", "minLength": 1 },
+        "operator": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "$defs": {
+    "packetSection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source_layer", "title", "key_points", "evidence_refs"],
+      "properties": {
+        "id": {
+          "enum": [
+            "trajectory_summary",
+            "dynamic_degradation_summary",
+            "irreversibility_summary",
+            "recognition_gap_summary",
+            "governance_attack_surface_summary",
+            "safeguard_coverage_summary",
+            "intervention_actionability_summary"
+          ]
+        },
+        "source_layer": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "key_points": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -467,3 +467,11 @@ automatic enforcement, automatic attack detection, automatic blocking, a scoring
 model, a legal conclusion, formal verification, complete prevention, production
 security, or production security coverage. Its purpose is to help reviewers see
 what to inspect, not to have VERITAS automatically decide correctness.
+
+Governance Evidence Packet Contract v0 fixes this deterministic representative reviewer packet with a JSON Schema and golden fixture. The contract makes the packet structure reviewer-ready while preserving non-claim boundaries: it does not claim certification, is not automatic enforcement, and is not production security.
+
+Contract artifacts:
+
+- `docs/en/demo/schemas/governance-evidence-packet-v0.schema.json`
+- `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
+- `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -296,3 +296,11 @@ governability degradation、safeguard visibility、representative intervention c
 automatic attack detection、automatic blocking、scoring model、legal conclusion、formal
 verification、complete prevention、production security、production security coverage は主張しません。
 目的は VERITAS が自動で正否判定することではなく、reviewer が何を点検すべきかを示すことです。
+
+Governance Evidence Packet Contract v0 は、この deterministic representative reviewer packet を JSON Schema と golden fixture で固定します。contract は reviewer-ready な構造を維持しつつ、not certification、not automatic enforcement、not production security guarantee、not scoring model、not legal conclusion の境界を明示します。
+
+Contract artifacts:
+
+- `docs/en/demo/schemas/governance-evidence-packet-v0.schema.json`
+- `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
+- `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`

--- a/frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts
+++ b/frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts
@@ -1,0 +1,305 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { GET } from "./route";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../../../../..");
+const FIXTURE_PATH = join(REPO_ROOT, "docs/en/demo/fixtures/governance-evidence-packet-v0.json");
+const SCHEMA_PATH = join(REPO_ROOT, "docs/en/demo/schemas/governance-evidence-packet-v0.schema.json");
+
+const REQUIRED_SECTION_IDS = [
+  "trajectory_summary",
+  "dynamic_degradation_summary",
+  "irreversibility_summary",
+  "recognition_gap_summary",
+  "governance_attack_surface_summary",
+  "safeguard_coverage_summary",
+  "intervention_actionability_summary",
+] as const;
+
+const REQUIRED_REVIEWER_QUESTIONS = [
+  "What was the bind outcome?",
+  "What decision-space narrowing occurred before bind?",
+  "When did intervention viability begin degrading?",
+  "Where was the last meaningful intervention point?",
+  "Did actor recognition lag behind structural degradation?",
+  "Which governance attack surfaces were relevant?",
+  "Which safeguards made those surfaces visible?",
+  "Which intervention categories were representative?",
+  "What does this packet not claim?",
+] as const;
+
+const REQUIRED_PRESERVED_EVIDENCE_REFS = [
+  "governance_layer_snapshot.trajectory_shaping_lineage",
+  "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case",
+  "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon",
+  "governance_layer_snapshot.trajectory_shaping_lineage.dynamic_conditions_validation_case.irreversibility_horizon.actor_recognition_gap",
+  "governance_layer_snapshot.governance_attack_surface_registry",
+  "governance_layer_snapshot.governance_attack_surface_registry.safeguard_coverage_matrix",
+  "governance_layer_snapshot.intervention_actionability_map",
+] as const;
+
+const REQUIRED_LIMITATIONS = [
+  "not_certification",
+  "not_production_security_guarantee",
+  "not_automatic_enforcement",
+  "not_automatic_attack_detection",
+  "not_scoring_model",
+  "not_legal_conclusion",
+  "representative_demo_packet_only",
+] as const;
+
+const FORBIDDEN_CLAIM_PHRASES = [
+  "certified",
+  "certification guaranteed",
+  "production security guaranteed",
+  "automatic enforcement enabled",
+  "legal conclusion",
+  "formal verification complete",
+  "complete prevention guaranteed",
+] as const;
+
+type JsonSchema = {
+  $ref?: string;
+  type?: "object" | "array" | "string";
+  const?: unknown;
+  enum?: unknown[];
+  required?: string[];
+  properties?: Record<string, JsonSchema>;
+  additionalProperties?: boolean;
+  minLength?: number;
+  minItems?: number;
+  items?: JsonSchema;
+  contains?: JsonSchema;
+  allOf?: JsonSchema[];
+  $defs?: Record<string, JsonSchema>;
+};
+
+type GovernanceEvidencePacketFixture = {
+  version: string;
+  packet_id: string;
+  packet_model: string;
+  purpose: string;
+  generated_from: {
+    scenario_id: string;
+    source_payload: string;
+  };
+  decision_context_summary: Record<string, string>;
+  packet_sections: Array<{
+    id: string;
+    source_layer: string;
+    title: string;
+    key_points: string[];
+    evidence_refs: string[];
+  }>;
+  reviewer_questions: string[];
+  preserved_evidence_refs: string[];
+  limitations: string[];
+  summary: {
+    concise: string;
+    operator: string;
+  };
+};
+
+function loadJsonFixture(path: string): GovernanceEvidencePacketFixture {
+  return JSON.parse(readFileSync(path, "utf-8")) as GovernanceEvidencePacketFixture;
+}
+
+function loadJsonSchema(path: string): JsonSchema {
+  return JSON.parse(readFileSync(path, "utf-8")) as JsonSchema;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveRef(schema: JsonSchema, rootSchema: JsonSchema): JsonSchema {
+  if (!schema.$ref) {
+    return schema;
+  }
+
+  const prefix = "#/$defs/";
+  expect(schema.$ref.startsWith(prefix)).toBe(true);
+  const definitionName = schema.$ref.slice(prefix.length);
+  const resolved = rootSchema.$defs?.[definitionName];
+  expect(resolved, `Missing schema definition: ${schema.$ref}`).toBeDefined();
+  return resolved as JsonSchema;
+}
+
+function validateSchema(schema: JsonSchema, value: unknown, rootSchema: JsonSchema, path = "$ "): string[] {
+  const resolvedSchema = resolveRef(schema, rootSchema);
+  const errors: string[] = [];
+
+  if (Object.prototype.hasOwnProperty.call(resolvedSchema, "const") && value !== resolvedSchema.const) {
+    errors.push(`${path}must equal ${String(resolvedSchema.const)}`);
+  }
+
+  if (resolvedSchema.enum && !resolvedSchema.enum.includes(value)) {
+    errors.push(`${path}must be one of ${resolvedSchema.enum.join(", ")}`);
+  }
+
+  if (resolvedSchema.type === "object" && !isRecord(value)) {
+    errors.push(`${path}must be an object`);
+    return errors;
+  }
+
+  if (resolvedSchema.type === "array" && !Array.isArray(value)) {
+    errors.push(`${path}must be an array`);
+    return errors;
+  }
+
+  if (resolvedSchema.type === "string" && typeof value !== "string") {
+    errors.push(`${path}must be a string`);
+    return errors;
+  }
+
+  if (typeof value === "string" && resolvedSchema.minLength && value.length < resolvedSchema.minLength) {
+    errors.push(`${path}must not be empty`);
+  }
+
+  if (Array.isArray(value)) {
+    if (resolvedSchema.minItems && value.length < resolvedSchema.minItems) {
+      errors.push(`${path}must contain at least ${resolvedSchema.minItems} items`);
+    }
+
+    if (resolvedSchema.items) {
+      value.forEach((item, index) => {
+        errors.push(...validateSchema(resolvedSchema.items as JsonSchema, item, rootSchema, `${path}[${index}]`));
+      });
+    }
+
+    if (resolvedSchema.contains) {
+      const containsMatch = value.some(
+        (item) => validateSchema(resolvedSchema.contains as JsonSchema, item, rootSchema, path).length === 0,
+      );
+      if (!containsMatch) {
+        errors.push(`${path}must contain required schema match`);
+      }
+    }
+  }
+
+  if (isRecord(value)) {
+    for (const requiredProperty of resolvedSchema.required ?? []) {
+      if (!Object.prototype.hasOwnProperty.call(value, requiredProperty)) {
+        errors.push(`${path}.${requiredProperty} is required`);
+      }
+    }
+
+    if (resolvedSchema.additionalProperties === false && resolvedSchema.properties) {
+      for (const propertyName of Object.keys(value)) {
+        if (!Object.prototype.hasOwnProperty.call(resolvedSchema.properties, propertyName)) {
+          errors.push(`${path}.${propertyName} is not allowed`);
+        }
+      }
+    }
+
+    for (const [propertyName, propertySchema] of Object.entries(resolvedSchema.properties ?? {})) {
+      if (Object.prototype.hasOwnProperty.call(value, propertyName)) {
+        errors.push(...validateSchema(propertySchema, value[propertyName], rootSchema, `${path}.${propertyName}`));
+      }
+    }
+  }
+
+  for (const subSchema of resolvedSchema.allOf ?? []) {
+    errors.push(...validateSchema(subSchema, value, rootSchema, path));
+  }
+
+  return errors;
+}
+
+describe("Governance Evidence Packet v0 contract", () => {
+  it("validates the API packet against the checked-in JSON Schema", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/veritas/v1/report/governance?demo_scenario=pre_boundary_collapse"),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      governance_layer_snapshot: {
+        governance_evidence_packet: GovernanceEvidencePacketFixture;
+      };
+    };
+    const packet = payload.governance_layer_snapshot.governance_evidence_packet;
+    const schema = loadJsonSchema(SCHEMA_PATH);
+
+    expect(validateSchema(schema, packet, schema)).toEqual([]);
+  });
+
+  it("matches the checked-in golden fixture", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/veritas/v1/report/governance?demo_scenario=pre_boundary_collapse"),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      governance_layer_snapshot: {
+        governance_evidence_packet: GovernanceEvidencePacketFixture;
+      };
+    };
+    const fixture = loadJsonFixture(FIXTURE_PATH);
+
+    expect(payload.governance_layer_snapshot.governance_evidence_packet).toEqual(fixture);
+  });
+
+  it("keeps required packet structure, evidence refs, and non-claims present", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/veritas/v1/report/governance?demo_scenario=pre_boundary_collapse"),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      governance_layer_snapshot: {
+        governance_evidence_packet: GovernanceEvidencePacketFixture;
+      };
+    };
+    const packet = payload.governance_layer_snapshot.governance_evidence_packet;
+
+    expect(packet.version).toBe("v0");
+    expect(packet.packet_id).toBe("pre_boundary_collapse_governance_evidence_packet_v0");
+    expect(packet.packet_model).toBe("deterministic_representative_reviewer_packet");
+    expect(packet.generated_from).toEqual({
+      scenario_id: "pre_boundary_collapse",
+      source_payload: "governance_layer_snapshot",
+    });
+    expect(packet.decision_context_summary).toMatchObject({
+      bind_outcome: "FORMALLY_VALID_STRUCTURALLY_COLLAPSED",
+      participation_signal: "decision_shaping",
+      preservation_state: "collapsed",
+      intervention_viability: "lost",
+      decision_space_state: "structurally_narrowed_before_bind",
+    });
+
+    expect(packet.packet_sections.map((section) => section.id)).toEqual(
+      expect.arrayContaining([...REQUIRED_SECTION_IDS]),
+    );
+    expect(packet.reviewer_questions).toEqual(expect.arrayContaining([...REQUIRED_REVIEWER_QUESTIONS]));
+    expect(packet.preserved_evidence_refs).toEqual(expect.arrayContaining([...REQUIRED_PRESERVED_EVIDENCE_REFS]));
+    expect(packet.limitations).toEqual(expect.arrayContaining([...REQUIRED_LIMITATIONS]));
+
+    for (const section of packet.packet_sections) {
+      expect(section.key_points.length).toBeGreaterThan(0);
+      expect(section.evidence_refs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("blocks forbidden overclaim phrases from the packet payload", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/veritas/v1/report/governance?demo_scenario=pre_boundary_collapse"),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      governance_layer_snapshot: {
+        governance_evidence_packet: GovernanceEvidencePacketFixture;
+      };
+    };
+    const packetText = JSON.stringify(payload.governance_layer_snapshot.governance_evidence_packet).toLowerCase();
+
+    for (const forbiddenPhrase of FORBIDDEN_CLAIM_PHRASES) {
+      expect(packetText).not.toContain(forbiddenPhrase);
+    }
+  });
+});

--- a/tests/docs/test_governance_evidence_packet_contract_docs.py
+++ b/tests/docs/test_governance_evidence_packet_contract_docs.py
@@ -1,0 +1,84 @@
+"""String-presence checks for Governance Evidence Packet v0 contract docs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SCHEMA_PATH = Path(
+    "docs/en/demo/schemas/governance-evidence-packet-v0.schema.json"
+)
+FIXTURE_PATH = Path(
+    "docs/en/demo/fixtures/governance-evidence-packet-v0.json"
+)
+README_PATH = Path("README.md")
+EN_DEMO_PATH = Path("docs/en/demos/pre_boundary_collapse_demo.md")
+JA_DEMO_PATH = Path("docs/ja/demos/pre_boundary_collapse_demo.md")
+ARTIFACT_INDEX_PATH = Path(
+    "docs/en/demo/external-reviewer-artifact-index.md"
+)
+
+SCHEMA_FILE_NAME = "governance-evidence-packet-v0.schema.json"
+FIXTURE_FILE_NAME = "governance-evidence-packet-v0.json"
+CONTRACT_TEST_PATH = (
+    "frontend/app/api/veritas/v1/report/governance/"
+    "governance-evidence-packet-contract.test.ts"
+)
+EN_DEMO_TERMS = [
+    "Governance Evidence Packet v0",
+    "deterministic representative reviewer packet",
+    "not claim certification",
+    "not automatic enforcement",
+    "not production security",
+]
+JA_DEMO_TERMS = [
+    "Governance Evidence Packet v0",
+    "deterministic representative reviewer packet",
+    "certification",
+    "automatic enforcement",
+    "production security",
+]
+NON_CLAIM_TERMS = [
+    "not certification",
+    "not production security guarantee",
+    "not automatic enforcement",
+    "not scoring model",
+    "not legal conclusion",
+]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_governance_evidence_packet_contract_files_exist() -> None:
+    assert SCHEMA_PATH.exists()
+    assert FIXTURE_PATH.exists()
+
+
+def test_demo_docs_reference_governance_evidence_packet_contract() -> None:
+    en_content = _read(EN_DEMO_PATH)
+    ja_content = _read(JA_DEMO_PATH)
+
+    for term in EN_DEMO_TERMS:
+        assert term in en_content
+
+    for term in JA_DEMO_TERMS:
+        assert term in ja_content
+
+
+def test_readme_or_external_reviewer_index_references_contract_artifacts() -> None:
+    content = "\n".join([_read(README_PATH), _read(ARTIFACT_INDEX_PATH)])
+
+    assert SCHEMA_FILE_NAME in content
+    assert FIXTURE_FILE_NAME in content
+    assert CONTRACT_TEST_PATH in content
+
+
+def test_reviewer_docs_preserve_governance_evidence_packet_non_claims() -> None:
+    content = "\n".join(
+        _read(path) for path in (README_PATH, EN_DEMO_PATH, JA_DEMO_PATH)
+    ).lower()
+
+    for term in NON_CLAIM_TERMS:
+        assert term in content


### PR DESCRIPTION
### Motivation

- Stabilize and lock the existing Governance Evidence Packet v0 as a reviewer-ready contract so future changes cannot accidentally weaken the reviewer trace summary or introduce certifying/production/automatic-enforcement claims.
- Ensure the packet remains deterministic, complete (required sections/questions/refs/limitations present), and explicitly non-certifying while avoiding any runtime behavior changes.

### Description

- Add JSON Schema `docs/en/demo/schemas/governance-evidence-packet-v0.schema.json` that uses Draft 2020-12 and enforces `version`, fixed `packet_id`, fixed `packet_model`, `generated_from` constants, required `decision_context_summary` constants, required packet section IDs, reviewer questions, preserved evidence refs, limitations/non-claims, and `summary`.
- Add golden fixture `docs/en/demo/fixtures/governance-evidence-packet-v0.json` that is verbatim to the existing `governance_layer_snapshot.governance_evidence_packet` output for `pre_boundary_collapse` and preserves deterministic ordering and content.
- Add frontend contract test `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts` that fetches the demo payload, validates the packet against the checked-in schema (local validator implementation to avoid adding runtime deps), asserts deep equality with the golden fixture, verifies required section IDs/questions/preserved refs/limitations, and blocks forbidden overclaim phrases.
- Add docs presence test `tests/docs/test_governance_evidence_packet_contract_docs.py` and update `README.md`, `README_JP.md`, `docs/en/demo/external-reviewer-artifact-index.md`, and EN/JA demo docs to reference the schema, fixture, contract test, and explicit non-claims.

### Testing

- Ran frontend unit/contract tests: `pnpm -C frontend test -- app/api/veritas/v1/report/governance/route.test.ts app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`, which passed (Vitest run reported the suite and the new contract tests executed successfully).
- Ran frontend typecheck: `pnpm -C frontend typecheck`, which completed successfully (`tsc --noEmit`).
- Ran docs presence tests: `PYENV_VERSION=3.12.13 pytest -q tests/docs/test_governance_evidence_packet_contract_docs.py`, which passed (4 tests, 1 unrelated pytest config warning).

Notes: an attempt to add `ajv` as a new dev dependency was blocked by the environment registry, so the contract test uses a small, focused JSON Schema validator implementation sufficient for the schema features used; this keeps the change additive and avoids runtime behavior edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c654d222c83268748f0f9172179d7)