### PR TITLE
Add Evaluation Drift Detection helper v1

### DIFF
--- a/docs/en/demo/examples/evaluation-drift-detection-helper-v1/README.md
+++ b/docs/en/demo/examples/evaluation-drift-detection-helper-v1/README.md
@@ -1,0 +1,33 @@
+# Evaluation Drift Detection Helper v1 Example
+
+This directory contains a synthetic, offline example for the Evaluation Drift
+Detection helper v1.
+
+The helper reads a local Outcome Delta Attribution v1 JSON artifact and produces
+a draft Evaluation Drift Detection v1 JSON artifact. The generated artifact is
+schema-shaped review material only.
+
+## Scope and non-goals
+
+This v1 helper:
+
+- is non-enforcing;
+- does not change runtime admissibility;
+- does not change `/v1/decide` behavior;
+- does not prove legitimacy;
+- does not certify compliance;
+- does not mutate production governance configuration;
+- does not dereference artifact references;
+- does not require network access;
+- does not require secrets, environment variables, or external services.
+
+## Example command
+
+```bash
+python scripts/demo/generate_evaluation_drift_detection.py \
+  --attribution docs/en/demo/examples/evaluation-drift-detection-helper-v1/outcome-delta-attribution.example.json \
+  --output /tmp/evaluation-drift-detection.json
+```
+
+If `--output` is omitted, the generated Evaluation Drift Detection JSON is
+printed to stdout.

--- a/docs/en/demo/examples/evaluation-drift-detection-helper-v1/evaluation-drift-detection.generated.example.json
+++ b/docs/en/demo/examples/evaluation-drift-detection-helper-v1/evaluation-drift-detection.generated.example.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "evaluation-drift-detection-v1",
+  "detection_id": "evaluation-drift-detection-example-001",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_delta_attribution_ref": "outcome-delta-attribution-example-001",
+  "outcome_delta_attribution_hash": "ca26d00e3d02eac68cf10cfc41b880628c03bb86d8d07b96041adc6b8c647589",
+  "prior_evaluation_receipt_ref": "outcome-delta-helper-prior-receipt-001",
+  "current_evaluation_receipt_ref": "outcome-delta-helper-current-receipt-001",
+  "drift_detected": true,
+  "drift_status": "suspected",
+  "drift_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "severity": "medium",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The evaluator version changed between receipts."
+    },
+    {
+      "cause_type": "rule_version_changed",
+      "severity": "medium",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The rule set version changed between receipts."
+    },
+    {
+      "cause_type": "qualifier_state_ambiguous",
+      "severity": "medium",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "Qualifier 'authority_evidence_freshness' freshness or hash changed."
+    }
+  ],
+  "evaluator_consistency_status": "unknown",
+  "explanation_status": "partially_explained",
+  "recommended_governance_action": "requalify_evaluator",
+  "detection_summary": "Draft detection marked suspected drift from allow to escalate.",
+  "detection_hash": "68fdd6932bd4fc0d2271b10406f8bd9ce367b1c17233e73c5873a70a95c4f452"
+}

