### PR TITLE
Add Trajectory-Level Admissibility Monitor schema v1

### DIFF
--- a/docs/en/architecture/evaluation-drift-detection-v1.md
+++ b/docs/en/architecture/evaluation-drift-detection-v1.md
@@ -98,6 +98,6 @@ Future work can build on Evaluation Drift Detection v1 with:
 - automated drift detection from Outcome Delta Attribution
 - runtime fail-closed integration
 - evaluator requalification workflow
-- Trajectory-Level Admissibility Monitor
+- Trajectory-Level Admissibility Monitor v1 for sequence-level admissibility scope review
 - Legitimacy Impact Review
 - reviewer evidence packet integration

--- a/docs/en/architecture/trajectory-admissibility-monitor-v1.md
+++ b/docs/en/architecture/trajectory-admissibility-monitor-v1.md
@@ -1,0 +1,89 @@
+# Trajectory-Level Admissibility Monitor v1
+
+## 1. Purpose
+
+Trajectory-Level Admissibility Monitor v1 records whether a sequence of
+Evaluation Receipts, Outcome Delta Attributions, and Evaluation Drift Detections
+suggests admissibility scope expansion over time. It is a schema-only artifact
+for making trajectory-level admissibility movement visible to reviewers.
+
+The monitor does not decide that any individual bind or evaluation event is
+invalid. Instead, it records whether repeated locally valid events may be
+widening the admissibility envelope, delegated authority, requalification
+posture, refusal boundary, or escalation requirements across the trajectory.
+
+## 2. Relationship to previous artifacts
+
+Trajectory-Level Admissibility Monitor v1 builds on the preceding schema-only
+foundations:
+
+- **Evaluation Receipt v1** records one evaluation instance, including the
+  governed evaluation inputs, outcome, determiners, and evidence references for
+  that instance.
+- **Outcome Delta Attribution v1** explains outcome changes between two
+  Evaluation Receipts, including candidate causes, confidence, unresolved delta
+  state, and recommended governance action.
+- **Evaluation Drift Detection v1** records suspected evaluator drift,
+  unauthorized determiner influence, unexplained evaluation behavior, or
+  non-deterministically governed evaluation.
+- **Trajectory-Level Admissibility Monitor v1** examines the sequence across
+  repeated evaluations to determine whether the admissibility scope appears to
+  be expanding over time.
+
+## 3. Strategic Admissibility Drift
+
+Strategic admissibility drift can occur when individual bind or evaluation
+events appear locally valid while the overall admissibility envelope expands
+across repeated continuity events. A single event may preserve evidence,
+complete requalification, or classify a change as low risk; however, the
+sequence may still produce a more permissive governance posture than the
+original authority scope allowed.
+
+This artifact is intended to make that trajectory visible. It records whether
+continuity is preserving evidence or beginning to manufacture legitimacy by
+accumulating small, locally acceptable changes into a broader authority scope.
+
+## 4. What the monitor captures
+
+The monitor captures reviewable evidence for trajectory-level admissibility
+movement, including:
+
+- evaluation receipt references
+- attribution references
+- drift detection references
+- trajectory window
+- baseline and current authority scope
+- admissibility scope change
+- continuity event summary
+- trajectory risk signals
+- trajectory status
+- recommended governance action
+
+These fields are informational in v1 and provide a foundation for later reviewer
+and runtime integrations.
+
+## 5. v1 scope
+
+Trajectory-Level Admissibility Monitor v1 is intentionally limited:
+
+- schema-only
+- no runtime enforcement
+- no automatic legitimacy judgment
+- no `/v1/decide` behavior change
+- no production governance mutation
+- no fail-closed integration yet
+
+This v1 foundation does not modify bind/admissibility logic, production
+governance configuration, policy loading, TrustLog persistence, FUJI Gate
+behavior, continuity handling, or any runtime resolver.
+
+## 6. Future work
+
+Future work can build on Trajectory-Level Admissibility Monitor v1 with:
+
+- automated trajectory analysis from Evaluation Receipts
+- strategic admissibility drift detection
+- legitimacy impact review
+- governance exhaustion safeguards
+- runtime fail-closed integration
+- reviewer evidence packet integration

