### PR TITLE
docs: add Governance Recognizability Conditions v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ External reviewers can use the Regulated Action Governance External Reviewer Fee
   - Governance Evidence Packet fixture: `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
   - Governance Evidence Packet contract test: `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
   - Non-claims: not certification; not production security guarantee; not automatic enforcement; not scoring model; not legal conclusion.
+  - VERITAS also documents Governance Recognizability Conditions v0, clarifying that visibility conditions can become a governance function when reviewers must later recognize maneuverability contraction despite procedural admissibility.
 - **Mini proof: covered `/v1/decide` pre-bind formation refusal**: [`docs/en/validation/pre-bind-formation-refusal-mini-proof.md`](docs/en/validation/pre-bind-formation-refusal-mini-proof.md)
 - **Regulated Action Governance Kernel**: [`docs/en/architecture/regulated-action-governance-kernel.md`](docs/en/architecture/regulated-action-governance-kernel.md)
 - **Authority Evidence vs Audit Log**: [`docs/en/architecture/authority-evidence-vs-audit-log.md`](docs/en/architecture/authority-evidence-vs-audit-log.md)

--- a/README_JP.md
+++ b/README_JP.md
@@ -255,6 +255,7 @@ VERITAS は、本番の enforce と開発時の observe を区別します。本
   - Governance Evidence Packet fixture: `docs/en/demo/fixtures/governance-evidence-packet-v0.json`
   - Governance Evidence Packet contract test: `frontend/app/api/veritas/v1/report/governance/governance-evidence-packet-contract.test.ts`
   - Non-claims: not certification; not production security guarantee; not automatic enforcement; not scoring model; not legal conclusion.
+- VERITAS は Governance Recognizability Conditions v0 も文書化し、手続き上の許容可能性が保たれている場合でも、reviewer が maneuverability の収縮を後から認識するための visibility conditions が governance function になり得ることを整理しています。
 
 ## 何を解決するか
 

--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -4,6 +4,8 @@ Key local/offline reviewer-facing artifacts:
 
 - `docs/en/demos/pre_boundary_collapse_demo.md#procedural-admissibility-vs-maneuverability-observables-v0`
   - Procedural Admissibility vs. Maneuverability Observables v0: a reviewer-facing note clarifying that a process can remain admissible, documented, inspectable, and procedurally coherent while practical maneuverability contracts upstream. The note frames visibility of that contraction as a governance function, without adding production claims or runtime behavior.
+- `docs/en/demos/pre_boundary_collapse_demo.md#governance-recognizability-conditions-v0`
+  - Governance Recognizability Conditions v0: A reviewer-facing note clarifying the visibility conditions under which governance remains recognizable to later reviewers. It explains that preserving evidence of maneuverability contraction may become as important as preserving evidence of procedural admissibility, without adding runtime behavior, production claims, or certification language.
 - `scripts/demo/saas_permission_change_governed_demo.py`
   - deterministic local/offline SaaS permission-change governed execution demo
 - `scripts/demo/export_reviewer_evidence_packet.py`

--- a/docs/en/demos/pre_boundary_collapse_demo.md
+++ b/docs/en/demos/pre_boundary_collapse_demo.md
@@ -503,11 +503,51 @@ Evidence Packet Contract v0 fixes the packet shape for deterministic review.
 Together, these layers help reviewers inspect whether evidence of maneuverability
 contraction was preserved even when procedural admissibility remained intact.
 
-Visibility may become a governance function in its own right, rather than merely
-a property of documentation.
+Visibility may become a governance function in its own right, rather than merely a property of documentation.
 
 This note is not certification, not production security, not a production
 security guarantee, not automatic enforcement, not automatic blocking, not
 automatic attack detection, not a scoring model, not a prediction claim, not a
 psychological inference about actor beliefs, intent, or subjective experience,
 and not a legal conclusion.
