### PR TITLE
Add Outcome Delta Attribution helper v1

### DIFF
--- a/docs/en/demo/examples/outcome-delta-attribution-helper-v1/README.md
+++ b/docs/en/demo/examples/outcome-delta-attribution-helper-v1/README.md
@@ -1,0 +1,27 @@
+# Outcome Delta Attribution Helper v1 Example
+
+This directory contains a synthetic offline helper example for Evaluation
+Governance. The helper compares two Evaluation Receipt v1 JSON files and
+produces a draft Outcome Delta Attribution v1 JSON artifact.
+
+The example is intentionally limited:
+
+- It is non-enforcing in v1.
+- It does not change runtime admissibility behavior.
+- It does not prove legitimacy.
+- It does not certify compliance.
+- It does not dereference artifact references.
+- It does not require network access.
+- It uses synthetic data only, with no secrets, PII, customer data, or real
+  organization data.
+
+## Example command
+
+```bash
+python scripts/demo/generate_outcome_delta_attribution.py \
+  --prior docs/en/demo/examples/outcome-delta-attribution-helper-v1/prior-evaluation-receipt.example.json \
+  --current docs/en/demo/examples/outcome-delta-attribution-helper-v1/current-evaluation-receipt.example.json \
+  --output /tmp/outcome-delta-attribution.json
+```
+
+When `--output` is omitted, the generated JSON is printed to stdout instead.

--- a/docs/en/demo/examples/outcome-delta-attribution-helper-v1/current-evaluation-receipt.example.json
+++ b/docs/en/demo/examples/outcome-delta-attribution-helper-v1/current-evaluation-receipt.example.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "outcome-delta-helper-current-receipt-001",
+  "issued_at": "2026-01-01T00:05:00Z",
+  "evaluation_id": "outcome-delta-helper-current-evaluation-001",
+  "evaluation_function_manifest_ref": "sample://evaluation-function/outcome-delta-helper-v1",
+  "evaluation_function_manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root_authority_manifest_ref": "sample://root-authority/outcome-delta-helper-v1",
+  "evaluator_id": "synthetic-outcome-delta-evaluator",
+  "evaluator_version": "eval-v1.1.0",
+  "policy_identity": {
+    "policy_id": "synthetic-outcome-delta-policy",
+    "policy_version": "policy-v1",
+    "policy_source_ref": "sample://policy/synthetic-outcome-delta-policy"
+  },
+  "rule_set_version": "rules-v2",
+  "authority_evidence_refs": [
+    "authority-evidence-example-v2"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "authority_evidence_freshness",
+      "source_ref": "sample://qualifier/authority-evidence-freshness",
+      "freshness_state": "stale",
+      "required_at_bind": true,
+      "qualifier_hash": "2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-authority-scope-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "synthetic_outcome_delta_scope",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "synthetic_decision_context",
+      "input_type": "synthetic_context_ref",
+      "input_ref": "sample://input/outcome-delta-helper-current-context",
+      "required": true,
+      "input_hash": "3333333333333333333333333333333333333333333333333333333333333333"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-high-consequence",
+    "class_label": "high",
+    "classifier_id": "synthetic-consequence-classifier",
+    "classifier_version": "classifier-v2"
+  },
+  "material_context": {
+    "context_ref": "sample://context/outcome-delta-helper",
+    "context_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "escalate",
+  "rationale_codes": [
+    "synthetic_current_escalate",
+    "synthetic_review_required"
+  ],
+  "input_state_hash": "4444444444444444444444444444444444444444444444444444444444444444",
+  "evaluation_state_hash": "5555555555555555555555555555555555555555555555555555555555555555",
+  "receipt_hash": "6666666666666666666666666666666666666666666666666666666666666666"
+}

