### PR TITLE
docs: add Procedural Admissibility vs Maneuverability Observables v0

### DIFF
--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -2,6 +2,8 @@
 
 Key local/offline reviewer-facing artifacts:
 
+- `docs/en/demos/pre_boundary_collapse_demo.md#procedural-admissibility-vs-maneuverability-observables-v0`
+  - Procedural Admissibility vs. Maneuverability Observables v0: a reviewer-facing note clarifying that a process can remain admissible, documented, inspectable, and procedurally coherent while practical maneuverability contracts upstream. The note frames visibility of that contraction as a governance function, without adding production claims or runtime behavior.
 - `scripts/demo/saas_permission_change_governed_demo.py`
   - deterministic local/offline SaaS permission-change governed execution demo
 - `scripts/demo/export_reviewer_evidence_packet.py`

--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -475,3 +475,39 @@ Contract artifacts:
 - `docs/en/demo/schemas/governance-evidence-packet-v0.schema.json`
 - `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
 - `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
+
+## Procedural Admissibility vs. Maneuverability Observables v0
+
+Procedural admissibility and maneuverability are treated here as partially
+independent observables. Procedural admissibility asks whether a process remains
+formally allowable, documented, inspectable, and procedurally coherent.
+Maneuverability asks whether effective intervention, redirection, correction,
+or reframing remains practically available.
+
+A process can remain admissible, documented, inspectable, and procedurally
+coherent while the viable intervention space continues to contract. That does
+not mean governance has failed in a binary sense. It means the reviewer question
+is not only, "Was the process admissible?" The companion question is, "Did the
+process preserve enough evidence for reviewers to recognize the contraction of
+maneuverability itself?"
+
+This distinction connects existing VERITAS layers without adding runtime
+behavior. Trajectory Shaping Lineage v0 preserves the visible sequence of
+framing and option-narrowing steps. Irreversibility Horizon v0 names points
+where intervention capacity becomes operationally hard to recover. Actor
+Recognition Gap v0 marks reviewer-visible recognition gaps around remaining
+intervention capacity without inferring actor beliefs, intent, or subjective
+experience. Governance
+Evidence Packet v0 collects these reviewer-facing signals, while Governance
+Evidence Packet Contract v0 fixes the packet shape for deterministic review.
+Together, these layers help reviewers inspect whether evidence of maneuverability
+contraction was preserved even when procedural admissibility remained intact.
+
+Visibility may become a governance function in its own right, rather than merely
+a property of documentation.
+
+This note is not certification, not production security, not a production
+security guarantee, not automatic enforcement, not automatic blocking, not
+automatic attack detection, not a scoring model, not a prediction claim, not a
+psychological inference about actor beliefs, intent, or subjective experience,
+and not a legal conclusion.

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -304,3 +304,32 @@ Contract artifacts:
 - `docs/en/demo/schemas/governance-evidence-packet-v0.schema.json`
 - `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
 - `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
+
+## Procedural Admissibility vs. Maneuverability Observables v0
+
+この note では、procedural admissibility（手続き上の許容可能性）と
+maneuverability（実質的な介入・方向転換の余地）を partially independent
+observables として扱います。procedural admissibility は、process が formal に許容可能で、
+documented、inspectable、procedurally coherent であるかを見ます。maneuverability は、
+effective な intervention、方向転換、修正、reframing がまだ実質的に可能かを見ます。
+
+process が admissible / documented / inspectable / procedurally coherent であっても、
+実際に有効な intervention space は収縮している可能性があります。これは governance が
+binary に失敗したという意味ではありません。問いは「その process は admissible だったか？」
+だけではなく、「maneuverability の収縮を reviewer が後から認識できるだけの evidence を保存していたか？」
+になります。
+
+この区別は、既存の VERITAS layer と接続されます。Trajectory Shaping Lineage v0 は、
+framing と option narrowing の visible sequence を保存します。Irreversibility Horizon v0 は、
+intervention capacity の回復が operationally hard になる地点を示します。Actor Recognition
+Gap v0 は、remaining intervention capacity をめぐる reviewer-visible な recognition gap を、
+actor の beliefs、intent、subjective experience を推測せずに扱います。Governance Evidence Packet v0 は、これらの reviewer-facing
+signals をまとめ、Governance Evidence Packet Contract v0 は deterministic review のために
+packet shape を固定します。これにより、procedural admissibility が保たれている場合でも、
+maneuverability contraction の evidence が保存されていたかを reviewer が点検しやすくなります。
+
+visibility は単なる documentation の性質ではなく、それ自体が governance function になり得ます。
+
+この note は、certification、production security、production security guarantee、automatic
+enforcement、automatic blocking、automatic attack detection、scoring model、prediction claim、
+actor psychology inference、legal conclusion ではありません。

