### PR TITLE
Add Outcome Delta Attribution schema v1

### DIFF
--- a/docs/en/architecture/evaluation-receipt-v1.md
+++ b/docs/en/architecture/evaluation-receipt-v1.md
@@ -66,7 +66,9 @@ whether outcome changes are attributable to explicit governed causes, including:
 - unexplained evaluation drift
 
 Evaluation Receipt v1 does not perform this attribution at runtime. It only
-provides the schema foundation needed for later comparison and review.
+provides the schema foundation needed for later comparison and review. Outcome
+Delta Attribution v1 is the companion schema-only artifact that records that
+comparison between two Evaluation Receipts.
 
 ## 5. v1 scope
 

--- a/docs/en/architecture/outcome-delta-attribution-v1.md
+++ b/docs/en/architecture/outcome-delta-attribution-v1.md
@@ -1,0 +1,92 @@
+# Outcome Delta Attribution v1
+
+## 1. Purpose
+
+Outcome Delta Attribution v1 records why an admissibility outcome changed
+between two Evaluation Receipts. It compares a prior evaluation instance with a
+current evaluation instance and records whether the outcome changed, which
+material deltas were observed, and whether any delta remains unresolved.
+
+The artifact is designed for audit and review. It documents attribution claims
+without deciding that the change was automatically legitimate.
+
+## 2. Relationship to Evaluation Receipt
+
+Evaluation Receipt v1 records one evaluation instance. It captures the governed
+state, evaluator identity, policy identity, rule-set version, authority evidence,
+qualifier state, determiners, admissibility inputs, consequence class, material
+context, outcome, rationale codes, and hashes for that single evaluation.
+
+Outcome Delta Attribution v1 compares two evaluation instances. It references a
+prior Evaluation Receipt and a current Evaluation Receipt, records their hashes,
+compares their outcomes, and lists the causes that explain the observed outcome
+delta.
+
+In short:
+
+- **Evaluation Receipt** records what happened during one evaluation.
+- **Outcome Delta Attribution** records why the result changed between two
+  evaluations.
+
+## 3. What the attribution captures
+
+An Outcome Delta Attribution captures:
+
+- prior and current Evaluation Receipt references
+- prior and current Evaluation Receipt hashes
+- prior and current admissibility outcomes
+- whether the admissibility outcome changed
+- delta causes and supporting evidence references
+- attribution summary
+- attribution confidence
+- unresolved delta status
+- recommended governance action
+- attribution hash for later audit comparison
+
+These fields make the comparison inspectable while preserving the distinction
+between an attributed change and a governance-approved change.
+
+## 4. Evaluation consistency
+
+Outcome Delta Attribution supports evaluation consistency by separating outcome
+changes that may be explained by governed causes from changes that require
+review. In particular, it can distinguish:
+
+- legitimate state evolution
+- policy, rule, or authority change
+- qualifier freshness change
+- consequence class change
+- evaluator version change
+- authorized determiner change
+- unauthorized determiner influence
+- unexplained evaluation drift
+
+This separation helps reviewers identify whether an outcome delta is plausibly
+attributable to governed state, policy identity, rule-set version, authority
+state, qualifier freshness, consequence classification, evaluator version, or
+other recorded causes.
+
+## 5. v1 scope
+
+Outcome Delta Attribution v1 is intentionally limited:
+
+- schema-only
+- no runtime enforcement
+- no automatic legitimacy judgment
+- no `/v1/decide` behavior change
+- no production governance mutation
+- no fail-closed integration yet
+
+This v1 foundation does not modify bind/admissibility logic, production
+governance configuration, policy loading, TrustLog persistence, FUJI Gate
+behavior, or any runtime resolver.
+
+## 6. Future work
+
+Future work can build on Outcome Delta Attribution v1 with:
+
+- Evaluation Drift Detection
+- Trajectory-Level Admissibility Monitor
+- Legitimacy Impact Review
+- Runtime fail-closed integration
+- Automated comparison from live Evaluation Receipts

