### PR TITLE
Add Trajectory-Level Admissibility Monitor helper v1

### DIFF
--- a/docs/en/architecture/evaluation-governance-overview-v1.md
+++ b/docs/en/architecture/evaluation-governance-overview-v1.md
@@ -96,7 +96,7 @@ including:
    artifacts
 2. Automated Outcome Delta Attribution
 3. Automated Evaluation Drift Detection
-4. Automated Trajectory-Level Admissibility analysis
+4. Automated Trajectory-Level Admissibility analysis with the synthetic [helper example](../demo/examples/trajectory-admissibility-monitor-helper-v1/README.md)
 5. Legitimacy Impact Review workflow
 6. Runtime fail-closed integration after reviewer validation matures
 

--- a/docs/en/architecture/trajectory-admissibility-monitor-v1.md
+++ b/docs/en/architecture/trajectory-admissibility-monitor-v1.md
@@ -77,7 +77,15 @@ This v1 foundation does not modify bind/admissibility logic, production
 governance configuration, policy loading, TrustLog persistence, FUJI Gate
 behavior, continuity handling, or any runtime resolver.
 
-## 6. Future work
+## 6. Offline helper example
+
+A synthetic non-enforcing helper example is available at
+[`trajectory-admissibility-monitor-helper-v1`](../demo/examples/trajectory-admissibility-monitor-helper-v1/README.md).
+It reads local Evaluation Receipts, Outcome Delta Attributions, and Evaluation
+Drift Detections without dereferencing artifact refs or changing runtime
+admissibility behavior.
+
+## 7. Future work
 
 Future work can build on Trajectory-Level Admissibility Monitor v1 with:
 

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/README.md
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/README.md
@@ -1,0 +1,36 @@
+# Trajectory-Level Admissibility Monitor Helper v1 Example
+
+This directory contains a synthetic offline helper example for generating a
+Draft Trajectory-Level Admissibility Monitor v1 artifact.
+
+The helper reads local Evaluation Governance artifacts:
+
+- Evaluation Receipts
+- Outcome Delta Attributions
+- Evaluation Drift Detections
+
+It then produces a draft Trajectory-Level Admissibility Monitor JSON object for
+review. In v1 this helper is non-enforcing: it does not change runtime
+admissibility, does not prove legitimacy, and does not certify compliance.
+
+The helper also does not dereference artifact refs, does not require network
+access, does not require environment variables, and does not require secrets.
+All data in this example is synthetic and intentionally avoids real
+organization, customer, or person data.
+
+## Example command
+
+```bash
+python scripts/demo/generate_trajectory_admissibility_monitor.py \
+  --evaluation-receipts \
+    docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-1.example.json \
+    docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-2.example.json \
+    docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-3.example.json \
+  --attributions \
+    docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/outcome-delta-attribution-1.example.json \
+    docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/outcome-delta-attribution-2.example.json \
+  --drift-detections \
+    docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-drift-detection-1.example.json \
+    docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-drift-detection-2.example.json \
+  --output /tmp/trajectory-admissibility-monitor.json
+```

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-drift-detection-1.example.json
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-drift-detection-1.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "evaluation-drift-detection-v1",
+  "detection_id": "tam-helper-evaluation-drift-detection-001",
+  "issued_at": "2026-01-02T00:20:00Z",
+  "outcome_delta_attribution_ref": "tam-helper-outcome-delta-attribution-001",
+  "outcome_delta_attribution_hash": "7777777777777777777777777777777777777777777777777777777777777777",
+  "prior_evaluation_receipt_ref": "tam-helper-evaluation-receipt-001",
+  "current_evaluation_receipt_ref": "tam-helper-evaluation-receipt-002",
+  "drift_detected": true,
+  "drift_status": "suspected",
+  "drift_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "severity": "medium",
+      "evidence_refs": [
+        "tam-helper-outcome-delta-attribution-001"
+      ],
+      "explanation": "Synthetic suspected drift signal for offline helper chaining."
+    }
+  ],
+  "evaluator_consistency_status": "unknown",
+  "explanation_status": "partially_explained",
+  "recommended_governance_action": "requalify_evaluator",
+  "detection_summary": "Synthetic suspected drift detection for trajectory helper example.",
+  "detection_hash": "8888888888888888888888888888888888888888888888888888888888888888"
+}

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-drift-detection-2.example.json
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-drift-detection-2.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "evaluation-drift-detection-v1",
+  "detection_id": "tam-helper-evaluation-drift-detection-002",
+  "issued_at": "2026-01-03T00:20:00Z",
+  "outcome_delta_attribution_ref": "tam-helper-outcome-delta-attribution-002",
+  "outcome_delta_attribution_hash": "8888888888888888888888888888888888888888888888888888888888888888",
+  "prior_evaluation_receipt_ref": "tam-helper-evaluation-receipt-002",
+  "current_evaluation_receipt_ref": "tam-helper-evaluation-receipt-003",
+  "drift_detected": true,
+  "drift_status": "suspected",
+  "drift_causes": [
+    {
+      "cause_type": "rule_version_changed",
+      "severity": "medium",
+      "evidence_refs": [
+        "tam-helper-outcome-delta-attribution-002"
+      ],
+      "explanation": "Synthetic suspected drift signal for offline helper chaining."
+    }
+  ],
+  "evaluator_consistency_status": "unknown",
+  "explanation_status": "partially_explained",
+  "recommended_governance_action": "review",
+  "detection_summary": "Synthetic suspected drift detection for trajectory helper example.",
+  "detection_hash": "9999999999999999999999999999999999999999999999999999999999999999"
+}

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-1.example.json
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-1.example.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "tam-helper-evaluation-receipt-001",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "evaluation_id": "tam-helper-evaluation-001",
+  "evaluation_function_manifest_ref": "tam-helper-evaluation-function-v1",
+  "evaluation_function_manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root_authority_manifest_ref": "tam-helper-root-authority-v1",
+  "evaluator_id": "synthetic-trajectory-evaluator",
+  "evaluator_version": "1.0.0-demo",
+  "policy_identity": {
+    "policy_id": "synthetic-trajectory-policy",
+    "policy_version": "2026.01-demo",
+    "policy_source_ref": "sample://policy/synthetic-trajectory-policy"
+  },
+  "rule_set_version": "synthetic-ruleset-v1",
+  "authority_evidence_refs": [
+    "authority-evidence-example-v1"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "delegated_scope_validity",
+      "source_ref": "tam-helper-root-authority-v1",
+      "freshness_state": "fresh",
+      "required_at_bind": true,
+      "qualifier_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-delegated-authority-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "synthetic_trajectory_scope",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "delegated_authority_scope",
+      "input_type": "synthetic_scope_ref",
+      "input_ref": "sample://input/delegated-authority-scope",
+      "required": true,
+      "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-medium-trajectory-event",
+    "class_label": "medium",
+    "classifier_id": "synthetic-trajectory-classifier",
+    "classifier_version": "1.0.0-demo"
+  },
+  "material_context": {
+    "context_ref": "sample://context/trajectory-monitor-helper-001",
+    "context_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "allow",
+  "rationale_codes": [
+    "synthetic_trajectory_example"
+  ],
+  "input_state_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "evaluation_state_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+  "receipt_hash": "4444444444444444444444444444444444444444444444444444444444444444"
+}

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-2.example.json
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-2.example.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "tam-helper-evaluation-receipt-002",
+  "issued_at": "2026-01-02T00:00:00Z",
+  "evaluation_id": "tam-helper-evaluation-002",
+  "evaluation_function_manifest_ref": "tam-helper-evaluation-function-v1",
+  "evaluation_function_manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root_authority_manifest_ref": "tam-helper-root-authority-v1",
+  "evaluator_id": "synthetic-trajectory-evaluator",
+  "evaluator_version": "1.1.0-demo",
+  "policy_identity": {
+    "policy_id": "synthetic-trajectory-policy",
+    "policy_version": "2026.01-demo",
+    "policy_source_ref": "sample://policy/synthetic-trajectory-policy"
+  },
+  "rule_set_version": "synthetic-ruleset-v1",
+  "authority_evidence_refs": [
+    "authority-evidence-example-v2"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "delegated_scope_validity",
+      "source_ref": "tam-helper-root-authority-v1",
+      "freshness_state": "fresh",
+      "required_at_bind": true,
+      "qualifier_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-delegated-authority-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "synthetic_trajectory_scope",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "delegated_authority_scope",
+      "input_type": "synthetic_scope_ref",
+      "input_ref": "sample://input/delegated-authority-scope",
+      "required": true,
+      "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-high-trajectory-event",
+    "class_label": "high",
+    "classifier_id": "synthetic-trajectory-classifier",
+    "classifier_version": "1.0.0-demo"
+  },
+  "material_context": {
+    "context_ref": "sample://context/trajectory-monitor-helper-001",
+    "context_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "escalate",
+  "rationale_codes": [
+    "synthetic_trajectory_example"
+  ],
+  "input_state_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "evaluation_state_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+  "receipt_hash": "5555555555555555555555555555555555555555555555555555555555555555"
+}

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-3.example.json
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/evaluation-receipt-3.example.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "tam-helper-evaluation-receipt-003",
+  "issued_at": "2026-01-03T00:00:00Z",
+  "evaluation_id": "tam-helper-evaluation-003",
+  "evaluation_function_manifest_ref": "tam-helper-evaluation-function-v1",
+  "evaluation_function_manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root_authority_manifest_ref": "tam-helper-root-authority-v1",
+  "evaluator_id": "synthetic-trajectory-evaluator",
+  "evaluator_version": "1.1.0-demo",
+  "policy_identity": {
+    "policy_id": "synthetic-trajectory-policy",
+    "policy_version": "2026.01-demo",
+    "policy_source_ref": "sample://policy/synthetic-trajectory-policy"
+  },
+  "rule_set_version": "synthetic-ruleset-v2",
+  "authority_evidence_refs": [
+    "authority-evidence-example-v2"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "delegated_scope_validity",
+      "source_ref": "tam-helper-root-authority-v1",
+      "freshness_state": "fresh",
+      "required_at_bind": true,
+      "qualifier_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-delegated-authority-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "synthetic_trajectory_scope",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "delegated_authority_scope",
+      "input_type": "synthetic_scope_ref",
+      "input_ref": "sample://input/delegated-authority-scope",
+      "required": true,
+      "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-high-trajectory-event",
+    "class_label": "high",
+    "classifier_id": "synthetic-trajectory-classifier",
+    "classifier_version": "1.0.0-demo"
+  },
+  "material_context": {
+    "context_ref": "sample://context/trajectory-monitor-helper-001",
+    "context_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "escalate",
+  "rationale_codes": [
+    "synthetic_trajectory_example"
+  ],
+  "input_state_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "evaluation_state_hash": "3333333333333333333333333333333333333333333333333333333333333333",
+  "receipt_hash": "6666666666666666666666666666666666666666666666666666666666666666"
+}

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/outcome-delta-attribution-1.example.json
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/outcome-delta-attribution-1.example.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "outcome-delta-attribution-v1",
+  "attribution_id": "tam-helper-outcome-delta-attribution-001",
+  "issued_at": "2026-01-02T00:10:00Z",
+  "prior_evaluation_receipt_ref": "tam-helper-evaluation-receipt-001",
+  "current_evaluation_receipt_ref": "tam-helper-evaluation-receipt-002",
+  "prior_evaluation_receipt_hash": "4444444444444444444444444444444444444444444444444444444444444444",
+  "current_evaluation_receipt_hash": "5555555555555555555555555555555555555555555555555555555555555555",
+  "prior_outcome": "allow",
+  "current_outcome": "escalate",
+  "outcome_changed": true,
+  "delta_causes": [
+    {
+      "cause_type": "authority_state_changed",
+      "severity": "high",
+      "prior_value_ref": "authority-evidence-example-v1",
+      "current_value_ref": "authority-evidence-example-v2",
+      "evidence_refs": [
+        "authority-evidence-example-v1",
+        "authority-evidence-example-v2"
+      ],
+      "explanation": "Authority evidence changed between the first two synthetic receipts."
+    },
+    {
+      "cause_type": "qualifier_freshness_changed",
+      "severity": "medium",
+      "prior_value_ref": "fresh",
+      "current_value_ref": "fresh",
+      "evidence_refs": [
+        "tam-helper-root-authority-v1"
+      ],
+      "explanation": "Qualifier state was reviewed as part of the synthetic comparison."
+    },
+    {
+      "cause_type": "consequence_class_changed",
+      "severity": "high",
+      "prior_value_ref": "medium",
+      "current_value_ref": "high",
+      "evidence_refs": [
+        "sample://context/trajectory-monitor-helper-001"
+      ],
+      "explanation": "The consequence class changed in the synthetic trajectory."
+    }
+  ],
+  "attribution_summary": "Synthetic attribution from allow to escalate with delegated authority evidence change.",
+  "attribution_confidence": "high",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "Synthetic causes explain the compared receipt delta.",
+    "requires_review": false
+  },
+  "recommended_governance_action": "requalify",
+  "attribution_hash": "6666666666666666666666666666666666666666666666666666666666666666"
+}

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/outcome-delta-attribution-2.example.json
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/outcome-delta-attribution-2.example.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "outcome-delta-attribution-v1",
+  "attribution_id": "tam-helper-outcome-delta-attribution-002",
+  "issued_at": "2026-01-03T00:10:00Z",
+  "prior_evaluation_receipt_ref": "tam-helper-evaluation-receipt-002",
+  "current_evaluation_receipt_ref": "tam-helper-evaluation-receipt-003",
+  "prior_evaluation_receipt_hash": "5555555555555555555555555555555555555555555555555555555555555555",
+  "current_evaluation_receipt_hash": "6666666666666666666666666666666666666666666666666666666666666666",
+  "prior_outcome": "escalate",
+  "current_outcome": "escalate",
+  "outcome_changed": false,
+  "delta_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "severity": "medium",
+      "prior_value_ref": "1.0.0-demo",
+      "current_value_ref": "1.1.0-demo",
+      "evidence_refs": [
+        "tam-helper-evaluation-function-v1"
+      ],
+      "explanation": "Evaluator version changed in the synthetic trajectory."
+    },
+    {
+      "cause_type": "rule_version_changed",
+      "severity": "medium",
+      "prior_value_ref": "synthetic-ruleset-v1",
+      "current_value_ref": "synthetic-ruleset-v2",
+      "evidence_refs": [
+        "sample://policy/synthetic-trajectory-policy"
+      ],
+      "explanation": "Rule version changed while the outcome stayed escalate."
+    }
+  ],
+  "attribution_summary": "Synthetic attribution records evaluator and rule version changes with unchanged outcome.",
+  "attribution_confidence": "medium",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "Synthetic causes explain the compared receipt delta.",
+    "requires_review": false
+  },
+  "recommended_governance_action": "review",
+  "attribution_hash": "7777777777777777777777777777777777777777777777777777777777777777"
+}

