### PR TITLE
Add Legitimacy Impact Review schema v1

### DIFF
--- a/docs/en/architecture/legitimacy-impact-review-v1.md
+++ b/docs/en/architecture/legitimacy-impact-review-v1.md
@@ -1,0 +1,82 @@
+# Legitimacy Impact Review v1
+
+## 1. Purpose
+
+Legitimacy Impact Review v1 records when a governance change may affect
+legitimacy-relevant properties. These properties include authority scope, human
+oversight, refusal boundaries, escalation requirements, auditability, and
+high-risk admissibility posture.
+
+The review is an auditable, schema-only artifact for making legitimacy-impacting
+changes visible to reviewers. It does not decide that a change is legitimate or
+illegitimate, and it does not enforce runtime behavior in v1.
+
+## 2. Important boundary
+
+VERITAS does not automatically create or guarantee legitimacy.
+
+VERITAS makes legitimacy-impacting changes explicit, versioned, challengeable,
+reviewable, and auditable. A Legitimacy Impact Review records the relevant
+signals and recommended governance action so human reviewers and future workflow
+integrations can evaluate the change against the applicable authority model.
+
+## 3. Relationship to previous artifacts
+
+Legitimacy Impact Review v1 builds on the preceding governance artifact
+foundation:
+
+- **Root Authority Manifest** defines asserted authority.
+- **Evaluation Function Manifest** defines the governed evaluator.
+- **Manifest Change Receipt** records governance manifest changes.
+- **Evaluation Receipt v1** records a specific evaluation.
+- **Outcome Delta Attribution v1** explains outcome changes.
+- **Evaluation Drift Detection v1** flags possible evaluator drift.
+- **Trajectory-Level Admissibility Monitor v1** watches admissibility movement
+  over time.
+- **Legitimacy Impact Review v1** records when changes may affect authority,
+  oversight, refusal, escalation, auditability, or high-risk posture.
+
+## 4. What counts as legitimacy-impacting
+
+Examples of legitimacy-impacting changes include:
+
+- authority scope expansion
+- trusted authority source change
+- policy source change
+- human oversight weakened
+- refusal boundary relaxed
+- escalation requirement reduced
+- auditability or replayability reduced
+- high-risk admissibility expanded
+- root authority changed
+- constitutional trust anchor changed
+
+These signals are review inputs. They do not automatically prove that a change
+is permitted, prohibited, legitimate, or illegitimate.
+
+## 5. v1 scope
+
+Legitimacy Impact Review v1 is intentionally limited:
+
+- schema-only
+- no runtime enforcement
+- no automatic legitimacy judgment
+- no `/v1/decide` behavior change
+- no production governance mutation
+- no fail-closed integration yet
+
+This v1 foundation does not modify bind/admissibility logic, production
+governance configuration, policy loading, TrustLog persistence, FUJI Gate
+behavior, continuity handling, or any runtime resolver.
+
+## 6. Future work
+
+Future work can build on Legitimacy Impact Review v1 with:
+
+- automated legitimacy impact detection from Manifest Change Receipts
+- multi-party review workflow
+- external audit flagging
+- runtime fail-closed integration
+- reviewer evidence packet integration
+- policy bundle integration
+- legitimacy impact dashboards

--- a/docs/en/architecture/trajectory-admissibility-monitor-v1.md
+++ b/docs/en/architecture/trajectory-admissibility-monitor-v1.md
@@ -83,7 +83,7 @@ Future work can build on Trajectory-Level Admissibility Monitor v1 with:
 
 - automated trajectory analysis from Evaluation Receipts
 - strategic admissibility drift detection
-- legitimacy impact review
+- legitimacy impact review using [Legitimacy Impact Review v1](legitimacy-impact-review-v1.md)
 - governance exhaustion safeguards
 - runtime fail-closed integration
 - reviewer evidence packet integration

