### PR TITLE
Add Evaluation Governance sample bundle v1

### DIFF
--- a/docs/en/architecture/evaluation-governance-overview-v1.md
+++ b/docs/en/architecture/evaluation-governance-overview-v1.md
@@ -79,6 +79,7 @@ See:
 
 - [Reviewer Evidence Packet v1](../demo/reviewer-evidence-packet.md)
 - [Reviewer Evidence Packet example with Evaluation Governance attachments](../demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json)
+- [Evaluation Governance sample bundle v1](../demo/examples/evaluation-governance-sample-bundle-v1/)
 
 In v1, this packet integration is optional, non-enforcing, and reference-only.
 It does not require live runtime generation yet and does not change `/v1/decide`

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/README.md
@@ -1,0 +1,50 @@
+# Evaluation Governance Sample Bundle v1
+
+This directory contains a synthetic, non-enforcing sample bundle for external reviewers who want to inspect how Evaluation Governance artifacts can be represented together.
+
+The bundle demonstrates a complete artifact chain for a fictional scenario: a high-risk internal approval workflow where a delegated authority scope changes, an evaluator version changes, and the trajectory monitor flags potential admissibility expansion.
+
+## What this bundle is
+
+- A reviewer-facing example of Evaluation Governance JSON artifacts.
+- A synthetic, offline documentation fixture.
+- A compact way to understand references between governance artifacts.
+- A sample that contains deterministic placeholder hashes shaped like SHA-256 values.
+- A bundle intended for external reviewer understanding.
+
+## What this bundle is not
+
+- It does not prove runtime enforcement.
+- It does not automatically establish legitimacy.
+- It does not certify regulatory compliance.
+- It does not introduce live receipt generation.
+- It does not modify production governance configuration.
+- It does not contain secrets or personally identifiable information (PII).
+
+## Compact artifact flow
+
+```text
+Root Authority Manifest
+→ Evaluation Function Manifest
+→ Manifest Change Receipt
+→ Evaluation Receipt
+→ Outcome Delta Attribution
+→ Evaluation Drift Detection
+→ Trajectory-Level Admissibility Monitor
+→ Legitimacy Impact Review
+```
+
+## Included artifacts
+
+| Artifact | Example file | Purpose |
+| --- | --- | --- |
+| Root Authority Manifest | `root-authority-manifest.example.json` | Defines the synthetic root trust anchor and authority sources. |
+| Evaluation Function Manifest | `evaluation-function-manifest.example.json` | Describes the governed evaluator and references the root authority manifest. |
+| Manifest Change Receipt | `manifest-change-receipt.example.json` | Records a synthetic evaluator manifest change. |
+| Evaluation Receipt | `evaluation-receipt.example.json` | Records a synthetic admissibility evaluation using the evaluator manifest. |
+| Outcome Delta Attribution | `outcome-delta-attribution.example.json` | Attributes a synthetic outcome change to evaluator and authority-scope changes. |
+| Evaluation Drift Detection | `evaluation-drift-detection.example.json` | Marks evaluator drift as suspected based on the attribution artifact. |
+| Trajectory-Level Admissibility Monitor | `trajectory-admissibility-monitor.example.json` | Flags possible admissibility expansion across the synthetic trajectory. |
+| Legitimacy Impact Review | `legitimacy-impact-review.example.json` | Reviews legitimacy-relevant impact from the manifest change. |
+
+All examples are documentation fixtures only and validate against their corresponding schemas in `docs/en/demo/schemas/`.

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/evaluation-drift-detection.example.json
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/evaluation-drift-detection.example.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "evaluation-drift-detection-v1",
+  "detection_id": "egov-sample-drift-detection-001",
+  "issued_at": "2026-05-01T00:30:00Z",
+  "outcome_delta_attribution_ref": "egov-sample-outcome-delta-001",
+  "outcome_delta_attribution_hash": "4444444444444444444444444444444444444444444444444444444444444444",
+  "prior_evaluation_receipt_ref": "sample://evaluation-receipts/egov-sample-evaluation-receipt-prior-001",
+  "current_evaluation_receipt_ref": "egov-sample-evaluation-receipt-current-001",
+  "drift_detected": true,
+  "drift_status": "suspected",
+  "drift_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "severity": "medium",
+      "evidence_refs": [
+        "egov-sample-outcome-delta-001",
+        "egov-sample-manifest-change-001"
+      ],
+      "explanation": "The evaluator version changed in the synthetic chain."
+    }
+  ],
+  "evaluator_consistency_status": "inconsistent",
+  "explanation_status": "partially_explained",
+  "recommended_governance_action": "mark_evaluation_drift",
+  "detection_summary": "Synthetic drift detection marks the changed evaluator behavior as suspected drift for reviewer inspection.",
+  "detection_hash": "5555555555555555555555555555555555555555555555555555555555555555"
+}

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/evaluation-function-manifest.example.json
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/evaluation-function-manifest.example.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "evaluation-function-manifest-v1",
+  "manifest_id": "egov-sample-evaluation-function-v2",
+  "issued_at": "2026-05-01T00:10:00Z",
+  "evaluator_id": "synthetic-high-risk-approval-evaluator",
+  "evaluator_version": "2.0.0-demo",
+  "policy_identity": {
+    "policy_id": "synthetic-high-risk-approval-policy",
+    "policy_version": "2026.05-demo",
+    "policy_source_ref": "sample://policy/synthetic-high-risk-approval-policy"
+  },
+  "rule_set_version": "synthetic-ruleset-2026.05-expanded-scope",
+  "authorized_determiners": [
+    {
+      "determiner_id": "synthetic-delegated-authority-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "internal_approval_high_risk_expanded_demo",
+      "may_influence_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "delegated_authority_scope",
+      "input_type": "synthetic_scope_ref",
+      "required": true,
+      "freshness_required": true
+    },
+    {
+      "input_name": "approval_request_context",
+      "input_type": "synthetic_context_ref",
+      "required": true,
+      "freshness_required": true
+    }
+  ],
+  "qualifier_sources": [
+    {
+      "qualifier_name": "delegated_scope_validity",
+      "source_ref": "egov-sample-root-authority-v1",
+      "freshness_ttl_seconds": 3600,
+      "required_at_bind": true
+    }
+  ],
+  "consequence_classifier": {
+    "classifier_id": "synthetic-high-risk-consequence-classifier",
+    "classifier_version": "2.0.0-demo"
+  },
+  "threshold_resolver": {
+    "resolver_id": "synthetic-expanded-threshold-resolver",
+    "resolver_version": "2.0.0-demo"
+  },
+  "refusal_boundaries": [
+    {
+      "boundary_id": "missing-delegated-authority",
+      "condition": "delegated authority scope evidence is missing",
+      "action": "escalate_or_refuse"
+    }
+  ],
+  "escalation_resolver": {
+    "resolver_id": "synthetic-human-review-escalation-resolver",
+    "resolver_version": "2.0.0-demo",
+    "authority_validation_required": true
+  },
+  "baseline_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "root_authority_manifest_ref": "egov-sample-root-authority-v1",
+  "manifest_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/evaluation-receipt.example.json
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/evaluation-receipt.example.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "egov-sample-evaluation-receipt-current-001",
+  "issued_at": "2026-05-01T00:20:00Z",
+  "evaluation_id": "egov-sample-evaluation-current-001",
+  "evaluation_function_manifest_ref": "egov-sample-evaluation-function-v2",
+  "evaluation_function_manifest_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "root_authority_manifest_ref": "egov-sample-root-authority-v1",
+  "evaluator_id": "synthetic-high-risk-approval-evaluator",
+  "evaluator_version": "2.0.0-demo",
+  "policy_identity": {
+    "policy_id": "synthetic-high-risk-approval-policy",
+    "policy_version": "2026.05-demo",
+    "policy_source_ref": "sample://policy/synthetic-high-risk-approval-policy"
+  },
+  "rule_set_version": "synthetic-ruleset-2026.05-expanded-scope",
+  "authority_evidence_refs": [
+    "sample://authority/synthetic-board-charter-v1",
+    "sample://approval/synthetic-reviewer-approval-a"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "delegated_scope_validity",
+      "source_ref": "egov-sample-root-authority-v1",
+      "freshness_state": "fresh",
+      "required_at_bind": true,
+      "qualifier_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-delegated-authority-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "internal_approval_high_risk_expanded_demo",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "delegated_authority_scope",
+      "input_type": "synthetic_scope_ref",
+      "input_ref": "sample://input/delegated-authority-expanded",
+      "required": true,
+      "input_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-high-risk-internal-approval",
+    "class_label": "high_risk_internal_approval",
+    "classifier_id": "synthetic-high-risk-consequence-classifier",
+    "classifier_version": "2.0.0-demo"
+  },
+  "material_context": {
+    "context_ref": "sample://context/internal-approval-workflow-001",
+    "context_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "escalate",
+  "rationale_codes": [
+    "delegated_scope_expanded",
+    "human_review_required"
+  ],
+  "input_state_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "evaluation_state_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+  "receipt_hash": "2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/legitimacy-impact-review.example.json
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/legitimacy-impact-review.example.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "legitimacy-impact-review-v1",
+  "review_id": "egov-sample-legitimacy-impact-review-001",
+  "issued_at": "2026-05-01T00:40:00Z",
+  "reviewed_artifact_type": "trajectory_admissibility_monitor",
+  "reviewed_artifact_ref": "egov-sample-trajectory-monitor-001",
+  "reviewed_artifact_hash": "6666666666666666666666666666666666666666666666666666666666666666",
+  "triggering_change_ref": "egov-sample-manifest-change-001",
+  "triggering_change_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "legitimacy_impact_detected": true,
+  "impact_categories": [
+    "authority_scope_expansion",
+    "high_risk_admissibility_expanded",
+    "evaluation_behavior_changed"
+  ],
+  "authority_impact": {
+    "authority_scope_expanded": true,
+    "trusted_authority_source_changed": false,
+    "root_authority_changed": false,
+    "evidence_refs": [
+      "egov-sample-manifest-change-001"
+    ],
+    "explanation": "Synthetic delegated authority scope expanded."
+  },
+  "oversight_impact": {
+    "human_oversight_weakened": false,
+    "approval_requirement_reduced": false,
+    "reviewer_authority_changed": false,
+    "evidence_refs": [
+      "sample://approval/synthetic-reviewer-approval-a",
+      "sample://approval/synthetic-reviewer-approval-b"
+    ],
+    "explanation": "Synthetic approval references remain present."
+  },
+  "refusal_boundary_impact": {
+    "refusal_boundary_relaxed": false,
+    "refusal_condition_removed": false,
+    "refusal_condition_changed": false,
+    "evidence_refs": [
+      "egov-sample-evaluation-function-v2"
+    ],
+    "explanation": "No synthetic refusal boundary relaxation is claimed."
+  },
+  "escalation_impact": {
+    "escalation_requirement_reduced": false,
+    "escalation_path_changed": true,
+    "escalation_authority_changed": false,
+    "evidence_refs": [
+      "egov-sample-evaluation-receipt-current-001"
+    ],
+    "explanation": "The synthetic outcome now escalates instead of refusing."
+  },
+  "auditability_impact": {
+    "auditability_reduced": false,
+    "replayability_reduced": false,
+    "evidence_chain_weakened": false,
+    "receipt_requirements_reduced": false,
+    "evidence_refs": [
+      "egov-sample-outcome-delta-001",
+      "egov-sample-drift-detection-001"
+    ],
+    "explanation": "The sample keeps explicit artifact references for reviewer inspection."
+  },
+  "high_risk_admissibility_impact": {
+    "high_risk_scope_expanded": true,
+    "high_risk_controls_weakened": false,
+    "high_risk_review_requirement_reduced": false,
+    "evidence_refs": [
+      "egov-sample-trajectory-monitor-001"
+    ],
+    "explanation": "The synthetic trajectory monitor flags a high-risk delegated scope expansion."
+  },
+  "review_status": "required",
+  "recommended_governance_action": "mark_legitimacy_impact",
+  "review_summary": "Synthetic legitimacy review marks possible impact from evaluator and delegated authority scope changes; it is not a compliance certification.",
+  "review_hash": "7777777777777777777777777777777777777777777777777777777777777777"
+}

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/manifest-change-receipt.example.json
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/manifest-change-receipt.example.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "manifest-change-receipt-v1",
+  "receipt_id": "egov-sample-manifest-change-001",
+  "issued_at": "2026-05-01T00:12:00Z",
+  "changed_manifest_type": "evaluation_function_manifest",
+  "changed_manifest_id": "egov-sample-evaluation-function-v2",
+  "previous_manifest_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "new_manifest_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "change_reason": "Synthetic delegated authority scope and evaluator version changed for reviewer demonstration.",
+  "changed_by": {
+    "actor_id": "synthetic-governance-maintainer",
+    "role": "demo_governance_maintainer"
+  },
+  "authority_evidence_ref": "sample://authority/synthetic-board-charter-v1",
+  "approval_evidence_refs": [
+    "sample://approval/synthetic-reviewer-approval-a",
+    "sample://approval/synthetic-reviewer-approval-b"
+  ],
+  "impact_scope": [
+    "synthetic_internal_approval_high_risk",
+    "delegated_authority_scope"
+  ],
+  "legitimacy_impact_flags": [
+    "authority_scope_expanded",
+    "evaluator_behavior_changed"
+  ],
+  "rollback_conditions": [
+    "synthetic approval evidence is withdrawn",
+    "scope expansion cannot be requalified"
+  ]
+}

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/outcome-delta-attribution.example.json
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/outcome-delta-attribution.example.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "outcome-delta-attribution-v1",
+  "attribution_id": "egov-sample-outcome-delta-001",
+  "issued_at": "2026-05-01T00:25:00Z",
+  "prior_evaluation_receipt_ref": "sample://evaluation-receipts/egov-sample-evaluation-receipt-prior-001",
+  "current_evaluation_receipt_ref": "egov-sample-evaluation-receipt-current-001",
+  "prior_evaluation_receipt_hash": "3333333333333333333333333333333333333333333333333333333333333333",
+  "current_evaluation_receipt_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+  "prior_outcome": "refuse",
+  "current_outcome": "escalate",
+  "outcome_changed": true,
+  "delta_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "severity": "medium",
+      "prior_value_ref": "synthetic-high-risk-approval-evaluator@1.0.0-demo",
+      "current_value_ref": "synthetic-high-risk-approval-evaluator@2.0.0-demo",
+      "evidence_refs": [
+        "egov-sample-manifest-change-001"
+      ],
+      "explanation": "The synthetic evaluator version changed between the prior and current receipt."
+    },
+    {
+      "cause_type": "authority_state_changed",
+      "severity": "high",
+      "prior_value_ref": "internal_approval_high_risk_limited_demo",
+      "current_value_ref": "internal_approval_high_risk_expanded_demo",
+      "evidence_refs": [
+        "egov-sample-evaluation-receipt-current-001"
+      ],
+      "explanation": "The current evaluation used an expanded delegated authority scope."
+    }
+  ],
+  "attribution_summary": "Synthetic outcome changed from refuse to escalate after evaluator and delegated authority scope changes.",
+  "attribution_confidence": "medium",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "Synthetic references provide a reviewer-facing explanation only.",
+    "requires_review": true
+  },
+  "recommended_governance_action": "review",
+  "attribution_hash": "4444444444444444444444444444444444444444444444444444444444444444"
+}

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/root-authority-manifest.example.json
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/root-authority-manifest.example.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "root-authority-manifest-v1",
+  "manifest_id": "egov-sample-root-authority-v1",
+  "issued_at": "2026-05-01T00:00:00Z",
+  "root_authority_id": "synthetic-root-authority-internal-approval-v1",
+  "trusted_authority_sources": [
+    {
+      "source_id": "synthetic-board-charter-v1",
+      "source_type": "synthetic_internal_charter",
+      "validity_status": "active_demo_only",
+      "evidence_ref": "sample://authority/synthetic-board-charter-v1"
+    }
+  ],
+  "authorized_manifest_modifiers": [
+    {
+      "actor_id": "synthetic-governance-maintainer",
+      "role": "demo_governance_maintainer",
+      "scope": "synthetic_evaluation_governance_examples",
+      "approval_required": true
+    }
+  ],
+  "authoritative_policy_sources": [
+    {
+      "policy_source_id": "synthetic-high-risk-approval-policy",
+      "policy_domain": "synthetic_internal_approval",
+      "version": "2026.05-demo",
+      "evidence_ref": "sample://policy/synthetic-high-risk-approval-policy"
+    }
+  ],
+  "approval_requirements": [
+    {
+      "change_type": "delegated_authority_scope_change",
+      "required_approvals": 2,
+      "human_review_required": true
+    },
+    {
+      "change_type": "evaluation_function_manifest_update",
+      "required_approvals": 2,
+      "human_review_required": true
+    }
+  ],
+  "fail_closed_conditions": [
+    "synthetic authority evidence is missing",
+    "synthetic delegated scope is not reviewable"
+  ],
+  "challenge_process": {
+    "challenge_allowed": true,
+    "review_authority": "synthetic-review-board",
+    "evidence_required": [
+      "sample authority evidence",
+      "sample approval receipts"
+    ]
+  },
+  "manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/trajectory-admissibility-monitor.example.json
+++ b/docs/en/demo/examples/evaluation-governance-sample-bundle-v1/trajectory-admissibility-monitor.example.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "trajectory-admissibility-monitor-v1",
+  "monitor_id": "egov-sample-trajectory-monitor-001",
+  "issued_at": "2026-05-01T00:35:00Z",
+  "trajectory_id": "egov-sample-high-risk-internal-approval-trajectory",
+  "evaluation_receipt_refs": [
+    "sample://evaluation-receipts/egov-sample-evaluation-receipt-prior-001",
+    "egov-sample-evaluation-receipt-current-001"
+  ],
+  "outcome_delta_attribution_refs": [
+    "egov-sample-outcome-delta-001"
+  ],
+  "evaluation_drift_detection_refs": [
+    "egov-sample-drift-detection-001"
+  ],
+  "trajectory_window": {
+    "started_at": "2026-05-01T00:00:00Z",
+    "ended_at": "2026-05-01T00:35:00Z",
+    "evaluation_count": 2
+  },
+  "baseline_authority_scope": {
+    "scope_id": "internal_approval_high_risk_limited_demo",
+    "scope_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "authority_evidence_ref": "sample://authority/scope-limited"
+  },
+  "current_authority_scope": {
+    "scope_id": "internal_approval_high_risk_expanded_demo",
+    "scope_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "authority_evidence_ref": "sample://authority/scope-expanded"
+  },
+  "admissibility_scope_change": {
+    "scope_expanded": true,
+    "expansion_type": "delegated_authority_expansion",
+    "explicit_reauthorization_present": true,
+    "reauthorization_evidence_refs": [
+      "egov-sample-manifest-change-001"
+    ]
+  },
+  "continuity_event_summary": {
+    "continuity_events_observed": 2,
+    "low_risk_events_count": 0,
+    "material_change_events_count": 1,
+    "requalification_events_count": 1,
+    "escalation_events_count": 1
+  },
+  "trajectory_risk_signals": [
+    {
+      "signal_type": "admissibility_envelope_expansion",
+      "severity": "high",
+      "evidence_refs": [
+        "egov-sample-evaluation-receipt-current-001",
+        "egov-sample-outcome-delta-001",
+        "egov-sample-drift-detection-001"
+      ],
+      "explanation": "The synthetic trajectory indicates a wider delegated authority envelope than the baseline."
+    }
+  ],
+  "trajectory_status": "watch",
+  "recommended_governance_action": "reconcile_authority_scope",
+  "monitor_summary": "Synthetic monitor flags potential admissibility expansion for reviewer inspection only.",
+  "monitor_hash": "6666666666666666666666666666666666666666666666666666666666666666"
+}

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -36,7 +36,7 @@ Optional Evaluation Governance artifact references may include:
 
 These attachments are optional reviewer evidence attachments in v1. Reviewer packets do not require them, and schema validation only checks the attachment reference shape, hash format, and declared schema reference; it does not dereference files or validate the target artifact itself.
 
