### PR TITLE
Enforce strict TrustLog mirror capabilities in secure/prod posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,23 @@ Additionally, startup refuses when:
 - `VERITAS_API_SECRET_REF` is not set (external secret manager enforcement)
 - Backend-specific configuration is incomplete (e.g. missing `VERITAS_TRUSTLOG_KMS_KEY_ID` for `aws_kms`, missing S3 bucket/prefix for `s3_object_lock`)
 
+#### TrustLog strict mirror capabilities in secure/prod
+
+In `secure`/`prod` posture, TrustLog startup validation fails closed unless
+the selected mirror backend advertises both `immutable_retention` and
+`fail_closed`. The current backend that advertises this full strict capability
+set is `s3_object_lock`, configured with
+`VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock`,
+`VERITAS_TRUSTLOG_S3_BUCKET`, and `VERITAS_TRUSTLOG_S3_PREFIX` (plus
+`VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE` and
+`VERITAS_TRUSTLOG_S3_RETENTION_DAYS` according to the deployment retention
+policy). A local WORM mirror is useful for local/dev or secondary mirror
+workflows, but it is not a substitute for production strict mirror requirements
+unless the existing backend contract explicitly registers it as compliant by
+advertising the full strict capability set: `immutable_retention` and
+`fail_closed`. Lower `VERITAS_POSTURE` only for non-production/local
+development when existing policy allows it.
+
 > **Note:** In `prod` posture, `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD`
 > is unconditionally ignored — there is no break-glass for insecure signers in
 > production.  In `secure` posture this override remains available as an
@@ -1855,7 +1872,7 @@ All environment variables in one place. Set these in `.env` (git-ignored) or you
 - Existing deployments continue to work with no change because `VERITAS_TRUSTLOG_MIRROR_BACKEND` defaults to `local` and keeps `VERITAS_TRUSTLOG_WORM_MIRROR_PATH` behavior.
 - To migrate to S3 Object Lock, set `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock` and provide at minimum `VERITAS_TRUSTLOG_S3_BUCKET` (plus optional prefix/region/retention settings).
 - `VERITAS_TRUSTLOG_WORM_HARD_FAIL` semantics are unchanged and apply to both backends.
-- In `secure`/`prod`, the startup validator requires backends with the `immutable_retention` capability. The current implementation satisfying this is `s3_object_lock`; both `VERITAS_TRUSTLOG_S3_BUCKET` and `VERITAS_TRUSTLOG_S3_PREFIX` must be set.
+- In `secure`/`prod`, the startup validator requires mirror backends with both `immutable_retention` and `fail_closed`. The current implementation satisfying this full strict capability set is `s3_object_lock`; both `VERITAS_TRUSTLOG_S3_BUCKET` and `VERITAS_TRUSTLOG_S3_PREFIX` must be set. If the selected backend is `local`, startup is refused fail-closed because a local WORM mirror does not advertise the full strict capability set and is not a production immutable-retention substitute.
 
 #### TrustLog mirror verification modes
 

--- a/docs/en/validation/production-validation.md
+++ b/docs/en/validation/production-validation.md
@@ -589,6 +589,21 @@ The core validation logic (`validate_posture_startup`) does **not** need to chan
 | Anchor | `tsa` | `transparency_anchoring`, `fail_closed` |
 | Anchor | `noop` | *(none — dev/staging only)* |
 
