### PR TITLE
Add Evaluation Receipt schema v1

### DIFF
--- a/docs/en/architecture/evaluation-function-governance-v1.md
+++ b/docs/en/architecture/evaluation-function-governance-v1.md
@@ -65,6 +65,9 @@ The v1 manifests do not perform this attribution at runtime. They provide the
 schema foundation needed for future receipts and monitors to compare governed
 evaluation state and explain why outcomes differ.
 
+Evaluation Receipt v1 builds on this foundation by recording specific
+evaluation instances for later replay, comparison, and drift analysis.
+
 ## 5. Trust anchor
 
 The governance chain should terminate in an explicit constitutional trust anchor,

--- a/docs/en/architecture/evaluation-receipt-v1.md
+++ b/docs/en/architecture/evaluation-receipt-v1.md
@@ -1,0 +1,94 @@
+# Evaluation Receipt v1
+
+## 1. Purpose
+
+Evaluation Receipt v1 records how a specific admissibility evaluation was
+performed at bind/evaluation time. The receipt makes the evaluation function
+visible, replayable, attributable, and auditable by recording the governed state
+that participated in one evaluation instance.
+
+The v1 receipt does not enforce behavior. It is a schema-only foundation for
+reviewers and future tooling to inspect what the evaluator claimed to use and
+what admissibility outcome it produced.
+
+## 2. Relationship to Evaluation Function Manifest
+
+The Evaluation Function Manifest defines the governed evaluation mechanism. It
+names the evaluator, evaluator version, policy identity, rule-set version,
+authorized determiners, admissibility inputs, qualifier sources, refusal
+boundaries, escalation resolver, and root authority manifest reference.
+
+The Evaluation Receipt records a specific use of that mechanism. It points back
+to the Evaluation Function Manifest and records the evaluation-time state that
+was actually used, including hashes that support later replay, comparison, and
+drift analysis.
+
+In short:
+
+- **Evaluation Function Manifest** defines what the governed evaluator is allowed
+  to be.
+- **Evaluation Receipt** records what one evaluation instance did with that
+  governed evaluator.
+
+## 3. What the receipt captures
+
+An Evaluation Receipt captures:
+
+- evaluator identity and version
+- policy identity and rule-set version
+- Evaluation Function Manifest reference and hash
+- Root Authority Manifest reference
+- authority evidence references
+- qualifier state, source references, freshness state, and qualifier hashes
+- authorized determiners used and whether each determiner influenced the outcome
+- admissibility inputs, input references, required flags, and input hashes
+- consequence class and classifier metadata
+- material context reference, freshness state, stale-context allowance, and hash
+- admissibility outcome
+- rationale codes explaining the outcome
+- input-state, evaluation-state, and receipt hashes for later comparison
+
+These fields are intended to make the evaluation attributable without declaring
+that the evaluation was automatically legitimate.
+
+## 4. Evaluation consistency
+
+Future Evaluation Drift Detection can compare Evaluation Receipts to determine
+whether outcome changes are attributable to explicit governed causes, including:
+
+- governed state change
+- policy identity change
+- rule version change
+- authority state change
+- qualifier freshness change
+- evaluator version change
+- unauthorized determiner influence
+- unexplained evaluation drift
+
+Evaluation Receipt v1 does not perform this attribution at runtime. It only
+provides the schema foundation needed for later comparison and review.
+
+## 5. v1 scope
+
+Evaluation Receipt v1 is intentionally limited:
+
+- schema-only
+- no runtime enforcement
+- no automatic legitimacy judgment
+- no `/v1/decide` behavior change
+- no production governance mutation
+- no fail-closed integration yet
+
+This PR does not modify bind/admissibility logic, production governance
+configuration, policy loading, TrustLog persistence, or FUJI Gate behavior.
+
+## 6. Future work
+
+Future work can build on Evaluation Receipt v1 with:
+
+- Outcome Delta Attribution
+- Evaluation Drift Detection
+- Trajectory-Level Admissibility Monitor
+- Legitimacy Impact Review
+- Runtime fail-closed integration
+- Receipt generation from live bind/admissibility paths

