### PR TITLE
Clarify and enforce restrictive decision precedence across decision & bind paths

### DIFF
--- a/docs/en/architecture/decision-semantics.md
+++ b/docs/en/architecture/decision-semantics.md
@@ -25,6 +25,8 @@ finalization.
 - `COMPATIBLE_GATE_DECISION_VALUES` (ingestion surface)
 - `GATE_DECISION_ALIAS_TO_CANONICAL` (single canonicalization mapping)
 - `FORBIDDEN_GATE_BUSINESS_COMBINATIONS` (single forbidden pair table)
+- `DECISION_SEVERITY_ALIASES` (machine-readable restrictive precedence)
+- `resolve_decision_precedence` / `most_restrictive_decision` (shared resolver)
 
 Other modules must reference these helpers/constants rather than redefining
 their own alias tables or forbidden-combination logic.
@@ -43,7 +45,7 @@ labels and are not recommended for new public payload contracts.
 - Canonical public values are prioritized: `proceed|hold|block|human_review_required`.
 - Legacy values (`allow|deny|modify|rejected|abstain`) are normalized before validation.
 - Forbidden combination checks are enforced on canonicalized values.
-- `unknown` remains fallback-compatible, but normal runtime derivation converges to canonical values.
+- `unknown` remains accepted on compatibility ingestion surfaces, but enforcement derivation fails closed to canonical `block`.
 - Mission Control adapters now canonicalize legacy gate aliases before UI rendering.
 - PoC compare helper normalizes gate decisions to canonical public values before diffing.
 - Evidence Bundle `decision_record.gate_decision` is canonicalized for external-facing audit payloads.
@@ -68,7 +70,7 @@ labels and are not recommended for new public payload contracts.
 | `modify` | Legacy “allowed with modification” | Compatibility | Gate hold | Yes | Limited | Often mapped into `hold` path | Medium |
 | `rejected` | Legacy deny alias | Compatibility | Blocked by gate | Yes | Limited | Treated same as `block` | High |
 | `abstain` | Legacy deferred/abstain signal | Compatibility | Gate hold | Yes | Limited | Treated as `hold` in public semantics | Medium |
-| `unknown` | Fallback when decision is absent | Defensive default | Gate status | Yes | No (except fallback) | Eventually resolved through stop reasons and defaults | Lowest |
+| `unknown` | Fallback when decision is absent | Defensive fail-closed default | Gate status | Yes | No (except fallback) | Enforcement derivation resolves malformed/unknown values to `block` | Highest (fail-closed) |
 
 ### Clarifications
 
@@ -118,6 +120,27 @@ Contract hardening policy:
 - Legacy gate aliases remain compatibility-only inputs and are canonicalized
   before public output.
 
+
+## C1. Cross-source restrictive precedence
+
+Decision sources are resolved by restrictive precedence. A permissive decision
+from one component cannot override a restrictive decision from another component.
+In particular, downstream bind/commit systems must not treat a rejected or deny
+FUJI decision as advisory. The effective decision is the most restrictive
+decision across gate, policy, business, FUJI, and bind-time checks.
+
+| Severity | Canonical meaning | Example terms | Canonical gate output | Bind effect |
+|---|---|---|---|---|
+| 3 | Reject / block execution | `deny`, `rejected`, `block`, `refuse` | `block` | block commit |
+| 2 | Hold / human review required | `hold`, `review`, `escalate`, `human_review_required` | `hold` or `human_review_required` | escalate / no silent commit |
+| 1 | Allow execution | `allow`, `approved`, `approve`, `proceed` | `proceed` | eligible only if all bind checks pass |
+
+The resolver preserves surface-specific vocabulary instead of flattening all
+outputs: FUJI compatibility paths may still ingest `rejected`, public gate output
+uses `block`, business output uses `DENY`/`HOLD`/`APPROVE`, and bind output uses
+`block`/`escalate`/`eligible_to_commit`. Unknown or malformed decision strings
+fail closed to severity 3 for enforcement surfaces.
+
 ## D. stop_reasons priority (current implementation order)
 
 Current order is implemented in
@@ -127,7 +150,7 @@ and consumed from `_derive_business_fields`:
 1. `rollback_not_supported` → `block`
 2. `irreversible_action` + `audit_trail_incomplete` → `block`
 3. `secure_prod_controls_missing` → `block`