+
+## Governance Recognizability Conditions v0
+
+Governance recognizability conditions are the visibility conditions under which
+governance remains recognizable to later reviewers. Visibility conditions are the conditions under which governance remains recognizable to later reviewers, even when the process remains procedurally admissible.
+
+This note shifts the reviewer focus from documenting governance processes alone
+to documenting the visibility conditions under which governance remains
+recognizable after the fact. A governance process can remain admissible,
+documented, inspectable, and procedurally coherent while the practical
+intervention space contracts. In that situation, preserving evidence of
+maneuverability contraction may become as important as preserving evidence of
+procedural admissibility.
+
+The key question is therefore not only:
+
+- Was the process admissible?
+
+It is also:
+
+- Did the process preserve enough evidence for reviewers to recognize the
+  contraction of maneuverability itself?
+
+This connects directly to Procedural Admissibility vs. Maneuverability
+Observables v0, which separates formal procedural admissibility from practical
+maneuverability. Trajectory Shaping Lineage v0 preserves the visible sequence of
+framing and option-narrowing steps. Irreversibility Horizon v0 identifies points
+where intervention capacity becomes operationally hard to recover. Actor
+Recognition Gap v0 names reviewer-visible recognition gaps without inferring
+actor psychology, intent, beliefs, or subjective experience. Governance Evidence
+Packet v0 groups the reviewer-facing evidence, and Governance Evidence Packet
+Contract v0 keeps that packet shape deterministic for review without changing
+its contract in this note.
+
+Visibility may become a governance function in its own right, rather than merely a property of documentation.
+
+This reviewer note is not certification, not a production security guarantee,
+not production security, not automatic enforcement, not automatic blocking, not
+automatic attack detection, not a scoring model, not a prediction claim, not an
+inevitability claim, not a psychological inference, not actor psychology
+inference, and not a legal conclusion.

--- a/docs/ja/demos/pre_boundary_collapse_demo.md
+++ b/docs/ja/demos/pre_boundary_collapse_demo.md
@@ -333,3 +333,33 @@ visibility は単なる documentation の性質ではなく、それ自体が go
 この note は、certification、production security、production security guarantee、automatic
 enforcement、automatic blocking、automatic attack detection、scoring model、prediction claim、
 actor psychology inference、legal conclusion ではありません。
+
+## Governance Recognizability Conditions v0
+
+governance recognizability conditions とは、後から reviewer が governance state を
+認識できるための visibility conditions です。この note は、governance process を
+文書化するだけでなく、governance が後から認識可能であり続ける条件を文書化します。
+
+process が admissible / documented / inspectable / procedurally coherent であっても、
+実際の intervention space は収縮している可能性があります。その場合、maneuverability
+contraction の evidence を保存することは、procedural admissibility（手続き上の許容可能性）
+の evidence を保存することと同じくらい重要になり得ます。
+
+問いは「その process は admissible だったか？」だけではありません。
+
+- 「maneuverability の収縮そのものを reviewer が後から認識できるだけの evidence が
+  保存されていたか？」も問います。
+
+この整理は、Procedural Admissibility vs. Maneuverability Observables v0 の上に置かれます。
+Trajectory Shaping Lineage v0 は framing と option narrowing の visible sequence を保存し、
+Irreversibility Horizon v0 は intervention capacity の回復が operationally hard になる地点を示し、
+Actor Recognition Gap v0 は actor の心理、intent、beliefs、subjective experience を推測せずに
+reviewer-visible な recognition gap を扱います。Governance Evidence Packet v0 はこれらの
+evidence を reviewer-facing に束ね、Governance Evidence Packet Contract v0 は deterministic review
+のための packet shape を保ちます。この note はその contract を変更しません。
+
+visibility は単なる documentation の性質ではなく、それ自体が governance function になり得ます。
+
+これは certification / production security / production security guarantee / automatic enforcement /
+automatic blocking / automatic attack detection / scoring model / prediction claim / inevitability claim /
+actor psychology inference / legal conclusion ではありません。

