### PR TITLE
Add Evaluation Drift Detection schema v1

### DIFF
--- a/docs/en/architecture/evaluation-drift-detection-v1.md
+++ b/docs/en/architecture/evaluation-drift-detection-v1.md
@@ -1,0 +1,103 @@
+# Evaluation Drift Detection v1
+
+## 1. Purpose
+
+Evaluation Drift Detection v1 records whether a comparison between Evaluation
+Receipts suggests evaluator drift or unexplained evaluation behavior. It is a
+schema-only artifact that references an Outcome Delta Attribution and records
+whether the attributed or unattributed delta indicates possible evaluator drift,
+unauthorized determiner influence, unexplained evaluation behavior, or
+non-deterministically governed evaluation.
+
+The artifact is intended to make drift signals reviewable without deciding that
+a changed evaluation was automatically illegitimate.
+
+## 2. Relationship to Outcome Delta Attribution
+
+Outcome Delta Attribution records why an outcome changed between a prior
+Evaluation Receipt and a current Evaluation Receipt. It captures the observed
+outcome delta, candidate causes, confidence, unresolved delta state, supporting
+evidence references, and recommended governance action.
+
+Evaluation Drift Detection records whether the attributed or unattributed delta
+indicates evaluation drift. It consumes the comparison established by Outcome
+Delta Attribution and classifies the evaluation as stable, suspicious, drifted,
+unexplained, or non-deterministically governed for future review.
+
+In short:
+
+- **Outcome Delta Attribution** records why an outcome changed.
+- **Evaluation Drift Detection** records whether that attributed or unattributed
+  delta indicates evaluation drift.
+
+## 3. What counts as evaluation drift
+
+Evaluation drift may be indicated when a changed outcome cannot be cleanly
+explained by governed, authorized, and comparable evaluation state. Possible
+causes include:
+
+- unexplained outcome change
+- unauthorized determiner influence
+- evaluator version change without clear authority
+- rule-set or threshold change affecting outcome
+- policy identity ambiguity
+- qualifier ambiguity
+- material context ambiguity
+- attribution inconclusive
+
+A drift cause is not itself a runtime enforcement decision in v1. It records a
+review signal and the evidence references that support that signal.
+
+## 4. Evaluation consistency
+
+Evaluation consistency requires VERITAS to distinguish between different kinds
+of evaluation change before treating a result as stable. In particular, review
+needs to distinguish:
+
+- legitimate governed-state evolution
+- evaluator change
+- unauthorized determiner influence
+- unexplained evaluation drift
+
+This distinction helps reviewers separate expected governance evolution from
+unexpected behavior. A consistent evaluator can produce a different result when
+governed state legitimately changes; an inconsistent evaluator may require
+requalification, qualifier reconciliation, escalation, refusal, or drift marking
+in a future runtime integration.
+
+## 5. Non-deterministically governed state
+
+When the system cannot attribute the delta, v1 can mark the evaluation as
+non-deterministically governed for future review. This status means the available
+receipts and attribution are insufficient to explain why the outcome changed in
+a governed and deterministic way.
+
+The v1 marker is non-enforcing. It does not reject requests, alter admissibility,
+change policy identity, mutate governance configuration, or trigger fail-closed
+behavior.
+
+## 6. v1 scope
+
+Evaluation Drift Detection v1 is intentionally limited:
+
+- schema-only
+- no runtime enforcement
+- no automatic legitimacy judgment
+- no `/v1/decide` behavior change
+- no production governance mutation
+- no fail-closed integration yet
+
+This v1 foundation does not modify bind/admissibility logic, production
+governance configuration, policy loading, TrustLog persistence, FUJI Gate
+behavior, or any runtime resolver.
+
+## 7. Future work
+
+Future work can build on Evaluation Drift Detection v1 with:
+
+- automated drift detection from Outcome Delta Attribution
+- runtime fail-closed integration
+- evaluator requalification workflow
+- Trajectory-Level Admissibility Monitor
+- Legitimacy Impact Review
+- reviewer evidence packet integration

--- a/docs/en/architecture/outcome-delta-attribution-v1.md
+++ b/docs/en/architecture/outcome-delta-attribution-v1.md
@@ -28,6 +28,11 @@ In short:
 - **Outcome Delta Attribution** records why the result changed between two
   evaluations.
 
+Evaluation Drift Detection v1 builds on this comparison by recording whether an
+attributed or unattributed outcome delta suggests evaluator drift, unauthorized
+determiner influence, unexplained evaluation behavior, or non-deterministically
+governed evaluation. It remains non-enforcing in v1.
+
 ## 3. What the attribution captures
 
 An Outcome Delta Attribution captures:

