### PR TITLE
test(frontend): restore middleware mocks after each test

### DIFF
--- a/frontend/middleware.test.ts
+++ b/frontend/middleware.test.ts
@@ -17,6 +17,7 @@ import {
 
 describe("middleware CSP", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
   it("generates a nonce string", () => {


### PR DESCRIPTION
### Motivation
- Vitest 4 revealed test isolation leakage where `console.warn` spies persisted across middleware CSP tests, causing false failures; the change ensures mocks/spies are reset between tests.

### Description
- Add `vi.restoreAllMocks()` to the existing `afterEach` in `frontend/middleware.test.ts` so the cleanup block becomes `vi.restoreAllMocks(); vi.unstubAllEnvs();` and no production middleware logic or CSP assertions are modified.

### Testing
- Ran `pnpm ui:test` and `pnpm --filter frontend test -- middleware.test.ts`, and the frontend test suite (including `middleware.test.ts`) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5340e8688326bac1d4bf8e6ab746)