### PR TITLE
Add Evaluation Governance Manifest schemas v1

### DIFF
--- a/docs/en/architecture/evaluation-function-governance-v1.md
+++ b/docs/en/architecture/evaluation-function-governance-v1.md
@@ -1,0 +1,102 @@
+# Evaluation Function Governance v1
+
+## 1. Purpose
+
+VERITAS should not treat the admissibility evaluator as an invisible runtime
+mechanism. Bind decisions are important, but the function that decides whether a
+regulated action is admissible is itself a governance artifact.
+
+Evaluation Function Governance v1 adds schema-only foundations for making that
+evaluation function explicit, versioned, challengeable, and auditable. The v1
+artifacts identify the authority basis for governance changes, the governed
+evaluation inputs and determiners, and the receipts that record manifest changes.
+
+## 2. Problem
+
+Admissibility governance has a recursion problem:
+
+- VERITAS governs decisions.
+- VERITAS must also govern the mechanism that produces those decisions.
+- VERITAS must also govern the authority by which that mechanism can be changed.
+
+If the evaluator changes without an explicit authority trail, then downstream
+bind outcomes may appear legitimate merely because runtime code produced them.
+That is not sufficient for an auditable decision OS. The evaluator needs a
+recorded basis for its authorized inputs, rule versions, policy identities,
+qualifier sources, and authority dependencies.
+
+## 3. Key distinction
+
+Evaluation Function Governance v1 separates three concepts:
+
+- **Root Authority Manifest** governs authority. It defines the constitutional
+  trust anchor for governance artifacts, including trusted authority sources,
+  authorized manifest modifiers, approval requirements, and fail-closed
+  conditions.
+- **Evaluation Function Manifest** governs evaluation. It defines the
+  admissibility evaluation function as a governed artifact, including authorized
+  determiners, admissibility inputs, qualifier sources, policy identity, rule
+  set version, evaluator version, refusal boundaries, and escalation resolver.
+- **Manifest Change Receipt** records changes. It records who changed a
+  governance manifest, what changed, why it changed, under what authority, with
+  what approval evidence, and with what impact scope.
+
+VERITAS does not automatically create legitimacy. VERITAS makes the asserted
+authority basis explicit, versioned, challengeable, and auditable so reviewers
+can inspect whether a decision, evaluator, or governance change rests on an
+acceptable authority chain.
+
+## 4. Evaluation consistency
+
+If materially equivalent governance state produces different admissibility
+outcomes, VERITAS should be able to attribute the delta to one or more explicit
+causes:
+
+- governed state changed
+- policy identity changed
+- rule version changed
+- authority state changed
+- qualifier freshness changed
+- evaluator version changed
+- unauthorized determiner influence
+- unexplained evaluation drift
+
+The v1 manifests do not perform this attribution at runtime. They provide the
+schema foundation needed for future receipts and monitors to compare governed
+evaluation state and explain why outcomes differ.
+
+## 5. Trust anchor
+
+The governance chain should terminate in an explicit constitutional trust anchor,
+not in an implicit runtime assumption. The Root Authority Manifest exists to name
+that anchor and the evidence sources that support it.
+
+This does not mean VERITAS declares the anchor legitimate by itself. It means the
+system records the asserted root authority so humans, auditors, and future
+verification tools can challenge or accept the basis for governance changes.
+
+## 6. v1 scope
+
+Evaluation Function Governance v1 is intentionally limited:
+
+- schema-only
+- no runtime enforcement
+- no automatic legitimacy judgment
+- no `/v1/decide` behavior change
+- no production governance configuration mutation
+- intended as a foundation for future hardening
+
+These artifacts are documentation and validation-test foundations only. They do
+not modify bind/admissibility logic, fail-closed behavior, policy loading,
+TrustLog persistence, or production governance state.
+
+## 7. Future work
+
+Future hardening can build on these schema foundations with:
+
+- Evaluation Receipt
+- Outcome Delta Attribution
+- Evaluation Drift Detection
+- Trajectory-Level Admissibility Monitor
+- Legitimacy Impact Review
+- Runtime fail-closed integration