--- a/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/trajectory-admissibility-monitor.generated.example.json
+++ b/docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/trajectory-admissibility-monitor.generated.example.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "trajectory-admissibility-monitor-v1",
+  "monitor_id": "trajectory-admissibility-monitor-example-001",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "trajectory_id": "trajectory-admissibility-monitor-example-001",
+  "evaluation_receipt_refs": [
+    "tam-helper-evaluation-receipt-001",
+    "tam-helper-evaluation-receipt-002",
+    "tam-helper-evaluation-receipt-003"
+  ],
+  "outcome_delta_attribution_refs": [
+    "tam-helper-outcome-delta-attribution-001",
+    "tam-helper-outcome-delta-attribution-002"
+  ],
+  "evaluation_drift_detection_refs": [
+    "tam-helper-evaluation-drift-detection-001",
+    "tam-helper-evaluation-drift-detection-002"
+  ],
+  "trajectory_window": {
+    "started_at": "2026-01-01T00:00:00Z",
+    "ended_at": "2026-01-03T00:00:00Z",
+    "evaluation_count": 3
+  },
+  "baseline_authority_scope": {
+    "scope_id": "baseline-authority-scope",
+    "scope_hash": "cd394c49479686f78fafa76d3c430017143b0cf186d705744d5c792d0c6f1a21",
+    "authority_evidence_ref": "authority-evidence-example-v1"
+  },
+  "current_authority_scope": {
+    "scope_id": "current-authority-scope",
+    "scope_hash": "a1d920789a49e251e52fe44e6a90e0f473eff97d69964e40b5ff9e5f1d501176",
+    "authority_evidence_ref": "authority-evidence-example-v2"
+  },
+  "admissibility_scope_change": {
+    "scope_expanded": true,
+    "expansion_type": "delegated_authority_expansion",
+    "explicit_reauthorization_present": false,
+    "reauthorization_evidence_refs": []
+  },
+  "continuity_event_summary": {
+    "continuity_events_observed": 3,
+    "low_risk_events_count": 1,
+    "material_change_events_count": 1,
+    "requalification_events_count": 1,
+    "escalation_events_count": 2
+  },
+  "trajectory_risk_signals": [
+    {
+      "signal_type": "admissibility_envelope_expansion",
+      "severity": "high",
+      "evidence_refs": [
+        "tam-helper-evaluation-receipt-001",
+        "tam-helper-evaluation-receipt-002",
+        "tam-helper-evaluation-receipt-003",
+        "tam-helper-outcome-delta-attribution-001",
+        "tam-helper-outcome-delta-attribution-002",
+        "tam-helper-evaluation-drift-detection-001",
+        "tam-helper-evaluation-drift-detection-002"
+      ],
+      "explanation": "The v1 helper observed trajectory-level scope expansion."
+    },
+    {
+      "signal_type": "delegated_scope_widening",
+      "severity": "high",
+      "evidence_refs": [
+        "tam-helper-evaluation-receipt-001",
+        "tam-helper-evaluation-receipt-002",
+        "tam-helper-evaluation-receipt-003",
+        "tam-helper-outcome-delta-attribution-001",
+        "tam-helper-outcome-delta-attribution-002"
+      ],
+      "explanation": "Authority evidence or authority state changed over time."
+    },
+    {
+      "signal_type": "continuity_as_authorization_risk",
+      "severity": "medium",
+      "evidence_refs": [
+        "tam-helper-evaluation-receipt-001",
+        "tam-helper-evaluation-receipt-002",
+        "tam-helper-evaluation-receipt-003"
+      ],
+      "explanation": "Repeated continuity events lacked explicit reauthorization evidence."
+    },
+    {
+      "signal_type": "strategic_admissibility_drift",
+      "severity": "high",
+      "evidence_refs": [
+        "tam-helper-outcome-delta-attribution-001",
+        "tam-helper-outcome-delta-attribution-002",
+        "tam-helper-evaluation-drift-detection-001",
+        "tam-helper-evaluation-drift-detection-002"
+      ],
+      "explanation": "Scope expansion appeared across repeated attribution or drift artifacts."
+    },
+    {
+      "signal_type": "governance_exhaustion_signal",
+      "severity": "medium",
+      "evidence_refs": [
+        "tam-helper-evaluation-receipt-001",
+        "tam-helper-evaluation-receipt-002",
+        "tam-helper-evaluation-receipt-003",
+        "tam-helper-evaluation-drift-detection-001",
+        "tam-helper-evaluation-drift-detection-002"
+      ],
+      "explanation": "Repeated escalation or requalification events were observed."
+    }
+  ],
+  "trajectory_status": "strategically_shaped",
+  "recommended_governance_action": "mark_strategic_admissibility_drift",
+  "monitor_summary": "Trajectory monitor observed 3 evaluation receipts, 2 outcome delta attributions, and 2 drift detections. Authority scope changed across the trajectory and repeated continuity events may indicate admissibility envelope expansion.",
+  "monitor_hash": "63be7efda71c799ea0348a053812368cec51af0d71d56dcbff6b29e3312560c7"
+}