--- a/docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json
+++ b/docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json
@@ -1,0 +1,340 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritas-os.local/schemas/legitimacy-impact-review-v1.schema.json",
+  "title": "Legitimacy Impact Review v1",
+  "description": "Schema-only review artifact that records when governance changes may affect legitimacy-relevant properties such as authority scope, human oversight, refusal boundaries, escalation requirements, auditability, or high-risk admissibility posture. It is non-enforcing in v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "review_id",
+    "issued_at",
+    "reviewed_artifact_type",
+    "reviewed_artifact_ref",
+    "reviewed_artifact_hash",
+    "triggering_change_ref",
+    "triggering_change_hash",
+    "legitimacy_impact_detected",
+    "impact_categories",
+    "authority_impact",
+    "oversight_impact",
+    "refusal_boundary_impact",
+    "escalation_impact",
+    "auditability_impact",
+    "high_risk_admissibility_impact",
+    "review_status",
+    "recommended_governance_action",
+    "review_summary",
+    "review_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "legitimacy-impact-review-v1"
+    },
+    "review_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "reviewed_artifact_type": {
+      "$ref": "#/$defs/artifact_type"
+    },
+    "reviewed_artifact_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reviewed_artifact_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "triggering_change_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "triggering_change_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "legitimacy_impact_detected": {
+      "type": "boolean"
+    },
+    "impact_categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/impact_category"
+      }
+    },
+    "authority_impact": {
+      "$ref": "#/$defs/authority_impact"
+    },
+    "oversight_impact": {
+      "$ref": "#/$defs/oversight_impact"
+    },
+    "refusal_boundary_impact": {
+      "$ref": "#/$defs/refusal_boundary_impact"
+    },
+    "escalation_impact": {
+      "$ref": "#/$defs/escalation_impact"
+    },
+    "auditability_impact": {
+      "$ref": "#/$defs/auditability_impact"
+    },
+    "high_risk_admissibility_impact": {
+      "$ref": "#/$defs/high_risk_admissibility_impact"
+    },
+    "review_status": {
+      "$ref": "#/$defs/review_status"
+    },
+    "recommended_governance_action": {
+      "$ref": "#/$defs/governance_action"
+    },
+    "review_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "review_hash": {
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "$defs": {
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "artifact_type": {
+      "enum": [
+        "root_authority_manifest",
+        "evaluation_function_manifest",
+        "manifest_change_receipt",
+        "evaluation_receipt",
+        "outcome_delta_attribution",
+        "evaluation_drift_detection",
+        "trajectory_admissibility_monitor",
+        "other_governance_artifact"
+      ]
+    },
+    "impact_category": {
+      "enum": [
+        "authority_scope_expansion",
+        "trusted_authority_source_changed",
+        "policy_source_changed",
+        "human_oversight_weakened",
+        "refusal_boundary_relaxed",
+        "escalation_requirement_reduced",
+        "auditability_reduced",
+        "replayability_reduced",
+        "high_risk_admissibility_expanded",
+        "evaluation_behavior_changed",
+        "root_authority_changed",
+        "constitutional_trust_anchor_changed",
+        "unknown_legitimacy_impact"
+      ]
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "authority_impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_scope_expanded",
+        "trusted_authority_source_changed",
+        "root_authority_changed",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "authority_scope_expanded": {
+          "type": "boolean"
+        },
+        "trusted_authority_source_changed": {
+          "type": "boolean"
+        },
+        "root_authority_changed": {
+          "type": "boolean"
+        },
+        "evidence_refs": {
+          "$ref": "#/$defs/evidence_refs"
+        },
+        "explanation": {
+          "type": "string"
+        }
+      }
+    },
+    "oversight_impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "human_oversight_weakened",
+        "approval_requirement_reduced",
+        "reviewer_authority_changed",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "human_oversight_weakened": {
+          "type": "boolean"
+        },
+        "approval_requirement_reduced": {
+          "type": "boolean"
+        },
+        "reviewer_authority_changed": {
+          "type": "boolean"
+        },
+        "evidence_refs": {
+          "$ref": "#/$defs/evidence_refs"
+        },
+        "explanation": {
+          "type": "string"
+        }
+      }
+    },
+    "refusal_boundary_impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "refusal_boundary_relaxed",
+        "refusal_condition_removed",
+        "refusal_condition_changed",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "refusal_boundary_relaxed": {
+          "type": "boolean"
+        },
+        "refusal_condition_removed": {
+          "type": "boolean"
+        },
+        "refusal_condition_changed": {
+          "type": "boolean"
+        },
+        "evidence_refs": {
+          "$ref": "#/$defs/evidence_refs"
+        },
+        "explanation": {
+          "type": "string"
+        }
+      }
+    },
+    "escalation_impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "escalation_requirement_reduced",
+        "escalation_path_changed",
+        "escalation_authority_changed",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "escalation_requirement_reduced": {
+          "type": "boolean"
+        },
+        "escalation_path_changed": {
+          "type": "boolean"
+        },
+        "escalation_authority_changed": {
+          "type": "boolean"
+        },
+        "evidence_refs": {
+          "$ref": "#/$defs/evidence_refs"
+        },
+        "explanation": {
+          "type": "string"
+        }
+      }
+    },
+    "auditability_impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "auditability_reduced",
+        "replayability_reduced",
+        "evidence_chain_weakened",
+        "receipt_requirements_reduced",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "auditability_reduced": {
+          "type": "boolean"
+        },
+        "replayability_reduced": {
+          "type": "boolean"
+        },
+        "evidence_chain_weakened": {
+          "type": "boolean"
+        },
+        "receipt_requirements_reduced": {
+          "type": "boolean"
+        },
+        "evidence_refs": {
+          "$ref": "#/$defs/evidence_refs"
+        },
+        "explanation": {
+          "type": "string"
+        }
+      }
+    },
+    "high_risk_admissibility_impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "high_risk_scope_expanded",
+        "high_risk_controls_weakened",
+        "high_risk_review_requirement_reduced",
+        "evidence_refs",
+        "explanation"
+      ],
+      "properties": {
+        "high_risk_scope_expanded": {
+          "type": "boolean"
+        },
+        "high_risk_controls_weakened": {
+          "type": "boolean"
+        },
+        "high_risk_review_requirement_reduced": {
+          "type": "boolean"
+        },
+        "evidence_refs": {
+          "$ref": "#/$defs/evidence_refs"
+        },
+        "explanation": {
+          "type": "string"
+        }
+      }
+    },
+    "review_status": {
+      "enum": [
+        "not_required",
+        "required",
+        "pending",
+        "approved",
+        "rejected",
+        "requires_external_review",
+        "unresolved"
+      ]
+    },
+    "governance_action": {
+      "enum": [
+        "none",
+        "review",
+        "multi_party_review",
+        "external_audit_flag",
+        "requalify_authority",
+        "requalify_evaluator",
+        "rollback",
+        "escalate",
+        "refuse",
+        "mark_legitimacy_impact"
+      ]
+    }
+  }
+}