--- a/docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json
+++ b/docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/evaluation-drift-detection-v1.schema.json",
+  "title": "Evaluation Drift Detection v1",
+  "description": "Schema-only detection artifact that records whether an Outcome Delta Attribution indicates possible evaluator drift, unauthorized determiner influence, unexplained evaluation behavior, or non-deterministically governed evaluation. It is non-enforcing in v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "detection_id",
+    "issued_at",
+    "outcome_delta_attribution_ref",
+    "outcome_delta_attribution_hash",
+    "prior_evaluation_receipt_ref",
+    "current_evaluation_receipt_ref",
+    "drift_detected",
+    "drift_status",
+    "drift_causes",
+    "evaluator_consistency_status",
+    "explanation_status",
+    "recommended_governance_action",
+    "detection_summary",
+    "detection_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "evaluation-drift-detection-v1"
+    },
+    "detection_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "outcome_delta_attribution_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "outcome_delta_attribution_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "prior_evaluation_receipt_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "current_evaluation_receipt_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "drift_detected": {
+      "type": "boolean"
+    },
+    "drift_status": {
+      "$ref": "#/$defs/drift_status"
+    },
+    "drift_causes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/drift_cause"
+      }
+    },
+    "evaluator_consistency_status": {
+      "$ref": "#/$defs/evaluator_consistency_status"
+    },
+    "explanation_status": {
+      "$ref": "#/$defs/explanation_status"
+    },
+    "recommended_governance_action": {
+      "$ref": "#/$defs/governance_action"
+    },
+    "detection_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "detection_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "drift_status": {
+      "enum": [
+        "not_detected",
+        "suspected",
+        "confirmed",
+        "unexplained",
+        "non_deterministically_governed"
+      ]
+    },
+    "drift_cause": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cause_type",
+        "severity",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "cause_type": {
+          "enum": [
+            "unexplained_evaluation_drift",
+            "unauthorized_determiner_influence",
+            "evaluator_version_changed",
+            "rule_version_changed",
+            "policy_identity_changed",
+            "threshold_state_changed",
+            "refusal_boundary_changed",
+            "escalation_resolver_changed",
+            "material_context_ambiguous",
+            "qualifier_state_ambiguous",
+            "attribution_inconclusive"
+          ]
+        },
+        "severity": {
+          "$ref": "#/$defs/severity"
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "explanation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "severity": {
+      "enum": [
+        "info",
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "evaluator_consistency_status": {
+      "enum": [
+        "consistent",
+        "inconsistent",
+        "unknown",
+        "not_comparable"
+      ]
+    },
+    "explanation_status": {
+      "enum": [
+        "fully_explained",
+        "partially_explained",
+        "unexplained",
+        "requires_review"
+      ]
+    },
+    "governance_action": {
+      "enum": [
+        "none",
+        "review",
+        "requalify_evaluator",
+        "reconcile_qualifiers",
+        "escalate",
+        "refuse",
+        "mark_evaluation_drift",
+        "mark_non_deterministically_governed"
+      ]
+    }
+  }
+}