--- a/docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json
+++ b/docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/outcome-delta-attribution-v1.schema.json",
+  "title": "Outcome Delta Attribution v1",
+  "description": "Schema-only attribution artifact that compares two Evaluation Receipts and records why an admissibility outcome changed. It is non-enforcing in v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "attribution_id",
+    "issued_at",
+    "prior_evaluation_receipt_ref",
+    "current_evaluation_receipt_ref",
+    "prior_evaluation_receipt_hash",
+    "current_evaluation_receipt_hash",
+    "prior_outcome",
+    "current_outcome",
+    "outcome_changed",
+    "delta_causes",
+    "attribution_summary",
+    "attribution_confidence",
+    "unresolved_delta",
+    "recommended_governance_action",
+    "attribution_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "outcome-delta-attribution-v1"
+    },
+    "attribution_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "prior_evaluation_receipt_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "current_evaluation_receipt_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "prior_evaluation_receipt_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "current_evaluation_receipt_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "prior_outcome": {
+      "$ref": "#/$defs/admissibility_outcome"
+    },
+    "current_outcome": {
+      "$ref": "#/$defs/admissibility_outcome"
+    },
+    "outcome_changed": {
+      "type": "boolean"
+    },
+    "delta_causes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/delta_cause"
+      }
+    },
+    "attribution_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "attribution_confidence": {
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "unresolved_delta": {
+      "$ref": "#/$defs/unresolved_delta"
+    },
+    "recommended_governance_action": {
+      "$ref": "#/$defs/governance_action"
+    },
+    "attribution_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "admissibility_outcome": {
+      "enum": [
+        "allow",
+        "escalate",
+        "refuse",
+        "error",
+        "undetermined"
+      ]
+    },
+    "delta_cause": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cause_type",
+        "severity",
+        "prior_value_ref",
+        "current_value_ref",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "cause_type": {
+          "enum": [
+            "governed_state_changed",
+            "policy_identity_changed",
+            "rule_version_changed",
+            "authority_state_changed",
+            "qualifier_freshness_changed",
+            "consequence_class_changed",
+            "material_context_changed",
+            "evaluator_version_changed",
+            "authorized_determiner_changed",
+            "unauthorized_determiner_influence",
+            "threshold_state_changed",
+            "refusal_boundary_changed",
+            "escalation_resolver_changed",
+            "unexplained_evaluation_drift"
+          ]
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ]
+        },
+        "prior_value_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "current_value_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "explanation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "unresolved_delta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "present",
+        "reason",
+        "requires_review"
+      ],
+      "properties": {
+        "present": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "requires_review": {
+          "type": "boolean"
+        }
+      }
+    },
+    "governance_action": {
+      "enum": [
+        "none",
+        "review",
+        "requalify",
+        "escalate",
+        "refuse",
+        "mark_evaluation_drift",
+        "mark_non_deterministically_governed"
+      ]
+    }
+  }
+}