--- a/docs/en/demo/schemas/evaluation-function-manifest-v1.schema.json
+++ b/docs/en/demo/schemas/evaluation-function-manifest-v1.schema.json
@@ -1,0 +1,292 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/evaluation-function-manifest-v1.schema.json",
+  "title": "Evaluation Function Manifest v1",
+  "description": "Schema-only governance artifact that describes the admissibility evaluation function as a governed artifact. It is non-enforcing in v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "manifest_id",
+    "issued_at",
+    "evaluator_id",
+    "evaluator_version",
+    "policy_identity",
+    "rule_set_version",
+    "authorized_determiners",
+    "admissibility_inputs",
+    "qualifier_sources",
+    "consequence_classifier",
+    "threshold_resolver",
+    "refusal_boundaries",
+    "escalation_resolver",
+    "baseline_hash",
+    "root_authority_manifest_ref",
+    "manifest_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "evaluation-function-manifest-v1"
+    },
+    "manifest_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "evaluator_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evaluator_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "policy_identity": {
+      "$ref": "#/$defs/policy_identity"
+    },
+    "rule_set_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authorized_determiners": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/authorized_determiner"
+      }
+    },
+    "admissibility_inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/admissibility_input"
+      }
+    },
+    "qualifier_sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/qualifier_source"
+      }
+    },
+    "consequence_classifier": {
+      "$ref": "#/$defs/consequence_classifier"
+    },
+    "threshold_resolver": {
+      "$ref": "#/$defs/threshold_resolver"
+    },
+    "refusal_boundaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/refusal_boundary"
+      }
+    },
+    "escalation_resolver": {
+      "$ref": "#/$defs/escalation_resolver"
+    },
+    "baseline_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "root_authority_manifest_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "manifest_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "policy_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_id",
+        "policy_version",
+        "policy_source_ref"
+      ],
+      "properties": {
+        "policy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_source_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "authorized_determiner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "determiner_id",
+        "determiner_type",
+        "authority_scope",
+        "may_influence_outcome"
+      ],
+      "properties": {
+        "determiner_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "determiner_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "may_influence_outcome": {
+          "type": "boolean"
+        }
+      }
+    },
+    "admissibility_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_name",
+        "input_type",
+        "required",
+        "freshness_required"
+      ],
+      "properties": {
+        "input_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "freshness_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "qualifier_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "qualifier_name",
+        "source_ref",
+        "freshness_ttl_seconds",
+        "required_at_bind"
+      ],
+      "properties": {
+        "qualifier_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "freshness_ttl_seconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "required_at_bind": {
+          "type": "boolean"
+        }
+      }
+    },
+    "consequence_classifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "classifier_id",
+        "classifier_version"
+      ],
+      "properties": {
+        "classifier_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "classifier_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "threshold_resolver": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resolver_id",
+        "resolver_version"
+      ],
+      "properties": {
+        "resolver_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolver_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "refusal_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "boundary_id",
+        "condition",
+        "action"
+      ],
+      "properties": {
+        "boundary_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "condition": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "escalation_resolver": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resolver_id",
+        "resolver_version",
+        "authority_validation_required"
+      ],
+      "properties": {
+        "resolver_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolver_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_validation_required": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/docs/en/demo/schemas/manifest-change-receipt-v1.schema.json
+++ b/docs/en/demo/schemas/manifest-change-receipt-v1.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/manifest-change-receipt-v1.schema.json",
+  "title": "Manifest Change Receipt v1",
+  "description": "Schema-only governance receipt that records changes to governance manifests. It is non-enforcing in v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "issued_at",
+    "changed_manifest_type",
+    "changed_manifest_id",
+    "previous_manifest_hash",
+    "new_manifest_hash",
+    "change_reason",
+    "changed_by",
+    "authority_evidence_ref",
+    "approval_evidence_refs",
+    "impact_scope",
+    "legitimacy_impact_flags",
+    "rollback_conditions"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "manifest-change-receipt-v1"
+    },
+    "receipt_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "changed_manifest_type": {
+      "enum": [
+        "root_authority_manifest",
+        "evaluation_function_manifest",
+        "other_governance_manifest"
+      ]
+    },
+    "changed_manifest_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "previous_manifest_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "new_manifest_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "change_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "changed_by": {
+      "$ref": "#/$defs/changed_by"
+    },
+    "authority_evidence_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "approval_evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "impact_scope": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "legitimacy_impact_flags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/legitimacy_impact_flag"
+      },
+      "uniqueItems": true
+    },
+    "rollback_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "changed_by": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actor_id",
+        "role"
+      ],
+      "properties": {
+        "actor_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "legitimacy_impact_flag": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Examples include authority_scope_expanded, human_oversight_weakened, refusal_boundary_relaxed, escalation_requirement_reduced, policy_source_changed, and evaluator_behavior_changed."
+    }
+  }
+}

