### PR TITLE
Clarify continuation observed vs enforced posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1589,10 +1589,13 @@ Posture-based defaults:
 
 Setting `VERITAS_POSTURE=prod` does not by itself make continuation governance enforcement blocking. If `VERITAS_CONTINUATION_ENFORCEMENT_MODE=advisory`, VERITAS emits governance events but does not block execution. This is an observed posture, not an enforced governance posture. Regulated deployments should use `VERITAS_CONTINUATION_ENFORCEMENT_MODE=enforce`, or explicitly document advisory mode as a temporary evaluation posture.
 
+Both `observe` and `advisory` are non-blocking continuation modes. `observe` is observation-only and remains the legacy/default non-blocking mode. `advisory` is the explicit governance-advisory non-blocking mode surfaced by posture classification. `enforce` is the only blocking continuation governance mode.
+
 | VERITAS_POSTURE | VERITAS_CONTINUATION_ENFORCEMENT_MODE | Meaning |
 |---|---|---|
-| dev/local | advisory | Development observation mode |
-| prod/secure | advisory | Production observation mode; non-blocking |
+| any | observe | Observation-only mode; non-blocking |
+| dev/local | advisory | Development/evaluation advisory mode; non-blocking |
+| prod/secure | advisory | Production observation/advisory mode; non-blocking; not enforced governance |
 | prod/secure | enforce | Production enforcement mode; blocking governance active |
 
 ### Key Concepts

--- a/README.md
+++ b/README.md
@@ -1585,6 +1585,16 @@ Posture-based defaults:
 - **secure/prod**: `advisory` (emit events, no blocking)
 - Set `VERITAS_CONTINUATION_ENFORCEMENT_MODE=enforce` to enable limited enforcement in any posture.
 
+### Observed Posture vs Enforced Posture
+
+Setting `VERITAS_POSTURE=prod` does not by itself make continuation governance enforcement blocking. If `VERITAS_CONTINUATION_ENFORCEMENT_MODE=advisory`, VERITAS emits governance events but does not block execution. This is an observed posture, not an enforced governance posture. Regulated deployments should use `VERITAS_CONTINUATION_ENFORCEMENT_MODE=enforce`, or explicitly document advisory mode as a temporary evaluation posture.
+
+| VERITAS_POSTURE | VERITAS_CONTINUATION_ENFORCEMENT_MODE | Meaning |
+|---|---|---|
+| dev/local | advisory | Development observation mode |
+| prod/secure | advisory | Production observation mode; non-blocking |
+| prod/secure | enforce | Production enforcement mode; blocking governance active |
+
 ### Key Concepts
 
 - **Snapshot** (state): minimal governable facts — support basis, scope, burden, headroom, law version

--- a/docs/architecture/continuation_enforcement_design_note.md
+++ b/docs/architecture/continuation_enforcement_design_note.md
@@ -142,10 +142,13 @@ operators and governance reviewers, not to halt the chain.
 
 Setting `VERITAS_POSTURE=prod` does not by itself make continuation governance enforcement blocking. If `VERITAS_CONTINUATION_ENFORCEMENT_MODE=advisory`, VERITAS emits governance events but does not block execution. This is an observed posture, not an enforced governance posture. Regulated deployments should use `VERITAS_CONTINUATION_ENFORCEMENT_MODE=enforce`, or explicitly document advisory mode as a temporary evaluation posture.
 
+Both `observe` and `advisory` are non-blocking continuation modes. `observe` is observation-only and remains the legacy/default non-blocking mode. `advisory` is the explicit governance-advisory non-blocking mode surfaced by posture classification. `enforce` is the only blocking continuation governance mode.
+
 | VERITAS_POSTURE | VERITAS_CONTINUATION_ENFORCEMENT_MODE | Meaning |
 |---|---|---|