--- a/docs/en/demo/examples/outcome-delta-attribution-helper-v1/outcome-delta-attribution.generated.example.json
+++ b/docs/en/demo/examples/outcome-delta-attribution-helper-v1/outcome-delta-attribution.generated.example.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "outcome-delta-attribution-v1",
+  "attribution_id": "outcome-delta-attribution-example-001",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "prior_evaluation_receipt_ref": "outcome-delta-helper-prior-receipt-001",
+  "current_evaluation_receipt_ref": "outcome-delta-helper-current-receipt-001",
+  "prior_evaluation_receipt_hash": "fab594a592537c03b94ed0558261fb9ec808fb96a0a646f8f407689a90aa9548",
+  "current_evaluation_receipt_hash": "02a39fff28479bca7eb046dad0176c96dfc66c36fb4011228b03f207ea219cea",
+  "prior_outcome": "allow",
+  "current_outcome": "escalate",
+  "outcome_changed": true,
+  "delta_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "severity": "medium",
+      "prior_value_ref": "eval-v1.0.0",
+      "current_value_ref": "eval-v1.1.0",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The evaluator version changed between receipts."
+    },
+    {
+      "cause_type": "rule_version_changed",
+      "severity": "medium",
+      "prior_value_ref": "rules-v1",
+      "current_value_ref": "rules-v2",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The rule set version changed between receipts."
+    },
+    {
+      "cause_type": "authority_state_changed",
+      "severity": "high",
+      "prior_value_ref": "[\"authority-evidence-example-v1\"]",
+      "current_value_ref": "[\"authority-evidence-example-v2\"]",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The authority evidence references changed between receipts."
+    },
+    {
+      "cause_type": "qualifier_freshness_changed",
+      "severity": "medium",
+      "prior_value_ref": "{\"freshness_state\": \"fresh\", \"qualifier_hash\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\", \"qualifier_name\": \"authority_evidence_freshness\"}",
+      "current_value_ref": "{\"freshness_state\": \"stale\", \"qualifier_hash\": \"2222222222222222222222222222222222222222222222222222222222222222\", \"qualifier_name\": \"authority_evidence_freshness\"}",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "Qualifier 'authority_evidence_freshness' freshness or hash changed."
+    },
+    {
+      "cause_type": "consequence_class_changed",
+      "severity": "high",
+      "prior_value_ref": "{\"class_id\": \"synthetic-medium-consequence\", \"class_label\": \"medium\", \"classifier_id\": \"synthetic-consequence-classifier\", \"classifier_version\": \"classifier-v1\"}",
+      "current_value_ref": "{\"class_id\": \"synthetic-high-consequence\", \"class_label\": \"high\", \"classifier_id\": \"synthetic-consequence-classifier\", \"classifier_version\": \"classifier-v2\"}",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The consequence classification changed between receipts."
+    }
+  ],
+  "attribution_summary": "Outcome changed from allow to escalate; detected causes: evaluator_version_changed, rule_version_changed, authority_state_changed, qualifier_freshness_changed, consequence_class_changed.",
+  "attribution_confidence": "high",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "No unexplained evaluation drift was detected.",
+    "requires_review": false
+  },
+  "recommended_governance_action": "review",
+  "attribution_hash": "a5a6647a4d84c887b00f0460e42f33fd8445bda5264c292308a899b5583fc48f"
+}