+### TrustLog strict mirror capability startup refusal
+
+In `secure`/`prod` posture, startup fails closed when the selected TrustLog
+mirror backend does not advertise both `immutable_retention` and `fail_closed`.
+The actionable remediation is to configure the S3 Object Lock capable mirror
+with `VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock`,
+`VERITAS_TRUSTLOG_S3_BUCKET`, and `VERITAS_TRUSTLOG_S3_PREFIX`; set
+`VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE` and
+`VERITAS_TRUSTLOG_S3_RETENTION_DAYS` according to the deployment retention
+policy. Lower `VERITAS_POSTURE` only for non-production/local development when
+existing policy allows it. The local WORM mirror remains appropriate for
+local/dev or secondary mirror use, but it is not a substitute for production
+strict mirror requirements unless the backend contract explicitly registers the
+full strict capability set: `immutable_retention` and `fail_closed`.
+
 > **Note:** The current production-supported implementation uses **AWS KMS** for
 > signing and **S3 Object Lock** for mirroring. No new backend implementations
 > were added in this release — only the validation framework was restructured

--- a/docs/ja/operations/postgresql-production-guide.md
+++ b/docs/ja/operations/postgresql-production-guide.md
@@ -45,6 +45,21 @@ PostgreSQL を本番で運用する際の確認観点を、日本語で短く整
   - `VERITAS_TRUSTLOG_MIRROR_BACKEND` が未知値（warning には正規化された backend 値を含む）
 - 注: `VERITAS_TRUSTLOG_ALLOW_INSECURE_SIGNER_IN_PROD` は、この production posture checker では考慮されません。本番姿勢チェックでは `VERITAS_TRUSTLOG_SIGNER_BACKEND=aws_kms` を要求し、`file` / `local` / `noop` / 未設定の signer は、break-glass フラグがあっても failure になります。
 
+## TrustLog strict mirror capability の startup 拒否
+
+`secure`/`prod` 姿勢では、選択された TrustLog mirror backend が
+`immutable_retention` と `fail_closed` の両方を宣言していない場合、
+startup は fail-closed で拒否されます。S3 Object Lock 対応 mirror を
+使うには、`VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock`、
+`VERITAS_TRUSTLOG_S3_BUCKET`、`VERITAS_TRUSTLOG_S3_PREFIX` を設定し、
+保持ポリシーに応じて `VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE` と
+`VERITAS_TRUSTLOG_S3_RETENTION_DAYS` を設定してください。local WORM mirror
+は local/dev または二次 mirror 用であり、既存の backend contract が
+`immutable_retention` と `fail_closed` の full strict capability set を
+明示的に登録していない限り、本番 strict mirror 要件の代替には
+なりません。`VERITAS_POSTURE` を下げるのは、既存ポリシーで許可された
+非本番/local 開発に限定してください。
+
 ## 現時点の制限
 - ここで示す内容は一般指針で、各環境のHA/DR要件を代替しません。
 - 本番適用前に監査設計・鍵管理・アクセス統制を追加してください。

--- a/veritas_os/core/posture.py
+++ b/veritas_os/core/posture.py
@@ -359,6 +359,11 @@ _MIRROR_CAPABILITIES: Dict[str, frozenset[BackendCapability]] = {
     # local mirror: no immutable retention guarantee
     "local": frozenset(),
 }
