### PR TITLE
docs: add Lara / PromptLedger static review response matrix

### DIFF
--- a/docs/REVIEWER_ENTRYPOINT.md
+++ b/docs/REVIEWER_ENTRYPOINT.md
@@ -13,32 +13,34 @@ This entry point is organized around the current enterprise review path: busines
 1. [Enterprise Value Brief](en/positioning/enterprise-value-brief.md) — one-page business/investor overview.
 2. [README](../README.md) — core product definition and repository entry map.
 3. [Current Implementation Matrix](en/validation/current-implementation-matrix.md) — current implementation facts vs roadmap.
-4. [Operational Readiness Runbook](en/operations/operational-readiness-runbook.md) — release evidence commands, staged readiness report interpretation, and what compose/live subreports do and do not prove.
-5. [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md) — what reviewers should inspect, collect, and treat as success/failure evidence in a One-Day PoC.
-6. [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md) — how operators prepare, collect, package, and hand off PoC evidence.
-7. [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md) — submit-ready handoff format for PoC results.
-8. [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md) — submit-ready format for release evidence, staged readiness interpretation, subreport presence/absence, and reviewer acknowledgement.
-9. [Provider Support Matrix](en/operations/provider-support-matrix.md) — provider tiers, support boundaries, and non-claims.
-10. [Public Positioning](en/positioning/public-positioning.md) — conservative positioning and legal/compliance boundary statements.
+4. [Lara / PromptLedger Static Review Response Matrix](en/validation/lara-promptledger-static-review-response.md) — reviewer-facing map from static review findings to implemented repository responses, with audit/certification caveats.
+5. [Operational Readiness Runbook](en/operations/operational-readiness-runbook.md) — release evidence commands, staged readiness report interpretation, and what compose/live subreports do and do not prove.
+6. [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md) — what reviewers should inspect, collect, and treat as success/failure evidence in a One-Day PoC.
+7. [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md) — how operators prepare, collect, package, and hand off PoC evidence.
+8. [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md) — submit-ready handoff format for PoC results.
+9. [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md) — submit-ready format for release evidence, staged readiness interpretation, subreport presence/absence, and reviewer acknowledgement.
+10. [Provider Support Matrix](en/operations/provider-support-matrix.md) — provider tiers, support boundaries, and non-claims.
+11. [Public Positioning](en/positioning/public-positioning.md) — conservative positioning and legal/compliance boundary statements.
 
 ## 30-minute technical review path
 
 1. [Enterprise Value Brief](en/positioning/enterprise-value-brief.md)
 2. [Current Implementation Matrix](en/validation/current-implementation-matrix.md)
 3. [Operational Readiness Runbook](en/operations/operational-readiness-runbook.md)
