### PR TITLE
Integrate Evaluation Governance artifacts into reviewer evidence packets

### DIFF
--- a/docs/en/demo/external-reviewer-artifact-index.md
+++ b/docs/en/demo/external-reviewer-artifact-index.md
@@ -56,3 +56,18 @@ Key local/offline reviewer-facing artifacts:
   - EvidenceChainVerifier documentation
 - `docs/en/architecture/bind-coverage-registry.md`
   - Bind Coverage Registry documentation
+
+## Evaluation Governance reviewer artifacts
+
+Evaluation Governance artifacts may be referenced as optional reviewer evidence attachments in Reviewer Evidence Packet v1. These references are non-enforcing in v1 and support external review without changing runtime admissibility.
+
+- Root Authority Manifest — asserted authority/trust anchor
+- Evaluation Function Manifest — governed evaluator definition
+- Manifest Change Receipt — governance manifest change record
+- Evaluation Receipt — specific evaluation instance record
+- Outcome Delta Attribution — outcome change explanation
+- Evaluation Drift Detection — evaluator drift signal
+- Trajectory-Level Admissibility Monitor — admissibility trajectory movement
+- Legitimacy Impact Review — reviewable legitimacy-impacting change
+- Adversarial Architecture Test Matrix — failure class map
+- Adversarial Scenario Fixtures — concrete reviewer scenarios

--- a/docs/en/demo/external-reviewer-quickstart.md
+++ b/docs/en/demo/external-reviewer-quickstart.md
@@ -49,6 +49,7 @@ Use this 10–15 minute path for a reviewer-facing inspection:
    `scripts/demo/export_reviewer_evidence_packet.py`
 6. Inspect the original demo:
    `scripts/demo/saas_permission_change_governed_demo.py`
+7. Optionally review Evaluation Governance artifacts, if present. These attachments are optional in v1, non-enforcing, and useful for architecture-hardening review without changing runtime admissibility.
 
 ## Local bundle generation
 
@@ -119,6 +120,10 @@ A pass/fail report that verifies generated packet equality with the fixture, pac
 ### Evidence Chain
 
 Authority, approval, bind-time decision, outcome, and verification are linked into a traceable local/offline evidence chain.
+
+### Evaluation Governance artifacts
+
+If present, Evaluation Governance artifact references are optional reviewer evidence attachments for architecture-hardening review. They may help reviewers inspect authority anchors, evaluator definitions, evaluation receipts, drift signals, trajectory-level admissibility movement, legitimacy-impacting changes, and adversarial scenarios. They are non-enforcing in v1 and do not automatically establish legitimacy or change runtime admissibility.
 
 ## Boundary and non-claims
 

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -17,6 +17,27 @@ The packet is built from `run_saas_permission_change_governed_demo()` and includ
 - deterministic reviewer notes
 - a deterministic packet hash that excludes `packet_hash` itself from the hash payload
 
+## Evaluation Governance Artifact Attachments
+
+Reviewer Evidence Packet v1 may include optional reviewer evidence attachments for Evaluation Governance artifacts. These references are intended to help external reviewers inspect the authority basis, evaluator definition, evaluation receipt, drift signals, trajectory movement, and legitimacy-impacting changes that may be relevant to an architecture-hardening review.
+
+Optional Evaluation Governance artifact references may include:
+
+- Root Authority Manifest
+- Evaluation Function Manifest
+- Manifest Change Receipt
+- Evaluation Receipt
+- Outcome Delta Attribution
+- Evaluation Drift Detection
+- Trajectory-Level Admissibility Monitor
+- Legitimacy Impact Review
+- Adversarial Architecture Test Matrix
+- Adversarial Scenario Fixtures
+
+These attachments are optional reviewer evidence attachments in v1. Reviewer packets do not require them, and schema validation only checks the attachment reference shape, hash format, and declared schema reference; it does not dereference files or validate the target artifact itself.
+
+Evaluation Governance artifacts are non-enforcing in v1 unless future runtime integration is added. Their presence supports external review, but does not automatically establish legitimacy, does not change runtime admissibility, does not introduce fail-closed behavior, and does not require live receipt generation.
+
 ## Local/offline boundary
 
 Reviewer Evidence Packet v1 is a local/offline fixture export only.
@@ -49,7 +70,7 @@ If the generated packet changes intentionally in the future, update the golden f
 Reviewer Evidence Packet v1 has a checked-in schema at:
 `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json`
 
-The schema documents the required packet fields, case summaries, nested evidence summaries, aggregate summary, reviewer notes, and packet hash format. The golden fixture and generated packet are tested against this schema. Future intentional packet-shape changes should update the schema, exporter, tests, and golden fixture in the same PR.
+The schema documents the required packet fields, case summaries, nested evidence summaries, aggregate summary, reviewer notes, packet hash format, and optional `evaluation_governance_artifacts` reference shape. The golden fixture and generated packet are tested against this schema. Future intentional packet-shape changes should update the schema, exporter, tests, and golden fixture in the same PR.
 
 This schema is for a local/offline reviewer packet. It is not a production audit certification, regulatory approval, or proof of live deployment.
 

--- a/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
+++ b/docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json
@@ -68,6 +68,12 @@
     },
     "packet_hash": {
       "$ref": "#/$defs/sha256_hex"
+    },
+    "evaluation_governance_artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/evaluation_governance_artifact"
+      }
     }
   },
   "$defs": {
@@ -609,6 +615,47 @@
         },
         "local_offline_only": {
           "const": true
+        }
+      }
+    },
+    "evaluation_governance_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_type",
+        "artifact_ref",
+        "artifact_hash",
+        "schema_ref",
+        "required_for_review"
+      ],
+      "properties": {
+        "artifact_type": {
+          "enum": [
+            "root_authority_manifest",
+            "evaluation_function_manifest",
+            "manifest_change_receipt",
+            "evaluation_receipt",
+            "outcome_delta_attribution",
+            "evaluation_drift_detection",
+            "trajectory_admissibility_monitor",
+            "legitimacy_impact_review",
+            "adversarial_architecture_test_matrix",
+            "adversarial_scenario_fixtures"
+          ]
+        },
+        "artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact_hash": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "schema_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required_for_review": {
+          "type": "boolean"
         }
       }
     }