-4. deny-family input (`deny/rejected/block`) → `block`
+4. deny-family input (`deny/rejected/block`) or malformed decision input → `block`
 5. `required_evidence_missing` → `hold`
 6. `high_risk_ambiguity` (with `risk_score >= 0.8`) → `human_review_required`
 7. `approval_boundary_unknown` OR `human_review_required=true` → `human_review_required`

--- a/docs/ja/architecture/decision-semantics.md
+++ b/docs/ja/architecture/decision-semantics.md
@@ -13,6 +13,23 @@
 - TrustLog と `governance_identity` / ガバナンス識別子 を合わせることで、意思決定から副作用までの系譜を監査可能にします。
 - Mission Control は `bind_summary` / bind概要 と `BindReceipt` を併用して、運用 triage と証跡確認を分離します。
 
+
+## 判断ソース間の制限的優先順位
+
+VERITAS では、複数の判断ソースが食い違う場合、**より制限的な判断が優先されます**。
+あるコンポーネントの permissive decision（許可的判断）は、別コンポーネントの restrictive decision（制限的判断）を上書きできません。
+特に、FUJI が `deny` / `rejected` / `block` 相当の判断を返した場合、downstream bind/commit systems はそれを advisory（参考情報）として扱ってはなりません。
+
+| 優先度 | 意味 | 代表的な語彙 | bind/commit での扱い |
+|---|---|---|---|
+| 3 | 拒否 / 実行ブロック | `deny`, `rejected`, `block` | commit 不可（block） |
+| 2 | 保留 / 人間レビュー・エスカレーション必須 | `hold`, `review`, `escalate`, `human_review_required` | silent allow 禁止（escalate / review） |
+| 1 | 許可 / 実行可能候補 | `allow`, `approved`, `approve`, `proceed` | 他に制限的判断がない場合のみ bind 候補 |
+
+実効判断は、gate、policy、business、FUJI、bind-time checks の全体から最も制限的な判断として解決されます。
+そのため、`gate_decision=allow` や `business_decision=APPROVE` が存在しても、FUJI 側に `rejected` / `deny` があれば、bind/commit は fail-closed で停止します。
+未知または malformed な判断文字列も、実行境界では安全側（block）に倒す必要があります。
+
 ## 実装上の確認ポイント
 - `/v1/decide` とガバナンス mutation API の bind 公開フィールドが整合しているか。
 - `/v1/governance/bind-receipts`（list/export/detail）で `BindReceipt` を再取得できるか。