--- a/docs/en/demo/examples/outcome-delta-attribution-helper-v1/prior-evaluation-receipt.example.json
+++ b/docs/en/demo/examples/outcome-delta-attribution-helper-v1/prior-evaluation-receipt.example.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "outcome-delta-helper-prior-receipt-001",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "evaluation_id": "outcome-delta-helper-prior-evaluation-001",
+  "evaluation_function_manifest_ref": "sample://evaluation-function/outcome-delta-helper-v1",
+  "evaluation_function_manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root_authority_manifest_ref": "sample://root-authority/outcome-delta-helper-v1",
+  "evaluator_id": "synthetic-outcome-delta-evaluator",
+  "evaluator_version": "eval-v1.0.0",
+  "policy_identity": {
+    "policy_id": "synthetic-outcome-delta-policy",
+    "policy_version": "policy-v1",
+    "policy_source_ref": "sample://policy/synthetic-outcome-delta-policy"
+  },
+  "rule_set_version": "rules-v1",
+  "authority_evidence_refs": [
+    "authority-evidence-example-v1"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "authority_evidence_freshness",
+      "source_ref": "sample://qualifier/authority-evidence-freshness",
+      "freshness_state": "fresh",
+      "required_at_bind": true,
+      "qualifier_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-authority-scope-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "synthetic_outcome_delta_scope",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "synthetic_decision_context",
+      "input_type": "synthetic_context_ref",
+      "input_ref": "sample://input/outcome-delta-helper-prior-context",
+      "required": true,
+      "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-medium-consequence",
+    "class_label": "medium",
+    "classifier_id": "synthetic-consequence-classifier",
+    "classifier_version": "classifier-v1"
+  },
+  "material_context": {
+    "context_ref": "sample://context/outcome-delta-helper",
+    "context_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "allow",
+  "rationale_codes": [
+    "synthetic_prior_allow"
+  ],
+  "input_state_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "evaluation_state_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "receipt_hash": "1111111111111111111111111111111111111111111111111111111111111111"
+}

