### PR TITLE
feat(fuji): gate canary promotion on false negatives

### DIFF
--- a/docs/architecture/debate-safety-policy-migration-map.md
+++ b/docs/architecture/debate-safety-policy-migration-map.md
@@ -112,7 +112,13 @@ Phase 3 remains blocked until all criteria below are satisfied:
 
 This migration area is safety-sensitive. Any mapping change that can alter
 runtime behavior must be reviewed as a security-relevant change before
-feature-flagged enforcement is considered.
+feature-flagged enforcement is considered. Canary rollout metrics are not
+advisory-only. Promotion is blocked when the canary policy produces a
+false-negative rate above the configured threshold. A false negative occurs
+when the stable policy would HOLD or DENY but the canary policy would ALLOW.
+This prevents a more permissive canary policy from being promoted in
+safety-critical gates, and is especially important for high-risk categories
+such as `risk_negation_terms` and `refusal_context_patterns`.
 
 
 ## Phase 2.7 artifact status

--- a/veritas_os/core/fuji/fuji_policy_rollout.py
+++ b/veritas_os/core/fuji/fuji_policy_rollout.py
@@ -3,7 +3,7 @@
 This module provides P0-3 controls described in the code review:
 - deterministic A/B replay against old/new policies
 - allow/hold/deny transition metrics
-- false-positive / false-negative estimates when expected labels exist
+- false-positive / false-negative policy-regression estimates
 - deterministic canary assignment by request id
 
 The implementation is scoped to FUJI policy evaluation only.
@@ -14,11 +14,33 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass
 import hashlib
+import math
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from veritas_os.core import fuji
 
 _ALLOWED_DECISIONS = {"allow", "hold", "deny"}
+DEFAULT_FALSE_NEGATIVE_PROMOTION_THRESHOLD = 0.0
+PROMOTION_BLOCKED_METRICS_UNAVAILABLE = "promotion_blocked_metrics_unavailable"
+
+
+@dataclass(frozen=True)
+class CanaryPromotionGateResult:
+    """Promotion decision derived from canary replay safety metrics.
+
+    False negatives are safety-critical because they mean the stable policy
+    would HOLD or DENY while the canary policy would ALLOW. High-risk
+    migrations, including negation/refusal-context category moves, should
+    treat this gate as a promotion blocker rather than advisory telemetry.
+    """
+
+    allowed: bool
+    reason: str
+    false_negative_rate: float
+    false_negative_threshold: float
+    change_rate: float | None
+    false_negatives: int
+    samples_checked: int
 
 
 @dataclass(frozen=True)
@@ -33,13 +55,11 @@ class PolicyReplaySample:
     expected_decision: Optional[str] = None
 
 
-
 def _normalize_expected_decision(value: Optional[str]) -> Optional[str]:
     if value is None:
         return None
     norm = str(value).strip().lower()
     return norm if norm in _ALLOWED_DECISIONS else None
-
 
 
 def _evaluate_sample(sample: PolicyReplaySample, policy: Mapping[str, Any]) -> str:
@@ -64,7 +84,6 @@ def _evaluate_sample(sample: PolicyReplaySample, policy: Mapping[str, Any]) -> s
     if decision not in _ALLOWED_DECISIONS:
         return "hold"
     return decision