-| dev/local | advisory | Development observation mode |
-| prod/secure | advisory | Production observation mode; non-blocking |
+| any | observe | Observation-only mode; non-blocking |
+| dev/local | advisory | Development/evaluation advisory mode; non-blocking |
+| prod/secure | advisory | Production observation/advisory mode; non-blocking; not enforced governance |
 | prod/secure | enforce | Production enforcement mode; blocking governance active |
 
 Changelog note: clarified that production posture with advisory continuation mode is observation-only and not blocking enforcement. Added explicit documentation and tests for observed vs enforced continuation governance posture.

--- a/docs/architecture/continuation_enforcement_design_note.md
+++ b/docs/architecture/continuation_enforcement_design_note.md
@@ -138,6 +138,18 @@ operators and governance reviewers, not to halt the chain.
 | `VERITAS_CAP_CONTINUATION_RUNTIME` | `0` | Enable Continuation Runtime |
 | `VERITAS_CONTINUATION_ENFORCEMENT_MODE` | `observe` | `observe` / `advisory` / `enforce` |
 
+### Observed Posture vs Enforced Posture
+
+Setting `VERITAS_POSTURE=prod` does not by itself make continuation governance enforcement blocking. If `VERITAS_CONTINUATION_ENFORCEMENT_MODE=advisory`, VERITAS emits governance events but does not block execution. This is an observed posture, not an enforced governance posture. Regulated deployments should use `VERITAS_CONTINUATION_ENFORCEMENT_MODE=enforce`, or explicitly document advisory mode as a temporary evaluation posture.
+
+| VERITAS_POSTURE | VERITAS_CONTINUATION_ENFORCEMENT_MODE | Meaning |
+|---|---|---|
+| dev/local | advisory | Development observation mode |
+| prod/secure | advisory | Production observation mode; non-blocking |
+| prod/secure | enforce | Production enforcement mode; blocking governance active |
+
+Changelog note: clarified that production posture with advisory continuation mode is observation-only and not blocking enforcement. Added explicit documentation and tests for observed vs enforced continuation governance posture.
+
 ### Enforcement Config Defaults
 
 | Parameter | Default | Description |

--- a/veritas_os/core/posture.py
+++ b/veritas_os/core/posture.py
@@ -13,8 +13,10 @@ Posture levels
 - **staging** – pre-production; warnings for missing integrations, no hard fail.
 - **secure**  – hardened non-production; same defaults as *prod* but allows
                 documented escape hatches via ``VERITAS_POSTURE_OVERRIDE_*``.