+_STRICT_MIRROR_CAPABILITY_ORDER = (
+    BackendCapability.IMMUTABLE_RETENTION,
+    BackendCapability.FAIL_CLOSED,
+)
+_STRICT_MIRROR_CAPABILITIES = frozenset(_STRICT_MIRROR_CAPABILITY_ORDER)
 
 _ANCHOR_CAPABILITIES: Dict[str, frozenset[BackendCapability]] = {
     "local": frozenset({
@@ -390,6 +395,9 @@ def anchor_capabilities(backend_name: str) -> frozenset[BackendCapability]:
 
 # ── Startup validation ──────────────────────────────────────────────────
 
+TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING = "TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING"
+
+
 class PostureStartupError(RuntimeError):
     """Raised when the active posture detects a fatal misconfiguration."""
 
@@ -416,6 +424,70 @@ def _trustlog_anchor_backend() -> str:
     """Return normalized TrustLog anchor backend name."""
     return normalize_trustlog_anchor_backend(
         os.getenv("VERITAS_TRUSTLOG_ANCHOR_BACKEND")
+    )
+
+
+def _format_mirror_capabilities(
+    capabilities: frozenset[BackendCapability],
+) -> str:
+    """Format strict mirror capabilities in stable operator-facing order."""
+    ordered = [
+        capability.value
+        for capability in _STRICT_MIRROR_CAPABILITY_ORDER
+        if capability in capabilities
+    ]
+    extras = sorted(
+        capability.value
+        for capability in capabilities
+        if capability not in _STRICT_MIRROR_CAPABILITIES
+    )
+    return ", ".join([*ordered, *extras])
+
+
+def _trustlog_strict_mirror_capabilities_required_message(
+    *,
+    posture: PostureLevel,
+    mirror_backend: str,
+    missing_capabilities: frozenset[BackendCapability],
+) -> str:
+    """Build the strict-posture TrustLog mirror capability refusal message.
+
+    The message intentionally includes only non-secret backend metadata,
+    missing/required capability names, and environment variable names so
+    operators receive actionable remediation without leaking bucket names,
+    paths, credentials, or raw connection strings.
+    """
+    required = _format_mirror_capabilities(_STRICT_MIRROR_CAPABILITIES)
+    missing = _format_mirror_capabilities(missing_capabilities)
+    details = (
+        f"{TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING}: Startup refused "
+        f"fail-closed: posture={posture.value} requires TrustLog strict "
+        "mirror capabilities. "
+        f"Selected TrustLog mirror backend={mirror_backend!r} does not "
+        "advertise the required strict mirror capability set "
+        f"(missing capabilities: {missing}; required capabilities: "
+        f"{required}). "
+    )
+    if mirror_backend == "local":
+        details += (
+            "Local WORM mirror does not satisfy secure/prod strict mirror "
+            "capability requirements unless the existing backend contract "
+            "explicitly registers it as compliant by advertising the full "
+            f"strict capability set: {required}. "
+        )
+    elif mirror_backend not in _MIRROR_CAPABILITIES:
+        known_backends = ", ".join(sorted(_MIRROR_CAPABILITIES))
+        details += f"Known TrustLog mirror backends: {known_backends}. "
+
+    return (
+        details
+        + "Remediation: configure the S3 Object Lock capable TrustLog mirror "
+        "with VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock and set "
+        "VERITAS_TRUSTLOG_S3_BUCKET and VERITAS_TRUSTLOG_S3_PREFIX; set "
+        "VERITAS_TRUSTLOG_S3_OBJECT_LOCK_MODE and "
+        "VERITAS_TRUSTLOG_S3_RETENTION_DAYS as required by your retention "
+        "policy; or lower VERITAS_POSTURE only for non-production/local "
+        "development if existing policy allows it."
     )
 
 
@@ -561,13 +633,14 @@ def validate_posture_startup(defaults: PostureDefaults) -> List[str]:
     mirror_caps = mirror_capabilities(mirror_backend)
 
     if defaults.posture in {PostureLevel.SECURE, PostureLevel.PROD}:
-        if BackendCapability.IMMUTABLE_RETENTION not in mirror_caps:
+        missing_mirror_caps = _STRICT_MIRROR_CAPABILITIES - mirror_caps
+        if missing_mirror_caps:
             errors.append(
-                f"TrustLog mirror backend {mirror_backend!r} does not provide "
-                "the 'immutable_retention' capability required in "
-                f"{defaults.posture.value} posture. "
-                "Configure a mirror with immutable retention support "
-                "(e.g. VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock)."
+                _trustlog_strict_mirror_capabilities_required_message(
+                    posture=defaults.posture,
+                    mirror_backend=mirror_backend,
+                    missing_capabilities=missing_mirror_caps,
+                )
             )
     elif mirror_backend not in _MIRROR_CAPABILITIES:
         errors.append(

--- a/veritas_os/tests/test_posture.py
+++ b/veritas_os/tests/test_posture.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 import pytest
 
 from veritas_os.core.posture import (
+    TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING,
     PostureDefaults,
     PostureLevel,
     PostureStartupError,
@@ -829,7 +830,7 @@ class TestCapabilityAwareValidation:
         assert any("managed_signing" in e for e in errors)
 
     def test_secure_rejects_incapable_mirror(self, monkeypatch):
-        """Secure posture rejects mirror without immutable_retention."""
+        """Secure posture rejects mirror without strict mirror capabilities."""
         _clean_env(monkeypatch)
         _set_minimum_strict_integrations(monkeypatch)
         monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
@@ -948,9 +949,8 @@ class TestMockFutureBackendCapability:
         # aws_kms-specific config, but that doesn't apply here)
         assert not any("managed_signing" in e for e in errors)
 
-    def test_future_mirror_with_immutable_retention_passes_prod(self, monkeypatch):
-        """A hypothetical 'azure_blob_immutable' mirror with
-        immutable_retention should pass secure/prod validation."""
+    def test_future_mirror_with_strict_capabilities_passes_prod(self, monkeypatch):
+        """A hypothetical mirror with full strict capabilities passes prod."""
         from veritas_os.core.posture import (
             BackendCapability,
             _MIRROR_CAPABILITIES,
@@ -969,7 +969,7 @@ class TestMockFutureBackendCapability:
         monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:key")
         d = derive_defaults(PostureLevel.PROD)
         errors = validate_posture_startup(d)
-        assert not any("immutable_retention" in e for e in errors)
+        assert not any("strict mirror capabilities" in e for e in errors)
 
     def test_future_backend_without_capability_rejected(self, monkeypatch):
         """A future backend without the needed capability is rejected."""
@@ -1205,6 +1205,200 @@ class TestCapabilityAwareRefusalMessages:
         mirror_errs = [e for e in errors if "mirror" in e.lower()]
         assert len(mirror_errs) >= 1
         assert "immutable_retention" in mirror_errs[0]
+
+    def test_prod_local_mirror_error_is_actionable_and_unambiguous(
+        self,
+        monkeypatch,
+    ):
+        """Prod local mirror refusal is explicit, actionable, and fail-closed."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/tmp/local-worm")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:key")
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.PROD))
+        mirror_error = next(e for e in errors if "strict mirror capabilities" in e)
+
+        assert TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING in mirror_error
+        assert "Startup refused fail-closed" in mirror_error
+        assert "posture=prod" in mirror_error
+        assert "backend='local'" in mirror_error
+        assert "does not advertise" in mirror_error
+        assert "missing capabilities: immutable_retention, fail_closed" in mirror_error
+        assert "required capabilities: immutable_retention, fail_closed" in mirror_error
+        assert "Local WORM mirror does not satisfy secure/prod" in mirror_error
+        assert "full strict capability set" in mirror_error
+        assert "VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock" in mirror_error
+        assert "VERITAS_TRUSTLOG_S3_BUCKET" in mirror_error
+        assert "VERITAS_TRUSTLOG_S3_PREFIX" in mirror_error
+        assert "VERITAS_POSTURE" in mirror_error
+        assert "Known TrustLog mirror backends" not in mirror_error
+        assert "local WORM mirror satisfies" not in mirror_error.lower()
+        assert "local WORM mirror is sufficient" not in mirror_error.lower()
+
+    def test_mirror_missing_only_immutable_retention_reports_that_capability(
+        self,
+        monkeypatch,
+    ):
+        """Strict mirror refusal names immutable_retention when only it is absent."""
+        from veritas_os.core.posture import (
+            BackendCapability,
+            _MIRROR_CAPABILITIES,
+        )
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setitem(_MIRROR_CAPABILITIES, "fail_closed_only", frozenset({
+            BackendCapability.FAIL_CLOSED,
+        }))
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "fail_closed_only")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:key")
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.PROD))
+        mirror_error = next(e for e in errors if "strict mirror capabilities" in e)
+
+        assert TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING in mirror_error
+        assert "missing capabilities: immutable_retention" in mirror_error
+        assert "missing capabilities: fail_closed" not in mirror_error
+        assert "required capabilities: immutable_retention, fail_closed" in mirror_error
+
+    def test_mirror_missing_only_fail_closed_reports_that_capability(
+        self,
+        monkeypatch,
+    ):
+        """Strict mirror refusal uses broad code when only fail_closed is absent."""
+        from veritas_os.core.posture import (
+            BackendCapability,
+            _MIRROR_CAPABILITIES,
+        )
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setitem(_MIRROR_CAPABILITIES, "retention_only", frozenset({
+            BackendCapability.IMMUTABLE_RETENTION,
+        }))
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "retention_only")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:key")
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.PROD))
+        mirror_error = next(e for e in errors if "strict mirror capabilities" in e)
+
+        assert TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING in mirror_error
+        assert "TRUSTLOG_WORM_IMMUTABLE_RETENTION_MISSING" not in mirror_error
+        assert "missing capabilities: fail_closed" in mirror_error
+        assert "missing capabilities: immutable_retention" not in mirror_error
+        assert "required capabilities: immutable_retention, fail_closed" in mirror_error
+
+    def test_unknown_mirror_backend_lists_known_backends_without_local_warning(
+        self,
+        monkeypatch,
+    ):
+        """Unknown mirror refusal lists safe backend names without local wording."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "custom_worm")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:key")
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.PROD))
+        mirror_error = next(e for e in errors if "strict mirror capabilities" in e)
+
+        assert "Selected TrustLog mirror backend='custom_worm'" in mirror_error
+        assert "missing capabilities: immutable_retention, fail_closed" in mirror_error
+        assert "required capabilities: immutable_retention, fail_closed" in mirror_error
+        assert "Known TrustLog mirror backends: local, s3_object_lock" in mirror_error
+        assert "Local WORM mirror does not satisfy secure/prod" not in mirror_error
+        assert "VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock" in mirror_error
+
+    def test_unknown_mirror_backend_hint_does_not_echo_sensitive_values(
+        self,
+        monkeypatch,
+    ):
+        """Known-backends hint excludes unrelated sensitive env values."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        bucket_value = "secret-prod-bucket-value"
+        prefix_value = "secret/prefix/value"
+        kms_value = "arn:aws:kms:us-east-1:111:key/secret-value"
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "custom_worm")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_BUCKET", bucket_value)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_PREFIX", prefix_value)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", kms_value)
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.PROD))
+        mirror_error = next(e for e in errors if "strict mirror capabilities" in e)
+
+        assert "Known TrustLog mirror backends: local, s3_object_lock" in mirror_error
+        assert bucket_value not in mirror_error
+        assert prefix_value not in mirror_error
+        assert kms_value not in mirror_error
+
+    def test_secure_missing_strict_mirror_capabilities_startup_error_is_fail_closed(
+        self,
+        monkeypatch,
+    ):
+        """init_posture preserves refusal while surfacing actionable details."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", "/tmp/local-worm")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", "arn:key")
+
+        with pytest.raises(PostureStartupError) as exc_info:
+            init_posture(explicit="secure")
+
+        message = str(exc_info.value)
+        assert "Posture 'secure' startup refused" in message
+        assert TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING in message
+        assert "Startup refused fail-closed" in message
+        assert "posture=secure" in message
+        assert "Selected TrustLog mirror backend='local'" in message
+        assert "VERITAS_TRUSTLOG_MIRROR_BACKEND=s3_object_lock" in message
+        assert "VERITAS_TRUSTLOG_S3_BUCKET" in message
+        assert "VERITAS_TRUSTLOG_S3_PREFIX" in message
+
+    def test_dev_local_mirror_behavior_remains_unchanged(self, monkeypatch):
+        """Dev posture does not receive strict mirror capability errors."""
+        _clean_env(monkeypatch)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local")
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.DEV))
+
+        assert not any(TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING in e for e in errors)
+        assert not any("Startup refused fail-closed" in e for e in errors)
+        assert not any("immutable_retention" in e for e in errors)
+
+    def test_strict_mirror_error_does_not_echo_sensitive_values(
+        self,
+        monkeypatch,
+    ):
+        """Strict mirror refusal includes env names, never sensitive env values."""
+        _clean_env(monkeypatch)
+        _set_minimum_strict_integrations(monkeypatch)
+        bucket_value = "secret-prod-bucket-value"
+        prefix_value = "secret/prefix/value"
+        path_value = "/secret/local/worm/path"
+        kms_value = "arn:aws:kms:us-east-1:111:key/secret-value"
+        monkeypatch.setenv("VERITAS_TRUSTLOG_MIRROR_BACKEND", "local")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_WORM_MIRROR_PATH", path_value)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_BUCKET", bucket_value)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_S3_PREFIX", prefix_value)
+        monkeypatch.setenv("VERITAS_TRUSTLOG_SIGNER_BACKEND", "aws_kms")
+        monkeypatch.setenv("VERITAS_TRUSTLOG_KMS_KEY_ID", kms_value)
+
+        errors = validate_posture_startup(derive_defaults(PostureLevel.PROD))
+        mirror_error = next(e for e in errors if "strict mirror capabilities" in e)
+
+        assert "VERITAS_TRUSTLOG_S3_BUCKET" in mirror_error
+        assert "VERITAS_TRUSTLOG_S3_PREFIX" in mirror_error
+        assert bucket_value not in mirror_error
+        assert prefix_value not in mirror_error
+        assert path_value not in mirror_error
+        assert kms_value not in mirror_error
 
     def test_dummy_capable_backend_passes_prod(self, monkeypatch):
         """A dummy backend with all required capabilities passes prod."""