--- a/tests/demo/test_evaluation_drift_detection_schema.py
+++ b/tests/demo/test_evaluation_drift_detection_schema.py
@@ -1,0 +1,144 @@
+import copy
+import importlib.util
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(
+    "docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json"
+)
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _build_minimal_detection() -> dict[str, Any]:
+    return {
+        "schema_version": "evaluation-drift-detection-v1",
+        "detection_id": "evaluation-drift-demo-v1",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "outcome_delta_attribution_ref": "outcome-delta-demo-v1",
+        "outcome_delta_attribution_hash": HASH_A,
+        "prior_evaluation_receipt_ref": "evaluation-receipt-demo-prior-v1",
+        "current_evaluation_receipt_ref": "evaluation-receipt-demo-current-v1",
+        "drift_detected": True,
+        "drift_status": "suspected",
+        "drift_causes": [
+            {
+                "cause_type": "attribution_inconclusive",
+                "severity": "medium",
+                "evidence_refs": [
+                    "evidence://outcome-delta-attribution/unresolved-delta"
+                ],
+                "explanation": "Attribution did not fully explain the delta.",
+            }
+        ],
+        "evaluator_consistency_status": "unknown",
+        "explanation_status": "requires_review",
+        "recommended_governance_action": "review",
+        "detection_summary": "Potential drift requires reviewer assessment.",
+        "detection_hash": HASH_B,
+    }
+
+
+def _validate(payload: dict[str, Any], schema: dict[str, Any]) -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(payload)
+        return
+
+    missing = [field for field in schema["required"] if field not in payload]
+    assert not missing, f"missing required fields: {missing}"
+    assert payload["schema_version"] == "evaluation-drift-detection-v1"
+    assert payload["drift_status"] in schema["$defs"]["drift_status"]["enum"]
+    assert payload["drift_causes"][0]["cause_type"] in (
+        schema["$defs"]["drift_cause"]["properties"]["cause_type"]["enum"]
+    )
+    assert payload["recommended_governance_action"] in (
+        schema["$defs"]["governance_action"]["enum"]
+    )
+    sha256_pattern = re.compile(r"^[0-9a-f]{64}$")
+    assert sha256_pattern.match(payload["outcome_delta_attribution_hash"])
+    assert sha256_pattern.match(payload["detection_hash"])
+    assert set(payload) <= set(schema["properties"])
+
+
+def _is_rejected(payload: dict[str, Any], schema: dict[str, Any]) -> bool:
+    try:
+        _validate(payload, schema)
+    except (AssertionError, Exception):
+        return True
+    return False
+
+
+def test_schema_file_exists() -> None:
+    assert SCHEMA_PATH.is_file()
+
+
+def test_schema_file_parses_as_valid_json_schema() -> None:
+    schema = _load_schema()
+    assert isinstance(schema, dict)
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_minimal_valid_example_validates() -> None:
+    _validate(_build_minimal_detection(), _load_schema())
+
+
+def test_missing_required_field_fails_validation() -> None:
+    payload = _build_minimal_detection()
+    payload.pop("current_evaluation_receipt_ref")
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_drift_status_enum_fails_validation() -> None:
+    payload = _build_minimal_detection()
+    payload["drift_status"] = "stable"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_drift_cause_type_enum_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_detection())
+    payload["drift_causes"][0]["cause_type"] = "runtime_enforcement_changed"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_recommended_governance_action_enum_fails_validation() -> None:
+    payload = _build_minimal_detection()
+    payload["recommended_governance_action"] = "auto_enforce"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_sha256_hash_fails_validation() -> None:
+    payload = _build_minimal_detection()
+    payload["outcome_delta_attribution_hash"] = "not-a-sha256-hash"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_unexpected_top_level_property_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_detection())
+    payload["unexpected_runtime_enforcement"] = True
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_schema_validation_requires_no_network_or_environment_dependency(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _validate(_build_minimal_detection(), _load_schema())


### PR DESCRIPTION
### Motivation
- Add a schema-only foundation to record when an Outcome Delta Attribution suggests evaluator drift, unauthorized determiner influence, unexplained evaluation behavior, or non-deterministically governed evaluation.
- Provide a reviewable, non-enforcing artifact that builds on Outcome Delta Attribution without changing `/v1/decide` or runtime admissibility behavior.
- Keep the scope strictly documentation/schema/validation-only so future runtime integrations can opt into enforcement after human review.
- Security note: no secrets or policy configuration were changed in this PR, but downstream runtime integration must follow governance approval to avoid accidental enforcement or data exposure.

### Description
- Add `docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json` implemented as JSON Schema draft 2020-12 with required fields, `$defs` for enums and `sha256_hex`, and `additionalProperties: false`. 
- Add `docs/en/architecture/evaluation-drift-detection-v1.md` documenting purpose, relationship to Outcome Delta Attribution, drift causes, evaluation consistency, non-deterministically governed state, explicit v1 non-enforcing scope, and future work. 
- Add `tests/demo/test_evaluation_drift_detection_schema.py` which validates a minimal valid example and negative cases (missing required fields, invalid enums, invalid sha256, unexpected top-level properties) following existing schema-test style. 
- Add a brief cross-reference line to `docs/en/architecture/outcome-delta-attribution-v1.md`; no runtime code, governance mutations, admissibility logic, or FUJI fail-closed behavior were modified.

### Testing
- Validated JSON structure with `jq empty docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json` (success). 
- Ran schema tests with `pytest tests/demo/test_evaluation_drift_detection_schema.py tests/demo/test_outcome_delta_attribution_schema.py` which completed with `21 passed, 1 warning`. 
- The tests exercise the minimal valid payload and negative validation cases and all assertions passed in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24df2695548326bf36a83d34456933)