--- a/docs/en/demo/examples/evaluation-drift-detection-helper-v1/outcome-delta-attribution.example.json
+++ b/docs/en/demo/examples/evaluation-drift-detection-helper-v1/outcome-delta-attribution.example.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "outcome-delta-attribution-v1",
+  "attribution_id": "outcome-delta-attribution-example-001",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "prior_evaluation_receipt_ref": "outcome-delta-helper-prior-receipt-001",
+  "current_evaluation_receipt_ref": "outcome-delta-helper-current-receipt-001",
+  "prior_evaluation_receipt_hash": "fab594a592537c03b94ed0558261fb9ec808fb96a0a646f8f407689a90aa9548",
+  "current_evaluation_receipt_hash": "02a39fff28479bca7eb046dad0176c96dfc66c36fb4011228b03f207ea219cea",
+  "prior_outcome": "allow",
+  "current_outcome": "escalate",
+  "outcome_changed": true,
+  "delta_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "severity": "medium",
+      "prior_value_ref": "eval-v1.0.0",
+      "current_value_ref": "eval-v1.1.0",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The evaluator version changed between receipts."
+    },
+    {
+      "cause_type": "rule_version_changed",
+      "severity": "medium",
+      "prior_value_ref": "rules-v1",
+      "current_value_ref": "rules-v2",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The rule set version changed between receipts."
+    },
+    {
+      "cause_type": "authority_state_changed",
+      "severity": "high",
+      "prior_value_ref": "[\"authority-evidence-example-v1\"]",
+      "current_value_ref": "[\"authority-evidence-example-v2\"]",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The authority evidence references changed between receipts."
+    },
+    {
+      "cause_type": "qualifier_freshness_changed",
+      "severity": "medium",
+      "prior_value_ref": "{\"freshness_state\": \"fresh\", \"qualifier_hash\": \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\", \"qualifier_name\": \"authority_evidence_freshness\"}",
+      "current_value_ref": "{\"freshness_state\": \"stale\", \"qualifier_hash\": \"2222222222222222222222222222222222222222222222222222222222222222\", \"qualifier_name\": \"authority_evidence_freshness\"}",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "Qualifier 'authority_evidence_freshness' freshness or hash changed."
+    },
+    {
+      "cause_type": "consequence_class_changed",
+      "severity": "high",
+      "prior_value_ref": "{\"class_id\": \"synthetic-medium-consequence\", \"class_label\": \"medium\", \"classifier_id\": \"synthetic-consequence-classifier\", \"classifier_version\": \"classifier-v1\"}",
+      "current_value_ref": "{\"class_id\": \"synthetic-high-consequence\", \"class_label\": \"high\", \"classifier_id\": \"synthetic-consequence-classifier\", \"classifier_version\": \"classifier-v2\"}",
+      "evidence_refs": [
+        "outcome-delta-helper-current-receipt-001"
+      ],
+      "explanation": "The consequence classification changed between receipts."
+    }
+  ],
+  "attribution_summary": "Outcome changed from allow to escalate; detected causes: evaluator_version_changed, rule_version_changed, authority_state_changed, qualifier_freshness_changed, consequence_class_changed.",
+  "attribution_confidence": "high",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "No unexplained evaluation drift was detected.",
+    "requires_review": false
+  },
+  "recommended_governance_action": "review",
+  "attribution_hash": "a5a6647a4d84c887b00f0460e42f33fd8445bda5264c292308a899b5583fc48f"
+}