--- a/tests/demo/test_legitimacy_impact_review_schema.py
+++ b/tests/demo/test_legitimacy_impact_review_schema.py
@@ -1,0 +1,199 @@
+import copy
+import importlib.util
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(
+    "docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json"
+)
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+HASH_C = "c" * 64
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _impact(
+    explanation: str,
+    **flags: bool,
+) -> dict[str, Any]:
+    return {
+        **flags,
+        "evidence_refs": ["evidence://legitimacy-impact/demo"],
+        "explanation": explanation,
+    }
+
+
+def _build_minimal_review() -> dict[str, Any]:
+    return {
+        "schema_version": "legitimacy-impact-review-v1",
+        "review_id": "legitimacy-impact-review-demo-v1",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "reviewed_artifact_type": "trajectory_admissibility_monitor",
+        "reviewed_artifact_ref": "trajectory-admissibility-monitor-demo-v1",
+        "reviewed_artifact_hash": HASH_A,
+        "triggering_change_ref": "manifest-change-receipt-demo-v1",
+        "triggering_change_hash": HASH_B,
+        "legitimacy_impact_detected": True,
+        "impact_categories": [
+            "authority_scope_expansion",
+            "high_risk_admissibility_expanded",
+        ],
+        "authority_impact": _impact(
+            "The reviewed change expands the asserted authority scope.",
+            authority_scope_expanded=True,
+            trusted_authority_source_changed=False,
+            root_authority_changed=False,
+        ),
+        "oversight_impact": _impact(
+            "Human oversight requirements are unchanged.",
+            human_oversight_weakened=False,
+            approval_requirement_reduced=False,
+            reviewer_authority_changed=False,
+        ),
+        "refusal_boundary_impact": _impact(
+            "Refusal boundaries are unchanged.",
+            refusal_boundary_relaxed=False,
+            refusal_condition_removed=False,
+            refusal_condition_changed=False,
+        ),
+        "escalation_impact": _impact(
+            "Escalation requirements are unchanged.",
+            escalation_requirement_reduced=False,
+            escalation_path_changed=False,
+            escalation_authority_changed=False,
+        ),
+        "auditability_impact": _impact(
+            "Auditability and replayability requirements are unchanged.",
+            auditability_reduced=False,
+            replayability_reduced=False,
+            evidence_chain_weakened=False,
+            receipt_requirements_reduced=False,
+        ),
+        "high_risk_admissibility_impact": _impact(
+            "The high-risk admissibility posture may expand.",
+            high_risk_scope_expanded=True,
+            high_risk_controls_weakened=False,
+            high_risk_review_requirement_reduced=False,
+        ),
+        "review_status": "required",
+        "recommended_governance_action": "multi_party_review",
+        "review_summary": "The change requires legitimacy impact review.",
+        "review_hash": HASH_C,
+    }
+
+
+def _validate(payload: dict[str, Any], schema: dict[str, Any]) -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(payload)
+        return
+
+    missing = [field for field in schema["required"] if field not in payload]
+    assert not missing, f"missing required fields: {missing}"
+    assert payload["schema_version"] == "legitimacy-impact-review-v1"
+    assert payload["reviewed_artifact_type"] in (
+        schema["$defs"]["artifact_type"]["enum"]
+    )
+    assert all(
+        category in schema["$defs"]["impact_category"]["enum"]
+        for category in payload["impact_categories"]
+    )
+    assert payload["review_status"] in (
+        schema["$defs"]["review_status"]["enum"]
+    )
+    assert payload["recommended_governance_action"] in (
+        schema["$defs"]["governance_action"]["enum"]
+    )
+    sha256_pattern = re.compile(r"^[0-9a-f]{64}$")
+    assert sha256_pattern.match(payload["reviewed_artifact_hash"])
+    assert sha256_pattern.match(payload["triggering_change_hash"])
+    assert sha256_pattern.match(payload["review_hash"])
+    assert set(payload) <= set(schema["properties"])
+
+
+def _is_rejected(payload: dict[str, Any], schema: dict[str, Any]) -> bool:
+    try:
+        _validate(payload, schema)
+    except (AssertionError, Exception):
+        return True
+    return False
+
+
+def test_schema_file_exists() -> None:
+    assert SCHEMA_PATH.is_file()
+
+
+def test_schema_file_parses_as_valid_json_schema() -> None:
+    schema = _load_schema()
+    assert isinstance(schema, dict)
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_minimal_valid_example_validates() -> None:
+    _validate(_build_minimal_review(), _load_schema())
+
+
+def test_missing_required_field_fails_validation() -> None:
+    payload = _build_minimal_review()
+    payload.pop("reviewed_artifact_hash")
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_reviewed_artifact_type_enum_fails_validation() -> None:
+    payload = _build_minimal_review()
+    payload["reviewed_artifact_type"] = "runtime_decision"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_impact_categories_enum_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_review())
+    payload["impact_categories"][0] = "automatic_legitimacy_created"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_review_status_enum_fails_validation() -> None:
+    payload = _build_minimal_review()
+    payload["review_status"] = "auto_approved"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_recommended_governance_action_enum_fails_validation() -> None:
+    payload = _build_minimal_review()
+    payload["recommended_governance_action"] = "auto_enforce"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_invalid_sha256_hash_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_review())
+    payload["triggering_change_hash"] = "not-a-sha256-hash"
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_unexpected_top_level_property_fails_validation() -> None:
+    payload = copy.deepcopy(_build_minimal_review())
+    payload["unexpected_runtime_enforcement"] = True
+    assert _is_rejected(payload, _load_schema())
+
+
+def test_schema_validation_requires_no_network_or_environment_dependency(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("VERITAS_API_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _validate(_build_minimal_review(), _load_schema())


### PR DESCRIPTION
### Motivation
- Introduce a schema-only foundation for recording when governance changes may affect legitimacy-relevant properties (authority scope, human oversight, refusal boundaries, escalation, auditability, high-risk admissibility) so such changes are explicit, versioned, challengeable, and auditable.
- Provide a non-enforcing v1 artifact that builds on prior schema artifacts (Root Authority Manifest, Evaluation Function Manifest, Manifest Change Receipt, Evaluation Receipt, Outcome Delta Attribution, Evaluation Drift Detection, Trajectory-Level Admissibility Monitor) without altering runtime behavior.
- Keep the change strictly schema/documentation/test-only to avoid any `/v1/decide` behavior, production governance config, admissibility logic, or fail-closed semantics modifications.
- Security warning: this PR does not introduce enforcement, but future integrations that act on these reviews (automatic enforcement, fail-closed integration, or runtime policy mutation) are high-risk and require human review and explicit safeguards.

### Description
- Add JSON Schema `docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json` (draft 2020-12) with strict `additionalProperties: false`, required fields, reusable `$defs` (including `sha256_hex`, `artifact_type`, `impact_category`, impact object defs, `review_status`, and `governance_action`), and SHA-256 hex validation.
- Add architecture documentation `docs/en/architecture/legitimacy-impact-review-v1.md` that clearly states the v1 artifact is schema-only, non-enforcing, and that VERITAS does not automatically create or guarantee legitimacy.
- Add tests `tests/demo/test_legitimacy_impact_review_schema.py` which validate a minimal valid example and assert invalid/missing enums, invalid SHA-256, unexpected top-level properties, and that schema parsing requires no network/environment dependencies.
- Add a short cross-reference from the Trajectory-Level Admissibility Monitor future-work section to the new Legitimacy Impact Review documentation.

### Testing
- Ran the schema unit tests with `python -m pytest tests/demo/test_legitimacy_impact_review_schema.py` and they passed (`11 passed`).
- Ran combined demo schema tests with `python -m pytest tests/demo/test_trajectory_admissibility_monitor_schema.py tests/demo/test_legitimacy_impact_review_schema.py` and they passed (`22 passed`).
- Ran style checks with `python -m ruff check tests/demo/test_legitimacy_impact_review_schema.py` and they passed.
- The schema was validated as JSON Schema (via `jsonschema.Draft202012Validator.check_schema` when available) as part of the tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24ffa1a9e883269dd5bfe65afa7b01)