### PR TITLE
Generate reviewer evidence packet from Evaluation Governance offline chain

### DIFF
--- a/docs/en/architecture/evaluation-governance-overview-v1.md
+++ b/docs/en/architecture/evaluation-governance-overview-v1.md
@@ -80,6 +80,7 @@ See:
 - [Reviewer Evidence Packet v1](../demo/reviewer-evidence-packet.md)
 - [Reviewer Evidence Packet example with Evaluation Governance attachments](../demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json)
 - [Evaluation Governance sample bundle v1](../demo/examples/evaluation-governance-sample-bundle-v1/)
+- [Evaluation Governance offline-chain Reviewer Evidence Packet example](../demo/examples/evaluation-governance-chain-reviewer-packet-v1/)
 
 The synthetic sample bundle can be validated locally with `scripts/demo/validate_evaluation_governance_sample_bundle.py`.
 

--- a/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/README.md
@@ -1,0 +1,40 @@
+# Evaluation Governance chain Reviewer Evidence Packet v1
+
+This directory contains a synthetic, reviewer-facing Reviewer Evidence Packet
+example generated from the Evaluation Governance offline chain manifest.
+
+The generated packet attaches Evaluation Governance artifacts as optional
+reviewer evidence. It is intended for local architecture/demo review only.
+
+## Boundary
+
+This v1 example is:
+
+- synthetic and local/offline only;
+- generated from
+  `docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/chain-manifest.generated.example.json`;
+- populated with Evaluation Governance artifact attachments from the offline
+  chain manifest;
+- non-runtime and non-enforcing;
+- not connected to `/v1/decide`;
+- not a change to runtime admissibility or production governance
+  configuration;
+- not proof of legitimacy;
+- not regulatory, audit, legal, or compliance certification;
+- not a workflow that dereferences external artifact references;
+- not dependent on network access; and
+- not a container for secrets, PII, customer data, or live external service
+  data.
+
+## Generate the packet
+
+```bash
+python scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py \
+  --chain-manifest docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/chain-manifest.generated.example.json \
+  --artifact-base-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --output /tmp/reviewer-evidence-packet.json
+```
+
+When `--output` is omitted, the helper prints the generated Reviewer Evidence
+Packet JSON to stdout. When `--output` is provided, it writes the JSON to that
+path and prints a short local/offline summary.

