### PR TITLE
Add Evaluation Governance offline chain runner v1

### DIFF
--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/README.md
@@ -1,0 +1,34 @@
+# Evaluation Governance Offline Chain v1 Example
+
+This directory contains a synthetic offline Evaluation Governance chain example.
+It demonstrates how the existing reviewer-facing helper sequence can be run over
+local example inputs:
+
+Evaluation Receipt -> Outcome Delta Attribution -> Evaluation Drift Detection ->
+Trajectory-Level Admissibility Monitor -> Legitimacy Impact Review.
+
+The example is non-runtime and non-enforcing in v1. It does not change runtime
+admissibility, does not call `/v1/decide`, does not prove legitimacy, does not
+certify compliance, does not dereference artifact refs, does not require network
+access, and does not include secrets or PII.
+
+## Generate into a temporary output directory
+
+```bash
+python scripts/demo/run_evaluation_governance_offline_chain.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --output-dir /tmp/evaluation-governance-offline-chain-output
+```
+
+## Regenerate checked-in example outputs intentionally
+
+```bash
+python scripts/demo/run_evaluation_governance_offline_chain.py \
+  --input-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --write-example-output
+```
+
+The checked-in generated examples are included only for reviewer readability.
+The helper validates schema shape when `jsonschema` is available locally. It does
+not verify present legitimacy, does not enforce runtime decisions, does not
+verify external artifact hashes, and does not require artifact refs to resolve.

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/evaluation-receipt-1.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/evaluation-receipt-1.example.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "evaluation-governance-offline-chain-receipt-001",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "evaluation_id": "evaluation-governance-offline-chain-evaluation-001",
+  "evaluation_function_manifest_ref": "evaluation-function-manifest-example-v1",
+  "evaluation_function_manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root_authority_manifest_ref": "root-authority-manifest-example-v1",
+  "evaluator_id": "synthetic-evaluation-governance-evaluator",
+  "evaluator_version": "eval-v1.0.0",
+  "policy_identity": {
+    "policy_id": "synthetic-evaluation-governance-policy",
+    "policy_version": "2026.01-demo",
+    "policy_source_ref": "sample://policy/synthetic-evaluation-governance-policy"
+  },
+  "rule_set_version": "rules-v1",
+  "authority_evidence_refs": [
+    "authority-evidence-example-v1"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "delegated_scope_validity",
+      "source_ref": "tam-helper-root-authority-v1",
+      "freshness_state": "fresh",
+      "required_at_bind": true,
+      "qualifier_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-delegated-authority-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "synthetic_trajectory_scope",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "delegated_authority_scope",
+      "input_type": "synthetic_scope_ref",
+      "input_ref": "sample://input/delegated-authority-scope",
+      "required": true,
+      "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-medium-evaluation-governance-event",
+    "class_label": "medium",
+    "classifier_id": "synthetic-trajectory-classifier",
+    "classifier_version": "1.0.0-demo"
+  },
+  "material_context": {
+    "context_ref": "sample://context/trajectory-monitor-helper-001",
+    "context_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "allow",
+  "rationale_codes": [
+    "synthetic_evaluation_governance_offline_chain"
+  ],
+  "input_state_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "evaluation_state_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+  "receipt_hash": "4444444444444444444444444444444444444444444444444444444444444444"
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/evaluation-receipt-2.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/evaluation-receipt-2.example.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "evaluation-governance-offline-chain-receipt-002",
+  "issued_at": "2026-01-02T00:00:00Z",
+  "evaluation_id": "evaluation-governance-offline-chain-evaluation-002",
+  "evaluation_function_manifest_ref": "evaluation-function-manifest-example-v1",
+  "evaluation_function_manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root_authority_manifest_ref": "root-authority-manifest-example-v1",
+  "evaluator_id": "synthetic-evaluation-governance-evaluator",
+  "evaluator_version": "eval-v1.1.0",
+  "policy_identity": {
+    "policy_id": "synthetic-evaluation-governance-policy",
+    "policy_version": "2026.01-demo",
+    "policy_source_ref": "sample://policy/synthetic-evaluation-governance-policy"
+  },
+  "rule_set_version": "rules-v2",
+  "authority_evidence_refs": [
+    "authority-evidence-example-v2"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "delegated_scope_validity",
+      "source_ref": "tam-helper-root-authority-v1",
+      "freshness_state": "fresh",
+      "required_at_bind": true,
+      "qualifier_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-delegated-authority-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "synthetic_trajectory_scope",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "delegated_authority_scope",
+      "input_type": "synthetic_scope_ref",
+      "input_ref": "sample://input/delegated-authority-scope",
+      "required": true,
+      "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-high-evaluation-governance-event",
+    "class_label": "high",
+    "classifier_id": "synthetic-trajectory-classifier",
+    "classifier_version": "1.0.0-demo"
+  },
+  "material_context": {
+    "context_ref": "sample://context/trajectory-monitor-helper-001",
+    "context_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "escalate",
+  "rationale_codes": [
+    "synthetic_evaluation_governance_offline_chain"
+  ],
+  "input_state_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "evaluation_state_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+  "receipt_hash": "5555555555555555555555555555555555555555555555555555555555555555"
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/evaluation-receipt-3.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/evaluation-receipt-3.example.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "evaluation-receipt-v1",
+  "receipt_id": "evaluation-governance-offline-chain-receipt-003",
+  "issued_at": "2026-01-03T00:00:00Z",
+  "evaluation_id": "evaluation-governance-offline-chain-evaluation-003",
+  "evaluation_function_manifest_ref": "evaluation-function-manifest-example-v1",
+  "evaluation_function_manifest_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root_authority_manifest_ref": "root-authority-manifest-example-v1",
+  "evaluator_id": "synthetic-evaluation-governance-evaluator",
+  "evaluator_version": "eval-v1.1.0",
+  "policy_identity": {
+    "policy_id": "synthetic-evaluation-governance-policy",
+    "policy_version": "2026.01-demo",
+    "policy_source_ref": "sample://policy/synthetic-evaluation-governance-policy"
+  },
+  "rule_set_version": "rules-v2",
+  "authority_evidence_refs": [
+    "authority-evidence-example-v2"
+  ],
+  "qualifier_state": [
+    {
+      "qualifier_name": "delegated_scope_validity",
+      "source_ref": "tam-helper-root-authority-v1",
+      "freshness_state": "fresh",
+      "required_at_bind": true,
+      "qualifier_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "authorized_determiners_used": [
+    {
+      "determiner_id": "synthetic-delegated-authority-check",
+      "determiner_type": "authority_scope_validation",
+      "authority_scope": "synthetic_trajectory_scope",
+      "influenced_outcome": true
+    }
+  ],
+  "admissibility_inputs": [
+    {
+      "input_name": "delegated_authority_scope",
+      "input_type": "synthetic_scope_ref",
+      "input_ref": "sample://input/delegated-authority-scope",
+      "required": true,
+      "input_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "consequence_class": {
+    "class_id": "synthetic-high-evaluation-governance-event",
+    "class_label": "high",
+    "classifier_id": "synthetic-trajectory-classifier",
+    "classifier_version": "1.0.0-demo"
+  },
+  "material_context": {
+    "context_ref": "sample://context/trajectory-monitor-helper-002",
+    "context_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "context_freshness_state": "fresh",
+    "stale_context_allowed": false
+  },
+  "outcome": "escalate",
+  "rationale_codes": [
+    "synthetic_evaluation_governance_offline_chain"
+  ],
+  "input_state_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "evaluation_state_hash": "3333333333333333333333333333333333333333333333333333333333333333",
+  "receipt_hash": "6666666666666666666666666666666666666666666666666666666666666666"
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/chain-manifest.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/chain-manifest.generated.example.json
@@ -1,0 +1,67 @@
+{
+  "artifacts": [
+    {
+      "artifact_hash": "5cae168299c60becc997dde84fc143fa059edc2b5fca81dde1997f5916f4500f",
+      "artifact_ref": "evaluation-receipt-1.example.json",
+      "artifact_type": "evaluation_receipt"
+    },
+    {
+      "artifact_hash": "81c64573c36975ccf755f53718d1b759d00f612832aee47c35081117824a9cfa",
+      "artifact_ref": "evaluation-receipt-2.example.json",
+      "artifact_type": "evaluation_receipt"
+    },
+    {
+      "artifact_hash": "9e029c8f3a1df6f1b368def1d6cc7a665ffd6efe1b5c05c1d198d18f5105efb4",
+      "artifact_ref": "evaluation-receipt-3.example.json",
+      "artifact_type": "evaluation_receipt"
+    },
+    {
+      "artifact_hash": "4ce275c69363b76007a280e2ffcfb384efa2bc795532745f88dfc4da10ae6421",
+      "artifact_ref": "manifest-change-receipt.example.json",
+      "artifact_type": "manifest_change_receipt"
+    },
+    {
+      "artifact_hash": "17029f187996728b120db5bbf7bb92f26d6a16f833bdc3b7c66bd05077d62d33",
+      "artifact_ref": "generated/outcome-delta-attribution-1.generated.example.json",
+      "artifact_type": "outcome_delta_attribution"
+    },
+    {
+      "artifact_hash": "59fac37138155946793fd958cdf2e8c96a842671fa1f64829e6c1f99b3dd531e",
+      "artifact_ref": "generated/outcome-delta-attribution-2.generated.example.json",
+      "artifact_type": "outcome_delta_attribution"
+    },
+    {
+      "artifact_hash": "9e6390164ff4d51dcc66d19b58dc9ca08f915ad07637ef580228aca4a39d3c6e",
+      "artifact_ref": "generated/evaluation-drift-detection-1.generated.example.json",
+      "artifact_type": "evaluation_drift_detection"
+    },
+    {
+      "artifact_hash": "16b7d149551c7a415ee931a10d83c5e4d486fab59b0adda649d65b1e81d08b40",
+      "artifact_ref": "generated/evaluation-drift-detection-2.generated.example.json",
+      "artifact_type": "evaluation_drift_detection"
+    },
+    {
+      "artifact_hash": "900ca433a0128a9f4e9308f9da783c6ae11dc7ae68af5fdd61add67d30f67c89",
+      "artifact_ref": "generated/trajectory-admissibility-monitor.generated.example.json",
+      "artifact_type": "trajectory_admissibility_monitor"
+    },
+    {
+      "artifact_hash": "2af7ec64add0c6e1919216fb79c47d56ad3f60653a009503646cc108d61efda0",
+      "artifact_ref": "generated/legitimacy-impact-review.generated.example.json",
+      "artifact_type": "legitimacy_impact_review"
+    }
+  ],
+  "chain_id": "evaluation-governance-offline-chain-example-001",
+  "chain_summary": "Synthetic offline Evaluation Governance chain generated for reviewer-facing architecture review.",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "non_enforcing": true,
+  "non_goals": [
+    "does_not_change_runtime_behavior",
+    "does_not_establish_legitimacy",
+    "does_not_certify_compliance",
+    "does_not_call_v1_decide",
+    "does_not_dereference_artifact_refs"
+  ],
+  "non_runtime": true,
+  "schema_version": "evaluation-governance-offline-chain-manifest-v1"
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/evaluation-drift-detection-1.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/evaluation-drift-detection-1.generated.example.json
@@ -1,0 +1,34 @@
+{
+  "current_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-002",
+  "detection_hash": "f53cab1310a7fccd8efa8815d50685be5a4fff42f14ac575cbbdc9e490c82c66",
+  "detection_id": "evaluation-governance-offline-chain-drift-detection-001",
+  "detection_summary": "Draft detection marked suspected drift from allow to escalate.",
+  "drift_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The evaluator version changed between receipts.",
+      "severity": "medium"
+    },
+    {
+      "cause_type": "rule_version_changed",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The rule set version changed between receipts.",
+      "severity": "medium"
+    }
+  ],
+  "drift_detected": true,
+  "drift_status": "suspected",
+  "evaluator_consistency_status": "unknown",
+  "explanation_status": "partially_explained",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_delta_attribution_hash": "17029f187996728b120db5bbf7bb92f26d6a16f833bdc3b7c66bd05077d62d33",
+  "outcome_delta_attribution_ref": "evaluation-governance-offline-chain-attribution-001",
+  "prior_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-001",
+  "recommended_governance_action": "requalify_evaluator",
+  "schema_version": "evaluation-drift-detection-v1"
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/evaluation-drift-detection-2.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/evaluation-drift-detection-2.generated.example.json
@@ -1,0 +1,26 @@
+{
+  "current_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-003",
+  "detection_hash": "8f41b1da1892d642e7aef809ee3ec8e36694bf03fb5396595d0e0805e29812bd",
+  "detection_id": "evaluation-governance-offline-chain-drift-detection-002",
+  "detection_summary": "Draft detection did not detect evaluator drift from escalate to escalate.",
+  "drift_causes": [
+    {
+      "cause_type": "material_context_ambiguous",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-003"
+      ],
+      "explanation": "The material context state changed between receipts.",
+      "severity": "medium"
+    }
+  ],
+  "drift_detected": false,
+  "drift_status": "not_detected",
+  "evaluator_consistency_status": "not_comparable",
+  "explanation_status": "fully_explained",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_delta_attribution_hash": "59fac37138155946793fd958cdf2e8c96a842671fa1f64829e6c1f99b3dd531e",
+  "outcome_delta_attribution_ref": "evaluation-governance-offline-chain-attribution-002",
+  "prior_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-002",
+  "recommended_governance_action": "none",
+  "schema_version": "evaluation-drift-detection-v1"
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/legitimacy-impact-review.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/legitimacy-impact-review.generated.example.json
@@ -1,0 +1,83 @@
+{
+  "auditability_impact": {
+    "auditability_reduced": false,
+    "evidence_chain_weakened": false,
+    "evidence_refs": [
+      "legitimacy-helper-manifest-change-001"
+    ],
+    "explanation": "No auditability reduction was detected.",
+    "receipt_requirements_reduced": false,
+    "replayability_reduced": false
+  },
+  "authority_impact": {
+    "authority_scope_expanded": true,
+    "evidence_refs": [
+      "sample://authority/synthetic-board-charter-v1",
+      "legitimacy-helper-manifest-change-001",
+      "trajectory-admissibility-monitor-example-001"
+    ],
+    "explanation": "Authority-impacting signals were detected for reviewer assessment.",
+    "root_authority_changed": false,
+    "trusted_authority_source_changed": false
+  },
+  "escalation_impact": {
+    "escalation_authority_changed": true,
+    "escalation_path_changed": true,
+    "escalation_requirement_reduced": true,
+    "evidence_refs": [
+      "legitimacy-helper-manifest-change-001",
+      "approval-evidence-example-001"
+    ],
+    "explanation": "Escalation requirements or authority may have changed."
+  },
+  "high_risk_admissibility_impact": {
+    "evidence_refs": [
+      "legitimacy-helper-manifest-change-001",
+      "trajectory-admissibility-monitor-example-001"
+    ],
+    "explanation": "High-risk admissibility scope expansion signals require review.",
+    "high_risk_controls_weakened": true,
+    "high_risk_review_requirement_reduced": true,
+    "high_risk_scope_expanded": true
+  },
+  "impact_categories": [
+    "authority_scope_expansion",
+    "human_oversight_weakened",
+    "escalation_requirement_reduced",
+    "high_risk_admissibility_expanded",
+    "evaluation_behavior_changed"
+  ],
+  "issued_at": "2026-01-01T00:00:00Z",
+  "legitimacy_impact_detected": true,
+  "oversight_impact": {
+    "approval_requirement_reduced": true,
+    "evidence_refs": [
+      "approval-evidence-example-001",
+      "legitimacy-helper-manifest-change-001"
+    ],
+    "explanation": "Human oversight or approval requirements may be weakened.",
+    "human_oversight_weakened": true,
+    "reviewer_authority_changed": false
+  },
+  "recommended_governance_action": "multi_party_review",
+  "refusal_boundary_impact": {
+    "evidence_refs": [
+      "legitimacy-helper-manifest-change-001",
+      "trajectory-admissibility-monitor-example-001"
+    ],
+    "explanation": "No refusal boundary relaxation was detected.",
+    "refusal_boundary_relaxed": false,
+    "refusal_condition_changed": false,
+    "refusal_condition_removed": false
+  },
+  "review_hash": "795e3d6d9d5968f9c058dfb99dd77d7b545bd6c5fbd10b9a3f793a54d24b4619",
+  "review_id": "legitimacy-impact-review-example-001",
+  "review_status": "pending",
+  "review_summary": "Draft offline review surfaced legitimacy-impacting signals (authority_scope_expansion, human_oversight_weakened, escalation_requirement_reduced, high_risk_admissibility_expanded, evaluation_behavior_changed); status=pending, recommended_action=multi_party_review. This is reviewable evidence only, not an automatic legitimacy or compliance determination.",
+  "reviewed_artifact_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+  "reviewed_artifact_ref": "evaluation-function-manifest-example-001",
+  "reviewed_artifact_type": "evaluation_function_manifest",
+  "schema_version": "legitimacy-impact-review-v1",
+  "triggering_change_hash": "4ce275c69363b76007a280e2ffcfb384efa2bc795532745f88dfc4da10ae6421",
+  "triggering_change_ref": "legitimacy-helper-manifest-change-001"
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/outcome-delta-attribution-1.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/outcome-delta-attribution-1.generated.example.json
@@ -1,0 +1,63 @@
+{
+  "attribution_confidence": "high",
+  "attribution_hash": "41f28700eaaa596b60e5d775d2d014827a4200f3595c90b3d689bf684584165d",
+  "attribution_id": "evaluation-governance-offline-chain-attribution-001",
+  "attribution_summary": "Outcome changed from allow to escalate; detected causes: evaluator_version_changed, rule_version_changed, authority_state_changed, consequence_class_changed.",
+  "current_evaluation_receipt_hash": "81c64573c36975ccf755f53718d1b759d00f612832aee47c35081117824a9cfa",
+  "current_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-002",
+  "current_outcome": "escalate",
+  "delta_causes": [
+    {
+      "cause_type": "evaluator_version_changed",
+      "current_value_ref": "eval-v1.1.0",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The evaluator version changed between receipts.",
+      "prior_value_ref": "eval-v1.0.0",
+      "severity": "medium"
+    },
+    {
+      "cause_type": "rule_version_changed",
+      "current_value_ref": "rules-v2",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The rule set version changed between receipts.",
+      "prior_value_ref": "rules-v1",
+      "severity": "medium"
+    },
+    {
+      "cause_type": "authority_state_changed",
+      "current_value_ref": "[\"authority-evidence-example-v2\"]",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The authority evidence references changed between receipts.",
+      "prior_value_ref": "[\"authority-evidence-example-v1\"]",
+      "severity": "high"
+    },
+    {
+      "cause_type": "consequence_class_changed",
+      "current_value_ref": "{\"class_id\": \"synthetic-high-evaluation-governance-event\", \"class_label\": \"high\", \"classifier_id\": \"synthetic-trajectory-classifier\", \"classifier_version\": \"1.0.0-demo\"}",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-002"
+      ],
+      "explanation": "The consequence classification changed between receipts.",
+      "prior_value_ref": "{\"class_id\": \"synthetic-medium-evaluation-governance-event\", \"class_label\": \"medium\", \"classifier_id\": \"synthetic-trajectory-classifier\", \"classifier_version\": \"1.0.0-demo\"}",
+      "severity": "high"
+    }
+  ],
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_changed": true,
+  "prior_evaluation_receipt_hash": "5cae168299c60becc997dde84fc143fa059edc2b5fca81dde1997f5916f4500f",
+  "prior_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-001",
+  "prior_outcome": "allow",
+  "recommended_governance_action": "review",
+  "schema_version": "outcome-delta-attribution-v1",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "No unexplained evaluation drift was detected.",
+    "requires_review": false
+  }
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/outcome-delta-attribution-2.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/outcome-delta-attribution-2.generated.example.json
@@ -1,0 +1,33 @@
+{
+  "attribution_confidence": "medium",
+  "attribution_hash": "f2ecc5814675be88bed77cca104a904d2af2e262b4e2afd8d42b9033c37d63dc",
+  "attribution_id": "evaluation-governance-offline-chain-attribution-002",
+  "attribution_summary": "Outcome changed from escalate to escalate; detected causes: material_context_changed.",
+  "current_evaluation_receipt_hash": "9e029c8f3a1df6f1b368def1d6cc7a665ffd6efe1b5c05c1d198d18f5105efb4",
+  "current_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-003",
+  "current_outcome": "escalate",
+  "delta_causes": [
+    {
+      "cause_type": "material_context_changed",
+      "current_value_ref": "{\"context_freshness_state\": \"fresh\", \"context_hash\": \"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\", \"stale_context_allowed\": false}",
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-003"
+      ],
+      "explanation": "The material context state changed between receipts.",
+      "prior_value_ref": "{\"context_freshness_state\": \"fresh\", \"context_hash\": \"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\", \"stale_context_allowed\": false}",
+      "severity": "medium"
+    }
+  ],
+  "issued_at": "2026-01-01T00:00:00Z",
+  "outcome_changed": false,
+  "prior_evaluation_receipt_hash": "81c64573c36975ccf755f53718d1b759d00f612832aee47c35081117824a9cfa",
+  "prior_evaluation_receipt_ref": "evaluation-governance-offline-chain-receipt-002",
+  "prior_outcome": "escalate",
+  "recommended_governance_action": "review",
+  "schema_version": "outcome-delta-attribution-v1",
+  "unresolved_delta": {
+    "present": false,
+    "reason": "No unexplained evaluation drift was detected.",
+    "requires_review": false
+  }
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/trajectory-admissibility-monitor.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/trajectory-admissibility-monitor.generated.example.json
@@ -1,0 +1,112 @@
+{
+  "admissibility_scope_change": {
+    "expansion_type": "delegated_authority_expansion",
+    "explicit_reauthorization_present": false,
+    "reauthorization_evidence_refs": [],
+    "scope_expanded": true
+  },
+  "baseline_authority_scope": {
+    "authority_evidence_ref": "authority-evidence-example-v1",
+    "scope_hash": "cd394c49479686f78fafa76d3c430017143b0cf186d705744d5c792d0c6f1a21",
+    "scope_id": "baseline-authority-scope"
+  },
+  "continuity_event_summary": {
+    "continuity_events_observed": 3,
+    "escalation_events_count": 2,
+    "low_risk_events_count": 1,
+    "material_change_events_count": 2,
+    "requalification_events_count": 1
+  },
+  "current_authority_scope": {
+    "authority_evidence_ref": "authority-evidence-example-v2",
+    "scope_hash": "a1d920789a49e251e52fe44e6a90e0f473eff97d69964e40b5ff9e5f1d501176",
+    "scope_id": "current-authority-scope"
+  },
+  "evaluation_drift_detection_refs": [
+    "evaluation-governance-offline-chain-drift-detection-001",
+    "evaluation-governance-offline-chain-drift-detection-002"
+  ],
+  "evaluation_receipt_refs": [
+    "evaluation-governance-offline-chain-receipt-001",
+    "evaluation-governance-offline-chain-receipt-002",
+    "evaluation-governance-offline-chain-receipt-003"
+  ],
+  "issued_at": "2026-01-01T00:00:00Z",
+  "monitor_hash": "3c1ca1fd304f9dc5d6a55916487cb427dea2fe3d8027aadf70d804ba81b8dede",
+  "monitor_id": "trajectory-admissibility-monitor-example-001",
+  "monitor_summary": "Trajectory monitor observed 3 evaluation receipts, 2 outcome delta attributions, and 2 drift detections. Authority scope changed across the trajectory and repeated continuity events may indicate admissibility envelope expansion.",
+  "outcome_delta_attribution_refs": [
+    "evaluation-governance-offline-chain-attribution-001",
+    "evaluation-governance-offline-chain-attribution-002"
+  ],
+  "recommended_governance_action": "mark_strategic_admissibility_drift",
+  "schema_version": "trajectory-admissibility-monitor-v1",
+  "trajectory_id": "trajectory-admissibility-monitor-example-001",
+  "trajectory_risk_signals": [
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-001",
+        "evaluation-governance-offline-chain-receipt-002",
+        "evaluation-governance-offline-chain-receipt-003",
+        "evaluation-governance-offline-chain-attribution-001",
+        "evaluation-governance-offline-chain-attribution-002",
+        "evaluation-governance-offline-chain-drift-detection-001",
+        "evaluation-governance-offline-chain-drift-detection-002"
+      ],
+      "explanation": "The v1 helper observed trajectory-level scope expansion.",
+      "severity": "high",
+      "signal_type": "admissibility_envelope_expansion"
+    },
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-001",
+        "evaluation-governance-offline-chain-receipt-002",
+        "evaluation-governance-offline-chain-receipt-003",
+        "evaluation-governance-offline-chain-attribution-001",
+        "evaluation-governance-offline-chain-attribution-002"
+      ],
+      "explanation": "Authority evidence or authority state changed over time.",
+      "severity": "high",
+      "signal_type": "delegated_scope_widening"
+    },
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-001",
+        "evaluation-governance-offline-chain-receipt-002",
+        "evaluation-governance-offline-chain-receipt-003"
+      ],
+      "explanation": "Repeated continuity events lacked explicit reauthorization evidence.",
+      "severity": "medium",
+      "signal_type": "continuity_as_authorization_risk"
+    },
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-attribution-001",
+        "evaluation-governance-offline-chain-attribution-002",
+        "evaluation-governance-offline-chain-drift-detection-001",
+        "evaluation-governance-offline-chain-drift-detection-002"
+      ],
+      "explanation": "Scope expansion appeared across repeated attribution or drift artifacts.",
+      "severity": "high",
+      "signal_type": "strategic_admissibility_drift"
+    },
+    {
+      "evidence_refs": [
+        "evaluation-governance-offline-chain-receipt-001",
+        "evaluation-governance-offline-chain-receipt-002",
+        "evaluation-governance-offline-chain-receipt-003",
+        "evaluation-governance-offline-chain-drift-detection-001",
+        "evaluation-governance-offline-chain-drift-detection-002"
+      ],
+      "explanation": "Repeated escalation or requalification events were observed.",
+      "severity": "medium",
+      "signal_type": "governance_exhaustion_signal"
+    }
+  ],
+  "trajectory_status": "strategically_shaped",
+  "trajectory_window": {
+    "ended_at": "2026-01-03T00:00:00Z",
+    "evaluation_count": 3,
+    "started_at": "2026-01-01T00:00:00Z"
+  }
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/manifest-change-receipt.example.json
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/manifest-change-receipt.example.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "manifest-change-receipt-v1",
+  "receipt_id": "legitimacy-helper-manifest-change-001",
+  "issued_at": "2026-01-01T00:00:00Z",
+  "changed_manifest_type": "evaluation_function_manifest",
+  "changed_manifest_id": "evaluation-function-manifest-example-001",
+  "previous_manifest_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+  "new_manifest_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+  "change_reason": "Synthetic evaluator change expands delegated authority scope for high-risk internal approval and reduces escalation requirements for reviewer demonstration.",
+  "changed_by": {
+    "actor_id": "synthetic-governance-maintainer",
+    "role": "demo_governance_maintainer"
+  },
+  "authority_evidence_ref": "sample://authority/synthetic-board-charter-v1",
+  "approval_evidence_refs": [
+    "approval-evidence-example-001"
+  ],
+  "impact_scope": [
+    "high_risk_internal_approval"
+  ],
+  "legitimacy_impact_flags": [
+    "authority_scope_expanded",
+    "human_oversight_weakened",
+    "escalation_requirement_reduced"
+  ],
+  "rollback_conditions": [
+    "rollback-if-external-review-rejects-change"
+  ]
+}