--- a/docs/en/demo/schemas/root-authority-manifest-v1.schema.json
+++ b/docs/en/demo/schemas/root-authority-manifest-v1.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/root-authority-manifest-v1.schema.json",
+  "title": "Root Authority Manifest v1",
+  "description": "Schema-only governance artifact that defines the constitutional trust anchor for VERITAS governance manifests. It is non-enforcing in v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "manifest_id",
+    "issued_at",
+    "root_authority_id",
+    "trusted_authority_sources",
+    "authorized_manifest_modifiers",
+    "authoritative_policy_sources",
+    "approval_requirements",
+    "fail_closed_conditions",
+    "challenge_process",
+    "manifest_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "root-authority-manifest-v1"
+    },
+    "manifest_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "root_authority_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trusted_authority_sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/trusted_authority_source"
+      }
+    },
+    "authorized_manifest_modifiers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/authorized_manifest_modifier"
+      }
+    },
+    "authoritative_policy_sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/authoritative_policy_source"
+      }
+    },
+    "approval_requirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/approval_requirement"
+      }
+    },
+    "fail_closed_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "challenge_process": {
+      "$ref": "#/$defs/challenge_process"
+    },
+    "manifest_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trusted_authority_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "source_type",
+        "validity_status",
+        "evidence_ref"
+      ],
+      "properties": {
+        "source_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "validity_status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "authorized_manifest_modifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actor_id",
+        "role",
+        "scope",
+        "approval_required"
+      ],
+      "properties": {
+        "actor_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approval_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "authoritative_policy_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_source_id",
+        "policy_domain",
+        "version",
+        "evidence_ref"
+      ],
+      "properties": {
+        "policy_source_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_domain": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "approval_requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "change_type",
+        "required_approvals",
+        "human_review_required"
+      ],
+      "properties": {
+        "change_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required_approvals": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "human_review_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "challenge_process": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "challenge_allowed",
+        "review_authority",
+        "evidence_required"
+      ],
+      "properties": {
+        "challenge_allowed": {
+          "type": "boolean"
+        },
+        "review_authority": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_required": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/demo/test_evaluation_governance_manifest_schemas.py
+++ b/tests/demo/test_evaluation_governance_manifest_schemas.py
@@ -1,0 +1,261 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCHEMA_DIR = Path("docs/en/demo/schemas")
+ROOT_AUTHORITY_SCHEMA_PATH = SCHEMA_DIR / "root-authority-manifest-v1.schema.json"
+EVALUATION_FUNCTION_SCHEMA_PATH = (
+    SCHEMA_DIR / "evaluation-function-manifest-v1.schema.json"
+)
+MANIFEST_CHANGE_RECEIPT_SCHEMA_PATH = (
+    SCHEMA_DIR / "manifest-change-receipt-v1.schema.json"
+)
+
+SCHEMA_CASES = [
+    (
+        ROOT_AUTHORITY_SCHEMA_PATH,
+        "root_authority_manifest",
+        "root_authority_id",
+    ),
+    (
+        EVALUATION_FUNCTION_SCHEMA_PATH,
+        "evaluation_function_manifest",
+        "evaluator_id",
+    ),
+    (
+        MANIFEST_CHANGE_RECEIPT_SCHEMA_PATH,
+        "manifest_change_receipt",
+        "change_reason",
+    ),
+]
+
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+HASH_C = "c" * 64
+HASH_D = "d" * 64
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _build_root_authority_manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "root-authority-manifest-v1",
+        "manifest_id": "root-authority-demo-v1",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "root_authority_id": "constitutional-trust-anchor-demo",
+        "trusted_authority_sources": [
+            {
+                "source_id": "board-resolution-2026-001",
+                "source_type": "board_resolution",
+                "validity_status": "active",
+                "evidence_ref": "evidence://authority/board-resolution-2026-001",
+            }
+        ],
+        "authorized_manifest_modifiers": [
+            {
+                "actor_id": "governance-maintainer-demo",
+                "role": "governance_maintainer",
+                "scope": "demo_governance_manifests",
+                "approval_required": True,
+            }
+        ],
+        "authoritative_policy_sources": [
+            {
+                "policy_source_id": "policy-source-demo",
+                "policy_domain": "demo_admissibility",
+                "version": "2026.01",
+                "evidence_ref": "evidence://policy/source-demo",
+            }
+        ],
+        "approval_requirements": [
+            {
+                "change_type": "evaluation_function_manifest_update",
+                "required_approvals": 2,
+                "human_review_required": True,
+            }
+        ],
+        "fail_closed_conditions": [
+            "root authority evidence is missing or revoked"
+        ],
+        "challenge_process": {
+            "challenge_allowed": True,
+            "review_authority": "governance-review-board-demo",
+            "evidence_required": ["authority_evidence", "approval_receipts"],
+        },
+        "manifest_hash": HASH_A,
+    }
+
+
+def _build_evaluation_function_manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "evaluation-function-manifest-v1",
+        "manifest_id": "evaluation-function-demo-v1",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "evaluator_id": "bind-time-admissibility-evaluator-demo",
+        "evaluator_version": "1.0.0",
+        "policy_identity": {
+            "policy_id": "demo-admissibility-policy",
+            "policy_version": "2026.01",
+            "policy_source_ref": "policy-source-demo",
+        },
+        "rule_set_version": "ruleset-2026.01",
+        "authorized_determiners": [
+            {
+                "determiner_id": "authority-evidence-check-demo",
+                "determiner_type": "authority_validation",
+                "authority_scope": "regulated_action_bind",
+                "may_influence_outcome": True,
+            }
+        ],
+        "admissibility_inputs": [
+            {
+                "input_name": "authority_evidence",
+                "input_type": "evidence_reference",
+                "required": True,
+                "freshness_required": True,
+            }
+        ],
+        "qualifier_sources": [
+            {
+                "qualifier_name": "authority_validity_status",
+                "source_ref": "root-authority-demo-v1",
+                "freshness_ttl_seconds": 3600,
+                "required_at_bind": True,
+            }
+        ],
+        "consequence_classifier": {
+            "classifier_id": "consequence-classifier-demo",
+            "classifier_version": "1.0.0",
+        },
+        "threshold_resolver": {
+            "resolver_id": "threshold-resolver-demo",
+            "resolver_version": "1.0.0",
+        },
+        "refusal_boundaries": [
+            {
+                "boundary_id": "missing-authority-evidence",
+                "condition": "required authority evidence is unavailable",
+                "action": "refuse_or_escalate",
+            }
+        ],
+        "escalation_resolver": {
+            "resolver_id": "escalation-resolver-demo",
+            "resolver_version": "1.0.0",
+            "authority_validation_required": True,
+        },
+        "baseline_hash": HASH_B,
+        "root_authority_manifest_ref": "root-authority-demo-v1",
+        "manifest_hash": HASH_C,
+    }
+
+
+def _build_manifest_change_receipt() -> dict[str, Any]:
+    return {
+        "schema_version": "manifest-change-receipt-v1",
+        "receipt_id": "manifest-change-demo-v1",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "changed_manifest_type": "evaluation_function_manifest",
+        "changed_manifest_id": "evaluation-function-demo-v1",
+        "previous_manifest_hash": HASH_C,
+        "new_manifest_hash": HASH_D,
+        "change_reason": "Add explicit evaluator governance metadata.",
+        "changed_by": {
+            "actor_id": "governance-maintainer-demo",
+            "role": "governance_maintainer",
+        },
+        "authority_evidence_ref": "evidence://authority/board-resolution-2026-001",
+        "approval_evidence_refs": ["evidence://approval/demo-001"],
+        "impact_scope": ["demo_schema_foundation"],
+        "legitimacy_impact_flags": ["evaluator_behavior_changed"],
+        "rollback_conditions": ["approval evidence is invalidated"],
+    }
+
+
+def _example_for_schema(name: str) -> dict[str, Any]:
+    if name == "root_authority_manifest":
+        return _build_root_authority_manifest()
+    if name == "evaluation_function_manifest":
+        return _build_evaluation_function_manifest()
+    if name == "manifest_change_receipt":
+        return _build_manifest_change_receipt()
+    raise AssertionError(f"unknown schema example: {name}")
+
+
+def _validate_or_fallback(payload: dict[str, Any], schema: dict[str, Any]) -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(payload)
+        return
+
+    missing = [field for field in schema["required"] if field not in payload]
+    assert not missing, f"missing required fields: {missing}"
+    for field, field_schema in schema["properties"].items():
+        if field not in payload or "const" not in field_schema:
+            continue
+        assert payload[field] == field_schema["const"]
+
+
+def _is_rejected_or_fallback_detected(
+    payload: dict[str, Any], schema: dict[str, Any]
+) -> bool:
+    try:
+        _validate_or_fallback(payload, schema)
+    except (AssertionError, Exception):
+        return True
+    return False
+
+
+@pytest.mark.parametrize(("schema_path", "_name", "_field"), SCHEMA_CASES)
+def test_schema_files_exist(schema_path: Path, _name: str, _field: str) -> None:
+    assert schema_path.is_file()
+
+
+@pytest.mark.parametrize(("schema_path", "_name", "_field"), SCHEMA_CASES)
+def test_schema_files_parse_as_valid_json(
+    schema_path: Path, _name: str, _field: str
+) -> None:
+    schema = _load_json(schema_path)
+    assert isinstance(schema, dict)
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.parametrize(("schema_path", "name", "_field"), SCHEMA_CASES)
+def test_minimal_valid_examples_validate(
+    schema_path: Path, name: str, _field: str
+) -> None:
+    _validate_or_fallback(_example_for_schema(name), _load_json(schema_path))
+
+
+@pytest.mark.parametrize(("schema_path", "name", "missing_field"), SCHEMA_CASES)
+def test_missing_required_fields_fail_validation(
+    schema_path: Path, name: str, missing_field: str
+) -> None:
+    payload = copy.deepcopy(_example_for_schema(name))
+    payload.pop(missing_field)
+    assert _is_rejected_or_fallback_detected(payload, _load_json(schema_path))
+
+
+@pytest.mark.parametrize(("schema_path", "name", "_field"), SCHEMA_CASES)
+def test_schema_validation_requires_no_network_or_environment_dependency(
+    monkeypatch: pytest.MonkeyPatch, schema_path: Path, name: str, _field: str
+) -> None:
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _validate_or_fallback(_example_for_schema(name), _load_json(schema_path))