--- a/tests/demo/test_reviewer_evidence_packet_schema.py
+++ b/tests/demo/test_reviewer_evidence_packet_schema.py
@@ -136,6 +136,14 @@ REQUIRED_AGGREGATE_FIELDS = [
     "local_offline_only",
 ]
 
+EVALUATION_GOVERNANCE_ARTIFACT = {
+    "artifact_type": "root_authority_manifest",
+    "artifact_ref": "docs/en/demo/fixtures/root-authority-manifest-v1.json",
+    "artifact_hash": "0" * 64,
+    "schema_ref": "docs/en/demo/schemas/root-authority-manifest-v1.schema.json",
+    "required_for_review": False,
+}
+
 
 def _load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -417,3 +425,47 @@ def test_schema_validation_requires_no_network_or_environment_dependency(
     monkeypatch.delenv("VERITAS_API_KEY", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
     _validate_or_fallback(_build_reviewer_evidence_packet(), _load_json(SCHEMA_PATH))
+
+
+def test_schema_accepts_optional_evaluation_governance_artifacts() -> None:
+    packet = copy.deepcopy(_load_json(FIXTURE_PATH))
+    packet["evaluation_governance_artifacts"] = [
+        EVALUATION_GOVERNANCE_ARTIFACT.copy()
+    ]
+
+    _validate_or_fallback(packet, _load_json(SCHEMA_PATH))
+
+
+def test_evaluation_governance_artifacts_remain_optional() -> None:
+    packet = _load_json(FIXTURE_PATH)
+
+    assert "evaluation_governance_artifacts" not in packet
+    _validate_or_fallback(packet, _load_json(SCHEMA_PATH))
+
+
+def test_schema_rejects_invalid_evaluation_governance_artifact_type() -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        pytest.skip("jsonschema is unavailable")
+    packet = copy.deepcopy(_load_json(FIXTURE_PATH))
+    artifact = EVALUATION_GOVERNANCE_ARTIFACT.copy()
+    artifact["artifact_type"] = "required_runtime_artifact"
+    packet["evaluation_governance_artifacts"] = [artifact]
+
+    validator = jsonschema.Draft202012Validator(_load_json(SCHEMA_PATH))
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(packet)
+
+
+def test_schema_rejects_invalid_evaluation_governance_artifact_hash() -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        pytest.skip("jsonschema is unavailable")
+    packet = copy.deepcopy(_load_json(FIXTURE_PATH))
+    artifact = EVALUATION_GOVERNANCE_ARTIFACT.copy()
+    artifact["artifact_hash"] = "not-a-sha256-hex"
+    packet["evaluation_governance_artifacts"] = [artifact]
+
+    validator = jsonschema.Draft202012Validator(_load_json(SCHEMA_PATH))
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(packet)


### PR DESCRIPTION
### Motivation
- Connect the recently added Evaluation Governance artifact types to the reviewer-facing evidence packet flow so external reviewers can optionally reference them without changing runtime behavior.  
- Make it explicit that these artifacts are optional reviewer evidence attachments in v1 and are non-enforcing (no effect on `/v1/decide`, admissibility logic, production governance, or fail-closed behavior).  
- Security note: this PR is docs/schema/tests only and introduces no secrets, but reviewers should avoid including credentials or PII in any referenced artifacts since the schema only validates references and hashes, not payload contents.

### Description
- Documentation: added an `Evaluation Governance Artifact Attachments` section to `docs/en/demo/reviewer-evidence-packet.md`, added a compact listing to `docs/en/demo/external-reviewer-artifact-index.md`, and added an optional quick-review step and guidance to `docs/en/demo/external-reviewer-quickstart.md`.  
- Schema: extended `docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json` with an optional top-level `evaluation_governance_artifacts` array (not in `required`) whose item type (`$defs/evaluation_governance_artifact`) is `additionalProperties: false` and requires `artifact_type`, `artifact_ref`, `artifact_hash`, `schema_ref`, and `required_for_review`; `artifact_type` is an enum of the 10 requested artifact names and `artifact_hash` uses the existing `#/$defs/sha256_hex`.  
- Tests: extended `tests/demo/test_reviewer_evidence_packet_schema.py` with a valid example including `evaluation_governance_artifacts`, a test asserting artifacts remain optional, and negative tests for invalid `artifact_type` enum and invalid `artifact_hash` format; test logic validates shape only and does not dereference artifacts.
- Non-runtime: no production config, runtime code, `/v1/decide` behavior, admissibility logic, or live receipt generation were changed.

### Testing
- Static checks passed: `python3 -m json.tool docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json` and `python3 -m py_compile tests/demo/test_reviewer_evidence_packet_schema.py`.  
- Schema-local assertions passed via an ad-hoc Python check that confirmed `evaluation_governance_artifacts` is optional, its item definition matches the required properties, enum contains the 10 artifact types, and `artifact_hash` references `#/$defs/sha256_hex`.  
- Unit test execution (`make test` / `pytest`) could not be completed in this environment due to interpreter/fetch/network constraints (pyenv requested Python 3.12.12 not installed and dependency fetches from PyPI failed), so the new tests were added but full pytest run was blocked by the environment; CI should run the updated tests normally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a255440f5888326a9125e06c8694de2)