-- **prod**    – production; all governance controls are on, startup refuses
-                to proceed when required integrations are missing.
+- **prod**    – production; posture defaults are strict, startup refuses
+                to proceed when required integrations are missing. Continuation
+                governance is blocking only when its enforcement mode is
+                ``enforce``.
 """
 from __future__ import annotations
 
@@ -138,6 +140,81 @@ class PostureDefaults:
     def is_strict(self) -> bool:
         """Return True when the posture is secure or prod."""
         return self.posture in {PostureLevel.SECURE, PostureLevel.PROD}
+
+
+@dataclass(frozen=True)
+class ContinuationPostureClassification:
+    """Machine-readable continuation governance posture classification.
+
+    The runtime posture (``dev``/``staging``/``secure``/``prod``) and the
+    continuation enforcement mode are related but independent. In particular,
+    ``prod`` or ``secure`` with ``advisory`` mode is a production observation
+    posture, not blocking continuation governance.
+    """
+
+    status: str
+    message: str
+
+
+def classify_continuation_posture(
+    posture: PostureLevel | str,
+    enforcement_mode: str,
+) -> ContinuationPostureClassification:
+    """Classify continuation posture as observed, advisory, or enforced.
+
+    Args:
+        posture: Runtime posture level or posture string.
+        enforcement_mode: Continuation enforcement mode string.
+
+    Returns:
+        A machine-readable status and operator-facing message clarifying
+        whether continuation governance is blocking.
+    """
+    posture_value = posture.value if isinstance(posture, PostureLevel) else posture
+    normalized_posture = (posture_value or "").strip().lower()
+    normalized_mode = (enforcement_mode or "").strip().lower()
+    production_postures = {PostureLevel.PROD.value, PostureLevel.SECURE.value}
+
+    if normalized_posture in production_postures and normalized_mode == "advisory":
+        return ContinuationPostureClassification(
+            status="observed_not_enforced",
+            message=(
+                "Production posture with advisory continuation mode emits "
+                "governance events but does not block execution."
+            ),
+        )
+
+    if normalized_posture in production_postures and normalized_mode == "enforce":
+        return ContinuationPostureClassification(
+            status="enforced",
+            message=(
+                "Production posture with enforce mode blocks execution "
+                "according to continuation governance."
+            ),
+        )
+
+    if normalized_mode == "advisory":
+        return ContinuationPostureClassification(
+            status="advisory",
+            message=(
+                "Advisory mode is acceptable for development, evaluation, "
+                "and observation."
+            ),
+        )
+
+    if normalized_mode == "enforce":
+        return ContinuationPostureClassification(
+            status="enforced",
+            message=(
+                "Continuation enforce mode blocks execution according to "
+                "continuation governance."
+            ),
+        )
+
+    return ContinuationPostureClassification(
+        status="observe",
+        message="Continuation governance is observation-only and non-blocking.",
+    )
 
 
 # Escape-hatch env vars accepted only in *secure* posture.
@@ -678,22 +755,43 @@ def log_posture_banner(defaults: PostureDefaults) -> str:
 
     posture_name = defaults.posture.value
     cont_mode = defaults.continuation_enforcement_mode
+    continuation_posture = classify_continuation_posture(
+        defaults.posture,
+        cont_mode,
+    )
     on_text = ", ".join(on_flags) if on_flags else "(none)"
     off_text = ", ".join(off_flags) if off_flags else "(none)"
     _logger.info(
         "[POSTURE] Active posture: %s | ON: %s | OFF: %s "
-        "| continuation_enforcement: %s",
+        "| continuation_enforcement: %s "
+        "| continuation_posture_status: %s",
         posture_name,
         on_text,
         off_text,
         cont_mode,
+        continuation_posture.status,
     )
+    if continuation_posture.status == "observed_not_enforced":
+        _logger.warning(
+            "[POSTURE] continuation_posture_status=%s message=%s",
+            continuation_posture.status,
+            continuation_posture.message,
+        )
     return (
         "[POSTURE] Active posture: %s\n"
         "[POSTURE] Guarantees ON : %s\n"
         "[POSTURE] Guarantees OFF: %s\n"
-        "[POSTURE] Continuation enforcement: %s"
-    ) % (posture_name, on_text, off_text, cont_mode)
+        "[POSTURE] Continuation enforcement: %s\n"
+        "[POSTURE] Continuation posture status: %s\n"
+        "[POSTURE] Continuation posture message: %s"
+    ) % (
+        posture_name,
+        on_text,
+        off_text,
+        cont_mode,
+        continuation_posture.status,
+        continuation_posture.message,
+    )
 
 
 # ── Convenience: resolve + derive + validate in one call ────────────────

--- a/veritas_os/tests/test_posture.py
+++ b/veritas_os/tests/test_posture.py
@@ -23,6 +23,7 @@ from veritas_os.core.posture import (
     PostureLevel,
     PostureStartupError,
     _validate_backend_config,
+    classify_continuation_posture,
     derive_defaults,
     get_active_posture,
     init_posture,
@@ -47,6 +48,7 @@ def _clean_env(monkeypatch):
         "VERITAS_TRUSTLOG_TRANSPARENCY_REQUIRED",
         "VERITAS_TRUSTLOG_WORM_HARD_FAIL",
         "VERITAS_REPLAY_STRICT",
+        "VERITAS_CONTINUATION_ENFORCEMENT_MODE",
         "VERITAS_POSTURE_OVERRIDE_POLICY_ENFORCE",
         "VERITAS_POSTURE_OVERRIDE_EXTERNAL_SECRET_MGR",
         "VERITAS_POSTURE_OVERRIDE_TRUSTLOG_TRANSPARENCY",
@@ -599,6 +601,48 @@ class TestLogPostureBanner:
         caplog.set_level(logging.INFO)
         log_posture_banner(d)
         assert "[POSTURE]" in caplog.text
+
+
+# ============================================================
+# continuation posture classification
+# ============================================================
+
+class TestContinuationPostureClassification:
+    """Continuation posture classification distinguishes modes."""
+
+    def test_prod_advisory_is_observed_not_enforced(self):
+        result = classify_continuation_posture(PostureLevel.PROD, "advisory")
+
+        assert result.status == "observed_not_enforced"
+        assert "does not block execution" in result.message
+
+    def test_secure_advisory_is_observed_not_enforced(self):
+        result = classify_continuation_posture(PostureLevel.SECURE, "advisory")
+
+        assert result.status == "observed_not_enforced"
+        assert "governance events" in result.message
+
+    def test_prod_enforce_is_enforced(self):
+        result = classify_continuation_posture(PostureLevel.PROD, "enforce")
+
+        assert result.status == "enforced"
+        assert "blocks execution" in result.message
+
+    def test_dev_advisory_is_advisory_without_regulated_warning(self):
+        result = classify_continuation_posture(PostureLevel.DEV, "advisory")
+
+        assert result.status == "advisory"
+        assert "acceptable for development" in result.message
+
+    def test_banner_records_prod_advisory_warning(self, monkeypatch, caplog):
+        _clean_env(monkeypatch)
+        d = derive_defaults(PostureLevel.PROD)
+
+        caplog.set_level(logging.WARNING)
+        banner = log_posture_banner(d)
+
+        assert "Continuation posture status: observed_not_enforced" in banner
+        assert "continuation_posture_status=observed_not_enforced" in caplog.text
 
 
 # ============================================================


### PR DESCRIPTION
### Motivation
- External review showed `VERITAS_POSTURE=prod` combined with `VERITAS_CONTINUATION_ENFORCEMENT_MODE=advisory` can be mistaken for blocking governance, so the distinction must be explicit in code and docs. 
- Make the runtime semantics machine-readable and surface an operator-facing warning while preserving backwards compatibility and not introducing fail-closed startup changes. 

### Description
- Add `ContinuationPostureClassification` and `classify_continuation_posture(posture, enforcement_mode)` to `veritas_os/core/posture.py` to return a machine-readable `status` and `message` clarifying whether continuation governance is blocking. 
- Update `log_posture_banner()` to include `continuation_posture_status` and to log a `WARNING` when running `prod`/`secure` with `advisory` mode (classified as `observed_not_enforced`). 
- Update documentation with an "Observed Posture vs Enforced Posture" section and a small table in `README.md` and `docs/architecture/continuation_enforcement_design_note.md` that explains `prod+advisory` is observation-only and that regulated deployments should set `VERITAS_CONTINUATION_ENFORCEMENT_MODE=enforce`. 
- Add unit tests in `veritas_os/tests/test_posture.py` covering `prod+advisory`, `secure+advisory`, `prod+enforce`, `dev+advisory`, and a banner/warning check, and include `VERITAS_CONTINUATION_ENFORCEMENT_MODE` in the test env cleanup helper. 

### Testing
- `python -m py_compile veritas_os/core/posture.py veritas_os/tests/test_posture.py` succeeded. 
- `ruff check veritas_os/core/posture.py veritas_os/tests/test_posture.py` succeeded. 
- Ran a small smoke script invoking `classify_continuation_posture` which produced expected classifications (`prod advisory -> observed_not_enforced`, `prod enforce -> enforced`, `dev advisory -> advisory`). 
- Attempted to run `pytest` for the modified tests but full `pytest` execution was blocked by missing runtime dependencies in the local environment (`ModuleNotFoundError: No module named 'pydantic'`) and by inability to fetch PyPI packages in the test runner environment; therefore the new tests were added but not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ccb27e02083269b677eddfe464c62)