-4. [Production Validation](en/validation/production-validation.md)
-5. [Regulated Action Governance Proof Pack](en/validation/regulated-action-governance-proof-pack.md)
-6. [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md)
-7. [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md)
-8. [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md)
-9. [One-Day PoC Reviewer Pack](en/poc/one-day-poc-reviewer-pack.md)
-10. [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
-11. [Type Safety Baseline](en/operations/type-safety-baseline.md)
-12. [Maintainer Handoff](en/operations/maintainer-handoff.md)
-13. [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md)
-14. [Provider Support Matrix](en/operations/provider-support-matrix.md)
-15. [Regulated Action Governance Kernel](en/architecture/regulated-action-governance-kernel.md)
-16. [Bind Boundary Governance Artifacts](en/architecture/bind-boundary-governance-artifacts.md)
+4. [Lara / PromptLedger Static Review Response Matrix](en/validation/lara-promptledger-static-review-response.md)
+5. [Production Validation](en/validation/production-validation.md)
+6. [Regulated Action Governance Proof Pack](en/validation/regulated-action-governance-proof-pack.md)
+7. [One-Day PoC Evidence Pack](en/poc/one-day-poc-evidence-pack.md)
+8. [One-Day PoC Operator Runbook](en/poc/one-day-poc-operator-runbook.md)
+9. [One-Day PoC Reviewer Handoff Template](en/poc/one-day-poc-reviewer-handoff-template.md)
+10. [One-Day PoC Reviewer Pack](en/poc/one-day-poc-reviewer-pack.md)
+11. [One-Day PoC Performance Report](en/poc/one-day-poc-performance-report.md)
+12. [Type Safety Baseline](en/operations/type-safety-baseline.md)
+13. [Maintainer Handoff](en/operations/maintainer-handoff.md)
+14. [Release Evidence Reviewer Handoff Template](en/validation/release-evidence-reviewer-handoff-template.md)
+15. [Provider Support Matrix](en/operations/provider-support-matrix.md)
+16. [Regulated Action Governance Kernel](en/architecture/regulated-action-governance-kernel.md)
+17. [Bind Boundary Governance Artifacts](en/architecture/bind-boundary-governance-artifacts.md)
 
 ## What VERITAS OS is
 

--- a/docs/en/validation/lara-promptledger-static-review-response.md
+++ b/docs/en/validation/lara-promptledger-static-review-response.md
@@ -1,0 +1,55 @@
+# Lara / PromptLedger Static Review Response Matrix
+
+## A. Scope and caveat
+
+This document records VERITAS OS responses to a static documentation and
+architecture review attributed to Lara / PromptLedger. It is intended as a
+reviewer-facing evidence summary that maps review findings to repository
+changes.
+
+This document is:
+
+- a response to a static documentation/architecture review;
+- not a third-party audit;
+- not certification;
+- not a runtime assessment by Lara;
+- not evidence that Lara performed deployment, production, or regulated-use
+  validation.
+
+Its purpose is to show how VERITAS responded to the review findings in the
+repository. It should be read together with the current implementation,
+production-readiness, and external-review readiness materials linked from the
+reviewer entry point.
+
+## B. Review findings mapped to implemented changes
+
+| Review finding | Risk | Repository response | PR / implementation reference | Current status |
+|---|---|---|---|---|
+| **prod + advisory ambiguity** — Production posture could be mistaken for enforced governance even when continuation enforcement mode remains advisory. | A deployer believes governance is blocking when it is only observing. | Clarified `observed_not_enforced` / advisory semantics and production caveats. | Implemented in [PR #1931](https://github.com/veritasfuji-japan/veritas_os/pull/1931). Repository references: [Continuation Runtime Rollout](../../architecture/continuation_runtime_rollout.md), [Continuation Enforcement Design Note](../../architecture/continuation_enforcement_design_note.md), and [README production caveats](../../../README.md). | Implemented in PR #1931. |
+| **Canary false-negative promotion risk** — Canary policy rollout surfaced false-negative metrics, but promotion blocking was not explicit enough. | A more permissive canary policy could advance in a regulated deployment. | False-negative rate is now a promotion blocker. | Implemented in [PR #1932](https://github.com/veritasfuji-japan/veritas_os/pull/1932). Repository references: [Debate Safety Policy Migration Map](../../architecture/debate-safety-policy-migration-map.md) and [Governance Policy Bundle Promotion](../guides/governance-policy-bundle-promotion.md) materials. | Implemented in PR #1932. |
+| **Decision precedence / restrictive signal dominance** — Permissive signals must not override restrictive signals across gate, business, FUJI, and bind surfaces. | `allow` / `proceed` could weaken `hold` / `review` / `block` semantics. | Added a shared restrictive precedence contract: `deny` / `rejected` / `block` > `hold` / `review` / `escalate` > `allow` / `approved`. Bind/commit handling cannot downgrade `BLOCKED` to `ESCALATED`. | Implemented in [PR #1937](https://github.com/veritasfuji-japan/veritas_os/pull/1937). Repository references: [Bind Execution Contract](../../architecture/bind-execution-contract.md), [Bind Boundary Governance Artifacts](../architecture/bind-boundary-governance-artifacts.md), and related bind/admissibility tests. | Implemented in PR #1937. |
+| **TrustLog WORM startup failure messaging** — secure/prod startup refusal needed more actionable output around immutable retention. | Operators might misunderstand a local WORM mirror as production-compliant. | Strict mirror capabilities are required in secure/prod: `immutable_retention` and `fail_closed`. The local WORM mirror is not secure/prod compliant in this release. The current production-supported mirror backend is `s3_object_lock`. | Implemented in [PR #1943](https://github.com/veritasfuji-japan/veritas_os/pull/1943). Repository references: [TrustLog Production Readiness Checklist](../operations/trustlog-production-readiness-checklist.md), [PostgreSQL Production Guide](../operations/postgresql-production-guide.md), and [README TrustLog mirror posture](../../../README.md). | Implemented in PR #1943. |
+
+## C. Remaining caveats
+
+- VERITAS OS remains a prototype / reviewer-facing governance prototype for
+  this evidence path.
+- This document is not certification.
+- This document is not regulatory approval.
+- This document is not a completed third-party audit.
+- This document does not claim that Lara performed runtime validation.
+- Further runtime testing, operator validation, environment-specific security
+  hardening, retention validation, deployment drills, and regulated-use review
+  are still required before regulated production use.
+
+## D. Why this matters
+
+The external review findings were converted into concrete runtime, documentation,
+and test changes in the repository while preserving explicit non-claim
+boundaries. The result is clearer production posture language, more explicit
+promotion-blocking behavior, stronger restrictive-signal precedence, and more
+actionable TrustLog secure/prod startup requirements.
+
+For deployers and reviewers, this improves safety, auditability, and reviewer
+trust by making the response path inspectable instead of relying on unsupported
+claims about certification, audit completion, or runtime validation by Lara.

--- a/docs/en/validation/third-party-review-readiness.md
+++ b/docs/en/validation/third-party-review-readiness.md
@@ -41,6 +41,7 @@ Related documentation map:
 
 - [Technical Proof Pack](technical-proof-pack.md)
 - [Validation Evidence Map](validation-evidence-map.md)
+- [Lara / PromptLedger Static Review Response Matrix](lara-promptledger-static-review-response.md)
 
 ---
 

--- a/docs/ja/validation/lara-promptledger-static-review-response.md
+++ b/docs/ja/validation/lara-promptledger-static-review-response.md
@@ -1,0 +1,44 @@
+# Lara / PromptLedger 静的レビュー対応マトリクス
+
+## A. スコープと注意事項
+
+この文書は、Lara / PromptLedger による静的なドキュメント／アーキテクチャレビューに対して、VERITAS OS がリポジトリ上でどのように対応したかを整理するレビュー担当者向けの説明ページです。
+
+この文書は次のものではありません。
+
+- 第三者監査ではありません。
+- 認証ではありません。
+- 規制当局の承認ではありません。
+- Lara によるランタイム評価ではありません。
+- Lara による本番デプロイ検証ではありません。
+- regulated production use への適合を保証するものではありません。
+
+目的は、レビュー指摘と、それに対する VERITAS OS の実装・文書・テスト上の対応を対応表として残すことです。厳密な仕様確認が必要な場合は、英語正本と参照先の実装・テスト・関連文書を確認してください。
+
+## B. レビュー指摘と実装済み対応の対応表
+
+| レビュー指摘 | リスク | リポジトリ上の対応 | PR / 実装参照 | 現在の状態 |
+|---|---|---|---|---|
+| **prod + advisory の曖昧さ** — continuation enforcement mode が advisory のままでも、本番姿勢が enforced governance と誤解される可能性がある。 | デプロイヤーが、実際には観測のみである governance を、ブロッキング enforcement と誤認する。 | `observed_not_enforced` / advisory semantics と本番 caveat を明確化した。 | [PR #1931](https://github.com/veritasfuji-japan/veritas_os/pull/1931)。関連文書: [Continuation Runtime Rollout](../../architecture/continuation_runtime_rollout.md)、[Continuation Enforcement Design Note](../../architecture/continuation_enforcement_design_note.md)、[README production caveats](../../../README.md)。 | PR #1931 で実装済み。 |
+| **Canary false-negative promotion risk** — canary policy rollout で false-negative metrics は見えていたが、promotion blocking が十分に明示されていなかった。 | より permissive な canary policy が regulated deployment に昇格してしまう可能性がある。 | false-negative rate を promotion blocker として明示した。 | [PR #1932](https://github.com/veritasfuji-japan/veritas_os/pull/1932)。関連文書: [Debate Safety Policy Migration Map](../../architecture/debate-safety-policy-migration-map.md)、[ポリシーバンドル昇格](../guides/governance-policy-bundle-promotion.md)。 | PR #1932 で実装済み。 |
+| **Decision precedence / restrictive signal dominance** — gate、business、FUJI、bind の各 surface で permissive signal が restrictive signal を上書きしてはならない。 | `allow` / `proceed` が `hold` / `review` / `block` semantics を弱める可能性がある。 | 共通の restrictive precedence contract を追加した: `deny` / `rejected` / `block` > `hold` / `review` / `escalate` > `allow` / `approved`。Bind/commit handling は `BLOCKED` を `ESCALATED` に downgrade できない。 | [PR #1937](https://github.com/veritasfuji-japan/veritas_os/pull/1937)。関連文書: [Bind Execution Contract](../../architecture/bind-execution-contract.md)、[Bind Boundary Governance Artifacts](../architecture/bind-boundary-governance-artifacts.md)、関連 bind/admissibility tests。 | PR #1937 で実装済み。 |
+| **TrustLog WORM / strict mirror startup posture** — secure/prod startup refusal で immutable retention に関する出力をより actionable にする必要があった。 | operator が local WORM mirror を production-compliant と誤解する可能性がある。 | secure/prod では strict mirror capabilities として `immutable_retention` と `fail_closed` を要求する。local WORM mirror はこのリリースでは secure/prod compliant ではない。現時点の production-supported mirror backend は `s3_object_lock`。 | [PR #1943](https://github.com/veritasfuji-japan/veritas_os/pull/1943)。関連文書: [TrustLog Production Readiness Checklist](../operations/trustlog-production-readiness-checklist.md)、[PostgreSQL Production Guide](../operations/postgresql-production-guide.md)、[README TrustLog mirror posture](../../../README.md)。 | PR #1943 で実装済み。 |
+
+## C. 残る caveat
+
+- この evidence path において、VERITAS OS は引き続き prototype / reviewer-facing governance prototype です。
+- この文書は認証ではありません。
+- この文書は規制当局の承認ではありません。
+- この文書は完了済みの第三者監査ではありません。
+- Lara が runtime validation を実施したという主張ではありません。
+- regulated production use の前には、追加のランタイムテスト、operator validation、環境固有の security hardening、retention validation、deployment drill、regulated-use review が必要です。
+
+## D. なぜ重要か
+
+外部レビューの指摘を、リポジトリ上で確認可能な runtime / documentation / test changes に変換したことを示すためです。これにより、production posture の境界、promotion blocker、restrictive-signal precedence、TrustLog secure/prod startup requirements がより明確になります。
+
+同時に、このページは audit completion、certification、regulatory approval、Lara runtime validation といった未確認の主張を行わないことで、VERITAS の honesty discipline を維持します。
+
+## 英語正本
+
+- [Lara / PromptLedger Static Review Response Matrix](../../en/validation/lara-promptledger-static-review-response.md)

--- a/docs/ja/validation/third-party-review-readiness.md
+++ b/docs/ja/validation/third-party-review-readiness.md
@@ -16,6 +16,7 @@
 - レビュー向けに evidence bundle と手順書が再現可能か。
 - bind-governed effect path の範囲が README と一致しているか。
 - [直近のハードニング整理](../development/recent-hardening.md) で、監査性・観測性・CI品質ゲート・API互換性・依存関係リスク可視化に関する最近の強化内容を確認してください。
+- 関連資料: [Lara / PromptLedger 静的レビュー対応マトリクス](lara-promptledger-static-review-response.md)
 - 詳細は英語正本または実装ファイルを確認してください。
 
 ## 現時点の制限

--- a/veritas_os/tests/test_reviewer_entrypoint_current_path.py
+++ b/veritas_os/tests/test_reviewer_entrypoint_current_path.py
@@ -199,4 +199,20 @@ def test_reviewer_entrypoint_includes_release_evidence_path() -> None:
 
 def test_reviewer_entrypoint_numbers_public_positioning_in_10_minute_path() -> None:
     text = _entrypoint_text()
-    assert "10. [Public Positioning]" in text
+    assert "11. [Public Positioning]" in text
+
+
+def test_reviewer_entrypoint_links_lara_promptledger_matrix() -> None:
+    text = _entrypoint_text()
+    matrix_link = (
+        "[Lara / PromptLedger Static Review Response Matrix]"
+        "(en/validation/lara-promptledger-static-review-response.md)"
+    )
+    ten_minute_path = text.split("## 30-minute technical review path", 1)[0]
+    thirty_minute_path = text.split("## 30-minute technical review path", 1)[1]
+
+    assert f"4. {matrix_link} — reviewer-facing map" in ten_minute_path
+    assert f"4. {matrix_link}" in thirty_minute_path
+
+    targets = set(_markdown_link_targets())
+    assert "en/validation/lara-promptledger-static-review-response.md" in targets


### PR DESCRIPTION
### Motivation
- Capture and expose the repository response to a static documentation/architecture review from Lara / PromptLedger so external reviewers can map findings to concrete PRs and repository changes.
- Preserve explicit non-claim boundaries (not a third‑party audit, not certification, not runtime validation) while improving reviewer evidence discoverability.

### Description
- Add new reviewer-facing document `docs/en/validation/lara-promptledger-static-review-response.md` that maps four review findings to repository responses and references PRs `#1931`, `#1932`, `#1937`, and `#1943` and relevant doc locations.
- Update `docs/REVIEWER_ENTRYPOINT.md` to include the new matrix in the 10‑minute and 30‑minute reviewer paths and add a single link to the matrix from `docs/en/validation/third-party-review-readiness.md`.
- The matrix includes: prod + advisory ambiguity (PR #1931), canary false-negative promotion blocker (PR #1932), restrictive/decision precedence (PR #1937), and TrustLog WORM/startup messaging + s3_object_lock posture (PR #1943), and explicit caveats about prototype/non‑certification status.

### Testing
- Run `PYENV_VERSION=3.12.13 make check-bilingual-docs` and it passed: `[check-bilingual-docs] all checks passed`.
- Run `PYENV_VERSION=3.12.13 python scripts/quality/check_operational_docs_consistency.py` and it passed: `Operational documentation consistency checks passed.`
- Run `PYENV_VERSION=3.12.13 python scripts/quality/check_frontend_docs_consistency.py` and it passed: `Frontend documentation consistency checks passed.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a24e21308326bff8de04fb058b5a)