--- a/scripts/demo/generate_trajectory_admissibility_monitor.py
+++ b/scripts/demo/generate_trajectory_admissibility_monitor.py
@@ -1,0 +1,716 @@
+#!/usr/bin/env python3
+"""Generate a draft Trajectory-Level Admissibility Monitor.
+
+This offline demo helper is intentionally schema-shaped and non-enforcing. It
+reads local Evaluation Receipt v1, Outcome Delta Attribution v1, and Evaluation
+Drift Detection v1 JSON objects, summarizes deterministic trajectory-level
+signals, and optionally validates inputs and output with ``jsonschema`` when
+that package is available locally. It never dereferences artifact references,
+accesses the network, or connects to runtime admissibility paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = REPO_ROOT / "docs/en/demo/schemas"
+EVALUATION_RECEIPT_SCHEMA_PATH = SCHEMA_DIR / "evaluation-receipt-v1.schema.json"
+OUTCOME_DELTA_ATTRIBUTION_SCHEMA_PATH = (
+    SCHEMA_DIR / "outcome-delta-attribution-v1.schema.json"
+)
+EVALUATION_DRIFT_DETECTION_SCHEMA_PATH = (
+    SCHEMA_DIR / "evaluation-drift-detection-v1.schema.json"
+)
+TRAJECTORY_ADMISSIBILITY_MONITOR_SCHEMA_PATH = (
+    SCHEMA_DIR / "trajectory-admissibility-monitor-v1.schema.json"
+)
+
+ISSUED_AT = "2026-01-01T00:00:00Z"
+MONITOR_ID = "trajectory-admissibility-monitor-example-001"
+TRAJECTORY_ID = "trajectory-admissibility-monitor-example-001"
+UNKNOWN_AUTHORITY_EVIDENCE = "unknown-authority-evidence"
+
+SCOPE_EXPANDING_CAUSE_TYPES = {
+    "authority_state_changed",
+    "threshold_state_changed",
+    "refusal_boundary_changed",
+    "escalation_resolver_changed",
+}
+DRIFT_SCOPE_EXPANDING_STATUSES = {
+    "suspected",
+    "confirmed",
+    "unexplained",
+    "non_deterministically_governed",
+}
+MORE_PERMISSIVE_RANK = {
+    "refuse": 0,
+    "escalate": 1,
+    "allow": 2,
+}
+RISK_SIGNAL_SEVERITY = {
+    "admissibility_envelope_expansion": "high",
+    "delegated_scope_widening": "high",
+    "permissive_requalification_trend": "medium",
+    "low_risk_event_accumulation": "medium",
+    "continuity_as_authorization_risk": "medium",
+    "strategic_admissibility_drift": "high",
+    "governance_exhaustion_signal": "medium",
+    "unexplained_trajectory_shift": "high",
+}
+
+
+def _jsonschema_module() -> Any | None:
+    """Return the optional jsonschema module when available locally."""
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+
+    import jsonschema
+
+    return jsonschema
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    """Load a JSON object from a local file with reviewer-friendly errors."""
+    if not path.is_file():
+        raise FileNotFoundError(f"missing file: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object in {path}")
+    return payload
+
+
+def _validate_against_schema(payload: dict[str, Any], schema_path: Path) -> None:
+    """Validate a JSON object when jsonschema is installed locally."""
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        return
+
+    schema = _load_json_object(schema_path)
+    validator = jsonschema.Draft202012Validator(schema)
+    validator.validate(payload)
+
+
+def _canonical_json_bytes(payload: Any) -> bytes:
+    """Return deterministic UTF-8 JSON bytes for hashing."""
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_json_hash(payload: Any) -> str:
+    """Return the SHA-256 hex digest of canonical JSON."""
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _string_list(value: Any) -> list[str]:
+    """Return non-empty strings from a JSON value when it is a list."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def _receipt_id(receipt: dict[str, Any]) -> str:
+    """Return a stable receipt reference without dereferencing artifacts."""
+    receipt_id = receipt.get("receipt_id")
+    if isinstance(receipt_id, str) and receipt_id:
+        return receipt_id
+    return "unknown-evaluation-receipt"
+
+
+def _attribution_id(attribution: dict[str, Any]) -> str:
+    """Return a stable attribution reference without dereferencing artifacts."""
+    attribution_id = attribution.get("attribution_id")
+    if isinstance(attribution_id, str) and attribution_id:
+        return attribution_id
+    return "unknown-outcome-delta-attribution"
+
+
+def _detection_id(detection: dict[str, Any]) -> str:
+    """Return a stable detection reference without dereferencing artifacts."""
+    detection_id = detection.get("detection_id")
+    if isinstance(detection_id, str) and detection_id:
+        return detection_id
+    return "unknown-evaluation-drift-detection"
+
+
+def _authority_evidence_refs(receipt: dict[str, Any]) -> list[str]:
+    """Return local authority evidence refs from a receipt."""
+    return _string_list(receipt.get("authority_evidence_refs"))
+
+
+def _authority_scope(receipt: dict[str, Any], scope_id: str) -> dict[str, str]:
+    """Build a schema-shaped authority scope from receipt evidence refs."""
+    evidence_refs = _authority_evidence_refs(receipt)
+    authority_evidence_ref = (
+        evidence_refs[0] if evidence_refs else UNKNOWN_AUTHORITY_EVIDENCE
+    )
+    return {
+        "scope_id": scope_id,
+        "scope_hash": canonical_json_hash(evidence_refs),
+        "authority_evidence_ref": authority_evidence_ref,
+    }
+
+
+def _delta_causes(attribution: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return well-shaped delta cause dictionaries from an attribution."""
+    causes = attribution.get("delta_causes", [])
+    if not isinstance(causes, list):
+        return []
+    return [cause for cause in causes if isinstance(cause, dict)]
+
+
+def _cause_types(attributions: list[dict[str, Any]]) -> set[str]:
+    """Return all delta cause types observed across attribution artifacts."""
+    cause_types = set()
+    for attribution in attributions:
+        for cause in _delta_causes(attribution):
+            cause_type = cause.get("cause_type")
+            if isinstance(cause_type, str):
+                cause_types.add(cause_type)
+    return cause_types
+
+
+def _drift_statuses(drift_detections: list[dict[str, Any]]) -> set[str]:
+    """Return all drift statuses observed across detection artifacts."""
+    statuses = set()
+    for detection in drift_detections:
+        drift_status = detection.get("drift_status")
+        if isinstance(drift_status, str):
+            statuses.add(drift_status)
+    return statuses
+
+
+def _more_permissive_outcome_trend(receipts: list[dict[str, Any]]) -> bool:
+    """Return true when receipt outcomes become more permissive over time."""
+    ranks = []
+    for receipt in receipts:
+        outcome = receipt.get("outcome")
+        if isinstance(outcome, str) and outcome in MORE_PERMISSIVE_RANK:
+            ranks.append(MORE_PERMISSIVE_RANK[outcome])
+    return any(
+        current > prior
+        for prior, current in zip(ranks, ranks[1:], strict=False)
+    )
+
+
+def _reauthorization_evidence_refs(
+    attributions: list[dict[str, Any]],
+) -> list[str]:
+    """Return attribution evidence refs that mention reauthorization."""
+    refs = []
+    seen = set()
+    for attribution in attributions:
+        for cause in _delta_causes(attribution):
+            for evidence_ref in _string_list(cause.get("evidence_refs")):
+                if "reauthorization" not in evidence_ref.lower():
+                    continue
+                if evidence_ref in seen:
+                    continue
+                seen.add(evidence_ref)
+                refs.append(evidence_ref)
+    return refs
+
+
+def _expansion_type(
+    evidence_changed: bool,
+    cause_types: set[str],
+    scope_expanded: bool,
+    increasingly_permissive: bool,
+) -> str:
+    """Classify the first applicable v1 expansion type."""
+    if not scope_expanded:
+        return "none"
+    if evidence_changed or "authority_state_changed" in cause_types:
+        return "delegated_authority_expansion"
+    if "threshold_state_changed" in cause_types:
+        return "threshold_expansion"
+    if "refusal_boundary_changed" in cause_types:
+        return "refusal_boundary_relaxation"
+    if "escalation_resolver_changed" in cause_types:
+        return "escalation_requirement_reduction"
+    if "material_context_changed" in cause_types and increasingly_permissive:
+        return "contextual_scope_expansion"
+    return "unknown"
+
+
+def detect_scope_change(
+    receipts: list[dict[str, Any]],
+    attributions: list[dict[str, Any]] | None = None,
+    drift_detections: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Detect deterministic v1 admissibility scope change signals.
+
+    Args:
+        receipts: Evaluation Receipt v1 JSON objects in trajectory order.
+        attributions: Outcome Delta Attribution v1 JSON objects.
+        drift_detections: Evaluation Drift Detection v1 JSON objects.
+
+    Returns:
+        Schema-shaped admissibility scope change summary.
+    """
+    attributions = attributions or []
+    drift_detections = drift_detections or []
+    first_refs = _authority_evidence_refs(receipts[0])
+    last_refs = _authority_evidence_refs(receipts[-1])
+    evidence_changed = first_refs != last_refs
+    cause_types = _cause_types(attributions)
+    drift_statuses = _drift_statuses(drift_detections)
+    increasingly_permissive = _more_permissive_outcome_trend(receipts)
+    scope_expanded = any(
+        (
+            evidence_changed,
+            bool(cause_types & SCOPE_EXPANDING_CAUSE_TYPES),
+            bool(drift_statuses & DRIFT_SCOPE_EXPANDING_STATUSES),
+            increasingly_permissive,
+        )
+    )
+    reauthorization_refs = _reauthorization_evidence_refs(attributions)
+
+    return {
+        "scope_expanded": scope_expanded,
+        "expansion_type": _expansion_type(
+            evidence_changed,
+            cause_types,
+            scope_expanded,
+            increasingly_permissive,
+        ),
+        "explicit_reauthorization_present": bool(reauthorization_refs),
+        "reauthorization_evidence_refs": reauthorization_refs,
+    }
+
+
+def summarize_continuity_events(
+    receipts: list[dict[str, Any]],
+    attributions: list[dict[str, Any]] | None = None,
+    drift_detections: list[dict[str, Any]] | None = None,
+) -> dict[str, int]:
+    """Summarize deterministic v1 continuity event counts."""
+    attributions = attributions or []
+    drift_detections = drift_detections or []
+    cause_type_sets = [_cause_types([attribution]) for attribution in attributions]
+
+    low_risk_events_count = 0
+    escalation_events_count = 0
+    for receipt in receipts:
+        consequence_class = receipt.get("consequence_class", {})
+        class_label = ""
+        if isinstance(consequence_class, dict):
+            label = consequence_class.get("class_label")
+            if isinstance(label, str):
+                class_label = label.lower()
+        if class_label in {"low", "medium"}:
+            low_risk_events_count += 1
+        if receipt.get("outcome") == "escalate":
+            escalation_events_count += 1
+
+    material_change_events_count = sum(
+        1
+        for cause_types in cause_type_sets
+        if cause_types & {"material_context_changed", "consequence_class_changed"}
+    )
+    requalification_events_count = sum(
+        1
+        for detection in drift_detections
+        if detection.get("recommended_governance_action")
+        in {"requalify_evaluator", "reconcile_qualifiers"}
+    )
+    escalation_events_count += sum(
+        1
+        for detection in drift_detections
+        if detection.get("recommended_governance_action") == "escalate"
+    )
+
+    return {
+        "continuity_events_observed": len(receipts),
+        "low_risk_events_count": low_risk_events_count,
+        "material_change_events_count": material_change_events_count,
+        "requalification_events_count": requalification_events_count,
+        "escalation_events_count": escalation_events_count,
+    }
+
+
+def _signal(
+    signal_type: str,
+    evidence_refs: list[str],
+    explanation: str,
+) -> dict[str, Any]:
+    """Build a schema-shaped trajectory risk signal."""
+    return {
+        "signal_type": signal_type,
+        "severity": RISK_SIGNAL_SEVERITY[signal_type],
+        "evidence_refs": evidence_refs,
+        "explanation": explanation,
+    }
+
+
+def generate_risk_signals(
+    receipts: list[dict[str, Any]],
+    attributions: list[dict[str, Any]] | None = None,
+    drift_detections: list[dict[str, Any]] | None = None,
+    scope_change: dict[str, Any] | None = None,
+    continuity_summary: dict[str, int] | None = None,
+) -> list[dict[str, Any]]:
+    """Generate deterministic v1 trajectory risk signals."""
+    attributions = attributions or []
+    drift_detections = drift_detections or []
+    scope_change = scope_change or detect_scope_change(
+        receipts, attributions, drift_detections
+    )
+    continuity_summary = continuity_summary or summarize_continuity_events(
+        receipts, attributions, drift_detections
+    )
+    receipt_refs = [_receipt_id(receipt) for receipt in receipts]
+    attribution_refs = [_attribution_id(attribution) for attribution in attributions]
+    detection_refs = [_detection_id(detection) for detection in drift_detections]
+    cause_types = _cause_types(attributions)
+    drift_statuses = _drift_statuses(drift_detections)
+    first_refs = _authority_evidence_refs(receipts[0])
+    last_refs = _authority_evidence_refs(receipts[-1])
+    signals = []
+
+    if scope_change["scope_expanded"] is True:
+        signals.append(
+            _signal(
+                "admissibility_envelope_expansion",
+                receipt_refs + attribution_refs + detection_refs,
+                "The v1 helper observed trajectory-level scope expansion.",
+            )
+        )
+    if "authority_state_changed" in cause_types or first_refs != last_refs:
+        signals.append(
+            _signal(
+                "delegated_scope_widening",
+                receipt_refs + attribution_refs,
+                "Authority evidence or authority state changed over time.",
+            )
+        )
+    if _more_permissive_outcome_trend(receipts):
+        signals.append(
+            _signal(
+                "permissive_requalification_trend",
+                receipt_refs,
+                "Evaluation outcomes became more permissive over time.",
+            )
+        )
+    if (
+        continuity_summary["low_risk_events_count"] >= 2
+        and continuity_summary["continuity_events_observed"] >= 3
+    ):
+        signals.append(
+            _signal(
+                "low_risk_event_accumulation",
+                receipt_refs,
+                "Multiple low or medium risk events accumulated in one trajectory.",
+            )
+        )
+    if (
+        continuity_summary["continuity_events_observed"] >= 3
+        and scope_change["explicit_reauthorization_present"] is False
+    ):
+        signals.append(
+            _signal(
+                "continuity_as_authorization_risk",
+                receipt_refs,
+                "Repeated continuity events lacked explicit reauthorization evidence.",
+            )
+        )
+    if scope_change["scope_expanded"] is True and (
+        len(attributions) >= 2 or len(drift_detections) >= 2
+    ):
+        signals.append(
+            _signal(
+                "strategic_admissibility_drift",
+                attribution_refs + detection_refs,
+                "Scope expansion appeared across repeated attribution or drift artifacts.",
+            )
+        )
+    if (
+        continuity_summary["escalation_events_count"] >= 2
+        or continuity_summary["requalification_events_count"] >= 2
+    ):
+        signals.append(
+            _signal(
+                "governance_exhaustion_signal",
+                receipt_refs + detection_refs,
+                "Repeated escalation or requalification events were observed.",
+            )
+        )
+    if drift_statuses & {"unexplained", "non_deterministically_governed"}:
+        signals.append(
+            _signal(
+                "unexplained_trajectory_shift",
+                detection_refs,
+                "A drift detection reported unexplained or non-deterministic governance.",
+            )
+        )
+
+    return signals
+
+
+def classify_trajectory_status(
+    risk_signals: list[dict[str, Any]],
+    drift_detections: list[dict[str, Any]] | None = None,
+    scope_change: dict[str, Any] | None = None,
+) -> str:
+    """Classify trajectory status using the v1 priority order."""
+    drift_detections = drift_detections or []
+    drift_statuses = _drift_statuses(drift_detections)
+    signal_types = {
+        signal.get("signal_type")
+        for signal in risk_signals
+        if isinstance(signal, dict)
+    }
+    severities = {
+        signal.get("severity") for signal in risk_signals if isinstance(signal, dict)
+    }
+    scope_expanded = bool(scope_change and scope_change.get("scope_expanded"))
+
+    if "non_deterministically_governed" in drift_statuses:
+        return "non_deterministically_governed"
+    if drift_statuses & {"confirmed", "unexplained"}:
+        return "drift_detected"
+    if "strategic_admissibility_drift" in signal_types:
+        return "strategically_shaped"
+    if scope_expanded or "high" in severities:
+        return "suspicious"
+    if "medium" in severities:
+        return "watch"
+    return "stable"
+
+
+def _recommended_governance_action(
+    trajectory_status: str,
+    risk_signals: list[dict[str, Any]],
+) -> str:
+    """Map trajectory status and risk signals to a draft governance action."""
+    signal_types = {
+        signal.get("signal_type")
+        for signal in risk_signals
+        if isinstance(signal, dict)
+    }
+    if trajectory_status == "non_deterministically_governed":
+        return "mark_non_deterministically_governed"
+    if trajectory_status == "strategically_shaped":
+        return "mark_strategic_admissibility_drift"
+    if trajectory_status == "drift_detected":
+        return "requalify_trajectory"
+    if "delegated_scope_widening" in signal_types:
+        return "reconcile_authority_scope"
+    if trajectory_status in {"suspicious", "watch"}:
+        return "review"
+    return "none"
+
+
+def _monitor_summary(
+    receipt_count: int,
+    attribution_count: int,
+    drift_detection_count: int,
+    scope_change: dict[str, Any],
+) -> str:
+    """Build a concise human-readable monitor summary."""
+    summary = (
+        f"Trajectory monitor observed {receipt_count} evaluation receipts, "
+        f"{attribution_count} outcome delta attributions, and "
+        f"{drift_detection_count} drift detections."
+    )
+    if scope_change["scope_expanded"] is True:
+        return (
+            f"{summary} Authority scope changed across the trajectory and "
+            "repeated continuity events may indicate admissibility envelope "
+            "expansion."
+        )
+    return f"{summary} No v1 admissibility scope expansion was detected."
+
+
+def _trajectory_window(receipts: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build trajectory window from receipt issued_at values."""
+    issued_at_values = []
+    for receipt in receipts:
+        issued_at = receipt.get("issued_at")
+        if isinstance(issued_at, str) and issued_at:
+            issued_at_values.append(issued_at)
+    if not issued_at_values:
+        raise ValueError("evaluation receipts must include issued_at values")
+    return {
+        "started_at": min(issued_at_values),
+        "ended_at": max(issued_at_values),
+        "evaluation_count": len(receipts),
+    }
+
+
+def generate_trajectory_admissibility_monitor(
+    evaluation_receipts: list[dict[str, Any]],
+    attributions: list[dict[str, Any]] | None = None,
+    drift_detections: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Generate a Trajectory-Level Admissibility Monitor v1 object.
+
+    Args:
+        evaluation_receipts: One or more Evaluation Receipt v1 JSON objects.
+        attributions: Zero or more Outcome Delta Attribution v1 JSON objects.
+        drift_detections: Zero or more Evaluation Drift Detection v1 JSON objects.
+
+    Returns:
+        Deterministic Trajectory-Level Admissibility Monitor v1 JSON object.
+
+    Raises:
+        ValueError: If no evaluation receipts are provided.
+        jsonschema.ValidationError: If ``jsonschema`` is available and an input
+            artifact or generated monitor does not validate locally.
+    """
+    if not evaluation_receipts:
+        raise ValueError("at least one evaluation receipt is required")
+
+    attributions = attributions or []
+    drift_detections = drift_detections or []
+    for receipt in evaluation_receipts:
+        _validate_against_schema(receipt, EVALUATION_RECEIPT_SCHEMA_PATH)
+    for attribution in attributions:
+        _validate_against_schema(
+            attribution, OUTCOME_DELTA_ATTRIBUTION_SCHEMA_PATH
+        )
+    for detection in drift_detections:
+        _validate_against_schema(
+            detection, EVALUATION_DRIFT_DETECTION_SCHEMA_PATH
+        )
+
+    scope_change = detect_scope_change(
+        evaluation_receipts, attributions, drift_detections
+    )
+    continuity_summary = summarize_continuity_events(
+        evaluation_receipts, attributions, drift_detections
+    )
+    risk_signals = generate_risk_signals(
+        evaluation_receipts,
+        attributions,
+        drift_detections,
+        scope_change,
+        continuity_summary,
+    )
+    trajectory_status = classify_trajectory_status(
+        risk_signals, drift_detections, scope_change
+    )
+    monitor: dict[str, Any] = {
+        "schema_version": "trajectory-admissibility-monitor-v1",
+        "monitor_id": MONITOR_ID,
+        "issued_at": ISSUED_AT,
+        "trajectory_id": TRAJECTORY_ID,
+        "evaluation_receipt_refs": [
+            _receipt_id(receipt) for receipt in evaluation_receipts
+        ],
+        "outcome_delta_attribution_refs": [
+            _attribution_id(attribution) for attribution in attributions
+        ],
+        "evaluation_drift_detection_refs": [
+            _detection_id(detection) for detection in drift_detections
+        ],
+        "trajectory_window": _trajectory_window(evaluation_receipts),
+        "baseline_authority_scope": _authority_scope(
+            evaluation_receipts[0], "baseline-authority-scope"
+        ),
+        "current_authority_scope": _authority_scope(
+            evaluation_receipts[-1], "current-authority-scope"
+        ),
+        "admissibility_scope_change": scope_change,
+        "continuity_event_summary": continuity_summary,
+        "trajectory_risk_signals": risk_signals,
+        "trajectory_status": trajectory_status,
+        "recommended_governance_action": _recommended_governance_action(
+            trajectory_status, risk_signals
+        ),
+        "monitor_summary": _monitor_summary(
+            len(evaluation_receipts),
+            len(attributions),
+            len(drift_detections),
+            scope_change,
+        ),
+        "monitor_hash": "0" * 64,
+    }
+    monitor_without_hash = dict(monitor)
+    monitor_without_hash.pop("monitor_hash")
+    monitor["monitor_hash"] = canonical_json_hash(monitor_without_hash)
+
+    _validate_against_schema(monitor, TRAJECTORY_ADMISSIBILITY_MONITOR_SCHEMA_PATH)
+    return monitor
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a draft Trajectory-Level Admissibility Monitor v1 JSON "
+            "object from local Evaluation Governance artifacts."
+        )
+    )
+    parser.add_argument(
+        "--evaluation-receipts",
+        required=True,
+        nargs="+",
+        type=Path,
+        help="One or more local Evaluation Receipt v1 JSON files.",
+    )
+    parser.add_argument(
+        "--attributions",
+        nargs="*",
+        type=Path,
+        default=[],
+        help="Zero or more local Outcome Delta Attribution v1 JSON files.",
+    )
+    parser.add_argument(
+        "--drift-detections",
+        nargs="*",
+        type=Path,
+        default=[],
+        help="Zero or more local Evaluation Drift Detection v1 JSON files.",
+    )
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the CLI and return a process exit code."""
+    args = _parse_args()
+    try:
+        receipts = [_load_json_object(path) for path in args.evaluation_receipts]
+        attributions = [_load_json_object(path) for path in args.attributions]
+        drift_detections = [
+            _load_json_object(path) for path in args.drift_detections
+        ]
+        monitor = generate_trajectory_admissibility_monitor(
+            receipts, attributions, drift_detections
+        )
+        output = json.dumps(monitor, indent=2, ensure_ascii=False)
+        if args.output is None:
+            print(output)
+        else:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(f"{output}\n", encoding="utf-8")
+            print(
+                "Generated Trajectory-Level Admissibility Monitor v1: "
+                f"{args.output} "
+                f"(status={monitor['trajectory_status']}, "
+                f"signals={len(monitor['trajectory_risk_signals'])})"
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_trajectory_admissibility_monitor_helper.py
+++ b/tests/demo/test_trajectory_admissibility_monitor_helper.py
@@ -1,0 +1,141 @@
+"""Tests for the offline Trajectory-Level Admissibility Monitor helper."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.demo import generate_trajectory_admissibility_monitor as helper
+from scripts.demo import validate_evaluation_governance_sample_bundle as validator
+
+EXAMPLE_DIR = Path(
+    "docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1"
+)
+RECEIPT_PATHS = [
+    EXAMPLE_DIR / f"evaluation-receipt-{index}.example.json"
+    for index in range(1, 4)
+]
+ATTRIBUTION_PATHS = [
+    EXAMPLE_DIR / f"outcome-delta-attribution-{index}.example.json"
+    for index in range(1, 3)
+]
+DRIFT_DETECTION_PATHS = [
+    EXAMPLE_DIR / f"evaluation-drift-detection-{index}.example.json"
+    for index in range(1, 3)
+]
+GENERATED_EXAMPLE_PATH = (
+    EXAMPLE_DIR / "trajectory-admissibility-monitor.generated.example.json"
+)
+SCHEMA_PATH = Path(
+    "docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json"
+)
+SCRIPT_PATH = Path(
+    "scripts/demo/generate_trajectory_admissibility_monitor.py"
+)
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_all(paths: list[Path]) -> list[dict[str, object]]:
+    return [_load_json(path) for path in paths]
+
+
+def _validate_generated_monitor(monitor: dict[str, object]) -> None:
+    schema = _load_json(SCHEMA_PATH)
+    validator._validate_payload(monitor, schema)
+
+
+def _signal_types(monitor: dict[str, object]) -> set[str]:
+    signals = monitor["trajectory_risk_signals"]
+    assert isinstance(signals, list)
+    return {signal["signal_type"] for signal in signals}
+
+
+def test_generate_trajectory_monitor_from_examples() -> None:
+    receipts = _load_all(RECEIPT_PATHS)
+    attributions = _load_all(ATTRIBUTION_PATHS)
+    drift_detections = _load_all(DRIFT_DETECTION_PATHS)
+
+    monitor = helper.generate_trajectory_admissibility_monitor(
+        receipts, attributions, drift_detections
+    )
+
+    assert monitor["schema_version"] == "trajectory-admissibility-monitor-v1"
+    scope_change = monitor["admissibility_scope_change"]
+    assert isinstance(scope_change, dict)
+    assert scope_change["scope_expanded"] is True
+    assert scope_change["expansion_type"] == "delegated_authority_expansion"
+    signal_types = _signal_types(monitor)
+    assert "admissibility_envelope_expansion" in signal_types
+    assert "delegated_scope_widening" in signal_types
+    assert "continuity_as_authorization_risk" in signal_types
+    assert "strategic_admissibility_drift" in signal_types
+    assert monitor["trajectory_status"] in {
+        "suspicious",
+        "strategically_shaped",
+        "drift_detected",
+        "non_deterministically_governed",
+    }
+    _validate_generated_monitor(monitor)
+
+
+def test_generated_example_monitor_validates() -> None:
+    monitor = _load_json(GENERATED_EXAMPLE_PATH)
+
+    assert monitor["schema_version"] == "trajectory-admissibility-monitor-v1"
+    _validate_generated_monitor(monitor)
+
+
+def test_helper_cli_writes_schema_shaped_output(tmp_path: Path) -> None:
+    output_path = tmp_path / "trajectory-admissibility-monitor.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--evaluation-receipts",
+            *(str(path) for path in RECEIPT_PATHS),
+            "--attributions",
+            *(str(path) for path in ATTRIBUTION_PATHS),
+            "--drift-detections",
+            *(str(path) for path in DRIFT_DETECTION_PATHS),
+            "--output",
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "Generated Trajectory-Level Admissibility Monitor v1" in completed.stdout
+    monitor = _load_json(output_path)
+    assert monitor["schema_version"] == "trajectory-admissibility-monitor-v1"
+    _validate_generated_monitor(monitor)
+
+
+def test_helper_cli_prints_json_to_stdout_when_output_omitted() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--evaluation-receipts",
+            *(str(path) for path in RECEIPT_PATHS),
+            "--attributions",
+            *(str(path) for path in ATTRIBUTION_PATHS),
+            "--drift-detections",
+            *(str(path) for path in DRIFT_DETECTION_PATHS),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    monitor = json.loads(completed.stdout)
+    assert monitor["schema_version"] == "trajectory-admissibility-monitor-v1"
+    _validate_generated_monitor(monitor)