-A non-enforcing example packet with optional Evaluation Governance attachment references is checked in at `docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json`.
+A non-enforcing example packet with optional Evaluation Governance attachment references is checked in at `docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json`. A synthetic end-to-end Evaluation Governance sample bundle is also available at `docs/en/demo/examples/evaluation-governance-sample-bundle-v1/`.
 
 Evaluation Governance artifacts are non-enforcing in v1 unless future runtime integration is added. Their presence supports external review, but does not automatically establish legitimacy, does not change runtime admissibility, does not introduce fail-closed behavior, and does not require live receipt generation.
 

--- a/tests/demo/test_evaluation_governance_sample_bundle.py
+++ b/tests/demo/test_evaluation_governance_sample_bundle.py
@@ -1,0 +1,184 @@
+import importlib.util
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+BUNDLE_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-sample-bundle-v1"
+)
+SCHEMA_DIR = Path("docs/en/demo/schemas")
+
+SAMPLE_SCHEMA_PAIRS = [
+    (
+        "root-authority-manifest.example.json",
+        "root-authority-manifest-v1.schema.json",
+    ),
+    (
+        "evaluation-function-manifest.example.json",
+        "evaluation-function-manifest-v1.schema.json",
+    ),
+    (
+        "manifest-change-receipt.example.json",
+        "manifest-change-receipt-v1.schema.json",
+    ),
+    (
+        "evaluation-receipt.example.json",
+        "evaluation-receipt-v1.schema.json",
+    ),
+    (
+        "outcome-delta-attribution.example.json",
+        "outcome-delta-attribution-v1.schema.json",
+    ),
+    (
+        "evaluation-drift-detection.example.json",
+        "evaluation-drift-detection-v1.schema.json",
+    ),
+    (
+        "trajectory-admissibility-monitor.example.json",
+        "trajectory-admissibility-monitor-v1.schema.json",
+    ),
+    (
+        "legitimacy-impact-review.example.json",
+        "legitimacy-impact-review-v1.schema.json",
+    ),
+]
+
+DATE_TIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+    import jsonschema
+
+    return jsonschema
+
+
+def _resolve_ref(ref: str, root_schema: dict[str, Any]) -> dict[str, Any]:
+    if not ref.startswith("#/"):
+        raise AssertionError(f"unsupported external schema ref: {ref}")
+
+    current: Any = root_schema
+    for part in ref[2:].split("/"):
+        current = current[part]
+    assert isinstance(current, dict)
+    return current
+
+
+def _validate_with_local_subset(
+    payload: Any,
+    schema: dict[str, Any],
+    root_schema: dict[str, Any],
+    path: str = "$",
+) -> None:
+    if "$ref" in schema:
+        _validate_with_local_subset(
+            payload,
+            _resolve_ref(schema["$ref"], root_schema),
+            root_schema,
+            path,
+        )
+        return
+
+    if "const" in schema:
+        assert payload == schema["const"], f"{path} did not match const"
+    if "enum" in schema:
+        assert payload in schema["enum"], f"{path} did not match enum"
+
+    expected_type = schema.get("type")
+    if expected_type == "object":
+        assert isinstance(payload, dict), f"{path} is not an object"
+        required = schema.get("required", [])
+        missing = [field for field in required if field not in payload]
+        assert not missing, f"{path} missing required fields: {missing}"
+
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = set(payload) - set(properties)
+            assert not extra, f"{path} has unexpected fields: {sorted(extra)}"
+
+        for field, value in payload.items():
+            if field in properties:
+                _validate_with_local_subset(
+                    value,
+                    properties[field],
+                    root_schema,
+                    f"{path}.{field}",
+                )
+    elif expected_type == "array":
+        assert isinstance(payload, list), f"{path} is not an array"
+        min_items = schema.get("minItems")
+        if min_items is not None:
+            assert len(payload) >= min_items, f"{path} has too few items"
+        if schema.get("uniqueItems"):
+            serialized = [json.dumps(item, sort_keys=True) for item in payload]
+            assert len(serialized) == len(set(serialized)), (
+                f"{path} has duplicate items"
+            )
+        if "items" in schema:
+            for index, item in enumerate(payload):
+                _validate_with_local_subset(
+                    item,
+                    schema["items"],
+                    root_schema,
+                    f"{path}[{index}]",
+                )
+    elif expected_type == "string":
+        assert isinstance(payload, str), f"{path} is not a string"
+        min_length = schema.get("minLength")
+        if min_length is not None:
+            assert len(payload) >= min_length, f"{path} is too short"
+        pattern = schema.get("pattern")
+        if pattern is not None:
+            assert re.match(pattern, payload), f"{path} does not match pattern"
+        if schema.get("format") == "date-time":
+            assert DATE_TIME_RE.match(payload), f"{path} is not date-time shaped"
+    elif expected_type == "boolean":
+        assert isinstance(payload, bool), f"{path} is not a boolean"
+    elif expected_type == "integer":
+        assert isinstance(payload, int), f"{path} is not an integer"
+        minimum = schema.get("minimum")
+        if minimum is not None:
+            assert payload >= minimum, f"{path} is below minimum"
+
+
+def _validate_sample(payload: dict[str, Any], schema: dict[str, Any]) -> None:
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(payload)
+        return
+
+    _validate_with_local_subset(payload, schema, schema)
+
+
+def test_sample_bundle_readme_exists() -> None:
+    assert (BUNDLE_DIR / "README.md").is_file()
+
+
+@pytest.mark.parametrize(("sample_name", "schema_name"), SAMPLE_SCHEMA_PAIRS)
+def test_sample_json_artifacts_validate_against_schemas(
+    sample_name: str,
+    schema_name: str,
+) -> None:
+    sample = _load_json(BUNDLE_DIR / sample_name)
+    schema = _load_json(SCHEMA_DIR / schema_name)
+
+    assert isinstance(sample, dict)
+    _validate_sample(sample, schema)
+
+
+def test_all_bundled_json_files_are_covered_by_schema_validation() -> None:
+    expected_files = {sample_name for sample_name, _schema_name in SAMPLE_SCHEMA_PAIRS}
+    bundled_files = {path.name for path in BUNDLE_DIR.glob("*.json")}
+
+    assert bundled_files == expected_files