--- a/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
+++ b/docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json
@@ -1,0 +1,752 @@
+{
+  "aggregate_summary": {
+    "blocked_cases": 4,
+    "committed_cases": 1,
+    "failed_chains": 0,
+    "incomplete_chains": 0,
+    "indeterminate_chains": 0,
+    "local_offline_only": true,
+    "passed_cases": 5,
+    "total_cases": 5,
+    "verified_chains": 5
+  },
+  "boundary_note": "local/offline synthetic reviewer evidence only; no /v1/decide call, runtime admissibility change, live service integration, legitimacy determination, or compliance certification",
+  "cases": [
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "missing_authority",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": null,
+        "authority_evidence_id": null,
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
+        "human_approval_receipt_id": "har-saas-001",
+        "manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "manifest_id": "ecm-saas-permission-change-missing_authority",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "authority_evidence_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-missing_authority",
+        "outcome_receipt_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
+        "refusal_basis": [
+          "authority_expired_or_missing",
+          "authority_invalid",
+          "authority_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-missing_authority",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "authority_evidence_hash"
+        ],
+        "operation_id": "saas-permission-change-missing_authority",
+        "recomputed_manifest_hash": "66e0d0a277ca167b9021191e721a87c19edffa954f70d671e35bfe434613db8e",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "bind_coverage_operation_id",
+          "human_approval_receipt_hash",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "authority_expired_or_missing",
+        "authority_invalid",
+        "authority_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": "har-saas-001",
+        "approved": true,
+        "approved_scope": [
+          "saas:grant_admin"
+        ],
+        "approver_identity": "human:synthetic_reviewer",
+        "approver_role": "synthetic_reviewer",
+        "failure_reasons": [],
+        "receipt_hash_present": true
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "authority_expired_or_missing",
+          "authority_invalid",
+          "authority_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-missing_authority",
+        "outcome_hash": "8f28c45ec0f7efd2f8f4cd25b02fe46450c012b10a06ed715d9ed25f899ea71f",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_authority",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "authority_expired_or_missing",
+        "authority_invalid",
+        "authority_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because AuthorityEvidence was missing.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "missing_human_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "86bd3a69cb781db382f94e0a87e6a36aaa203d934403a23ac36e8856a9d5e940",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "manifest_id": "ecm-saas-permission-change-missing_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "outcome_receipt_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
+        "refusal_basis": [
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-missing_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "recomputed_manifest_hash": "de5f807be0e901dc94a3968a831a30485aa059dc04722e479771199d1226477b",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-missing_human_approval",
+        "outcome_hash": "9675064eed76fafddc5aae73292bba314f31a3e106f81451c4a0f3d472bf6ebd",
+        "outcome_receipt_id": "outcome-saas-permission-change-missing_human_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because HumanApprovalReceipt was missing.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "expired_human_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "86bd3a69cb781db382f94e0a87e6a36aaa203d934403a23ac36e8856a9d5e940",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "manifest_id": "ecm-saas-permission-change-expired_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "outcome_receipt_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
+        "refusal_basis": [
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-expired_human_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "recomputed_manifest_hash": "a01e60928b028538839d9d0709424d92d7bf164efd209adcc7cfcc768982f20a",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_expired"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-expired_human_approval",
+        "outcome_hash": "04f7b00e736648ed570282482a90bf453e4e8d871e26f4ca4d173467f0be92af",
+        "outcome_receipt_id": "outcome-saas-permission-change-expired_human_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because HumanApprovalReceipt was expired.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "block",
+      "authority_validation_status": "fail",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "scope_mismatch",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "f3ef007f0aa8236117004edd91c0abd105762b8f4d02f8b2572a5988c6c0647a",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "blocked",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "block",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": null,
+        "human_approval_receipt_id": null,
+        "manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "manifest_id": "ecm-saas-permission-change-scope_mismatch",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "observed_effects_summary": [],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "outcome_receipt_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
+        "refusal_basis": [
+          "authority_invalid",
+          "human_approval_missing"
+        ],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-scope_mismatch",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [
+          "human_approval_receipt_hash"
+        ],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "recomputed_manifest_hash": "4e3785488ebac6a6e58abf0f23303ff0f7737f1899ec1618ac809432934d7484",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "block",
+      "failure_reasons": [
+        "authority_invalid",
+        "human_approval_missing"
+      ],
+      "human_approval_summary": {
+        "approval_receipt_id": null,
+        "approved": false,
+        "approved_scope": [],
+        "approver_identity": null,
+        "approver_role": null,
+        "failure_reasons": [
+          "human_approval_scope_not_granted"
+        ],
+        "receipt_hash_present": false
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": true,
+        "committed": false,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [
+          "authority_invalid",
+          "human_approval_missing"
+        ],
+        "final_outcome": "block",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [],
+        "operation_id": "saas-permission-change-scope_mismatch",
+        "outcome_hash": "3fff28c56dd93ff5d7e11c71a9ed6ba134c31dc8a057810e72d24b93f2c8a54f",
+        "outcome_receipt_id": "outcome-saas-permission-change-scope_mismatch",
+        "post_state_fingerprint": null,
+        "postcondition_status": "skipped",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [
+        "authority_invalid",
+        "human_approval_missing"
+      ],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "The local/offline fixture blocked because approved authority or approval scope was insufficient.",
+      "runtime_recommended_outcome": "block",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    },
+    {
+      "actual_outcome": "commit",
+      "authority_validation_status": "pass",
+      "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+      "case_id": "valid_authority_and_approval",
+      "evidence_chain_manifest_summary": {
+        "action_class": "permission_change",
+        "authority_evidence_hash": "6879ecdcdeded375a2e81832fe8819a698c9c5df151d7819224420f21a7a53a0",
+        "authority_evidence_id": "aev-saas-001",
+        "bind_coverage_operation_id": "saas_permission_change_demo",
+        "bind_receipt_hash": null,
+        "bind_receipt_id": null,
+        "chain_status": "complete",
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "final_outcome": "commit",
+        "generated_at": "2026-04-26T00:00:00+00:00",
+        "human_approval_receipt_hash": "22c26614740e5a495beea2a46f1e8a498303e8c50d96a2f25a2a8e788d1c4547",
+        "human_approval_receipt_id": "har-saas-001",
+        "manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "missing_links": [],
+        "observed_effects_summary": [
+          {
+            "effect_type": "permission_grant",
+            "fixture_only": true,
+            "permission": "saas:grant_admin",
+            "target_resource": "synthetic_offline_resource"
+          }
+        ],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "outcome_receipt_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
+        "refusal_basis": [],
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "evidence_chain_verification_summary": {
+        "decision_id": "decision-saas-001",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "is_valid": true,
+        "manifest_hash_matches": true,
+        "manifest_id": "ecm-saas-permission-change-valid_authority_and_approval",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "mismatched_links": [],
+        "missing_links": [],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "recomputed_manifest_hash": "264d650ff037717002e56642e702db0853792e256bf0b624cd5d6df2f5bc1bcb",
+        "verification_status": "verified",
+        "verified_at": "2026-04-26T00:00:00+00:00",
+        "verified_links": [
+          "authority_evidence_hash",
+          "bind_coverage_operation_id",
+          "human_approval_receipt_hash",
+          "manifest_hash",
+          "outcome_receipt_hash"
+        ]
+      },
+      "expected_outcome": "commit",
+      "failure_reasons": [],
+      "human_approval_summary": {
+        "approval_receipt_id": "har-saas-001",
+        "approved": true,
+        "approved_scope": [
+          "saas:grant_admin"
+        ],
+        "approver_identity": "human:synthetic_reviewer",
+        "approver_role": "synthetic_reviewer",
+        "failure_reasons": [],
+        "receipt_hash_present": true
+      },
+      "outcome_receipt_summary": {
+        "action_class": "permission_change",
+        "bind_receipt_id": null,
+        "blocked": false,
+        "committed": true,
+        "decision_id": "decision-saas-001",
+        "escalated": false,
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "execution_intent_id": "intent-saas-001",
+        "failure_reasons": [],
+        "final_outcome": "commit",
+        "intended_action": "grant_admin_permission",
+        "metadata": {
+          "boundary_note": "local/offline fixture only; no live SaaS/IAM/IdP integration",
+          "fixture_only": true
+        },
+        "observed_effects": [
+          {
+            "effect_type": "permission_grant",
+            "fixture_only": true,
+            "permission": "saas:grant_admin",
+            "target_resource": "synthetic_offline_resource"
+          }
+        ],
+        "operation_id": "saas-permission-change-valid_authority_and_approval",
+        "outcome_hash": "e8eb969be01b97993b20283a6f0314f5e83be4d6377e879f7b3719562e5a036a",
+        "outcome_receipt_id": "outcome-saas-permission-change-valid_authority_and_approval",
+        "post_state_fingerprint": null,
+        "postcondition_status": "passed",
+        "pre_state_fingerprint": null,
+        "requested_scope": [
+          "saas:grant_admin"
+        ],
+        "rollback_status": null,
+        "rolled_back": false,
+        "target_resource": "synthetic_offline_resource",
+        "target_system": "mock_saas_directory"
+      },
+      "passed": true,
+      "refusal_basis": [],
+      "requested_scope": [
+        "saas:grant_admin"
+      ],
+      "reviewer_interpretation": "AuthorityEvidence and HumanApprovalReceipt were sufficient for the local/offline fixture to reach a commit outcome.",
+      "runtime_recommended_outcome": "commit",
+      "target_resource": "synthetic_offline_resource",
+      "target_system": "mock_saas_directory"
+    }
+  ],
+  "demo_id": "evaluation_governance_offline_chain_reviewer_packet_v1",
+  "evaluation_governance_artifacts": [
+    {
+      "artifact_hash": "5cae168299c60becc997dde84fc143fa059edc2b5fca81dde1997f5916f4500f",
+      "artifact_ref": "evaluation-receipt-1.example.json",
+      "artifact_type": "evaluation_receipt",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-receipt-v1.schema.json"
+    },
+    {
+      "artifact_hash": "81c64573c36975ccf755f53718d1b759d00f612832aee47c35081117824a9cfa",
+      "artifact_ref": "evaluation-receipt-2.example.json",
+      "artifact_type": "evaluation_receipt",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-receipt-v1.schema.json"
+    },
+    {
+      "artifact_hash": "9e029c8f3a1df6f1b368def1d6cc7a665ffd6efe1b5c05c1d198d18f5105efb4",
+      "artifact_ref": "evaluation-receipt-3.example.json",
+      "artifact_type": "evaluation_receipt",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-receipt-v1.schema.json"
+    },
+    {
+      "artifact_hash": "4ce275c69363b76007a280e2ffcfb384efa2bc795532745f88dfc4da10ae6421",
+      "artifact_ref": "manifest-change-receipt.example.json",
+      "artifact_type": "manifest_change_receipt",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/manifest-change-receipt-v1.schema.json"
+    },
+    {
+      "artifact_hash": "17029f187996728b120db5bbf7bb92f26d6a16f833bdc3b7c66bd05077d62d33",
+      "artifact_ref": "generated/outcome-delta-attribution-1.generated.example.json",
+      "artifact_type": "outcome_delta_attribution",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json"
+    },
+    {
+      "artifact_hash": "59fac37138155946793fd958cdf2e8c96a842671fa1f64829e6c1f99b3dd531e",
+      "artifact_ref": "generated/outcome-delta-attribution-2.generated.example.json",
+      "artifact_type": "outcome_delta_attribution",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json"
+    },
+    {
+      "artifact_hash": "9e6390164ff4d51dcc66d19b58dc9ca08f915ad07637ef580228aca4a39d3c6e",
+      "artifact_ref": "generated/evaluation-drift-detection-1.generated.example.json",
+      "artifact_type": "evaluation_drift_detection",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json"
+    },
+    {
+      "artifact_hash": "16b7d149551c7a415ee931a10d83c5e4d486fab59b0adda649d65b1e81d08b40",
+      "artifact_ref": "generated/evaluation-drift-detection-2.generated.example.json",
+      "artifact_type": "evaluation_drift_detection",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json"
+    },
+    {
+      "artifact_hash": "900ca433a0128a9f4e9308f9da783c6ae11dc7ae68af5fdd61add67d30f67c89",
+      "artifact_ref": "generated/trajectory-admissibility-monitor.generated.example.json",
+      "artifact_type": "trajectory_admissibility_monitor",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json"
+    },
+    {
+      "artifact_hash": "2af7ec64add0c6e1919216fb79c47d56ad3f60653a009503646cc108d61efda0",
+      "artifact_ref": "generated/legitimacy-impact-review.generated.example.json",
+      "artifact_type": "legitimacy_impact_review",
+      "required_for_review": false,
+      "schema_ref": "docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json"
+    }
+  ],
+  "generated_at": "2026-01-01T00:00:00Z",
+  "local_offline_only": true,
+  "packet_hash": "5daaabfc86ef1af7dbfc9c9362979231c9881f4d4fd07b54a630adc8c323da49",
+  "packet_id": "reviewer-evidence-packet-saas-permission-change-v1",
+  "packet_version": "v1",
+  "reviewer_notes": [
+    "This packet is a synthetic offline reviewer evidence packet generated from an Evaluation Governance offline chain manifest.",
+    "Evaluation Governance artifacts are attached as optional reviewer evidence and are not runtime enforcement inputs.",
+    "This helper does not call /v1/decide, change runtime admissibility, or introduce fail-closed behavior.",
+    "This packet does not prove legitimacy, certify compliance, or include secrets, PII, customer data, or live external service data."
+  ],
+  "summary": "Synthetic local/offline reviewer packet generated from Evaluation Governance offline chain manifest 'evaluation-governance-offline-chain-example-001'. It attaches chain artifacts as optional reviewer evidence and does not establish legitimacy or certify compliance.",
+  "title": "Evaluation Governance Offline Chain Reviewer Evidence Packet"
+}

--- a/docs/en/demo/examples/evaluation-governance-offline-chain-v1/README.md
+++ b/docs/en/demo/examples/evaluation-governance-offline-chain-v1/README.md
@@ -20,6 +20,24 @@ python scripts/demo/run_evaluation_governance_offline_chain.py \
   --output-dir /tmp/evaluation-governance-offline-chain-output
 ```
 
+## Generate a Reviewer Evidence Packet from the chain
+
+The generated chain manifest can also be converted into a synthetic,
+local/offline Reviewer Evidence Packet with Evaluation Governance artifact
+attachments:
+
+```bash
+python scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py \
+  --chain-manifest docs/en/demo/examples/evaluation-governance-offline-chain-v1/generated/chain-manifest.generated.example.json \
+  --artifact-base-dir docs/en/demo/examples/evaluation-governance-offline-chain-v1 \
+  --output /tmp/reviewer-evidence-packet.json
+```
+
+The checked-in packet example is available at
+`docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/`.
+It remains non-runtime, non-enforcing, and does not establish legitimacy or
+certify compliance.
+
 ## Regenerate checked-in example outputs intentionally
 
 ```bash

--- a/docs/en/demo/reviewer-evidence-packet.md
+++ b/docs/en/demo/reviewer-evidence-packet.md
@@ -36,7 +36,7 @@ Optional Evaluation Governance artifact references may include:
 
 These attachments are optional reviewer evidence attachments in v1. Reviewer packets do not require them, and schema validation only checks the attachment reference shape, hash format, and declared schema reference; it does not dereference files or validate the target artifact itself.
 
-A non-enforcing example packet with optional Evaluation Governance attachment references is checked in at `docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json`. A synthetic end-to-end Evaluation Governance sample bundle is also available at `docs/en/demo/examples/evaluation-governance-sample-bundle-v1/`.
+A non-enforcing example packet with optional Evaluation Governance attachment references is checked in at `docs/en/demo/examples/reviewer-evidence-packet-with-evaluation-governance-v1.json`. A synthetic end-to-end Evaluation Governance sample bundle is also available at `docs/en/demo/examples/evaluation-governance-sample-bundle-v1/`. A synthetic packet generated from the Evaluation Governance offline chain manifest is checked in at `docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/`.
 
 Evaluation Governance artifacts are non-enforcing in v1 unless future runtime integration is added. Their presence supports external review, but does not automatically establish legitimacy, does not change runtime admissibility, does not introduce fail-closed behavior, and does not require live receipt generation.
 

--- a/scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py
+++ b/scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Generate a reviewer packet from an offline Evaluation Governance chain.
+
+This helper is intentionally local/offline and non-enforcing. It reads a chain
+manifest produced by the Evaluation Governance offline chain runner, maps the
+manifest's local artifact metadata into Reviewer Evidence Packet v1 attachment
+entries, and emits a synthetic reviewer-facing packet. It does not call runtime
+paths, does not dereference external artifact references, and does not establish
+legitimacy or certify compliance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REVIEWER_PACKET_SCHEMA_PATH = (
+    REPO_ROOT / "docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json"
+)
+REVIEWER_PACKET_TEMPLATE_PATH = (
+    REPO_ROOT
+    / "docs/en/demo/examples"
+    / "reviewer-evidence-packet-with-evaluation-governance-v1.json"
+)
+SHA256_HEX_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+ARTIFACT_TYPE_MAP = {
+    "evaluation_receipt": "evaluation_receipt",
+    "manifest_change_receipt": "manifest_change_receipt",
+    "outcome_delta_attribution": "outcome_delta_attribution",
+    "evaluation_drift_detection": "evaluation_drift_detection",
+    "trajectory_admissibility_monitor": "trajectory_admissibility_monitor",
+    "legitimacy_impact_review": "legitimacy_impact_review",
+}
+
+SCHEMA_REFS_BY_ARTIFACT_TYPE = {
+    "evaluation_receipt": "docs/en/demo/schemas/evaluation-receipt-v1.schema.json",
+    "manifest_change_receipt": (
+        "docs/en/demo/schemas/manifest-change-receipt-v1.schema.json"
+    ),
+    "outcome_delta_attribution": (
+        "docs/en/demo/schemas/outcome-delta-attribution-v1.schema.json"
+    ),
+    "evaluation_drift_detection": (
+        "docs/en/demo/schemas/evaluation-drift-detection-v1.schema.json"
+    ),
+    "trajectory_admissibility_monitor": (
+        "docs/en/demo/schemas/trajectory-admissibility-monitor-v1.schema.json"
+    ),
+    "legitimacy_impact_review": (
+        "docs/en/demo/schemas/legitimacy-impact-review-v1.schema.json"
+    ),
+}
+
+REVIEWER_NOTES = [
+    (
+        "This packet is a synthetic offline reviewer evidence packet generated "
+        "from an Evaluation Governance offline chain manifest."
+    ),
+    (
+        "Evaluation Governance artifacts are attached as optional reviewer "
+        "evidence and are not runtime enforcement inputs."
+    ),
+    (
+        "This helper does not call /v1/decide, change runtime admissibility, "
+        "or introduce fail-closed behavior."
+    ),
+    (
+        "This packet does not prove legitimacy, certify compliance, or include "
+        "secrets, PII, customer data, or live external service data."
+    ),
+]
+
+
+def _jsonschema_module() -> Any | None:
+    """Return the optional jsonschema module when available locally."""
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+
+    import jsonschema
+
+    return jsonschema
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Load a local JSON object from ``path`` with clear helper errors."""
+    if not path.is_file():
+        raise FileNotFoundError(f"missing chain manifest or JSON file: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object in {path}")
+    return payload
+
+
+def canonical_json_hash(payload: Any) -> str:
+    """Return the SHA-256 digest of canonical JSON for local artifacts."""
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def map_artifact_type(chain_artifact_type: str) -> str:
+    """Map a chain artifact type to a Reviewer Evidence Packet artifact type."""
+    mapped_type = ARTIFACT_TYPE_MAP.get(chain_artifact_type)
+    if mapped_type is None:
+        supported = ", ".join(sorted(ARTIFACT_TYPE_MAP))
+        raise ValueError(
+            "unsupported Evaluation Governance chain artifact_type "
+            f"{chain_artifact_type!r}; supported types: {supported}"
+        )
+    return mapped_type
+
+
+def schema_ref_for_artifact_type(artifact_type: str) -> str:
+    """Return the Reviewer Evidence Packet schema_ref for ``artifact_type``."""
+    schema_ref = SCHEMA_REFS_BY_ARTIFACT_TYPE.get(artifact_type)
+    if schema_ref is None:
+        raise ValueError(f"no schema_ref mapping for artifact_type {artifact_type!r}")
+    return schema_ref
+
+
+def _is_external_ref(artifact_ref: str) -> bool:
+    parsed = urlparse(artifact_ref)
+    return bool(parsed.scheme and parsed.scheme not in {"", "file"})
+
+
+def _local_artifact_path(artifact_base_dir: Path, artifact_ref: str) -> Path:
+    """Return a safe local path for ``artifact_ref`` below artifact_base_dir."""
+    artifact_path = Path(artifact_ref)
+    if artifact_path.is_absolute():
+        raise ValueError(
+            f"artifact_ref must be relative for local hash computation: {artifact_ref}"
+        )
+
+    base = artifact_base_dir.resolve()
+    candidate = (base / artifact_path).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(
+            f"artifact_ref escapes artifact_base_dir: {artifact_ref}"
+        ) from exc
+    return candidate
+
+
+def _hash_local_artifact(artifact_base_dir: Path, artifact_ref: str) -> str:
+    """Compute a local artifact hash without dereferencing external refs."""
+    if _is_external_ref(artifact_ref):
+        raise ValueError(
+            "cannot compute artifact_hash for external artifact_ref without "
+            f"dereferencing it: {artifact_ref}"
+        )
+
+    artifact_path = _local_artifact_path(artifact_base_dir, artifact_ref)
+    if not artifact_path.is_file():
+        raise FileNotFoundError(
+            "missing local artifact file needed to compute artifact_hash: "
+            f"{artifact_path}"
+        )
+
+    try:
+        return canonical_json_hash(load_json(artifact_path))
+    except (TypeError, ValueError):
+        return hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+
+
+def _artifact_hash(
+    manifest_artifact: dict[str, Any],
+    artifact_base_dir: Path,
+    artifact_ref: str,
+) -> str:
+    candidate_hash = manifest_artifact.get("artifact_hash")
+    if isinstance(candidate_hash, str) and SHA256_HEX_PATTERN.fullmatch(
+        candidate_hash
+    ):
+        return candidate_hash
+    if candidate_hash is not None:
+        raise ValueError(
+            "artifact_hash must be a sha256 hex string when present for "
+            f"artifact_ref {artifact_ref!r}"
+        )
+    return _hash_local_artifact(artifact_base_dir, artifact_ref)
+
+
+def build_evaluation_governance_artifacts(
+    chain_manifest: dict[str, Any], artifact_base_dir: Path
+) -> list[dict[str, Any]]:
+    """Build Reviewer Evidence Packet Evaluation Governance attachments."""
+    artifacts = chain_manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("chain manifest must contain an artifacts array")
+
+    reviewer_artifacts: list[dict[str, Any]] = []
+    for index, manifest_artifact in enumerate(artifacts):
+        if not isinstance(manifest_artifact, dict):
+            raise TypeError(f"chain manifest artifacts[{index}] must be an object")
+
+        chain_artifact_type = manifest_artifact.get("artifact_type")
+        artifact_ref = manifest_artifact.get("artifact_ref")
+        if not isinstance(chain_artifact_type, str) or not chain_artifact_type:
+            raise ValueError(f"chain manifest artifacts[{index}] missing artifact_type")
+        if not isinstance(artifact_ref, str) or not artifact_ref:
+            raise ValueError(f"chain manifest artifacts[{index}] missing artifact_ref")
+
+        artifact_type = map_artifact_type(chain_artifact_type)
+        reviewer_artifacts.append(
+            {
+                "artifact_type": artifact_type,
+                "artifact_ref": artifact_ref,
+                "artifact_hash": _artifact_hash(
+                    manifest_artifact,
+                    artifact_base_dir,
+                    artifact_ref,
+                ),
+                "schema_ref": schema_ref_for_artifact_type(artifact_type),
+                "required_for_review": False,
+            }
+        )
+
+    return reviewer_artifacts
+
+
+def _sanitize_synthetic_template_values(payload: Any) -> Any:
+    """Remove email-shaped demo strings from the reused packet template."""
+    replacements = {
+        "contractor:external.user@example.test": "synthetic_offline_resource",
+        "human:manager.alex": "human:synthetic_reviewer",
+        "engineering_manager": "synthetic_reviewer",
+    }
+    if isinstance(payload, dict):
+        return {
+            key: _sanitize_synthetic_template_values(value)
+            for key, value in payload.items()
+        }
+    if isinstance(payload, list):
+        return [_sanitize_synthetic_template_values(value) for value in payload]
+    if isinstance(payload, str):
+        return replacements.get(payload, payload)
+    return payload
+
+
+def _packet_hash(packet: dict[str, Any]) -> str:
+    """Compute Reviewer Evidence Packet hash excluding packet_hash itself."""
+    payload = copy.deepcopy(packet)
+    payload.pop("packet_hash", None)
+    return canonical_json_hash(payload)
+
+
+def validate_reviewer_packet(packet: dict[str, Any]) -> None:
+    """Validate generated packet against Reviewer Evidence Packet v1 if possible."""
+    jsonschema = _jsonschema_module()
+    if jsonschema is None:
+        return
+
+    schema = load_json(REVIEWER_PACKET_SCHEMA_PATH)
+    try:
+        jsonschema.Draft202012Validator(schema).validate(packet)
+    except jsonschema.ValidationError as exc:
+        raise ValueError(
+            f"Reviewer Evidence Packet schema validation failed: {exc}"
+        ) from exc
+
+
+def generate_reviewer_evidence_packet_from_chain(
+    chain_manifest: dict[str, Any], artifact_base_dir: Path
+) -> dict[str, Any]:
+    """Generate a Reviewer Evidence Packet v1 from an offline chain manifest.
+
+    The returned packet is synthetic, local/offline-only, and non-enforcing. It
+    preserves the existing Reviewer Evidence Packet v1 shape while replacing
+    Evaluation Governance attachments with artifacts listed in the chain
+    manifest.
+    """
+    reviewer_artifacts = build_evaluation_governance_artifacts(
+        chain_manifest,
+        artifact_base_dir,
+    )
+    chain_id = chain_manifest.get("chain_id", "evaluation-governance-chain")
+    issued_at = chain_manifest.get("issued_at", "2026-01-01T00:00:00Z")
+
+    packet = _sanitize_synthetic_template_values(
+        load_json(REVIEWER_PACKET_TEMPLATE_PATH)
+    )
+    packet["demo_id"] = "evaluation_governance_offline_chain_reviewer_packet_v1"
+    packet["generated_at"] = issued_at
+    packet["title"] = "Evaluation Governance Offline Chain Reviewer Evidence Packet"
+    packet["summary"] = (
+        "Synthetic local/offline reviewer packet generated from Evaluation "
+        f"Governance offline chain manifest {chain_id!r}. It attaches chain "
+        "artifacts as optional reviewer evidence and does not establish "
+        "legitimacy or certify compliance."
+    )
+    packet["boundary_note"] = (
+        "local/offline synthetic reviewer evidence only; no /v1/decide call, "
+        "runtime admissibility change, live service integration, legitimacy "
+        "determination, or compliance certification"
+    )
+    packet["local_offline_only"] = True
+    packet["evaluation_governance_artifacts"] = reviewer_artifacts
+    packet["reviewer_notes"] = list(REVIEWER_NOTES)
+    packet["packet_hash"] = _packet_hash(packet)
+
+    validate_reviewer_packet(packet)
+    return packet
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"{json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)}\n",
+        encoding="utf-8",
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a synthetic Reviewer Evidence Packet from an offline "
+            "Evaluation Governance chain manifest."
+        )
+    )
+    parser.add_argument(
+        "--chain-manifest",
+        required=True,
+        type=Path,
+        help="Path to the Evaluation Governance offline chain manifest JSON.",
+    )
+    parser.add_argument(
+        "--artifact-base-dir",
+        required=True,
+        type=Path,
+        help="Base directory for resolving local chain artifact refs if needed.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional output JSON path; stdout is used when omitted.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the offline reviewer packet helper."""
+    args = _parse_args(argv)
+    try:
+        chain_manifest = load_json(args.chain_manifest)
+        packet = generate_reviewer_evidence_packet_from_chain(
+            chain_manifest,
+            args.artifact_base_dir,
+        )
+    except Exception as exc:  # noqa: BLE001 - CLI must present clear errors.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output is None:
+        print(json.dumps(packet, indent=2, ensure_ascii=False, sort_keys=True))
+    else:
+        _write_json(args.output, packet)
+        print(
+            "Generated Reviewer Evidence Packet from Evaluation Governance "
+            f"offline chain: {args.output} "
+            f"({len(packet['evaluation_governance_artifacts'])} artifacts)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/demo/test_evaluation_governance_chain_reviewer_packet.py
+++ b/tests/demo/test_evaluation_governance_chain_reviewer_packet.py
@@ -1,0 +1,143 @@
+"""Tests for generating Reviewer Evidence Packets from offline chains."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.demo import (
+    generate_reviewer_evidence_packet_from_evaluation_governance_chain as helper,
+)
+
+EXAMPLE_DIR = Path(
+    "docs/en/demo/examples/evaluation-governance-offline-chain-v1"
+)
+CHAIN_MANIFEST_PATH = EXAMPLE_DIR / "generated/chain-manifest.generated.example.json"
+SCRIPT_PATH = Path(
+    "scripts/demo/"
+    "generate_reviewer_evidence_packet_from_evaluation_governance_chain.py"
+)
+SCHEMA_PATH = Path("docs/en/demo/schemas/reviewer-evidence-packet-v1.schema.json")
+REQUIRED_ARTIFACT_TYPES = {
+    "evaluation_receipt",
+    "manifest_change_receipt",
+    "outcome_delta_attribution",
+    "evaluation_drift_detection",
+    "trajectory_admissibility_monitor",
+    "legitimacy_impact_review",
+}
+REQUIRED_ATTACHMENT_FIELDS = {
+    "artifact_type",
+    "artifact_ref",
+    "artifact_hash",
+    "schema_ref",
+    "required_for_review",
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jsonschema_module() -> Any | None:
+    if importlib.util.find_spec("jsonschema") is None:
+        return None
+
+    import jsonschema
+
+    return jsonschema
+
+
+def _validate_packet(packet: dict[str, Any]) -> None:
+    helper.validate_reviewer_packet(packet)
+    jsonschema = _jsonschema_module()
+    if jsonschema is not None:
+        validator = jsonschema.Draft202012Validator(_load_json(SCHEMA_PATH))
+        validator.validate(packet)
+
+
+def test_helper_imports_cleanly() -> None:
+    assert callable(helper.load_json)
+    assert callable(helper.canonical_json_hash)
+    assert callable(helper.map_artifact_type)
+    assert callable(helper.schema_ref_for_artifact_type)
+    assert callable(helper.build_evaluation_governance_artifacts)
+    assert callable(helper.validate_reviewer_packet)
+    assert callable(helper.generate_reviewer_evidence_packet_from_chain)
+
+
+def test_generate_packet_from_checked_in_chain_manifest() -> None:
+    chain_manifest = helper.load_json(CHAIN_MANIFEST_PATH)
+
+    packet = helper.generate_reviewer_evidence_packet_from_chain(
+        chain_manifest,
+        EXAMPLE_DIR,
+    )
+
+    _validate_packet(packet)
+    artifacts = packet.get("evaluation_governance_artifacts")
+    assert isinstance(artifacts, list)
+    assert artifacts
+
+    artifact_types = {artifact["artifact_type"] for artifact in artifacts}
+    assert REQUIRED_ARTIFACT_TYPES <= artifact_types
+    for artifact in artifacts:
+        assert REQUIRED_ATTACHMENT_FIELDS <= set(artifact)
+        assert artifact["required_for_review"] is False
+
+
+def test_cli_writes_packet_to_output_path(tmp_path: Path) -> None:
+    output_path = tmp_path / "reviewer-evidence-packet.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--chain-manifest",
+            str(CHAIN_MANIFEST_PATH),
+            "--artifact-base-dir",
+            str(EXAMPLE_DIR),
+            "--output",
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Generated Reviewer Evidence Packet" in completed.stdout
+    assert output_path.is_file()
+
+    packet = _load_json(output_path)
+    _validate_packet(packet)
+    assert packet["evaluation_governance_artifacts"]
+
+
+def test_unsupported_artifact_type_fails_clearly(tmp_path: Path) -> None:
+    chain_manifest = {
+        "schema_version": "evaluation-governance-offline-chain-manifest-v1",
+        "chain_id": "unsupported-artifact-type-test",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "non_runtime": True,
+        "non_enforcing": True,
+        "artifacts": [
+            {
+                "artifact_type": "unsafe_unknown_artifact",
+                "artifact_ref": "unsafe-unknown-artifact.example.json",
+                "artifact_hash": "0" * 64,
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="unsupported.*artifact_type"):
+        helper.generate_reviewer_evidence_packet_from_chain(
+            chain_manifest,
+            tmp_path,
+        )


### PR DESCRIPTION
### Motivation
- Provide a non-runtime, reviewer-facing helper to convert an Evaluation Governance offline chain manifest into a Reviewer Evidence Packet v1 with Evaluation Governance artifact attachments for offline review.
- Enable external reviewers to inspect chain artifacts (receipts, attributions, drift signals, trajectory monitor, legitimacy review) without changing runtime behavior, schemas, admissibility logic, or production configuration.

### Description
- Add a CLI/helper `scripts/demo/generate_reviewer_evidence_packet_from_evaluation_governance_chain.py` that loads a chain manifest, maps chain artifact types to `evaluation_governance_artifacts`, preserves or computes sha256-shaped `artifact_hash` values, and emits a schema-shaped Reviewer Evidence Packet JSON; the helper never dereferences external refs or accesses network.
- Add unit tests `tests/demo/test_evaluation_governance_chain_reviewer_packet.py` that import the helper, exercise the generator on the checked-in chain manifest, assert schema validation (when `jsonschema` is available), verify required attachment fields and artifact types, test CLI `--output` behavior, and assert clear failure on unsupported artifact types.
- Add a checked-in generated example and README under `docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/` and wire minimal doc links into existing demo/architecture pages to document the offline, non-enforcing boundary.
- Key helper functions implemented: `load_json`, `canonical_json_hash`, `map_artifact_type`, `schema_ref_for_artifact_type`, `build_evaluation_governance_artifacts`, `validate_reviewer_packet`, and `generate_reviewer_evidence_packet_from_chain`; the CLI exposes `--chain-manifest`, `--artifact-base-dir`, and optional `--output`.

### Testing
- Ran the new demo tests: `tests/demo/test_evaluation_governance_chain_reviewer_packet.py` (4 tests) which passed in the local environment.
- Confirmed compatibility with the offline chain runner by running `tests/demo/test_evaluation_governance_offline_chain_runner.py` alongside the new tests and observed those tests passed.
- Executed the CLI to generate the checked-in example file and wrote `docs/en/demo/examples/evaluation-governance-chain-reviewer-packet-v1/reviewer-evidence-packet.generated.example.json`, and `py_compile` succeeded for the new script.
- Note: running the broader reviewer-packet schema test (`tests/demo/test_reviewer_evidence_packet_schema.py`) in this container failed due to a missing `yaml`/PyYAML runtime dependency that could not be installed in the environment (package-index access blocked); this is an environment dependency issue and not a change in code or schemas.

Security / boundary note: the helper is explicitly local/offline and non-enforcing, does not call `/v1/decide`, does not introduce live receipt generation or fail-closed behavior, and the generated example contains synthetic values only and avoids secrets or PII.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ab3540d483268ba8bf4c6303182f)