--- a/tests/docs/test_procedural_admissibility_maneuverability_observables_docs.py
+++ b/tests/docs/test_procedural_admissibility_maneuverability_observables_docs.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ENGLISH_DEMO_DOC = ROOT / "docs/en/demos/pre_boundary_collapse_demo.md"
+JAPANESE_DEMO_DOC = ROOT / "docs/ja/demos/pre_boundary_collapse_demo.md"
+REVIEWER_ARTIFACT_INDEX = (
+    ROOT / "docs/en/demo/external-reviewer-artifact-index.md"
+)
+ENGLISH_README = ROOT / "README.md"
+JAPANESE_README = ROOT / "README_JP.md"
+
+
+def test_english_demo_documents_procedural_admissibility_observables() -> None:
+    text = _normalize_whitespace(
+        ENGLISH_DEMO_DOC.read_text(encoding="utf-8")
+    )
+
+    expected_fragments = [
+        "Procedural Admissibility vs. Maneuverability Observables v0",
+        "partially independent observables",
+        "Was the process admissible?",
+        (
+            "Did the process preserve enough evidence for reviewers to "
+            "recognize the contraction of maneuverability itself?"
+        ),
+        "Visibility may become a governance function",
+        "not certification",
+        "not production security",
+        "not automatic enforcement",
+        "not a psychological inference",
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in text
+
+
+def test_japanese_demo_documents_procedural_admissibility_observables() -> None:
+    if not JAPANESE_DEMO_DOC.exists():
+        return
+
+    text = _normalize_whitespace(
+        JAPANESE_DEMO_DOC.read_text(encoding="utf-8")
+    )
+
+    expected_fragments = [
+        "Procedural Admissibility vs. Maneuverability Observables v0",
+        "手続き上の許容可能性",
+        "実質的な介入",
+        "reviewer",
+        "certification",
+        "production security",
+        "automatic enforcement",
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in text
+
+
+def test_reviewer_index_or_readme_references_observables_note() -> None:
+    candidate_paths = [
+        REVIEWER_ARTIFACT_INDEX,
+        ENGLISH_README,
+        JAPANESE_README,
+    ]
+    combined_text = _normalize_whitespace(
+        "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in candidate_paths
+            if path.exists()
+        )
+    )
+
+    assert (
+        "Procedural Admissibility vs. Maneuverability Observables v0"
+        in combined_text
+    )


### PR DESCRIPTION
### Motivation

- Clarify for reviewers that `procedural admissibility` and `maneuverability` are partially independent observables so a process can remain formally admissible while practical intervention space contracts. 
- Surface how this distinction connects to existing evidence layers (`Trajectory Shaping Lineage v0`, `Irreversibility Horizon v0`, `Actor Recognition Gap v0`, `Governance Evidence Packet v0`, and its contract) without adding runtime behavior or new governance claims. 

### Description

- Added an English reviewer-note section `## Procedural Admissibility vs. Maneuverability Observables v0` to `docs/en/demos/pre_boundary_collapse_demo.md` explaining the distinction, linking to existing VERITAS layers, and explicitly listing non-claims. 
- Added the corresponding Japanese section to `docs/ja/demos/pre_boundary_collapse_demo.md` because the Japanese demo document exists. 
- Updated the external reviewer artifact index `docs/en/demo/external-reviewer-artifact-index.md` with a short entry pointing to the new note. 
- Added a docs-presence test `tests/docs/test_procedural_admissibility_maneuverability_observables_docs.py` that asserts the English doc contains the required fragments, optionally checks the Japanese doc, and verifies the artifact index/README references the note. 

### Testing

- Ran the focused test with `PYENV_VERSION=3.12.13 pytest -q tests/docs/test_procedural_admissibility_maneuverability_observables_docs.py` and it passed. 
- Ran the docs test suite with `PYENV_VERSION=3.12.13 pytest -q tests/docs` and all docs tests passed (`44 passed`, one pytest config warning about `asyncio_default_fixture_loop_scope` was emitted but did not affect results). 
- No automated test failures were observed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20d8dcadbc8326b4cdb6e00f85e130)