-
 
 
 def replay_policy_diff(
@@ -103,14 +122,15 @@ def replay_policy_diff(
 
         is_fp = False
         is_fn = False
+        if before == "allow" and after in {"hold", "deny"}:
+            fp += 1
+            is_fp = True
+        elif before in {"hold", "deny"} and after == "allow":
+            fn += 1
+            is_fn = True
+
         if expected is not None:
             labeled += 1
-            if after in {"hold", "deny"} and expected == "allow":
-                fp += 1
-                is_fp = True
-            elif after == "allow" and expected in {"hold", "deny"}:
-                fn += 1
-                is_fn = True
 
         outcomes.append(
             {
@@ -125,11 +145,12 @@ def replay_policy_diff(
         )
 
     change_rate = (changed / total) if total else 0.0
-    fp_rate = (fp / labeled) if labeled else 0.0
-    fn_rate = (fn / labeled) if labeled else 0.0
+    fp_rate = (fp / total) if total else 0.0
+    fn_rate = (fn / total) if total else 0.0
 
     return {
         "total": total,
+        "samples_checked": total,
         "changed": changed,
         "change_rate": round(change_rate, 6),
         "false_positive": fp,
@@ -141,6 +162,112 @@ def replay_policy_diff(
         "outcomes": outcomes,
     }
 
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _nonnegative_int(value: Any) -> int | None:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    if number < 0:
+        return None
+    return number
+
+
+def evaluate_canary_promotion_gate(
+    diff_result: Any,
+    *,
+    false_negative_threshold: float = DEFAULT_FALSE_NEGATIVE_PROMOTION_THRESHOLD,
+) -> CanaryPromotionGateResult:
+    """Evaluate whether canary policy replay metrics permit promotion.
+
+    Promotion fails closed when metrics are unavailable or malformed. A false
+    negative is a permissive regression where the stable policy would HOLD or
+    DENY but the canary policy would ALLOW.
+
+    Args:
+        diff_result: Result produced by :func:`replay_policy_diff`.
+        false_negative_threshold: Maximum tolerated false-negative rate.
+
+    Returns:
+        Explicit canary promotion decision and the safety metrics used.
+    """
+    threshold = _finite_float(false_negative_threshold)
+    if threshold is None or threshold < 0.0:
+        threshold = DEFAULT_FALSE_NEGATIVE_PROMOTION_THRESHOLD
+
+    blocked_result = CanaryPromotionGateResult(
+        allowed=False,
+        reason=PROMOTION_BLOCKED_METRICS_UNAVAILABLE,
+        false_negative_rate=0.0,
+        false_negative_threshold=threshold,
+        change_rate=None,
+        false_negatives=0,
+        samples_checked=0,
+    )
+
+    if not isinstance(diff_result, Mapping):
+        return blocked_result
+
+    false_negative_rate = _finite_float(diff_result.get("false_negative_rate"))
+    raw_change_rate = diff_result.get("change_rate")
+    change_rate = _finite_float(raw_change_rate)
+    false_negatives = _nonnegative_int(diff_result.get("false_negative"))
+    samples_checked = _nonnegative_int(
+        diff_result.get("samples_checked", diff_result.get("total"))
+    )
+
+    if (
+        false_negative_rate is None
+        or false_negative_rate < 0.0
+        or false_negative_rate > 1.0
+        or false_negatives is None
+        or samples_checked is None
+        or samples_checked == 0
+        or false_negatives > samples_checked
+        or (raw_change_rate is not None and change_rate is None)
+    ):
+        return blocked_result
+
+    if false_negative_rate > threshold:
+        return CanaryPromotionGateResult(
+            allowed=False,
+            reason="promotion_blocked_false_negative_rate_exceeded",
+            false_negative_rate=false_negative_rate,
+            false_negative_threshold=threshold,
+            change_rate=change_rate,
+            false_negatives=false_negatives,
+            samples_checked=samples_checked,
+        )
+
+    return CanaryPromotionGateResult(
+        allowed=True,
+        reason="promotion_allowed",
+        false_negative_rate=false_negative_rate,
+        false_negative_threshold=threshold,
+        change_rate=change_rate,
+        false_negatives=false_negatives,
+        samples_checked=samples_checked,
+    )
+
+
+def canary_promotion_allowed(
+    diff_result: Any,
+    *,
+    false_negative_threshold: float = DEFAULT_FALSE_NEGATIVE_PROMOTION_THRESHOLD,
+) -> bool:
+    """Return whether canary replay metrics pass the promotion gate."""
+    return evaluate_canary_promotion_gate(
+        diff_result,
+        false_negative_threshold=false_negative_threshold,
+    ).allowed
 
 
 def canary_bucket(request_id: str, canary_ratio: float) -> str:

--- a/veritas_os/core/fuji/fuji_policy_rollout.py
+++ b/veritas_os/core/fuji/fuji_policy_rollout.py
@@ -22,6 +22,7 @@ from veritas_os.core import fuji
 _ALLOWED_DECISIONS = {"allow", "hold", "deny"}
 DEFAULT_FALSE_NEGATIVE_PROMOTION_THRESHOLD = 0.0
 PROMOTION_BLOCKED_METRICS_UNAVAILABLE = "promotion_blocked_metrics_unavailable"
+_FALSE_NEGATIVE_RATE_TOLERANCE = 1e-6
 
 
 @dataclass(frozen=True)
@@ -233,6 +234,13 @@ def evaluate_canary_promotion_gate(
         or samples_checked == 0
         or false_negatives > samples_checked
         or (raw_change_rate is not None and change_rate is None)
+    ):
+        return blocked_result
+
+    expected_false_negative_rate = false_negatives / samples_checked
+    if (
+        abs(false_negative_rate - expected_false_negative_rate)
+        > _FALSE_NEGATIVE_RATE_TOLERANCE
     ):
         return blocked_result
 

--- a/veritas_os/tests/unit/test_fuji_gate.py
+++ b/veritas_os/tests/unit/test_fuji_gate.py
@@ -3384,11 +3384,29 @@ import math
 
 from veritas_os.core.fuji import _DEFAULT_POLICY
 from veritas_os.core.fuji_policy_rollout import (
+    DEFAULT_FALSE_NEGATIVE_PROMOTION_THRESHOLD,
+    PROMOTION_BLOCKED_METRICS_UNAVAILABLE,
     PolicyReplaySample,
     _evaluate_sample,
     canary_bucket,
+    canary_promotion_allowed,
+    evaluate_canary_promotion_gate,
     replay_policy_diff,
 )
+
+
+def _allow_all_policy() -> dict:
+    policy = dict(_DEFAULT_POLICY)
+    policy["categories"] = {}
+    policy["actions"] = {"allow": {"risk_upper": 1.0}}
+    return policy
+
+
+def _deny_all_policy() -> dict:
+    policy = dict(_DEFAULT_POLICY)
+    policy["categories"] = {}
+    policy["actions"] = {"deny": {"risk_upper": 1.0}}
+    return policy
 
 
 def _strict_policy() -> dict:
@@ -3420,7 +3438,7 @@ def test_replay_policy_diff_returns_transition_metrics() -> None:
     assert len(result["outcomes"]) == 3
 
 
-def test_replay_policy_diff_calculates_fp_fn_when_labels_exist() -> None:
+def test_replay_policy_diff_calculates_fp_fn_rates() -> None:
     stable = dict(_DEFAULT_POLICY)
     canary = _strict_policy()
 
@@ -3437,6 +3455,136 @@ def test_replay_policy_diff_calculates_fp_fn_when_labels_exist() -> None:
     assert result["false_negative"] >= 0
     assert 0.0 <= result["false_positive_rate"] <= 1.0
     assert 0.0 <= result["false_negative_rate"] <= 1.0
+
+
+def test_canary_promotion_gate_allows_zero_false_negatives() -> None:
+    result = evaluate_canary_promotion_gate(
+        {
+            "false_negative_rate": 0.0,
+            "false_negative": 0,
+            "samples_checked": 3,
+            "change_rate": 0.0,
+        }
+    )
+
+    assert result.allowed is True
+    assert result.reason == "promotion_allowed"
+    assert result.false_negative_threshold == DEFAULT_FALSE_NEGATIVE_PROMOTION_THRESHOLD
+    assert canary_promotion_allowed(
+        {
+            "false_negative_rate": 0.0,
+            "false_negative": 0,
+            "samples_checked": 1,
+        }
+    )
+
+
+def test_canary_promotion_gate_allows_rate_equal_to_threshold() -> None:
+    result = evaluate_canary_promotion_gate(
+        {
+            "false_negative_rate": 0.05,
+            "false_negative": 1,
+            "samples_checked": 20,
+            "change_rate": 0.05,
+        },
+        false_negative_threshold=0.05,
+    )
+
+    assert result.allowed is True
+    assert result.false_negative_rate == 0.05
+    assert result.false_negative_threshold == 0.05
+
+
+def test_canary_promotion_gate_blocks_rate_above_threshold() -> None:
+    result = evaluate_canary_promotion_gate(
+        {
+            "false_negative_rate": 0.1,
+            "false_negative": 1,
+            "samples_checked": 10,
+            "change_rate": 0.2,
+        },
+        false_negative_threshold=0.05,
+    )
+
+    assert result.allowed is False
+    assert result.reason == "promotion_blocked_false_negative_rate_exceeded"
+    assert result.false_negatives == 1
+    assert result.samples_checked == 10
+    assert canary_promotion_allowed(
+        {
+            "false_negative_rate": 0.1,
+            "false_negative": 1,
+            "samples_checked": 10,
+        },
+        false_negative_threshold=0.05,
+    ) is False
+
+
+def test_canary_promotion_gate_blocks_missing_metrics_fail_closed() -> None:
+    result = evaluate_canary_promotion_gate(
+        {"false_negative": 0, "samples_checked": 2}
+    )
+
+    assert result.allowed is False
+    assert result.reason == PROMOTION_BLOCKED_METRICS_UNAVAILABLE
+
+
+def test_canary_promotion_gate_blocks_zero_samples_fail_closed() -> None:
+    result = evaluate_canary_promotion_gate(
+        {
+            "false_negative_rate": 0.0,
+            "false_negative": 0,
+            "samples_checked": 0,
+        }
+    )
+
+    assert result.allowed is False
+    assert result.reason == PROMOTION_BLOCKED_METRICS_UNAVAILABLE
+
+
+def test_replay_policy_diff_counts_stable_hold_canary_allow_as_false_negative() -> None:
+    result = replay_policy_diff(
+        samples=[
+            PolicyReplaySample(sample_id="hold-to-allow", risk=0.5, categories=[])
+        ],
+        stable_policy=dict(_DEFAULT_POLICY),
+        canary_policy=_allow_all_policy(),
+    )
+
+    assert result["false_negative"] == 1
+    assert result["false_negative_rate"] == 1.0
+    assert result["false_positive"] == 0
+    assert result["transitions"] == {"hold->allow": 1}
+
+
+def test_replay_policy_diff_counts_stable_deny_canary_allow_as_false_negative() -> None:
+    result = replay_policy_diff(
+        samples=[
+            PolicyReplaySample(sample_id="deny-to-allow", risk=0.95, categories=[])
+        ],
+        stable_policy=dict(_DEFAULT_POLICY),
+        canary_policy=_allow_all_policy(),
+    )
+
+    assert result["false_negative"] == 1
+    assert result["false_negative_rate"] == 1.0
+    assert result["false_positive"] == 0
+    assert result["transitions"] == {"deny->allow": 1}
+
+
+def test_replay_policy_diff_counts_stable_allow_canary_deny_as_false_positive() -> None:
+    result = replay_policy_diff(
+        samples=[
+            PolicyReplaySample(sample_id="allow-to-deny", risk=0.25, categories=[])
+        ],
+        stable_policy=dict(_DEFAULT_POLICY),
+        canary_policy=_deny_all_policy(),
+    )
+
+    assert result["false_positive"] == 1
+    assert result["false_positive_rate"] == 1.0
+    assert result["false_negative"] == 0
+    assert result["transitions"] == {"allow->deny": 1}
 
 
 def test_canary_bucket_is_deterministic_and_respects_ratio() -> None:

--- a/veritas_os/tests/unit/test_fuji_gate.py
+++ b/veritas_os/tests/unit/test_fuji_gate.py
@@ -3542,6 +3542,19 @@ def test_canary_promotion_gate_blocks_zero_samples_fail_closed() -> None:
     assert result.reason == PROMOTION_BLOCKED_METRICS_UNAVAILABLE
 
 
+def test_canary_promotion_gate_blocks_inconsistent_metrics_fail_closed() -> None:
+    result = evaluate_canary_promotion_gate(
+        {
+            "false_negative_rate": 0.0,
+            "false_negative": 1,
+            "samples_checked": 10,
+        }
+    )
+
+    assert result.allowed is False
+    assert result.reason == PROMOTION_BLOCKED_METRICS_UNAVAILABLE
+
+
 def test_replay_policy_diff_counts_stable_hold_canary_allow_as_false_negative() -> None:
     result = replay_policy_diff(
         samples=[


### PR DESCRIPTION
### Motivation
- Canary promotions can silently widen access if false negatives (stable HOLD/DENY → canary ALLOW) occur, so add an explicit promotion gate to refuse promotion when the canary false-negative rate exceeds a configured threshold and require human review for this high-risk change. 
- The gate must be separate from telemetry: keep existing replay metrics but make promotion decisions fail-closed when metrics are unavailable or malformed. 

### Description
- Added `DEFAULT_FALSE_NEGATIVE_PROMOTION_THRESHOLD = 0.0`, `PROMOTION_BLOCKED_METRICS_UNAVAILABLE`, `CanaryPromotionGateResult` dataclass, `evaluate_canary_promotion_gate(diff_result, *, false_negative_threshold=...)` and `canary_promotion_allowed(...)` to `veritas_os/core/fuji/fuji_policy_rollout.py` to return an explicit promotion decision containing `allowed`, `reason`, `false_negative_rate`, `false_negative_threshold`, `change_rate`, `false_negatives`, and `samples_checked`.
- Adjusted `replay_policy_diff` to count transitions as false negatives when stable `hold|deny` → canary `allow` and as false positives when stable `allow` → canary `hold|deny`, preserved existing metric fields (`false_positive`, `false_negative`, `false_positive_rate`, `false_negative_rate`, `change_rate`) and added `samples_checked` for clarity and compatibility.
- Updated architecture note `docs/architecture/debate-safety-policy-migration-map.md` to document that canary rollout metrics are not advisory-only, and added unit tests in `veritas_os/tests/unit/test_fuji_gate.py` covering zero/threshold/above-threshold cases, missing metrics, zero samples, and transition counting.

### Testing
- Performed static/compile checks: `python -m py_compile veritas_os/core/fuji/fuji_policy_rollout.py` and `veritas_os/tests/unit/test_fuji_gate.py` and `ruff check veritas_os/core/fuji/fuji_policy_rollout.py`, which succeeded. 
- Ran an isolated smoke import/runtime test with a stubbed `fuji._apply_policy` that verified `replay_policy_diff` counts false negatives and `evaluate_canary_promotion_gate` blocks promotion when appropriate, which passed. 
- Attempted full `pytest` but it could not complete in this environment due to missing test dependencies (`pydantic`, `cryptography`) and network/PyPI fetch failures, so the new unit tests are present and compile but were not executed under full test runner here.

Security note: this change touches FUJI promotion gating (a high-risk area) and is intentionally fail-closed; it requires human maintainer review and CI verification before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cdf0795b88326b7c3c7c04f058074)