### PR DESCRIPTION
### Motivation

- Make the admissibility evaluator and the authority that may change it explicit, versioned, and auditable without introducing runtime enforcement. 
- Provide schema-first artifacts that separate authority (Root Authority Manifest), evaluation (Evaluation Function Manifest), and change receipts (Manifest Change Receipt) to address governance recursion. 
- Ship documentation and validation tests as a safe foundation for future enforcement and monitoring work. 

### Description

- Add schema files: `docs/en/demo/schemas/root-authority-manifest-v1.schema.json`, `docs/en/demo/schemas/evaluation-function-manifest-v1.schema.json`, and `docs/en/demo/schemas/manifest-change-receipt-v1.schema.json` implementing the required fields and suggested structures for v1 (SHA256 hashes, date-time fields, required nested objects/arrays). 
- Add documentation: `docs/en/architecture/evaluation-function-governance-v1.md` describing purpose, problem statement, key distinctions, v1 scope (schema-only), trust-anchor intent, and future work. 
- Add validation tests: `tests/demo/test_evaluation_governance_manifest_schemas.py` which load each schema, validate a minimal valid example per schema, assert missing required fields fail validation, and avoid network/environment dependencies when possible. 
- This PR is schema-only and documentation-only: it does not change runtime admissibility, `/v1/decide` behavior, production governance configuration, or introduce enforcement logic. 

### Testing

- Verified each JSON schema parses as valid JSON using `python -m json.tool` for the three new schema files (success). 
- Ran the new schema tests with `pytest tests/demo/test_evaluation_governance_manifest_schemas.py` and they passed (15 passed). 
- Ran a ruff check on the new test file with `python -m ruff check tests/demo/test_evaluation_governance_manifest_schemas.py` and it passed. 
- Attempted a broader pytest run including existing `tests/demo/test_reviewer_evidence_packet_schema.py`; that run uncovered unrelated environment dependency issues (missing `yaml` module) causing failures, and an attempt to install `jsonschema` was blocked by network/proxy restrictions (`403 Forbidden`), so no network installs were performed; these failures are environment/dependency problems and are not caused by the added schema or tests. 

Security note: these manifests are a documentation and validation foundation only and do not enforce authority or evaluator behavior; treat them as non-enforcing until future fail-closed/runtime integration is implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2242db1a388326a219420c50b518d7)