--- a/scripts/demo/run_evaluation_governance_offline_chain.py
+++ b/scripts/demo/run_evaluation_governance_offline_chain.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Run the synthetic Evaluation Governance offline helper chain.
+
+This reviewer-facing demo runner composes existing offline helper functions over
+local example JSON files. It is intentionally non-runtime and non-enforcing: it
+never calls ``/v1/decide``, never dereferences artifact references, never uses
+network access, and never imports runtime admissibility logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.demo.generate_evaluation_drift_detection import (
+    EVALUATION_DRIFT_DETECTION_SCHEMA_PATH,
+    generate_evaluation_drift_detection,
+)
+from scripts.demo.generate_legitimacy_impact_review import (
+    LEGITIMACY_IMPACT_REVIEW_SCHEMA_PATH,
+    MANIFEST_CHANGE_RECEIPT_SCHEMA_PATH,
+    generate_legitimacy_impact_review,
+)
+from scripts.demo.generate_outcome_delta_attribution import (
+    OUTCOME_DELTA_ATTRIBUTION_SCHEMA_PATH,
+    generate_outcome_delta_attribution,
+)
+from scripts.demo.generate_trajectory_admissibility_monitor import (
+    EVALUATION_RECEIPT_SCHEMA_PATH,
+    TRAJECTORY_ADMISSIBILITY_MONITOR_SCHEMA_PATH,
+    generate_trajectory_admissibility_monitor,
+)
+
+ISSUED_AT = "2026-01-01T00:00:00Z"
+CHAIN_ID = "evaluation-governance-offline-chain-example-001"
+CHAIN_SCHEMA_VERSION = "evaluation-governance-offline-chain-manifest-v1"
+DEFAULT_GENERATED_DIR_NAME = "generated"
+
+INPUT_FILE_NAMES = {
+    "receipt_1": "evaluation-receipt-1.example.json",
+    "receipt_2": "evaluation-receipt-2.example.json",
+    "receipt_3": "evaluation-receipt-3.example.json",
+    "manifest_change": "manifest-change-receipt.example.json",
+}
+GENERATED_FILE_NAMES = {
+    "attribution_1": "outcome-delta-attribution-1.generated.example.json",
+    "attribution_2": "outcome-delta-attribution-2.generated.example.json",
+    "drift_1": "evaluation-drift-detection-1.generated.example.json",
+    "drift_2": "evaluation-drift-detection-2.generated.example.json",
+    "monitor": "trajectory-admissibility-monitor.generated.example.json",
+    "review": "legitimacy-impact-review.generated.example.json",
+    "manifest": "chain-manifest.generated.example.json",
+}
+SCHEMA_PATHS_BY_VERSION = {
+    "evaluation-receipt-v1": EVALUATION_RECEIPT_SCHEMA_PATH,
+    "manifest-change-receipt-v1": MANIFEST_CHANGE_RECEIPT_SCHEMA_PATH,
+    "outcome-delta-attribution-v1": OUTCOME_DELTA_ATTRIBUTION_SCHEMA_PATH,
+    "evaluation-drift-detection-v1": EVALUATION_DRIFT_DETECTION_SCHEMA_PATH,
+    "trajectory-admissibility-monitor-v1": (
+        TRAJECTORY_ADMISSIBILITY_MONITOR_SCHEMA_PATH
+    ),
+    "legitimacy-impact-review-v1": LEGITIMACY_IMPACT_REVIEW_SCHEMA_PATH,
+}
+
+
+@dataclass(frozen=True)
+class ChainRunResult:
+    """Result metadata returned by ``run_offline_chain`` for tests and CLIs."""
+
+    output_dir: Path
+    artifacts: dict[str, dict[str, Any]]
+    artifact_paths: dict[str, Path]
+    manifest: dict[str, Any]
+
+
+def _jsonschema_module() -> Any | None:
+    """Return the optional jsonschema module when it is installed locally."""
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+
+    import jsonschema
+
+    return jsonschema
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object from ``path`` with clear offline-runner errors."""
+    if not path.is_file():
+        raise FileNotFoundError(f"missing input file: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object in {path}")
+    return payload
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` as stable, reviewer-readable JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"{json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)}\n",
+        encoding="utf-8",
+    )
+
+
+def canonical_json_hash(payload: Any) -> str:
+    """Return the SHA-256 digest of canonical JSON for local artifacts."""
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def validate_generated_artifact(payload: dict[str, Any]) -> None:
+    """Validate an artifact against its schema when jsonschema is available."""
+    schema_version = payload.get("schema_version")
+    if not isinstance(schema_version, str):
+        raise ValueError("generated artifact is missing string schema_version")
+
+    schema_path = SCHEMA_PATHS_BY_VERSION.get(schema_version)
+    if schema_path is None:
+        return
+
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        return
+
+    schema = load_json(schema_path)
+    jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def _set_hashed_identifier(
+    artifact: dict[str, Any],
+    identifier_field: str,
+    identifier: str,
+    hash_field: str,
+) -> dict[str, Any]:
+    """Return ``artifact`` with a runner-specific identifier and hash."""
+    updated = dict(artifact)
+    updated[identifier_field] = identifier
+    updated[hash_field] = "0" * 64
+    without_hash = dict(updated)
+    without_hash.pop(hash_field)
+    updated[hash_field] = canonical_json_hash(without_hash)
+    validate_generated_artifact(updated)
+    return updated
+
+
+def _artifact_ref(path: Path, output_dir: Path, input_dir: Path) -> str:
+    """Build a documentation-friendly local artifact reference."""
+    try:
+        return path.relative_to(input_dir).as_posix()
+    except ValueError:
+        return path.relative_to(output_dir).as_posix()
+
+
+def build_chain_manifest(
+    input_dir: Path,
+    output_dir: Path,
+    artifact_paths: dict[str, Path],
+    artifacts: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the simple v1 manifest for the generated offline chain."""
+    artifact_order = [
+        ("receipt_1", "evaluation_receipt"),
+        ("receipt_2", "evaluation_receipt"),
+        ("receipt_3", "evaluation_receipt"),
+        ("manifest_change", "manifest_change_receipt"),
+        ("attribution_1", "outcome_delta_attribution"),
+        ("attribution_2", "outcome_delta_attribution"),
+        ("drift_1", "evaluation_drift_detection"),
+        ("drift_2", "evaluation_drift_detection"),
+        ("monitor", "trajectory_admissibility_monitor"),
+        ("review", "legitimacy_impact_review"),
+    ]
+    manifest_artifacts = []
+    for key, artifact_type in artifact_order:
+        manifest_artifacts.append(
+            {
+                "artifact_type": artifact_type,
+                "artifact_ref": _artifact_ref(
+                    artifact_paths[key],
+                    output_dir,
+                    input_dir,
+                ),
+                "artifact_hash": canonical_json_hash(artifacts[key]),
+            }
+        )
+
+    return {
+        "schema_version": CHAIN_SCHEMA_VERSION,
+        "chain_id": CHAIN_ID,
+        "issued_at": ISSUED_AT,
+        "non_runtime": True,
+        "non_enforcing": True,
+        "artifacts": manifest_artifacts,
+        "chain_summary": (
+            "Synthetic offline Evaluation Governance chain generated for "
+            "reviewer-facing architecture review."
+        ),
+        "non_goals": [
+            "does_not_change_runtime_behavior",
+            "does_not_establish_legitimacy",
+            "does_not_certify_compliance",
+            "does_not_call_v1_decide",
+            "does_not_dereference_artifact_refs",
+        ],
+    }
+
+
+def run_offline_chain(input_dir: Path, output_dir: Path) -> ChainRunResult:
+    """Generate the complete synthetic offline governance chain.
+
+    Args:
+        input_dir: Directory containing the local example input artifacts.
+        output_dir: Directory where generated artifacts should be written.
+
+    Returns:
+        Metadata for generated artifacts and the chain manifest.
+
+    Raises:
+        FileNotFoundError: If required local input files are missing.
+        ValueError: If JSON is invalid or optional schema validation fails.
+        jsonschema.ValidationError: If jsonschema is installed and schema
+            validation fails for an input or generated artifact.
+    """
+    input_dir = input_dir.resolve()
+    output_dir = output_dir.resolve()
+
+    input_paths = {
+        key: input_dir / file_name
+        for key, file_name in INPUT_FILE_NAMES.items()
+    }
+    generated_paths = {
+        key: output_dir / file_name
+        for key, file_name in GENERATED_FILE_NAMES.items()
+    }
+
+    receipts = [
+        load_json(input_paths["receipt_1"]),
+        load_json(input_paths["receipt_2"]),
+        load_json(input_paths["receipt_3"]),
+    ]
+    manifest_change = load_json(input_paths["manifest_change"])
+    for artifact in [*receipts, manifest_change]:
+        validate_generated_artifact(artifact)
+
+    attribution_1 = generate_outcome_delta_attribution(receipts[0], receipts[1])
+    attribution_1 = _set_hashed_identifier(
+        attribution_1,
+        "attribution_id",
+        "evaluation-governance-offline-chain-attribution-001",
+        "attribution_hash",
+    )
+    attribution_2 = generate_outcome_delta_attribution(receipts[1], receipts[2])
+    attribution_2 = _set_hashed_identifier(
+        attribution_2,
+        "attribution_id",
+        "evaluation-governance-offline-chain-attribution-002",
+        "attribution_hash",
+    )
+
+    drift_1 = generate_evaluation_drift_detection(attribution_1)
+    drift_1 = _set_hashed_identifier(
+        drift_1,
+        "detection_id",
+        "evaluation-governance-offline-chain-drift-detection-001",
+        "detection_hash",
+    )
+    drift_2 = generate_evaluation_drift_detection(attribution_2)
+    drift_2 = _set_hashed_identifier(
+        drift_2,
+        "detection_id",
+        "evaluation-governance-offline-chain-drift-detection-002",
+        "detection_hash",
+    )
+
+    attributions = [attribution_1, attribution_2]
+    drift_detections = [drift_1, drift_2]
+    monitor = generate_trajectory_admissibility_monitor(
+        receipts,
+        attributions,
+        drift_detections,
+    )
+    review = generate_legitimacy_impact_review(manifest_change, monitor)
+    validate_generated_artifact(review)
+
+    artifacts = {
+        "receipt_1": receipts[0],
+        "receipt_2": receipts[1],
+        "receipt_3": receipts[2],
+        "manifest_change": manifest_change,
+        "attribution_1": attribution_1,
+        "attribution_2": attribution_2,
+        "drift_1": drift_1,
+        "drift_2": drift_2,
+        "monitor": monitor,
+        "review": review,
+    }
+    artifact_paths = {**input_paths, **generated_paths}
+    manifest = build_chain_manifest(input_dir, output_dir, artifact_paths, artifacts)
+    artifacts["manifest"] = manifest
+
+    for key in GENERATED_FILE_NAMES:
+        write_json(generated_paths[key], artifacts[key])
+
+    return ChainRunResult(
+        output_dir=output_dir,
+        artifacts=artifacts,
+        artifact_paths=generated_paths,
+        manifest=manifest,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the offline chain runner."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate the non-runtime, non-enforcing Evaluation Governance "
+            "offline helper chain from local example inputs."
+        )
+    )
+    parser.add_argument("--input-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument(
+        "--write-example-output",
+        action="store_true",
+        help=(
+            "Intentionally overwrite the input example directory's generated/ "
+            "artifacts. Required when --output-dir is omitted."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _resolve_output_dir(args: argparse.Namespace) -> Path:
+    """Resolve the requested output directory while preventing mutations."""
+    if args.output_dir is not None:
+        return args.output_dir
+    if args.write_example_output:
+        return args.input_dir / DEFAULT_GENERATED_DIR_NAME
+    raise ValueError(
+        "refusing to write checked-in generated examples without "
+        "--write-example-output; pass --output-dir for safe temporary output"
+    )
+
+
+def main() -> int:
+    """Run the Evaluation Governance offline chain CLI."""
+    args = _parse_args()
+    try:
+        output_dir = _resolve_output_dir(args)
+        result = run_offline_chain(args.input_dir, output_dir)
+    except Exception as exc:  # noqa: BLE001 - CLI presents concise errors.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    monitor = result.artifacts["monitor"]
+    review = result.artifacts["review"]
+    print(
+        "Generated Evaluation Governance offline chain v1: "
+        f"{result.output_dir} "
+        f"(generated_artifacts={len(GENERATED_FILE_NAMES)}, "
+        f"trajectory_status={monitor['trajectory_status']}, "
+        f"legitimacy_impact_detected={review['legitimacy_impact_detected']})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_evaluation_governance_offline_chain_runner.py
+++ b/tests/demo/test_evaluation_governance_offline_chain_runner.py
@@ -1,0 +1,168 @@
+"""Tests for the Evaluation Governance offline chain runner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.demo import run_evaluation_governance_offline_chain as runner
+from scripts.demo import validate_evaluation_governance_sample_bundle as validator
+
+EXAMPLE_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+SCRIPT_PATH = Path("scripts/demo/run_evaluation_governance_offline_chain.py")
+SCHEMA_PATHS_BY_VERSION = {
+    "outcome-delta-attribution-v1": Path(
+        "docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json"
+    ),
+    "evaluation-drift-detection-v1": Path(
+        "docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json"
+    ),
+    "trajectory-admissibility-monitor-v1": Path(
+        "docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json"
+    ),
+    "legitimacy-impact-review-v1": Path(
+        "docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json"
+    ),
+}
+GENERATED_FILE_NAMES = [
+    "outcome-delta-attribution-1.generated.example.json",
+    "outcome-delta-attribution-2.generated.example.json",
+    "evaluation-drift-detection-1.generated.example.json",
+    "evaluation-drift-detection-2.generated.example.json",
+    "trajectory-admissibility-monitor.generated.example.json",
+    "legitimacy-impact-review.generated.example.json",
+    "chain-manifest.generated.example.json",
+]
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_schema_shape(payload: dict[str, object]) -> None:
+    schema_version = payload["schema_version"]
+    assert isinstance(schema_version, str)
+    schema_path = SCHEMA_PATHS_BY_VERSION.get(schema_version)
+    if schema_path is None:
+        return
+    schema = _load_json(schema_path)
+    validator._validate_payload(payload, schema)
+
+
+def _signal_types(monitor: dict[str, object]) -> set[str]:
+    signals = monitor["trajectory_risk_signals"]
+    assert isinstance(signals, list)
+    return {signal["signal_type"] for signal in signals}
+
+
+def test_runner_imports_cleanly() -> None:
+    assert callable(runner.run_offline_chain)
+    assert callable(runner.load_json)
+    assert callable(runner.write_json)
+    assert callable(runner.canonical_json_hash)
+    assert callable(runner.validate_generated_artifact)
+    assert callable(runner.build_chain_manifest)
+
+
+def test_run_offline_chain_generates_expected_artifacts(tmp_path: Path) -> None:
+    result = runner.run_offline_chain(EXAMPLE_DIR, tmp_path)
+
+    for file_name in GENERATED_FILE_NAMES:
+        assert (tmp_path / file_name).is_file()
+
+    attribution_1 = _load_json(
+        tmp_path / "outcome-delta-attribution-1.generated.example.json"
+    )
+    attribution_2 = _load_json(
+        tmp_path / "outcome-delta-attribution-2.generated.example.json"
+    )
+    drift_1 = _load_json(
+        tmp_path / "evaluation-drift-detection-1.generated.example.json"
+    )
+    drift_2 = _load_json(
+        tmp_path / "evaluation-drift-detection-2.generated.example.json"
+    )
+    monitor = _load_json(
+        tmp_path / "trajectory-admissibility-monitor.generated.example.json"
+    )
+    review = _load_json(
+        tmp_path / "legitimacy-impact-review.generated.example.json"
+    )
+    manifest = _load_json(tmp_path / "chain-manifest.generated.example.json")
+
+    assert attribution_1["schema_version"] == "outcome-delta-attribution-v1"
+    assert attribution_2["schema_version"] == "outcome-delta-attribution-v1"
+    assert drift_1["schema_version"] == "evaluation-drift-detection-v1"
+    assert drift_2["schema_version"] == "evaluation-drift-detection-v1"
+    assert monitor["schema_version"] == "trajectory-admissibility-monitor-v1"
+    assert review["schema_version"] == "legitimacy-impact-review-v1"
+    assert (
+        manifest["schema_version"]
+        == "evaluation-governance-offline-chain-manifest-v1"
+    )
+
+    for payload in [
+        attribution_1,
+        attribution_2,
+        drift_1,
+        drift_2,
+        monitor,
+        review,
+    ]:
+        _validate_schema_shape(payload)
+
+    assert "strategic_admissibility_drift" in _signal_types(monitor)
+    assert monitor["trajectory_status"] in {
+        "suspicious",
+        "strategically_shaped",
+        "drift_detected",
+        "non_deterministically_governed",
+    }
+    assert review["legitimacy_impact_detected"] is True
+    assert manifest["non_runtime"] is True
+    assert manifest["non_enforcing"] is True
+    assert result.manifest == manifest
+
+
+def test_runner_cli_writes_to_output_dir(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--input-dir",
+            str(EXAMPLE_DIR),
+            "--output-dir",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "Generated Evaluation Governance offline chain v1" in completed.stdout
+    assert "trajectory_status=" in completed.stdout
+    assert "legitimacy_impact_detected=True" in completed.stdout
+    for file_name in GENERATED_FILE_NAMES:
+        assert (tmp_path / file_name).is_file()
+
+
+def test_runner_cli_refuses_implicit_example_mutation() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--input-dir",
+            str(EXAMPLE_DIR),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "refusing to write checked-in generated examples" in completed.stderr


### PR DESCRIPTION
### Motivation
- Provide a non-runtime, reviewer-facing orchestration that composes the existing Evaluation Governance helper chain to produce a complete synthetic review artifact sequence for architecture/review purposes.
- Ensure this is strictly a docs/demo/tests-only helper: it must not change runtime behavior, modify governance config or schemas, call `/v1/decide`, or require network access or secrets.
- Make it easy to regenerate human-readable checked-in example outputs while preventing accidental repository mutation by default.

### Description
- Add `scripts/demo/run_evaluation_governance_offline_chain.py` implementing `run_offline_chain(input_dir, output_dir)` plus CLI and helper functions `load_json`, `write_json`, `canonical_json_hash`, `validate_generated_artifact`, and `build_chain_manifest`; the runner reuses existing helpers (`generate_outcome_delta_attribution`, `generate_evaluation_drift_detection`, `generate_trajectory_admissibility_monitor`, `generate_legitimacy_impact_review`) and only uses stdlib plus optional `jsonschema` when present.
- Add a synthetic example directory `docs/en/demo/examples/evaluation-governance-offline-chain-v1/` containing three input receipts, one manifest-change receipt, a README, and checked-in generated artifacts under `generated/`, plus a simple chain manifest that marks the output `non_runtime` and `non_enforcing`.
- Add tests `tests/demo/test_evaluation_governance_offline_chain_runner.py` that import the runner, call `run_offline_chain(...)` against the example inputs and assert the existence and schema-version of generated artifacts, validate schema shape when schemas are available, check trajectory/legitimacy signals, and exercise the CLI modes including refusal to overwrite checked-in examples unless `--write-example-output` is supplied.
- Safety measures: the runner never dereferences artifact refs, never accesses the network, never imports runtime admissibility logic, and requires an explicit flag to overwrite checked-in generated examples.

### Testing
- Ran the new test file: `python -m pytest -q tests/demo/test_evaluation_governance_offline_chain_runner.py` — passed (4 tests, all green in the local run).
- Ran related helper test suites to ensure no regressions: `python -m pytest -q tests/demo/test_outcome_delta_attribution_helper.py tests/demo/test_evaluation_drift_detection_helper.py tests/demo/test_trajectory_admissibility_monitor_helper.py tests/demo/test_legitimacy_impact_review_helper.py tests/demo/test_evaluation_governance_sample_bundle_validator.py` — all passed (combined helper tests passed locally).
- CLI and end-to-end checks: exercised the CLI in both safe temporary output (`--output-dir`) and intentional overwrite (`--write-example-output`) modes and asserted concise success stdout; the refusal behavior without `--write-example-output` also asserted in tests.
- Static checks: ran `ruff` on the new script and test file — no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25a25667b48326825a91f3b0a7b369)