### PR DESCRIPTION
### Motivation

- Provide a reviewer-facing, synthetic sample bundle that demonstrates the full Evaluation Governance artifact chain end-to-end for a single consistent scenario (high-risk internal approval with delegated authority scope change and evaluator version change). 
- Keep the change strictly examples/docs/tests-only and avoid any runtime, enforcement, admissibility logic, or production configuration changes. 
- Make it easy for external reviewers to inspect concrete artifact references without live receipts or network dependencies. 
- Security note: the bundle uses synthetic IDs and deterministic placeholder SHA-256-shaped hashes and contains no secrets or PII; reviewers must not treat these artifacts as runtime enforcement or regulatory certification.

### Description

- Added a new example bundle at `docs/en/demo/examples/evaluation-governance-sample-bundle-v1/` with `README.md` and eight schema-shaped JSON artifacts: `root-authority-manifest.example.json`, `evaluation-function-manifest.example.json`, `manifest-change-receipt.example.json`, `evaluation-receipt.example.json`, `outcome-delta-attribution.example.json`, `evaluation-drift-detection.example.json`, `trajectory-admissibility-monitor.example.json`, and `legitimacy-impact-review.example.json`.
- Each JSON example was authored to reference one another consistently (root manifest → eval manifest → manifest change receipt → eval receipt → outcome attribution → drift detection → trajectory monitor → legitimacy review) and uses deterministic placeholder sha256-like hashes (e.g., `aaaaaaaa...`).
- Added an offline test `tests/demo/test_evaluation_governance_sample_bundle.py` that loads each sample, loads the corresponding schema from `docs/en/demo/schemas/`, and validates via `jsonschema` when available or via a local subset validator fallback that avoids network dereferencing.
- Made minimal docs link updates to `docs/en/architecture/evaluation-governance-overview-v1.md` and `docs/en/demo/reviewer-evidence-packet.md` pointing to the new sample bundle.

### Testing

- Executed `PYENV_VERSION=3.12.13 python -m pytest tests/demo/test_evaluation_governance_sample_bundle.py` and the new bundle tests passed (all sample validations succeeded; skipped when `jsonschema` unavailable). 
- Executed the broader schema test suite: `PYENV_VERSION=3.12.13 python -m pytest tests/demo/test_evaluation_governance_manifest_schemas.py tests/demo/test_evaluation_receipt_schema.py tests/demo/test_outcome_delta_attribution_schema.py tests/demo/test_evaluation_drift_detection_schema.py tests/demo/test_trajectory_admissibility_monitor_schema.py tests/demo/test_legitimacy_impact_review_schema.py tests/demo/test_evaluation_governance_sample_bundle.py` and all tests passed (full run: 76 passed, 1 warning).
- Ran static checks `PYENV_VERSION=3.12.13 python -m ruff check tests/demo/test_evaluation_governance_sample_bundle.py` which reported no issues.

If you want changes to the sample text, scenario details, or different placeholder-hash values, I can update the JSON fixtures and re-run the offline validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2572b5ca8883269740939ffbe8eee1)