--- a/tests/demo/test_outcome_delta_attribution_schema.py
+++ b/tests/demo/test_outcome_delta_attribution_schema.py
@@ -1,0 +1,161 @@
+import copy
+import importlib.util
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(
+    "docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json"
+)
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+HASH_C = "c" * 64
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _build_minimal_attribution() -> dict[str, Any]:
+    return {
+        "schema_version": "outcome-delta-attribution-v1",
+        "attribution_id": "outcome-delta-demo-v1",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "prior_evaluation_receipt_ref": "evaluation-receipt-demo-prior-v1",
+        "current_evaluation_receipt_ref": "evaluation-receipt-demo-current-v1",
+        "prior_evaluation_receipt_hash": HASH_A,
+        "current_evaluation_receipt_hash": HASH_B,
+        "prior_outcome": "allow",
+        "current_outcome": "escalate",
+        "outcome_changed": True,
+        "delta_causes": [
+            {
+                "cause_type": "qualifier_freshness_changed",
+                "severity": "medium",
+                "prior_value_ref": "qualifier://authority_validity_status/fresh",
+                "current_value_ref": "qualifier://authority_validity_status/stale",
+                "evidence_refs": [
+                    "evidence://receipt-comparison/qualifier-freshness"
+                ],
+                "explanation": "Authority qualifier freshness changed.",
+            }
+        ],
+        "attribution_summary": "Outcome changed after qualifier freshness changed.",
+        "attribution_confidence": "high",
+        "unresolved_delta": {
+            "present": False,
+            "reason": "All material deltas are attributed.",
+            "requires_review": False,
+        },
+        "recommended_governance_action": "review",
+        "attribution_hash": HASH_C,
+    }
+
+
+def _validate(payload: dict[str, Any], schema: dict[str, Any]) -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(payload)
+        return
+
+    missing = [field for field in schema["required"] if field not in payload]
+    assert not missing, f"missing required fields: {missing}"
+    assert payload["schema_version"] == "outcome-delta-attribution-v1"
+    outcome_enum = schema["$defs"]["admissibility_outcome"]["enum"]
+    assert payload["prior_outcome"] in outcome_enum
+    assert payload["current_outcome"] in outcome_enum
+    assert payload["delta_causes"][0]["cause_type"] in (
+        schema["$defs"]["delta_cause"]["properties"]["cause_type"]["enum"]
+    )
+    assert payload["recommended_governance_action"] in (
+        schema["$defs"]["governance_action"]["enum"]
+    )
+    sha256_pattern = re.compile(r"^[0-9a-f]{64}$")
+    assert sha256_pattern.match(payload["prior_evaluation_receipt_hash"])
+    assert sha256_pattern.match(payload["current_evaluation_receipt_hash"])
+    assert sha256_pattern.match(payload["attribution_hash"])
+    assert set(payload) <= set(schema["properties"])
+
+
+def _is_rejected(payload: dict[str, Any], schema: dict[str, Any]) -> bool:
+    try:
+        _validate(payload, schema)
+    except (AssertionError, Exception):
+        return True
+    return False
+
+
+def test_schema_file_exists() -> None:
+    assert SCHEMA_PATH.is_file()
+
+
+def test_schema_file_parses_as_valid_json_schema() -> None:
+    schema = _load_schema()
+    assert isinstance(schema, dict)
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_minimal_valid_example_validates() -> None:
+    _validate(_build_minimal_attribution(), _load_schema())
+
+
+def test_missing_required_field_fails_validation() -> None:
+    payload = _build_minimal_attribution()
+    payload.pop("current_evaluation_receipt_ref")
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_prior_outcome_enum_fails_validation() -> None:
+    payload = _build_minimal_attribution()
+    payload["prior_outcome"] = "approve"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_current_outcome_enum_fails_validation() -> None:
+    payload = _build_minimal_attribution()
+    payload["current_outcome"] = "approve"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_cause_type_enum_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_attribution())
+    payload["delta_causes"][0]["cause_type"] = "runtime_enforcement_changed"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_recommended_governance_action_enum_fails_validation() -> None:
+    payload = _build_minimal_attribution()
+    payload["recommended_governance_action"] = "auto_enforce"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_sha256_hash_fails_validation() -> None:
+    payload = _build_minimal_attribution()
+    payload["current_evaluation_receipt_hash"] = "not-a-sha256-hash"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_unexpected_top_level_property_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_attribution())
+    payload["unexpected_runtime_enforcement"] = True
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_schema_validation_requires_no_network_or_environment_dependency(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _validate(_build_minimal_attribution(), _load_schema())


### PR DESCRIPTION
### Motivation

- Introduce a schema-only, documentation-first artifact to compare two `Evaluation Receipt v1` instances and record why an admissibility outcome changed. 
- Provide a structured foundation for attribution questions such as whether the change is due to governed state, policy/rule/version changes, evaluator version, qualifier freshness, unauthorized determiner influence, or unexplained drift. 
- Keep scope safe and low-risk by making this v1 schema-only and non-enforcing with no runtime, `/v1/decide`, admissibility logic, or production governance configuration changes.

### Description

- Add the JSON Schema `docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json` implementing draft 2020-12 with `additionalProperties: false`, `$defs` for reusable items (`sha256_hex`, `admissibility_outcome`, `delta_cause`, `unresolved_delta`, `governance_action`), required fields, and enumerations as specified. 
- Add architecture documentation `docs/en/architecture/outcome-delta-attribution-v1.md` describing purpose, relationship to `Evaluation Receipt v1`, captured fields, v1 non-enforcing scope, and future work. 
- Add a short cross-reference to the new artifact in `docs/en/architecture/evaluation-receipt-v1.md`. 
- Add validation-focused tests `tests/demo/test_outcome_delta_attribution_schema.py` that exercise a minimal valid example and assert failures for missing required fields, invalid enums, invalid SHA-256 hashes, and unexpected top-level properties.

### Testing

- Confirmed the schema is valid JSON by running `python -m json.tool docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json` with success. 
- Performed static checks by running `python -m py_compile tests/demo/test_outcome_delta_attribution_schema.py` and executed the test module's test functions directly (manual invocation) which passed. 
- Attempted to run the full `pytest` invocation via the local tooling, but environment dependency fetches from PyPI failed; this prevented executing the full `pytest` run in this sandbox, though the local manual checks above passed. 
- CI is expected to run full test matrix and JSON Schema validation (including `jsonschema`-based validation) where the tests will be exercised under normal network/packaging conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23a5840678832680201008b1a33c25)