--- a/docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json
+++ b/docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json
@@ -1,0 +1,291 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/trajectory-admissibility-monitor-v1.schema.json",
+  "title": "Trajectory-Level Admissibility Monitor v1",
+  "description": "Schema-only monitor artifact that records whether a sequence of Evaluation Receipts, Outcome Delta Attributions, and Evaluation Drift Detections suggests admissibility scope expansion over time. It is non-enforcing in v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "monitor_id",
+    "issued_at",
+    "trajectory_id",
+    "evaluation_receipt_refs",
+    "outcome_delta_attribution_refs",
+    "evaluation_drift_detection_refs",
+    "trajectory_window",
+    "baseline_authority_scope",
+    "current_authority_scope",
+    "admissibility_scope_change",
+    "continuity_event_summary",
+    "trajectory_risk_signals",
+    "trajectory_status",
+    "recommended_governance_action",
+    "monitor_summary",
+    "monitor_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "trajectory-admissibility-monitor-v1"
+    },
+    "monitor_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trajectory_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evaluation_receipt_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "outcome_delta_attribution_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "evaluation_drift_detection_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "trajectory_window": {
+      "$ref": "#/$defs/trajectory_window"
+    },
+    "baseline_authority_scope": {
+      "$ref": "#/$defs/authority_scope"
+    },
+    "current_authority_scope": {
+      "$ref": "#/$defs/authority_scope"
+    },
+    "admissibility_scope_change": {
+      "$ref": "#/$defs/admissibility_scope_change"
+    },
+    "continuity_event_summary": {
+      "$ref": "#/$defs/continuity_event_summary"
+    },
+    "trajectory_risk_signals": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/trajectory_risk_signal"
+      }
+    },
+    "trajectory_status": {
+      "$ref": "#/$defs/trajectory_status"
+    },
+    "recommended_governance_action": {
+      "$ref": "#/$defs/governance_action"
+    },
+    "monitor_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "monitor_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "trajectory_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "started_at",
+        "ended_at",
+        "evaluation_count"
+      ],
+      "properties": {
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ended_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "evaluation_count": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "authority_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope_id",
+        "scope_hash",
+        "authority_evidence_ref"
+      ],
+      "properties": {
+        "scope_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scope_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "authority_evidence_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "admissibility_scope_change": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope_expanded",
+        "expansion_type",
+        "explicit_reauthorization_present",
+        "reauthorization_evidence_refs"
+      ],
+      "properties": {
+        "scope_expanded": {
+          "type": "boolean"
+        },
+        "expansion_type": {
+          "enum": [
+            "none",
+            "delegated_authority_expansion",
+            "threshold_expansion",
+            "policy_scope_expansion",
+            "refusal_boundary_relaxation",
+            "escalation_requirement_reduction",
+            "contextual_scope_expansion",
+            "unknown"
+          ]
+        },
+        "explicit_reauthorization_present": {
+          "type": "boolean"
+        },
+        "reauthorization_evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "continuity_event_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "continuity_events_observed",
+        "low_risk_events_count",
+        "material_change_events_count",
+        "requalification_events_count",
+        "escalation_events_count"
+      ],
+      "properties": {
+        "continuity_events_observed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "low_risk_events_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "material_change_events_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requalification_events_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "escalation_events_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "trajectory_risk_signal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "signal_type",
+        "severity",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "signal_type": {
+          "enum": [
+            "admissibility_envelope_expansion",
+            "delegated_scope_widening",
+            "permissive_requalification_trend",
+            "low_risk_event_accumulation",
+            "continuity_as_authorization_risk",
+            "strategic_admissibility_drift",
+            "governance_exhaustion_signal",
+            "unexplained_trajectory_shift"
+          ]
+        },
+        "severity": {
+          "$ref": "#/$defs/severity"
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "explanation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "severity": {
+      "enum": [
+        "info",
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "trajectory_status": {
+      "enum": [
+        "stable",
+        "watch",
+        "suspicious",
+        "drift_detected",
+        "strategically_shaped",
+        "non_deterministically_governed"
+      ]
+    },
+    "governance_action": {
+      "enum": [
+        "none",
+        "review",
+        "requalify_trajectory",
+        "reconcile_authority_scope",
+        "escalate",
+        "refuse",
+        "mark_strategic_admissibility_drift",
+        "mark_non_deterministically_governed"
+      ]
+    }
+  }
+}

--- a/tests/demo/test_trajectory_admissibility_monitor_schema.py
+++ b/tests/demo/test_trajectory_admissibility_monitor_schema.py
@@ -1,0 +1,189 @@
+import copy
+import importlib.util
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(
+    "docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json"
+)
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+HASH_C = "c" * 64
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _build_minimal_monitor() -> dict[str, Any]:
+    return {
+        "schema_version": "trajectory-admissibility-monitor-v1",
+        "monitor_id": "trajectory-admissibility-monitor-demo-v1",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "trajectory_id": "trajectory-demo-v1",
+        "evaluation_receipt_refs": [
+            "evaluation-receipt-demo-prior-v1",
+            "evaluation-receipt-demo-current-v1",
+        ],
+        "outcome_delta_attribution_refs": ["outcome-delta-demo-v1"],
+        "evaluation_drift_detection_refs": ["evaluation-drift-demo-v1"],
+        "trajectory_window": {
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "2026-01-02T00:00:00Z",
+            "evaluation_count": 2,
+        },
+        "baseline_authority_scope": {
+            "scope_id": "authority-scope-baseline-v1",
+            "scope_hash": HASH_A,
+            "authority_evidence_ref": "evidence://authority/baseline",
+        },
+        "current_authority_scope": {
+            "scope_id": "authority-scope-current-v1",
+            "scope_hash": HASH_B,
+            "authority_evidence_ref": "evidence://authority/current",
+        },
+        "admissibility_scope_change": {
+            "scope_expanded": True,
+            "expansion_type": "delegated_authority_expansion",
+            "explicit_reauthorization_present": False,
+            "reauthorization_evidence_refs": [],
+        },
+        "continuity_event_summary": {
+            "continuity_events_observed": 2,
+            "low_risk_events_count": 1,
+            "material_change_events_count": 1,
+            "requalification_events_count": 1,
+            "escalation_events_count": 0,
+        },
+        "trajectory_risk_signals": [
+            {
+                "signal_type": "admissibility_envelope_expansion",
+                "severity": "medium",
+                "evidence_refs": ["evidence://trajectory/scope-expansion"],
+                "explanation": "The current scope is broader than baseline.",
+            }
+        ],
+        "trajectory_status": "watch",
+        "recommended_governance_action": "review",
+        "monitor_summary": "Trajectory requires reviewer assessment.",
+        "monitor_hash": HASH_C,
+    }
+
+
+def _validate(payload: dict[str, Any], schema: dict[str, Any]) -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(payload)
+        return
+
+    missing = [field for field in schema["required"] if field not in payload]
+    assert not missing, f"missing required fields: {missing}"
+    assert payload["schema_version"] == "trajectory-admissibility-monitor-v1"
+    assert payload["admissibility_scope_change"]["expansion_type"] in (
+        schema["$defs"]["admissibility_scope_change"]["properties"][
+            "expansion_type"
+        ]["enum"]
+    )
+    assert payload["trajectory_risk_signals"][0]["signal_type"] in (
+        schema["$defs"]["trajectory_risk_signal"]["properties"][
+            "signal_type"
+        ]["enum"]
+    )
+    assert payload["trajectory_status"] in (
+        schema["$defs"]["trajectory_status"]["enum"]
+    )
+    assert payload["recommended_governance_action"] in (
+        schema["$defs"]["governance_action"]["enum"]
+    )
+    sha256_pattern = re.compile(r"^[0-9a-f]{64}$")
+    assert sha256_pattern.match(
+        payload["baseline_authority_scope"]["scope_hash"]
+    )
+    assert sha256_pattern.match(payload["current_authority_scope"]["scope_hash"])
+    assert sha256_pattern.match(payload["monitor_hash"])
+    assert set(payload) <= set(schema["properties"])
+
+
+def _is_rejected(payload: dict[str, Any], schema: dict[str, Any]) -> bool:
+    try:
+        _validate(payload, schema)
+    except (AssertionError, Exception):
+        return True
+    return False
+
+
+def test_schema_file_exists() -> None:
+    assert SCHEMA_PATH.is_file()
+
+
+def test_schema_file_parses_as_valid_json_schema() -> None:
+    schema = _load_schema()
+    assert isinstance(schema, dict)
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_minimal_valid_example_validates() -> None:
+    _validate(_build_minimal_monitor(), _load_schema())
+
+
+def test_missing_required_field_fails_validation() -> None:
+    payload = _build_minimal_monitor()
+    payload.pop("current_authority_scope")
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_expansion_type_enum_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_monitor())
+    payload["admissibility_scope_change"]["expansion_type"] = "auto_expand"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_signal_type_enum_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_monitor())
+    payload["trajectory_risk_signals"][0]["signal_type"] = "runtime_refusal"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_trajectory_status_enum_fails_validation() -> None:
+    payload = _build_minimal_monitor()
+    payload["trajectory_status"] = "auto_enforced"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_recommended_governance_action_enum_fails_validation() -> None:
+    payload = _build_minimal_monitor()
+    payload["recommended_governance_action"] = "auto_enforce"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_sha256_hash_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_monitor())
+    payload["baseline_authority_scope"]["scope_hash"] = "not-a-sha256-hash"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_unexpected_top_level_property_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_monitor())
+    payload["unexpected_runtime_enforcement"] = True
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_schema_validation_requires_no_network_or_environment_dependency(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _validate(_build_minimal_monitor(), _load_schema())


### PR DESCRIPTION
### Motivation
- Provide a schema-only foundation for a Trajectory-Level Admissibility Monitor that surfaces whether sequences of evaluations appear to expand admissibility scope over time. 
- Continue the series of non-enforcing artifacts (after Evaluation Receipt, Outcome Delta Attribution, and Evaluation Drift Detection) while avoiding any runtime or governance enforcement in v1. 
- Keep the change small and reviewable: schema + documentation + validation tests only, with explicit non-enforcing scope.

### Description
- Added JSON Schema `docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json` (Draft 2020-12) defining required fields, strict `additionalProperties: false`, `$defs` for reusable structures (`sha256_hex`, `trajectory_window`, `authority_scope`, `admissibility_scope_change`, `continuity_event_summary`, `trajectory_risk_signal`, `severity`, `trajectory_status`, `governance_action`), and enums/sha256 patterns as specified. 
- Added architecture doc `docs/en/architecture/trajectory-admissibility-monitor-v1.md` describing purpose, relationship to prior artifacts, strategic admissibility drift, captured fields, clear v1 scope (schema-only, non-enforcing), and future work. 
- Added validation tests `tests/demo/test_trajectory_admissibility_monitor_schema.py` following existing schema-test style which validate a minimal example and assert rejections for missing/invalid fields, invalid enums, invalid SHA-256 hashes, and unexpected additional properties. 
- Added a short cross-reference in `docs/en/architecture/evaluation-drift-detection-v1.md` future-work list pointing to the new trajectory monitor.

### Testing
- Ran schema tests: `python -m pytest tests/demo/test_trajectory_admissibility_monitor_schema.py` and full validation pair: `python -m pytest tests/demo/test_evaluation_drift_detection_schema.py tests/demo/test_trajectory_admissibility_monitor_schema.py`, both succeeded (`21 passed`).
- Linted tests with `ruff check` on the new test file and it passed (`All checks passed`).
- Security note: this PR is documentation/schema-only and does not introduce runtime enforcement, governance mutations, secrets, or fail-closed behavior; reviewers should still confirm no governance or runtime code was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24ee7c2cf8832682b760fac623a046)