--- a/scripts/demo/generate_evaluation_drift_detection.py
+++ b/scripts/demo/generate_evaluation_drift_detection.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Generate a draft Evaluation Drift Detection from attribution JSON.
+
+This offline demo helper is intentionally schema-shaped and non-enforcing. It
+reads one local Outcome Delta Attribution v1 JSON object, classifies drift
+signals deterministically, and optionally validates input and output with
+``jsonschema`` when that package is available locally. It never dereferences
+artifact references, accesses the network, or connects to runtime admissibility
+paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = REPO_ROOT / "docs/en/demo/schemas"
+OUTCOME_DELTA_ATTRIBUTION_SCHEMA_PATH = (
+    SCHEMA_DIR / "outcome-delta-attribution-v1.schema.json"
+)
+EVALUATION_DRIFT_DETECTION_SCHEMA_PATH = (
+    SCHEMA_DIR / "evaluation-drift-detection-v1.schema.json"
+)
+DETECTION_ID = "evaluation-drift-detection-example-001"
+ISSUED_AT = "2026-01-01T00:00:00Z"
+
+DRIFT_CAUSE_TYPE_BY_ATTRIBUTION_CAUSE = {
+    "unexplained_evaluation_drift": "unexplained_evaluation_drift",
+    "unauthorized_determiner_influence": "unauthorized_determiner_influence",
+    "evaluator_version_changed": "evaluator_version_changed",
+    "rule_version_changed": "rule_version_changed",
+    "policy_identity_changed": "policy_identity_changed",
+    "threshold_state_changed": "threshold_state_changed",
+    "refusal_boundary_changed": "refusal_boundary_changed",
+    "escalation_resolver_changed": "escalation_resolver_changed",
+    "material_context_changed": "material_context_ambiguous",
+    "qualifier_freshness_changed": "qualifier_state_ambiguous",
+}
+DRIFT_LIKE_CAUSE_TYPES = {
+    "unexplained_evaluation_drift",
+    "unauthorized_determiner_influence",
+    "evaluator_version_changed",
+    "rule_version_changed",
+    "policy_identity_changed",
+    "threshold_state_changed",
+    "refusal_boundary_changed",
+    "escalation_resolver_changed",
+}
+CONTEXT_OR_QUALIFIER_CAUSE_TYPES = {
+    "material_context_changed",
+    "qualifier_freshness_changed",
+}
+DEFAULT_SEVERITY_BY_DRIFT_CAUSE_TYPE = {
+    "unexplained_evaluation_drift": "high",
+    "unauthorized_determiner_influence": "high",
+    "evaluator_version_changed": "medium",
+    "rule_version_changed": "medium",
+    "policy_identity_changed": "medium",
+    "threshold_state_changed": "medium",
+    "refusal_boundary_changed": "high",
+    "escalation_resolver_changed": "medium",
+    "material_context_ambiguous": "medium",
+    "qualifier_state_ambiguous": "medium",
+    "attribution_inconclusive": "medium",
+}
+ACTION_BY_ATTRIBUTION_ACTION = {
+    "none": "none",
+    "review": "review",
+    "requalify": "requalify_evaluator",
+    "escalate": "escalate",
+    "refuse": "refuse",
+    "mark_evaluation_drift": "mark_evaluation_drift",
+    "mark_non_deterministically_governed": (
+        "mark_non_deterministically_governed"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class DriftClassification:
+    """Computed drift classification fields for a detection artifact."""
+
+    drift_detected: bool
+    drift_status: str
+    evaluator_consistency_status: str
+    explanation_status: str
+    recommended_governance_action: str
+
+
+def _jsonschema_module() -> Any | None:
+    """Return the optional jsonschema module when available locally."""
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+
+    import jsonschema
+
+    return jsonschema
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    """Load a JSON object from a local file with reviewer-friendly errors."""
+    if not path.is_file():
+        raise FileNotFoundError(f"missing file: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object in {path}")
+    return payload
+
+
+def _validate_against_schema(payload: dict[str, Any], schema_path: Path) -> None:
+    """Validate a JSON object when jsonschema is installed locally."""
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        return
+
+    schema = _load_json_object(schema_path)
+    validator = jsonschema.Draft202012Validator(schema)
+    validator.validate(payload)
+
+
+def _canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    """Return deterministic UTF-8 JSON bytes for hashing."""
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sha256_json(payload: dict[str, Any]) -> str:
+    """Return the SHA-256 hex digest of canonical JSON."""
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _delta_causes(attribution: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return well-shaped delta cause dictionaries from an attribution."""
+    causes = attribution.get("delta_causes", [])
+    if not isinstance(causes, list):
+        return []
+    return [cause for cause in causes if isinstance(cause, dict)]
+
+
+def _cause_types(attribution: dict[str, Any]) -> set[str]:
+    """Return the set of string cause types in an attribution."""
+    cause_types = set()
+    for cause in _delta_causes(attribution):
+        cause_type = cause.get("cause_type")
+        if isinstance(cause_type, str):
+            cause_types.add(cause_type)
+    return cause_types
+
+
+def _attribution_action(attribution: dict[str, Any]) -> str:
+    """Map attribution governance action into detection governance action."""
+    action = attribution.get("recommended_governance_action")
+    if isinstance(action, str):
+        return ACTION_BY_ATTRIBUTION_ACTION.get(action, "review")
+    return "review"
+
+
+def _has_unresolved_delta(attribution: dict[str, Any]) -> bool:
+    """Return whether the attribution reports an unresolved delta."""
+    unresolved_delta = attribution.get("unresolved_delta", {})
+    if not isinstance(unresolved_delta, dict):
+        return False
+    return unresolved_delta.get("present") is True
+
+
+def classify_drift(attribution: dict[str, Any]) -> DriftClassification:
+    """Classify attribution causes into Evaluation Drift Detection fields.
+
+    Args:
+        attribution: Outcome Delta Attribution v1 JSON object.
+
+    Returns:
+        Deterministic drift classification for the generated detection object.
+    """
+    cause_types = _cause_types(attribution)
+    outcome_changed = attribution.get("outcome_changed") is True
+    has_drift_like_causes = bool(cause_types & DRIFT_LIKE_CAUSE_TYPES)
+
+    if "unexplained_evaluation_drift" in cause_types:
+        return DriftClassification(
+            drift_detected=True,
+            drift_status="unexplained",
+            evaluator_consistency_status="inconsistent",
+            explanation_status="unexplained",
+            recommended_governance_action="mark_evaluation_drift",
+        )
+    if "unauthorized_determiner_influence" in cause_types:
+        return DriftClassification(
+            drift_detected=True,
+            drift_status="confirmed",
+            evaluator_consistency_status="inconsistent",
+            explanation_status="requires_review",
+            recommended_governance_action="escalate",
+        )
+    if _has_unresolved_delta(attribution):
+        return DriftClassification(
+            drift_detected=True,
+            drift_status="non_deterministically_governed",
+            evaluator_consistency_status="unknown",
+            explanation_status="requires_review",
+            recommended_governance_action="mark_non_deterministically_governed",
+        )
+    if "evaluator_version_changed" in cause_types:
+        return DriftClassification(
+            drift_detected=True,
+            drift_status="suspected",
+            evaluator_consistency_status="unknown",
+            explanation_status="partially_explained",
+            recommended_governance_action="requalify_evaluator",
+        )
+    if cause_types & {
+        "rule_version_changed",
+        "policy_identity_changed",
+        "threshold_state_changed",
+    }:
+        return DriftClassification(
+            drift_detected=True,
+            drift_status="suspected",
+            evaluator_consistency_status="unknown",
+            explanation_status="partially_explained",
+            recommended_governance_action=_attribution_action(attribution),
+        )
+    if cause_types & {
+        "refusal_boundary_changed",
+        "escalation_resolver_changed",
+    }:
+        return DriftClassification(
+            drift_detected=True,
+            drift_status="suspected",
+            evaluator_consistency_status="unknown",
+            explanation_status="requires_review",
+            recommended_governance_action=_attribution_action(attribution),
+        )
+    if cause_types and cause_types <= CONTEXT_OR_QUALIFIER_CAUSE_TYPES:
+        return DriftClassification(
+            drift_detected=False,
+            drift_status="not_detected",
+            evaluator_consistency_status="not_comparable",
+            explanation_status="fully_explained",
+            recommended_governance_action="review" if outcome_changed else "none",
+        )
+    if not outcome_changed and not has_drift_like_causes:
+        return DriftClassification(
+            drift_detected=False,
+            drift_status="not_detected",
+            evaluator_consistency_status="consistent",
+            explanation_status="fully_explained",
+            recommended_governance_action="none",
+        )
+    return DriftClassification(
+        drift_detected=False,
+        drift_status="not_detected",
+        evaluator_consistency_status="not_comparable",
+        explanation_status="fully_explained",
+        recommended_governance_action=_attribution_action(attribution),
+    )
+
+
+def _drift_cause_from_delta_cause(cause: dict[str, Any]) -> dict[str, Any] | None:
+    """Map one attribution delta cause into one drift detection cause."""
+    attribution_cause_type = cause.get("cause_type")
+    if not isinstance(attribution_cause_type, str):
+        return None
+
+    drift_cause_type = DRIFT_CAUSE_TYPE_BY_ATTRIBUTION_CAUSE.get(
+        attribution_cause_type
+    )
+    if drift_cause_type is None:
+        return None
+
+    severity = cause.get("severity")
+    if not isinstance(severity, str):
+        severity = DEFAULT_SEVERITY_BY_DRIFT_CAUSE_TYPE[drift_cause_type]
+
+    evidence_refs = cause.get("evidence_refs")
+    if not isinstance(evidence_refs, list):
+        evidence_refs = []
+    evidence_refs = [ref for ref in evidence_refs if isinstance(ref, str) and ref]
+
+    explanation = cause.get("explanation")
+    if not isinstance(explanation, str) or not explanation:
+        explanation = f"Attribution reported {attribution_cause_type}."
+
+    return {
+        "cause_type": drift_cause_type,
+        "severity": severity,
+        "evidence_refs": evidence_refs,
+        "explanation": explanation,
+    }
+
+
+def _drift_causes(attribution: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build a non-empty, schema-shaped drift cause list."""
+    drift_causes = []
+    seen = set()
+    for cause in _delta_causes(attribution):
+        drift_cause = _drift_cause_from_delta_cause(cause)
+        if drift_cause is None:
+            continue
+        cause_type = drift_cause["cause_type"]
+        if cause_type in seen:
+            continue
+        seen.add(cause_type)
+        drift_causes.append(drift_cause)
+
+    if drift_causes:
+        return drift_causes
+
+    attribution_id = attribution.get("attribution_id", "unknown-attribution")
+    evidence_refs = [attribution_id] if isinstance(attribution_id, str) else []
+    return [
+        {
+            "cause_type": "attribution_inconclusive",
+            "severity": DEFAULT_SEVERITY_BY_DRIFT_CAUSE_TYPE[
+                "attribution_inconclusive"
+            ],
+            "evidence_refs": evidence_refs,
+            "explanation": (
+                "No v1 drift-specific attribution cause was present; the "
+                "draft detection records a neutral inconclusive cause to "
+                "satisfy the schema shape."
+            ),
+        }
+    ]
+
+
+def _summary(
+    attribution: dict[str, Any], classification: DriftClassification
+) -> str:
+    """Build a concise human-readable drift detection summary."""
+    prior_outcome = attribution.get("prior_outcome", "unknown")
+    current_outcome = attribution.get("current_outcome", "unknown")
+    if classification.drift_detected:
+        return (
+            f"Draft detection marked {classification.drift_status} drift "
+            f"from {prior_outcome} to {current_outcome}."
+        )
+    return (
+        "Draft detection did not detect evaluator drift from "
+        f"{prior_outcome} to {current_outcome}."
+    )
+
+
+def generate_evaluation_drift_detection(
+    attribution: dict[str, Any]
+) -> dict[str, Any]:
+    """Generate a schema-shaped Evaluation Drift Detection v1 object.
+
+    Args:
+        attribution: Outcome Delta Attribution v1 JSON object.
+
+    Returns:
+        Deterministic Evaluation Drift Detection v1 JSON object.
+
+    Raises:
+        jsonschema.ValidationError: If ``jsonschema`` is available and the
+            attribution or generated detection does not validate locally.
+    """
+    _validate_against_schema(attribution, OUTCOME_DELTA_ATTRIBUTION_SCHEMA_PATH)
+
+    classification = classify_drift(attribution)
+    attribution_id = attribution.get("attribution_id", "unknown-attribution")
+    prior_ref = attribution.get(
+        "prior_evaluation_receipt_ref", "unknown-prior-evaluation-receipt"
+    )
+    current_ref = attribution.get(
+        "current_evaluation_receipt_ref", "unknown-current-evaluation-receipt"
+    )
+    detection: dict[str, Any] = {
+        "schema_version": "evaluation-drift-detection-v1",
+        "detection_id": DETECTION_ID,
+        "issued_at": ISSUED_AT,
+        "outcome_delta_attribution_ref": str(attribution_id),
+        "outcome_delta_attribution_hash": _sha256_json(attribution),
+        "prior_evaluation_receipt_ref": str(prior_ref),
+        "current_evaluation_receipt_ref": str(current_ref),
+        "drift_detected": classification.drift_detected,
+        "drift_status": classification.drift_status,
+        "drift_causes": _drift_causes(attribution),
+        "evaluator_consistency_status": (
+            classification.evaluator_consistency_status
+        ),
+        "explanation_status": classification.explanation_status,
+        "recommended_governance_action": (
+            classification.recommended_governance_action
+        ),
+        "detection_summary": _summary(attribution, classification),
+        "detection_hash": "0" * 64,
+    }
+    detection_without_hash = dict(detection)
+    detection_without_hash.pop("detection_hash")
+    detection["detection_hash"] = _sha256_json(detection_without_hash)
+
+    _validate_against_schema(detection, EVALUATION_DRIFT_DETECTION_SCHEMA_PATH)
+    return detection
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a draft Evaluation Drift Detection v1 JSON object from "
+            "one local Outcome Delta Attribution v1 JSON file."
+        )
+    )
+    parser.add_argument("--attribution", required=True, type=Path)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the CLI and return a process exit code."""
+    args = _parse_args()
+    try:
+        attribution = _load_json_object(args.attribution)
+        detection = generate_evaluation_drift_detection(attribution)
+        output = json.dumps(detection, indent=2, ensure_ascii=False)
+        if args.output is None:
+            print(output)
+        else:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(f"{output}\n", encoding="utf-8")
+            print(
+                "Generated Evaluation Drift Detection v1: "
+                f"{args.output} "
+                f"(status={detection['drift_status']}, "
+                f"causes={len(detection['drift_causes'])})"
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_evaluation_drift_detection_helper.py
+++ b/tests/demo/test_evaluation_drift_detection_helper.py
@@ -1,0 +1,131 @@
+"""Tests for the offline Evaluation Drift Detection helper."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.demo import generate_evaluation_drift_detection as helper
+from scripts.demo import validate_evaluation_governance_sample_bundle as validator
+
+EXAMPLE_DIR = Path(
+    "docs/en/demo/examples/evaluation-drift-detection-helper-v1"
+)
+ATTRIBUTION_PATH = EXAMPLE_DIR / "outcome-delta-attribution.example.json"
+SCHEMA_PATH = Path(
+    "docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json"
+)
+SCRIPT_PATH = Path("scripts/demo/generate_evaluation_drift_detection.py")
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_generated_detection(detection: dict[str, object]) -> None:
+    schema = _load_json(SCHEMA_PATH)
+    validator._validate_payload(detection, schema)
+
+
+def _cause_types(detection: dict[str, object]) -> set[str]:
+    causes = detection["drift_causes"]
+    assert isinstance(causes, list)
+    return {cause["cause_type"] for cause in causes}
+
+
+def test_generate_evaluation_drift_detection_from_example() -> None:
+    attribution = _load_json(ATTRIBUTION_PATH)
+
+    detection = helper.generate_evaluation_drift_detection(attribution)
+
+    assert detection["schema_version"] == "evaluation-drift-detection-v1"
+    assert detection["drift_detected"] is True
+    assert detection["drift_status"] == "suspected"
+    assert detection["evaluator_consistency_status"] == "unknown"
+    assert detection["explanation_status"] == "partially_explained"
+    assert detection["recommended_governance_action"] == (
+        "requalify_evaluator"
+    )
+    cause_types = _cause_types(detection)
+    assert "evaluator_version_changed" in cause_types
+    assert "rule_version_changed" in cause_types
+    _validate_generated_detection(detection)
+
+
+def test_helper_cli_writes_schema_shaped_output(tmp_path: Path) -> None:
+    output_path = tmp_path / "evaluation-drift-detection.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--attribution",
+            str(ATTRIBUTION_PATH),
+            "--output",
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "Generated Evaluation Drift Detection v1" in completed.stdout
+    detection = _load_json(output_path)
+    assert detection["schema_version"] == "evaluation-drift-detection-v1"
+    _validate_generated_detection(detection)
+
+
+def test_helper_cli_prints_json_to_stdout_when_output_omitted() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--attribution",
+            str(ATTRIBUTION_PATH),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    detection = json.loads(completed.stdout)
+    assert detection["schema_version"] == "evaluation-drift-detection-v1"
+    _validate_generated_detection(detection)
+
+
+def test_no_outcome_change_without_drift_like_cause_recommends_none() -> None:
+    attribution = _load_json(ATTRIBUTION_PATH)
+    attribution["current_outcome"] = attribution["prior_outcome"]
+    attribution["outcome_changed"] = False
+    attribution["delta_causes"] = [
+        {
+            "cause_type": "governed_state_changed",
+            "severity": "info",
+            "prior_value_ref": "no_compared_delta_detected",
+            "current_value_ref": "no_compared_delta_detected",
+            "evidence_refs": ["synthetic-receipt-ref"],
+            "explanation": "No compared receipt fields changed.",
+        }
+    ]
+    attribution["recommended_governance_action"] = "none"
+    attribution["unresolved_delta"] = {
+        "present": False,
+        "reason": "No unexplained evaluation drift was detected.",
+        "requires_review": False,
+    }
+    attribution_without_hash = dict(attribution)
+    attribution_without_hash.pop("attribution_hash")
+    attribution["attribution_hash"] = helper._sha256_json(
+        attribution_without_hash
+    )
+
+    detection = helper.generate_evaluation_drift_detection(attribution)
+
+    assert detection["drift_detected"] is False
+    assert detection["drift_status"] == "not_detected"
+    assert detection["recommended_governance_action"] == "none"
+    _validate_generated_detection(detection)


### PR DESCRIPTION
### Motivation
- Provide a non-runtime, offline helper that consumes an Outcome Delta Attribution v1 artifact and produces a draft Evaluation Drift Detection v1 artifact for reviewer-facing drift signals. 
- Keep the helper docs/tests-only and explicitly avoid changing runtime `/v1/decide` behavior, production governance, admissibility logic, or dereferencing artifact refs. 

### Description
- Added `scripts/demo/generate_evaluation_drift_detection.py`, a CLI and library helper that implements `generate_evaluation_drift_detection(attribution)` and `classify_drift(attribution)` to map attribution `delta_causes`, `unresolved_delta`, `recommended_governance_action`, `attribution_confidence`, and `outcome_changed` into an `evaluation-drift-detection-v1` shaped JSON object. 
- Mapping implements the specified cause/status/action rules, preserves or supplies default `severity` values, computes deterministic SHA-256 hashes via canonical JSON, and populates deterministic `detection_id` and `issued_at` example values. 
- Validation is optional and local-only using `jsonschema` when available; the helper never accesses the network, dereferences artifact refs, requires env vars/secrets, or mutates repository/runtime state. 
- Added example artifacts and README at `docs/en/demo/examples/evaluation-drift-detection-helper-v1/` and tests at `tests/demo/test_evaluation_drift_detection_helper.py` that exercise importable helpers and CLI behavior. 

### Testing
- Ran static/style checks: `python -m ruff check scripts/demo/generate_evaluation_drift_detection.py tests/demo/test_evaluation_drift_detection_helper.py` and the check passed. 
- Ran unit/CLI tests: `python -m pytest tests/demo/test_evaluation_drift_detection_helper.py tests/demo/test_outcome_delta_attribution_helper.py tests/demo/test_evaluation_governance_sample_bundle_validator.py` and all tests passed (`10 passed, 1 warning`). 
- Exercised the CLI and example artifacts: generated artifact via the helper CLI and validated the generated example against `docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json` using the existing local validator, and validation succeeded. 
- Notes: tooling warnings related to local pyenv/virtualenv setup were observed but did not affect the helper behavior or the test results; no network access, secrets, or runtime integrations were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a258e2174e08326a5d9050c299db4ee)