--- a/scripts/demo/generate_outcome_delta_attribution.py
+++ b/scripts/demo/generate_outcome_delta_attribution.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Generate a draft Outcome Delta Attribution from two receipts.
+
+This offline demo helper is intentionally schema-shaped and non-enforcing. It
+compares two local Evaluation Receipt v1 JSON objects, records deterministic
+candidate delta causes, and optionally validates the inputs and output with
+``jsonschema`` when that package is available locally. It never dereferences
+artifact references, accesses the network, or connects to runtime admissibility
+paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = REPO_ROOT / "docs/en/demo/schemas"
+EVALUATION_RECEIPT_SCHEMA_PATH = (
+    SCHEMA_DIR / "evaluation-receipt-v1.schema.json"
+)
+OUTCOME_DELTA_ATTRIBUTION_SCHEMA_PATH = (
+    SCHEMA_DIR / "outcome-delta-attribution-v1.schema.json"
+)
+ISSUED_AT = "2026-01-01T00:00:00Z"
+ATTRIBUTION_ID = "outcome-delta-attribution-example-001"
+NO_DELTA_CAUSE_TYPE = "governed_state_changed"
+
+SEVERITY_BY_CAUSE_TYPE = {
+    "evaluator_version_changed": "medium",
+    "policy_identity_changed": "medium",
+    "rule_version_changed": "medium",
+    "authority_state_changed": "high",
+    "qualifier_freshness_changed": "medium",
+    "consequence_class_changed": "high",
+    "material_context_changed": "medium",
+    "authorized_determiner_changed": "medium",
+    "unauthorized_determiner_influence": "high",
+    "unexplained_evaluation_drift": "high",
+    NO_DELTA_CAUSE_TYPE: "info",
+}
+UNAUTHORIZED_AUTHORITY_SCOPE_MARKERS = {
+    "",
+    "unknown",
+    "unauthorized",
+    "unauthorised",
+    "explicitly_unauthorized",
+    "explicitly_unauthorised",
+}
+
+
+def _jsonschema_module() -> Any | None:
+    """Return the optional jsonschema module when available locally."""
+    try:
+        import jsonschema
+    except ImportError:
+        return None
+    return jsonschema
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    """Load a JSON object from a local file with reviewer-friendly errors."""
+    if not path.is_file():
+        raise FileNotFoundError(f"missing file: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object in {path}")
+    return payload
+
+
+def _validate_against_schema(payload: dict[str, Any], schema_path: Path) -> None:
+    """Validate a JSON object when jsonschema is installed locally."""
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        return
+
+    schema = _load_json_object(schema_path)
+    validator = jsonschema.Draft202012Validator(schema)
+    validator.validate(payload)
+
+
+def _canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    """Return deterministic UTF-8 JSON bytes for hashing."""
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sha256_json(payload: dict[str, Any]) -> str:
+    """Return the SHA-256 hex digest of canonical JSON."""
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _receipt_ref(receipt: dict[str, Any]) -> str:
+    """Return a stable receipt reference without dereferencing artifacts."""
+    receipt_id = receipt.get("receipt_id")
+    if isinstance(receipt_id, str) and receipt_id:
+        return receipt_id
+    evaluation_id = receipt.get("evaluation_id")
+    if isinstance(evaluation_id, str) and evaluation_id:
+        return evaluation_id
+    return "unknown-evaluation-receipt"
+
+
+def _json_value_ref(value: Any) -> str:
+    """Serialize a compared value into a compact deterministic reference."""
+    if isinstance(value, str) and value:
+        return value
+    if value is None:
+        return "missing"
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _cause(
+    cause_type: str,
+    prior_value: Any,
+    current_value: Any,
+    evidence_refs: list[str],
+    explanation: str,
+) -> dict[str, Any]:
+    """Build a schema-shaped delta cause object."""
+    return {
+        "cause_type": cause_type,
+        "severity": SEVERITY_BY_CAUSE_TYPE[cause_type],
+        "prior_value_ref": _json_value_ref(prior_value),
+        "current_value_ref": _json_value_ref(current_value),
+        "evidence_refs": evidence_refs,
+        "explanation": explanation,
+    }
+
+
+def _compare_field(
+    causes: list[dict[str, Any]],
+    prior: Any,
+    current: Any,
+    cause_type: str,
+    evidence_refs: list[str],
+    explanation: str,
+) -> None:
+    """Append a cause when two comparable values differ."""
+    if prior != current:
+        causes.append(
+            _cause(cause_type, prior, current, evidence_refs, explanation)
+        )
+
+
+def _qualifier_map(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Index qualifier state by qualifier_name."""
+    qualifiers = receipt.get("qualifier_state", [])
+    if not isinstance(qualifiers, list):
+        return {}
+
+    result = {}
+    for qualifier in qualifiers:
+        if not isinstance(qualifier, dict):
+            continue
+        name = qualifier.get("qualifier_name")
+        if isinstance(name, str) and name:
+            result[name] = qualifier
+    return result
+
+
+def _determiner_identity_set(receipt: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return sorted determiner_id/determiner_type pairs."""
+    determiners = receipt.get("authorized_determiners_used", [])
+    if not isinstance(determiners, list):
+        return []
+
+    identities = set()
+    for determiner in determiners:
+        if not isinstance(determiner, dict):
+            continue
+        determiner_id = determiner.get("determiner_id")
+        determiner_type = determiner.get("determiner_type")
+        if isinstance(determiner_id, str) and isinstance(determiner_type, str):
+            identities.add((determiner_id, determiner_type))
+    return sorted(identities)
+
+
+def _has_unauthorized_determiner(receipt: dict[str, Any]) -> bool:
+    """Detect current determiners represented as unauthorized in example data."""
+    determiners = receipt.get("authorized_determiners_used", [])
+    if not isinstance(determiners, list):
+        return False
+
+    for determiner in determiners:
+        if not isinstance(determiner, dict):
+            continue
+        authority_scope = str(determiner.get("authority_scope", ""))
+        normalized_scope = authority_scope.strip().lower()
+        if normalized_scope in UNAUTHORIZED_AUTHORITY_SCOPE_MARKERS:
+            return True
+        if "unauthorized" in normalized_scope or "unauthorised" in normalized_scope:
+            return True
+    return False
+
+
+def compare_receipts(
+    prior: dict[str, Any], current: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Compare two Evaluation Receipts and return deterministic delta causes.
+
+    The comparison is limited to local JSON fields and does not dereference any
+    artifact reference fields. Causes are emitted in a stable order so repeated
+    runs over the same input objects produce identical attribution JSON.
+    """
+    current_ref = _receipt_ref(current)
+    evidence_refs = [current_ref]
+    causes: list[dict[str, Any]] = []
+
+    _compare_field(
+        causes,
+        prior.get("evaluator_version"),
+        current.get("evaluator_version"),
+        "evaluator_version_changed",
+        evidence_refs,
+        "The evaluator version changed between receipts.",
+    )
+    policy_identity_fields = (
+        "policy_id",
+        "policy_version",
+        "policy_source_ref",
+    )
+    prior_policy = prior.get("policy_identity", {})
+    current_policy = current.get("policy_identity", {})
+    _compare_field(
+        causes,
+        {field: prior_policy.get(field) for field in policy_identity_fields},
+        {field: current_policy.get(field) for field in policy_identity_fields},
+        "policy_identity_changed",
+        evidence_refs,
+        "The policy identity fields changed between receipts.",
+    )
+    _compare_field(
+        causes,
+        prior.get("rule_set_version"),
+        current.get("rule_set_version"),
+        "rule_version_changed",
+        evidence_refs,
+        "The rule set version changed between receipts.",
+    )
+    _compare_field(
+        causes,
+        prior.get("authority_evidence_refs", []),
+        current.get("authority_evidence_refs", []),
+        "authority_state_changed",
+        evidence_refs,
+        "The authority evidence references changed between receipts.",
+    )
+
+    prior_qualifiers = _qualifier_map(prior)
+    current_qualifiers = _qualifier_map(current)
+    for qualifier_name in sorted(set(prior_qualifiers) | set(current_qualifiers)):
+        prior_qualifier = prior_qualifiers.get(qualifier_name, {})
+        current_qualifier = current_qualifiers.get(qualifier_name, {})
+        prior_value = {
+            "freshness_state": prior_qualifier.get("freshness_state"),
+            "qualifier_hash": prior_qualifier.get("qualifier_hash"),
+        }
+        current_value = {
+            "freshness_state": current_qualifier.get("freshness_state"),
+            "qualifier_hash": current_qualifier.get("qualifier_hash"),
+        }
+        if prior_value != current_value:
+            causes.append(
+                _cause(
+                    "qualifier_freshness_changed",
+                    {"qualifier_name": qualifier_name, **prior_value},
+                    {"qualifier_name": qualifier_name, **current_value},
+                    evidence_refs,
+                    f"Qualifier {qualifier_name!r} freshness or hash changed.",
+                )
+            )
+
+    consequence_fields = (
+        "class_id",
+        "class_label",
+        "classifier_id",
+        "classifier_version",
+    )
+    prior_consequence = prior.get("consequence_class", {})
+    current_consequence = current.get("consequence_class", {})
+    _compare_field(
+        causes,
+        {field: prior_consequence.get(field) for field in consequence_fields},
+        {field: current_consequence.get(field) for field in consequence_fields},
+        "consequence_class_changed",
+        evidence_refs,
+        "The consequence classification changed between receipts.",
+    )
+
+    material_context_fields = (
+        "context_hash",
+        "context_freshness_state",
+        "stale_context_allowed",
+    )
+    prior_context = prior.get("material_context", {})
+    current_context = current.get("material_context", {})
+    _compare_field(
+        causes,
+        {field: prior_context.get(field) for field in material_context_fields},
+        {field: current_context.get(field) for field in material_context_fields},
+        "material_context_changed",
+        evidence_refs,
+        "The material context state changed between receipts.",
+    )
+
+    _compare_field(
+        causes,
+        _determiner_identity_set(prior),
+        _determiner_identity_set(current),
+        "authorized_determiner_changed",
+        evidence_refs,
+        "The authorized determiner identity set changed between receipts.",
+    )
+
+    if _has_unauthorized_determiner(current):
+        causes.append(
+            _cause(
+                "unauthorized_determiner_influence",
+                "not_detected_in_prior_receipt",
+                "unauthorized_or_unknown_authority_scope_in_current_receipt",
+                evidence_refs,
+                (
+                    "The current receipt contains a determiner with an "
+                    "unknown or unauthorized authority scope marker."
+                ),
+            )
+        )
+
+    outcome_changed = prior.get("outcome") != current.get("outcome")
+    if outcome_changed and not causes:
+        causes.append(
+            _cause(
+                "unexplained_evaluation_drift",
+                prior.get("outcome"),
+                current.get("outcome"),
+                evidence_refs,
+                "The outcome changed, but no configured comparison field explained the delta.",
+            )
+        )
+
+    if not outcome_changed and not causes:
+        causes.append(
+            _cause(
+                NO_DELTA_CAUSE_TYPE,
+                "no_compared_delta_detected",
+                "no_compared_delta_detected",
+                evidence_refs,
+                (
+                    "No compared receipt fields changed; this neutral cause "
+                    "satisfies the v1 schema shape."
+                ),
+            )
+        )
+
+    return causes
+
+
+def _recommended_action(
+    outcome_changed: bool, causes: list[dict[str, Any]]
+) -> str:
+    """Map generated causes to a governance action recommendation."""
+    cause_types = {cause["cause_type"] for cause in causes}
+    if "unauthorized_determiner_influence" in cause_types:
+        return "escalate"
+    if "unexplained_evaluation_drift" in cause_types:
+        return "mark_evaluation_drift"
+    if not outcome_changed and cause_types == {NO_DELTA_CAUSE_TYPE}:
+        return "none"
+    if outcome_changed:
+        return "review"
+    return "review"
+
+
+def _attribution_confidence(
+    outcome_changed: bool, causes: list[dict[str, Any]]
+) -> str:
+    """Return deterministic attribution confidence for the draft output."""
+    cause_types = {cause["cause_type"] for cause in causes}
+    if "unexplained_evaluation_drift" in cause_types:
+        return "low"
+    if outcome_changed and cause_types:
+        return "high"
+    return "medium"
+
+
+def _summary(
+    prior_outcome: str,
+    current_outcome: str,
+    causes: list[dict[str, Any]],
+) -> str:
+    """Build a concise human-readable attribution summary."""
+    cause_types = [cause["cause_type"] for cause in causes]
+    if cause_types == [NO_DELTA_CAUSE_TYPE]:
+        return "No outcome change or compared receipt-field delta was detected."
+    joined_causes = ", ".join(cause_types)
+    return (
+        f"Outcome changed from {prior_outcome} to {current_outcome}; "
+        f"detected causes: {joined_causes}."
+    )
+
+
+def generate_outcome_delta_attribution(
+    prior: dict[str, Any], current: dict[str, Any]
+) -> dict[str, Any]:
+    """Generate a schema-shaped Outcome Delta Attribution v1 object.
+
+    Args:
+        prior: Prior Evaluation Receipt v1 JSON object.
+        current: Current Evaluation Receipt v1 JSON object.
+
+    Returns:
+        Deterministic Outcome Delta Attribution v1 JSON object.
+
+    Raises:
+        jsonschema.ValidationError: If ``jsonschema`` is available and either
+            receipt or the generated attribution does not validate locally.
+    """
+    _validate_against_schema(prior, EVALUATION_RECEIPT_SCHEMA_PATH)
+    _validate_against_schema(current, EVALUATION_RECEIPT_SCHEMA_PATH)
+
+    prior_outcome = str(prior.get("outcome", "undetermined"))
+    current_outcome = str(current.get("outcome", "undetermined"))
+    outcome_changed = prior_outcome != current_outcome
+    causes = compare_receipts(prior, current)
+    cause_types = {cause["cause_type"] for cause in causes}
+    unresolved_present = "unexplained_evaluation_drift" in cause_types
+
+    attribution: dict[str, Any] = {
+        "schema_version": "outcome-delta-attribution-v1",
+        "attribution_id": ATTRIBUTION_ID,
+        "issued_at": ISSUED_AT,
+        "prior_evaluation_receipt_ref": _receipt_ref(prior),
+        "current_evaluation_receipt_ref": _receipt_ref(current),
+        "prior_evaluation_receipt_hash": _sha256_json(prior),
+        "current_evaluation_receipt_hash": _sha256_json(current),
+        "prior_outcome": prior_outcome,
+        "current_outcome": current_outcome,
+        "outcome_changed": outcome_changed,
+        "delta_causes": causes,
+        "attribution_summary": _summary(prior_outcome, current_outcome, causes),
+        "attribution_confidence": _attribution_confidence(outcome_changed, causes),
+        "unresolved_delta": {
+            "present": unresolved_present,
+            "reason": (
+                "Outcome changed without a configured comparison-field cause."
+                if unresolved_present
+                else "No unexplained evaluation drift was detected."
+            ),
+            "requires_review": unresolved_present,
+        },
+        "recommended_governance_action": _recommended_action(
+            outcome_changed, causes
+        ),
+        "attribution_hash": "0" * 64,
+    }
+    attribution_without_hash = dict(attribution)
+    attribution_without_hash.pop("attribution_hash")
+    attribution["attribution_hash"] = _sha256_json(attribution_without_hash)
+
+    _validate_against_schema(attribution, OUTCOME_DELTA_ATTRIBUTION_SCHEMA_PATH)
+    return attribution
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a draft Outcome Delta Attribution v1 JSON object from "
+            "two local Evaluation Receipt v1 JSON files."
+        )
+    )
+    parser.add_argument("--prior", required=True, type=Path)
+    parser.add_argument("--current", required=True, type=Path)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the CLI and return a process exit code."""
+    args = _parse_args()
+    try:
+        prior = _load_json_object(args.prior)
+        current = _load_json_object(args.current)
+        attribution = generate_outcome_delta_attribution(prior, current)
+        output = json.dumps(attribution, indent=2, ensure_ascii=False)
+        if args.output is None:
+            print(output)
+        else:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(f"{output}\n", encoding="utf-8")
+            print(
+                "Generated Outcome Delta Attribution v1: "
+                f"{args.output} "
+                f"({attribution['prior_outcome']} -> "
+                f"{attribution['current_outcome']}, "
+                f"{len(attribution['delta_causes'])} causes)"
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_outcome_delta_attribution_helper.py
+++ b/tests/demo/test_outcome_delta_attribution_helper.py
@@ -1,0 +1,111 @@
+"""Tests for the offline Outcome Delta Attribution helper."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.demo import generate_outcome_delta_attribution as helper
+from scripts.demo import validate_evaluation_governance_sample_bundle as validator
+
+EXAMPLE_DIR = Path(
+    "docs/en/demo/examples/outcome-delta-attribution-helper-v1"
+)
+PRIOR_RECEIPT_PATH = EXAMPLE_DIR / "prior-evaluation-receipt.example.json"
+CURRENT_RECEIPT_PATH = EXAMPLE_DIR / "current-evaluation-receipt.example.json"
+SCHEMA_PATH = Path(
+    "docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json"
+)
+SCRIPT_PATH = Path("scripts/demo/generate_outcome_delta_attribution.py")
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_generated_attribution(attribution: dict[str, object]) -> None:
+    schema = _load_json(SCHEMA_PATH)
+    validator._validate_payload(attribution, schema)
+
+
+def test_generate_outcome_delta_attribution_from_examples() -> None:
+    prior = _load_json(PRIOR_RECEIPT_PATH)
+    current = _load_json(CURRENT_RECEIPT_PATH)
+
+    attribution = helper.generate_outcome_delta_attribution(prior, current)
+
+    assert attribution["prior_outcome"] == "allow"
+    assert attribution["current_outcome"] == "escalate"
+    assert attribution["outcome_changed"] is True
+    cause_types = {
+        cause["cause_type"] for cause in attribution["delta_causes"]
+    }
+    assert "evaluator_version_changed" in cause_types
+    assert "rule_version_changed" in cause_types
+    assert "authority_state_changed" in cause_types
+    assert "qualifier_freshness_changed" in cause_types
+    assert "consequence_class_changed" in cause_types
+    _validate_generated_attribution(attribution)
+
+
+def test_helper_cli_writes_schema_shaped_output(tmp_path: Path) -> None:
+    output_path = tmp_path / "outcome-delta-attribution.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--prior",
+            str(PRIOR_RECEIPT_PATH),
+            "--current",
+            str(CURRENT_RECEIPT_PATH),
+            "--output",
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "Generated Outcome Delta Attribution v1" in completed.stdout
+    attribution = _load_json(output_path)
+    assert attribution["schema_version"] == "outcome-delta-attribution-v1"
+    _validate_generated_attribution(attribution)
+
+
+def test_helper_cli_prints_json_to_stdout_when_output_omitted() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--prior",
+            str(PRIOR_RECEIPT_PATH),
+            "--current",
+            str(CURRENT_RECEIPT_PATH),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    attribution = json.loads(completed.stdout)
+    assert attribution["schema_version"] == "outcome-delta-attribution-v1"
+
+
+def test_identical_receipts_recommend_no_governance_action() -> None:
+    prior = _load_json(PRIOR_RECEIPT_PATH)
+
+    attribution = helper.generate_outcome_delta_attribution(prior, dict(prior))
+
+    assert attribution["outcome_changed"] is False
+    assert attribution["recommended_governance_action"] == "none"
+    assert attribution["unresolved_delta"] == {
+        "present": False,
+        "reason": "No unexplained evaluation drift was detected.",
+        "requires_review": False,
+    }
+    _validate_generated_attribution(attribution)


### PR DESCRIPTION
### Motivation

- Provide a non-runtime, deterministic offline helper to compare two Evaluation Receipt v1 artifacts and draft an Outcome Delta Attribution v1 for reviewer-facing Evaluation Governance workflows.
- Enable local validation and reproducible examples for the recently added Evaluation Governance schemas without changing runtime admissibility or production governance behavior.

### Description

- Add CLI helper `scripts/demo/generate_outcome_delta_attribution.py` with `generate_outcome_delta_attribution(prior, current)` and `main()` to load receipts, optionally validate with `jsonschema`, deterministically hash canonical JSON with `sha256`, compare configured receipt fields, and emit a schema-shaped attribution JSON.
- Implement deterministic comparison of `outcome`, `evaluator_version`, `policy_identity` (broken into fields), `rule_set_version`, `authority_evidence_refs`, qualifier freshness/hash by `qualifier_name`, `consequence_class`, `material_context`, authorized determiner identity set, unauthorized-determiner markers, unexplained-drift fallback, severity mapping, and recommended governance-action mapping.
- Add synthetic example inputs and output under `docs/en/demo/examples/outcome-delta-attribution-helper-v1/` including `README.md`, `prior-evaluation-receipt.example.json`, `current-evaluation-receipt.example.json`, and `outcome-delta-attribution.generated.example.json` demonstrating an `allow -> escalate` scenario.
- Add tests `tests/demo/test_outcome_delta_attribution_helper.py` that import the helper, assert expected detected causes, validate generated output against `docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json`, and exercise the CLI both with `--output` and printing to stdout; all changes are docs/tests/helpers-only and do not touch runtime `/v1/decide` behavior or production governance configuration.

### Testing

- Ran linter: `python -m ruff check scripts/demo/generate_outcome_delta_attribution.py tests/demo/test_outcome_delta_attribution_helper.py` and it passed.
- Ran unit tests under `PYENV_VERSION=3.12.13`: `python -m pytest tests/demo/test_outcome_delta_attribution_helper.py tests/demo/test_evaluation_governance_sample_bundle.py tests/demo/test_evaluation_governance_sample_bundle_validator.py` and all tests passed (16 passed, 1 pytest config warning about an unrelated option).
- Exercised the CLI end-to-end with `python scripts/demo/generate_outcome_delta_attribution.py --prior <prior> --current <current> --output <path>` and validated both the generated example file and stdout JSON against the `outcome-delta-attribution-v1` schema using the repository's local validator.
- Security note: the helper is offline-only, does not access the network, does not dereference artifact refs, and includes only synthetic examples; reviewers should still confirm no PII or secrets are present before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25888186908326bebf90d43a87b126)