--- a/docs/en/demo/schemas/evaluation-receipt-v1.schema.json
+++ b/docs/en/demo/schemas/evaluation-receipt-v1.schema.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/evaluation-receipt-v1.schema.json",
+  "title": "Evaluation Receipt v1",
+  "description": "Schema-only receipt that records a specific admissibility evaluation. It is non-enforcing in v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "issued_at",
+    "evaluation_id",
+    "evaluation_function_manifest_ref",
+    "evaluation_function_manifest_hash",
+    "root_authority_manifest_ref",
+    "evaluator_id",
+    "evaluator_version",
+    "policy_identity",
+    "rule_set_version",
+    "authority_evidence_refs",
+    "qualifier_state",
+    "authorized_determiners_used",
+    "admissibility_inputs",
+    "consequence_class",
+    "material_context",
+    "outcome",
+    "rationale_codes",
+    "input_state_hash",
+    "evaluation_state_hash",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "evaluation-receipt-v1"
+    },
+    "receipt_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "evaluation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evaluation_function_manifest_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evaluation_function_manifest_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "root_authority_manifest_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evaluator_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evaluator_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "policy_identity": {
+      "$ref": "#/$defs/policy_identity"
+    },
+    "rule_set_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authority_evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "qualifier_state": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/qualifier_state_item"
+      }
+    },
+    "authorized_determiners_used": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/determiner_used"
+      }
+    },
+    "admissibility_inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/admissibility_input"
+      }
+    },
+    "consequence_class": {
+      "$ref": "#/$defs/consequence_class"
+    },
+    "material_context": {
+      "$ref": "#/$defs/material_context"
+    },
+    "outcome": {
+      "enum": [
+        "allow",
+        "escalate",
+        "refuse",
+        "error",
+        "undetermined"
+      ]
+    },
+    "rationale_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "input_state_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "evaluation_state_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "receipt_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "policy_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_id",
+        "policy_version",
+        "policy_source_ref"
+      ],
+      "properties": {
+        "policy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_source_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "qualifier_state_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "qualifier_name",
+        "source_ref",
+        "freshness_state",
+        "required_at_bind",
+        "qualifier_hash"
+      ],
+      "properties": {
+        "qualifier_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "freshness_state": {
+          "enum": [
+            "fresh",
+            "stale",
+            "expired",
+            "unknown",
+            "not_required"
+          ]
+        },
+        "required_at_bind": {
+          "type": "boolean"
+        },
+        "qualifier_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        }
+      }
+    },
+    "determiner_used": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "determiner_id",
+        "determiner_type",
+        "authority_scope",
+        "influenced_outcome"
+      ],
+      "properties": {
+        "determiner_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "determiner_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "influenced_outcome": {
+          "type": "boolean"
+        }
+      }
+    },
+    "admissibility_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_name",
+        "input_type",
+        "input_ref",
+        "required",
+        "input_hash"
+      ],
+      "properties": {
+        "input_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "input_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        }
+      }
+    },
+    "consequence_class": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "class_id",
+        "class_label",
+        "classifier_id",
+        "classifier_version"
+      ],
+      "properties": {
+        "class_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "class_label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "classifier_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "classifier_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "material_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "context_ref",
+        "context_hash",
+        "context_freshness_state",
+        "stale_context_allowed"
+      ],
+      "properties": {
+        "context_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "context_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "context_freshness_state": {
+          "enum": [
+            "fresh",
+            "stale",
+            "expired",
+            "unknown"
+          ]
+        },
+        "stale_context_allowed": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/tests/demo/test_evaluation_receipt_schema.py
+++ b/tests/demo/test_evaluation_receipt_schema.py
@@ -1,0 +1,162 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path("docs/en/demo/schemas/evaluation-receipt-v1.schema.json")
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+HASH_C = "c" * 64
+HASH_D = "d" * 64
+HASH_E = "e" * 64
+HASH_F = "f" * 64
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _build_minimal_receipt() -> dict[str, Any]:
+    return {
+        "schema_version": "evaluation-receipt-v1",
+        "receipt_id": "evaluation-receipt-demo-v1",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "evaluation_id": "evaluation-demo-001",
+        "evaluation_function_manifest_ref": "evaluation-function-demo-v1",
+        "evaluation_function_manifest_hash": HASH_A,
+        "root_authority_manifest_ref": "root-authority-demo-v1",
+        "evaluator_id": "bind-time-admissibility-evaluator-demo",
+        "evaluator_version": "1.0.0",
+        "policy_identity": {
+            "policy_id": "demo-admissibility-policy",
+            "policy_version": "2026.01",
+            "policy_source_ref": "policy-source-demo",
+        },
+        "rule_set_version": "ruleset-2026.01",
+        "authority_evidence_refs": [
+            "evidence://authority/board-resolution-2026-001"
+        ],
+        "qualifier_state": [
+            {
+                "qualifier_name": "authority_validity_status",
+                "source_ref": "root-authority-demo-v1",
+                "freshness_state": "fresh",
+                "required_at_bind": True,
+                "qualifier_hash": HASH_B,
+            }
+        ],
+        "authorized_determiners_used": [
+            {
+                "determiner_id": "authority-evidence-check-demo",
+                "determiner_type": "authority_validation",
+                "authority_scope": "regulated_action_bind",
+                "influenced_outcome": True,
+            }
+        ],
+        "admissibility_inputs": [
+            {
+                "input_name": "authority_evidence",
+                "input_type": "evidence_reference",
+                "input_ref": "evidence://authority/board-resolution-2026-001",
+                "required": True,
+                "input_hash": HASH_C,
+            }
+        ],
+        "consequence_class": {
+            "class_id": "demo-low-risk",
+            "class_label": "Demo Low Risk",
+            "classifier_id": "consequence-classifier-demo",
+            "classifier_version": "1.0.0",
+        },
+        "material_context": {
+            "context_ref": "context://demo/evaluation-001",
+            "context_hash": HASH_D,
+            "context_freshness_state": "fresh",
+            "stale_context_allowed": False,
+        },
+        "outcome": "allow",
+        "rationale_codes": ["authority_evidence_fresh"],
+        "input_state_hash": HASH_E,
+        "evaluation_state_hash": HASH_F,
+        "receipt_hash": HASH_A,
+    }
+
+
+def _validate(payload: dict[str, Any], schema: dict[str, Any]) -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(payload)
+        return
+
+    missing = [field for field in schema["required"] if field not in payload]
+    assert not missing, f"missing required fields: {missing}"
+    assert payload["schema_version"] == "evaluation-receipt-v1"
+    assert payload["outcome"] in schema["properties"]["outcome"]["enum"]
+    assert len(payload["receipt_hash"]) == 64
+    assert set(payload) <= set(schema["properties"])
+
+
+def _is_rejected(payload: dict[str, Any], schema: dict[str, Any]) -> bool:
+    try:
+        _validate(payload, schema)
+    except (AssertionError, Exception):
+        return True
+    return False
+
+
+def test_schema_file_exists() -> None:
+    assert SCHEMA_PATH.is_file()
+
+
+def test_schema_file_parses_as_valid_json_schema() -> None:
+    schema = _load_schema()
+    assert isinstance(schema, dict)
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_minimal_valid_example_validates() -> None:
+    _validate(_build_minimal_receipt(), _load_schema())
+
+
+def test_missing_required_field_fails_validation() -> None:
+    payload = _build_minimal_receipt()
+    payload.pop("evaluation_id")
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_outcome_enum_fails_validation() -> None:
+    payload = _build_minimal_receipt()
+    payload["outcome"] = "approve"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_sha256_hash_fails_validation() -> None:
+    payload = _build_minimal_receipt()
+    payload["receipt_hash"] = "not-a-sha256-hash"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_unexpected_top_level_property_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_receipt())
+    payload["unexpected_runtime_enforcement"] = True
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_schema_validation_requires_no_network_or_environment_dependency(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _validate(_build_minimal_receipt(), _load_schema())


### PR DESCRIPTION
### Motivation
- Provide a schema-only, auditable foundation for recording how a specific admissibility evaluation was performed at bind/evaluation time so evaluations are visible, replayable, and attributable.
- Continue the schema-first rollout after Evaluation Function/Root Authority/Manifest Change artifacts without changing runtime enforcement or `/v1/decide` behavior.
- Enable future drift/attribution tooling by recording evaluator, policy, rule-set, authority evidence, qualifier/determiner/input state, consequence/material context, outcome, rationale, and replay hashes.
- Security note: this PR is docs/schema/tests-only and does not change runtime, but receipts may reference authority evidence and hashes—avoid recording secrets or PII in receipts and ensure downstream handling is secured. 

### Description
- Add JSON Schema `docs/en/demo/schemas/evaluation-receipt-v1.schema.json` (draft 2020-12) that requires `schema_version == "evaluation-receipt-v1"`, `receipt_id`, `issued_at`, `evaluation_id`, evaluation manifest refs/hashes, evaluator/policy/rule metadata, authority evidence refs, `qualifier_state`, `authorized_determiners_used`, `admissibility_inputs`, `consequence_class`, `material_context`, `outcome`, `rationale_codes`, and `input/evaluation/receipt` hashes.
- Provide reusable `$defs` including `sha256_hex`, `policy_identity`, `qualifier_state_item`, `determiner_used`, `admissibility_input`, `consequence_class`, and `material_context` with `additionalProperties: false` to enforce strict structure.
- Add documentation `docs/en/architecture/evaluation-receipt-v1.md` describing purpose, relationship to Evaluation Function Manifest, captured fields, evaluation consistency / drift use cases, explicit v1 scope (schema-only), and future work.
- Add a minimal cross-reference line to `docs/en/architecture/evaluation-function-governance-v1.md` linking the manifest foundations to the new receipt foundation.

### Testing
- Added `tests/demo/test_evaluation_receipt_schema.py` and ran `PYENV_VERSION=3.12.13 pytest tests/demo/test_evaluation_receipt_schema.py -q`, which passed (`8 passed`).
- Ran combined schema tests with `PYENV_VERSION=3.12.13 pytest tests/demo/test_evaluation_governance_manifest_schemas.py tests/demo/test_evaluation_receipt_schema.py -q`, which passed (`23 passed`).
- Ran static style check `PYENV_VERSION=3.12.13 python -m ruff check tests/demo/test_evaluation_receipt_schema.py`, which passed.
- All tests exercised only JSON schema validation and local examples and required no network access; no runtime behavior or production governance configuration was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a226bcbdad0832698a4f5621acc989f)