--- a/tests/docs/test_governance_recognizability_conditions_docs.py
+++ b/tests/docs/test_governance_recognizability_conditions_docs.py
@@ -1,0 +1,91 @@
+"""Presence checks for Governance Recognizability Conditions v0 docs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ENGLISH_DEMO_DOC = ROOT / "docs/en/demos/pre_boundary_collapse_demo.md"
+JAPANESE_DEMO_DOC = ROOT / "docs/ja/demos/pre_boundary_collapse_demo.md"
+REVIEWER_ARTIFACT_INDEX = (
+    ROOT / "docs/en/demo/external-reviewer-artifact-index.md"
+)
+ENGLISH_README = ROOT / "README.md"
+JAPANESE_README = ROOT / "README_JP.md"
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_english_demo_documents_governance_recognizability() -> None:
+    text = _normalize_whitespace(
+        ENGLISH_DEMO_DOC.read_text(encoding="utf-8")
+    )
+
+    expected_fragments = [
+        "Governance Recognizability Conditions v0",
+        (
+            "Visibility conditions are the conditions under which governance "
+            "remains recognizable to later reviewers"
+        ),
+        "Was the process admissible?",
+        (
+            "Did the process preserve enough evidence for reviewers to "
+            "recognize the contraction of maneuverability itself?"
+        ),
+        "Visibility may become a governance function",
+        "Procedural Admissibility vs. Maneuverability Observables v0",
+        "Governance Evidence Packet v0",
+        "Governance Evidence Packet Contract v0",
+        "not certification",
+        "not production security",
+        "not automatic enforcement",
+        "not a psychological inference",
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in text
+
+
+def test_japanese_demo_documents_governance_recognizability() -> None:
+    if not JAPANESE_DEMO_DOC.exists():
+        return
+
+    text = _normalize_whitespace(
+        JAPANESE_DEMO_DOC.read_text(encoding="utf-8")
+    )
+
+    expected_fragments = [
+        "Governance Recognizability Conditions v0",
+        "governance state",
+        "visibility conditions",
+        "maneuverability",
+        "手続き上の許容可能性",
+        "実際の intervention space",
+        "reviewer",
+        "certification",
+        "production security",
+        "automatic enforcement",
+    ]
+
+    for fragment in expected_fragments:
+        assert fragment in text
+
+
+def test_reviewer_index_or_readme_references_recognizability() -> None:
+    candidate_paths = [
+        REVIEWER_ARTIFACT_INDEX,
+        ENGLISH_README,
+        JAPANESE_README,
+    ]
+    combined_text = _normalize_whitespace(
+        "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in candidate_paths
+            if path.exists()
+        )
+    )
+
+    assert "Governance Recognizability Conditions v0" in combined_text


### PR DESCRIPTION
### Motivation
- Document Governance Recognizability Conditions v0 to clarify the visibility conditions under which governance remains recognizable to later reviewers.
- Surface the distinction between formal procedural admissibility and the preservation of evidence needed to recognize maneuverability contraction.
- Keep this change docs-only and explicitly avoid adding runtime behavior, new claims, certification language, or new governance markers.

### Description
- Add an English `## Governance Recognizability Conditions v0` section to `docs/en/demos/pre_boundary_collapse_demo.md` that defines recognizability as a reviewer-facing visibility condition and connects it to existing layers such as `Trajectory Shaping Lineage v0`, `Irreversibility Horizon v0`, `Actor Recognition Gap v0`, `Governance Evidence Packet v0`, and its contract. 
- Add a corresponding Japanese section to `docs/ja/demos/pre_boundary_collapse_demo.md` with the required localized fragments. 
- Add a short entry referencing the new note in `docs/en/demo/external-reviewer-artifact-index.md` and add brief references in `README.md` and `README_JP.md` for discoverability. 
- Add a docs presence test `tests/docs/test_governance_recognizability_conditions_docs.py` that asserts required English/Japanese fragments and that an index/README references the note, while preserving that no runtime/API/schema/contract changes were made.

### Testing
- `pytest -q tests/docs/test_governance_recognizability_conditions_docs.py` was attempted but initially blocked by the environment expecting `pyenv` Python `3.12.12` (shim missing).  
- `PYENV_VERSION=3.12.13 pytest -q tests/docs/test_governance_recognizability_conditions_docs.py` ran and passed (all tests in that file passed).  
- `PYENV_VERSION=3.12.13 pytest -q tests/docs/test_procedural_admissibility_maneuverability_observables_docs.py tests/docs/test_governance_evidence_packet_contract_docs.py` ran and passed (all tests passed).  
- `git diff --check` / whitespace checks were run and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a212ab35e14832688a3e9ebc9c8773f)