### PR DESCRIPTION
### Motivation
- Provide a non-runtime, offline helper that synthesizes a Trajectory-Level Admissibility Monitor v1 from sequences of Evaluation Receipts, Outcome Delta Attributions, and Evaluation Drift Detections to make trajectory-level admissibility movement visible to reviewers.
- Fit the helper into the existing offline demo helper chain (Receipt → Attribution → Drift Detection → Trajectory Monitor) without changing runtime `/v1/decide` behavior or production governance configuration.

### Description
- Add `scripts/demo/generate_trajectory_admissibility_monitor.py` implementing `generate_trajectory_admissibility_monitor(...)` and helper functions `canonical_json_hash`, `detect_scope_change`, `summarize_continuity_events`, `generate_risk_signals`, and `classify_trajectory_status`; CLI supports `--evaluation-receipts`, `--attributions`, `--drift-detections`, and `--output` and validates with `jsonschema` when available.
- Add synthetic example artifacts and a generated example to `docs/en/demo/examples/trajectory-admissibility-monitor-helper-v1/` including `README.md`, three `evaluation-receipt-*.example.json`, two `outcome-delta-attribution-*.example.json`, two `evaluation-drift-detection-*.example.json`, and `trajectory-admissibility-monitor.generated.example.json`.
- Add tests `tests/demo/test_trajectory_admissibility_monitor_helper.py` that import and call `generate_trajectory_admissibility_monitor()`, validate output against the monitor schema, assert expected signals/status, and exercise the CLI (stdout and `--output`).
- Add minimal architecture doc links to `docs/en/architecture/trajectory-admissibility-monitor-v1.md` and `docs/en/architecture/evaluation-governance-overview-v1.md` pointing to the synthetic helper example; preserve explicit non-runtime/non-enforcing scope and do not modify schemas or runtime logic.

### Testing
- Ran unit tests: `python -m pytest tests/demo/test_trajectory_admissibility_monitor_helper.py tests/demo/test_outcome_delta_attribution_helper.py tests/demo/test_evaluation_drift_detection_helper.py tests/demo/test_evaluation_governance_sample_bundle_validator.py` with `PYENV_VERSION=3.12.13`; all tests passed (14 passed, 1 warning).
- Ran style/lint: `python -m ruff check scripts/demo/generate_trajectory_admissibility_monitor.py tests/demo/test_trajectory_admissibility_monitor_helper.py`; lint checks passed.
- Exercised CLI end-to-end by running the helper with the example inputs and `--output` and verified produced JSON `schema_version == trajectory-admissibility-monitor-v1` and that the generated example matches the schema; the CLI returned exit code 0 and printed a short summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2592ab66188326b1afdc63ca345a91)