--- a/veritas_os/core/decision_semantics.py
+++ b/veritas_os/core/decision_semantics.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Literal, Mapping
 
 CANONICAL_GATE_DECISION_VALUES: tuple[str, ...] = (
     "proceed",
@@ -53,6 +53,50 @@ GATE_DECISION_ALIAS_TO_CANONICAL = {
     "block": "block",
     "human_review_required": "human_review_required",
 }
+
+
+# Machine-readable restrictive precedence for all decision-like surfaces.
+# Severity 3 blocks execution, severity 2 requires hold/review/escalation,
+# and severity 1 allows/proceeds. Unknown values fail closed to severity 3.
+DECISION_SEVERITY_ALIASES: dict[int, tuple[str, ...]] = {
+    3: ("block", "deny", "denied", "rejected", "reject", "refuse", "refused"),
+    2: (
+        "hold",
+        "review",
+        "review_required",
+        "human_review_required",
+        "escalate",
+        "escalated",
+        "modify",
+        "abstain",
+        "evidence_required",
+        "policy_definition_required",
+    ),
+    1: (
+        "proceed",
+        "allow",
+        "allowed",
+        "approve",
+        "approved",
+        "eligible_to_commit",
+        "committed",
+    ),
+}
+
+DECISION_TERM_SEVERITY: dict[str, int] = {
+    term: severity
+    for severity, terms in DECISION_SEVERITY_ALIASES.items()
+    for term in terms
+}
+
+DECISION_OUTPUT_TERMS: dict[str, dict[int, str]] = {
+    "gate": {3: "block", 2: "hold", 1: "proceed"},
+    "business": {3: "DENY", 2: "HOLD", 1: "APPROVE"},
+    "fuji": {3: "rejected", 2: "abstain", 1: "allow"},
+    "bind": {3: "block", 2: "escalate", 1: "eligible_to_commit"},
+}
+
+DecisionOutputSurface = Literal["preserve", "gate", "business", "fuji", "bind"]
 
 FORBIDDEN_GATE_BUSINESS_COMBINATIONS: frozenset[tuple[str, str]] = frozenset(
     {
@@ -152,6 +196,67 @@ def canonicalize_public_gate_decision(
     return fallback
 
 
+
+def normalize_decision(value: object) -> str:
+    """Normalize a decision-like value for precedence comparisons.
+
+    The normal form is lower-case snake-case. Empty, ``None``, and malformed
+    values are returned as ``"unknown"`` so callers can fail closed via
+    :func:`decision_severity` or :func:`resolve_decision_precedence`.
+    """
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized or "unknown"
+
+
+def decision_severity(value: object) -> int:
+    """Return restrictive severity for a decision-like value.
+
+    Severity order is machine-readable and fail-closed:
+    ``3`` = reject/block execution, ``2`` = hold/review/escalate,
+    ``1`` = allow/proceed. Unknown or malformed values return ``3``.
+    """
+    normalized = normalize_decision(value)
+    return DECISION_TERM_SEVERITY.get(normalized, 3)
+
+
+def resolve_decision_precedence(
+    *values: object,
+    output: DecisionOutputSurface = "preserve",
+) -> str:
+    """Return the most restrictive decision across decision-like values.
+
+    A permissive source cannot override a restrictive source. Unknown or
+    malformed values fail closed to the reject/block severity. When ``output``
+    names a VERITAS surface, the returned term is canonical for that surface;
+    otherwise the first most-restrictive input term is preserved.
+    """
+    if not values:
+        severity = 3
+        selected = "unknown"
+    else:
+        normalized_values = [normalize_decision(value) for value in values]
+        severity = max(decision_severity(value) for value in normalized_values)
+        selected = next(
+            value
+            for value in normalized_values
+            if decision_severity(value) == severity
+        )
+
+    if output == "preserve":
+        if selected not in DECISION_TERM_SEVERITY:
+            return "block"
+        return selected
+    return DECISION_OUTPUT_TERMS[output][severity]
+
+
+def most_restrictive_decision(
+    *values: object,
+    output: DecisionOutputSurface = "preserve",
+) -> str:
+    """Alias for :func:`resolve_decision_precedence` using VERITAS wording."""
+    return resolve_decision_precedence(*values, output=output)
+
+
 def normalize_required_evidence_keys(values: Iterable[object] | None) -> list[str]:
     """Normalize evidence keys via taxonomy aliases while keeping free strings."""
     if values is None:
@@ -164,6 +269,7 @@ def normalize_required_evidence_keys(values: Iterable[object] | None) -> list[st
             continue
         out.append(alias_map.get(key, key))
     return out
+
 
 
 def normalize_required_evidence_keys_with_diagnostics(
@@ -355,8 +461,8 @@ def derive_gate_decision_from_stop_reasons(
 ) -> tuple[str, bool]:
     """Classify canonical gate decision using a single priority definition."""
     reasons = set(stop_reasons)
-    normalized_raw_gate = canonicalize_gate_decision(raw_gate_decision)
-    normalized_decision_status = canonicalize_gate_decision(decision_status)
+    normalized_raw_gate = resolve_decision_precedence(raw_gate_decision, output="gate")
+    normalized_decision_status = resolve_decision_precedence(decision_status, output="gate")
     # Decision-semantics.md section D priority order.
     if "rollback_not_supported" in reasons:
         return "block", human_review_required
@@ -377,6 +483,7 @@ def derive_gate_decision_from_stop_reasons(
     if (
         {"rule_undefined", "audit_trail_incomplete", "secure_controls_missing"} & reasons
         or normalized_raw_gate == "hold"
+        or normalized_decision_status == "hold"
     ):
         return "hold", human_review_required
     return "proceed", human_review_required

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -27,6 +27,7 @@ from veritas_os.core.decision_semantics import (
     get_required_evidence_profiles,
     normalize_required_evidence_keys_with_diagnostics,
     normalize_required_evidence_keys,
+    resolve_decision_precedence,
     unique_preserve_order,
     validate_gate_business_combination,
 )
@@ -713,7 +714,21 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         risk_score=risk_score,
         human_review_required=human_review_required,
     )
-    gate_decision = canonicalize_public_gate_decision(gate_decision)
+    explicit_business_decision = ctx.context.get("business_decision")
+    gate_decision = canonicalize_public_gate_decision(
+        resolve_decision_precedence(
+            gate_decision,
+            explicit_business_decision,
+            output="gate",
+        )
+    )
+    if gate_decision == "hold" and str(explicit_business_decision or "").upper() in {
+        "REVIEW",
+        "REVIEW_REQUIRED",
+        "ESCALATE",
+    }:
+        gate_decision = "human_review_required"
+        human_review_required = True
 
     if missing_evidence:
         business_decision = "EVIDENCE_REQUIRED"

--- a/veritas_os/core/pipeline/pipeline_response.py
+++ b/veritas_os/core/pipeline/pipeline_response.py
@@ -715,14 +715,19 @@ def _derive_business_fields(ctx: PipelineContext) -> Dict[str, Any]:
         human_review_required=human_review_required,
     )
     explicit_business_decision = ctx.context.get("business_decision")
+    business_decision_supplied = bool(str(explicit_business_decision or "").strip())
+    precedence_inputs: list[object] = [gate_decision]
+    if business_decision_supplied:
+        precedence_inputs.append(explicit_business_decision)
     gate_decision = canonicalize_public_gate_decision(
         resolve_decision_precedence(
-            gate_decision,
-            explicit_business_decision,
+            *precedence_inputs,
             output="gate",
         )
     )
-    if gate_decision == "hold" and str(explicit_business_decision or "").upper() in {
+    if gate_decision == "hold" and business_decision_supplied and str(
+        explicit_business_decision
+    ).upper() in {
         "REVIEW",
         "REVIEW_REQUIRED",
         "ESCALATE",

--- a/veritas_os/policy/bind_core/core.py
+++ b/veritas_os/policy/bind_core/core.py
@@ -12,6 +12,11 @@ from veritas_os.core.continuation_runtime.bind_admissibility import (
     CheckStatus,
     evaluate_bind_admissibility,
 )
+from veritas_os.core.decision_semantics import (
+    decision_severity,
+    normalize_decision,
+    resolve_decision_precedence,
+)
 from veritas_os.governance.action_contracts import (
     ActionClassContract,
     validate_action_class_contract,
@@ -300,6 +305,46 @@ def execute_bind_adjudication(
     drift_result = _check_from_runtime(admissibility.drift_check_result)
     risk_result = _check_from_runtime(admissibility.risk_check_result)
     regulated_context = _resolve_regulated_action_context(normalized_intent)
+    bind_decision_values = _extract_bind_decision_values(normalized_intent)
+    final_bind_decision = (
+        resolve_decision_precedence(*bind_decision_values, output="bind")
+        if bind_decision_values
+        else "eligible_to_commit"
+    )
+    if final_bind_decision != "eligible_to_commit":
+        blocked_outcome = FinalOutcome.BLOCKED
+        recommended_outcome = "block"
+        reason_code = "BIND_DECISION_PRECEDENCE_BLOCKED"
+        escalation_reason = None
+        if final_bind_decision == "escalate":
+            blocked_outcome = FinalOutcome.ESCALATED
+            recommended_outcome = "escalate"
+            reason_code = "BIND_DECISION_PRECEDENCE_ESCALATED"
+            escalation_reason = reason_code
+
+        return _finalize_receipt(
+            execution_intent=normalized_intent,
+            append_trustlog=append_trustlog,
+            receipt=_with_receipt(
+                base_receipt,
+                live_state_fingerprint_before=pre_fingerprint,
+                authority_check_result=authority_result,
+                constraint_check_result=constraint_result,
+                drift_check_result=drift_result,
+                risk_check_result=risk_result,
+                admissibility_result={
+                    "admissible": False,
+                    "recommended_outcome": recommended_outcome,
+                    "effective_decision": final_bind_decision,
+                    "decision_sources": bind_decision_values,
+                    "reason_codes": [reason_code],
+                    "target": adapter.describe_target(),
+                },
+                final_outcome=blocked_outcome,
+                escalation_reason=escalation_reason,
+                **_regulated_receipt_updates(regulated_context, None),
+            ),
+        )
 
     if not admissibility.admissibility_result:
         blocked_outcome = FinalOutcome.BLOCKED
@@ -511,6 +556,47 @@ def execute_bind_adjudication(
             **regulated_receipt_updates,
         ),
     )
+
+
+
+def _extract_bind_decision_values(execution_intent: ExecutionIntent) -> list[str]:
+    """Extract decision-like lineage values that constrain bind authority.
+
+    Bind/commit is allowed only when no stricter decision source exists. FUJI
+    deny/rejected, business hold/review, malformed decision strings, and other
+    restrictive values are carried into the shared precedence resolver before
+    any side effect is applied.
+    """
+    values: list[str] = []
+    for container in (execution_intent.approval_context, execution_intent.policy_lineage):
+        if not isinstance(container, dict):
+            continue
+        _collect_decision_values(container, values)
+        decision_semantics = container.get("decision_semantics")
+        if isinstance(decision_semantics, dict):
+            _collect_decision_values(decision_semantics, values)
+    return values
+
+
+def _collect_decision_values(container: dict[str, Any], values: list[str]) -> None:
+    for key in (
+        "gate_decision",
+        "business_decision",
+        "fuji_decision",
+        "bind_decision",
+        "decision_status",
+    ):
+        if key not in container:
+            continue
+        normalized = normalize_decision(container.get(key))
+        if normalized == "unknown" or normalized in {"none", "null"}:
+            continue
+        values.append(normalized)
+
+
+def _has_restrictive_bind_decision(execution_intent: ExecutionIntent) -> bool:
+    """Return whether decision lineage contains hold/review/block severity."""
+    return any(decision_severity(value) > 1 for value in _extract_bind_decision_values(execution_intent))
 
 
 def _resolve_regulated_action_context(execution_intent: ExecutionIntent) -> dict[str, Any]:

--- a/veritas_os/policy/bind_core/core.py
+++ b/veritas_os/policy/bind_core/core.py
@@ -588,10 +588,7 @@ def _collect_decision_values(container: dict[str, Any], values: list[str]) -> No
     ):
         if key not in container:
             continue
-        normalized = normalize_decision(container.get(key))
-        if normalized == "unknown" or normalized in {"none", "null"}:
-            continue
-        values.append(normalized)
+        values.append(normalize_decision(container.get(key)))
 
 
 def _has_restrictive_bind_decision(execution_intent: ExecutionIntent) -> bool:

--- a/veritas_os/tests/test_bind_execution.py
+++ b/veritas_os/tests/test_bind_execution.py
@@ -538,3 +538,26 @@ def test_bind_execution_allow_commits_when_no_stricter_decision_exists() -> None
 
     assert receipt.final_outcome is FinalOutcome.COMMITTED
     assert adapter.state["version"] == 2
+
+
+@pytest.mark.parametrize("raw_decision", ["unknown", "maybe"])
+def test_bind_execution_unknown_or_malformed_decision_fails_closed(
+    raw_decision: str,
+) -> None:
+    """Explicit unknown/malformed decision lineage must block bind apply."""
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(
+        expected_fingerprint=adapter.fingerprint_state({"version": 1}),
+        approval_context={
+            "decision_semantics": {
+                "gate_decision": raw_decision,
+            }
+        },
+    )
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert adapter.state["version"] == 1
+    assert receipt.admissibility_result["effective_decision"] == "block"
+    assert "BIND_DECISION_PRECEDENCE_BLOCKED" in receipt.admissibility_result["reason_codes"]

--- a/veritas_os/tests/test_bind_execution.py
+++ b/veritas_os/tests/test_bind_execution.py
@@ -474,3 +474,67 @@ def test_bind_execution_failure_taxonomy_minimum_mapping() -> None:
         append_trustlog=False,
     )
     assert precondition.failure_category == "PRECONDITION"
+
+
+def test_bind_execution_fuji_rejected_decision_is_not_advisory() -> None:
+    """FUJI reject/deny lineage must block before bind apply."""
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(
+        expected_fingerprint=adapter.fingerprint_state({"version": 1}),
+        approval_context={
+            "decision_semantics": {
+                "gate_decision": "allow",
+                "business_decision": "APPROVE",
+                "fuji_decision": "rejected",
+            }
+        },
+    )
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.BLOCKED
+    assert adapter.state["version"] == 1
+    assert receipt.admissibility_result["effective_decision"] == "block"
+    assert "BIND_DECISION_PRECEDENCE_BLOCKED" in receipt.admissibility_result["reason_codes"]
+
+
+def test_bind_execution_hold_decision_requires_review_not_commit() -> None:
+    """Hold/review lineage must escalate instead of silently becoming allow."""
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(
+        expected_fingerprint=adapter.fingerprint_state({"version": 1}),
+        policy_lineage={
+            "decision_semantics": {
+                "gate_decision": "allow",
+                "business_decision": "HOLD",
+                "fuji_decision": "allow",
+            }
+        },
+    )
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.ESCALATED
+    assert adapter.state["version"] == 1
+    assert receipt.admissibility_result["effective_decision"] == "escalate"
+    assert "BIND_DECISION_PRECEDENCE_ESCALATED" in receipt.admissibility_result["reason_codes"]
+
+
+def test_bind_execution_allow_commits_when_no_stricter_decision_exists() -> None:
+    """Allow/proceed/approved lineage may bind when all other checks pass."""
+    adapter = ReferenceBindAdapter(state={"version": 1}, pending_changes={"version": 2})
+    intent = _intent(
+        expected_fingerprint=adapter.fingerprint_state({"version": 1}),
+        approval_context={
+            "decision_semantics": {
+                "gate_decision": "allow",
+                "business_decision": "APPROVED",
+                "fuji_decision": "allow",
+            }
+        },
+    )
+
+    receipt = execute_bind_boundary(execution_intent=intent, adapter=adapter)
+
+    assert receipt.final_outcome is FinalOutcome.COMMITTED
+    assert adapter.state["version"] == 2

--- a/veritas_os/tests/test_decision_semantics_conformance.py
+++ b/veritas_os/tests/test_decision_semantics_conformance.py
@@ -208,3 +208,22 @@ def test_decision_path_conflicts_resolve_to_stricter_outcome(
 
     assert payload["gate_decision"] == expected_gate
     assert payload["business_decision"] == expected_business
+
+
+def test_absent_business_decision_does_not_fail_closed_allow_path() -> None:
+    """Absent business_decision must not be treated as unknown/block."""
+    ctx = PipelineContext(
+        request_id="req-precedence-absent-business-decision",
+        query="conformance",
+        fuji_dict={"decision_status": "allow", "status": "allow"},
+        decision_status="allow",
+        context={},
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == "proceed"
+    assert payload["business_decision"] == "APPROVE"

--- a/veritas_os/tests/test_decision_semantics_conformance.py
+++ b/veritas_os/tests/test_decision_semantics_conformance.py
@@ -157,3 +157,54 @@ def test_compare_helper_and_runtime_alias_maps_stay_consistent() -> None:
             "human_review_required": False,
         }
         assert compare_expected_semantics(expected_payload, actual_payload) == {}
+
+
+def test_restrictive_decision_precedence_pure_contract() -> None:
+    """Decision precedence is machine-readable and fail-closed."""
+    from veritas_os.core.decision_semantics import (
+        decision_severity,
+        resolve_decision_precedence,
+    )
+
+    assert decision_severity("deny") > decision_severity("hold")
+    assert decision_severity("hold") > decision_severity("allow")
+    assert resolve_decision_precedence("allow", "allow") == "allow"
+    assert resolve_decision_precedence("allow", "hold") == "hold"
+    assert resolve_decision_precedence("hold", "deny") == "deny"
+    assert resolve_decision_precedence("approved", "rejected") == "rejected"
+    assert resolve_decision_precedence("malformed_decision") == "block"
+    assert resolve_decision_precedence("malformed_decision", output="gate") == "block"
+
+
+@pytest.mark.parametrize(
+    "fuji_decision, business_decision, expected_gate, expected_business",
+    [
+        ("allow", "HOLD", "hold", "HOLD"),
+        ("deny", "APPROVE", "block", "DENY"),
+        ("rejected", "APPROVED", "block", "DENY"),
+        ("hold", "APPROVE", "hold", "HOLD"),
+        ("malformed_decision", "APPROVE", "block", "DENY"),
+    ],
+)
+def test_decision_path_conflicts_resolve_to_stricter_outcome(
+    fuji_decision: str,
+    business_decision: str,
+    expected_gate: str,
+    expected_business: str,
+) -> None:
+    """Gate/business/FUJI conflicts must converge on the stricter outcome."""
+    ctx = PipelineContext(
+        request_id=f"req-precedence-{fuji_decision}-{business_decision}",
+        query="conformance",
+        fuji_dict={"decision_status": fuji_decision, "status": fuji_decision},
+        decision_status=fuji_decision,
+        context={"business_decision": business_decision},
+    )
+    payload = assemble_response(
+        ctx,
+        load_persona_fn=lambda: {},
+        plan={"steps": [], "source": "test"},
+    )
+
+    assert payload["gate_decision"] == expected_gate
+    assert payload["business_decision"] == expected_business

--- a/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
+++ b/veritas_os/tests/unit/test_decision_semantics_runtime_contract.py
@@ -223,8 +223,8 @@ def test_public_response_prefers_canonical_gate_decision() -> None:
     assert payload["gate_decision"] == "proceed"
 
 
-def test_public_response_avoids_unknown_in_normal_runtime_path() -> None:
-    """Unknown FUJI status should still resolve into canonical public gate decision."""
+def test_public_response_fails_closed_on_unknown_decision() -> None:
+    """Unknown FUJI status should fail closed to canonical block."""
     ctx = PipelineContext(
         request_id="req-gate-unknown-normalized",
         query="test unknown gate",
@@ -237,7 +237,7 @@ def test_public_response_avoids_unknown_in_normal_runtime_path() -> None:
         load_persona_fn=lambda: {},
         plan={"steps": [], "source": "test"},
     )
-    assert payload["gate_decision"] == "proceed"
+    assert payload["gate_decision"] == "block"
 
 
 def test_backward_compat_decision_status_stays_legacy_field() -> None:


### PR DESCRIPTION
### Motivation
- Make decision precedence explicit and machine-readable so that the strictest decision (deny/reject/block) always wins across gate, business, FUJI, and bind surfaces. 
- Ensure downstream bind/commit cannot treat a FUJI `rejected`/deny result as advisory and that hold/review never silently becomes allow at bind time. 
- Keep existing public semantics and aliases while exposing a single canonical precedence rule and preserving surface-specific vocabulary.

### Description
- Added a machine-readable precedence contract and helpers in `veritas_os/core/decision_semantics.py`: `DECISION_SEVERITY_ALIASES`, `DECISION_TERM_SEVERITY`, `DECISION_OUTPUT_TERMS`, and helper APIs `normalize_decision`, `decision_severity`, `resolve_decision_precedence`, and `most_restrictive_decision` to compute the most restrictive outcome programmatically. 
- Integrated the precedence resolver into the decision assembly path in `veritas_os/core/pipeline/pipeline_response.py` so derived `gate_decision` is reconciled with explicit business decisions using restrictive precedence before emitting the public payload. 
- Enforced precedence in the bind/commit path in `veritas_os/policy/bind_core/core.py` by extracting decision-like lineage from `approval_context` and `policy_lineage` and resolving them with the shared resolver; non-eligible (block/escalate) results short-circuit before calling adapter `apply`. 
- Documentation: updated `docs/en/architecture/decision-semantics.md` with the precedence table, wording and examples showing mapping to gate/business/FUJI/bind outputs. 
- Tests: added conformance tests covering pure precedence rules and decision-path conflicts and bind-path behavior (`veritas_os/tests/test_decision_semantics_conformance.py`, `veritas_os/tests/test_bind_execution.py`) and updated an existing runtime contract test to assert fail-closed unknown handling. 

### Testing
- Static/quality checks: ran `python3 -m py_compile` across modified modules (success) and `ruff check` (success). 
- Sanity / runtime checks: executed small python invocations of `resolve_decision_precedence` to confirm expected mappings (e.g. `approved` + `rejected` -> `rejected`, malformed -> `block`). 
- Unit/functional test run: attempted `pytest` for the new/updated conformance and bind tests, but the environment lacked required test dependencies (`pydantic`) so full pytest runs could not be completed here (dependency fetch was blocked in this environment). 

Security / approval note: this PR touches bind/admissibility behavior (high-risk area); per project rules it requires human review/approval before merging and should be reviewed by governance/security owners.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ceb83dd188326b34c7c1b50cbea18)