### PR DESCRIPTION
### Motivation

- Ensure production-grade TrustLog mirrors provide both immutable retention and fail-closed semantics so startup refuses unsafe configurations in `secure`/`prod` posture.
- Provide actionable, non-sensitive operator-facing error messages that explain missing capabilities and remediation steps without echoing secrets.
- Document the stricter posture requirements across English and Japanese operational docs and the README.

### Description

- Added a strict mirror capability set and registry-driven capability checks to `veritas_os/core/posture.py`, including `_STRICT_MIRROR_CAPABILITIES`, a stable formatter `_format_mirror_capabilities`, and a detailed refusal message builder `_trustlog_strict_mirror_capabilities_required_message` and error marker `TRUSTLOG_STRICT_MIRROR_CAPABILITIES_MISSING`.
- Updated `validate_posture_startup` to require the full strict mirror capability set (`immutable_retention` + `fail_closed`) for `secure`/`prod` postures and to emit the new actionable refusal message when capabilities are missing.
- Enhanced unit tests in `veritas_os/tests/test_posture.py` to reflect the new strict-mirror semantics, renaming/adjusting tests and adding many assertions that verify failure mode text, non-leakage of sensitive values, and correct behavior across `dev`, `secure`, and `prod` postures.
- Updated documentation and README (`README.md`, `docs/en/validation/production-validation.md`, `docs/ja/operations/postgresql-production-guide.md`) to describe the strict mirror capability requirement and migration/configuration guidance for S3 Object Lock.

### Testing

- Ran the posture unit tests via `pytest veritas_os/tests/test_posture.py`, which exercise capability-aware startup validation and message contents, and they passed locally.
- New and updated tests verify that missing strict mirror capabilities cause fail-closed startup refusals in `secure`/`prod` and that messages include only non-sensitive remediation hints.
- Existing dev-mode behavior tests were retained to confirm `dev` posture is unaffected by strict mirror checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5011b02c8326b68674182359d3d1)